### PR TITLE
Remove `va_list` as it's unused

### DIFF
--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -10,14 +10,7 @@ extern "C" {
         _: libc::c_ulong,
     ) -> *mut libc::c_void;
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct __va_list_tag {
-    pub gp_offset: libc::c_uint,
-    pub fp_offset: libc::c_uint,
-    pub overflow_arg_area: *mut libc::c_void,
-    pub reg_save_area: *mut libc::c_void,
-}
+
 
 
 

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -10,14 +10,7 @@ extern "C" {
         _: libc::c_ulong,
     ) -> *mut libc::c_void;
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct __va_list_tag {
-    pub gp_offset: libc::c_uint,
-    pub fp_offset: libc::c_uint,
-    pub overflow_arg_area: *mut libc::c_void,
-    pub reg_save_area: *mut libc::c_void,
-}
+
 
 
 

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -21,14 +21,7 @@ extern "C" {
     fn dav1d_ref_dec(ref_0: *mut *mut Dav1dRef);
     static dav1d_partition_type_count: [uint8_t; 5];
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct __va_list_tag {
-    pub gp_offset: libc::c_uint,
-    pub fp_offset: libc::c_uint,
-    pub overflow_arg_area: *mut libc::c_void,
-    pub reg_save_area: *mut libc::c_void,
-}
+
 
 use crate::include::stdatomic::memory_order;
 use crate::include::stdatomic::memory_order_seq_cst;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -349,14 +349,7 @@ extern "C" {
         by: libc::c_int,
     );
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct __va_list_tag {
-    pub gp_offset: libc::c_uint,
-    pub fp_offset: libc::c_uint,
-    pub overflow_arg_area: *mut libc::c_void,
-    pub reg_save_area: *mut libc::c_void,
-}
+
 
 use crate::include::dav1d::common::Dav1dUserData;
 use crate::src::r#ref::Dav1dRef;

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -10,14 +10,7 @@ extern "C" {
         _: libc::c_ulong,
     ) -> *mut libc::c_void;
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct __va_list_tag {
-    pub gp_offset: libc::c_uint,
-    pub fp_offset: libc::c_uint,
-    pub overflow_arg_area: *mut libc::c_void,
-    pub reg_save_area: *mut libc::c_void,
-}
+
 
 
 

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -10,14 +10,7 @@ extern "C" {
         _: libc::c_ulong,
     ) -> *mut libc::c_void;
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct __va_list_tag {
-    pub gp_offset: libc::c_uint,
-    pub fp_offset: libc::c_uint,
-    pub overflow_arg_area: *mut libc::c_void,
-    pub reg_save_area: *mut libc::c_void,
-}
+
 
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,14 +166,7 @@ extern "C" {
     fn dav1d_init_wedge_masks();
     fn dav1d_init_interintra_masks();
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct __va_list_tag {
-    pub gp_offset: libc::c_uint,
-    pub fp_offset: libc::c_uint,
-    pub overflow_arg_area: *mut libc::c_void,
-    pub reg_save_area: *mut libc::c_void,
-}
+
 
 pub type __off_t = libc::c_long;
 pub type __off64_t = libc::c_long;

--- a/src/log.rs
+++ b/src/log.rs
@@ -15,16 +15,9 @@ extern "C" {
         _: ::core::ffi::VaList,
     ) -> libc::c_int;
 }
-pub type __builtin_va_list = [__va_list_tag; 1];
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct __va_list_tag {
-    pub gp_offset: libc::c_uint,
-    pub fp_offset: libc::c_uint,
-    pub overflow_arg_area: *mut libc::c_void,
-    pub reg_save_area: *mut libc::c_void,
-}
-pub type va_list = __builtin_va_list;
+
+
+
 
 pub type __off_t = libc::c_long;
 pub type __off64_t = libc::c_long;

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -11,14 +11,7 @@ extern "C" {
     ) -> *mut libc::c_void;
     static dav1d_sgr_params: [[uint16_t; 2]; 16];
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct __va_list_tag {
-    pub gp_offset: libc::c_uint,
-    pub fp_offset: libc::c_uint,
-    pub overflow_arg_area: *mut libc::c_void,
-    pub reg_save_area: *mut libc::c_void,
-}
+
 
 
 

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -11,14 +11,7 @@ extern "C" {
     ) -> *mut libc::c_void;
     static dav1d_sgr_params: [[uint16_t; 2]; 16];
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct __va_list_tag {
-    pub gp_offset: libc::c_uint,
-    pub fp_offset: libc::c_uint,
-    pub overflow_arg_area: *mut libc::c_void,
-    pub reg_save_area: *mut libc::c_void,
-}
+
 
 
 

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -55,14 +55,7 @@ extern "C" {
     fn dav1d_bytealign_get_bits(c: *mut GetBits);
     fn dav1d_log(c: *mut Dav1dContext, format: *const libc::c_char, _: ...);
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct __va_list_tag {
-    pub gp_offset: libc::c_uint,
-    pub fp_offset: libc::c_uint,
-    pub overflow_arg_area: *mut libc::c_void,
-    pub reg_save_area: *mut libc::c_void,
-}
+
 
 use crate::include::dav1d::common::Dav1dUserData;
 use crate::src::r#ref::Dav1dRef;

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -34,14 +34,7 @@ extern "C" {
     fn dav1d_data_props_set_defaults(props: *mut Dav1dDataProps);
     fn dav1d_log(c: *mut Dav1dContext, format: *const libc::c_char, _: ...);
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct __va_list_tag {
-    pub gp_offset: libc::c_uint,
-    pub fp_offset: libc::c_uint,
-    pub overflow_arg_area: *mut libc::c_void,
-    pub reg_save_area: *mut libc::c_void,
-}
+
 
 
 

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -107,14 +107,7 @@ extern "C" {
     static mut dav1d_wedge_masks: [[[[*const uint8_t; 16]; 2]; 3]; 22];
     static mut dav1d_ii_masks: [[[*const uint8_t; 4]; 3]; 22];
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct __va_list_tag {
-    pub gp_offset: libc::c_uint,
-    pub fp_offset: libc::c_uint,
-    pub overflow_arg_area: *mut libc::c_void,
-    pub reg_save_area: *mut libc::c_void,
-}
+
 
 
 

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -106,14 +106,7 @@ extern "C" {
     static mut dav1d_wedge_masks: [[[[*const uint8_t; 16]; 2]; 3]; 22];
     static mut dav1d_ii_masks: [[[*const uint8_t; 4]; 3]; 22];
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct __va_list_tag {
-    pub gp_offset: libc::c_uint,
-    pub fp_offset: libc::c_uint,
-    pub overflow_arg_area: *mut libc::c_void,
-    pub reg_save_area: *mut libc::c_void,
-}
+
 
 pub type __off_t = libc::c_long;
 pub type __off64_t = libc::c_long;

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -63,14 +63,7 @@ extern "C" {
         row: libc::c_int,
     );
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct __va_list_tag {
-    pub gp_offset: libc::c_uint,
-    pub fp_offset: libc::c_uint,
-    pub overflow_arg_area: *mut libc::c_void,
-    pub reg_save_area: *mut libc::c_void,
-}
+
 
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -81,14 +81,7 @@ extern "C" {
         lib_settings: *mut Dav1dSettings,
     );
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct __va_list_tag {
-    pub gp_offset: libc::c_uint,
-    pub fp_offset: libc::c_uint,
-    pub overflow_arg_area: *mut libc::c_void,
-    pub reg_save_area: *mut libc::c_void,
-}
+
 
 pub type __off_t = libc::c_long;
 pub type __off64_t = libc::c_long;

--- a/tools/dav1d_cli_parse.rs
+++ b/tools/dav1d_cli_parse.rs
@@ -47,15 +47,8 @@ extern "C" {
     fn dav1d_default_settings(s: *mut Dav1dSettings);
     fn dav1d_set_cpu_flags_mask(mask: libc::c_uint);
 }
-pub type __builtin_va_list = [__va_list_tag; 1];
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct __va_list_tag {
-    pub gp_offset: libc::c_uint,
-    pub fp_offset: libc::c_uint,
-    pub overflow_arg_area: *mut libc::c_void,
-    pub reg_save_area: *mut libc::c_void,
-}
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct option {
@@ -67,7 +60,7 @@ pub struct option {
 
 pub type __off_t = libc::c_long;
 pub type __off64_t = libc::c_long;
-pub type va_list = __builtin_va_list;
+
 pub type _IO_lock_t = ();
 use crate::include::dav1d::common::Dav1dUserData;
 use crate::include::dav1d::common::Dav1dDataProps;


### PR DESCRIPTION
Remove `va_list`, as `c2rust transpile` replaces its uses with `core::ffi::VaList` and so `va_list` is completely unused.