### PR TITLE
Setup basic CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,6 +24,16 @@ jobs:
             ~/.rustup/update-hashes
             ~/.rustup/settings.toml
           key: ${{ runner.os }}-rust-toolchain-${{ hashFiles('rust-toolchain', 'rust-toolchain.toml') }}
+      - name: cache rust crates
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo build --release
       - name: meson setup
         run: (mkdir build && cd build && meson setup ..)

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,6 +16,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
+      - name: cache rust toolchain
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.rustup/toolchains
+            ~/.rustup/update-hashes
+            ~/.rustup/settings.toml
+          key: ${{ runner.os }}-rust-toolchain-${{ hashFiles('rust-toolchain', 'rust-toolchain.toml') }}
       - run: cargo build --release
       - name: meson setup
         run: (mkdir build && cd build && meson setup ..)

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,31 @@
+name: build and test
+on: [push, pull_request]
+jobs:
+  test-on-ubuntu-latest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: install prerequisites
+        run: |
+          # make sure we don't silently continue
+          set -euo pipefail
+          sudo apt-get update --quiet=2
+          sudo apt-get install --yes meson nasm
+        env:
+          DEBIAN_FRONTEND: noninteractive
+      - name: git checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - run: cargo build --release
+      - name: meson setup
+        run: (mkdir build && cd build && meson setup ..)
+      # NOTE: Currently only the testdata-* suites are setup to test against the
+      #       Rust executable
+      - name: meson test
+        run: (cd build && meson test)
+      - name: upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: meson-test-logs
+          path: |
+             ${{ github.workspace }}/build/meson-logs/testlog.txt


### PR DESCRIPTION
Closes #4.

Notes:
- covers x86_64 on ubuntu-latest. 
- caches rust toolchain and crates
- all tests are run (not just those that exercise the transpiled rust). I ran into some problem running the transpiled subset; not sure this is worth chasing down but it does increase the time to complete the test.
- uploads the test log as build artefact.