### PR TITLE
Build and test i686 target

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ jobs:
           # make sure we don't silently continue
           set -euo pipefail
           sudo apt-get update --quiet=2
-          sudo apt-get install --yes meson nasm
+          sudo apt-get install --yes meson nasm gcc-multilib
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: git checkout
@@ -37,10 +37,25 @@ jobs:
       - name: cargo build
         run: cargo build --release
       - name: meson test
-        run: .github/workflows/test.sh
+        run: |
+          .github/workflows/test.sh
+          cp ${{ github.workspace }}/build/meson-logs/testlog.txt \
+             ${{ github.workspace }}/build/meson-logs/testlog-$(uname -m).txt
+      - name: cargo build for i686 (assembly temporarily disabled)
+        run: |
+          cargo clean
+          rustup target add i686-unknown-linux-gnu --toolchain nightly-2022-08-08
+          cargo build --release --target i686-unknown-linux-gnu \
+              --no-default-features --features bitdepth_8,bitdepth_16
+          ln target/i686-unknown-linux-gnu/release/dav1d target/release/dav1d
+      - name: meson test i686
+        run: |
+          .github/workflows/test.sh
+          cp ${{ github.workspace }}/build/meson-logs/testlog.txt \
+             ${{ github.workspace }}/build/meson-logs/testlog-i686.txt
       - name: upload build artifacts
         uses: actions/upload-artifact@v3
         with:
           name: meson-test-logs
           path: |
-             ${{ github.workspace }}/build/meson-logs/testlog.txt
+             ${{ github.workspace }}/build/meson-logs/testlog-*.txt


### PR DESCRIPTION
Assembly is disabled since it doesn't link properly for i686. I suggest we merge and then enable assembly once issue #119 is fixed. WDYT?