### PR TITLE
Deduplicate `union alias[0-9]+` types

### DIFF
--- a/c2rust-lib.rs
+++ b/c2rust-lib.rs
@@ -47,6 +47,7 @@ pub mod cdef_tmpl_16;
 pub mod cdef_tmpl_8;
 pub mod cdf;
 pub mod cpu;
+pub mod ctx;
 pub mod data;
 pub mod decode;
 pub mod dequant_tables;

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1,4 +1,5 @@
 use crate::include::stdint::uint16_t;
+use crate::include::stdint::uint32_t;
 use crate::include::stdint::uint8_t;
 
 #[derive(Copy, Clone)]
@@ -12,4 +13,11 @@ pub union alias8 {
 pub union alias16 {
     pub u16_0: uint16_t,
     pub u8_0: [uint8_t; 2],
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub union alias32 {
+    pub u32_0: uint32_t,
+    pub u8_0: [uint8_t; 4],
 }

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1,7 +1,15 @@
+use crate::include::stdint::uint16_t;
 use crate::include::stdint::uint8_t;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union alias8 {
     pub u8_0: uint8_t,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub union alias16 {
+    pub u16_0: uint16_t,
+    pub u8_0: [uint8_t; 2],
 }

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1,0 +1,7 @@
+use crate::include::stdint::uint8_t;
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub union alias8 {
+    pub u8_0: uint8_t,
+}

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1,5 +1,6 @@
 use crate::include::stdint::uint16_t;
 use crate::include::stdint::uint32_t;
+use crate::include::stdint::uint64_t;
 use crate::include::stdint::uint8_t;
 
 #[derive(Copy, Clone)]
@@ -20,4 +21,11 @@ pub union alias16 {
 pub union alias32 {
     pub u32_0: uint32_t,
     pub u8_0: [uint8_t; 4],
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub union alias64 {
+    pub u64_0: uint64_t,
+    pub u8_0: [uint8_t; 8],
 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -362,12 +362,7 @@ pub union alias64 {
     pub u64_0: uint64_t,
     pub u8_0: [uint8_t; 8],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union alias32 {
-    pub u32_0: uint32_t,
-    pub u8_0: [uint8_t; 4],
-}
+use crate::src::ctx::alias32;
 use crate::src::ctx::alias16;
 use crate::src::ctx::alias8;
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -374,11 +374,7 @@ pub union alias16 {
     pub u16_0: uint16_t,
     pub u8_0: [uint8_t; 2],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union alias8 {
-    pub u8_0: uint8_t,
-}
+use crate::src::ctx::alias8;
 
 
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -368,12 +368,7 @@ pub union alias32 {
     pub u32_0: uint32_t,
     pub u8_0: [uint8_t; 4],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union alias16 {
-    pub u16_0: uint16_t,
-    pub u8_0: [uint8_t; 2],
-}
+use crate::src::ctx::alias16;
 use crate::src::ctx::alias8;
 
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -356,12 +356,7 @@ use crate::src::r#ref::Dav1dRef;
 use crate::include::stdatomic::atomic_int;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union alias64 {
-    pub u64_0: uint64_t,
-    pub u8_0: [uint8_t; 8],
-}
+use crate::src::ctx::alias64;
 use crate::src::ctx::alias32;
 use crate::src::ctx::alias16;
 use crate::src::ctx::alias8;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -34,12 +34,7 @@ pub union alias32 {
     pub u32_0: uint32_t,
     pub u8_0: [uint8_t; 4],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union alias16 {
-    pub u16_0: uint16_t,
-    pub u8_0: [uint8_t; 2],
-}
+use crate::src::ctx::alias16;
 use crate::src::ctx::alias8;
 
 

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -28,12 +28,7 @@ pub union alias64 {
     pub u64_0: uint64_t,
     pub u8_0: [uint8_t; 8],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union alias32 {
-    pub u32_0: uint32_t,
-    pub u8_0: [uint8_t; 4],
-}
+use crate::src::ctx::alias32;
 use crate::src::ctx::alias16;
 use crate::src::ctx::alias8;
 

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -22,12 +22,7 @@ extern "C" {
 
 
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union alias64 {
-    pub u64_0: uint64_t,
-    pub u8_0: [uint8_t; 8],
-}
+use crate::src::ctx::alias64;
 use crate::src::ctx::alias32;
 use crate::src::ctx::alias16;
 use crate::src::ctx::alias8;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -40,11 +40,7 @@ pub union alias16 {
     pub u16_0: uint16_t,
     pub u8_0: [uint8_t; 2],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union alias8 {
-    pub u8_0: uint8_t,
-}
+use crate::src::ctx::alias8;
 
 
 

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1185,11 +1185,7 @@ pub union alias16 {
     pub u16_0: uint16_t,
     pub u8_0: [uint8_t; 2],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union alias8 {
-    pub u8_0: uint8_t,
-}
+use crate::src::ctx::alias8;
 #[inline]
 unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     if x & 1 != 0 {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1179,12 +1179,7 @@ pub union alias32 {
     pub u32_0: uint32_t,
     pub u8_0: [uint8_t; 4],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union alias16 {
-    pub u16_0: uint16_t,
-    pub u8_0: [uint8_t; 2],
-}
+use crate::src::ctx::alias16;
 use crate::src::ctx::alias8;
 #[inline]
 unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1173,12 +1173,7 @@ pub union alias64 {
     pub u64_0: uint64_t,
     pub u8_0: [uint8_t; 8],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union alias32 {
-    pub u32_0: uint32_t,
-    pub u8_0: [uint8_t; 4],
-}
+use crate::src::ctx::alias32;
 use crate::src::ctx::alias16;
 use crate::src::ctx::alias8;
 #[inline]

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1167,12 +1167,7 @@ pub struct TxfmInfo {
     pub sub: uint8_t,
     pub ctx: uint8_t,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union alias64 {
-    pub u64_0: uint64_t,
-    pub u8_0: [uint8_t; 8],
-}
+use crate::src::ctx::alias64;
 use crate::src::ctx::alias32;
 use crate::src::ctx::alias16;
 use crate::src::ctx::alias8;

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1140,12 +1140,7 @@ pub union alias32 {
     pub u32_0: uint32_t,
     pub u8_0: [uint8_t; 4],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union alias16 {
-    pub u16_0: uint16_t,
-    pub u8_0: [uint8_t; 2],
-}
+use crate::src::ctx::alias16;
 use crate::src::ctx::alias8;
 #[inline]
 unsafe extern "C" fn hex_fdump(

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1146,11 +1146,7 @@ pub union alias16 {
     pub u16_0: uint16_t,
     pub u8_0: [uint8_t; 2],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union alias8 {
-    pub u8_0: uint8_t,
-}
+use crate::src::ctx::alias8;
 #[inline]
 unsafe extern "C" fn hex_fdump(
     mut out: *mut libc::FILE,

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1128,12 +1128,7 @@ pub struct TxfmInfo {
     pub sub: uint8_t,
     pub ctx: uint8_t,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union alias64 {
-    pub u64_0: uint64_t,
-    pub u8_0: [uint8_t; 8],
-}
+use crate::src::ctx::alias64;
 use crate::src::ctx::alias32;
 use crate::src::ctx::alias16;
 use crate::src::ctx::alias8;

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1134,12 +1134,7 @@ pub union alias64 {
     pub u64_0: uint64_t,
     pub u8_0: [uint8_t; 8],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union alias32 {
-    pub u32_0: uint32_t,
-    pub u8_0: [uint8_t; 4],
-}
+use crate::src::ctx::alias32;
 use crate::src::ctx::alias16;
 use crate::src::ctx::alias8;
 #[inline]


### PR DESCRIPTION
These should be the last non-bitdepth-dependent types to deduplicate.