### PR TITLE
Deduplicate most remaining duplicated inline `fn`s

### DIFF
--- a/c2rust-lib.rs
+++ b/c2rust-lib.rs
@@ -18,6 +18,7 @@ extern crate libc;
 pub mod include {
 pub mod common {
 pub mod attributes;
+pub mod dump;
 pub mod intops;
 } // mod common
 pub mod dav1d {

--- a/c2rust-lib.rs
+++ b/c2rust-lib.rs
@@ -112,6 +112,7 @@ pub mod obu;
 pub mod picture;
 pub mod qm;
 pub mod r#ref;
+pub mod recon;
 #[cfg(feature = "bitdepth_16")]
 pub mod recon_tmpl_16;
 #[cfg(feature = "bitdepth_8")]

--- a/c2rust-lib.rs
+++ b/c2rust-lib.rs
@@ -73,6 +73,7 @@ pub mod ipred_prepare;
 pub mod ipred_prepare_tmpl_16;
 #[cfg(feature = "bitdepth_8")]
 pub mod ipred_prepare_tmpl_8;
+pub mod ipred;
 #[cfg(feature = "bitdepth_16")]
 pub mod ipred_tmpl_16;
 #[cfg(feature = "bitdepth_8")]

--- a/c2rust-lib.rs
+++ b/c2rust-lib.rs
@@ -67,6 +67,7 @@ pub mod filmgrain_tmpl_8;
 pub mod getbits;
 pub mod internal;
 pub mod intra_edge;
+pub mod ipred_prepare;
 #[cfg(feature = "bitdepth_16")]
 pub mod ipred_prepare_tmpl_16;
 #[cfg(feature = "bitdepth_8")]

--- a/c2rust-lib.rs
+++ b/c2rust-lib.rs
@@ -61,6 +61,7 @@ pub mod env;
 pub mod fg_apply_tmpl_16;
 #[cfg(feature = "bitdepth_8")]
 pub mod fg_apply_tmpl_8;
+pub mod filmgrain;
 #[cfg(feature = "bitdepth_16")]
 pub mod filmgrain_tmpl_16;
 #[cfg(feature = "bitdepth_8")]

--- a/include/common/dump.rs
+++ b/include/common/dump.rs
@@ -1,0 +1,32 @@
+use crate::include::stdint::int16_t;
+
+extern "C" {
+    fn printf(_: *const libc::c_char, _: ...) -> libc::c_int;
+}
+
+#[inline]
+pub unsafe extern "C" fn ac_dump(
+    mut buf: *const int16_t,
+    mut w: libc::c_int,
+    mut h: libc::c_int,
+    mut what: *const libc::c_char,
+) {
+    printf(b"%s\n\0" as *const u8 as *const libc::c_char, what);
+    loop {
+        let fresh1 = h;
+        h = h - 1;
+        if !(fresh1 != 0) {
+            break;
+        }
+        let mut x: libc::c_int = 0 as libc::c_int;
+        while x < w {
+            printf(
+                b" %03d\0" as *const u8 as *const libc::c_char,
+                *buf.offset(x as isize) as libc::c_int,
+            );
+            x += 1;
+        }
+        buf = buf.offset(w as isize);
+        printf(b"\n\0" as *const u8 as *const libc::c_char);
+    };
+}

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -1,6 +1,8 @@
 use crate::include::common::intops::apply_sign;
 use crate::include::common::intops::imax;
 use crate::include::common::intops::imin;
+use crate::include::stdint::int16_t;
+use crate::include::stddef::ptrdiff_t;
 
 extern "C" {
     fn abs(_: libc::c_int) -> libc::c_int;
@@ -23,4 +25,26 @@ pub unsafe extern "C" fn constrain(
         imin(adiff, imax(0 as libc::c_int, threshold - (adiff >> shift))),
         diff,
     );
+}
+
+#[inline]
+pub unsafe extern "C" fn fill(
+    mut tmp: *mut int16_t,
+    stride: ptrdiff_t,
+    w: libc::c_int,
+    h: libc::c_int,
+) {
+    let mut y: libc::c_int = 0 as libc::c_int;
+    while y < h {
+        let mut x: libc::c_int = 0 as libc::c_int;
+        while x < w {
+            *tmp
+                .offset(
+                    x as isize,
+                ) = (-(32767 as libc::c_int) - 1 as libc::c_int) as int16_t;
+            x += 1;
+        }
+        tmp = tmp.offset(stride as isize);
+        y += 1;
+    }
 }

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -1,5 +1,26 @@
+use crate::include::common::intops::apply_sign;
+use crate::include::common::intops::imax;
+use crate::include::common::intops::imin;
+
+extern "C" {
+    fn abs(_: libc::c_int) -> libc::c_int;
+}
+
 pub type CdefEdgeFlags = libc::c_uint;
 pub const CDEF_HAVE_BOTTOM: CdefEdgeFlags = 8;
 pub const CDEF_HAVE_TOP: CdefEdgeFlags = 4;
 pub const CDEF_HAVE_RIGHT: CdefEdgeFlags = 2;
 pub const CDEF_HAVE_LEFT: CdefEdgeFlags = 1;
+
+#[inline]
+pub unsafe extern "C" fn constrain(
+    diff: libc::c_int,
+    threshold: libc::c_int,
+    shift: libc::c_int,
+) -> libc::c_int {
+    let adiff: libc::c_int = abs(diff);
+    return apply_sign(
+        imin(adiff, imax(0 as libc::c_int, threshold - (adiff >> shift))),
+        diff,
+    );
+}

--- a/src/cdef_tmpl_16.rs
+++ b/src/cdef_tmpl_16.rs
@@ -270,27 +270,7 @@ unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     return x >> 1 as libc::c_int;
 }
 use crate::src::cdef::constrain;
-#[inline]
-unsafe extern "C" fn fill(
-    mut tmp: *mut int16_t,
-    stride: ptrdiff_t,
-    w: libc::c_int,
-    h: libc::c_int,
-) {
-    let mut y: libc::c_int = 0 as libc::c_int;
-    while y < h {
-        let mut x: libc::c_int = 0 as libc::c_int;
-        while x < w {
-            *tmp
-                .offset(
-                    x as isize,
-                ) = (-(32767 as libc::c_int) - 1 as libc::c_int) as int16_t;
-            x += 1;
-        }
-        tmp = tmp.offset(stride as isize);
-        y += 1;
-    }
-}
+use crate::src::cdef::fill;
 unsafe extern "C" fn padding(
     mut tmp: *mut int16_t,
     tmp_stride: ptrdiff_t,

--- a/src/cdef_tmpl_16.rs
+++ b/src/cdef_tmpl_16.rs
@@ -257,10 +257,10 @@ pub type CpuFlags = libc::c_uint;
 pub const DAV1D_X86_CPU_FLAG_SLOW_GATHER: CpuFlags = 32;
 use crate::include::common::attributes::clz;
 use crate::include::common::intops::imax;
-use crate::include::common::intops::imin;
+
 use crate::include::common::intops::umin;
 use crate::include::common::intops::iclip;
-use crate::include::common::intops::apply_sign;
+
 use crate::include::common::intops::ulog2;
 #[inline]
 unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
@@ -269,18 +269,7 @@ unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     }
     return x >> 1 as libc::c_int;
 }
