### PR TITLE
Deduplicate `enum LrRestorePlanes` to `src/lr_apply.rs`

### DIFF
--- a/c2rust-lib.rs
+++ b/c2rust-lib.rs
@@ -82,6 +82,7 @@ pub mod looprestoration;
 pub mod looprestoration_tmpl_16;
 #[cfg(feature = "bitdepth_8")]
 pub mod looprestoration_tmpl_8;
+pub mod lr_apply;
 #[cfg(feature = "bitdepth_16")]
 pub mod lr_apply_tmpl_16;
 #[cfg(feature = "bitdepth_8")]

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -1603,10 +1603,10 @@ pub struct ScalableMotionParams {
     pub scale: libc::c_int,
     pub step: libc::c_int,
 }
-pub const LR_RESTORE_V: LrRestorePlanes = 4;
-pub const LR_RESTORE_U: LrRestorePlanes = 2;
-pub const LR_RESTORE_Y: LrRestorePlanes = 1;
-pub type LrRestorePlanes = libc::c_uint;
+use crate::src::lr_apply::LR_RESTORE_V;
+use crate::src::lr_apply::LR_RESTORE_U;
+use crate::src::lr_apply::LR_RESTORE_Y;
+
 #[inline]
 unsafe extern "C" fn imin(a: libc::c_int, b: libc::c_int) -> libc::c_int {
     return if a < b { a } else { b };

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -1573,10 +1573,10 @@ pub struct ScalableMotionParams {
     pub scale: libc::c_int,
     pub step: libc::c_int,
 }
-pub const LR_RESTORE_V: LrRestorePlanes = 4;
-pub const LR_RESTORE_U: LrRestorePlanes = 2;
-pub const LR_RESTORE_Y: LrRestorePlanes = 1;
-pub type LrRestorePlanes = libc::c_uint;
+use crate::src::lr_apply::LR_RESTORE_V;
+use crate::src::lr_apply::LR_RESTORE_U;
+use crate::src::lr_apply::LR_RESTORE_Y;
+
 #[inline]
 unsafe extern "C" fn imin(a: libc::c_int, b: libc::c_int) -> libc::c_int {
     return if a < b { a } else { b };

--- a/src/lr_apply.rs
+++ b/src/lr_apply.rs
@@ -1,0 +1,4 @@
+pub type LrRestorePlanes = libc::c_uint;
+pub const LR_RESTORE_V: LrRestorePlanes = 4;
+pub const LR_RESTORE_U: LrRestorePlanes = 2;
+pub const LR_RESTORE_Y: LrRestorePlanes = 1;

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -1604,10 +1604,10 @@ pub struct ScalableMotionParams {
     pub scale: libc::c_int,
     pub step: libc::c_int,
 }
-pub type LrRestorePlanes = libc::c_uint;
-pub const LR_RESTORE_V: LrRestorePlanes = 4;
-pub const LR_RESTORE_U: LrRestorePlanes = 2;
-pub const LR_RESTORE_Y: LrRestorePlanes = 1;
+
+use crate::src::lr_apply::LR_RESTORE_V;
+use crate::src::lr_apply::LR_RESTORE_U;
+use crate::src::lr_apply::LR_RESTORE_Y;
 #[inline]
 unsafe extern "C" fn imin(a: libc::c_int, b: libc::c_int) -> libc::c_int {
     return if a < b { a } else { b };

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -1574,10 +1574,10 @@ pub struct ScalableMotionParams {
     pub scale: libc::c_int,
     pub step: libc::c_int,
 }
-pub type LrRestorePlanes = libc::c_uint;
-pub const LR_RESTORE_V: LrRestorePlanes = 4;
-pub const LR_RESTORE_U: LrRestorePlanes = 2;
-pub const LR_RESTORE_Y: LrRestorePlanes = 1;
+
+use crate::src::lr_apply::LR_RESTORE_V;
+use crate::src::lr_apply::LR_RESTORE_U;
+use crate::src::lr_apply::LR_RESTORE_Y;
 #[inline]
 unsafe extern "C" fn imin(a: libc::c_int, b: libc::c_int) -> libc::c_int {
     return if a < b { a } else { b };


### PR DESCRIPTION
`enum LrRestorePlanes` is originally from `src/lr_apply.h`, and so is the same in all instantiations of `src/lr_apply_tmpl.c`, so I've defined it in the newly-created `src/lr_apply.rs` (which will be where `src/lr_apply_tmpl_{8, 16}.rs` will later merge to).