### PR TITLE
Deduplicate previously unnamed `union Dav1dTaskContext_scratch_interintra_edge` and its 2 unnamed `struct` fields

### DIFF
--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -780,12 +780,7 @@ pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
-    pub interintra_16bpc: [uint16_t; 4096],
-    pub edge_16bpc: [uint16_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -786,12 +786,7 @@ pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
-    pub interintra_8bpc: [uint8_t; 4096],
-    pub edge_8bpc: [uint8_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -777,7 +777,7 @@ pub struct C2RustUnnamed_32 {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_33 {
-    pub c2rust_unnamed: C2RustUnnamed_35,
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: C2RustUnnamed_34,
 }
 #[derive(Copy, Clone)]
@@ -788,7 +788,7 @@ pub struct C2RustUnnamed_34 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_35 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],
 }

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -774,14 +774,9 @@ pub struct C2RustUnnamed_32 {
     pub pal: [[uint16_t; 8]; 3],
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -772,11 +772,11 @@ pub struct C2RustUnnamed_32 {
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: C2RustUnnamed_33,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_33 {
+pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -778,11 +778,11 @@ pub struct C2RustUnnamed_32 {
 #[repr(C)]
 pub union C2RustUnnamed_33 {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: C2RustUnnamed_34,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_34 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -780,12 +780,7 @@ pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
-    pub interintra_16bpc: [uint16_t; 4096],
-    pub edge_16bpc: [uint16_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -786,12 +786,7 @@ pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
-    pub interintra_8bpc: [uint8_t; 4096],
-    pub edge_8bpc: [uint8_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -777,7 +777,7 @@ pub struct C2RustUnnamed_32 {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_33 {
-    pub c2rust_unnamed: C2RustUnnamed_35,
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: C2RustUnnamed_34,
 }
 #[derive(Copy, Clone)]
@@ -788,7 +788,7 @@ pub struct C2RustUnnamed_34 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_35 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],
 }

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -774,14 +774,9 @@ pub struct C2RustUnnamed_32 {
     pub pal: [[uint16_t; 8]; 3],
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -772,11 +772,11 @@ pub struct C2RustUnnamed_32 {
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: C2RustUnnamed_33,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_33 {
+pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -778,11 +778,11 @@ pub struct C2RustUnnamed_32 {
 #[repr(C)]
 pub union C2RustUnnamed_33 {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: C2RustUnnamed_34,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_34 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -797,12 +797,7 @@ pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
-    pub interintra_8bpc: [uint8_t; 4096],
-    pub edge_8bpc: [uint8_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -791,12 +791,7 @@ pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
-    pub interintra_16bpc: [uint16_t; 4096],
-    pub edge_16bpc: [uint16_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -783,11 +783,11 @@ pub struct C2RustUnnamed_32 {
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: C2RustUnnamed_33,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_33 {
+pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -788,7 +788,7 @@ pub struct C2RustUnnamed_32 {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_33 {
-    pub c2rust_unnamed: C2RustUnnamed_35,
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: C2RustUnnamed_34,
 }
 #[derive(Copy, Clone)]
@@ -799,7 +799,7 @@ pub struct C2RustUnnamed_34 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_35 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],
 }

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -785,14 +785,9 @@ pub struct C2RustUnnamed_32 {
     pub pal: [[uint16_t; 8]; 3],
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -789,11 +789,11 @@ pub struct C2RustUnnamed_32 {
 #[repr(C)]
 pub union C2RustUnnamed_33 {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: C2RustUnnamed_34,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_34 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1148,12 +1148,7 @@ pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
-    pub interintra_8bpc: [uint8_t; 4096],
-    pub edge_8bpc: [uint8_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1140,11 +1140,11 @@ pub struct C2RustUnnamed_32 {
 #[repr(C)]
 pub union C2RustUnnamed_33 {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: C2RustUnnamed_34,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_34 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1142,12 +1142,7 @@ pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
-    pub interintra_16bpc: [uint16_t; 4096],
-    pub edge_16bpc: [uint16_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1136,14 +1136,9 @@ pub struct C2RustUnnamed_32 {
     pub pal: [[uint16_t; 8]; 3],
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1134,11 +1134,11 @@ pub struct C2RustUnnamed_32 {
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: C2RustUnnamed_33,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_33 {
+pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1139,7 +1139,7 @@ pub struct C2RustUnnamed_32 {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_33 {
-    pub c2rust_unnamed: C2RustUnnamed_35,
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: C2RustUnnamed_34,
 }
 #[derive(Copy, Clone)]
@@ -1150,7 +1150,7 @@ pub struct C2RustUnnamed_34 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_35 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -65,3 +65,10 @@ pub union Dav1dTaskContext_cf {
     pub cf_8bpc: [int16_t; 1024],
     pub cf_16bpc: [int32_t; 1024],
 }
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
+    pub interintra_8bpc: [uint8_t; 4096],
+    pub edge_8bpc: [uint8_t; 257],
+}

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -2,6 +2,7 @@ use crate::include::dav1d::data::Dav1dData;
 use crate::include::stdint::int16_t;
 use crate::include::stdint::int32_t;
 use crate::include::stdint::uint8_t;
+use crate::include::stdint::uint16_t;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -71,4 +72,11 @@ pub union Dav1dTaskContext_cf {
 pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
+    pub interintra_16bpc: [uint16_t; 4096],
+    pub edge_16bpc: [uint16_t; 257],
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -80,3 +80,10 @@ pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub union Dav1dTaskContext_scratch_interintra_edge {
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
+}

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -780,12 +780,7 @@ pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
-    pub interintra_16bpc: [uint16_t; 4096],
-    pub edge_16bpc: [uint16_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -786,12 +786,7 @@ pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
-    pub interintra_8bpc: [uint8_t; 4096],
-    pub edge_8bpc: [uint8_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -777,7 +777,7 @@ pub struct C2RustUnnamed_32 {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_33 {
-    pub c2rust_unnamed: C2RustUnnamed_35,
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: C2RustUnnamed_34,
 }
 #[derive(Copy, Clone)]
@@ -788,7 +788,7 @@ pub struct C2RustUnnamed_34 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_35 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],
 }

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -774,14 +774,9 @@ pub struct C2RustUnnamed_32 {
     pub pal: [[uint16_t; 8]; 3],
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -772,11 +772,11 @@ pub struct C2RustUnnamed_32 {
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: C2RustUnnamed_33,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_33 {
+pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -778,11 +778,11 @@ pub struct C2RustUnnamed_32 {
 #[repr(C)]
 pub union C2RustUnnamed_33 {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: C2RustUnnamed_34,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_34 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -780,12 +780,7 @@ pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
-    pub interintra_16bpc: [uint16_t; 4096],
-    pub edge_16bpc: [uint16_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -786,12 +786,7 @@ pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
-    pub interintra_8bpc: [uint8_t; 4096],
-    pub edge_8bpc: [uint8_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -777,7 +777,7 @@ pub struct C2RustUnnamed_32 {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_33 {
-    pub c2rust_unnamed: C2RustUnnamed_35,
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: C2RustUnnamed_34,
 }
 #[derive(Copy, Clone)]
@@ -788,7 +788,7 @@ pub struct C2RustUnnamed_34 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_35 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],
 }

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -774,14 +774,9 @@ pub struct C2RustUnnamed_32 {
     pub pal: [[uint16_t; 8]; 3],
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -772,11 +772,11 @@ pub struct C2RustUnnamed_32 {
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: C2RustUnnamed_33,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_33 {
+pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -778,11 +778,11 @@ pub struct C2RustUnnamed_32 {
 #[repr(C)]
 pub union C2RustUnnamed_33 {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: C2RustUnnamed_34,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_34 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1207,12 +1207,7 @@ pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
-    pub interintra_16bpc: [uint16_t; 4096],
-    pub edge_16bpc: [uint16_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1199,11 +1199,11 @@ pub struct C2RustUnnamed_26 {
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: C2RustUnnamed_27,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_27 {
+pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1213,12 +1213,7 @@ pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
-    pub interintra_8bpc: [uint8_t; 4096],
-    pub edge_8bpc: [uint8_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_30 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1204,7 +1204,7 @@ pub struct C2RustUnnamed_26 {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_27 {
-    pub c2rust_unnamed: C2RustUnnamed_29,
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: C2RustUnnamed_28,
 }
 #[derive(Copy, Clone)]
@@ -1215,7 +1215,7 @@ pub struct C2RustUnnamed_28 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_29 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1201,14 +1201,9 @@ pub struct C2RustUnnamed_26 {
     pub pal: [[uint16_t; 8]; 3],
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_30 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1205,11 +1205,11 @@ pub struct C2RustUnnamed_26 {
 #[repr(C)]
 pub union C2RustUnnamed_27 {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: C2RustUnnamed_28,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_28 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -1059,12 +1059,7 @@ pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
-    pub interintra_16bpc: [uint16_t; 4096],
-    pub edge_16bpc: [uint16_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/log.rs
+++ b/src/log.rs
@@ -1056,7 +1056,7 @@ pub struct C2RustUnnamed_26 {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_27 {
-    pub c2rust_unnamed: C2RustUnnamed_29,
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: C2RustUnnamed_28,
 }
 #[derive(Copy, Clone)]
@@ -1067,7 +1067,7 @@ pub struct C2RustUnnamed_28 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_29 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -1053,14 +1053,9 @@ pub struct C2RustUnnamed_26 {
     pub pal: [[uint16_t; 8]; 3],
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_30 {

--- a/src/log.rs
+++ b/src/log.rs
@@ -1065,12 +1065,7 @@ pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
-    pub interintra_8bpc: [uint8_t; 4096],
-    pub edge_8bpc: [uint8_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_30 {

--- a/src/log.rs
+++ b/src/log.rs
@@ -1051,11 +1051,11 @@ pub struct C2RustUnnamed_26 {
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: C2RustUnnamed_27,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_27 {
+pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -1057,11 +1057,11 @@ pub struct C2RustUnnamed_26 {
 #[repr(C)]
 pub union C2RustUnnamed_27 {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: C2RustUnnamed_28,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_28 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -778,7 +778,7 @@ pub struct C2RustUnnamed_32 {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_33 {
-    pub c2rust_unnamed: C2RustUnnamed_35,
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: C2RustUnnamed_34,
 }
 #[derive(Copy, Clone)]
@@ -789,7 +789,7 @@ pub struct C2RustUnnamed_34 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_35 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],
 }

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -787,12 +787,7 @@ pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
-    pub interintra_8bpc: [uint8_t; 4096],
-    pub edge_8bpc: [uint8_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -779,11 +779,11 @@ pub struct C2RustUnnamed_32 {
 #[repr(C)]
 pub union C2RustUnnamed_33 {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: C2RustUnnamed_34,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_34 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -773,11 +773,11 @@ pub struct C2RustUnnamed_32 {
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: C2RustUnnamed_33,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_33 {
+pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -781,12 +781,7 @@ pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
-    pub interintra_16bpc: [uint16_t; 4096],
-    pub edge_16bpc: [uint16_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -775,14 +775,9 @@ pub struct C2RustUnnamed_32 {
     pub pal: [[uint16_t; 8]; 3],
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -778,7 +778,7 @@ pub struct C2RustUnnamed_32 {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_33 {
-    pub c2rust_unnamed: C2RustUnnamed_35,
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: C2RustUnnamed_34,
 }
 #[derive(Copy, Clone)]
@@ -789,7 +789,7 @@ pub struct C2RustUnnamed_34 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_35 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],
 }

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -787,12 +787,7 @@ pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
-    pub interintra_8bpc: [uint8_t; 4096],
-    pub edge_8bpc: [uint8_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -779,11 +779,11 @@ pub struct C2RustUnnamed_32 {
 #[repr(C)]
 pub union C2RustUnnamed_33 {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: C2RustUnnamed_34,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_34 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -773,11 +773,11 @@ pub struct C2RustUnnamed_32 {
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: C2RustUnnamed_33,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_33 {
+pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -781,12 +781,7 @@ pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
-    pub interintra_16bpc: [uint16_t; 4096],
-    pub edge_16bpc: [uint16_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -775,14 +775,9 @@ pub struct C2RustUnnamed_32 {
     pub pal: [[uint16_t; 8]; 3],
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -825,12 +825,7 @@ pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
-    pub interintra_16bpc: [uint16_t; 4096],
-    pub edge_16bpc: [uint16_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -831,12 +831,7 @@ pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
-    pub interintra_8bpc: [uint8_t; 4096],
-    pub edge_8bpc: [uint8_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -817,11 +817,11 @@ pub struct C2RustUnnamed_32 {
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: C2RustUnnamed_33,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_33 {
+pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -822,7 +822,7 @@ pub struct C2RustUnnamed_32 {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_33 {
-    pub c2rust_unnamed: C2RustUnnamed_35,
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: C2RustUnnamed_34,
 }
 #[derive(Copy, Clone)]
@@ -833,7 +833,7 @@ pub struct C2RustUnnamed_34 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_35 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],
 }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -823,11 +823,11 @@ pub struct C2RustUnnamed_32 {
 #[repr(C)]
 pub union C2RustUnnamed_33 {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: C2RustUnnamed_34,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_34 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -819,14 +819,9 @@ pub struct C2RustUnnamed_32 {
     pub pal: [[uint16_t; 8]; 3],
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -819,11 +819,11 @@ pub struct C2RustUnnamed_32 {
 #[repr(C)]
 pub union C2RustUnnamed_33 {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: C2RustUnnamed_34,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_34 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -821,12 +821,7 @@ pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
-    pub interintra_16bpc: [uint16_t; 4096],
-    pub edge_16bpc: [uint16_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -818,7 +818,7 @@ pub struct C2RustUnnamed_32 {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_33 {
-    pub c2rust_unnamed: C2RustUnnamed_35,
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: C2RustUnnamed_34,
 }
 #[derive(Copy, Clone)]
@@ -829,7 +829,7 @@ pub struct C2RustUnnamed_34 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_35 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],
 }

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -815,14 +815,9 @@ pub struct C2RustUnnamed_32 {
     pub pal: [[uint16_t; 8]; 3],
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -813,11 +813,11 @@ pub struct C2RustUnnamed_32 {
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: C2RustUnnamed_33,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_33 {
+pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -827,12 +827,7 @@ pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
-    pub interintra_8bpc: [uint8_t; 4096],
-    pub edge_8bpc: [uint8_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -877,12 +877,7 @@ pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
-    pub interintra_16bpc: [uint16_t; 4096],
-    pub edge_16bpc: [uint16_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -875,11 +875,11 @@ pub struct C2RustUnnamed_32 {
 #[repr(C)]
 pub union C2RustUnnamed_33 {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: C2RustUnnamed_34,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_34 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -874,7 +874,7 @@ pub struct C2RustUnnamed_32 {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_33 {
-    pub c2rust_unnamed: C2RustUnnamed_35,
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: C2RustUnnamed_34,
 }
 #[derive(Copy, Clone)]
@@ -885,7 +885,7 @@ pub struct C2RustUnnamed_34 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_35 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],
 }

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -871,14 +871,9 @@ pub struct C2RustUnnamed_32 {
     pub pal: [[uint16_t; 8]; 3],
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -883,12 +883,7 @@ pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
-    pub interintra_8bpc: [uint8_t; 4096],
-    pub edge_8bpc: [uint8_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -869,11 +869,11 @@ pub struct C2RustUnnamed_32 {
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: C2RustUnnamed_33,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_33 {
+pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -866,7 +866,7 @@ pub struct C2RustUnnamed_32 {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_33 {
-    pub c2rust_unnamed: C2RustUnnamed_35,
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: C2RustUnnamed_34,
 }
 #[derive(Copy, Clone)]
@@ -877,7 +877,7 @@ pub struct C2RustUnnamed_34 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_35 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],
 }

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -863,14 +863,9 @@ pub struct C2RustUnnamed_32 {
     pub pal: [[uint16_t; 8]; 3],
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -867,11 +867,11 @@ pub struct C2RustUnnamed_32 {
 #[repr(C)]
 pub union C2RustUnnamed_33 {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: C2RustUnnamed_34,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_34 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -875,12 +875,7 @@ pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
-    pub interintra_8bpc: [uint8_t; 4096],
-    pub edge_8bpc: [uint8_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -869,12 +869,7 @@ pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
-    pub interintra_16bpc: [uint16_t; 4096],
-    pub edge_16bpc: [uint16_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -861,11 +861,11 @@ pub struct C2RustUnnamed_32 {
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: C2RustUnnamed_33,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_33 {
+pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -818,11 +818,11 @@ pub struct C2RustUnnamed_32 {
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: C2RustUnnamed_33,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_33 {
+pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -820,14 +820,9 @@ pub struct C2RustUnnamed_32 {
     pub pal: [[uint16_t; 8]; 3],
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -824,11 +824,11 @@ pub struct C2RustUnnamed_32 {
 #[repr(C)]
 pub union C2RustUnnamed_33 {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: C2RustUnnamed_34,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_34 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -823,7 +823,7 @@ pub struct C2RustUnnamed_32 {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_33 {
-    pub c2rust_unnamed: C2RustUnnamed_35,
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: C2RustUnnamed_34,
 }
 #[derive(Copy, Clone)]
@@ -834,7 +834,7 @@ pub struct C2RustUnnamed_34 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_35 {
+pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],
 }

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -826,12 +826,7 @@ pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
-    pub interintra_16bpc: [uint16_t; 4096],
-    pub edge_16bpc: [uint16_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_16;
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -832,12 +832,7 @@ pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
-    pub interintra_8bpc: [uint8_t; 4096],
-    pub edge_8bpc: [uint8_t; 257],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge_8;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_36 {


### PR DESCRIPTION
Now that type is deduplicated, it can be easily `#[repr(align(64))]`ed like in the C source: https://github.com/memorysafety/rav1d/blob/c2fb626189f313dd3ed8f1b74dbcfd80f333a43c/src/internal.h#L433-L442