### PR TITLE
Deduplicate `struct TxfmInfo` to `src/tables.rs`

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1168,18 +1168,7 @@ use crate::src::levels::INTER_INTRA_NONE;
 use crate::src::levels::MM_WARP;
 use crate::src::levels::MM_OBMC;
 use crate::src::levels::MM_TRANSLATION;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct TxfmInfo {
-    pub w: uint8_t,
-    pub h: uint8_t,
-    pub lw: uint8_t,
-    pub lh: uint8_t,
-    pub min: uint8_t,
-    pub max: uint8_t,
-    pub sub: uint8_t,
-    pub ctx: uint8_t,
-}
+use crate::src::tables::TxfmInfo;
 use crate::src::refmvs::refmvs_candidate;
 #[inline]
 unsafe extern "C" fn ctz(mask: libc::c_uint) -> libc::c_int {

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -63,18 +63,7 @@ pub struct Av1Filter {
 pub struct Av1Restoration {
     pub lr: [[Av1RestorationUnit; 4]; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct TxfmInfo {
-    pub w: uint8_t,
-    pub h: uint8_t,
-    pub lw: uint8_t,
-    pub lh: uint8_t,
-    pub min: uint8_t,
-    pub max: uint8_t,
-    pub sub: uint8_t,
-    pub ctx: uint8_t,
-}
+use crate::src::tables::TxfmInfo;
 #[inline]
 unsafe extern "C" fn iclip(
     v: libc::c_int,

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -877,18 +877,7 @@ use crate::src::levels::INTER_INTRA_BLEND;
 use crate::src::levels::MM_WARP;
 use crate::src::levels::MM_OBMC;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct TxfmInfo {
-    pub w: uint8_t,
-    pub h: uint8_t,
-    pub lw: uint8_t,
-    pub lh: uint8_t,
-    pub min: uint8_t,
-    pub max: uint8_t,
-    pub sub: uint8_t,
-    pub ctx: uint8_t,
-}
+use crate::src::tables::TxfmInfo;
 use crate::src::ctx::alias64;
 use crate::src::ctx::alias32;
 use crate::src::ctx::alias16;

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -846,18 +846,7 @@ use crate::src::levels::INTER_INTRA_BLEND;
 use crate::src::levels::MM_WARP;
 use crate::src::levels::MM_OBMC;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct TxfmInfo {
-    pub w: uint8_t,
-    pub h: uint8_t,
-    pub lw: uint8_t,
-    pub lh: uint8_t,
-    pub min: uint8_t,
-    pub max: uint8_t,
-    pub sub: uint8_t,
-    pub ctx: uint8_t,
-}
+use crate::src::tables::TxfmInfo;
 use crate::src::ctx::alias64;
 use crate::src::ctx::alias32;
 use crate::src::ctx::alias16;

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -92,6 +92,7 @@ use crate::src::levels::NEWMV;
 use crate::src::levels::GLOBALMV;
 use crate::src::levels::NEARMV;
 use crate::src::levels::NEARESTMV;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct TxfmInfo {
@@ -104,6 +105,7 @@ pub struct TxfmInfo {
     pub sub: uint8_t,
     pub ctx: uint8_t,
 }
+
 #[no_mangle]
 pub static mut dav1d_al_part_ctx: [[[uint8_t; 10]; 5]; 2] = [
     [


### PR DESCRIPTION
Actually this is the last non-bitdepth-dependent deduplicated type.