### PR TITLE
Remove non-functional inline assembly

### DIFF
--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -2849,10 +2849,6 @@ unsafe extern "C" fn get_dc_sign_ctx(
     let mut mask: uint64_t = 0xc0c0c0c0c0c0c0c0 as libc::c_ulonglong as uint64_t;
     let mut mul: uint64_t = 0x101010101010101 as libc::c_ulonglong as uint64_t;
     let mut s: libc::c_int = 0;
-    asm!(
-        "/* {0} {1} */", inlateout(reg) mask, inlateout(reg) mul, options(preserves_flags, pure,
-        readonly, att_syntax)
-    );
     let mut current_block_66: u64;
     match tx {
         0 => {

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -2811,10 +2811,6 @@ unsafe extern "C" fn get_dc_sign_ctx(
     let mut mask: uint64_t = 0xc0c0c0c0c0c0c0c0 as libc::c_ulonglong as uint64_t;
     let mut mul: uint64_t = 0x101010101010101 as libc::c_ulonglong as uint64_t;
     let mut s: libc::c_int = 0;
-    asm!(
-        "/* {0} {1} */", inlateout(reg) mask, inlateout(reg) mul, options(preserves_flags, pure,
-        readonly, att_syntax)
-    );
     let mut current_block_66: u64;
     match tx {
         0 => {


### PR DESCRIPTION
The assembly code is specific to x86-64 compilers and a comment in the C code indicates that it is meant to coerce the compiler into generating better code for 64-bit constants. See https://github.com/memorysafety/rav1d/blob/main/src/recon_tmpl.c#L147.

All tests pass on linux-aarch64 with this change. Closes #17.