### PR TITLE
Get CPU flags for arm targets

### DIFF
--- a/c2rust-lib.rs
+++ b/c2rust-lib.rs
@@ -92,9 +92,11 @@ pub mod tables;
 pub mod thread_task;
 pub mod warpmv;
 pub mod wedge;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub mod x86 {
 pub mod cpu;
 } // mod x86
+#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 pub mod arm {
 pub mod cpu;
 } // mod arm

--- a/c2rust-lib.rs
+++ b/c2rust-lib.rs
@@ -95,6 +95,9 @@ pub mod wedge;
 pub mod x86 {
 pub mod cpu;
 } // mod x86
+pub mod arm {
+pub mod cpu;
+} // mod arm
 } // mod src
 pub mod tools {
 pub mod dav1d_cli_parse;

--- a/src/arm/cpu.rs
+++ b/src/arm/cpu.rs
@@ -21,7 +21,7 @@ pub unsafe extern "C" fn dav1d_get_cpu_flags_arm() -> libc::c_uint {
             todo!("Android is not yet supported")
         } else {
             if (libc::getauxval(libc::AT_HWCAP) & NEON_HWCAP) != 0 {
-                flags |= DAV1D_ARM_CPU_FLAG_NEON
+                flags |= DAV1D_ARM_CPU_FLAG_NEON;
             }
         }
     }

--- a/src/arm/cpu.rs
+++ b/src/arm/cpu.rs
@@ -17,6 +17,8 @@ pub unsafe extern "C" fn dav1d_get_cpu_flags_arm() -> libc::c_uint {
             target_os = "macos"
         ))] {
             flags |= DAV1D_ARM_CPU_FLAG_NEON;
+        } else if #[cfg(target_os = "android")] {
+            todo!("Android is not yet supported")
         } else {
             if (libc::getauxval(libc::AT_HWCAP) & NEON_HWCAP) != 0 {
                 flags |= DAV1D_ARM_CPU_FLAG_NEON

--- a/src/arm/cpu.rs
+++ b/src/arm/cpu.rs
@@ -1,0 +1,28 @@
+use cfg_if::cfg_if;
+use libc;
+
+pub const DAV1D_ARM_CPU_FLAG_NEON: libc::c_uint = 1 << 0;
+pub const NEON_HWCAP: libc::c_ulong = 1 << 12;
+
+#[no_mangle]
+#[cold]
+pub unsafe extern "C" fn dav1d_get_cpu_flags_arm() -> libc::c_uint {
+    let mut flags = 0;
+
+    // TODO: Support Android by parsing `/proc/cpuinfo` the way the original C does.
+    cfg_if! {
+        if #[cfg(any(
+            target_arch = "aarch64",
+            target_os = "windows",
+            target_os = "macos"
+        ))] {
+            flags |= DAV1D_ARM_CPU_FLAG_NEON;
+        } else {
+            if (libc::getauxval(libc::AT_HWCAP) & NEON_HWCAP) != 0 {
+                flags |= DAV1D_ARM_CPU_FLAG_NEON
+            }
+        }
+    }
+
+    flags
+}

--- a/src/arm/cpu.rs
+++ b/src/arm/cpu.rs
@@ -16,13 +16,13 @@ pub unsafe extern "C" fn dav1d_get_cpu_flags_arm() -> libc::c_uint {
             target_os = "macos"
         ))] {
             flags |= DAV1D_ARM_CPU_FLAG_NEON;
-        } else if #[cfg(target_os = "android")] {
-            // TODO: Support Android by parsing `/proc/cpuinfo` the way the original C does.
-            todo!("Android is not yet supported")
-        } else {
+        } else if #[cfg(target_arch = "arm")] {
             if (libc::getauxval(libc::AT_HWCAP) & NEON_HWCAP) != 0 {
                 flags |= DAV1D_ARM_CPU_FLAG_NEON;
             }
+        } else if #[cfg(target_os = "android")] {
+            // TODO: Support Android by parsing `/proc/cpuinfo` the way the original C does.
+            todo!("Android is not yet supported")
         }
     }
 

--- a/src/arm/cpu.rs
+++ b/src/arm/cpu.rs
@@ -9,7 +9,6 @@ pub const NEON_HWCAP: libc::c_ulong = 1 << 12;
 pub unsafe extern "C" fn dav1d_get_cpu_flags_arm() -> libc::c_uint {
     let mut flags = 0;
 
-    // TODO: Support Android by parsing `/proc/cpuinfo` the way the original C does.
     cfg_if! {
         if #[cfg(any(
             target_arch = "aarch64",
@@ -18,6 +17,7 @@ pub unsafe extern "C" fn dav1d_get_cpu_flags_arm() -> libc::c_uint {
         ))] {
             flags |= DAV1D_ARM_CPU_FLAG_NEON;
         } else if #[cfg(target_os = "android")] {
+            // TODO: Support Android by parsing `/proc/cpuinfo` the way the original C does.
             todo!("Android is not yet supported")
         } else {
             if (libc::getauxval(libc::AT_HWCAP) & NEON_HWCAP) != 0 {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -4,6 +4,8 @@ extern "C" {
     pub type Dav1dContext;
     #[cfg(target_arch = "x86_64")]
     fn dav1d_get_cpu_flags_x86() -> libc::c_uint;
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    fn dav1d_get_cpu_flags_arm() -> libc::c_uint;
     fn dav1d_log(c: *mut Dav1dContext, format: *const libc::c_char, _: ...);
     fn __sched_cpucount(__setsize: size_t, __setp: *const cpu_set_t) -> libc::c_int;
     fn pthread_self() -> pthread_t;
@@ -32,6 +34,8 @@ pub unsafe extern "C" fn dav1d_init_cpu() {
     cfg_if! {
         if #[cfg(target_arch = "x86_64")] {
             dav1d_cpu_flags = dav1d_get_cpu_flags_x86();
+        } else if #[cfg(any(target_arch = "arm", target_arch = "aarch64"))] {
+            dav1d_cpu_flags = dav1d_get_cpu_flags_arm();
         }
     }
 }


### PR DESCRIPTION
Translate the logic for [`dav1d_get_cpu_flags_arm`](https://github.com/memorysafety/rav1d/blob/39968db983ce4211e48ca173e8d5d189b3b666c6/src/arm/cpu.c#L83). I tried to replicate the original logic using Rust's conditional compilation mechanisms, but the translations isn't one-to-one.  