### PR TITLE
Deduplicate `enum LrEdgeFlags` to `src/looprestoration.rs`

### DIFF
--- a/c2rust-lib.rs
+++ b/c2rust-lib.rs
@@ -77,6 +77,7 @@ pub mod log;
 pub mod loopfilter_tmpl_16;
 #[cfg(feature = "bitdepth_8")]
 pub mod loopfilter_tmpl_8;
+pub mod looprestoration;
 #[cfg(feature = "bitdepth_16")]
 pub mod looprestoration_tmpl_16;
 #[cfg(feature = "bitdepth_8")]

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -1148,11 +1148,11 @@ pub type looprestorationfilter_fn = Option::<
         libc::c_int,
     ) -> (),
 >;
-pub type LrEdgeFlags = libc::c_uint;
-pub const LR_HAVE_BOTTOM: LrEdgeFlags = 8;
-pub const LR_HAVE_TOP: LrEdgeFlags = 4;
-pub const LR_HAVE_RIGHT: LrEdgeFlags = 2;
-pub const LR_HAVE_LEFT: LrEdgeFlags = 1;
+use crate::src::looprestoration::LrEdgeFlags;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union LooprestorationParams {

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -1147,11 +1147,11 @@ pub type looprestorationfilter_fn = Option::<
         LrEdgeFlags,
     ) -> (),
 >;
-pub type LrEdgeFlags = libc::c_uint;
-pub const LR_HAVE_BOTTOM: LrEdgeFlags = 8;
-pub const LR_HAVE_TOP: LrEdgeFlags = 4;
-pub const LR_HAVE_RIGHT: LrEdgeFlags = 2;
-pub const LR_HAVE_LEFT: LrEdgeFlags = 1;
+use crate::src::looprestoration::LrEdgeFlags;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union LooprestorationParams {

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -1257,11 +1257,11 @@ pub type looprestorationfilter_fn = Option::<
         LrEdgeFlags,
     ) -> (),
 >;
-pub type LrEdgeFlags = libc::c_uint;
-pub const LR_HAVE_BOTTOM: LrEdgeFlags = 8;
-pub const LR_HAVE_TOP: LrEdgeFlags = 4;
-pub const LR_HAVE_RIGHT: LrEdgeFlags = 2;
-pub const LR_HAVE_LEFT: LrEdgeFlags = 1;
+use crate::src::looprestoration::LrEdgeFlags;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union LooprestorationParams {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1509,11 +1509,11 @@ pub type looprestorationfilter_fn = Option::<
         LrEdgeFlags,
     ) -> (),
 >;
-pub type LrEdgeFlags = libc::c_uint;
-pub const LR_HAVE_BOTTOM: LrEdgeFlags = 8;
-pub const LR_HAVE_TOP: LrEdgeFlags = 4;
-pub const LR_HAVE_RIGHT: LrEdgeFlags = 2;
-pub const LR_HAVE_LEFT: LrEdgeFlags = 1;
+use crate::src::looprestoration::LrEdgeFlags;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union LooprestorationParams {

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -1148,11 +1148,11 @@ pub type looprestorationfilter_fn = Option::<
         libc::c_int,
     ) -> (),
 >;
-pub type LrEdgeFlags = libc::c_uint;
-pub const LR_HAVE_BOTTOM: LrEdgeFlags = 8;
-pub const LR_HAVE_TOP: LrEdgeFlags = 4;
-pub const LR_HAVE_RIGHT: LrEdgeFlags = 2;
-pub const LR_HAVE_LEFT: LrEdgeFlags = 1;
+use crate::src::looprestoration::LrEdgeFlags;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union LooprestorationParams {

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -1147,11 +1147,11 @@ pub type looprestorationfilter_fn = Option::<
         LrEdgeFlags,
     ) -> (),
 >;
-pub type LrEdgeFlags = libc::c_uint;
-pub const LR_HAVE_BOTTOM: LrEdgeFlags = 8;
-pub const LR_HAVE_TOP: LrEdgeFlags = 4;
-pub const LR_HAVE_RIGHT: LrEdgeFlags = 2;
-pub const LR_HAVE_LEFT: LrEdgeFlags = 1;
+use crate::src::looprestoration::LrEdgeFlags;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union LooprestorationParams {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -700,11 +700,11 @@ pub type looprestorationfilter_fn = Option::<
         LrEdgeFlags,
     ) -> (),
 >;
