### PR TITLE
Deduplicate previously unnamed `union Dav1dTaskContext_cf`

### DIFF
--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -829,12 +829,7 @@ pub struct C2RustUnnamed_41 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_cf {
-    pub cf_8bpc: [int16_t; 1024],
-    pub cf_16bpc: [int32_t; 1024],
-}
+use crate::src::internal::Dav1dTaskContext_cf;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct refmvs_tile {

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -718,7 +718,7 @@ pub struct Dav1dTaskContext {
     pub l: BlockContext,
     pub a: *mut BlockContext,
     pub rt: refmvs_tile,
-    pub c2rust_unnamed: C2RustUnnamed_42,
+    pub c2rust_unnamed: Dav1dTaskContext_cf,
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
@@ -831,7 +831,7 @@ pub struct C2RustUnnamed_41 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_42 {
+pub union Dav1dTaskContext_cf {
     pub cf_8bpc: [int16_t; 1024],
     pub cf_16bpc: [int32_t; 1024],
 }

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -829,12 +829,7 @@ pub struct C2RustUnnamed_41 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_cf {
-    pub cf_8bpc: [int16_t; 1024],
-    pub cf_16bpc: [int32_t; 1024],
-}
+use crate::src::internal::Dav1dTaskContext_cf;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct refmvs_tile {

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -718,7 +718,7 @@ pub struct Dav1dTaskContext {
     pub l: BlockContext,
     pub a: *mut BlockContext,
     pub rt: refmvs_tile,
-    pub c2rust_unnamed: C2RustUnnamed_42,
+    pub c2rust_unnamed: Dav1dTaskContext_cf,
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
@@ -831,7 +831,7 @@ pub struct C2RustUnnamed_41 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_42 {
+pub union Dav1dTaskContext_cf {
     pub cf_8bpc: [int16_t; 1024],
     pub cf_16bpc: [int32_t; 1024],
 }

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -729,7 +729,7 @@ pub struct Dav1dTaskContext {
     pub l: BlockContext,
     pub a: *mut BlockContext,
     pub rt: refmvs_tile,
-    pub c2rust_unnamed: C2RustUnnamed_42,
+    pub c2rust_unnamed: Dav1dTaskContext_cf,
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
@@ -842,7 +842,7 @@ pub struct C2RustUnnamed_41 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_42 {
+pub union Dav1dTaskContext_cf {
     pub cf_8bpc: [int16_t; 1024],
     pub cf_16bpc: [int32_t; 1024],
 }

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -840,12 +840,7 @@ pub struct C2RustUnnamed_41 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_cf {
-    pub cf_8bpc: [int16_t; 1024],
-    pub cf_16bpc: [int32_t; 1024],
-}
+use crate::src::internal::Dav1dTaskContext_cf;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct refmvs_tile {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1191,12 +1191,7 @@ pub struct C2RustUnnamed_41 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_cf {
-    pub cf_8bpc: [int16_t; 1024],
-    pub cf_16bpc: [int32_t; 1024],
-}
+use crate::src::internal::Dav1dTaskContext_cf;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct refmvs_tile {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1080,7 +1080,7 @@ pub struct Dav1dTaskContext {
     pub l: BlockContext,
     pub a: *mut BlockContext,
     pub rt: refmvs_tile,
-    pub c2rust_unnamed: C2RustUnnamed_42,
+    pub c2rust_unnamed: Dav1dTaskContext_cf,
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
@@ -1193,7 +1193,7 @@ pub struct C2RustUnnamed_41 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_42 {
+pub union Dav1dTaskContext_cf {
     pub cf_8bpc: [int16_t; 1024],
     pub cf_16bpc: [int32_t; 1024],
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,5 +1,6 @@
 use crate::include::dav1d::data::Dav1dData;
 use crate::include::stdint::int16_t;
+use crate::include::stdint::int32_t;
 use crate::include::stdint::uint8_t;
 
 #[derive(Copy, Clone)]
@@ -56,4 +57,11 @@ pub struct CodedBlockInfo {
 pub struct FrameTileThreadData {
     pub lowest_pixel_mem: *mut [[libc::c_int; 2]; 7],
     pub lowest_pixel_mem_sz: libc::c_int,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub union Dav1dTaskContext_cf {
+    pub cf_8bpc: [int16_t; 1024],
+    pub cf_16bpc: [int32_t; 1024],
 }

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -829,12 +829,7 @@ pub struct C2RustUnnamed_41 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_cf {
-    pub cf_8bpc: [int16_t; 1024],
-    pub cf_16bpc: [int32_t; 1024],
-}
+use crate::src::internal::Dav1dTaskContext_cf;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct refmvs_tile {

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -718,7 +718,7 @@ pub struct Dav1dTaskContext {
     pub l: BlockContext,
     pub a: *mut BlockContext,
     pub rt: refmvs_tile,
-    pub c2rust_unnamed: C2RustUnnamed_42,
+    pub c2rust_unnamed: Dav1dTaskContext_cf,
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
@@ -831,7 +831,7 @@ pub struct C2RustUnnamed_41 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_42 {
+pub union Dav1dTaskContext_cf {
     pub cf_8bpc: [int16_t; 1024],
     pub cf_16bpc: [int32_t; 1024],
 }

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -829,12 +829,7 @@ pub struct C2RustUnnamed_41 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_cf {
-    pub cf_8bpc: [int16_t; 1024],
-    pub cf_16bpc: [int32_t; 1024],
-}
+use crate::src::internal::Dav1dTaskContext_cf;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct refmvs_tile {

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -718,7 +718,7 @@ pub struct Dav1dTaskContext {
     pub l: BlockContext,
     pub a: *mut BlockContext,
     pub rt: refmvs_tile,
-    pub c2rust_unnamed: C2RustUnnamed_42,
+    pub c2rust_unnamed: Dav1dTaskContext_cf,
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
@@ -831,7 +831,7 @@ pub struct C2RustUnnamed_41 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_42 {
+pub union Dav1dTaskContext_cf {
     pub cf_8bpc: [int16_t; 1024],
     pub cf_16bpc: [int32_t; 1024],
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1143,7 +1143,7 @@ pub struct Dav1dTaskContext {
     pub l: BlockContext,
     pub a: *mut BlockContext,
     pub rt: refmvs_tile,
-    pub c2rust_unnamed: C2RustUnnamed_36,
+    pub c2rust_unnamed: Dav1dTaskContext_cf,
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
@@ -1258,7 +1258,7 @@ pub struct C2RustUnnamed_35 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_36 {
+pub union Dav1dTaskContext_cf {
     pub cf_8bpc: [int16_t; 1024],
     pub cf_16bpc: [int32_t; 1024],
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1256,12 +1256,7 @@ pub struct C2RustUnnamed_35 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_cf {
-    pub cf_8bpc: [int16_t; 1024],
-    pub cf_16bpc: [int32_t; 1024],
-}
+use crate::src::internal::Dav1dTaskContext_cf;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct refmvs_tile {

--- a/src/log.rs
+++ b/src/log.rs
@@ -1108,12 +1108,7 @@ pub struct C2RustUnnamed_35 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_cf {
-    pub cf_8bpc: [int16_t; 1024],
-    pub cf_16bpc: [int32_t; 1024],
-}
+use crate::src::internal::Dav1dTaskContext_cf;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct refmvs_tile {

--- a/src/log.rs
+++ b/src/log.rs
@@ -995,7 +995,7 @@ pub struct Dav1dTaskContext {
     pub l: BlockContext,
     pub a: *mut BlockContext,
     pub rt: refmvs_tile,
-    pub c2rust_unnamed: C2RustUnnamed_36,
+    pub c2rust_unnamed: Dav1dTaskContext_cf,
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
@@ -1110,7 +1110,7 @@ pub struct C2RustUnnamed_35 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_36 {
+pub union Dav1dTaskContext_cf {
     pub cf_8bpc: [int16_t; 1024],
     pub cf_16bpc: [int32_t; 1024],
 }

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -830,12 +830,7 @@ pub struct C2RustUnnamed_41 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_cf {
-    pub cf_8bpc: [int16_t; 1024],
-    pub cf_16bpc: [int32_t; 1024],
-}
+use crate::src::internal::Dav1dTaskContext_cf;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct refmvs_tile {

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -719,7 +719,7 @@ pub struct Dav1dTaskContext {
     pub l: BlockContext,
     pub a: *mut BlockContext,
     pub rt: refmvs_tile,
-    pub c2rust_unnamed: C2RustUnnamed_42,
+    pub c2rust_unnamed: Dav1dTaskContext_cf,
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
@@ -832,7 +832,7 @@ pub struct C2RustUnnamed_41 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_42 {
+pub union Dav1dTaskContext_cf {
     pub cf_8bpc: [int16_t; 1024],
     pub cf_16bpc: [int32_t; 1024],
 }

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -830,12 +830,7 @@ pub struct C2RustUnnamed_41 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_cf {
-    pub cf_8bpc: [int16_t; 1024],
-    pub cf_16bpc: [int32_t; 1024],
-}
+use crate::src::internal::Dav1dTaskContext_cf;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct refmvs_tile {

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -719,7 +719,7 @@ pub struct Dav1dTaskContext {
     pub l: BlockContext,
     pub a: *mut BlockContext,
     pub rt: refmvs_tile,
-    pub c2rust_unnamed: C2RustUnnamed_42,
+    pub c2rust_unnamed: Dav1dTaskContext_cf,
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
@@ -832,7 +832,7 @@ pub struct C2RustUnnamed_41 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_42 {
+pub union Dav1dTaskContext_cf {
     pub cf_8bpc: [int16_t; 1024],
     pub cf_16bpc: [int32_t; 1024],
 }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -874,12 +874,7 @@ pub struct C2RustUnnamed_41 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_cf {
-    pub cf_8bpc: [int16_t; 1024],
-    pub cf_16bpc: [int32_t; 1024],
-}
+use crate::src::internal::Dav1dTaskContext_cf;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct refmvs_tile {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -763,7 +763,7 @@ pub struct Dav1dTaskContext {
     pub l: BlockContext,
     pub a: *mut BlockContext,
     pub rt: refmvs_tile,
-    pub c2rust_unnamed: C2RustUnnamed_42,
+    pub c2rust_unnamed: Dav1dTaskContext_cf,
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
@@ -876,7 +876,7 @@ pub struct C2RustUnnamed_41 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_42 {
+pub union Dav1dTaskContext_cf {
     pub cf_8bpc: [int16_t; 1024],
     pub cf_16bpc: [int32_t; 1024],
 }

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -870,12 +870,7 @@ pub struct C2RustUnnamed_41 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_cf {
-    pub cf_8bpc: [int16_t; 1024],
-    pub cf_16bpc: [int32_t; 1024],
-}
+use crate::src::internal::Dav1dTaskContext_cf;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct refmvs_tile {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -760,7 +760,7 @@ pub struct Dav1dTaskContext {
     pub l: BlockContext,
     pub a: *mut BlockContext,
     pub rt: refmvs_tile,
-    pub c2rust_unnamed: C2RustUnnamed_42,
+    pub c2rust_unnamed: Dav1dTaskContext_cf,
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
@@ -872,7 +872,7 @@ pub struct C2RustUnnamed_41 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_42 {
+pub union Dav1dTaskContext_cf {
     pub cf_8bpc: [int16_t; 1024],
     pub cf_16bpc: [int32_t; 1024],
 }

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -926,12 +926,7 @@ pub struct C2RustUnnamed_41 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_cf {
-    pub cf_8bpc: [int16_t; 1024],
-    pub cf_16bpc: [int32_t; 1024],
-}
+use crate::src::internal::Dav1dTaskContext_cf;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct refmvs_tile {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -815,7 +815,7 @@ pub struct Dav1dTaskContext {
     pub l: BlockContext,
     pub a: *mut BlockContext,
     pub rt: refmvs_tile,
-    pub c2rust_unnamed: C2RustUnnamed_42,
+    pub c2rust_unnamed: Dav1dTaskContext_cf,
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
@@ -928,7 +928,7 @@ pub struct C2RustUnnamed_41 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_42 {
+pub union Dav1dTaskContext_cf {
     pub cf_8bpc: [int16_t; 1024],
     pub cf_16bpc: [int32_t; 1024],
 }

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -807,7 +807,7 @@ pub struct Dav1dTaskContext {
     pub l: BlockContext,
     pub a: *mut BlockContext,
     pub rt: refmvs_tile,
-    pub c2rust_unnamed: C2RustUnnamed_42,
+    pub c2rust_unnamed: Dav1dTaskContext_cf,
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
@@ -920,7 +920,7 @@ pub struct C2RustUnnamed_41 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_42 {
+pub union Dav1dTaskContext_cf {
     pub cf_8bpc: [int16_t; 1024],
     pub cf_16bpc: [int32_t; 1024],
 }

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -918,12 +918,7 @@ pub struct C2RustUnnamed_41 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_cf {
-    pub cf_8bpc: [int16_t; 1024],
-    pub cf_16bpc: [int32_t; 1024],
-}
+use crate::src::internal::Dav1dTaskContext_cf;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct refmvs_tile {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -875,12 +875,7 @@ pub struct C2RustUnnamed_41 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_cf {
-    pub cf_8bpc: [int16_t; 1024],
-    pub cf_16bpc: [int32_t; 1024],
-}
+use crate::src::internal::Dav1dTaskContext_cf;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct refmvs_tile {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -764,7 +764,7 @@ pub struct Dav1dTaskContext {
     pub l: BlockContext,
     pub a: *mut BlockContext,
     pub rt: refmvs_tile,
-    pub c2rust_unnamed: C2RustUnnamed_42,
+    pub c2rust_unnamed: Dav1dTaskContext_cf,
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
@@ -877,7 +877,7 @@ pub struct C2RustUnnamed_41 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_42 {
+pub union Dav1dTaskContext_cf {
     pub cf_8bpc: [int16_t; 1024],
     pub cf_16bpc: [int32_t; 1024],
 }


### PR DESCRIPTION
Now that type is deduplicated, it can be easily `#[repr(align(64))]`ed like in the C source: https://github.com/memorysafety/rav1d/blob/c2fb626189f313dd3ed8f1b74dbcfd80f333a43c/src/internal.h#L397-L400