### PR TITLE
Fix alignment in dav1d_apply_grain

### DIFF
--- a/src/align.rs
+++ b/src/align.rs
@@ -9,6 +9,30 @@
 use std::ops::{Index, IndexMut};
 
 #[derive(Copy, Clone)]
+#[repr(C, align(64))]
+pub struct Align64<T>(pub T);
+
+impl<T> From<T> for Align64<T> {
+    fn from(from: T) -> Self {
+        Align64(from)
+    }
+}
+
+impl<T: Index<usize>> Index<usize> for Align64<T> {
+    type Output = T::Output;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl<T: IndexMut<usize>> IndexMut<usize> for Align64<T> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
+
+#[derive(Copy, Clone)]
 #[repr(C, align(32))]
 pub struct Align32<T>(pub T);
 

--- a/src/fg_apply_tmpl_16.rs
+++ b/src/fg_apply_tmpl_16.rs
@@ -1,5 +1,6 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
+use crate::src::align::{Align16, Align64};
 use ::libc;
 extern "C" {
     pub type Dav1dRef;
@@ -774,18 +775,18 @@ pub unsafe extern "C" fn dav1d_apply_grain_16bpc(
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,
 ) {
-    let mut grain_lut: [[[entry; 82]; 74]; 3] = [[[0; 82]; 74]; 3];
-    let mut scaling: [[uint8_t; 4096]; 3] = [[0; 4096]; 3];
+    let mut grain_lut = Align16([[[0; 82]; 74]; 3]);
+    let mut scaling = Align64([[0; 4096]; 3]);
     let rows: libc::c_int = (*out).p.h + 31 as libc::c_int >> 5 as libc::c_int;
-    dav1d_prep_grain_16bpc(dsp, out, in_0, scaling.as_mut_ptr(), grain_lut.as_mut_ptr());
+    dav1d_prep_grain_16bpc(dsp, out, in_0, scaling.0.as_mut_ptr(), grain_lut.0.as_mut_ptr());
     let mut row: libc::c_int = 0 as libc::c_int;
     while row < rows {
         dav1d_apply_grain_row_16bpc(
             dsp,
             out,
             in_0,
-            scaling.as_mut_ptr() as *const [uint8_t; 4096],
-            grain_lut.as_mut_ptr() as *const [[entry; 82]; 74],
+            scaling.0.as_mut_ptr() as *const [uint8_t; 4096],
+            grain_lut.0.as_mut_ptr() as *const [[entry; 82]; 74],
             row,
         );
         row += 1;

--- a/src/fg_apply_tmpl_8.rs
+++ b/src/fg_apply_tmpl_8.rs
@@ -1,5 +1,6 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
+use crate::src::align::{Align16, Align64};
 use ::libc;
 extern "C" {
     pub type Dav1dRef;
@@ -716,18 +717,18 @@ pub unsafe extern "C" fn dav1d_apply_grain_8bpc(
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,
 ) {
-    let mut grain_lut: [[[entry; 82]; 74]; 3] = [[[0; 82]; 74]; 3];
-    let mut scaling: [[uint8_t; 256]; 3] = [[0; 256]; 3];
+    let mut grain_lut = Align16([[[0; 82]; 74]; 3]);
+    let mut scaling = Align64([[0; 256]; 3]);
     let rows: libc::c_int = (*out).p.h + 31 as libc::c_int >> 5 as libc::c_int;
-    dav1d_prep_grain_8bpc(dsp, out, in_0, scaling.as_mut_ptr(), grain_lut.as_mut_ptr());
+    dav1d_prep_grain_8bpc(dsp, out, in_0, scaling.0.as_mut_ptr(), grain_lut.0.as_mut_ptr());
     let mut row: libc::c_int = 0 as libc::c_int;
     while row < rows {
         dav1d_apply_grain_row_8bpc(
             dsp,
             out,
             in_0,
-            scaling.as_mut_ptr() as *const [uint8_t; 256],
-            grain_lut.as_mut_ptr() as *const [[entry; 82]; 74],
+            scaling.0.as_mut_ptr() as *const [uint8_t; 256],
+            grain_lut.0.as_mut_ptr() as *const [[entry; 82]; 74],
             row,
         );
         row += 1;


### PR DESCRIPTION
We were missing some alignment wrappers which was causing some avx512 assembly instructions to segfault.

@thedataking I'm curious why this isn't caught in CI, and if we can maybe fix that before merging the fix. My best guess is maybe my local CPU has more advanced SIMD capabilites, e.g. maybe my machine is using the avx512 instructions but the CI machines only have SSE.