### PR TITLE
Re-transpilation after naming the unnamed types that don't require other code changes (i.e. naming fields)

### DIFF
--- a/examples/dav1dplay.c
+++ b/examples/dav1dplay.c
@@ -146,7 +146,7 @@ static void dp_rd_ctx_parse_args(Dav1dPlayRenderContext *rd_ctx,
     // Short options
     static const char short_opts[] = "i:vuzgr:";
 
-    enum {
+    enum arg {
         ARG_THREADS = 256,
         ARG_FRAME_DELAY,
         ARG_HIGH_QUALITY,

--- a/examples/dp_renderer.h
+++ b/examples/dp_renderer.h
@@ -66,7 +66,7 @@ typedef struct {
 #define WINDOW_WIDTH  910
 #define WINDOW_HEIGHT 512
 
-enum {
+enum dav1d_event {
     DAV1D_EVENT_NEW_FRAME,
     DAV1D_EVENT_SEEK_FRAME,
     DAV1D_EVENT_DEC_QUIT

--- a/include/dav1d/headers.h
+++ b/include/dav1d/headers.h
@@ -93,8 +93,8 @@ enum Dav1dWarpedMotionType {
 typedef struct Dav1dWarpedMotionParams {
     enum Dav1dWarpedMotionType type;
     int32_t matrix[6];
-    union {
-        struct {
+    union Dav1dWarpedMotionParams_u {
+        struct Dav1dWarpedMotionParams_u_p {
             int16_t alpha, beta, gamma, delta;
         } p;
         int16_t abcd[4];
@@ -333,7 +333,7 @@ typedef struct Dav1dFilmGrainData {
 } Dav1dFilmGrainData;
 
 typedef struct Dav1dFrameHeader {
-    struct {
+    struct Dav1dFrameHeader_film_grain {
         Dav1dFilmGrainData data;
         int present, update;
     } film_grain; ///< film grain parameters
@@ -361,7 +361,7 @@ typedef struct Dav1dFrameHeader {
     } operating_points[DAV1D_MAX_OPERATING_POINTS];
     int refresh_frame_flags;
     int render_width, render_height;
-    struct {
+    struct Dav1dFrameHeader_super_res {
         int width_scale_denominator;
         int enabled;
     } super_res;
@@ -374,7 +374,7 @@ typedef struct Dav1dFrameHeader {
     int switchable_motion_mode;
     int use_ref_frame_mvs;
     int refresh_context;
-    struct {
+    struct Dav1dFrameHeader_tiling {
         int uniform;
         unsigned n_bytes;
         int min_log2_cols, max_log2_cols, log2_cols, cols;
@@ -383,30 +383,30 @@ typedef struct Dav1dFrameHeader {
         uint16_t row_start_sb[DAV1D_MAX_TILE_ROWS + 1];
         int update;
     } tiling;
-    struct {
+    struct Dav1dFrameHeader_quant {
         int yac;
         int ydc_delta;
         int udc_delta, uac_delta, vdc_delta, vac_delta;
         int qm, qm_y, qm_u, qm_v;
     } quant;
-    struct {
+    struct Dav1dFrameHeader_segmentation {
         int enabled, update_map, temporal, update_data;
         Dav1dSegmentationDataSet seg_data;
         int lossless[DAV1D_MAX_SEGMENTS], qidx[DAV1D_MAX_SEGMENTS];
     } segmentation;
-    struct {
-        struct {
+    struct Dav1dFrameHeader_delta {
+        struct Dav1dFrameHeader_delta_q {
             int present;
             int res_log2;
         } q;
-        struct {
+        struct Dav1dFrameHeader_delta_lf {
             int present;
             int res_log2;
             int multi;
         } lf;
     } delta;
     int all_lossless;
-    struct {
+    struct Dav1dFrameHeader_loopfilter {
         int level_y[2 /* dir */];
         int level_u, level_v;
         int mode_ref_delta_enabled;
@@ -414,13 +414,13 @@ typedef struct Dav1dFrameHeader {
         Dav1dLoopfilterModeRefDeltas mode_ref_deltas;
         int sharpness;
     } loopfilter;
-    struct {
+    struct Dav1dFrameHeader_cdef {
         int damping;
         int n_bits;
         int y_strength[DAV1D_MAX_CDEF_STRENGTHS];
         int uv_strength[DAV1D_MAX_CDEF_STRENGTHS];
     } cdef;
-    struct {
+    struct Dav1dFrameHeader_restoration {
         enum Dav1dRestorationType type[3 /* plane */];
         int unit_size[2 /* y, uv */];
     } restoration;

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -60,7 +60,7 @@ pub struct Dav1dFrameContext {
     pub ts: *mut Dav1dTileState,
     pub n_ts: libc::c_int,
     pub dsp: *const Dav1dDSPContext,
-    pub bd_fn: C2RustUnnamed_28,
+    pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
     pub ipred_edge: [*mut pixel; 3],
     pub b4_stride: ptrdiff_t,
@@ -81,15 +81,15 @@ pub struct Dav1dFrameContext {
     pub rf: refmvs_frame,
     pub jnt_weights: [[uint8_t; 7]; 7],
     pub bitdepth_max: libc::c_int,
-    pub frame_thread: C2RustUnnamed_20,
-    pub lf: C2RustUnnamed_19,
-    pub task_thread: C2RustUnnamed,
+    pub frame_thread: Dav1dFrameContext_frame_thread,
+    pub lf: Dav1dFrameContext_lf,
+    pub task_thread: Dav1dFrameContext_task_thread,
     pub tile_thread: FrameTileThreadData,
 }
 use crate::src::internal::FrameTileThreadData;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed {
+pub struct Dav1dFrameContext_task_thread {
     pub lock: pthread_mutex_t,
     pub cond: pthread_cond_t,
     pub ttd: *mut TaskThreadData,
@@ -107,11 +107,11 @@ pub struct C2RustUnnamed {
     pub task_head: *mut Dav1dTask,
     pub task_tail: *mut Dav1dTask,
     pub task_cur_prev: *mut Dav1dTask,
-    pub pending_tasks: C2RustUnnamed_0,
+    pub pending_tasks: Dav1dFrameContext_task_thread_pending_tasks,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dFrameContext_task_thread_pending_tasks {
     pub merge: atomic_int,
     pub lock: pthread_mutex_t,
     pub head: *mut Dav1dTask,
@@ -145,35 +145,35 @@ pub struct TaskThreadData {
     pub cur: libc::c_uint,
     pub reset_task_cur: atomic_uint,
     pub cond_signaled: atomic_int,
-    pub delayed_fg: C2RustUnnamed_1,
+    pub delayed_fg: Dav1dContext_task_thread_delayed_fg,
     pub inited: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dContext_task_thread_delayed_fg {
     pub exec: libc::c_int,
     pub cond: pthread_cond_t,
     pub in_0: *const Dav1dPicture,
     pub out: *mut Dav1dPicture,
     pub type_0: TaskType,
     pub progress: [atomic_int; 2],
-    pub c2rust_unnamed: C2RustUnnamed_2,
+    pub c2rust_unnamed: C2RustUnnamed,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_2 {
-    pub c2rust_unnamed: C2RustUnnamed_4,
-    pub c2rust_unnamed_0: C2RustUnnamed_3,
+pub union C2RustUnnamed {
+    pub c2rust_unnamed: C2RustUnnamed_1,
+    pub c2rust_unnamed_0: C2RustUnnamed_0,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct C2RustUnnamed_0 {
     pub grain_lut_16bpc: [[[int16_t; 82]; 74]; 3],
     pub scaling_16bpc: [[uint8_t; 4096]; 3],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
+pub struct C2RustUnnamed_1 {
     pub grain_lut_8bpc: [[[int8_t; 82]; 74]; 3],
     pub scaling_8bpc: [[uint8_t; 256]; 3],
 }
@@ -211,7 +211,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_17,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -235,7 +235,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_16,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -245,14 +245,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_15,
-    pub quant: C2RustUnnamed_14,
-    pub segmentation: C2RustUnnamed_13,
-    pub delta: C2RustUnnamed_10,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_9,
-    pub cdef: C2RustUnnamed_8,
-    pub restoration: C2RustUnnamed_7,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -267,17 +267,17 @@ pub struct Dav1dFrameHeader {
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed_5,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_5 {
-    pub p: C2RustUnnamed_6,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -295,7 +295,7 @@ use crate::include::dav1d::headers::Dav1dTxfmMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
@@ -306,7 +306,7 @@ use crate::include::dav1d::headers::Dav1dRestorationType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -314,7 +314,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -326,26 +326,26 @@ pub struct C2RustUnnamed_9 {
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
-    pub q: C2RustUnnamed_12,
-    pub lf: C2RustUnnamed_11,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_12 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_13 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -358,7 +358,7 @@ use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_14 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -372,7 +372,7 @@ pub struct C2RustUnnamed_14 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_15 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -397,7 +397,7 @@ use crate::include::dav1d::headers::Dav1dFilterMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_16 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
@@ -409,7 +409,7 @@ use crate::include::dav1d::headers::Dav1dFrameType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_17 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
@@ -481,7 +481,7 @@ use crate::include::pthread::pthread_cond_t;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_19 {
+pub struct Dav1dFrameContext_lf {
     pub level: *mut [uint8_t; 4],
     pub mask: *mut Av1Filter,
     pub lr_mask: *mut Av1Restoration,
@@ -515,7 +515,7 @@ use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_20 {
+pub struct Dav1dFrameContext_frame_thread {
     pub next_tile_row: [libc::c_int; 2],
     pub entropy_progress: atomic_int,
     pub deblock_progress: atomic_int,
@@ -544,18 +544,18 @@ pub struct Av1Block {
     pub skip_mode: uint8_t,
     pub skip: uint8_t,
     pub uvtx: uint8_t,
-    pub c2rust_unnamed: C2RustUnnamed_21,
+    pub c2rust_unnamed: C2RustUnnamed_3,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_21 {
-    pub c2rust_unnamed: C2RustUnnamed_27,
-    pub c2rust_unnamed_0: C2RustUnnamed_22,
+pub union C2RustUnnamed_3 {
+    pub c2rust_unnamed: C2RustUnnamed_9,
+    pub c2rust_unnamed_0: C2RustUnnamed_4,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_22 {
-    pub c2rust_unnamed: C2RustUnnamed_23,
+pub struct C2RustUnnamed_4 {
+    pub c2rust_unnamed: C2RustUnnamed_5,
     pub comp_type: uint8_t,
     pub inter_mode: uint8_t,
     pub motion_mode: uint8_t,
@@ -569,31 +569,31 @@ pub struct C2RustUnnamed_22 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_23 {
-    pub c2rust_unnamed: C2RustUnnamed_26,
-    pub c2rust_unnamed_0: C2RustUnnamed_24,
+pub union C2RustUnnamed_5 {
+    pub c2rust_unnamed: C2RustUnnamed_8,
+    pub c2rust_unnamed_0: C2RustUnnamed_6,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_24 {
+pub struct C2RustUnnamed_6 {
     pub mv2d: mv,
     pub matrix: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union mv {
-    pub c2rust_unnamed: C2RustUnnamed_25,
+    pub c2rust_unnamed: C2RustUnnamed_7,
     pub n: uint32_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_25 {
+pub struct C2RustUnnamed_7 {
     pub y: int16_t,
     pub x: int16_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_26 {
+pub struct C2RustUnnamed_8 {
     pub mv: [mv; 2],
     pub wedge_idx: uint8_t,
     pub mask_sign: uint8_t,
@@ -601,7 +601,7 @@ pub struct C2RustUnnamed_26 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_27 {
+pub struct C2RustUnnamed_9 {
     pub y_mode: uint8_t,
     pub uv_mode: uint8_t,
     pub tx: uint8_t,
@@ -666,7 +666,7 @@ pub struct refmvs_temporal_block {
 use crate::src::env::BlockContext;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_28 {
+pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
     pub recon_b_inter: recon_b_inter_fn,
     pub filter_sbrow: filter_sbrow_fn,
@@ -722,18 +722,18 @@ pub struct Dav1dTaskContext {
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
-    pub scratch: C2RustUnnamed_31,
+    pub scratch: Dav1dTaskContext_scratch,
     pub warpmv: Dav1dWarpedMotionParams,
     pub lf_mask: *mut Av1Filter,
     pub top_pre_cdef_toggle: libc::c_int,
     pub cur_sb_cdef_idx_ptr: *mut int8_t,
     pub tl_4x4_filter: Filter2d,
-    pub frame_thread: C2RustUnnamed_30,
-    pub task_thread: C2RustUnnamed_29,
+    pub frame_thread: Dav1dTaskContext_frame_thread,
+    pub task_thread: Dav1dTaskContext_task_thread,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_29 {
+pub struct Dav1dTaskContext_task_thread {
     pub td: thread_data,
     pub ttd: *mut TaskThreadData,
     pub fttd: *mut FrameTileThreadData,
@@ -744,7 +744,7 @@ use crate::src::thread_data::thread_data;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_30 {
+pub struct Dav1dTaskContext_frame_thread {
     pub pass: libc::c_int,
 }
 use crate::src::levels::Filter2d;
@@ -761,14 +761,14 @@ use crate::src::levels::Filter2d;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_31 {
-    pub c2rust_unnamed: C2RustUnnamed_38,
-    pub c2rust_unnamed_0: C2RustUnnamed_32,
+pub union Dav1dTaskContext_scratch {
+    pub c2rust_unnamed: C2RustUnnamed_16,
+    pub c2rust_unnamed_0: C2RustUnnamed_10,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_32 {
-    pub c2rust_unnamed: C2RustUnnamed_36,
+pub struct C2RustUnnamed_10 {
+    pub c2rust_unnamed: C2RustUnnamed_14,
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
@@ -779,38 +779,38 @@ use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_36 {
+pub union C2RustUnnamed_14 {
     pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: C2RustUnnamed_37,
+    pub c2rust_unnamed: C2RustUnnamed_15,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_37 {
+pub struct C2RustUnnamed_15 {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_38 {
-    pub c2rust_unnamed: C2RustUnnamed_40,
-    pub c2rust_unnamed_0: C2RustUnnamed_39,
+pub struct C2RustUnnamed_16 {
+    pub c2rust_unnamed: C2RustUnnamed_18,
+    pub c2rust_unnamed_0: C2RustUnnamed_17,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_39 {
+pub union C2RustUnnamed_17 {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_40 {
+pub union C2RustUnnamed_18 {
     pub lap_8bpc: [uint8_t; 4096],
     pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: C2RustUnnamed_41,
+    pub c2rust_unnamed: C2RustUnnamed_19,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_41 {
+pub struct C2RustUnnamed_19 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
@@ -821,12 +821,12 @@ pub struct refmvs_tile {
     pub rf: *const refmvs_frame,
     pub r: [*mut refmvs_block; 37],
     pub rp_proj: *mut refmvs_temporal_block,
-    pub tile_col: C2RustUnnamed_43,
-    pub tile_row: C2RustUnnamed_43,
+    pub tile_col: refmvs_tile_range,
+    pub tile_row: refmvs_tile_range,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_43 {
+pub struct refmvs_tile_range {
     pub start: libc::c_int,
     pub end: libc::c_int,
 }
@@ -835,9 +835,9 @@ pub struct C2RustUnnamed_43 {
 pub struct Dav1dTileState {
     pub cdf: CdfContext,
     pub msac: MsacContext,
-    pub tiling: C2RustUnnamed_45,
+    pub tiling: Dav1dTileState_tiling,
     pub progress: [atomic_int; 2],
-    pub frame_thread: [C2RustUnnamed_44; 2],
+    pub frame_thread: [Dav1dTileState_frame_thread; 2],
     pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
     pub dqmem: [[[uint16_t; 2]; 3]; 8],
     pub dq: *const [[uint16_t; 2]; 3],
@@ -849,13 +849,13 @@ pub struct Dav1dTileState {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_44 {
+pub struct Dav1dTileState_frame_thread {
     pub pal_idx: *mut uint8_t,
     pub cf: *mut coef,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_45 {
+pub struct Dav1dTileState_tiling {
     pub col_start: libc::c_int,
     pub col_end: libc::c_int,
     pub row_start: libc::c_int,
@@ -892,16 +892,16 @@ pub struct Dav1dContext {
     pub cache: Dav1dThreadPicture,
     pub flush_mem: atomic_int,
     pub flush: *mut atomic_int,
-    pub frame_thread: C2RustUnnamed_50,
+    pub frame_thread: Dav1dContext_frame_thread,
     pub task_thread: TaskThreadData,
     pub segmap_pool: *mut Dav1dMemPool,
     pub refmvs_pool: *mut Dav1dMemPool,
-    pub refs: [C2RustUnnamed_49; 8],
+    pub refs: [Dav1dContext_refs; 8],
     pub cdf_pool: *mut Dav1dMemPool,
     pub cdf: [CdfThreadContext; 8],
     pub dsp: [Dav1dDSPContext; 3],
     pub refmvs_dsp: Dav1dRefmvsDSPContext,
-    pub intra_edge: C2RustUnnamed_46,
+    pub intra_edge: Dav1dContext_intra_edge,
     pub allocator: Dav1dPicAllocator,
     pub apply_grain: libc::c_int,
     pub operating_point: libc::c_int,
@@ -955,7 +955,7 @@ pub struct Dav1dPicAllocator {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_46 {
+pub struct Dav1dContext_intra_edge {
     pub root: [*mut EdgeNode; 2],
     pub branch_sb128: [EdgeBranch; 85],
     pub branch_sb64: [EdgeBranch; 21],
@@ -1025,11 +1025,11 @@ use crate::src::looprestoration::LrEdgeFlags;
 #[repr(C)]
 pub union LooprestorationParams {
     pub filter: [[int16_t; 8]; 2],
-    pub sgr: C2RustUnnamed_47,
+    pub sgr: LooprestorationParams_sgr,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_47 {
+pub struct LooprestorationParams_sgr {
     pub s0: uint32_t,
     pub s1: uint32_t,
     pub w0: int16_t,
@@ -1405,18 +1405,18 @@ pub type generate_grain_y_fn = Option::<
 #[repr(C)]
 pub struct CdfThreadContext {
     pub ref_0: *mut Dav1dRef,
-    pub data: C2RustUnnamed_48,
+    pub data: CdfThreadContext_data,
     pub progress: *mut atomic_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_48 {
+pub union CdfThreadContext_data {
     pub cdf: *mut CdfContext,
     pub qcat: libc::c_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_49 {
+pub struct Dav1dContext_refs {
     pub p: Dav1dThreadPicture,
     pub segmap: *mut Dav1dRef,
     pub refmvs: *mut Dav1dRef,
@@ -1433,7 +1433,7 @@ pub struct Dav1dThreadPicture {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_50 {
+pub struct Dav1dContext_frame_thread {
     pub out_delayed: *mut Dav1dThreadPicture,
     pub next: libc::c_uint,
 }

--- a/src/cdf.h
+++ b/src/cdf.h
@@ -131,7 +131,7 @@ typedef struct CdfContext {
 
 typedef struct CdfThreadContext {
     Dav1dRef *ref; ///< allocation origin
-    union {
+    union CdfThreadContext_data {
         CdfContext *cdf; // if ref != NULL
         unsigned qcat; // if ref == NULL, from static CDF tables
     } data;

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -69,7 +69,7 @@ pub struct Dav1dFrameContext {
     pub ts: *mut Dav1dTileState,
     pub n_ts: libc::c_int,
     pub dsp: *const Dav1dDSPContext,
-    pub bd_fn: C2RustUnnamed_28,
+    pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
     pub ipred_edge: [*mut libc::c_void; 3],
     pub b4_stride: ptrdiff_t,
@@ -90,15 +90,15 @@ pub struct Dav1dFrameContext {
     pub rf: refmvs_frame,
     pub jnt_weights: [[uint8_t; 7]; 7],
     pub bitdepth_max: libc::c_int,
-    pub frame_thread: C2RustUnnamed_20,
-    pub lf: C2RustUnnamed_19,
-    pub task_thread: C2RustUnnamed,
+    pub frame_thread: Dav1dFrameContext_frame_thread,
+    pub lf: Dav1dFrameContext_lf,
+    pub task_thread: Dav1dFrameContext_task_thread,
     pub tile_thread: FrameTileThreadData,
 }
 use crate::src::internal::FrameTileThreadData;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed {
+pub struct Dav1dFrameContext_task_thread {
     pub lock: pthread_mutex_t,
     pub cond: pthread_cond_t,
     pub ttd: *mut TaskThreadData,
@@ -116,11 +116,11 @@ pub struct C2RustUnnamed {
     pub task_head: *mut Dav1dTask,
     pub task_tail: *mut Dav1dTask,
     pub task_cur_prev: *mut Dav1dTask,
-    pub pending_tasks: C2RustUnnamed_0,
+    pub pending_tasks: Dav1dFrameContext_task_thread_pending_tasks,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dFrameContext_task_thread_pending_tasks {
     pub merge: atomic_int,
     pub lock: pthread_mutex_t,
     pub head: *mut Dav1dTask,
@@ -154,35 +154,35 @@ pub struct TaskThreadData {
     pub cur: libc::c_uint,
     pub reset_task_cur: atomic_uint,
     pub cond_signaled: atomic_int,
-    pub delayed_fg: C2RustUnnamed_1,
+    pub delayed_fg: Dav1dContext_task_thread_delayed_fg,
     pub inited: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dContext_task_thread_delayed_fg {
     pub exec: libc::c_int,
     pub cond: pthread_cond_t,
     pub in_0: *const Dav1dPicture,
     pub out: *mut Dav1dPicture,
     pub type_0: TaskType,
     pub progress: [atomic_int; 2],
-    pub c2rust_unnamed: C2RustUnnamed_2,
+    pub c2rust_unnamed: C2RustUnnamed,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_2 {
-    pub c2rust_unnamed: C2RustUnnamed_4,
-    pub c2rust_unnamed_0: C2RustUnnamed_3,
+pub union C2RustUnnamed {
+    pub c2rust_unnamed: C2RustUnnamed_1,
+    pub c2rust_unnamed_0: C2RustUnnamed_0,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct C2RustUnnamed_0 {
     pub grain_lut_16bpc: [[[int16_t; 82]; 74]; 3],
     pub scaling_16bpc: [[uint8_t; 4096]; 3],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
+pub struct C2RustUnnamed_1 {
     pub grain_lut_8bpc: [[[int8_t; 82]; 74]; 3],
     pub scaling_8bpc: [[uint8_t; 256]; 3],
 }
@@ -220,7 +220,7 @@ use crate::include::dav1d::picture::Dav1dPictureParameters;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_17,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -244,7 +244,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_16,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -254,14 +254,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_15,
-    pub quant: C2RustUnnamed_14,
-    pub segmentation: C2RustUnnamed_13,
-    pub delta: C2RustUnnamed_10,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_9,
-    pub cdef: C2RustUnnamed_8,
-    pub restoration: C2RustUnnamed_7,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -276,17 +276,17 @@ pub struct Dav1dFrameHeader {
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed_5,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_5 {
-    pub p: C2RustUnnamed_6,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -304,7 +304,7 @@ use crate::include::dav1d::headers::Dav1dTxfmMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
@@ -315,7 +315,7 @@ use crate::include::dav1d::headers::Dav1dRestorationType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -323,7 +323,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -335,26 +335,26 @@ pub struct C2RustUnnamed_9 {
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
-    pub q: C2RustUnnamed_12,
-    pub lf: C2RustUnnamed_11,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_12 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_13 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -367,7 +367,7 @@ use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_14 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -381,7 +381,7 @@ pub struct C2RustUnnamed_14 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_15 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -406,7 +406,7 @@ use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_16 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
@@ -418,7 +418,7 @@ use crate::include::dav1d::headers::Dav1dFrameType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_17 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
@@ -490,7 +490,7 @@ use crate::include::pthread::pthread_cond_t;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_19 {
+pub struct Dav1dFrameContext_lf {
     pub level: *mut [uint8_t; 4],
     pub mask: *mut Av1Filter,
     pub lr_mask: *mut Av1Restoration,
@@ -525,7 +525,7 @@ use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_20 {
+pub struct Dav1dFrameContext_frame_thread {
     pub next_tile_row: [libc::c_int; 2],
     pub entropy_progress: atomic_int,
     pub deblock_progress: atomic_int,
@@ -555,18 +555,18 @@ pub struct Av1Block {
     pub skip_mode: uint8_t,
     pub skip: uint8_t,
     pub uvtx: uint8_t,
-    pub c2rust_unnamed: C2RustUnnamed_21,
+    pub c2rust_unnamed: C2RustUnnamed_3,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_21 {
-    pub c2rust_unnamed: C2RustUnnamed_27,
-    pub c2rust_unnamed_0: C2RustUnnamed_22,
+pub union C2RustUnnamed_3 {
+    pub c2rust_unnamed: C2RustUnnamed_9,
+    pub c2rust_unnamed_0: C2RustUnnamed_4,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_22 {
-    pub c2rust_unnamed: C2RustUnnamed_23,
+pub struct C2RustUnnamed_4 {
+    pub c2rust_unnamed: C2RustUnnamed_5,
     pub comp_type: uint8_t,
     pub inter_mode: uint8_t,
     pub motion_mode: uint8_t,
@@ -580,31 +580,31 @@ pub struct C2RustUnnamed_22 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_23 {
-    pub c2rust_unnamed: C2RustUnnamed_26,
-    pub c2rust_unnamed_0: C2RustUnnamed_24,
+pub union C2RustUnnamed_5 {
+    pub c2rust_unnamed: C2RustUnnamed_8,
+    pub c2rust_unnamed_0: C2RustUnnamed_6,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_24 {
+pub struct C2RustUnnamed_6 {
     pub mv2d: mv,
     pub matrix: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union mv {
-    pub c2rust_unnamed: C2RustUnnamed_25,
+    pub c2rust_unnamed: C2RustUnnamed_7,
     pub n: uint32_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_25 {
+pub struct C2RustUnnamed_7 {
     pub y: int16_t,
     pub x: int16_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_26 {
+pub struct C2RustUnnamed_8 {
     pub mv: [mv; 2],
     pub wedge_idx: uint8_t,
     pub mask_sign: uint8_t,
@@ -612,7 +612,7 @@ pub struct C2RustUnnamed_26 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_27 {
+pub struct C2RustUnnamed_9 {
     pub y_mode: uint8_t,
     pub uv_mode: uint8_t,
     pub tx: uint8_t,
@@ -677,7 +677,7 @@ pub struct refmvs_temporal_block {
 use crate::src::env::BlockContext;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_28 {
+pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
     pub recon_b_inter: recon_b_inter_fn,
     pub filter_sbrow: filter_sbrow_fn,
@@ -733,18 +733,18 @@ pub struct Dav1dTaskContext {
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
-    pub scratch: C2RustUnnamed_31,
+    pub scratch: Dav1dTaskContext_scratch,
     pub warpmv: Dav1dWarpedMotionParams,
     pub lf_mask: *mut Av1Filter,
     pub top_pre_cdef_toggle: libc::c_int,
     pub cur_sb_cdef_idx_ptr: *mut int8_t,
     pub tl_4x4_filter: Filter2d,
-    pub frame_thread: C2RustUnnamed_30,
-    pub task_thread: C2RustUnnamed_29,
+    pub frame_thread: Dav1dTaskContext_frame_thread,
+    pub task_thread: Dav1dTaskContext_task_thread,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_29 {
+pub struct Dav1dTaskContext_task_thread {
     pub td: thread_data,
     pub ttd: *mut TaskThreadData,
     pub fttd: *mut FrameTileThreadData,
@@ -755,7 +755,7 @@ use crate::src::thread_data::thread_data;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_30 {
+pub struct Dav1dTaskContext_frame_thread {
     pub pass: libc::c_int,
 }
 use crate::src::levels::Filter2d;
@@ -772,14 +772,14 @@ use crate::src::levels::Filter2d;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_31 {
-    pub c2rust_unnamed: C2RustUnnamed_38,
-    pub c2rust_unnamed_0: C2RustUnnamed_32,
+pub union Dav1dTaskContext_scratch {
+    pub c2rust_unnamed: C2RustUnnamed_16,
+    pub c2rust_unnamed_0: C2RustUnnamed_10,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_32 {
-    pub c2rust_unnamed: C2RustUnnamed_36,
+pub struct C2RustUnnamed_10 {
+    pub c2rust_unnamed: C2RustUnnamed_14,
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
@@ -790,38 +790,38 @@ use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_36 {
+pub union C2RustUnnamed_14 {
     pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: C2RustUnnamed_37,
+    pub c2rust_unnamed: C2RustUnnamed_15,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_37 {
+pub struct C2RustUnnamed_15 {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_38 {
-    pub c2rust_unnamed: C2RustUnnamed_40,
-    pub c2rust_unnamed_0: C2RustUnnamed_39,
+pub struct C2RustUnnamed_16 {
+    pub c2rust_unnamed: C2RustUnnamed_18,
+    pub c2rust_unnamed_0: C2RustUnnamed_17,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_39 {
+pub union C2RustUnnamed_17 {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_40 {
+pub union C2RustUnnamed_18 {
     pub lap_8bpc: [uint8_t; 4096],
     pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: C2RustUnnamed_41,
+    pub c2rust_unnamed: C2RustUnnamed_19,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_41 {
+pub struct C2RustUnnamed_19 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
@@ -832,12 +832,12 @@ pub struct refmvs_tile {
     pub rf: *const refmvs_frame,
     pub r: [*mut refmvs_block; 37],
     pub rp_proj: *mut refmvs_temporal_block,
-    pub tile_col: C2RustUnnamed_43,
-    pub tile_row: C2RustUnnamed_43,
+    pub tile_col: refmvs_tile_range,
+    pub tile_row: refmvs_tile_range,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_43 {
+pub struct refmvs_tile_range {
     pub start: libc::c_int,
     pub end: libc::c_int,
 }
@@ -846,9 +846,9 @@ pub struct C2RustUnnamed_43 {
 pub struct Dav1dTileState {
     pub cdf: CdfContext,
     pub msac: MsacContext,
-    pub tiling: C2RustUnnamed_45,
+    pub tiling: Dav1dTileState_tiling,
     pub progress: [atomic_int; 2],
-    pub frame_thread: [C2RustUnnamed_44; 2],
+    pub frame_thread: [Dav1dTileState_frame_thread; 2],
     pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
     pub dqmem: [[[uint16_t; 2]; 3]; 8],
     pub dq: *const [[uint16_t; 2]; 3],
@@ -860,13 +860,13 @@ pub struct Dav1dTileState {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_44 {
+pub struct Dav1dTileState_frame_thread {
     pub pal_idx: *mut uint8_t,
     pub cf: *mut libc::c_void,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_45 {
+pub struct Dav1dTileState_tiling {
     pub col_start: libc::c_int,
     pub col_end: libc::c_int,
     pub row_start: libc::c_int,
@@ -1002,16 +1002,16 @@ pub struct Dav1dContext {
     pub cache: Dav1dThreadPicture,
     pub flush_mem: atomic_int,
     pub flush: *mut atomic_int,
-    pub frame_thread: C2RustUnnamed_50,
+    pub frame_thread: Dav1dContext_frame_thread,
     pub task_thread: TaskThreadData,
     pub segmap_pool: *mut Dav1dMemPool,
     pub refmvs_pool: *mut Dav1dMemPool,
-    pub refs: [C2RustUnnamed_49; 8],
+    pub refs: [Dav1dContext_refs; 8],
     pub cdf_pool: *mut Dav1dMemPool,
     pub cdf: [CdfThreadContext; 8],
     pub dsp: [Dav1dDSPContext; 3],
     pub refmvs_dsp: Dav1dRefmvsDSPContext,
-    pub intra_edge: C2RustUnnamed_46,
+    pub intra_edge: Dav1dContext_intra_edge,
     pub allocator: Dav1dPicAllocator,
     pub apply_grain: libc::c_int,
     pub operating_point: libc::c_int,
@@ -1065,7 +1065,7 @@ pub struct Dav1dPicAllocator {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_46 {
+pub struct Dav1dContext_intra_edge {
     pub root: [*mut EdgeNode; 2],
     pub branch_sb128: [EdgeBranch; 85],
     pub branch_sb64: [EdgeBranch; 21],
@@ -1134,11 +1134,11 @@ use crate::src::looprestoration::LrEdgeFlags;
 #[repr(C)]
 pub union LooprestorationParams {
     pub filter: [[int16_t; 8]; 2],
-    pub sgr: C2RustUnnamed_47,
+    pub sgr: LooprestorationParams_sgr,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_47 {
+pub struct LooprestorationParams_sgr {
     pub s0: uint32_t,
     pub s1: uint32_t,
     pub w0: int16_t,
@@ -1494,18 +1494,18 @@ pub type generate_grain_y_fn = Option::<
 #[repr(C)]
 pub struct CdfThreadContext {
     pub ref_0: *mut Dav1dRef,
-    pub data: C2RustUnnamed_48,
+    pub data: CdfThreadContext_data,
     pub progress: *mut atomic_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_48 {
+pub union CdfThreadContext_data {
     pub cdf: *mut CdfContext,
     pub qcat: libc::c_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_49 {
+pub struct Dav1dContext_refs {
     pub p: Dav1dThreadPicture,
     pub segmap: *mut Dav1dRef,
     pub refmvs: *mut Dav1dRef,
@@ -1522,7 +1522,7 @@ pub struct Dav1dThreadPicture {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_50 {
+pub struct Dav1dContext_frame_thread {
     pub out_delayed: *mut Dav1dThreadPicture,
     pub next: libc::c_uint,
 }
@@ -24591,7 +24591,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_ref(
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_cdf_thread_unref(cdf: *mut CdfThreadContext) {
     memset(
-        &mut (*cdf).data as *mut C2RustUnnamed_48 as *mut libc::c_void,
+        &mut (*cdf).data as *mut CdfThreadContext_data as *mut libc::c_void,
         0 as libc::c_int,
         (::core::mem::size_of::<CdfThreadContext>() as libc::c_ulong)
             .wrapping_sub(8 as libc::c_ulong),

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -420,7 +420,7 @@ pub struct Dav1dFrameContext {
     pub ts: *mut Dav1dTileState,
     pub n_ts: libc::c_int,
     pub dsp: *const Dav1dDSPContext,
-    pub bd_fn: C2RustUnnamed_28,
+    pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
     pub ipred_edge: [*mut libc::c_void; 3],
     pub b4_stride: ptrdiff_t,
@@ -441,15 +441,15 @@ pub struct Dav1dFrameContext {
     pub rf: refmvs_frame,
     pub jnt_weights: [[uint8_t; 7]; 7],
     pub bitdepth_max: libc::c_int,
-    pub frame_thread: C2RustUnnamed_20,
-    pub lf: C2RustUnnamed_19,
-    pub task_thread: C2RustUnnamed,
+    pub frame_thread: Dav1dFrameContext_frame_thread,
+    pub lf: Dav1dFrameContext_lf,
+    pub task_thread: Dav1dFrameContext_task_thread,
     pub tile_thread: FrameTileThreadData,
 }
 use crate::src::internal::FrameTileThreadData;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed {
+pub struct Dav1dFrameContext_task_thread {
     pub lock: pthread_mutex_t,
     pub cond: pthread_cond_t,
     pub ttd: *mut TaskThreadData,
@@ -467,11 +467,11 @@ pub struct C2RustUnnamed {
     pub task_head: *mut Dav1dTask,
     pub task_tail: *mut Dav1dTask,
     pub task_cur_prev: *mut Dav1dTask,
-    pub pending_tasks: C2RustUnnamed_0,
+    pub pending_tasks: Dav1dFrameContext_task_thread_pending_tasks,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dFrameContext_task_thread_pending_tasks {
     pub merge: atomic_int,
     pub lock: pthread_mutex_t,
     pub head: *mut Dav1dTask,
@@ -505,35 +505,35 @@ pub struct TaskThreadData {
     pub cur: libc::c_uint,
     pub reset_task_cur: atomic_uint,
     pub cond_signaled: atomic_int,
-    pub delayed_fg: C2RustUnnamed_1,
+    pub delayed_fg: Dav1dContext_task_thread_delayed_fg,
     pub inited: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dContext_task_thread_delayed_fg {
     pub exec: libc::c_int,
     pub cond: pthread_cond_t,
     pub in_0: *const Dav1dPicture,
     pub out: *mut Dav1dPicture,
     pub type_0: TaskType,
     pub progress: [atomic_int; 2],
-    pub c2rust_unnamed: C2RustUnnamed_2,
+    pub c2rust_unnamed: C2RustUnnamed,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_2 {
-    pub c2rust_unnamed: C2RustUnnamed_4,
-    pub c2rust_unnamed_0: C2RustUnnamed_3,
+pub union C2RustUnnamed {
+    pub c2rust_unnamed: C2RustUnnamed_1,
+    pub c2rust_unnamed_0: C2RustUnnamed_0,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct C2RustUnnamed_0 {
     pub grain_lut_16bpc: [[[int16_t; 82]; 74]; 3],
     pub scaling_16bpc: [[uint8_t; 4096]; 3],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
+pub struct C2RustUnnamed_1 {
     pub grain_lut_8bpc: [[[int8_t; 82]; 74]; 3],
     pub scaling_8bpc: [[uint8_t; 256]; 3],
 }
@@ -571,7 +571,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_17,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -595,7 +595,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_16,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -605,14 +605,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_15,
-    pub quant: C2RustUnnamed_14,
-    pub segmentation: C2RustUnnamed_13,
-    pub delta: C2RustUnnamed_10,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_9,
-    pub cdef: C2RustUnnamed_8,
-    pub restoration: C2RustUnnamed_7,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -627,17 +627,17 @@ pub struct Dav1dFrameHeader {
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed_5,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_5 {
-    pub p: C2RustUnnamed_6,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -655,7 +655,7 @@ use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
@@ -666,7 +666,7 @@ use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -674,7 +674,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -686,26 +686,26 @@ pub struct C2RustUnnamed_9 {
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
-    pub q: C2RustUnnamed_12,
-    pub lf: C2RustUnnamed_11,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_12 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_13 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -718,7 +718,7 @@ use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 use crate::include::dav1d::headers::Dav1dSegmentationData;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_14 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -732,7 +732,7 @@ pub struct C2RustUnnamed_14 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_15 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -757,7 +757,7 @@ use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
 use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_16 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
@@ -769,7 +769,7 @@ use crate::include::dav1d::headers::Dav1dFrameType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_17 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
@@ -841,7 +841,7 @@ use crate::include::pthread::pthread_cond_t;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_19 {
+pub struct Dav1dFrameContext_lf {
     pub level: *mut [uint8_t; 4],
     pub mask: *mut Av1Filter,
     pub lr_mask: *mut Av1Restoration,
@@ -876,7 +876,7 @@ use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_20 {
+pub struct Dav1dFrameContext_frame_thread {
     pub next_tile_row: [libc::c_int; 2],
     pub entropy_progress: atomic_int,
     pub deblock_progress: atomic_int,
@@ -906,18 +906,18 @@ pub struct Av1Block {
     pub skip_mode: uint8_t,
     pub skip: uint8_t,
     pub uvtx: uint8_t,
-    pub c2rust_unnamed: C2RustUnnamed_21,
+    pub c2rust_unnamed: C2RustUnnamed_3,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_21 {
-    pub c2rust_unnamed: C2RustUnnamed_27,
-    pub c2rust_unnamed_0: C2RustUnnamed_22,
+pub union C2RustUnnamed_3 {
+    pub c2rust_unnamed: C2RustUnnamed_9,
+    pub c2rust_unnamed_0: C2RustUnnamed_4,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_22 {
-    pub c2rust_unnamed: C2RustUnnamed_23,
+pub struct C2RustUnnamed_4 {
+    pub c2rust_unnamed: C2RustUnnamed_5,
     pub comp_type: uint8_t,
     pub inter_mode: uint8_t,
     pub motion_mode: uint8_t,
@@ -931,31 +931,31 @@ pub struct C2RustUnnamed_22 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_23 {
-    pub c2rust_unnamed: C2RustUnnamed_26,
-    pub c2rust_unnamed_0: C2RustUnnamed_24,
+pub union C2RustUnnamed_5 {
+    pub c2rust_unnamed: C2RustUnnamed_8,
+    pub c2rust_unnamed_0: C2RustUnnamed_6,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_24 {
+pub struct C2RustUnnamed_6 {
     pub mv2d: mv,
     pub matrix: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union mv {
-    pub c2rust_unnamed: C2RustUnnamed_25,
+    pub c2rust_unnamed: C2RustUnnamed_7,
     pub n: uint32_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_25 {
+pub struct C2RustUnnamed_7 {
     pub y: int16_t,
     pub x: int16_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_26 {
+pub struct C2RustUnnamed_8 {
     pub mv: [mv; 2],
     pub wedge_idx: uint8_t,
     pub mask_sign: uint8_t,
@@ -963,7 +963,7 @@ pub struct C2RustUnnamed_26 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_27 {
+pub struct C2RustUnnamed_9 {
     pub y_mode: uint8_t,
     pub uv_mode: uint8_t,
     pub tx: uint8_t,
@@ -1028,7 +1028,7 @@ pub struct refmvs_temporal_block {
 use crate::src::env::BlockContext;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_28 {
+pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
     pub recon_b_inter: recon_b_inter_fn,
     pub filter_sbrow: filter_sbrow_fn,
@@ -1084,18 +1084,18 @@ pub struct Dav1dTaskContext {
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
-    pub scratch: C2RustUnnamed_31,
+    pub scratch: Dav1dTaskContext_scratch,
     pub warpmv: Dav1dWarpedMotionParams,
     pub lf_mask: *mut Av1Filter,
     pub top_pre_cdef_toggle: libc::c_int,
     pub cur_sb_cdef_idx_ptr: *mut int8_t,
     pub tl_4x4_filter: Filter2d,
-    pub frame_thread: C2RustUnnamed_30,
-    pub task_thread: C2RustUnnamed_29,
+    pub frame_thread: Dav1dTaskContext_frame_thread,
+    pub task_thread: Dav1dTaskContext_task_thread,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_29 {
+pub struct Dav1dTaskContext_task_thread {
     pub td: thread_data,
     pub ttd: *mut TaskThreadData,
     pub fttd: *mut FrameTileThreadData,
@@ -1106,7 +1106,7 @@ use crate::src::thread_data::thread_data;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_30 {
+pub struct Dav1dTaskContext_frame_thread {
     pub pass: libc::c_int,
 }
 use crate::src::levels::Filter2d;
@@ -1123,14 +1123,14 @@ use crate::src::levels::FILTER_2D_BILINEAR;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_31 {
-    pub c2rust_unnamed: C2RustUnnamed_38,
-    pub c2rust_unnamed_0: C2RustUnnamed_32,
+pub union Dav1dTaskContext_scratch {
+    pub c2rust_unnamed: C2RustUnnamed_16,
+    pub c2rust_unnamed_0: C2RustUnnamed_10,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_32 {
-    pub c2rust_unnamed: C2RustUnnamed_36,
+pub struct C2RustUnnamed_10 {
+    pub c2rust_unnamed: C2RustUnnamed_14,
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
@@ -1141,38 +1141,38 @@ use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_36 {
+pub union C2RustUnnamed_14 {
     pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: C2RustUnnamed_37,
+    pub c2rust_unnamed: C2RustUnnamed_15,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_37 {
+pub struct C2RustUnnamed_15 {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_38 {
-    pub c2rust_unnamed: C2RustUnnamed_40,
-    pub c2rust_unnamed_0: C2RustUnnamed_39,
+pub struct C2RustUnnamed_16 {
+    pub c2rust_unnamed: C2RustUnnamed_18,
+    pub c2rust_unnamed_0: C2RustUnnamed_17,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_39 {
+pub union C2RustUnnamed_17 {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_40 {
+pub union C2RustUnnamed_18 {
     pub lap_8bpc: [uint8_t; 4096],
     pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: C2RustUnnamed_41,
+    pub c2rust_unnamed: C2RustUnnamed_19,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_41 {
+pub struct C2RustUnnamed_19 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
@@ -1183,12 +1183,12 @@ pub struct refmvs_tile {
     pub rf: *const refmvs_frame,
     pub r: [*mut refmvs_block; 37],
     pub rp_proj: *mut refmvs_temporal_block,
-    pub tile_col: C2RustUnnamed_43,
-    pub tile_row: C2RustUnnamed_43,
+    pub tile_col: refmvs_tile_range,
+    pub tile_row: refmvs_tile_range,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_43 {
+pub struct refmvs_tile_range {
     pub start: libc::c_int,
     pub end: libc::c_int,
 }
@@ -1197,9 +1197,9 @@ pub struct C2RustUnnamed_43 {
 pub struct Dav1dTileState {
     pub cdf: CdfContext,
     pub msac: MsacContext,
-    pub tiling: C2RustUnnamed_45,
+    pub tiling: Dav1dTileState_tiling,
     pub progress: [atomic_int; 2],
-    pub frame_thread: [C2RustUnnamed_44; 2],
+    pub frame_thread: [Dav1dTileState_frame_thread; 2],
     pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
     pub dqmem: [[[uint16_t; 2]; 3]; 8],
     pub dq: *const [[uint16_t; 2]; 3],
@@ -1211,13 +1211,13 @@ pub struct Dav1dTileState {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_44 {
+pub struct Dav1dTileState_frame_thread {
     pub pal_idx: *mut uint8_t,
     pub cf: *mut libc::c_void,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_45 {
+pub struct Dav1dTileState_tiling {
     pub col_start: libc::c_int,
     pub col_end: libc::c_int,
     pub row_start: libc::c_int,
@@ -1254,16 +1254,16 @@ pub struct Dav1dContext {
     pub cache: Dav1dThreadPicture,
     pub flush_mem: atomic_int,
     pub flush: *mut atomic_int,
-    pub frame_thread: C2RustUnnamed_50,
+    pub frame_thread: Dav1dContext_frame_thread,
     pub task_thread: TaskThreadData,
     pub segmap_pool: *mut Dav1dMemPool,
     pub refmvs_pool: *mut Dav1dMemPool,
-    pub refs: [C2RustUnnamed_49; 8],
+    pub refs: [Dav1dContext_refs; 8],
     pub cdf_pool: *mut Dav1dMemPool,
     pub cdf: [CdfThreadContext; 8],
     pub dsp: [Dav1dDSPContext; 3],
     pub refmvs_dsp: Dav1dRefmvsDSPContext,
-    pub intra_edge: C2RustUnnamed_46,
+    pub intra_edge: Dav1dContext_intra_edge,
     pub allocator: Dav1dPicAllocator,
     pub apply_grain: libc::c_int,
     pub operating_point: libc::c_int,
@@ -1317,7 +1317,7 @@ pub struct Dav1dPicAllocator {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_46 {
+pub struct Dav1dContext_intra_edge {
     pub root: [*mut EdgeNode; 2],
     pub branch_sb128: [EdgeBranch; 85],
     pub branch_sb64: [EdgeBranch; 21],
@@ -1386,11 +1386,11 @@ use crate::src::looprestoration::LrEdgeFlags;
 #[repr(C)]
 pub union LooprestorationParams {
     pub filter: [[int16_t; 8]; 2],
-    pub sgr: C2RustUnnamed_47,
+    pub sgr: LooprestorationParams_sgr,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_47 {
+pub struct LooprestorationParams_sgr {
     pub s0: uint32_t,
     pub s1: uint32_t,
     pub w0: int16_t,
@@ -1746,18 +1746,18 @@ pub type generate_grain_y_fn = Option::<
 #[repr(C)]
 pub struct CdfThreadContext {
     pub ref_0: *mut Dav1dRef,
-    pub data: C2RustUnnamed_48,
+    pub data: CdfThreadContext_data,
     pub progress: *mut atomic_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_48 {
+pub union CdfThreadContext_data {
     pub cdf: *mut CdfContext,
     pub qcat: libc::c_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_49 {
+pub struct Dav1dContext_refs {
     pub p: Dav1dThreadPicture,
     pub segmap: *mut Dav1dRef,
     pub refmvs: *mut Dav1dRef,
@@ -1774,7 +1774,7 @@ pub struct Dav1dThreadPicture {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_50 {
+pub struct Dav1dContext_frame_thread {
     pub out_delayed: *mut Dav1dThreadPicture,
     pub next: libc::c_uint,
 }
@@ -2831,7 +2831,7 @@ unsafe extern "C" fn get_gmv_2d(
         1 => {
             let mut res_0: mv = mv {
                 c2rust_unnamed: {
-                    let mut init = C2RustUnnamed_25 {
+                    let mut init = C2RustUnnamed_7 {
                         y: ((*gmv).matrix[0 as libc::c_int as usize]
                             >> 13 as libc::c_int) as int16_t,
                         x: ((*gmv).matrix[1 as libc::c_int as usize]
@@ -2848,7 +2848,7 @@ unsafe extern "C" fn get_gmv_2d(
         0 => {
             return mv {
                 c2rust_unnamed: {
-                    let mut init = C2RustUnnamed_25 {
+                    let mut init = C2RustUnnamed_7 {
                         y: 0 as libc::c_int as int16_t,
                         x: 0 as libc::c_int as int16_t,
                     };
@@ -2875,7 +2875,7 @@ unsafe extern "C" fn get_gmv_2d(
     let round: libc::c_int = (1 as libc::c_int) << shift >> 1 as libc::c_int;
     let mut res: mv = mv {
         c2rust_unnamed: {
-            let mut init = C2RustUnnamed_25 {
+            let mut init = C2RustUnnamed_7 {
                 y: apply_sign(
                     abs(yc) + round >> shift << ((*hdr).hp == 0) as libc::c_int,
                     yc,
@@ -4988,7 +4988,7 @@ unsafe extern "C" fn splat_oneref_mv(
                         .c2rust_unnamed
                         .mv[0 as libc::c_int as usize],
                     mv {
-                        c2rust_unnamed: C2RustUnnamed_25 { y: 0, x: 0 },
+                        c2rust_unnamed: C2RustUnnamed_7 { y: 0, x: 0 },
                     },
                 ],
             },
@@ -5049,7 +5049,7 @@ unsafe extern "C" fn splat_intrabc_mv(
                         .c2rust_unnamed
                         .mv[0 as libc::c_int as usize],
                     mv {
-                        c2rust_unnamed: C2RustUnnamed_25 { y: 0, x: 0 },
+                        c2rust_unnamed: C2RustUnnamed_7 { y: 0, x: 0 },
                     },
                 ],
             },
@@ -5157,7 +5157,7 @@ unsafe extern "C" fn splat_intraref(
                         n: 0x80008000 as libc::c_uint,
                     },
                     mv {
-                        c2rust_unnamed: C2RustUnnamed_25 { y: 0, x: 0 },
+                        c2rust_unnamed: C2RustUnnamed_7 { y: 0, x: 0 },
                     },
                 ],
             },
@@ -5472,8 +5472,8 @@ unsafe extern "C" fn decode_b(
         skip_mode: 0,
         skip: 0,
         uvtx: 0,
-        c2rust_unnamed: C2RustUnnamed_21 {
-            c2rust_unnamed: C2RustUnnamed_27 {
+        c2rust_unnamed: C2RustUnnamed_3 {
+            c2rust_unnamed: C2RustUnnamed_9 {
                 y_mode: 0,
                 uv_mode: 0,
                 tx: 0,
@@ -10000,7 +10000,7 @@ unsafe extern "C" fn decode_b(
         let mut mvstack: [refmvs_candidate; 8] = [refmvs_candidate {
             mv: refmvs_mvpair {
                 mv: [mv {
-                    c2rust_unnamed: C2RustUnnamed_25 { y: 0, x: 0 },
+                    c2rust_unnamed: C2RustUnnamed_7 { y: 0, x: 0 },
                 }; 2],
             },
             weight: 0,
@@ -11281,7 +11281,7 @@ unsafe extern "C" fn decode_b(
             let mut mvstack_0: [refmvs_candidate; 8] = [refmvs_candidate {
                 mv: refmvs_mvpair {
                     mv: [mv {
-                        c2rust_unnamed: C2RustUnnamed_25 { y: 0, x: 0 },
+                        c2rust_unnamed: C2RustUnnamed_7 { y: 0, x: 0 },
                     }; 2],
                 },
                 weight: 0,
@@ -11614,7 +11614,7 @@ unsafe extern "C" fn decode_b(
             let mut mvstack_1: [refmvs_candidate; 8] = [refmvs_candidate {
                 mv: refmvs_mvpair {
                     mv: [mv {
-                        c2rust_unnamed: C2RustUnnamed_25 { y: 0, x: 0 },
+                        c2rust_unnamed: C2RustUnnamed_7 { y: 0, x: 0 },
                     }; 2],
                 },
                 weight: 0,
@@ -12305,7 +12305,7 @@ unsafe extern "C" fn decode_b(
             let mut mvstack_2: [refmvs_candidate; 8] = [refmvs_candidate {
                 mv: refmvs_mvpair {
                     mv: [mv {
-                        c2rust_unnamed: C2RustUnnamed_25 { y: 0, x: 0 },
+                        c2rust_unnamed: C2RustUnnamed_7 { y: 0, x: 0 },
                     }; 2],
                 },
                 weight: 0,

--- a/src/fg_apply_tmpl_16.rs
+++ b/src/fg_apply_tmpl_16.rs
@@ -50,17 +50,17 @@ use crate::include::dav1d::headers::Dav1dWarpedMotionType;
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed {
-    pub p: C2RustUnnamed_0,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -142,7 +142,7 @@ use crate::include::dav1d::headers::Dav1dFilmGrainData;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_11,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -166,7 +166,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_10,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -176,14 +176,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_9,
-    pub quant: C2RustUnnamed_8,
-    pub segmentation: C2RustUnnamed_7,
-    pub delta: C2RustUnnamed_4,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_3,
-    pub cdef: C2RustUnnamed_2,
-    pub restoration: C2RustUnnamed_1,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -195,13 +195,13 @@ pub struct Dav1dFrameHeader {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_2 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -209,7 +209,7 @@ pub struct C2RustUnnamed_2 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -220,26 +220,26 @@ pub struct C2RustUnnamed_3 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
-    pub q: C2RustUnnamed_6,
-    pub lf: C2RustUnnamed_5,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_5 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -250,7 +250,7 @@ pub struct C2RustUnnamed_7 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -264,7 +264,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -281,14 +281,14 @@ pub struct C2RustUnnamed_9 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,

--- a/src/ipred_prepare_tmpl.c
+++ b/src/ipred_prepare_tmpl.c
@@ -47,7 +47,7 @@ static const uint8_t av1_mode_to_angle_map[8] = {
     90, 180, 45, 135, 113, 157, 203, 67
 };
 
-static const struct {
+static const struct av1_intra_prediction_edge {
     uint8_t needs_left:1;
     uint8_t needs_top:1;
     uint8_t needs_topleft:1;

--- a/src/ipred_prepare_tmpl_16.rs
+++ b/src/ipred_prepare_tmpl_16.rs
@@ -46,7 +46,7 @@ use crate::src::intra_edge::EDGE_I444_LEFT_HAS_BOTTOM;
 use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
 #[derive(Copy, Clone, BitfieldStruct)]
 #[repr(C)]
-pub struct C2RustUnnamed {
+pub struct av1_intra_prediction_edge {
     #[bitfield(name = "needs_left", ty = "uint8_t", bits = "0..=0")]
     #[bitfield(name = "needs_top", ty = "uint8_t", bits = "1..=1")]
     #[bitfield(name = "needs_topleft", ty = "uint8_t", bits = "2..=2")]
@@ -108,7 +108,7 @@ static mut av1_mode_to_angle_map: [uint8_t; 8] = [
     203 as libc::c_int as uint8_t,
     67 as libc::c_int as uint8_t,
 ];
-static mut av1_intra_prediction_edges: [C2RustUnnamed; 14] = [C2RustUnnamed {
+static mut av1_intra_prediction_edges: [av1_intra_prediction_edge; 14] = [av1_intra_prediction_edge {
     needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
 }; 14];
 #[no_mangle]
@@ -345,7 +345,7 @@ pub unsafe extern "C" fn dav1d_prepare_intra_edges_16bpc(
 unsafe extern "C" fn run_static_initializers() {
     av1_intra_prediction_edges = [
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(1 as libc::c_int as uint8_t);
@@ -356,7 +356,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(0);
@@ -367,7 +367,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(1 as libc::c_int as uint8_t);
@@ -378,7 +378,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(1 as libc::c_int as uint8_t);
@@ -389,7 +389,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(0);
@@ -400,7 +400,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(0 as libc::c_int as uint8_t);
@@ -411,7 +411,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(0);
@@ -422,7 +422,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(1 as libc::c_int as uint8_t);
@@ -433,7 +433,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(1 as libc::c_int as uint8_t);
@@ -444,7 +444,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(1 as libc::c_int as uint8_t);
@@ -455,7 +455,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(1 as libc::c_int as uint8_t);
@@ -466,7 +466,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(1 as libc::c_int as uint8_t);
@@ -477,7 +477,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(1 as libc::c_int as uint8_t);
@@ -488,7 +488,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(1 as libc::c_int as uint8_t);

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -60,7 +60,7 @@ pub struct Dav1dFrameContext {
     pub ts: *mut Dav1dTileState,
     pub n_ts: libc::c_int,
     pub dsp: *const Dav1dDSPContext,
-    pub bd_fn: C2RustUnnamed_28,
+    pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
     pub ipred_edge: [*mut pixel; 3],
     pub b4_stride: ptrdiff_t,
@@ -81,15 +81,15 @@ pub struct Dav1dFrameContext {
     pub rf: refmvs_frame,
     pub jnt_weights: [[uint8_t; 7]; 7],
     pub bitdepth_max: libc::c_int,
-    pub frame_thread: C2RustUnnamed_20,
-    pub lf: C2RustUnnamed_19,
-    pub task_thread: C2RustUnnamed,
+    pub frame_thread: Dav1dFrameContext_frame_thread,
+    pub lf: Dav1dFrameContext_lf,
+    pub task_thread: Dav1dFrameContext_task_thread,
     pub tile_thread: FrameTileThreadData,
 }
 use crate::src::internal::FrameTileThreadData;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed {
+pub struct Dav1dFrameContext_task_thread {
     pub lock: pthread_mutex_t,
     pub cond: pthread_cond_t,
     pub ttd: *mut TaskThreadData,
@@ -107,11 +107,11 @@ pub struct C2RustUnnamed {
     pub task_head: *mut Dav1dTask,
     pub task_tail: *mut Dav1dTask,
     pub task_cur_prev: *mut Dav1dTask,
-    pub pending_tasks: C2RustUnnamed_0,
+    pub pending_tasks: Dav1dFrameContext_task_thread_pending_tasks,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dFrameContext_task_thread_pending_tasks {
     pub merge: atomic_int,
     pub lock: pthread_mutex_t,
     pub head: *mut Dav1dTask,
@@ -145,35 +145,35 @@ pub struct TaskThreadData {
     pub cur: libc::c_uint,
     pub reset_task_cur: atomic_uint,
     pub cond_signaled: atomic_int,
-    pub delayed_fg: C2RustUnnamed_1,
+    pub delayed_fg: Dav1dContext_task_thread_delayed_fg,
     pub inited: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dContext_task_thread_delayed_fg {
     pub exec: libc::c_int,
     pub cond: pthread_cond_t,
     pub in_0: *const Dav1dPicture,
     pub out: *mut Dav1dPicture,
     pub type_0: TaskType,
     pub progress: [atomic_int; 2],
-    pub c2rust_unnamed: C2RustUnnamed_2,
+    pub c2rust_unnamed: C2RustUnnamed,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_2 {
-    pub c2rust_unnamed: C2RustUnnamed_4,
-    pub c2rust_unnamed_0: C2RustUnnamed_3,
+pub union C2RustUnnamed {
+    pub c2rust_unnamed: C2RustUnnamed_1,
+    pub c2rust_unnamed_0: C2RustUnnamed_0,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct C2RustUnnamed_0 {
     pub grain_lut_16bpc: [[[int16_t; 82]; 74]; 3],
     pub scaling_16bpc: [[uint8_t; 4096]; 3],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
+pub struct C2RustUnnamed_1 {
     pub grain_lut_8bpc: [[[int8_t; 82]; 74]; 3],
     pub scaling_8bpc: [[uint8_t; 256]; 3],
 }
@@ -211,7 +211,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_17,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -235,7 +235,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_16,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -245,14 +245,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_15,
-    pub quant: C2RustUnnamed_14,
-    pub segmentation: C2RustUnnamed_13,
-    pub delta: C2RustUnnamed_10,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_9,
-    pub cdef: C2RustUnnamed_8,
-    pub restoration: C2RustUnnamed_7,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -267,17 +267,17 @@ pub struct Dav1dFrameHeader {
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed_5,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_5 {
-    pub p: C2RustUnnamed_6,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -295,7 +295,7 @@ use crate::include::dav1d::headers::Dav1dTxfmMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
@@ -306,7 +306,7 @@ use crate::include::dav1d::headers::Dav1dRestorationType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -314,7 +314,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -326,26 +326,26 @@ pub struct C2RustUnnamed_9 {
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
-    pub q: C2RustUnnamed_12,
-    pub lf: C2RustUnnamed_11,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_12 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_13 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -358,7 +358,7 @@ use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_14 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -372,7 +372,7 @@ pub struct C2RustUnnamed_14 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_15 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -397,7 +397,7 @@ use crate::include::dav1d::headers::Dav1dFilterMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_16 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
@@ -409,7 +409,7 @@ use crate::include::dav1d::headers::Dav1dFrameType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_17 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
@@ -481,7 +481,7 @@ use crate::include::pthread::pthread_cond_t;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_19 {
+pub struct Dav1dFrameContext_lf {
     pub level: *mut [uint8_t; 4],
     pub mask: *mut Av1Filter,
     pub lr_mask: *mut Av1Restoration,
@@ -515,7 +515,7 @@ use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_20 {
+pub struct Dav1dFrameContext_frame_thread {
     pub next_tile_row: [libc::c_int; 2],
     pub entropy_progress: atomic_int,
     pub deblock_progress: atomic_int,
@@ -544,18 +544,18 @@ pub struct Av1Block {
     pub skip_mode: uint8_t,
     pub skip: uint8_t,
     pub uvtx: uint8_t,
-    pub c2rust_unnamed: C2RustUnnamed_21,
+    pub c2rust_unnamed: C2RustUnnamed_3,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_21 {
-    pub c2rust_unnamed: C2RustUnnamed_27,
-    pub c2rust_unnamed_0: C2RustUnnamed_22,
+pub union C2RustUnnamed_3 {
+    pub c2rust_unnamed: C2RustUnnamed_9,
+    pub c2rust_unnamed_0: C2RustUnnamed_4,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_22 {
-    pub c2rust_unnamed: C2RustUnnamed_23,
+pub struct C2RustUnnamed_4 {
+    pub c2rust_unnamed: C2RustUnnamed_5,
     pub comp_type: uint8_t,
     pub inter_mode: uint8_t,
     pub motion_mode: uint8_t,
@@ -569,31 +569,31 @@ pub struct C2RustUnnamed_22 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_23 {
-    pub c2rust_unnamed: C2RustUnnamed_26,
-    pub c2rust_unnamed_0: C2RustUnnamed_24,
+pub union C2RustUnnamed_5 {
+    pub c2rust_unnamed: C2RustUnnamed_8,
+    pub c2rust_unnamed_0: C2RustUnnamed_6,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_24 {
+pub struct C2RustUnnamed_6 {
     pub mv2d: mv,
     pub matrix: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union mv {
-    pub c2rust_unnamed: C2RustUnnamed_25,
+    pub c2rust_unnamed: C2RustUnnamed_7,
     pub n: uint32_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_25 {
+pub struct C2RustUnnamed_7 {
     pub y: int16_t,
     pub x: int16_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_26 {
+pub struct C2RustUnnamed_8 {
     pub mv: [mv; 2],
     pub wedge_idx: uint8_t,
     pub mask_sign: uint8_t,
@@ -601,7 +601,7 @@ pub struct C2RustUnnamed_26 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_27 {
+pub struct C2RustUnnamed_9 {
     pub y_mode: uint8_t,
     pub uv_mode: uint8_t,
     pub tx: uint8_t,
@@ -666,7 +666,7 @@ pub struct refmvs_temporal_block {
 use crate::src::env::BlockContext;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_28 {
+pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
     pub recon_b_inter: recon_b_inter_fn,
     pub filter_sbrow: filter_sbrow_fn,
@@ -722,18 +722,18 @@ pub struct Dav1dTaskContext {
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
-    pub scratch: C2RustUnnamed_31,
+    pub scratch: Dav1dTaskContext_scratch,
     pub warpmv: Dav1dWarpedMotionParams,
     pub lf_mask: *mut Av1Filter,
     pub top_pre_cdef_toggle: libc::c_int,
     pub cur_sb_cdef_idx_ptr: *mut int8_t,
     pub tl_4x4_filter: Filter2d,
-    pub frame_thread: C2RustUnnamed_30,
-    pub task_thread: C2RustUnnamed_29,
+    pub frame_thread: Dav1dTaskContext_frame_thread,
+    pub task_thread: Dav1dTaskContext_task_thread,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_29 {
+pub struct Dav1dTaskContext_task_thread {
     pub td: thread_data,
     pub ttd: *mut TaskThreadData,
     pub fttd: *mut FrameTileThreadData,
@@ -744,7 +744,7 @@ use crate::src::thread_data::thread_data;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_30 {
+pub struct Dav1dTaskContext_frame_thread {
     pub pass: libc::c_int,
 }
 use crate::src::levels::Filter2d;
@@ -761,14 +761,14 @@ use crate::src::levels::Filter2d;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_31 {
-    pub c2rust_unnamed: C2RustUnnamed_38,
-    pub c2rust_unnamed_0: C2RustUnnamed_32,
+pub union Dav1dTaskContext_scratch {
+    pub c2rust_unnamed: C2RustUnnamed_16,
+    pub c2rust_unnamed_0: C2RustUnnamed_10,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_32 {
-    pub c2rust_unnamed: C2RustUnnamed_36,
+pub struct C2RustUnnamed_10 {
+    pub c2rust_unnamed: C2RustUnnamed_14,
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
@@ -779,38 +779,38 @@ use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_36 {
+pub union C2RustUnnamed_14 {
     pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: C2RustUnnamed_37,
+    pub c2rust_unnamed: C2RustUnnamed_15,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_37 {
+pub struct C2RustUnnamed_15 {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_38 {
-    pub c2rust_unnamed: C2RustUnnamed_40,
-    pub c2rust_unnamed_0: C2RustUnnamed_39,
+pub struct C2RustUnnamed_16 {
+    pub c2rust_unnamed: C2RustUnnamed_18,
+    pub c2rust_unnamed_0: C2RustUnnamed_17,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_39 {
+pub union C2RustUnnamed_17 {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_40 {
+pub union C2RustUnnamed_18 {
     pub lap_8bpc: [uint8_t; 4096],
     pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: C2RustUnnamed_41,
+    pub c2rust_unnamed: C2RustUnnamed_19,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_41 {
+pub struct C2RustUnnamed_19 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
@@ -821,12 +821,12 @@ pub struct refmvs_tile {
     pub rf: *const refmvs_frame,
     pub r: [*mut refmvs_block; 37],
     pub rp_proj: *mut refmvs_temporal_block,
-    pub tile_col: C2RustUnnamed_43,
-    pub tile_row: C2RustUnnamed_43,
+    pub tile_col: refmvs_tile_range,
+    pub tile_row: refmvs_tile_range,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_43 {
+pub struct refmvs_tile_range {
     pub start: libc::c_int,
     pub end: libc::c_int,
 }
@@ -835,9 +835,9 @@ pub struct C2RustUnnamed_43 {
 pub struct Dav1dTileState {
     pub cdf: CdfContext,
     pub msac: MsacContext,
-    pub tiling: C2RustUnnamed_45,
+    pub tiling: Dav1dTileState_tiling,
     pub progress: [atomic_int; 2],
-    pub frame_thread: [C2RustUnnamed_44; 2],
+    pub frame_thread: [Dav1dTileState_frame_thread; 2],
     pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
     pub dqmem: [[[uint16_t; 2]; 3]; 8],
     pub dq: *const [[uint16_t; 2]; 3],
@@ -849,13 +849,13 @@ pub struct Dav1dTileState {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_44 {
+pub struct Dav1dTileState_frame_thread {
     pub pal_idx: *mut uint8_t,
     pub cf: *mut coef,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_45 {
+pub struct Dav1dTileState_tiling {
     pub col_start: libc::c_int,
     pub col_end: libc::c_int,
     pub row_start: libc::c_int,
@@ -892,16 +892,16 @@ pub struct Dav1dContext {
     pub cache: Dav1dThreadPicture,
     pub flush_mem: atomic_int,
     pub flush: *mut atomic_int,
-    pub frame_thread: C2RustUnnamed_50,
+    pub frame_thread: Dav1dContext_frame_thread,
     pub task_thread: TaskThreadData,
     pub segmap_pool: *mut Dav1dMemPool,
     pub refmvs_pool: *mut Dav1dMemPool,
-    pub refs: [C2RustUnnamed_49; 8],
+    pub refs: [Dav1dContext_refs; 8],
     pub cdf_pool: *mut Dav1dMemPool,
     pub cdf: [CdfThreadContext; 8],
     pub dsp: [Dav1dDSPContext; 3],
     pub refmvs_dsp: Dav1dRefmvsDSPContext,
-    pub intra_edge: C2RustUnnamed_46,
+    pub intra_edge: Dav1dContext_intra_edge,
     pub allocator: Dav1dPicAllocator,
     pub apply_grain: libc::c_int,
     pub operating_point: libc::c_int,
@@ -955,7 +955,7 @@ pub struct Dav1dPicAllocator {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_46 {
+pub struct Dav1dContext_intra_edge {
     pub root: [*mut EdgeNode; 2],
     pub branch_sb128: [EdgeBranch; 85],
     pub branch_sb64: [EdgeBranch; 21],
@@ -1025,11 +1025,11 @@ use crate::src::looprestoration::LrEdgeFlags;
 #[repr(C)]
 pub union LooprestorationParams {
     pub filter: [[int16_t; 8]; 2],
-    pub sgr: C2RustUnnamed_47,
+    pub sgr: LooprestorationParams_sgr,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_47 {
+pub struct LooprestorationParams_sgr {
     pub s0: uint32_t,
     pub s1: uint32_t,
     pub w0: int16_t,
@@ -1405,18 +1405,18 @@ pub type generate_grain_y_fn = Option::<
 #[repr(C)]
 pub struct CdfThreadContext {
     pub ref_0: *mut Dav1dRef,
-    pub data: C2RustUnnamed_48,
+    pub data: CdfThreadContext_data,
     pub progress: *mut atomic_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_48 {
+pub union CdfThreadContext_data {
     pub cdf: *mut CdfContext,
     pub qcat: libc::c_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_49 {
+pub struct Dav1dContext_refs {
     pub p: Dav1dThreadPicture,
     pub segmap: *mut Dav1dRef,
     pub refmvs: *mut Dav1dRef,
@@ -1433,7 +1433,7 @@ pub struct Dav1dThreadPicture {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_50 {
+pub struct Dav1dContext_frame_thread {
     pub out_delayed: *mut Dav1dThreadPicture,
     pub next: libc::c_uint,
 }

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -73,17 +73,17 @@ use crate::include::dav1d::headers::Dav1dWarpedMotionType;
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed {
-    pub p: C2RustUnnamed_0,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -106,7 +106,7 @@ use crate::include::dav1d::headers::Dav1dFilmGrainData;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_11,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -130,7 +130,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_10,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -140,14 +140,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_9,
-    pub quant: C2RustUnnamed_8,
-    pub segmentation: C2RustUnnamed_7,
-    pub delta: C2RustUnnamed_4,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_3,
-    pub cdef: C2RustUnnamed_2,
-    pub restoration: C2RustUnnamed_1,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -159,13 +159,13 @@ pub struct Dav1dFrameHeader {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_2 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -173,7 +173,7 @@ pub struct C2RustUnnamed_2 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -184,26 +184,26 @@ pub struct C2RustUnnamed_3 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
-    pub q: C2RustUnnamed_6,
-    pub lf: C2RustUnnamed_5,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_5 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -214,7 +214,7 @@ pub struct C2RustUnnamed_7 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -228,7 +228,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -245,14 +245,14 @@ pub struct C2RustUnnamed_9 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,17 +203,17 @@ use crate::include::dav1d::headers::Dav1dWarpedMotionType;
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed {
-    pub p: C2RustUnnamed_0,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -295,7 +295,7 @@ use crate::include::dav1d::headers::Dav1dFilmGrainData;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_11,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -319,7 +319,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_10,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -329,14 +329,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_9,
-    pub quant: C2RustUnnamed_8,
-    pub segmentation: C2RustUnnamed_7,
-    pub delta: C2RustUnnamed_4,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_3,
-    pub cdef: C2RustUnnamed_2,
-    pub restoration: C2RustUnnamed_1,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -348,13 +348,13 @@ pub struct Dav1dFrameHeader {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_2 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -362,7 +362,7 @@ pub struct C2RustUnnamed_2 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -373,26 +373,26 @@ pub struct C2RustUnnamed_3 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
-    pub q: C2RustUnnamed_6,
-    pub lf: C2RustUnnamed_5,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_5 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -403,7 +403,7 @@ pub struct C2RustUnnamed_7 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -417,7 +417,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -434,14 +434,14 @@ pub struct C2RustUnnamed_9 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
@@ -509,16 +509,16 @@ pub struct Dav1dContext {
     pub cache: Dav1dThreadPicture,
     pub flush_mem: atomic_int,
     pub flush: *mut atomic_int,
-    pub frame_thread: C2RustUnnamed_22,
+    pub frame_thread: Dav1dContext_frame_thread,
     pub task_thread: TaskThreadData,
     pub segmap_pool: *mut Dav1dMemPool,
     pub refmvs_pool: *mut Dav1dMemPool,
-    pub refs: [C2RustUnnamed_16; 8],
+    pub refs: [Dav1dContext_refs; 8],
     pub cdf_pool: *mut Dav1dMemPool,
     pub cdf: [CdfThreadContext; 8],
     pub dsp: [Dav1dDSPContext; 3],
     pub refmvs_dsp: Dav1dRefmvsDSPContext,
-    pub intra_edge: C2RustUnnamed_12,
+    pub intra_edge: Dav1dContext_intra_edge,
     pub allocator: Dav1dPicAllocator,
     pub apply_grain: libc::c_int,
     pub operating_point: libc::c_int,
@@ -565,7 +565,7 @@ use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_ALL;
 use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_12 {
+pub struct Dav1dContext_intra_edge {
     pub root: [*mut EdgeNode; 2],
     pub branch_sb128: [EdgeBranch; 85],
     pub branch_sb64: [EdgeBranch; 21],
@@ -619,12 +619,12 @@ pub union refmvs_mvpair {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union mv {
-    pub c2rust_unnamed: C2RustUnnamed_13,
+    pub c2rust_unnamed: C2RustUnnamed,
     pub n: uint32_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_13 {
+pub struct C2RustUnnamed {
     pub y: int16_t,
     pub x: int16_t,
 }
@@ -666,11 +666,11 @@ use crate::src::looprestoration::LrEdgeFlags;
 #[repr(C)]
 pub union LooprestorationParams {
     pub filter: [[int16_t; 8]; 2],
-    pub sgr: C2RustUnnamed_14,
+    pub sgr: LooprestorationParams_sgr,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_14 {
+pub struct LooprestorationParams_sgr {
     pub s0: uint32_t,
     pub s1: uint32_t,
     pub w0: int16_t,
@@ -1029,19 +1029,19 @@ pub type generate_grain_y_fn = Option::<
 #[repr(C)]
 pub struct CdfThreadContext {
     pub ref_0: *mut Dav1dRef,
-    pub data: C2RustUnnamed_15,
+    pub data: CdfThreadContext_data,
     pub progress: *mut atomic_uint,
 }
 use crate::include::stdatomic::atomic_uint;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_15 {
+pub union CdfThreadContext_data {
     pub cdf: *mut CdfContext,
     pub qcat: libc::c_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_16 {
+pub struct Dav1dContext_refs {
     pub p: Dav1dThreadPicture,
     pub segmap: *mut Dav1dRef,
     pub refmvs: *mut Dav1dRef,
@@ -1065,35 +1065,35 @@ pub struct TaskThreadData {
     pub cur: libc::c_uint,
     pub reset_task_cur: atomic_uint,
     pub cond_signaled: atomic_int,
-    pub delayed_fg: C2RustUnnamed_17,
+    pub delayed_fg: Dav1dContext_task_thread_delayed_fg,
     pub inited: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_17 {
+pub struct Dav1dContext_task_thread_delayed_fg {
     pub exec: libc::c_int,
     pub cond: pthread_cond_t,
     pub in_0: *const Dav1dPicture,
     pub out: *mut Dav1dPicture,
     pub type_0: TaskType,
     pub progress: [atomic_int; 2],
-    pub c2rust_unnamed: C2RustUnnamed_18,
+    pub c2rust_unnamed: C2RustUnnamed_0,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_18 {
-    pub c2rust_unnamed: C2RustUnnamed_20,
-    pub c2rust_unnamed_0: C2RustUnnamed_19,
+pub union C2RustUnnamed_0 {
+    pub c2rust_unnamed: C2RustUnnamed_2,
+    pub c2rust_unnamed_0: C2RustUnnamed_1,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_19 {
+pub struct C2RustUnnamed_1 {
     pub grain_lut_16bpc: [[[int16_t; 82]; 74]; 3],
     pub scaling_16bpc: [[uint8_t; 4096]; 3],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_20 {
+pub struct C2RustUnnamed_2 {
     pub grain_lut_8bpc: [[[int8_t; 82]; 74]; 3],
     pub scaling_8bpc: [[uint8_t; 256]; 3],
 }
@@ -1117,17 +1117,17 @@ use crate::include::pthread::pthread_cond_t;
 #[repr(C)]
 pub union __atomic_wide_counter {
     pub __value64: libc::c_ulonglong,
-    pub __value32: C2RustUnnamed_21,
+    pub __value32: C2RustUnnamed_3,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_21 {
+pub struct C2RustUnnamed_3 {
     pub __low: libc::c_uint,
     pub __high: libc::c_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_22 {
+pub struct Dav1dContext_frame_thread {
     pub out_delayed: *mut Dav1dThreadPicture,
     pub next: libc::c_uint,
 }
@@ -1147,18 +1147,18 @@ pub struct Dav1dTaskContext {
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
-    pub scratch: C2RustUnnamed_25,
+    pub scratch: Dav1dTaskContext_scratch,
     pub warpmv: Dav1dWarpedMotionParams,
     pub lf_mask: *mut Av1Filter,
     pub top_pre_cdef_toggle: libc::c_int,
     pub cur_sb_cdef_idx_ptr: *mut int8_t,
     pub tl_4x4_filter: Filter2d,
-    pub frame_thread: C2RustUnnamed_24,
-    pub task_thread: C2RustUnnamed_23,
+    pub frame_thread: Dav1dTaskContext_frame_thread,
+    pub task_thread: Dav1dTaskContext_task_thread,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_23 {
+pub struct Dav1dTaskContext_task_thread {
     pub td: thread_data,
     pub ttd: *mut TaskThreadData,
     pub fttd: *mut FrameTileThreadData,
@@ -1170,7 +1170,7 @@ use crate::src::thread_data::thread_data;
 use crate::include::pthread::pthread_t;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_24 {
+pub struct Dav1dTaskContext_frame_thread {
     pub pass: libc::c_int,
 }
 use crate::src::levels::Filter2d;
@@ -1188,14 +1188,14 @@ use crate::src::levels::Filter2d;
 use crate::src::lf_mask::Av1Filter;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_25 {
-    pub c2rust_unnamed: C2RustUnnamed_32,
-    pub c2rust_unnamed_0: C2RustUnnamed_26,
+pub union Dav1dTaskContext_scratch {
+    pub c2rust_unnamed: C2RustUnnamed_10,
+    pub c2rust_unnamed_0: C2RustUnnamed_4,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_26 {
-    pub c2rust_unnamed: C2RustUnnamed_30,
+pub struct C2RustUnnamed_4 {
+    pub c2rust_unnamed: C2RustUnnamed_8,
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
@@ -1206,38 +1206,38 @@ use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_30 {
+pub union C2RustUnnamed_8 {
     pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: C2RustUnnamed_31,
+    pub c2rust_unnamed: C2RustUnnamed_9,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_31 {
+pub struct C2RustUnnamed_9 {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_32 {
-    pub c2rust_unnamed: C2RustUnnamed_34,
-    pub c2rust_unnamed_0: C2RustUnnamed_33,
+pub struct C2RustUnnamed_10 {
+    pub c2rust_unnamed: C2RustUnnamed_12,
+    pub c2rust_unnamed_0: C2RustUnnamed_11,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_33 {
+pub union C2RustUnnamed_11 {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_34 {
+pub union C2RustUnnamed_12 {
     pub lap_8bpc: [uint8_t; 4096],
     pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: C2RustUnnamed_35,
+    pub c2rust_unnamed: C2RustUnnamed_13,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_35 {
+pub struct C2RustUnnamed_13 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
@@ -1248,12 +1248,12 @@ pub struct refmvs_tile {
     pub rf: *const refmvs_frame,
     pub r: [*mut refmvs_block; 37],
     pub rp_proj: *mut refmvs_temporal_block,
-    pub tile_col: C2RustUnnamed_37,
-    pub tile_row: C2RustUnnamed_37,
+    pub tile_col: refmvs_tile_range,
+    pub tile_row: refmvs_tile_range,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_37 {
+pub struct refmvs_tile_range {
     pub start: libc::c_int,
     pub end: libc::c_int,
 }
@@ -1296,9 +1296,9 @@ use crate::src::env::BlockContext;
 pub struct Dav1dTileState {
     pub cdf: CdfContext,
     pub msac: MsacContext,
-    pub tiling: C2RustUnnamed_39,
+    pub tiling: Dav1dTileState_tiling,
     pub progress: [atomic_int; 2],
-    pub frame_thread: [C2RustUnnamed_38; 2],
+    pub frame_thread: [Dav1dTileState_frame_thread; 2],
     pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
     pub dqmem: [[[uint16_t; 2]; 3]; 8],
     pub dq: *const [[uint16_t; 2]; 3],
@@ -1311,13 +1311,13 @@ pub struct Dav1dTileState {
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_38 {
+pub struct Dav1dTileState_frame_thread {
     pub pal_idx: *mut uint8_t,
     pub cf: *mut libc::c_void,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_39 {
+pub struct Dav1dTileState_tiling {
     pub col_start: libc::c_int,
     pub col_end: libc::c_int,
     pub row_start: libc::c_int,
@@ -1359,7 +1359,7 @@ pub struct Dav1dFrameContext {
     pub ts: *mut Dav1dTileState,
     pub n_ts: libc::c_int,
     pub dsp: *const Dav1dDSPContext,
-    pub bd_fn: C2RustUnnamed_50,
+    pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
     pub ipred_edge: [*mut libc::c_void; 3],
     pub b4_stride: ptrdiff_t,
@@ -1380,14 +1380,14 @@ pub struct Dav1dFrameContext {
     pub rf: refmvs_frame,
     pub jnt_weights: [[uint8_t; 7]; 7],
     pub bitdepth_max: libc::c_int,
-    pub frame_thread: C2RustUnnamed_43,
-    pub lf: C2RustUnnamed_42,
-    pub task_thread: C2RustUnnamed_40,
+    pub frame_thread: Dav1dFrameContext_frame_thread,
+    pub lf: Dav1dFrameContext_lf,
+    pub task_thread: Dav1dFrameContext_task_thread,
     pub tile_thread: FrameTileThreadData,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_40 {
+pub struct Dav1dFrameContext_task_thread {
     pub lock: pthread_mutex_t,
     pub cond: pthread_cond_t,
     pub ttd: *mut TaskThreadData,
@@ -1405,11 +1405,11 @@ pub struct C2RustUnnamed_40 {
     pub task_head: *mut Dav1dTask,
     pub task_tail: *mut Dav1dTask,
     pub task_cur_prev: *mut Dav1dTask,
-    pub pending_tasks: C2RustUnnamed_41,
+    pub pending_tasks: Dav1dFrameContext_task_thread_pending_tasks,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_41 {
+pub struct Dav1dFrameContext_task_thread_pending_tasks {
     pub merge: atomic_int,
     pub lock: pthread_mutex_t,
     pub head: *mut Dav1dTask,
@@ -1418,7 +1418,7 @@ pub struct C2RustUnnamed_41 {
 use crate::src::internal::Dav1dTask;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_42 {
+pub struct Dav1dFrameContext_lf {
     pub level: *mut [uint8_t; 4],
     pub mask: *mut Av1Filter,
     pub lr_mask: *mut Av1Restoration,
@@ -1449,7 +1449,7 @@ pub struct C2RustUnnamed_42 {
 use crate::src::lf_mask::Av1Restoration;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_43 {
+pub struct Dav1dFrameContext_frame_thread {
     pub next_tile_row: [libc::c_int; 2],
     pub entropy_progress: atomic_int,
     pub deblock_progress: atomic_int,
@@ -1478,18 +1478,18 @@ pub struct Av1Block {
     pub skip_mode: uint8_t,
     pub skip: uint8_t,
     pub uvtx: uint8_t,
-    pub c2rust_unnamed: C2RustUnnamed_44,
+    pub c2rust_unnamed: C2RustUnnamed_15,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_44 {
-    pub c2rust_unnamed: C2RustUnnamed_49,
-    pub c2rust_unnamed_0: C2RustUnnamed_45,
+pub union C2RustUnnamed_15 {
+    pub c2rust_unnamed: C2RustUnnamed_20,
+    pub c2rust_unnamed_0: C2RustUnnamed_16,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_45 {
-    pub c2rust_unnamed: C2RustUnnamed_46,
+pub struct C2RustUnnamed_16 {
+    pub c2rust_unnamed: C2RustUnnamed_17,
     pub comp_type: uint8_t,
     pub inter_mode: uint8_t,
     pub motion_mode: uint8_t,
@@ -1503,19 +1503,19 @@ pub struct C2RustUnnamed_45 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_46 {
-    pub c2rust_unnamed: C2RustUnnamed_48,
-    pub c2rust_unnamed_0: C2RustUnnamed_47,
+pub union C2RustUnnamed_17 {
+    pub c2rust_unnamed: C2RustUnnamed_19,
+    pub c2rust_unnamed_0: C2RustUnnamed_18,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_47 {
+pub struct C2RustUnnamed_18 {
     pub mv2d: mv,
     pub matrix: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_48 {
+pub struct C2RustUnnamed_19 {
     pub mv: [mv; 2],
     pub wedge_idx: uint8_t,
     pub mask_sign: uint8_t,
@@ -1523,7 +1523,7 @@ pub struct C2RustUnnamed_48 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_49 {
+pub struct C2RustUnnamed_20 {
     pub y_mode: uint8_t,
     pub uv_mode: uint8_t,
     pub tx: uint8_t,
@@ -1534,7 +1534,7 @@ pub struct C2RustUnnamed_49 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_50 {
+pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
     pub recon_b_inter: recon_b_inter_fn,
     pub filter_sbrow: filter_sbrow_fn,

--- a/src/log.rs
+++ b/src/log.rs
@@ -55,17 +55,17 @@ use crate::include::dav1d::headers::Dav1dWarpedMotionType;
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed {
-    pub p: C2RustUnnamed_0,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -147,7 +147,7 @@ use crate::include::dav1d::headers::Dav1dFilmGrainData;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_11,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -171,7 +171,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_10,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -181,14 +181,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_9,
-    pub quant: C2RustUnnamed_8,
-    pub segmentation: C2RustUnnamed_7,
-    pub delta: C2RustUnnamed_4,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_3,
-    pub cdef: C2RustUnnamed_2,
-    pub restoration: C2RustUnnamed_1,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -200,13 +200,13 @@ pub struct Dav1dFrameHeader {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_2 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -214,7 +214,7 @@ pub struct C2RustUnnamed_2 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -225,26 +225,26 @@ pub struct C2RustUnnamed_3 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
-    pub q: C2RustUnnamed_6,
-    pub lf: C2RustUnnamed_5,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_5 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -255,7 +255,7 @@ pub struct C2RustUnnamed_7 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -269,7 +269,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -286,14 +286,14 @@ pub struct C2RustUnnamed_9 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
@@ -361,16 +361,16 @@ pub struct Dav1dContext {
     pub cache: Dav1dThreadPicture,
     pub flush_mem: atomic_int,
     pub flush: *mut atomic_int,
-    pub frame_thread: C2RustUnnamed_22,
+    pub frame_thread: Dav1dContext_frame_thread,
     pub task_thread: TaskThreadData,
     pub segmap_pool: *mut Dav1dMemPool,
     pub refmvs_pool: *mut Dav1dMemPool,
-    pub refs: [C2RustUnnamed_16; 8],
+    pub refs: [Dav1dContext_refs; 8],
     pub cdf_pool: *mut Dav1dMemPool,
     pub cdf: [CdfThreadContext; 8],
     pub dsp: [Dav1dDSPContext; 3],
     pub refmvs_dsp: Dav1dRefmvsDSPContext,
-    pub intra_edge: C2RustUnnamed_12,
+    pub intra_edge: Dav1dContext_intra_edge,
     pub allocator: Dav1dPicAllocator,
     pub apply_grain: libc::c_int,
     pub operating_point: libc::c_int,
@@ -417,7 +417,7 @@ use crate::include::dav1d::dav1d::Dav1dInloopFilterType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_12 {
+pub struct Dav1dContext_intra_edge {
     pub root: [*mut EdgeNode; 2],
     pub branch_sb128: [EdgeBranch; 85],
     pub branch_sb64: [EdgeBranch; 21],
@@ -471,12 +471,12 @@ pub union refmvs_mvpair {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union mv {
-    pub c2rust_unnamed: C2RustUnnamed_13,
+    pub c2rust_unnamed: C2RustUnnamed,
     pub n: uint32_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_13 {
+pub struct C2RustUnnamed {
     pub y: int16_t,
     pub x: int16_t,
 }
@@ -518,11 +518,11 @@ use crate::src::looprestoration::LrEdgeFlags;
 #[repr(C)]
 pub union LooprestorationParams {
     pub filter: [[int16_t; 8]; 2],
-    pub sgr: C2RustUnnamed_14,
+    pub sgr: LooprestorationParams_sgr,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_14 {
+pub struct LooprestorationParams_sgr {
     pub s0: uint32_t,
     pub s1: uint32_t,
     pub w0: int16_t,
@@ -881,19 +881,19 @@ pub type generate_grain_y_fn = Option::<
 #[repr(C)]
 pub struct CdfThreadContext {
     pub ref_0: *mut Dav1dRef,
-    pub data: C2RustUnnamed_15,
+    pub data: CdfThreadContext_data,
     pub progress: *mut atomic_uint,
 }
 use crate::include::stdatomic::atomic_uint;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_15 {
+pub union CdfThreadContext_data {
     pub cdf: *mut CdfContext,
     pub qcat: libc::c_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_16 {
+pub struct Dav1dContext_refs {
     pub p: Dav1dThreadPicture,
     pub segmap: *mut Dav1dRef,
     pub refmvs: *mut Dav1dRef,
@@ -917,35 +917,35 @@ pub struct TaskThreadData {
     pub cur: libc::c_uint,
     pub reset_task_cur: atomic_uint,
     pub cond_signaled: atomic_int,
-    pub delayed_fg: C2RustUnnamed_17,
+    pub delayed_fg: Dav1dContext_task_thread_delayed_fg,
     pub inited: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_17 {
+pub struct Dav1dContext_task_thread_delayed_fg {
     pub exec: libc::c_int,
     pub cond: pthread_cond_t,
     pub in_0: *const Dav1dPicture,
     pub out: *mut Dav1dPicture,
     pub type_0: TaskType,
     pub progress: [atomic_int; 2],
-    pub c2rust_unnamed: C2RustUnnamed_18,
+    pub c2rust_unnamed: C2RustUnnamed_0,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_18 {
-    pub c2rust_unnamed: C2RustUnnamed_20,
-    pub c2rust_unnamed_0: C2RustUnnamed_19,
+pub union C2RustUnnamed_0 {
+    pub c2rust_unnamed: C2RustUnnamed_2,
+    pub c2rust_unnamed_0: C2RustUnnamed_1,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_19 {
+pub struct C2RustUnnamed_1 {
     pub grain_lut_16bpc: [[[int16_t; 82]; 74]; 3],
     pub scaling_16bpc: [[uint8_t; 4096]; 3],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_20 {
+pub struct C2RustUnnamed_2 {
     pub grain_lut_8bpc: [[[int8_t; 82]; 74]; 3],
     pub scaling_8bpc: [[uint8_t; 256]; 3],
 }
@@ -969,17 +969,17 @@ use crate::include::pthread::pthread_cond_t;
 #[repr(C)]
 pub union __atomic_wide_counter {
     pub __value64: libc::c_ulonglong,
-    pub __value32: C2RustUnnamed_21,
+    pub __value32: C2RustUnnamed_3,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_21 {
+pub struct C2RustUnnamed_3 {
     pub __low: libc::c_uint,
     pub __high: libc::c_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_22 {
+pub struct Dav1dContext_frame_thread {
     pub out_delayed: *mut Dav1dThreadPicture,
     pub next: libc::c_uint,
 }
@@ -999,18 +999,18 @@ pub struct Dav1dTaskContext {
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
-    pub scratch: C2RustUnnamed_25,
+    pub scratch: Dav1dTaskContext_scratch,
     pub warpmv: Dav1dWarpedMotionParams,
     pub lf_mask: *mut Av1Filter,
     pub top_pre_cdef_toggle: libc::c_int,
     pub cur_sb_cdef_idx_ptr: *mut int8_t,
     pub tl_4x4_filter: Filter2d,
-    pub frame_thread: C2RustUnnamed_24,
-    pub task_thread: C2RustUnnamed_23,
+    pub frame_thread: Dav1dTaskContext_frame_thread,
+    pub task_thread: Dav1dTaskContext_task_thread,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_23 {
+pub struct Dav1dTaskContext_task_thread {
     pub td: thread_data,
     pub ttd: *mut TaskThreadData,
     pub fttd: *mut FrameTileThreadData,
@@ -1022,7 +1022,7 @@ use crate::src::thread_data::thread_data;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_24 {
+pub struct Dav1dTaskContext_frame_thread {
     pub pass: libc::c_int,
 }
 use crate::src::levels::Filter2d;
@@ -1040,14 +1040,14 @@ use crate::src::levels::Filter2d;
 use crate::src::lf_mask::Av1Filter;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_25 {
-    pub c2rust_unnamed: C2RustUnnamed_32,
-    pub c2rust_unnamed_0: C2RustUnnamed_26,
+pub union Dav1dTaskContext_scratch {
+    pub c2rust_unnamed: C2RustUnnamed_10,
+    pub c2rust_unnamed_0: C2RustUnnamed_4,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_26 {
-    pub c2rust_unnamed: C2RustUnnamed_30,
+pub struct C2RustUnnamed_4 {
+    pub c2rust_unnamed: C2RustUnnamed_8,
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
@@ -1058,38 +1058,38 @@ use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_30 {
+pub union C2RustUnnamed_8 {
     pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: C2RustUnnamed_31,
+    pub c2rust_unnamed: C2RustUnnamed_9,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_31 {
+pub struct C2RustUnnamed_9 {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_32 {
-    pub c2rust_unnamed: C2RustUnnamed_34,
-    pub c2rust_unnamed_0: C2RustUnnamed_33,
+pub struct C2RustUnnamed_10 {
+    pub c2rust_unnamed: C2RustUnnamed_12,
+    pub c2rust_unnamed_0: C2RustUnnamed_11,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_33 {
+pub union C2RustUnnamed_11 {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_34 {
+pub union C2RustUnnamed_12 {
     pub lap_8bpc: [uint8_t; 4096],
     pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: C2RustUnnamed_35,
+    pub c2rust_unnamed: C2RustUnnamed_13,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_35 {
+pub struct C2RustUnnamed_13 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
@@ -1100,12 +1100,12 @@ pub struct refmvs_tile {
     pub rf: *const refmvs_frame,
     pub r: [*mut refmvs_block; 37],
     pub rp_proj: *mut refmvs_temporal_block,
-    pub tile_col: C2RustUnnamed_37,
-    pub tile_row: C2RustUnnamed_37,
+    pub tile_col: refmvs_tile_range,
+    pub tile_row: refmvs_tile_range,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_37 {
+pub struct refmvs_tile_range {
     pub start: libc::c_int,
     pub end: libc::c_int,
 }
@@ -1148,9 +1148,9 @@ use crate::src::env::BlockContext;
 pub struct Dav1dTileState {
     pub cdf: CdfContext,
     pub msac: MsacContext,
-    pub tiling: C2RustUnnamed_39,
+    pub tiling: Dav1dTileState_tiling,
     pub progress: [atomic_int; 2],
-    pub frame_thread: [C2RustUnnamed_38; 2],
+    pub frame_thread: [Dav1dTileState_frame_thread; 2],
     pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
     pub dqmem: [[[uint16_t; 2]; 3]; 8],
     pub dq: *const [[uint16_t; 2]; 3],
@@ -1163,13 +1163,13 @@ pub struct Dav1dTileState {
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_38 {
+pub struct Dav1dTileState_frame_thread {
     pub pal_idx: *mut uint8_t,
     pub cf: *mut libc::c_void,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_39 {
+pub struct Dav1dTileState_tiling {
     pub col_start: libc::c_int,
     pub col_end: libc::c_int,
     pub row_start: libc::c_int,
@@ -1211,7 +1211,7 @@ pub struct Dav1dFrameContext {
     pub ts: *mut Dav1dTileState,
     pub n_ts: libc::c_int,
     pub dsp: *const Dav1dDSPContext,
-    pub bd_fn: C2RustUnnamed_50,
+    pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
     pub ipred_edge: [*mut libc::c_void; 3],
     pub b4_stride: ptrdiff_t,
@@ -1232,14 +1232,14 @@ pub struct Dav1dFrameContext {
     pub rf: refmvs_frame,
     pub jnt_weights: [[uint8_t; 7]; 7],
     pub bitdepth_max: libc::c_int,
-    pub frame_thread: C2RustUnnamed_43,
-    pub lf: C2RustUnnamed_42,
-    pub task_thread: C2RustUnnamed_40,
+    pub frame_thread: Dav1dFrameContext_frame_thread,
+    pub lf: Dav1dFrameContext_lf,
+    pub task_thread: Dav1dFrameContext_task_thread,
     pub tile_thread: FrameTileThreadData,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_40 {
+pub struct Dav1dFrameContext_task_thread {
     pub lock: pthread_mutex_t,
     pub cond: pthread_cond_t,
     pub ttd: *mut TaskThreadData,
@@ -1257,11 +1257,11 @@ pub struct C2RustUnnamed_40 {
     pub task_head: *mut Dav1dTask,
     pub task_tail: *mut Dav1dTask,
     pub task_cur_prev: *mut Dav1dTask,
-    pub pending_tasks: C2RustUnnamed_41,
+    pub pending_tasks: Dav1dFrameContext_task_thread_pending_tasks,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_41 {
+pub struct Dav1dFrameContext_task_thread_pending_tasks {
     pub merge: atomic_int,
     pub lock: pthread_mutex_t,
     pub head: *mut Dav1dTask,
@@ -1270,7 +1270,7 @@ pub struct C2RustUnnamed_41 {
 use crate::src::internal::Dav1dTask;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_42 {
+pub struct Dav1dFrameContext_lf {
     pub level: *mut [uint8_t; 4],
     pub mask: *mut Av1Filter,
     pub lr_mask: *mut Av1Restoration,
@@ -1301,7 +1301,7 @@ pub struct C2RustUnnamed_42 {
 use crate::src::lf_mask::Av1Restoration;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_43 {
+pub struct Dav1dFrameContext_frame_thread {
     pub next_tile_row: [libc::c_int; 2],
     pub entropy_progress: atomic_int,
     pub deblock_progress: atomic_int,
@@ -1330,18 +1330,18 @@ pub struct Av1Block {
     pub skip_mode: uint8_t,
     pub skip: uint8_t,
     pub uvtx: uint8_t,
-    pub c2rust_unnamed: C2RustUnnamed_44,
+    pub c2rust_unnamed: C2RustUnnamed_15,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_44 {
-    pub c2rust_unnamed: C2RustUnnamed_49,
-    pub c2rust_unnamed_0: C2RustUnnamed_45,
+pub union C2RustUnnamed_15 {
+    pub c2rust_unnamed: C2RustUnnamed_20,
+    pub c2rust_unnamed_0: C2RustUnnamed_16,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_45 {
-    pub c2rust_unnamed: C2RustUnnamed_46,
+pub struct C2RustUnnamed_16 {
+    pub c2rust_unnamed: C2RustUnnamed_17,
     pub comp_type: uint8_t,
     pub inter_mode: uint8_t,
     pub motion_mode: uint8_t,
@@ -1355,19 +1355,19 @@ pub struct C2RustUnnamed_45 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_46 {
-    pub c2rust_unnamed: C2RustUnnamed_48,
-    pub c2rust_unnamed_0: C2RustUnnamed_47,
+pub union C2RustUnnamed_17 {
+    pub c2rust_unnamed: C2RustUnnamed_19,
+    pub c2rust_unnamed_0: C2RustUnnamed_18,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_47 {
+pub struct C2RustUnnamed_18 {
     pub mv2d: mv,
     pub matrix: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_48 {
+pub struct C2RustUnnamed_19 {
     pub mv: [mv; 2],
     pub wedge_idx: uint8_t,
     pub mask_sign: uint8_t,
@@ -1375,7 +1375,7 @@ pub struct C2RustUnnamed_48 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_49 {
+pub struct C2RustUnnamed_20 {
     pub y_mode: uint8_t,
     pub uv_mode: uint8_t,
     pub tx: uint8_t,
@@ -1386,7 +1386,7 @@ pub struct C2RustUnnamed_49 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_50 {
+pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
     pub recon_b_inter: recon_b_inter_fn,
     pub filter_sbrow: filter_sbrow_fn,

--- a/src/looprestoration.h
+++ b/src/looprestoration.h
@@ -48,7 +48,7 @@ typedef const void *const_left_pixel_row;
 
 typedef union LooprestorationParams {
     ALIGN(int16_t filter[2][8], 16);
-    struct {
+    struct LooprestorationParams_sgr {
         uint32_t s0, s1;
         int16_t w0, w1;
     } sgr;

--- a/src/looprestoration_tmpl_16.rs
+++ b/src/looprestoration_tmpl_16.rs
@@ -322,11 +322,11 @@ pub type const_left_pixel_row = *const [pixel; 4];
 #[repr(C)]
 pub union LooprestorationParams {
     pub filter: [[int16_t; 8]; 2],
-    pub sgr: C2RustUnnamed,
+    pub sgr: LooprestorationParams_sgr,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed {
+pub struct LooprestorationParams_sgr {
     pub s0: uint32_t,
     pub s1: uint32_t,
     pub w0: int16_t,

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -61,7 +61,7 @@ pub struct Dav1dFrameContext {
     pub ts: *mut Dav1dTileState,
     pub n_ts: libc::c_int,
     pub dsp: *const Dav1dDSPContext,
-    pub bd_fn: C2RustUnnamed_28,
+    pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
     pub ipred_edge: [*mut pixel; 3],
     pub b4_stride: ptrdiff_t,
@@ -82,15 +82,15 @@ pub struct Dav1dFrameContext {
     pub rf: refmvs_frame,
     pub jnt_weights: [[uint8_t; 7]; 7],
     pub bitdepth_max: libc::c_int,
-    pub frame_thread: C2RustUnnamed_20,
-    pub lf: C2RustUnnamed_19,
-    pub task_thread: C2RustUnnamed,
+    pub frame_thread: Dav1dFrameContext_frame_thread,
+    pub lf: Dav1dFrameContext_lf,
+    pub task_thread: Dav1dFrameContext_task_thread,
     pub tile_thread: FrameTileThreadData,
 }
 use crate::src::internal::FrameTileThreadData;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed {
+pub struct Dav1dFrameContext_task_thread {
     pub lock: pthread_mutex_t,
     pub cond: pthread_cond_t,
     pub ttd: *mut TaskThreadData,
@@ -108,11 +108,11 @@ pub struct C2RustUnnamed {
     pub task_head: *mut Dav1dTask,
     pub task_tail: *mut Dav1dTask,
     pub task_cur_prev: *mut Dav1dTask,
-    pub pending_tasks: C2RustUnnamed_0,
+    pub pending_tasks: Dav1dFrameContext_task_thread_pending_tasks,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dFrameContext_task_thread_pending_tasks {
     pub merge: atomic_int,
     pub lock: pthread_mutex_t,
     pub head: *mut Dav1dTask,
@@ -146,35 +146,35 @@ pub struct TaskThreadData {
     pub cur: libc::c_uint,
     pub reset_task_cur: atomic_uint,
     pub cond_signaled: atomic_int,
-    pub delayed_fg: C2RustUnnamed_1,
+    pub delayed_fg: Dav1dContext_task_thread_delayed_fg,
     pub inited: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dContext_task_thread_delayed_fg {
     pub exec: libc::c_int,
     pub cond: pthread_cond_t,
     pub in_0: *const Dav1dPicture,
     pub out: *mut Dav1dPicture,
     pub type_0: TaskType,
     pub progress: [atomic_int; 2],
-    pub c2rust_unnamed: C2RustUnnamed_2,
+    pub c2rust_unnamed: C2RustUnnamed,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_2 {
-    pub c2rust_unnamed: C2RustUnnamed_4,
-    pub c2rust_unnamed_0: C2RustUnnamed_3,
+pub union C2RustUnnamed {
+    pub c2rust_unnamed: C2RustUnnamed_1,
+    pub c2rust_unnamed_0: C2RustUnnamed_0,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct C2RustUnnamed_0 {
     pub grain_lut_16bpc: [[[int16_t; 82]; 74]; 3],
     pub scaling_16bpc: [[uint8_t; 4096]; 3],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
+pub struct C2RustUnnamed_1 {
     pub grain_lut_8bpc: [[[int8_t; 82]; 74]; 3],
     pub scaling_8bpc: [[uint8_t; 256]; 3],
 }
@@ -212,7 +212,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_17,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -236,7 +236,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_16,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -246,14 +246,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_15,
-    pub quant: C2RustUnnamed_14,
-    pub segmentation: C2RustUnnamed_13,
-    pub delta: C2RustUnnamed_10,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_9,
-    pub cdef: C2RustUnnamed_8,
-    pub restoration: C2RustUnnamed_7,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -268,17 +268,17 @@ pub struct Dav1dFrameHeader {
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed_5,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_5 {
-    pub p: C2RustUnnamed_6,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -296,7 +296,7 @@ use crate::include::dav1d::headers::Dav1dTxfmMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
@@ -307,7 +307,7 @@ use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -315,7 +315,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -327,26 +327,26 @@ pub struct C2RustUnnamed_9 {
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
-    pub q: C2RustUnnamed_12,
-    pub lf: C2RustUnnamed_11,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_12 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_13 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -359,7 +359,7 @@ use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_14 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -373,7 +373,7 @@ pub struct C2RustUnnamed_14 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_15 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -398,7 +398,7 @@ use crate::include::dav1d::headers::Dav1dFilterMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_16 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
@@ -410,7 +410,7 @@ use crate::include::dav1d::headers::Dav1dFrameType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_17 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
@@ -482,7 +482,7 @@ use crate::include::pthread::pthread_cond_t;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_19 {
+pub struct Dav1dFrameContext_lf {
     pub level: *mut [uint8_t; 4],
     pub mask: *mut Av1Filter,
     pub lr_mask: *mut Av1Restoration,
@@ -516,7 +516,7 @@ use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_20 {
+pub struct Dav1dFrameContext_frame_thread {
     pub next_tile_row: [libc::c_int; 2],
     pub entropy_progress: atomic_int,
     pub deblock_progress: atomic_int,
@@ -545,18 +545,18 @@ pub struct Av1Block {
     pub skip_mode: uint8_t,
     pub skip: uint8_t,
     pub uvtx: uint8_t,
-    pub c2rust_unnamed: C2RustUnnamed_21,
+    pub c2rust_unnamed: C2RustUnnamed_3,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_21 {
-    pub c2rust_unnamed: C2RustUnnamed_27,
-    pub c2rust_unnamed_0: C2RustUnnamed_22,
+pub union C2RustUnnamed_3 {
+    pub c2rust_unnamed: C2RustUnnamed_9,
+    pub c2rust_unnamed_0: C2RustUnnamed_4,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_22 {
-    pub c2rust_unnamed: C2RustUnnamed_23,
+pub struct C2RustUnnamed_4 {
+    pub c2rust_unnamed: C2RustUnnamed_5,
     pub comp_type: uint8_t,
     pub inter_mode: uint8_t,
     pub motion_mode: uint8_t,
@@ -570,31 +570,31 @@ pub struct C2RustUnnamed_22 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_23 {
-    pub c2rust_unnamed: C2RustUnnamed_26,
-    pub c2rust_unnamed_0: C2RustUnnamed_24,
+pub union C2RustUnnamed_5 {
+    pub c2rust_unnamed: C2RustUnnamed_8,
+    pub c2rust_unnamed_0: C2RustUnnamed_6,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_24 {
+pub struct C2RustUnnamed_6 {
     pub mv2d: mv,
     pub matrix: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union mv {
-    pub c2rust_unnamed: C2RustUnnamed_25,
+    pub c2rust_unnamed: C2RustUnnamed_7,
     pub n: uint32_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_25 {
+pub struct C2RustUnnamed_7 {
     pub y: int16_t,
     pub x: int16_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_26 {
+pub struct C2RustUnnamed_8 {
     pub mv: [mv; 2],
     pub wedge_idx: uint8_t,
     pub mask_sign: uint8_t,
@@ -602,7 +602,7 @@ pub struct C2RustUnnamed_26 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_27 {
+pub struct C2RustUnnamed_9 {
     pub y_mode: uint8_t,
     pub uv_mode: uint8_t,
     pub tx: uint8_t,
@@ -667,7 +667,7 @@ pub struct refmvs_temporal_block {
 use crate::src::env::BlockContext;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_28 {
+pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
     pub recon_b_inter: recon_b_inter_fn,
     pub filter_sbrow: filter_sbrow_fn,
@@ -723,18 +723,18 @@ pub struct Dav1dTaskContext {
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
-    pub scratch: C2RustUnnamed_31,
+    pub scratch: Dav1dTaskContext_scratch,
     pub warpmv: Dav1dWarpedMotionParams,
     pub lf_mask: *mut Av1Filter,
     pub top_pre_cdef_toggle: libc::c_int,
     pub cur_sb_cdef_idx_ptr: *mut int8_t,
     pub tl_4x4_filter: Filter2d,
-    pub frame_thread: C2RustUnnamed_30,
-    pub task_thread: C2RustUnnamed_29,
+    pub frame_thread: Dav1dTaskContext_frame_thread,
+    pub task_thread: Dav1dTaskContext_task_thread,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_29 {
+pub struct Dav1dTaskContext_task_thread {
     pub td: thread_data,
     pub ttd: *mut TaskThreadData,
     pub fttd: *mut FrameTileThreadData,
@@ -745,7 +745,7 @@ use crate::src::thread_data::thread_data;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_30 {
+pub struct Dav1dTaskContext_frame_thread {
     pub pass: libc::c_int,
 }
 use crate::src::levels::Filter2d;
@@ -762,14 +762,14 @@ use crate::src::levels::Filter2d;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_31 {
-    pub c2rust_unnamed: C2RustUnnamed_38,
-    pub c2rust_unnamed_0: C2RustUnnamed_32,
+pub union Dav1dTaskContext_scratch {
+    pub c2rust_unnamed: C2RustUnnamed_16,
+    pub c2rust_unnamed_0: C2RustUnnamed_10,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_32 {
-    pub c2rust_unnamed: C2RustUnnamed_36,
+pub struct C2RustUnnamed_10 {
+    pub c2rust_unnamed: C2RustUnnamed_14,
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
@@ -780,38 +780,38 @@ use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_36 {
+pub union C2RustUnnamed_14 {
     pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: C2RustUnnamed_37,
+    pub c2rust_unnamed: C2RustUnnamed_15,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_37 {
+pub struct C2RustUnnamed_15 {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_38 {
-    pub c2rust_unnamed: C2RustUnnamed_40,
-    pub c2rust_unnamed_0: C2RustUnnamed_39,
+pub struct C2RustUnnamed_16 {
+    pub c2rust_unnamed: C2RustUnnamed_18,
+    pub c2rust_unnamed_0: C2RustUnnamed_17,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_39 {
+pub union C2RustUnnamed_17 {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_40 {
+pub union C2RustUnnamed_18 {
     pub lap_8bpc: [uint8_t; 4096],
     pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: C2RustUnnamed_41,
+    pub c2rust_unnamed: C2RustUnnamed_19,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_41 {
+pub struct C2RustUnnamed_19 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
@@ -822,12 +822,12 @@ pub struct refmvs_tile {
     pub rf: *const refmvs_frame,
     pub r: [*mut refmvs_block; 37],
     pub rp_proj: *mut refmvs_temporal_block,
-    pub tile_col: C2RustUnnamed_43,
-    pub tile_row: C2RustUnnamed_43,
+    pub tile_col: refmvs_tile_range,
+    pub tile_row: refmvs_tile_range,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_43 {
+pub struct refmvs_tile_range {
     pub start: libc::c_int,
     pub end: libc::c_int,
 }
@@ -836,9 +836,9 @@ pub struct C2RustUnnamed_43 {
 pub struct Dav1dTileState {
     pub cdf: CdfContext,
     pub msac: MsacContext,
-    pub tiling: C2RustUnnamed_45,
+    pub tiling: Dav1dTileState_tiling,
     pub progress: [atomic_int; 2],
-    pub frame_thread: [C2RustUnnamed_44; 2],
+    pub frame_thread: [Dav1dTileState_frame_thread; 2],
     pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
     pub dqmem: [[[uint16_t; 2]; 3]; 8],
     pub dq: *const [[uint16_t; 2]; 3],
@@ -850,13 +850,13 @@ pub struct Dav1dTileState {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_44 {
+pub struct Dav1dTileState_frame_thread {
     pub pal_idx: *mut uint8_t,
     pub cf: *mut coef,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_45 {
+pub struct Dav1dTileState_tiling {
     pub col_start: libc::c_int,
     pub col_end: libc::c_int,
     pub row_start: libc::c_int,
@@ -893,16 +893,16 @@ pub struct Dav1dContext {
     pub cache: Dav1dThreadPicture,
     pub flush_mem: atomic_int,
     pub flush: *mut atomic_int,
-    pub frame_thread: C2RustUnnamed_50,
+    pub frame_thread: Dav1dContext_frame_thread,
     pub task_thread: TaskThreadData,
     pub segmap_pool: *mut Dav1dMemPool,
     pub refmvs_pool: *mut Dav1dMemPool,
-    pub refs: [C2RustUnnamed_49; 8],
+    pub refs: [Dav1dContext_refs; 8],
     pub cdf_pool: *mut Dav1dMemPool,
     pub cdf: [CdfThreadContext; 8],
     pub dsp: [Dav1dDSPContext; 3],
     pub refmvs_dsp: Dav1dRefmvsDSPContext,
-    pub intra_edge: C2RustUnnamed_46,
+    pub intra_edge: Dav1dContext_intra_edge,
     pub allocator: Dav1dPicAllocator,
     pub apply_grain: libc::c_int,
     pub operating_point: libc::c_int,
@@ -956,7 +956,7 @@ pub struct Dav1dPicAllocator {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_46 {
+pub struct Dav1dContext_intra_edge {
     pub root: [*mut EdgeNode; 2],
     pub branch_sb128: [EdgeBranch; 85],
     pub branch_sb64: [EdgeBranch; 21],
@@ -1026,11 +1026,11 @@ use crate::src::looprestoration::LR_HAVE_LEFT;
 #[repr(C)]
 pub union LooprestorationParams {
     pub filter: [[int16_t; 8]; 2],
-    pub sgr: C2RustUnnamed_47,
+    pub sgr: LooprestorationParams_sgr,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_47 {
+pub struct LooprestorationParams_sgr {
     pub s0: uint32_t,
     pub s1: uint32_t,
     pub w0: int16_t,
@@ -1406,18 +1406,18 @@ pub type generate_grain_y_fn = Option::<
 #[repr(C)]
 pub struct CdfThreadContext {
     pub ref_0: *mut Dav1dRef,
-    pub data: C2RustUnnamed_48,
+    pub data: CdfThreadContext_data,
     pub progress: *mut atomic_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_48 {
+pub union CdfThreadContext_data {
     pub cdf: *mut CdfContext,
     pub qcat: libc::c_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_49 {
+pub struct Dav1dContext_refs {
     pub p: Dav1dThreadPicture,
     pub segmap: *mut Dav1dRef,
     pub refmvs: *mut Dav1dRef,
@@ -1434,7 +1434,7 @@ pub struct Dav1dThreadPicture {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_50 {
+pub struct Dav1dContext_frame_thread {
     pub out_delayed: *mut Dav1dThreadPicture,
     pub next: libc::c_uint,
 }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -103,7 +103,7 @@ pub struct Dav1dFrameContext {
     pub ts: *mut Dav1dTileState,
     pub n_ts: libc::c_int,
     pub dsp: *const Dav1dDSPContext,
-    pub bd_fn: C2RustUnnamed_28,
+    pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
     pub ipred_edge: [*mut libc::c_void; 3],
     pub b4_stride: ptrdiff_t,
@@ -124,15 +124,15 @@ pub struct Dav1dFrameContext {
     pub rf: refmvs_frame,
     pub jnt_weights: [[uint8_t; 7]; 7],
     pub bitdepth_max: libc::c_int,
-    pub frame_thread: C2RustUnnamed_20,
-    pub lf: C2RustUnnamed_19,
-    pub task_thread: C2RustUnnamed,
+    pub frame_thread: Dav1dFrameContext_frame_thread,
+    pub lf: Dav1dFrameContext_lf,
+    pub task_thread: Dav1dFrameContext_task_thread,
     pub tile_thread: FrameTileThreadData,
 }
 use crate::src::internal::FrameTileThreadData;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed {
+pub struct Dav1dFrameContext_task_thread {
     pub lock: pthread_mutex_t,
     pub cond: pthread_cond_t,
     pub ttd: *mut TaskThreadData,
@@ -150,11 +150,11 @@ pub struct C2RustUnnamed {
     pub task_head: *mut Dav1dTask,
     pub task_tail: *mut Dav1dTask,
     pub task_cur_prev: *mut Dav1dTask,
-    pub pending_tasks: C2RustUnnamed_0,
+    pub pending_tasks: Dav1dFrameContext_task_thread_pending_tasks,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dFrameContext_task_thread_pending_tasks {
     pub merge: atomic_int,
     pub lock: pthread_mutex_t,
     pub head: *mut Dav1dTask,
@@ -188,35 +188,35 @@ pub struct TaskThreadData {
     pub cur: libc::c_uint,
     pub reset_task_cur: atomic_uint,
     pub cond_signaled: atomic_int,
-    pub delayed_fg: C2RustUnnamed_1,
+    pub delayed_fg: Dav1dContext_task_thread_delayed_fg,
     pub inited: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dContext_task_thread_delayed_fg {
     pub exec: libc::c_int,
     pub cond: pthread_cond_t,
     pub in_0: *const Dav1dPicture,
     pub out: *mut Dav1dPicture,
     pub type_0: TaskType,
     pub progress: [atomic_int; 2],
-    pub c2rust_unnamed: C2RustUnnamed_2,
+    pub c2rust_unnamed: C2RustUnnamed,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_2 {
-    pub c2rust_unnamed: C2RustUnnamed_4,
-    pub c2rust_unnamed_0: C2RustUnnamed_3,
+pub union C2RustUnnamed {
+    pub c2rust_unnamed: C2RustUnnamed_1,
+    pub c2rust_unnamed_0: C2RustUnnamed_0,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct C2RustUnnamed_0 {
     pub grain_lut_16bpc: [[[int16_t; 82]; 74]; 3],
     pub scaling_16bpc: [[uint8_t; 4096]; 3],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
+pub struct C2RustUnnamed_1 {
     pub grain_lut_8bpc: [[[int8_t; 82]; 74]; 3],
     pub scaling_8bpc: [[uint8_t; 256]; 3],
 }
@@ -254,7 +254,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_17,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -278,7 +278,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_16,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -288,14 +288,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_15,
-    pub quant: C2RustUnnamed_14,
-    pub segmentation: C2RustUnnamed_13,
-    pub delta: C2RustUnnamed_10,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_9,
-    pub cdef: C2RustUnnamed_8,
-    pub restoration: C2RustUnnamed_7,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -310,17 +310,17 @@ pub struct Dav1dFrameHeader {
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed_5,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_5 {
-    pub p: C2RustUnnamed_6,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -338,7 +338,7 @@ use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
 use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
@@ -349,7 +349,7 @@ use crate::include::dav1d::headers::Dav1dRestorationType;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -357,7 +357,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -369,26 +369,26 @@ pub struct C2RustUnnamed_9 {
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
-    pub q: C2RustUnnamed_12,
-    pub lf: C2RustUnnamed_11,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_12 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_13 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -401,7 +401,7 @@ use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 use crate::include::dav1d::headers::Dav1dSegmentationData;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_14 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -415,7 +415,7 @@ pub struct C2RustUnnamed_14 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_15 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -440,7 +440,7 @@ use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_16 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
@@ -452,7 +452,7 @@ use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
 use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_17 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
@@ -524,7 +524,7 @@ use crate::include::pthread::pthread_cond_t;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_19 {
+pub struct Dav1dFrameContext_lf {
     pub level: *mut [uint8_t; 4],
     pub mask: *mut Av1Filter,
     pub lr_mask: *mut Av1Restoration,
@@ -559,7 +559,7 @@ use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_20 {
+pub struct Dav1dFrameContext_frame_thread {
     pub next_tile_row: [libc::c_int; 2],
     pub entropy_progress: atomic_int,
     pub deblock_progress: atomic_int,
@@ -589,18 +589,18 @@ pub struct Av1Block {
     pub skip_mode: uint8_t,
     pub skip: uint8_t,
     pub uvtx: uint8_t,
-    pub c2rust_unnamed: C2RustUnnamed_21,
+    pub c2rust_unnamed: C2RustUnnamed_3,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_21 {
-    pub c2rust_unnamed: C2RustUnnamed_27,
-    pub c2rust_unnamed_0: C2RustUnnamed_22,
+pub union C2RustUnnamed_3 {
+    pub c2rust_unnamed: C2RustUnnamed_9,
+    pub c2rust_unnamed_0: C2RustUnnamed_4,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_22 {
-    pub c2rust_unnamed: C2RustUnnamed_23,
+pub struct C2RustUnnamed_4 {
+    pub c2rust_unnamed: C2RustUnnamed_5,
     pub comp_type: uint8_t,
     pub inter_mode: uint8_t,
     pub motion_mode: uint8_t,
@@ -614,31 +614,31 @@ pub struct C2RustUnnamed_22 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_23 {
-    pub c2rust_unnamed: C2RustUnnamed_26,
-    pub c2rust_unnamed_0: C2RustUnnamed_24,
+pub union C2RustUnnamed_5 {
+    pub c2rust_unnamed: C2RustUnnamed_8,
+    pub c2rust_unnamed_0: C2RustUnnamed_6,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_24 {
+pub struct C2RustUnnamed_6 {
     pub mv2d: mv,
     pub matrix: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union mv {
-    pub c2rust_unnamed: C2RustUnnamed_25,
+    pub c2rust_unnamed: C2RustUnnamed_7,
     pub n: uint32_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_25 {
+pub struct C2RustUnnamed_7 {
     pub y: int16_t,
     pub x: int16_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_26 {
+pub struct C2RustUnnamed_8 {
     pub mv: [mv; 2],
     pub wedge_idx: uint8_t,
     pub mask_sign: uint8_t,
@@ -646,7 +646,7 @@ pub struct C2RustUnnamed_26 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_27 {
+pub struct C2RustUnnamed_9 {
     pub y_mode: uint8_t,
     pub uv_mode: uint8_t,
     pub tx: uint8_t,
@@ -711,7 +711,7 @@ pub struct refmvs_temporal_block {
 use crate::src::env::BlockContext;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_28 {
+pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
     pub recon_b_inter: recon_b_inter_fn,
     pub filter_sbrow: filter_sbrow_fn,
@@ -767,18 +767,18 @@ pub struct Dav1dTaskContext {
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
-    pub scratch: C2RustUnnamed_31,
+    pub scratch: Dav1dTaskContext_scratch,
     pub warpmv: Dav1dWarpedMotionParams,
     pub lf_mask: *mut Av1Filter,
     pub top_pre_cdef_toggle: libc::c_int,
     pub cur_sb_cdef_idx_ptr: *mut int8_t,
     pub tl_4x4_filter: Filter2d,
-    pub frame_thread: C2RustUnnamed_30,
-    pub task_thread: C2RustUnnamed_29,
+    pub frame_thread: Dav1dTaskContext_frame_thread,
+    pub task_thread: Dav1dTaskContext_task_thread,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_29 {
+pub struct Dav1dTaskContext_task_thread {
     pub td: thread_data,
     pub ttd: *mut TaskThreadData,
     pub fttd: *mut FrameTileThreadData,
@@ -789,7 +789,7 @@ use crate::src::thread_data::thread_data;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_30 {
+pub struct Dav1dTaskContext_frame_thread {
     pub pass: libc::c_int,
 }
 use crate::src::levels::Filter2d;
@@ -806,14 +806,14 @@ use crate::src::levels::Filter2d;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_31 {
-    pub c2rust_unnamed: C2RustUnnamed_38,
-    pub c2rust_unnamed_0: C2RustUnnamed_32,
+pub union Dav1dTaskContext_scratch {
+    pub c2rust_unnamed: C2RustUnnamed_16,
+    pub c2rust_unnamed_0: C2RustUnnamed_10,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_32 {
-    pub c2rust_unnamed: C2RustUnnamed_36,
+pub struct C2RustUnnamed_10 {
+    pub c2rust_unnamed: C2RustUnnamed_14,
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
@@ -824,38 +824,38 @@ use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_36 {
+pub union C2RustUnnamed_14 {
     pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: C2RustUnnamed_37,
+    pub c2rust_unnamed: C2RustUnnamed_15,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_37 {
+pub struct C2RustUnnamed_15 {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_38 {
-    pub c2rust_unnamed: C2RustUnnamed_40,
-    pub c2rust_unnamed_0: C2RustUnnamed_39,
+pub struct C2RustUnnamed_16 {
+    pub c2rust_unnamed: C2RustUnnamed_18,
+    pub c2rust_unnamed_0: C2RustUnnamed_17,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_39 {
+pub union C2RustUnnamed_17 {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_40 {
+pub union C2RustUnnamed_18 {
     pub lap_8bpc: [uint8_t; 4096],
     pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: C2RustUnnamed_41,
+    pub c2rust_unnamed: C2RustUnnamed_19,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_41 {
+pub struct C2RustUnnamed_19 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
@@ -866,12 +866,12 @@ pub struct refmvs_tile {
     pub rf: *const refmvs_frame,
     pub r: [*mut refmvs_block; 37],
     pub rp_proj: *mut refmvs_temporal_block,
-    pub tile_col: C2RustUnnamed_43,
-    pub tile_row: C2RustUnnamed_43,
+    pub tile_col: refmvs_tile_range,
+    pub tile_row: refmvs_tile_range,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_43 {
+pub struct refmvs_tile_range {
     pub start: libc::c_int,
     pub end: libc::c_int,
 }
@@ -880,9 +880,9 @@ pub struct C2RustUnnamed_43 {
 pub struct Dav1dTileState {
     pub cdf: CdfContext,
     pub msac: MsacContext,
-    pub tiling: C2RustUnnamed_45,
+    pub tiling: Dav1dTileState_tiling,
     pub progress: [atomic_int; 2],
-    pub frame_thread: [C2RustUnnamed_44; 2],
+    pub frame_thread: [Dav1dTileState_frame_thread; 2],
     pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
     pub dqmem: [[[uint16_t; 2]; 3]; 8],
     pub dq: *const [[uint16_t; 2]; 3],
@@ -894,13 +894,13 @@ pub struct Dav1dTileState {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_44 {
+pub struct Dav1dTileState_frame_thread {
     pub pal_idx: *mut uint8_t,
     pub cf: *mut libc::c_void,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_45 {
+pub struct Dav1dTileState_tiling {
     pub col_start: libc::c_int,
     pub col_end: libc::c_int,
     pub row_start: libc::c_int,
@@ -937,16 +937,16 @@ pub struct Dav1dContext {
     pub cache: Dav1dThreadPicture,
     pub flush_mem: atomic_int,
     pub flush: *mut atomic_int,
-    pub frame_thread: C2RustUnnamed_50,
+    pub frame_thread: Dav1dContext_frame_thread,
     pub task_thread: TaskThreadData,
     pub segmap_pool: *mut Dav1dMemPool,
     pub refmvs_pool: *mut Dav1dMemPool,
-    pub refs: [C2RustUnnamed_49; 8],
+    pub refs: [Dav1dContext_refs; 8],
     pub cdf_pool: *mut Dav1dMemPool,
     pub cdf: [CdfThreadContext; 8],
     pub dsp: [Dav1dDSPContext; 3],
     pub refmvs_dsp: Dav1dRefmvsDSPContext,
-    pub intra_edge: C2RustUnnamed_46,
+    pub intra_edge: Dav1dContext_intra_edge,
     pub allocator: Dav1dPicAllocator,
     pub apply_grain: libc::c_int,
     pub operating_point: libc::c_int,
@@ -1000,7 +1000,7 @@ pub struct Dav1dPicAllocator {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_46 {
+pub struct Dav1dContext_intra_edge {
     pub root: [*mut EdgeNode; 2],
     pub branch_sb128: [EdgeBranch; 85],
     pub branch_sb64: [EdgeBranch; 21],
@@ -1069,11 +1069,11 @@ use crate::src::looprestoration::LrEdgeFlags;
 #[repr(C)]
 pub union LooprestorationParams {
     pub filter: [[int16_t; 8]; 2],
-    pub sgr: C2RustUnnamed_47,
+    pub sgr: LooprestorationParams_sgr,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_47 {
+pub struct LooprestorationParams_sgr {
     pub s0: uint32_t,
     pub s1: uint32_t,
     pub w0: int16_t,
@@ -1429,18 +1429,18 @@ pub type generate_grain_y_fn = Option::<
 #[repr(C)]
 pub struct CdfThreadContext {
     pub ref_0: *mut Dav1dRef,
-    pub data: C2RustUnnamed_48,
+    pub data: CdfThreadContext_data,
     pub progress: *mut atomic_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_48 {
+pub union CdfThreadContext_data {
     pub cdf: *mut CdfContext,
     pub qcat: libc::c_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_49 {
+pub struct Dav1dContext_refs {
     pub p: Dav1dThreadPicture,
     pub segmap: *mut Dav1dRef,
     pub refmvs: *mut Dav1dRef,
@@ -1457,7 +1457,7 @@ pub struct Dav1dThreadPicture {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_50 {
+pub struct Dav1dContext_frame_thread {
     pub out_delayed: *mut Dav1dThreadPicture,
     pub next: libc::c_uint,
 }

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -108,7 +108,7 @@ pub struct Dav1dFrameContext {
     pub ts: *mut Dav1dTileState,
     pub n_ts: libc::c_int,
     pub dsp: *const Dav1dDSPContext,
-    pub bd_fn: C2RustUnnamed_28,
+    pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
     pub ipred_edge: [*mut libc::c_void; 3],
     pub b4_stride: ptrdiff_t,
@@ -129,15 +129,15 @@ pub struct Dav1dFrameContext {
     pub rf: refmvs_frame,
     pub jnt_weights: [[uint8_t; 7]; 7],
     pub bitdepth_max: libc::c_int,
-    pub frame_thread: C2RustUnnamed_20,
-    pub lf: C2RustUnnamed_19,
-    pub task_thread: C2RustUnnamed_0,
+    pub frame_thread: Dav1dFrameContext_frame_thread,
+    pub lf: Dav1dFrameContext_lf,
+    pub task_thread: Dav1dFrameContext_task_thread,
     pub tile_thread: FrameTileThreadData,
 }
 use crate::src::internal::FrameTileThreadData;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dFrameContext_task_thread {
     pub lock: pthread_mutex_t,
     pub cond: pthread_cond_t,
     pub ttd: *mut TaskThreadData,
@@ -155,11 +155,11 @@ pub struct C2RustUnnamed_0 {
     pub task_head: *mut Dav1dTask,
     pub task_tail: *mut Dav1dTask,
     pub task_cur_prev: *mut Dav1dTask,
-    pub pending_tasks: C2RustUnnamed_1,
+    pub pending_tasks: Dav1dFrameContext_task_thread_pending_tasks,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dFrameContext_task_thread_pending_tasks {
     pub merge: atomic_int,
     pub lock: pthread_mutex_t,
     pub head: *mut Dav1dTask,
@@ -189,35 +189,35 @@ pub struct TaskThreadData {
     pub cur: libc::c_uint,
     pub reset_task_cur: atomic_uint,
     pub cond_signaled: atomic_int,
-    pub delayed_fg: C2RustUnnamed_2,
+    pub delayed_fg: Dav1dContext_task_thread_delayed_fg,
     pub inited: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_2 {
+pub struct Dav1dContext_task_thread_delayed_fg {
     pub exec: libc::c_int,
     pub cond: pthread_cond_t,
     pub in_0: *const Dav1dPicture,
     pub out: *mut Dav1dPicture,
     pub type_0: TaskType,
     pub progress: [atomic_int; 2],
-    pub c2rust_unnamed: C2RustUnnamed_3,
+    pub c2rust_unnamed: C2RustUnnamed_0,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_3 {
-    pub c2rust_unnamed: C2RustUnnamed_5,
-    pub c2rust_unnamed_0: C2RustUnnamed_4,
+pub union C2RustUnnamed_0 {
+    pub c2rust_unnamed: C2RustUnnamed_2,
+    pub c2rust_unnamed_0: C2RustUnnamed_1,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
+pub struct C2RustUnnamed_1 {
     pub grain_lut_16bpc: [[[int16_t; 82]; 74]; 3],
     pub scaling_16bpc: [[uint8_t; 4096]; 3],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_5 {
+pub struct C2RustUnnamed_2 {
     pub grain_lut_8bpc: [[[int8_t; 82]; 74]; 3],
     pub scaling_8bpc: [[uint8_t; 256]; 3],
 }
@@ -255,7 +255,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_18,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -279,7 +279,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_17,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -289,14 +289,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_16,
-    pub quant: C2RustUnnamed_15,
-    pub segmentation: C2RustUnnamed_14,
-    pub delta: C2RustUnnamed_11,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_10,
-    pub cdef: C2RustUnnamed_9,
-    pub restoration: C2RustUnnamed_8,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -311,17 +311,17 @@ pub struct Dav1dFrameHeader {
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed_6,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_6 {
-    pub p: C2RustUnnamed_7,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -339,7 +339,7 @@ use crate::include::dav1d::headers::Dav1dTxfmMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
@@ -350,7 +350,7 @@ use crate::include::dav1d::headers::Dav1dRestorationType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -358,7 +358,7 @@ pub struct C2RustUnnamed_9 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -370,26 +370,26 @@ pub struct C2RustUnnamed_10 {
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
-    pub q: C2RustUnnamed_13,
-    pub lf: C2RustUnnamed_12,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_12 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_13 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_14 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -402,7 +402,7 @@ use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_15 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -416,7 +416,7 @@ pub struct C2RustUnnamed_15 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_16 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -441,7 +441,7 @@ use crate::include::dav1d::headers::Dav1dFilterMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_17 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
@@ -453,7 +453,7 @@ use crate::include::dav1d::headers::Dav1dFrameType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_18 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
@@ -521,7 +521,7 @@ use crate::include::dav1d::headers::Dav1dSequenceHeader;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_19 {
+pub struct Dav1dFrameContext_lf {
     pub level: *mut [uint8_t; 4],
     pub mask: *mut Av1Filter,
     pub lr_mask: *mut Av1Restoration,
@@ -556,7 +556,7 @@ use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_20 {
+pub struct Dav1dFrameContext_frame_thread {
     pub next_tile_row: [libc::c_int; 2],
     pub entropy_progress: atomic_int,
     pub deblock_progress: atomic_int,
@@ -586,18 +586,18 @@ pub struct Av1Block {
     pub skip_mode: uint8_t,
     pub skip: uint8_t,
     pub uvtx: uint8_t,
-    pub c2rust_unnamed: C2RustUnnamed_21,
+    pub c2rust_unnamed: C2RustUnnamed_3,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_21 {
-    pub c2rust_unnamed: C2RustUnnamed_27,
-    pub c2rust_unnamed_0: C2RustUnnamed_22,
+pub union C2RustUnnamed_3 {
+    pub c2rust_unnamed: C2RustUnnamed_9,
+    pub c2rust_unnamed_0: C2RustUnnamed_4,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_22 {
-    pub c2rust_unnamed: C2RustUnnamed_23,
+pub struct C2RustUnnamed_4 {
+    pub c2rust_unnamed: C2RustUnnamed_5,
     pub comp_type: uint8_t,
     pub inter_mode: uint8_t,
     pub motion_mode: uint8_t,
@@ -611,31 +611,31 @@ pub struct C2RustUnnamed_22 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_23 {
-    pub c2rust_unnamed: C2RustUnnamed_26,
-    pub c2rust_unnamed_0: C2RustUnnamed_24,
+pub union C2RustUnnamed_5 {
+    pub c2rust_unnamed: C2RustUnnamed_8,
+    pub c2rust_unnamed_0: C2RustUnnamed_6,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_24 {
+pub struct C2RustUnnamed_6 {
     pub mv2d: mv,
     pub matrix: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union mv {
-    pub c2rust_unnamed: C2RustUnnamed_25,
+    pub c2rust_unnamed: C2RustUnnamed_7,
     pub n: uint32_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_25 {
+pub struct C2RustUnnamed_7 {
     pub y: int16_t,
     pub x: int16_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_26 {
+pub struct C2RustUnnamed_8 {
     pub mv: [mv; 2],
     pub wedge_idx: uint8_t,
     pub mask_sign: uint8_t,
@@ -643,7 +643,7 @@ pub struct C2RustUnnamed_26 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_27 {
+pub struct C2RustUnnamed_9 {
     pub y_mode: uint8_t,
     pub uv_mode: uint8_t,
     pub tx: uint8_t,
@@ -708,7 +708,7 @@ pub struct refmvs_temporal_block {
 use crate::src::env::BlockContext;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_28 {
+pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
     pub recon_b_inter: recon_b_inter_fn,
     pub filter_sbrow: filter_sbrow_fn,
@@ -764,18 +764,18 @@ pub struct Dav1dTaskContext {
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
-    pub scratch: C2RustUnnamed_31,
+    pub scratch: Dav1dTaskContext_scratch,
     pub warpmv: Dav1dWarpedMotionParams,
     pub lf_mask: *mut Av1Filter,
     pub top_pre_cdef_toggle: libc::c_int,
     pub cur_sb_cdef_idx_ptr: *mut int8_t,
     pub tl_4x4_filter: Filter2d,
-    pub frame_thread: C2RustUnnamed_30,
-    pub task_thread: C2RustUnnamed_29,
+    pub frame_thread: Dav1dTaskContext_frame_thread,
+    pub task_thread: Dav1dTaskContext_task_thread,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_29 {
+pub struct Dav1dTaskContext_task_thread {
     pub td: thread_data,
     pub ttd: *mut TaskThreadData,
     pub fttd: *mut FrameTileThreadData,
@@ -785,7 +785,7 @@ pub struct C2RustUnnamed_29 {
 use crate::src::thread_data::thread_data;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_30 {
+pub struct Dav1dTaskContext_frame_thread {
     pub pass: libc::c_int,
 }
 use crate::src::levels::Filter2d;
@@ -802,14 +802,14 @@ use crate::src::levels::Filter2d;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_31 {
-    pub c2rust_unnamed: C2RustUnnamed_38,
-    pub c2rust_unnamed_0: C2RustUnnamed_32,
+pub union Dav1dTaskContext_scratch {
+    pub c2rust_unnamed: C2RustUnnamed_16,
+    pub c2rust_unnamed_0: C2RustUnnamed_10,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_32 {
-    pub c2rust_unnamed: C2RustUnnamed_36,
+pub struct C2RustUnnamed_10 {
+    pub c2rust_unnamed: C2RustUnnamed_14,
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
@@ -820,38 +820,38 @@ use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_36 {
+pub union C2RustUnnamed_14 {
     pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: C2RustUnnamed_37,
+    pub c2rust_unnamed: C2RustUnnamed_15,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_37 {
+pub struct C2RustUnnamed_15 {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_38 {
-    pub c2rust_unnamed: C2RustUnnamed_40,
-    pub c2rust_unnamed_0: C2RustUnnamed_39,
+pub struct C2RustUnnamed_16 {
+    pub c2rust_unnamed: C2RustUnnamed_18,
+    pub c2rust_unnamed_0: C2RustUnnamed_17,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_39 {
+pub union C2RustUnnamed_17 {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_40 {
+pub union C2RustUnnamed_18 {
     pub lap_8bpc: [uint8_t; 4096],
     pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: C2RustUnnamed_41,
+    pub c2rust_unnamed: C2RustUnnamed_19,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_41 {
+pub struct C2RustUnnamed_19 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
@@ -862,12 +862,12 @@ pub struct refmvs_tile {
     pub rf: *const refmvs_frame,
     pub r: [*mut refmvs_block; 37],
     pub rp_proj: *mut refmvs_temporal_block,
-    pub tile_col: C2RustUnnamed_43,
-    pub tile_row: C2RustUnnamed_43,
+    pub tile_col: refmvs_tile_range,
+    pub tile_row: refmvs_tile_range,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_43 {
+pub struct refmvs_tile_range {
     pub start: libc::c_int,
     pub end: libc::c_int,
 }
@@ -876,9 +876,9 @@ pub struct C2RustUnnamed_43 {
 pub struct Dav1dTileState {
     pub cdf: CdfContext,
     pub msac: MsacContext,
-    pub tiling: C2RustUnnamed_45,
+    pub tiling: Dav1dTileState_tiling,
     pub progress: [atomic_int; 2],
-    pub frame_thread: [C2RustUnnamed_44; 2],
+    pub frame_thread: [Dav1dTileState_frame_thread; 2],
     pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
     pub dqmem: [[[uint16_t; 2]; 3]; 8],
     pub dq: *const [[uint16_t; 2]; 3],
@@ -890,13 +890,13 @@ pub struct Dav1dTileState {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_44 {
+pub struct Dav1dTileState_frame_thread {
     pub pal_idx: *mut uint8_t,
     pub cf: *mut libc::c_void,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_45 {
+pub struct Dav1dTileState_tiling {
     pub col_start: libc::c_int,
     pub col_end: libc::c_int,
     pub row_start: libc::c_int,
@@ -933,16 +933,16 @@ pub struct Dav1dContext {
     pub cache: Dav1dThreadPicture,
     pub flush_mem: atomic_int,
     pub flush: *mut atomic_int,
-    pub frame_thread: C2RustUnnamed_50,
+    pub frame_thread: Dav1dContext_frame_thread,
     pub task_thread: TaskThreadData,
     pub segmap_pool: *mut Dav1dMemPool,
     pub refmvs_pool: *mut Dav1dMemPool,
-    pub refs: [C2RustUnnamed_49; 8],
+    pub refs: [Dav1dContext_refs; 8],
     pub cdf_pool: *mut Dav1dMemPool,
     pub cdf: [CdfThreadContext; 8],
     pub dsp: [Dav1dDSPContext; 3],
     pub refmvs_dsp: Dav1dRefmvsDSPContext,
-    pub intra_edge: C2RustUnnamed_46,
+    pub intra_edge: Dav1dContext_intra_edge,
     pub allocator: Dav1dPicAllocator,
     pub apply_grain: libc::c_int,
     pub operating_point: libc::c_int,
@@ -996,7 +996,7 @@ pub struct Dav1dPicAllocator {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_46 {
+pub struct Dav1dContext_intra_edge {
     pub root: [*mut EdgeNode; 2],
     pub branch_sb128: [EdgeBranch; 85],
     pub branch_sb64: [EdgeBranch; 21],
@@ -1065,11 +1065,11 @@ use crate::src::looprestoration::LrEdgeFlags;
 #[repr(C)]
 pub union LooprestorationParams {
     pub filter: [[int16_t; 8]; 2],
-    pub sgr: C2RustUnnamed_47,
+    pub sgr: LooprestorationParams_sgr,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_47 {
+pub struct LooprestorationParams_sgr {
     pub s0: uint32_t,
     pub s1: uint32_t,
     pub w0: int16_t,
@@ -1425,18 +1425,18 @@ pub type generate_grain_y_fn = Option::<
 #[repr(C)]
 pub struct CdfThreadContext {
     pub ref_0: *mut Dav1dRef,
-    pub data: C2RustUnnamed_48,
+    pub data: CdfThreadContext_data,
     pub progress: *mut atomic_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_48 {
+pub union CdfThreadContext_data {
     pub cdf: *mut CdfContext,
     pub qcat: libc::c_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_49 {
+pub struct Dav1dContext_refs {
     pub p: Dav1dThreadPicture,
     pub segmap: *mut Dav1dRef,
     pub refmvs: *mut Dav1dRef,
@@ -1453,7 +1453,7 @@ pub struct Dav1dThreadPicture {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_50 {
+pub struct Dav1dContext_frame_thread {
     pub out_delayed: *mut Dav1dThreadPicture,
     pub next: libc::c_uint,
 }

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -149,7 +149,7 @@ pub struct Dav1dFrameContext {
     pub ts: *mut Dav1dTileState,
     pub n_ts: libc::c_int,
     pub dsp: *const Dav1dDSPContext,
-    pub bd_fn: C2RustUnnamed_28,
+    pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
     pub ipred_edge: [*mut pixel; 3],
     pub b4_stride: ptrdiff_t,
@@ -170,15 +170,15 @@ pub struct Dav1dFrameContext {
     pub rf: refmvs_frame,
     pub jnt_weights: [[uint8_t; 7]; 7],
     pub bitdepth_max: libc::c_int,
-    pub frame_thread: C2RustUnnamed_20,
-    pub lf: C2RustUnnamed_19,
-    pub task_thread: C2RustUnnamed,
+    pub frame_thread: Dav1dFrameContext_frame_thread,
+    pub lf: Dav1dFrameContext_lf,
+    pub task_thread: Dav1dFrameContext_task_thread,
     pub tile_thread: FrameTileThreadData,
 }
 use crate::src::internal::FrameTileThreadData;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed {
+pub struct Dav1dFrameContext_task_thread {
     pub lock: pthread_mutex_t,
     pub cond: pthread_cond_t,
     pub ttd: *mut TaskThreadData,
@@ -196,11 +196,11 @@ pub struct C2RustUnnamed {
     pub task_head: *mut Dav1dTask,
     pub task_tail: *mut Dav1dTask,
     pub task_cur_prev: *mut Dav1dTask,
-    pub pending_tasks: C2RustUnnamed_0,
+    pub pending_tasks: Dav1dFrameContext_task_thread_pending_tasks,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dFrameContext_task_thread_pending_tasks {
     pub merge: atomic_int,
     pub lock: pthread_mutex_t,
     pub head: *mut Dav1dTask,
@@ -234,35 +234,35 @@ pub struct TaskThreadData {
     pub cur: libc::c_uint,
     pub reset_task_cur: atomic_uint,
     pub cond_signaled: atomic_int,
-    pub delayed_fg: C2RustUnnamed_1,
+    pub delayed_fg: Dav1dContext_task_thread_delayed_fg,
     pub inited: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dContext_task_thread_delayed_fg {
     pub exec: libc::c_int,
     pub cond: pthread_cond_t,
     pub in_0: *const Dav1dPicture,
     pub out: *mut Dav1dPicture,
     pub type_0: TaskType,
     pub progress: [atomic_int; 2],
-    pub c2rust_unnamed: C2RustUnnamed_2,
+    pub c2rust_unnamed: C2RustUnnamed,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_2 {
-    pub c2rust_unnamed: C2RustUnnamed_4,
-    pub c2rust_unnamed_0: C2RustUnnamed_3,
+pub union C2RustUnnamed {
+    pub c2rust_unnamed: C2RustUnnamed_1,
+    pub c2rust_unnamed_0: C2RustUnnamed_0,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct C2RustUnnamed_0 {
     pub grain_lut_16bpc: [[[int16_t; 82]; 74]; 3],
     pub scaling_16bpc: [[uint8_t; 4096]; 3],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
+pub struct C2RustUnnamed_1 {
     pub grain_lut_8bpc: [[[int8_t; 82]; 74]; 3],
     pub scaling_8bpc: [[uint8_t; 256]; 3],
 }
@@ -300,7 +300,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_17,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -324,7 +324,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_16,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -334,14 +334,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_15,
-    pub quant: C2RustUnnamed_14,
-    pub segmentation: C2RustUnnamed_13,
-    pub delta: C2RustUnnamed_10,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_9,
-    pub cdef: C2RustUnnamed_8,
-    pub restoration: C2RustUnnamed_7,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -356,17 +356,17 @@ pub struct Dav1dFrameHeader {
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed_5,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_5 {
-    pub p: C2RustUnnamed_6,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -384,7 +384,7 @@ use crate::include::dav1d::headers::Dav1dTxfmMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
@@ -395,7 +395,7 @@ use crate::include::dav1d::headers::Dav1dRestorationType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -403,7 +403,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -415,26 +415,26 @@ pub struct C2RustUnnamed_9 {
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
-    pub q: C2RustUnnamed_12,
-    pub lf: C2RustUnnamed_11,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_12 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_13 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -447,7 +447,7 @@ use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_14 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -461,7 +461,7 @@ pub struct C2RustUnnamed_14 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_15 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -486,7 +486,7 @@ use crate::include::dav1d::headers::Dav1dFilterMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_16 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
@@ -498,7 +498,7 @@ use crate::include::dav1d::headers::Dav1dFrameType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_17 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
@@ -570,7 +570,7 @@ use crate::include::pthread::pthread_cond_t;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_19 {
+pub struct Dav1dFrameContext_lf {
     pub level: *mut [uint8_t; 4],
     pub mask: *mut Av1Filter,
     pub lr_mask: *mut Av1Restoration,
@@ -604,7 +604,7 @@ use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_20 {
+pub struct Dav1dFrameContext_frame_thread {
     pub next_tile_row: [libc::c_int; 2],
     pub entropy_progress: atomic_int,
     pub deblock_progress: atomic_int,
@@ -633,18 +633,18 @@ pub struct Av1Block {
     pub skip_mode: uint8_t,
     pub skip: uint8_t,
     pub uvtx: uint8_t,
-    pub c2rust_unnamed: C2RustUnnamed_21,
+    pub c2rust_unnamed: C2RustUnnamed_3,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_21 {
-    pub c2rust_unnamed: C2RustUnnamed_27,
-    pub c2rust_unnamed_0: C2RustUnnamed_22,
+pub union C2RustUnnamed_3 {
+    pub c2rust_unnamed: C2RustUnnamed_9,
+    pub c2rust_unnamed_0: C2RustUnnamed_4,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_22 {
-    pub c2rust_unnamed: C2RustUnnamed_23,
+pub struct C2RustUnnamed_4 {
+    pub c2rust_unnamed: C2RustUnnamed_5,
     pub comp_type: uint8_t,
     pub inter_mode: uint8_t,
     pub motion_mode: uint8_t,
@@ -658,31 +658,31 @@ pub struct C2RustUnnamed_22 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_23 {
-    pub c2rust_unnamed: C2RustUnnamed_26,
-    pub c2rust_unnamed_0: C2RustUnnamed_24,
+pub union C2RustUnnamed_5 {
+    pub c2rust_unnamed: C2RustUnnamed_8,
+    pub c2rust_unnamed_0: C2RustUnnamed_6,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_24 {
+pub struct C2RustUnnamed_6 {
     pub mv2d: mv,
     pub matrix: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union mv {
-    pub c2rust_unnamed: C2RustUnnamed_25,
+    pub c2rust_unnamed: C2RustUnnamed_7,
     pub n: uint32_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_25 {
+pub struct C2RustUnnamed_7 {
     pub y: int16_t,
     pub x: int16_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_26 {
+pub struct C2RustUnnamed_8 {
     pub mv: [mv; 2],
     pub wedge_idx: uint8_t,
     pub mask_sign: uint8_t,
@@ -690,7 +690,7 @@ pub struct C2RustUnnamed_26 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_27 {
+pub struct C2RustUnnamed_9 {
     pub y_mode: uint8_t,
     pub uv_mode: uint8_t,
     pub tx: uint8_t,
@@ -755,7 +755,7 @@ pub struct refmvs_temporal_block {
 use crate::src::env::BlockContext;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_28 {
+pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
     pub recon_b_inter: recon_b_inter_fn,
     pub filter_sbrow: filter_sbrow_fn,
@@ -811,18 +811,18 @@ pub struct Dav1dTaskContext {
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
-    pub scratch: C2RustUnnamed_31,
+    pub scratch: Dav1dTaskContext_scratch,
     pub warpmv: Dav1dWarpedMotionParams,
     pub lf_mask: *mut Av1Filter,
     pub top_pre_cdef_toggle: libc::c_int,
     pub cur_sb_cdef_idx_ptr: *mut int8_t,
     pub tl_4x4_filter: Filter2d,
-    pub frame_thread: C2RustUnnamed_30,
-    pub task_thread: C2RustUnnamed_29,
+    pub frame_thread: Dav1dTaskContext_frame_thread,
+    pub task_thread: Dav1dTaskContext_task_thread,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_29 {
+pub struct Dav1dTaskContext_task_thread {
     pub td: thread_data,
     pub ttd: *mut TaskThreadData,
     pub fttd: *mut FrameTileThreadData,
@@ -833,7 +833,7 @@ use crate::src::thread_data::thread_data;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_30 {
+pub struct Dav1dTaskContext_frame_thread {
     pub pass: libc::c_int,
 }
 use crate::src::levels::Filter2d;
@@ -850,14 +850,14 @@ use crate::src::levels::FILTER_2D_BILINEAR;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_31 {
-    pub c2rust_unnamed: C2RustUnnamed_38,
-    pub c2rust_unnamed_0: C2RustUnnamed_32,
+pub union Dav1dTaskContext_scratch {
+    pub c2rust_unnamed: C2RustUnnamed_16,
+    pub c2rust_unnamed_0: C2RustUnnamed_10,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_32 {
-    pub c2rust_unnamed: C2RustUnnamed_36,
+pub struct C2RustUnnamed_10 {
+    pub c2rust_unnamed: C2RustUnnamed_14,
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
@@ -868,38 +868,38 @@ use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_36 {
+pub union C2RustUnnamed_14 {
     pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: C2RustUnnamed_37,
+    pub c2rust_unnamed: C2RustUnnamed_15,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_37 {
+pub struct C2RustUnnamed_15 {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_38 {
-    pub c2rust_unnamed: C2RustUnnamed_40,
-    pub c2rust_unnamed_0: C2RustUnnamed_39,
+pub struct C2RustUnnamed_16 {
+    pub c2rust_unnamed: C2RustUnnamed_18,
+    pub c2rust_unnamed_0: C2RustUnnamed_17,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_39 {
+pub union C2RustUnnamed_17 {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_40 {
+pub union C2RustUnnamed_18 {
     pub lap_8bpc: [uint8_t; 4096],
     pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: C2RustUnnamed_41,
+    pub c2rust_unnamed: C2RustUnnamed_19,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_41 {
+pub struct C2RustUnnamed_19 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
@@ -910,12 +910,12 @@ pub struct refmvs_tile {
     pub rf: *const refmvs_frame,
     pub r: [*mut refmvs_block; 37],
     pub rp_proj: *mut refmvs_temporal_block,
-    pub tile_col: C2RustUnnamed_43,
-    pub tile_row: C2RustUnnamed_43,
+    pub tile_col: refmvs_tile_range,
+    pub tile_row: refmvs_tile_range,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_43 {
+pub struct refmvs_tile_range {
     pub start: libc::c_int,
     pub end: libc::c_int,
 }
@@ -924,9 +924,9 @@ pub struct C2RustUnnamed_43 {
 pub struct Dav1dTileState {
     pub cdf: CdfContext,
     pub msac: MsacContext,
-    pub tiling: C2RustUnnamed_45,
+    pub tiling: Dav1dTileState_tiling,
     pub progress: [atomic_int; 2],
-    pub frame_thread: [C2RustUnnamed_44; 2],
+    pub frame_thread: [Dav1dTileState_frame_thread; 2],
     pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
     pub dqmem: [[[uint16_t; 2]; 3]; 8],
     pub dq: *const [[uint16_t; 2]; 3],
@@ -938,13 +938,13 @@ pub struct Dav1dTileState {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_44 {
+pub struct Dav1dTileState_frame_thread {
     pub pal_idx: *mut uint8_t,
     pub cf: *mut coef,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_45 {
+pub struct Dav1dTileState_tiling {
     pub col_start: libc::c_int,
     pub col_end: libc::c_int,
     pub row_start: libc::c_int,
@@ -981,16 +981,16 @@ pub struct Dav1dContext {
     pub cache: Dav1dThreadPicture,
     pub flush_mem: atomic_int,
     pub flush: *mut atomic_int,
-    pub frame_thread: C2RustUnnamed_50,
+    pub frame_thread: Dav1dContext_frame_thread,
     pub task_thread: TaskThreadData,
     pub segmap_pool: *mut Dav1dMemPool,
     pub refmvs_pool: *mut Dav1dMemPool,
-    pub refs: [C2RustUnnamed_49; 8],
+    pub refs: [Dav1dContext_refs; 8],
     pub cdf_pool: *mut Dav1dMemPool,
     pub cdf: [CdfThreadContext; 8],
     pub dsp: [Dav1dDSPContext; 3],
     pub refmvs_dsp: Dav1dRefmvsDSPContext,
-    pub intra_edge: C2RustUnnamed_46,
+    pub intra_edge: Dav1dContext_intra_edge,
     pub allocator: Dav1dPicAllocator,
     pub apply_grain: libc::c_int,
     pub operating_point: libc::c_int,
@@ -1044,7 +1044,7 @@ pub struct Dav1dPicAllocator {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_46 {
+pub struct Dav1dContext_intra_edge {
     pub root: [*mut EdgeNode; 2],
     pub branch_sb128: [EdgeBranch; 85],
     pub branch_sb64: [EdgeBranch; 21],
@@ -1113,11 +1113,11 @@ use crate::src::looprestoration::LrEdgeFlags;
 #[repr(C)]
 pub union LooprestorationParams {
     pub filter: [[int16_t; 8]; 2],
-    pub sgr: C2RustUnnamed_47,
+    pub sgr: LooprestorationParams_sgr,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_47 {
+pub struct LooprestorationParams_sgr {
     pub s0: uint32_t,
     pub s1: uint32_t,
     pub w0: int16_t,
@@ -1464,18 +1464,18 @@ pub type generate_grain_y_fn = Option::<
 #[repr(C)]
 pub struct CdfThreadContext {
     pub ref_0: *mut Dav1dRef,
-    pub data: C2RustUnnamed_48,
+    pub data: CdfThreadContext_data,
     pub progress: *mut atomic_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_48 {
+pub union CdfThreadContext_data {
     pub cdf: *mut CdfContext,
     pub qcat: libc::c_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_49 {
+pub struct Dav1dContext_refs {
     pub p: Dav1dThreadPicture,
     pub segmap: *mut Dav1dRef,
     pub refmvs: *mut Dav1dRef,
@@ -1492,7 +1492,7 @@ pub struct Dav1dThreadPicture {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_50 {
+pub struct Dav1dContext_frame_thread {
     pub out_delayed: *mut Dav1dThreadPicture,
     pub next: libc::c_uint,
 }

--- a/src/refmvs.h
+++ b/src/refmvs.h
@@ -86,7 +86,7 @@ typedef struct refmvs_tile {
     const refmvs_frame *rf;
     refmvs_block *r[32 + 5];
     refmvs_temporal_block *rp_proj;
-    struct {
+    struct refmvs_tile_range {
         int start, end;
     } tile_col, tile_row;
 } refmvs_tile;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -93,17 +93,17 @@ use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed {
-    pub p: C2RustUnnamed_0,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -182,7 +182,7 @@ use crate::include::dav1d::headers::Dav1dFilmGrainData;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_11,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -206,7 +206,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_10,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -216,14 +216,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_9,
-    pub quant: C2RustUnnamed_8,
-    pub segmentation: C2RustUnnamed_7,
-    pub delta: C2RustUnnamed_4,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_3,
-    pub cdef: C2RustUnnamed_2,
-    pub restoration: C2RustUnnamed_1,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -235,13 +235,13 @@ pub struct Dav1dFrameHeader {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_2 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -249,7 +249,7 @@ pub struct C2RustUnnamed_2 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -260,26 +260,26 @@ pub struct C2RustUnnamed_3 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
-    pub q: C2RustUnnamed_6,
-    pub lf: C2RustUnnamed_5,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_5 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -290,7 +290,7 @@ pub struct C2RustUnnamed_7 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -304,7 +304,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -321,14 +321,14 @@ pub struct C2RustUnnamed_9 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
@@ -360,12 +360,12 @@ use crate::src::levels::BlockSize;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union mv {
-    pub c2rust_unnamed: C2RustUnnamed_12,
+    pub c2rust_unnamed: C2RustUnnamed,
     pub n: uint32_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_12 {
+pub struct C2RustUnnamed {
     pub y: int16_t,
     pub x: int16_t,
 }
@@ -435,12 +435,12 @@ pub struct refmvs_tile {
     pub rf: *const refmvs_frame,
     pub r: [*mut refmvs_block; 37],
     pub rp_proj: *mut refmvs_temporal_block,
-    pub tile_col: C2RustUnnamed_13,
-    pub tile_row: C2RustUnnamed_13,
+    pub tile_col: refmvs_tile_range,
+    pub tile_row: refmvs_tile_range,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_13 {
+pub struct refmvs_tile_range {
     pub start: libc::c_int,
     pub end: libc::c_int,
 }
@@ -559,7 +559,7 @@ unsafe extern "C" fn get_gmv_2d(
         1 => {
             let mut res_0: mv = mv {
                 c2rust_unnamed: {
-                    let mut init = C2RustUnnamed_12 {
+                    let mut init = C2RustUnnamed {
                         y: ((*gmv).matrix[0 as libc::c_int as usize]
                             >> 13 as libc::c_int) as int16_t,
                         x: ((*gmv).matrix[1 as libc::c_int as usize]
@@ -576,7 +576,7 @@ unsafe extern "C" fn get_gmv_2d(
         0 => {
             return mv {
                 c2rust_unnamed: {
-                    let mut init = C2RustUnnamed_12 {
+                    let mut init = C2RustUnnamed {
                         y: 0 as libc::c_int as int16_t,
                         x: 0 as libc::c_int as int16_t,
                     };
@@ -603,7 +603,7 @@ unsafe extern "C" fn get_gmv_2d(
     let round: libc::c_int = (1 as libc::c_int) << shift >> 1 as libc::c_int;
     let mut res: mv = mv {
         c2rust_unnamed: {
-            let mut init = C2RustUnnamed_12 {
+            let mut init = C2RustUnnamed {
                 y: apply_sign(
                     abs(yc) + round >> shift << ((*hdr).hp == 0) as libc::c_int,
                     yc,
@@ -926,7 +926,7 @@ unsafe extern "C" fn mv_projection(mv: mv, num: libc::c_int, den: libc::c_int) -
     let x: libc::c_int = mv.c2rust_unnamed.x as libc::c_int * frac;
     return mv {
         c2rust_unnamed: {
-            let mut init = C2RustUnnamed_12 {
+            let mut init = C2RustUnnamed {
                 y: iclip(
                     y + 8192 as libc::c_int + (y >> 31 as libc::c_int)
                         >> 14 as libc::c_int,
@@ -1102,7 +1102,7 @@ unsafe extern "C" fn add_compound_extended_candidate(
         } else {
             let mut i_cand_mv: mv = mv {
                 c2rust_unnamed: {
-                    let mut init = C2RustUnnamed_12 {
+                    let mut init = C2RustUnnamed {
                         y: -(cand_mv.c2rust_unnamed.y as libc::c_int) as int16_t,
                         x: -(cand_mv.c2rust_unnamed.x as libc::c_int) as int16_t,
                     };
@@ -1208,10 +1208,10 @@ pub unsafe extern "C" fn dav1d_refmvs_find(
     let bh4: libc::c_int = *b_dim.offset(1 as libc::c_int as isize) as libc::c_int;
     let h4: libc::c_int = imin(imin(bh4, 16 as libc::c_int), (*rt).tile_row.end - by4);
     let mut gmv: [mv; 2] = [mv {
-        c2rust_unnamed: C2RustUnnamed_12 { y: 0, x: 0 },
+        c2rust_unnamed: C2RustUnnamed { y: 0, x: 0 },
     }; 2];
     let mut tgmv: [mv; 2] = [mv {
-        c2rust_unnamed: C2RustUnnamed_12 { y: 0, x: 0 },
+        c2rust_unnamed: C2RustUnnamed { y: 0, x: 0 },
     }; 2];
     *cnt = 0 as libc::c_int;
     if !(ref_0.ref_0[0 as libc::c_int as usize] as libc::c_int >= 0 as libc::c_int

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -19,17 +19,17 @@ use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed {
-    pub p: C2RustUnnamed_0,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -1286,9 +1286,9 @@ pub static mut dav1d_default_wm_params: Dav1dWarpedMotionParams = {
             0 as libc::c_int,
             (1 as libc::c_int) << 16 as libc::c_int,
         ],
-        u: C2RustUnnamed {
+        u: Dav1dWarpedMotionParams_u {
             p: {
-                let mut init = C2RustUnnamed_0 {
+                let mut init = Dav1dWarpedMotionParams_u_p {
                     alpha: 0 as libc::c_int as int16_t,
                     beta: 0 as libc::c_int as int16_t,
                     gamma: 0 as libc::c_int as int16_t,

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -104,7 +104,7 @@ pub struct Dav1dFrameContext {
     pub ts: *mut Dav1dTileState,
     pub n_ts: libc::c_int,
     pub dsp: *const Dav1dDSPContext,
-    pub bd_fn: C2RustUnnamed_28,
+    pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
     pub ipred_edge: [*mut libc::c_void; 3],
     pub b4_stride: ptrdiff_t,
@@ -125,15 +125,15 @@ pub struct Dav1dFrameContext {
     pub rf: refmvs_frame,
     pub jnt_weights: [[uint8_t; 7]; 7],
     pub bitdepth_max: libc::c_int,
-    pub frame_thread: C2RustUnnamed_20,
-    pub lf: C2RustUnnamed_19,
-    pub task_thread: C2RustUnnamed,
+    pub frame_thread: Dav1dFrameContext_frame_thread,
+    pub lf: Dav1dFrameContext_lf,
+    pub task_thread: Dav1dFrameContext_task_thread,
     pub tile_thread: FrameTileThreadData,
 }
 use crate::src::internal::FrameTileThreadData;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed {
+pub struct Dav1dFrameContext_task_thread {
     pub lock: pthread_mutex_t,
     pub cond: pthread_cond_t,
     pub ttd: *mut TaskThreadData,
@@ -151,11 +151,11 @@ pub struct C2RustUnnamed {
     pub task_head: *mut Dav1dTask,
     pub task_tail: *mut Dav1dTask,
     pub task_cur_prev: *mut Dav1dTask,
-    pub pending_tasks: C2RustUnnamed_0,
+    pub pending_tasks: Dav1dFrameContext_task_thread_pending_tasks,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dFrameContext_task_thread_pending_tasks {
     pub merge: atomic_int,
     pub lock: pthread_mutex_t,
     pub head: *mut Dav1dTask,
@@ -189,35 +189,35 @@ pub struct TaskThreadData {
     pub cur: libc::c_uint,
     pub reset_task_cur: atomic_uint,
     pub cond_signaled: atomic_int,
-    pub delayed_fg: C2RustUnnamed_1,
+    pub delayed_fg: Dav1dContext_task_thread_delayed_fg,
     pub inited: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dContext_task_thread_delayed_fg {
     pub exec: libc::c_int,
     pub cond: pthread_cond_t,
     pub in_0: *const Dav1dPicture,
     pub out: *mut Dav1dPicture,
     pub type_0: TaskType,
     pub progress: [atomic_int; 2],
-    pub c2rust_unnamed: C2RustUnnamed_2,
+    pub c2rust_unnamed: C2RustUnnamed,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_2 {
-    pub c2rust_unnamed: C2RustUnnamed_4,
-    pub c2rust_unnamed_0: C2RustUnnamed_3,
+pub union C2RustUnnamed {
+    pub c2rust_unnamed: C2RustUnnamed_1,
+    pub c2rust_unnamed_0: C2RustUnnamed_0,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct C2RustUnnamed_0 {
     pub grain_lut_16bpc: [[[int16_t; 82]; 74]; 3],
     pub scaling_16bpc: [[uint8_t; 4096]; 3],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
+pub struct C2RustUnnamed_1 {
     pub grain_lut_8bpc: [[[int8_t; 82]; 74]; 3],
     pub scaling_8bpc: [[uint8_t; 256]; 3],
 }
@@ -255,7 +255,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_17,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -279,7 +279,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_16,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -289,14 +289,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_15,
-    pub quant: C2RustUnnamed_14,
-    pub segmentation: C2RustUnnamed_13,
-    pub delta: C2RustUnnamed_10,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_9,
-    pub cdef: C2RustUnnamed_8,
-    pub restoration: C2RustUnnamed_7,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -311,17 +311,17 @@ pub struct Dav1dFrameHeader {
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed_5,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_5 {
-    pub p: C2RustUnnamed_6,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -339,7 +339,7 @@ use crate::include::dav1d::headers::Dav1dTxfmMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
@@ -350,7 +350,7 @@ use crate::include::dav1d::headers::Dav1dRestorationType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -358,7 +358,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -370,26 +370,26 @@ pub struct C2RustUnnamed_9 {
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
-    pub q: C2RustUnnamed_12,
-    pub lf: C2RustUnnamed_11,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_12 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_13 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -402,7 +402,7 @@ use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_14 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -416,7 +416,7 @@ pub struct C2RustUnnamed_14 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_15 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -441,7 +441,7 @@ use crate::include::dav1d::headers::Dav1dFilterMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_16 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
@@ -453,7 +453,7 @@ use crate::include::dav1d::headers::Dav1dFrameType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_17 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
@@ -525,7 +525,7 @@ use crate::include::pthread::pthread_cond_t;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_19 {
+pub struct Dav1dFrameContext_lf {
     pub level: *mut [uint8_t; 4],
     pub mask: *mut Av1Filter,
     pub lr_mask: *mut Av1Restoration,
@@ -560,7 +560,7 @@ use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_20 {
+pub struct Dav1dFrameContext_frame_thread {
     pub next_tile_row: [libc::c_int; 2],
     pub entropy_progress: atomic_int,
     pub deblock_progress: atomic_int,
@@ -590,18 +590,18 @@ pub struct Av1Block {
     pub skip_mode: uint8_t,
     pub skip: uint8_t,
     pub uvtx: uint8_t,
-    pub c2rust_unnamed: C2RustUnnamed_21,
+    pub c2rust_unnamed: C2RustUnnamed_3,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_21 {
-    pub c2rust_unnamed: C2RustUnnamed_27,
-    pub c2rust_unnamed_0: C2RustUnnamed_22,
+pub union C2RustUnnamed_3 {
+    pub c2rust_unnamed: C2RustUnnamed_9,
+    pub c2rust_unnamed_0: C2RustUnnamed_4,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_22 {
-    pub c2rust_unnamed: C2RustUnnamed_23,
+pub struct C2RustUnnamed_4 {
+    pub c2rust_unnamed: C2RustUnnamed_5,
     pub comp_type: uint8_t,
     pub inter_mode: uint8_t,
     pub motion_mode: uint8_t,
@@ -615,31 +615,31 @@ pub struct C2RustUnnamed_22 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_23 {
-    pub c2rust_unnamed: C2RustUnnamed_26,
-    pub c2rust_unnamed_0: C2RustUnnamed_24,
+pub union C2RustUnnamed_5 {
+    pub c2rust_unnamed: C2RustUnnamed_8,
+    pub c2rust_unnamed_0: C2RustUnnamed_6,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_24 {
+pub struct C2RustUnnamed_6 {
     pub mv2d: mv,
     pub matrix: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union mv {
-    pub c2rust_unnamed: C2RustUnnamed_25,
+    pub c2rust_unnamed: C2RustUnnamed_7,
     pub n: uint32_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_25 {
+pub struct C2RustUnnamed_7 {
     pub y: int16_t,
     pub x: int16_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_26 {
+pub struct C2RustUnnamed_8 {
     pub mv: [mv; 2],
     pub wedge_idx: uint8_t,
     pub mask_sign: uint8_t,
@@ -647,7 +647,7 @@ pub struct C2RustUnnamed_26 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_27 {
+pub struct C2RustUnnamed_9 {
     pub y_mode: uint8_t,
     pub uv_mode: uint8_t,
     pub tx: uint8_t,
@@ -712,7 +712,7 @@ pub struct refmvs_temporal_block {
 use crate::src::env::BlockContext;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_28 {
+pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
     pub recon_b_inter: recon_b_inter_fn,
     pub filter_sbrow: filter_sbrow_fn,
@@ -768,18 +768,18 @@ pub struct Dav1dTaskContext {
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
-    pub scratch: C2RustUnnamed_31,
+    pub scratch: Dav1dTaskContext_scratch,
     pub warpmv: Dav1dWarpedMotionParams,
     pub lf_mask: *mut Av1Filter,
     pub top_pre_cdef_toggle: libc::c_int,
     pub cur_sb_cdef_idx_ptr: *mut int8_t,
     pub tl_4x4_filter: Filter2d,
-    pub frame_thread: C2RustUnnamed_30,
-    pub task_thread: C2RustUnnamed_29,
+    pub frame_thread: Dav1dTaskContext_frame_thread,
+    pub task_thread: Dav1dTaskContext_task_thread,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_29 {
+pub struct Dav1dTaskContext_task_thread {
     pub td: thread_data,
     pub ttd: *mut TaskThreadData,
     pub fttd: *mut FrameTileThreadData,
@@ -790,7 +790,7 @@ use crate::src::thread_data::thread_data;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_30 {
+pub struct Dav1dTaskContext_frame_thread {
     pub pass: libc::c_int,
 }
 use crate::src::levels::Filter2d;
@@ -807,14 +807,14 @@ use crate::src::levels::Filter2d;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_31 {
-    pub c2rust_unnamed: C2RustUnnamed_38,
-    pub c2rust_unnamed_0: C2RustUnnamed_32,
+pub union Dav1dTaskContext_scratch {
+    pub c2rust_unnamed: C2RustUnnamed_16,
+    pub c2rust_unnamed_0: C2RustUnnamed_10,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_32 {
-    pub c2rust_unnamed: C2RustUnnamed_36,
+pub struct C2RustUnnamed_10 {
+    pub c2rust_unnamed: C2RustUnnamed_14,
     pub ac: [int16_t; 1024],
     pub pal_idx: [uint8_t; 8192],
     pub pal: [[uint16_t; 8]; 3],
@@ -825,38 +825,38 @@ use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_36 {
+pub union C2RustUnnamed_14 {
     pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: C2RustUnnamed_37,
+    pub c2rust_unnamed: C2RustUnnamed_15,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_37 {
+pub struct C2RustUnnamed_15 {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_38 {
-    pub c2rust_unnamed: C2RustUnnamed_40,
-    pub c2rust_unnamed_0: C2RustUnnamed_39,
+pub struct C2RustUnnamed_16 {
+    pub c2rust_unnamed: C2RustUnnamed_18,
+    pub c2rust_unnamed_0: C2RustUnnamed_17,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_39 {
+pub union C2RustUnnamed_17 {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_40 {
+pub union C2RustUnnamed_18 {
     pub lap_8bpc: [uint8_t; 4096],
     pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: C2RustUnnamed_41,
+    pub c2rust_unnamed: C2RustUnnamed_19,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_41 {
+pub struct C2RustUnnamed_19 {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
@@ -867,12 +867,12 @@ pub struct refmvs_tile {
     pub rf: *const refmvs_frame,
     pub r: [*mut refmvs_block; 37],
     pub rp_proj: *mut refmvs_temporal_block,
-    pub tile_col: C2RustUnnamed_43,
-    pub tile_row: C2RustUnnamed_43,
+    pub tile_col: refmvs_tile_range,
+    pub tile_row: refmvs_tile_range,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_43 {
+pub struct refmvs_tile_range {
     pub start: libc::c_int,
     pub end: libc::c_int,
 }
@@ -881,9 +881,9 @@ pub struct C2RustUnnamed_43 {
 pub struct Dav1dTileState {
     pub cdf: CdfContext,
     pub msac: MsacContext,
-    pub tiling: C2RustUnnamed_45,
+    pub tiling: Dav1dTileState_tiling,
     pub progress: [atomic_int; 2],
-    pub frame_thread: [C2RustUnnamed_44; 2],
+    pub frame_thread: [Dav1dTileState_frame_thread; 2],
     pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
     pub dqmem: [[[uint16_t; 2]; 3]; 8],
     pub dq: *const [[uint16_t; 2]; 3],
@@ -895,13 +895,13 @@ pub struct Dav1dTileState {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_44 {
+pub struct Dav1dTileState_frame_thread {
     pub pal_idx: *mut uint8_t,
     pub cf: *mut libc::c_void,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_45 {
+pub struct Dav1dTileState_tiling {
     pub col_start: libc::c_int,
     pub col_end: libc::c_int,
     pub row_start: libc::c_int,
@@ -938,16 +938,16 @@ pub struct Dav1dContext {
     pub cache: Dav1dThreadPicture,
     pub flush_mem: atomic_int,
     pub flush: *mut atomic_int,
-    pub frame_thread: C2RustUnnamed_50,
+    pub frame_thread: Dav1dContext_frame_thread,
     pub task_thread: TaskThreadData,
     pub segmap_pool: *mut Dav1dMemPool,
     pub refmvs_pool: *mut Dav1dMemPool,
-    pub refs: [C2RustUnnamed_49; 8],
+    pub refs: [Dav1dContext_refs; 8],
     pub cdf_pool: *mut Dav1dMemPool,
     pub cdf: [CdfThreadContext; 8],
     pub dsp: [Dav1dDSPContext; 3],
     pub refmvs_dsp: Dav1dRefmvsDSPContext,
-    pub intra_edge: C2RustUnnamed_46,
+    pub intra_edge: Dav1dContext_intra_edge,
     pub allocator: Dav1dPicAllocator,
     pub apply_grain: libc::c_int,
     pub operating_point: libc::c_int,
@@ -1001,7 +1001,7 @@ pub struct Dav1dPicAllocator {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_46 {
+pub struct Dav1dContext_intra_edge {
     pub root: [*mut EdgeNode; 2],
     pub branch_sb128: [EdgeBranch; 85],
     pub branch_sb64: [EdgeBranch; 21],
@@ -1070,11 +1070,11 @@ use crate::src::looprestoration::LrEdgeFlags;
 #[repr(C)]
 pub union LooprestorationParams {
     pub filter: [[int16_t; 8]; 2],
-    pub sgr: C2RustUnnamed_47,
+    pub sgr: LooprestorationParams_sgr,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_47 {
+pub struct LooprestorationParams_sgr {
     pub s0: uint32_t,
     pub s1: uint32_t,
     pub w0: int16_t,
@@ -1430,18 +1430,18 @@ pub type generate_grain_y_fn = Option::<
 #[repr(C)]
 pub struct CdfThreadContext {
     pub ref_0: *mut Dav1dRef,
-    pub data: C2RustUnnamed_48,
+    pub data: CdfThreadContext_data,
     pub progress: *mut atomic_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_48 {
+pub union CdfThreadContext_data {
     pub cdf: *mut CdfContext,
     pub qcat: libc::c_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_49 {
+pub struct Dav1dContext_refs {
     pub p: Dav1dThreadPicture,
     pub segmap: *mut Dav1dRef,
     pub refmvs: *mut Dav1dRef,
@@ -1458,7 +1458,7 @@ pub struct Dav1dThreadPicture {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_50 {
+pub struct Dav1dContext_frame_thread {
     pub out_delayed: *mut Dav1dThreadPicture,
     pub next: libc::c_uint,
 }

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -15,17 +15,17 @@ use crate::include::dav1d::headers::Dav1dWarpedMotionType;
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed {
-    pub p: C2RustUnnamed_0,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -34,12 +34,12 @@ pub struct C2RustUnnamed_0 {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union mv {
-    pub c2rust_unnamed: C2RustUnnamed_1,
+    pub c2rust_unnamed: C2RustUnnamed,
     pub n: uint32_t,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct C2RustUnnamed {
     pub y: int16_t,
     pub x: int16_t,
 }

--- a/src/x86/cpu.c
+++ b/src/x86/cpu.c
@@ -44,7 +44,7 @@ uint64_t dav1d_cpu_xgetbv(unsigned xcr);
 #define X(reg, mask) (((reg) & (mask)) == (mask))
 
 COLD unsigned dav1d_get_cpu_flags_x86(void) {
-    union {
+    union cpu {
         CpuidRegisters r;
         struct {
             uint32_t max_leaf;

--- a/tests/checkasm/checkasm.c
+++ b/tests/checkasm/checkasm.c
@@ -55,7 +55,7 @@
 #endif
 
 /* List of tests to invoke */
-static const struct {
+static const struct test {
     const char *name;
     void (*func)(void);
 } tests[] = {
@@ -83,7 +83,7 @@ static const struct {
 };
 
 /* List of cpu flags to check */
-static const struct {
+static const struct cpu {
     const char *name;
     const char *suffix;
     unsigned flag;
@@ -120,7 +120,7 @@ typedef struct CheckasmFunc {
 } CheckasmFunc;
 
 /* Internal state */
-static struct {
+static struct state {
     CheckasmFunc *funcs;
     CheckasmFunc *current_func;
     CheckasmFuncVersion *current_func_ver;

--- a/tests/checkasm/looprestoration.c
+++ b/tests/checkasm/looprestoration.c
@@ -128,7 +128,7 @@ static void check_sgr(Dav1dLoopRestorationDSPContext *const c, const int bpc) {
                  const LooprestorationParams *params,
                  enum LrEdgeFlags edges HIGHBD_DECL_SUFFIX);
 
-    static const struct { char name[4]; uint8_t idx; } sgr_data[3] = {
+    static const struct sgr_data { char name[4]; uint8_t idx; } sgr_data[3] = {
         { "5x5", 14 },
         { "3x3", 10 },
         { "mix",  0 },

--- a/tests/checkasm/refmvs.c
+++ b/tests/checkasm/refmvs.c
@@ -49,7 +49,7 @@ static void check_splat_mv(const Dav1dRefmvsDSPContext *const c) {
             const int w_uint32 = w * sizeof(refmvs_block) / sizeof(uint32_t);
             for (int h = h_min; h <= h_max; h *= 2) {
                 const int offset = (int) ((unsigned) w * rnd()) & 31;
-                union {
+                union tmp {
                     refmvs_block rmv;
                     uint32_t u32[3];
                 } ALIGN(tmp, 16);

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -123,17 +123,17 @@ use crate::include::dav1d::headers::Dav1dWarpedMotionType;
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed {
-    pub p: C2RustUnnamed_0,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -215,7 +215,7 @@ use crate::include::dav1d::headers::Dav1dFilmGrainData;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_11,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -239,7 +239,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_10,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -249,14 +249,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_9,
-    pub quant: C2RustUnnamed_8,
-    pub segmentation: C2RustUnnamed_7,
-    pub delta: C2RustUnnamed_4,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_3,
-    pub cdef: C2RustUnnamed_2,
-    pub restoration: C2RustUnnamed_1,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -268,13 +268,13 @@ pub struct Dav1dFrameHeader {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_2 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -282,7 +282,7 @@ pub struct C2RustUnnamed_2 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -293,26 +293,26 @@ pub struct C2RustUnnamed_3 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
-    pub q: C2RustUnnamed_6,
-    pub lf: C2RustUnnamed_5,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_5 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -323,7 +323,7 @@ pub struct C2RustUnnamed_7 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -337,7 +337,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -354,14 +354,14 @@ pub struct C2RustUnnamed_9 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
@@ -442,15 +442,15 @@ pub struct CLISettings {
     pub limit: libc::c_uint,
     pub skip: libc::c_uint,
     pub quiet: libc::c_int,
-    pub realtime: C2RustUnnamed_12,
+    pub realtime: CLISettings_realtime,
     pub realtime_fps: libc::c_double,
     pub realtime_cache: libc::c_uint,
     pub neg_stride: libc::c_int,
 }
-pub type C2RustUnnamed_12 = libc::c_uint;
-pub const REALTIME_CUSTOM: C2RustUnnamed_12 = 2;
-pub const REALTIME_INPUT: C2RustUnnamed_12 = 1;
-pub const REALTIME_DISABLE: C2RustUnnamed_12 = 0;
+pub type CLISettings_realtime = libc::c_uint;
+pub const REALTIME_CUSTOM: CLISettings_realtime = 2;
+pub const REALTIME_INPUT: CLISettings_realtime = 1;
+pub const REALTIME_DISABLE: CLISettings_realtime = 0;
 unsafe extern "C" fn get_time_nanos() -> uint64_t {
     let mut ts: timespec = timespec { tv_sec: 0, tv_nsec: 0 };
     clock_gettime(1 as libc::c_int, &mut ts);

--- a/tools/dav1d_cli_parse.c
+++ b/tools/dav1d_cli_parse.c
@@ -44,7 +44,7 @@
 
 static const char short_opts[] = "i:o:vql:s:";
 
-enum {
+enum arg {
     ARG_DEMUXER = 256,
     ARG_MUXER,
     ARG_FRAME_TIMES,

--- a/tools/dav1d_cli_parse.h
+++ b/tools/dav1d_cli_parse.h
@@ -39,7 +39,7 @@ typedef struct {
     const char *verify;
     unsigned limit, skip;
     int quiet;
-    enum {
+    enum CLISettings_realtime {
         REALTIME_DISABLE = 0,
         REALTIME_INPUT,
         REALTIME_CUSTOM,

--- a/tools/dav1d_cli_parse.rs
+++ b/tools/dav1d_cli_parse.rs
@@ -93,17 +93,17 @@ use crate::include::dav1d::headers::Dav1dWarpedMotionType;
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed {
-    pub p: C2RustUnnamed_0,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -185,7 +185,7 @@ use crate::include::dav1d::headers::Dav1dFilmGrainData;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_11,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -209,7 +209,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_10,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -219,14 +219,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_9,
-    pub quant: C2RustUnnamed_8,
-    pub segmentation: C2RustUnnamed_7,
-    pub delta: C2RustUnnamed_4,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_3,
-    pub cdef: C2RustUnnamed_2,
-    pub restoration: C2RustUnnamed_1,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -238,13 +238,13 @@ pub struct Dav1dFrameHeader {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_2 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -252,7 +252,7 @@ pub struct C2RustUnnamed_2 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -263,26 +263,26 @@ pub struct C2RustUnnamed_3 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
-    pub q: C2RustUnnamed_6,
-    pub lf: C2RustUnnamed_5,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_5 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -293,7 +293,7 @@ pub struct C2RustUnnamed_7 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -307,7 +307,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -324,14 +324,14 @@ pub struct C2RustUnnamed_9 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
@@ -411,45 +411,45 @@ pub struct CLISettings {
     pub limit: libc::c_uint,
     pub skip: libc::c_uint,
     pub quiet: libc::c_int,
-    pub realtime: C2RustUnnamed_12,
+    pub realtime: CLISettings_realtime,
     pub realtime_fps: libc::c_double,
     pub realtime_cache: libc::c_uint,
     pub neg_stride: libc::c_int,
 }
-pub type C2RustUnnamed_12 = libc::c_uint;
-pub const REALTIME_CUSTOM: C2RustUnnamed_12 = 2;
-pub const REALTIME_INPUT: C2RustUnnamed_12 = 1;
-pub const REALTIME_DISABLE: C2RustUnnamed_12 = 0;
-pub const ARG_DECODE_FRAME_TYPE: C2RustUnnamed_13 = 273;
+pub type CLISettings_realtime = libc::c_uint;
+pub const REALTIME_CUSTOM: CLISettings_realtime = 2;
+pub const REALTIME_INPUT: CLISettings_realtime = 1;
+pub const REALTIME_DISABLE: CLISettings_realtime = 0;
+pub const ARG_DECODE_FRAME_TYPE: arg = 273;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct EnumParseTable {
     pub str_0: *const libc::c_char,
     pub val: libc::c_int,
 }
-pub const ARG_INLOOP_FILTERS: C2RustUnnamed_13 = 272;
-pub const ARG_OUTPUT_INVISIBLE: C2RustUnnamed_13 = 271;
-pub const ARG_NEG_STRIDE: C2RustUnnamed_13 = 270;
-pub const ARG_CPU_MASK: C2RustUnnamed_13 = 269;
-pub const ARG_STRICT_STD_COMPLIANCE: C2RustUnnamed_13 = 268;
-pub const ARG_SIZE_LIMIT: C2RustUnnamed_13 = 267;
-pub const ARG_ALL_LAYERS: C2RustUnnamed_13 = 266;
-pub const ARG_OPPOINT: C2RustUnnamed_13 = 265;
-pub const ARG_FILM_GRAIN: C2RustUnnamed_13 = 264;
-pub const ARG_VERIFY: C2RustUnnamed_13 = 263;
-pub const ARG_FRAME_DELAY: C2RustUnnamed_13 = 262;
-pub const ARG_THREADS: C2RustUnnamed_13 = 261;
-pub const ARG_REALTIME_CACHE: C2RustUnnamed_13 = 260;
-pub const ARG_REALTIME: C2RustUnnamed_13 = 259;
-pub const ARG_FRAME_TIMES: C2RustUnnamed_13 = 258;
-pub const ARG_MUXER: C2RustUnnamed_13 = 257;
-pub const ARG_DEMUXER: C2RustUnnamed_13 = 256;
+pub const ARG_INLOOP_FILTERS: arg = 272;
+pub const ARG_OUTPUT_INVISIBLE: arg = 271;
+pub const ARG_NEG_STRIDE: arg = 270;
+pub const ARG_CPU_MASK: arg = 269;
+pub const ARG_STRICT_STD_COMPLIANCE: arg = 268;
+pub const ARG_SIZE_LIMIT: arg = 267;
+pub const ARG_ALL_LAYERS: arg = 266;
+pub const ARG_OPPOINT: arg = 265;
+pub const ARG_FILM_GRAIN: arg = 264;
+pub const ARG_VERIFY: arg = 263;
+pub const ARG_FRAME_DELAY: arg = 262;
+pub const ARG_THREADS: arg = 261;
+pub const ARG_REALTIME_CACHE: arg = 260;
+pub const ARG_REALTIME: arg = 259;
+pub const ARG_FRAME_TIMES: arg = 258;
+pub const ARG_MUXER: arg = 257;
+pub const ARG_DEMUXER: arg = 256;
 pub const X86_CPU_MASK_AVX512ICL: CpuMask = 31;
 pub const X86_CPU_MASK_AVX2: CpuMask = 15;
 pub const X86_CPU_MASK_SSE41: CpuMask = 7;
 pub const X86_CPU_MASK_SSSE3: CpuMask = 3;
 pub const X86_CPU_MASK_SSE2: CpuMask = 1;
-pub type C2RustUnnamed_13 = libc::c_uint;
+pub type arg = libc::c_uint;
 pub type CpuMask = libc::c_uint;
 static mut short_opts: [libc::c_char; 11] = unsafe {
     *::core::mem::transmute::<&[u8; 11], &[libc::c_char; 11]>(b"i:o:vql:s:\0")
@@ -1058,7 +1058,7 @@ pub unsafe extern "C" fn parse(
                         ARG_REALTIME as libc::c_int,
                         *argv.offset(0 as libc::c_int as isize),
                         &mut (*cli_settings).realtime_fps,
-                    )) as C2RustUnnamed_12;
+                    )) as CLISettings_realtime;
             }
             260 => {
                 (*cli_settings)

--- a/tools/output/md5.rs
+++ b/tools/output/md5.rs
@@ -66,17 +66,17 @@ use crate::include::dav1d::headers::Dav1dWarpedMotionType;
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed {
-    pub p: C2RustUnnamed_0,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -158,7 +158,7 @@ use crate::include::dav1d::headers::Dav1dFilmGrainData;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_11,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -182,7 +182,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_10,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -192,14 +192,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_9,
-    pub quant: C2RustUnnamed_8,
-    pub segmentation: C2RustUnnamed_7,
-    pub delta: C2RustUnnamed_4,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_3,
-    pub cdef: C2RustUnnamed_2,
-    pub restoration: C2RustUnnamed_1,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -211,13 +211,13 @@ pub struct Dav1dFrameHeader {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_2 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -225,7 +225,7 @@ pub struct C2RustUnnamed_2 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -236,26 +236,26 @@ pub struct C2RustUnnamed_3 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
-    pub q: C2RustUnnamed_6,
-    pub lf: C2RustUnnamed_5,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_5 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -266,7 +266,7 @@ pub struct C2RustUnnamed_7 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -280,7 +280,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -297,14 +297,14 @@ pub struct C2RustUnnamed_9 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
@@ -336,13 +336,13 @@ pub struct Dav1dPicture {
 #[repr(C)]
 pub struct MuxerPriv {
     pub abcd: [uint32_t; 4],
-    pub c2rust_unnamed: C2RustUnnamed_12,
+    pub c2rust_unnamed: C2RustUnnamed,
     pub len: uint64_t,
     pub f: *mut libc::FILE,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_12 {
+pub union C2RustUnnamed {
     pub data: [uint8_t; 64],
     pub data32: [uint32_t; 16],
 }

--- a/tools/output/null.rs
+++ b/tools/output/null.rs
@@ -41,17 +41,17 @@ use crate::include::dav1d::headers::Dav1dWarpedMotionType;
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed {
-    pub p: C2RustUnnamed_0,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -133,7 +133,7 @@ use crate::include::dav1d::headers::Dav1dFilmGrainData;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_11,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -157,7 +157,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_10,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -167,14 +167,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_9,
-    pub quant: C2RustUnnamed_8,
-    pub segmentation: C2RustUnnamed_7,
-    pub delta: C2RustUnnamed_4,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_3,
-    pub cdef: C2RustUnnamed_2,
-    pub restoration: C2RustUnnamed_1,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -186,13 +186,13 @@ pub struct Dav1dFrameHeader {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_2 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -200,7 +200,7 @@ pub struct C2RustUnnamed_2 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -211,26 +211,26 @@ pub struct C2RustUnnamed_3 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
-    pub q: C2RustUnnamed_6,
-    pub lf: C2RustUnnamed_5,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_5 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -241,7 +241,7 @@ pub struct C2RustUnnamed_7 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -255,7 +255,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -272,14 +272,14 @@ pub struct C2RustUnnamed_9 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,

--- a/tools/output/output.rs
+++ b/tools/output/output.rs
@@ -70,17 +70,17 @@ use crate::include::dav1d::headers::Dav1dWarpedMotionType;
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed {
-    pub p: C2RustUnnamed_0,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -162,7 +162,7 @@ use crate::include::dav1d::headers::Dav1dFilmGrainData;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_11,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -186,7 +186,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_10,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -196,14 +196,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_9,
-    pub quant: C2RustUnnamed_8,
-    pub segmentation: C2RustUnnamed_7,
-    pub delta: C2RustUnnamed_4,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_3,
-    pub cdef: C2RustUnnamed_2,
-    pub restoration: C2RustUnnamed_1,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -215,13 +215,13 @@ pub struct Dav1dFrameHeader {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_2 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -229,7 +229,7 @@ pub struct C2RustUnnamed_2 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -240,26 +240,26 @@ pub struct C2RustUnnamed_3 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
-    pub q: C2RustUnnamed_6,
-    pub lf: C2RustUnnamed_5,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_5 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -270,7 +270,7 @@ pub struct C2RustUnnamed_7 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -284,7 +284,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -301,14 +301,14 @@ pub struct C2RustUnnamed_9 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,

--- a/tools/output/y4m2.rs
+++ b/tools/output/y4m2.rs
@@ -56,17 +56,17 @@ use crate::include::dav1d::headers::Dav1dWarpedMotionType;
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed {
-    pub p: C2RustUnnamed_0,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -148,7 +148,7 @@ use crate::include::dav1d::headers::Dav1dFilmGrainData;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_11,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -172,7 +172,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_10,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -182,14 +182,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_9,
-    pub quant: C2RustUnnamed_8,
-    pub segmentation: C2RustUnnamed_7,
-    pub delta: C2RustUnnamed_4,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_3,
-    pub cdef: C2RustUnnamed_2,
-    pub restoration: C2RustUnnamed_1,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -201,13 +201,13 @@ pub struct Dav1dFrameHeader {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_2 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -215,7 +215,7 @@ pub struct C2RustUnnamed_2 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -226,26 +226,26 @@ pub struct C2RustUnnamed_3 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
-    pub q: C2RustUnnamed_6,
-    pub lf: C2RustUnnamed_5,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_5 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -256,7 +256,7 @@ pub struct C2RustUnnamed_7 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -270,7 +270,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -287,14 +287,14 @@ pub struct C2RustUnnamed_9 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,

--- a/tools/output/yuv.rs
+++ b/tools/output/yuv.rs
@@ -56,17 +56,17 @@ use crate::include::dav1d::headers::Dav1dWarpedMotionType;
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed {
-    pub p: C2RustUnnamed_0,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -148,7 +148,7 @@ use crate::include::dav1d::headers::Dav1dFilmGrainData;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_11,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -172,7 +172,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_10,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -182,14 +182,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_9,
-    pub quant: C2RustUnnamed_8,
-    pub segmentation: C2RustUnnamed_7,
-    pub delta: C2RustUnnamed_4,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_3,
-    pub cdef: C2RustUnnamed_2,
-    pub restoration: C2RustUnnamed_1,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -201,13 +201,13 @@ pub struct Dav1dFrameHeader {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_2 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -215,7 +215,7 @@ pub struct C2RustUnnamed_2 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -226,26 +226,26 @@ pub struct C2RustUnnamed_3 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
-    pub q: C2RustUnnamed_6,
-    pub lf: C2RustUnnamed_5,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_5 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -256,7 +256,7 @@ pub struct C2RustUnnamed_7 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -270,7 +270,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -287,14 +287,14 @@ pub struct C2RustUnnamed_9 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,


### PR DESCRIPTION
Unnamed types, mostly anonymous inner types, that do have named fields/variables can be named without any other change.  That was done in the C source code, then the C re-transpiled to Rust from a branch closer to the initial transpilation, and then the commit `cherry-pick`ed to `main`.  Unnamed types where the field is not named cannot be named without also naming the field, so I'm keeping those separate, though those changes are coming next.

Note: the re-transpilation was `cherry-pick`ed from [`kkysen/retranspile-name-unnamed-simple`](https://github.com/memorysafety/rav1d/tree/kkysen/retranspile-name-unnamed-simple) and merged, as the re-transpilation diff is simpler there.

The type names I chose are generally based on the field name with the parent type as a prefix, `enum` variants' names, etc.