-#[inline]
-unsafe extern "C" fn constrain(
-    diff: libc::c_int,
-    threshold: libc::c_int,
-    shift: libc::c_int,
-) -> libc::c_int {
-    let adiff: libc::c_int = abs(diff);
-    return apply_sign(
-        imin(adiff, imax(0 as libc::c_int, threshold - (adiff >> shift))),
-        diff,
-    );
-}
+use crate::src::cdef::constrain;
 #[inline]
 unsafe extern "C" fn fill(
     mut tmp: *mut int16_t,

--- a/src/cdef_tmpl_8.rs
+++ b/src/cdef_tmpl_8.rs
@@ -314,27 +314,7 @@ use crate::include::common::intops::iclip;
 
 use crate::include::common::intops::ulog2;
 use crate::src::cdef::constrain;
-#[inline]
-unsafe extern "C" fn fill(
-    mut tmp: *mut int16_t,
-    stride: ptrdiff_t,
-    w: libc::c_int,
-    h: libc::c_int,
-) {
-    let mut y: libc::c_int = 0 as libc::c_int;
-    while y < h {
-        let mut x: libc::c_int = 0 as libc::c_int;
-        while x < w {
-            *tmp
-                .offset(
-                    x as isize,
-                ) = (-(32767 as libc::c_int) - 1 as libc::c_int) as int16_t;
-            x += 1;
-        }
-        tmp = tmp.offset(stride as isize);
-        y += 1;
-    }
-}
+use crate::src::cdef::fill;
 unsafe extern "C" fn padding(
     mut tmp: *mut int16_t,
     tmp_stride: ptrdiff_t,

--- a/src/cdef_tmpl_8.rs
+++ b/src/cdef_tmpl_8.rs
@@ -308,23 +308,12 @@ pub type CpuFlags = libc::c_uint;
 pub const DAV1D_X86_CPU_FLAG_SLOW_GATHER: CpuFlags = 32;
 use crate::include::common::intops::imax;
 
-use crate::include::common::intops::imin;
+
 use crate::include::common::intops::umin;
 use crate::include::common::intops::iclip;
-use crate::include::common::intops::apply_sign;
+
 use crate::include::common::intops::ulog2;
-#[inline]
-unsafe extern "C" fn constrain(
-    diff: libc::c_int,
-    threshold: libc::c_int,
-    shift: libc::c_int,
-) -> libc::c_int {
-    let adiff: libc::c_int = abs(diff);
-    return apply_sign(
-        imin(adiff, imax(0 as libc::c_int, threshold - (adiff >> shift))),
-        diff,
-    );
-}
+use crate::src::cdef::constrain;
 #[inline]
 unsafe extern "C" fn fill(
     mut tmp: *mut int16_t,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1176,7 +1176,7 @@ use crate::include::common::intops::imax;
 use crate::include::common::intops::imin;
 use crate::include::common::intops::iclip;
 use crate::include::common::intops::iclip_u8;
-use crate::include::common::intops::apply_sign;
+
 use crate::include::common::intops::apply_sign64;
 use crate::include::common::intops::ulog2;
 use crate::src::mem::dav1d_alloc_aligned;
@@ -1936,95 +1936,9 @@ unsafe extern "C" fn get_cur_frame_segid(
         }) as libc::c_uint;
     };
 }
-use crate::src::env::fix_int_mv_precision;
+
 use crate::src::env::fix_mv_precision;
-#[inline]
-unsafe extern "C" fn get_gmv_2d(
-    gmv: *const Dav1dWarpedMotionParams,
-    bx4: libc::c_int,
-    by4: libc::c_int,
-    bw4: libc::c_int,
-    bh4: libc::c_int,
-    hdr: *const Dav1dFrameHeader,
-) -> mv {
-    match (*gmv).type_0 as libc::c_uint {
-        2 => {
-            if !((*gmv).matrix[5 as libc::c_int as usize]
-                == (*gmv).matrix[2 as libc::c_int as usize])
-            {
-                unreachable!();
-            }
-            if !((*gmv).matrix[4 as libc::c_int as usize]
-                == -(*gmv).matrix[3 as libc::c_int as usize])
-            {
-                unreachable!();
-            }
-        }
-        1 => {
-            let mut res_0: mv = mv {
-                c2rust_unnamed: {
-                    let mut init = mv_xy {
-                        y: ((*gmv).matrix[0 as libc::c_int as usize]
-                            >> 13 as libc::c_int) as int16_t,
-                        x: ((*gmv).matrix[1 as libc::c_int as usize]
-                            >> 13 as libc::c_int) as int16_t,
-                    };
-                    init
-                },
-            };
-            if (*hdr).force_integer_mv != 0 {
-                fix_int_mv_precision(&mut res_0);
-            }
-            return res_0;
-        }
-        0 => {
-            return mv {
-                c2rust_unnamed: {
-                    let mut init = mv_xy {
-                        y: 0 as libc::c_int as int16_t,
-                        x: 0 as libc::c_int as int16_t,
-                    };
-                    init
-                },
-            };
-        }
-        3 | _ => {}
-    }
-    let x: libc::c_int = bx4 * 4 as libc::c_int + bw4 * 2 as libc::c_int
-        - 1 as libc::c_int;
-    let y: libc::c_int = by4 * 4 as libc::c_int + bh4 * 2 as libc::c_int
-        - 1 as libc::c_int;
-    let xc: libc::c_int = ((*gmv).matrix[2 as libc::c_int as usize]
-        - ((1 as libc::c_int) << 16 as libc::c_int)) * x
-        + (*gmv).matrix[3 as libc::c_int as usize] * y
-        + (*gmv).matrix[0 as libc::c_int as usize];
-    let yc: libc::c_int = ((*gmv).matrix[5 as libc::c_int as usize]
-        - ((1 as libc::c_int) << 16 as libc::c_int)) * y
-        + (*gmv).matrix[4 as libc::c_int as usize] * x
-        + (*gmv).matrix[1 as libc::c_int as usize];
-    let shift: libc::c_int = 16 as libc::c_int
-        - (3 as libc::c_int - ((*hdr).hp == 0) as libc::c_int);
-    let round: libc::c_int = (1 as libc::c_int) << shift >> 1 as libc::c_int;
-    let mut res: mv = mv {
-        c2rust_unnamed: {
-            let mut init = mv_xy {
-                y: apply_sign(
-                    abs(yc) + round >> shift << ((*hdr).hp == 0) as libc::c_int,
-                    yc,
-                ) as int16_t,
-                x: apply_sign(
-                    abs(xc) + round >> shift << ((*hdr).hp == 0) as libc::c_int,
-                    xc,
-                ) as int16_t,
-            };
-            init
-        },
-    };
-    if (*hdr).force_integer_mv != 0 {
-        fix_int_mv_precision(&mut res);
-    }
-    return res;
-}
+use crate::src::env::get_gmv_2d;
 use crate::src::msac::dav1d_msac_decode_bools;
 #[inline]
 unsafe extern "C" fn dav1d_msac_decode_uniform(

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1937,23 +1937,7 @@ unsafe extern "C" fn get_cur_frame_segid(
     };
 }
 use crate::src::env::fix_int_mv_precision;
-#[inline]
-unsafe extern "C" fn fix_mv_precision(hdr: *const Dav1dFrameHeader, mv: *mut mv) {
-    if (*hdr).force_integer_mv != 0 {
-        fix_int_mv_precision(mv);
-    } else if (*hdr).hp == 0 {
-        (*mv)
-            .c2rust_unnamed
-            .x = (((*mv).c2rust_unnamed.x as libc::c_int
-            - ((*mv).c2rust_unnamed.x as libc::c_int >> 15 as libc::c_int))
-            as libc::c_uint & !(1 as libc::c_uint)) as int16_t;
-        (*mv)
-            .c2rust_unnamed
-            .y = (((*mv).c2rust_unnamed.y as libc::c_int
-            - ((*mv).c2rust_unnamed.y as libc::c_int >> 15 as libc::c_int))
-            as libc::c_uint & !(1 as libc::c_uint)) as int16_t;
-    }
-}
+use crate::src::env::fix_mv_precision;
 #[inline]
 unsafe extern "C" fn get_gmv_2d(
     gmv: *const Dav1dWarpedMotionParams,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1503,19 +1503,7 @@ unsafe extern "C" fn get_comp_dir_ctx(
         return 2 as libc::c_int
     };
 }
