### PR TITLE
Deduplicate `ec_win` to `src/msac.rs`

### DIFF
--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -902,7 +902,7 @@ pub struct C2RustUnnamed_45 {
     pub col: libc::c_int,
     pub row: libc::c_int,
 }
-pub type ec_win = size_t;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -902,7 +902,7 @@ pub struct C2RustUnnamed_45 {
     pub col: libc::c_int,
     pub row: libc::c_int,
 }
-pub type ec_win = size_t;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -913,7 +913,7 @@ pub struct C2RustUnnamed_45 {
     pub col: libc::c_int,
     pub row: libc::c_int,
 }
-pub type ec_win = size_t;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct CdfContext {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1264,7 +1264,7 @@ pub struct C2RustUnnamed_45 {
     pub col: libc::c_int,
     pub row: libc::c_int,
 }
-pub type ec_win = size_t;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -902,7 +902,7 @@ pub struct C2RustUnnamed_45 {
     pub col: libc::c_int,
     pub row: libc::c_int,
 }
-pub type ec_win = size_t;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -902,7 +902,7 @@ pub struct C2RustUnnamed_45 {
     pub col: libc::c_int,
     pub row: libc::c_int,
 }
-pub type ec_win = size_t;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1375,7 +1375,7 @@ pub struct C2RustUnnamed_39 {
     pub col: libc::c_int,
     pub row: libc::c_int,
 }
-pub type ec_win = size_t;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext {

--- a/src/log.rs
+++ b/src/log.rs
@@ -1227,7 +1227,7 @@ pub struct C2RustUnnamed_39 {
     pub col: libc::c_int,
     pub row: libc::c_int,
 }
-pub type ec_win = size_t;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext {

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -903,7 +903,7 @@ pub struct C2RustUnnamed_45 {
     pub col: libc::c_int,
     pub row: libc::c_int,
 }
-pub type ec_win = size_t;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -903,7 +903,7 @@ pub struct C2RustUnnamed_45 {
     pub col: libc::c_int,
     pub row: libc::c_int,
 }
-pub type ec_win = size_t;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -947,7 +947,7 @@ pub struct C2RustUnnamed_45 {
     pub col: libc::c_int,
     pub row: libc::c_int,
 }
-pub type ec_win = size_t;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -943,7 +943,7 @@ pub struct C2RustUnnamed_45 {
     pub col: libc::c_int,
     pub row: libc::c_int,
 }
-pub type ec_win = size_t;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -999,7 +999,7 @@ pub struct C2RustUnnamed_45 {
     pub col: libc::c_int,
     pub row: libc::c_int,
 }
-pub type ec_win = size_t;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -991,7 +991,7 @@ pub struct C2RustUnnamed_45 {
     pub col: libc::c_int,
     pub row: libc::c_int,
 }
-pub type ec_win = size_t;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -948,7 +948,7 @@ pub struct C2RustUnnamed_45 {
     pub col: libc::c_int,
     pub row: libc::c_int,
 }
-pub type ec_win = size_t;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {


### PR DESCRIPTION
These should be all of the non-`BITDEPTH`-dependent `typedef`s.