### PR TITLE
Deduplicate `struct Dav1dTaskContext_scratch` and its previously unnamed inner types to `src/internal.rs`

### DIFF
--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -475,14 +475,9 @@ pub struct Dav1dTaskContext_scratch_pal {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_lap_emu_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
-use crate::src::internal::Dav1dTaskContext_scratch_lap;
+use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -481,12 +481,7 @@ pub struct Dav1dTaskContext_scratch_lap_emu_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_emu_edge {
-    pub emu_edge_8bpc: [uint8_t; 84160],
-    pub emu_edge_16bpc: [uint16_t; 84160],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
 use crate::src::internal::Dav1dTaskContext_scratch_lap;
 
 use crate::src::internal::Dav1dTaskContext_cf;

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -494,12 +494,7 @@ pub union Dav1dTaskContext_scratch_lap {
     pub lap_16bpc: [uint16_t; 4096],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_compinter_seg_mask {
-    pub compinter: [[int16_t; 16384]; 2],
-    pub seg_mask: [uint8_t; 16384],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -463,13 +463,8 @@ pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_levels_pal {
-    pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_pal;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -445,19 +445,14 @@ use crate::src::levels::Filter2d;
 
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch;
 
 
 
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 
 

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -487,14 +487,8 @@ pub union Dav1dTaskContext_scratch_emu_edge {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_lap {
-    pub lap_8bpc: [uint8_t; 4096],
-    pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
+use crate::src::internal::Dav1dTaskContext_scratch_lap;
+
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -451,19 +451,11 @@ pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_levels_pal,
-    pub ac: [int16_t; 1024],
-    pub pal_idx: [uint8_t; 8192],
-    pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
+
 
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -469,12 +469,7 @@ pub union Dav1dTaskContext_scratch_levels_pal {
     pub levels: [uint8_t; 1088],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_pal {
-    pub pal_order: [[uint8_t; 8]; 64],
-    pub pal_ctx: [uint8_t; 64],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_pal;
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -464,13 +464,8 @@ pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_levels_pal {
-    pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_pal;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -482,12 +482,7 @@ pub struct Dav1dTaskContext_scratch_lap_emu_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_emu_edge {
-    pub emu_edge_8bpc: [uint8_t; 84160],
-    pub emu_edge_16bpc: [uint16_t; 84160],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
 use crate::src::internal::Dav1dTaskContext_scratch_lap;
 
 use crate::src::internal::Dav1dTaskContext_cf;

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -446,19 +446,14 @@ use crate::src::levels::Filter2d;
 
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch;
 
 
 
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 
 

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -495,12 +495,7 @@ pub union Dav1dTaskContext_scratch_lap {
     pub lap_16bpc: [uint16_t; 4096],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_compinter_seg_mask {
-    pub compinter: [[int16_t; 16384]; 2],
-    pub seg_mask: [uint8_t; 16384],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -476,14 +476,9 @@ pub struct Dav1dTaskContext_scratch_pal {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_lap_emu_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
-use crate::src::internal::Dav1dTaskContext_scratch_lap;
+use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -488,14 +488,8 @@ pub union Dav1dTaskContext_scratch_emu_edge {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_lap {
-    pub lap_8bpc: [uint8_t; 4096],
-    pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
+use crate::src::internal::Dav1dTaskContext_scratch_lap;
+
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -470,12 +470,7 @@ pub union Dav1dTaskContext_scratch_levels_pal {
     pub levels: [uint8_t; 1088],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_pal {
-    pub pal_order: [[uint8_t; 8]; 64],
-    pub pal_ctx: [uint8_t; 64],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_pal;
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -452,19 +452,11 @@ pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_levels_pal,
-    pub ac: [int16_t; 1024],
-    pub pal_idx: [uint8_t; 8192],
-    pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
+
 
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -492,12 +492,7 @@ pub struct Dav1dTaskContext_scratch_lap_emu_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_emu_edge {
-    pub emu_edge_8bpc: [uint8_t; 84160],
-    pub emu_edge_16bpc: [uint16_t; 84160],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
 use crate::src::internal::Dav1dTaskContext_scratch_lap;
 
 use crate::src::internal::Dav1dTaskContext_cf;

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -486,14 +486,9 @@ pub struct Dav1dTaskContext_scratch_pal {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_lap_emu_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
-use crate::src::internal::Dav1dTaskContext_scratch_lap;
+use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -498,14 +498,8 @@ pub union Dav1dTaskContext_scratch_emu_edge {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_lap {
-    pub lap_8bpc: [uint8_t; 4096],
-    pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
+use crate::src::internal::Dav1dTaskContext_scratch_lap;
+
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -505,12 +505,7 @@ pub union Dav1dTaskContext_scratch_lap {
     pub lap_16bpc: [uint16_t; 4096],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_compinter_seg_mask {
-    pub compinter: [[int16_t; 16384]; 2],
-    pub seg_mask: [uint8_t; 16384],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -474,13 +474,8 @@ pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_levels_pal {
-    pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_pal;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -480,12 +480,7 @@ pub union Dav1dTaskContext_scratch_levels_pal {
     pub levels: [uint8_t; 1088],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_pal {
-    pub pal_order: [[uint8_t; 8]; 64],
-    pub pal_ctx: [uint8_t; 64],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_pal;
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -462,19 +462,11 @@ pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_levels_pal,
-    pub ac: [int16_t; 1024],
-    pub pal_idx: [uint8_t; 8192],
-    pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
+
 
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -456,19 +456,14 @@ use crate::src::levels::Filter2d;
 
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch;
 
 
 
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -807,19 +807,14 @@ use crate::src::levels::FILTER_2D_BILINEAR;
 
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch;
 
 
 
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -825,13 +825,8 @@ pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_levels_pal {
-    pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_pal;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -813,19 +813,11 @@ pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_levels_pal,
-    pub ac: [int16_t; 1024],
-    pub pal_idx: [uint8_t; 8192],
-    pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
+
 
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -831,12 +831,7 @@ pub union Dav1dTaskContext_scratch_levels_pal {
     pub levels: [uint8_t; 1088],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_pal {
-    pub pal_order: [[uint8_t; 8]; 64],
-    pub pal_ctx: [uint8_t; 64],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_pal;
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -849,14 +849,8 @@ pub union Dav1dTaskContext_scratch_emu_edge {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_lap {
-    pub lap_8bpc: [uint8_t; 4096],
-    pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
+use crate::src::internal::Dav1dTaskContext_scratch_lap;
+
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -856,12 +856,7 @@ pub union Dav1dTaskContext_scratch_lap {
     pub lap_16bpc: [uint16_t; 4096],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_compinter_seg_mask {
-    pub compinter: [[int16_t; 16384]; 2],
-    pub seg_mask: [uint8_t; 16384],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -843,12 +843,7 @@ pub struct Dav1dTaskContext_scratch_lap_emu_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_emu_edge {
-    pub emu_edge_8bpc: [uint8_t; 84160],
-    pub emu_edge_16bpc: [uint16_t; 84160],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
 use crate::src::internal::Dav1dTaskContext_scratch_lap;
 
 use crate::src::internal::Dav1dTaskContext_cf;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -837,14 +837,9 @@ pub struct Dav1dTaskContext_scratch_pal {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_lap_emu_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
-use crate::src::internal::Dav1dTaskContext_scratch_lap;
+use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -196,6 +196,13 @@ pub union Dav1dTaskContext_cf {
 
 #[derive(Copy, Clone)]
 #[repr(C)]
+pub struct Dav1dTaskContext_scratch_compinter_seg_mask {
+    pub compinter: [[int16_t; 16384]; 2],
+    pub seg_mask: [uint8_t; 16384],
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
 pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -260,6 +260,23 @@ pub union Dav1dTaskContext_scratch_interintra_edge {
 
 #[derive(Copy, Clone)]
 #[repr(C)]
+pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_levels_pal,
+    pub ac: [int16_t; 1024],
+    pub pal_idx: [uint8_t; 8192],
+    pub pal: [[uint16_t; 8]; 3],
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub union Dav1dTaskContext_scratch {
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
 pub struct Dav1dTaskContext_frame_thread {
     pub pass: libc::c_int,
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -203,6 +203,14 @@ pub struct Dav1dTaskContext_scratch_compinter_seg_mask {
 
 #[derive(Copy, Clone)]
 #[repr(C)]
+pub union Dav1dTaskContext_scratch_lap {
+    pub lap_8bpc: [uint8_t; 4096],
+    pub lap_16bpc: [uint16_t; 4096],
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
 pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -232,6 +232,13 @@ pub struct Dav1dTaskContext_scratch_pal {
 
 #[derive(Copy, Clone)]
 #[repr(C)]
+pub union Dav1dTaskContext_scratch_levels_pal {
+    pub levels: [uint8_t; 1088],
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
 pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -218,6 +218,20 @@ pub union Dav1dTaskContext_scratch_emu_edge {
 
 #[derive(Copy, Clone)]
 #[repr(C)]
+pub struct Dav1dTaskContext_scratch_lap_emu_edge {
+    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
+    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Dav1dTaskContext_scratch_pal {
+    pub pal_order: [[uint8_t; 8]; 64],
+    pub pal_ctx: [uint8_t; 64],
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
 pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -211,6 +211,13 @@ pub union Dav1dTaskContext_scratch_lap {
 
 #[derive(Copy, Clone)]
 #[repr(C)]
+pub union Dav1dTaskContext_scratch_emu_edge {
+    pub emu_edge_8bpc: [uint8_t; 84160],
+    pub emu_edge_16bpc: [uint16_t; 84160],
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
 pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -475,14 +475,9 @@ pub struct Dav1dTaskContext_scratch_pal {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_lap_emu_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
-use crate::src::internal::Dav1dTaskContext_scratch_lap;
+use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -481,12 +481,7 @@ pub struct Dav1dTaskContext_scratch_lap_emu_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_emu_edge {
-    pub emu_edge_8bpc: [uint8_t; 84160],
-    pub emu_edge_16bpc: [uint16_t; 84160],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
 use crate::src::internal::Dav1dTaskContext_scratch_lap;
 
 use crate::src::internal::Dav1dTaskContext_cf;

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -494,12 +494,7 @@ pub union Dav1dTaskContext_scratch_lap {
     pub lap_16bpc: [uint16_t; 4096],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_compinter_seg_mask {
-    pub compinter: [[int16_t; 16384]; 2],
-    pub seg_mask: [uint8_t; 16384],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -463,13 +463,8 @@ pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_levels_pal {
-    pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_pal;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -445,19 +445,14 @@ use crate::src::levels::Filter2d;
 
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch;
 
 
 
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 
 

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -487,14 +487,8 @@ pub union Dav1dTaskContext_scratch_emu_edge {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_lap {
-    pub lap_8bpc: [uint8_t; 4096],
-    pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
+use crate::src::internal::Dav1dTaskContext_scratch_lap;
+
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -451,19 +451,11 @@ pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_levels_pal,
-    pub ac: [int16_t; 1024],
-    pub pal_idx: [uint8_t; 8192],
-    pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
+
 
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -469,12 +469,7 @@ pub union Dav1dTaskContext_scratch_levels_pal {
     pub levels: [uint8_t; 1088],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_pal {
-    pub pal_order: [[uint8_t; 8]; 64],
-    pub pal_ctx: [uint8_t; 64],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_pal;
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -464,13 +464,8 @@ pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_levels_pal {
-    pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_pal;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -482,12 +482,7 @@ pub struct Dav1dTaskContext_scratch_lap_emu_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_emu_edge {
-    pub emu_edge_8bpc: [uint8_t; 84160],
-    pub emu_edge_16bpc: [uint16_t; 84160],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
 use crate::src::internal::Dav1dTaskContext_scratch_lap;
 
 use crate::src::internal::Dav1dTaskContext_cf;

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -446,19 +446,14 @@ use crate::src::levels::Filter2d;
 
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch;
 
 
 
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 
 

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -495,12 +495,7 @@ pub union Dav1dTaskContext_scratch_lap {
     pub lap_16bpc: [uint16_t; 4096],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_compinter_seg_mask {
-    pub compinter: [[int16_t; 16384]; 2],
-    pub seg_mask: [uint8_t; 16384],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -476,14 +476,9 @@ pub struct Dav1dTaskContext_scratch_pal {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_lap_emu_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
-use crate::src::internal::Dav1dTaskContext_scratch_lap;
+use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -488,14 +488,8 @@ pub union Dav1dTaskContext_scratch_emu_edge {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_lap {
-    pub lap_8bpc: [uint8_t; 4096],
-    pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
+use crate::src::internal::Dav1dTaskContext_scratch_lap;
+
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -470,12 +470,7 @@ pub union Dav1dTaskContext_scratch_levels_pal {
     pub levels: [uint8_t; 1088],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_pal {
-    pub pal_order: [[uint8_t; 8]; 64],
-    pub pal_ctx: [uint8_t; 64],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_pal;
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -452,19 +452,11 @@ pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_levels_pal,
-    pub ac: [int16_t; 1024],
-    pub pal_idx: [uint8_t; 8192],
-    pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
+
 
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -888,14 +888,9 @@ pub struct Dav1dTaskContext_scratch_pal {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_lap_emu_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
-use crate::src::internal::Dav1dTaskContext_scratch_lap;
+use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -882,12 +882,7 @@ pub union Dav1dTaskContext_scratch_levels_pal {
     pub levels: [uint8_t; 1088],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_pal {
-    pub pal_order: [[uint8_t; 8]; 64],
-    pub pal_ctx: [uint8_t; 64],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_pal;
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -876,13 +876,8 @@ pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_levels_pal {
-    pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_pal;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -894,12 +894,7 @@ pub struct Dav1dTaskContext_scratch_lap_emu_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_emu_edge {
-    pub emu_edge_8bpc: [uint8_t; 84160],
-    pub emu_edge_16bpc: [uint16_t; 84160],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
 use crate::src::internal::Dav1dTaskContext_scratch_lap;
 
 use crate::src::internal::Dav1dTaskContext_cf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -864,19 +864,11 @@ pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_levels_pal,
-    pub ac: [int16_t; 1024],
-    pub pal_idx: [uint8_t; 8192],
-    pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
+
 
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -900,14 +900,8 @@ pub union Dav1dTaskContext_scratch_emu_edge {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_lap {
-    pub lap_8bpc: [uint8_t; 4096],
-    pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
+use crate::src::internal::Dav1dTaskContext_scratch_lap;
+
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -858,19 +858,14 @@ use crate::src::levels::Filter2d;
 
 
 use crate::src::lf_mask::Av1Filter;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch;
 
 
 
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -907,12 +907,7 @@ pub union Dav1dTaskContext_scratch_lap {
     pub lap_16bpc: [uint16_t; 4096],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_compinter_seg_mask {
-    pub compinter: [[int16_t; 16384]; 2],
-    pub seg_mask: [uint8_t; 16384],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -746,12 +746,7 @@ pub struct Dav1dTaskContext_scratch_lap_emu_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_emu_edge {
-    pub emu_edge_8bpc: [uint8_t; 84160],
-    pub emu_edge_16bpc: [uint16_t; 84160],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
 use crate::src::internal::Dav1dTaskContext_scratch_lap;
 
 use crate::src::internal::Dav1dTaskContext_cf;

--- a/src/log.rs
+++ b/src/log.rs
@@ -734,12 +734,7 @@ pub union Dav1dTaskContext_scratch_levels_pal {
     pub levels: [uint8_t; 1088],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_pal {
-    pub pal_order: [[uint8_t; 8]; 64],
-    pub pal_ctx: [uint8_t; 64],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_pal;
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -728,13 +728,8 @@ pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_levels_pal {
-    pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_pal;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -740,14 +740,9 @@ pub struct Dav1dTaskContext_scratch_pal {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_lap_emu_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
-use crate::src::internal::Dav1dTaskContext_scratch_lap;
+use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;

--- a/src/log.rs
+++ b/src/log.rs
@@ -752,14 +752,8 @@ pub union Dav1dTaskContext_scratch_emu_edge {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_lap {
-    pub lap_8bpc: [uint8_t; 4096],
-    pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
+use crate::src::internal::Dav1dTaskContext_scratch_lap;
+
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -759,12 +759,7 @@ pub union Dav1dTaskContext_scratch_lap {
     pub lap_16bpc: [uint16_t; 4096],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_compinter_seg_mask {
-    pub compinter: [[int16_t; 16384]; 2],
-    pub seg_mask: [uint8_t; 16384],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -710,19 +710,14 @@ use crate::src::levels::Filter2d;
 
 
 use crate::src::lf_mask::Av1Filter;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch;
 
 
 
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -716,19 +716,11 @@ pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_levels_pal,
-    pub ac: [int16_t; 1024],
-    pub pal_idx: [uint8_t; 8192],
-    pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
+
 
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -464,13 +464,8 @@ pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_levels_pal {
-    pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_pal;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -482,12 +482,7 @@ pub struct Dav1dTaskContext_scratch_lap_emu_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_emu_edge {
-    pub emu_edge_8bpc: [uint8_t; 84160],
-    pub emu_edge_16bpc: [uint16_t; 84160],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
 use crate::src::internal::Dav1dTaskContext_scratch_lap;
 
 use crate::src::internal::Dav1dTaskContext_cf;

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -446,19 +446,14 @@ use crate::src::levels::Filter2d;
 
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch;
 
 
 
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 
 

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -495,12 +495,7 @@ pub union Dav1dTaskContext_scratch_lap {
     pub lap_16bpc: [uint16_t; 4096],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_compinter_seg_mask {
-    pub compinter: [[int16_t; 16384]; 2],
-    pub seg_mask: [uint8_t; 16384],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -476,14 +476,9 @@ pub struct Dav1dTaskContext_scratch_pal {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_lap_emu_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
-use crate::src::internal::Dav1dTaskContext_scratch_lap;
+use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -488,14 +488,8 @@ pub union Dav1dTaskContext_scratch_emu_edge {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_lap {
-    pub lap_8bpc: [uint8_t; 4096],
-    pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
+use crate::src::internal::Dav1dTaskContext_scratch_lap;
+
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -470,12 +470,7 @@ pub union Dav1dTaskContext_scratch_levels_pal {
     pub levels: [uint8_t; 1088],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_pal {
-    pub pal_order: [[uint8_t; 8]; 64],
-    pub pal_ctx: [uint8_t; 64],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_pal;
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -452,19 +452,11 @@ pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_levels_pal,
-    pub ac: [int16_t; 1024],
-    pub pal_idx: [uint8_t; 8192],
-    pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
+
 
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -471,12 +471,7 @@ pub union Dav1dTaskContext_scratch_levels_pal {
     pub levels: [uint8_t; 1088],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_pal {
-    pub pal_order: [[uint8_t; 8]; 64],
-    pub pal_ctx: [uint8_t; 64],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_pal;
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -489,14 +489,8 @@ pub union Dav1dTaskContext_scratch_emu_edge {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_lap {
-    pub lap_8bpc: [uint8_t; 4096],
-    pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
+use crate::src::internal::Dav1dTaskContext_scratch_lap;
+
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -453,19 +453,11 @@ pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_levels_pal,
-    pub ac: [int16_t; 1024],
-    pub pal_idx: [uint8_t; 8192],
-    pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
+
 
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -447,19 +447,14 @@ use crate::src::levels::Filter2d;
 
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch;
 
 
 
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 
 

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -465,13 +465,8 @@ pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_levels_pal {
-    pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_pal;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -496,12 +496,7 @@ pub union Dav1dTaskContext_scratch_lap {
     pub lap_16bpc: [uint16_t; 4096],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_compinter_seg_mask {
-    pub compinter: [[int16_t; 16384]; 2],
-    pub seg_mask: [uint8_t; 16384],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -483,12 +483,7 @@ pub struct Dav1dTaskContext_scratch_lap_emu_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_emu_edge {
-    pub emu_edge_8bpc: [uint8_t; 84160],
-    pub emu_edge_16bpc: [uint16_t; 84160],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
 use crate::src::internal::Dav1dTaskContext_scratch_lap;
 
 use crate::src::internal::Dav1dTaskContext_cf;

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -477,14 +477,9 @@ pub struct Dav1dTaskContext_scratch_pal {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_lap_emu_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
-use crate::src::internal::Dav1dTaskContext_scratch_lap;
+use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -539,12 +539,7 @@ pub union Dav1dTaskContext_scratch_lap {
     pub lap_16bpc: [uint16_t; 4096],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_compinter_seg_mask {
-    pub compinter: [[int16_t; 16384]; 2],
-    pub seg_mask: [uint8_t; 16384],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -508,13 +508,8 @@ pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_levels_pal {
-    pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_pal;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -520,14 +520,9 @@ pub struct Dav1dTaskContext_scratch_pal {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_lap_emu_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
-use crate::src::internal::Dav1dTaskContext_scratch_lap;
+use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -496,19 +496,11 @@ pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_levels_pal,
-    pub ac: [int16_t; 1024],
-    pub pal_idx: [uint8_t; 8192],
-    pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
+
 
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -526,12 +526,7 @@ pub struct Dav1dTaskContext_scratch_lap_emu_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_emu_edge {
-    pub emu_edge_8bpc: [uint8_t; 84160],
-    pub emu_edge_16bpc: [uint16_t; 84160],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
 use crate::src::internal::Dav1dTaskContext_scratch_lap;
 
 use crate::src::internal::Dav1dTaskContext_cf;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -514,12 +514,7 @@ pub union Dav1dTaskContext_scratch_levels_pal {
     pub levels: [uint8_t; 1088],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_pal {
-    pub pal_order: [[uint8_t; 8]; 64],
-    pub pal_ctx: [uint8_t; 64],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_pal;
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -532,14 +532,8 @@ pub union Dav1dTaskContext_scratch_emu_edge {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_lap {
-    pub lap_8bpc: [uint8_t; 4096],
-    pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
+use crate::src::internal::Dav1dTaskContext_scratch_lap;
+
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -490,19 +490,14 @@ use crate::src::levels::Filter2d;
 
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch;
 
 
 
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 
 

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -528,14 +528,8 @@ pub union Dav1dTaskContext_scratch_emu_edge {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_lap {
-    pub lap_8bpc: [uint8_t; 4096],
-    pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
+use crate::src::internal::Dav1dTaskContext_scratch_lap;
+
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -522,12 +522,7 @@ pub struct Dav1dTaskContext_scratch_lap_emu_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_emu_edge {
-    pub emu_edge_8bpc: [uint8_t; 84160],
-    pub emu_edge_16bpc: [uint16_t; 84160],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
 use crate::src::internal::Dav1dTaskContext_scratch_lap;
 
 use crate::src::internal::Dav1dTaskContext_cf;

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -510,12 +510,7 @@ pub union Dav1dTaskContext_scratch_levels_pal {
     pub levels: [uint8_t; 1088],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_pal {
-    pub pal_order: [[uint8_t; 8]; 64],
-    pub pal_ctx: [uint8_t; 64],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_pal;
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -486,19 +486,14 @@ use crate::src::levels::Filter2d;
 
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch;
 
 
 
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 
 

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -516,14 +516,9 @@ pub struct Dav1dTaskContext_scratch_pal {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_lap_emu_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
-use crate::src::internal::Dav1dTaskContext_scratch_lap;
+use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -535,12 +535,7 @@ pub union Dav1dTaskContext_scratch_lap {
     pub lap_16bpc: [uint16_t; 4096],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_compinter_seg_mask {
-    pub compinter: [[int16_t; 16384]; 2],
-    pub seg_mask: [uint8_t; 16384],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -492,19 +492,11 @@ pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_levels_pal,
-    pub ac: [int16_t; 1024],
-    pub pal_idx: [uint8_t; 8192],
-    pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
+
 
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -504,13 +504,8 @@ pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_levels_pal {
-    pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_pal;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -592,12 +592,7 @@ pub union Dav1dTaskContext_scratch_lap {
     pub lap_16bpc: [uint16_t; 4096],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_compinter_seg_mask {
-    pub compinter: [[int16_t; 16384]; 2],
-    pub seg_mask: [uint8_t; 16384],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -561,13 +561,8 @@ pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_levels_pal {
-    pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_pal;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -585,14 +585,8 @@ pub union Dav1dTaskContext_scratch_emu_edge {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_lap {
-    pub lap_8bpc: [uint8_t; 4096],
-    pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
+use crate::src::internal::Dav1dTaskContext_scratch_lap;
+
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -573,14 +573,9 @@ pub struct Dav1dTaskContext_scratch_pal {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_lap_emu_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
-use crate::src::internal::Dav1dTaskContext_scratch_lap;
+use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -543,19 +543,14 @@ use crate::src::levels::FILTER_2D_BILINEAR;
 
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch;
 
 
 
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 
 

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -579,12 +579,7 @@ pub struct Dav1dTaskContext_scratch_lap_emu_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_emu_edge {
-    pub emu_edge_8bpc: [uint8_t; 84160],
-    pub emu_edge_16bpc: [uint16_t; 84160],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
 use crate::src::internal::Dav1dTaskContext_scratch_lap;
 
 use crate::src::internal::Dav1dTaskContext_cf;

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -549,19 +549,11 @@ pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_levels_pal,
-    pub ac: [int16_t; 1024],
-    pub pal_idx: [uint8_t; 8192],
-    pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
+
 
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -567,12 +567,7 @@ pub union Dav1dTaskContext_scratch_levels_pal {
     pub levels: [uint8_t; 1088],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_pal {
-    pub pal_order: [[uint8_t; 8]; 64],
-    pub pal_ctx: [uint8_t; 64],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_pal;
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -570,12 +570,7 @@ pub struct Dav1dTaskContext_scratch_lap_emu_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_emu_edge {
-    pub emu_edge_8bpc: [uint8_t; 84160],
-    pub emu_edge_16bpc: [uint16_t; 84160],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
 use crate::src::internal::Dav1dTaskContext_scratch_lap;
 
 use crate::src::internal::Dav1dTaskContext_cf;

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -583,12 +583,7 @@ pub union Dav1dTaskContext_scratch_lap {
     pub lap_16bpc: [uint16_t; 4096],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_compinter_seg_mask {
-    pub compinter: [[int16_t; 16384]; 2],
-    pub seg_mask: [uint8_t; 16384],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -564,14 +564,9 @@ pub struct Dav1dTaskContext_scratch_pal {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_lap_emu_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
-use crate::src::internal::Dav1dTaskContext_scratch_lap;
+use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -576,14 +576,8 @@ pub union Dav1dTaskContext_scratch_emu_edge {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_lap {
-    pub lap_8bpc: [uint8_t; 4096],
-    pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
+use crate::src::internal::Dav1dTaskContext_scratch_lap;
+
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -534,19 +534,14 @@ use crate::src::levels::FILTER_2D_BILINEAR;
 
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch;
 
 
 
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 
 

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -540,19 +540,11 @@ pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_levels_pal,
-    pub ac: [int16_t; 1024],
-    pub pal_idx: [uint8_t; 8192],
-    pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
+
 
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -558,12 +558,7 @@ pub union Dav1dTaskContext_scratch_levels_pal {
     pub levels: [uint8_t; 1088],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_pal {
-    pub pal_order: [[uint8_t; 8]; 64],
-    pub pal_ctx: [uint8_t; 64],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_pal;
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -552,13 +552,8 @@ pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_levels_pal {
-    pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_pal;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -509,13 +509,8 @@ pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
 use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_levels_pal {
-    pub levels: [uint8_t; 1088],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_pal;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -527,12 +527,7 @@ pub struct Dav1dTaskContext_scratch_lap_emu_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_emu_edge {
-    pub emu_edge_8bpc: [uint8_t; 84160],
-    pub emu_edge_16bpc: [uint16_t; 84160],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
 use crate::src::internal::Dav1dTaskContext_scratch_lap;
 
 use crate::src::internal::Dav1dTaskContext_cf;

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -521,14 +521,9 @@ pub struct Dav1dTaskContext_scratch_pal {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_lap_emu_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_emu_edge;
-use crate::src::internal::Dav1dTaskContext_scratch_lap;
+use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -491,19 +491,14 @@ use crate::src::levels::Filter2d;
 
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch;
 
 
 
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
+
+
 
 
 

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -533,14 +533,8 @@ pub union Dav1dTaskContext_scratch_emu_edge {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dTaskContext_scratch_lap {
-    pub lap_8bpc: [uint8_t; 4096],
-    pub lap_16bpc: [uint16_t; 4096],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
+use crate::src::internal::Dav1dTaskContext_scratch_lap;
+
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -497,19 +497,11 @@ pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_levels_pal,
-    pub ac: [int16_t; 1024],
-    pub pal_idx: [uint8_t; 8192],
-    pub pal: [[uint16_t; 8]; 3],
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
-}
-use crate::src::internal::Dav1dTaskContext_scratch_interintra_edge;
+use crate::src::internal::Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge;
 
 
-use crate::src::internal::Dav1dTaskContext_scratch_levels_pal;
+
+
 
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -515,12 +515,7 @@ pub union Dav1dTaskContext_scratch_levels_pal {
     pub levels: [uint8_t; 1088],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_pal {
-    pub pal_order: [[uint8_t; 8]; 64],
-    pub pal_ctx: [uint8_t; 64],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_pal;
 use crate::src::internal::Dav1dTaskContext_scratch_lap_emu_edge;
 
 

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -540,12 +540,7 @@ pub union Dav1dTaskContext_scratch_lap {
     pub lap_16bpc: [uint16_t; 4096],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTaskContext_scratch_compinter_seg_mask {
-    pub compinter: [[int16_t; 16384]; 2],
-    pub seg_mask: [uint8_t; 16384],
-}
+use crate::src::internal::Dav1dTaskContext_scratch_compinter_seg_mask;
 use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::refmvs::refmvs_tile;
 


### PR DESCRIPTION
Now that type is deduplicated, it can be easily `#[repr(align(64))]`ed like in the C source: https://github.com/memorysafety/rav1d/blob/1b882647c4d16f94efcce81a7111503db3c491d9/src/internal.h#L406-L444