### PR TITLE
Fix translation of atomic_add

### DIFF
--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -2009,9 +2009,7 @@ pub const NEARMV_NEARMV: CompInterPredMode = 1;
 pub const NEARESTMV_NEARESTMV: CompInterPredMode = 0;
 #[inline]
 unsafe extern "C" fn dav1d_ref_inc(ref_0: *mut Dav1dRef) {
-    let fresh0 = &mut (*ref_0).ref_cnt;
-    let fresh1 = 1 as libc::c_int;
-    ::core::intrinsics::atomic_xadd_relaxed(fresh0, fresh1) + fresh1;
+    ::core::intrinsics::atomic_xadd_relaxed(&mut (*ref_0).ref_cnt, 1 as libc::c_int);
 }
 #[inline]
 unsafe extern "C" fn imin(a: libc::c_int, b: libc::c_int) -> libc::c_int {

--- a/src/data.rs
+++ b/src/data.rs
@@ -107,9 +107,7 @@ pub const memory_order_acquire: memory_order = 2;
 pub const memory_order_consume: memory_order = 1;
 #[inline]
 unsafe extern "C" fn dav1d_ref_inc(ref_0: *mut Dav1dRef) {
-    let fresh0 = &mut (*ref_0).ref_cnt;
-    let fresh1 = 1 as libc::c_int;
-    ::core::intrinsics::atomic_xadd_relaxed(fresh0, fresh1) + fresh1;
+    ::core::intrinsics::atomic_xadd_relaxed(&mut (*ref_0).ref_cnt, 1 as libc::c_int);
 }
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_data_create_internal(

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2435,9 +2435,7 @@ unsafe extern "C" fn freep(mut ptr: *mut libc::c_void) {
 }
 #[inline]
 unsafe extern "C" fn dav1d_ref_inc(ref_0: *mut Dav1dRef) {
-    let fresh0 = &mut (*ref_0).ref_cnt;
-    let fresh1 = 1 as libc::c_int;
-    ::core::intrinsics::atomic_xadd_relaxed(fresh0, fresh1) + fresh1;
+    ::core::intrinsics::atomic_xadd_relaxed(&mut (*ref_0).ref_cnt, 1 as libc::c_int);
 }
 static mut cfl_allowed_mask: libc::c_uint = ((1 as libc::c_int)
     << BS_32x32 as libc::c_int | (1 as libc::c_int) << BS_32x16 as libc::c_int
@@ -19212,9 +19210,10 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                 &mut (*c).task_thread.first,
             );
             if first.wrapping_add(1 as libc::c_uint) < (*c).n_fc {
-                let fresh42 = &mut (*c).task_thread.first;
-                let fresh43 = 1 as libc::c_uint;
-                ::core::intrinsics::atomic_xadd_seqcst(fresh42, fresh43) + fresh43;
+                ::core::intrinsics::atomic_xadd_seqcst(
+                    &mut (*c).task_thread.first,
+                    1 as libc::c_uint,
+                );
             } else {
                 ::core::intrinsics::atomic_store_seqcst(
                     &mut (*c).task_thread.first,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3098,9 +3098,10 @@ unsafe extern "C" fn drain_picture(
             &mut (*c).task_thread.first,
         );
         if first.wrapping_add(1 as libc::c_uint) < (*c).n_fc {
-            let fresh0 = &mut (*c).task_thread.first;
-            let fresh1 = 1 as libc::c_uint;
-            ::core::intrinsics::atomic_xadd_seqcst(fresh0, fresh1) + fresh1;
+            ::core::intrinsics::atomic_xadd_seqcst(
+                &mut (*c).task_thread.first,
+                1 as libc::c_uint,
+            );
         } else {
             ::core::intrinsics::atomic_store_seqcst(
                 &mut (*c).task_thread.first,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2041,9 +2041,7 @@ unsafe extern "C" fn clz(mask: libc::c_uint) -> libc::c_int {
 }
 #[inline]
 unsafe extern "C" fn dav1d_ref_inc(ref_0: *mut Dav1dRef) {
-    let fresh0 = &mut (*ref_0).ref_cnt;
-    let fresh1 = 1 as libc::c_int;
-    ::core::intrinsics::atomic_xadd_relaxed(fresh0, fresh1) + fresh1;
+    ::core::intrinsics::atomic_xadd_relaxed(&mut (*ref_0).ref_cnt, 1 as libc::c_int);
 }
 #[inline]
 unsafe extern "C" fn get_poc_diff(
@@ -5033,10 +5031,10 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                                                         &mut (*c).task_thread.first,
                                                                     );
                                                                     if first.wrapping_add(1 as libc::c_uint) < (*c).n_fc {
-                                                                        let fresh4 = &mut (*c).task_thread.first;
-                                                                        let fresh5 = 1 as libc::c_uint;
-                                                                        ::core::intrinsics::atomic_xadd_seqcst(fresh4, fresh5)
-                                                                            + fresh5;
+                                                                        ::core::intrinsics::atomic_xadd_seqcst(
+                                                                            &mut (*c).task_thread.first,
+                                                                            1 as libc::c_uint,
+                                                                        );
                                                                     } else {
                                                                         ::core::intrinsics::atomic_store_seqcst(
                                                                             &mut (*c).task_thread.first,

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -2012,9 +2012,7 @@ pub struct pic_ctx_context {
 }
 #[inline]
 unsafe extern "C" fn dav1d_ref_inc(ref_0: *mut Dav1dRef) {
-    let fresh0 = &mut (*ref_0).ref_cnt;
-    let fresh1 = 1 as libc::c_int;
-    ::core::intrinsics::atomic_xadd_relaxed(fresh0, fresh1) + fresh1;
+    ::core::intrinsics::atomic_xadd_relaxed(&mut (*ref_0).ref_cnt, 1 as libc::c_int);
 }
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_default_picture_alloc(

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -2812,11 +2812,11 @@ unsafe extern "C" fn delayed_fg_task(c: *const Dav1dContext, ttd: *mut TaskThrea
             abort();
         }
     }
-    let fresh10 = &mut *((*ttd).delayed_fg.progress)
-        .as_mut_ptr()
-        .offset(0 as libc::c_int as isize) as *mut atomic_int;
-    let fresh11 = 1 as libc::c_int;
-    row = ::core::intrinsics::atomic_xadd_seqcst(fresh10, fresh11) + fresh11;
+    row = ::core::intrinsics::atomic_xadd_seqcst(
+        &mut *((*ttd).delayed_fg.progress).as_mut_ptr().offset(0 as libc::c_int as isize)
+            as *mut atomic_int,
+        1 as libc::c_int,
+    );
     pthread_mutex_unlock(&mut (*ttd).lock);
     progmax = (*out).p.h + 31 as libc::c_int >> 5 as libc::c_int;
     loop {
@@ -2847,17 +2847,18 @@ unsafe extern "C" fn delayed_fg_task(c: *const Dav1dContext, ttd: *mut TaskThrea
                 abort();
             }
         }
-        let fresh12 = &mut *((*ttd).delayed_fg.progress)
-            .as_mut_ptr()
-            .offset(0 as libc::c_int as isize) as *mut atomic_int;
-        let fresh13 = 1 as libc::c_int;
-        row = ::core::intrinsics::atomic_xadd_seqcst(fresh12, fresh13) + fresh13;
-        let fresh14 = &mut *((*ttd).delayed_fg.progress)
-            .as_mut_ptr()
-            .offset(1 as libc::c_int as isize) as *mut atomic_int;
-        let fresh15 = 1 as libc::c_int;
-        done = ::core::intrinsics::atomic_xadd_seqcst(fresh14, fresh15) + fresh15
-            + 1 as libc::c_int;
+        row = ::core::intrinsics::atomic_xadd_seqcst(
+            &mut *((*ttd).delayed_fg.progress)
+                .as_mut_ptr()
+                .offset(0 as libc::c_int as isize) as *mut atomic_int,
+            1 as libc::c_int,
+        );
+        done = ::core::intrinsics::atomic_xadd_seqcst(
+            &mut *((*ttd).delayed_fg.progress)
+                .as_mut_ptr()
+                .offset(1 as libc::c_int as isize) as *mut atomic_int,
+            1 as libc::c_int,
+        ) + 1 as libc::c_int;
         if row < progmax {
             continue;
         }
@@ -2865,12 +2866,11 @@ unsafe extern "C" fn delayed_fg_task(c: *const Dav1dContext, ttd: *mut TaskThrea
         (*ttd).delayed_fg.exec = 0 as libc::c_int;
         break;
     }
-    let fresh16 = &mut *((*ttd).delayed_fg.progress)
-        .as_mut_ptr()
-        .offset(1 as libc::c_int as isize) as *mut atomic_int;
-    let fresh17 = 1 as libc::c_int;
-    done = ::core::intrinsics::atomic_xadd_seqcst(fresh16, fresh17) + fresh17
-        + 1 as libc::c_int;
+    done = ::core::intrinsics::atomic_xadd_seqcst(
+        &mut *((*ttd).delayed_fg.progress).as_mut_ptr().offset(1 as libc::c_int as isize)
+            as *mut atomic_int,
+        1 as libc::c_int,
+    ) + 1 as libc::c_int;
     progmax = ::core::intrinsics::atomic_load_seqcst(
         &mut *((*ttd).delayed_fg.progress).as_mut_ptr().offset(0 as libc::c_int as isize)
             as *mut atomic_int,


### PR DESCRIPTION
The initial transpile used a version of dav1d which did not handle C11 atomics correctly. This change fixes translations of atomic_add.