### PR TITLE
Fix missed unnamed renames from #84

### DIFF
--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -60,7 +60,7 @@ pub struct Dav1dFrameContext {
     pub ts: *mut Dav1dTileState,
     pub n_ts: libc::c_int,
     pub dsp: *const Dav1dDSPContext,
-    pub bd_fn: C2RustUnnamed_28,
+    pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
     pub ipred_edge: [*mut pixel; 3],
     pub b4_stride: ptrdiff_t,
@@ -81,15 +81,15 @@ pub struct Dav1dFrameContext {
     pub rf: refmvs_frame,
     pub jnt_weights: [[uint8_t; 7]; 7],
     pub bitdepth_max: libc::c_int,
-    pub frame_thread: C2RustUnnamed_20,
-    pub lf: C2RustUnnamed_19,
-    pub task_thread: C2RustUnnamed,
+    pub frame_thread: Dav1dFrameContext_frame_thread,
+    pub lf: Dav1dFrameContext_lf,
+    pub task_thread: Dav1dFrameContext_task_thread,
     pub tile_thread: FrameTileThreadData,
 }
 use crate::src::internal::FrameTileThreadData;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed {
+pub struct Dav1dFrameContext_task_thread {
     pub lock: pthread_mutex_t,
     pub cond: pthread_cond_t,
     pub ttd: *mut TaskThreadData,
@@ -107,11 +107,11 @@ pub struct C2RustUnnamed {
     pub task_head: *mut Dav1dTask,
     pub task_tail: *mut Dav1dTask,
     pub task_cur_prev: *mut Dav1dTask,
-    pub pending_tasks: C2RustUnnamed_0,
+    pub pending_tasks: Dav1dFrameContext_task_thread_pending_tasks,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dFrameContext_task_thread_pending_tasks {
     pub merge: atomic_int,
     pub lock: pthread_mutex_t,
     pub head: *mut Dav1dTask,
@@ -145,12 +145,12 @@ pub struct TaskThreadData {
     pub cur: libc::c_uint,
     pub reset_task_cur: atomic_uint,
     pub cond_signaled: atomic_int,
-    pub delayed_fg: C2RustUnnamed_1,
+    pub delayed_fg: Dav1dContext_task_thread_delayed_fg,
     pub inited: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dContext_task_thread_delayed_fg {
     pub exec: libc::c_int,
     pub cond: pthread_cond_t,
     pub in_0: *const Dav1dPicture,
@@ -211,7 +211,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_17,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -235,7 +235,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_16,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -245,14 +245,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_15,
-    pub quant: C2RustUnnamed_14,
-    pub segmentation: C2RustUnnamed_13,
-    pub delta: C2RustUnnamed_10,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_9,
-    pub cdef: C2RustUnnamed_8,
-    pub restoration: C2RustUnnamed_7,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -262,22 +262,23 @@ pub struct Dav1dFrameHeader {
     pub reduced_txtp_set: libc::c_int,
     pub gmv: [Dav1dWarpedMotionParams; 7],
 }
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed_5,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_5 {
-    pub p: C2RustUnnamed_6,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -295,7 +296,7 @@ use crate::include::dav1d::headers::Dav1dTxfmMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
@@ -306,7 +307,7 @@ use crate::include::dav1d::headers::Dav1dRestorationType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -314,7 +315,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -326,26 +327,26 @@ pub struct C2RustUnnamed_9 {
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
-    pub q: C2RustUnnamed_12,
-    pub lf: C2RustUnnamed_11,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_12 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_13 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -358,7 +359,7 @@ use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_14 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -372,7 +373,7 @@ pub struct C2RustUnnamed_14 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_15 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -397,7 +398,7 @@ use crate::include::dav1d::headers::Dav1dFilterMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_16 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
@@ -409,7 +410,7 @@ use crate::include::dav1d::headers::Dav1dFrameType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_17 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
@@ -481,7 +482,7 @@ use crate::include::pthread::pthread_cond_t;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_19 {
+pub struct Dav1dFrameContext_lf {
     pub level: *mut [uint8_t; 4],
     pub mask: *mut Av1Filter,
     pub lr_mask: *mut Av1Restoration,
@@ -515,7 +516,7 @@ use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_20 {
+pub struct Dav1dFrameContext_frame_thread {
     pub next_tile_row: [libc::c_int; 2],
     pub entropy_progress: atomic_int,
     pub deblock_progress: atomic_int,
@@ -666,7 +667,7 @@ pub struct refmvs_temporal_block {
 use crate::src::env::BlockContext;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_28 {
+pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
     pub recon_b_inter: recon_b_inter_fn,
     pub filter_sbrow: filter_sbrow_fn,
@@ -722,18 +723,18 @@ pub struct Dav1dTaskContext {
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
-    pub scratch: C2RustUnnamed_31,
+    pub scratch: Dav1dTaskContext_scratch,
     pub warpmv: Dav1dWarpedMotionParams,
     pub lf_mask: *mut Av1Filter,
     pub top_pre_cdef_toggle: libc::c_int,
     pub cur_sb_cdef_idx_ptr: *mut int8_t,
     pub tl_4x4_filter: Filter2d,
-    pub frame_thread: C2RustUnnamed_30,
-    pub task_thread: C2RustUnnamed_29,
+    pub frame_thread: Dav1dTaskContext_frame_thread,
+    pub task_thread: Dav1dTaskContext_task_thread,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_29 {
+pub struct Dav1dTaskContext_task_thread {
     pub td: thread_data,
     pub ttd: *mut TaskThreadData,
     pub fttd: *mut FrameTileThreadData,
@@ -744,7 +745,7 @@ use crate::src::thread_data::thread_data;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_30 {
+pub struct Dav1dTaskContext_frame_thread {
     pub pass: libc::c_int,
 }
 use crate::src::levels::Filter2d;
@@ -761,7 +762,7 @@ use crate::src::levels::Filter2d;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_31 {
+pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: C2RustUnnamed_38,
     pub c2rust_unnamed_0: C2RustUnnamed_32,
 }
@@ -821,12 +822,12 @@ pub struct refmvs_tile {
     pub rf: *const refmvs_frame,
     pub r: [*mut refmvs_block; 37],
     pub rp_proj: *mut refmvs_temporal_block,
-    pub tile_col: C2RustUnnamed_43,
-    pub tile_row: C2RustUnnamed_43,
+    pub tile_col: refmvs_tile_range,
+    pub tile_row: refmvs_tile_range,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_43 {
+pub struct refmvs_tile_range {
     pub start: libc::c_int,
     pub end: libc::c_int,
 }
@@ -835,9 +836,9 @@ pub struct C2RustUnnamed_43 {
 pub struct Dav1dTileState {
     pub cdf: CdfContext,
     pub msac: MsacContext,
-    pub tiling: C2RustUnnamed_45,
+    pub tiling: Dav1dTileState_tiling,
     pub progress: [atomic_int; 2],
-    pub frame_thread: [C2RustUnnamed_44; 2],
+    pub frame_thread: [Dav1dTileState_frame_thread; 2],
     pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
     pub dqmem: [[[uint16_t; 2]; 3]; 8],
     pub dq: *const [[uint16_t; 2]; 3],
@@ -849,13 +850,13 @@ pub struct Dav1dTileState {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_44 {
+pub struct Dav1dTileState_frame_thread {
     pub pal_idx: *mut uint8_t,
     pub cf: *mut coef,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_45 {
+pub struct Dav1dTileState_tiling {
     pub col_start: libc::c_int,
     pub col_end: libc::c_int,
     pub row_start: libc::c_int,
@@ -892,16 +893,16 @@ pub struct Dav1dContext {
     pub cache: Dav1dThreadPicture,
     pub flush_mem: atomic_int,
     pub flush: *mut atomic_int,
-    pub frame_thread: C2RustUnnamed_50,
+    pub frame_thread: Dav1dContext_frame_thread,
     pub task_thread: TaskThreadData,
     pub segmap_pool: *mut Dav1dMemPool,
     pub refmvs_pool: *mut Dav1dMemPool,
-    pub refs: [C2RustUnnamed_49; 8],
+    pub refs: [Dav1dContext_refs; 8],
     pub cdf_pool: *mut Dav1dMemPool,
     pub cdf: [CdfThreadContext; 8],
     pub dsp: [Dav1dDSPContext; 3],
     pub refmvs_dsp: Dav1dRefmvsDSPContext,
-    pub intra_edge: C2RustUnnamed_46,
+    pub intra_edge: Dav1dContext_intra_edge,
     pub allocator: Dav1dPicAllocator,
     pub apply_grain: libc::c_int,
     pub operating_point: libc::c_int,
@@ -955,7 +956,7 @@ pub struct Dav1dPicAllocator {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_46 {
+pub struct Dav1dContext_intra_edge {
     pub root: [*mut EdgeNode; 2],
     pub branch_sb128: [EdgeBranch; 85],
     pub branch_sb64: [EdgeBranch; 21],
@@ -1024,11 +1025,11 @@ use crate::src::looprestoration::LrEdgeFlags;
 #[repr(C)]
 pub union LooprestorationParams {
     pub filter: [[int16_t; 8]; 2],
-    pub sgr: C2RustUnnamed_47,
+    pub sgr: LooprestorationParams_sgr,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_47 {
+pub struct LooprestorationParams_sgr {
     pub s0: uint32_t,
     pub s1: uint32_t,
     pub w0: int16_t,
@@ -1375,18 +1376,18 @@ pub type generate_grain_y_fn = Option::<
 #[repr(C)]
 pub struct CdfThreadContext {
     pub ref_0: *mut Dav1dRef,
-    pub data: C2RustUnnamed_48,
+    pub data: CdfThreadContext_data,
     pub progress: *mut atomic_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_48 {
+pub union CdfThreadContext_data {
     pub cdf: *mut CdfContext,
     pub qcat: libc::c_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_49 {
+pub struct Dav1dContext_refs {
     pub p: Dav1dThreadPicture,
     pub segmap: *mut Dav1dRef,
     pub refmvs: *mut Dav1dRef,
@@ -1403,7 +1404,7 @@ pub struct Dav1dThreadPicture {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_50 {
+pub struct Dav1dContext_frame_thread {
     pub out_delayed: *mut Dav1dThreadPicture,
     pub next: libc::c_uint,
 }

--- a/src/fg_apply_tmpl_8.rs
+++ b/src/fg_apply_tmpl_8.rs
@@ -45,22 +45,23 @@ use crate::include::dav1d::headers::Dav1dWarpedMotionType;
 
 
 
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed {
-    pub p: C2RustUnnamed_0,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -142,7 +143,7 @@ use crate::include::dav1d::headers::Dav1dFilmGrainData;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_11,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -166,7 +167,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_10,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -176,14 +177,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_9,
-    pub quant: C2RustUnnamed_8,
-    pub segmentation: C2RustUnnamed_7,
-    pub delta: C2RustUnnamed_4,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_3,
-    pub cdef: C2RustUnnamed_2,
-    pub restoration: C2RustUnnamed_1,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -195,13 +196,13 @@ pub struct Dav1dFrameHeader {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_2 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -209,7 +210,7 @@ pub struct C2RustUnnamed_2 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_3 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -220,26 +221,26 @@ pub struct C2RustUnnamed_3 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_4 {
-    pub q: C2RustUnnamed_6,
-    pub lf: C2RustUnnamed_5,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_5 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -250,7 +251,7 @@ pub struct C2RustUnnamed_7 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -264,7 +265,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -281,14 +282,14 @@ pub struct C2RustUnnamed_9 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
 use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,

--- a/src/ipred_prepare_tmpl_8.rs
+++ b/src/ipred_prepare_tmpl_8.rs
@@ -49,7 +49,7 @@ use crate::src::intra_edge::EDGE_I444_LEFT_HAS_BOTTOM;
 use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
 #[derive(Copy, Clone, BitfieldStruct)]
 #[repr(C)]
-pub struct C2RustUnnamed {
+pub struct av1_intra_prediction_edge {
     #[bitfield(name = "needs_left", ty = "uint8_t", bits = "0..=0")]
     #[bitfield(name = "needs_top", ty = "uint8_t", bits = "1..=1")]
     #[bitfield(name = "needs_topleft", ty = "uint8_t", bits = "2..=2")]
@@ -92,7 +92,7 @@ static mut av1_mode_to_angle_map: [uint8_t; 8] = [
     203 as libc::c_int as uint8_t,
     67 as libc::c_int as uint8_t,
 ];
-static mut av1_intra_prediction_edges: [C2RustUnnamed; 14] = [C2RustUnnamed {
+static mut av1_intra_prediction_edges: [av1_intra_prediction_edge; 14] = [av1_intra_prediction_edge {
     needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
 }; 14];
 #[no_mangle]
@@ -326,7 +326,7 @@ pub unsafe extern "C" fn dav1d_prepare_intra_edges_8bpc(
 unsafe extern "C" fn run_static_initializers() {
     av1_intra_prediction_edges = [
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(1 as libc::c_int as uint8_t);
@@ -337,7 +337,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(0);
@@ -348,7 +348,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(1 as libc::c_int as uint8_t);
@@ -359,7 +359,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(1 as libc::c_int as uint8_t);
@@ -370,7 +370,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(0);
@@ -381,7 +381,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(0 as libc::c_int as uint8_t);
@@ -392,7 +392,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(0);
@@ -403,7 +403,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(1 as libc::c_int as uint8_t);
@@ -414,7 +414,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(1 as libc::c_int as uint8_t);
@@ -425,7 +425,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(1 as libc::c_int as uint8_t);
@@ -436,7 +436,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(1 as libc::c_int as uint8_t);
@@ -447,7 +447,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(1 as libc::c_int as uint8_t);
@@ -458,7 +458,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(1 as libc::c_int as uint8_t);
@@ -469,7 +469,7 @@ unsafe extern "C" fn run_static_initializers() {
             init
         },
         {
-            let mut init = C2RustUnnamed {
+            let mut init = av1_intra_prediction_edge {
                 needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
             };
             init.set_needs_left(1 as libc::c_int as uint8_t);

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -60,7 +60,7 @@ pub struct Dav1dFrameContext {
     pub ts: *mut Dav1dTileState,
     pub n_ts: libc::c_int,
     pub dsp: *const Dav1dDSPContext,
-    pub bd_fn: C2RustUnnamed_28,
+    pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
     pub ipred_edge: [*mut pixel; 3],
     pub b4_stride: ptrdiff_t,
@@ -81,15 +81,15 @@ pub struct Dav1dFrameContext {
     pub rf: refmvs_frame,
     pub jnt_weights: [[uint8_t; 7]; 7],
     pub bitdepth_max: libc::c_int,
-    pub frame_thread: C2RustUnnamed_20,
-    pub lf: C2RustUnnamed_19,
-    pub task_thread: C2RustUnnamed,
+    pub frame_thread: Dav1dFrameContext_frame_thread,
+    pub lf: Dav1dFrameContext_lf,
+    pub task_thread: Dav1dFrameContext_task_thread,
     pub tile_thread: FrameTileThreadData,
 }
 use crate::src::internal::FrameTileThreadData;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed {
+pub struct Dav1dFrameContext_task_thread {
     pub lock: pthread_mutex_t,
     pub cond: pthread_cond_t,
     pub ttd: *mut TaskThreadData,
@@ -107,11 +107,11 @@ pub struct C2RustUnnamed {
     pub task_head: *mut Dav1dTask,
     pub task_tail: *mut Dav1dTask,
     pub task_cur_prev: *mut Dav1dTask,
-    pub pending_tasks: C2RustUnnamed_0,
+    pub pending_tasks: Dav1dFrameContext_task_thread_pending_tasks,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dFrameContext_task_thread_pending_tasks {
     pub merge: atomic_int,
     pub lock: pthread_mutex_t,
     pub head: *mut Dav1dTask,
@@ -145,12 +145,12 @@ pub struct TaskThreadData {
     pub cur: libc::c_uint,
     pub reset_task_cur: atomic_uint,
     pub cond_signaled: atomic_int,
-    pub delayed_fg: C2RustUnnamed_1,
+    pub delayed_fg: Dav1dContext_task_thread_delayed_fg,
     pub inited: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dContext_task_thread_delayed_fg {
     pub exec: libc::c_int,
     pub cond: pthread_cond_t,
     pub in_0: *const Dav1dPicture,
@@ -211,7 +211,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_17,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -235,7 +235,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_16,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -245,14 +245,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_15,
-    pub quant: C2RustUnnamed_14,
-    pub segmentation: C2RustUnnamed_13,
-    pub delta: C2RustUnnamed_10,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_9,
-    pub cdef: C2RustUnnamed_8,
-    pub restoration: C2RustUnnamed_7,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -262,22 +262,23 @@ pub struct Dav1dFrameHeader {
     pub reduced_txtp_set: libc::c_int,
     pub gmv: [Dav1dWarpedMotionParams; 7],
 }
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed_5,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_5 {
-    pub p: C2RustUnnamed_6,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -295,7 +296,7 @@ use crate::include::dav1d::headers::Dav1dTxfmMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
@@ -306,7 +307,7 @@ use crate::include::dav1d::headers::Dav1dRestorationType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -314,7 +315,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -326,26 +327,26 @@ pub struct C2RustUnnamed_9 {
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
-    pub q: C2RustUnnamed_12,
-    pub lf: C2RustUnnamed_11,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_12 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_13 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -358,7 +359,7 @@ use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_14 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -372,7 +373,7 @@ pub struct C2RustUnnamed_14 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_15 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -397,7 +398,7 @@ use crate::include::dav1d::headers::Dav1dFilterMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_16 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
@@ -409,7 +410,7 @@ use crate::include::dav1d::headers::Dav1dFrameType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_17 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
@@ -481,7 +482,7 @@ use crate::include::pthread::pthread_cond_t;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_19 {
+pub struct Dav1dFrameContext_lf {
     pub level: *mut [uint8_t; 4],
     pub mask: *mut Av1Filter,
     pub lr_mask: *mut Av1Restoration,
@@ -515,7 +516,7 @@ use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_20 {
+pub struct Dav1dFrameContext_frame_thread {
     pub next_tile_row: [libc::c_int; 2],
     pub entropy_progress: atomic_int,
     pub deblock_progress: atomic_int,
@@ -666,7 +667,7 @@ pub struct refmvs_temporal_block {
 use crate::src::env::BlockContext;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_28 {
+pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
     pub recon_b_inter: recon_b_inter_fn,
     pub filter_sbrow: filter_sbrow_fn,
@@ -722,18 +723,18 @@ pub struct Dav1dTaskContext {
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
-    pub scratch: C2RustUnnamed_31,
+    pub scratch: Dav1dTaskContext_scratch,
     pub warpmv: Dav1dWarpedMotionParams,
     pub lf_mask: *mut Av1Filter,
     pub top_pre_cdef_toggle: libc::c_int,
     pub cur_sb_cdef_idx_ptr: *mut int8_t,
     pub tl_4x4_filter: Filter2d,
-    pub frame_thread: C2RustUnnamed_30,
-    pub task_thread: C2RustUnnamed_29,
+    pub frame_thread: Dav1dTaskContext_frame_thread,
+    pub task_thread: Dav1dTaskContext_task_thread,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_29 {
+pub struct Dav1dTaskContext_task_thread {
     pub td: thread_data,
     pub ttd: *mut TaskThreadData,
     pub fttd: *mut FrameTileThreadData,
@@ -744,7 +745,7 @@ use crate::src::thread_data::thread_data;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_30 {
+pub struct Dav1dTaskContext_frame_thread {
     pub pass: libc::c_int,
 }
 use crate::src::levels::Filter2d;
@@ -761,7 +762,7 @@ use crate::src::levels::Filter2d;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_31 {
+pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: C2RustUnnamed_38,
     pub c2rust_unnamed_0: C2RustUnnamed_32,
 }
@@ -821,12 +822,12 @@ pub struct refmvs_tile {
     pub rf: *const refmvs_frame,
     pub r: [*mut refmvs_block; 37],
     pub rp_proj: *mut refmvs_temporal_block,
-    pub tile_col: C2RustUnnamed_43,
-    pub tile_row: C2RustUnnamed_43,
+    pub tile_col: refmvs_tile_range,
+    pub tile_row: refmvs_tile_range,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_43 {
+pub struct refmvs_tile_range {
     pub start: libc::c_int,
     pub end: libc::c_int,
 }
@@ -835,9 +836,9 @@ pub struct C2RustUnnamed_43 {
 pub struct Dav1dTileState {
     pub cdf: CdfContext,
     pub msac: MsacContext,
-    pub tiling: C2RustUnnamed_45,
+    pub tiling: Dav1dTileState_tiling,
     pub progress: [atomic_int; 2],
-    pub frame_thread: [C2RustUnnamed_44; 2],
+    pub frame_thread: [Dav1dTileState_frame_thread; 2],
     pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
     pub dqmem: [[[uint16_t; 2]; 3]; 8],
     pub dq: *const [[uint16_t; 2]; 3],
@@ -849,13 +850,13 @@ pub struct Dav1dTileState {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_44 {
+pub struct Dav1dTileState_frame_thread {
     pub pal_idx: *mut uint8_t,
     pub cf: *mut coef,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_45 {
+pub struct Dav1dTileState_tiling {
     pub col_start: libc::c_int,
     pub col_end: libc::c_int,
     pub row_start: libc::c_int,
@@ -892,16 +893,16 @@ pub struct Dav1dContext {
     pub cache: Dav1dThreadPicture,
     pub flush_mem: atomic_int,
     pub flush: *mut atomic_int,
-    pub frame_thread: C2RustUnnamed_50,
+    pub frame_thread: Dav1dContext_frame_thread,
     pub task_thread: TaskThreadData,
     pub segmap_pool: *mut Dav1dMemPool,
     pub refmvs_pool: *mut Dav1dMemPool,
-    pub refs: [C2RustUnnamed_49; 8],
+    pub refs: [Dav1dContext_refs; 8],
     pub cdf_pool: *mut Dav1dMemPool,
     pub cdf: [CdfThreadContext; 8],
     pub dsp: [Dav1dDSPContext; 3],
     pub refmvs_dsp: Dav1dRefmvsDSPContext,
-    pub intra_edge: C2RustUnnamed_46,
+    pub intra_edge: Dav1dContext_intra_edge,
     pub allocator: Dav1dPicAllocator,
     pub apply_grain: libc::c_int,
     pub operating_point: libc::c_int,
@@ -955,7 +956,7 @@ pub struct Dav1dPicAllocator {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_46 {
+pub struct Dav1dContext_intra_edge {
     pub root: [*mut EdgeNode; 2],
     pub branch_sb128: [EdgeBranch; 85],
     pub branch_sb64: [EdgeBranch; 21],
@@ -1024,11 +1025,11 @@ use crate::src::looprestoration::LrEdgeFlags;
 #[repr(C)]
 pub union LooprestorationParams {
     pub filter: [[int16_t; 8]; 2],
-    pub sgr: C2RustUnnamed_47,
+    pub sgr: LooprestorationParams_sgr,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_47 {
+pub struct LooprestorationParams_sgr {
     pub s0: uint32_t,
     pub s1: uint32_t,
     pub w0: int16_t,
@@ -1375,18 +1376,18 @@ pub type generate_grain_y_fn = Option::<
 #[repr(C)]
 pub struct CdfThreadContext {
     pub ref_0: *mut Dav1dRef,
-    pub data: C2RustUnnamed_48,
+    pub data: CdfThreadContext_data,
     pub progress: *mut atomic_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_48 {
+pub union CdfThreadContext_data {
     pub cdf: *mut CdfContext,
     pub qcat: libc::c_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_49 {
+pub struct Dav1dContext_refs {
     pub p: Dav1dThreadPicture,
     pub segmap: *mut Dav1dRef,
     pub refmvs: *mut Dav1dRef,
@@ -1403,7 +1404,7 @@ pub struct Dav1dThreadPicture {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_50 {
+pub struct Dav1dContext_frame_thread {
     pub out_delayed: *mut Dav1dThreadPicture,
     pub next: libc::c_uint,
 }

--- a/src/looprestoration_tmpl_8.rs
+++ b/src/looprestoration_tmpl_8.rs
@@ -320,11 +320,11 @@ pub type const_left_pixel_row = *const [pixel; 4];
 #[repr(C)]
 pub union LooprestorationParams {
     pub filter: [[int16_t; 8]; 2],
-    pub sgr: C2RustUnnamed,
+    pub sgr: LooprestorationParams_sgr,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed {
+pub struct LooprestorationParams_sgr {
     pub s0: uint32_t,
     pub s1: uint32_t,
     pub w0: int16_t,

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -61,7 +61,7 @@ pub struct Dav1dFrameContext {
     pub ts: *mut Dav1dTileState,
     pub n_ts: libc::c_int,
     pub dsp: *const Dav1dDSPContext,
-    pub bd_fn: C2RustUnnamed_28,
+    pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
     pub ipred_edge: [*mut pixel; 3],
     pub b4_stride: ptrdiff_t,
@@ -82,15 +82,15 @@ pub struct Dav1dFrameContext {
     pub rf: refmvs_frame,
     pub jnt_weights: [[uint8_t; 7]; 7],
     pub bitdepth_max: libc::c_int,
-    pub frame_thread: C2RustUnnamed_20,
-    pub lf: C2RustUnnamed_19,
-    pub task_thread: C2RustUnnamed,
+    pub frame_thread: Dav1dFrameContext_frame_thread,
+    pub lf: Dav1dFrameContext_lf,
+    pub task_thread: Dav1dFrameContext_task_thread,
     pub tile_thread: FrameTileThreadData,
 }
 use crate::src::internal::FrameTileThreadData;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed {
+pub struct Dav1dFrameContext_task_thread {
     pub lock: pthread_mutex_t,
     pub cond: pthread_cond_t,
     pub ttd: *mut TaskThreadData,
@@ -108,11 +108,11 @@ pub struct C2RustUnnamed {
     pub task_head: *mut Dav1dTask,
     pub task_tail: *mut Dav1dTask,
     pub task_cur_prev: *mut Dav1dTask,
-    pub pending_tasks: C2RustUnnamed_0,
+    pub pending_tasks: Dav1dFrameContext_task_thread_pending_tasks,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dFrameContext_task_thread_pending_tasks {
     pub merge: atomic_int,
     pub lock: pthread_mutex_t,
     pub head: *mut Dav1dTask,
@@ -146,12 +146,12 @@ pub struct TaskThreadData {
     pub cur: libc::c_uint,
     pub reset_task_cur: atomic_uint,
     pub cond_signaled: atomic_int,
-    pub delayed_fg: C2RustUnnamed_1,
+    pub delayed_fg: Dav1dContext_task_thread_delayed_fg,
     pub inited: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dContext_task_thread_delayed_fg {
     pub exec: libc::c_int,
     pub cond: pthread_cond_t,
     pub in_0: *const Dav1dPicture,
@@ -212,7 +212,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_17,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -236,7 +236,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_16,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -246,14 +246,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_15,
-    pub quant: C2RustUnnamed_14,
-    pub segmentation: C2RustUnnamed_13,
-    pub delta: C2RustUnnamed_10,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_9,
-    pub cdef: C2RustUnnamed_8,
-    pub restoration: C2RustUnnamed_7,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -263,22 +263,23 @@ pub struct Dav1dFrameHeader {
     pub reduced_txtp_set: libc::c_int,
     pub gmv: [Dav1dWarpedMotionParams; 7],
 }
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed_5,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_5 {
-    pub p: C2RustUnnamed_6,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -296,7 +297,7 @@ use crate::include::dav1d::headers::Dav1dTxfmMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
@@ -307,7 +308,7 @@ use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -315,7 +316,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -327,26 +328,26 @@ pub struct C2RustUnnamed_9 {
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
-    pub q: C2RustUnnamed_12,
-    pub lf: C2RustUnnamed_11,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_12 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_13 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -359,7 +360,7 @@ use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_14 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -373,7 +374,7 @@ pub struct C2RustUnnamed_14 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_15 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -398,7 +399,7 @@ use crate::include::dav1d::headers::Dav1dFilterMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_16 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
@@ -410,7 +411,7 @@ use crate::include::dav1d::headers::Dav1dFrameType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_17 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
@@ -482,7 +483,7 @@ use crate::include::pthread::pthread_cond_t;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_19 {
+pub struct Dav1dFrameContext_lf {
     pub level: *mut [uint8_t; 4],
     pub mask: *mut Av1Filter,
     pub lr_mask: *mut Av1Restoration,
@@ -516,7 +517,7 @@ use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_20 {
+pub struct Dav1dFrameContext_frame_thread {
     pub next_tile_row: [libc::c_int; 2],
     pub entropy_progress: atomic_int,
     pub deblock_progress: atomic_int,
@@ -667,7 +668,7 @@ pub struct refmvs_temporal_block {
 use crate::src::env::BlockContext;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_28 {
+pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
     pub recon_b_inter: recon_b_inter_fn,
     pub filter_sbrow: filter_sbrow_fn,
@@ -723,18 +724,18 @@ pub struct Dav1dTaskContext {
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
-    pub scratch: C2RustUnnamed_31,
+    pub scratch: Dav1dTaskContext_scratch,
     pub warpmv: Dav1dWarpedMotionParams,
     pub lf_mask: *mut Av1Filter,
     pub top_pre_cdef_toggle: libc::c_int,
     pub cur_sb_cdef_idx_ptr: *mut int8_t,
     pub tl_4x4_filter: Filter2d,
-    pub frame_thread: C2RustUnnamed_30,
-    pub task_thread: C2RustUnnamed_29,
+    pub frame_thread: Dav1dTaskContext_frame_thread,
+    pub task_thread: Dav1dTaskContext_task_thread,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_29 {
+pub struct Dav1dTaskContext_task_thread {
     pub td: thread_data,
     pub ttd: *mut TaskThreadData,
     pub fttd: *mut FrameTileThreadData,
@@ -745,7 +746,7 @@ use crate::src::thread_data::thread_data;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_30 {
+pub struct Dav1dTaskContext_frame_thread {
     pub pass: libc::c_int,
 }
 use crate::src::levels::Filter2d;
@@ -762,7 +763,7 @@ use crate::src::levels::Filter2d;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_31 {
+pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: C2RustUnnamed_38,
     pub c2rust_unnamed_0: C2RustUnnamed_32,
 }
@@ -822,12 +823,12 @@ pub struct refmvs_tile {
     pub rf: *const refmvs_frame,
     pub r: [*mut refmvs_block; 37],
     pub rp_proj: *mut refmvs_temporal_block,
-    pub tile_col: C2RustUnnamed_43,
-    pub tile_row: C2RustUnnamed_43,
+    pub tile_col: refmvs_tile_range,
+    pub tile_row: refmvs_tile_range,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_43 {
+pub struct refmvs_tile_range {
     pub start: libc::c_int,
     pub end: libc::c_int,
 }
@@ -836,9 +837,9 @@ pub struct C2RustUnnamed_43 {
 pub struct Dav1dTileState {
     pub cdf: CdfContext,
     pub msac: MsacContext,
-    pub tiling: C2RustUnnamed_45,
+    pub tiling: Dav1dTileState_tiling,
     pub progress: [atomic_int; 2],
-    pub frame_thread: [C2RustUnnamed_44; 2],
+    pub frame_thread: [Dav1dTileState_frame_thread; 2],
     pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
     pub dqmem: [[[uint16_t; 2]; 3]; 8],
     pub dq: *const [[uint16_t; 2]; 3],
@@ -850,13 +851,13 @@ pub struct Dav1dTileState {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_44 {
+pub struct Dav1dTileState_frame_thread {
     pub pal_idx: *mut uint8_t,
     pub cf: *mut coef,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_45 {
+pub struct Dav1dTileState_tiling {
     pub col_start: libc::c_int,
     pub col_end: libc::c_int,
     pub row_start: libc::c_int,
@@ -893,16 +894,16 @@ pub struct Dav1dContext {
     pub cache: Dav1dThreadPicture,
     pub flush_mem: atomic_int,
     pub flush: *mut atomic_int,
-    pub frame_thread: C2RustUnnamed_50,
+    pub frame_thread: Dav1dContext_frame_thread,
     pub task_thread: TaskThreadData,
     pub segmap_pool: *mut Dav1dMemPool,
     pub refmvs_pool: *mut Dav1dMemPool,
-    pub refs: [C2RustUnnamed_49; 8],
+    pub refs: [Dav1dContext_refs; 8],
     pub cdf_pool: *mut Dav1dMemPool,
     pub cdf: [CdfThreadContext; 8],
     pub dsp: [Dav1dDSPContext; 3],
     pub refmvs_dsp: Dav1dRefmvsDSPContext,
-    pub intra_edge: C2RustUnnamed_46,
+    pub intra_edge: Dav1dContext_intra_edge,
     pub allocator: Dav1dPicAllocator,
     pub apply_grain: libc::c_int,
     pub operating_point: libc::c_int,
@@ -956,7 +957,7 @@ pub struct Dav1dPicAllocator {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_46 {
+pub struct Dav1dContext_intra_edge {
     pub root: [*mut EdgeNode; 2],
     pub branch_sb128: [EdgeBranch; 85],
     pub branch_sb64: [EdgeBranch; 21],
@@ -1025,11 +1026,11 @@ use crate::src::looprestoration::LR_HAVE_LEFT;
 #[repr(C)]
 pub union LooprestorationParams {
     pub filter: [[int16_t; 8]; 2],
-    pub sgr: C2RustUnnamed_47,
+    pub sgr: LooprestorationParams_sgr,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_47 {
+pub struct LooprestorationParams_sgr {
     pub s0: uint32_t,
     pub s1: uint32_t,
     pub w0: int16_t,
@@ -1376,18 +1377,18 @@ pub type generate_grain_y_fn = Option::<
 #[repr(C)]
 pub struct CdfThreadContext {
     pub ref_0: *mut Dav1dRef,
-    pub data: C2RustUnnamed_48,
+    pub data: CdfThreadContext_data,
     pub progress: *mut atomic_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_48 {
+pub union CdfThreadContext_data {
     pub cdf: *mut CdfContext,
     pub qcat: libc::c_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_49 {
+pub struct Dav1dContext_refs {
     pub p: Dav1dThreadPicture,
     pub segmap: *mut Dav1dRef,
     pub refmvs: *mut Dav1dRef,
@@ -1404,7 +1405,7 @@ pub struct Dav1dThreadPicture {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_50 {
+pub struct Dav1dContext_frame_thread {
     pub out_delayed: *mut Dav1dThreadPicture,
     pub next: libc::c_uint,
 }

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -157,7 +157,7 @@ pub struct Dav1dFrameContext {
     pub ts: *mut Dav1dTileState,
     pub n_ts: libc::c_int,
     pub dsp: *const Dav1dDSPContext,
-    pub bd_fn: C2RustUnnamed_28,
+    pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
     pub ipred_edge: [*mut pixel; 3],
     pub b4_stride: ptrdiff_t,
@@ -178,15 +178,15 @@ pub struct Dav1dFrameContext {
     pub rf: refmvs_frame,
     pub jnt_weights: [[uint8_t; 7]; 7],
     pub bitdepth_max: libc::c_int,
-    pub frame_thread: C2RustUnnamed_20,
-    pub lf: C2RustUnnamed_19,
-    pub task_thread: C2RustUnnamed,
+    pub frame_thread: Dav1dFrameContext_frame_thread,
+    pub lf: Dav1dFrameContext_lf,
+    pub task_thread: Dav1dFrameContext_task_thread,
     pub tile_thread: FrameTileThreadData,
 }
 use crate::src::internal::FrameTileThreadData;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed {
+pub struct Dav1dFrameContext_task_thread {
     pub lock: pthread_mutex_t,
     pub cond: pthread_cond_t,
     pub ttd: *mut TaskThreadData,
@@ -204,11 +204,11 @@ pub struct C2RustUnnamed {
     pub task_head: *mut Dav1dTask,
     pub task_tail: *mut Dav1dTask,
     pub task_cur_prev: *mut Dav1dTask,
-    pub pending_tasks: C2RustUnnamed_0,
+    pub pending_tasks: Dav1dFrameContext_task_thread_pending_tasks,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_0 {
+pub struct Dav1dFrameContext_task_thread_pending_tasks {
     pub merge: atomic_int,
     pub lock: pthread_mutex_t,
     pub head: *mut Dav1dTask,
@@ -242,12 +242,12 @@ pub struct TaskThreadData {
     pub cur: libc::c_uint,
     pub reset_task_cur: atomic_uint,
     pub cond_signaled: atomic_int,
-    pub delayed_fg: C2RustUnnamed_1,
+    pub delayed_fg: Dav1dContext_task_thread_delayed_fg,
     pub inited: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_1 {
+pub struct Dav1dContext_task_thread_delayed_fg {
     pub exec: libc::c_int,
     pub cond: pthread_cond_t,
     pub in_0: *const Dav1dPicture,
@@ -308,7 +308,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: C2RustUnnamed_17,
+    pub film_grain: Dav1dFrameHeader_film_grain,
     pub frame_type: Dav1dFrameType,
     pub width: [libc::c_int; 2],
     pub height: libc::c_int,
@@ -332,7 +332,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: libc::c_int,
     pub render_width: libc::c_int,
     pub render_height: libc::c_int,
-    pub super_res: C2RustUnnamed_16,
+    pub super_res: Dav1dFrameHeader_super_res,
     pub have_render_size: libc::c_int,
     pub allow_intrabc: libc::c_int,
     pub frame_ref_short_signaling: libc::c_int,
@@ -342,14 +342,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: libc::c_int,
     pub use_ref_frame_mvs: libc::c_int,
     pub refresh_context: libc::c_int,
-    pub tiling: C2RustUnnamed_15,
-    pub quant: C2RustUnnamed_14,
-    pub segmentation: C2RustUnnamed_13,
-    pub delta: C2RustUnnamed_10,
+    pub tiling: Dav1dFrameHeader_tiling,
+    pub quant: Dav1dFrameHeader_quant,
+    pub segmentation: Dav1dFrameHeader_segmentation,
+    pub delta: Dav1dFrameHeader_delta,
     pub all_lossless: libc::c_int,
-    pub loopfilter: C2RustUnnamed_9,
-    pub cdef: C2RustUnnamed_8,
-    pub restoration: C2RustUnnamed_7,
+    pub loopfilter: Dav1dFrameHeader_loopfilter,
+    pub cdef: Dav1dFrameHeader_cdef,
+    pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: libc::c_int,
     pub skip_mode_allowed: libc::c_int,
@@ -359,22 +359,23 @@ pub struct Dav1dFrameHeader {
     pub reduced_txtp_set: libc::c_int,
     pub gmv: [Dav1dWarpedMotionParams; 7],
 }
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [int32_t; 6],
-    pub u: C2RustUnnamed_5,
+    pub u: Dav1dWarpedMotionParams_u,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_5 {
-    pub p: C2RustUnnamed_6,
+pub union Dav1dWarpedMotionParams_u {
+    pub p: Dav1dWarpedMotionParams_u_p,
     pub abcd: [int16_t; 4],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_6 {
+pub struct Dav1dWarpedMotionParams_u_p {
     pub alpha: int16_t,
     pub beta: int16_t,
     pub gamma: int16_t,
@@ -392,7 +393,7 @@ use crate::include::dav1d::headers::Dav1dTxfmMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_7 {
+pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
@@ -403,7 +404,7 @@ use crate::include::dav1d::headers::Dav1dRestorationType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_8 {
+pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
     pub n_bits: libc::c_int,
     pub y_strength: [libc::c_int; 8],
@@ -411,7 +412,7 @@ pub struct C2RustUnnamed_8 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_9 {
+pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
     pub level_u: libc::c_int,
     pub level_v: libc::c_int,
@@ -423,26 +424,26 @@ pub struct C2RustUnnamed_9 {
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_10 {
-    pub q: C2RustUnnamed_12,
-    pub lf: C2RustUnnamed_11,
+pub struct Dav1dFrameHeader_delta {
+    pub q: Dav1dFrameHeader_delta_q,
+    pub lf: Dav1dFrameHeader_delta_lf,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_11 {
+pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_12 {
+pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_13 {
+pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
     pub update_map: libc::c_int,
     pub temporal: libc::c_int,
@@ -455,7 +456,7 @@ use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_14 {
+pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
     pub ydc_delta: libc::c_int,
     pub udc_delta: libc::c_int,
@@ -469,7 +470,7 @@ pub struct C2RustUnnamed_14 {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_15 {
+pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
     pub n_bytes: libc::c_uint,
     pub min_log2_cols: libc::c_int,
@@ -494,7 +495,7 @@ use crate::include::dav1d::headers::Dav1dFilterMode;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_16 {
+pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
@@ -506,7 +507,7 @@ use crate::include::dav1d::headers::Dav1dFrameType;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_17 {
+pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
@@ -578,7 +579,7 @@ use crate::include::pthread::pthread_cond_t;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_19 {
+pub struct Dav1dFrameContext_lf {
     pub level: *mut [uint8_t; 4],
     pub mask: *mut Av1Filter,
     pub lr_mask: *mut Av1Restoration,
@@ -612,7 +613,7 @@ use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_20 {
+pub struct Dav1dFrameContext_frame_thread {
     pub next_tile_row: [libc::c_int; 2],
     pub entropy_progress: atomic_int,
     pub deblock_progress: atomic_int,
@@ -763,7 +764,7 @@ pub struct refmvs_temporal_block {
 use crate::src::env::BlockContext;
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_28 {
+pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
     pub recon_b_inter: recon_b_inter_fn,
     pub filter_sbrow: filter_sbrow_fn,
@@ -819,18 +820,18 @@ pub struct Dav1dTaskContext {
     pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[uint8_t; 32]; 2],
     pub txtp_map: [uint8_t; 1024],
-    pub scratch: C2RustUnnamed_31,
+    pub scratch: Dav1dTaskContext_scratch,
     pub warpmv: Dav1dWarpedMotionParams,
     pub lf_mask: *mut Av1Filter,
     pub top_pre_cdef_toggle: libc::c_int,
     pub cur_sb_cdef_idx_ptr: *mut int8_t,
     pub tl_4x4_filter: Filter2d,
-    pub frame_thread: C2RustUnnamed_30,
-    pub task_thread: C2RustUnnamed_29,
+    pub frame_thread: Dav1dTaskContext_frame_thread,
+    pub task_thread: Dav1dTaskContext_task_thread,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_29 {
+pub struct Dav1dTaskContext_task_thread {
     pub td: thread_data,
     pub ttd: *mut TaskThreadData,
     pub fttd: *mut FrameTileThreadData,
@@ -841,7 +842,7 @@ use crate::src::thread_data::thread_data;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_30 {
+pub struct Dav1dTaskContext_frame_thread {
     pub pass: libc::c_int,
 }
 use crate::src::levels::Filter2d;
@@ -858,7 +859,7 @@ use crate::src::levels::FILTER_2D_BILINEAR;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_31 {
+pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: C2RustUnnamed_38,
     pub c2rust_unnamed_0: C2RustUnnamed_32,
 }
@@ -918,12 +919,12 @@ pub struct refmvs_tile {
     pub rf: *const refmvs_frame,
     pub r: [*mut refmvs_block; 37],
     pub rp_proj: *mut refmvs_temporal_block,
-    pub tile_col: C2RustUnnamed_43,
-    pub tile_row: C2RustUnnamed_43,
+    pub tile_col: refmvs_tile_range,
+    pub tile_row: refmvs_tile_range,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_43 {
+pub struct refmvs_tile_range {
     pub start: libc::c_int,
     pub end: libc::c_int,
 }
@@ -932,9 +933,9 @@ pub struct C2RustUnnamed_43 {
 pub struct Dav1dTileState {
     pub cdf: CdfContext,
     pub msac: MsacContext,
-    pub tiling: C2RustUnnamed_45,
+    pub tiling: Dav1dTileState_tiling,
     pub progress: [atomic_int; 2],
-    pub frame_thread: [C2RustUnnamed_44; 2],
+    pub frame_thread: [Dav1dTileState_frame_thread; 2],
     pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
     pub dqmem: [[[uint16_t; 2]; 3]; 8],
     pub dq: *const [[uint16_t; 2]; 3],
@@ -946,13 +947,13 @@ pub struct Dav1dTileState {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_44 {
+pub struct Dav1dTileState_frame_thread {
     pub pal_idx: *mut uint8_t,
     pub cf: *mut coef,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_45 {
+pub struct Dav1dTileState_tiling {
     pub col_start: libc::c_int,
     pub col_end: libc::c_int,
     pub row_start: libc::c_int,
@@ -989,16 +990,16 @@ pub struct Dav1dContext {
     pub cache: Dav1dThreadPicture,
     pub flush_mem: atomic_int,
     pub flush: *mut atomic_int,
-    pub frame_thread: C2RustUnnamed_50,
+    pub frame_thread: Dav1dContext_frame_thread,
     pub task_thread: TaskThreadData,
     pub segmap_pool: *mut Dav1dMemPool,
     pub refmvs_pool: *mut Dav1dMemPool,
-    pub refs: [C2RustUnnamed_49; 8],
+    pub refs: [Dav1dContext_refs; 8],
     pub cdf_pool: *mut Dav1dMemPool,
     pub cdf: [CdfThreadContext; 8],
     pub dsp: [Dav1dDSPContext; 3],
     pub refmvs_dsp: Dav1dRefmvsDSPContext,
-    pub intra_edge: C2RustUnnamed_46,
+    pub intra_edge: Dav1dContext_intra_edge,
     pub allocator: Dav1dPicAllocator,
     pub apply_grain: libc::c_int,
     pub operating_point: libc::c_int,
@@ -1052,7 +1053,7 @@ pub struct Dav1dPicAllocator {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_46 {
+pub struct Dav1dContext_intra_edge {
     pub root: [*mut EdgeNode; 2],
     pub branch_sb128: [EdgeBranch; 85],
     pub branch_sb64: [EdgeBranch; 21],
@@ -1122,11 +1123,11 @@ use crate::src::looprestoration::LrEdgeFlags;
 #[repr(C)]
 pub union LooprestorationParams {
     pub filter: [[int16_t; 8]; 2],
-    pub sgr: C2RustUnnamed_47,
+    pub sgr: LooprestorationParams_sgr,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_47 {
+pub struct LooprestorationParams_sgr {
     pub s0: uint32_t,
     pub s1: uint32_t,
     pub w0: int16_t,
@@ -1502,18 +1503,18 @@ pub type generate_grain_y_fn = Option::<
 #[repr(C)]
 pub struct CdfThreadContext {
     pub ref_0: *mut Dav1dRef,
-    pub data: C2RustUnnamed_48,
+    pub data: CdfThreadContext_data,
     pub progress: *mut atomic_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub union C2RustUnnamed_48 {
+pub union CdfThreadContext_data {
     pub cdf: *mut CdfContext,
     pub qcat: libc::c_uint,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_49 {
+pub struct Dav1dContext_refs {
     pub p: Dav1dThreadPicture,
     pub segmap: *mut Dav1dRef,
     pub refmvs: *mut Dav1dRef,
@@ -1530,7 +1531,7 @@ pub struct Dav1dThreadPicture {
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct C2RustUnnamed_50 {
+pub struct Dav1dContext_frame_thread {
     pub out_delayed: *mut Dav1dThreadPicture,
     pub next: libc::c_uint,
 }


### PR DESCRIPTION
Accidentally missed some unnamed renames from #84, mostly due to the re-transpilation `cherry-pick` only applying to either the 8 or 16 bitdepth version.  I now went through each renamed type and checked for remaining `C2RustUnnamed_*` types and fixed them.