### PR TITLE
Run cargo fix to cleanup warnings

### DIFF
--- a/c2rust-lib.rs
+++ b/c2rust-lib.rs
@@ -5,7 +5,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(unused_assignments)]
 #![allow(unused_mut)]
-#![feature(asm)]
 #![feature(c_variadic)]
 #![feature(core_intrinsics)]
 #![feature(extern_types)]

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -30,7 +30,7 @@ pub type pixel = uint16_t;
 pub type coef = int32_t;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::src::r#ref::Dav1dRef;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
@@ -313,15 +313,15 @@ pub struct C2RustUnnamed_6 {
     pub delta: int16_t,
 }
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_7 {
@@ -329,10 +329,10 @@ pub struct C2RustUnnamed_7 {
     pub unit_size: [libc::c_int; 2],
 }
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_8 {
@@ -384,7 +384,7 @@ pub struct C2RustUnnamed_13 {
     pub qidx: [libc::c_int; 8],
 }
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_14 {
@@ -417,13 +417,13 @@ pub struct C2RustUnnamed_15 {
     pub update: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
+
+
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_16 {
@@ -432,10 +432,10 @@ pub struct C2RustUnnamed_16 {
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_17 {
@@ -445,65 +445,65 @@ pub struct C2RustUnnamed_17 {
 }
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::pthread::pthread_cond_t;
 
 
@@ -1028,7 +1028,7 @@ pub struct Dav1dContext {
     pub picture_pool: *mut Dav1dMemPool,
 }
 use crate::src::mem::Dav1dMemPool;
-use crate::src::mem::Dav1dMemPoolBuffer;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dLogger {
@@ -1042,23 +1042,23 @@ pub struct Dav1dLogger {
     >,
 }
 use crate::include::dav1d::dav1d::Dav1dEventFlags;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_SEQUENCE;
+
+
 pub type PictureFlags = libc::c_uint;
 pub const PICTURE_FLAG_NEW_TEMPORAL_UNIT: PictureFlags = 4;
 pub const PICTURE_FLAG_NEW_OP_PARAMS_INFO: PictureFlags = 2;
 pub const PICTURE_FLAG_NEW_SEQUENCE: PictureFlags = 1;
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_KEY;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_INTRA;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_REFERENCE;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
+
+
+
+
 use crate::include::dav1d::dav1d::Dav1dInloopFilterType;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_ALL;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_CDEF;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_DEBLOCK;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dPicAllocator {

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -30,7 +30,7 @@ pub type pixel = uint8_t;
 pub type coef = int16_t;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::src::r#ref::Dav1dRef;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
@@ -313,15 +313,15 @@ pub struct C2RustUnnamed_6 {
     pub delta: int16_t,
 }
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_7 {
@@ -329,10 +329,10 @@ pub struct C2RustUnnamed_7 {
     pub unit_size: [libc::c_int; 2],
 }
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_8 {
@@ -384,7 +384,7 @@ pub struct C2RustUnnamed_13 {
     pub qidx: [libc::c_int; 8],
 }
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_14 {
@@ -417,13 +417,13 @@ pub struct C2RustUnnamed_15 {
     pub update: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
+
+
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_16 {
@@ -432,10 +432,10 @@ pub struct C2RustUnnamed_16 {
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_17 {
@@ -445,65 +445,65 @@ pub struct C2RustUnnamed_17 {
 }
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::pthread::pthread_cond_t;
 
 
@@ -1028,7 +1028,7 @@ pub struct Dav1dContext {
     pub picture_pool: *mut Dav1dMemPool,
 }
 use crate::src::mem::Dav1dMemPool;
-use crate::src::mem::Dav1dMemPoolBuffer;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dLogger {
@@ -1042,23 +1042,23 @@ pub struct Dav1dLogger {
     >,
 }
 use crate::include::dav1d::dav1d::Dav1dEventFlags;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_SEQUENCE;
+
+
 pub type PictureFlags = libc::c_uint;
 pub const PICTURE_FLAG_NEW_TEMPORAL_UNIT: PictureFlags = 4;
 pub const PICTURE_FLAG_NEW_OP_PARAMS_INFO: PictureFlags = 2;
 pub const PICTURE_FLAG_NEW_SEQUENCE: PictureFlags = 1;
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_KEY;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_INTRA;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_REFERENCE;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
+
+
+
+
 use crate::include::dav1d::dav1d::Dav1dInloopFilterType;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_ALL;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_CDEF;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_DEBLOCK;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dPicAllocator {

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -30,16 +30,16 @@ pub struct __va_list_tag {
     pub reg_save_area: *mut libc::c_void,
 }
 
-use crate::include::stdatomic::memory_order;
-use crate::include::stdatomic::memory_order_seq_cst;
-use crate::include::stdatomic::memory_order_acq_rel;
-use crate::include::stdatomic::memory_order_release;
-use crate::include::stdatomic::memory_order_acquire;
-use crate::include::stdatomic::memory_order_consume;
-use crate::include::stdatomic::memory_order_relaxed;
+
+
+
+
+
+
+
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::src::r#ref::Dav1dRef;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
@@ -242,10 +242,10 @@ pub struct Dav1dPictureParameters {
     pub bpc: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
@@ -322,15 +322,15 @@ pub struct C2RustUnnamed_6 {
     pub delta: int16_t,
 }
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_7 {
@@ -338,10 +338,10 @@ pub struct C2RustUnnamed_7 {
     pub unit_size: [libc::c_int; 2],
 }
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_8 {
@@ -393,7 +393,7 @@ pub struct C2RustUnnamed_13 {
     pub qidx: [libc::c_int; 8],
 }
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_14 {
@@ -426,13 +426,13 @@ pub struct C2RustUnnamed_15 {
     pub update: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
+
+
+
 use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_16 {
@@ -441,10 +441,10 @@ pub struct C2RustUnnamed_16 {
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_17 {
@@ -454,65 +454,65 @@ pub struct C2RustUnnamed_17 {
 }
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::pthread::pthread_cond_t;
 
 
@@ -1138,7 +1138,7 @@ pub struct Dav1dContext {
     pub picture_pool: *mut Dav1dMemPool,
 }
 use crate::src::mem::Dav1dMemPool;
-use crate::src::mem::Dav1dMemPoolBuffer;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dLogger {
@@ -1152,23 +1152,23 @@ pub struct Dav1dLogger {
     >,
 }
 use crate::include::dav1d::dav1d::Dav1dEventFlags;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_SEQUENCE;
+
+
 pub type PictureFlags = libc::c_uint;
 pub const PICTURE_FLAG_NEW_TEMPORAL_UNIT: PictureFlags = 4;
 pub const PICTURE_FLAG_NEW_OP_PARAMS_INFO: PictureFlags = 2;
 pub const PICTURE_FLAG_NEW_SEQUENCE: PictureFlags = 1;
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_KEY;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_INTRA;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_REFERENCE;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
+
+
+
+
 use crate::include::dav1d::dav1d::Dav1dInloopFilterType;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_ALL;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_CDEF;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_DEBLOCK;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dPicAllocator {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -47,7 +47,7 @@ pub unsafe extern "C" fn dav1d_set_cpu_flags_mask(mask: libc::c_uint) {
 #[no_mangle]
 #[cold]
 pub unsafe extern "C" fn dav1d_num_logical_processors(
-    c: *mut Dav1dContext,
+    _c: *mut Dav1dContext,
 ) -> libc::c_int {
     num_cpus::get() as libc::c_int
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -26,19 +26,19 @@ extern "C" {
 
 pub type __off_t = libc::c_long;
 pub type __off64_t = libc::c_long;
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::src::r#ref::Dav1dRef;
-use crate::include::stdatomic::atomic_int;
+
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
 pub type _IO_lock_t = ();
-use crate::include::stdatomic::memory_order_relaxed;
-use crate::include::stdatomic::memory_order;
-use crate::include::stdatomic::memory_order_seq_cst;
-use crate::include::stdatomic::memory_order_acq_rel;
-use crate::include::stdatomic::memory_order_release;
-use crate::include::stdatomic::memory_order_acquire;
-use crate::include::stdatomic::memory_order_consume;
+
+
+
+
+
+
+
 #[inline]
 unsafe extern "C" fn dav1d_ref_inc(ref_0: *mut Dav1dRef) {
     ::core::intrinsics::atomic_xadd_relaxed(&mut (*ref_0).ref_cnt, 1 as libc::c_int);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -358,7 +358,7 @@ pub struct __va_list_tag {
     pub reg_save_area: *mut libc::c_void,
 }
 
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::src::r#ref::Dav1dRef;
 use crate::include::stdatomic::atomic_int;
 use crate::include::dav1d::common::Dav1dDataProps;
@@ -386,13 +386,13 @@ pub union alias16 {
 pub union alias8 {
     pub u8_0: uint8_t,
 }
-use crate::include::stdatomic::memory_order;
-use crate::include::stdatomic::memory_order_seq_cst;
-use crate::include::stdatomic::memory_order_acq_rel;
-use crate::include::stdatomic::memory_order_release;
-use crate::include::stdatomic::memory_order_acquire;
-use crate::include::stdatomic::memory_order_consume;
-use crate::include::stdatomic::memory_order_relaxed;
+
+
+
+
+
+
+
 use crate::include::stdatomic::atomic_uint;
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -674,14 +674,14 @@ pub struct C2RustUnnamed_6 {
 }
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
 use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
+
 use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
 use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
+
 use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_7 {
@@ -778,11 +778,11 @@ pub struct C2RustUnnamed_15 {
 }
 use crate::include::dav1d::headers::Dav1dFilterMode;
 use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
+
+
 use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
+
+
 use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -792,10 +792,10 @@ pub struct C2RustUnnamed_16 {
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_17 {
@@ -805,65 +805,65 @@ pub struct C2RustUnnamed_17 {
 }
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::pthread::pthread_cond_t;
 
 
@@ -1390,7 +1390,7 @@ pub struct Dav1dContext {
     pub picture_pool: *mut Dav1dMemPool,
 }
 use crate::src::mem::Dav1dMemPool;
-use crate::src::mem::Dav1dMemPoolBuffer;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dLogger {
@@ -1404,23 +1404,23 @@ pub struct Dav1dLogger {
     >,
 }
 use crate::include::dav1d::dav1d::Dav1dEventFlags;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_SEQUENCE;
+
+
 pub type PictureFlags = libc::c_uint;
 pub const PICTURE_FLAG_NEW_TEMPORAL_UNIT: PictureFlags = 4;
 pub const PICTURE_FLAG_NEW_OP_PARAMS_INFO: PictureFlags = 2;
 pub const PICTURE_FLAG_NEW_SEQUENCE: PictureFlags = 1;
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_KEY;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_INTRA;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_REFERENCE;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
+
+
+
+
 use crate::include::dav1d::dav1d::Dav1dInloopFilterType;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_ALL;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_CDEF;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_DEBLOCK;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dPicAllocator {
@@ -5454,8 +5454,8 @@ unsafe extern "C" fn obmc_lowest_px(
     dst: *mut [libc::c_int; 2],
     is_chroma: libc::c_int,
     b_dim: *const uint8_t,
-    bx4: libc::c_int,
-    by4: libc::c_int,
+    _bx4: libc::c_int,
+    _by4: libc::c_int,
     w4: libc::c_int,
     h4: libc::c_int,
 ) {

--- a/src/fg_apply_tmpl_16.rs
+++ b/src/fg_apply_tmpl_16.rs
@@ -15,35 +15,35 @@ extern "C" {
     ) -> *mut libc::c_void;
 }
 
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
@@ -67,74 +67,74 @@ pub struct C2RustUnnamed_0 {
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
+
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
+
+
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;

--- a/src/fg_apply_tmpl_8.rs
+++ b/src/fg_apply_tmpl_8.rs
@@ -15,35 +15,35 @@ extern "C" {
     ) -> *mut libc::c_void;
 }
 
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
@@ -67,74 +67,74 @@ pub struct C2RustUnnamed_0 {
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
+
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
+
+
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
@@ -378,7 +378,7 @@ unsafe extern "C" fn imin(a: libc::c_int, b: libc::c_int) -> libc::c_int {
     return if a < b { a } else { b };
 }
 unsafe extern "C" fn generate_scaling(
-    bitdepth: libc::c_int,
+    _bitdepth: libc::c_int,
     mut points: *const [uint8_t; 2],
     num: libc::c_int,
     mut scaling: *mut uint8_t,

--- a/src/filmgrain_tmpl_16.rs
+++ b/src/filmgrain_tmpl_16.rs
@@ -10,11 +10,11 @@ extern "C" {
 
 
 pub type pixel = uint16_t;
-use crate::include::dav1d::headers::Dav1dPixelLayout;
+
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 pub type entry = int16_t;
 pub type generate_grain_y_fn = Option::<

--- a/src/filmgrain_tmpl_8.rs
+++ b/src/filmgrain_tmpl_8.rs
@@ -9,11 +9,11 @@ extern "C" {
 
 
 pub type pixel = uint8_t;
-use crate::include::dav1d::headers::Dav1dPixelLayout;
+
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 pub type entry = int8_t;
 pub type generate_grain_y_fn = Option::<

--- a/src/ipred_tmpl_16.rs
+++ b/src/ipred_tmpl_16.rs
@@ -18,11 +18,11 @@ extern "C" {
 
 
 pub type pixel = uint16_t;
-use crate::include::dav1d::headers::Dav1dPixelLayout;
+
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+
 pub type IntraPredMode = libc::c_uint;
 pub const FILTER_PRED: IntraPredMode = 13;
 pub const Z3_PRED: IntraPredMode = 8;
@@ -222,9 +222,9 @@ unsafe extern "C" fn ipred_dc_top_c(
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    a: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
+    _a: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
     splat_dc(
@@ -278,9 +278,9 @@ unsafe extern "C" fn ipred_dc_left_c(
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    a: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
+    _a: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
     splat_dc(
@@ -349,9 +349,9 @@ unsafe extern "C" fn ipred_dc_c(
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    a: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
+    _a: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
     splat_dc(
@@ -379,12 +379,12 @@ unsafe extern "C" fn ipred_cfl_c(
 unsafe extern "C" fn ipred_dc_128_c(
     mut dst: *mut pixel,
     stride: ptrdiff_t,
-    topleft: *const pixel,
+    _topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    a: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
+    _a: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
     let dc: libc::c_int = bitdepth_max + 1 as libc::c_int >> 1 as libc::c_int;
@@ -393,7 +393,7 @@ unsafe extern "C" fn ipred_dc_128_c(
 unsafe extern "C" fn ipred_cfl_128_c(
     mut dst: *mut pixel,
     stride: ptrdiff_t,
-    topleft: *const pixel,
+    _topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
     mut ac: *const int16_t,
@@ -409,10 +409,10 @@ unsafe extern "C" fn ipred_v_c(
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    a: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
-    bitdepth_max: libc::c_int,
+    _a: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
+    _bitdepth_max: libc::c_int,
 ) {
     let mut y: libc::c_int = 0 as libc::c_int;
     while y < height {
@@ -431,10 +431,10 @@ unsafe extern "C" fn ipred_h_c(
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    a: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
-    bitdepth_max: libc::c_int,
+    _a: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
+    _bitdepth_max: libc::c_int,
 ) {
     let mut y: libc::c_int = 0 as libc::c_int;
     while y < height {
@@ -453,10 +453,10 @@ unsafe extern "C" fn ipred_paeth_c(
     tl_ptr: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    a: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
-    bitdepth_max: libc::c_int,
+    _a: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
+    _bitdepth_max: libc::c_int,
 ) {
     let topleft: libc::c_int = *tl_ptr.offset(0 as libc::c_int as isize) as libc::c_int;
     let mut y: libc::c_int = 0 as libc::c_int;
@@ -493,10 +493,10 @@ unsafe extern "C" fn ipred_smooth_c(
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    a: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
-    bitdepth_max: libc::c_int,
+    _a: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
+    _bitdepth_max: libc::c_int,
 ) {
     let weights_hor: *const uint8_t = &*dav1d_sm_weights.as_ptr().offset(width as isize)
         as *const uint8_t;
@@ -532,10 +532,10 @@ unsafe extern "C" fn ipred_smooth_v_c(
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    a: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
-    bitdepth_max: libc::c_int,
+    _a: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
+    _bitdepth_max: libc::c_int,
 ) {
     let weights_ver: *const uint8_t = &*dav1d_sm_weights.as_ptr().offset(height as isize)
         as *const uint8_t;
@@ -564,10 +564,10 @@ unsafe extern "C" fn ipred_smooth_h_c(
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    a: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
-    bitdepth_max: libc::c_int,
+    _a: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
+    _bitdepth_max: libc::c_int,
 ) {
     let weights_hor: *const uint8_t = &*dav1d_sm_weights.as_ptr().offset(width as isize)
         as *const uint8_t;
@@ -783,8 +783,8 @@ unsafe extern "C" fn ipred_z1_c(
     width: libc::c_int,
     height: libc::c_int,
     mut angle: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
     let is_sm: libc::c_int = angle >> 9 as libc::c_int & 0x1 as libc::c_int;
@@ -1030,8 +1030,8 @@ unsafe extern "C" fn ipred_z3_c(
     width: libc::c_int,
     height: libc::c_int,
     mut angle: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
     let is_sm: libc::c_int = angle >> 9 as libc::c_int & 0x1 as libc::c_int;
@@ -1137,8 +1137,8 @@ unsafe extern "C" fn ipred_filter_c(
     width: libc::c_int,
     height: libc::c_int,
     mut filt_idx: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
     filt_idx &= 511 as libc::c_int;

--- a/src/ipred_tmpl_8.rs
+++ b/src/ipred_tmpl_8.rs
@@ -23,11 +23,11 @@ extern "C" {
 
 
 pub type pixel = uint8_t;
-use crate::include::dav1d::headers::Dav1dPixelLayout;
+
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+
 pub type IntraPredMode = libc::c_uint;
 pub const FILTER_PRED: IntraPredMode = 13;
 pub const Z3_PRED: IntraPredMode = 8;
@@ -227,9 +227,9 @@ unsafe extern "C" fn ipred_dc_top_c(
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    a: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
+    _a: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
 ) {
     splat_dc(dst, stride, width, height, dc_gen_top(topleft, width) as libc::c_int);
 }
@@ -273,9 +273,9 @@ unsafe extern "C" fn ipred_dc_left_c(
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    a: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
+    _a: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
 ) {
     splat_dc(dst, stride, width, height, dc_gen_left(topleft, height) as libc::c_int);
 }
@@ -335,9 +335,9 @@ unsafe extern "C" fn ipred_dc_c(
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    a: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
+    _a: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
 ) {
     splat_dc(dst, stride, width, height, dc_gen(topleft, width, height) as libc::c_int);
 }
@@ -356,12 +356,12 @@ unsafe extern "C" fn ipred_cfl_c(
 unsafe extern "C" fn ipred_dc_128_c(
     mut dst: *mut pixel,
     stride: ptrdiff_t,
-    topleft: *const pixel,
+    _topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    a: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
+    _a: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
 ) {
     let dc: libc::c_int = 128 as libc::c_int;
     splat_dc(dst, stride, width, height, dc);
@@ -369,7 +369,7 @@ unsafe extern "C" fn ipred_dc_128_c(
 unsafe extern "C" fn ipred_cfl_128_c(
     mut dst: *mut pixel,
     stride: ptrdiff_t,
-    topleft: *const pixel,
+    _topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
     mut ac: *const int16_t,
@@ -384,9 +384,9 @@ unsafe extern "C" fn ipred_v_c(
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    a: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
+    _a: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
 ) {
     let mut y: libc::c_int = 0 as libc::c_int;
     while y < height {
@@ -405,9 +405,9 @@ unsafe extern "C" fn ipred_h_c(
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    a: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
+    _a: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
 ) {
     let mut y: libc::c_int = 0 as libc::c_int;
     while y < height {
@@ -426,9 +426,9 @@ unsafe extern "C" fn ipred_paeth_c(
     tl_ptr: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    a: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
+    _a: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
 ) {
     let topleft: libc::c_int = *tl_ptr.offset(0 as libc::c_int as isize) as libc::c_int;
     let mut y: libc::c_int = 0 as libc::c_int;
@@ -465,9 +465,9 @@ unsafe extern "C" fn ipred_smooth_c(
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    a: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
+    _a: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
 ) {
     let weights_hor: *const uint8_t = &*dav1d_sm_weights.as_ptr().offset(width as isize)
         as *const uint8_t;
@@ -503,9 +503,9 @@ unsafe extern "C" fn ipred_smooth_v_c(
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    a: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
+    _a: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
 ) {
     let weights_ver: *const uint8_t = &*dav1d_sm_weights.as_ptr().offset(height as isize)
         as *const uint8_t;
@@ -534,9 +534,9 @@ unsafe extern "C" fn ipred_smooth_h_c(
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    a: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
+    _a: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
 ) {
     let weights_hor: *const uint8_t = &*dav1d_sm_weights.as_ptr().offset(width as isize)
         as *const uint8_t;
@@ -747,8 +747,8 @@ unsafe extern "C" fn ipred_z1_c(
     width: libc::c_int,
     height: libc::c_int,
     mut angle: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
 ) {
     let is_sm: libc::c_int = angle >> 9 as libc::c_int & 0x1 as libc::c_int;
     let enable_intra_edge_filter: libc::c_int = angle >> 10 as libc::c_int;
@@ -989,8 +989,8 @@ unsafe extern "C" fn ipred_z3_c(
     width: libc::c_int,
     height: libc::c_int,
     mut angle: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
 ) {
     let is_sm: libc::c_int = angle >> 9 as libc::c_int & 0x1 as libc::c_int;
     let enable_intra_edge_filter: libc::c_int = angle >> 10 as libc::c_int;
@@ -1092,8 +1092,8 @@ unsafe extern "C" fn ipred_filter_c(
     width: libc::c_int,
     height: libc::c_int,
     mut filt_idx: libc::c_int,
-    max_width: libc::c_int,
-    max_height: libc::c_int,
+    _max_width: libc::c_int,
+    _max_height: libc::c_int,
 ) {
     filt_idx &= 511 as libc::c_int;
     if !(filt_idx < 5 as libc::c_int) {

--- a/src/itx_1d.rs
+++ b/src/itx_1d.rs
@@ -1428,8 +1428,8 @@ pub unsafe extern "C" fn dav1d_inv_dct64_1d_c(
 unsafe extern "C" fn inv_adst4_1d_internal_c(
     in_0: *const int32_t,
     in_s: ptrdiff_t,
-    min: libc::c_int,
-    max: libc::c_int,
+    _min: libc::c_int,
+    _max: libc::c_int,
     out: *mut int32_t,
     out_s: ptrdiff_t,
 ) {
@@ -1892,8 +1892,8 @@ pub unsafe extern "C" fn dav1d_inv_adst16_1d_c(
 pub unsafe extern "C" fn dav1d_inv_identity4_1d_c(
     c: *mut int32_t,
     stride: ptrdiff_t,
-    min: libc::c_int,
-    max: libc::c_int,
+    _min: libc::c_int,
+    _max: libc::c_int,
 ) {
     if !(stride > 0 as libc::c_int as libc::c_long) {
         unreachable!();
@@ -1913,8 +1913,8 @@ pub unsafe extern "C" fn dav1d_inv_identity4_1d_c(
 pub unsafe extern "C" fn dav1d_inv_identity8_1d_c(
     c: *mut int32_t,
     stride: ptrdiff_t,
-    min: libc::c_int,
-    max: libc::c_int,
+    _min: libc::c_int,
+    _max: libc::c_int,
 ) {
     if !(stride > 0 as libc::c_int as libc::c_long) {
         unreachable!();
@@ -1930,8 +1930,8 @@ pub unsafe extern "C" fn dav1d_inv_identity8_1d_c(
 pub unsafe extern "C" fn dav1d_inv_identity16_1d_c(
     c: *mut int32_t,
     stride: ptrdiff_t,
-    min: libc::c_int,
-    max: libc::c_int,
+    _min: libc::c_int,
+    _max: libc::c_int,
 ) {
     if !(stride > 0 as libc::c_int as libc::c_long) {
         unreachable!();
@@ -1951,8 +1951,8 @@ pub unsafe extern "C" fn dav1d_inv_identity16_1d_c(
 pub unsafe extern "C" fn dav1d_inv_identity32_1d_c(
     c: *mut int32_t,
     stride: ptrdiff_t,
-    min: libc::c_int,
-    max: libc::c_int,
+    _min: libc::c_int,
+    _max: libc::c_int,
 ) {
     if !(stride > 0 as libc::c_int as libc::c_long) {
         unreachable!();

--- a/src/itx_tmpl_16.rs
+++ b/src/itx_tmpl_16.rs
@@ -6064,7 +6064,7 @@ unsafe extern "C" fn inv_txfm_add_wht_wht_4x4_c(
     mut dst: *mut pixel,
     stride: ptrdiff_t,
     coeff: *mut coef,
-    eob: libc::c_int,
+    _eob: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
     let mut tmp: [int32_t; 16] = [0; 16];
@@ -6124,7 +6124,7 @@ unsafe extern "C" fn inv_txfm_add_wht_wht_4x4_c(
 #[cold]
 pub unsafe extern "C" fn dav1d_itx_dsp_init_16bpc(
     c: *mut Dav1dInvTxfmDSPContext,
-    mut bpc: libc::c_int,
+    mut _bpc: libc::c_int,
 ) {
     (*c)
         .itxfm_add[TX_4X4 as libc::c_int

--- a/src/itx_tmpl_8.rs
+++ b/src/itx_tmpl_8.rs
@@ -5741,7 +5741,7 @@ unsafe extern "C" fn inv_txfm_add_wht_wht_4x4_c(
     mut dst: *mut pixel,
     stride: ptrdiff_t,
     coeff: *mut coef,
-    eob: libc::c_int,
+    _eob: libc::c_int,
 ) {
     let mut tmp: [int32_t; 16] = [0; 16];
     let mut c: *mut int32_t = tmp.as_mut_ptr();
@@ -5797,7 +5797,7 @@ unsafe extern "C" fn inv_txfm_add_wht_wht_4x4_c(
 #[cold]
 pub unsafe extern "C" fn dav1d_itx_dsp_init_8bpc(
     c: *mut Dav1dInvTxfmDSPContext,
-    mut bpc: libc::c_int,
+    mut _bpc: libc::c_int,
 ) {
     (*c)
         .itxfm_add[TX_4X4 as libc::c_int

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -30,7 +30,7 @@ pub type pixel = uint16_t;
 pub type coef = int32_t;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::src::r#ref::Dav1dRef;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
@@ -234,7 +234,7 @@ pub struct Dav1dPictureParameters {
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
+
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 #[derive(Copy, Clone)]
@@ -313,15 +313,15 @@ pub struct C2RustUnnamed_6 {
     pub delta: int16_t,
 }
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_7 {
@@ -329,10 +329,10 @@ pub struct C2RustUnnamed_7 {
     pub unit_size: [libc::c_int; 2],
 }
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_8 {
@@ -384,7 +384,7 @@ pub struct C2RustUnnamed_13 {
     pub qidx: [libc::c_int; 8],
 }
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_14 {
@@ -417,13 +417,13 @@ pub struct C2RustUnnamed_15 {
     pub update: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
+
+
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_16 {
@@ -432,10 +432,10 @@ pub struct C2RustUnnamed_16 {
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_17 {
@@ -445,65 +445,65 @@ pub struct C2RustUnnamed_17 {
 }
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::pthread::pthread_cond_t;
 
 
@@ -1028,7 +1028,7 @@ pub struct Dav1dContext {
     pub picture_pool: *mut Dav1dMemPool,
 }
 use crate::src::mem::Dav1dMemPool;
-use crate::src::mem::Dav1dMemPoolBuffer;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dLogger {
@@ -1042,23 +1042,23 @@ pub struct Dav1dLogger {
     >,
 }
 use crate::include::dav1d::dav1d::Dav1dEventFlags;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_SEQUENCE;
+
+
 pub type PictureFlags = libc::c_uint;
 pub const PICTURE_FLAG_NEW_TEMPORAL_UNIT: PictureFlags = 4;
 pub const PICTURE_FLAG_NEW_OP_PARAMS_INFO: PictureFlags = 2;
 pub const PICTURE_FLAG_NEW_SEQUENCE: PictureFlags = 1;
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_KEY;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_INTRA;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_REFERENCE;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
+
+
+
+
 use crate::include::dav1d::dav1d::Dav1dInloopFilterType;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_ALL;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_CDEF;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_DEBLOCK;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dPicAllocator {

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -30,7 +30,7 @@ pub type pixel = uint8_t;
 pub type coef = int16_t;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::src::r#ref::Dav1dRef;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
@@ -234,7 +234,7 @@ pub struct Dav1dPictureParameters {
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
+
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 #[derive(Copy, Clone)]
@@ -313,15 +313,15 @@ pub struct C2RustUnnamed_6 {
     pub delta: int16_t,
 }
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_7 {
@@ -329,10 +329,10 @@ pub struct C2RustUnnamed_7 {
     pub unit_size: [libc::c_int; 2],
 }
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_8 {
@@ -384,7 +384,7 @@ pub struct C2RustUnnamed_13 {
     pub qidx: [libc::c_int; 8],
 }
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_14 {
@@ -417,13 +417,13 @@ pub struct C2RustUnnamed_15 {
     pub update: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
+
+
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_16 {
@@ -432,10 +432,10 @@ pub struct C2RustUnnamed_16 {
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_17 {
@@ -445,65 +445,65 @@ pub struct C2RustUnnamed_17 {
 }
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::pthread::pthread_cond_t;
 
 
@@ -1028,7 +1028,7 @@ pub struct Dav1dContext {
     pub picture_pool: *mut Dav1dMemPool,
 }
 use crate::src::mem::Dav1dMemPool;
-use crate::src::mem::Dav1dMemPoolBuffer;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dLogger {
@@ -1042,23 +1042,23 @@ pub struct Dav1dLogger {
     >,
 }
 use crate::include::dav1d::dav1d::Dav1dEventFlags;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_SEQUENCE;
+
+
 pub type PictureFlags = libc::c_uint;
 pub const PICTURE_FLAG_NEW_TEMPORAL_UNIT: PictureFlags = 4;
 pub const PICTURE_FLAG_NEW_OP_PARAMS_INFO: PictureFlags = 2;
 pub const PICTURE_FLAG_NEW_SEQUENCE: PictureFlags = 1;
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_KEY;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_INTRA;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_REFERENCE;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
+
+
+
+
 use crate::include::dav1d::dav1d::Dav1dInloopFilterType;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_ALL;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_CDEF;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_DEBLOCK;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dPicAllocator {

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -46,28 +46,28 @@ pub union alias8 {
     pub u8_0: uint8_t,
 }
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
@@ -91,14 +91,14 @@ pub struct C2RustUnnamed_0 {
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
+
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dSegmentationData;
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,32 +182,32 @@ use crate::src::r#ref::Dav1dRef;
 use crate::include::stdatomic::atomic_int;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
@@ -230,75 +230,75 @@ pub struct C2RustUnnamed_0 {
     pub delta: int16_t,
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
+
+
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
@@ -556,7 +556,7 @@ pub struct Dav1dContext {
     pub picture_pool: *mut Dav1dMemPool,
 }
 use crate::src::mem::Dav1dMemPool;
-use crate::src::mem::Dav1dMemPoolBuffer;
+
 use crate::include::pthread::pthread_mutex_t;
 
 
@@ -574,22 +574,22 @@ pub struct Dav1dLogger {
     >,
 }
 use crate::include::dav1d::dav1d::Dav1dEventFlags;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_SEQUENCE;
+
+
 pub type PictureFlags = libc::c_uint;
 pub const PICTURE_FLAG_NEW_TEMPORAL_UNIT: PictureFlags = 4;
 pub const PICTURE_FLAG_NEW_OP_PARAMS_INFO: PictureFlags = 2;
 pub const PICTURE_FLAG_NEW_SEQUENCE: PictureFlags = 1;
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
 use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_KEY;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_INTRA;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_REFERENCE;
+
+
 use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
 use crate::include::dav1d::dav1d::Dav1dInloopFilterType;
 use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_ALL;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_CDEF;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_DEBLOCK;
+
+
+
 use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -1808,18 +1808,18 @@ pub struct _IO_FILE {
 }
 pub type _IO_lock_t = ();
 pub type pthread_once_t = libc::c_int;
-use crate::include::stdatomic::memory_order_relaxed;
+
 pub type BlockLevel = libc::c_uint;
 pub const N_BL_LEVELS: BlockLevel = 5;
 pub const BL_8X8: BlockLevel = 4;
 pub const BL_16X16: BlockLevel = 3;
 pub const BL_32X32: BlockLevel = 2;
-use crate::include::stdatomic::memory_order;
-use crate::include::stdatomic::memory_order_seq_cst;
-use crate::include::stdatomic::memory_order_acq_rel;
-use crate::include::stdatomic::memory_order_release;
-use crate::include::stdatomic::memory_order_acquire;
-use crate::include::stdatomic::memory_order_consume;
+
+
+
+
+
+
 #[inline]
 unsafe extern "C" fn umin(a: libc::c_uint, b: libc::c_uint) -> libc::c_uint {
     return if a < b { a } else { b };

--- a/src/log.rs
+++ b/src/log.rs
@@ -29,37 +29,37 @@ pub type va_list = __builtin_va_list;
 pub type __off_t = libc::c_long;
 pub type __off64_t = libc::c_long;
 pub type _IO_lock_t = ();
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::src::r#ref::Dav1dRef;
 use crate::include::stdatomic::atomic_int;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
@@ -82,75 +82,75 @@ pub struct C2RustUnnamed_0 {
     pub delta: int16_t,
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
+
+
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
@@ -408,7 +408,7 @@ pub struct Dav1dContext {
     pub picture_pool: *mut Dav1dMemPool,
 }
 use crate::src::mem::Dav1dMemPool;
-use crate::src::mem::Dav1dMemPoolBuffer;
+
 use crate::include::pthread::pthread_mutex_t;
 
 
@@ -426,23 +426,23 @@ pub struct Dav1dLogger {
     >,
 }
 use crate::include::dav1d::dav1d::Dav1dEventFlags;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_SEQUENCE;
+
+
 pub type PictureFlags = libc::c_uint;
 pub const PICTURE_FLAG_NEW_TEMPORAL_UNIT: PictureFlags = 4;
 pub const PICTURE_FLAG_NEW_OP_PARAMS_INFO: PictureFlags = 2;
 pub const PICTURE_FLAG_NEW_SEQUENCE: PictureFlags = 1;
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_KEY;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_INTRA;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_REFERENCE;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
+
+
+
+
 use crate::include::dav1d::dav1d::Dav1dInloopFilterType;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_ALL;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_CDEF;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_DEBLOCK;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_12 {
@@ -1605,7 +1605,7 @@ pub struct ScalableMotionParams {
 #[no_mangle]
 #[cold]
 pub unsafe extern "C" fn dav1d_log_default_callback(
-    cookie: *mut libc::c_void,
+    _cookie: *mut libc::c_void,
     format: *const libc::c_char,
     mut ap: ::core::ffi::VaList,
 ) {

--- a/src/loopfilter_tmpl_16.rs
+++ b/src/loopfilter_tmpl_16.rs
@@ -357,7 +357,7 @@ unsafe extern "C" fn loop_filter_h_sb128y_c(
     mut l: *const [uint8_t; 4],
     mut b4_stride: ptrdiff_t,
     mut lut: *const Av1FilterLUT,
-    h: libc::c_int,
+    _h: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
     let vm: libc::c_uint = *vmask.offset(0 as libc::c_int as isize)
@@ -411,7 +411,7 @@ unsafe extern "C" fn loop_filter_v_sb128y_c(
     mut l: *const [uint8_t; 4],
     mut b4_stride: ptrdiff_t,
     mut lut: *const Av1FilterLUT,
-    w: libc::c_int,
+    _w: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
     let vm: libc::c_uint = *vmask.offset(0 as libc::c_int as isize)
@@ -465,7 +465,7 @@ unsafe extern "C" fn loop_filter_h_sb128uv_c(
     mut l: *const [uint8_t; 4],
     mut b4_stride: ptrdiff_t,
     mut lut: *const Av1FilterLUT,
-    h: libc::c_int,
+    _h: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
     let vm: libc::c_uint = *vmask.offset(0 as libc::c_int as isize)
@@ -513,7 +513,7 @@ unsafe extern "C" fn loop_filter_v_sb128uv_c(
     mut l: *const [uint8_t; 4],
     mut b4_stride: ptrdiff_t,
     mut lut: *const Av1FilterLUT,
-    w: libc::c_int,
+    _w: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
     let vm: libc::c_uint = *vmask.offset(0 as libc::c_int as isize)

--- a/src/loopfilter_tmpl_8.rs
+++ b/src/loopfilter_tmpl_8.rs
@@ -346,7 +346,7 @@ unsafe extern "C" fn loop_filter_h_sb128y_c(
     mut l: *const [uint8_t; 4],
     mut b4_stride: ptrdiff_t,
     mut lut: *const Av1FilterLUT,
-    h: libc::c_int,
+    _h: libc::c_int,
 ) {
     let vm: libc::c_uint = *vmask.offset(0 as libc::c_int as isize)
         | *vmask.offset(1 as libc::c_int as isize)
@@ -398,7 +398,7 @@ unsafe extern "C" fn loop_filter_v_sb128y_c(
     mut l: *const [uint8_t; 4],
     mut b4_stride: ptrdiff_t,
     mut lut: *const Av1FilterLUT,
-    w: libc::c_int,
+    _w: libc::c_int,
 ) {
     let vm: libc::c_uint = *vmask.offset(0 as libc::c_int as isize)
         | *vmask.offset(1 as libc::c_int as isize)
@@ -450,7 +450,7 @@ unsafe extern "C" fn loop_filter_h_sb128uv_c(
     mut l: *const [uint8_t; 4],
     mut b4_stride: ptrdiff_t,
     mut lut: *const Av1FilterLUT,
-    h: libc::c_int,
+    _h: libc::c_int,
 ) {
     let vm: libc::c_uint = *vmask.offset(0 as libc::c_int as isize)
         | *vmask.offset(1 as libc::c_int as isize);
@@ -496,7 +496,7 @@ unsafe extern "C" fn loop_filter_v_sb128uv_c(
     mut l: *const [uint8_t; 4],
     mut b4_stride: ptrdiff_t,
     mut lut: *const Av1FilterLUT,
-    w: libc::c_int,
+    _w: libc::c_int,
 ) {
     let vm: libc::c_uint = *vmask.offset(0 as libc::c_int as isize)
         | *vmask.offset(1 as libc::c_int as isize);

--- a/src/looprestoration_tmpl_16.rs
+++ b/src/looprestoration_tmpl_16.rs
@@ -527,7 +527,7 @@ unsafe extern "C" fn boxsum5(
 unsafe extern "C" fn selfguided_filter(
     mut dst: *mut coef,
     mut src: *const pixel,
-    src_stride: ptrdiff_t,
+    _src_stride: ptrdiff_t,
     w: libc::c_int,
     h: libc::c_int,
     n: libc::c_int,
@@ -928,7 +928,7 @@ unsafe extern "C" fn sgr_mix_c(
 #[cold]
 pub unsafe extern "C" fn dav1d_loop_restoration_dsp_init_16bpc(
     c: *mut Dav1dLoopRestorationDSPContext,
-    bpc: libc::c_int,
+    _bpc: libc::c_int,
 ) {
     (*c)
         .wiener[1 as libc::c_int

--- a/src/looprestoration_tmpl_8.rs
+++ b/src/looprestoration_tmpl_8.rs
@@ -520,7 +520,7 @@ unsafe extern "C" fn boxsum5(
 unsafe extern "C" fn selfguided_filter(
     mut dst: *mut coef,
     mut src: *const pixel,
-    src_stride: ptrdiff_t,
+    _src_stride: ptrdiff_t,
     w: libc::c_int,
     h: libc::c_int,
     n: libc::c_int,
@@ -922,7 +922,7 @@ unsafe extern "C" fn sgr_mix_c(
 #[cold]
 pub unsafe extern "C" fn dav1d_loop_restoration_dsp_init_8bpc(
     c: *mut Dav1dLoopRestorationDSPContext,
-    bpc: libc::c_int,
+    _bpc: libc::c_int,
 ) {
     (*c)
         .wiener[1 as libc::c_int

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -31,7 +31,7 @@ pub type pixel = uint16_t;
 pub type coef = int32_t;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::src::r#ref::Dav1dRef;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
@@ -235,9 +235,9 @@ pub struct Dav1dPictureParameters {
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
+
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
@@ -314,15 +314,15 @@ pub struct C2RustUnnamed_6 {
     pub delta: int16_t,
 }
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_7 {
@@ -332,7 +332,7 @@ pub struct C2RustUnnamed_7 {
 use crate::include::dav1d::headers::Dav1dRestorationType;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
+
 use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -385,7 +385,7 @@ pub struct C2RustUnnamed_13 {
     pub qidx: [libc::c_int; 8],
 }
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_14 {
@@ -418,13 +418,13 @@ pub struct C2RustUnnamed_15 {
     pub update: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
+
+
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_16 {
@@ -433,10 +433,10 @@ pub struct C2RustUnnamed_16 {
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_17 {
@@ -446,65 +446,65 @@ pub struct C2RustUnnamed_17 {
 }
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::pthread::pthread_cond_t;
 
 
@@ -1029,7 +1029,7 @@ pub struct Dav1dContext {
     pub picture_pool: *mut Dav1dMemPool,
 }
 use crate::src::mem::Dav1dMemPool;
-use crate::src::mem::Dav1dMemPoolBuffer;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dLogger {
@@ -1043,23 +1043,23 @@ pub struct Dav1dLogger {
     >,
 }
 use crate::include::dav1d::dav1d::Dav1dEventFlags;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_SEQUENCE;
+
+
 pub type PictureFlags = libc::c_uint;
 pub const PICTURE_FLAG_NEW_TEMPORAL_UNIT: PictureFlags = 4;
 pub const PICTURE_FLAG_NEW_OP_PARAMS_INFO: PictureFlags = 2;
 pub const PICTURE_FLAG_NEW_SEQUENCE: PictureFlags = 1;
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_KEY;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_INTRA;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_REFERENCE;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
+
+
+
+
 use crate::include::dav1d::dav1d::Dav1dInloopFilterType;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_ALL;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_CDEF;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_DEBLOCK;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dPicAllocator {

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -31,7 +31,7 @@ pub type pixel = uint8_t;
 pub type coef = int16_t;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::src::r#ref::Dav1dRef;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
@@ -235,9 +235,9 @@ pub struct Dav1dPictureParameters {
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
+
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
@@ -314,15 +314,15 @@ pub struct C2RustUnnamed_6 {
     pub delta: int16_t,
 }
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_7 {
@@ -332,7 +332,7 @@ pub struct C2RustUnnamed_7 {
 use crate::include::dav1d::headers::Dav1dRestorationType;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
+
 use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -385,7 +385,7 @@ pub struct C2RustUnnamed_13 {
     pub qidx: [libc::c_int; 8],
 }
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_14 {
@@ -418,13 +418,13 @@ pub struct C2RustUnnamed_15 {
     pub update: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
+
+
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_16 {
@@ -433,10 +433,10 @@ pub struct C2RustUnnamed_16 {
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_17 {
@@ -446,65 +446,65 @@ pub struct C2RustUnnamed_17 {
 }
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::pthread::pthread_cond_t;
 
 
@@ -1029,7 +1029,7 @@ pub struct Dav1dContext {
     pub picture_pool: *mut Dav1dMemPool,
 }
 use crate::src::mem::Dav1dMemPool;
-use crate::src::mem::Dav1dMemPoolBuffer;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dLogger {
@@ -1043,23 +1043,23 @@ pub struct Dav1dLogger {
     >,
 }
 use crate::include::dav1d::dav1d::Dav1dEventFlags;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_SEQUENCE;
+
+
 pub type PictureFlags = libc::c_uint;
 pub const PICTURE_FLAG_NEW_TEMPORAL_UNIT: PictureFlags = 4;
 pub const PICTURE_FLAG_NEW_OP_PARAMS_INFO: PictureFlags = 2;
 pub const PICTURE_FLAG_NEW_SEQUENCE: PictureFlags = 1;
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_KEY;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_INTRA;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_REFERENCE;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
+
+
+
+
 use crate::include::dav1d::dav1d::Dav1dInloopFilterType;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_ALL;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_CDEF;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_DEBLOCK;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dPicAllocator {

--- a/src/mc_tmpl_16.rs
+++ b/src/mc_tmpl_16.rs
@@ -18,11 +18,11 @@ extern "C" {
 
 
 pub type pixel = uint16_t;
-use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
+
+
+
+
+
 use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
 use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
 use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;

--- a/src/mc_tmpl_8.rs
+++ b/src/mc_tmpl_8.rs
@@ -22,11 +22,11 @@ extern "C" {
 
 
 pub type pixel = uint8_t;
-use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
+
+
+
+
+
 use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
 use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
 use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -64,18 +64,18 @@ pub struct __va_list_tag {
     pub reg_save_area: *mut libc::c_void,
 }
 
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::src::r#ref::Dav1dRef;
 use crate::include::stdatomic::atomic_int;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
-use crate::include::stdatomic::memory_order;
-use crate::include::stdatomic::memory_order_seq_cst;
-use crate::include::stdatomic::memory_order_acq_rel;
-use crate::include::stdatomic::memory_order_release;
-use crate::include::stdatomic::memory_order_acquire;
-use crate::include::stdatomic::memory_order_consume;
-use crate::include::stdatomic::memory_order_relaxed;
+
+
+
+
+
+
+
 use crate::include::stdatomic::atomic_uint;
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -361,7 +361,7 @@ use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
 use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
 use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
+
 use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
 use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
 use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
@@ -372,9 +372,9 @@ pub struct C2RustUnnamed_7 {
     pub unit_size: [libc::c_int; 2],
 }
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
+
+
+
 use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -461,12 +461,12 @@ pub struct C2RustUnnamed_15 {
 }
 use crate::include::dav1d::headers::Dav1dFilterMode;
 use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
+
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_16 {
@@ -491,60 +491,60 @@ use crate::include::dav1d::headers::Dav1dSequenceHeader;
 use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
 use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
 use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
+
+
 use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
 use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
+
+
 use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
 use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
+
 use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
 use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
+
+
+
+
+
+
 use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
+
 use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
 use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
 use crate::include::pthread::pthread_cond_t;
@@ -1073,7 +1073,7 @@ pub struct Dav1dContext {
     pub picture_pool: *mut Dav1dMemPool,
 }
 use crate::src::mem::Dav1dMemPool;
-use crate::src::mem::Dav1dMemPoolBuffer;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dLogger {
@@ -1087,23 +1087,23 @@ pub struct Dav1dLogger {
     >,
 }
 use crate::include::dav1d::dav1d::Dav1dEventFlags;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_SEQUENCE;
+
+
 pub type PictureFlags = libc::c_uint;
 pub const PICTURE_FLAG_NEW_TEMPORAL_UNIT: PictureFlags = 4;
 pub const PICTURE_FLAG_NEW_OP_PARAMS_INFO: PictureFlags = 2;
 pub const PICTURE_FLAG_NEW_SEQUENCE: PictureFlags = 1;
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_KEY;
+
 use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_INTRA;
 use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_REFERENCE;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
+
 use crate::include::dav1d::dav1d::Dav1dInloopFilterType;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_ALL;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_CDEF;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_DEBLOCK;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dPicAllocator {
@@ -1635,12 +1635,12 @@ pub struct ScalableMotionParams {
     pub step: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dObuType;
-use crate::include::dav1d::headers::DAV1D_OBU_PADDING;
-use crate::include::dav1d::headers::DAV1D_OBU_REDUNDANT_FRAME_HDR;
+
+
 use crate::include::dav1d::headers::DAV1D_OBU_FRAME;
-use crate::include::dav1d::headers::DAV1D_OBU_METADATA;
-use crate::include::dav1d::headers::DAV1D_OBU_TILE_GRP;
-use crate::include::dav1d::headers::DAV1D_OBU_FRAME_HDR;
+
+
+
 use crate::include::dav1d::headers::DAV1D_OBU_TD;
 use crate::include::dav1d::headers::DAV1D_OBU_SEQ_HDR;
 pub type ObuMetaType = libc::c_uint;

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -72,16 +72,16 @@ pub struct C2RustUnnamed {
 pub type pthread_t = libc::c_ulong;
 use crate::include::pthread::pthread_mutex_t;
 use crate::include::pthread::pthread_cond_t;
-use crate::include::stdatomic::memory_order;
-use crate::include::stdatomic::memory_order_seq_cst;
-use crate::include::stdatomic::memory_order_acq_rel;
-use crate::include::stdatomic::memory_order_release;
-use crate::include::stdatomic::memory_order_acquire;
-use crate::include::stdatomic::memory_order_consume;
-use crate::include::stdatomic::memory_order_relaxed;
+
+
+
+
+
+
+
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::src::r#ref::Dav1dRef;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
@@ -281,7 +281,7 @@ pub struct Dav1dPictureParameters {
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
+
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 #[derive(Copy, Clone)]
@@ -360,15 +360,15 @@ pub struct C2RustUnnamed_7 {
     pub delta: int16_t,
 }
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_8 {
@@ -376,10 +376,10 @@ pub struct C2RustUnnamed_8 {
     pub unit_size: [libc::c_int; 2],
 }
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_9 {
@@ -431,7 +431,7 @@ pub struct C2RustUnnamed_14 {
     pub qidx: [libc::c_int; 8],
 }
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_15 {
@@ -464,13 +464,13 @@ pub struct C2RustUnnamed_16 {
     pub update: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
+
+
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_17 {
@@ -479,10 +479,10 @@ pub struct C2RustUnnamed_17 {
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_18 {
@@ -492,65 +492,65 @@ pub struct C2RustUnnamed_18 {
 }
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_19 {
@@ -1093,16 +1093,16 @@ pub const PICTURE_FLAG_NEW_TEMPORAL_UNIT: PictureFlags = 4;
 pub const PICTURE_FLAG_NEW_OP_PARAMS_INFO: PictureFlags = 2;
 pub const PICTURE_FLAG_NEW_SEQUENCE: PictureFlags = 1;
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_KEY;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_INTRA;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_REFERENCE;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
+
+
+
+
 use crate::include::dav1d::dav1d::Dav1dInloopFilterType;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_ALL;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_CDEF;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_DEBLOCK;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dPicAllocator {
@@ -1719,7 +1719,7 @@ pub unsafe extern "C" fn dav1d_default_picture_release(
         (*p).allocator_data as *mut Dav1dMemPoolBuffer,
     );
 }
-unsafe extern "C" fn free_buffer(data: *const uint8_t, user_data: *mut libc::c_void) {
+unsafe extern "C" fn free_buffer(_data: *const uint8_t, user_data: *mut libc::c_void) {
     let mut pic_ctx: *mut pic_ctx_context = user_data as *mut pic_ctx_context;
     ((*pic_ctx).allocator.release_picture_callback)
         .expect(

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1,10 +1,10 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 use ::libc;
-use core::arch::asm;
+
 use crate::src::cdf::CdfContext;
 use crate::src::msac::MsacContext;
-use crate::{stdout,stderr};
+use crate::{stdout};
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
@@ -130,7 +130,7 @@ pub type pixel = uint16_t;
 pub type coef = int32_t;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::src::r#ref::Dav1dRef;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
@@ -334,7 +334,7 @@ pub struct Dav1dPictureParameters {
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
+
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 #[derive(Copy, Clone)]
@@ -413,15 +413,15 @@ pub struct C2RustUnnamed_6 {
     pub delta: int16_t,
 }
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
+
+
 use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_7 {
@@ -429,10 +429,10 @@ pub struct C2RustUnnamed_7 {
     pub unit_size: [libc::c_int; 2],
 }
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_8 {
@@ -484,7 +484,7 @@ pub struct C2RustUnnamed_13 {
     pub qidx: [libc::c_int; 8],
 }
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_14 {
@@ -517,13 +517,13 @@ pub struct C2RustUnnamed_15 {
     pub update: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
+
+
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_16 {
@@ -532,10 +532,10 @@ pub struct C2RustUnnamed_16 {
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_17 {
@@ -545,65 +545,65 @@ pub struct C2RustUnnamed_17 {
 }
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::pthread::pthread_cond_t;
 
 
@@ -1128,7 +1128,7 @@ pub struct Dav1dContext {
     pub picture_pool: *mut Dav1dMemPool,
 }
 use crate::src::mem::Dav1dMemPool;
-use crate::src::mem::Dav1dMemPoolBuffer;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dLogger {
@@ -1142,23 +1142,23 @@ pub struct Dav1dLogger {
     >,
 }
 use crate::include::dav1d::dav1d::Dav1dEventFlags;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_SEQUENCE;
+
+
 pub type PictureFlags = libc::c_uint;
 pub const PICTURE_FLAG_NEW_TEMPORAL_UNIT: PictureFlags = 4;
 pub const PICTURE_FLAG_NEW_OP_PARAMS_INFO: PictureFlags = 2;
 pub const PICTURE_FLAG_NEW_SEQUENCE: PictureFlags = 1;
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_KEY;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_INTRA;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_REFERENCE;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
+
+
+
+
 use crate::include::dav1d::dav1d::Dav1dInloopFilterType;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_ALL;
+
 use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
 use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_CDEF;
 use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_DEBLOCK;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dPicAllocator {
@@ -2808,20 +2808,20 @@ unsafe extern "C" fn get_lo_ctx(
             );
         offset = (26 as libc::c_int as libc::c_uint)
             .wrapping_add(
-                (if y > 1 as libc::c_int as libc::c_uint {
+                if y > 1 as libc::c_int as libc::c_uint {
                     10 as libc::c_int as libc::c_uint
                 } else {
                     y.wrapping_mul(5 as libc::c_int as libc::c_uint)
-                }),
+                },
             );
     }
     return offset
         .wrapping_add(
-            (if mag > 512 as libc::c_int as libc::c_uint {
+            if mag > 512 as libc::c_int as libc::c_uint {
                 4 as libc::c_int as libc::c_uint
             } else {
                 mag.wrapping_add(64 as libc::c_int as libc::c_uint) >> 7 as libc::c_int
-            }),
+            },
         );
 }
 unsafe extern "C" fn decode_coefs(
@@ -3326,12 +3326,12 @@ unsafe extern "C" fn decode_coefs(
                             7 as libc::c_int
                         }) as libc::c_uint)
                             .wrapping_add(
-                                (if mag > 12 as libc::c_int as libc::c_uint {
+                                if mag > 12 as libc::c_int as libc::c_uint {
                                     6 as libc::c_int as libc::c_uint
                                 } else {
                                     mag.wrapping_add(1 as libc::c_int as libc::c_uint)
                                         >> 1 as libc::c_int
-                                }),
+                                },
                             );
                         tok = dav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
@@ -3584,12 +3584,12 @@ unsafe extern "C" fn decode_coefs(
                             7 as libc::c_int
                         }) as libc::c_uint)
                             .wrapping_add(
-                                (if mag > 12 as libc::c_int as libc::c_uint {
+                                if mag > 12 as libc::c_int as libc::c_uint {
                                     6 as libc::c_int as libc::c_uint
                                 } else {
                                     mag.wrapping_add(1 as libc::c_int as libc::c_uint)
                                         >> 1 as libc::c_int
-                                }),
+                                },
                             );
                         tok = dav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
@@ -3843,12 +3843,12 @@ unsafe extern "C" fn decode_coefs(
                             7 as libc::c_int
                         }) as libc::c_uint)
                             .wrapping_add(
-                                (if mag > 12 as libc::c_int as libc::c_uint {
+                                if mag > 12 as libc::c_int as libc::c_uint {
                                     6 as libc::c_int as libc::c_uint
                                 } else {
                                     mag.wrapping_add(1 as libc::c_int as libc::c_uint)
                                         >> 1 as libc::c_int
-                                }),
+                                },
                             );
                         tok = dav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1,10 +1,10 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 use ::libc;
-use core::arch::asm;
+
 use crate::src::cdf::CdfContext;
 use crate::src::msac::MsacContext;
-use crate::{stdout,stderr};
+use crate::{stdout};
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
@@ -122,7 +122,7 @@ pub type pixel = uint8_t;
 pub type coef = int16_t;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::src::r#ref::Dav1dRef;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
@@ -326,7 +326,7 @@ pub struct Dav1dPictureParameters {
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
+
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 #[derive(Copy, Clone)]
@@ -405,15 +405,15 @@ pub struct C2RustUnnamed_6 {
     pub delta: int16_t,
 }
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
+
+
 use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_7 {
@@ -421,10 +421,10 @@ pub struct C2RustUnnamed_7 {
     pub unit_size: [libc::c_int; 2],
 }
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_8 {
@@ -476,7 +476,7 @@ pub struct C2RustUnnamed_13 {
     pub qidx: [libc::c_int; 8],
 }
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_14 {
@@ -509,13 +509,13 @@ pub struct C2RustUnnamed_15 {
     pub update: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
+
+
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_16 {
@@ -524,10 +524,10 @@ pub struct C2RustUnnamed_16 {
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_17 {
@@ -537,65 +537,65 @@ pub struct C2RustUnnamed_17 {
 }
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::pthread::pthread_cond_t;
 
 
@@ -1120,7 +1120,7 @@ pub struct Dav1dContext {
     pub picture_pool: *mut Dav1dMemPool,
 }
 use crate::src::mem::Dav1dMemPool;
-use crate::src::mem::Dav1dMemPoolBuffer;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dLogger {
@@ -1134,23 +1134,23 @@ pub struct Dav1dLogger {
     >,
 }
 use crate::include::dav1d::dav1d::Dav1dEventFlags;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_SEQUENCE;
+
+
 pub type PictureFlags = libc::c_uint;
 pub const PICTURE_FLAG_NEW_TEMPORAL_UNIT: PictureFlags = 4;
 pub const PICTURE_FLAG_NEW_OP_PARAMS_INFO: PictureFlags = 2;
 pub const PICTURE_FLAG_NEW_SEQUENCE: PictureFlags = 1;
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_KEY;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_INTRA;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_REFERENCE;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
+
+
+
+
 use crate::include::dav1d::dav1d::Dav1dInloopFilterType;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_ALL;
+
 use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
 use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_CDEF;
 use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_DEBLOCK;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dPicAllocator {
@@ -2763,20 +2763,20 @@ unsafe extern "C" fn get_lo_ctx(
             );
         offset = (26 as libc::c_int as libc::c_uint)
             .wrapping_add(
-                (if y > 1 as libc::c_int as libc::c_uint {
+                if y > 1 as libc::c_int as libc::c_uint {
                     10 as libc::c_int as libc::c_uint
                 } else {
                     y.wrapping_mul(5 as libc::c_int as libc::c_uint)
-                }),
+                },
             );
     }
     return offset
         .wrapping_add(
-            (if mag > 512 as libc::c_int as libc::c_uint {
+            if mag > 512 as libc::c_int as libc::c_uint {
                 4 as libc::c_int as libc::c_uint
             } else {
                 mag.wrapping_add(64 as libc::c_int as libc::c_uint) >> 7 as libc::c_int
-            }),
+            },
         );
 }
 unsafe extern "C" fn decode_coefs(
@@ -3281,12 +3281,12 @@ unsafe extern "C" fn decode_coefs(
                             7 as libc::c_int
                         }) as libc::c_uint)
                             .wrapping_add(
-                                (if mag > 12 as libc::c_int as libc::c_uint {
+                                if mag > 12 as libc::c_int as libc::c_uint {
                                     6 as libc::c_int as libc::c_uint
                                 } else {
                                     mag.wrapping_add(1 as libc::c_int as libc::c_uint)
                                         >> 1 as libc::c_int
-                                }),
+                                },
                             );
                         tok = dav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
@@ -3539,12 +3539,12 @@ unsafe extern "C" fn decode_coefs(
                             7 as libc::c_int
                         }) as libc::c_uint)
                             .wrapping_add(
-                                (if mag > 12 as libc::c_int as libc::c_uint {
+                                if mag > 12 as libc::c_int as libc::c_uint {
                                     6 as libc::c_int as libc::c_uint
                                 } else {
                                     mag.wrapping_add(1 as libc::c_int as libc::c_uint)
                                         >> 1 as libc::c_int
-                                }),
+                                },
                             );
                         tok = dav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
@@ -3798,12 +3798,12 @@ unsafe extern "C" fn decode_coefs(
                             7 as libc::c_int
                         }) as libc::c_uint)
                             .wrapping_add(
-                                (if mag > 12 as libc::c_int as libc::c_uint {
+                                if mag > 12 as libc::c_int as libc::c_uint {
                                     6 as libc::c_int as libc::c_uint
                                 } else {
                                     mag.wrapping_add(1 as libc::c_int as libc::c_uint)
                                         >> 1 as libc::c_int
-                                }),
+                                },
                             );
                         tok = dav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -29,7 +29,7 @@ pub struct Dav1dRef {
     pub user_data: *mut libc::c_void,
 }
 use crate::include::stdatomic::atomic_int;
-use crate::include::pthread::pthread_mutex_t;
+
 use crate::src::mem::Dav1dMemPoolBuffer;
 use crate::src::mem::Dav1dMemPool;
 #[inline]

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -62,32 +62,32 @@ extern "C" {
 }
 
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
+
+
 use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
@@ -109,73 +109,73 @@ pub struct C2RustUnnamed_0 {
     pub gamma: int16_t,
     pub delta: int16_t,
 }
-use crate::include::dav1d::headers::Dav1dPixelLayout;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
+
+
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -1,18 +1,18 @@
 use crate::include::stdint::*;
 use ::libc;
 
-use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
+
+
+
 use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
+
 use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
 use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
 use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
+
+
+
 use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -74,7 +74,7 @@ pub struct __va_list_tag {
 
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::src::r#ref::Dav1dRef;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
@@ -277,10 +277,10 @@ pub struct Dav1dPictureParameters {
     pub bpc: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
+
+
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
@@ -357,15 +357,15 @@ pub struct C2RustUnnamed_6 {
     pub delta: int16_t,
 }
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_7 {
@@ -373,10 +373,10 @@ pub struct C2RustUnnamed_7 {
     pub unit_size: [libc::c_int; 2],
 }
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_8 {
@@ -428,7 +428,7 @@ pub struct C2RustUnnamed_13 {
     pub qidx: [libc::c_int; 8],
 }
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_14 {
@@ -461,13 +461,13 @@ pub struct C2RustUnnamed_15 {
     pub update: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
+
+
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_16 {
@@ -476,10 +476,10 @@ pub struct C2RustUnnamed_16 {
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct C2RustUnnamed_17 {
@@ -489,65 +489,65 @@ pub struct C2RustUnnamed_17 {
 }
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::pthread::pthread_cond_t;
 
 
@@ -1074,7 +1074,7 @@ pub struct Dav1dContext {
     pub picture_pool: *mut Dav1dMemPool,
 }
 use crate::src::mem::Dav1dMemPool;
-use crate::src::mem::Dav1dMemPoolBuffer;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dLogger {
@@ -1088,23 +1088,23 @@ pub struct Dav1dLogger {
     >,
 }
 use crate::include::dav1d::dav1d::Dav1dEventFlags;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_SEQUENCE;
+
+
 pub type PictureFlags = libc::c_uint;
 pub const PICTURE_FLAG_NEW_TEMPORAL_UNIT: PictureFlags = 4;
 pub const PICTURE_FLAG_NEW_OP_PARAMS_INFO: PictureFlags = 2;
 pub const PICTURE_FLAG_NEW_SEQUENCE: PictureFlags = 1;
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_KEY;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_INTRA;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_REFERENCE;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
+
+
+
+
 use crate::include::dav1d::dav1d::Dav1dInloopFilterType;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_ALL;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_CDEF;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_DEBLOCK;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
+
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dPicAllocator {
@@ -2076,7 +2076,7 @@ unsafe extern "C" fn create_filter_sbrow(
 pub unsafe extern "C" fn dav1d_task_create_tile_sbrow(
     f: *mut Dav1dFrameContext,
     pass: libc::c_int,
-    cond_signal: libc::c_int,
+    _cond_signal: libc::c_int,
 ) -> libc::c_int {
     let mut tasks: *mut Dav1dTask = (*f)
         .task_thread

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -6,10 +6,10 @@ extern "C" {
 }
 
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -107,32 +107,32 @@ pub type _IO_lock_t = ();
 use crate::include::dav1d::common::Dav1dUserData;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::DAV1D_OFF;
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
@@ -156,66 +156,66 @@ pub struct C2RustUnnamed_0 {
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
+
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
+
+
+
 use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
@@ -223,7 +223,7 @@ use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
 use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
 use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
@@ -436,15 +436,15 @@ pub struct Dav1dLogger {
     >,
 }
 use crate::include::dav1d::dav1d::Dav1dInloopFilterType;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_ALL;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_CDEF;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_DEBLOCK;
+
+
+
+
 use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_KEY;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_INTRA;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_REFERENCE;
+
+
+
 use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/tools/dav1d_cli_parse.rs
+++ b/tools/dav1d_cli_parse.rs
@@ -69,35 +69,35 @@ pub type __off_t = libc::c_long;
 pub type __off64_t = libc::c_long;
 pub type va_list = __builtin_va_list;
 pub type _IO_lock_t = ();
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
@@ -120,75 +120,75 @@ pub struct C2RustUnnamed_0 {
     pub delta: int16_t,
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
+
+
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;

--- a/tools/input/annexb.rs
+++ b/tools/input/annexb.rs
@@ -31,16 +31,16 @@ pub type __off_t = libc::c_long;
 pub type __off64_t = libc::c_long;
 pub type _IO_lock_t = ();
 use crate::include::dav1d::headers::Dav1dObuType;
-use crate::include::dav1d::headers::DAV1D_OBU_PADDING;
-use crate::include::dav1d::headers::DAV1D_OBU_REDUNDANT_FRAME_HDR;
-use crate::include::dav1d::headers::DAV1D_OBU_FRAME;
-use crate::include::dav1d::headers::DAV1D_OBU_METADATA;
-use crate::include::dav1d::headers::DAV1D_OBU_TILE_GRP;
-use crate::include::dav1d::headers::DAV1D_OBU_FRAME_HDR;
+
+
+
+
+
+
 use crate::include::dav1d::headers::DAV1D_OBU_TD;
-use crate::include::dav1d::headers::DAV1D_OBU_SEQ_HDR;
-use crate::include::dav1d::common::Dav1dUserData;
-use crate::include::dav1d::common::Dav1dDataProps;
+
+
+
 use crate::include::dav1d::data::Dav1dData;
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -382,38 +382,36 @@ unsafe extern "C" fn annexb_close(c: *mut AnnexbInputContext) {
     fclose((*c).f);
 }
 #[no_mangle]
-pub static mut annexb_demuxer: Demuxer = unsafe {
-    {
-        let mut init = Demuxer {
-            priv_data_size: ::core::mem::size_of::<AnnexbInputContext>() as libc::c_ulong
-                as libc::c_int,
-            name: b"annexb\0" as *const u8 as *const libc::c_char,
-            probe_sz: 2048 as libc::c_int,
-            probe: Some(
-                annexb_probe as unsafe extern "C" fn(*const uint8_t) -> libc::c_int,
-            ),
-            open: Some(
-                annexb_open
-                    as unsafe extern "C" fn(
-                        *mut AnnexbInputContext,
-                        *const libc::c_char,
-                        *mut libc::c_uint,
-                        *mut libc::c_uint,
-                        *mut libc::c_uint,
-                    ) -> libc::c_int,
-            ),
-            read: Some(
-                annexb_read
-                    as unsafe extern "C" fn(
-                        *mut AnnexbInputContext,
-                        *mut Dav1dData,
-                    ) -> libc::c_int,
-            ),
-            seek: None,
-            close: Some(
-                annexb_close as unsafe extern "C" fn(*mut AnnexbInputContext) -> (),
-            ),
-        };
-        init
-    }
+pub static mut annexb_demuxer: Demuxer = {
+    let mut init = Demuxer {
+        priv_data_size: ::core::mem::size_of::<AnnexbInputContext>() as libc::c_ulong
+            as libc::c_int,
+        name: b"annexb\0" as *const u8 as *const libc::c_char,
+        probe_sz: 2048 as libc::c_int,
+        probe: Some(
+            annexb_probe as unsafe extern "C" fn(*const uint8_t) -> libc::c_int,
+        ),
+        open: Some(
+            annexb_open
+                as unsafe extern "C" fn(
+                    *mut AnnexbInputContext,
+                    *const libc::c_char,
+                    *mut libc::c_uint,
+                    *mut libc::c_uint,
+                    *mut libc::c_uint,
+                ) -> libc::c_int,
+        ),
+        read: Some(
+            annexb_read
+                as unsafe extern "C" fn(
+                    *mut AnnexbInputContext,
+                    *mut Dav1dData,
+                ) -> libc::c_int,
+        ),
+        seek: None,
+        close: Some(
+            annexb_close as unsafe extern "C" fn(*mut AnnexbInputContext) -> (),
+        ),
+    };
+    init
 };

--- a/tools/input/input.rs
+++ b/tools/input/input.rs
@@ -1,4 +1,4 @@
-use crate::include::stddef::*;
+
 use crate::include::stdint::*;
 use ::libc;
 use crate::stderr;
@@ -31,8 +31,8 @@ extern "C" {
 pub type __off_t = libc::c_long;
 pub type __off64_t = libc::c_long;
 pub type _IO_lock_t = ();
-use crate::include::dav1d::common::Dav1dUserData;
-use crate::include::dav1d::common::Dav1dDataProps;
+
+
 use crate::include::dav1d::data::Dav1dData;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/tools/input/ivf.rs
+++ b/tools/input/ivf.rs
@@ -37,8 +37,8 @@ extern "C" {
 pub type __off_t = libc::c_long;
 pub type __off64_t = libc::c_long;
 pub type _IO_lock_t = ();
-use crate::include::dav1d::common::Dav1dUserData;
-use crate::include::dav1d::common::Dav1dDataProps;
+
+
 use crate::include::dav1d::data::Dav1dData;
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -402,43 +402,41 @@ unsafe extern "C" fn ivf_close(c: *mut IvfInputContext) {
     fclose((*c).f);
 }
 #[no_mangle]
-pub static mut ivf_demuxer: Demuxer = unsafe {
-    {
-        let mut init = Demuxer {
-            priv_data_size: ::core::mem::size_of::<IvfInputContext>() as libc::c_ulong
-                as libc::c_int,
-            name: b"ivf\0" as *const u8 as *const libc::c_char,
-            probe_sz: ::core::mem::size_of::<[uint8_t; 12]>() as libc::c_ulong
-                as libc::c_int,
-            probe: Some(
-                ivf_probe as unsafe extern "C" fn(*const uint8_t) -> libc::c_int,
-            ),
-            open: Some(
-                ivf_open
-                    as unsafe extern "C" fn(
-                        *mut IvfInputContext,
-                        *const libc::c_char,
-                        *mut libc::c_uint,
-                        *mut libc::c_uint,
-                        *mut libc::c_uint,
-                    ) -> libc::c_int,
-            ),
-            read: Some(
-                ivf_read
-                    as unsafe extern "C" fn(
-                        *mut IvfInputContext,
-                        *mut Dav1dData,
-                    ) -> libc::c_int,
-            ),
-            seek: Some(
-                ivf_seek
-                    as unsafe extern "C" fn(
-                        *mut IvfInputContext,
-                        uint64_t,
-                    ) -> libc::c_int,
-            ),
-            close: Some(ivf_close as unsafe extern "C" fn(*mut IvfInputContext) -> ()),
-        };
-        init
-    }
+pub static mut ivf_demuxer: Demuxer = {
+    let mut init = Demuxer {
+        priv_data_size: ::core::mem::size_of::<IvfInputContext>() as libc::c_ulong
+            as libc::c_int,
+        name: b"ivf\0" as *const u8 as *const libc::c_char,
+        probe_sz: ::core::mem::size_of::<[uint8_t; 12]>() as libc::c_ulong
+            as libc::c_int,
+        probe: Some(
+            ivf_probe as unsafe extern "C" fn(*const uint8_t) -> libc::c_int,
+        ),
+        open: Some(
+            ivf_open
+                as unsafe extern "C" fn(
+                    *mut IvfInputContext,
+                    *const libc::c_char,
+                    *mut libc::c_uint,
+                    *mut libc::c_uint,
+                    *mut libc::c_uint,
+                ) -> libc::c_int,
+        ),
+        read: Some(
+            ivf_read
+                as unsafe extern "C" fn(
+                    *mut IvfInputContext,
+                    *mut Dav1dData,
+                ) -> libc::c_int,
+        ),
+        seek: Some(
+            ivf_seek
+                as unsafe extern "C" fn(
+                    *mut IvfInputContext,
+                    uint64_t,
+                ) -> libc::c_int,
+        ),
+        close: Some(ivf_close as unsafe extern "C" fn(*mut IvfInputContext) -> ()),
+    };
+    init
 };

--- a/tools/input/section5.rs
+++ b/tools/input/section5.rs
@@ -33,16 +33,16 @@ pub type __off64_t = libc::c_long;
 pub type _IO_lock_t = ();
 pub type off_t = __off64_t;
 use crate::include::dav1d::headers::Dav1dObuType;
-use crate::include::dav1d::headers::DAV1D_OBU_PADDING;
-use crate::include::dav1d::headers::DAV1D_OBU_REDUNDANT_FRAME_HDR;
-use crate::include::dav1d::headers::DAV1D_OBU_FRAME;
-use crate::include::dav1d::headers::DAV1D_OBU_METADATA;
-use crate::include::dav1d::headers::DAV1D_OBU_TILE_GRP;
-use crate::include::dav1d::headers::DAV1D_OBU_FRAME_HDR;
+
+
+
+
+
+
 use crate::include::dav1d::headers::DAV1D_OBU_TD;
-use crate::include::dav1d::headers::DAV1D_OBU_SEQ_HDR;
-use crate::include::dav1d::common::Dav1dUserData;
-use crate::include::dav1d::common::Dav1dDataProps;
+
+
+
 use crate::include::dav1d::data::Dav1dData;
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -386,38 +386,36 @@ unsafe extern "C" fn section5_close(c: *mut Section5InputContext) {
     fclose((*c).f);
 }
 #[no_mangle]
-pub static mut section5_demuxer: Demuxer = unsafe {
-    {
-        let mut init = Demuxer {
-            priv_data_size: ::core::mem::size_of::<Section5InputContext>()
-                as libc::c_ulong as libc::c_int,
-            name: b"section5\0" as *const u8 as *const libc::c_char,
-            probe_sz: 2048 as libc::c_int,
-            probe: Some(
-                section5_probe as unsafe extern "C" fn(*const uint8_t) -> libc::c_int,
-            ),
-            open: Some(
-                section5_open
-                    as unsafe extern "C" fn(
-                        *mut Section5InputContext,
-                        *const libc::c_char,
-                        *mut libc::c_uint,
-                        *mut libc::c_uint,
-                        *mut libc::c_uint,
-                    ) -> libc::c_int,
-            ),
-            read: Some(
-                section5_read
-                    as unsafe extern "C" fn(
-                        *mut Section5InputContext,
-                        *mut Dav1dData,
-                    ) -> libc::c_int,
-            ),
-            seek: None,
-            close: Some(
-                section5_close as unsafe extern "C" fn(*mut Section5InputContext) -> (),
-            ),
-        };
-        init
-    }
+pub static mut section5_demuxer: Demuxer = {
+    let mut init = Demuxer {
+        priv_data_size: ::core::mem::size_of::<Section5InputContext>()
+            as libc::c_ulong as libc::c_int,
+        name: b"section5\0" as *const u8 as *const libc::c_char,
+        probe_sz: 2048 as libc::c_int,
+        probe: Some(
+            section5_probe as unsafe extern "C" fn(*const uint8_t) -> libc::c_int,
+        ),
+        open: Some(
+            section5_open
+                as unsafe extern "C" fn(
+                    *mut Section5InputContext,
+                    *const libc::c_char,
+                    *mut libc::c_uint,
+                    *mut libc::c_uint,
+                    *mut libc::c_uint,
+                ) -> libc::c_int,
+        ),
+        read: Some(
+            section5_read
+                as unsafe extern "C" fn(
+                    *mut Section5InputContext,
+                    *mut Dav1dData,
+                ) -> libc::c_int,
+        ),
+        seek: None,
+        close: Some(
+            section5_close as unsafe extern "C" fn(*mut Section5InputContext) -> (),
+        ),
+    };
+    init
 };

--- a/tools/output/md5.rs
+++ b/tools/output/md5.rs
@@ -35,35 +35,35 @@ extern "C" {
 pub type __off_t = libc::c_long;
 pub type __off64_t = libc::c_long;
 pub type _IO_lock_t = ();
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
@@ -87,74 +87,74 @@ pub struct C2RustUnnamed_0 {
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
+
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
+
+
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
@@ -452,8 +452,8 @@ static mut k: [uint32_t; 64] = [
 unsafe extern "C" fn md5_open(
     md5: *mut MD5Context,
     file: *const libc::c_char,
-    p: *const Dav1dPictureParameters,
-    mut fps: *const libc::c_uint,
+    _p: *const Dav1dPictureParameters,
+    mut _fps: *const libc::c_uint,
 ) -> libc::c_int {
     if strcmp(file, b"-\0" as *const u8 as *const libc::c_char) == 0 {
         (*md5).f = stdout;
@@ -1638,40 +1638,38 @@ unsafe extern "C" fn md5_verify(
     ) != 0) as libc::c_int;
 }
 #[no_mangle]
-pub static mut md5_muxer: Muxer = unsafe {
-    {
-        let mut init = Muxer {
-            priv_data_size: ::core::mem::size_of::<MD5Context>() as libc::c_ulong
-                as libc::c_int,
-            name: b"md5\0" as *const u8 as *const libc::c_char,
-            extension: b"md5\0" as *const u8 as *const libc::c_char,
-            write_header: Some(
-                md5_open
-                    as unsafe extern "C" fn(
-                        *mut MD5Context,
-                        *const libc::c_char,
-                        *const Dav1dPictureParameters,
-                        *const libc::c_uint,
-                    ) -> libc::c_int,
-            ),
-            write_picture: Some(
-                md5_write
-                    as unsafe extern "C" fn(
-                        *mut MD5Context,
-                        *mut Dav1dPicture,
-                    ) -> libc::c_int,
-            ),
-            write_trailer: Some(
-                md5_close as unsafe extern "C" fn(*mut MD5Context) -> (),
-            ),
-            verify: Some(
-                md5_verify
-                    as unsafe extern "C" fn(
-                        *mut MD5Context,
-                        *const libc::c_char,
-                    ) -> libc::c_int,
-            ),
-        };
-        init
-    }
+pub static mut md5_muxer: Muxer = {
+    let mut init = Muxer {
+        priv_data_size: ::core::mem::size_of::<MD5Context>() as libc::c_ulong
+            as libc::c_int,
+        name: b"md5\0" as *const u8 as *const libc::c_char,
+        extension: b"md5\0" as *const u8 as *const libc::c_char,
+        write_header: Some(
+            md5_open
+                as unsafe extern "C" fn(
+                    *mut MD5Context,
+                    *const libc::c_char,
+                    *const Dav1dPictureParameters,
+                    *const libc::c_uint,
+                ) -> libc::c_int,
+        ),
+        write_picture: Some(
+            md5_write
+                as unsafe extern "C" fn(
+                    *mut MD5Context,
+                    *mut Dav1dPicture,
+                ) -> libc::c_int,
+        ),
+        write_trailer: Some(
+            md5_close as unsafe extern "C" fn(*mut MD5Context) -> (),
+        ),
+        verify: Some(
+            md5_verify
+                as unsafe extern "C" fn(
+                    *mut MD5Context,
+                    *const libc::c_char,
+                ) -> libc::c_int,
+        ),
+    };
+    init
 };

--- a/tools/output/null.rs
+++ b/tools/output/null.rs
@@ -7,35 +7,35 @@ extern "C" {
     fn dav1d_picture_unref(p: *mut Dav1dPicture);
 }
 
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
@@ -58,75 +58,75 @@ pub struct C2RustUnnamed_0 {
     pub delta: int16_t,
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
+
+
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
@@ -338,30 +338,28 @@ pub struct Muxer {
 }
 pub type NullOutputContext = MuxerPriv;
 unsafe extern "C" fn null_write(
-    c: *mut NullOutputContext,
+    _c: *mut NullOutputContext,
     p: *mut Dav1dPicture,
 ) -> libc::c_int {
     dav1d_picture_unref(p);
     return 0 as libc::c_int;
 }
 #[no_mangle]
-pub static mut null_muxer: Muxer = unsafe {
-    {
-        let mut init = Muxer {
-            priv_data_size: 0 as libc::c_int,
-            name: b"null\0" as *const u8 as *const libc::c_char,
-            extension: b"null\0" as *const u8 as *const libc::c_char,
-            write_header: None,
-            write_picture: Some(
-                null_write
-                    as unsafe extern "C" fn(
-                        *mut NullOutputContext,
-                        *mut Dav1dPicture,
-                    ) -> libc::c_int,
-            ),
-            write_trailer: None,
-            verify: None,
-        };
-        init
-    }
+pub static mut null_muxer: Muxer = {
+    let mut init = Muxer {
+        priv_data_size: 0 as libc::c_int,
+        name: b"null\0" as *const u8 as *const libc::c_char,
+        extension: b"null\0" as *const u8 as *const libc::c_char,
+        write_header: None,
+        write_picture: Some(
+            null_write
+                as unsafe extern "C" fn(
+                    *mut NullOutputContext,
+                    *mut Dav1dPicture,
+                ) -> libc::c_int,
+        ),
+        write_trailer: None,
+        verify: None,
+    };
+    init
 };

--- a/tools/output/output.rs
+++ b/tools/output/output.rs
@@ -39,35 +39,35 @@ extern "C" {
 pub type __off_t = libc::c_long;
 pub type __off64_t = libc::c_long;
 pub type _IO_lock_t = ();
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
@@ -90,75 +90,75 @@ pub struct C2RustUnnamed_0 {
     pub delta: int16_t,
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
+
+
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;

--- a/tools/output/y4m2.rs
+++ b/tools/output/y4m2.rs
@@ -25,35 +25,35 @@ extern "C" {
 pub type __off_t = libc::c_long;
 pub type __off64_t = libc::c_long;
 pub type _IO_lock_t = ();
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
@@ -77,74 +77,74 @@ pub struct C2RustUnnamed_0 {
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
+
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
+
+
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
@@ -365,7 +365,7 @@ pub type Y4m2OutputContext = MuxerPriv;
 unsafe extern "C" fn y4m2_open(
     c: *mut Y4m2OutputContext,
     file: *const libc::c_char,
-    mut p: *const Dav1dPictureParameters,
+    mut _p: *const Dav1dPictureParameters,
     mut fps: *const libc::c_uint,
 ) -> libc::c_int {
     if strcmp(file, b"-\0" as *const u8 as *const libc::c_char) == 0 {
@@ -565,34 +565,32 @@ unsafe extern "C" fn y4m2_close(c: *mut Y4m2OutputContext) {
     }
 }
 #[no_mangle]
-pub static mut y4m2_muxer: Muxer = unsafe {
-    {
-        let mut init = Muxer {
-            priv_data_size: ::core::mem::size_of::<Y4m2OutputContext>() as libc::c_ulong
-                as libc::c_int,
-            name: b"yuv4mpeg2\0" as *const u8 as *const libc::c_char,
-            extension: b"y4m\0" as *const u8 as *const libc::c_char,
-            write_header: Some(
-                y4m2_open
-                    as unsafe extern "C" fn(
-                        *mut Y4m2OutputContext,
-                        *const libc::c_char,
-                        *const Dav1dPictureParameters,
-                        *const libc::c_uint,
-                    ) -> libc::c_int,
-            ),
-            write_picture: Some(
-                y4m2_write
-                    as unsafe extern "C" fn(
-                        *mut Y4m2OutputContext,
-                        *mut Dav1dPicture,
-                    ) -> libc::c_int,
-            ),
-            write_trailer: Some(
-                y4m2_close as unsafe extern "C" fn(*mut Y4m2OutputContext) -> (),
-            ),
-            verify: None,
-        };
-        init
-    }
+pub static mut y4m2_muxer: Muxer = {
+    let mut init = Muxer {
+        priv_data_size: ::core::mem::size_of::<Y4m2OutputContext>() as libc::c_ulong
+            as libc::c_int,
+        name: b"yuv4mpeg2\0" as *const u8 as *const libc::c_char,
+        extension: b"y4m\0" as *const u8 as *const libc::c_char,
+        write_header: Some(
+            y4m2_open
+                as unsafe extern "C" fn(
+                    *mut Y4m2OutputContext,
+                    *const libc::c_char,
+                    *const Dav1dPictureParameters,
+                    *const libc::c_uint,
+                ) -> libc::c_int,
+        ),
+        write_picture: Some(
+            y4m2_write
+                as unsafe extern "C" fn(
+                    *mut Y4m2OutputContext,
+                    *mut Dav1dPicture,
+                ) -> libc::c_int,
+        ),
+        write_trailer: Some(
+            y4m2_close as unsafe extern "C" fn(*mut Y4m2OutputContext) -> (),
+        ),
+        verify: None,
+    };
+    init
 };

--- a/tools/output/yuv.rs
+++ b/tools/output/yuv.rs
@@ -25,35 +25,35 @@ extern "C" {
 pub type __off_t = libc::c_long;
 pub type __off64_t = libc::c_long;
 pub type _IO_lock_t = ();
-use crate::include::dav1d::common::Dav1dUserData;
+
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::DAV1D_N_TX_MODES;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_ON;
-use crate::include::dav1d::headers::DAV1D_OFF;
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+
+
+
+
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+
+
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
@@ -77,74 +77,74 @@ pub struct C2RustUnnamed_0 {
 }
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
+
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::Dav1dFrameType;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_RESERVED;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_EBU3213;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE432;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE431;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_XYZ;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT2020;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_FILM;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT601;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470BG;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT470M;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::DAV1D_TRC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_TRC_HLG;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE428;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE2084;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_12BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_BT2020_10BIT;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_BT1361;
-use crate::include::dav1d::headers::DAV1D_TRC_IEC61966;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100_SQRT10;
-use crate::include::dav1d::headers::DAV1D_TRC_LOG100;
-use crate::include::dav1d::headers::DAV1D_TRC_LINEAR;
-use crate::include::dav1d::headers::DAV1D_TRC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_TRC_BT601;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_TRC_BT470M;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TRC_BT709;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::DAV1D_MC_RESERVED;
-use crate::include::dav1d::headers::DAV1D_MC_ICTCP;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_CL;
-use crate::include::dav1d::headers::DAV1D_MC_CHROMAT_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE2085;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_CL;
-use crate::include::dav1d::headers::DAV1D_MC_BT2020_NCL;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE_YCGCO;
-use crate::include::dav1d::headers::DAV1D_MC_SMPTE240;
-use crate::include::dav1d::headers::DAV1D_MC_BT601;
-use crate::include::dav1d::headers::DAV1D_MC_BT470BG;
-use crate::include::dav1d::headers::DAV1D_MC_FCC;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_BT709;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::DAV1D_CHR_COLOCATED;
-use crate::include::dav1d::headers::DAV1D_CHR_VERTICAL;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
+
+
+
 use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
@@ -363,8 +363,8 @@ pub type YuvOutputContext = MuxerPriv;
 unsafe extern "C" fn yuv_open(
     c: *mut YuvOutputContext,
     file: *const libc::c_char,
-    p: *const Dav1dPictureParameters,
-    mut fps: *const libc::c_uint,
+    _p: *const Dav1dPictureParameters,
+    mut _fps: *const libc::c_uint,
 ) -> libc::c_int {
     if strcmp(file, b"-\0" as *const u8 as *const libc::c_char) == 0 {
         (*c).f = stdout;
@@ -474,34 +474,32 @@ unsafe extern "C" fn yuv_close(c: *mut YuvOutputContext) {
     }
 }
 #[no_mangle]
-pub static mut yuv_muxer: Muxer = unsafe {
-    {
-        let mut init = Muxer {
-            priv_data_size: ::core::mem::size_of::<YuvOutputContext>() as libc::c_ulong
-                as libc::c_int,
-            name: b"yuv\0" as *const u8 as *const libc::c_char,
-            extension: b"yuv\0" as *const u8 as *const libc::c_char,
-            write_header: Some(
-                yuv_open
-                    as unsafe extern "C" fn(
-                        *mut YuvOutputContext,
-                        *const libc::c_char,
-                        *const Dav1dPictureParameters,
-                        *const libc::c_uint,
-                    ) -> libc::c_int,
-            ),
-            write_picture: Some(
-                yuv_write
-                    as unsafe extern "C" fn(
-                        *mut YuvOutputContext,
-                        *mut Dav1dPicture,
-                    ) -> libc::c_int,
-            ),
-            write_trailer: Some(
-                yuv_close as unsafe extern "C" fn(*mut YuvOutputContext) -> (),
-            ),
-            verify: None,
-        };
-        init
-    }
+pub static mut yuv_muxer: Muxer = {
+    let mut init = Muxer {
+        priv_data_size: ::core::mem::size_of::<YuvOutputContext>() as libc::c_ulong
+            as libc::c_int,
+        name: b"yuv\0" as *const u8 as *const libc::c_char,
+        extension: b"yuv\0" as *const u8 as *const libc::c_char,
+        write_header: Some(
+            yuv_open
+                as unsafe extern "C" fn(
+                    *mut YuvOutputContext,
+                    *const libc::c_char,
+                    *const Dav1dPictureParameters,
+                    *const libc::c_uint,
+                ) -> libc::c_int,
+        ),
+        write_picture: Some(
+            yuv_write
+                as unsafe extern "C" fn(
+                    *mut YuvOutputContext,
+                    *mut Dav1dPicture,
+                ) -> libc::c_int,
+        ),
+        write_trailer: Some(
+            yuv_close as unsafe extern "C" fn(*mut YuvOutputContext) -> (),
+        ),
+        verify: None,
+    };
+    init
 };


### PR DESCRIPTION
Run `cargo fix` to cleanup the many, many warnings we had. Most of the cleanup is unused variable warnings from the recent batch of deduplication PRs. There's also a number of places where unused function arguments from the initial transpile that have been renamed to suppress the unused variable warnings.