### PR TITLE
Add a timeout multiplier of 2 for arm7 tests

### DIFF
--- a/.github/workflows/qemu-arm7.yml
+++ b/.github/workflows/qemu-arm7.yml
@@ -57,7 +57,7 @@ jobs:
             -w ${{ github.workspace }} \
             --platform linux/arm/v7 \
             ghcr.io/immunant/rav1d/debian-bullseye-arm7:latest \
-            .github/workflows/test.sh
+            .github/workflows/test.sh -t 2
       - name: upload build artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -3,6 +3,14 @@
 set -eu
 set -o pipefail
 
+timeout_multiplier=1
+while getopts t: flag
+do
+    case "${flag}" in
+        t) timeout_multiplier=${OPTARG};;
+    esac
+done
+
 mkdir -p build && pushd build
 
 meson setup ..
@@ -10,4 +18,5 @@ meson test --no-rebuild \
     --suite testdata-8 \
     --suite testdata-10 \
     --suite testdata-12 \
-    --suite testdata-multi
+    --suite testdata-multi \
+    --timeout-multiplier $timeout_multiplier


### PR DESCRIPTION
This is a low risk change so merging without further review. Ping me if autostitch or other tests still time out occasionally.