-#[inline]
-unsafe extern "C" fn get_poc_diff(
-    order_hint_n_bits: libc::c_int,
-    poc0: libc::c_int,
-    poc1: libc::c_int,
-) -> libc::c_int {
-    if order_hint_n_bits == 0 {
-        return 0 as libc::c_int;
-    }
-    let mask: libc::c_int = (1 as libc::c_int) << order_hint_n_bits - 1 as libc::c_int;
-    let diff: libc::c_int = poc0 - poc1;
-    return (diff & mask - 1 as libc::c_int) - (diff & mask);
-}
+use crate::src::env::get_poc_diff;
 #[inline]
 unsafe extern "C" fn get_jnt_comp_ctx(
     order_hint_n_bits: libc::c_int,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1936,19 +1936,7 @@ unsafe extern "C" fn get_cur_frame_segid(
         }) as libc::c_uint;
     };
 }
-#[inline]
-unsafe extern "C" fn fix_int_mv_precision(mv: *mut mv) {
-    (*mv)
-        .c2rust_unnamed
-        .x = (((*mv).c2rust_unnamed.x as libc::c_int
-        - ((*mv).c2rust_unnamed.x as libc::c_int >> 15 as libc::c_int)
-        + 3 as libc::c_int) as libc::c_uint & !(7 as libc::c_uint)) as int16_t;
-    (*mv)
-        .c2rust_unnamed
-        .y = (((*mv).c2rust_unnamed.y as libc::c_int
-        - ((*mv).c2rust_unnamed.y as libc::c_int >> 15 as libc::c_int)
-        + 3 as libc::c_int) as libc::c_uint & !(7 as libc::c_uint)) as int16_t;
-}
+use crate::src::env::fix_int_mv_precision;
 #[inline]
 unsafe extern "C" fn fix_mv_precision(hdr: *const Dav1dFrameHeader, mv: *mut mv) {
     if (*hdr).force_integer_mv != 0 {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2065,22 +2065,7 @@ unsafe extern "C" fn get_gmv_2d(
     }
     return res;
 }
-#[inline]
-unsafe extern "C" fn dav1d_msac_decode_bools(
-    s: *mut MsacContext,
-    mut n: libc::c_uint,
-) -> libc::c_uint {
-    let mut v: libc::c_uint = 0 as libc::c_int as libc::c_uint;
-    loop {
-        let fresh0 = n;
-        n = n.wrapping_sub(1);
-        if !(fresh0 != 0) {
-            break;
-        }
-        v = v << 1 as libc::c_int | dav1d_msac_decode_bool_equi(s);
-    }
-    return v;
-}
+use crate::src::msac::dav1d_msac_decode_bools;
 #[inline]
 unsafe extern "C" fn dav1d_msac_decode_uniform(
     s: *mut MsacContext,

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,8 +1,11 @@
+use crate::include::common::intops::apply_sign;
 use crate::include::dav1d::headers::Dav1dFrameHeader;
+use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
 use crate::include::stdint::int16_t;
 use crate::include::stdint::int8_t;
 use crate::include::stdint::uint8_t;
 use crate::src::levels::mv;
+use crate::src::levels::mv_xy;
 use crate::src::levels::TxfmType;
 use crate::src::levels::DCT_DCT;
 use crate::src::levels::H_ADST;
@@ -13,6 +16,10 @@ use crate::src::levels::TX_32X32;
 use crate::src::levels::V_ADST;
 use crate::src::levels::V_FLIPADST;
 use crate::src::tables::TxfmInfo;
+
+extern "C" {
+    fn abs(_: libc::c_int) -> libc::c_int;
+}
 
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -104,4 +111,92 @@ pub unsafe extern "C" fn fix_mv_precision(hdr: *const Dav1dFrameHeader, mv: *mut
             - ((*mv).c2rust_unnamed.y as libc::c_int >> 15 as libc::c_int))
             as libc::c_uint & !(1 as libc::c_uint)) as int16_t;
     }