-pub type LrEdgeFlags = libc::c_uint;
-pub const LR_HAVE_BOTTOM: LrEdgeFlags = 8;
-pub const LR_HAVE_TOP: LrEdgeFlags = 4;
-pub const LR_HAVE_RIGHT: LrEdgeFlags = 2;
-pub const LR_HAVE_LEFT: LrEdgeFlags = 1;
+use crate::src::looprestoration::LrEdgeFlags;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union LooprestorationParams {

--- a/src/log.rs
+++ b/src/log.rs
@@ -552,11 +552,11 @@ pub type looprestorationfilter_fn = Option::<
         LrEdgeFlags,
     ) -> (),
 >;
-pub type LrEdgeFlags = libc::c_uint;
-pub const LR_HAVE_BOTTOM: LrEdgeFlags = 8;
-pub const LR_HAVE_TOP: LrEdgeFlags = 4;
-pub const LR_HAVE_RIGHT: LrEdgeFlags = 2;
-pub const LR_HAVE_LEFT: LrEdgeFlags = 1;
+use crate::src::looprestoration::LrEdgeFlags;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union LooprestorationParams {

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -1,0 +1,5 @@
+pub type LrEdgeFlags = libc::c_uint;
+pub const LR_HAVE_BOTTOM: LrEdgeFlags = 8;
+pub const LR_HAVE_TOP: LrEdgeFlags = 4;
+pub const LR_HAVE_RIGHT: LrEdgeFlags = 2;
+pub const LR_HAVE_LEFT: LrEdgeFlags = 1;

--- a/src/looprestoration_tmpl_16.rs
+++ b/src/looprestoration_tmpl_16.rs
@@ -16,11 +16,11 @@ extern "C" {
 
 pub type pixel = uint16_t;
 pub type coef = int32_t;
-pub type LrEdgeFlags = libc::c_uint;
-pub const LR_HAVE_BOTTOM: LrEdgeFlags = 8;
-pub const LR_HAVE_TOP: LrEdgeFlags = 4;
-pub const LR_HAVE_RIGHT: LrEdgeFlags = 2;
-pub const LR_HAVE_LEFT: LrEdgeFlags = 1;
+use crate::src::looprestoration::LrEdgeFlags;
+use crate::src::looprestoration::LR_HAVE_BOTTOM;
+use crate::src::looprestoration::LR_HAVE_TOP;
+use crate::src::looprestoration::LR_HAVE_RIGHT;
+use crate::src::looprestoration::LR_HAVE_LEFT;
 pub type const_left_pixel_row = *const [pixel; 4];
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/looprestoration_tmpl_8.rs
+++ b/src/looprestoration_tmpl_8.rs
@@ -21,11 +21,11 @@ extern "C" {
 
 pub type pixel = uint8_t;
 pub type coef = int16_t;
-pub type LrEdgeFlags = libc::c_uint;
-pub const LR_HAVE_BOTTOM: LrEdgeFlags = 8;
-pub const LR_HAVE_TOP: LrEdgeFlags = 4;
-pub const LR_HAVE_RIGHT: LrEdgeFlags = 2;
-pub const LR_HAVE_LEFT: LrEdgeFlags = 1;
+use crate::src::looprestoration::LrEdgeFlags;
+use crate::src::looprestoration::LR_HAVE_BOTTOM;
+use crate::src::looprestoration::LR_HAVE_TOP;
+use crate::src::looprestoration::LR_HAVE_RIGHT;
+use crate::src::looprestoration::LR_HAVE_LEFT;
 pub type const_left_pixel_row = *const [pixel; 4];
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -1149,11 +1149,11 @@ pub type looprestorationfilter_fn = Option::<
         libc::c_int,
     ) -> (),
 >;
-pub type LrEdgeFlags = libc::c_uint;
-pub const LR_HAVE_BOTTOM: LrEdgeFlags = 8;
-pub const LR_HAVE_TOP: LrEdgeFlags = 4;
-pub const LR_HAVE_RIGHT: LrEdgeFlags = 2;
-pub const LR_HAVE_LEFT: LrEdgeFlags = 1;
+use crate::src::looprestoration::LrEdgeFlags;
+use crate::src::looprestoration::LR_HAVE_BOTTOM;
+use crate::src::looprestoration::LR_HAVE_TOP;
+use crate::src::looprestoration::LR_HAVE_RIGHT;
+use crate::src::looprestoration::LR_HAVE_LEFT;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union LooprestorationParams {

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -1148,11 +1148,11 @@ pub type looprestorationfilter_fn = Option::<
         LrEdgeFlags,
     ) -> (),
 >;
-pub type LrEdgeFlags = libc::c_uint;
-pub const LR_HAVE_BOTTOM: LrEdgeFlags = 8;
-pub const LR_HAVE_TOP: LrEdgeFlags = 4;
-pub const LR_HAVE_RIGHT: LrEdgeFlags = 2;
-pub const LR_HAVE_LEFT: LrEdgeFlags = 1;
+use crate::src::looprestoration::LrEdgeFlags;
+use crate::src::looprestoration::LR_HAVE_BOTTOM;
+use crate::src::looprestoration::LR_HAVE_TOP;
+use crate::src::looprestoration::LR_HAVE_RIGHT;
+use crate::src::looprestoration::LR_HAVE_LEFT;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union LooprestorationParams {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1192,11 +1192,11 @@ pub type looprestorationfilter_fn = Option::<
         LrEdgeFlags,
     ) -> (),
 >;
-pub type LrEdgeFlags = libc::c_uint;
-pub const LR_HAVE_BOTTOM: LrEdgeFlags = 8;
-pub const LR_HAVE_TOP: LrEdgeFlags = 4;
-pub const LR_HAVE_RIGHT: LrEdgeFlags = 2;
-pub const LR_HAVE_LEFT: LrEdgeFlags = 1;
+use crate::src::looprestoration::LrEdgeFlags;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union LooprestorationParams {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -1191,11 +1191,11 @@ pub type looprestorationfilter_fn = Option::<
         LrEdgeFlags,
     ) -> (),
 >;
-pub type LrEdgeFlags = libc::c_uint;
-pub const LR_HAVE_BOTTOM: LrEdgeFlags = 8;
-pub const LR_HAVE_TOP: LrEdgeFlags = 4;
-pub const LR_HAVE_RIGHT: LrEdgeFlags = 2;
-pub const LR_HAVE_LEFT: LrEdgeFlags = 1;
+use crate::src::looprestoration::LrEdgeFlags;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union LooprestorationParams {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1248,11 +1248,11 @@ pub type looprestorationfilter_fn = Option::<
         libc::c_int,
     ) -> (),
 >;
-pub type LrEdgeFlags = libc::c_uint;
-pub const LR_HAVE_BOTTOM: LrEdgeFlags = 8;
-pub const LR_HAVE_TOP: LrEdgeFlags = 4;
-pub const LR_HAVE_RIGHT: LrEdgeFlags = 2;
-pub const LR_HAVE_LEFT: LrEdgeFlags = 1;
+use crate::src::looprestoration::LrEdgeFlags;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union LooprestorationParams {

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1239,11 +1239,11 @@ pub type looprestorationfilter_fn = Option::<
         LrEdgeFlags,
     ) -> (),
 >;
-pub type LrEdgeFlags = libc::c_uint;
-pub const LR_HAVE_BOTTOM: LrEdgeFlags = 8;
-pub const LR_HAVE_TOP: LrEdgeFlags = 4;
-pub const LR_HAVE_RIGHT: LrEdgeFlags = 2;
-pub const LR_HAVE_LEFT: LrEdgeFlags = 1;
+use crate::src::looprestoration::LrEdgeFlags;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union LooprestorationParams {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1193,11 +1193,11 @@ pub type looprestorationfilter_fn = Option::<
         LrEdgeFlags,
     ) -> (),
 >;
-pub type LrEdgeFlags = libc::c_uint;
-pub const LR_HAVE_BOTTOM: LrEdgeFlags = 8;
-pub const LR_HAVE_TOP: LrEdgeFlags = 4;
-pub const LR_HAVE_RIGHT: LrEdgeFlags = 2;
-pub const LR_HAVE_LEFT: LrEdgeFlags = 1;
+use crate::src::looprestoration::LrEdgeFlags;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union LooprestorationParams {


### PR DESCRIPTION
`enum LrEdgeFlags` is originally from `src/looprestoration.h`, and so is the same in all instantiations of `src/looprestoration_tmpl.c`, so I've defined it in the newly-created `src/looprestoration.rs` (which will be where `src/looprestoration_tmpl_{8, 16}.rs` will later merge to).