### PR TITLE
Deduplicate `struct`s from/to `src/lf_mask.{h,rs}`

### DIFF
--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -533,11 +533,7 @@ pub struct C2RustUnnamed_19 {
 }
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Restoration {
-    pub lr: [[Av1RestorationUnit; 4]; 3],
-}
+use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -545,15 +545,7 @@ use crate::src::lf_mask::Av1FilterLUT;
 pub struct Av1Restoration {
     pub lr: [[Av1RestorationUnit; 4]; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1RestorationUnit {
-    pub type_0: uint8_t,
-    pub filter_h: [int8_t; 3],
-    pub filter_v: [int8_t; 3],
-    pub sgr_idx: uint8_t,
-    pub sgr_weights: [int8_t; 2],
-}
+use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_20 {

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -539,13 +539,7 @@ pub struct Av1Filter {
     pub cdef_idx: [int8_t; 4],
     pub noskip_mask: [[uint16_t; 2]; 16],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1FilterLUT {
-    pub e: [uint8_t; 64],
-    pub i: [uint8_t; 64],
-    pub sharp: [uint64_t; 2],
-}
+use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Av1Restoration {

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -531,14 +531,7 @@ pub struct C2RustUnnamed_19 {
     pub prev_mask_ptr: *mut Av1Filter,
     pub restore_planes: libc::c_int,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Filter {
-    pub filter_y: [[[[uint16_t; 2]; 3]; 32]; 2],
-    pub filter_uv: [[[[uint16_t; 2]; 2]; 32]; 2],
-    pub cdef_idx: [int8_t; 4],
-    pub noskip_mask: [[uint16_t; 2]; 16],
-}
+use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -533,11 +533,7 @@ pub struct C2RustUnnamed_19 {
 }
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Restoration {
-    pub lr: [[Av1RestorationUnit; 4]; 3],
-}
+use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -545,15 +545,7 @@ use crate::src::lf_mask::Av1FilterLUT;
 pub struct Av1Restoration {
     pub lr: [[Av1RestorationUnit; 4]; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1RestorationUnit {
-    pub type_0: uint8_t,
-    pub filter_h: [int8_t; 3],
-    pub filter_v: [int8_t; 3],
-    pub sgr_idx: uint8_t,
-    pub sgr_weights: [int8_t; 2],
-}
+use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_20 {

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -539,13 +539,7 @@ pub struct Av1Filter {
     pub cdef_idx: [int8_t; 4],
     pub noskip_mask: [[uint16_t; 2]; 16],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1FilterLUT {
-    pub e: [uint8_t; 64],
-    pub i: [uint8_t; 64],
-    pub sharp: [uint64_t; 2],
-}
+use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Av1Restoration {

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -531,14 +531,7 @@ pub struct C2RustUnnamed_19 {
     pub prev_mask_ptr: *mut Av1Filter,
     pub restore_planes: libc::c_int,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Filter {
-    pub filter_y: [[[[uint16_t; 2]; 3]; 32]; 2],
-    pub filter_uv: [[[[uint16_t; 2]; 2]; 32]; 2],
-    pub cdef_idx: [int8_t; 4],
-    pub noskip_mask: [[uint16_t; 2]; 16],
-}
+use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -549,13 +549,7 @@ pub struct Av1Filter {
     pub noskip_mask: [[uint16_t; 2]; 16],
 }
 pub type pixel = ();
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1FilterLUT {
-    pub e: [uint8_t; 64],
-    pub i: [uint8_t; 64],
-    pub sharp: [uint64_t; 2],
-}
+use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Av1Restoration {

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -540,14 +540,7 @@ pub struct C2RustUnnamed_19 {
     pub prev_mask_ptr: *mut Av1Filter,
     pub restore_planes: libc::c_int,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Filter {
-    pub filter_y: [[[[uint16_t; 2]; 3]; 32]; 2],
-    pub filter_uv: [[[[uint16_t; 2]; 2]; 32]; 2],
-    pub cdef_idx: [int8_t; 4],
-    pub noskip_mask: [[uint16_t; 2]; 16],
-}
+use crate::src::lf_mask::Av1Filter;
 pub type pixel = ();
 use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -555,15 +555,7 @@ use crate::src::lf_mask::Av1FilterLUT;
 pub struct Av1Restoration {
     pub lr: [[Av1RestorationUnit; 4]; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1RestorationUnit {
-    pub type_0: uint8_t,
-    pub filter_h: [int8_t; 3],
-    pub filter_v: [int8_t; 3],
-    pub sgr_idx: uint8_t,
-    pub sgr_weights: [int8_t; 2],
-}
+use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_20 {

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -543,11 +543,7 @@ pub struct C2RustUnnamed_19 {
 use crate::src::lf_mask::Av1Filter;
 pub type pixel = ();
 use crate::src::lf_mask::Av1FilterLUT;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Restoration {
-    pub lr: [[Av1RestorationUnit; 4]; 3],
-}
+use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -906,15 +906,7 @@ use crate::src::lf_mask::Av1FilterLUT;
 pub struct Av1Restoration {
     pub lr: [[Av1RestorationUnit; 4]; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1RestorationUnit {
-    pub type_0: uint8_t,
-    pub filter_h: [int8_t; 3],
-    pub filter_v: [int8_t; 3],
-    pub sgr_idx: uint8_t,
-    pub sgr_weights: [int8_t; 2],
-}
+use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_20 {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -900,13 +900,7 @@ pub struct Av1Filter {
     pub noskip_mask: [[uint16_t; 2]; 16],
 }
 pub type pixel = ();
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1FilterLUT {
-    pub e: [uint8_t; 64],
-    pub i: [uint8_t; 64],
-    pub sharp: [uint64_t; 2],
-}
+use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Av1Restoration {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -891,14 +891,7 @@ pub struct C2RustUnnamed_19 {
     pub prev_mask_ptr: *mut Av1Filter,
     pub restore_planes: libc::c_int,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Filter {
-    pub filter_y: [[[[uint16_t; 2]; 3]; 32]; 2],
-    pub filter_uv: [[[[uint16_t; 2]; 2]; 32]; 2],
-    pub cdef_idx: [int8_t; 4],
-    pub noskip_mask: [[uint16_t; 2]; 16],
-}
+use crate::src::lf_mask::Av1Filter;
 pub type pixel = ();
 use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -894,11 +894,7 @@ pub struct C2RustUnnamed_19 {
 use crate::src::lf_mask::Av1Filter;
 pub type pixel = ();
 use crate::src::lf_mask::Av1FilterLUT;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Restoration {
-    pub lr: [[Av1RestorationUnit; 4]; 3],
-}
+use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -533,11 +533,7 @@ pub struct C2RustUnnamed_19 {
 }
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Restoration {
-    pub lr: [[Av1RestorationUnit; 4]; 3],
-}
+use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -545,15 +545,7 @@ use crate::src::lf_mask::Av1FilterLUT;
 pub struct Av1Restoration {
     pub lr: [[Av1RestorationUnit; 4]; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1RestorationUnit {
-    pub type_0: uint8_t,
-    pub filter_h: [int8_t; 3],
-    pub filter_v: [int8_t; 3],
-    pub sgr_idx: uint8_t,
-    pub sgr_weights: [int8_t; 2],
-}
+use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_20 {

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -539,13 +539,7 @@ pub struct Av1Filter {
     pub cdef_idx: [int8_t; 4],
     pub noskip_mask: [[uint16_t; 2]; 16],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1FilterLUT {
-    pub e: [uint8_t; 64],
-    pub i: [uint8_t; 64],
-    pub sharp: [uint64_t; 2],
-}
+use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Av1Restoration {

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -531,14 +531,7 @@ pub struct C2RustUnnamed_19 {
     pub prev_mask_ptr: *mut Av1Filter,
     pub restore_planes: libc::c_int,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Filter {
-    pub filter_y: [[[[uint16_t; 2]; 3]; 32]; 2],
-    pub filter_uv: [[[[uint16_t; 2]; 2]; 32]; 2],
-    pub cdef_idx: [int8_t; 4],
-    pub noskip_mask: [[uint16_t; 2]; 16],
-}
+use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -533,11 +533,7 @@ pub struct C2RustUnnamed_19 {
 }
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Restoration {
-    pub lr: [[Av1RestorationUnit; 4]; 3],
-}
+use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -545,15 +545,7 @@ use crate::src::lf_mask::Av1FilterLUT;
 pub struct Av1Restoration {
     pub lr: [[Av1RestorationUnit; 4]; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1RestorationUnit {
-    pub type_0: uint8_t,
-    pub filter_h: [int8_t; 3],
-    pub filter_v: [int8_t; 3],
-    pub sgr_idx: uint8_t,
-    pub sgr_weights: [int8_t; 2],
-}
+use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_20 {

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -539,13 +539,7 @@ pub struct Av1Filter {
     pub cdef_idx: [int8_t; 4],
     pub noskip_mask: [[uint16_t; 2]; 16],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1FilterLUT {
-    pub e: [uint8_t; 64],
-    pub i: [uint8_t; 64],
-    pub sharp: [uint64_t; 2],
-}
+use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Av1Restoration {

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -531,14 +531,7 @@ pub struct C2RustUnnamed_19 {
     pub prev_mask_ptr: *mut Av1Filter,
     pub restore_planes: libc::c_int,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Filter {
-    pub filter_y: [[[[uint16_t; 2]; 3]; 32]; 2],
-    pub filter_uv: [[[[uint16_t; 2]; 2]; 32]; 2],
-    pub cdef_idx: [int8_t; 4],
-    pub noskip_mask: [[uint16_t; 2]; 16],
-}
+use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -313,6 +313,15 @@ pub struct Av1FilterLUT {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
+pub struct Av1RestorationUnit {
+    pub type_0: uint8_t,
+    pub filter_h: [int8_t; 3],
+    pub filter_v: [int8_t; 3],
+    pub sgr_idx: uint8_t,
+    pub sgr_weights: [int8_t; 2],
+}
+#[derive(Copy, Clone)]
+#[repr(C)]
 pub struct Av1Filter {
     pub filter_y: [[[[uint16_t; 2]; 3]; 32]; 2],
     pub filter_uv: [[[[uint16_t; 2]; 2]; 32]; 2],

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -330,6 +330,11 @@ pub struct Av1Filter {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
+pub struct Av1Restoration {
+    pub lr: [[Av1RestorationUnit; 4]; 3],
+}
+#[derive(Copy, Clone)]
+#[repr(C)]
 pub struct TxfmInfo {
     pub w: uint8_t,
     pub h: uint8_t,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -770,13 +770,7 @@ pub type loopfilter_sb_fn = Option::<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1FilterLUT {
-    pub e: [uint8_t; 64],
-    pub i: [uint8_t; 64],
-    pub sharp: [uint64_t; 2],
-}
+use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dInvTxfmDSPContext {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1416,15 +1416,7 @@ pub struct Dav1dTileState {
     pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
     pub lr_ref: [*mut Av1RestorationUnit; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1RestorationUnit {
-    pub type_0: uint8_t,
-    pub filter_h: [int8_t; 3],
-    pub filter_v: [int8_t; 3],
-    pub sgr_idx: uint8_t,
-    pub sgr_weights: [int8_t; 2],
-}
+use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_38 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1246,14 +1246,7 @@ use crate::src::levels::Filter2d;
 
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Filter {
-    pub filter_y: [[[[uint16_t; 2]; 3]; 32]; 2],
-    pub filter_uv: [[[[uint16_t; 2]; 2]; 32]; 2],
-    pub cdef_idx: [int8_t; 4],
-    pub noskip_mask: [[uint16_t; 2]; 16],
-}
+use crate::src::lf_mask::Av1Filter;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_25 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1557,11 +1557,7 @@ pub struct C2RustUnnamed_42 {
     pub prev_mask_ptr: *mut Av1Filter,
     pub restore_planes: libc::c_int,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Restoration {
-    pub lr: [[Av1RestorationUnit; 4]; 3],
-}
+use crate::src::lf_mask::Av1Restoration;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_43 {

--- a/src/log.rs
+++ b/src/log.rs
@@ -1098,14 +1098,7 @@ use crate::src::levels::Filter2d;
 
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Filter {
-    pub filter_y: [[[[uint16_t; 2]; 3]; 32]; 2],
-    pub filter_uv: [[[[uint16_t; 2]; 2]; 32]; 2],
-    pub cdef_idx: [int8_t; 4],
-    pub noskip_mask: [[uint16_t; 2]; 16],
-}
+use crate::src::lf_mask::Av1Filter;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_25 {

--- a/src/log.rs
+++ b/src/log.rs
@@ -1268,15 +1268,7 @@ pub struct Dav1dTileState {
     pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
     pub lr_ref: [*mut Av1RestorationUnit; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1RestorationUnit {
-    pub type_0: uint8_t,
-    pub filter_h: [int8_t; 3],
-    pub filter_v: [int8_t; 3],
-    pub sgr_idx: uint8_t,
-    pub sgr_weights: [int8_t; 2],
-}
+use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_38 {

--- a/src/log.rs
+++ b/src/log.rs
@@ -1409,11 +1409,7 @@ pub struct C2RustUnnamed_42 {
     pub prev_mask_ptr: *mut Av1Filter,
     pub restore_planes: libc::c_int,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Restoration {
-    pub lr: [[Av1RestorationUnit; 4]; 3],
-}
+use crate::src::lf_mask::Av1Restoration;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_43 {

--- a/src/log.rs
+++ b/src/log.rs
@@ -622,13 +622,7 @@ pub type loopfilter_sb_fn = Option::<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1FilterLUT {
-    pub e: [uint8_t; 64],
-    pub i: [uint8_t; 64],
-    pub sharp: [uint64_t; 2],
-}
+use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dInvTxfmDSPContext {

--- a/src/loopfilter_tmpl_16.rs
+++ b/src/loopfilter_tmpl_16.rs
@@ -9,13 +9,7 @@ extern "C" {
 
 
 pub type pixel = uint16_t;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1FilterLUT {
-    pub e: [uint8_t; 64],
-    pub i: [uint8_t; 64],
-    pub sharp: [uint64_t; 2],
-}
+use crate::src::lf_mask::Av1FilterLUT;
 pub type loopfilter_sb_fn = Option::<
     unsafe extern "C" fn(
         *mut pixel,

--- a/src/loopfilter_tmpl_8.rs
+++ b/src/loopfilter_tmpl_8.rs
@@ -8,13 +8,7 @@ extern "C" {
 
 
 pub type pixel = uint8_t;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1FilterLUT {
-    pub e: [uint8_t; 64],
-    pub i: [uint8_t; 64],
-    pub sharp: [uint64_t; 2],
-}
+use crate::src::lf_mask::Av1FilterLUT;
 pub type loopfilter_sb_fn = Option::<
     unsafe extern "C" fn(
         *mut pixel,

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -546,15 +546,7 @@ use crate::src::lf_mask::Av1FilterLUT;
 pub struct Av1Restoration {
     pub lr: [[Av1RestorationUnit; 4]; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1RestorationUnit {
-    pub type_0: uint8_t,
-    pub filter_h: [int8_t; 3],
-    pub filter_v: [int8_t; 3],
-    pub sgr_idx: uint8_t,
-    pub sgr_weights: [int8_t; 2],
-}
+use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_20 {

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -534,11 +534,7 @@ pub struct C2RustUnnamed_19 {
 }
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Restoration {
-    pub lr: [[Av1RestorationUnit; 4]; 3],
-}
+use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -532,14 +532,7 @@ pub struct C2RustUnnamed_19 {
     pub prev_mask_ptr: *mut Av1Filter,
     pub restore_planes: libc::c_int,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Filter {
-    pub filter_y: [[[[uint16_t; 2]; 3]; 32]; 2],
-    pub filter_uv: [[[[uint16_t; 2]; 2]; 32]; 2],
-    pub cdef_idx: [int8_t; 4],
-    pub noskip_mask: [[uint16_t; 2]; 16],
-}
+use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -540,13 +540,7 @@ pub struct Av1Filter {
     pub cdef_idx: [int8_t; 4],
     pub noskip_mask: [[uint16_t; 2]; 16],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1FilterLUT {
-    pub e: [uint8_t; 64],
-    pub i: [uint8_t; 64],
-    pub sharp: [uint64_t; 2],
-}
+use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Av1Restoration {

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -546,15 +546,7 @@ use crate::src::lf_mask::Av1FilterLUT;
 pub struct Av1Restoration {
     pub lr: [[Av1RestorationUnit; 4]; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1RestorationUnit {
-    pub type_0: uint8_t,
-    pub filter_h: [int8_t; 3],
-    pub filter_v: [int8_t; 3],
-    pub sgr_idx: uint8_t,
-    pub sgr_weights: [int8_t; 2],
-}
+use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_20 {

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -534,11 +534,7 @@ pub struct C2RustUnnamed_19 {
 }
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Restoration {
-    pub lr: [[Av1RestorationUnit; 4]; 3],
-}
+use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -532,14 +532,7 @@ pub struct C2RustUnnamed_19 {
     pub prev_mask_ptr: *mut Av1Filter,
     pub restore_planes: libc::c_int,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Filter {
-    pub filter_y: [[[[uint16_t; 2]; 3]; 32]; 2],
-    pub filter_uv: [[[[uint16_t; 2]; 2]; 32]; 2],
-    pub cdef_idx: [int8_t; 4],
-    pub noskip_mask: [[uint16_t; 2]; 16],
-}
+use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -540,13 +540,7 @@ pub struct Av1Filter {
     pub cdef_idx: [int8_t; 4],
     pub noskip_mask: [[uint16_t; 2]; 16],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1FilterLUT {
-    pub e: [uint8_t; 64],
-    pub i: [uint8_t; 64],
-    pub sharp: [uint64_t; 2],
-}
+use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Av1Restoration {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -577,11 +577,7 @@ pub struct C2RustUnnamed_19 {
 use crate::src::lf_mask::Av1Filter;
 pub type pixel = ();
 use crate::src::lf_mask::Av1FilterLUT;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Restoration {
-    pub lr: [[Av1RestorationUnit; 4]; 3],
-}
+use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -574,14 +574,7 @@ pub struct C2RustUnnamed_19 {
     pub prev_mask_ptr: *mut Av1Filter,
     pub restore_planes: libc::c_int,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Filter {
-    pub filter_y: [[[[uint16_t; 2]; 3]; 32]; 2],
-    pub filter_uv: [[[[uint16_t; 2]; 2]; 32]; 2],
-    pub cdef_idx: [int8_t; 4],
-    pub noskip_mask: [[uint16_t; 2]; 16],
-}
+use crate::src::lf_mask::Av1Filter;
 pub type pixel = ();
 use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -589,15 +589,7 @@ use crate::src::lf_mask::Av1FilterLUT;
 pub struct Av1Restoration {
     pub lr: [[Av1RestorationUnit; 4]; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1RestorationUnit {
-    pub type_0: uint8_t,
-    pub filter_h: [int8_t; 3],
-    pub filter_v: [int8_t; 3],
-    pub sgr_idx: uint8_t,
-    pub sgr_weights: [int8_t; 2],
-}
+use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_20 {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -583,13 +583,7 @@ pub struct Av1Filter {
     pub noskip_mask: [[uint16_t; 2]; 16],
 }
 pub type pixel = ();
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1FilterLUT {
-    pub e: [uint8_t; 64],
-    pub i: [uint8_t; 64],
-    pub sharp: [uint64_t; 2],
-}
+use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Av1Restoration {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -577,11 +577,7 @@ pub struct C2RustUnnamed_19 {
 use crate::src::lf_mask::Av1Filter;
 pub type pixel = ();
 use crate::src::lf_mask::Av1FilterLUT;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Restoration {
-    pub lr: [[Av1RestorationUnit; 4]; 3],
-}
+use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -574,14 +574,7 @@ pub struct C2RustUnnamed_19 {
     pub prev_mask_ptr: *mut Av1Filter,
     pub restore_planes: libc::c_int,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Filter {
-    pub filter_y: [[[[uint16_t; 2]; 3]; 32]; 2],
-    pub filter_uv: [[[[uint16_t; 2]; 2]; 32]; 2],
-    pub cdef_idx: [int8_t; 4],
-    pub noskip_mask: [[uint16_t; 2]; 16],
-}
+use crate::src::lf_mask::Av1Filter;
 pub type pixel = ();
 use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -589,15 +589,7 @@ use crate::src::lf_mask::Av1FilterLUT;
 pub struct Av1Restoration {
     pub lr: [[Av1RestorationUnit; 4]; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1RestorationUnit {
-    pub type_0: uint8_t,
-    pub filter_h: [int8_t; 3],
-    pub filter_v: [int8_t; 3],
-    pub sgr_idx: uint8_t,
-    pub sgr_weights: [int8_t; 2],
-}
+use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_20 {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -583,13 +583,7 @@ pub struct Av1Filter {
     pub noskip_mask: [[uint16_t; 2]; 16],
 }
 pub type pixel = ();
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1FilterLUT {
-    pub e: [uint8_t; 64],
-    pub i: [uint8_t; 64],
-    pub sharp: [uint64_t; 2],
-}
+use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Av1Restoration {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -639,13 +639,7 @@ pub struct Av1Filter {
     pub cdef_idx: [int8_t; 4],
     pub noskip_mask: [[uint16_t; 2]; 16],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1FilterLUT {
-    pub e: [uint8_t; 64],
-    pub i: [uint8_t; 64],
-    pub sharp: [uint64_t; 2],
-}
+use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Av1Restoration {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -645,15 +645,7 @@ use crate::src::lf_mask::Av1FilterLUT;
 pub struct Av1Restoration {
     pub lr: [[Av1RestorationUnit; 4]; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1RestorationUnit {
-    pub type_0: uint8_t,
-    pub filter_h: [int8_t; 3],
-    pub filter_v: [int8_t; 3],
-    pub sgr_idx: uint8_t,
-    pub sgr_weights: [int8_t; 2],
-}
+use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_20 {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -633,11 +633,7 @@ pub struct C2RustUnnamed_19 {
 }
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Restoration {
-    pub lr: [[Av1RestorationUnit; 4]; 3],
-}
+use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -631,14 +631,7 @@ pub struct C2RustUnnamed_19 {
     pub prev_mask_ptr: *mut Av1Filter,
     pub restore_planes: libc::c_int,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Filter {
-    pub filter_y: [[[[uint16_t; 2]; 3]; 32]; 2],
-    pub filter_uv: [[[[uint16_t; 2]; 2]; 32]; 2],
-    pub cdef_idx: [int8_t; 4],
-    pub noskip_mask: [[uint16_t; 2]; 16],
-}
+use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -631,13 +631,7 @@ pub struct Av1Filter {
     pub cdef_idx: [int8_t; 4],
     pub noskip_mask: [[uint16_t; 2]; 16],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1FilterLUT {
-    pub e: [uint8_t; 64],
-    pub i: [uint8_t; 64],
-    pub sharp: [uint64_t; 2],
-}
+use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Av1Restoration {

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -625,11 +625,7 @@ pub struct C2RustUnnamed_19 {
 }
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Restoration {
-    pub lr: [[Av1RestorationUnit; 4]; 3],
-}
+use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -637,15 +637,7 @@ use crate::src::lf_mask::Av1FilterLUT;
 pub struct Av1Restoration {
     pub lr: [[Av1RestorationUnit; 4]; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1RestorationUnit {
-    pub type_0: uint8_t,
-    pub filter_h: [int8_t; 3],
-    pub filter_v: [int8_t; 3],
-    pub sgr_idx: uint8_t,
-    pub sgr_weights: [int8_t; 2],
-}
+use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_20 {

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -623,14 +623,7 @@ pub struct C2RustUnnamed_19 {
     pub prev_mask_ptr: *mut Av1Filter,
     pub restore_planes: libc::c_int,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Filter {
-    pub filter_y: [[[[uint16_t; 2]; 3]; 32]; 2],
-    pub filter_uv: [[[[uint16_t; 2]; 2]; 32]; 2],
-    pub cdef_idx: [int8_t; 4],
-    pub noskip_mask: [[uint16_t; 2]; 16],
-}
+use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -575,14 +575,7 @@ pub struct C2RustUnnamed_19 {
     pub prev_mask_ptr: *mut Av1Filter,
     pub restore_planes: libc::c_int,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Filter {
-    pub filter_y: [[[[uint16_t; 2]; 3]; 32]; 2],
-    pub filter_uv: [[[[uint16_t; 2]; 2]; 32]; 2],
-    pub cdef_idx: [int8_t; 4],
-    pub noskip_mask: [[uint16_t; 2]; 16],
-}
+use crate::src::lf_mask::Av1Filter;
 pub type pixel = ();
 use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -578,11 +578,7 @@ pub struct C2RustUnnamed_19 {
 use crate::src::lf_mask::Av1Filter;
 pub type pixel = ();
 use crate::src::lf_mask::Av1FilterLUT;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1Restoration {
-    pub lr: [[Av1RestorationUnit; 4]; 3],
-}
+use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -590,15 +590,7 @@ use crate::src::lf_mask::Av1FilterLUT;
 pub struct Av1Restoration {
     pub lr: [[Av1RestorationUnit; 4]; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1RestorationUnit {
-    pub type_0: uint8_t,
-    pub filter_h: [int8_t; 3],
-    pub filter_v: [int8_t; 3],
-    pub sgr_idx: uint8_t,
-    pub sgr_weights: [int8_t; 2],
-}
+use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_20 {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -584,13 +584,7 @@ pub struct Av1Filter {
     pub noskip_mask: [[uint16_t; 2]; 16],
 }
 pub type pixel = ();
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Av1FilterLUT {
-    pub e: [uint8_t; 64],
-    pub i: [uint8_t; 64],
-    pub sharp: [uint64_t; 2],
-}
+use crate::src::lf_mask::Av1FilterLUT;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Av1Restoration {


### PR DESCRIPTION
All of these `struct`s are originally from `src/lf_mask.h`, so I've deduplicated them to `src/lf_mask.rs`.  `struct Av1FilterLUT` (b066e6a6f1ac893315b42493f8bd0ef7180cac39) and `struct Av1Filter` (9c3e71c26876eb226a4afa0c3ac05e8cd7863865) were already in `src/lf_mask.rs`, while `struct Av1RestorationUnit` (537bc3a69a89541195f1921e9e87b36162321311) and `struct Av1Restoration` (c3dadcf9336e7fd0857a3277afca7d59aa0bbfe1) were only defined in other `*.rs` files, so they've been deduplicated to `src/lf_mask.rs`, since they were from `src/lf_mask.h`.