+}
+
+#[inline]
+pub unsafe extern "C" fn get_gmv_2d(
+    gmv: *const Dav1dWarpedMotionParams,
+    bx4: libc::c_int,
+    by4: libc::c_int,
+    bw4: libc::c_int,
+    bh4: libc::c_int,
+    hdr: *const Dav1dFrameHeader,
+) -> mv {
+    match (*gmv).type_0 as libc::c_uint {
+        2 => {
+            if !((*gmv).matrix[5 as libc::c_int as usize]
+                == (*gmv).matrix[2 as libc::c_int as usize])
+            {
+                unreachable!();
+            }
+            if !((*gmv).matrix[4 as libc::c_int as usize]
+                == -(*gmv).matrix[3 as libc::c_int as usize])
+            {
+                unreachable!();
+            }
+        }
+        1 => {
+            let mut res_0: mv = mv {
+                c2rust_unnamed: {
+                    let mut init = mv_xy {
+                        y: ((*gmv).matrix[0 as libc::c_int as usize]
+                            >> 13 as libc::c_int) as int16_t,
+                        x: ((*gmv).matrix[1 as libc::c_int as usize]
+                            >> 13 as libc::c_int) as int16_t,
+                    };
+                    init
+                },
+            };
+            if (*hdr).force_integer_mv != 0 {
+                fix_int_mv_precision(&mut res_0);
+            }
+            return res_0;
+        }
+        0 => {
+            return mv {
+                c2rust_unnamed: {
+                    let mut init = mv_xy {
+                        y: 0 as libc::c_int as int16_t,
+                        x: 0 as libc::c_int as int16_t,
+                    };
+                    init
+                },
+            };
+        }
+        3 | _ => {}
+    }
+    let x: libc::c_int = bx4 * 4 as libc::c_int + bw4 * 2 as libc::c_int
+        - 1 as libc::c_int;
+    let y: libc::c_int = by4 * 4 as libc::c_int + bh4 * 2 as libc::c_int
+        - 1 as libc::c_int;
+    let xc: libc::c_int = ((*gmv).matrix[2 as libc::c_int as usize]
+        - ((1 as libc::c_int) << 16 as libc::c_int)) * x
+        + (*gmv).matrix[3 as libc::c_int as usize] * y
+        + (*gmv).matrix[0 as libc::c_int as usize];
+    let yc: libc::c_int = ((*gmv).matrix[5 as libc::c_int as usize]
+        - ((1 as libc::c_int) << 16 as libc::c_int)) * y
+        + (*gmv).matrix[4 as libc::c_int as usize] * x
+        + (*gmv).matrix[1 as libc::c_int as usize];
+    let shift: libc::c_int = 16 as libc::c_int
+        - (3 as libc::c_int - ((*hdr).hp == 0) as libc::c_int);
+    let round: libc::c_int = (1 as libc::c_int) << shift >> 1 as libc::c_int;
+    let mut res: mv = mv {
+        c2rust_unnamed: {
+            let mut init = mv_xy {
+                y: apply_sign(
+                    abs(yc) + round >> shift << ((*hdr).hp == 0) as libc::c_int,
+                    yc,
+                ) as int16_t,
+                x: apply_sign(
+                    abs(xc) + round >> shift << ((*hdr).hp == 0) as libc::c_int,
+                    xc,
+                ) as int16_t,
+            };
+            init
+        },
+    };
+    if (*hdr).force_integer_mv != 0 {
+        fix_int_mv_precision(&mut res);
+    }
+    return res;
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -22,3 +22,17 @@ pub struct BlockContext {
     pub uvmode: [uint8_t; 32],
     pub pal_sz: [uint8_t; 32],
 }
+
+#[inline]
+pub unsafe extern "C" fn get_poc_diff(
+    order_hint_n_bits: libc::c_int,
+    poc0: libc::c_int,
+    poc1: libc::c_int,
+) -> libc::c_int {
+    if order_hint_n_bits == 0 {
+        return 0 as libc::c_int;
+    }
+    let mask: libc::c_int = (1 as libc::c_int) << order_hint_n_bits - 1 as libc::c_int;
+    let diff: libc::c_int = poc0 - poc1;
+    return (diff & mask - 1 as libc::c_int) - (diff & mask);
+}

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,5 +1,7 @@
+use crate::include::stdint::int16_t;
 use crate::include::stdint::int8_t;
 use crate::include::stdint::uint8_t;
+use crate::src::levels::mv;
 use crate::src::levels::TxfmType;
 use crate::src::levels::DCT_DCT;
 use crate::src::levels::H_ADST;
@@ -69,4 +71,18 @@ pub unsafe extern "C" fn get_poc_diff(
     let mask: libc::c_int = (1 as libc::c_int) << order_hint_n_bits - 1 as libc::c_int;
     let diff: libc::c_int = poc0 - poc1;
     return (diff & mask - 1 as libc::c_int) - (diff & mask);
+}
+
+#[inline]
+pub unsafe extern "C" fn fix_int_mv_precision(mv: *mut mv) {
+    (*mv)
+        .c2rust_unnamed
+        .x = (((*mv).c2rust_unnamed.x as libc::c_int
+        - ((*mv).c2rust_unnamed.x as libc::c_int >> 15 as libc::c_int)
+        + 3 as libc::c_int) as libc::c_uint & !(7 as libc::c_uint)) as int16_t;
+    (*mv)
+        .c2rust_unnamed
+        .y = (((*mv).c2rust_unnamed.y as libc::c_int
+        - ((*mv).c2rust_unnamed.y as libc::c_int >> 15 as libc::c_int)
+        + 3 as libc::c_int) as libc::c_uint & !(7 as libc::c_uint)) as int16_t;
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,3 +1,4 @@
+use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::stdint::int16_t;
 use crate::include::stdint::int8_t;
 use crate::include::stdint::uint8_t;
@@ -85,4 +86,22 @@ pub unsafe extern "C" fn fix_int_mv_precision(mv: *mut mv) {
         .y = (((*mv).c2rust_unnamed.y as libc::c_int
         - ((*mv).c2rust_unnamed.y as libc::c_int >> 15 as libc::c_int)
         + 3 as libc::c_int) as libc::c_uint & !(7 as libc::c_uint)) as int16_t;
+}
+
+#[inline]
+pub unsafe extern "C" fn fix_mv_precision(hdr: *const Dav1dFrameHeader, mv: *mut mv) {
+    if (*hdr).force_integer_mv != 0 {
+        fix_int_mv_precision(mv);
+    } else if (*hdr).hp == 0 {
+        (*mv)
+            .c2rust_unnamed
+            .x = (((*mv).c2rust_unnamed.x as libc::c_int
+            - ((*mv).c2rust_unnamed.x as libc::c_int >> 15 as libc::c_int))
+            as libc::c_uint & !(1 as libc::c_uint)) as int16_t;
+        (*mv)
+            .c2rust_unnamed
+            .y = (((*mv).c2rust_unnamed.y as libc::c_int
+            - ((*mv).c2rust_unnamed.y as libc::c_int >> 15 as libc::c_int))
+            as libc::c_uint & !(1 as libc::c_uint)) as int16_t;
+    }
 }

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -1,3 +1,5 @@
+use crate::include::stdint::uint64_t;
+
 #[inline]
 pub unsafe extern "C" fn get_random_number(
     bits: libc::c_int,
@@ -11,4 +13,9 @@ pub unsafe extern "C" fn get_random_number(
     return (*state >> 16 as libc::c_int - bits
         & (((1 as libc::c_int) << bits) - 1 as libc::c_int) as libc::c_uint)
         as libc::c_int;
+}
+
+#[inline]
+pub unsafe extern "C" fn round2(x: libc::c_int, shift: uint64_t) -> libc::c_int {
+    return x + ((1 as libc::c_int) << shift >> 1 as libc::c_int) >> shift;
 }

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -1,0 +1,14 @@
+#[inline]
+pub unsafe extern "C" fn get_random_number(
+    bits: libc::c_int,
+    state: *mut libc::c_uint,
+) -> libc::c_int {
+    let r: libc::c_int = *state as libc::c_int;
+    let mut bit: libc::c_uint = ((r >> 0 as libc::c_int ^ r >> 1 as libc::c_int
+        ^ r >> 3 as libc::c_int ^ r >> 12 as libc::c_int) & 1 as libc::c_int)
+        as libc::c_uint;
+    *state = (r >> 1 as libc::c_int) as libc::c_uint | bit << 15 as libc::c_int;
+    return (*state >> 16 as libc::c_int - bits
+        & (((1 as libc::c_int) << bits) - 1 as libc::c_int) as libc::c_uint)
+        as libc::c_int;
+}

--- a/src/filmgrain_tmpl_16.rs
+++ b/src/filmgrain_tmpl_16.rs
@@ -423,20 +423,7 @@ unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     }
     return x >> 1 as libc::c_int;
 }
-#[inline]
-unsafe extern "C" fn get_random_number(
-    bits: libc::c_int,
-    state: *mut libc::c_uint,
-) -> libc::c_int {
-    let r: libc::c_int = *state as libc::c_int;
-    let mut bit: libc::c_uint = ((r >> 0 as libc::c_int ^ r >> 1 as libc::c_int
-        ^ r >> 3 as libc::c_int ^ r >> 12 as libc::c_int) & 1 as libc::c_int)
-        as libc::c_uint;
-    *state = (r >> 1 as libc::c_int) as libc::c_uint | bit << 15 as libc::c_int;
-    return (*state >> 16 as libc::c_int - bits
-        & (((1 as libc::c_int) << bits) - 1 as libc::c_int) as libc::c_uint)
-        as libc::c_int;
-}
+use crate::src::filmgrain::get_random_number;
 #[inline]
 unsafe extern "C" fn round2(x: libc::c_int, shift: uint64_t) -> libc::c_int {
     return x + ((1 as libc::c_int) << shift >> 1 as libc::c_int) >> shift;

--- a/src/filmgrain_tmpl_16.rs
+++ b/src/filmgrain_tmpl_16.rs
@@ -424,10 +424,7 @@ unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     return x >> 1 as libc::c_int;
 }
 use crate::src::filmgrain::get_random_number;
-#[inline]
-unsafe extern "C" fn round2(x: libc::c_int, shift: uint64_t) -> libc::c_int {
-    return x + ((1 as libc::c_int) << shift >> 1 as libc::c_int) >> shift;
-}
+use crate::src::filmgrain::round2;
 unsafe extern "C" fn generate_grain_y_c(
     mut buf: *mut [entry; 82],
     data: *const Dav1dFilmGrainData,

--- a/src/filmgrain_tmpl_8.rs
+++ b/src/filmgrain_tmpl_8.rs
@@ -390,10 +390,7 @@ use crate::include::common::intops::iclip_u8;
 use crate::include::common::intops::iclip;
 use crate::include::common::intops::imin;
 use crate::src::filmgrain::get_random_number;
-#[inline]
-unsafe extern "C" fn round2(x: libc::c_int, shift: uint64_t) -> libc::c_int {
-    return x + ((1 as libc::c_int) << shift >> 1 as libc::c_int) >> shift;
-}
+use crate::src::filmgrain::round2;
 unsafe extern "C" fn generate_grain_y_c(
     mut buf: *mut [entry; 82],
     data: *const Dav1dFilmGrainData,

--- a/src/filmgrain_tmpl_8.rs
+++ b/src/filmgrain_tmpl_8.rs
@@ -389,20 +389,7 @@ pub const DAV1D_X86_CPU_FLAG_SSE41: CpuFlags = 4;
 use crate::include::common::intops::iclip_u8;
 use crate::include::common::intops::iclip;
 use crate::include::common::intops::imin;
-#[inline]
-unsafe extern "C" fn get_random_number(
-    bits: libc::c_int,
-    state: *mut libc::c_uint,
-) -> libc::c_int {
-    let r: libc::c_int = *state as libc::c_int;
-    let mut bit: libc::c_uint = ((r >> 0 as libc::c_int ^ r >> 1 as libc::c_int
-        ^ r >> 3 as libc::c_int ^ r >> 12 as libc::c_int) & 1 as libc::c_int)
-        as libc::c_uint;
-    *state = (r >> 1 as libc::c_int) as libc::c_uint | bit << 15 as libc::c_int;
-    return (*state >> 16 as libc::c_int - bits
-        & (((1 as libc::c_int) << bits) - 1 as libc::c_int) as libc::c_uint)
-        as libc::c_int;
-}
+use crate::src::filmgrain::get_random_number;
 #[inline]
 unsafe extern "C" fn round2(x: libc::c_int, shift: uint64_t) -> libc::c_int {
     return x + ((1 as libc::c_int) << shift >> 1 as libc::c_int) >> shift;

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -1,0 +1,9 @@
+#[inline]
+pub unsafe extern "C" fn get_upsample(
+    wh: libc::c_int,
+    angle: libc::c_int,
+    is_sm: libc::c_int,
+) -> libc::c_int {
+    return (angle < 40 as libc::c_int && wh <= 16 as libc::c_int >> is_sm)
+        as libc::c_int;
+}

--- a/src/ipred_prepare.rs
+++ b/src/ipred_prepare.rs
@@ -1,0 +1,21 @@
+use crate::src::env::BlockContext;
+use crate::src::levels::IntraPredMode;
+use crate::src::levels::SMOOTH_H_PRED;
+use crate::src::levels::SMOOTH_PRED;
+use crate::src::levels::SMOOTH_V_PRED;
+
+#[inline]
+pub unsafe extern "C" fn sm_flag(b: *const BlockContext, idx: libc::c_int) -> libc::c_int {
+    if (*b).intra[idx as usize] == 0 {
+        return 0 as libc::c_int;
+    }
+    let m: IntraPredMode = (*b).mode[idx as usize] as IntraPredMode;
+    return if m as libc::c_uint == SMOOTH_PRED as libc::c_int as libc::c_uint
+        || m as libc::c_uint == SMOOTH_H_PRED as libc::c_int as libc::c_uint
+        || m as libc::c_uint == SMOOTH_V_PRED as libc::c_int as libc::c_uint
+    {
+        512 as libc::c_int
+    } else {
+        0 as libc::c_int
+    };
+}

--- a/src/ipred_prepare.rs
+++ b/src/ipred_prepare.rs
@@ -19,3 +19,19 @@ pub unsafe extern "C" fn sm_flag(b: *const BlockContext, idx: libc::c_int) -> li
         0 as libc::c_int
     };
 }
+
+#[inline]
+pub unsafe extern "C" fn sm_uv_flag(
+    b: *const BlockContext,
+    idx: libc::c_int,
+) -> libc::c_int {
+    let m: IntraPredMode = (*b).uvmode[idx as usize] as IntraPredMode;
+    return if m as libc::c_uint == SMOOTH_PRED as libc::c_int as libc::c_uint
+        || m as libc::c_uint == SMOOTH_H_PRED as libc::c_int as libc::c_uint
+        || m as libc::c_uint == SMOOTH_V_PRED as libc::c_int as libc::c_uint
+    {
+        512 as libc::c_int
+    } else {
+        0 as libc::c_int
+    };
+}

--- a/src/ipred_tmpl_16.rs
+++ b/src/ipred_tmpl_16.rs
@@ -685,15 +685,7 @@ unsafe extern "C" fn filter_edge(
         i += 1;
     }
 }
-#[inline]
-unsafe extern "C" fn get_upsample(
-    wh: libc::c_int,
-    angle: libc::c_int,
-    is_sm: libc::c_int,
-) -> libc::c_int {
-    return (angle < 40 as libc::c_int && wh <= 16 as libc::c_int >> is_sm)
-        as libc::c_int;
-}
+use crate::src::ipred::get_upsample;
 #[inline(never)]
 unsafe extern "C" fn upsample_edge(
     out: *mut pixel,

--- a/src/ipred_tmpl_8.rs
+++ b/src/ipred_tmpl_8.rs
@@ -651,15 +651,7 @@ unsafe extern "C" fn filter_edge(
         i += 1;
     }
 }
-#[inline]
-unsafe extern "C" fn get_upsample(
-    wh: libc::c_int,
-    angle: libc::c_int,
-    is_sm: libc::c_int,
-) -> libc::c_int {
-    return (angle < 40 as libc::c_int && wh <= 16 as libc::c_int >> is_sm)
-        as libc::c_int;
-}
+use crate::src::ipred::get_upsample;
 #[inline(never)]
 unsafe extern "C" fn upsample_edge(
     out: *mut pixel,

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -97,8 +97,9 @@ cfg_if! {
     }
 }
 use crate::include::common::intops::inv_recenter;
+
 #[inline]
-unsafe extern "C" fn dav1d_msac_decode_bools(
+pub unsafe extern "C" fn dav1d_msac_decode_bools(
     s: *mut MsacContext,
     mut n: libc::c_uint,
 ) -> libc::c_uint {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -830,19 +830,7 @@ use crate::include::common::intops::iclip_u8;
 use crate::include::common::intops::ulog2;
 
 use crate::src::r#ref::dav1d_ref_inc;
-#[inline]
-unsafe extern "C" fn get_poc_diff(
-    order_hint_n_bits: libc::c_int,
-    poc0: libc::c_int,
-    poc1: libc::c_int,
-) -> libc::c_int {
-    if order_hint_n_bits == 0 {
-        return 0 as libc::c_int;
-    }
-    let mask: libc::c_int = (1 as libc::c_int) << order_hint_n_bits - 1 as libc::c_int;
-    let diff: libc::c_int = poc0 - poc1;
-    return (diff & mask - 1 as libc::c_int) - (diff & mask);
-}
+use crate::src::env::get_poc_diff;
 #[inline]
 unsafe extern "C" fn dav1d_get_bits_pos(mut c: *const GetBits) -> libc::c_uint {
     return (((*c).ptr).offset_from((*c).ptr_start) as libc::c_long as libc::c_uint)

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -1,0 +1,20 @@
+use crate::src::msac::dav1d_msac_decode_bool_equi;
+use crate::src::msac::MsacContext;
+
+#[inline]
+pub unsafe extern "C" fn read_golomb(msac: *mut MsacContext) -> libc::c_uint {
+    let mut len: libc::c_int = 0 as libc::c_int;
+    let mut val: libc::c_uint = 1 as libc::c_int as libc::c_uint;
+    while dav1d_msac_decode_bool_equi(msac) == 0 && len < 32 as libc::c_int {
+        len += 1;
+    }
+    loop {
+        let fresh3 = len;
+        len = len - 1;
+        if !(fresh3 != 0) {
+            break;
+        }
+        val = (val << 1 as libc::c_int).wrapping_add(dav1d_msac_decode_bool_equi(msac));
+    }
+    return val.wrapping_sub(1 as libc::c_int as libc::c_uint);
+}

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1011,21 +1011,7 @@ unsafe extern "C" fn get_uv_inter_txtp(
     return ytxtp;
 }
 use crate::src::msac::dav1d_msac_decode_bools;
-#[inline]
-unsafe extern "C" fn sm_flag(b: *const BlockContext, idx: libc::c_int) -> libc::c_int {
-    if (*b).intra[idx as usize] == 0 {
-        return 0 as libc::c_int;
-    }
-    let m: IntraPredMode = (*b).mode[idx as usize] as IntraPredMode;
-    return if m as libc::c_uint == SMOOTH_PRED as libc::c_int as libc::c_uint
-        || m as libc::c_uint == SMOOTH_H_PRED as libc::c_int as libc::c_uint
-        || m as libc::c_uint == SMOOTH_V_PRED as libc::c_int as libc::c_uint
-    {
-        512 as libc::c_int
-    } else {
-        0 as libc::c_int
-    };
-}
+use crate::src::ipred_prepare::sm_flag;
 #[inline]
 unsafe extern "C" fn sm_uv_flag(
     b: *const BlockContext,

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -847,13 +847,7 @@ use crate::src::levels::TX_4X4;
 use crate::src::levels::RectTxfmSize;
 use crate::src::levels::RTX_4X8;
 use crate::src::levels::TxfmType;
-
 use crate::src::levels::WHT_WHT;
-
-use crate::src::levels::H_FLIPADST;
-use crate::src::levels::V_FLIPADST;
-use crate::src::levels::H_ADST;
-use crate::src::levels::V_ADST;
 use crate::src::levels::IDTX;
 use crate::src::levels::DCT_DCT;
 use crate::src::levels::TxClass;
@@ -867,9 +861,7 @@ use crate::src::levels::SMOOTH_PRED;
 use crate::src::levels::DC_PRED;
 use crate::src::levels::II_SMOOTH_PRED;
 use crate::src::levels::GLOBALMV;
-
 use crate::src::levels::GLOBALMV_GLOBALMV;
-
 use crate::src::levels::COMP_INTER_NONE;
 use crate::src::levels::INTER_INTRA_BLEND;
 use crate::src::levels::MM_WARP;
@@ -960,29 +952,7 @@ use crate::include::common::intops::imin;
 use crate::include::common::intops::umin;
 use crate::include::common::intops::iclip;
 use crate::include::common::intops::apply_sign64;
-#[inline]
-unsafe extern "C" fn get_uv_inter_txtp(
-    uvt_dim: *const TxfmInfo,
-    ytxtp: TxfmType,
-) -> TxfmType {
-    if (*uvt_dim).max as libc::c_int == TX_32X32 as libc::c_int {
-        return (if ytxtp as libc::c_uint == IDTX as libc::c_int as libc::c_uint {
-            IDTX as libc::c_int
-        } else {
-            DCT_DCT as libc::c_int
-        }) as TxfmType;
-    }
-    if (*uvt_dim).min as libc::c_int == TX_16X16 as libc::c_int
-        && (1 as libc::c_int) << ytxtp as libc::c_uint
-            & ((1 as libc::c_int) << H_FLIPADST as libc::c_int
-                | (1 as libc::c_int) << V_FLIPADST as libc::c_int
-                | (1 as libc::c_int) << H_ADST as libc::c_int
-                | (1 as libc::c_int) << V_ADST as libc::c_int) != 0
-    {
-        return DCT_DCT;
-    }
-    return ytxtp;
-}
+use crate::src::env::get_uv_inter_txtp;
 use crate::src::msac::dav1d_msac_decode_bools;
 use crate::src::ipred_prepare::sm_flag;
 use crate::src::ipred_prepare::sm_uv_flag;

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -863,8 +863,6 @@ use crate::src::levels::TX_CLASS_2D;
 use crate::src::levels::IntraPredMode;
 use crate::src::levels::FILTER_PRED;
 use crate::src::levels::CFL_PRED;
-use crate::src::levels::SMOOTH_H_PRED;
-use crate::src::levels::SMOOTH_V_PRED;
 use crate::src::levels::SMOOTH_PRED;
 use crate::src::levels::DC_PRED;
 use crate::src::levels::II_SMOOTH_PRED;
@@ -1012,21 +1010,7 @@ unsafe extern "C" fn get_uv_inter_txtp(
 }
 use crate::src::msac::dav1d_msac_decode_bools;
 use crate::src::ipred_prepare::sm_flag;
-#[inline]
-unsafe extern "C" fn sm_uv_flag(
-    b: *const BlockContext,
-    idx: libc::c_int,
-) -> libc::c_int {
-    let m: IntraPredMode = (*b).uvmode[idx as usize] as IntraPredMode;
-    return if m as libc::c_uint == SMOOTH_PRED as libc::c_int as libc::c_uint
-        || m as libc::c_uint == SMOOTH_H_PRED as libc::c_int as libc::c_uint
-        || m as libc::c_uint == SMOOTH_V_PRED as libc::c_int as libc::c_uint
-    {
-        512 as libc::c_int
-    } else {
-        0 as libc::c_int
-    };
-}
+use crate::src::ipred_prepare::sm_uv_flag;
 #[inline]
 unsafe extern "C" fn read_golomb(msac: *mut MsacContext) -> libc::c_uint {
     let mut len: libc::c_int = 0 as libc::c_int;

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1011,23 +1011,7 @@ unsafe extern "C" fn get_uv_inter_txtp(
 use crate::src::msac::dav1d_msac_decode_bools;
 use crate::src::ipred_prepare::sm_flag;
 use crate::src::ipred_prepare::sm_uv_flag;
-#[inline]
-unsafe extern "C" fn read_golomb(msac: *mut MsacContext) -> libc::c_uint {
-    let mut len: libc::c_int = 0 as libc::c_int;
-    let mut val: libc::c_uint = 1 as libc::c_int as libc::c_uint;
-    while dav1d_msac_decode_bool_equi(msac) == 0 && len < 32 as libc::c_int {
-        len += 1;
-    }
-    loop {
-        let fresh3 = len;
-        len = len - 1;
-        if !(fresh3 != 0) {
-            break;
-        }
-        val = (val << 1 as libc::c_int).wrapping_add(dav1d_msac_decode_bool_equi(msac));
-    }
-    return val.wrapping_sub(1 as libc::c_int as libc::c_uint);
-}
+use crate::src::recon::read_golomb;
 // If the C macro is called like `MERGE_CTX(a, uint8_t,  0x40)`, the
 // corresponding call to this macro is `MERGE_CTX(ca, a, uint8_t,  0x40)`.
 macro_rules! MERGE_CTX {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -954,32 +954,7 @@ unsafe extern "C" fn coef_dump(
         y += 1;
     }
 }
-#[inline]
-unsafe extern "C" fn ac_dump(
-    mut buf: *const int16_t,
-    mut w: libc::c_int,
-    mut h: libc::c_int,
-    mut what: *const libc::c_char,
-) {
-    printf(b"%s\n\0" as *const u8 as *const libc::c_char, what);
-    loop {
-        let fresh1 = h;
-        h = h - 1;
-        if !(fresh1 != 0) {
-            break;
-        }
-        let mut x: libc::c_int = 0 as libc::c_int;
-        while x < w {
-            printf(
-                b" %03d\0" as *const u8 as *const libc::c_char,
-                *buf.offset(x as isize) as libc::c_int,
-            );
-            x += 1;
-        }
-        buf = buf.offset(w as isize);
-        printf(b"\n\0" as *const u8 as *const libc::c_char);
-    };
-}
+use crate::include::common::dump::ac_dump;
 use crate::include::common::intops::imax;
 use crate::include::common::intops::imin;
 use crate::include::common::intops::umin;

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1010,22 +1010,7 @@ unsafe extern "C" fn get_uv_inter_txtp(
     }
     return ytxtp;
 }
-#[inline]
-unsafe extern "C" fn dav1d_msac_decode_bools(
-    s: *mut MsacContext,
-    mut n: libc::c_uint,
-) -> libc::c_uint {
-    let mut v: libc::c_uint = 0 as libc::c_int as libc::c_uint;
-    loop {
-        let fresh2 = n;
-        n = n.wrapping_sub(1);
-        if !(fresh2 != 0) {
-            break;
-        }
-        v = v << 1 as libc::c_int | dav1d_msac_decode_bool_equi(s);
-    }
-    return v;
-}
+use crate::src::msac::dav1d_msac_decode_bools;
 #[inline]
 unsafe extern "C" fn sm_flag(b: *const BlockContext, idx: libc::c_int) -> libc::c_int {
     if (*b).intra[idx as usize] == 0 {

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -973,21 +973,7 @@ unsafe extern "C" fn get_uv_inter_txtp(
     return ytxtp;
 }
 use crate::src::msac::dav1d_msac_decode_bools;
-#[inline]
-unsafe extern "C" fn sm_flag(b: *const BlockContext, idx: libc::c_int) -> libc::c_int {
-    if (*b).intra[idx as usize] == 0 {
-        return 0 as libc::c_int;
-    }
-    let m: IntraPredMode = (*b).mode[idx as usize] as IntraPredMode;
-    return if m as libc::c_uint == SMOOTH_PRED as libc::c_int as libc::c_uint
-        || m as libc::c_uint == SMOOTH_H_PRED as libc::c_int as libc::c_uint
-        || m as libc::c_uint == SMOOTH_V_PRED as libc::c_int as libc::c_uint
-    {
-        512 as libc::c_int
-    } else {
-        0 as libc::c_int
-    };
-}
+use crate::src::ipred_prepare::sm_flag;
 #[inline]
 unsafe extern "C" fn sm_uv_flag(
     b: *const BlockContext,

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -972,22 +972,7 @@ unsafe extern "C" fn get_uv_inter_txtp(
     }
     return ytxtp;
 }
-#[inline]
-unsafe extern "C" fn dav1d_msac_decode_bools(
-    s: *mut MsacContext,
-    mut n: libc::c_uint,
-) -> libc::c_uint {
-    let mut v: libc::c_uint = 0 as libc::c_int as libc::c_uint;
-    loop {
-        let fresh2 = n;
-        n = n.wrapping_sub(1);
-        if !(fresh2 != 0) {
-            break;
-        }
-        v = v << 1 as libc::c_int | dav1d_msac_decode_bool_equi(s);
-    }
-    return v;
-}
+use crate::src::msac::dav1d_msac_decode_bools;
 #[inline]
 unsafe extern "C" fn sm_flag(b: *const BlockContext, idx: libc::c_int) -> libc::c_int {
     if (*b).intra[idx as usize] == 0 {

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -973,23 +973,7 @@ unsafe extern "C" fn get_uv_inter_txtp(
 use crate::src::msac::dav1d_msac_decode_bools;
 use crate::src::ipred_prepare::sm_flag;
 use crate::src::ipred_prepare::sm_uv_flag;
-#[inline]
-unsafe extern "C" fn read_golomb(msac: *mut MsacContext) -> libc::c_uint {
-    let mut len: libc::c_int = 0 as libc::c_int;
-    let mut val: libc::c_uint = 1 as libc::c_int as libc::c_uint;
-    while dav1d_msac_decode_bool_equi(msac) == 0 && len < 32 as libc::c_int {
-        len += 1;
-    }
-    loop {
-        let fresh3 = len;
-        len = len - 1;
-        if !(fresh3 != 0) {
-            break;
-        }
-        val = (val << 1 as libc::c_int).wrapping_add(dav1d_msac_decode_bool_equi(msac));
-    }
-    return val.wrapping_sub(1 as libc::c_int as libc::c_uint);
-}
+use crate::src::recon::read_golomb;
 #[inline]
 unsafe extern "C" fn get_skip_ctx(
     t_dim: *const TxfmInfo,

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -916,32 +916,7 @@ unsafe extern "C" fn coef_dump(
         y += 1;
     }
 }
-#[inline]
-unsafe extern "C" fn ac_dump(
-    mut buf: *const int16_t,
-    mut w: libc::c_int,
-    mut h: libc::c_int,
-    mut what: *const libc::c_char,
-) {
-    printf(b"%s\n\0" as *const u8 as *const libc::c_char, what);
-    loop {
-        let fresh1 = h;
-        h = h - 1;
-        if !(fresh1 != 0) {
-            break;
-        }
-        let mut x: libc::c_int = 0 as libc::c_int;
-        while x < w {
-            printf(
-                b" %03d\0" as *const u8 as *const libc::c_char,
-                *buf.offset(x as isize) as libc::c_int,
-            );
-            x += 1;
-        }
-        buf = buf.offset(w as isize);
-        printf(b"\n\0" as *const u8 as *const libc::c_char);
-    };
-}
+use crate::include::common::dump::ac_dump;
 use crate::include::common::intops::imax;
 use crate::include::common::intops::imin;
 use crate::include::common::intops::umin;

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -832,8 +832,6 @@ use crate::src::levels::TX_CLASS_2D;
 use crate::src::levels::IntraPredMode;
 use crate::src::levels::FILTER_PRED;
 use crate::src::levels::CFL_PRED;
-use crate::src::levels::SMOOTH_H_PRED;
-use crate::src::levels::SMOOTH_V_PRED;
 use crate::src::levels::SMOOTH_PRED;
 use crate::src::levels::DC_PRED;
 use crate::src::levels::II_SMOOTH_PRED;
@@ -974,21 +972,7 @@ unsafe extern "C" fn get_uv_inter_txtp(
 }
 use crate::src::msac::dav1d_msac_decode_bools;
 use crate::src::ipred_prepare::sm_flag;
-#[inline]
-unsafe extern "C" fn sm_uv_flag(
-    b: *const BlockContext,
-    idx: libc::c_int,
-) -> libc::c_int {
-    let m: IntraPredMode = (*b).uvmode[idx as usize] as IntraPredMode;
-    return if m as libc::c_uint == SMOOTH_PRED as libc::c_int as libc::c_uint
-        || m as libc::c_uint == SMOOTH_H_PRED as libc::c_int as libc::c_uint
-        || m as libc::c_uint == SMOOTH_V_PRED as libc::c_int as libc::c_uint
-    {
-        512 as libc::c_int
-    } else {
-        0 as libc::c_int
-    };
-}
+use crate::src::ipred_prepare::sm_uv_flag;
 #[inline]
 unsafe extern "C" fn read_golomb(msac: *mut MsacContext) -> libc::c_uint {
     let mut len: libc::c_int = 0 as libc::c_int;

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -816,13 +816,7 @@ use crate::src::levels::TX_4X4;
 use crate::src::levels::RectTxfmSize;
 use crate::src::levels::RTX_4X8;
 use crate::src::levels::TxfmType;
-
 use crate::src::levels::WHT_WHT;
-
-use crate::src::levels::H_FLIPADST;
-use crate::src::levels::V_FLIPADST;
-use crate::src::levels::H_ADST;
-use crate::src::levels::V_ADST;
 use crate::src::levels::IDTX;
 use crate::src::levels::DCT_DCT;
 use crate::src::levels::TxClass;
@@ -836,9 +830,7 @@ use crate::src::levels::SMOOTH_PRED;
 use crate::src::levels::DC_PRED;
 use crate::src::levels::II_SMOOTH_PRED;
 use crate::src::levels::GLOBALMV;
-
 use crate::src::levels::GLOBALMV_GLOBALMV;
-
 use crate::src::levels::COMP_INTER_NONE;
 use crate::src::levels::INTER_INTRA_BLEND;
 use crate::src::levels::MM_WARP;
@@ -922,29 +914,7 @@ use crate::include::common::intops::imin;
 use crate::include::common::intops::umin;
 use crate::include::common::intops::iclip;
 use crate::include::common::intops::apply_sign64;
-#[inline]
-unsafe extern "C" fn get_uv_inter_txtp(
-    uvt_dim: *const TxfmInfo,
-    ytxtp: TxfmType,
-) -> TxfmType {
-    if (*uvt_dim).max as libc::c_int == TX_32X32 as libc::c_int {
-        return (if ytxtp as libc::c_uint == IDTX as libc::c_int as libc::c_uint {
-            IDTX as libc::c_int
-        } else {
-            DCT_DCT as libc::c_int
-        }) as TxfmType;
-    }
-    if (*uvt_dim).min as libc::c_int == TX_16X16 as libc::c_int
-        && (1 as libc::c_int) << ytxtp as libc::c_uint
-            & ((1 as libc::c_int) << H_FLIPADST as libc::c_int
-                | (1 as libc::c_int) << V_FLIPADST as libc::c_int
-                | (1 as libc::c_int) << H_ADST as libc::c_int
-                | (1 as libc::c_int) << V_ADST as libc::c_int) != 0
-    {
-        return DCT_DCT;
-    }
-    return ytxtp;
-}
+use crate::src::env::get_uv_inter_txtp;
 use crate::src::msac::dav1d_msac_decode_bools;
 use crate::src::ipred_prepare::sm_flag;
 use crate::src::ipred_prepare::sm_uv_flag;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -62,7 +62,7 @@ extern "C" {
 }
 use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
 
-use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
+
 
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
 use crate::include::dav1d::headers::Dav1dFrameHeader;
@@ -174,94 +174,8 @@ use crate::include::common::intops::iclip;
 use crate::include::common::intops::apply_sign;
 use crate::src::env::get_poc_diff;
 use crate::src::env::fix_mv_precision;
-use crate::src::env::fix_int_mv_precision;
-#[inline]
-unsafe extern "C" fn get_gmv_2d(
-    gmv: *const Dav1dWarpedMotionParams,
-    bx4: libc::c_int,
-    by4: libc::c_int,
-    bw4: libc::c_int,
-    bh4: libc::c_int,
-    hdr: *const Dav1dFrameHeader,
-) -> mv {
-    match (*gmv).type_0 as libc::c_uint {
-        2 => {
-            if !((*gmv).matrix[5 as libc::c_int as usize]
-                == (*gmv).matrix[2 as libc::c_int as usize])
-            {
-                unreachable!();
-            }
-            if !((*gmv).matrix[4 as libc::c_int as usize]
-                == -(*gmv).matrix[3 as libc::c_int as usize])
-            {
-                unreachable!();
-            }
-        }
-        1 => {
-            let mut res_0: mv = mv {
-                c2rust_unnamed: {
-                    let mut init = mv_xy {
-                        y: ((*gmv).matrix[0 as libc::c_int as usize]
-                            >> 13 as libc::c_int) as int16_t,
-                        x: ((*gmv).matrix[1 as libc::c_int as usize]
-                            >> 13 as libc::c_int) as int16_t,
-                    };
-                    init
-                },
-            };
-            if (*hdr).force_integer_mv != 0 {
-                fix_int_mv_precision(&mut res_0);
-            }
-            return res_0;
-        }
-        0 => {
-            return mv {
-                c2rust_unnamed: {
-                    let mut init = mv_xy {
-                        y: 0 as libc::c_int as int16_t,
-                        x: 0 as libc::c_int as int16_t,
-                    };
-                    init
-                },
-            };
-        }
-        3 | _ => {}
-    }
-    let x: libc::c_int = bx4 * 4 as libc::c_int + bw4 * 2 as libc::c_int
-        - 1 as libc::c_int;
-    let y: libc::c_int = by4 * 4 as libc::c_int + bh4 * 2 as libc::c_int
-        - 1 as libc::c_int;
-    let xc: libc::c_int = ((*gmv).matrix[2 as libc::c_int as usize]
-        - ((1 as libc::c_int) << 16 as libc::c_int)) * x
-        + (*gmv).matrix[3 as libc::c_int as usize] * y
-        + (*gmv).matrix[0 as libc::c_int as usize];
-    let yc: libc::c_int = ((*gmv).matrix[5 as libc::c_int as usize]
-        - ((1 as libc::c_int) << 16 as libc::c_int)) * y
-        + (*gmv).matrix[4 as libc::c_int as usize] * x
-        + (*gmv).matrix[1 as libc::c_int as usize];
-    let shift: libc::c_int = 16 as libc::c_int
-        - (3 as libc::c_int - ((*hdr).hp == 0) as libc::c_int);
-    let round: libc::c_int = (1 as libc::c_int) << shift >> 1 as libc::c_int;
-    let mut res: mv = mv {
-        c2rust_unnamed: {
-            let mut init = mv_xy {
-                y: apply_sign(
-                    abs(yc) + round >> shift << ((*hdr).hp == 0) as libc::c_int,
-                    yc,
-                ) as int16_t,
-                x: apply_sign(
-                    abs(xc) + round >> shift << ((*hdr).hp == 0) as libc::c_int,
-                    xc,
-                ) as int16_t,
-            };
-            init
-        },
-    };
-    if (*hdr).force_integer_mv != 0 {
-        fix_int_mv_precision(&mut res);
-    }
-    return res;
-}
+
+use crate::src::env::get_gmv_2d;
 use crate::src::mem::dav1d_freep_aligned;
 
 use crate::src::mem::dav1d_alloc_aligned;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -173,23 +173,7 @@ use crate::include::common::intops::imin;
 use crate::include::common::intops::iclip;
 use crate::include::common::intops::apply_sign;
 use crate::src::env::get_poc_diff;
-#[inline]
-unsafe extern "C" fn fix_mv_precision(hdr: *const Dav1dFrameHeader, mv: *mut mv) {
-    if (*hdr).force_integer_mv != 0 {
-        fix_int_mv_precision(mv);
-    } else if (*hdr).hp == 0 {
-        (*mv)
-            .c2rust_unnamed
-            .x = (((*mv).c2rust_unnamed.x as libc::c_int
-            - ((*mv).c2rust_unnamed.x as libc::c_int >> 15 as libc::c_int))
-            as libc::c_uint & !(1 as libc::c_uint)) as int16_t;
-        (*mv)
-            .c2rust_unnamed
-            .y = (((*mv).c2rust_unnamed.y as libc::c_int
-            - ((*mv).c2rust_unnamed.y as libc::c_int >> 15 as libc::c_int))
-            as libc::c_uint & !(1 as libc::c_uint)) as int16_t;
-    }
-}
+use crate::src::env::fix_mv_precision;
 use crate::src::env::fix_int_mv_precision;
 #[inline]
 unsafe extern "C" fn get_gmv_2d(

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -172,19 +172,7 @@ use crate::include::common::intops::imax;
 use crate::include::common::intops::imin;
 use crate::include::common::intops::iclip;
 use crate::include::common::intops::apply_sign;
-#[inline]
-unsafe extern "C" fn get_poc_diff(
-    order_hint_n_bits: libc::c_int,
-    poc0: libc::c_int,
-    poc1: libc::c_int,
-) -> libc::c_int {
-    if order_hint_n_bits == 0 {
-        return 0 as libc::c_int;
-    }
-    let mask: libc::c_int = (1 as libc::c_int) << order_hint_n_bits - 1 as libc::c_int;
-    let diff: libc::c_int = poc0 - poc1;
-    return (diff & mask - 1 as libc::c_int) - (diff & mask);
-}
+use crate::src::env::get_poc_diff;
 #[inline]
 unsafe extern "C" fn fix_mv_precision(hdr: *const Dav1dFrameHeader, mv: *mut mv) {
     if (*hdr).force_integer_mv != 0 {

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -190,19 +190,7 @@ unsafe extern "C" fn fix_mv_precision(hdr: *const Dav1dFrameHeader, mv: *mut mv)
             as libc::c_uint & !(1 as libc::c_uint)) as int16_t;
     }
 }
-#[inline]
-unsafe extern "C" fn fix_int_mv_precision(mv: *mut mv) {
-    (*mv)
-        .c2rust_unnamed
-        .x = (((*mv).c2rust_unnamed.x as libc::c_int
-        - ((*mv).c2rust_unnamed.x as libc::c_int >> 15 as libc::c_int)
-        + 3 as libc::c_int) as libc::c_uint & !(7 as libc::c_uint)) as int16_t;
-    (*mv)
-        .c2rust_unnamed
-        .y = (((*mv).c2rust_unnamed.y as libc::c_int
-        - ((*mv).c2rust_unnamed.y as libc::c_int >> 15 as libc::c_int)
-        + 3 as libc::c_int) as libc::c_uint & !(7 as libc::c_uint)) as int16_t;
-}
+use crate::src::env::fix_int_mv_precision;
 #[inline]
 unsafe extern "C" fn get_gmv_2d(
     gmv: *const Dav1dWarpedMotionParams,


### PR DESCRIPTION
This deduplicates most of the remaining duplicated inline `fn`s, with the exception of
* a few very large functions that I want to deduplicate in a separate PR
* functions that depend on other duplicated, `static` `fn`s
* and bitdepth-dependent functions
* also I missed non-verbatim `#[inline]` functions, like `#[inline(always)]` and `#[cfg(feature = "asm")]` ones