### PR TITLE
`cargo fix` after #24

### DIFF
--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1992,7 +1992,7 @@ unsafe extern "C" fn get_skip_ctx(
     } else {
         let mut la: libc::c_uint = 0;
         let mut ll: libc::c_uint = 0;
-        let mut current_block_80: u64;
+        let mut _current_block_80: u64;
         match (*t_dim).lw  as libc::c_uint {
             TX_4X4 =>   MERGE_CTX_TX!(la, a, uint8_t,  TX_4X4),
             TX_8X8 =>   MERGE_CTX_TX!(la, a, uint16_t, TX_8X8),

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1957,7 +1957,7 @@ pub unsafe extern "C" fn dav1d_refmvs_tile_sbrow_init(
     };
     let mut r: *mut refmvs_block = &mut *((*rf).r)
         .offset(
-            (35 * (*rf).r_stride * tile_row_idx as isize + pass_off),
+            35 * (*rf).r_stride * tile_row_idx as isize + pass_off,
         ) as *mut refmvs_block;
     let sbsz: libc::c_int = (*rf).sbsz;
     let off: libc::c_int = sbsz * sby & 16 as libc::c_int;
@@ -2024,8 +2024,8 @@ pub unsafe extern "C" fn dav1d_refmvs_load_tmvs(
     let stride: ptrdiff_t = (*rf).rp_stride;
     let mut rp_proj: *mut refmvs_temporal_block = &mut *((*rf).rp_proj)
         .offset(
-            (16  * stride * tile_row_idx as isize
-                + (row_start8 & 15) as isize * stride),
+            16  * stride * tile_row_idx as isize
+                + (row_start8 & 15) as isize * stride,
         ) as *mut refmvs_temporal_block;
     let mut y: libc::c_int = row_start8;
     while y < row_end8 {
@@ -2038,7 +2038,7 @@ pub unsafe extern "C" fn dav1d_refmvs_load_tmvs(
         y += 1;
     }
     rp_proj = &mut *((*rf).rp_proj)
-        .offset((16 * stride * tile_row_idx as isize)) as *mut refmvs_temporal_block;
+        .offset(16 * stride * tile_row_idx as isize) as *mut refmvs_temporal_block;
     let mut n: libc::c_int = 0 as libc::c_int;
     while n < (*rf).n_mfmvs {
         let ref2cur: libc::c_int = (*rf).mfmv_ref2cur[n as usize];

--- a/tools/input/section5.rs
+++ b/tools/input/section5.rs
@@ -28,7 +28,7 @@ extern "C" {
 
 use crate::include::sys::types::__off64_t;
 
-use crate::include::sys::types::off_t;
+
 use crate::include::dav1d::headers::Dav1dObuType;
 
 


### PR DESCRIPTION
To keep things `cargo fix`-clean after #56 so `cargo fix` can be easily used for removing unused imports during deduplication, for example.

Should be mergeable right away; just wanted to double-check with CI first; hence the PR. 