### PR TITLE
Fix some of the trivial warnings

### DIFF
--- a/c2rust-lib.rs
+++ b/c2rust-lib.rs
@@ -5,7 +5,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(unused_assignments)]
 #![allow(unused_mut)]
-#![feature(asm)]
 #![feature(c_variadic)]
 #![feature(core_intrinsics)]
 #![feature(extern_types)]

--- a/tools/input/annexb.rs
+++ b/tools/input/annexb.rs
@@ -382,38 +382,33 @@ unsafe extern "C" fn annexb_close(c: *mut AnnexbInputContext) {
     fclose((*c).f);
 }
 #[no_mangle]
-pub static mut annexb_demuxer: Demuxer = unsafe {
-    {
-        let mut init = Demuxer {
-            priv_data_size: ::core::mem::size_of::<AnnexbInputContext>() as libc::c_ulong
-                as libc::c_int,
-            name: b"annexb\0" as *const u8 as *const libc::c_char,
-            probe_sz: 2048 as libc::c_int,
-            probe: Some(
-                annexb_probe as unsafe extern "C" fn(*const uint8_t) -> libc::c_int,
-            ),
-            open: Some(
-                annexb_open
-                    as unsafe extern "C" fn(
-                        *mut AnnexbInputContext,
-                        *const libc::c_char,
-                        *mut libc::c_uint,
-                        *mut libc::c_uint,
-                        *mut libc::c_uint,
-                    ) -> libc::c_int,
-            ),
-            read: Some(
-                annexb_read
-                    as unsafe extern "C" fn(
-                        *mut AnnexbInputContext,
-                        *mut Dav1dData,
-                    ) -> libc::c_int,
-            ),
-            seek: None,
-            close: Some(
-                annexb_close as unsafe extern "C" fn(*mut AnnexbInputContext) -> (),
-            ),
-        };
-        init
-    }
+pub static mut annexb_demuxer: Demuxer = Demuxer {
+    priv_data_size: ::core::mem::size_of::<AnnexbInputContext>() as libc::c_ulong
+        as libc::c_int,
+    name: b"annexb\0" as *const u8 as *const libc::c_char,
+    probe_sz: 2048 as libc::c_int,
+    probe: Some(
+        annexb_probe as unsafe extern "C" fn(*const uint8_t) -> libc::c_int,
+    ),
+    open: Some(
+        annexb_open
+            as unsafe extern "C" fn(
+                *mut AnnexbInputContext,
+                *const libc::c_char,
+                *mut libc::c_uint,
+                *mut libc::c_uint,
+                *mut libc::c_uint,
+            ) -> libc::c_int,
+    ),
+    read: Some(
+        annexb_read
+            as unsafe extern "C" fn(
+                *mut AnnexbInputContext,
+                *mut Dav1dData,
+            ) -> libc::c_int,
+    ),
+    seek: None,
+    close: Some(
+        annexb_close as unsafe extern "C" fn(*mut AnnexbInputContext) -> (),
+    ),
 };

--- a/tools/input/ivf.rs
+++ b/tools/input/ivf.rs
@@ -402,43 +402,38 @@ unsafe extern "C" fn ivf_close(c: *mut IvfInputContext) {
     fclose((*c).f);
 }
 #[no_mangle]
-pub static mut ivf_demuxer: Demuxer = unsafe {
-    {
-        let mut init = Demuxer {
-            priv_data_size: ::core::mem::size_of::<IvfInputContext>() as libc::c_ulong
-                as libc::c_int,
-            name: b"ivf\0" as *const u8 as *const libc::c_char,
-            probe_sz: ::core::mem::size_of::<[uint8_t; 12]>() as libc::c_ulong
-                as libc::c_int,
-            probe: Some(
-                ivf_probe as unsafe extern "C" fn(*const uint8_t) -> libc::c_int,
-            ),
-            open: Some(
-                ivf_open
-                    as unsafe extern "C" fn(
-                        *mut IvfInputContext,
-                        *const libc::c_char,
-                        *mut libc::c_uint,
-                        *mut libc::c_uint,
-                        *mut libc::c_uint,
-                    ) -> libc::c_int,
-            ),
-            read: Some(
-                ivf_read
-                    as unsafe extern "C" fn(
-                        *mut IvfInputContext,
-                        *mut Dav1dData,
-                    ) -> libc::c_int,
-            ),
-            seek: Some(
-                ivf_seek
-                    as unsafe extern "C" fn(
-                        *mut IvfInputContext,
-                        uint64_t,
-                    ) -> libc::c_int,
-            ),
-            close: Some(ivf_close as unsafe extern "C" fn(*mut IvfInputContext) -> ()),
-        };
-        init
-    }
+pub static mut ivf_demuxer: Demuxer = Demuxer {
+    priv_data_size: ::core::mem::size_of::<IvfInputContext>() as libc::c_ulong
+        as libc::c_int,
+    name: b"ivf\0" as *const u8 as *const libc::c_char,
+    probe_sz: ::core::mem::size_of::<[uint8_t; 12]>() as libc::c_ulong
+        as libc::c_int,
+    probe: Some(
+        ivf_probe as unsafe extern "C" fn(*const uint8_t) -> libc::c_int,
+    ),
+    open: Some(
+        ivf_open
+            as unsafe extern "C" fn(
+                *mut IvfInputContext,
+                *const libc::c_char,
+                *mut libc::c_uint,
+                *mut libc::c_uint,
+                *mut libc::c_uint,
+            ) -> libc::c_int,
+    ),
+    read: Some(
+        ivf_read
+            as unsafe extern "C" fn(
+                *mut IvfInputContext,
+                *mut Dav1dData,
+            ) -> libc::c_int,
+    ),
+    seek: Some(
+        ivf_seek
+            as unsafe extern "C" fn(
+                *mut IvfInputContext,
+                uint64_t,
+            ) -> libc::c_int,
+    ),
+    close: Some(ivf_close as unsafe extern "C" fn(*mut IvfInputContext) -> ()),
 };

--- a/tools/input/section5.rs
+++ b/tools/input/section5.rs
@@ -386,38 +386,33 @@ unsafe extern "C" fn section5_close(c: *mut Section5InputContext) {
     fclose((*c).f);
 }
 #[no_mangle]
-pub static mut section5_demuxer: Demuxer = unsafe {
-    {
-        let mut init = Demuxer {
-            priv_data_size: ::core::mem::size_of::<Section5InputContext>()
-                as libc::c_ulong as libc::c_int,
-            name: b"section5\0" as *const u8 as *const libc::c_char,
-            probe_sz: 2048 as libc::c_int,
-            probe: Some(
-                section5_probe as unsafe extern "C" fn(*const uint8_t) -> libc::c_int,
-            ),
-            open: Some(
-                section5_open
-                    as unsafe extern "C" fn(
-                        *mut Section5InputContext,
-                        *const libc::c_char,
-                        *mut libc::c_uint,
-                        *mut libc::c_uint,
-                        *mut libc::c_uint,
-                    ) -> libc::c_int,
-            ),
-            read: Some(
-                section5_read
-                    as unsafe extern "C" fn(
-                        *mut Section5InputContext,
-                        *mut Dav1dData,
-                    ) -> libc::c_int,
-            ),
-            seek: None,
-            close: Some(
-                section5_close as unsafe extern "C" fn(*mut Section5InputContext) -> (),
-            ),
-        };
-        init
-    }
+pub static mut section5_demuxer: Demuxer = Demuxer {
+    priv_data_size: ::core::mem::size_of::<Section5InputContext>()
+        as libc::c_ulong as libc::c_int,
+    name: b"section5\0" as *const u8 as *const libc::c_char,
+    probe_sz: 2048 as libc::c_int,
+    probe: Some(
+        section5_probe as unsafe extern "C" fn(*const uint8_t) -> libc::c_int,
+    ),
+    open: Some(
+        section5_open
+            as unsafe extern "C" fn(
+                *mut Section5InputContext,
+                *const libc::c_char,
+                *mut libc::c_uint,
+                *mut libc::c_uint,
+                *mut libc::c_uint,
+            ) -> libc::c_int,
+    ),
+    read: Some(
+        section5_read
+            as unsafe extern "C" fn(
+                *mut Section5InputContext,
+                *mut Dav1dData,
+            ) -> libc::c_int,
+    ),
+    seek: None,
+    close: Some(
+        section5_close as unsafe extern "C" fn(*mut Section5InputContext) -> (),
+    ),
 };

--- a/tools/output/md5.rs
+++ b/tools/output/md5.rs
@@ -1638,40 +1638,35 @@ unsafe extern "C" fn md5_verify(
     ) != 0) as libc::c_int;
 }
 #[no_mangle]
-pub static mut md5_muxer: Muxer = unsafe {
-    {
-        let mut init = Muxer {
-            priv_data_size: ::core::mem::size_of::<MD5Context>() as libc::c_ulong
-                as libc::c_int,
-            name: b"md5\0" as *const u8 as *const libc::c_char,
-            extension: b"md5\0" as *const u8 as *const libc::c_char,
-            write_header: Some(
-                md5_open
-                    as unsafe extern "C" fn(
-                        *mut MD5Context,
-                        *const libc::c_char,
-                        *const Dav1dPictureParameters,
-                        *const libc::c_uint,
-                    ) -> libc::c_int,
-            ),
-            write_picture: Some(
-                md5_write
-                    as unsafe extern "C" fn(
-                        *mut MD5Context,
-                        *mut Dav1dPicture,
-                    ) -> libc::c_int,
-            ),
-            write_trailer: Some(
-                md5_close as unsafe extern "C" fn(*mut MD5Context) -> (),
-            ),
-            verify: Some(
-                md5_verify
-                    as unsafe extern "C" fn(
-                        *mut MD5Context,
-                        *const libc::c_char,
-                    ) -> libc::c_int,
-            ),
-        };
-        init
-    }
+pub static mut md5_muxer: Muxer = Muxer {
+    priv_data_size: ::core::mem::size_of::<MD5Context>() as libc::c_ulong
+        as libc::c_int,
+    name: b"md5\0" as *const u8 as *const libc::c_char,
+    extension: b"md5\0" as *const u8 as *const libc::c_char,
+    write_header: Some(
+        md5_open
+            as unsafe extern "C" fn(
+                *mut MD5Context,
+                *const libc::c_char,
+                *const Dav1dPictureParameters,
+                *const libc::c_uint,
+            ) -> libc::c_int,
+    ),
+    write_picture: Some(
+        md5_write
+            as unsafe extern "C" fn(
+                *mut MD5Context,
+                *mut Dav1dPicture,
+            ) -> libc::c_int,
+    ),
+    write_trailer: Some(
+        md5_close as unsafe extern "C" fn(*mut MD5Context) -> (),
+    ),
+    verify: Some(
+        md5_verify
+            as unsafe extern "C" fn(
+                *mut MD5Context,
+                *const libc::c_char,
+            ) -> libc::c_int,
+    ),
 };

--- a/tools/output/null.rs
+++ b/tools/output/null.rs
@@ -345,23 +345,18 @@ unsafe extern "C" fn null_write(
     return 0 as libc::c_int;
 }
 #[no_mangle]
-pub static mut null_muxer: Muxer = unsafe {
-    {
-        let mut init = Muxer {
-            priv_data_size: 0 as libc::c_int,
-            name: b"null\0" as *const u8 as *const libc::c_char,
-            extension: b"null\0" as *const u8 as *const libc::c_char,
-            write_header: None,
-            write_picture: Some(
-                null_write
-                    as unsafe extern "C" fn(
-                        *mut NullOutputContext,
-                        *mut Dav1dPicture,
-                    ) -> libc::c_int,
-            ),
-            write_trailer: None,
-            verify: None,
-        };
-        init
-    }
+pub static mut null_muxer: Muxer = Muxer {
+    priv_data_size: 0 as libc::c_int,
+    name: b"null\0" as *const u8 as *const libc::c_char,
+    extension: b"null\0" as *const u8 as *const libc::c_char,
+    write_header: None,
+    write_picture: Some(
+        null_write
+            as unsafe extern "C" fn(
+                *mut NullOutputContext,
+                *mut Dav1dPicture,
+            ) -> libc::c_int,
+    ),
+    write_trailer: None,
+    verify: None,
 };

--- a/tools/output/y4m2.rs
+++ b/tools/output/y4m2.rs
@@ -565,34 +565,29 @@ unsafe extern "C" fn y4m2_close(c: *mut Y4m2OutputContext) {
     }
 }
 #[no_mangle]
-pub static mut y4m2_muxer: Muxer = unsafe {
-    {
-        let mut init = Muxer {
-            priv_data_size: ::core::mem::size_of::<Y4m2OutputContext>() as libc::c_ulong
-                as libc::c_int,
-            name: b"yuv4mpeg2\0" as *const u8 as *const libc::c_char,
-            extension: b"y4m\0" as *const u8 as *const libc::c_char,
-            write_header: Some(
-                y4m2_open
-                    as unsafe extern "C" fn(
-                        *mut Y4m2OutputContext,
-                        *const libc::c_char,
-                        *const Dav1dPictureParameters,
-                        *const libc::c_uint,
-                    ) -> libc::c_int,
-            ),
-            write_picture: Some(
-                y4m2_write
-                    as unsafe extern "C" fn(
-                        *mut Y4m2OutputContext,
-                        *mut Dav1dPicture,
-                    ) -> libc::c_int,
-            ),
-            write_trailer: Some(
-                y4m2_close as unsafe extern "C" fn(*mut Y4m2OutputContext) -> (),
-            ),
-            verify: None,
-        };
-        init
-    }
+pub static mut y4m2_muxer: Muxer = Muxer {
+    priv_data_size: ::core::mem::size_of::<Y4m2OutputContext>() as libc::c_ulong
+        as libc::c_int,
+    name: b"yuv4mpeg2\0" as *const u8 as *const libc::c_char,
+    extension: b"y4m\0" as *const u8 as *const libc::c_char,
+    write_header: Some(
+        y4m2_open
+            as unsafe extern "C" fn(
+                *mut Y4m2OutputContext,
+                *const libc::c_char,
+                *const Dav1dPictureParameters,
+                *const libc::c_uint,
+            ) -> libc::c_int,
+    ),
+    write_picture: Some(
+        y4m2_write
+            as unsafe extern "C" fn(
+                *mut Y4m2OutputContext,
+                *mut Dav1dPicture,
+            ) -> libc::c_int,
+    ),
+    write_trailer: Some(
+        y4m2_close as unsafe extern "C" fn(*mut Y4m2OutputContext) -> (),
+    ),
+    verify: None,
 };

--- a/tools/output/yuv.rs
+++ b/tools/output/yuv.rs
@@ -474,34 +474,29 @@ unsafe extern "C" fn yuv_close(c: *mut YuvOutputContext) {
     }
 }
 #[no_mangle]
-pub static mut yuv_muxer: Muxer = unsafe {
-    {
-        let mut init = Muxer {
-            priv_data_size: ::core::mem::size_of::<YuvOutputContext>() as libc::c_ulong
-                as libc::c_int,
-            name: b"yuv\0" as *const u8 as *const libc::c_char,
-            extension: b"yuv\0" as *const u8 as *const libc::c_char,
-            write_header: Some(
-                yuv_open
-                    as unsafe extern "C" fn(
-                        *mut YuvOutputContext,
-                        *const libc::c_char,
-                        *const Dav1dPictureParameters,
-                        *const libc::c_uint,
-                    ) -> libc::c_int,
-            ),
-            write_picture: Some(
-                yuv_write
-                    as unsafe extern "C" fn(
-                        *mut YuvOutputContext,
-                        *mut Dav1dPicture,
-                    ) -> libc::c_int,
-            ),
-            write_trailer: Some(
-                yuv_close as unsafe extern "C" fn(*mut YuvOutputContext) -> (),
-            ),
-            verify: None,
-        };
-        init
-    }
+pub static mut yuv_muxer: Muxer = Muxer {
+    priv_data_size: ::core::mem::size_of::<YuvOutputContext>() as libc::c_ulong
+        as libc::c_int,
+    name: b"yuv\0" as *const u8 as *const libc::c_char,
+    extension: b"yuv\0" as *const u8 as *const libc::c_char,
+    write_header: Some(
+        yuv_open
+            as unsafe extern "C" fn(
+                *mut YuvOutputContext,
+                *const libc::c_char,
+                *const Dav1dPictureParameters,
+                *const libc::c_uint,
+            ) -> libc::c_int,
+    ),
+    write_picture: Some(
+        yuv_write
+            as unsafe extern "C" fn(
+                *mut YuvOutputContext,
+                *mut Dav1dPicture,
+            ) -> libc::c_int,
+    ),
+    write_trailer: Some(
+        yuv_close as unsafe extern "C" fn(*mut YuvOutputContext) -> (),
+    ),
+    verify: None,
 };


### PR DESCRIPTION
This fixes some of the trivial warnings, namely
* `#[warn(stable_features)]`
* `#[warn(unused_unsafe)]`

Reducing the number of warnings (especially those not in `c2rust_out` like the `unused_unsafe`s) makes other work, especially deduplication with its many, but small and rapid changes, much smoother.  And I don't think these fixes conflict with any of the other work we're doing, as they're quite simple.