### PR TITLE
Integrate x86-64 assembly from msac.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/build*
+/build
 /Session.vim
 [._]*.swp
 *~

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,14 +27,35 @@ name = "c2rust_out"
 version = "0.0.0"
 dependencies = [
  "c2rust-bitfields",
+ "cc",
+ "cfg-if",
  "libc",
+ "nasm-rs",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "libc"
 version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "nasm-rs"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce095842aee9aa3ecbda7a5d2a4df680375fd128a8596b6b56f8e497e231f483"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ c2rust-bitfields= "0.3"
 libc= "0.2"
 
 [features]
-default = ["bitdepth_8", "bitdepth_16"]
+default = ["asm", "bitdepth_8", "bitdepth_16"]
+asm = []
 bitdepth_8 = []
 bitdepth_16 = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ path = "tools/dav1d.rs"
 name = "dav1d"
 [dependencies]
 c2rust-bitfields= "0.3"
+cfg-if = "1.0.0"
 libc= "0.2"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ c2rust-bitfields= "0.3"
 cfg-if = "1.0.0"
 libc= "0.2"
 
+[build-dependencies]
+cc = "1.0.79"
+nasm-rs = "0.2.4"
+
 [features]
 default = ["asm", "bitdepth_8", "bitdepth_16"]
 asm = []

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,71 @@
+use std::env;
+use std::path::Path;
+
+fn main() {
+    let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+
+    #[cfg(feature = "asm")]
+    {
+        if arch == "x86_64" {
+            println!("cargo:rustc-cfg={}", "nasm_x86_64");
+            build_nasm_files()
+        }
+        if arch == "aarch64" {
+            println!("cargo:rustc-cfg={}", "asm_neon");
+            build_asm_files()
+        }
+    }
+}
+
+#[cfg(feature = "asm")]
+fn build_nasm_files() {
+    use std::fs::File;
+    use std::io::Write;
+    let out_dir = env::var("OUT_DIR").unwrap();
+
+    let dest_path = Path::new(&out_dir).join("config.asm");
+    let mut config_file = File::create(&dest_path).unwrap();
+    config_file
+        .write(b"%define private_prefix dav1d\n")
+        .unwrap();
+    config_file.write(b"%define ARCH_X86_32 0\n").unwrap();
+    config_file.write(b"%define ARCH_X86_64 1\n").unwrap();
+    config_file.write(b"%define PIC 1\n").unwrap();
+    config_file.write(b"%define STACK_ALIGNMENT 16\n").unwrap();
+    config_file
+        .write(b"%define FORCE_VEX_ENCODING 0\n")
+        .unwrap();
+
+    let asm_files = &["src/x86/msac.asm", "src/x86/cpuid.asm"];
+
+    let mut config_include_arg = String::from("-I");
+    config_include_arg.push_str(&out_dir);
+    config_include_arg.push('/');
+
+    let mut nasm = nasm_rs::Build::new();
+    nasm.min_version(2, 14, 0);
+    for file in asm_files {
+        nasm.file(file);
+    }
+    nasm.flag(&config_include_arg);
+    nasm.flag("-Isrc/");
+    let obj = nasm.compile_objects().unwrap_or_else(|e| {
+      println!("cargo:warning={e}");
+      panic!("NASM build failed. Make sure you have nasm installed or disable the \"asm\" feature.\n\
+        You can get NASM from https://nasm.us or your system's package manager.\n\nerror: {e}");
+    });
+
+    // cc is better at finding the correct archiver
+    let mut cc = cc::Build::new();
+    for o in obj {
+      cc.object(o);
+    }
+    cc.compile("rav1dasm");
+
+    println!("cargo:rustc-link-lib=static=rav1dasm");
+}
+
+#[cfg(feature = "asm")]
+fn build_asm_files() {
+    todo!();
+}

--- a/c2rust-lib.rs
+++ b/c2rust-lib.rs
@@ -91,6 +91,9 @@ pub mod tables;
 pub mod thread_task;
 pub mod warpmv;
 pub mod wedge;
+pub mod x86 {
+pub mod cpu;
+} // mod x86
 } // mod src
 pub mod tools {
 pub mod dav1d_cli_parse;

--- a/c2rust-lib.rs
+++ b/c2rust-lib.rs
@@ -17,6 +17,7 @@ compile_error!("No bitdepths enabled. Enable one or more of the following featur
 extern crate c2rust_bitfields;
 extern crate libc;
 pub mod src {
+pub mod align;
 #[cfg(feature = "bitdepth_16")]
 pub mod cdef_apply_tmpl_16;
 #[cfg(feature = "bitdepth_8")]

--- a/src/align.rs
+++ b/src/align.rs
@@ -1,0 +1,97 @@
+use std::ops::{Index, IndexMut};
+
+#[derive(Copy, Clone)]
+#[repr(C, align(32))]
+pub struct Align32<T>(pub T);
+
+impl<T> From<T> for Align32<T> {
+    fn from(from: T) -> Self {
+        Align32(from)
+    }
+}
+
+impl<T: Index<usize>> Index<usize> for Align32<T> {
+    type Output = T::Output;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl<T: IndexMut<usize>> IndexMut<usize> for Align32<T> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
+
+#[derive(Copy, Clone)]
+#[repr(C, align(16))]
+pub struct Align16<T>(pub T);
+
+impl<T> From<T> for Align16<T> {
+    fn from(from: T) -> Self {
+        Align16(from)
+    }
+}
+
+impl<T: Index<usize>> Index<usize> for Align16<T> {
+    type Output = T::Output;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl<T: IndexMut<usize>> IndexMut<usize> for Align16<T> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
+
+#[derive(Copy, Clone)]
+#[repr(C, align(8))]
+pub struct Align8<T>(pub T);
+
+impl<T> From<T> for Align8<T> {
+    fn from(from: T) -> Self {
+        Align8(from)
+    }
+}
+
+impl<T: Index<usize>> Index<usize> for Align8<T> {
+    type Output = T::Output;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl<T: IndexMut<usize>> IndexMut<usize> for Align8<T> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
+
+#[derive(Copy, Clone)]
+#[repr(C, align(4))]
+pub struct Align4<T>(pub T);
+
+impl<T> From<T> for Align4<T> {
+    fn from(from: T) -> Self {
+        Align4(from)
+    }
+}
+
+impl<T: Index<usize>> Index<usize> for Align4<T> {
+    type Output = T::Output;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl<T: IndexMut<usize>> IndexMut<usize> for Align4<T> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}

--- a/src/align.rs
+++ b/src/align.rs
@@ -1,3 +1,11 @@
+//! Types for enforcing alignment on struct fields.
+//! 
+//! This module defines a handful of `AlignN` types, where `N` is alignment
+//! enforced by that type. These types also implement a few useful traits to
+//! make them easier to use in common cases, e.g. [`From`] and
+//! [`Index`]/[`IndexMut`] (since it's usually array fields that require
+//! specific aligment for use with SIMD instructions).
+
 use std::ops::{Index, IndexMut};
 
 #[derive(Copy, Clone)]

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -1,6 +1,6 @@
 use ::libc;
+use crate::src::cdf::CdfContext;
 use crate::src::msac::MsacContext;
-use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1196,21 +1196,6 @@ pub struct C2RustUnnamed_45 {
     pub row: libc::c_int,
 }
 pub type ec_win = size_t;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfContext {
-    pub m: CdfModeContext,
-    pub kfym: [[[uint16_t; 16]; 5]; 5],
-    pub coef: CdfCoefContext,
-    pub mv: CdfMvContext,
-    pub dmv: CdfMvContext,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvContext {
-    pub comp: [CdfMvComponent; 2],
-    pub joint: [uint16_t; 4],
-}
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -1,5 +1,6 @@
 use ::libc;
 use crate::src::msac::MsacContext;
+use crate::src::cdf::CdfModeContext;
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1238,61 +1239,6 @@ pub struct CdfCoefContext {
     pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
     pub skip: [[[uint16_t; 2]; 13]; 5],
     pub dc_sign: [[[uint16_t; 2]; 3]; 2],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfModeContext {
-    pub y_mode: [[uint16_t; 16]; 4],
-    pub uv_mode: [[[uint16_t; 16]; 13]; 2],
-    pub wedge_idx: [[uint16_t; 16]; 9],
-    pub partition: [[[uint16_t; 16]; 4]; 5],
-    pub cfl_alpha: [[uint16_t; 16]; 6],
-    pub txtp_inter1: [[uint16_t; 16]; 2],
-    pub txtp_inter2: [uint16_t; 16],
-    pub txtp_intra1: [[[uint16_t; 8]; 13]; 2],
-    pub txtp_intra2: [[[uint16_t; 8]; 13]; 3],
-    pub cfl_sign: [uint16_t; 8],
-    pub angle_delta: [[uint16_t; 8]; 8],
-    pub filter_intra: [uint16_t; 8],
-    pub comp_inter_mode: [[uint16_t; 8]; 8],
-    pub seg_id: [[uint16_t; 8]; 3],
-    pub pal_sz: [[[uint16_t; 8]; 7]; 2],
-    pub color_map: [[[[uint16_t; 8]; 5]; 7]; 2],
-    pub filter: [[[uint16_t; 4]; 8]; 2],
-    pub txsz: [[[uint16_t; 4]; 3]; 4],
-    pub motion_mode: [[uint16_t; 4]; 22],
-    pub delta_q: [uint16_t; 4],
-    pub delta_lf: [[uint16_t; 4]; 5],
-    pub interintra_mode: [[uint16_t; 4]; 4],
-    pub restore_switchable: [uint16_t; 4],
-    pub restore_wiener: [uint16_t; 2],
-    pub restore_sgrproj: [uint16_t; 2],
-    pub interintra: [[uint16_t; 2]; 7],
-    pub interintra_wedge: [[uint16_t; 2]; 7],
-    pub txtp_inter3: [[uint16_t; 2]; 4],
-    pub use_filter_intra: [[uint16_t; 2]; 22],
-    pub newmv_mode: [[uint16_t; 2]; 6],
-    pub globalmv_mode: [[uint16_t; 2]; 2],
-    pub refmv_mode: [[uint16_t; 2]; 6],
-    pub drl_bit: [[uint16_t; 2]; 3],
-    pub intra: [[uint16_t; 2]; 4],
-    pub comp: [[uint16_t; 2]; 5],
-    pub comp_dir: [[uint16_t; 2]; 5],
-    pub jnt_comp: [[uint16_t; 2]; 6],
-    pub mask_comp: [[uint16_t; 2]; 6],
-    pub wedge_comp: [[uint16_t; 2]; 9],
-    pub ref_0: [[[uint16_t; 2]; 3]; 6],
-    pub comp_fwd_ref: [[[uint16_t; 2]; 3]; 3],
-    pub comp_bwd_ref: [[[uint16_t; 2]; 3]; 2],
-    pub comp_uni_ref: [[[uint16_t; 2]; 3]; 3],
-    pub txpart: [[[uint16_t; 2]; 3]; 7],
-    pub skip: [[uint16_t; 2]; 3],
-    pub skip_mode: [[uint16_t; 2]; 3],
-    pub seg_pred: [[uint16_t; 2]; 3],
-    pub obmc: [[uint16_t; 2]; 22],
-    pub pal_y: [[[uint16_t; 2]; 3]; 7],
-    pub pal_uv: [[uint16_t; 2]; 2],
-    pub intrabc: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -1,6 +1,6 @@
 use ::libc;
 use crate::src::msac::MsacContext;
-use crate::src::cdf::CdfModeContext;
+use crate::src::cdf::{CdfModeContext, CdfMvComponent};
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1210,18 +1210,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvComponent {
-    pub classes: [uint16_t; 16],
-    pub class0_fp: [[uint16_t; 4]; 2],
-    pub classN_fp: [uint16_t; 4],
-    pub class0_hp: [uint16_t; 2],
-    pub classN_hp: [uint16_t; 2],
-    pub class0: [uint16_t; 2],
-    pub classN: [[uint16_t; 2]; 10],
-    pub sign: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -1,6 +1,6 @@
 use ::libc;
 use crate::src::msac::MsacContext;
-use crate::src::cdf::{CdfModeContext, CdfMvComponent};
+use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1210,23 +1210,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfCoefContext {
-    pub eob_bin_16: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_32: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_64: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_128: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_256: [[[uint16_t; 16]; 2]; 2],
-    pub eob_bin_512: [[uint16_t; 16]; 2],
-    pub eob_bin_1024: [[uint16_t; 16]; 2],
-    pub eob_base_tok: [[[[uint16_t; 4]; 4]; 2]; 5],
-    pub base_tok: [[[[uint16_t; 4]; 41]; 2]; 5],
-    pub br_tok: [[[[uint16_t; 4]; 21]; 2]; 4],
-    pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
-    pub skip: [[[uint16_t; 2]; 13]; 5],
-    pub dc_sign: [[[uint16_t; 2]; 3]; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -1,4 +1,5 @@
 use ::libc;
+use crate::src::msac::MsacContext;
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1192,16 +1193,6 @@ pub struct C2RustUnnamed_45 {
     pub row_end: libc::c_int,
     pub col: libc::c_int,
     pub row: libc::c_int,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct MsacContext {
-    pub buf_pos: *const uint8_t,
-    pub buf_end: *const uint8_t,
-    pub dif: ec_win,
-    pub rng: libc::c_uint,
-    pub cnt: libc::c_int,
-    pub allow_update_cdf: libc::c_int,
 }
 pub type ec_win = size_t;
 #[derive(Copy, Clone)]

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -1,5 +1,6 @@
 use ::libc;
 use crate::src::msac::MsacContext;
+use crate::src::cdf::CdfModeContext;
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1238,61 +1239,6 @@ pub struct CdfCoefContext {
     pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
     pub skip: [[[uint16_t; 2]; 13]; 5],
     pub dc_sign: [[[uint16_t; 2]; 3]; 2],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfModeContext {
-    pub y_mode: [[uint16_t; 16]; 4],
-    pub uv_mode: [[[uint16_t; 16]; 13]; 2],
-    pub wedge_idx: [[uint16_t; 16]; 9],
-    pub partition: [[[uint16_t; 16]; 4]; 5],
-    pub cfl_alpha: [[uint16_t; 16]; 6],
-    pub txtp_inter1: [[uint16_t; 16]; 2],
-    pub txtp_inter2: [uint16_t; 16],
-    pub txtp_intra1: [[[uint16_t; 8]; 13]; 2],
-    pub txtp_intra2: [[[uint16_t; 8]; 13]; 3],
-    pub cfl_sign: [uint16_t; 8],
-    pub angle_delta: [[uint16_t; 8]; 8],
-    pub filter_intra: [uint16_t; 8],
-    pub comp_inter_mode: [[uint16_t; 8]; 8],
-    pub seg_id: [[uint16_t; 8]; 3],
-    pub pal_sz: [[[uint16_t; 8]; 7]; 2],
-    pub color_map: [[[[uint16_t; 8]; 5]; 7]; 2],
-    pub filter: [[[uint16_t; 4]; 8]; 2],
-    pub txsz: [[[uint16_t; 4]; 3]; 4],
-    pub motion_mode: [[uint16_t; 4]; 22],
-    pub delta_q: [uint16_t; 4],
-    pub delta_lf: [[uint16_t; 4]; 5],
-    pub interintra_mode: [[uint16_t; 4]; 4],
-    pub restore_switchable: [uint16_t; 4],
-    pub restore_wiener: [uint16_t; 2],
-    pub restore_sgrproj: [uint16_t; 2],
-    pub interintra: [[uint16_t; 2]; 7],
-    pub interintra_wedge: [[uint16_t; 2]; 7],
-    pub txtp_inter3: [[uint16_t; 2]; 4],
-    pub use_filter_intra: [[uint16_t; 2]; 22],
-    pub newmv_mode: [[uint16_t; 2]; 6],
-    pub globalmv_mode: [[uint16_t; 2]; 2],
-    pub refmv_mode: [[uint16_t; 2]; 6],
-    pub drl_bit: [[uint16_t; 2]; 3],
-    pub intra: [[uint16_t; 2]; 4],
-    pub comp: [[uint16_t; 2]; 5],
-    pub comp_dir: [[uint16_t; 2]; 5],
-    pub jnt_comp: [[uint16_t; 2]; 6],
-    pub mask_comp: [[uint16_t; 2]; 6],
-    pub wedge_comp: [[uint16_t; 2]; 9],
-    pub ref_0: [[[uint16_t; 2]; 3]; 6],
-    pub comp_fwd_ref: [[[uint16_t; 2]; 3]; 3],
-    pub comp_bwd_ref: [[[uint16_t; 2]; 3]; 2],
-    pub comp_uni_ref: [[[uint16_t; 2]; 3]; 3],
-    pub txpart: [[[uint16_t; 2]; 3]; 7],
-    pub skip: [[uint16_t; 2]; 3],
-    pub skip_mode: [[uint16_t; 2]; 3],
-    pub seg_pred: [[uint16_t; 2]; 3],
-    pub obmc: [[uint16_t; 2]; 22],
-    pub pal_y: [[[uint16_t; 2]; 3]; 7],
-    pub pal_uv: [[uint16_t; 2]; 2],
-    pub intrabc: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -1,6 +1,6 @@
 use ::libc;
 use crate::src::msac::MsacContext;
-use crate::src::cdf::CdfModeContext;
+use crate::src::cdf::{CdfModeContext, CdfMvComponent};
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1210,18 +1210,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvComponent {
-    pub classes: [uint16_t; 16],
-    pub class0_fp: [[uint16_t; 4]; 2],
-    pub classN_fp: [uint16_t; 4],
-    pub class0_hp: [uint16_t; 2],
-    pub classN_hp: [uint16_t; 2],
-    pub class0: [uint16_t; 2],
-    pub classN: [[uint16_t; 2]; 10],
-    pub sign: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -1,6 +1,6 @@
 use ::libc;
 use crate::src::msac::MsacContext;
-use crate::src::cdf::{CdfModeContext, CdfMvComponent};
+use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1210,23 +1210,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfCoefContext {
-    pub eob_bin_16: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_32: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_64: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_128: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_256: [[[uint16_t; 16]; 2]; 2],
-    pub eob_bin_512: [[uint16_t; 16]; 2],
-    pub eob_bin_1024: [[uint16_t; 16]; 2],
-    pub eob_base_tok: [[[[uint16_t; 4]; 4]; 2]; 5],
-    pub base_tok: [[[[uint16_t; 4]; 41]; 2]; 5],
-    pub br_tok: [[[[uint16_t; 4]; 21]; 2]; 4],
-    pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
-    pub skip: [[[uint16_t; 2]; 13]; 5],
-    pub dc_sign: [[[uint16_t; 2]; 3]; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -1,6 +1,6 @@
 use ::libc;
 use crate::src::msac::MsacContext;
-use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
+use crate::src::cdf::CdfContext;
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1196,21 +1196,6 @@ pub struct C2RustUnnamed_45 {
     pub row: libc::c_int,
 }
 pub type ec_win = size_t;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfContext {
-    pub m: CdfModeContext,
-    pub kfym: [[[uint16_t; 16]; 5]; 5],
-    pub coef: CdfCoefContext,
-    pub mv: CdfMvContext,
-    pub dmv: CdfMvContext,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvContext {
-    pub comp: [CdfMvComponent; 2],
-    pub joint: [uint16_t; 4],
-}
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -1,4 +1,5 @@
 use ::libc;
+use crate::src::msac::MsacContext;
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1192,16 +1193,6 @@ pub struct C2RustUnnamed_45 {
     pub row_end: libc::c_int,
     pub col: libc::c_int,
     pub row: libc::c_int,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct MsacContext {
-    pub buf_pos: *const uint8_t,
-    pub buf_end: *const uint8_t,
-    pub dif: ec_win,
-    pub rng: libc::c_uint,
-    pub cnt: libc::c_int,
-    pub allow_update_cdf: libc::c_int,
 }
 pub type ec_win = size_t;
 #[derive(Copy, Clone)]

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -1232,14 +1232,14 @@ pub struct CdfMvContext {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct CdfMvComponent {
-    pub classes: [uint16_t; 16],
-    pub class0_fp: [[uint16_t; 4]; 2],
-    pub classN_fp: [uint16_t; 4],
-    pub class0_hp: [uint16_t; 2],
-    pub classN_hp: [uint16_t; 2],
-    pub class0: [uint16_t; 2],
-    pub classN: [[uint16_t; 2]; 10],
-    pub sign: [uint16_t; 2],
+    pub classes: Align32<[uint16_t; 16]>,
+    pub class0_fp: Align8<[[uint16_t; 4]; 2]>,
+    pub classN_fp: Align8<[uint16_t; 4]>,
+    pub class0_hp: Align4<[uint16_t; 2]>,
+    pub classN_hp: Align4<[uint16_t; 2]>,
+    pub class0: Align4<[uint16_t; 2]>,
+    pub classN: Align4<[[uint16_t; 2]; 10]>,
+    pub sign: Align4<[uint16_t; 2]>,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -5688,7 +5688,7 @@ pub fn av1_default_cdf() -> CdfModeContext {
     };
     init
 }
-static mut default_mv_component_cdf: CdfMvComponent = {
+pub fn default_mv_component_cdf() -> CdfMvComponent {
     let mut init = CdfMvComponent {
         classes: [
             (32768 as libc::c_int - 28672 as libc::c_int) as uint16_t,
@@ -5707,7 +5707,7 @@ static mut default_mv_component_cdf: CdfMvComponent = {
             0,
             0,
             0,
-        ],
+        ].into(),
         class0_fp: [
             [
                 (32768 as libc::c_int - 16384 as libc::c_int) as uint16_t,
@@ -5721,16 +5721,16 @@ static mut default_mv_component_cdf: CdfMvComponent = {
                 (32768 as libc::c_int - 24128 as libc::c_int) as uint16_t,
                 0,
             ],
-        ],
+        ].into(),
         classN_fp: [
             (32768 as libc::c_int - 8192 as libc::c_int) as uint16_t,
             (32768 as libc::c_int - 17408 as libc::c_int) as uint16_t,
             (32768 as libc::c_int - 21248 as libc::c_int) as uint16_t,
             0,
-        ],
-        class0_hp: [(32768 as libc::c_int - 20480 as libc::c_int) as uint16_t, 0],
-        classN_hp: [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
-        class0: [(32768 as libc::c_int - 27648 as libc::c_int) as uint16_t, 0],
+        ].into(),
+        class0_hp: [(32768 as libc::c_int - 20480 as libc::c_int) as uint16_t, 0].into(),
+        classN_hp: [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0].into(),
+        class0: [(32768 as libc::c_int - 27648 as libc::c_int) as uint16_t, 0].into(),
         classN: [
             [(32768 as libc::c_int - 17408 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 17920 as libc::c_int) as uint16_t, 0],
@@ -5742,11 +5742,11 @@ static mut default_mv_component_cdf: CdfMvComponent = {
             [(32768 as libc::c_int - 29952 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 29952 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 30720 as libc::c_int) as uint16_t, 0],
-        ],
-        sign: [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
+        ].into(),
+        sign: [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0].into(),
     };
     init
-};
+}
 static mut default_mv_joint_cdf: [uint16_t; 4] = [
     (32768 as libc::c_int - 4096 as libc::c_int) as uint16_t,
     (32768 as libc::c_int - 11264 as libc::c_int) as uint16_t,
@@ -24351,9 +24351,9 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
         let mut k_15: libc::c_int = 0 as libc::c_int;
         while k_15 < 2 as libc::c_int {
             memcpy(
-                ((*dst).dmv.comp[k_15 as usize].classes).as_mut_ptr()
+                ((*dst).dmv.comp[k_15 as usize].classes.0).as_mut_ptr()
                     as *mut libc::c_void,
-                ((*src).dmv.comp[k_15 as usize].classes).as_ptr() as *const libc::c_void,
+                ((*src).dmv.comp[k_15 as usize].classes.0).as_ptr() as *const libc::c_void,
                 ::core::mem::size_of::<[uint16_t; 16]>() as libc::c_ulong,
             );
             (*dst)
@@ -24787,8 +24787,8 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     let mut k_17: libc::c_int = 0 as libc::c_int;
     while k_17 < 2 as libc::c_int {
         memcpy(
-            ((*dst).mv.comp[k_17 as usize].classes).as_mut_ptr() as *mut libc::c_void,
-            ((*src).mv.comp[k_17 as usize].classes).as_ptr() as *const libc::c_void,
+            ((*dst).mv.comp[k_17 as usize].classes.0).as_mut_ptr() as *mut libc::c_void,
+            ((*src).mv.comp[k_17 as usize].classes.0).as_ptr() as *const libc::c_void,
             ::core::mem::size_of::<[uint16_t; 16]>() as libc::c_ulong,
         );
         (*dst)
@@ -24839,8 +24839,8 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
             j_36 += 1;
         }
         memcpy(
-            ((*dst).mv.comp[k_17 as usize].classN_fp).as_mut_ptr() as *mut libc::c_void,
-            ((*src).mv.comp[k_17 as usize].classN_fp).as_ptr() as *const libc::c_void,
+            ((*dst).mv.comp[k_17 as usize].classN_fp.0).as_mut_ptr() as *mut libc::c_void,
+            ((*src).mv.comp[k_17 as usize].classN_fp.0).as_ptr() as *const libc::c_void,
             ::core::mem::size_of::<[uint16_t; 4]>() as libc::c_ulong,
         );
         (*dst)
@@ -24933,7 +24933,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_copy(
             default_mv_joint_cdf.as_ptr() as *const libc::c_void,
             ::core::mem::size_of::<[uint16_t; 4]>() as libc::c_ulong,
         );
-        (*dst).dmv.comp[1 as libc::c_int as usize] = default_mv_component_cdf;
+        (*dst).dmv.comp[1 as libc::c_int as usize] = default_mv_component_cdf();
         (*dst)
             .dmv
             .comp[0 as libc::c_int

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -1244,19 +1244,19 @@ pub struct CdfMvComponent {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct CdfCoefContext {
-    pub eob_bin_16: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_32: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_64: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_128: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_256: [[[uint16_t; 16]; 2]; 2],
-    pub eob_bin_512: [[uint16_t; 16]; 2],
-    pub eob_bin_1024: [[uint16_t; 16]; 2],
-    pub eob_base_tok: [[[[uint16_t; 4]; 4]; 2]; 5],
-    pub base_tok: [[[[uint16_t; 4]; 41]; 2]; 5],
-    pub br_tok: [[[[uint16_t; 4]; 21]; 2]; 4],
-    pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
-    pub skip: [[[uint16_t; 2]; 13]; 5],
-    pub dc_sign: [[[uint16_t; 2]; 3]; 2],
+    pub eob_bin_16: Align16<[[[uint16_t; 8]; 2]; 2]>,
+    pub eob_bin_32: Align16<[[[uint16_t; 8]; 2]; 2]>,
+    pub eob_bin_64: Align16<[[[uint16_t; 8]; 2]; 2]>,
+    pub eob_bin_128: Align16<[[[uint16_t; 8]; 2]; 2]>,
+    pub eob_bin_256: Align32<[[[uint16_t; 16]; 2]; 2]>,
+    pub eob_bin_512: Align32<[[uint16_t; 16]; 2]>,
+    pub eob_bin_1024: Align32<[[uint16_t; 16]; 2]>,
+    pub eob_base_tok: Align8<[[[[uint16_t; 4]; 4]; 2]; 5]>,
+    pub base_tok: Align8<[[[[uint16_t; 4]; 41]; 2]; 5]>,
+    pub br_tok: Align8<[[[[uint16_t; 4]; 21]; 2]; 4]>,
+    pub eob_hi_bit: Align4<[[[[uint16_t; 2]; 11]; 2]; 5]>,
+    pub skip: Align4<[[[uint16_t; 2]; 13]; 5]>,
+    pub dc_sign: Align4<[[[uint16_t; 2]; 3]; 2]>,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -6215,7 +6215,8 @@ static mut default_kf_y_mode_cdf: [[[uint16_t; 16]; 5]; 5] = [
         ],
     ],
 ];
-static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
+pub fn av1_default_coef_cdf() -> [CdfCoefContext; 4] {
+[
     {
         let mut init = CdfCoefContext {
             eob_bin_16: [
@@ -6263,7 +6264,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         0,
                     ],
                 ],
-            ],
+            ].into(),
             eob_bin_32: [
                 [
                     [
@@ -6309,7 +6310,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         0,
                     ],
                 ],
-            ],
+            ].into(),
             eob_bin_64: [
                 [
                     [
@@ -6355,7 +6356,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         0,
                     ],
                 ],
-            ],
+            ].into(),
             eob_bin_128: [
                 [
                     [
@@ -6401,7 +6402,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         0,
                     ],
                 ],
-            ],
+            ].into(),
             eob_bin_256: [
                 [
                     [
@@ -6479,7 +6480,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         0,
                     ],
                 ],
-            ],
+            ].into(),
             eob_bin_512: [
                 [
                     (32768 as libc::c_int - 641 as libc::c_int) as uint16_t,
@@ -6517,7 +6518,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                     0,
                     0,
                 ],
-            ],
+            ].into(),
             eob_bin_1024: [
                 [
                     (32768 as libc::c_int - 393 as libc::c_int) as uint16_t,
@@ -6555,7 +6556,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                     0,
                     0,
                 ],
-            ],
+            ].into(),
             eob_base_tok: [
                 [
                     [
@@ -6827,7 +6828,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         ],
                     ],
                 ],
-            ],
+            ].into(),
             base_tok: [
                 [
                     [
@@ -9319,7 +9320,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         ],
                     ],
                 ],
-            ],
+            ].into(),
             br_tok: [
                 [
                     [
@@ -10353,7 +10354,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         ],
                     ],
                 ],
-            ],
+            ].into(),
             eob_hi_bit: [
                 [
                     [
@@ -10495,7 +10496,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
                     ],
                 ],
-            ],
+            ].into(),
             skip: [
                 [
                     [(32768 as libc::c_int - 31849 as libc::c_int) as uint16_t, 0],
@@ -10572,7 +10573,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                     [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
                     [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
                 ],
-            ],
+            ].into(),
             dc_sign: [
                 [
                     [(32768 as libc::c_int - 16000 as libc::c_int) as uint16_t, 0],
@@ -10584,7 +10585,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                     [(32768 as libc::c_int - 12928 as libc::c_int) as uint16_t, 0],
                     [(32768 as libc::c_int - 17280 as libc::c_int) as uint16_t, 0],
                 ],
-            ],
+            ].into(),
         };
         init
     },
@@ -10635,7 +10636,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         0,
                     ],
                 ],
-            ],
+            ].into(),
             eob_bin_32: [
                 [
                     [
@@ -10681,7 +10682,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         0,
                     ],
                 ],
-            ],
+            ].into(),
             eob_bin_64: [
                 [
                     [
@@ -10727,7 +10728,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         0,
                     ],
                 ],
-            ],
+            ].into(),
             eob_bin_128: [
                 [
                     [
@@ -10773,7 +10774,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         0,
                     ],
                 ],
-            ],
+            ].into(),
             eob_bin_256: [
                 [
                     [
@@ -10851,7 +10852,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         0,
                     ],
                 ],
-            ],
+            ].into(),
             eob_bin_512: [
                 [
                     (32768 as libc::c_int - 1230 as libc::c_int) as uint16_t,
@@ -10889,7 +10890,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                     0,
                     0,
                 ],
-            ],
+            ].into(),
             eob_bin_1024: [
                 [
                     (32768 as libc::c_int - 696 as libc::c_int) as uint16_t,
@@ -10927,7 +10928,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                     0,
                     0,
                 ],
-            ],
+            ].into(),
             eob_base_tok: [
                 [
                     [
@@ -11199,7 +11200,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         ],
                     ],
                 ],
-            ],
+            ].into(),
             base_tok: [
                 [
                     [
@@ -13691,7 +13692,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         ],
                     ],
                 ],
-            ],
+            ].into(),
             br_tok: [
                 [
                     [
@@ -14725,7 +14726,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         ],
                     ],
                 ],
-            ],
+            ].into(),
             eob_hi_bit: [
                 [
                     [
@@ -14867,7 +14868,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
                     ],
                 ],
-            ],
+            ].into(),
             skip: [
                 [
                     [(32768 as libc::c_int - 30371 as libc::c_int) as uint16_t, 0],
@@ -14944,7 +14945,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                     [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
                     [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
                 ],
-            ],
+            ].into(),
             dc_sign: [
                 [
                     [(32768 as libc::c_int - 16000 as libc::c_int) as uint16_t, 0],
@@ -14956,7 +14957,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                     [(32768 as libc::c_int - 12928 as libc::c_int) as uint16_t, 0],
                     [(32768 as libc::c_int - 17280 as libc::c_int) as uint16_t, 0],
                 ],
-            ],
+            ].into(),
         };
         init
     },
@@ -15007,7 +15008,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         0,
                     ],
                 ],
-            ],
+            ].into(),
             eob_bin_32: [
                 [
                     [
@@ -15053,7 +15054,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         0,
                     ],
                 ],
-            ],
+            ].into(),
             eob_bin_64: [
                 [
                     [
@@ -15099,7 +15100,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         0,
                     ],
                 ],
-            ],
+            ].into(),
             eob_bin_128: [
                 [
                     [
@@ -15145,7 +15146,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         0,
                     ],
                 ],
-            ],
+            ].into(),
             eob_bin_256: [
                 [
                     [
@@ -15223,7 +15224,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         0,
                     ],
                 ],
-            ],
+            ].into(),
             eob_bin_512: [
                 [
                     (32768 as libc::c_int - 2624 as libc::c_int) as uint16_t,
@@ -15261,7 +15262,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                     0,
                     0,
                 ],
-            ],
+            ].into(),
             eob_bin_1024: [
                 [
                     (32768 as libc::c_int - 2784 as libc::c_int) as uint16_t,
@@ -15299,7 +15300,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                     0,
                     0,
                 ],
-            ],
+            ].into(),
             eob_base_tok: [
                 [
                     [
@@ -15571,7 +15572,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         ],
                     ],
                 ],
-            ],
+            ].into(),
             base_tok: [
                 [
                     [
@@ -18063,7 +18064,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         ],
                     ],
                 ],
-            ],
+            ].into(),
             br_tok: [
                 [
                     [
@@ -19097,7 +19098,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         ],
                     ],
                 ],
-            ],
+            ].into(),
             eob_hi_bit: [
                 [
                     [
@@ -19239,7 +19240,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
                     ],
                 ],
-            ],
+            ].into(),
             skip: [
                 [
                     [(32768 as libc::c_int - 29614 as libc::c_int) as uint16_t, 0],
@@ -19316,7 +19317,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                     [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
                     [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
                 ],
-            ],
+            ].into(),
             dc_sign: [
                 [
                     [(32768 as libc::c_int - 16000 as libc::c_int) as uint16_t, 0],
@@ -19328,7 +19329,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                     [(32768 as libc::c_int - 12928 as libc::c_int) as uint16_t, 0],
                     [(32768 as libc::c_int - 17280 as libc::c_int) as uint16_t, 0],
                 ],
-            ],
+            ].into(),
         };
         init
     },
@@ -19379,7 +19380,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         0,
                     ],
                 ],
-            ],
+            ].into(),
             eob_bin_32: [
                 [
                     [
@@ -19425,7 +19426,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         0,
                     ],
                 ],
-            ],
+            ].into(),
             eob_bin_64: [
                 [
                     [
@@ -19471,7 +19472,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         0,
                     ],
                 ],
-            ],
+            ].into(),
             eob_bin_128: [
                 [
                     [
@@ -19517,7 +19518,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         0,
                     ],
                 ],
-            ],
+            ].into(),
             eob_bin_256: [
                 [
                     [
@@ -19595,7 +19596,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         0,
                     ],
                 ],
-            ],
+            ].into(),
             eob_bin_512: [
                 [
                     (32768 as libc::c_int - 5927 as libc::c_int) as uint16_t,
@@ -19633,7 +19634,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                     0,
                     0,
                 ],
-            ],
+            ].into(),
             eob_bin_1024: [
                 [
                     (32768 as libc::c_int - 6698 as libc::c_int) as uint16_t,
@@ -19671,7 +19672,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                     0,
                     0,
                 ],
-            ],
+            ].into(),
             eob_base_tok: [
                 [
                     [
@@ -19943,7 +19944,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         ],
                     ],
                 ],
-            ],
+            ].into(),
             base_tok: [
                 [
                     [
@@ -22435,7 +22436,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         ],
                     ],
                 ],
-            ],
+            ].into(),
             br_tok: [
                 [
                     [
@@ -23469,7 +23470,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         ],
                     ],
                 ],
-            ],
+            ].into(),
             eob_hi_bit: [
                 [
                     [
@@ -23611,7 +23612,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                         [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
                     ],
                 ],
-            ],
+            ].into(),
             skip: [
                 [
                     [(32768 as libc::c_int - 26887 as libc::c_int) as uint16_t, 0],
@@ -23688,7 +23689,7 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                     [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
                     [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
                 ],
-            ],
+            ].into(),
             dc_sign: [
                 [
                     [(32768 as libc::c_int - 16000 as libc::c_int) as uint16_t, 0],
@@ -23700,11 +23701,12 @@ static mut av1_default_coef_cdf: [CdfCoefContext; 4] = [
                     [(32768 as libc::c_int - 12928 as libc::c_int) as uint16_t, 0],
                     [(32768 as libc::c_int - 17280 as libc::c_int) as uint16_t, 0],
                 ],
-            ],
+            ].into(),
         };
         init
     },
-];
+]
+}
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_cdf_thread_update(
     hdr: *const Dav1dFrameHeader,
@@ -24922,7 +24924,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_copy(
             default_kf_y_mode_cdf.as_ptr() as *const libc::c_void,
             ::core::mem::size_of::<[[[uint16_t; 16]; 5]; 5]>() as libc::c_ulong,
         );
-        (*dst).coef = av1_default_coef_cdf[(*src).data.qcat as usize];
+        (*dst).coef = av1_default_coef_cdf()[(*src).data.qcat as usize];
         memcpy(
             ((*dst).mv.joint).as_mut_ptr() as *mut libc::c_void,
             default_mv_joint_cdf.as_ptr() as *const libc::c_void,

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -1218,7 +1218,7 @@ pub type ec_win = size_t;
 #[repr(C)]
 pub struct CdfContext {
     pub m: CdfModeContext,
-    pub kfym: [[[uint16_t; 16]; 5]; 5],
+    pub kfym: Align32<[[[uint16_t; 16]; 5]; 5]>,
     pub coef: CdfCoefContext,
     pub mv: CdfMvContext,
     pub dmv: CdfMvContext,
@@ -1227,7 +1227,7 @@ pub struct CdfContext {
 #[repr(C)]
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
-    pub joint: [uint16_t; 4],
+    pub joint: Align8<[uint16_t; 4]>,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -24342,8 +24342,8 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
             as usize] = (*src).m.intrabc[0 as libc::c_int as usize];
         (*dst).m.intrabc[1 as libc::c_int as usize] = 0 as libc::c_int as uint16_t;
         memcpy(
-            ((*dst).dmv.joint).as_mut_ptr() as *mut libc::c_void,
-            ((*src).dmv.joint).as_ptr() as *const libc::c_void,
+            ((*dst).dmv.joint.0).as_mut_ptr() as *mut libc::c_void,
+            ((*src).dmv.joint.0).as_ptr() as *const libc::c_void,
             ::core::mem::size_of::<[uint16_t; 4]>() as libc::c_ulong,
         );
         (*dst)
@@ -24778,8 +24778,8 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
         i_27 += 1;
     }
     memcpy(
-        ((*dst).mv.joint).as_mut_ptr() as *mut libc::c_void,
-        ((*src).mv.joint).as_ptr() as *const libc::c_void,
+        ((*dst).mv.joint.0).as_mut_ptr() as *mut libc::c_void,
+        ((*src).mv.joint.0).as_ptr() as *const libc::c_void,
         ::core::mem::size_of::<[uint16_t; 4]>() as libc::c_ulong,
     );
     (*dst)
@@ -24920,18 +24920,18 @@ pub unsafe extern "C" fn dav1d_cdf_thread_copy(
     } else {
         (*dst).m = av1_default_cdf();
         memcpy(
-            ((*dst).kfym).as_mut_ptr() as *mut libc::c_void,
+            ((*dst).kfym.0).as_mut_ptr() as *mut libc::c_void,
             default_kf_y_mode_cdf.as_ptr() as *const libc::c_void,
             ::core::mem::size_of::<[[[uint16_t; 16]; 5]; 5]>() as libc::c_ulong,
         );
         (*dst).coef = av1_default_coef_cdf()[(*src).data.qcat as usize];
         memcpy(
-            ((*dst).mv.joint).as_mut_ptr() as *mut libc::c_void,
+            ((*dst).mv.joint.0).as_mut_ptr() as *mut libc::c_void,
             default_mv_joint_cdf.as_ptr() as *const libc::c_void,
             ::core::mem::size_of::<[uint16_t; 4]>() as libc::c_ulong,
         );
         memcpy(
-            ((*dst).dmv.joint).as_mut_ptr() as *mut libc::c_void,
+            ((*dst).dmv.joint.0).as_mut_ptr() as *mut libc::c_void,
             default_mv_joint_cdf.as_ptr() as *const libc::c_void,
             ::core::mem::size_of::<[uint16_t; 4]>() as libc::c_ulong,
         );

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -1,4 +1,5 @@
 use ::libc;
+use crate::src::msac::MsacContext;
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1210,16 +1211,6 @@ pub struct C2RustUnnamed_45 {
     pub row_end: libc::c_int,
     pub col: libc::c_int,
     pub row: libc::c_int,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct MsacContext {
-    pub buf_pos: *const uint8_t,
-    pub buf_end: *const uint8_t,
-    pub dif: ec_win,
-    pub rng: libc::c_uint,
-    pub cnt: libc::c_int,
-    pub allow_update_cdf: libc::c_int,
 }
 pub type ec_win = size_t;
 #[derive(Copy, Clone)]

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -1,4 +1,5 @@
 use ::libc;
+use crate::src::align::*;
 use crate::src::msac::MsacContext;
 extern "C" {
     fn memcpy(
@@ -1260,57 +1261,57 @@ pub struct CdfCoefContext {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct CdfModeContext {
-    pub y_mode: [[uint16_t; 16]; 4],
-    pub uv_mode: [[[uint16_t; 16]; 13]; 2],
-    pub wedge_idx: [[uint16_t; 16]; 9],
-    pub partition: [[[uint16_t; 16]; 4]; 5],
-    pub cfl_alpha: [[uint16_t; 16]; 6],
-    pub txtp_inter1: [[uint16_t; 16]; 2],
-    pub txtp_inter2: [uint16_t; 16],
-    pub txtp_intra1: [[[uint16_t; 8]; 13]; 2],
-    pub txtp_intra2: [[[uint16_t; 8]; 13]; 3],
-    pub cfl_sign: [uint16_t; 8],
-    pub angle_delta: [[uint16_t; 8]; 8],
-    pub filter_intra: [uint16_t; 8],
-    pub comp_inter_mode: [[uint16_t; 8]; 8],
-    pub seg_id: [[uint16_t; 8]; 3],
-    pub pal_sz: [[[uint16_t; 8]; 7]; 2],
-    pub color_map: [[[[uint16_t; 8]; 5]; 7]; 2],
-    pub filter: [[[uint16_t; 4]; 8]; 2],
-    pub txsz: [[[uint16_t; 4]; 3]; 4],
-    pub motion_mode: [[uint16_t; 4]; 22],
-    pub delta_q: [uint16_t; 4],
-    pub delta_lf: [[uint16_t; 4]; 5],
-    pub interintra_mode: [[uint16_t; 4]; 4],
-    pub restore_switchable: [uint16_t; 4],
-    pub restore_wiener: [uint16_t; 2],
-    pub restore_sgrproj: [uint16_t; 2],
-    pub interintra: [[uint16_t; 2]; 7],
-    pub interintra_wedge: [[uint16_t; 2]; 7],
-    pub txtp_inter3: [[uint16_t; 2]; 4],
-    pub use_filter_intra: [[uint16_t; 2]; 22],
-    pub newmv_mode: [[uint16_t; 2]; 6],
-    pub globalmv_mode: [[uint16_t; 2]; 2],
-    pub refmv_mode: [[uint16_t; 2]; 6],
-    pub drl_bit: [[uint16_t; 2]; 3],
-    pub intra: [[uint16_t; 2]; 4],
-    pub comp: [[uint16_t; 2]; 5],
-    pub comp_dir: [[uint16_t; 2]; 5],
-    pub jnt_comp: [[uint16_t; 2]; 6],
-    pub mask_comp: [[uint16_t; 2]; 6],
-    pub wedge_comp: [[uint16_t; 2]; 9],
-    pub ref_0: [[[uint16_t; 2]; 3]; 6],
-    pub comp_fwd_ref: [[[uint16_t; 2]; 3]; 3],
-    pub comp_bwd_ref: [[[uint16_t; 2]; 3]; 2],
-    pub comp_uni_ref: [[[uint16_t; 2]; 3]; 3],
-    pub txpart: [[[uint16_t; 2]; 3]; 7],
-    pub skip: [[uint16_t; 2]; 3],
-    pub skip_mode: [[uint16_t; 2]; 3],
-    pub seg_pred: [[uint16_t; 2]; 3],
-    pub obmc: [[uint16_t; 2]; 22],
-    pub pal_y: [[[uint16_t; 2]; 3]; 7],
-    pub pal_uv: [[uint16_t; 2]; 2],
-    pub intrabc: [uint16_t; 2],
+    pub y_mode: Align32<[[uint16_t; 16]; 4]>,
+    pub uv_mode: Align32<[[[uint16_t; 16]; 13]; 2]>,
+    pub wedge_idx: Align32<[[uint16_t; 16]; 9]>,
+    pub partition: Align32<[[[uint16_t; 16]; 4]; 5]>,
+    pub cfl_alpha: Align32<[[uint16_t; 16]; 6]>,
+    pub txtp_inter1: Align32<[[uint16_t; 16]; 2]>,
+    pub txtp_inter2: Align32<[uint16_t; 16]>,
+    pub txtp_intra1: Align16<[[[uint16_t; 8]; 13]; 2]>,
+    pub txtp_intra2: Align16<[[[uint16_t; 8]; 13]; 3]>,
+    pub cfl_sign: Align16<[uint16_t; 8]>,
+    pub angle_delta: Align16<[[uint16_t; 8]; 8]>,
+    pub filter_intra: Align16<[uint16_t; 8]>,
+    pub comp_inter_mode: Align16<[[uint16_t; 8]; 8]>,
+    pub seg_id: Align16<[[uint16_t; 8]; 3]>,
+    pub pal_sz: Align16<[[[uint16_t; 8]; 7]; 2]>,
+    pub color_map: Align16<[[[[uint16_t; 8]; 5]; 7]; 2]>,
+    pub filter: Align8<[[[uint16_t; 4]; 8]; 2]>,
+    pub txsz: Align8<[[[uint16_t; 4]; 3]; 4]>,
+    pub motion_mode: Align8<[[uint16_t; 4]; 22]>,
+    pub delta_q: Align8<[uint16_t; 4]>,
+    pub delta_lf: Align8<[[uint16_t; 4]; 5]>,
+    pub interintra_mode: Align8<[[uint16_t; 4]; 4]>,
+    pub restore_switchable: Align8<[uint16_t; 4]>,
+    pub restore_wiener: Align4<[uint16_t; 2]>,
+    pub restore_sgrproj: Align4<[uint16_t; 2]>,
+    pub interintra: Align4<[[uint16_t; 2]; 7]>,
+    pub interintra_wedge: Align4<[[uint16_t; 2]; 7]>,
+    pub txtp_inter3: Align4<[[uint16_t; 2]; 4]>,
+    pub use_filter_intra: Align4<[[uint16_t; 2]; 22]>,
+    pub newmv_mode: Align4<[[uint16_t; 2]; 6]>,
+    pub globalmv_mode: Align4<[[uint16_t; 2]; 2]>,
+    pub refmv_mode: Align4<[[uint16_t; 2]; 6]>,
+    pub drl_bit: Align4<[[uint16_t; 2]; 3]>,
+    pub intra: Align4<[[uint16_t; 2]; 4]>,
+    pub comp: Align4<[[uint16_t; 2]; 5]>,
+    pub comp_dir: Align4<[[uint16_t; 2]; 5]>,
+    pub jnt_comp: Align4<[[uint16_t; 2]; 6]>,
+    pub mask_comp: Align4<[[uint16_t; 2]; 6]>,
+    pub wedge_comp: Align4<[[uint16_t; 2]; 9]>,
+    pub ref_0: Align4<[[[uint16_t; 2]; 3]; 6]>,
+    pub comp_fwd_ref: Align4<[[[uint16_t; 2]; 3]; 3]>,
+    pub comp_bwd_ref: Align4<[[[uint16_t; 2]; 3]; 2]>,
+    pub comp_uni_ref: Align4<[[[uint16_t; 2]; 3]; 3]>,
+    pub txpart: Align4<[[[uint16_t; 2]; 3]; 7]>,
+    pub skip: Align4<[[uint16_t; 2]; 3]>,
+    pub skip_mode: Align4<[[uint16_t; 2]; 3]>,
+    pub seg_pred: Align4<[[uint16_t; 2]; 3]>,
+    pub obmc: Align4<[[uint16_t; 2]; 22]>,
+    pub pal_y: Align4<[[[uint16_t; 2]; 3]; 7]>,
+    pub pal_uv: Align4<[[uint16_t; 2]; 2]>,
+    pub intrabc: Align4<[uint16_t; 2]>,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -2006,7 +2007,7 @@ unsafe extern "C" fn dav1d_ref_inc(ref_0: *mut Dav1dRef) {
 unsafe extern "C" fn imin(a: libc::c_int, b: libc::c_int) -> libc::c_int {
     return if a < b { a } else { b };
 }
-static mut av1_default_cdf: CdfModeContext = {
+pub fn av1_default_cdf() -> CdfModeContext {
     let mut init = CdfModeContext {
         y_mode: [
             [
@@ -2081,7 +2082,7 @@ static mut av1_default_cdf: CdfModeContext = {
                 0,
                 0,
             ],
-        ],
+        ].into(),
         uv_mode: [
             [
                 [
@@ -2555,7 +2556,7 @@ static mut av1_default_cdf: CdfModeContext = {
                     0,
                 ],
             ],
-        ],
+        ].into(),
         wedge_idx: [
             [
                 (32768 as libc::c_int - 2438 as libc::c_int) as uint16_t,
@@ -2719,7 +2720,7 @@ static mut av1_default_cdf: CdfModeContext = {
                 (32768 as libc::c_int - 31933 as libc::c_int) as uint16_t,
                 0,
             ],
-        ],
+        ].into(),
         partition: [
             [
                 [
@@ -3091,7 +3092,7 @@ static mut av1_default_cdf: CdfModeContext = {
                     0,
                 ],
             ],
-        ],
+        ].into(),
         cfl_alpha: [
             [
                 (32768 as libc::c_int - 7637 as libc::c_int) as uint16_t,
@@ -3201,7 +3202,7 @@ static mut av1_default_cdf: CdfModeContext = {
                 (32768 as libc::c_int - 32660 as libc::c_int) as uint16_t,
                 0,
             ],
-        ],
+        ].into(),
         txtp_inter1: [
             [
                 (32768 as libc::c_int - 4458 as libc::c_int) as uint16_t,
@@ -3239,7 +3240,7 @@ static mut av1_default_cdf: CdfModeContext = {
                 (32768 as libc::c_int - 30749 as libc::c_int) as uint16_t,
                 0,
             ],
-        ],
+        ].into(),
         txtp_inter2: [
             (32768 as libc::c_int - 770 as libc::c_int) as uint16_t,
             (32768 as libc::c_int - 2421 as libc::c_int) as uint16_t,
@@ -3257,7 +3258,7 @@ static mut av1_default_cdf: CdfModeContext = {
             0,
             0,
             0,
-        ],
+        ].into(),
         txtp_intra1: [
             [
                 [
@@ -3523,7 +3524,7 @@ static mut av1_default_cdf: CdfModeContext = {
                     0,
                 ],
             ],
-        ],
+        ].into(),
         txtp_intra2: [
             [
                 [
@@ -3921,7 +3922,7 @@ static mut av1_default_cdf: CdfModeContext = {
                     0,
                 ],
             ],
-        ],
+        ].into(),
         cfl_sign: [
             (32768 as libc::c_int - 1418 as libc::c_int) as uint16_t,
             (32768 as libc::c_int - 2123 as libc::c_int) as uint16_t,
@@ -3931,7 +3932,7 @@ static mut av1_default_cdf: CdfModeContext = {
             (32768 as libc::c_int - 28343 as libc::c_int) as uint16_t,
             (32768 as libc::c_int - 32294 as libc::c_int) as uint16_t,
             0,
-        ],
+        ].into(),
         angle_delta: [
             [
                 (32768 as libc::c_int - 2180 as libc::c_int) as uint16_t,
@@ -4013,7 +4014,7 @@ static mut av1_default_cdf: CdfModeContext = {
                 0,
                 0,
             ],
-        ],
+        ].into(),
         filter_intra: [
             (32768 as libc::c_int - 8949 as libc::c_int) as uint16_t,
             (32768 as libc::c_int - 12776 as libc::c_int) as uint16_t,
@@ -4023,7 +4024,7 @@ static mut av1_default_cdf: CdfModeContext = {
             0,
             0,
             0,
-        ],
+        ].into(),
         comp_inter_mode: [
             [
                 (32768 as libc::c_int - 7760 as libc::c_int) as uint16_t,
@@ -4105,7 +4106,7 @@ static mut av1_default_cdf: CdfModeContext = {
                 (32768 as libc::c_int - 29330 as libc::c_int) as uint16_t,
                 0,
             ],
-        ],
+        ].into(),
         seg_id: [
             [
                 (32768 as libc::c_int - 5622 as libc::c_int) as uint16_t,
@@ -4137,7 +4138,7 @@ static mut av1_default_cdf: CdfModeContext = {
                 (32768 as libc::c_int - 32679 as libc::c_int) as uint16_t,
                 0,
             ],
-        ],
+        ].into(),
         pal_sz: [
             [
                 [
@@ -4283,7 +4284,7 @@ static mut av1_default_cdf: CdfModeContext = {
                     0,
                 ],
             ],
-        ],
+        ].into(),
         color_map: [
             [
                 [
@@ -5017,7 +5018,7 @@ static mut av1_default_cdf: CdfModeContext = {
                     ],
                 ],
             ],
-        ],
+        ].into(),
         filter: [
             [
                 [
@@ -5119,7 +5120,7 @@ static mut av1_default_cdf: CdfModeContext = {
                     0,
                 ],
             ],
-        ],
+        ].into(),
         txsz: [
             [
                 [(32768 as libc::c_int - 19968 as libc::c_int) as uint16_t, 0, 0, 0],
@@ -5186,7 +5187,7 @@ static mut av1_default_cdf: CdfModeContext = {
                     0,
                 ],
             ],
-        ],
+        ].into(),
         motion_mode: [
             [
                 (32768 as libc::c_int - 32507 as libc::c_int) as uint16_t,
@@ -5295,13 +5296,13 @@ static mut av1_default_cdf: CdfModeContext = {
             [0; 4],
             [0; 4],
             [0; 4],
-        ],
+        ].into(),
         delta_q: [
             (32768 as libc::c_int - 28160 as libc::c_int) as uint16_t,
             (32768 as libc::c_int - 32120 as libc::c_int) as uint16_t,
             (32768 as libc::c_int - 32677 as libc::c_int) as uint16_t,
             0,
-        ],
+        ].into(),
         delta_lf: [
             [
                 (32768 as libc::c_int - 28160 as libc::c_int) as uint16_t,
@@ -5333,7 +5334,7 @@ static mut av1_default_cdf: CdfModeContext = {
                 (32768 as libc::c_int - 32677 as libc::c_int) as uint16_t,
                 0,
             ],
-        ],
+        ].into(),
         interintra_mode: [
             [
                 (32768 as libc::c_int - 8192 as libc::c_int) as uint16_t,
@@ -5359,15 +5360,15 @@ static mut av1_default_cdf: CdfModeContext = {
                 (32768 as libc::c_int - 25926 as libc::c_int) as uint16_t,
                 0,
             ],
-        ],
+        ].into(),
         restore_switchable: [
             (32768 as libc::c_int - 9413 as libc::c_int) as uint16_t,
             (32768 as libc::c_int - 22581 as libc::c_int) as uint16_t,
             0,
             0,
-        ],
-        restore_wiener: [(32768 as libc::c_int - 11570 as libc::c_int) as uint16_t, 0],
-        restore_sgrproj: [(32768 as libc::c_int - 16855 as libc::c_int) as uint16_t, 0],
+        ].into(),
+        restore_wiener: [(32768 as libc::c_int - 11570 as libc::c_int) as uint16_t, 0].into(),
+        restore_sgrproj: [(32768 as libc::c_int - 16855 as libc::c_int) as uint16_t, 0].into(),
         interintra: [
             [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 26887 as libc::c_int) as uint16_t, 0],
@@ -5376,7 +5377,7 @@ static mut av1_default_cdf: CdfModeContext = {
             [0; 2],
             [0; 2],
             [0; 2],
-        ],
+        ].into(),
         interintra_wedge: [
             [(32768 as libc::c_int - 20036 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 24957 as libc::c_int) as uint16_t, 0],
@@ -5385,13 +5386,13 @@ static mut av1_default_cdf: CdfModeContext = {
             [(32768 as libc::c_int - 29564 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 29444 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 26872 as libc::c_int) as uint16_t, 0],
-        ],
+        ].into(),
         txtp_inter3: [
             [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 4167 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 1998 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 748 as libc::c_int) as uint16_t, 0],
-        ],
+        ].into(),
         use_filter_intra: [
             [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
@@ -5415,7 +5416,7 @@ static mut av1_default_cdf: CdfModeContext = {
             [(32768 as libc::c_int - 12770 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 6743 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 4621 as libc::c_int) as uint16_t, 0],
-        ],
+        ].into(),
         newmv_mode: [
             [(32768 as libc::c_int - 24035 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 16630 as libc::c_int) as uint16_t, 0],
@@ -5423,11 +5424,11 @@ static mut av1_default_cdf: CdfModeContext = {
             [(32768 as libc::c_int - 8386 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 12222 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 4676 as libc::c_int) as uint16_t, 0],
-        ],
+        ].into(),
         globalmv_mode: [
             [(32768 as libc::c_int - 2175 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 1054 as libc::c_int) as uint16_t, 0],
-        ],
+        ].into(),
         refmv_mode: [
             [(32768 as libc::c_int - 23974 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 24188 as libc::c_int) as uint16_t, 0],
@@ -5435,32 +5436,32 @@ static mut av1_default_cdf: CdfModeContext = {
             [(32768 as libc::c_int - 28622 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 24312 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 19923 as libc::c_int) as uint16_t, 0],
-        ],
+        ].into(),
         drl_bit: [
             [(32768 as libc::c_int - 13104 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 24560 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 18945 as libc::c_int) as uint16_t, 0],
-        ],
+        ].into(),
         intra: [
             [(32768 as libc::c_int - 806 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 16662 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 20186 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 26538 as libc::c_int) as uint16_t, 0],
-        ],
+        ].into(),
         comp: [
             [(32768 as libc::c_int - 26828 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 24035 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 12031 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 10640 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 2901 as libc::c_int) as uint16_t, 0],
-        ],
+        ].into(),
         comp_dir: [
             [(32768 as libc::c_int - 1198 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 2070 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 9166 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 7499 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 22475 as libc::c_int) as uint16_t, 0],
-        ],
+        ].into(),
         jnt_comp: [
             [(32768 as libc::c_int - 18244 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 12865 as libc::c_int) as uint16_t, 0],
@@ -5468,7 +5469,7 @@ static mut av1_default_cdf: CdfModeContext = {
             [(32768 as libc::c_int - 13259 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 9334 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 4644 as libc::c_int) as uint16_t, 0],
-        ],
+        ].into(),
         mask_comp: [
             [(32768 as libc::c_int - 26607 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 22891 as libc::c_int) as uint16_t, 0],
@@ -5476,7 +5477,7 @@ static mut av1_default_cdf: CdfModeContext = {
             [(32768 as libc::c_int - 24594 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 19934 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 22674 as libc::c_int) as uint16_t, 0],
-        ],
+        ].into(),
         wedge_comp: [
             [(32768 as libc::c_int - 23431 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 13171 as libc::c_int) as uint16_t, 0],
@@ -5487,7 +5488,7 @@ static mut av1_default_cdf: CdfModeContext = {
             [(32768 as libc::c_int - 6172 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 11820 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 7701 as libc::c_int) as uint16_t, 0],
-        ],
+        ].into(),
         ref_0: [
             [
                 [(32768 as libc::c_int - 4897 as libc::c_int) as uint16_t, 0],
@@ -5519,7 +5520,7 @@ static mut av1_default_cdf: CdfModeContext = {
                 [(32768 as libc::c_int - 15087 as libc::c_int) as uint16_t, 0],
                 [(32768 as libc::c_int - 30304 as libc::c_int) as uint16_t, 0],
             ],
-        ],
+        ].into(),
         comp_fwd_ref: [
             [
                 [(32768 as libc::c_int - 4946 as libc::c_int) as uint16_t, 0],
@@ -5536,7 +5537,7 @@ static mut av1_default_cdf: CdfModeContext = {
                 [(32768 as libc::c_int - 15160 as libc::c_int) as uint16_t, 0],
                 [(32768 as libc::c_int - 27544 as libc::c_int) as uint16_t, 0],
             ],
-        ],
+        ].into(),
         comp_bwd_ref: [
             [
                 [(32768 as libc::c_int - 2235 as libc::c_int) as uint16_t, 0],
@@ -5548,7 +5549,7 @@ static mut av1_default_cdf: CdfModeContext = {
                 [(32768 as libc::c_int - 15175 as libc::c_int) as uint16_t, 0],
                 [(32768 as libc::c_int - 30489 as libc::c_int) as uint16_t, 0],
             ],
-        ],
+        ].into(),
         comp_uni_ref: [
             [
                 [(32768 as libc::c_int - 5284 as libc::c_int) as uint16_t, 0],
@@ -5565,7 +5566,7 @@ static mut av1_default_cdf: CdfModeContext = {
                 [(32768 as libc::c_int - 15270 as libc::c_int) as uint16_t, 0],
                 [(32768 as libc::c_int - 26710 as libc::c_int) as uint16_t, 0],
             ],
-        ],
+        ].into(),
         txpart: [
             [
                 [(32768 as libc::c_int - 28581 as libc::c_int) as uint16_t, 0],
@@ -5602,22 +5603,22 @@ static mut av1_default_cdf: CdfModeContext = {
                 [(32768 as libc::c_int - 22401 as libc::c_int) as uint16_t, 0],
                 [(32768 as libc::c_int - 16088 as libc::c_int) as uint16_t, 0],
             ],
-        ],
+        ].into(),
         skip: [
             [(32768 as libc::c_int - 31671 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 16515 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 4576 as libc::c_int) as uint16_t, 0],
-        ],
+        ].into(),
         skip_mode: [
             [(32768 as libc::c_int - 32621 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 20708 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 8127 as libc::c_int) as uint16_t, 0],
-        ],
+        ].into(),
         seg_pred: [
             [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 16384 as libc::c_int) as uint16_t, 0],
-        ],
+        ].into(),
         obmc: [
             [(32768 as libc::c_int - 32638 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 31560 as libc::c_int) as uint16_t, 0],
@@ -5641,7 +5642,7 @@ static mut av1_default_cdf: CdfModeContext = {
             [0; 2],
             [0; 2],
             [0; 2],
-        ],
+        ].into(),
         pal_y: [
             [
                 [(32768 as libc::c_int - 31676 as libc::c_int) as uint16_t, 0],
@@ -5678,15 +5679,15 @@ static mut av1_default_cdf: CdfModeContext = {
                 [(32768 as libc::c_int - 7946 as libc::c_int) as uint16_t, 0],
                 [(32768 as libc::c_int - 129 as libc::c_int) as uint16_t, 0],
             ],
-        ],
+        ].into(),
         pal_uv: [
             [(32768 as libc::c_int - 32461 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 21488 as libc::c_int) as uint16_t, 0],
-        ],
-        intrabc: [(32768 as libc::c_int - 30531 as libc::c_int) as uint16_t, 0],
+        ].into(),
+        intrabc: [(32768 as libc::c_int - 30531 as libc::c_int) as uint16_t, 0].into(),
     };
     init
-};
+}
 static mut default_mv_component_cdf: CdfMvComponent = {
     let mut init = CdfMvComponent {
         classes: [
@@ -23724,8 +23725,8 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
         i += 1;
     }
     memcpy(
-        ((*dst).m.filter_intra).as_mut_ptr() as *mut libc::c_void,
-        ((*src).m.filter_intra).as_ptr() as *const libc::c_void,
+        ((*dst).m.filter_intra).0.as_mut_ptr() as *mut libc::c_void,
+        ((*src).m.filter_intra).0.as_ptr() as *const libc::c_void,
         ::core::mem::size_of::<[uint16_t; 8]>() as libc::c_ulong,
     );
     (*dst).m.filter_intra[4 as libc::c_int as usize] = 0 as libc::c_int as uint16_t;
@@ -24144,8 +24145,8 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
         j_18 += 1;
     }
     memcpy(
-        ((*dst).m.cfl_sign).as_mut_ptr() as *mut libc::c_void,
-        ((*src).m.cfl_sign).as_ptr() as *const libc::c_void,
+        ((*dst).m.cfl_sign).0.as_mut_ptr() as *mut libc::c_void,
+        ((*src).m.cfl_sign).0.as_ptr() as *const libc::c_void,
         ::core::mem::size_of::<[uint16_t; 8]>() as libc::c_ulong,
     );
     (*dst).m.cfl_sign[7 as libc::c_int as usize] = 0 as libc::c_int as uint16_t;
@@ -24173,16 +24174,16 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
         as usize] = (*src).m.restore_sgrproj[0 as libc::c_int as usize];
     (*dst).m.restore_sgrproj[1 as libc::c_int as usize] = 0 as libc::c_int as uint16_t;
     memcpy(
-        ((*dst).m.restore_switchable).as_mut_ptr() as *mut libc::c_void,
-        ((*src).m.restore_switchable).as_ptr() as *const libc::c_void,
+        ((*dst).m.restore_switchable).0.as_mut_ptr() as *mut libc::c_void,
+        ((*src).m.restore_switchable).0.as_ptr() as *const libc::c_void,
         ::core::mem::size_of::<[uint16_t; 4]>() as libc::c_ulong,
     );
     (*dst)
         .m
         .restore_switchable[2 as libc::c_int as usize] = 0 as libc::c_int as uint16_t;
     memcpy(
-        ((*dst).m.delta_q).as_mut_ptr() as *mut libc::c_void,
-        ((*src).m.delta_q).as_ptr() as *const libc::c_void,
+        ((*dst).m.delta_q).0.as_mut_ptr() as *mut libc::c_void,
+        ((*src).m.delta_q).0.as_ptr() as *const libc::c_void,
         ::core::mem::size_of::<[uint16_t; 4]>() as libc::c_ulong,
     );
     (*dst).m.delta_q[3 as libc::c_int as usize] = 0 as libc::c_int as uint16_t;
@@ -24314,8 +24315,8 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
         j_25 += 1;
     }
     memcpy(
-        ((*dst).m.txtp_inter2).as_mut_ptr() as *mut libc::c_void,
-        ((*src).m.txtp_inter2).as_ptr() as *const libc::c_void,
+        ((*dst).m.txtp_inter2.0).as_mut_ptr() as *mut libc::c_void,
+        ((*src).m.txtp_inter2.0).as_ptr() as *const libc::c_void,
         ::core::mem::size_of::<[uint16_t; 16]>() as libc::c_ulong,
     );
     (*dst).m.txtp_inter2[11 as libc::c_int as usize] = 0 as libc::c_int as uint16_t;
@@ -24409,25 +24410,25 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     while i_9 < 3 as libc::c_int {
         (*dst)
             .m
-            .skip_mode[i_9
+            .skip_mode.0[i_9
             as usize][0 as libc::c_int
-            as usize] = (*src).m.skip_mode[i_9 as usize][0 as libc::c_int as usize];
+            as usize] = (*src).m.skip_mode.0[i_9 as usize][0 as libc::c_int as usize];
         (*dst)
             .m
-            .skip_mode[i_9
+            .skip_mode.0[i_9
             as usize][1 as libc::c_int as usize] = 0 as libc::c_int as uint16_t;
         i_9 += 1;
     }
     let mut j_26: libc::c_int = 0 as libc::c_int;
     while j_26 < 4 as libc::c_int {
         memcpy(
-            ((*dst).m.y_mode[j_26 as usize]).as_mut_ptr() as *mut libc::c_void,
-            ((*src).m.y_mode[j_26 as usize]).as_ptr() as *const libc::c_void,
+            ((*dst).m.y_mode.0[j_26 as usize]).as_mut_ptr() as *mut libc::c_void,
+            ((*src).m.y_mode.0[j_26 as usize]).as_ptr() as *const libc::c_void,
             ::core::mem::size_of::<[uint16_t; 16]>() as libc::c_ulong,
         );
         (*dst)
             .m
-            .y_mode[j_26
+            .y_mode.0[j_26
             as usize][(N_INTRA_PRED_MODES as libc::c_int - 1 as libc::c_int)
             as usize] = 0 as libc::c_int as uint16_t;
         j_26 += 1;
@@ -24437,15 +24438,15 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
         let mut j_27: libc::c_int = 0 as libc::c_int;
         while j_27 < 8 as libc::c_int {
             memcpy(
-                ((*dst).m.filter[k_16 as usize][j_27 as usize]).as_mut_ptr()
+                ((*dst).m.filter.0[k_16 as usize][j_27 as usize]).as_mut_ptr()
                     as *mut libc::c_void,
-                ((*src).m.filter[k_16 as usize][j_27 as usize]).as_ptr()
+                ((*src).m.filter.0[k_16 as usize][j_27 as usize]).as_ptr()
                     as *const libc::c_void,
                 ::core::mem::size_of::<[uint16_t; 4]>() as libc::c_ulong,
             );
             (*dst)
                 .m
-                .filter[k_16
+                .filter.0[k_16
                 as usize][j_27
                 as usize][(DAV1D_N_SWITCHABLE_FILTERS as libc::c_int - 1 as libc::c_int)
                 as usize] = 0 as libc::c_int as uint16_t;
@@ -24457,12 +24458,12 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     while i_10 < 6 as libc::c_int {
         (*dst)
             .m
-            .newmv_mode[i_10
+            .newmv_mode.0[i_10
             as usize][0 as libc::c_int
-            as usize] = (*src).m.newmv_mode[i_10 as usize][0 as libc::c_int as usize];
+            as usize] = (*src).m.newmv_mode.0[i_10 as usize][0 as libc::c_int as usize];
         (*dst)
             .m
-            .newmv_mode[i_10
+            .newmv_mode.0[i_10
             as usize][1 as libc::c_int as usize] = 0 as libc::c_int as uint16_t;
         i_10 += 1;
     }
@@ -24470,12 +24471,12 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     while i_11 < 2 as libc::c_int {
         (*dst)
             .m
-            .globalmv_mode[i_11
+            .globalmv_mode.0[i_11
             as usize][0 as libc::c_int
-            as usize] = (*src).m.globalmv_mode[i_11 as usize][0 as libc::c_int as usize];
+            as usize] = (*src).m.globalmv_mode.0[i_11 as usize][0 as libc::c_int as usize];
         (*dst)
             .m
-            .globalmv_mode[i_11
+            .globalmv_mode.0[i_11
             as usize][1 as libc::c_int as usize] = 0 as libc::c_int as uint16_t;
         i_11 += 1;
     }
@@ -24483,12 +24484,12 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     while i_12 < 6 as libc::c_int {
         (*dst)
             .m
-            .refmv_mode[i_12
+            .refmv_mode.0[i_12
             as usize][0 as libc::c_int
-            as usize] = (*src).m.refmv_mode[i_12 as usize][0 as libc::c_int as usize];
+            as usize] = (*src).m.refmv_mode.0[i_12 as usize][0 as libc::c_int as usize];
         (*dst)
             .m
-            .refmv_mode[i_12
+            .refmv_mode.0[i_12
             as usize][1 as libc::c_int as usize] = 0 as libc::c_int as uint16_t;
         i_12 += 1;
     }
@@ -24496,25 +24497,25 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     while i_13 < 3 as libc::c_int {
         (*dst)
             .m
-            .drl_bit[i_13
+            .drl_bit.0[i_13
             as usize][0 as libc::c_int
-            as usize] = (*src).m.drl_bit[i_13 as usize][0 as libc::c_int as usize];
+            as usize] = (*src).m.drl_bit.0[i_13 as usize][0 as libc::c_int as usize];
         (*dst)
             .m
-            .drl_bit[i_13
+            .drl_bit.0[i_13
             as usize][1 as libc::c_int as usize] = 0 as libc::c_int as uint16_t;
         i_13 += 1;
     }
     let mut j_28: libc::c_int = 0 as libc::c_int;
     while j_28 < 8 as libc::c_int {
         memcpy(
-            ((*dst).m.comp_inter_mode[j_28 as usize]).as_mut_ptr() as *mut libc::c_void,
-            ((*src).m.comp_inter_mode[j_28 as usize]).as_ptr() as *const libc::c_void,
+            ((*dst).m.comp_inter_mode.0[j_28 as usize]).as_mut_ptr() as *mut libc::c_void,
+            ((*src).m.comp_inter_mode.0[j_28 as usize]).as_ptr() as *const libc::c_void,
             ::core::mem::size_of::<[uint16_t; 8]>() as libc::c_ulong,
         );
         (*dst)
             .m
-            .comp_inter_mode[j_28
+            .comp_inter_mode.0[j_28
             as usize][(N_COMP_INTER_PRED_MODES as libc::c_int - 1 as libc::c_int)
             as usize] = 0 as libc::c_int as uint16_t;
         j_28 += 1;
@@ -24523,12 +24524,12 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     while i_14 < 4 as libc::c_int {
         (*dst)
             .m
-            .intra[i_14
+            .intra.0[i_14
             as usize][0 as libc::c_int
-            as usize] = (*src).m.intra[i_14 as usize][0 as libc::c_int as usize];
+            as usize] = (*src).m.intra.0[i_14 as usize][0 as libc::c_int as usize];
         (*dst)
             .m
-            .intra[i_14
+            .intra.0[i_14
             as usize][1 as libc::c_int as usize] = 0 as libc::c_int as uint16_t;
         i_14 += 1;
     }
@@ -24536,12 +24537,12 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     while i_15 < 5 as libc::c_int {
         (*dst)
             .m
-            .comp[i_15
+            .comp.0[i_15
             as usize][0 as libc::c_int
-            as usize] = (*src).m.comp[i_15 as usize][0 as libc::c_int as usize];
+            as usize] = (*src).m.comp.0[i_15 as usize][0 as libc::c_int as usize];
         (*dst)
             .m
-            .comp[i_15
+            .comp.0[i_15
             as usize][1 as libc::c_int as usize] = 0 as libc::c_int as uint16_t;
         i_15 += 1;
     }
@@ -24549,12 +24550,12 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     while i_16 < 5 as libc::c_int {
         (*dst)
             .m
-            .comp_dir[i_16
+            .comp_dir.0[i_16
             as usize][0 as libc::c_int
-            as usize] = (*src).m.comp_dir[i_16 as usize][0 as libc::c_int as usize];
+            as usize] = (*src).m.comp_dir.0[i_16 as usize][0 as libc::c_int as usize];
         (*dst)
             .m
-            .comp_dir[i_16
+            .comp_dir.0[i_16
             as usize][1 as libc::c_int as usize] = 0 as libc::c_int as uint16_t;
         i_16 += 1;
     }
@@ -24562,12 +24563,12 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     while i_17 < 6 as libc::c_int {
         (*dst)
             .m
-            .jnt_comp[i_17
+            .jnt_comp.0[i_17
             as usize][0 as libc::c_int
-            as usize] = (*src).m.jnt_comp[i_17 as usize][0 as libc::c_int as usize];
+            as usize] = (*src).m.jnt_comp.0[i_17 as usize][0 as libc::c_int as usize];
         (*dst)
             .m
-            .jnt_comp[i_17
+            .jnt_comp.0[i_17
             as usize][1 as libc::c_int as usize] = 0 as libc::c_int as uint16_t;
         i_17 += 1;
     }
@@ -24575,12 +24576,12 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     while i_18 < 6 as libc::c_int {
         (*dst)
             .m
-            .mask_comp[i_18
+            .mask_comp.0[i_18
             as usize][0 as libc::c_int
-            as usize] = (*src).m.mask_comp[i_18 as usize][0 as libc::c_int as usize];
+            as usize] = (*src).m.mask_comp.0[i_18 as usize][0 as libc::c_int as usize];
         (*dst)
             .m
-            .mask_comp[i_18
+            .mask_comp.0[i_18
             as usize][1 as libc::c_int as usize] = 0 as libc::c_int as uint16_t;
         i_18 += 1;
     }
@@ -24588,20 +24589,20 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     while i_19 < 9 as libc::c_int {
         (*dst)
             .m
-            .wedge_comp[i_19
+            .wedge_comp.0[i_19
             as usize][0 as libc::c_int
-            as usize] = (*src).m.wedge_comp[i_19 as usize][0 as libc::c_int as usize];
+            as usize] = (*src).m.wedge_comp.0[i_19 as usize][0 as libc::c_int as usize];
         (*dst)
             .m
-            .wedge_comp[i_19
+            .wedge_comp.0[i_19
             as usize][1 as libc::c_int as usize] = 0 as libc::c_int as uint16_t;
         i_19 += 1;
     }
     let mut j_29: libc::c_int = 0 as libc::c_int;
     while j_29 < 9 as libc::c_int {
         memcpy(
-            ((*dst).m.wedge_idx[j_29 as usize]).as_mut_ptr() as *mut libc::c_void,
-            ((*src).m.wedge_idx[j_29 as usize]).as_ptr() as *const libc::c_void,
+            ((*dst).m.wedge_idx.0[j_29 as usize]).as_mut_ptr() as *mut libc::c_void,
+            ((*src).m.wedge_idx.0[j_29 as usize]).as_ptr() as *const libc::c_void,
             ::core::mem::size_of::<[uint16_t; 16]>() as libc::c_ulong,
         );
         (*dst)
@@ -24915,7 +24916,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_copy(
             ::core::mem::size_of::<CdfContext>() as libc::c_ulong,
         );
     } else {
-        (*dst).m = av1_default_cdf;
+        (*dst).m = av1_default_cdf();
         memcpy(
             ((*dst).kfym).as_mut_ptr() as *mut libc::c_void,
             default_kf_y_mode_cdf.as_ptr() as *const libc::c_void,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -198,23 +198,33 @@ extern "C" {
         sz: size_t,
         disable_cdf_update_flag: libc::c_int,
     );
-    fn dav1d_msac_decode_symbol_adapt_c(
-        s: *mut MsacContext,
-        cdf: *mut uint16_t,
-        n_symbols: size_t,
-    ) -> libc::c_uint;
-    fn dav1d_msac_decode_bool_adapt_c(
-        s: *mut MsacContext,
-        cdf: *mut uint16_t,
-    ) -> libc::c_uint;
-    fn dav1d_msac_decode_bool_equi_c(s: *mut MsacContext) -> libc::c_uint;
-    fn dav1d_msac_decode_bool_c(s: *mut MsacContext, f: libc::c_uint) -> libc::c_uint;
     fn dav1d_msac_decode_subexp(
         s: *mut MsacContext,
         ref_0: libc::c_int,
         n: libc::c_int,
         k: libc::c_uint,
     ) -> libc::c_int;
+    fn dav1d_msac_decode_symbol_adapt4(
+        s: *mut MsacContext,
+        cdf: *mut uint16_t,
+        n_symbols: size_t,
+    ) -> libc::c_uint;
+    fn dav1d_msac_decode_symbol_adapt8(
+        s: *mut MsacContext,
+        cdf: *mut uint16_t,
+        n_symbols: size_t,
+    ) -> libc::c_uint;
+    fn dav1d_msac_decode_symbol_adapt16(
+        s: *mut MsacContext,
+        cdf: *mut uint16_t,
+        n_symbols: size_t,
+    ) -> libc::c_uint;
+    fn dav1d_msac_decode_bool_adapt(
+        s: *mut MsacContext,
+        cdf: *mut uint16_t,
+    ) -> libc::c_uint;
+    fn dav1d_msac_decode_bool_equi(s: *mut MsacContext) -> libc::c_uint;
+    fn dav1d_msac_decode_bool(s: *mut MsacContext, f: libc::c_uint) -> libc::c_uint;
     fn dav1d_thread_picture_alloc(
         c: *mut Dav1dContext,
         f: *mut Dav1dFrameContext,
@@ -3392,12 +3402,12 @@ unsafe extern "C" fn dav1d_msac_decode_bools(
 ) -> libc::c_uint {
     let mut v: libc::c_uint = 0 as libc::c_int as libc::c_uint;
     loop {
-        let fresh2 = n;
+        let fresh0 = n;
         n = n.wrapping_sub(1);
-        if !(fresh2 != 0) {
+        if !(fresh0 != 0) {
             break;
         }
-        v = v << 1 as libc::c_int | dav1d_msac_decode_bool_equi_c(s);
+        v = v << 1 as libc::c_int | dav1d_msac_decode_bool_equi(s);
     }
     return v;
 }
@@ -3423,7 +3433,7 @@ unsafe extern "C" fn dav1d_msac_decode_uniform(
     } else {
         (v << 1 as libc::c_int)
             .wrapping_sub(m)
-            .wrapping_add(dav1d_msac_decode_bool_equi_c(s))
+            .wrapping_add(dav1d_msac_decode_bool_equi(s))
     }) as libc::c_int;
 }
 unsafe extern "C" fn init_quant_tables(
@@ -3503,11 +3513,11 @@ unsafe extern "C" fn read_mv_component_diff(
     let ts: *mut Dav1dTileState = (*t).ts;
     let f: *const Dav1dFrameContext = (*t).f;
     let have_hp: libc::c_int = (*(*f).frame_hdr).hp;
-    let sign: libc::c_int = dav1d_msac_decode_bool_adapt_c(
+    let sign: libc::c_int = dav1d_msac_decode_bool_adapt(
         &mut (*ts).msac,
         ((*mv_comp).sign).as_mut_ptr(),
     ) as libc::c_int;
-    let cl: libc::c_int = dav1d_msac_decode_symbol_adapt_c(
+    let cl: libc::c_int = dav1d_msac_decode_symbol_adapt16(
         &mut (*ts).msac,
         ((*mv_comp).classes).as_mut_ptr(),
         10 as libc::c_int as size_t,
@@ -3516,18 +3526,18 @@ unsafe extern "C" fn read_mv_component_diff(
     let mut fp: libc::c_int = 0;
     let mut hp: libc::c_int = 0;
     if cl == 0 {
-        up = dav1d_msac_decode_bool_adapt_c(
+        up = dav1d_msac_decode_bool_adapt(
             &mut (*ts).msac,
             ((*mv_comp).class0).as_mut_ptr(),
         ) as libc::c_int;
         if have_fp != 0 {
-            fp = dav1d_msac_decode_symbol_adapt_c(
+            fp = dav1d_msac_decode_symbol_adapt4(
                 &mut (*ts).msac,
                 ((*mv_comp).class0_fp[up as usize]).as_mut_ptr(),
                 3 as libc::c_int as size_t,
             ) as libc::c_int;
             hp = (if have_hp != 0 {
-                dav1d_msac_decode_bool_adapt_c(
+                dav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
                     ((*mv_comp).class0_hp).as_mut_ptr(),
                 )
@@ -3543,20 +3553,20 @@ unsafe extern "C" fn read_mv_component_diff(
         let mut n: libc::c_int = 0 as libc::c_int;
         while n < cl {
             up = (up as libc::c_uint
-                | dav1d_msac_decode_bool_adapt_c(
+                | dav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
                     ((*mv_comp).classN[n as usize]).as_mut_ptr(),
                 ) << n) as libc::c_int;
             n += 1;
         }
         if have_fp != 0 {
-            fp = dav1d_msac_decode_symbol_adapt_c(
+            fp = dav1d_msac_decode_symbol_adapt4(
                 &mut (*ts).msac,
                 ((*mv_comp).classN_fp).as_mut_ptr(),
                 3 as libc::c_int as size_t,
             ) as libc::c_int;
             hp = (if have_hp != 0 {
-                dav1d_msac_decode_bool_adapt_c(
+                dav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
                     ((*mv_comp).classN_hp).as_mut_ptr(),
                 )
@@ -3578,7 +3588,7 @@ unsafe extern "C" fn read_mv_residual(
     mv_cdf: *mut CdfMvContext,
     have_fp: libc::c_int,
 ) {
-    match dav1d_msac_decode_symbol_adapt_c(
+    match dav1d_msac_decode_symbol_adapt4(
         &mut (*(*t).ts).msac,
         ((*(*t).ts).cdf.mv.joint).as_mut_ptr(),
         (N_MV_JOINTS as libc::c_int - 1 as libc::c_int) as size_t,
@@ -3657,13 +3667,13 @@ unsafe extern "C" fn read_tx_tree(
             as libc::c_int;
         let l: libc::c_int = (((*t).l.tx[by4 as usize] as libc::c_int) < txh)
             as libc::c_int;
-        is_split = dav1d_msac_decode_bool_adapt_c(
+        is_split = dav1d_msac_decode_bool_adapt(
             &mut (*(*t).ts).msac,
             ((*(*t).ts).cdf.m.txpart[cat as usize][(a + l) as usize]).as_mut_ptr(),
         ) as libc::c_int;
         if is_split != 0 {
-            let ref mut fresh3 = *masks.offset(depth as isize);
-            *fresh3 = (*fresh3 as libc::c_int
+            let ref mut fresh1 = *masks.offset(depth as isize);
+            *fresh1 = (*fresh1 as libc::c_int
                 | (1 as libc::c_int) << y_off * 4 as libc::c_int + x_off) as uint16_t;
         }
     } else {
@@ -3901,8 +3911,8 @@ unsafe extern "C" fn find_matching_ref(
             && (*r2).ref_0.ref_0[1 as libc::c_int as usize] as libc::c_int
                 == -(1 as libc::c_int)
         {
-            let ref mut fresh4 = *masks.offset(0 as libc::c_int as isize);
-            *fresh4 |= 1 as libc::c_int as libc::c_ulong;
+            let ref mut fresh2 = *masks.offset(0 as libc::c_int as isize);
+            *fresh2 |= 1 as libc::c_int as libc::c_ulong;
             count = 1 as libc::c_int;
         }
         let mut aw4: libc::c_int = dav1d_block_dimensions[(*r2).bs
@@ -3925,8 +3935,8 @@ unsafe extern "C" fn find_matching_ref(
                     && (*r2).ref_0.ref_0[1 as libc::c_int as usize] as libc::c_int
                         == -(1 as libc::c_int)
                 {
-                    let ref mut fresh5 = *masks.offset(0 as libc::c_int as isize);
-                    *fresh5 |= mask as libc::c_ulong;
+                    let ref mut fresh3 = *masks.offset(0 as libc::c_int as isize);
+                    *fresh3 |= mask as libc::c_ulong;
                     count += 1;
                     if count >= 8 as libc::c_int {
                         return;
@@ -3950,8 +3960,8 @@ unsafe extern "C" fn find_matching_ref(
                 .ref_0
                 .ref_0[1 as libc::c_int as usize] as libc::c_int == -(1 as libc::c_int)
         {
-            let ref mut fresh6 = *masks.offset(1 as libc::c_int as isize);
-            *fresh6 |= 1 as libc::c_int as libc::c_ulong;
+            let ref mut fresh4 = *masks.offset(1 as libc::c_int as isize);
+            *fresh4 |= 1 as libc::c_int as libc::c_ulong;
             count += 1;
             if count >= 8 as libc::c_int {
                 return;
@@ -3981,8 +3991,8 @@ unsafe extern "C" fn find_matching_ref(
                         .ref_0[1 as libc::c_int as usize] as libc::c_int
                         == -(1 as libc::c_int)
                 {
-                    let ref mut fresh7 = *masks.offset(1 as libc::c_int as isize);
-                    *fresh7 |= mask_0 as libc::c_ulong;
+                    let ref mut fresh5 = *masks.offset(1 as libc::c_int as isize);
+                    *fresh5 |= mask_0 as libc::c_ulong;
                     count += 1;
                     if count >= 8 as libc::c_int {
                         return;
@@ -4006,8 +4016,8 @@ unsafe extern "C" fn find_matching_ref(
                 .ref_0
                 .ref_0[1 as libc::c_int as usize] as libc::c_int == -(1 as libc::c_int))
     {
-        let ref mut fresh8 = *masks.offset(1 as libc::c_int as isize);
-        *fresh8 = (*fresh8 as libc::c_ulonglong
+        let ref mut fresh6 = *masks.offset(1 as libc::c_int as isize);
+        *fresh6 = (*fresh6 as libc::c_ulonglong
             | (1 as libc::c_ulonglong) << 32 as libc::c_int) as uint64_t;
         count += 1;
         if count >= 8 as libc::c_int {
@@ -4023,8 +4033,8 @@ unsafe extern "C" fn find_matching_ref(
                 .ref_0
                 .ref_0[1 as libc::c_int as usize] as libc::c_int == -(1 as libc::c_int))
     {
-        let ref mut fresh9 = *masks.offset(0 as libc::c_int as isize);
-        *fresh9 = (*fresh9 as libc::c_ulonglong
+        let ref mut fresh7 = *masks.offset(0 as libc::c_int as isize);
+        *fresh7 = (*fresh7 as libc::c_ulonglong
             | (1 as libc::c_ulonglong) << 32 as libc::c_int) as uint64_t;
     }
 }
@@ -4465,7 +4475,7 @@ unsafe extern "C" fn read_pal_plane(
         .c2rust_unnamed
         .c2rust_unnamed
         .pal_sz[pl
-        as usize] = (dav1d_msac_decode_symbol_adapt_c(
+        as usize] = (dav1d_msac_decode_symbol_adapt8(
         &mut (*ts).msac,
         ((*ts).cdf.m.pal_sz[pl as usize][sz_ctx as usize]).as_mut_ptr(),
         6 as libc::c_int as size_t,
@@ -4502,9 +4512,9 @@ unsafe extern "C" fn read_pal_plane(
                 || cache[(n_cache - 1 as libc::c_int) as usize] as libc::c_int
                     != *l as libc::c_int
             {
-                let fresh10 = n_cache;
+                let fresh8 = n_cache;
                 n_cache = n_cache + 1;
-                cache[fresh10 as usize] = *l;
+                cache[fresh8 as usize] = *l;
             }
             l = l.offset(1);
             l_cache -= 1;
@@ -4517,9 +4527,9 @@ unsafe extern "C" fn read_pal_plane(
                 || cache[(n_cache - 1 as libc::c_int) as usize] as libc::c_int
                     != *a as libc::c_int
             {
-                let fresh11 = n_cache;
+                let fresh9 = n_cache;
                 n_cache = n_cache + 1;
-                cache[fresh11 as usize] = *a;
+                cache[fresh9 as usize] = *a;
             }
             a = a.offset(1);
             a_cache -= 1;
@@ -4531,9 +4541,9 @@ unsafe extern "C" fn read_pal_plane(
                 || cache[(n_cache - 1 as libc::c_int) as usize] as libc::c_int
                     != *l as libc::c_int
             {
-                let fresh12 = n_cache;
+                let fresh10 = n_cache;
                 n_cache = n_cache + 1;
-                cache[fresh12 as usize] = *l;
+                cache[fresh10 as usize] = *l;
             }
             l = l.offset(1);
             l_cache -= 1;
@@ -4547,9 +4557,9 @@ unsafe extern "C" fn read_pal_plane(
                 || cache[(n_cache - 1 as libc::c_int) as usize] as libc::c_int
                     != *a as libc::c_int
             {
-                let fresh13 = n_cache;
+                let fresh11 = n_cache;
                 n_cache = n_cache + 1;
-                cache[fresh13 as usize] = *a;
+                cache[fresh11 as usize] = *a;
             }
             a = a.offset(1);
             a_cache -= 1;
@@ -4561,10 +4571,10 @@ unsafe extern "C" fn read_pal_plane(
     let mut i: libc::c_int = 0 as libc::c_int;
     let mut n: libc::c_int = 0 as libc::c_int;
     while n < n_cache && i < pal_sz {
-        if dav1d_msac_decode_bool_equi_c(&mut (*ts).msac) != 0 {
-            let fresh14 = i;
+        if dav1d_msac_decode_bool_equi(&mut (*ts).msac) != 0 {
+            let fresh12 = i;
             i = i + 1;
-            used_cache[fresh14 as usize] = cache[n as usize];
+            used_cache[fresh12 as usize] = cache[n as usize];
         }
         n += 1;
     }
@@ -4582,14 +4592,14 @@ unsafe extern "C" fn read_pal_plane(
         ((*t).scratch.c2rust_unnamed_0.pal[pl as usize]).as_mut_ptr()
     };
     if i < pal_sz {
-        let fresh15 = i;
+        let fresh13 = i;
         i = i + 1;
-        let ref mut fresh16 = *pal.offset(fresh15 as isize);
-        *fresh16 = dav1d_msac_decode_bools(
+        let ref mut fresh14 = *pal.offset(fresh13 as isize);
+        *fresh14 = dav1d_msac_decode_bools(
             &mut (*ts).msac,
             (*f).cur.p.bpc as libc::c_uint,
         ) as uint16_t;
-        let mut prev: libc::c_int = *fresh16 as libc::c_int;
+        let mut prev: libc::c_int = *fresh14 as libc::c_int;
         if i < pal_sz {
             let mut bits: libc::c_int = (((*f).cur.p.bpc - 3 as libc::c_int)
                 as libc::c_uint)
@@ -4606,12 +4616,12 @@ unsafe extern "C" fn read_pal_plane(
                     &mut (*ts).msac,
                     bits as libc::c_uint,
                 ) as libc::c_int;
-                let fresh17 = i;
+                let fresh15 = i;
                 i = i + 1;
-                let ref mut fresh18 = *pal.offset(fresh17 as isize);
-                *fresh18 = imin(prev + delta + (pl == 0) as libc::c_int, max)
+                let ref mut fresh16 = *pal.offset(fresh15 as isize);
+                *fresh16 = imin(prev + delta + (pl == 0) as libc::c_int, max)
                     as uint16_t;
-                prev = *fresh18 as libc::c_int;
+                prev = *fresh16 as libc::c_int;
                 if prev + (pl == 0) as libc::c_int >= max {
                     while i < pal_sz {
                         *pal.offset(i as isize) = max as uint16_t;
@@ -4641,16 +4651,16 @@ unsafe extern "C" fn read_pal_plane(
                     || used_cache[n_0 as usize] as libc::c_int
                         <= *pal.offset(m as isize) as libc::c_int)
             {
-                let fresh19 = n_0;
+                let fresh17 = n_0;
                 n_0 = n_0 + 1;
-                *pal.offset(i as isize) = used_cache[fresh19 as usize];
+                *pal.offset(i as isize) = used_cache[fresh17 as usize];
             } else {
                 if !(m < pal_sz) {
                     unreachable!();
                 }
-                let fresh20 = m;
+                let fresh18 = m;
                 m = m + 1;
-                *pal.offset(i as isize) = *pal.offset(fresh20 as isize);
+                *pal.offset(i as isize) = *pal.offset(fresh18 as isize);
             }
             i += 1;
         }
@@ -4726,7 +4736,7 @@ unsafe extern "C" fn read_pal_uv(
     } else {
         ((*t).scratch.c2rust_unnamed_0.pal[2 as libc::c_int as usize]).as_mut_ptr()
     };
-    if dav1d_msac_decode_bool_equi_c(&mut (*ts).msac) != 0 {
+    if dav1d_msac_decode_bool_equi(&mut (*ts).msac) != 0 {
         let bits: libc::c_int = (((*f).cur.p.bpc - 4 as libc::c_int) as libc::c_uint)
             .wrapping_add(
                 dav1d_msac_decode_bools(
@@ -4734,12 +4744,12 @@ unsafe extern "C" fn read_pal_uv(
                     2 as libc::c_int as libc::c_uint,
                 ),
             ) as libc::c_int;
-        let ref mut fresh21 = *pal.offset(0 as libc::c_int as isize);
-        *fresh21 = dav1d_msac_decode_bools(
+        let ref mut fresh19 = *pal.offset(0 as libc::c_int as isize);
+        *fresh19 = dav1d_msac_decode_bools(
             &mut (*ts).msac,
             (*f).cur.p.bpc as libc::c_uint,
         ) as uint16_t;
-        let mut prev: libc::c_int = *fresh21 as libc::c_int;
+        let mut prev: libc::c_int = *fresh19 as libc::c_int;
         let max: libc::c_int = ((1 as libc::c_int) << (*f).cur.p.bpc) - 1 as libc::c_int;
         let mut i: libc::c_int = 1 as libc::c_int;
         while i
@@ -4750,12 +4760,12 @@ unsafe extern "C" fn read_pal_uv(
                 &mut (*ts).msac,
                 bits as libc::c_uint,
             ) as libc::c_int;
-            if delta != 0 && dav1d_msac_decode_bool_equi_c(&mut (*ts).msac) != 0 {
+            if delta != 0 && dav1d_msac_decode_bool_equi(&mut (*ts).msac) != 0 {
                 delta = -delta;
             }
-            let ref mut fresh22 = *pal.offset(i as isize);
-            *fresh22 = (prev + delta & max) as uint16_t;
-            prev = *fresh22 as libc::c_int;
+            let ref mut fresh20 = *pal.offset(i as isize);
+            *fresh20 = (prev + delta & max) as uint16_t;
+            prev = *fresh20 as libc::c_int;
             i += 1;
         }
     } else {
@@ -4827,9 +4837,9 @@ unsafe extern "C" fn order_palette(
             if !((v as libc::c_uint) < 8 as libc::c_uint) {
                 unreachable!();
             }
-            let fresh23 = o_idx;
+            let fresh21 = o_idx;
             o_idx = o_idx + 1;
-            (*order.offset(n as isize))[fresh23 as usize] = v as uint8_t;
+            (*order.offset(n as isize))[fresh21 as usize] = v as uint8_t;
             mask |= ((1 as libc::c_int) << v) as libc::c_uint;
         } else if have_top == 0 {
             *ctx.offset(n as isize) = 0 as libc::c_int as uint8_t;
@@ -4838,9 +4848,9 @@ unsafe extern "C" fn order_palette(
             if !((v_0 as libc::c_uint) < 8 as libc::c_uint) {
                 unreachable!();
             }
-            let fresh24 = o_idx;
+            let fresh22 = o_idx;
             o_idx = o_idx + 1;
-            (*order.offset(n as isize))[fresh24 as usize] = v_0 as uint8_t;
+            (*order.offset(n as isize))[fresh22 as usize] = v_0 as uint8_t;
             mask |= ((1 as libc::c_int) << v_0) as libc::c_uint;
         } else {
             let l: libc::c_int = *pal_idx.offset(-(1 as libc::c_int) as isize)
@@ -4859,9 +4869,9 @@ unsafe extern "C" fn order_palette(
                 if !((v_1 as libc::c_uint) < 8 as libc::c_uint) {
                     unreachable!();
                 }
-                let fresh25 = o_idx;
+                let fresh23 = o_idx;
                 o_idx = o_idx + 1;
-                (*order.offset(n as isize))[fresh25 as usize] = v_1 as uint8_t;
+                (*order.offset(n as isize))[fresh23 as usize] = v_1 as uint8_t;
                 mask |= ((1 as libc::c_int) << v_1) as libc::c_uint;
             } else if same_t_l != 0 {
                 *ctx.offset(n as isize) = 3 as libc::c_int as uint8_t;
@@ -4869,17 +4879,17 @@ unsafe extern "C" fn order_palette(
                 if !((v_2 as libc::c_uint) < 8 as libc::c_uint) {
                     unreachable!();
                 }
-                let fresh26 = o_idx;
+                let fresh24 = o_idx;
                 o_idx = o_idx + 1;
-                (*order.offset(n as isize))[fresh26 as usize] = v_2 as uint8_t;
+                (*order.offset(n as isize))[fresh24 as usize] = v_2 as uint8_t;
                 mask |= ((1 as libc::c_int) << v_2) as libc::c_uint;
                 let v_3: libc::c_int = tl;
                 if !((v_3 as libc::c_uint) < 8 as libc::c_uint) {
                     unreachable!();
                 }
-                let fresh27 = o_idx;
+                let fresh25 = o_idx;
                 o_idx = o_idx + 1;
-                (*order.offset(n as isize))[fresh27 as usize] = v_3 as uint8_t;
+                (*order.offset(n as isize))[fresh25 as usize] = v_3 as uint8_t;
                 mask |= ((1 as libc::c_int) << v_3) as libc::c_uint;
             } else if same_t_tl | same_l_tl != 0 {
                 *ctx.offset(n as isize) = 2 as libc::c_int as uint8_t;
@@ -4887,17 +4897,17 @@ unsafe extern "C" fn order_palette(
                 if !((v_4 as libc::c_uint) < 8 as libc::c_uint) {
                     unreachable!();
                 }
-                let fresh28 = o_idx;
+                let fresh26 = o_idx;
                 o_idx = o_idx + 1;
-                (*order.offset(n as isize))[fresh28 as usize] = v_4 as uint8_t;
+                (*order.offset(n as isize))[fresh26 as usize] = v_4 as uint8_t;
                 mask |= ((1 as libc::c_int) << v_4) as libc::c_uint;
                 let v_5: libc::c_int = if same_t_tl != 0 { l } else { t };
                 if !((v_5 as libc::c_uint) < 8 as libc::c_uint) {
                     unreachable!();
                 }
-                let fresh29 = o_idx;
+                let fresh27 = o_idx;
                 o_idx = o_idx + 1;
-                (*order.offset(n as isize))[fresh29 as usize] = v_5 as uint8_t;
+                (*order.offset(n as isize))[fresh27 as usize] = v_5 as uint8_t;
                 mask |= ((1 as libc::c_int) << v_5) as libc::c_uint;
             } else {
                 *ctx.offset(n as isize) = 1 as libc::c_int as uint8_t;
@@ -4905,25 +4915,25 @@ unsafe extern "C" fn order_palette(
                 if !((v_6 as libc::c_uint) < 8 as libc::c_uint) {
                     unreachable!();
                 }
-                let fresh30 = o_idx;
+                let fresh28 = o_idx;
                 o_idx = o_idx + 1;
-                (*order.offset(n as isize))[fresh30 as usize] = v_6 as uint8_t;
+                (*order.offset(n as isize))[fresh28 as usize] = v_6 as uint8_t;
                 mask |= ((1 as libc::c_int) << v_6) as libc::c_uint;
                 let v_7: libc::c_int = imax(t, l);
                 if !((v_7 as libc::c_uint) < 8 as libc::c_uint) {
                     unreachable!();
                 }
-                let fresh31 = o_idx;
+                let fresh29 = o_idx;
                 o_idx = o_idx + 1;
-                (*order.offset(n as isize))[fresh31 as usize] = v_7 as uint8_t;
+                (*order.offset(n as isize))[fresh29 as usize] = v_7 as uint8_t;
                 mask |= ((1 as libc::c_int) << v_7) as libc::c_uint;
                 let v_8: libc::c_int = tl;
                 if !((v_8 as libc::c_uint) < 8 as libc::c_uint) {
                     unreachable!();
                 }
-                let fresh32 = o_idx;
+                let fresh30 = o_idx;
                 o_idx = o_idx + 1;
-                (*order.offset(n as isize))[fresh32 as usize] = v_8 as uint8_t;
+                (*order.offset(n as isize))[fresh30 as usize] = v_8 as uint8_t;
                 mask |= ((1 as libc::c_int) << v_8) as libc::c_uint;
             }
         }
@@ -4931,9 +4941,9 @@ unsafe extern "C" fn order_palette(
         let mut bit: libc::c_uint = 0 as libc::c_int as libc::c_uint;
         while m < 0x100 as libc::c_int as libc::c_uint {
             if mask & m == 0 {
-                let fresh33 = o_idx;
+                let fresh31 = o_idx;
                 o_idx = o_idx + 1;
-                (*order.offset(n as isize))[fresh33 as usize] = bit as uint8_t;
+                (*order.offset(n as isize))[fresh31 as usize] = bit as uint8_t;
             }
             m <<= 1 as libc::c_int;
             bit = bit.wrapping_add(1);
@@ -5001,7 +5011,7 @@ unsafe extern "C" fn read_pal_indices(
         let mut j: libc::c_int = first;
         let mut m: libc::c_int = 0 as libc::c_int;
         while j >= last {
-            let color_idx: libc::c_int = dav1d_msac_decode_symbol_adapt_c(
+            let color_idx: libc::c_int = dav1d_msac_decode_symbol_adapt8(
                 &mut (*ts).msac,
                 (*color_map_cdf.offset(*ctx.offset(m as isize) as isize)).as_mut_ptr(),
                 ((*b).c2rust_unnamed.c2rust_unnamed.pal_sz[pl as usize] as libc::c_int
@@ -7319,7 +7329,7 @@ unsafe extern "C" fn decode_b(
         } else if (*(*f).frame_hdr).segmentation.seg_data.preskip != 0 {
             if (*(*f).frame_hdr).segmentation.temporal != 0
                 && {
-                    seg_pred = dav1d_msac_decode_bool_adapt_c(
+                    seg_pred = dav1d_msac_decode_bool_adapt(
                         &mut (*ts).msac,
                         ((*ts)
                             .cdf
@@ -7359,7 +7369,7 @@ unsafe extern "C" fn decode_b(
                     (*f).cur_segmap,
                     (*f).b4_stride,
                 );
-                let diff: libc::c_uint = dav1d_msac_decode_symbol_adapt_c(
+                let diff: libc::c_uint = dav1d_msac_decode_symbol_adapt8(
                     &mut (*ts).msac,
                     ((*ts).cdf.m.seg_id[seg_ctx as usize]).as_mut_ptr(),
                     (8 as libc::c_int - 1 as libc::c_int) as size_t,
@@ -7409,7 +7419,7 @@ unsafe extern "C" fn decode_b(
         let smctx: libc::c_int = (*(*t).a).skip_mode[bx4 as usize] as libc::c_int
             + (*t).l.skip_mode[by4 as usize] as libc::c_int;
         (*b)
-            .skip_mode = dav1d_msac_decode_bool_adapt_c(
+            .skip_mode = dav1d_msac_decode_bool_adapt(
             &mut (*ts).msac,
             ((*ts).cdf.m.skip_mode[smctx as usize]).as_mut_ptr(),
         ) as uint8_t;
@@ -7432,7 +7442,7 @@ unsafe extern "C" fn decode_b(
         let sctx: libc::c_int = (*(*t).a).skip[bx4 as usize] as libc::c_int
             + (*t).l.skip[by4 as usize] as libc::c_int;
         (*b)
-            .skip = dav1d_msac_decode_bool_adapt_c(
+            .skip = dav1d_msac_decode_bool_adapt(
             &mut (*ts).msac,
             ((*ts).cdf.m.skip[sctx as usize]).as_mut_ptr(),
         ) as uint8_t;
@@ -7453,7 +7463,7 @@ unsafe extern "C" fn decode_b(
     {
         if (*b).skip == 0 && (*(*f).frame_hdr).segmentation.temporal != 0
             && {
-                seg_pred = dav1d_msac_decode_bool_adapt_c(
+                seg_pred = dav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
                     ((*ts)
                         .cdf
@@ -7496,7 +7506,7 @@ unsafe extern "C" fn decode_b(
             if (*b).skip != 0 {
                 (*b).seg_id = pred_seg_id_0 as uint8_t;
             } else {
-                let diff_0: libc::c_uint = dav1d_msac_decode_symbol_adapt_c(
+                let diff_0: libc::c_uint = dav1d_msac_decode_symbol_adapt8(
                     &mut (*ts).msac,
                     ((*ts).cdf.m.seg_id[seg_ctx_0 as usize]).as_mut_ptr(),
                     (8 as libc::c_int - 1 as libc::c_int) as size_t,
@@ -7593,7 +7603,7 @@ unsafe extern "C" fn decode_b(
             4 as libc::c_int as libc::c_ulong,
         );
         if have_delta_q != 0 {
-            let mut delta_q: libc::c_int = dav1d_msac_decode_symbol_adapt_c(
+            let mut delta_q: libc::c_int = dav1d_msac_decode_symbol_adapt4(
                 &mut (*ts).msac,
                 ((*ts).cdf.m.delta_q).as_mut_ptr(),
                 3 as libc::c_int as size_t,
@@ -7615,7 +7625,7 @@ unsafe extern "C" fn decode_b(
                     as libc::c_int;
             }
             if delta_q != 0 {
-                if dav1d_msac_decode_bool_equi_c(&mut (*ts).msac) != 0 {
+                if dav1d_msac_decode_bool_equi(&mut (*ts).msac) != 0 {
                     delta_q = -delta_q;
                 }
                 delta_q *= (1 as libc::c_int) << (*(*f).frame_hdr).delta.q.res_log2;
@@ -7653,7 +7663,7 @@ unsafe extern "C" fn decode_b(
                 };
                 let mut i: libc::c_int = 0 as libc::c_int;
                 while i < n_lfs {
-                    let mut delta_lf: libc::c_int = dav1d_msac_decode_symbol_adapt_c(
+                    let mut delta_lf: libc::c_int = dav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
                         ((*ts)
                             .cdf
@@ -7680,7 +7690,7 @@ unsafe extern "C" fn decode_b(
                             ) as libc::c_int;
                     }
                     if delta_lf != 0 {
-                        if dav1d_msac_decode_bool_equi_c(&mut (*ts).msac) != 0 {
+                        if dav1d_msac_decode_bool_equi(&mut (*ts).msac) != 0 {
                             delta_lf = -delta_lf;
                         }
                         delta_lf
@@ -7765,7 +7775,7 @@ unsafe extern "C" fn decode_b(
                 have_left,
             );
             (*b)
-                .intra = (dav1d_msac_decode_bool_adapt_c(
+                .intra = (dav1d_msac_decode_bool_adapt(
                 &mut (*ts).msac,
                 ((*ts).cdf.m.intra[ictx as usize]).as_mut_ptr(),
             ) == 0) as libc::c_int as uint8_t;
@@ -7783,7 +7793,7 @@ unsafe extern "C" fn decode_b(
         }
     } else if (*(*f).frame_hdr).allow_intrabc != 0 {
         (*b)
-            .intra = (dav1d_msac_decode_bool_adapt_c(
+            .intra = (dav1d_msac_decode_bool_adapt(
             &mut (*ts).msac,
             ((*ts).cdf.m.intrabc).as_mut_ptr(),
         ) == 0) as libc::c_int as uint8_t;
@@ -7817,7 +7827,7 @@ unsafe extern "C" fn decode_b(
         (*b)
             .c2rust_unnamed
             .c2rust_unnamed
-            .y_mode = dav1d_msac_decode_symbol_adapt_c(
+            .y_mode = dav1d_msac_decode_symbol_adapt16(
             &mut (*ts).msac,
             ymode_cdf,
             (N_INTRA_PRED_MODES as libc::c_int - 1 as libc::c_int) as size_t,
@@ -7845,7 +7855,7 @@ unsafe extern "C" fn decode_b(
                 .angle_delta[((*b).c2rust_unnamed.c2rust_unnamed.y_mode as libc::c_int
                 - VERT_PRED as libc::c_int) as usize])
                 .as_mut_ptr();
-            let angle: libc::c_int = dav1d_msac_decode_symbol_adapt_c(
+            let angle: libc::c_int = dav1d_msac_decode_symbol_adapt8(
                 &mut (*ts).msac,
                 acdf,
                 6 as libc::c_int as size_t,
@@ -7877,7 +7887,7 @@ unsafe extern "C" fn decode_b(
             (*b)
                 .c2rust_unnamed
                 .c2rust_unnamed
-                .uv_mode = dav1d_msac_decode_symbol_adapt_c(
+                .uv_mode = dav1d_msac_decode_symbol_adapt16(
                 &mut (*ts).msac,
                 uvmode_cdf,
                 (N_UV_INTRA_PRED_MODES as libc::c_int - 1 as libc::c_int
@@ -7898,7 +7908,7 @@ unsafe extern "C" fn decode_b(
             if (*b).c2rust_unnamed.c2rust_unnamed.uv_mode as libc::c_int
                 == CFL_PRED as libc::c_int
             {
-                let sign: libc::c_int = (dav1d_msac_decode_symbol_adapt_c(
+                let sign: libc::c_int = (dav1d_msac_decode_symbol_adapt8(
                     &mut (*ts).msac,
                     ((*ts).cdf.m.cfl_sign).as_mut_ptr(),
                     7 as libc::c_int as size_t,
@@ -7916,7 +7926,7 @@ unsafe extern "C" fn decode_b(
                         .c2rust_unnamed
                         .c2rust_unnamed
                         .cfl_alpha[0 as libc::c_int
-                        as usize] = (dav1d_msac_decode_symbol_adapt_c(
+                        as usize] = (dav1d_msac_decode_symbol_adapt16(
                         &mut (*ts).msac,
                         ((*ts).cdf.m.cfl_alpha[ctx as usize]).as_mut_ptr(),
                         15 as libc::c_int as size_t,
@@ -7947,7 +7957,7 @@ unsafe extern "C" fn decode_b(
                         .c2rust_unnamed
                         .c2rust_unnamed
                         .cfl_alpha[1 as libc::c_int
-                        as usize] = (dav1d_msac_decode_symbol_adapt_c(
+                        as usize] = (dav1d_msac_decode_symbol_adapt16(
                         &mut (*ts).msac,
                         ((*ts).cdf.m.cfl_alpha[ctx_0 as usize]).as_mut_ptr(),
                         15 as libc::c_int as size_t,
@@ -8004,7 +8014,7 @@ unsafe extern "C" fn decode_b(
                     .angle_delta[((*b).c2rust_unnamed.c2rust_unnamed.uv_mode
                     as libc::c_int - VERT_PRED as libc::c_int) as usize])
                     .as_mut_ptr();
-                let angle_0: libc::c_int = dav1d_msac_decode_symbol_adapt_c(
+                let angle_0: libc::c_int = dav1d_msac_decode_symbol_adapt8(
                     &mut (*ts).msac,
                     acdf_0,
                     6 as libc::c_int as size_t,
@@ -8040,7 +8050,7 @@ unsafe extern "C" fn decode_b(
                     > 0 as libc::c_int) as libc::c_int
                     + ((*t).l.pal_sz[by4 as usize] as libc::c_int > 0 as libc::c_int)
                         as libc::c_int;
-                let use_y_pal: libc::c_int = dav1d_msac_decode_bool_adapt_c(
+                let use_y_pal: libc::c_int = dav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
                     ((*ts).cdf.m.pal_y[sz_ctx as usize][pal_ctx as usize]).as_mut_ptr(),
                 ) as libc::c_int;
@@ -8068,7 +8078,7 @@ unsafe extern "C" fn decode_b(
                     .c2rust_unnamed
                     .pal_sz[0 as libc::c_int as usize] as libc::c_int > 0 as libc::c_int)
                     as libc::c_int;
-                let use_uv_pal: libc::c_int = dav1d_msac_decode_bool_adapt_c(
+                let use_uv_pal: libc::c_int = dav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
                     ((*ts).cdf.m.pal_uv[pal_ctx_0 as usize]).as_mut_ptr(),
                 ) as libc::c_int;
@@ -8096,7 +8106,7 @@ unsafe extern "C" fn decode_b(
                 *b_dim.offset(3 as libc::c_int as isize) as libc::c_int,
             ) <= 3 as libc::c_int && (*(*f).seq_hdr).filter_intra != 0
         {
-            let is_filter: libc::c_int = dav1d_msac_decode_bool_adapt_c(
+            let is_filter: libc::c_int = dav1d_msac_decode_bool_adapt(
                 &mut (*ts).msac,
                 ((*ts).cdf.m.use_filter_intra[bs as usize]).as_mut_ptr(),
             ) as libc::c_int;
@@ -8108,7 +8118,7 @@ unsafe extern "C" fn decode_b(
                 (*b)
                     .c2rust_unnamed
                     .c2rust_unnamed
-                    .y_angle = dav1d_msac_decode_symbol_adapt_c(
+                    .y_angle = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
                     ((*ts).cdf.m.filter_intra).as_mut_ptr(),
                     4 as libc::c_int as size_t,
@@ -8217,15 +8227,15 @@ unsafe extern "C" fn decode_b(
                     .txsz[((*t_dim).max as libc::c_int - 1 as libc::c_int)
                     as usize][tctx as usize])
                     .as_mut_ptr();
-                let mut depth: libc::c_int = dav1d_msac_decode_symbol_adapt_c(
+                let mut depth: libc::c_int = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
                     tx_cdf,
                     imin((*t_dim).max as libc::c_int, 2 as libc::c_int) as size_t,
                 ) as libc::c_int;
                 loop {
-                    let fresh34 = depth;
+                    let fresh32 = depth;
                     depth = depth - 1;
-                    if !(fresh34 != 0) {
+                    if !(fresh32 != 0) {
                         break;
                     }
                     (*b).c2rust_unnamed.c2rust_unnamed.tx = (*t_dim).sub;
@@ -11770,7 +11780,7 @@ unsafe extern "C" fn decode_b(
                 have_top,
                 have_left,
             );
-            is_comp = dav1d_msac_decode_bool_adapt_c(
+            is_comp = dav1d_msac_decode_bool_adapt(
                 &mut (*ts).msac,
                 ((*ts).cdf.m.comp[ctx_2 as usize]).as_mut_ptr(),
             ) as libc::c_int;
@@ -11943,7 +11953,7 @@ unsafe extern "C" fn decode_b(
                 have_top,
                 have_left,
             );
-            if dav1d_msac_decode_bool_adapt_c(
+            if dav1d_msac_decode_bool_adapt(
                 &mut (*ts).msac,
                 ((*ts).cdf.m.comp_dir[dir_ctx as usize]).as_mut_ptr(),
             ) != 0
@@ -11956,7 +11966,7 @@ unsafe extern "C" fn decode_b(
                     have_top,
                     have_left,
                 );
-                if dav1d_msac_decode_bool_adapt_c(
+                if dav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
                     ((*ts).cdf.m.comp_fwd_ref[0 as libc::c_int as usize][ctx1 as usize])
                         .as_mut_ptr(),
@@ -11976,7 +11986,7 @@ unsafe extern "C" fn decode_b(
                         .ref_0[0 as libc::c_int
                         as usize] = (2 as libc::c_int as libc::c_uint)
                         .wrapping_add(
-                            dav1d_msac_decode_bool_adapt_c(
+                            dav1d_msac_decode_bool_adapt(
                                 &mut (*ts).msac,
                                 ((*ts)
                                     .cdf
@@ -11998,7 +12008,7 @@ unsafe extern "C" fn decode_b(
                         .c2rust_unnamed
                         .c2rust_unnamed_0
                         .ref_0[0 as libc::c_int
-                        as usize] = dav1d_msac_decode_bool_adapt_c(
+                        as usize] = dav1d_msac_decode_bool_adapt(
                         &mut (*ts).msac,
                         ((*ts)
                             .cdf
@@ -12015,7 +12025,7 @@ unsafe extern "C" fn decode_b(
                     have_top,
                     have_left,
                 );
-                if dav1d_msac_decode_bool_adapt_c(
+                if dav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
                     ((*ts).cdf.m.comp_bwd_ref[0 as libc::c_int as usize][ctx3 as usize])
                         .as_mut_ptr(),
@@ -12040,7 +12050,7 @@ unsafe extern "C" fn decode_b(
                         .ref_0[1 as libc::c_int
                         as usize] = (4 as libc::c_int as libc::c_uint)
                         .wrapping_add(
-                            dav1d_msac_decode_bool_adapt_c(
+                            dav1d_msac_decode_bool_adapt(
                                 &mut (*ts).msac,
                                 ((*ts)
                                     .cdf
@@ -12059,7 +12069,7 @@ unsafe extern "C" fn decode_b(
                     have_top,
                     have_left,
                 );
-                if dav1d_msac_decode_bool_adapt_c(
+                if dav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
                     ((*ts)
                         .cdf
@@ -12095,7 +12105,7 @@ unsafe extern "C" fn decode_b(
                         .ref_0[1 as libc::c_int
                         as usize] = (1 as libc::c_int as libc::c_uint)
                         .wrapping_add(
-                            dav1d_msac_decode_bool_adapt_c(
+                            dav1d_msac_decode_bool_adapt(
                                 &mut (*ts).msac,
                                 ((*ts)
                                     .cdf
@@ -12127,7 +12137,7 @@ unsafe extern "C" fn decode_b(
                             .c2rust_unnamed_0
                             .ref_0[1 as libc::c_int as usize] as libc::c_uint)
                             .wrapping_add(
-                                dav1d_msac_decode_bool_adapt_c(
+                                dav1d_msac_decode_bool_adapt(
                                     &mut (*ts).msac,
                                     ((*ts)
                                         .cdf
@@ -12190,7 +12200,7 @@ unsafe extern "C" fn decode_b(
             (*b)
                 .c2rust_unnamed
                 .c2rust_unnamed_0
-                .inter_mode = dav1d_msac_decode_symbol_adapt_c(
+                .inter_mode = dav1d_msac_decode_symbol_adapt8(
                 &mut (*ts).msac,
                 ((*ts).cdf.m.comp_inter_mode[ctx_4 as usize]).as_mut_ptr(),
                 (N_COMP_INTER_PRED_MODES as libc::c_int - 1 as libc::c_int) as size_t,
@@ -12232,7 +12242,7 @@ unsafe extern "C" fn decode_b(
                         .drl_idx = ((*b).c2rust_unnamed.c2rust_unnamed_0.drl_idx
                         as libc::c_uint)
                         .wrapping_add(
-                            dav1d_msac_decode_bool_adapt_c(
+                            dav1d_msac_decode_bool_adapt(
                                 &mut (*ts).msac,
                                 ((*ts).cdf.m.drl_bit[drl_ctx_v1 as usize]).as_mut_ptr(),
                             ),
@@ -12250,7 +12260,7 @@ unsafe extern "C" fn decode_b(
                             .drl_idx = ((*b).c2rust_unnamed.c2rust_unnamed_0.drl_idx
                             as libc::c_uint)
                             .wrapping_add(
-                                dav1d_msac_decode_bool_adapt_c(
+                                dav1d_msac_decode_bool_adapt(
                                     &mut (*ts).msac,
                                     ((*ts).cdf.m.drl_bit[drl_ctx_v2 as usize]).as_mut_ptr(),
                                 ),
@@ -12290,7 +12300,7 @@ unsafe extern "C" fn decode_b(
                         .drl_idx = ((*b).c2rust_unnamed.c2rust_unnamed_0.drl_idx
                         as libc::c_uint)
                         .wrapping_add(
-                            dav1d_msac_decode_bool_adapt_c(
+                            dav1d_msac_decode_bool_adapt(
                                 &mut (*ts).msac,
                                 ((*ts).cdf.m.drl_bit[drl_ctx_v2_0 as usize]).as_mut_ptr(),
                             ),
@@ -12308,7 +12318,7 @@ unsafe extern "C" fn decode_b(
                             .drl_idx = ((*b).c2rust_unnamed.c2rust_unnamed_0.drl_idx
                             as libc::c_uint)
                             .wrapping_add(
-                                dav1d_msac_decode_bool_adapt_c(
+                                dav1d_msac_decode_bool_adapt(
                                     &mut (*ts).msac,
                                     ((*ts).cdf.m.drl_bit[drl_ctx_v3 as usize]).as_mut_ptr(),
                                 ),
@@ -12562,7 +12572,7 @@ unsafe extern "C" fn decode_b(
                     by4,
                     bx4,
                 );
-                is_segwedge = dav1d_msac_decode_bool_adapt_c(
+                is_segwedge = dav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
                     ((*ts).cdf.m.mask_comp[mask_ctx as usize]).as_mut_ptr(),
                 ) as libc::c_int;
@@ -12612,7 +12622,7 @@ unsafe extern "C" fn decode_b(
                         .comp_type = (COMP_INTER_WEIGHTED_AVG as libc::c_int
                         as libc::c_uint)
                         .wrapping_add(
-                            dav1d_msac_decode_bool_adapt_c(
+                            dav1d_msac_decode_bool_adapt(
                                 &mut (*ts).msac,
                                 ((*ts).cdf.m.jnt_comp[jnt_ctx as usize]).as_mut_ptr(),
                             ),
@@ -12655,7 +12665,7 @@ unsafe extern "C" fn decode_b(
                         .c2rust_unnamed_0
                         .comp_type = (COMP_INTER_WEDGE as libc::c_int as libc::c_uint)
                         .wrapping_sub(
-                            dav1d_msac_decode_bool_adapt_c(
+                            dav1d_msac_decode_bool_adapt(
                                 &mut (*ts).msac,
                                 ((*ts).cdf.m.wedge_comp[ctx_5 as usize]).as_mut_ptr(),
                             ),
@@ -12668,7 +12678,7 @@ unsafe extern "C" fn decode_b(
                             .c2rust_unnamed_0
                             .c2rust_unnamed
                             .c2rust_unnamed
-                            .wedge_idx = dav1d_msac_decode_symbol_adapt_c(
+                            .wedge_idx = dav1d_msac_decode_symbol_adapt16(
                             &mut (*ts).msac,
                             ((*ts).cdf.m.wedge_idx[ctx_5 as usize]).as_mut_ptr(),
                             15 as libc::c_int as size_t,
@@ -12685,8 +12695,7 @@ unsafe extern "C" fn decode_b(
                     .c2rust_unnamed_0
                     .c2rust_unnamed
                     .c2rust_unnamed
-                    .mask_sign = dav1d_msac_decode_bool_equi_c(&mut (*ts).msac)
-                    as uint8_t;
+                    .mask_sign = dav1d_msac_decode_bool_equi(&mut (*ts).msac) as uint8_t;
                 if 0 as libc::c_int != 0
                     && (*(*f).frame_hdr).frame_offset == 2 as libc::c_int
                     && (*t).by >= 0 as libc::c_int && (*t).by < 4 as libc::c_int
@@ -12738,7 +12747,7 @@ unsafe extern "C" fn decode_b(
                     have_top,
                     have_left,
                 );
-                if dav1d_msac_decode_bool_adapt_c(
+                if dav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
                     ((*ts).cdf.m.ref_0[0 as libc::c_int as usize][ctx1_0 as usize])
                         .as_mut_ptr(),
@@ -12752,7 +12761,7 @@ unsafe extern "C" fn decode_b(
                         have_top,
                         have_left,
                     );
-                    if dav1d_msac_decode_bool_adapt_c(
+                    if dav1d_msac_decode_bool_adapt(
                         &mut (*ts).msac,
                         ((*ts).cdf.m.ref_0[1 as libc::c_int as usize][ctx2_1 as usize])
                             .as_mut_ptr(),
@@ -12778,7 +12787,7 @@ unsafe extern "C" fn decode_b(
                             .ref_0[0 as libc::c_int
                             as usize] = (4 as libc::c_int as libc::c_uint)
                             .wrapping_add(
-                                dav1d_msac_decode_bool_adapt_c(
+                                dav1d_msac_decode_bool_adapt(
                                     &mut (*ts).msac,
                                     ((*ts)
                                         .cdf
@@ -12797,7 +12806,7 @@ unsafe extern "C" fn decode_b(
                         have_top,
                         have_left,
                     );
-                    if dav1d_msac_decode_bool_adapt_c(
+                    if dav1d_msac_decode_bool_adapt(
                         &mut (*ts).msac,
                         ((*ts).cdf.m.ref_0[2 as libc::c_int as usize][ctx2_2 as usize])
                             .as_mut_ptr(),
@@ -12817,7 +12826,7 @@ unsafe extern "C" fn decode_b(
                             .ref_0[0 as libc::c_int
                             as usize] = (2 as libc::c_int as libc::c_uint)
                             .wrapping_add(
-                                dav1d_msac_decode_bool_adapt_c(
+                                dav1d_msac_decode_bool_adapt(
                                     &mut (*ts).msac,
                                     ((*ts)
                                         .cdf
@@ -12839,7 +12848,7 @@ unsafe extern "C" fn decode_b(
                             .c2rust_unnamed
                             .c2rust_unnamed_0
                             .ref_0[0 as libc::c_int
-                            as usize] = dav1d_msac_decode_bool_adapt_c(
+                            as usize] = dav1d_msac_decode_bool_adapt(
                             &mut (*ts).msac,
                             ((*ts)
                                 .cdf
@@ -12899,14 +12908,14 @@ unsafe extern "C" fn decode_b(
                 (*t).bx,
             );
             if !seg.is_null() && ((*seg).skip != 0 || (*seg).globalmv != 0)
-                || dav1d_msac_decode_bool_adapt_c(
+                || dav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
                     ((*ts).cdf.m.newmv_mode[(ctx_6 & 7 as libc::c_int) as usize])
                         .as_mut_ptr(),
                 ) != 0
             {
                 if !seg.is_null() && ((*seg).skip != 0 || (*seg).globalmv != 0)
-                    || dav1d_msac_decode_bool_adapt_c(
+                    || dav1d_msac_decode_bool_adapt(
                         &mut (*ts).msac,
                         ((*ts)
                             .cdf
@@ -12951,7 +12960,7 @@ unsafe extern "C" fn decode_b(
                         as libc::c_int;
                 } else {
                     has_subpel_filter = 1 as libc::c_int;
-                    if dav1d_msac_decode_bool_adapt_c(
+                    if dav1d_msac_decode_bool_adapt(
                         &mut (*ts).msac,
                         ((*ts)
                             .cdf
@@ -12980,7 +12989,7 @@ unsafe extern "C" fn decode_b(
                                 .drl_idx = ((*b).c2rust_unnamed.c2rust_unnamed_0.drl_idx
                                 as libc::c_uint)
                                 .wrapping_add(
-                                    dav1d_msac_decode_bool_adapt_c(
+                                    dav1d_msac_decode_bool_adapt(
                                         &mut (*ts).msac,
                                         ((*ts).cdf.m.drl_bit[drl_ctx_v2_1 as usize]).as_mut_ptr(),
                                     ),
@@ -12999,7 +13008,7 @@ unsafe extern "C" fn decode_b(
                                     .drl_idx = ((*b).c2rust_unnamed.c2rust_unnamed_0.drl_idx
                                     as libc::c_uint)
                                     .wrapping_add(
-                                        dav1d_msac_decode_bool_adapt_c(
+                                        dav1d_msac_decode_bool_adapt(
                                             &mut (*ts).msac,
                                             ((*ts).cdf.m.drl_bit[drl_ctx_v3_0 as usize]).as_mut_ptr(),
                                         ),
@@ -13102,7 +13111,7 @@ unsafe extern "C" fn decode_b(
                         .drl_idx = ((*b).c2rust_unnamed.c2rust_unnamed_0.drl_idx
                         as libc::c_uint)
                         .wrapping_add(
-                            dav1d_msac_decode_bool_adapt_c(
+                            dav1d_msac_decode_bool_adapt(
                                 &mut (*ts).msac,
                                 ((*ts).cdf.m.drl_bit[drl_ctx_v1_0 as usize]).as_mut_ptr(),
                             ),
@@ -13120,7 +13129,7 @@ unsafe extern "C" fn decode_b(
                             .drl_idx = ((*b).c2rust_unnamed.c2rust_unnamed_0.drl_idx
                             as libc::c_uint)
                             .wrapping_add(
-                                dav1d_msac_decode_bool_adapt_c(
+                                dav1d_msac_decode_bool_adapt(
                                     &mut (*ts).msac,
                                     ((*ts).cdf.m.drl_bit[drl_ctx_v2_2 as usize]).as_mut_ptr(),
                                 ),
@@ -13231,7 +13240,7 @@ unsafe extern "C" fn decode_b(
             if (*(*f).seq_hdr).inter_intra != 0
                 && interintra_allowed_mask
                     & ((1 as libc::c_int) << bs as libc::c_uint) as libc::c_uint != 0
-                && dav1d_msac_decode_bool_adapt_c(
+                && dav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
                     ((*ts).cdf.m.interintra[ii_sz_grp as usize]).as_mut_ptr(),
                 ) != 0
@@ -13241,7 +13250,7 @@ unsafe extern "C" fn decode_b(
                     .c2rust_unnamed_0
                     .c2rust_unnamed
                     .c2rust_unnamed
-                    .interintra_mode = dav1d_msac_decode_symbol_adapt_c(
+                    .interintra_mode = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
                     ((*ts).cdf.m.interintra_mode[ii_sz_grp as usize]).as_mut_ptr(),
                     (N_INTER_INTRA_PRED_MODES as libc::c_int - 1 as libc::c_int)
@@ -13254,7 +13263,7 @@ unsafe extern "C" fn decode_b(
                     .c2rust_unnamed_0
                     .interintra_type = (INTER_INTRA_BLEND as libc::c_int as libc::c_uint)
                     .wrapping_add(
-                        dav1d_msac_decode_bool_adapt_c(
+                        dav1d_msac_decode_bool_adapt(
                             &mut (*ts).msac,
                             ((*ts).cdf.m.interintra_wedge[wedge_ctx as usize])
                                 .as_mut_ptr(),
@@ -13268,7 +13277,7 @@ unsafe extern "C" fn decode_b(
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
-                        .wedge_idx = dav1d_msac_decode_symbol_adapt_c(
+                        .wedge_idx = dav1d_msac_decode_symbol_adapt16(
                         &mut (*ts).msac,
                         ((*ts).cdf.m.wedge_idx[wedge_ctx as usize]).as_mut_ptr(),
                         15 as libc::c_int as size_t,
@@ -13367,13 +13376,13 @@ unsafe extern "C" fn decode_b(
                     .c2rust_unnamed
                     .c2rust_unnamed_0
                     .motion_mode = (if allow_warp != 0 {
-                    dav1d_msac_decode_symbol_adapt_c(
+                    dav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
                         ((*ts).cdf.m.motion_mode[bs as usize]).as_mut_ptr(),
                         2 as libc::c_int as size_t,
                     )
                 } else {
-                    dav1d_msac_decode_bool_adapt_c(
+                    dav1d_msac_decode_bool_adapt(
                         &mut (*ts).msac,
                         ((*ts).cdf.m.obmc[bs as usize]).as_mut_ptr(),
                     )
@@ -13583,7 +13592,7 @@ unsafe extern "C" fn decode_b(
                     bx4,
                 );
                 filter_0[0 as libc::c_int
-                    as usize] = dav1d_msac_decode_symbol_adapt_c(
+                    as usize] = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
                     ((*ts).cdf.m.filter[0 as libc::c_int as usize][ctx1_1 as usize])
                         .as_mut_ptr(),
@@ -13617,7 +13626,7 @@ unsafe extern "C" fn decode_b(
                         );
                     }
                     filter_0[1 as libc::c_int
-                        as usize] = dav1d_msac_decode_symbol_adapt_c(
+                        as usize] = dav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
                         ((*ts).cdf.m.filter[1 as libc::c_int as usize][ctx2_3 as usize])
                             .as_mut_ptr(),
@@ -16262,7 +16271,7 @@ unsafe extern "C" fn decode_sb(
                 PARTITION_SPLIT as libc::c_int
             }) as BlockPartition;
         } else {
-            bp = dav1d_msac_decode_symbol_adapt_c(
+            bp = dav1d_msac_decode_symbol_adapt16(
                 &mut (*ts).msac,
                 pc,
                 dav1d_partition_type_count[bl as usize] as size_t,
@@ -16734,7 +16743,7 @@ unsafe extern "C" fn decode_sb(
             is_split = ((*b_1).bl as libc::c_uint != bl as libc::c_uint) as libc::c_int
                 as libc::c_uint;
         } else {
-            is_split = dav1d_msac_decode_bool_c(
+            is_split = dav1d_msac_decode_bool(
                 &mut (*ts).msac,
                 gather_top_partition_prob(pc, bl),
             );
@@ -16815,7 +16824,7 @@ unsafe extern "C" fn decode_sb(
             is_split_0 = ((*b_2).bl as libc::c_uint != bl as libc::c_uint) as libc::c_int
                 as libc::c_uint;
         } else {
-            is_split_0 = dav1d_msac_decode_bool_c(
+            is_split_0 = dav1d_msac_decode_bool(
                 &mut (*ts).msac,
                 gather_left_partition_prob(pc, bl),
             );
@@ -17279,7 +17288,7 @@ unsafe extern "C" fn read_restoration_info(
     if frame_type as libc::c_uint
         == DAV1D_RESTORATION_SWITCHABLE as libc::c_int as libc::c_uint
     {
-        let filter: libc::c_int = dav1d_msac_decode_symbol_adapt_c(
+        let filter: libc::c_int = dav1d_msac_decode_symbol_adapt4(
             &mut (*ts).msac,
             ((*ts).cdf.m.restore_switchable).as_mut_ptr(),
             2 as libc::c_int as size_t,
@@ -17295,7 +17304,7 @@ unsafe extern "C" fn read_restoration_info(
             DAV1D_RESTORATION_NONE as libc::c_int
         }) as uint8_t;
     } else {
-        let type_0: libc::c_uint = dav1d_msac_decode_bool_adapt_c(
+        let type_0: libc::c_uint = dav1d_msac_decode_bool_adapt(
             &mut (*ts).msac,
             if frame_type as libc::c_uint
                 == DAV1D_RESTORATION_WIENER as libc::c_int as libc::c_uint
@@ -17781,7 +17790,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
         ) as *mut uint8_t;
         if ((*f).lf.start_of_tile_row).is_null() {
             (*f).lf.start_of_tile_row_sz = 0 as libc::c_int;
-            current_block = 14580427646075712995;
+            current_block = 13495985911605184990;
         } else {
             (*f).lf.start_of_tile_row_sz = (*f).sbh;
             current_block = 6873731126896040597;
@@ -17794,20 +17803,20 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
             sby = 0 as libc::c_int;
             let mut tile_row: libc::c_int = 0 as libc::c_int;
             while tile_row < (*(*f).frame_hdr).tiling.rows {
-                let fresh35 = sby;
+                let fresh33 = sby;
                 sby = sby + 1;
                 *((*f).lf.start_of_tile_row)
-                    .offset(fresh35 as isize) = tile_row as uint8_t;
+                    .offset(fresh33 as isize) = tile_row as uint8_t;
                 while sby
                     < (*(*f).frame_hdr)
                         .tiling
                         .row_start_sb[(tile_row + 1 as libc::c_int) as usize]
                         as libc::c_int
                 {
-                    let fresh36 = sby;
+                    let fresh34 = sby;
                     sby = sby + 1;
                     *((*f).lf.start_of_tile_row)
-                        .offset(fresh36 as isize) = 0 as libc::c_int as uint8_t;
+                        .offset(fresh34 as isize) = 0 as libc::c_int as uint8_t;
                 }
                 tile_row += 1;
             }
@@ -17826,7 +17835,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                     ) as *mut libc::c_int;
                     if ((*f).frame_thread.tile_start_off).is_null() {
                         (*f).n_ts = 0 as libc::c_int;
-                        current_block = 14580427646075712995;
+                        current_block = 13495985911605184990;
                     } else {
                         current_block = 15976848397966268834;
                     }
@@ -17834,7 +17843,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                     current_block = 15976848397966268834;
                 }
                 match current_block {
-                    14580427646075712995 => {}
+                    13495985911605184990 => {}
                     _ => {
                         dav1d_free_aligned((*f).ts as *mut libc::c_void);
                         (*f)
@@ -17844,7 +17853,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                             32 as libc::c_int as size_t,
                         ) as *mut Dav1dTileState;
                         if ((*f).ts).is_null() {
-                            current_block = 14580427646075712995;
+                            current_block = 13495985911605184990;
                         } else {
                             (*f).n_ts = n_ts;
                             current_block = 11584701595673473500;
@@ -17855,7 +17864,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                 current_block = 11584701595673473500;
             }
             match current_block {
-                14580427646075712995 => {}
+                13495985911605184990 => {}
                 _ => {
                     a_sz = (*f).sb128w * (*(*f).frame_hdr).tiling.rows
                         * (1 as libc::c_int
@@ -17873,7 +17882,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                         ) as *mut BlockContext;
                         if ((*f).a).is_null() {
                             (*f).a_sz = 0 as libc::c_int;
-                            current_block = 14580427646075712995;
+                            current_block = 13495985911605184990;
                         } else {
                             (*f).a_sz = a_sz;
                             current_block = 2232869372362427478;
@@ -17882,7 +17891,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                         current_block = 2232869372362427478;
                     }
                     match current_block {
-                        14580427646075712995 => {}
+                        13495985911605184990 => {}
                         _ => {
                             num_sb128 = (*f).sb128w * (*f).sb128h;
                             size_mul = (ss_size_mul[(*f).cur.p.layout as usize])
@@ -17905,11 +17914,11 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                             as libc::c_int) * (*f).sb_step * 4 as libc::c_int;
                                     let mut tile_col: libc::c_int = 0 as libc::c_int;
                                     while tile_col < (*(*f).frame_hdr).tiling.cols {
-                                        let fresh37 = tile_idx;
+                                        let fresh35 = tile_idx;
                                         tile_idx = tile_idx + 1;
                                         *((*f).frame_thread.tile_start_off)
                                             .offset(
-                                                fresh37 as isize,
+                                                fresh35 as isize,
                                             ) = row_off
                                             + b_diff
                                                 * (*(*f).frame_hdr).tiling.col_start_sb[tile_col as usize]
@@ -17938,7 +17947,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                     ) as *mut [[libc::c_int; 2]; 7];
                                     if ((*f).tile_thread.lowest_pixel_mem).is_null() {
                                         (*f).tile_thread.lowest_pixel_mem_sz = 0 as libc::c_int;
-                                        current_block = 14580427646075712995;
+                                        current_block = 13495985911605184990;
                                     } else {
                                         (*f).tile_thread.lowest_pixel_mem_sz = lowest_pixel_mem_sz;
                                         current_block = 10891380440665537214;
@@ -17947,7 +17956,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                     current_block = 10891380440665537214;
                                 }
                                 match current_block {
-                                    14580427646075712995 => {}
+                                    13495985911605184990 => {}
                                     _ => {
                                         let mut lowest_pixel_ptr: *mut [[libc::c_int; 2]; 7] = (*f)
                                             .tile_thread
@@ -17963,10 +17972,10 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                                     as libc::c_int;
                                             let mut tile_col_0: libc::c_int = 0 as libc::c_int;
                                             while tile_col_0 < (*(*f).frame_hdr).tiling.cols {
-                                                let ref mut fresh38 = (*((*f).ts)
+                                                let ref mut fresh36 = (*((*f).ts)
                                                     .offset((tile_row_base + tile_col_0) as isize))
                                                     .lowest_pixel;
-                                                *fresh38 = lowest_pixel_ptr;
+                                                *fresh36 = lowest_pixel_ptr;
                                                 lowest_pixel_ptr = lowest_pixel_ptr
                                                     .offset(tile_row_sb_h as isize);
                                                 tile_col_0 += 1;
@@ -17993,7 +18002,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                             );
                                             if ((*f).frame_thread.cf).is_null() {
                                                 (*f).frame_thread.cf_sz = 0 as libc::c_int;
-                                                current_block = 14580427646075712995;
+                                                current_block = 13495985911605184990;
                                             } else {
                                                 memset(
                                                     (*f).frame_thread.cf,
@@ -18010,7 +18019,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                             current_block = 10930818133215224067;
                                         }
                                         match current_block {
-                                            14580427646075712995 => {}
+                                            13495985911605184990 => {}
                                             _ => {
                                                 if (*(*f).frame_hdr).allow_screen_content_tools != 0 {
                                                     if num_sb128 != (*f).frame_thread.pal_sz {
@@ -18030,7 +18039,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                                         ) as *mut [[uint16_t; 8]; 3];
                                                         if ((*f).frame_thread.pal).is_null() {
                                                             (*f).frame_thread.pal_sz = 0 as libc::c_int;
-                                                            current_block = 14580427646075712995;
+                                                            current_block = 13495985911605184990;
                                                         } else {
                                                             (*f).frame_thread.pal_sz = num_sb128;
                                                             current_block = 8835654301469918283;
@@ -18039,7 +18048,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                                         current_block = 8835654301469918283;
                                                     }
                                                     match current_block {
-                                                        14580427646075712995 => {}
+                                                        13495985911605184990 => {}
                                                         _ => {
                                                             let pal_idx_sz: libc::c_int = num_sb128
                                                                 * *size_mul.offset(1 as libc::c_int as isize)
@@ -18061,7 +18070,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                                                 ) as *mut uint8_t;
                                                                 if ((*f).frame_thread.pal_idx).is_null() {
                                                                     (*f).frame_thread.pal_idx_sz = 0 as libc::c_int;
-                                                                    current_block = 14580427646075712995;
+                                                                    current_block = 13495985911605184990;
                                                                 } else {
                                                                     (*f).frame_thread.pal_idx_sz = pal_idx_sz;
                                                                     current_block = 7178192492338286402;
@@ -18094,7 +18103,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                 current_block = 7178192492338286402;
                             }
                             match current_block {
-                                14580427646075712995 => {}
+                                13495985911605184990 => {}
                                 _ => {
                                     y_stride = (*f).cur.stride[0 as libc::c_int as usize];
                                     uv_stride = (*f).cur.stride[1 as libc::c_int as usize];
@@ -18152,7 +18161,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                                 as usize] = (*f)
                                                 .lf
                                                 .cdef_buf_plane_sz[1 as libc::c_int as usize];
-                                            current_block = 14580427646075712995;
+                                            current_block = 13495985911605184990;
                                         } else {
                                             ptr = ptr.offset(32 as libc::c_int as isize);
                                             if y_stride < 0 as libc::c_int as libc::c_long {
@@ -18356,7 +18365,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                         current_block = 8140372313878014523;
                                     }
                                     match current_block {
-                                        14580427646075712995 => {}
+                                        13495985911605184990 => {}
                                         _ => {
                                             sb128 = (*(*f).seq_hdr).sb128;
                                             num_lines = if (*c).n_tc > 1 as libc::c_int as libc::c_uint
@@ -18408,7 +18417,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                                         as usize] = (*f)
                                                         .lf
                                                         .lr_buf_plane_sz[1 as libc::c_int as usize];
-                                                    current_block = 14580427646075712995;
+                                                    current_block = 13495985911605184990;
                                                 } else {
                                                     ptr_0 = ptr_0.offset(64 as libc::c_int as isize);
                                                     if y_stride < 0 as libc::c_int as libc::c_long {
@@ -18477,7 +18486,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                                 current_block = 15456862084301247793;
                                             }
                                             match current_block {
-                                                14580427646075712995 => {}
+                                                13495985911605184990 => {}
                                                 _ => {
                                                     if num_sb128 != (*f).lf.mask_sz {
                                                         freep(
@@ -18505,7 +18514,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                                         ) as *mut [uint8_t; 4];
                                                         if ((*f).lf.mask).is_null() || ((*f).lf.level).is_null() {
                                                             (*f).lf.mask_sz = 0 as libc::c_int;
-                                                            current_block = 14580427646075712995;
+                                                            current_block = 13495985911605184990;
                                                         } else {
                                                             if (*c).n_fc > 1 as libc::c_int as libc::c_uint {
                                                                 freep(
@@ -18536,7 +18545,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                                                     || ((*f).frame_thread.cbi).is_null()
                                                                 {
                                                                     (*f).lf.mask_sz = 0 as libc::c_int;
-                                                                    current_block = 14580427646075712995;
+                                                                    current_block = 13495985911605184990;
                                                                 } else {
                                                                     current_block = 7923086311623215889;
                                                                 }
@@ -18544,7 +18553,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                                                 current_block = 7923086311623215889;
                                                             }
                                                             match current_block {
-                                                                14580427646075712995 => {}
+                                                                13495985911605184990 => {}
                                                                 _ => {
                                                                     (*f).lf.mask_sz = num_sb128;
                                                                     current_block = 3024573345131975588;
@@ -18555,7 +18564,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                                         current_block = 3024573345131975588;
                                                     }
                                                     match current_block {
-                                                        14580427646075712995 => {}
+                                                        13495985911605184990 => {}
                                                         _ => {
                                                             (*f)
                                                                 .sr_sb128w = (*f).sr_cur.p.p.w + 127 as libc::c_int
@@ -18574,7 +18583,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                                                 ) as *mut Av1Restoration;
                                                                 if ((*f).lf.lr_mask).is_null() {
                                                                     (*f).lf.lr_mask_sz = 0 as libc::c_int;
-                                                                    current_block = 14580427646075712995;
+                                                                    current_block = 13495985911605184990;
                                                                 } else {
                                                                     (*f).lf.lr_mask_sz = lr_mask_sz;
                                                                     current_block = 16077153431071379266;
@@ -18583,7 +18592,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                                                 current_block = 16077153431071379266;
                                                             }
                                                             match current_block {
-                                                                14580427646075712995 => {}
+                                                                13495985911605184990 => {}
                                                                 _ => {
                                                                     (*f)
                                                                         .lf
@@ -18649,7 +18658,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                                                             .ipred_edge[0 as libc::c_int as usize] as *mut uint8_t;
                                                                         if ptr_1.is_null() {
                                                                             (*f).ipred_edge_sz = 0 as libc::c_int;
-                                                                            current_block = 14580427646075712995;
+                                                                            current_block = 13495985911605184990;
                                                                         } else {
                                                                             (*f)
                                                                                 .ipred_edge[1 as libc::c_int
@@ -18672,7 +18681,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                                                         current_block = 10265667325682070567;
                                                                     }
                                                                     match current_block {
-                                                                        14580427646075712995 => {}
+                                                                        13495985911605184990 => {}
                                                                         _ => {
                                                                             re_sz = (*f).sb128h * (*(*f).frame_hdr).tiling.cols;
                                                                             if re_sz != (*f).lf.re_sz {
@@ -18693,7 +18702,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                                                                     .is_null()
                                                                                 {
                                                                                     (*f).lf.re_sz = 0 as libc::c_int;
-                                                                                    current_block = 14580427646075712995;
+                                                                                    current_block = 13495985911605184990;
                                                                                 } else {
                                                                                     (*f)
                                                                                         .lf
@@ -18709,7 +18718,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                                                                 current_block = 5511877782510663281;
                                                                             }
                                                                             match current_block {
-                                                                                14580427646075712995 => {}
+                                                                                13495985911605184990 => {}
                                                                                 _ => {
                                                                                     if (*(*f).frame_hdr).frame_type as libc::c_uint
                                                                                         & 1 as libc::c_int as libc::c_uint != 0
@@ -18728,7 +18737,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                                                                             (*(*f).c).n_fc as libc::c_int,
                                                                                         );
                                                                                         if ret < 0 as libc::c_int {
-                                                                                            current_block = 14580427646075712995;
+                                                                                            current_block = 13495985911605184990;
                                                                                         } else {
                                                                                             current_block = 6662862405959679103;
                                                                                         }
@@ -18736,7 +18745,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(
                                                                                         current_block = 6662862405959679103;
                                                                                     }
                                                                                     match current_block {
-                                                                                        14580427646075712995 => {}
+                                                                                        13495985911605184990 => {}
                                                                                         _ => {
                                                                                             init_quant_tables(
                                                                                                 (*f).seq_hdr,
@@ -18954,16 +18963,16 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(
                 tile_sz = size;
             } else {
                 if (*(*f).frame_hdr).tiling.n_bytes as libc::c_ulong > size {
-                    current_block = 618511089943751067;
+                    current_block = 610192855792336318;
                     break 's_19;
                 }
                 tile_sz = 0 as libc::c_int as size_t;
                 let mut k: libc::c_uint = 0 as libc::c_int as libc::c_uint;
                 while k < (*(*f).frame_hdr).tiling.n_bytes {
-                    let fresh39 = data;
+                    let fresh37 = data;
                     data = data.offset(1);
                     tile_sz
-                        |= ((*fresh39 as libc::c_uint)
+                        |= ((*fresh37 as libc::c_uint)
                             << k.wrapping_mul(8 as libc::c_int as libc::c_uint))
                             as libc::c_ulong;
                     k = k.wrapping_add(1);
@@ -18973,11 +18982,11 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(
                     .wrapping_sub((*(*f).frame_hdr).tiling.n_bytes as libc::c_ulong)
                     as size_t as size_t;
                 if tile_sz > size {
-                    current_block = 618511089943751067;
+                    current_block = 610192855792336318;
                     break 's_19;
                 }
             }
-            let fresh40 = tile_col;
+            let fresh38 = tile_col;
             tile_col = tile_col + 1;
             setup_tile(
                 &mut *((*f).ts).offset(j as isize),
@@ -18985,7 +18994,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(
                 data,
                 tile_sz,
                 tile_row,
-                fresh40,
+                fresh38,
                 if (*c).n_fc > 1 as libc::c_int as libc::c_uint {
                     *((*f).frame_thread.tile_start_off).offset(j as isize)
                 } else {
@@ -19098,7 +19107,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_main(
                         (tile_row * (*(*f).frame_hdr).tiling.cols + tile_col) as isize,
                     ) as *mut Dav1dTileState;
                 if dav1d_decode_tile_sbrow(t) != 0 {
-                    current_block = 14882469875328183048;
+                    current_block = 3839639024989683879;
                     break 's_44;
                 }
                 tile_col += 1;
@@ -19256,9 +19265,9 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
     let mut out_delayed: *mut Dav1dThreadPicture = 0 as *mut Dav1dThreadPicture;
     if (*c).n_fc > 1 as libc::c_int as libc::c_uint {
         pthread_mutex_lock(&mut (*c).task_thread.lock);
-        let fresh41 = (*c).frame_thread.next;
+        let fresh39 = (*c).frame_thread.next;
         (*c).frame_thread.next = ((*c).frame_thread.next).wrapping_add(1);
-        let next: libc::c_uint = fresh41;
+        let next: libc::c_uint = fresh39;
         if (*c).frame_thread.next == (*c).n_fc {
             (*c).frame_thread.next = 0 as libc::c_int as libc::c_uint;
         }
@@ -19287,15 +19296,15 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                     0 as libc::c_int as libc::c_uint,
                 );
             }
-            let fresh44 = ::core::intrinsics::atomic_cxchg_seqcst_seqcst(
+            let fresh40 = ::core::intrinsics::atomic_cxchg_seqcst_seqcst(
                 &mut (*c).task_thread.reset_task_cur,
                 *&mut first,
                 (2147483647 as libc::c_int as libc::c_uint)
                     .wrapping_mul(2 as libc::c_uint)
                     .wrapping_add(1 as libc::c_uint),
             );
-            *&mut first = fresh44.0;
-            fresh44.1;
+            *&mut first = fresh40.0;
+            fresh40.1;
             if (*c).task_thread.cur != 0 && (*c).task_thread.cur < (*c).n_fc {
                 (*c).task_thread.cur = ((*c).task_thread.cur).wrapping_sub(1);
             }
@@ -19379,7 +19388,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                     8 as libc::c_int + 2 as libc::c_int * (*(*f).seq_hdr).hbd,
                 );
                 res = -(92 as libc::c_int);
-                current_block = 4753055712789169719;
+                current_block = 9123693364129885070;
             }
         }
     } else {
@@ -19583,7 +19592,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                         .is_null()
                     {
                         res = -(22 as libc::c_int);
-                        current_block = 4753055712789169719;
+                        current_block = 9123693364129885070;
                     } else {
                         current_block = 13660591889533726445;
                     }
@@ -19591,7 +19600,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                     current_block = 13660591889533726445;
                 }
                 match current_block {
-                    4753055712789169719 => {}
+                    9123693364129885070 => {}
                     _ => {
                         let mut i: libc::c_int = 0 as libc::c_int;
                         loop {
@@ -19627,7 +19636,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                                     j += 1;
                                 }
                                 res = -(22 as libc::c_int);
-                                current_block = 4753055712789169719;
+                                current_block = 9123693364129885070;
                                 break;
                             } else {
                                 dav1d_thread_picture_ref(
@@ -19697,7 +19706,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                 current_block = 14648606000749551097;
             }
             match current_block {
-                4753055712789169719 => {}
+                9123693364129885070 => {}
                 _ => {
                     if (*(*f).frame_hdr).primary_ref_frame == 7 as libc::c_int {
                         dav1d_cdf_thread_init_static(
@@ -19719,7 +19728,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                             ((*c).n_fc > 1 as libc::c_int as libc::c_uint) as libc::c_int,
                         );
                         if res < 0 as libc::c_int {
-                            current_block = 4753055712789169719;
+                            current_block = 9123693364129885070;
                         } else {
                             current_block = 16037123508100270995;
                         }
@@ -19727,7 +19736,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                         current_block = 16037123508100270995;
                     }
                     match current_block {
-                        4753055712789169719 => {}
+                        9123693364129885070 => {}
                         _ => {
                             if (*f).n_tile_data_alloc < (*c).n_tile_data {
                                 freep(
@@ -19752,7 +19761,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                                     (*f).n_tile_data = 0 as libc::c_int;
                                     (*f).n_tile_data_alloc = (*f).n_tile_data;
                                     res = -(12 as libc::c_int);
-                                    current_block = 4753055712789169719;
+                                    current_block = 9123693364129885070;
                                 } else {
                                     (*f).n_tile_data_alloc = (*c).n_tile_data;
                                     current_block = 1417769144978639029;
@@ -19761,7 +19770,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                                 current_block = 1417769144978639029;
                             }
                             match current_block {
-                                4753055712789169719 => {}
+                                9123693364129885070 => {}
                                 _ => {
                                     memcpy(
                                         (*f).tile as *mut libc::c_void,
@@ -19793,7 +19802,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                                                 &mut (*f).sr_cur.p,
                                             );
                                             if res < 0 as libc::c_int {
-                                                current_block = 4753055712789169719;
+                                                current_block = 9123693364129885070;
                                             } else {
                                                 current_block = 5409161009579131794;
                                             }
@@ -19802,7 +19811,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                                             current_block = 5409161009579131794;
                                         }
                                         match current_block {
-                                            4753055712789169719 => {}
+                                            9123693364129885070 => {}
                                             _ => {
                                                 if (*(*f).frame_hdr).width[0 as libc::c_int as usize]
                                                     != (*(*f).frame_hdr).width[1 as libc::c_int as usize]
@@ -19908,7 +19917,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                                                     );
                                                     if ((*f).mvs_ref).is_null() {
                                                         res = -(12 as libc::c_int);
-                                                        current_block = 4753055712789169719;
+                                                        current_block = 9123693364129885070;
                                                     } else {
                                                         (*f)
                                                             .mvs = (*(*f).mvs_ref).data as *mut refmvs_temporal_block;
@@ -19983,7 +19992,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                                                     current_block = 2704538829018177290;
                                                 }
                                                 match current_block {
-                                                    4753055712789169719 => {}
+                                                    9123693364129885070 => {}
                                                     _ => {
                                                         if (*(*f).frame_hdr).segmentation.enabled != 0 {
                                                             (*f).prev_segmap_ref = 0 as *mut Dav1dRef;
@@ -20030,7 +20039,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                                                                 if ((*f).cur_segmap_ref).is_null() {
                                                                     dav1d_ref_dec(&mut (*f).prev_segmap_ref);
                                                                     res = -(12 as libc::c_int);
-                                                                    current_block = 4753055712789169719;
+                                                                    current_block = 9123693364129885070;
                                                                 } else {
                                                                     (*f)
                                                                         .cur_segmap = (*(*f).cur_segmap_ref).data as *mut uint8_t;
@@ -20055,7 +20064,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                                                                 );
                                                                 if ((*f).cur_segmap_ref).is_null() {
                                                                     res = -(12 as libc::c_int);
-                                                                    current_block = 4753055712789169719;
+                                                                    current_block = 9123693364129885070;
                                                                 } else {
                                                                     (*f)
                                                                         .cur_segmap = (*(*f).cur_segmap_ref).data as *mut uint8_t;
@@ -20074,7 +20083,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                                                             current_block = 10194589593280242392;
                                                         }
                                                         match current_block {
-                                                            4753055712789169719 => {}
+                                                            9123693364129885070 => {}
                                                             _ => {
                                                                 refresh_frame_flags = (*(*f).frame_hdr).refresh_frame_flags
                                                                     as libc::c_uint;
@@ -20157,7 +20166,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                                                                             }
                                                                             i_3 += 1;
                                                                         }
-                                                                        current_block = 4753055712789169719;
+                                                                        current_block = 9123693364129885070;
                                                                     } else {
                                                                         current_block = 8115217508953982058;
                                                                     }
@@ -20167,7 +20176,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                                                                     current_block = 8115217508953982058;
                                                                 }
                                                                 match current_block {
-                                                                    4753055712789169719 => {}
+                                                                    9123693364129885070 => {}
                                                                     _ => return 0 as libc::c_int,
                                                                 }
                                                             }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,6 +1,6 @@
 use ::libc;
 use crate::src::msac::MsacContext;
-use crate::src::cdf::CdfModeContext;
+use crate::src::cdf::{CdfModeContext, CdfMvComponent};
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1579,18 +1579,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvComponent {
-    pub classes: [uint16_t; 16],
-    pub class0_fp: [[uint16_t; 4]; 2],
-    pub classN_fp: [uint16_t; 4],
-    pub class0_hp: [uint16_t; 2],
-    pub classN_hp: [uint16_t; 2],
-    pub class0: [uint16_t; 2],
-    pub classN: [[uint16_t; 2]; 10],
-    pub sign: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -3452,11 +3440,11 @@ unsafe extern "C" fn read_mv_component_diff(
     let have_hp: libc::c_int = (*(*f).frame_hdr).hp;
     let sign: libc::c_int = dav1d_msac_decode_bool_adapt(
         &mut (*ts).msac,
-        ((*mv_comp).sign).as_mut_ptr(),
+        ((*mv_comp).sign.0).as_mut_ptr(),
     ) as libc::c_int;
     let cl: libc::c_int = dav1d_msac_decode_symbol_adapt16(
         &mut (*ts).msac,
-        ((*mv_comp).classes).as_mut_ptr(),
+        ((*mv_comp).classes.0).as_mut_ptr(),
         10 as libc::c_int as size_t,
     ) as libc::c_int;
     let mut up: libc::c_int = 0;
@@ -3465,7 +3453,7 @@ unsafe extern "C" fn read_mv_component_diff(
     if cl == 0 {
         up = dav1d_msac_decode_bool_adapt(
             &mut (*ts).msac,
-            ((*mv_comp).class0).as_mut_ptr(),
+            ((*mv_comp).class0.0).as_mut_ptr(),
         ) as libc::c_int;
         if have_fp != 0 {
             fp = dav1d_msac_decode_symbol_adapt4(
@@ -3476,7 +3464,7 @@ unsafe extern "C" fn read_mv_component_diff(
             hp = (if have_hp != 0 {
                 dav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
-                    ((*mv_comp).class0_hp).as_mut_ptr(),
+                    ((*mv_comp).class0_hp.0).as_mut_ptr(),
                 )
             } else {
                 1 as libc::c_int as libc::c_uint
@@ -3499,13 +3487,13 @@ unsafe extern "C" fn read_mv_component_diff(
         if have_fp != 0 {
             fp = dav1d_msac_decode_symbol_adapt4(
                 &mut (*ts).msac,
-                ((*mv_comp).classN_fp).as_mut_ptr(),
+                ((*mv_comp).classN_fp.0).as_mut_ptr(),
                 3 as libc::c_int as size_t,
             ) as libc::c_int;
             hp = (if have_hp != 0 {
                 dav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
-                    ((*mv_comp).classN_hp).as_mut_ptr(),
+                    ((*mv_comp).classN_hp.0).as_mut_ptr(),
                 )
             } else {
                 1 as libc::c_int as libc::c_uint

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,5 +1,6 @@
 use ::libc;
 use crate::src::msac::MsacContext;
+use crate::src::cdf::CdfModeContext;
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1607,61 +1608,6 @@ pub struct CdfCoefContext {
     pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
     pub skip: [[[uint16_t; 2]; 13]; 5],
     pub dc_sign: [[[uint16_t; 2]; 3]; 2],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfModeContext {
-    pub y_mode: [[uint16_t; 16]; 4],
-    pub uv_mode: [[[uint16_t; 16]; 13]; 2],
-    pub wedge_idx: [[uint16_t; 16]; 9],
-    pub partition: [[[uint16_t; 16]; 4]; 5],
-    pub cfl_alpha: [[uint16_t; 16]; 6],
-    pub txtp_inter1: [[uint16_t; 16]; 2],
-    pub txtp_inter2: [uint16_t; 16],
-    pub txtp_intra1: [[[uint16_t; 8]; 13]; 2],
-    pub txtp_intra2: [[[uint16_t; 8]; 13]; 3],
-    pub cfl_sign: [uint16_t; 8],
-    pub angle_delta: [[uint16_t; 8]; 8],
-    pub filter_intra: [uint16_t; 8],
-    pub comp_inter_mode: [[uint16_t; 8]; 8],
-    pub seg_id: [[uint16_t; 8]; 3],
-    pub pal_sz: [[[uint16_t; 8]; 7]; 2],
-    pub color_map: [[[[uint16_t; 8]; 5]; 7]; 2],
-    pub filter: [[[uint16_t; 4]; 8]; 2],
-    pub txsz: [[[uint16_t; 4]; 3]; 4],
-    pub motion_mode: [[uint16_t; 4]; 22],
-    pub delta_q: [uint16_t; 4],
-    pub delta_lf: [[uint16_t; 4]; 5],
-    pub interintra_mode: [[uint16_t; 4]; 4],
-    pub restore_switchable: [uint16_t; 4],
-    pub restore_wiener: [uint16_t; 2],
-    pub restore_sgrproj: [uint16_t; 2],
-    pub interintra: [[uint16_t; 2]; 7],
-    pub interintra_wedge: [[uint16_t; 2]; 7],
-    pub txtp_inter3: [[uint16_t; 2]; 4],
-    pub use_filter_intra: [[uint16_t; 2]; 22],
-    pub newmv_mode: [[uint16_t; 2]; 6],
-    pub globalmv_mode: [[uint16_t; 2]; 2],
-    pub refmv_mode: [[uint16_t; 2]; 6],
-    pub drl_bit: [[uint16_t; 2]; 3],
-    pub intra: [[uint16_t; 2]; 4],
-    pub comp: [[uint16_t; 2]; 5],
-    pub comp_dir: [[uint16_t; 2]; 5],
-    pub jnt_comp: [[uint16_t; 2]; 6],
-    pub mask_comp: [[uint16_t; 2]; 6],
-    pub wedge_comp: [[uint16_t; 2]; 9],
-    pub ref_0: [[[uint16_t; 2]; 3]; 6],
-    pub comp_fwd_ref: [[[uint16_t; 2]; 3]; 3],
-    pub comp_bwd_ref: [[[uint16_t; 2]; 3]; 2],
-    pub comp_uni_ref: [[[uint16_t; 2]; 3]; 3],
-    pub txpart: [[[uint16_t; 2]; 3]; 7],
-    pub skip: [[uint16_t; 2]; 3],
-    pub skip_mode: [[uint16_t; 2]; 3],
-    pub seg_pred: [[uint16_t; 2]; 3],
-    pub obmc: [[uint16_t; 2]; 22],
-    pub pal_y: [[[uint16_t; 2]; 3]; 7],
-    pub pal_uv: [[uint16_t; 2]; 2],
-    pub intrabc: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -7596,7 +7542,7 @@ unsafe extern "C" fn decode_b(
         if have_delta_q != 0 {
             let mut delta_q: libc::c_int = dav1d_msac_decode_symbol_adapt4(
                 &mut (*ts).msac,
-                ((*ts).cdf.m.delta_q).as_mut_ptr(),
+                ((*ts).cdf.m.delta_q.0).as_mut_ptr(),
                 3 as libc::c_int as size_t,
             ) as libc::c_int;
             if delta_q == 3 as libc::c_int {
@@ -7786,7 +7732,7 @@ unsafe extern "C" fn decode_b(
         (*b)
             .intra = (dav1d_msac_decode_bool_adapt(
             &mut (*ts).msac,
-            ((*ts).cdf.m.intrabc).as_mut_ptr(),
+            ((*ts).cdf.m.intrabc.0).as_mut_ptr(),
         ) == 0) as libc::c_int as uint8_t;
         if 0 as libc::c_int != 0 && (*(*f).frame_hdr).frame_offset == 2 as libc::c_int
             && (*t).by >= 0 as libc::c_int && (*t).by < 4 as libc::c_int
@@ -7901,7 +7847,7 @@ unsafe extern "C" fn decode_b(
             {
                 let sign: libc::c_int = (dav1d_msac_decode_symbol_adapt8(
                     &mut (*ts).msac,
-                    ((*ts).cdf.m.cfl_sign).as_mut_ptr(),
+                    ((*ts).cdf.m.cfl_sign.0).as_mut_ptr(),
                     7 as libc::c_int as size_t,
                 ))
                     .wrapping_add(1 as libc::c_int as libc::c_uint) as libc::c_int;
@@ -8111,7 +8057,7 @@ unsafe extern "C" fn decode_b(
                     .c2rust_unnamed
                     .y_angle = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
-                    ((*ts).cdf.m.filter_intra).as_mut_ptr(),
+                    ((*ts).cdf.m.filter_intra.0).as_mut_ptr(),
                     4 as libc::c_int as size_t,
                 ) as int8_t;
             }
@@ -17281,7 +17227,7 @@ unsafe extern "C" fn read_restoration_info(
     {
         let filter: libc::c_int = dav1d_msac_decode_symbol_adapt4(
             &mut (*ts).msac,
-            ((*ts).cdf.m.restore_switchable).as_mut_ptr(),
+            ((*ts).cdf.m.restore_switchable.0).as_mut_ptr(),
             2 as libc::c_int as size_t,
         ) as libc::c_int;
         (*lr)
@@ -17300,9 +17246,9 @@ unsafe extern "C" fn read_restoration_info(
             if frame_type as libc::c_uint
                 == DAV1D_RESTORATION_WIENER as libc::c_int as libc::c_uint
             {
-                ((*ts).cdf.m.restore_wiener).as_mut_ptr()
+                ((*ts).cdf.m.restore_wiener.0).as_mut_ptr()
             } else {
-                ((*ts).cdf.m.restore_sgrproj).as_mut_ptr()
+                ((*ts).cdf.m.restore_sgrproj.0).as_mut_ptr()
             },
         );
         (*lr)

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,6 +1,6 @@
 use ::libc;
 use crate::src::msac::MsacContext;
-use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
+use crate::src::cdf::{CdfContext, CdfMvComponent, CdfMvContext};
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1565,21 +1565,6 @@ pub struct C2RustUnnamed_45 {
     pub row: libc::c_int,
 }
 pub type ec_win = size_t;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfContext {
-    pub m: CdfModeContext,
-    pub kfym: [[[uint16_t; 16]; 5]; 5],
-    pub coef: CdfCoefContext,
-    pub mv: CdfMvContext,
-    pub dmv: CdfMvContext,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvContext {
-    pub comp: [CdfMvComponent; 2],
-    pub joint: [uint16_t; 4],
-}
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {
@@ -3498,7 +3483,7 @@ unsafe extern "C" fn read_mv_residual(
 ) {
     match dav1d_msac_decode_symbol_adapt4(
         &mut (*(*t).ts).msac,
-        ((*(*t).ts).cdf.mv.joint).as_mut_ptr(),
+        ((*(*t).ts).cdf.mv.joint.0).as_mut_ptr(),
         (N_MV_JOINTS as libc::c_int - 1 as libc::c_int) as size_t,
     ) {
         3 => {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,4 +1,5 @@
 use ::libc;
+use crate::src::msac::MsacContext;
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1561,16 +1562,6 @@ pub struct C2RustUnnamed_45 {
     pub row_end: libc::c_int,
     pub col: libc::c_int,
     pub row: libc::c_int,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct MsacContext {
-    pub buf_pos: *const uint8_t,
-    pub buf_end: *const uint8_t,
-    pub dif: ec_win,
-    pub rng: libc::c_uint,
-    pub cnt: libc::c_int,
-    pub allow_update_cdf: libc::c_int,
 }
 pub type ec_win = size_t;
 #[derive(Copy, Clone)]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,6 +1,6 @@
 use ::libc;
 use crate::src::msac::MsacContext;
-use crate::src::cdf::{CdfModeContext, CdfMvComponent};
+use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1579,23 +1579,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfCoefContext {
-    pub eob_bin_16: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_32: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_64: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_128: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_256: [[[uint16_t; 16]; 2]; 2],
-    pub eob_bin_512: [[uint16_t; 16]; 2],
-    pub eob_bin_1024: [[uint16_t; 16]; 2],
-    pub eob_base_tok: [[[[uint16_t; 4]; 4]; 2]; 5],
-    pub base_tok: [[[[uint16_t; 4]; 41]; 2]; 5],
-    pub br_tok: [[[[uint16_t; 4]; 21]; 2]; 4],
-    pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
-    pub skip: [[[uint16_t; 2]; 13]; 5],
-    pub dc_sign: [[[uint16_t; 2]; 3]; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -1,5 +1,6 @@
 use ::libc;
 use crate::src::msac::MsacContext;
+use crate::src::cdf::CdfModeContext;
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1238,61 +1239,6 @@ pub struct CdfCoefContext {
     pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
     pub skip: [[[uint16_t; 2]; 13]; 5],
     pub dc_sign: [[[uint16_t; 2]; 3]; 2],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfModeContext {
-    pub y_mode: [[uint16_t; 16]; 4],
-    pub uv_mode: [[[uint16_t; 16]; 13]; 2],
-    pub wedge_idx: [[uint16_t; 16]; 9],
-    pub partition: [[[uint16_t; 16]; 4]; 5],
-    pub cfl_alpha: [[uint16_t; 16]; 6],
-    pub txtp_inter1: [[uint16_t; 16]; 2],
-    pub txtp_inter2: [uint16_t; 16],
-    pub txtp_intra1: [[[uint16_t; 8]; 13]; 2],
-    pub txtp_intra2: [[[uint16_t; 8]; 13]; 3],
-    pub cfl_sign: [uint16_t; 8],
-    pub angle_delta: [[uint16_t; 8]; 8],
-    pub filter_intra: [uint16_t; 8],
-    pub comp_inter_mode: [[uint16_t; 8]; 8],
-    pub seg_id: [[uint16_t; 8]; 3],
-    pub pal_sz: [[[uint16_t; 8]; 7]; 2],
-    pub color_map: [[[[uint16_t; 8]; 5]; 7]; 2],
-    pub filter: [[[uint16_t; 4]; 8]; 2],
-    pub txsz: [[[uint16_t; 4]; 3]; 4],
-    pub motion_mode: [[uint16_t; 4]; 22],
-    pub delta_q: [uint16_t; 4],
-    pub delta_lf: [[uint16_t; 4]; 5],
-    pub interintra_mode: [[uint16_t; 4]; 4],
-    pub restore_switchable: [uint16_t; 4],
-    pub restore_wiener: [uint16_t; 2],
-    pub restore_sgrproj: [uint16_t; 2],
-    pub interintra: [[uint16_t; 2]; 7],
-    pub interintra_wedge: [[uint16_t; 2]; 7],
-    pub txtp_inter3: [[uint16_t; 2]; 4],
-    pub use_filter_intra: [[uint16_t; 2]; 22],
-    pub newmv_mode: [[uint16_t; 2]; 6],
-    pub globalmv_mode: [[uint16_t; 2]; 2],
-    pub refmv_mode: [[uint16_t; 2]; 6],
-    pub drl_bit: [[uint16_t; 2]; 3],
-    pub intra: [[uint16_t; 2]; 4],
-    pub comp: [[uint16_t; 2]; 5],
-    pub comp_dir: [[uint16_t; 2]; 5],
-    pub jnt_comp: [[uint16_t; 2]; 6],
-    pub mask_comp: [[uint16_t; 2]; 6],
-    pub wedge_comp: [[uint16_t; 2]; 9],
-    pub ref_0: [[[uint16_t; 2]; 3]; 6],
-    pub comp_fwd_ref: [[[uint16_t; 2]; 3]; 3],
-    pub comp_bwd_ref: [[[uint16_t; 2]; 3]; 2],
-    pub comp_uni_ref: [[[uint16_t; 2]; 3]; 3],
-    pub txpart: [[[uint16_t; 2]; 3]; 7],
-    pub skip: [[uint16_t; 2]; 3],
-    pub skip_mode: [[uint16_t; 2]; 3],
-    pub seg_pred: [[uint16_t; 2]; 3],
-    pub obmc: [[uint16_t; 2]; 22],
-    pub pal_y: [[[uint16_t; 2]; 3]; 7],
-    pub pal_uv: [[uint16_t; 2]; 2],
-    pub intrabc: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -1,6 +1,6 @@
 use ::libc;
 use crate::src::msac::MsacContext;
-use crate::src::cdf::CdfModeContext;
+use crate::src::cdf::{CdfModeContext, CdfMvComponent};
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1210,18 +1210,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvComponent {
-    pub classes: [uint16_t; 16],
-    pub class0_fp: [[uint16_t; 4]; 2],
-    pub classN_fp: [uint16_t; 4],
-    pub class0_hp: [uint16_t; 2],
-    pub classN_hp: [uint16_t; 2],
-    pub class0: [uint16_t; 2],
-    pub classN: [[uint16_t; 2]; 10],
-    pub sign: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
+use crate::src::cdf::CdfContext;
 use crate::src::msac::MsacContext;
 extern "C" {
     fn memcpy(
@@ -1196,21 +1196,6 @@ pub struct C2RustUnnamed_45 {
     pub row: libc::c_int,
 }
 pub type ec_win = size_t;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfContext {
-    pub m: CdfModeContext,
-    pub kfym: [[[uint16_t; 16]; 5]; 5],
-    pub coef: CdfCoefContext,
-    pub mv: CdfMvContext,
-    pub dmv: CdfMvContext,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvContext {
-    pub comp: [CdfMvComponent; 2],
-    pub joint: [uint16_t; 4],
-}
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -1,4 +1,5 @@
 use ::libc;
+use crate::src::msac::MsacContext;
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1192,16 +1193,6 @@ pub struct C2RustUnnamed_45 {
     pub row_end: libc::c_int,
     pub col: libc::c_int,
     pub row: libc::c_int,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct MsacContext {
-    pub buf_pos: *const uint8_t,
-    pub buf_end: *const uint8_t,
-    pub dif: ec_win,
-    pub rng: libc::c_uint,
-    pub cnt: libc::c_int,
-    pub allow_update_cdf: libc::c_int,
 }
 pub type ec_win = size_t;
 #[derive(Copy, Clone)]

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -1,6 +1,6 @@
 use ::libc;
+use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
 use crate::src::msac::MsacContext;
-use crate::src::cdf::{CdfModeContext, CdfMvComponent};
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1210,23 +1210,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfCoefContext {
-    pub eob_bin_16: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_32: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_64: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_128: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_256: [[[uint16_t; 16]; 2]; 2],
-    pub eob_bin_512: [[uint16_t; 16]; 2],
-    pub eob_bin_1024: [[uint16_t; 16]; 2],
-    pub eob_base_tok: [[[[uint16_t; 4]; 4]; 2]; 5],
-    pub base_tok: [[[[uint16_t; 4]; 41]; 2]; 5],
-    pub br_tok: [[[[uint16_t; 4]; 21]; 2]; 4],
-    pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
-    pub skip: [[[uint16_t; 2]; 13]; 5],
-    pub dc_sign: [[[uint16_t; 2]; 3]; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -1,5 +1,6 @@
 use ::libc;
 use crate::src::msac::MsacContext;
+use crate::src::cdf::CdfModeContext;
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1238,61 +1239,6 @@ pub struct CdfCoefContext {
     pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
     pub skip: [[[uint16_t; 2]; 13]; 5],
     pub dc_sign: [[[uint16_t; 2]; 3]; 2],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfModeContext {
-    pub y_mode: [[uint16_t; 16]; 4],
-    pub uv_mode: [[[uint16_t; 16]; 13]; 2],
-    pub wedge_idx: [[uint16_t; 16]; 9],
-    pub partition: [[[uint16_t; 16]; 4]; 5],
-    pub cfl_alpha: [[uint16_t; 16]; 6],
-    pub txtp_inter1: [[uint16_t; 16]; 2],
-    pub txtp_inter2: [uint16_t; 16],
-    pub txtp_intra1: [[[uint16_t; 8]; 13]; 2],
-    pub txtp_intra2: [[[uint16_t; 8]; 13]; 3],
-    pub cfl_sign: [uint16_t; 8],
-    pub angle_delta: [[uint16_t; 8]; 8],
-    pub filter_intra: [uint16_t; 8],
-    pub comp_inter_mode: [[uint16_t; 8]; 8],
-    pub seg_id: [[uint16_t; 8]; 3],
-    pub pal_sz: [[[uint16_t; 8]; 7]; 2],
-    pub color_map: [[[[uint16_t; 8]; 5]; 7]; 2],
-    pub filter: [[[uint16_t; 4]; 8]; 2],
-    pub txsz: [[[uint16_t; 4]; 3]; 4],
-    pub motion_mode: [[uint16_t; 4]; 22],
-    pub delta_q: [uint16_t; 4],
-    pub delta_lf: [[uint16_t; 4]; 5],
-    pub interintra_mode: [[uint16_t; 4]; 4],
-    pub restore_switchable: [uint16_t; 4],
-    pub restore_wiener: [uint16_t; 2],
-    pub restore_sgrproj: [uint16_t; 2],
-    pub interintra: [[uint16_t; 2]; 7],
-    pub interintra_wedge: [[uint16_t; 2]; 7],
-    pub txtp_inter3: [[uint16_t; 2]; 4],
-    pub use_filter_intra: [[uint16_t; 2]; 22],
-    pub newmv_mode: [[uint16_t; 2]; 6],
-    pub globalmv_mode: [[uint16_t; 2]; 2],
-    pub refmv_mode: [[uint16_t; 2]; 6],
-    pub drl_bit: [[uint16_t; 2]; 3],
-    pub intra: [[uint16_t; 2]; 4],
-    pub comp: [[uint16_t; 2]; 5],
-    pub comp_dir: [[uint16_t; 2]; 5],
-    pub jnt_comp: [[uint16_t; 2]; 6],
-    pub mask_comp: [[uint16_t; 2]; 6],
-    pub wedge_comp: [[uint16_t; 2]; 9],
-    pub ref_0: [[[uint16_t; 2]; 3]; 6],
-    pub comp_fwd_ref: [[[uint16_t; 2]; 3]; 3],
-    pub comp_bwd_ref: [[[uint16_t; 2]; 3]; 2],
-    pub comp_uni_ref: [[[uint16_t; 2]; 3]; 3],
-    pub txpart: [[[uint16_t; 2]; 3]; 7],
-    pub skip: [[uint16_t; 2]; 3],
-    pub skip_mode: [[uint16_t; 2]; 3],
-    pub seg_pred: [[uint16_t; 2]; 3],
-    pub obmc: [[uint16_t; 2]; 22],
-    pub pal_y: [[[uint16_t; 2]; 3]; 7],
-    pub pal_uv: [[uint16_t; 2]; 2],
-    pub intrabc: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -1,6 +1,6 @@
 use ::libc;
 use crate::src::msac::MsacContext;
-use crate::src::cdf::CdfModeContext;
+use crate::src::cdf::{CdfModeContext, CdfMvComponent};
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1210,18 +1210,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvComponent {
-    pub classes: [uint16_t; 16],
-    pub class0_fp: [[uint16_t; 4]; 2],
-    pub classN_fp: [uint16_t; 4],
-    pub class0_hp: [uint16_t; 2],
-    pub classN_hp: [uint16_t; 2],
-    pub class0: [uint16_t; 2],
-    pub classN: [[uint16_t; 2]; 10],
-    pub sign: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
+use crate::src::cdf::CdfContext;
 use crate::src::msac::MsacContext;
 extern "C" {
     fn memcpy(
@@ -1196,21 +1196,6 @@ pub struct C2RustUnnamed_45 {
     pub row: libc::c_int,
 }
 pub type ec_win = size_t;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfContext {
-    pub m: CdfModeContext,
-    pub kfym: [[[uint16_t; 16]; 5]; 5],
-    pub coef: CdfCoefContext,
-    pub mv: CdfMvContext,
-    pub dmv: CdfMvContext,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvContext {
-    pub comp: [CdfMvComponent; 2],
-    pub joint: [uint16_t; 4],
-}
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -1,4 +1,5 @@
 use ::libc;
+use crate::src::msac::MsacContext;
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1192,16 +1193,6 @@ pub struct C2RustUnnamed_45 {
     pub row_end: libc::c_int,
     pub col: libc::c_int,
     pub row: libc::c_int,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct MsacContext {
-    pub buf_pos: *const uint8_t,
-    pub buf_end: *const uint8_t,
-    pub dif: ec_win,
-    pub rng: libc::c_uint,
-    pub cnt: libc::c_int,
-    pub allow_update_cdf: libc::c_int,
 }
 pub type ec_win = size_t;
 #[derive(Copy, Clone)]

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -1,6 +1,6 @@
 use ::libc;
+use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
 use crate::src::msac::MsacContext;
-use crate::src::cdf::{CdfModeContext, CdfMvComponent};
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1210,23 +1210,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfCoefContext {
-    pub eob_bin_16: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_32: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_64: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_128: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_256: [[[uint16_t; 16]; 2]; 2],
-    pub eob_bin_512: [[uint16_t; 16]; 2],
-    pub eob_bin_1024: [[uint16_t; 16]; 2],
-    pub eob_base_tok: [[[[uint16_t; 4]; 4]; 2]; 5],
-    pub base_tok: [[[[uint16_t; 4]; 41]; 2]; 5],
-    pub br_tok: [[[[uint16_t; 4]; 21]; 2]; 4],
-    pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
-    pub skip: [[[uint16_t; 2]; 13]; 5],
-    pub dc_sign: [[[uint16_t; 2]; 3]; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2233,7 +2233,7 @@ unsafe extern "C" fn init_internal() {
 #[no_mangle]
 #[cold]
 pub unsafe extern "C" fn dav1d_version() -> *const libc::c_char {
-    return b"1.0.0-116-ge219a79\0" as *const u8 as *const libc::c_char;
+    return b"1.0.0-130-g26eca15\0" as *const u8 as *const libc::c_char;
 }
 #[no_mangle]
 #[cold]
@@ -3115,15 +3115,15 @@ unsafe extern "C" fn drain_picture(
                 0 as libc::c_int as libc::c_uint,
             );
         }
-        let fresh2 = ::core::intrinsics::atomic_cxchg_seqcst_seqcst(
+        let fresh0 = ::core::intrinsics::atomic_cxchg_seqcst_seqcst(
             &mut (*c).task_thread.reset_task_cur,
             *&mut first,
             (2147483647 as libc::c_int as libc::c_uint)
                 .wrapping_mul(2 as libc::c_uint)
                 .wrapping_add(1 as libc::c_uint),
         );
-        *&mut first = fresh2.0;
-        fresh2.1;
+        *&mut first = fresh0.0;
+        fresh0.1;
         if (*c).task_thread.cur != 0 && (*c).task_thread.cur < (*c).n_fc {
             (*c).task_thread.cur = ((*c).task_thread.cur).wrapping_sub(1);
         }
@@ -3466,24 +3466,24 @@ pub unsafe extern "C" fn dav1d_flush(c: *mut Dav1dContext) {
         }
         let mut i_1: libc::c_uint = 0 as libc::c_int as libc::c_uint;
         while i_1 < (*c).n_fc {
-            let ref mut fresh3 = (*((*c).fc).offset(i_1 as isize)).task_thread.task_head;
-            *fresh3 = 0 as *mut Dav1dTask;
-            let ref mut fresh4 = (*((*c).fc).offset(i_1 as isize)).task_thread.task_tail;
-            *fresh4 = 0 as *mut Dav1dTask;
-            let ref mut fresh5 = (*((*c).fc).offset(i_1 as isize))
+            let ref mut fresh1 = (*((*c).fc).offset(i_1 as isize)).task_thread.task_head;
+            *fresh1 = 0 as *mut Dav1dTask;
+            let ref mut fresh2 = (*((*c).fc).offset(i_1 as isize)).task_thread.task_tail;
+            *fresh2 = 0 as *mut Dav1dTask;
+            let ref mut fresh3 = (*((*c).fc).offset(i_1 as isize))
                 .task_thread
                 .task_cur_prev;
-            *fresh5 = 0 as *mut Dav1dTask;
-            let ref mut fresh6 = (*((*c).fc).offset(i_1 as isize))
+            *fresh3 = 0 as *mut Dav1dTask;
+            let ref mut fresh4 = (*((*c).fc).offset(i_1 as isize))
                 .task_thread
                 .pending_tasks
                 .head;
-            *fresh6 = 0 as *mut Dav1dTask;
-            let ref mut fresh7 = (*((*c).fc).offset(i_1 as isize))
+            *fresh4 = 0 as *mut Dav1dTask;
+            let ref mut fresh5 = (*((*c).fc).offset(i_1 as isize))
                 .task_thread
                 .pending_tasks
                 .tail;
-            *fresh7 = 0 as *mut Dav1dTask;
+            *fresh5 = 0 as *mut Dav1dTask;
             *&mut (*((*c).fc).offset(i_1 as isize))
                 .task_thread
                 .pending_tasks

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use ::libc;
 use crate::src::msac::MsacContext;
+use crate::src::cdf::CdfModeContext;
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
@@ -1356,61 +1357,6 @@ pub struct CdfCoefContext {
     pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
     pub skip: [[[uint16_t; 2]; 13]; 5],
     pub dc_sign: [[[uint16_t; 2]; 3]; 2],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfModeContext {
-    pub y_mode: [[uint16_t; 16]; 4],
-    pub uv_mode: [[[uint16_t; 16]; 13]; 2],
-    pub wedge_idx: [[uint16_t; 16]; 9],
-    pub partition: [[[uint16_t; 16]; 4]; 5],
-    pub cfl_alpha: [[uint16_t; 16]; 6],
-    pub txtp_inter1: [[uint16_t; 16]; 2],
-    pub txtp_inter2: [uint16_t; 16],
-    pub txtp_intra1: [[[uint16_t; 8]; 13]; 2],
-    pub txtp_intra2: [[[uint16_t; 8]; 13]; 3],
-    pub cfl_sign: [uint16_t; 8],
-    pub angle_delta: [[uint16_t; 8]; 8],
-    pub filter_intra: [uint16_t; 8],
-    pub comp_inter_mode: [[uint16_t; 8]; 8],
-    pub seg_id: [[uint16_t; 8]; 3],
-    pub pal_sz: [[[uint16_t; 8]; 7]; 2],
-    pub color_map: [[[[uint16_t; 8]; 5]; 7]; 2],
-    pub filter: [[[uint16_t; 4]; 8]; 2],
-    pub txsz: [[[uint16_t; 4]; 3]; 4],
-    pub motion_mode: [[uint16_t; 4]; 22],
-    pub delta_q: [uint16_t; 4],
-    pub delta_lf: [[uint16_t; 4]; 5],
-    pub interintra_mode: [[uint16_t; 4]; 4],
-    pub restore_switchable: [uint16_t; 4],
-    pub restore_wiener: [uint16_t; 2],
-    pub restore_sgrproj: [uint16_t; 2],
-    pub interintra: [[uint16_t; 2]; 7],
-    pub interintra_wedge: [[uint16_t; 2]; 7],
-    pub txtp_inter3: [[uint16_t; 2]; 4],
-    pub use_filter_intra: [[uint16_t; 2]; 22],
-    pub newmv_mode: [[uint16_t; 2]; 6],
-    pub globalmv_mode: [[uint16_t; 2]; 2],
-    pub refmv_mode: [[uint16_t; 2]; 6],
-    pub drl_bit: [[uint16_t; 2]; 3],
-    pub intra: [[uint16_t; 2]; 4],
-    pub comp: [[uint16_t; 2]; 5],
-    pub comp_dir: [[uint16_t; 2]; 5],
-    pub jnt_comp: [[uint16_t; 2]; 6],
-    pub mask_comp: [[uint16_t; 2]; 6],
-    pub wedge_comp: [[uint16_t; 2]; 9],
-    pub ref_0: [[[uint16_t; 2]; 3]; 6],
-    pub comp_fwd_ref: [[[uint16_t; 2]; 3]; 3],
-    pub comp_bwd_ref: [[[uint16_t; 2]; 3]; 2],
-    pub comp_uni_ref: [[[uint16_t; 2]; 3]; 3],
-    pub txpart: [[[uint16_t; 2]; 3]; 7],
-    pub skip: [[uint16_t; 2]; 3],
-    pub skip_mode: [[uint16_t; 2]; 3],
-    pub seg_pred: [[uint16_t; 2]; 3],
-    pub obmc: [[uint16_t; 2]; 22],
-    pub pal_y: [[[uint16_t; 2]; 3]; 7],
-    pub pal_uv: [[uint16_t; 2]; 2],
-    pub intrabc: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use ::libc;
+use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
 use crate::src::msac::MsacContext;
-use crate::src::cdf::{CdfModeContext, CdfMvComponent};
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
@@ -1328,23 +1328,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfCoefContext {
-    pub eob_bin_16: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_32: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_64: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_128: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_256: [[[uint16_t; 16]; 2]; 2],
-    pub eob_bin_512: [[uint16_t; 16]; 2],
-    pub eob_bin_1024: [[uint16_t; 16]; 2],
-    pub eob_base_tok: [[[[uint16_t; 4]; 4]; 2]; 5],
-    pub base_tok: [[[[uint16_t; 4]; 41]; 2]; 5],
-    pub br_tok: [[[[uint16_t; 4]; 21]; 2]; 4],
-    pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
-    pub skip: [[[uint16_t; 2]; 13]; 5],
-    pub dc_sign: [[[uint16_t; 2]; 3]; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use ::libc;
 use crate::src::msac::MsacContext;
-use crate::src::cdf::CdfModeContext;
+use crate::src::cdf::{CdfModeContext, CdfMvComponent};
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
@@ -1328,18 +1328,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvComponent {
-    pub classes: [uint16_t; 16],
-    pub class0_fp: [[uint16_t; 4]; 2],
-    pub classN_fp: [uint16_t; 4],
-    pub class0_hp: [uint16_t; 2],
-    pub classN_hp: [uint16_t; 2],
-    pub class0: [uint16_t; 2],
-    pub classN: [[uint16_t; 2]; 10],
-    pub sign: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
+use crate::src::cdf::CdfContext;
 use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
@@ -1313,21 +1313,6 @@ pub type atomic_uint = libc::c_uint;
 pub union C2RustUnnamed_15 {
     pub cdf: *mut CdfContext,
     pub qcat: libc::c_uint,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfContext {
-    pub m: CdfModeContext,
-    pub kfym: [[[uint16_t; 16]; 5]; 5],
-    pub coef: CdfCoefContext,
-    pub mv: CdfMvContext,
-    pub dmv: CdfMvContext,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvContext {
-    pub comp: [CdfMvComponent; 2],
-    pub joint: [uint16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 use ::libc;
+use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
@@ -1785,16 +1786,6 @@ pub struct C2RustUnnamed_39 {
     pub row_end: libc::c_int,
     pub col: libc::c_int,
     pub row: libc::c_int,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct MsacContext {
-    pub buf_pos: *const uint8_t,
-    pub buf_end: *const uint8_t,
-    pub dif: ec_win,
-    pub rng: libc::c_uint,
-    pub cnt: libc::c_int,
-    pub allow_update_cdf: libc::c_int,
 }
 pub type ec_win = size_t;
 #[derive(Copy, Clone)]

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,4 +1,5 @@
 use ::libc;
+use crate::src::cdf::CdfModeContext;
 use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
@@ -1242,61 +1243,6 @@ pub struct CdfCoefContext {
     pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
     pub skip: [[[uint16_t; 2]; 13]; 5],
     pub dc_sign: [[[uint16_t; 2]; 3]; 2],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfModeContext {
-    pub y_mode: [[uint16_t; 16]; 4],
-    pub uv_mode: [[[uint16_t; 16]; 13]; 2],
-    pub wedge_idx: [[uint16_t; 16]; 9],
-    pub partition: [[[uint16_t; 16]; 4]; 5],
-    pub cfl_alpha: [[uint16_t; 16]; 6],
-    pub txtp_inter1: [[uint16_t; 16]; 2],
-    pub txtp_inter2: [uint16_t; 16],
-    pub txtp_intra1: [[[uint16_t; 8]; 13]; 2],
-    pub txtp_intra2: [[[uint16_t; 8]; 13]; 3],
-    pub cfl_sign: [uint16_t; 8],
-    pub angle_delta: [[uint16_t; 8]; 8],
-    pub filter_intra: [uint16_t; 8],
-    pub comp_inter_mode: [[uint16_t; 8]; 8],
-    pub seg_id: [[uint16_t; 8]; 3],
-    pub pal_sz: [[[uint16_t; 8]; 7]; 2],
-    pub color_map: [[[[uint16_t; 8]; 5]; 7]; 2],
-    pub filter: [[[uint16_t; 4]; 8]; 2],
-    pub txsz: [[[uint16_t; 4]; 3]; 4],
-    pub motion_mode: [[uint16_t; 4]; 22],
-    pub delta_q: [uint16_t; 4],
-    pub delta_lf: [[uint16_t; 4]; 5],
-    pub interintra_mode: [[uint16_t; 4]; 4],
-    pub restore_switchable: [uint16_t; 4],
-    pub restore_wiener: [uint16_t; 2],
-    pub restore_sgrproj: [uint16_t; 2],
-    pub interintra: [[uint16_t; 2]; 7],
-    pub interintra_wedge: [[uint16_t; 2]; 7],
-    pub txtp_inter3: [[uint16_t; 2]; 4],
-    pub use_filter_intra: [[uint16_t; 2]; 22],
-    pub newmv_mode: [[uint16_t; 2]; 6],
-    pub globalmv_mode: [[uint16_t; 2]; 2],
-    pub refmv_mode: [[uint16_t; 2]; 6],
-    pub drl_bit: [[uint16_t; 2]; 3],
-    pub intra: [[uint16_t; 2]; 4],
-    pub comp: [[uint16_t; 2]; 5],
-    pub comp_dir: [[uint16_t; 2]; 5],
-    pub jnt_comp: [[uint16_t; 2]; 6],
-    pub mask_comp: [[uint16_t; 2]; 6],
-    pub wedge_comp: [[uint16_t; 2]; 9],
-    pub ref_0: [[[uint16_t; 2]; 3]; 6],
-    pub comp_fwd_ref: [[[uint16_t; 2]; 3]; 3],
-    pub comp_bwd_ref: [[[uint16_t; 2]; 3]; 2],
-    pub comp_uni_ref: [[[uint16_t; 2]; 3]; 3],
-    pub txpart: [[[uint16_t; 2]; 3]; 7],
-    pub skip: [[uint16_t; 2]; 3],
-    pub skip_mode: [[uint16_t; 2]; 3],
-    pub seg_pred: [[uint16_t; 2]; 3],
-    pub obmc: [[uint16_t; 2]; 22],
-    pub pal_y: [[[uint16_t; 2]; 3]; 7],
-    pub pal_uv: [[uint16_t; 2]; 2],
-    pub intrabc: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,4 +1,5 @@
 use ::libc;
+use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
@@ -1671,16 +1672,6 @@ pub struct C2RustUnnamed_39 {
     pub row_end: libc::c_int,
     pub col: libc::c_int,
     pub row: libc::c_int,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct MsacContext {
-    pub buf_pos: *const uint8_t,
-    pub buf_end: *const uint8_t,
-    pub dif: ec_win,
-    pub rng: libc::c_uint,
-    pub cnt: libc::c_int,
-    pub allow_update_cdf: libc::c_int,
 }
 pub type ec_win = size_t;
 #[derive(Copy, Clone)]

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
+use crate::src::cdf::CdfContext;
 use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
@@ -1199,21 +1199,6 @@ pub type atomic_uint = libc::c_uint;
 pub union C2RustUnnamed_15 {
     pub cdf: *mut CdfContext,
     pub qcat: libc::c_uint,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfContext {
-    pub m: CdfModeContext,
-    pub kfym: [[[uint16_t; 16]; 5]; 5],
-    pub coef: CdfCoefContext,
-    pub mv: CdfMvContext,
-    pub dmv: CdfMvContext,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvContext {
-    pub comp: [CdfMvComponent; 2],
-    pub joint: [uint16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::CdfModeContext;
+use crate::src::cdf::{CdfModeContext, CdfMvComponent};
 use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
@@ -1214,18 +1214,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvComponent {
-    pub classes: [uint16_t; 16],
-    pub class0_fp: [[uint16_t; 4]; 2],
-    pub classN_fp: [uint16_t; 4],
-    pub class0_hp: [uint16_t; 2],
-    pub classN_hp: [uint16_t; 2],
-    pub class0: [uint16_t; 2],
-    pub classN: [[uint16_t; 2]; 10],
-    pub sign: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::{CdfModeContext, CdfMvComponent};
+use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
 use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
@@ -1214,23 +1214,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfCoefContext {
-    pub eob_bin_16: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_32: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_64: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_128: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_256: [[[uint16_t; 16]; 2]; 2],
-    pub eob_bin_512: [[uint16_t; 16]; 2],
-    pub eob_bin_1024: [[uint16_t; 16]; 2],
-    pub eob_base_tok: [[[[uint16_t; 4]; 4]; 2]; 5],
-    pub base_tok: [[[[uint16_t; 4]; 41]; 2]; 5],
-    pub br_tok: [[[[uint16_t; 4]; 21]; 2]; 4],
-    pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
-    pub skip: [[[uint16_t; 2]; 13]; 5],
-    pub dc_sign: [[[uint16_t; 2]; 3]; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::CdfModeContext;
+use crate::src::cdf::{CdfModeContext, CdfMvComponent};
 use crate::src::msac::MsacContext;
 extern "C" {
     fn memcpy(
@@ -1211,18 +1211,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvComponent {
-    pub classes: [uint16_t; 16],
-    pub class0_fp: [[uint16_t; 4]; 2],
-    pub classN_fp: [uint16_t; 4],
-    pub class0_hp: [uint16_t; 2],
-    pub classN_hp: [uint16_t; 2],
-    pub class0: [uint16_t; 2],
-    pub classN: [[uint16_t; 2]; 10],
-    pub sign: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -1,4 +1,5 @@
 use ::libc;
+use crate::src::msac::MsacContext;
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1193,16 +1194,6 @@ pub struct C2RustUnnamed_45 {
     pub row_end: libc::c_int,
     pub col: libc::c_int,
     pub row: libc::c_int,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct MsacContext {
-    pub buf_pos: *const uint8_t,
-    pub buf_end: *const uint8_t,
-    pub dif: ec_win,
-    pub rng: libc::c_uint,
-    pub cnt: libc::c_int,
-    pub allow_update_cdf: libc::c_int,
 }
 pub type ec_win = size_t;
 #[derive(Copy, Clone)]

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
+use crate::src::cdf::CdfContext;
 use crate::src::msac::MsacContext;
 extern "C" {
     fn memcpy(
@@ -1197,21 +1197,6 @@ pub struct C2RustUnnamed_45 {
     pub row: libc::c_int,
 }
 pub type ec_win = size_t;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfContext {
-    pub m: CdfModeContext,
-    pub kfym: [[[uint16_t; 16]; 5]; 5],
-    pub coef: CdfCoefContext,
-    pub mv: CdfMvContext,
-    pub dmv: CdfMvContext,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvContext {
-    pub comp: [CdfMvComponent; 2],
-    pub joint: [uint16_t; 4],
-}
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -1,4 +1,5 @@
 use ::libc;
+use crate::src::cdf::CdfModeContext;
 use crate::src::msac::MsacContext;
 extern "C" {
     fn memcpy(
@@ -1239,61 +1240,6 @@ pub struct CdfCoefContext {
     pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
     pub skip: [[[uint16_t; 2]; 13]; 5],
     pub dc_sign: [[[uint16_t; 2]; 3]; 2],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfModeContext {
-    pub y_mode: [[uint16_t; 16]; 4],
-    pub uv_mode: [[[uint16_t; 16]; 13]; 2],
-    pub wedge_idx: [[uint16_t; 16]; 9],
-    pub partition: [[[uint16_t; 16]; 4]; 5],
-    pub cfl_alpha: [[uint16_t; 16]; 6],
-    pub txtp_inter1: [[uint16_t; 16]; 2],
-    pub txtp_inter2: [uint16_t; 16],
-    pub txtp_intra1: [[[uint16_t; 8]; 13]; 2],
-    pub txtp_intra2: [[[uint16_t; 8]; 13]; 3],
-    pub cfl_sign: [uint16_t; 8],
-    pub angle_delta: [[uint16_t; 8]; 8],
-    pub filter_intra: [uint16_t; 8],
-    pub comp_inter_mode: [[uint16_t; 8]; 8],
-    pub seg_id: [[uint16_t; 8]; 3],
-    pub pal_sz: [[[uint16_t; 8]; 7]; 2],
-    pub color_map: [[[[uint16_t; 8]; 5]; 7]; 2],
-    pub filter: [[[uint16_t; 4]; 8]; 2],
-    pub txsz: [[[uint16_t; 4]; 3]; 4],
-    pub motion_mode: [[uint16_t; 4]; 22],
-    pub delta_q: [uint16_t; 4],
-    pub delta_lf: [[uint16_t; 4]; 5],
-    pub interintra_mode: [[uint16_t; 4]; 4],
-    pub restore_switchable: [uint16_t; 4],
-    pub restore_wiener: [uint16_t; 2],
-    pub restore_sgrproj: [uint16_t; 2],
-    pub interintra: [[uint16_t; 2]; 7],
-    pub interintra_wedge: [[uint16_t; 2]; 7],
-    pub txtp_inter3: [[uint16_t; 2]; 4],
-    pub use_filter_intra: [[uint16_t; 2]; 22],
-    pub newmv_mode: [[uint16_t; 2]; 6],
-    pub globalmv_mode: [[uint16_t; 2]; 2],
-    pub refmv_mode: [[uint16_t; 2]; 6],
-    pub drl_bit: [[uint16_t; 2]; 3],
-    pub intra: [[uint16_t; 2]; 4],
-    pub comp: [[uint16_t; 2]; 5],
-    pub comp_dir: [[uint16_t; 2]; 5],
-    pub jnt_comp: [[uint16_t; 2]; 6],
-    pub mask_comp: [[uint16_t; 2]; 6],
-    pub wedge_comp: [[uint16_t; 2]; 9],
-    pub ref_0: [[[uint16_t; 2]; 3]; 6],
-    pub comp_fwd_ref: [[[uint16_t; 2]; 3]; 3],
-    pub comp_bwd_ref: [[[uint16_t; 2]; 3]; 2],
-    pub comp_uni_ref: [[[uint16_t; 2]; 3]; 3],
-    pub txpart: [[[uint16_t; 2]; 3]; 7],
-    pub skip: [[uint16_t; 2]; 3],
-    pub skip_mode: [[uint16_t; 2]; 3],
-    pub seg_pred: [[uint16_t; 2]; 3],
-    pub obmc: [[uint16_t; 2]; 22],
-    pub pal_y: [[[uint16_t; 2]; 3]; 7],
-    pub pal_uv: [[uint16_t; 2]; 2],
-    pub intrabc: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::{CdfModeContext, CdfMvComponent};
+use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
 use crate::src::msac::MsacContext;
 extern "C" {
     fn memcpy(
@@ -1211,23 +1211,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfCoefContext {
-    pub eob_bin_16: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_32: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_64: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_128: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_256: [[[uint16_t; 16]; 2]; 2],
-    pub eob_bin_512: [[uint16_t; 16]; 2],
-    pub eob_bin_1024: [[uint16_t; 16]; 2],
-    pub eob_base_tok: [[[[uint16_t; 4]; 4]; 2]; 5],
-    pub base_tok: [[[[uint16_t; 4]; 41]; 2]; 5],
-    pub br_tok: [[[[uint16_t; 4]; 21]; 2]; 4],
-    pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
-    pub skip: [[[uint16_t; 2]; 13]; 5],
-    pub dc_sign: [[[uint16_t; 2]; 3]; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::CdfModeContext;
+use crate::src::cdf::{CdfModeContext, CdfMvComponent};
 use crate::src::msac::MsacContext;
 extern "C" {
     fn memcpy(
@@ -1211,18 +1211,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvComponent {
-    pub classes: [uint16_t; 16],
-    pub class0_fp: [[uint16_t; 4]; 2],
-    pub classN_fp: [uint16_t; 4],
-    pub class0_hp: [uint16_t; 2],
-    pub classN_hp: [uint16_t; 2],
-    pub class0: [uint16_t; 2],
-    pub classN: [[uint16_t; 2]; 10],
-    pub sign: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -1,4 +1,5 @@
 use ::libc;
+use crate::src::msac::MsacContext;
 extern "C" {
     fn memcpy(
         _: *mut libc::c_void,
@@ -1193,16 +1194,6 @@ pub struct C2RustUnnamed_45 {
     pub row_end: libc::c_int,
     pub col: libc::c_int,
     pub row: libc::c_int,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct MsacContext {
-    pub buf_pos: *const uint8_t,
-    pub buf_end: *const uint8_t,
-    pub dif: ec_win,
-    pub rng: libc::c_uint,
-    pub cnt: libc::c_int,
-    pub allow_update_cdf: libc::c_int,
 }
 pub type ec_win = size_t;
 #[derive(Copy, Clone)]

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
+use crate::src::cdf::CdfContext;
 use crate::src::msac::MsacContext;
 extern "C" {
     fn memcpy(
@@ -1197,21 +1197,6 @@ pub struct C2RustUnnamed_45 {
     pub row: libc::c_int,
 }
 pub type ec_win = size_t;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfContext {
-    pub m: CdfModeContext,
-    pub kfym: [[[uint16_t; 16]; 5]; 5],
-    pub coef: CdfCoefContext,
-    pub mv: CdfMvContext,
-    pub dmv: CdfMvContext,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvContext {
-    pub comp: [CdfMvComponent; 2],
-    pub joint: [uint16_t; 4],
-}
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -1,4 +1,5 @@
 use ::libc;
+use crate::src::cdf::CdfModeContext;
 use crate::src::msac::MsacContext;
 extern "C" {
     fn memcpy(
@@ -1239,61 +1240,6 @@ pub struct CdfCoefContext {
     pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
     pub skip: [[[uint16_t; 2]; 13]; 5],
     pub dc_sign: [[[uint16_t; 2]; 3]; 2],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfModeContext {
-    pub y_mode: [[uint16_t; 16]; 4],
-    pub uv_mode: [[[uint16_t; 16]; 13]; 2],
-    pub wedge_idx: [[uint16_t; 16]; 9],
-    pub partition: [[[uint16_t; 16]; 4]; 5],
-    pub cfl_alpha: [[uint16_t; 16]; 6],
-    pub txtp_inter1: [[uint16_t; 16]; 2],
-    pub txtp_inter2: [uint16_t; 16],
-    pub txtp_intra1: [[[uint16_t; 8]; 13]; 2],
-    pub txtp_intra2: [[[uint16_t; 8]; 13]; 3],
-    pub cfl_sign: [uint16_t; 8],
-    pub angle_delta: [[uint16_t; 8]; 8],
-    pub filter_intra: [uint16_t; 8],
-    pub comp_inter_mode: [[uint16_t; 8]; 8],
-    pub seg_id: [[uint16_t; 8]; 3],
-    pub pal_sz: [[[uint16_t; 8]; 7]; 2],
-    pub color_map: [[[[uint16_t; 8]; 5]; 7]; 2],
-    pub filter: [[[uint16_t; 4]; 8]; 2],
-    pub txsz: [[[uint16_t; 4]; 3]; 4],
-    pub motion_mode: [[uint16_t; 4]; 22],
-    pub delta_q: [uint16_t; 4],
-    pub delta_lf: [[uint16_t; 4]; 5],
-    pub interintra_mode: [[uint16_t; 4]; 4],
-    pub restore_switchable: [uint16_t; 4],
-    pub restore_wiener: [uint16_t; 2],
-    pub restore_sgrproj: [uint16_t; 2],
-    pub interintra: [[uint16_t; 2]; 7],
-    pub interintra_wedge: [[uint16_t; 2]; 7],
-    pub txtp_inter3: [[uint16_t; 2]; 4],
-    pub use_filter_intra: [[uint16_t; 2]; 22],
-    pub newmv_mode: [[uint16_t; 2]; 6],
-    pub globalmv_mode: [[uint16_t; 2]; 2],
-    pub refmv_mode: [[uint16_t; 2]; 6],
-    pub drl_bit: [[uint16_t; 2]; 3],
-    pub intra: [[uint16_t; 2]; 4],
-    pub comp: [[uint16_t; 2]; 5],
-    pub comp_dir: [[uint16_t; 2]; 5],
-    pub jnt_comp: [[uint16_t; 2]; 6],
-    pub mask_comp: [[uint16_t; 2]; 6],
-    pub wedge_comp: [[uint16_t; 2]; 9],
-    pub ref_0: [[[uint16_t; 2]; 3]; 6],
-    pub comp_fwd_ref: [[[uint16_t; 2]; 3]; 3],
-    pub comp_bwd_ref: [[[uint16_t; 2]; 3]; 2],
-    pub comp_uni_ref: [[[uint16_t; 2]; 3]; 3],
-    pub txpart: [[[uint16_t; 2]; 3]; 7],
-    pub skip: [[uint16_t; 2]; 3],
-    pub skip_mode: [[uint16_t; 2]; 3],
-    pub seg_pred: [[uint16_t; 2]; 3],
-    pub obmc: [[uint16_t; 2]; 22],
-    pub pal_y: [[[uint16_t; 2]; 3]; 7],
-    pub pal_uv: [[uint16_t; 2]; 2],
-    pub intrabc: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::{CdfModeContext, CdfMvComponent};
+use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
 use crate::src::msac::MsacContext;
 extern "C" {
     fn memcpy(
@@ -1211,23 +1211,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfCoefContext {
-    pub eob_bin_16: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_32: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_64: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_128: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_256: [[[uint16_t; 16]; 2]; 2],
-    pub eob_bin_512: [[uint16_t; 16]; 2],
-    pub eob_bin_1024: [[uint16_t; 16]; 2],
-    pub eob_base_tok: [[[[uint16_t; 4]; 4]; 2]; 5],
-    pub base_tok: [[[[uint16_t; 4]; 41]; 2]; 5],
-    pub br_tok: [[[[uint16_t; 4]; 21]; 2]; 4],
-    pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
-    pub skip: [[[uint16_t; 2]; 13]; 5],
-    pub dc_sign: [[[uint16_t; 2]; 3]; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/msac.c
+++ b/src/msac.c
@@ -206,3 +206,43 @@ void dav1d_msac_init(MsacContext *const s, const uint8_t *const data,
     msac_init_x86(s);
 #endif
 }
+
+// C2RUST:
+
+unsigned dav1d_msac_decode_symbol_adapt4(MsacContext *s, uint16_t *cdf,
+                                          size_t n_symbols)
+{
+    return dav1d_msac_decode_symbol_adapt4_impl(s, cdf, n_symbols);
+}
+
+unsigned dav1d_msac_decode_symbol_adapt8(MsacContext *s, uint16_t *cdf,
+                                          size_t n_symbols)
+{
+    return dav1d_msac_decode_symbol_adapt8_impl(s, cdf, n_symbols);
+}
+
+unsigned dav1d_msac_decode_symbol_adapt16(MsacContext *s, uint16_t *cdf,
+                                          size_t n_symbols)
+{
+    return dav1d_msac_decode_symbol_adapt16_impl(s, cdf, n_symbols);
+}
+
+unsigned dav1d_msac_decode_bool_adapt(MsacContext *s, uint16_t *cdf)
+{
+    return dav1d_msac_decode_bool_adapt_impl(s, cdf);
+}
+
+unsigned dav1d_msac_decode_bool_equi(MsacContext *s)
+{
+    return dav1d_msac_decode_bool_equi_impl(s);
+}
+
+unsigned dav1d_msac_decode_bool(MsacContext *s, unsigned f)
+{
+    return dav1d_msac_decode_bool_impl(s, f);
+}
+
+unsigned dav1d_msac_decode_hi_tok(MsacContext *s, uint16_t *cdf)
+{
+    return dav1d_msac_decode_hi_tok_impl(s, cdf);
+}

--- a/src/msac.h
+++ b/src/msac.h
@@ -66,27 +66,38 @@ unsigned dav1d_msac_decode_bool_c(MsacContext *s, unsigned f);
 unsigned dav1d_msac_decode_hi_tok_c(MsacContext *s, uint16_t *cdf);
 int dav1d_msac_decode_subexp(MsacContext *s, int ref, int n, unsigned k);
 
+unsigned dav1d_msac_decode_symbol_adapt4(MsacContext *s, uint16_t *cdf,
+                                          size_t n_symbols);
+unsigned dav1d_msac_decode_symbol_adapt8(MsacContext *s, uint16_t *cdf,
+                                          size_t n_symbols);
+unsigned dav1d_msac_decode_symbol_adapt16(MsacContext *s, uint16_t *cdf,
+                                          size_t n_symbols);
+unsigned dav1d_msac_decode_bool_adapt(MsacContext *s, uint16_t *cdf);
+unsigned dav1d_msac_decode_bool_equi(MsacContext *s);
+unsigned dav1d_msac_decode_bool(MsacContext *s, unsigned f);
+unsigned dav1d_msac_decode_hi_tok(MsacContext *s, uint16_t *cdf);
+
 /* Supported n_symbols ranges: adapt4: 1-4, adapt8: 1-7, adapt16: 3-15 */
-#ifndef dav1d_msac_decode_symbol_adapt4
-#define dav1d_msac_decode_symbol_adapt4  dav1d_msac_decode_symbol_adapt_c
+#ifndef dav1d_msac_decode_symbol_adapt4_impl
+#define dav1d_msac_decode_symbol_adapt4_impl  dav1d_msac_decode_symbol_adapt_c
 #endif
-#ifndef dav1d_msac_decode_symbol_adapt8
-#define dav1d_msac_decode_symbol_adapt8  dav1d_msac_decode_symbol_adapt_c
+#ifndef dav1d_msac_decode_symbol_adapt8_impl
+#define dav1d_msac_decode_symbol_adapt8_impl  dav1d_msac_decode_symbol_adapt_c
 #endif
-#ifndef dav1d_msac_decode_symbol_adapt16
-#define dav1d_msac_decode_symbol_adapt16 dav1d_msac_decode_symbol_adapt_c
+#ifndef dav1d_msac_decode_symbol_adapt16_impl
+#define dav1d_msac_decode_symbol_adapt16_impl dav1d_msac_decode_symbol_adapt_c
 #endif
-#ifndef dav1d_msac_decode_bool_adapt
-#define dav1d_msac_decode_bool_adapt     dav1d_msac_decode_bool_adapt_c
+#ifndef dav1d_msac_decode_bool_adapt_impl
+#define dav1d_msac_decode_bool_adapt_impl     dav1d_msac_decode_bool_adapt_c
 #endif
-#ifndef dav1d_msac_decode_bool_equi
-#define dav1d_msac_decode_bool_equi      dav1d_msac_decode_bool_equi_c
+#ifndef dav1d_msac_decode_bool_equi_impl
+#define dav1d_msac_decode_bool_equi_impl      dav1d_msac_decode_bool_equi_c
 #endif
-#ifndef dav1d_msac_decode_bool
-#define dav1d_msac_decode_bool           dav1d_msac_decode_bool_c
+#ifndef dav1d_msac_decode_bool_impl
+#define dav1d_msac_decode_bool_impl           dav1d_msac_decode_bool_c
 #endif
-#ifndef dav1d_msac_decode_hi_tok
-#define dav1d_msac_decode_hi_tok         dav1d_msac_decode_hi_tok_c
+#ifndef dav1d_msac_decode_hi_tok_impl
+#define dav1d_msac_decode_hi_tok_impl         dav1d_msac_decode_hi_tok_c
 #endif
 
 static inline unsigned dav1d_msac_decode_bools(MsacContext *const s, unsigned n) {

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -44,7 +44,7 @@ unsafe extern "C" fn dav1d_msac_decode_bools(
         if !(fresh0 != 0) {
             break;
         }
-        v = v << 1 as libc::c_int | dav1d_msac_decode_bool_equi_c(s);
+        v = v << 1 as libc::c_int | dav1d_msac_decode_bool_equi(s);
     }
     return v;
 }
@@ -158,11 +158,11 @@ pub unsafe extern "C" fn dav1d_msac_decode_subexp(
         unreachable!();
     }
     let mut a: libc::c_uint = 0 as libc::c_int as libc::c_uint;
-    if dav1d_msac_decode_bool_equi_c(s) != 0 {
-        if dav1d_msac_decode_bool_equi_c(s) != 0 {
+    if dav1d_msac_decode_bool_equi(s) != 0 {
+        if dav1d_msac_decode_bool_equi(s) != 0 {
             k = k
                 .wrapping_add(
-                    (dav1d_msac_decode_bool_equi_c(s))
+                    (dav1d_msac_decode_bool_equi(s))
                         .wrapping_add(1 as libc::c_int as libc::c_uint),
                 );
         }
@@ -268,7 +268,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool_adapt_c(
     s: *mut MsacContext,
     cdf: *mut uint16_t,
 ) -> libc::c_uint {
-    let bit: libc::c_uint = dav1d_msac_decode_bool_c(s, *cdf as libc::c_uint);
+    let bit: libc::c_uint = dav1d_msac_decode_bool(s, *cdf as libc::c_uint);
     if (*s).allow_update_cdf != 0 {
         let count: libc::c_uint = *cdf.offset(1 as libc::c_int as isize) as libc::c_uint;
         let rate: libc::c_int = (4 as libc::c_int as libc::c_uint)
@@ -301,26 +301,22 @@ pub unsafe extern "C" fn dav1d_msac_decode_hi_tok_c(
     s: *mut MsacContext,
     cdf: *mut uint16_t,
 ) -> libc::c_uint {
-    let mut tok_br: libc::c_uint = dav1d_msac_decode_symbol_adapt_c(
+    let mut tok_br: libc::c_uint = dav1d_msac_decode_symbol_adapt4(
         s,
         cdf,
         3 as libc::c_int as size_t,
     );
     let mut tok: libc::c_uint = (3 as libc::c_int as libc::c_uint).wrapping_add(tok_br);
     if tok_br == 3 as libc::c_int as libc::c_uint {
-        tok_br = dav1d_msac_decode_symbol_adapt_c(s, cdf, 3 as libc::c_int as size_t);
+        tok_br = dav1d_msac_decode_symbol_adapt4(s, cdf, 3 as libc::c_int as size_t);
         tok = (6 as libc::c_int as libc::c_uint).wrapping_add(tok_br);
         if tok_br == 3 as libc::c_int as libc::c_uint {
-            tok_br = dav1d_msac_decode_symbol_adapt_c(
-                s,
-                cdf,
-                3 as libc::c_int as size_t,
-            );
+            tok_br = dav1d_msac_decode_symbol_adapt4(s, cdf, 3 as libc::c_int as size_t);
             tok = (9 as libc::c_int as libc::c_uint).wrapping_add(tok_br);
             if tok_br == 3 as libc::c_int as libc::c_uint {
                 tok = (12 as libc::c_int as libc::c_uint)
                     .wrapping_add(
-                        dav1d_msac_decode_symbol_adapt_c(
+                        dav1d_msac_decode_symbol_adapt4(
                             s,
                             cdf,
                             3 as libc::c_int as size_t,
@@ -349,4 +345,55 @@ pub unsafe extern "C" fn dav1d_msac_init(
     (*s).cnt = -(15 as libc::c_int);
     (*s).allow_update_cdf = (disable_cdf_update_flag == 0) as libc::c_int;
     ctx_refill(s);
+}
+#[no_mangle]
+pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt4(
+    mut s: *mut MsacContext,
+    mut cdf: *mut uint16_t,
+    mut n_symbols: size_t,
+) -> libc::c_uint {
+    return dav1d_msac_decode_symbol_adapt_c(s, cdf, n_symbols);
+}
+#[no_mangle]
+pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt8(
+    mut s: *mut MsacContext,
+    mut cdf: *mut uint16_t,
+    mut n_symbols: size_t,
+) -> libc::c_uint {
+    return dav1d_msac_decode_symbol_adapt_c(s, cdf, n_symbols);
+}
+#[no_mangle]
+pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt16(
+    mut s: *mut MsacContext,
+    mut cdf: *mut uint16_t,
+    mut n_symbols: size_t,
+) -> libc::c_uint {
+    return dav1d_msac_decode_symbol_adapt_c(s, cdf, n_symbols);
+}
+#[no_mangle]
+pub unsafe extern "C" fn dav1d_msac_decode_bool_adapt(
+    mut s: *mut MsacContext,
+    mut cdf: *mut uint16_t,
+) -> libc::c_uint {
+    return dav1d_msac_decode_bool_adapt_c(s, cdf);
+}
+#[no_mangle]
+pub unsafe extern "C" fn dav1d_msac_decode_bool_equi(
+    mut s: *mut MsacContext,
+) -> libc::c_uint {
+    return dav1d_msac_decode_bool_equi_c(s);
+}
+#[no_mangle]
+pub unsafe extern "C" fn dav1d_msac_decode_bool(
+    mut s: *mut MsacContext,
+    mut f: libc::c_uint,
+) -> libc::c_uint {
+    return dav1d_msac_decode_bool_c(s, f);
+}
+#[no_mangle]
+pub unsafe extern "C" fn dav1d_msac_decode_hi_tok(
+    mut s: *mut MsacContext,
+    mut cdf: *mut uint16_t,
+) -> libc::c_uint {
+    return dav1d_msac_decode_hi_tok_c(s, cdf);
 }

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -1,4 +1,41 @@
 use ::libc;
+use cfg_if::cfg_if;
+
+#[cfg(all(feature = "asm", target_arch = "x86_64"))]
+extern "C" {
+    fn dav1d_msac_decode_hi_tok_sse2(
+        s: *mut MsacContext,
+        cdf: *mut uint16_t,
+    ) -> libc::c_uint;
+    fn dav1d_msac_decode_bool_sse2(s: *mut MsacContext, f: libc::c_uint) -> libc::c_uint;
+    fn dav1d_msac_decode_bool_equi_sse2(s: *mut MsacContext) -> libc::c_uint;
+    fn dav1d_msac_decode_bool_adapt_sse2(
+        s: *mut MsacContext,
+        cdf: *mut uint16_t,
+    ) -> libc::c_uint;
+    fn dav1d_msac_decode_symbol_adapt16_avx2(
+        s: *mut MsacContext,
+        cdf: *mut uint16_t,
+        n_symbols: size_t,
+    ) -> libc::c_uint;
+    fn dav1d_msac_decode_symbol_adapt16_sse2(
+        s: *mut MsacContext,
+        cdf: *mut uint16_t,
+        n_symbols: size_t,
+    ) -> libc::c_uint;
+    fn dav1d_msac_decode_symbol_adapt8_sse2(
+        s: *mut MsacContext,
+        cdf: *mut uint16_t,
+        n_symbols: size_t,
+    ) -> libc::c_uint;
+    fn dav1d_msac_decode_symbol_adapt4_sse2(
+        s: *mut MsacContext,
+        cdf: *mut uint16_t,
+        n_symbols: size_t,
+    ) -> libc::c_uint;
+    static mut dav1d_cpu_flags_mask: libc::c_uint;
+    static mut dav1d_cpu_flags: libc::c_uint;
+}
 pub type __uint8_t = libc::c_uchar;
 pub type __uint16_t = libc::c_ushort;
 pub type uint8_t = __uint8_t;
@@ -14,10 +51,25 @@ pub struct MsacContext {
     pub rng: libc::c_uint,
     pub cnt: libc::c_int,
     pub allow_update_cdf: libc::c_int,
+    #[cfg(all(feature = "asm", target_arch = "x86_64"))]
+    pub symbol_adapt16: Option::<
+        unsafe extern "C" fn(*mut MsacContext, *mut uint16_t, size_t) -> libc::c_uint,
+    >,
 }
 #[inline]
 unsafe extern "C" fn clz(mask: libc::c_uint) -> libc::c_int {
     return mask.leading_zeros() as i32;
+}
+cfg_if! {
+    if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
+        pub type CpuFlags = libc::c_uint;
+        pub const DAV1D_X86_CPU_FLAG_SLOW_GATHER: CpuFlags = 32;
+        pub const DAV1D_X86_CPU_FLAG_AVX512ICL: CpuFlags = 16;
+        pub const DAV1D_X86_CPU_FLAG_AVX2: CpuFlags = 8;
+        pub const DAV1D_X86_CPU_FLAG_SSE41: CpuFlags = 4;
+        pub const DAV1D_X86_CPU_FLAG_SSSE3: CpuFlags = 2;
+        pub const DAV1D_X86_CPU_FLAG_SSE2: CpuFlags = 1;
+    }
 }
 #[inline]
 unsafe extern "C" fn inv_recenter(r: libc::c_uint, v: libc::c_uint) -> libc::c_uint {
@@ -47,6 +99,41 @@ unsafe extern "C" fn dav1d_msac_decode_bools(
         v = v << 1 as libc::c_int | dav1d_msac_decode_bool_equi(s);
     }
     return v;
+}
+
+#[cfg(all(feature = "asm", target_arch = "x86_64"))]
+#[inline(always)]
+unsafe extern "C" fn msac_init_x86(s: *mut MsacContext) {
+    let flags: libc::c_uint = dav1d_get_cpu_flags();
+    if flags & DAV1D_X86_CPU_FLAG_SSE2 as libc::c_int as libc::c_uint != 0 {
+        (*s)
+            .symbol_adapt16 = Some(
+            dav1d_msac_decode_symbol_adapt16_sse2
+                as unsafe extern "C" fn(
+                    *mut MsacContext,
+                    *mut uint16_t,
+                    size_t,
+                ) -> libc::c_uint,
+        );
+    }
+    if flags & DAV1D_X86_CPU_FLAG_AVX2 as libc::c_int as libc::c_uint != 0 {
+        (*s)
+            .symbol_adapt16 = Some(
+            dav1d_msac_decode_symbol_adapt16_avx2
+                as unsafe extern "C" fn(
+                    *mut MsacContext,
+                    *mut uint16_t,
+                    size_t,
+                ) -> libc::c_uint,
+        );
+    }
+}
+#[cfg(all(feature = "asm", target_arch = "x86_64"))]
+#[inline(always)]
+unsafe extern "C" fn dav1d_get_cpu_flags() -> libc::c_uint {
+    let mut flags: libc::c_uint = dav1d_cpu_flags & dav1d_cpu_flags_mask;
+    flags |= DAV1D_X86_CPU_FLAG_SSE2 as libc::c_int as libc::c_uint;
+    return flags;
 }
 #[inline]
 unsafe extern "C" fn ctx_refill(s: *mut MsacContext) {
@@ -345,6 +432,20 @@ pub unsafe extern "C" fn dav1d_msac_init(
     (*s).cnt = -(15 as libc::c_int);
     (*s).allow_update_cdf = (disable_cdf_update_flag == 0) as libc::c_int;
     ctx_refill(s);
+
+    #[cfg(all(feature = "asm", target_arch = "x86_64"))]
+    {
+        (*s)
+            .symbol_adapt16 = Some(
+            dav1d_msac_decode_symbol_adapt_c
+                as unsafe extern "C" fn(
+                    *mut MsacContext,
+                    *mut uint16_t,
+                    size_t,
+                ) -> libc::c_uint,
+        );
+        msac_init_x86(s);
+    }
 }
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt4(
@@ -352,7 +453,13 @@ pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt4(
     mut cdf: *mut uint16_t,
     mut n_symbols: size_t,
 ) -> libc::c_uint {
-    return dav1d_msac_decode_symbol_adapt_c(s, cdf, n_symbols);
+    cfg_if! {
+        if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
+            return dav1d_msac_decode_symbol_adapt4_sse2(s, cdf, n_symbols);
+        } else {
+            return dav1d_msac_decode_symbol_adapt_c(s, cdf, n_symbols);
+        }
+    }
 }
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt8(
@@ -360,7 +467,13 @@ pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt8(
     mut cdf: *mut uint16_t,
     mut n_symbols: size_t,
 ) -> libc::c_uint {
-    return dav1d_msac_decode_symbol_adapt_c(s, cdf, n_symbols);
+    cfg_if! {
+        if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
+            return dav1d_msac_decode_symbol_adapt8_sse2(s, cdf, n_symbols);
+        } else {
+            return dav1d_msac_decode_symbol_adapt_c(s, cdf, n_symbols);
+        }
+    }
 }
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt16(
@@ -368,32 +481,62 @@ pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt16(
     mut cdf: *mut uint16_t,
     mut n_symbols: size_t,
 ) -> libc::c_uint {
-    return dav1d_msac_decode_symbol_adapt_c(s, cdf, n_symbols);
+    cfg_if! {
+        if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
+            return ((*s).symbol_adapt16).expect("non-null function pointer")(s, cdf, n_symbols);
+        } else {
+            return dav1d_msac_decode_symbol_adapt_c(s, cdf, n_symbols);
+        }
+    }
 }
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_bool_adapt(
     mut s: *mut MsacContext,
     mut cdf: *mut uint16_t,
 ) -> libc::c_uint {
-    return dav1d_msac_decode_bool_adapt_c(s, cdf);
+    cfg_if! {
+        if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
+            return dav1d_msac_decode_bool_adapt_sse2(s, cdf);
+        } else {
+            return dav1d_msac_decode_bool_adapt_c(s, cdf);
+        }
+    }
 }
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_bool_equi(
     mut s: *mut MsacContext,
 ) -> libc::c_uint {
-    return dav1d_msac_decode_bool_equi_c(s);
+    cfg_if! {
+        if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
+            return dav1d_msac_decode_bool_equi_sse2(s);
+        } else {
+            return dav1d_msac_decode_bool_equi_c(s);
+        }
+    }
 }
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_bool(
     mut s: *mut MsacContext,
     mut f: libc::c_uint,
 ) -> libc::c_uint {
-    return dav1d_msac_decode_bool_c(s, f);
+    cfg_if! {
+        if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
+            return dav1d_msac_decode_bool_sse2(s, f);
+        } else {
+            return dav1d_msac_decode_bool_c(s, f);
+        }
+    }
 }
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_hi_tok(
     mut s: *mut MsacContext,
     mut cdf: *mut uint16_t,
 ) -> libc::c_uint {
-    return dav1d_msac_decode_hi_tok_c(s, cdf);
+    cfg_if! {
+        if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
+            return dav1d_msac_decode_hi_tok_sse2(s, cdf);
+        } else {
+            return dav1d_msac_decode_hi_tok_c(s, cdf);
+        }
+    }
 }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1,4 +1,5 @@
 use ::libc;
+use crate::src::msac::MsacContext;
 extern "C" {
     fn realloc(_: *mut libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
     fn memset(
@@ -1244,16 +1245,6 @@ pub struct C2RustUnnamed_45 {
     pub row_end: libc::c_int,
     pub col: libc::c_int,
     pub row: libc::c_int,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct MsacContext {
-    pub buf_pos: *const uint8_t,
-    pub buf_end: *const uint8_t,
-    pub dif: ec_win,
-    pub rng: libc::c_uint,
-    pub cnt: libc::c_int,
-    pub allow_update_cdf: libc::c_int,
 }
 pub type ec_win = size_t;
 #[derive(Copy, Clone)]

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::{CdfModeContext, CdfMvComponent};
+use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
 use crate::src::msac::MsacContext;
 extern "C" {
     fn realloc(_: *mut libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
@@ -1262,23 +1262,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfCoefContext {
-    pub eob_bin_16: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_32: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_64: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_128: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_256: [[[uint16_t; 16]; 2]; 2],
-    pub eob_bin_512: [[uint16_t; 16]; 2],
-    pub eob_bin_1024: [[uint16_t; 16]; 2],
-    pub eob_base_tok: [[[[uint16_t; 4]; 4]; 2]; 5],
-    pub base_tok: [[[[uint16_t; 4]; 41]; 2]; 5],
-    pub br_tok: [[[[uint16_t; 4]; 21]; 2]; 4],
-    pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
-    pub skip: [[[uint16_t; 2]; 13]; 5],
-    pub dc_sign: [[[uint16_t; 2]; 3]; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2105,7 +2105,7 @@ unsafe extern "C" fn parse_seq_hdr(
                     if (*hdr).equal_picture_interval != 0 {
                         let num_ticks_per_picture: libc::c_uint = dav1d_get_vlc(gb);
                         if num_ticks_per_picture == 0xffffffff as libc::c_uint {
-                            current_block = 17400737960072300055;
+                            current_block = 181392771181400725;
                         } else {
                             (*hdr)
                                 .num_ticks_per_picture = num_ticks_per_picture
@@ -2116,7 +2116,7 @@ unsafe extern "C" fn parse_seq_hdr(
                         current_block = 10048703153582371463;
                     }
                     match current_block {
-                        17400737960072300055 => {}
+                        181392771181400725 => {}
                         _ => {
                             (*hdr)
                                 .decoder_model_info_present = dav1d_get_bit(gb)
@@ -2156,7 +2156,7 @@ unsafe extern "C" fn parse_seq_hdr(
                     current_block = 4808432441040389987;
                 }
                 match current_block {
-                    17400737960072300055 => {}
+                    181392771181400725 => {}
                     _ => {
                         (*hdr)
                             .display_model_info_present = dav1d_get_bit(gb)
@@ -2185,7 +2185,7 @@ unsafe extern "C" fn parse_seq_hdr(
                                 && ((*op).idc & 0xff as libc::c_int == 0
                                     || (*op).idc & 0xf00 as libc::c_int == 0)
                             {
-                                current_block = 17400737960072300055;
+                                current_block = 181392771181400725;
                                 break;
                             }
                             (*op)
@@ -2241,7 +2241,7 @@ unsafe extern "C" fn parse_seq_hdr(
                 }
             }
             match current_block {
-                17400737960072300055 => {}
+                181392771181400725 => {}
                 _ => {
                     op_idx = if (*c).operating_point < (*hdr).num_operating_points {
                         (*c).operating_point
@@ -2379,7 +2379,7 @@ unsafe extern "C" fn parse_seq_hdr(
                             && !((*hdr).profile == 2 as libc::c_int
                                 && (*hdr).hbd == 2 as libc::c_int)
                         {
-                            current_block = 17400737960072300055;
+                            current_block = 181392771181400725;
                         } else {
                             current_block = 14141370668937312244;
                         }
@@ -2425,7 +2425,7 @@ unsafe extern "C" fn parse_seq_hdr(
                         current_block = 14141370668937312244;
                     }
                     match current_block {
-                        17400737960072300055 => {}
+                        181392771181400725 => {}
                         _ => {
                             if !((*c).strict_std_compliance != 0
                                 && (*hdr).mtrx as libc::c_uint
@@ -2620,7 +2620,7 @@ unsafe extern "C" fn parse_frame_hdr(
                 .p
                 .frame_hdr;
             if ref_frame_hdr.is_null() || (*ref_frame_hdr).frame_id != (*hdr).frame_id {
-                current_block = 13312636450699654424;
+                current_block = 17922947093064792850;
             } else {
                 current_block = 7351195479953500246;
             }
@@ -2628,7 +2628,7 @@ unsafe extern "C" fn parse_frame_hdr(
             current_block = 7351195479953500246;
         }
         match current_block {
-            13312636450699654424 => {}
+            17922947093064792850 => {}
             _ => return 0 as libc::c_int,
         }
     } else {
@@ -2773,9 +2773,9 @@ unsafe extern "C" fn parse_frame_hdr(
                     == DAV1D_FRAME_TYPE_INTRA as libc::c_int as libc::c_uint
                 && (*hdr).refresh_frame_flags == 0xff as libc::c_int
             {
-                current_block = 13312636450699654424;
+                current_block = 17922947093064792850;
             } else if read_frame_size(c, gb, 0 as libc::c_int) < 0 as libc::c_int {
-                current_block = 13312636450699654424;
+                current_block = 17922947093064792850;
             } else {
                 (*hdr)
                     .allow_intrabc = ((*hdr).allow_screen_content_tools != 0
@@ -2832,7 +2832,7 @@ unsafe extern "C" fn parse_frame_hdr(
                         break;
                     }
                     if ((*c).refs[i_2 as usize].p.p.frame_hdr).is_null() {
-                        current_block = 13312636450699654424;
+                        current_block = 17922947093064792850;
                         break;
                     }
                     shifted_frame_offset[i_2
@@ -2845,7 +2845,7 @@ unsafe extern "C" fn parse_frame_hdr(
                     i_2 += 1;
                 }
                 match current_block {
-                    13312636450699654424 => {}
+                    17922947093064792850 => {}
                     _ => {
                         let mut used_frame: [libc::c_int; 8] = [
                             0 as libc::c_int,
@@ -2961,7 +2961,7 @@ unsafe extern "C" fn parse_frame_hdr(
                 current_block = 16590946904645350046;
             }
             match current_block {
-                13312636450699654424 => {}
+                17922947093064792850 => {}
                 _ => {
                     let mut i_9: libc::c_int = 0 as libc::c_int;
                     loop {
@@ -2993,19 +2993,19 @@ unsafe extern "C" fn parse_frame_hdr(
                             if ref_frame_hdr_0.is_null()
                                 || (*ref_frame_hdr_0).frame_id != ref_frame_id
                             {
-                                current_block = 13312636450699654424;
+                                current_block = 17922947093064792850;
                                 break;
                             }
                         }
                         i_9 += 1;
                     }
                     match current_block {
-                        13312636450699654424 => {}
+                        17922947093064792850 => {}
                         _ => {
                             let use_ref: libc::c_int = ((*hdr).error_resilient_mode == 0
                                 && (*hdr).frame_size_override != 0) as libc::c_int;
                             if read_frame_size(c, gb, use_ref) < 0 as libc::c_int {
-                                current_block = 13312636450699654424;
+                                current_block = 17922947093064792850;
                             } else {
                                 (*hdr)
                                     .hp = ((*hdr).force_integer_mv == 0
@@ -3032,7 +3032,7 @@ unsafe extern "C" fn parse_frame_hdr(
             }
         }
         match current_block {
-            13312636450699654424 => {}
+            17922947093064792850 => {}
             _ => {
                 (*hdr)
                     .refresh_context = ((*seqhdr).reduced_still_picture_header == 0
@@ -3182,7 +3182,7 @@ unsafe extern "C" fn parse_frame_hdr(
                         (*hdr).tiling.log2_cols + (*hdr).tiling.log2_rows,
                     ) as libc::c_int;
                     if (*hdr).tiling.update >= (*hdr).tiling.cols * (*hdr).tiling.rows {
-                        current_block = 13312636450699654424;
+                        current_block = 17922947093064792850;
                     } else {
                         (*hdr)
                             .tiling
@@ -3196,7 +3196,7 @@ unsafe extern "C" fn parse_frame_hdr(
                     current_block = 1918110639124887667;
                 }
                 match current_block {
-                    13312636450699654424 => {}
+                    17922947093064792850 => {}
                     _ => {
                         (*hdr)
                             .quant
@@ -3360,7 +3360,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                 let pri_ref: libc::c_int = (*hdr)
                                     .refidx[(*hdr).primary_ref_frame as usize];
                                 if ((*c).refs[pri_ref as usize].p.p.frame_hdr).is_null() {
-                                    current_block = 13312636450699654424;
+                                    current_block = 17922947093064792850;
                                 } else {
                                     (*hdr)
                                         .segmentation
@@ -3390,7 +3390,7 @@ unsafe extern "C" fn parse_frame_hdr(
                             current_block = 8075351136037156718;
                         }
                         match current_block {
-                            13312636450699654424 => {}
+                            17922947093064792850 => {}
                             _ => {
                                 (*hdr)
                                     .delta
@@ -3512,7 +3512,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                         let ref_1: libc::c_int = (*hdr)
                                             .refidx[(*hdr).primary_ref_frame as usize];
                                         if ((*c).refs[ref_1 as usize].p.p.frame_hdr).is_null() {
-                                            current_block = 13312636450699654424;
+                                            current_block = 17922947093064792850;
                                         } else {
                                             (*hdr)
                                                 .loopfilter
@@ -3527,7 +3527,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                         }
                                     }
                                     match current_block {
-                                        13312636450699654424 => {}
+                                        17922947093064792850 => {}
                                         _ => {
                                             (*hdr)
                                                 .loopfilter
@@ -3566,7 +3566,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                     }
                                 }
                                 match current_block {
-                                    13312636450699654424 => {}
+                                    17922947093064792850 => {}
                                     _ => {
                                         if (*hdr).all_lossless == 0 && (*seqhdr).cdef != 0
                                             && (*hdr).allow_intrabc == 0
@@ -3740,7 +3740,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                                     .frame_hdr)
                                                     .is_null()
                                                 {
-                                                    current_block = 13312636450699654424;
+                                                    current_block = 17922947093064792850;
                                                     break;
                                                 }
                                                 let refpoc: libc::c_uint = (*(*c)
@@ -3779,7 +3779,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                                 i_16 += 1;
                                             }
                                             match current_block {
-                                                13312636450699654424 => {}
+                                                17922947093064792850 => {}
                                                 _ => {
                                                     if off_before != 0xffffffff as libc::c_uint
                                                         && off_after != -(1 as libc::c_int)
@@ -3809,7 +3809,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                                                 .frame_hdr)
                                                                 .is_null()
                                                             {
-                                                                current_block = 13312636450699654424;
+                                                                current_block = 17922947093064792850;
                                                                 break;
                                                             }
                                                             let refpoc_0: libc::c_uint = (*(*c)
@@ -3838,7 +3838,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                                             i_17 += 1;
                                                         }
                                                         match current_block {
-                                                            13312636450699654424 => {}
+                                                            17922947093064792850 => {}
                                                             _ => {
                                                                 if off_before2 != 0xffffffff as libc::c_uint {
                                                                     (*hdr)
@@ -3861,7 +3861,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                             current_block = 2126221883176060805;
                                         }
                                         match current_block {
-                                            13312636450699654424 => {}
+                                            17922947093064792850 => {}
                                             _ => {
                                                 (*hdr)
                                                     .skip_mode_enabled = (if (*hdr).skip_mode_allowed != 0 {
@@ -3912,7 +3912,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                                                 let pri_ref_0: libc::c_int = (*hdr)
                                                                     .refidx[(*hdr).primary_ref_frame as usize];
                                                                 if ((*c).refs[pri_ref_0 as usize].p.p.frame_hdr).is_null() {
-                                                                    current_block = 13312636450699654424;
+                                                                    current_block = 17922947093064792850;
                                                                     break;
                                                                 }
                                                                 ref_gmv = &mut *((*(*((*c).refs)
@@ -4019,7 +4019,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                                     current_block = 6933758620287070692;
                                                 }
                                                 match current_block {
-                                                    13312636450699654424 => {}
+                                                    17922947093064792850 => {}
                                                     _ => {
                                                         (*hdr)
                                                             .film_grain
@@ -4052,7 +4052,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                                                 if i_20 == 7 as libc::c_int
                                                                     || ((*c).refs[refidx as usize].p.p.frame_hdr).is_null()
                                                                 {
-                                                                    current_block = 13312636450699654424;
+                                                                    current_block = 17922947093064792850;
                                                                 } else {
                                                                     (*hdr)
                                                                         .film_grain
@@ -4071,7 +4071,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                                                     .num_y_points = dav1d_get_bits(gb, 4 as libc::c_int)
                                                                     as libc::c_int;
                                                                 if (*fgd).num_y_points > 14 as libc::c_int {
-                                                                    current_block = 13312636450699654424;
+                                                                    current_block = 17922947093064792850;
                                                                 } else {
                                                                     let mut i_21: libc::c_int = 0 as libc::c_int;
                                                                     loop {
@@ -4090,7 +4090,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                                                                 >= (*fgd).y_points[i_21 as usize][0 as libc::c_int as usize]
                                                                                     as libc::c_int
                                                                         {
-                                                                            current_block = 13312636450699654424;
+                                                                            current_block = 17922947093064792850;
                                                                             break;
                                                                         }
                                                                         (*fgd)
@@ -4100,7 +4100,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                                                         i_21 += 1;
                                                                     }
                                                                     match current_block {
-                                                                        13312636450699654424 => {}
+                                                                        17922947093064792850 => {}
                                                                         _ => {
                                                                             (*fgd)
                                                                                 .chroma_scaling_from_luma = ((*seqhdr).monochrome == 0
@@ -4130,7 +4130,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                                                                         as usize] = dav1d_get_bits(gb, 4 as libc::c_int)
                                                                                         as libc::c_int;
                                                                                     if (*fgd).num_uv_points[pl as usize] > 10 as libc::c_int {
-                                                                                        current_block = 13312636450699654424;
+                                                                                        current_block = 17922947093064792850;
                                                                                         break;
                                                                                     }
                                                                                     let mut i_22: libc::c_int = 0 as libc::c_int;
@@ -4150,7 +4150,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                                                                                     as usize][i_22 as usize][0 as libc::c_int as usize]
                                                                                                     as libc::c_int
                                                                                         {
-                                                                                            current_block = 13312636450699654424;
+                                                                                            current_block = 17922947093064792850;
                                                                                             break 's_1955;
                                                                                         }
                                                                                         (*fgd)
@@ -4164,7 +4164,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                                                                 }
                                                                             }
                                                                             match current_block {
-                                                                                13312636450699654424 => {}
+                                                                                17922947093064792850 => {}
                                                                                 _ => {
                                                                                     if (*seqhdr).ss_hor == 1 as libc::c_int
                                                                                         && (*seqhdr).ss_ver == 1 as libc::c_int
@@ -4173,7 +4173,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                                                                             != ((*fgd).num_uv_points[1 as libc::c_int as usize] != 0)
                                                                                                 as libc::c_int
                                                                                     {
-                                                                                        current_block = 13312636450699654424;
+                                                                                        current_block = 17922947093064792850;
                                                                                     } else {
                                                                                         (*fgd)
                                                                                             .scaling_shift = (dav1d_get_bits(gb, 2 as libc::c_int))
@@ -4269,7 +4269,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                                             current_block = 17095195114763350366;
                                                         }
                                                         match current_block {
-                                                            13312636450699654424 => {}
+                                                            17922947093064792850 => {}
                                                             _ => return 0 as libc::c_int,
                                                         }
                                                     }
@@ -4418,10 +4418,10 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                     res = parse_seq_hdr(c, &mut gb, seq_hdr);
                     if res < 0 as libc::c_int {
                         dav1d_ref_dec(&mut ref_0);
-                        current_block = 13588377604982898435;
+                        current_block = 2084488458830559219;
                     } else if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
                         dav1d_ref_dec(&mut ref_0);
-                        current_block = 13588377604982898435;
+                        current_block = 2084488458830559219;
                     } else {
                         if ((*c).seq_hdr).is_null() {
                             (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
@@ -4500,11 +4500,11 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                     if !((*c).frame_hdr).is_null() {
                         current_block = 2704538829018177290;
                     } else {
-                        current_block = 916061708005926980;
+                        current_block = 15432521118199951273;
                     }
                 }
                 6 | 3 => {
-                    current_block = 916061708005926980;
+                    current_block = 15432521118199951273;
                 }
                 4 => {
                     current_block = 919954187481050311;
@@ -4515,7 +4515,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                     let meta_type_len: libc::c_int = ((dav1d_get_bits_pos(&mut gb))
                         .wrapping_sub(init_bit_pos) >> 3 as libc::c_int) as libc::c_int;
                     if gb.error != 0 {
-                        current_block = 13588377604982898435;
+                        current_block = 2084488458830559219;
                     } else {
                         match meta_type as libc::c_uint {
                             1 => {
@@ -4542,7 +4542,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                 dav1d_bytealign_get_bits(&mut gb);
                                 if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
                                     dav1d_ref_dec(&mut ref_1);
-                                    current_block = 13588377604982898435;
+                                    current_block = 2084488458830559219;
                                 } else {
                                     dav1d_ref_dec(&mut (*c).content_light_ref);
                                     (*c).content_light = content_light;
@@ -4590,7 +4590,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                 dav1d_bytealign_get_bits(&mut gb);
                                 if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
                                     dav1d_ref_dec(&mut ref_2);
-                                    current_block = 13588377604982898435;
+                                    current_block = 2084488458830559219;
                                 } else {
                                     dav1d_ref_dec(&mut (*c).mastering_display_ref);
                                     (*c).mastering_display = mastering_display;
@@ -4712,14 +4712,14 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                 }
             }
             match current_block {
-                13588377604982898435 => {}
+                2084488458830559219 => {}
                 _ => {
                     match current_block {
-                        916061708005926980 => {
+                        15432521118199951273 => {
                             if global != 0 {
                                 current_block = 2704538829018177290;
                             } else if ((*c).seq_hdr).is_null() {
-                                current_block = 13588377604982898435;
+                                current_block = 2084488458830559219;
                             } else {
                                 if ((*c).frame_hdr_ref).is_null() {
                                     (*c)
@@ -4744,7 +4744,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                 res = parse_frame_hdr(c, &mut gb);
                                 if res < 0 as libc::c_int {
                                     (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
-                                    current_block = 13588377604982898435;
+                                    current_block = 2084488458830559219;
                                 } else {
                                     let mut n: libc::c_int = 0 as libc::c_int;
                                     while n < (*c).n_tile_data {
@@ -4761,7 +4761,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                         dav1d_get_bit(&mut gb);
                                         if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
                                             (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
-                                            current_block = 13588377604982898435;
+                                            current_block = 2084488458830559219;
                                         } else {
                                             current_block = 4216521074440650966;
                                         }
@@ -4769,7 +4769,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                         current_block = 4216521074440650966;
                                     }
                                     match current_block {
-                                        13588377604982898435 => {}
+                                        2084488458830559219 => {}
                                         _ => {
                                             if (*c).frame_size_limit != 0
                                                 && (*(*c).frame_hdr).width[1 as libc::c_int as usize]
@@ -4793,7 +4793,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                                 current_block = 2704538829018177290;
                                             } else if (*(*c).frame_hdr).show_existing_frame != 0 {
                                                 (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
-                                                current_block = 13588377604982898435;
+                                                current_block = 2084488458830559219;
                                             } else {
                                                 dav1d_bytealign_get_bits(&mut gb);
                                                 current_block = 919954187481050311;
@@ -4806,14 +4806,14 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                         _ => {}
                     }
                     match current_block {
-                        13588377604982898435 => {}
+                        2084488458830559219 => {}
                         _ => {
                             match current_block {
                                 919954187481050311 => {
                                     if global != 0 {
                                         current_block = 2704538829018177290;
                                     } else if ((*c).frame_hdr).is_null() {
-                                        current_block = 13588377604982898435;
+                                        current_block = 2084488458830559219;
                                     } else {
                                         if (*c).n_tile_data_alloc
                                             < (*c).n_tile_data + 1 as libc::c_int
@@ -4823,7 +4823,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                                     / ::core::mem::size_of::<Dav1dTileGroup>() as libc::c_ulong
                                                         as libc::c_int
                                             {
-                                                current_block = 13588377604982898435;
+                                                current_block = 2084488458830559219;
                                             } else {
                                                 let mut tile: *mut Dav1dTileGroup = realloc(
                                                     (*c).tile as *mut libc::c_void,
@@ -4833,7 +4833,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                                         ),
                                                 ) as *mut Dav1dTileGroup;
                                                 if tile.is_null() {
-                                                    current_block = 13588377604982898435;
+                                                    current_block = 2084488458830559219;
                                                 } else {
                                                     (*c).tile = tile;
                                                     memset(
@@ -4851,12 +4851,12 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                             current_block = 17711149709958600598;
                                         }
                                         match current_block {
-                                            13588377604982898435 => {}
+                                            2084488458830559219 => {}
                                             _ => {
                                                 parse_tile_hdr(c, &mut gb);
                                                 dav1d_bytealign_get_bits(&mut gb);
                                                 if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
-                                                    current_block = 13588377604982898435;
+                                                    current_block = 2084488458830559219;
                                                 } else {
                                                     let pkt_bytelen: libc::c_uint = init_byte_pos
                                                         .wrapping_add(len);
@@ -4873,11 +4873,11 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                                         &mut (*((*c).tile).offset((*c).n_tile_data as isize)).data,
                                                         in_0,
                                                     );
-                                                    let ref mut fresh2 = (*((*c).tile)
+                                                    let ref mut fresh0 = (*((*c).tile)
                                                         .offset((*c).n_tile_data as isize))
                                                         .data
                                                         .data;
-                                                    *fresh2 = (*fresh2)
+                                                    *fresh0 = (*fresh0)
                                                         .offset((bit_pos >> 3 as libc::c_int) as isize);
                                                     (*((*c).tile).offset((*c).n_tile_data as isize))
                                                         .data
@@ -4897,7 +4897,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                                         }
                                                         (*c).n_tile_data = 0 as libc::c_int;
                                                         (*c).n_tiles = 0 as libc::c_int;
-                                                        current_block = 13588377604982898435;
+                                                        current_block = 2084488458830559219;
                                                     } else {
                                                         (*c).n_tiles
                                                             += 1 as libc::c_int
@@ -4914,7 +4914,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                 _ => {}
                             }
                             match current_block {
-                                13588377604982898435 => {}
+                                2084488458830559219 => {}
                                 _ => {
                                     if !((*c).seq_hdr).is_null() && !((*c).frame_hdr).is_null()
                                     {
@@ -4926,7 +4926,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                                 .frame_hdr)
                                                 .is_null()
                                             {
-                                                current_block = 13588377604982898435;
+                                                current_block = 2084488458830559219;
                                             } else {
                                                 match (*(*c)
                                                     .refs[(*(*c).frame_hdr).existing_frame_idx as usize]
@@ -4940,7 +4940,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                                             > DAV1D_DECODEFRAMETYPE_REFERENCE as libc::c_int
                                                                 as libc::c_uint
                                                         {
-                                                            current_block = 13679153167263055587;
+                                                            current_block = 16317588828440302375;
                                                         } else {
                                                             current_block = 12969817083969514432;
                                                         }
@@ -4949,7 +4949,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                                         if (*c).decode_frame_type as libc::c_uint
                                                             > DAV1D_DECODEFRAMETYPE_INTRA as libc::c_int as libc::c_uint
                                                         {
-                                                            current_block = 13679153167263055587;
+                                                            current_block = 16317588828440302375;
                                                         } else {
                                                             current_block = 12969817083969514432;
                                                         }
@@ -4959,7 +4959,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                                     }
                                                 }
                                                 match current_block {
-                                                    13679153167263055587 => {}
+                                                    16317588828440302375 => {}
                                                     _ => {
                                                         if ((*c)
                                                             .refs[(*(*c).frame_hdr).existing_frame_idx as usize]
@@ -4968,14 +4968,14 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                                             .data[0 as libc::c_int as usize])
                                                             .is_null()
                                                         {
-                                                            current_block = 13588377604982898435;
+                                                            current_block = 2084488458830559219;
                                                         } else if (*c).strict_std_compliance != 0
                                                             && (*c)
                                                                 .refs[(*(*c).frame_hdr).existing_frame_idx as usize]
                                                                 .p
                                                                 .showable == 0
                                                         {
-                                                            current_block = 13588377604982898435;
+                                                            current_block = 2084488458830559219;
                                                         } else {
                                                             if (*c).n_fc == 1 as libc::c_int as libc::c_uint {
                                                                 dav1d_thread_picture_ref(
@@ -5001,11 +5001,11 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                                                 );
                                                             } else {
                                                                 pthread_mutex_lock(&mut (*c).task_thread.lock);
-                                                                let fresh3 = (*c).frame_thread.next;
+                                                                let fresh1 = (*c).frame_thread.next;
                                                                 (*c)
                                                                     .frame_thread
                                                                     .next = ((*c).frame_thread.next).wrapping_add(1);
-                                                                let next: libc::c_uint = fresh3;
+                                                                let next: libc::c_uint = fresh1;
                                                                 if (*c).frame_thread.next == (*c).n_fc {
                                                                     (*c).frame_thread.next = 0 as libc::c_int as libc::c_uint;
                                                                 }
@@ -5041,15 +5041,15 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                                                             0 as libc::c_int as libc::c_uint,
                                                                         );
                                                                     }
-                                                                    let fresh6 = ::core::intrinsics::atomic_cxchg_seqcst_seqcst(
+                                                                    let fresh2 = ::core::intrinsics::atomic_cxchg_seqcst_seqcst(
                                                                         &mut (*c).task_thread.reset_task_cur,
                                                                         *&mut first,
                                                                         (2147483647 as libc::c_int as libc::c_uint)
                                                                             .wrapping_mul(2 as libc::c_uint)
                                                                             .wrapping_add(1 as libc::c_uint),
                                                                     );
-                                                                    *&mut first = fresh6.0;
-                                                                    fresh6.1;
+                                                                    *&mut first = fresh2.0;
+                                                                    fresh2.1;
                                                                     if (*c).task_thread.cur != 0
                                                                         && (*c).task_thread.cur < (*c).n_fc
                                                                     {
@@ -5175,7 +5175,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                                                 as libc::c_uint
                                                             && (*(*c).frame_hdr).refresh_frame_flags == 0
                                                     {
-                                                        current_block = 13679153167263055587;
+                                                        current_block = 16317588828440302375;
                                                     } else {
                                                         current_block = 1622976744501948573;
                                                     }
@@ -5188,7 +5188,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                                                 as libc::c_uint
                                                             && (*(*c).frame_hdr).refresh_frame_flags == 0
                                                     {
-                                                        current_block = 13679153167263055587;
+                                                        current_block = 16317588828440302375;
                                                     } else {
                                                         current_block = 1622976744501948573;
                                                     }
@@ -5198,10 +5198,10 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                                 }
                                             }
                                             match current_block {
-                                                13679153167263055587 => {}
+                                                16317588828440302375 => {}
                                                 _ => {
                                                     if (*c).n_tile_data == 0 {
-                                                        current_block = 13588377604982898435;
+                                                        current_block = 2084488458830559219;
                                                     } else {
                                                         res = dav1d_submit_frame(c);
                                                         if res < 0 as libc::c_int {
@@ -5221,7 +5221,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                         }
                                         match current_block {
                                             16221891950104054966 => {}
-                                            13588377604982898435 => {}
+                                            2084488458830559219 => {}
                                             _ => {
                                                 let mut i_4: libc::c_int = 0 as libc::c_int;
                                                 while i_4 < 8 as libc::c_int {
@@ -5254,7 +5254,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                         current_block = 16221891950104054966;
                                     }
                                     match current_block {
-                                        13588377604982898435 => {}
+                                        2084488458830559219 => {}
                                         _ => return len.wrapping_add(init_byte_pos) as libc::c_int,
                                     }
                                 }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
+use crate::src::cdf::CdfContext;
 use crate::src::msac::MsacContext;
 extern "C" {
     fn realloc(_: *mut libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
@@ -1248,21 +1248,6 @@ pub struct C2RustUnnamed_45 {
     pub row: libc::c_int,
 }
 pub type ec_win = size_t;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfContext {
-    pub m: CdfModeContext,
-    pub kfym: [[[uint16_t; 16]; 5]; 5],
-    pub coef: CdfCoefContext,
-    pub mv: CdfMvContext,
-    pub dmv: CdfMvContext,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvContext {
-    pub comp: [CdfMvComponent; 2],
-    pub joint: [uint16_t; 4],
-}
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::CdfModeContext;
+use crate::src::cdf::{CdfModeContext, CdfMvComponent};
 use crate::src::msac::MsacContext;
 extern "C" {
     fn realloc(_: *mut libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
@@ -1262,18 +1262,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvComponent {
-    pub classes: [uint16_t; 16],
-    pub class0_fp: [[uint16_t; 4]; 2],
-    pub classN_fp: [uint16_t; 4],
-    pub class0_hp: [uint16_t; 2],
-    pub classN_hp: [uint16_t; 2],
-    pub class0: [uint16_t; 2],
-    pub classN: [[uint16_t; 2]; 10],
-    pub sign: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1,4 +1,5 @@
 use ::libc;
+use crate::src::cdf::CdfModeContext;
 use crate::src::msac::MsacContext;
 extern "C" {
     fn realloc(_: *mut libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
@@ -1290,61 +1291,6 @@ pub struct CdfCoefContext {
     pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
     pub skip: [[[uint16_t; 2]; 13]; 5],
     pub dc_sign: [[[uint16_t; 2]; 3]; 2],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfModeContext {
-    pub y_mode: [[uint16_t; 16]; 4],
-    pub uv_mode: [[[uint16_t; 16]; 13]; 2],
-    pub wedge_idx: [[uint16_t; 16]; 9],
-    pub partition: [[[uint16_t; 16]; 4]; 5],
-    pub cfl_alpha: [[uint16_t; 16]; 6],
-    pub txtp_inter1: [[uint16_t; 16]; 2],
-    pub txtp_inter2: [uint16_t; 16],
-    pub txtp_intra1: [[[uint16_t; 8]; 13]; 2],
-    pub txtp_intra2: [[[uint16_t; 8]; 13]; 3],
-    pub cfl_sign: [uint16_t; 8],
-    pub angle_delta: [[uint16_t; 8]; 8],
-    pub filter_intra: [uint16_t; 8],
-    pub comp_inter_mode: [[uint16_t; 8]; 8],
-    pub seg_id: [[uint16_t; 8]; 3],
-    pub pal_sz: [[[uint16_t; 8]; 7]; 2],
-    pub color_map: [[[[uint16_t; 8]; 5]; 7]; 2],
-    pub filter: [[[uint16_t; 4]; 8]; 2],
-    pub txsz: [[[uint16_t; 4]; 3]; 4],
-    pub motion_mode: [[uint16_t; 4]; 22],
-    pub delta_q: [uint16_t; 4],
-    pub delta_lf: [[uint16_t; 4]; 5],
-    pub interintra_mode: [[uint16_t; 4]; 4],
-    pub restore_switchable: [uint16_t; 4],
-    pub restore_wiener: [uint16_t; 2],
-    pub restore_sgrproj: [uint16_t; 2],
-    pub interintra: [[uint16_t; 2]; 7],
-    pub interintra_wedge: [[uint16_t; 2]; 7],
-    pub txtp_inter3: [[uint16_t; 2]; 4],
-    pub use_filter_intra: [[uint16_t; 2]; 22],
-    pub newmv_mode: [[uint16_t; 2]; 6],
-    pub globalmv_mode: [[uint16_t; 2]; 2],
-    pub refmv_mode: [[uint16_t; 2]; 6],
-    pub drl_bit: [[uint16_t; 2]; 3],
-    pub intra: [[uint16_t; 2]; 4],
-    pub comp: [[uint16_t; 2]; 5],
-    pub comp_dir: [[uint16_t; 2]; 5],
-    pub jnt_comp: [[uint16_t; 2]; 6],
-    pub mask_comp: [[uint16_t; 2]; 6],
-    pub wedge_comp: [[uint16_t; 2]; 9],
-    pub ref_0: [[[uint16_t; 2]; 3]; 6],
-    pub comp_fwd_ref: [[[uint16_t; 2]; 3]; 3],
-    pub comp_bwd_ref: [[[uint16_t; 2]; 3]; 2],
-    pub comp_uni_ref: [[[uint16_t; 2]; 3]; 3],
-    pub txpart: [[[uint16_t; 2]; 3]; 7],
-    pub skip: [[uint16_t; 2]; 3],
-    pub skip_mode: [[uint16_t; 2]; 3],
-    pub seg_pred: [[uint16_t; 2]; 3],
-    pub obmc: [[uint16_t; 2]; 22],
-    pub pal_y: [[[uint16_t; 2]; 3]; 7],
-    pub pal_uv: [[uint16_t; 2]; 2],
-    pub intrabc: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::CdfModeContext;
+use crate::src::cdf::{CdfModeContext, CdfMvComponent};
 use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
@@ -1279,18 +1279,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvComponent {
-    pub classes: [uint16_t; 16],
-    pub class0_fp: [[uint16_t; 4]; 2],
-    pub classN_fp: [uint16_t; 4],
-    pub class0_hp: [uint16_t; 2],
-    pub classN_hp: [uint16_t; 2],
-    pub class0: [uint16_t; 2],
-    pub classN: [[uint16_t; 2]; 10],
-    pub sign: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
+use crate::src::cdf::CdfContext;
 use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
@@ -1265,21 +1265,6 @@ pub struct C2RustUnnamed_45 {
     pub row: libc::c_int,
 }
 pub type ec_win = size_t;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfContext {
-    pub m: CdfModeContext,
-    pub kfym: [[[uint16_t; 16]; 5]; 5],
-    pub coef: CdfCoefContext,
-    pub mv: CdfMvContext,
-    pub dmv: CdfMvContext,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvContext {
-    pub comp: [CdfMvComponent; 2],
-    pub joint: [uint16_t; 4],
-}
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::{CdfModeContext, CdfMvComponent};
+use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
 use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
@@ -1279,23 +1279,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfCoefContext {
-    pub eob_bin_16: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_32: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_64: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_128: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_256: [[[uint16_t; 16]; 2]; 2],
-    pub eob_bin_512: [[uint16_t; 16]; 2],
-    pub eob_bin_1024: [[uint16_t; 16]; 2],
-    pub eob_base_tok: [[[[uint16_t; 4]; 4]; 2]; 5],
-    pub base_tok: [[[[uint16_t; 4]; 41]; 2]; 5],
-    pub br_tok: [[[[uint16_t; 4]; 21]; 2]; 4],
-    pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
-    pub skip: [[[uint16_t; 2]; 13]; 5],
-    pub dc_sign: [[[uint16_t; 2]; 3]; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -1,4 +1,5 @@
 use ::libc;
+use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
@@ -1261,16 +1262,6 @@ pub struct C2RustUnnamed_45 {
     pub row_end: libc::c_int,
     pub col: libc::c_int,
     pub row: libc::c_int,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct MsacContext {
-    pub buf_pos: *const uint8_t,
-    pub buf_end: *const uint8_t,
-    pub dif: ec_win,
-    pub rng: libc::c_uint,
-    pub cnt: libc::c_int,
-    pub allow_update_cdf: libc::c_int,
 }
 pub type ec_win = size_t;
 #[derive(Copy, Clone)]

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -1,4 +1,5 @@
 use ::libc;
+use crate::src::cdf::CdfModeContext;
 use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
@@ -1307,61 +1308,6 @@ pub struct CdfCoefContext {
     pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
     pub skip: [[[uint16_t; 2]; 13]; 5],
     pub dc_sign: [[[uint16_t; 2]; 3]; 2],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfModeContext {
-    pub y_mode: [[uint16_t; 16]; 4],
-    pub uv_mode: [[[uint16_t; 16]; 13]; 2],
-    pub wedge_idx: [[uint16_t; 16]; 9],
-    pub partition: [[[uint16_t; 16]; 4]; 5],
-    pub cfl_alpha: [[uint16_t; 16]; 6],
-    pub txtp_inter1: [[uint16_t; 16]; 2],
-    pub txtp_inter2: [uint16_t; 16],
-    pub txtp_intra1: [[[uint16_t; 8]; 13]; 2],
-    pub txtp_intra2: [[[uint16_t; 8]; 13]; 3],
-    pub cfl_sign: [uint16_t; 8],
-    pub angle_delta: [[uint16_t; 8]; 8],
-    pub filter_intra: [uint16_t; 8],
-    pub comp_inter_mode: [[uint16_t; 8]; 8],
-    pub seg_id: [[uint16_t; 8]; 3],
-    pub pal_sz: [[[uint16_t; 8]; 7]; 2],
-    pub color_map: [[[[uint16_t; 8]; 5]; 7]; 2],
-    pub filter: [[[uint16_t; 4]; 8]; 2],
-    pub txsz: [[[uint16_t; 4]; 3]; 4],
-    pub motion_mode: [[uint16_t; 4]; 22],
-    pub delta_q: [uint16_t; 4],
-    pub delta_lf: [[uint16_t; 4]; 5],
-    pub interintra_mode: [[uint16_t; 4]; 4],
-    pub restore_switchable: [uint16_t; 4],
-    pub restore_wiener: [uint16_t; 2],
-    pub restore_sgrproj: [uint16_t; 2],
-    pub interintra: [[uint16_t; 2]; 7],
-    pub interintra_wedge: [[uint16_t; 2]; 7],
-    pub txtp_inter3: [[uint16_t; 2]; 4],
-    pub use_filter_intra: [[uint16_t; 2]; 22],
-    pub newmv_mode: [[uint16_t; 2]; 6],
-    pub globalmv_mode: [[uint16_t; 2]; 2],
-    pub refmv_mode: [[uint16_t; 2]; 6],
-    pub drl_bit: [[uint16_t; 2]; 3],
-    pub intra: [[uint16_t; 2]; 4],
-    pub comp: [[uint16_t; 2]; 5],
-    pub comp_dir: [[uint16_t; 2]; 5],
-    pub jnt_comp: [[uint16_t; 2]; 6],
-    pub mask_comp: [[uint16_t; 2]; 6],
-    pub wedge_comp: [[uint16_t; 2]; 9],
-    pub ref_0: [[[uint16_t; 2]; 3]; 6],
-    pub comp_fwd_ref: [[[uint16_t; 2]; 3]; 3],
-    pub comp_bwd_ref: [[[uint16_t; 2]; 3]; 2],
-    pub comp_uni_ref: [[[uint16_t; 2]; 3]; 3],
-    pub txpart: [[[uint16_t; 2]; 3]; 7],
-    pub skip: [[uint16_t; 2]; 3],
-    pub skip_mode: [[uint16_t; 2]; 3],
-    pub seg_pred: [[uint16_t; 2]; 3],
-    pub obmc: [[uint16_t; 2]; 22],
-    pub pal_y: [[[uint16_t; 2]; 3]; 7],
-    pub pal_uv: [[uint16_t; 2]; 2],
-    pub intrabc: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1,6 +1,6 @@
 use ::libc;
 use core::arch::asm;
-use crate::src::cdf::CdfModeContext;
+use crate::src::cdf::{CdfModeContext, CdfMvComponent};
 use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
@@ -1344,18 +1344,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvComponent {
-    pub classes: [uint16_t; 16],
-    pub class0_fp: [[uint16_t; 4]; 2],
-    pub classN_fp: [uint16_t; 4],
-    pub class0_hp: [uint16_t; 2],
-    pub classN_hp: [uint16_t; 2],
-    pub class0: [uint16_t; 2],
-    pub classN: [[uint16_t; 2]; 10],
-    pub sign: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1,6 +1,6 @@
 use ::libc;
 use core::arch::asm;
-use crate::src::cdf::{CdfModeContext, CdfMvComponent};
+use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
 use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
@@ -1344,23 +1344,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfCoefContext {
-    pub eob_bin_16: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_32: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_64: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_128: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_256: [[[uint16_t; 16]; 2]; 2],
-    pub eob_bin_512: [[uint16_t; 16]; 2],
-    pub eob_bin_1024: [[uint16_t; 16]; 2],
-    pub eob_base_tok: [[[[uint16_t; 4]; 4]; 2]; 5],
-    pub base_tok: [[[[uint16_t; 4]; 41]; 2]; 5],
-    pub br_tok: [[[[uint16_t; 4]; 21]; 2]; 4],
-    pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
-    pub skip: [[[uint16_t; 2]; 13]; 5],
-    pub dc_sign: [[[uint16_t; 2]; 3]; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1,5 +1,6 @@
 use ::libc;
 use core::arch::asm;
+use crate::src::cdf::CdfModeContext;
 use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
@@ -1372,61 +1373,6 @@ pub struct CdfCoefContext {
     pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
     pub skip: [[[uint16_t; 2]; 13]; 5],
     pub dc_sign: [[[uint16_t; 2]; 3]; 2],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfModeContext {
-    pub y_mode: [[uint16_t; 16]; 4],
-    pub uv_mode: [[[uint16_t; 16]; 13]; 2],
-    pub wedge_idx: [[uint16_t; 16]; 9],
-    pub partition: [[[uint16_t; 16]; 4]; 5],
-    pub cfl_alpha: [[uint16_t; 16]; 6],
-    pub txtp_inter1: [[uint16_t; 16]; 2],
-    pub txtp_inter2: [uint16_t; 16],
-    pub txtp_intra1: [[[uint16_t; 8]; 13]; 2],
-    pub txtp_intra2: [[[uint16_t; 8]; 13]; 3],
-    pub cfl_sign: [uint16_t; 8],
-    pub angle_delta: [[uint16_t; 8]; 8],
-    pub filter_intra: [uint16_t; 8],
-    pub comp_inter_mode: [[uint16_t; 8]; 8],
-    pub seg_id: [[uint16_t; 8]; 3],
-    pub pal_sz: [[[uint16_t; 8]; 7]; 2],
-    pub color_map: [[[[uint16_t; 8]; 5]; 7]; 2],
-    pub filter: [[[uint16_t; 4]; 8]; 2],
-    pub txsz: [[[uint16_t; 4]; 3]; 4],
-    pub motion_mode: [[uint16_t; 4]; 22],
-    pub delta_q: [uint16_t; 4],
-    pub delta_lf: [[uint16_t; 4]; 5],
-    pub interintra_mode: [[uint16_t; 4]; 4],
-    pub restore_switchable: [uint16_t; 4],
-    pub restore_wiener: [uint16_t; 2],
-    pub restore_sgrproj: [uint16_t; 2],
-    pub interintra: [[uint16_t; 2]; 7],
-    pub interintra_wedge: [[uint16_t; 2]; 7],
-    pub txtp_inter3: [[uint16_t; 2]; 4],
-    pub use_filter_intra: [[uint16_t; 2]; 22],
-    pub newmv_mode: [[uint16_t; 2]; 6],
-    pub globalmv_mode: [[uint16_t; 2]; 2],
-    pub refmv_mode: [[uint16_t; 2]; 6],
-    pub drl_bit: [[uint16_t; 2]; 3],
-    pub intra: [[uint16_t; 2]; 4],
-    pub comp: [[uint16_t; 2]; 5],
-    pub comp_dir: [[uint16_t; 2]; 5],
-    pub jnt_comp: [[uint16_t; 2]; 6],
-    pub mask_comp: [[uint16_t; 2]; 6],
-    pub wedge_comp: [[uint16_t; 2]; 9],
-    pub ref_0: [[[uint16_t; 2]; 3]; 6],
-    pub comp_fwd_ref: [[[uint16_t; 2]; 3]; 3],
-    pub comp_bwd_ref: [[[uint16_t; 2]; 3]; 2],
-    pub comp_uni_ref: [[[uint16_t; 2]; 3]; 3],
-    pub txpart: [[[uint16_t; 2]; 3]; 7],
-    pub skip: [[uint16_t; 2]; 3],
-    pub skip_mode: [[uint16_t; 2]; 3],
-    pub seg_pred: [[uint16_t; 2]; 3],
-    pub obmc: [[uint16_t; 2]; 22],
-    pub pal_y: [[[uint16_t; 2]; 3]; 7],
-    pub pal_uv: [[uint16_t; 2]; 2],
-    pub intrabc: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -3335,7 +3281,7 @@ unsafe extern "C" fn decode_coefs(
             } else if (*t_dim).min as libc::c_int == TX_16X16 as libc::c_int {
                 idx = dav1d_msac_decode_symbol_adapt16(
                     &mut (*ts).msac,
-                    ((*ts).cdf.m.txtp_inter2).as_mut_ptr(),
+                    ((*ts).cdf.m.txtp_inter2.0).as_mut_ptr(),
                     11 as libc::c_int as size_t,
                 );
                 *txtp = dav1d_tx_types_per_set[idx

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -27,20 +27,27 @@ extern "C" {
     static dav1d_skip_ctx: [[uint8_t; 5]; 5];
     static dav1d_tx_type_class: [uint8_t; 17];
     static dav1d_filter_2d: [[uint8_t; 4]; 4];
-    fn dav1d_msac_decode_symbol_adapt_c(
+    fn dav1d_msac_decode_symbol_adapt4(
         s: *mut MsacContext,
         cdf: *mut uint16_t,
         n_symbols: size_t,
     ) -> libc::c_uint;
-    fn dav1d_msac_decode_bool_adapt_c(
+    fn dav1d_msac_decode_symbol_adapt8(
+        s: *mut MsacContext,
+        cdf: *mut uint16_t,
+        n_symbols: size_t,
+    ) -> libc::c_uint;
+    fn dav1d_msac_decode_symbol_adapt16(
+        s: *mut MsacContext,
+        cdf: *mut uint16_t,
+        n_symbols: size_t,
+    ) -> libc::c_uint;
+    fn dav1d_msac_decode_bool_adapt(
         s: *mut MsacContext,
         cdf: *mut uint16_t,
     ) -> libc::c_uint;
-    fn dav1d_msac_decode_bool_equi_c(s: *mut MsacContext) -> libc::c_uint;
-    fn dav1d_msac_decode_hi_tok_c(
-        s: *mut MsacContext,
-        cdf: *mut uint16_t,
-    ) -> libc::c_uint;
+    fn dav1d_msac_decode_bool_equi(s: *mut MsacContext) -> libc::c_uint;
+    fn dav1d_msac_decode_hi_tok(s: *mut MsacContext, cdf: *mut uint16_t) -> libc::c_uint;
     fn dav1d_cdef_brow_16bpc(
         tc: *mut Dav1dTaskContext,
         p: *const *mut pixel,
@@ -2384,7 +2391,7 @@ unsafe extern "C" fn dav1d_msac_decode_bools(
         if !(fresh2 != 0) {
             break;
         }
-        v = v << 1 as libc::c_int | dav1d_msac_decode_bool_equi_c(s);
+        v = v << 1 as libc::c_int | dav1d_msac_decode_bool_equi(s);
     }
     return v;
 }
@@ -2422,7 +2429,7 @@ unsafe extern "C" fn sm_uv_flag(
 unsafe extern "C" fn read_golomb(msac: *mut MsacContext) -> libc::c_uint {
     let mut len: libc::c_int = 0 as libc::c_int;
     let mut val: libc::c_uint = 1 as libc::c_int as libc::c_uint;
-    while dav1d_msac_decode_bool_equi_c(msac) == 0 && len < 32 as libc::c_int {
+    while dav1d_msac_decode_bool_equi(msac) == 0 && len < 32 as libc::c_int {
         len += 1;
     }
     loop {
@@ -2431,8 +2438,7 @@ unsafe extern "C" fn read_golomb(msac: *mut MsacContext) -> libc::c_uint {
         if !(fresh3 != 0) {
             break;
         }
-        val = (val << 1 as libc::c_int)
-            .wrapping_add(dav1d_msac_decode_bool_equi_c(msac));
+        val = (val << 1 as libc::c_int).wrapping_add(dav1d_msac_decode_bool_equi(msac));
     }
     return val.wrapping_sub(1 as libc::c_int as libc::c_uint);
 }
@@ -2463,7 +2469,7 @@ unsafe extern "C" fn get_skip_ctx(
         let mut current_block_7: u64;
         match (*t_dim).lw as libc::c_int {
             0 => {
-                current_block_7 = 10399555703668911007;
+                current_block_7 = 1099099133724271053;
             }
             1 => {
                 ca = (*(a as *const uint16_t) as libc::c_int != 0x4040 as libc::c_int)
@@ -2485,11 +2491,11 @@ unsafe extern "C" fn get_skip_ctx(
                 if 0 as libc::c_int == 0 {
                     unreachable!();
                 }
-                current_block_7 = 10399555703668911007;
+                current_block_7 = 1099099133724271053;
             }
         }
         match current_block_7 {
-            10399555703668911007 => {
+            1099099133724271053 => {
                 ca = (*a as libc::c_int != 0x40 as libc::c_int) as libc::c_int
                     as libc::c_uint;
             }
@@ -2498,7 +2504,7 @@ unsafe extern "C" fn get_skip_ctx(
         let mut current_block_16: u64;
         match (*t_dim).lh as libc::c_int {
             0 => {
-                current_block_16 = 3647848889923672344;
+                current_block_16 = 17248733373376933624;
             }
             1 => {
                 cl = (*(l as *const uint16_t) as libc::c_int != 0x4040 as libc::c_int)
@@ -2520,11 +2526,11 @@ unsafe extern "C" fn get_skip_ctx(
                 if 0 as libc::c_int == 0 {
                     unreachable!();
                 }
-                current_block_16 = 3647848889923672344;
+                current_block_16 = 17248733373376933624;
             }
         }
         match current_block_16 {
-            3647848889923672344 => {
+            17248733373376933624 => {
                 cl = (*l as libc::c_int != 0x40 as libc::c_int) as libc::c_int
                     as libc::c_uint;
             }
@@ -2545,7 +2551,7 @@ unsafe extern "C" fn get_skip_ctx(
         let mut current_block_80: u64;
         match (*t_dim).lw as libc::c_int {
             0 => {
-                current_block_80 = 15246099650128651744;
+                current_block_80 = 8746691339416183331;
             }
             1 => {
                 if TX_8X8 as libc::c_int == TX_64X64 as libc::c_int {
@@ -2655,11 +2661,11 @@ unsafe extern "C" fn get_skip_ctx(
                 if 0 as libc::c_int == 0 {
                     unreachable!();
                 }
-                current_block_80 = 15246099650128651744;
+                current_block_80 = 8746691339416183331;
             }
         }
         match current_block_80 {
-            15246099650128651744 => {
+            8746691339416183331 => {
                 if TX_4X4 as libc::c_int == TX_64X64 as libc::c_int {
                     let mut tmp: uint64_t = *(a as *const uint64_t);
                     tmp
@@ -2689,7 +2695,7 @@ unsafe extern "C" fn get_skip_ctx(
         let mut current_block_140: u64;
         match (*t_dim).lh as libc::c_int {
             0 => {
-                current_block_140 = 14339467614101779218;
+                current_block_140 = 11226773410460995356;
             }
             1 => {
                 if TX_8X8 as libc::c_int == TX_64X64 as libc::c_int {
@@ -2799,11 +2805,11 @@ unsafe extern "C" fn get_skip_ctx(
                 if 0 as libc::c_int == 0 {
                     unreachable!();
                 }
-                current_block_140 = 14339467614101779218;
+                current_block_140 = 11226773410460995356;
             }
         }
         match current_block_140 {
-            14339467614101779218 => {
+            11226773410460995356 => {
                 if TX_4X4 as libc::c_int == TX_64X64 as libc::c_int {
                     let mut tmp_4: uint64_t = *(l as *const uint64_t);
                     tmp_4
@@ -3237,7 +3243,7 @@ unsafe extern "C" fn decode_coefs(
     }
     let sctx: libc::c_int = get_skip_ctx(t_dim, bs, a, l, chroma, (*f).cur.p.layout)
         as libc::c_int;
-    let all_skip: libc::c_int = dav1d_msac_decode_bool_adapt_c(
+    let all_skip: libc::c_int = dav1d_msac_decode_bool_adapt(
         &mut (*ts).msac,
         ((*ts).cdf.coef.skip[(*t_dim).ctx as usize][sctx as usize]).as_mut_ptr(),
     ) as libc::c_int;
@@ -3287,7 +3293,7 @@ unsafe extern "C" fn decode_coefs(
             if (*(*f).frame_hdr).reduced_txtp_set != 0
                 || (*t_dim).min as libc::c_int == TX_16X16 as libc::c_int
             {
-                idx = dav1d_msac_decode_symbol_adapt_c(
+                idx = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
                     ((*ts)
                         .cdf
@@ -3300,7 +3306,7 @@ unsafe extern "C" fn decode_coefs(
                     .wrapping_add(0 as libc::c_int as libc::c_uint) as usize]
                     as TxfmType;
             } else {
-                idx = dav1d_msac_decode_symbol_adapt_c(
+                idx = dav1d_msac_decode_symbol_adapt8(
                     &mut (*ts).msac,
                     ((*ts)
                         .cdf
@@ -3329,14 +3335,14 @@ unsafe extern "C" fn decode_coefs(
             if (*(*f).frame_hdr).reduced_txtp_set != 0
                 || (*t_dim).max as libc::c_int == TX_32X32 as libc::c_int
             {
-                idx = dav1d_msac_decode_bool_adapt_c(
+                idx = dav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
                     ((*ts).cdf.m.txtp_inter3[(*t_dim).min as usize]).as_mut_ptr(),
                 );
                 *txtp = (idx.wrapping_sub(1 as libc::c_int as libc::c_uint)
                     & IDTX as libc::c_int as libc::c_uint) as TxfmType;
             } else if (*t_dim).min as libc::c_int == TX_16X16 as libc::c_int {
-                idx = dav1d_msac_decode_symbol_adapt_c(
+                idx = dav1d_msac_decode_symbol_adapt16(
                     &mut (*ts).msac,
                     ((*ts).cdf.m.txtp_inter2).as_mut_ptr(),
                     11 as libc::c_int as size_t,
@@ -3345,7 +3351,7 @@ unsafe extern "C" fn decode_coefs(
                     .wrapping_add(12 as libc::c_int as libc::c_uint) as usize]
                     as TxfmType;
             } else {
-                idx = dav1d_msac_decode_symbol_adapt_c(
+                idx = dav1d_msac_decode_symbol_adapt16(
                     &mut (*ts).msac,
                     ((*ts).cdf.m.txtp_inter1[(*t_dim).min as usize]).as_mut_ptr(),
                     15 as libc::c_int as size_t,
@@ -3382,7 +3388,7 @@ unsafe extern "C" fn decode_coefs(
                 .coef
                 .eob_bin_16[chroma as usize][is_1d as usize])
                 .as_mut_ptr();
-            eob_bin = dav1d_msac_decode_symbol_adapt_c(
+            eob_bin = dav1d_msac_decode_symbol_adapt4(
                 &mut (*ts).msac,
                 eob_bin_cdf,
                 (4 as libc::c_int + 0 as libc::c_int) as size_t,
@@ -3394,7 +3400,7 @@ unsafe extern "C" fn decode_coefs(
                 .coef
                 .eob_bin_32[chroma as usize][is_1d as usize])
                 .as_mut_ptr();
-            eob_bin = dav1d_msac_decode_symbol_adapt_c(
+            eob_bin = dav1d_msac_decode_symbol_adapt8(
                 &mut (*ts).msac,
                 eob_bin_cdf_0,
                 (4 as libc::c_int + 1 as libc::c_int) as size_t,
@@ -3406,7 +3412,7 @@ unsafe extern "C" fn decode_coefs(
                 .coef
                 .eob_bin_64[chroma as usize][is_1d as usize])
                 .as_mut_ptr();
-            eob_bin = dav1d_msac_decode_symbol_adapt_c(
+            eob_bin = dav1d_msac_decode_symbol_adapt8(
                 &mut (*ts).msac,
                 eob_bin_cdf_1,
                 (4 as libc::c_int + 2 as libc::c_int) as size_t,
@@ -3418,7 +3424,7 @@ unsafe extern "C" fn decode_coefs(
                 .coef
                 .eob_bin_128[chroma as usize][is_1d as usize])
                 .as_mut_ptr();
-            eob_bin = dav1d_msac_decode_symbol_adapt_c(
+            eob_bin = dav1d_msac_decode_symbol_adapt8(
                 &mut (*ts).msac,
                 eob_bin_cdf_2,
                 (4 as libc::c_int + 3 as libc::c_int) as size_t,
@@ -3430,7 +3436,7 @@ unsafe extern "C" fn decode_coefs(
                 .coef
                 .eob_bin_256[chroma as usize][is_1d as usize])
                 .as_mut_ptr();
-            eob_bin = dav1d_msac_decode_symbol_adapt_c(
+            eob_bin = dav1d_msac_decode_symbol_adapt16(
                 &mut (*ts).msac,
                 eob_bin_cdf_3,
                 (4 as libc::c_int + 4 as libc::c_int) as size_t,
@@ -3442,7 +3448,7 @@ unsafe extern "C" fn decode_coefs(
                 .coef
                 .eob_bin_512[chroma as usize])
                 .as_mut_ptr();
-            eob_bin = dav1d_msac_decode_symbol_adapt_c(
+            eob_bin = dav1d_msac_decode_symbol_adapt16(
                 &mut (*ts).msac,
                 eob_bin_cdf_4,
                 (4 as libc::c_int + 5 as libc::c_int) as size_t,
@@ -3454,7 +3460,7 @@ unsafe extern "C" fn decode_coefs(
                 .coef
                 .eob_bin_1024[chroma as usize])
                 .as_mut_ptr();
-            eob_bin = dav1d_msac_decode_symbol_adapt_c(
+            eob_bin = dav1d_msac_decode_symbol_adapt16(
                 &mut (*ts).msac,
                 eob_bin_cdf_5,
                 (4 as libc::c_int + 6 as libc::c_int) as size_t,
@@ -3479,7 +3485,7 @@ unsafe extern "C" fn decode_coefs(
             .coef
             .eob_hi_bit[(*t_dim).ctx as usize][chroma as usize][eob_bin as usize])
             .as_mut_ptr();
-        let eob_hi_bit: libc::c_int = dav1d_msac_decode_bool_adapt_c(
+        let eob_hi_bit: libc::c_int = dav1d_msac_decode_bool_adapt(
             &mut (*ts).msac,
             eob_hi_bit_cdf,
         ) as libc::c_int;
@@ -3539,7 +3545,7 @@ unsafe extern "C" fn decode_coefs(
         let mut ctx: libc::c_uint = (1 as libc::c_int
             + (eob > sw * sh * 2 as libc::c_int) as libc::c_int
             + (eob > sw * sh * 4 as libc::c_int) as libc::c_int) as libc::c_uint;
-        let mut eob_tok: libc::c_int = dav1d_msac_decode_symbol_adapt_c(
+        let mut eob_tok: libc::c_int = dav1d_msac_decode_symbol_adapt4(
             &mut (*ts).msac,
             (*eob_cdf.offset(ctx as isize)).as_mut_ptr(),
             2 as libc::c_int as size_t,
@@ -3614,7 +3620,7 @@ unsafe extern "C" fn decode_coefs(
                     } else {
                         7 as libc::c_int
                     }) as libc::c_uint;
-                    tok = dav1d_msac_decode_hi_tok_c(
+                    tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
                     ) as libc::c_int;
@@ -3674,7 +3680,7 @@ unsafe extern "C" fn decode_coefs(
                     if TX_CLASS_2D as libc::c_int == TX_CLASS_2D as libc::c_int {
                         y |= x;
                     }
-                    tok = dav1d_msac_decode_symbol_adapt_c(
+                    tok = dav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
                         (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
                         3 as libc::c_int as size_t,
@@ -3710,7 +3716,7 @@ unsafe extern "C" fn decode_coefs(
                                         >> 1 as libc::c_int
                                 }),
                             );
-                        tok = dav1d_msac_decode_hi_tok_c(
+                        tok = dav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
                             (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
                         ) as libc::c_int;
@@ -3760,7 +3766,7 @@ unsafe extern "C" fn decode_coefs(
                         stride,
                     )
                 };
-                dc_tok = dav1d_msac_decode_symbol_adapt_c(
+                dc_tok = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
                     (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
                     3 as libc::c_int as size_t,
@@ -3801,7 +3807,7 @@ unsafe extern "C" fn decode_coefs(
                         mag.wrapping_add(1 as libc::c_int as libc::c_uint)
                             >> 1 as libc::c_int
                     };
-                    dc_tok = dav1d_msac_decode_hi_tok_c(
+                    dc_tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
                     );
@@ -3872,7 +3878,7 @@ unsafe extern "C" fn decode_coefs(
                     } else {
                         7 as libc::c_int
                     }) as libc::c_uint;
-                    tok = dav1d_msac_decode_hi_tok_c(
+                    tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
                     ) as libc::c_int;
@@ -3932,7 +3938,7 @@ unsafe extern "C" fn decode_coefs(
                     if TX_CLASS_H as libc::c_int == TX_CLASS_2D as libc::c_int {
                         y_0 |= x_0;
                     }
-                    tok = dav1d_msac_decode_symbol_adapt_c(
+                    tok = dav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
                         (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
                         3 as libc::c_int as size_t,
@@ -3968,7 +3974,7 @@ unsafe extern "C" fn decode_coefs(
                                         >> 1 as libc::c_int
                                 }),
                             );
-                        tok = dav1d_msac_decode_hi_tok_c(
+                        tok = dav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
                             (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
                         ) as libc::c_int;
@@ -4018,7 +4024,7 @@ unsafe extern "C" fn decode_coefs(
                         stride_0,
                     )
                 };
-                dc_tok = dav1d_msac_decode_symbol_adapt_c(
+                dc_tok = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
                     (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
                     3 as libc::c_int as size_t,
@@ -4059,7 +4065,7 @@ unsafe extern "C" fn decode_coefs(
                         mag.wrapping_add(1 as libc::c_int as libc::c_uint)
                             >> 1 as libc::c_int
                     };
-                    dc_tok = dav1d_msac_decode_hi_tok_c(
+                    dc_tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
                     );
@@ -4131,7 +4137,7 @@ unsafe extern "C" fn decode_coefs(
                     } else {
                         7 as libc::c_int
                     }) as libc::c_uint;
-                    tok = dav1d_msac_decode_hi_tok_c(
+                    tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
                     ) as libc::c_int;
@@ -4191,7 +4197,7 @@ unsafe extern "C" fn decode_coefs(
                     if TX_CLASS_V as libc::c_int == TX_CLASS_2D as libc::c_int {
                         y_1 |= x_1;
                     }
-                    tok = dav1d_msac_decode_symbol_adapt_c(
+                    tok = dav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
                         (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
                         3 as libc::c_int as size_t,
@@ -4227,7 +4233,7 @@ unsafe extern "C" fn decode_coefs(
                                         >> 1 as libc::c_int
                                 }),
                             );
-                        tok = dav1d_msac_decode_hi_tok_c(
+                        tok = dav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
                             (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
                         ) as libc::c_int;
@@ -4277,7 +4283,7 @@ unsafe extern "C" fn decode_coefs(
                         stride_1,
                     )
                 };
-                dc_tok = dav1d_msac_decode_symbol_adapt_c(
+                dc_tok = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
                     (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
                     3 as libc::c_int as size_t,
@@ -4318,7 +4324,7 @@ unsafe extern "C" fn decode_coefs(
                         mag.wrapping_add(1 as libc::c_int as libc::c_uint)
                             >> 1 as libc::c_int
                     };
-                    dc_tok = dav1d_msac_decode_hi_tok_c(
+                    dc_tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
                     );
@@ -4341,7 +4347,7 @@ unsafe extern "C" fn decode_coefs(
             }
         }
     } else {
-        let mut tok_br: libc::c_int = dav1d_msac_decode_symbol_adapt_c(
+        let mut tok_br: libc::c_int = dav1d_msac_decode_symbol_adapt4(
             &mut (*ts).msac,
             (*eob_cdf.offset(0 as libc::c_int as isize)).as_mut_ptr(),
             2 as libc::c_int as size_t,
@@ -4359,7 +4365,7 @@ unsafe extern "C" fn decode_coefs(
             );
         }
         if tok_br == 2 as libc::c_int {
-            dc_tok = dav1d_msac_decode_hi_tok_c(
+            dc_tok = dav1d_msac_decode_hi_tok(
                 &mut (*ts).msac,
                 (*hi_cdf.offset(0 as libc::c_int as isize)).as_mut_ptr(),
             );
@@ -4402,15 +4408,15 @@ unsafe extern "C" fn decode_coefs(
         cul_level = 0 as libc::c_int as libc::c_uint;
         dc_sign_level = ((1 as libc::c_int) << 6 as libc::c_int) as libc::c_uint;
         if !qm_tbl.is_null() {
-            current_block = 14007949380551820454;
+            current_block = 1669574575799829731;
         } else {
-            current_block = 9537642579205451280;
+            current_block = 2404388531445638768;
         }
     } else {
         dc_sign_ctx = get_dc_sign_ctx(tx as libc::c_int, a, l) as libc::c_int;
         dc_sign_cdf = ((*ts).cdf.coef.dc_sign[chroma as usize][dc_sign_ctx as usize])
             .as_mut_ptr();
-        dc_sign = dav1d_msac_decode_bool_adapt_c(&mut (*ts).msac, dc_sign_cdf)
+        dc_sign = dav1d_msac_decode_bool_adapt(&mut (*ts).msac, dc_sign_cdf)
             as libc::c_int;
         if dbg != 0 {
             printf(
@@ -4459,7 +4465,7 @@ unsafe extern "C" fn decode_coefs(
                     0 as libc::c_int as isize,
                 ) = if dc_sign != 0 { -dc_dq } else { dc_dq };
             if rc != 0 {
-                current_block = 14007949380551820454;
+                current_block = 1669574575799829731;
             } else {
                 current_block = 15494703142406051947;
             }
@@ -4495,18 +4501,18 @@ unsafe extern "C" fn decode_coefs(
                     0 as libc::c_int as isize,
                 ) = if dc_sign != 0 { -dc_dq } else { dc_dq };
             if rc != 0 {
-                current_block = 9537642579205451280;
+                current_block = 2404388531445638768;
             } else {
                 current_block = 15494703142406051947;
             }
         }
     }
     match current_block {
-        14007949380551820454 => {
+        1669574575799829731 => {
             let ac_dq: libc::c_uint = *dq_tbl.offset(1 as libc::c_int as isize)
                 as libc::c_uint;
             loop {
-                let sign: libc::c_int = dav1d_msac_decode_bool_equi_c(&mut (*ts).msac)
+                let sign: libc::c_int = dav1d_msac_decode_bool_equi(&mut (*ts).msac)
                     as libc::c_int;
                 if dbg != 0 {
                     printf(
@@ -4556,11 +4562,11 @@ unsafe extern "C" fn decode_coefs(
                 }
             }
         }
-        9537642579205451280 => {
+        2404388531445638768 => {
             let ac_dq_0: libc::c_uint = *dq_tbl.offset(1 as libc::c_int as isize)
                 as libc::c_uint;
             loop {
-                let sign_0: libc::c_int = dav1d_msac_decode_bool_equi_c(&mut (*ts).msac)
+                let sign_0: libc::c_int = dav1d_msac_decode_bool_equi(&mut (*ts).msac)
                     as libc::c_int;
                 if dbg != 0 {
                     printf(

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1,5 +1,6 @@
 use ::libc;
 use core::arch::asm;
+use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
@@ -1326,16 +1327,6 @@ pub struct C2RustUnnamed_45 {
     pub row_end: libc::c_int,
     pub col: libc::c_int,
     pub row: libc::c_int,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct MsacContext {
-    pub buf_pos: *const uint8_t,
-    pub buf_end: *const uint8_t,
-    pub dif: ec_win,
-    pub rng: libc::c_uint,
-    pub cnt: libc::c_int,
-    pub allow_update_cdf: libc::c_int,
 }
 pub type ec_win = size_t;
 #[derive(Copy, Clone)]

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1,6 +1,6 @@
 use ::libc;
 use core::arch::asm;
-use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
+use crate::src::cdf::CdfContext;
 use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
@@ -1330,21 +1330,6 @@ pub struct C2RustUnnamed_45 {
     pub row: libc::c_int,
 }
 pub type ec_win = size_t;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfContext {
-    pub m: CdfModeContext,
-    pub kfym: [[[uint16_t; 16]; 5]; 5],
-    pub coef: CdfCoefContext,
-    pub mv: CdfMvContext,
-    pub dmv: CdfMvContext,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvContext {
-    pub comp: [CdfMvComponent; 2],
-    pub joint: [uint16_t; 4],
-}
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1,6 +1,6 @@
 use ::libc;
 use core::arch::asm;
-use crate::src::cdf::{CdfModeContext, CdfMvComponent};
+use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
 use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
@@ -1343,23 +1343,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfCoefContext {
-    pub eob_bin_16: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_32: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_64: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_128: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_256: [[[uint16_t; 16]; 2]; 2],
-    pub eob_bin_512: [[uint16_t; 16]; 2],
-    pub eob_bin_1024: [[uint16_t; 16]; 2],
-    pub eob_base_tok: [[[[uint16_t; 4]; 4]; 2]; 5],
-    pub base_tok: [[[[uint16_t; 4]; 41]; 2]; 5],
-    pub br_tok: [[[[uint16_t; 4]; 21]; 2]; 4],
-    pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
-    pub skip: [[[uint16_t; 2]; 13]; 5],
-    pub dc_sign: [[[uint16_t; 2]; 3]; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1,5 +1,6 @@
 use ::libc;
 use core::arch::asm;
+use crate::src::cdf::CdfModeContext;
 use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
@@ -1371,61 +1372,6 @@ pub struct CdfCoefContext {
     pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
     pub skip: [[[uint16_t; 2]; 13]; 5],
     pub dc_sign: [[[uint16_t; 2]; 3]; 2],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfModeContext {
-    pub y_mode: [[uint16_t; 16]; 4],
-    pub uv_mode: [[[uint16_t; 16]; 13]; 2],
-    pub wedge_idx: [[uint16_t; 16]; 9],
-    pub partition: [[[uint16_t; 16]; 4]; 5],
-    pub cfl_alpha: [[uint16_t; 16]; 6],
-    pub txtp_inter1: [[uint16_t; 16]; 2],
-    pub txtp_inter2: [uint16_t; 16],
-    pub txtp_intra1: [[[uint16_t; 8]; 13]; 2],
-    pub txtp_intra2: [[[uint16_t; 8]; 13]; 3],
-    pub cfl_sign: [uint16_t; 8],
-    pub angle_delta: [[uint16_t; 8]; 8],
-    pub filter_intra: [uint16_t; 8],
-    pub comp_inter_mode: [[uint16_t; 8]; 8],
-    pub seg_id: [[uint16_t; 8]; 3],
-    pub pal_sz: [[[uint16_t; 8]; 7]; 2],
-    pub color_map: [[[[uint16_t; 8]; 5]; 7]; 2],
-    pub filter: [[[uint16_t; 4]; 8]; 2],
-    pub txsz: [[[uint16_t; 4]; 3]; 4],
-    pub motion_mode: [[uint16_t; 4]; 22],
-    pub delta_q: [uint16_t; 4],
-    pub delta_lf: [[uint16_t; 4]; 5],
-    pub interintra_mode: [[uint16_t; 4]; 4],
-    pub restore_switchable: [uint16_t; 4],
-    pub restore_wiener: [uint16_t; 2],
-    pub restore_sgrproj: [uint16_t; 2],
-    pub interintra: [[uint16_t; 2]; 7],
-    pub interintra_wedge: [[uint16_t; 2]; 7],
-    pub txtp_inter3: [[uint16_t; 2]; 4],
-    pub use_filter_intra: [[uint16_t; 2]; 22],
-    pub newmv_mode: [[uint16_t; 2]; 6],
-    pub globalmv_mode: [[uint16_t; 2]; 2],
-    pub refmv_mode: [[uint16_t; 2]; 6],
-    pub drl_bit: [[uint16_t; 2]; 3],
-    pub intra: [[uint16_t; 2]; 4],
-    pub comp: [[uint16_t; 2]; 5],
-    pub comp_dir: [[uint16_t; 2]; 5],
-    pub jnt_comp: [[uint16_t; 2]; 6],
-    pub mask_comp: [[uint16_t; 2]; 6],
-    pub wedge_comp: [[uint16_t; 2]; 9],
-    pub ref_0: [[[uint16_t; 2]; 3]; 6],
-    pub comp_fwd_ref: [[[uint16_t; 2]; 3]; 3],
-    pub comp_bwd_ref: [[[uint16_t; 2]; 3]; 2],
-    pub comp_uni_ref: [[[uint16_t; 2]; 3]; 3],
-    pub txpart: [[[uint16_t; 2]; 3]; 7],
-    pub skip: [[uint16_t; 2]; 3],
-    pub skip_mode: [[uint16_t; 2]; 3],
-    pub seg_pred: [[uint16_t; 2]; 3],
-    pub obmc: [[uint16_t; 2]; 22],
-    pub pal_y: [[[uint16_t; 2]; 3]; 7],
-    pub pal_uv: [[uint16_t; 2]; 2],
-    pub intrabc: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -3297,7 +3243,7 @@ unsafe extern "C" fn decode_coefs(
             } else if (*t_dim).min as libc::c_int == TX_16X16 as libc::c_int {
                 idx = dav1d_msac_decode_symbol_adapt16(
                     &mut (*ts).msac,
-                    ((*ts).cdf.m.txtp_inter2).as_mut_ptr(),
+                    ((*ts).cdf.m.txtp_inter2.0).as_mut_ptr(),
                     11 as libc::c_int as size_t,
                 );
                 *txtp = dav1d_tx_types_per_set[idx

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1,5 +1,6 @@
 use ::libc;
 use core::arch::asm;
+use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
@@ -1325,16 +1326,6 @@ pub struct C2RustUnnamed_45 {
     pub row_end: libc::c_int,
     pub col: libc::c_int,
     pub row: libc::c_int,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct MsacContext {
-    pub buf_pos: *const uint8_t,
-    pub buf_end: *const uint8_t,
-    pub dif: ec_win,
-    pub rng: libc::c_uint,
-    pub cnt: libc::c_int,
-    pub allow_update_cdf: libc::c_int,
 }
 pub type ec_win = size_t;
 #[derive(Copy, Clone)]

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1,6 +1,6 @@
 use ::libc;
 use core::arch::asm;
-use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
+use crate::src::cdf::CdfContext;
 use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
@@ -1329,21 +1329,6 @@ pub struct C2RustUnnamed_45 {
     pub row: libc::c_int,
 }
 pub type ec_win = size_t;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfContext {
-    pub m: CdfModeContext,
-    pub kfym: [[[uint16_t; 16]; 5]; 5],
-    pub coef: CdfCoefContext,
-    pub mv: CdfMvContext,
-    pub dmv: CdfMvContext,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvContext {
-    pub comp: [CdfMvComponent; 2],
-    pub joint: [uint16_t; 4],
-}
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -27,20 +27,27 @@ extern "C" {
     static dav1d_skip_ctx: [[uint8_t; 5]; 5];
     static dav1d_tx_type_class: [uint8_t; 17];
     static dav1d_filter_2d: [[uint8_t; 4]; 4];
-    fn dav1d_msac_decode_symbol_adapt_c(
+    fn dav1d_msac_decode_symbol_adapt4(
         s: *mut MsacContext,
         cdf: *mut uint16_t,
         n_symbols: size_t,
     ) -> libc::c_uint;
-    fn dav1d_msac_decode_bool_adapt_c(
+    fn dav1d_msac_decode_symbol_adapt8(
+        s: *mut MsacContext,
+        cdf: *mut uint16_t,
+        n_symbols: size_t,
+    ) -> libc::c_uint;
+    fn dav1d_msac_decode_symbol_adapt16(
+        s: *mut MsacContext,
+        cdf: *mut uint16_t,
+        n_symbols: size_t,
+    ) -> libc::c_uint;
+    fn dav1d_msac_decode_bool_adapt(
         s: *mut MsacContext,
         cdf: *mut uint16_t,
     ) -> libc::c_uint;
-    fn dav1d_msac_decode_bool_equi_c(s: *mut MsacContext) -> libc::c_uint;
-    fn dav1d_msac_decode_hi_tok_c(
-        s: *mut MsacContext,
-        cdf: *mut uint16_t,
-    ) -> libc::c_uint;
+    fn dav1d_msac_decode_bool_equi(s: *mut MsacContext) -> libc::c_uint;
+    fn dav1d_msac_decode_hi_tok(s: *mut MsacContext, cdf: *mut uint16_t) -> libc::c_uint;
     fn dav1d_cdef_brow_8bpc(
         tc: *mut Dav1dTaskContext,
         p: *const *mut pixel,
@@ -2346,7 +2353,7 @@ unsafe extern "C" fn dav1d_msac_decode_bools(
         if !(fresh2 != 0) {
             break;
         }
-        v = v << 1 as libc::c_int | dav1d_msac_decode_bool_equi_c(s);
+        v = v << 1 as libc::c_int | dav1d_msac_decode_bool_equi(s);
     }
     return v;
 }
@@ -2384,7 +2391,7 @@ unsafe extern "C" fn sm_uv_flag(
 unsafe extern "C" fn read_golomb(msac: *mut MsacContext) -> libc::c_uint {
     let mut len: libc::c_int = 0 as libc::c_int;
     let mut val: libc::c_uint = 1 as libc::c_int as libc::c_uint;
-    while dav1d_msac_decode_bool_equi_c(msac) == 0 && len < 32 as libc::c_int {
+    while dav1d_msac_decode_bool_equi(msac) == 0 && len < 32 as libc::c_int {
         len += 1;
     }
     loop {
@@ -2393,8 +2400,7 @@ unsafe extern "C" fn read_golomb(msac: *mut MsacContext) -> libc::c_uint {
         if !(fresh3 != 0) {
             break;
         }
-        val = (val << 1 as libc::c_int)
-            .wrapping_add(dav1d_msac_decode_bool_equi_c(msac));
+        val = (val << 1 as libc::c_int).wrapping_add(dav1d_msac_decode_bool_equi(msac));
     }
     return val.wrapping_sub(1 as libc::c_int as libc::c_uint);
 }
@@ -2425,7 +2431,7 @@ unsafe extern "C" fn get_skip_ctx(
         let mut current_block_7: u64;
         match (*t_dim).lw as libc::c_int {
             0 => {
-                current_block_7 = 17248733373376933624;
+                current_block_7 = 11396040223254765297;
             }
             1 => {
                 ca = (*(a as *const uint16_t) as libc::c_int != 0x4040 as libc::c_int)
@@ -2447,11 +2453,11 @@ unsafe extern "C" fn get_skip_ctx(
                 if 0 as libc::c_int == 0 {
                     unreachable!();
                 }
-                current_block_7 = 17248733373376933624;
+                current_block_7 = 11396040223254765297;
             }
         }
         match current_block_7 {
-            17248733373376933624 => {
+            11396040223254765297 => {
                 ca = (*a as libc::c_int != 0x40 as libc::c_int) as libc::c_int
                     as libc::c_uint;
             }
@@ -2460,7 +2466,7 @@ unsafe extern "C" fn get_skip_ctx(
         let mut current_block_16: u64;
         match (*t_dim).lh as libc::c_int {
             0 => {
-                current_block_16 = 2186737012240701475;
+                current_block_16 = 15770135957368472560;
             }
             1 => {
                 cl = (*(l as *const uint16_t) as libc::c_int != 0x4040 as libc::c_int)
@@ -2482,11 +2488,11 @@ unsafe extern "C" fn get_skip_ctx(
                 if 0 as libc::c_int == 0 {
                     unreachable!();
                 }
-                current_block_16 = 2186737012240701475;
+                current_block_16 = 15770135957368472560;
             }
         }
         match current_block_16 {
-            2186737012240701475 => {
+            15770135957368472560 => {
                 cl = (*l as libc::c_int != 0x40 as libc::c_int) as libc::c_int
                     as libc::c_uint;
             }
@@ -2507,7 +2513,7 @@ unsafe extern "C" fn get_skip_ctx(
         let mut current_block_80: u64;
         match (*t_dim).lw as libc::c_int {
             0 => {
-                current_block_80 = 10616630223291068506;
+                current_block_80 = 15794479632267580089;
             }
             1 => {
                 if TX_8X8 as libc::c_int == TX_64X64 as libc::c_int {
@@ -2617,11 +2623,11 @@ unsafe extern "C" fn get_skip_ctx(
                 if 0 as libc::c_int == 0 {
                     unreachable!();
                 }
-                current_block_80 = 10616630223291068506;
+                current_block_80 = 15794479632267580089;
             }
         }
         match current_block_80 {
-            10616630223291068506 => {
+            15794479632267580089 => {
                 if TX_4X4 as libc::c_int == TX_64X64 as libc::c_int {
                     let mut tmp: uint64_t = *(a as *const uint64_t);
                     tmp
@@ -2651,7 +2657,7 @@ unsafe extern "C" fn get_skip_ctx(
         let mut current_block_140: u64;
         match (*t_dim).lh as libc::c_int {
             0 => {
-                current_block_140 = 11274586060294963737;
+                current_block_140 = 5167972421258071942;
             }
             1 => {
                 if TX_8X8 as libc::c_int == TX_64X64 as libc::c_int {
@@ -2761,11 +2767,11 @@ unsafe extern "C" fn get_skip_ctx(
                 if 0 as libc::c_int == 0 {
                     unreachable!();
                 }
-                current_block_140 = 11274586060294963737;
+                current_block_140 = 5167972421258071942;
             }
         }
         match current_block_140 {
-            11274586060294963737 => {
+            5167972421258071942 => {
                 if TX_4X4 as libc::c_int == TX_64X64 as libc::c_int {
                     let mut tmp_4: uint64_t = *(l as *const uint64_t);
                     tmp_4
@@ -3199,7 +3205,7 @@ unsafe extern "C" fn decode_coefs(
     }
     let sctx: libc::c_int = get_skip_ctx(t_dim, bs, a, l, chroma, (*f).cur.p.layout)
         as libc::c_int;
-    let all_skip: libc::c_int = dav1d_msac_decode_bool_adapt_c(
+    let all_skip: libc::c_int = dav1d_msac_decode_bool_adapt(
         &mut (*ts).msac,
         ((*ts).cdf.coef.skip[(*t_dim).ctx as usize][sctx as usize]).as_mut_ptr(),
     ) as libc::c_int;
@@ -3249,7 +3255,7 @@ unsafe extern "C" fn decode_coefs(
             if (*(*f).frame_hdr).reduced_txtp_set != 0
                 || (*t_dim).min as libc::c_int == TX_16X16 as libc::c_int
             {
-                idx = dav1d_msac_decode_symbol_adapt_c(
+                idx = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
                     ((*ts)
                         .cdf
@@ -3262,7 +3268,7 @@ unsafe extern "C" fn decode_coefs(
                     .wrapping_add(0 as libc::c_int as libc::c_uint) as usize]
                     as TxfmType;
             } else {
-                idx = dav1d_msac_decode_symbol_adapt_c(
+                idx = dav1d_msac_decode_symbol_adapt8(
                     &mut (*ts).msac,
                     ((*ts)
                         .cdf
@@ -3291,14 +3297,14 @@ unsafe extern "C" fn decode_coefs(
             if (*(*f).frame_hdr).reduced_txtp_set != 0
                 || (*t_dim).max as libc::c_int == TX_32X32 as libc::c_int
             {
-                idx = dav1d_msac_decode_bool_adapt_c(
+                idx = dav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
                     ((*ts).cdf.m.txtp_inter3[(*t_dim).min as usize]).as_mut_ptr(),
                 );
                 *txtp = (idx.wrapping_sub(1 as libc::c_int as libc::c_uint)
                     & IDTX as libc::c_int as libc::c_uint) as TxfmType;
             } else if (*t_dim).min as libc::c_int == TX_16X16 as libc::c_int {
-                idx = dav1d_msac_decode_symbol_adapt_c(
+                idx = dav1d_msac_decode_symbol_adapt16(
                     &mut (*ts).msac,
                     ((*ts).cdf.m.txtp_inter2).as_mut_ptr(),
                     11 as libc::c_int as size_t,
@@ -3307,7 +3313,7 @@ unsafe extern "C" fn decode_coefs(
                     .wrapping_add(12 as libc::c_int as libc::c_uint) as usize]
                     as TxfmType;
             } else {
-                idx = dav1d_msac_decode_symbol_adapt_c(
+                idx = dav1d_msac_decode_symbol_adapt16(
                     &mut (*ts).msac,
                     ((*ts).cdf.m.txtp_inter1[(*t_dim).min as usize]).as_mut_ptr(),
                     15 as libc::c_int as size_t,
@@ -3344,7 +3350,7 @@ unsafe extern "C" fn decode_coefs(
                 .coef
                 .eob_bin_16[chroma as usize][is_1d as usize])
                 .as_mut_ptr();
-            eob_bin = dav1d_msac_decode_symbol_adapt_c(
+            eob_bin = dav1d_msac_decode_symbol_adapt4(
                 &mut (*ts).msac,
                 eob_bin_cdf,
                 (4 as libc::c_int + 0 as libc::c_int) as size_t,
@@ -3356,7 +3362,7 @@ unsafe extern "C" fn decode_coefs(
                 .coef
                 .eob_bin_32[chroma as usize][is_1d as usize])
                 .as_mut_ptr();
-            eob_bin = dav1d_msac_decode_symbol_adapt_c(
+            eob_bin = dav1d_msac_decode_symbol_adapt8(
                 &mut (*ts).msac,
                 eob_bin_cdf_0,
                 (4 as libc::c_int + 1 as libc::c_int) as size_t,
@@ -3368,7 +3374,7 @@ unsafe extern "C" fn decode_coefs(
                 .coef
                 .eob_bin_64[chroma as usize][is_1d as usize])
                 .as_mut_ptr();
-            eob_bin = dav1d_msac_decode_symbol_adapt_c(
+            eob_bin = dav1d_msac_decode_symbol_adapt8(
                 &mut (*ts).msac,
                 eob_bin_cdf_1,
                 (4 as libc::c_int + 2 as libc::c_int) as size_t,
@@ -3380,7 +3386,7 @@ unsafe extern "C" fn decode_coefs(
                 .coef
                 .eob_bin_128[chroma as usize][is_1d as usize])
                 .as_mut_ptr();
-            eob_bin = dav1d_msac_decode_symbol_adapt_c(
+            eob_bin = dav1d_msac_decode_symbol_adapt8(
                 &mut (*ts).msac,
                 eob_bin_cdf_2,
                 (4 as libc::c_int + 3 as libc::c_int) as size_t,
@@ -3392,7 +3398,7 @@ unsafe extern "C" fn decode_coefs(
                 .coef
                 .eob_bin_256[chroma as usize][is_1d as usize])
                 .as_mut_ptr();
-            eob_bin = dav1d_msac_decode_symbol_adapt_c(
+            eob_bin = dav1d_msac_decode_symbol_adapt16(
                 &mut (*ts).msac,
                 eob_bin_cdf_3,
                 (4 as libc::c_int + 4 as libc::c_int) as size_t,
@@ -3404,7 +3410,7 @@ unsafe extern "C" fn decode_coefs(
                 .coef
                 .eob_bin_512[chroma as usize])
                 .as_mut_ptr();
-            eob_bin = dav1d_msac_decode_symbol_adapt_c(
+            eob_bin = dav1d_msac_decode_symbol_adapt16(
                 &mut (*ts).msac,
                 eob_bin_cdf_4,
                 (4 as libc::c_int + 5 as libc::c_int) as size_t,
@@ -3416,7 +3422,7 @@ unsafe extern "C" fn decode_coefs(
                 .coef
                 .eob_bin_1024[chroma as usize])
                 .as_mut_ptr();
-            eob_bin = dav1d_msac_decode_symbol_adapt_c(
+            eob_bin = dav1d_msac_decode_symbol_adapt16(
                 &mut (*ts).msac,
                 eob_bin_cdf_5,
                 (4 as libc::c_int + 6 as libc::c_int) as size_t,
@@ -3441,7 +3447,7 @@ unsafe extern "C" fn decode_coefs(
             .coef
             .eob_hi_bit[(*t_dim).ctx as usize][chroma as usize][eob_bin as usize])
             .as_mut_ptr();
-        let eob_hi_bit: libc::c_int = dav1d_msac_decode_bool_adapt_c(
+        let eob_hi_bit: libc::c_int = dav1d_msac_decode_bool_adapt(
             &mut (*ts).msac,
             eob_hi_bit_cdf,
         ) as libc::c_int;
@@ -3501,7 +3507,7 @@ unsafe extern "C" fn decode_coefs(
         let mut ctx: libc::c_uint = (1 as libc::c_int
             + (eob > sw * sh * 2 as libc::c_int) as libc::c_int
             + (eob > sw * sh * 4 as libc::c_int) as libc::c_int) as libc::c_uint;
-        let mut eob_tok: libc::c_int = dav1d_msac_decode_symbol_adapt_c(
+        let mut eob_tok: libc::c_int = dav1d_msac_decode_symbol_adapt4(
             &mut (*ts).msac,
             (*eob_cdf.offset(ctx as isize)).as_mut_ptr(),
             2 as libc::c_int as size_t,
@@ -3576,7 +3582,7 @@ unsafe extern "C" fn decode_coefs(
                     } else {
                         7 as libc::c_int
                     }) as libc::c_uint;
-                    tok = dav1d_msac_decode_hi_tok_c(
+                    tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
                     ) as libc::c_int;
@@ -3636,7 +3642,7 @@ unsafe extern "C" fn decode_coefs(
                     if TX_CLASS_2D as libc::c_int == TX_CLASS_2D as libc::c_int {
                         y |= x;
                     }
-                    tok = dav1d_msac_decode_symbol_adapt_c(
+                    tok = dav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
                         (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
                         3 as libc::c_int as size_t,
@@ -3672,7 +3678,7 @@ unsafe extern "C" fn decode_coefs(
                                         >> 1 as libc::c_int
                                 }),
                             );
-                        tok = dav1d_msac_decode_hi_tok_c(
+                        tok = dav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
                             (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
                         ) as libc::c_int;
@@ -3722,7 +3728,7 @@ unsafe extern "C" fn decode_coefs(
                         stride,
                     )
                 };
-                dc_tok = dav1d_msac_decode_symbol_adapt_c(
+                dc_tok = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
                     (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
                     3 as libc::c_int as size_t,
@@ -3763,7 +3769,7 @@ unsafe extern "C" fn decode_coefs(
                         mag.wrapping_add(1 as libc::c_int as libc::c_uint)
                             >> 1 as libc::c_int
                     };
-                    dc_tok = dav1d_msac_decode_hi_tok_c(
+                    dc_tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
                     );
@@ -3834,7 +3840,7 @@ unsafe extern "C" fn decode_coefs(
                     } else {
                         7 as libc::c_int
                     }) as libc::c_uint;
-                    tok = dav1d_msac_decode_hi_tok_c(
+                    tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
                     ) as libc::c_int;
@@ -3894,7 +3900,7 @@ unsafe extern "C" fn decode_coefs(
                     if TX_CLASS_H as libc::c_int == TX_CLASS_2D as libc::c_int {
                         y_0 |= x_0;
                     }
-                    tok = dav1d_msac_decode_symbol_adapt_c(
+                    tok = dav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
                         (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
                         3 as libc::c_int as size_t,
@@ -3930,7 +3936,7 @@ unsafe extern "C" fn decode_coefs(
                                         >> 1 as libc::c_int
                                 }),
                             );
-                        tok = dav1d_msac_decode_hi_tok_c(
+                        tok = dav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
                             (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
                         ) as libc::c_int;
@@ -3980,7 +3986,7 @@ unsafe extern "C" fn decode_coefs(
                         stride_0,
                     )
                 };
-                dc_tok = dav1d_msac_decode_symbol_adapt_c(
+                dc_tok = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
                     (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
                     3 as libc::c_int as size_t,
@@ -4021,7 +4027,7 @@ unsafe extern "C" fn decode_coefs(
                         mag.wrapping_add(1 as libc::c_int as libc::c_uint)
                             >> 1 as libc::c_int
                     };
-                    dc_tok = dav1d_msac_decode_hi_tok_c(
+                    dc_tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
                     );
@@ -4093,7 +4099,7 @@ unsafe extern "C" fn decode_coefs(
                     } else {
                         7 as libc::c_int
                     }) as libc::c_uint;
-                    tok = dav1d_msac_decode_hi_tok_c(
+                    tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
                     ) as libc::c_int;
@@ -4153,7 +4159,7 @@ unsafe extern "C" fn decode_coefs(
                     if TX_CLASS_V as libc::c_int == TX_CLASS_2D as libc::c_int {
                         y_1 |= x_1;
                     }
-                    tok = dav1d_msac_decode_symbol_adapt_c(
+                    tok = dav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
                         (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
                         3 as libc::c_int as size_t,
@@ -4189,7 +4195,7 @@ unsafe extern "C" fn decode_coefs(
                                         >> 1 as libc::c_int
                                 }),
                             );
-                        tok = dav1d_msac_decode_hi_tok_c(
+                        tok = dav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
                             (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
                         ) as libc::c_int;
@@ -4239,7 +4245,7 @@ unsafe extern "C" fn decode_coefs(
                         stride_1,
                     )
                 };
-                dc_tok = dav1d_msac_decode_symbol_adapt_c(
+                dc_tok = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
                     (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
                     3 as libc::c_int as size_t,
@@ -4280,7 +4286,7 @@ unsafe extern "C" fn decode_coefs(
                         mag.wrapping_add(1 as libc::c_int as libc::c_uint)
                             >> 1 as libc::c_int
                     };
-                    dc_tok = dav1d_msac_decode_hi_tok_c(
+                    dc_tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
                     );
@@ -4303,7 +4309,7 @@ unsafe extern "C" fn decode_coefs(
             }
         }
     } else {
-        let mut tok_br: libc::c_int = dav1d_msac_decode_symbol_adapt_c(
+        let mut tok_br: libc::c_int = dav1d_msac_decode_symbol_adapt4(
             &mut (*ts).msac,
             (*eob_cdf.offset(0 as libc::c_int as isize)).as_mut_ptr(),
             2 as libc::c_int as size_t,
@@ -4321,7 +4327,7 @@ unsafe extern "C" fn decode_coefs(
             );
         }
         if tok_br == 2 as libc::c_int {
-            dc_tok = dav1d_msac_decode_hi_tok_c(
+            dc_tok = dav1d_msac_decode_hi_tok(
                 &mut (*ts).msac,
                 (*hi_cdf.offset(0 as libc::c_int as isize)).as_mut_ptr(),
             );
@@ -4364,15 +4370,15 @@ unsafe extern "C" fn decode_coefs(
         cul_level = 0 as libc::c_int as libc::c_uint;
         dc_sign_level = ((1 as libc::c_int) << 6 as libc::c_int) as libc::c_uint;
         if !qm_tbl.is_null() {
-            current_block = 603431968413447153;
+            current_block = 10687245492419339872;
         } else {
-            current_block = 3525709679630925444;
+            current_block = 16948539754621368774;
         }
     } else {
         dc_sign_ctx = get_dc_sign_ctx(tx as libc::c_int, a, l) as libc::c_int;
         dc_sign_cdf = ((*ts).cdf.coef.dc_sign[chroma as usize][dc_sign_ctx as usize])
             .as_mut_ptr();
-        dc_sign = dav1d_msac_decode_bool_adapt_c(&mut (*ts).msac, dc_sign_cdf)
+        dc_sign = dav1d_msac_decode_bool_adapt(&mut (*ts).msac, dc_sign_cdf)
             as libc::c_int;
         if dbg != 0 {
             printf(
@@ -4421,7 +4427,7 @@ unsafe extern "C" fn decode_coefs(
                     0 as libc::c_int as isize,
                 ) = (if dc_sign != 0 { -dc_dq } else { dc_dq }) as coef;
             if rc != 0 {
-                current_block = 603431968413447153;
+                current_block = 10687245492419339872;
             } else {
                 current_block = 15494703142406051947;
             }
@@ -4457,18 +4463,18 @@ unsafe extern "C" fn decode_coefs(
                     0 as libc::c_int as isize,
                 ) = (if dc_sign != 0 { -dc_dq } else { dc_dq }) as coef;
             if rc != 0 {
-                current_block = 3525709679630925444;
+                current_block = 16948539754621368774;
             } else {
                 current_block = 15494703142406051947;
             }
         }
     }
     match current_block {
-        603431968413447153 => {
+        10687245492419339872 => {
             let ac_dq: libc::c_uint = *dq_tbl.offset(1 as libc::c_int as isize)
                 as libc::c_uint;
             loop {
-                let sign: libc::c_int = dav1d_msac_decode_bool_equi_c(&mut (*ts).msac)
+                let sign: libc::c_int = dav1d_msac_decode_bool_equi(&mut (*ts).msac)
                     as libc::c_int;
                 if dbg != 0 {
                     printf(
@@ -4521,11 +4527,11 @@ unsafe extern "C" fn decode_coefs(
                 }
             }
         }
-        3525709679630925444 => {
+        16948539754621368774 => {
             let ac_dq_0: libc::c_uint = *dq_tbl.offset(1 as libc::c_int as isize)
                 as libc::c_uint;
             loop {
-                let sign_0: libc::c_int = dav1d_msac_decode_bool_equi_c(&mut (*ts).msac)
+                let sign_0: libc::c_int = dav1d_msac_decode_bool_equi(&mut (*ts).msac)
                     as libc::c_int;
                 if dbg != 0 {
                     printf(

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1,6 +1,6 @@
 use ::libc;
 use core::arch::asm;
-use crate::src::cdf::CdfModeContext;
+use crate::src::cdf::{CdfModeContext, CdfMvComponent};
 use crate::src::msac::MsacContext;
 extern "C" {
     pub type _IO_wide_data;
@@ -1343,18 +1343,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvComponent {
-    pub classes: [uint16_t; 16],
-    pub class0_fp: [[uint16_t; 4]; 2],
-    pub classN_fp: [uint16_t; 4],
-    pub class0_hp: [uint16_t; 2],
-    pub classN_hp: [uint16_t; 2],
-    pub class0: [uint16_t; 2],
-    pub classN: [[uint16_t; 2]; 10],
-    pub sign: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -192,9 +192,10 @@ pub unsafe extern "C" fn dav1d_ref_dec(pref: *mut *mut Dav1dRef) {
         return;
     }
     *pref = 0 as *mut Dav1dRef;
-    let fresh0 = &mut (*ref_0).ref_cnt as *mut atomic_int;
-    let fresh1 = 1 as libc::c_int;
-    if ::core::intrinsics::atomic_xsub_seqcst(fresh0, fresh1) == 1 as libc::c_int
+    if ::core::intrinsics::atomic_xsub_seqcst(
+        &mut (*ref_0).ref_cnt as *mut atomic_int,
+        1 as libc::c_int,
+    ) == 1 as libc::c_int
     {
         let free_ref: libc::c_int = (*ref_0).free_ref;
         ((*ref_0).free_callback)

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::CdfModeContext;
+use crate::src::cdf::{CdfModeContext, CdfMvComponent};
 use crate::src::msac::MsacContext;
 extern "C" {
     fn memset(
@@ -1263,18 +1263,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvComponent {
-    pub classes: [uint16_t; 16],
-    pub class0_fp: [[uint16_t; 4]; 2],
-    pub classN_fp: [uint16_t; 4],
-    pub class0_hp: [uint16_t; 2],
-    pub classN_hp: [uint16_t; 2],
-    pub class0: [uint16_t; 2],
-    pub classN: [[uint16_t; 2]; 10],
-    pub sign: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1,4 +1,5 @@
 use ::libc;
+use crate::src::cdf::CdfModeContext;
 use crate::src::msac::MsacContext;
 extern "C" {
     fn memset(
@@ -1291,61 +1292,6 @@ pub struct CdfCoefContext {
     pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
     pub skip: [[[uint16_t; 2]; 13]; 5],
     pub dc_sign: [[[uint16_t; 2]; 3]; 2],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfModeContext {
-    pub y_mode: [[uint16_t; 16]; 4],
-    pub uv_mode: [[[uint16_t; 16]; 13]; 2],
-    pub wedge_idx: [[uint16_t; 16]; 9],
-    pub partition: [[[uint16_t; 16]; 4]; 5],
-    pub cfl_alpha: [[uint16_t; 16]; 6],
-    pub txtp_inter1: [[uint16_t; 16]; 2],
-    pub txtp_inter2: [uint16_t; 16],
-    pub txtp_intra1: [[[uint16_t; 8]; 13]; 2],
-    pub txtp_intra2: [[[uint16_t; 8]; 13]; 3],
-    pub cfl_sign: [uint16_t; 8],
-    pub angle_delta: [[uint16_t; 8]; 8],
-    pub filter_intra: [uint16_t; 8],
-    pub comp_inter_mode: [[uint16_t; 8]; 8],
-    pub seg_id: [[uint16_t; 8]; 3],
-    pub pal_sz: [[[uint16_t; 8]; 7]; 2],
-    pub color_map: [[[[uint16_t; 8]; 5]; 7]; 2],
-    pub filter: [[[uint16_t; 4]; 8]; 2],
-    pub txsz: [[[uint16_t; 4]; 3]; 4],
-    pub motion_mode: [[uint16_t; 4]; 22],
-    pub delta_q: [uint16_t; 4],
-    pub delta_lf: [[uint16_t; 4]; 5],
-    pub interintra_mode: [[uint16_t; 4]; 4],
-    pub restore_switchable: [uint16_t; 4],
-    pub restore_wiener: [uint16_t; 2],
-    pub restore_sgrproj: [uint16_t; 2],
-    pub interintra: [[uint16_t; 2]; 7],
-    pub interintra_wedge: [[uint16_t; 2]; 7],
-    pub txtp_inter3: [[uint16_t; 2]; 4],
-    pub use_filter_intra: [[uint16_t; 2]; 22],
-    pub newmv_mode: [[uint16_t; 2]; 6],
-    pub globalmv_mode: [[uint16_t; 2]; 2],
-    pub refmv_mode: [[uint16_t; 2]; 6],
-    pub drl_bit: [[uint16_t; 2]; 3],
-    pub intra: [[uint16_t; 2]; 4],
-    pub comp: [[uint16_t; 2]; 5],
-    pub comp_dir: [[uint16_t; 2]; 5],
-    pub jnt_comp: [[uint16_t; 2]; 6],
-    pub mask_comp: [[uint16_t; 2]; 6],
-    pub wedge_comp: [[uint16_t; 2]; 9],
-    pub ref_0: [[[uint16_t; 2]; 3]; 6],
-    pub comp_fwd_ref: [[[uint16_t; 2]; 3]; 3],
-    pub comp_bwd_ref: [[[uint16_t; 2]; 3]; 2],
-    pub comp_uni_ref: [[[uint16_t; 2]; 3]; 3],
-    pub txpart: [[[uint16_t; 2]; 3]; 7],
-    pub skip: [[uint16_t; 2]; 3],
-    pub skip_mode: [[uint16_t; 2]; 3],
-    pub seg_pred: [[uint16_t; 2]; 3],
-    pub obmc: [[uint16_t; 2]; 22],
-    pub pal_y: [[[uint16_t; 2]; 3]; 7],
-    pub pal_uv: [[uint16_t; 2]; 2],
-    pub intrabc: [uint16_t; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1,4 +1,5 @@
 use ::libc;
+use crate::src::msac::MsacContext;
 extern "C" {
     fn memset(
         _: *mut libc::c_void,
@@ -1245,16 +1246,6 @@ pub struct C2RustUnnamed_45 {
     pub row_end: libc::c_int,
     pub col: libc::c_int,
     pub row: libc::c_int,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct MsacContext {
-    pub buf_pos: *const uint8_t,
-    pub buf_end: *const uint8_t,
-    pub dif: ec_win,
-    pub rng: libc::c_uint,
-    pub cnt: libc::c_int,
-    pub allow_update_cdf: libc::c_int,
 }
 pub type ec_win = size_t;
 #[derive(Copy, Clone)]

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -2058,7 +2058,7 @@ unsafe extern "C" fn reset_task_cur(
                 return 0 as libc::c_int;
             }
             (*ttd).cur = reset_frame_idx.wrapping_sub(first);
-            current_block = 8033822862565898926;
+            current_block = 12921688021154394536;
         } else {
             current_block = 5399440093318478209;
         }
@@ -2173,11 +2173,10 @@ unsafe extern "C" fn insert_tasks_between(
     (*last).next = b;
     reset_task_cur((*f).c, ttd, (*first).frame_idx);
     if cond_signal != 0
-        && {
-            let fresh2 = &mut (*ttd).cond_signaled as *mut atomic_int;
-            let fresh3 = 1 as libc::c_int;
-            ::core::intrinsics::atomic_or_seqcst(fresh2, fresh3) == 0
-        }
+        && ::core::intrinsics::atomic_or_seqcst(
+            &mut (*ttd).cond_signaled as *mut atomic_int,
+            1 as libc::c_int,
+        ) == 0
     {
         pthread_cond_signal(&mut (*ttd).cond);
     }
@@ -2606,9 +2605,7 @@ unsafe extern "C" fn check_tile(
     }
     let mut error: libc::c_int = (p1 == 2147483647 as libc::c_int - 1 as libc::c_int)
         as libc::c_int;
-    let fresh4 = &mut (*f).task_thread.error;
-    let fresh5 = error;
-    error |= ::core::intrinsics::atomic_or_seqcst(fresh4, fresh5);
+    error |= ::core::intrinsics::atomic_or_seqcst(&mut (*f).task_thread.error, error);
     if error == 0 && frame_mt != 0 && tp == 0 {
         let p2: libc::c_int = ::core::intrinsics::atomic_load_seqcst(
             &mut *((*ts).progress).as_mut_ptr().offset(1 as libc::c_int as isize)
@@ -2618,9 +2615,8 @@ unsafe extern "C" fn check_tile(
             return 1 as libc::c_int;
         }
         error = (p2 == 2147483647 as libc::c_int - 1 as libc::c_int) as libc::c_int;
-        let fresh6 = &mut (*f).task_thread.error;
-        let fresh7 = error;
-        error |= ::core::intrinsics::atomic_or_seqcst(fresh6, fresh7);
+        error
+            |= ::core::intrinsics::atomic_or_seqcst(&mut (*f).task_thread.error, error);
     }
     if error == 0 && frame_mt != 0
         && (*(*f).frame_hdr).frame_type as libc::c_uint
@@ -2680,14 +2676,15 @@ unsafe extern "C" fn check_tile(
                     if p3 < lowest {
                         return 1 as libc::c_int;
                     }
-                    let fresh8 = &mut (*f).task_thread.error;
-                    let fresh9 = (p3
-                        == (2147483647 as libc::c_int as libc::c_uint)
-                            .wrapping_mul(2 as libc::c_uint)
-                            .wrapping_add(1 as libc::c_uint)
-                            .wrapping_sub(1 as libc::c_int as libc::c_uint))
-                        as libc::c_int;
-                    ::core::intrinsics::atomic_or_seqcst(fresh8, fresh9);
+                    ::core::intrinsics::atomic_or_seqcst(
+                        &mut (*f).task_thread.error,
+                        (p3
+                            == (2147483647 as libc::c_int as libc::c_uint)
+                                .wrapping_mul(2 as libc::c_uint)
+                                .wrapping_add(1 as libc::c_uint)
+                                .wrapping_sub(1 as libc::c_int as libc::c_uint))
+                            as libc::c_int,
+                    );
                 }
                 _ => {}
             }
@@ -2895,13 +2892,13 @@ unsafe extern "C" fn delayed_fg_task(c: *const Dav1dContext, ttd: *mut TaskThrea
         }
         row = ::core::intrinsics::atomic_xadd_seqcst(
             &mut *((*ttd).delayed_fg.progress)
-            .as_mut_ptr()
+                .as_mut_ptr()
                 .offset(0 as libc::c_int as isize) as *mut atomic_int,
             1 as libc::c_int,
         );
         done = ::core::intrinsics::atomic_xadd_seqcst(
             &mut *((*ttd).delayed_fg.progress)
-            .as_mut_ptr()
+                .as_mut_ptr()
                 .offset(1 as libc::c_int as isize) as *mut atomic_int,
             1 as libc::c_int,
         ) + 1 as libc::c_int;
@@ -2974,7 +2971,7 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                 if (*t).type_0 as libc::c_uint
                                     == DAV1D_TASK_TYPE_INIT as libc::c_int as libc::c_uint
                                 {
-                                    current_block = 13951626279954010388;
+                                    current_block = 7012560550443761033;
                                     break;
                                 }
                                 if (*t).type_0 as libc::c_uint
@@ -2987,12 +2984,12 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                         1 as libc::c_int as libc::c_uint
                                     }) as libc::c_int;
                                     if p1 != 0 {
-                                        let fresh18 = &mut (*f).task_thread.error;
-                                        let fresh19 = (p1
-                                            == 2147483647 as libc::c_int - 1 as libc::c_int)
-                                            as libc::c_int;
-                                        ::core::intrinsics::atomic_or_seqcst(fresh18, fresh19);
-                                        current_block = 13951626279954010388;
+                                        ::core::intrinsics::atomic_or_seqcst(
+                                            &mut (*f).task_thread.error,
+                                            (p1 == 2147483647 as libc::c_int - 1 as libc::c_int)
+                                                as libc::c_int,
+                                        );
+                                        current_block = 7012560550443761033;
                                         break;
                                     }
                                 }
@@ -3040,7 +3037,7 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                                     as libc::c_int,
                                             ) == 0
                                             {
-                                                current_block = 13951626279954010388;
+                                                current_block = 7012560550443761033;
                                                 continue 's_107;
                                             }
                                         } else if (*t).recon_progress != 0 {
@@ -3069,20 +3066,20 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                                     prog,
                                                 );
                                                 if p1_0 < (*t).sby {
-                                                    current_block = 1373748322570045674;
+                                                    current_block = 5395695591151878490;
                                                 } else {
-                                                    let fresh20 = &mut (*f).task_thread.error;
-                                                    let fresh21 = (p1_0
-                                                        == 2147483647 as libc::c_int - 1 as libc::c_int)
-                                                        as libc::c_int;
-                                                    ::core::intrinsics::atomic_or_seqcst(fresh20, fresh21);
+                                                    ::core::intrinsics::atomic_or_seqcst(
+                                                        &mut (*f).task_thread.error,
+                                                        (p1_0 == 2147483647 as libc::c_int - 1 as libc::c_int)
+                                                            as libc::c_int,
+                                                    );
                                                     current_block = 14832935472441733737;
                                                 }
                                             } else {
                                                 current_block = 14832935472441733737;
                                             }
                                             match current_block {
-                                                1373748322570045674 => {}
+                                                5395695591151878490 => {}
                                                 _ => {
                                                     let mut tc_0: libc::c_int = 0 as libc::c_int;
                                                     loop {
@@ -3098,18 +3095,18 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                                                 as *mut atomic_int,
                                                         );
                                                         if p2 < (*t).recon_progress {
-                                                            current_block = 1373748322570045674;
+                                                            current_block = 5395695591151878490;
                                                             break;
                                                         }
-                                                        let fresh22 = &mut (*f).task_thread.error;
-                                                        let fresh23 = (p2
-                                                            == 2147483647 as libc::c_int - 1 as libc::c_int)
-                                                            as libc::c_int;
-                                                        ::core::intrinsics::atomic_or_seqcst(fresh22, fresh23);
+                                                        ::core::intrinsics::atomic_or_seqcst(
+                                                            &mut (*f).task_thread.error,
+                                                            (p2 == 2147483647 as libc::c_int - 1 as libc::c_int)
+                                                                as libc::c_int,
+                                                        );
                                                         tc_0 += 1;
                                                     }
                                                     match current_block {
-                                                        1373748322570045674 => {}
+                                                        5395695591151878490 => {}
                                                         _ => {
                                                             if ((*t).sby + 1 as libc::c_int) < (*f).sbh {
                                                                 let mut next_t: *mut Dav1dTask = &mut *t
@@ -3128,7 +3125,7 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                                                 (*next_t).recon_progress = (*next_t).sby + 1 as libc::c_int;
                                                                 insert_task(f, next_t, 0 as libc::c_int);
                                                             }
-                                                            current_block = 13951626279954010388;
+                                                            current_block = 7012560550443761033;
                                                             continue 's_107;
                                                         }
                                                     }
@@ -3150,7 +3147,7 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                                 & (1 as libc::c_uint)
                                                     << ((*t).sby - 1 as libc::c_int & 31 as libc::c_int) != 0
                                             {
-                                                current_block = 13951626279954010388;
+                                                current_block = 7012560550443761033;
                                                 continue 's_107;
                                             }
                                         } else {
@@ -3161,12 +3158,12 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                                 &mut (*f).frame_thread.deblock_progress,
                                             );
                                             if p1_2 >= (*t).deblock_progress {
-                                                let fresh24 = &mut (*f).task_thread.error;
-                                                let fresh25 = (p1_2
-                                                    == 2147483647 as libc::c_int - 1 as libc::c_int)
-                                                    as libc::c_int;
-                                                ::core::intrinsics::atomic_or_seqcst(fresh24, fresh25);
-                                                current_block = 13951626279954010388;
+                                                ::core::intrinsics::atomic_or_seqcst(
+                                                    &mut (*f).task_thread.error,
+                                                    (p1_2 == 2147483647 as libc::c_int - 1 as libc::c_int)
+                                                        as libc::c_int,
+                                                );
+                                                current_block = 7012560550443761033;
                                                 continue 's_107;
                                             }
                                         }
@@ -3191,7 +3188,7 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                 if merge_pending(c) != 0 {
                                     continue 's_18;
                                 } else {
-                                    current_block = 2777461603309497930;
+                                    current_block = 14728000373531839883;
                                     break;
                                 }
                             }
@@ -3224,15 +3221,13 @@ pub unsafe extern "C" fn dav1d_worker_task(
                     }
                 }
                 match current_block {
-                    2777461603309497930 => {}
+                    14728000373531839883 => {}
                     _ => {
                         loop {
                             flush = ::core::intrinsics::atomic_load_seqcst((*c).flush);
-                            let fresh26 = &mut (*f).task_thread.error;
-                            let fresh27 = flush;
                             error_0 = ::core::intrinsics::atomic_or_seqcst(
-                                fresh26,
-                                fresh27,
+                                &mut (*f).task_thread.error,
+                                flush,
                             ) | flush;
                             (*tc).f = f;
                             sby = (*t).sby;
@@ -3316,10 +3311,11 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                                     &mut (*f).task_thread.error,
                                                     -(1 as libc::c_int),
                                                 );
-                                                let fresh28 = &mut (*f).task_thread.task_counter;
-                                                let fresh29 = (*(*f).frame_hdr).tiling.cols
-                                                    * (*(*f).frame_hdr).tiling.rows + (*f).sbh;
-                                                ::core::intrinsics::atomic_xsub_seqcst(fresh28, fresh29);
+                                                ::core::intrinsics::atomic_xsub_seqcst(
+                                                    &mut (*f).task_thread.task_counter,
+                                                    (*(*f).frame_hdr).tiling.cols
+                                                        * (*(*f).frame_hdr).tiling.rows + (*f).sbh,
+                                                );
                                                 ::core::intrinsics::atomic_store_seqcst(
                                                     &mut *((*f).sr_cur.progress)
                                                         .offset((p_0 - 1 as libc::c_int) as isize)
@@ -3402,9 +3398,10 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                     } else {
                                         1 as libc::c_int + sby
                                     };
-                                    let fresh30 = &mut (*f).task_thread.error;
-                                    let fresh31 = error_0;
-                                    ::core::intrinsics::atomic_or_seqcst(fresh30, fresh31);
+                                    ::core::intrinsics::atomic_or_seqcst(
+                                        &mut (*f).task_thread.error,
+                                        error_0,
+                                    );
                                     if (sby + 1 as libc::c_int) << (*f).sb_shift
                                         < (*ts_0).tiling.row_end
                                     {
@@ -3417,10 +3414,10 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                                 progress,
                                             );
                                             reset_task_cur_async(ttd, (*t).frame_idx, (*c).n_fc);
-                                            let fresh32 = &mut (*ttd).cond_signaled as *mut atomic_int;
-                                            let fresh33 = 1 as libc::c_int;
-                                            if ::core::intrinsics::atomic_or_seqcst(fresh32, fresh33)
-                                                == 0
+                                            if ::core::intrinsics::atomic_or_seqcst(
+                                                &mut (*ttd).cond_signaled as *mut atomic_int,
+                                                1 as libc::c_int,
+                                            ) == 0
                                             {
                                                 pthread_cond_signal(&mut (*ttd).cond);
                                             }
@@ -3470,11 +3467,10 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                                 );
                                             }
                                         }
-                                        let fresh34 = &mut (*f).task_thread.task_counter
-                                            as *mut atomic_int;
-                                        let fresh35 = 1 as libc::c_int;
-                                        if ::core::intrinsics::atomic_xsub_seqcst(fresh34, fresh35)
-                                            - 1 as libc::c_int == 0 as libc::c_int
+                                        if ::core::intrinsics::atomic_xsub_seqcst(
+                                            &mut (*f).task_thread.task_counter as *mut atomic_int,
+                                            1 as libc::c_int,
+                                        ) - 1 as libc::c_int == 0 as libc::c_int
                                             && ::core::intrinsics::atomic_load_seqcst(
                                                 &mut *((*f).task_thread.done)
                                                     .as_mut_ptr()
@@ -3506,10 +3502,10 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                         {
                                             unreachable!();
                                         }
-                                        let fresh36 = &mut (*ttd).cond_signaled as *mut atomic_int;
-                                        let fresh37 = 1 as libc::c_int;
-                                        if ::core::intrinsics::atomic_or_seqcst(fresh36, fresh37)
-                                            == 0
+                                        if ::core::intrinsics::atomic_or_seqcst(
+                                            &mut (*ttd).cond_signaled as *mut atomic_int,
+                                            1 as libc::c_int,
+                                        ) == 0
                                         {
                                             pthread_cond_signal(&mut (*ttd).cond);
                                         }
@@ -3535,32 +3531,32 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                     {
                                         continue 's_18;
                                     } else {
-                                        current_block = 6008637731897673938;
+                                        current_block = 16164772378964453469;
                                         break;
                                     }
                                 }
                                 6 => {
-                                    current_block = 6008637731897673938;
+                                    current_block = 16164772378964453469;
                                     break;
                                 }
                                 7 => {
-                                    current_block = 13240214649988793380;
+                                    current_block = 5292528706010880565;
                                     break;
                                 }
                                 8 => {
-                                    current_block = 14546186248892381816;
+                                    current_block = 12196494833634779273;
                                     break;
                                 }
                                 9 => {
-                                    current_block = 6750403331223000732;
+                                    current_block = 563177965161376451;
                                     break;
                                 }
                                 10 => {
-                                    current_block = 8542881708851390082;
+                                    current_block = 18238912670629178022;
                                     break;
                                 }
                                 3 => {
-                                    current_block = 7301429464686428633;
+                                    current_block = 7729400755948011248;
                                     break;
                                 }
                                 _ => {
@@ -3569,7 +3565,7 @@ pub unsafe extern "C" fn dav1d_worker_task(
                             }
                         }
                         match current_block {
-                            6008637731897673938 => {
+                            16164772378964453469 => {
                                 if ::core::intrinsics::atomic_load_seqcst(
                                     &mut (*f).task_thread.error as *mut atomic_int,
                                 ) == 0
@@ -3596,22 +3592,22 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                         },
                                     );
                                     reset_task_cur_async(ttd, (*t).frame_idx, (*c).n_fc);
-                                    let fresh38 = &mut (*ttd).cond_signaled as *mut atomic_int;
-                                    let fresh39 = 1 as libc::c_int;
-                                    if ::core::intrinsics::atomic_or_seqcst(fresh38, fresh39)
-                                        == 0
+                                    if ::core::intrinsics::atomic_or_seqcst(
+                                        &mut (*ttd).cond_signaled as *mut atomic_int,
+                                        1 as libc::c_int,
+                                    ) == 0
                                     {
                                         pthread_cond_signal(&mut (*ttd).cond);
                                     }
                                 } else if (*(*f).seq_hdr).cdef != 0
                                     || (*f).lf.restore_planes != 0
                                 {
-                                    let fresh40 = &mut *((*f).frame_thread.copy_lpf_progress)
-                                        .offset((sby >> 5 as libc::c_int) as isize)
-                                        as *mut atomic_uint;
-                                    let fresh41 = (1 as libc::c_uint)
-                                        << (sby & 31 as libc::c_int);
-                                    ::core::intrinsics::atomic_or_seqcst(fresh40, fresh41);
+                                    ::core::intrinsics::atomic_or_seqcst(
+                                        &mut *((*f).frame_thread.copy_lpf_progress)
+                                            .offset((sby >> 5 as libc::c_int) as isize)
+                                            as *mut atomic_uint,
+                                        (1 as libc::c_uint) << (sby & 31 as libc::c_int),
+                                    );
                                     if sby != 0 {
                                         let mut prog_1: libc::c_int = ::core::intrinsics::atomic_load_seqcst(
                                             &mut *((*f).frame_thread.copy_lpf_progress)
@@ -3632,12 +3628,12 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                         }
                                     }
                                 }
-                                current_block = 13240214649988793380;
+                                current_block = 5292528706010880565;
                             }
                             _ => {}
                         }
                         match current_block {
-                            13240214649988793380 => {
+                            5292528706010880565 => {
                                 if (*(*f).seq_hdr).cdef != 0 {
                                     if ::core::intrinsics::atomic_load_seqcst(
                                         &mut (*f).task_thread.error as *mut atomic_int,
@@ -3647,20 +3643,20 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                             .expect("non-null function pointer")(tc, sby);
                                     }
                                     reset_task_cur_async(ttd, (*t).frame_idx, (*c).n_fc);
-                                    let fresh42 = &mut (*ttd).cond_signaled as *mut atomic_int;
-                                    let fresh43 = 1 as libc::c_int;
-                                    if ::core::intrinsics::atomic_or_seqcst(fresh42, fresh43)
-                                        == 0
+                                    if ::core::intrinsics::atomic_or_seqcst(
+                                        &mut (*ttd).cond_signaled as *mut atomic_int,
+                                        1 as libc::c_int,
+                                    ) == 0
                                     {
                                         pthread_cond_signal(&mut (*ttd).cond);
                                     }
                                 }
-                                current_block = 14546186248892381816;
+                                current_block = 12196494833634779273;
                             }
                             _ => {}
                         }
                         match current_block {
-                            14546186248892381816 => {
+                            12196494833634779273 => {
                                 if (*(*f).frame_hdr).width[0 as libc::c_int as usize]
                                     != (*(*f).frame_hdr).width[1 as libc::c_int as usize]
                                 {
@@ -3672,12 +3668,12 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                             .expect("non-null function pointer")(f, sby);
                                     }
                                 }
-                                current_block = 6750403331223000732;
+                                current_block = 563177965161376451;
                             }
                             _ => {}
                         }
                         match current_block {
-                            6750403331223000732 => {
+                            563177965161376451 => {
                                 if ::core::intrinsics::atomic_load_seqcst(
                                     &mut (*f).task_thread.error as *mut atomic_int,
                                 ) == 0 && (*f).lf.restore_planes != 0
@@ -3685,12 +3681,12 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                     ((*f).bd_fn.filter_sbrow_lr)
                                         .expect("non-null function pointer")(f, sby);
                                 }
-                                current_block = 8542881708851390082;
+                                current_block = 18238912670629178022;
                             }
                             _ => {}
                         }
                         match current_block {
-                            8542881708851390082 => {}
+                            18238912670629178022 => {}
                             _ => {}
                         }
                         let uses_2pass_0: libc::c_int = ((*c).n_fc
@@ -3747,11 +3743,9 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                 );
                             }
                             pthread_mutex_lock(&mut (*ttd).lock);
-                            let fresh44 = &mut (*f).task_thread.task_counter;
-                            let fresh45 = 1 as libc::c_int;
                             let num_tasks: libc::c_int = ::core::intrinsics::atomic_xsub_seqcst(
-                                fresh44,
-                                fresh45,
+                                &mut (*f).task_thread.task_counter,
+                                1 as libc::c_int,
                             ) - 1 as libc::c_int;
                             if (sby + 1 as libc::c_int) < sbh && num_tasks != 0 {
                                 reset_task_cur(c, ttd, (*t).frame_idx);
@@ -3786,12 +3780,12 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                 continue;
                             }
                         } else {
-                            let fresh46 = &mut *((*f).frame_thread.frame_progress)
-                                .offset((sby >> 5 as libc::c_int) as isize)
-                                as *mut atomic_uint;
-                            let fresh47 = (1 as libc::c_uint)
-                                << (sby & 31 as libc::c_int);
-                            ::core::intrinsics::atomic_or_seqcst(fresh46, fresh47);
+                            ::core::intrinsics::atomic_or_seqcst(
+                                &mut *((*f).frame_thread.frame_progress)
+                                    .offset((sby >> 5 as libc::c_int) as isize)
+                                    as *mut atomic_uint,
+                                (1 as libc::c_uint) << (sby & 31 as libc::c_int),
+                            );
                             pthread_mutex_lock(&mut (*f).task_thread.lock);
                             sby = get_frame_progress(c, f);
                             error_0 = ::core::intrinsics::atomic_load_seqcst(
@@ -3832,11 +3826,9 @@ pub unsafe extern "C" fn dav1d_worker_task(
                                 );
                             }
                             pthread_mutex_lock(&mut (*ttd).lock);
-                            let fresh48 = &mut (*f).task_thread.task_counter;
-                            let fresh49 = 1 as libc::c_int;
                             let num_tasks_0: libc::c_int = ::core::intrinsics::atomic_xsub_seqcst(
-                                fresh48,
-                                fresh49,
+                                &mut (*f).task_thread.task_counter,
+                                1 as libc::c_int,
                             ) - 1 as libc::c_int;
                             if (sby + 1 as libc::c_int) < sbh && num_tasks_0 != 0 {
                                 reset_task_cur(c, ttd, (*t).frame_idx);

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
+use crate::src::cdf::CdfContext;
 use crate::src::msac::MsacContext;
 extern "C" {
     fn memset(
@@ -1249,21 +1249,6 @@ pub struct C2RustUnnamed_45 {
     pub row: libc::c_int,
 }
 pub type ec_win = size_t;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfContext {
-    pub m: CdfModeContext,
-    pub kfym: [[[uint16_t; 16]; 5]; 5],
-    pub coef: CdfCoefContext,
-    pub mv: CdfMvContext,
-    pub dmv: CdfMvContext,
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfMvContext {
-    pub comp: [CdfMvComponent; 2],
-    pub joint: [uint16_t; 4],
-}
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1,5 +1,5 @@
 use ::libc;
-use crate::src::cdf::{CdfModeContext, CdfMvComponent};
+use crate::src::cdf::{CdfCoefContext, CdfModeContext, CdfMvComponent};
 use crate::src::msac::MsacContext;
 extern "C" {
     fn memset(
@@ -1263,23 +1263,6 @@ pub struct CdfContext {
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: [uint16_t; 4],
-}
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct CdfCoefContext {
-    pub eob_bin_16: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_32: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_64: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_128: [[[uint16_t; 8]; 2]; 2],
-    pub eob_bin_256: [[[uint16_t; 16]; 2]; 2],
-    pub eob_bin_512: [[uint16_t; 16]; 2],
-    pub eob_bin_1024: [[uint16_t; 16]; 2],
-    pub eob_base_tok: [[[[uint16_t; 4]; 4]; 2]; 5],
-    pub base_tok: [[[[uint16_t; 4]; 41]; 2]; 5],
-    pub br_tok: [[[[uint16_t; 4]; 21]; 2]; 4],
-    pub eob_hi_bit: [[[[uint16_t; 2]; 11]; 2]; 5],
-    pub skip: [[[uint16_t; 2]; 13]; 5],
-    pub dc_sign: [[[uint16_t; 2]; 3]; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/x86/cpu.rs
+++ b/src/x86/cpu.rs
@@ -97,6 +97,9 @@ pub unsafe extern "C" fn dav1d_get_cpu_flags_x86() -> libc::c_uint {
                 }
             }
         }
+
+        // We only support >128-bit SIMD on x86-64.
+        #[cfg(target_arch = "x86_64")]
         if r.ecx & 0x18000000 as libc::c_int as libc::c_uint
             == 0x18000000 as libc::c_int as libc::c_uint
         {
@@ -131,6 +134,7 @@ pub unsafe extern "C" fn dav1d_get_cpu_flags_x86() -> libc::c_uint {
                 }
             }
         }
+
         if memcmp(
             (cpu.c2rust_unnamed.vendor).as_mut_ptr() as *const libc::c_void,
             b"AuthenticAMD\0" as *const u8 as *const libc::c_char as *const libc::c_void,

--- a/src/x86/msac.h
+++ b/src/x86/msac.h
@@ -44,17 +44,17 @@ unsigned dav1d_msac_decode_bool_sse2(MsacContext *s, unsigned f);
 unsigned dav1d_msac_decode_hi_tok_sse2(MsacContext *s, uint16_t *cdf);
 
 #if ARCH_X86_64 || defined(__SSE2__) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2)
-#define dav1d_msac_decode_symbol_adapt4  dav1d_msac_decode_symbol_adapt4_sse2
-#define dav1d_msac_decode_symbol_adapt8  dav1d_msac_decode_symbol_adapt8_sse2
-#define dav1d_msac_decode_hi_tok         dav1d_msac_decode_hi_tok_sse2
+#define dav1d_msac_decode_symbol_adapt4_impl  dav1d_msac_decode_symbol_adapt4_sse2
+#define dav1d_msac_decode_symbol_adapt8_impl  dav1d_msac_decode_symbol_adapt8_sse2
+#define dav1d_msac_decode_hi_tok_impl         dav1d_msac_decode_hi_tok_sse2
 #endif
 
-#define dav1d_msac_decode_bool_adapt     dav1d_msac_decode_bool_adapt_sse2
-#define dav1d_msac_decode_bool_equi      dav1d_msac_decode_bool_equi_sse2
-#define dav1d_msac_decode_bool           dav1d_msac_decode_bool_sse2
+#define dav1d_msac_decode_bool_adapt_impl     dav1d_msac_decode_bool_adapt_sse2
+#define dav1d_msac_decode_bool_equi_impl      dav1d_msac_decode_bool_equi_sse2
+#define dav1d_msac_decode_bool_impl           dav1d_msac_decode_bool_sse2
 
 #if ARCH_X86_64
-#define dav1d_msac_decode_symbol_adapt16(ctx, cdf, symb) ((ctx)->symbol_adapt16(ctx, cdf, symb))
+#define dav1d_msac_decode_symbol_adapt16_impl(ctx, cdf, symb) ((ctx)->symbol_adapt16(ctx, cdf, symb))
 
 static ALWAYS_INLINE void msac_init_x86(MsacContext *const s) {
     const unsigned flags = dav1d_get_cpu_flags();
@@ -69,7 +69,7 @@ static ALWAYS_INLINE void msac_init_x86(MsacContext *const s) {
 }
 
 #elif defined(__SSE2__) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2)
-#define dav1d_msac_decode_symbol_adapt16 dav1d_msac_decode_symbol_adapt16_sse2
+#define dav1d_msac_decode_symbol_adapt16_impl dav1d_msac_decode_symbol_adapt16_sse2
 #endif
 
 #endif /* DAV1D_SRC_X86_MSAC_H */

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -989,14 +989,14 @@ unsafe fn main_0(argc: libc::c_int, argv: *const *mut libc::c_char) -> libc::c_i
     let mut i_fps: libc::c_double = 0.;
     let mut frametimes: *mut FILE = 0 as *mut FILE;
     let mut version: *const libc::c_char = dav1d_version();
-    if strcmp(version, b"1.0.0-116-ge219a79\0" as *const u8 as *const libc::c_char) != 0
+    if strcmp(version, b"1.0.0-130-g26eca15\0" as *const u8 as *const libc::c_char) != 0
     {
         fprintf(
             stderr,
             b"Version mismatch (library: %s, executable: %s)\n\0" as *const u8
                 as *const libc::c_char,
             version,
-            b"1.0.0-116-ge219a79\0" as *const u8 as *const libc::c_char,
+            b"1.0.0-130-g26eca15\0" as *const u8 as *const libc::c_char,
         );
         return 1 as libc::c_int;
     }


### PR DESCRIPTION
* Setup `build.rs` to build and link x86 assembly. Initial setup builds `msac.asm` and `cpuid.asm`.
* Modify `msac.h` to replace asm `#define`s with function calls and re-transpile to update generated Rust.
* Fix alignment in structs defined in `cdf.h`. c2rust doesn't support transpiling alignment attributes, so the original transpile didn't respect alignment. This caused segfaults in the assembly since the SIMD instructions have stricter alignment requirements.
* De-duplicate structs defined in `cdf.h` to ensure that all usages of those structs share the same definition now that we have manual edits to them.
* Add `AlignN` structs to enforce struct field alignment.