### PR TITLE
Cleanup and make safe `attributes.rs` and `intops.rs`

### DIFF
--- a/include/common/attributes.rs
+++ b/include/common/attributes.rs
@@ -1,14 +1,14 @@
 #[inline]
-pub unsafe extern "C" fn ctz(mask: libc::c_uint) -> libc::c_int {
+pub fn ctz(mask: libc::c_uint) -> libc::c_int {
     return mask.trailing_zeros() as i32;
 }
 
 #[inline]
-pub unsafe extern "C" fn clz(mask: libc::c_uint) -> libc::c_int {
+pub fn clz(mask: libc::c_uint) -> libc::c_int {
     return mask.leading_zeros() as i32;
 }
 
 #[inline]
-pub unsafe extern "C" fn clzll(mask: libc::c_ulonglong) -> libc::c_int {
+pub fn clzll(mask: libc::c_ulonglong) -> libc::c_int {
     return mask.leading_zeros() as i32;
 }

--- a/include/common/attributes.rs
+++ b/include/common/attributes.rs
@@ -1,14 +1,16 @@
+use std::ffi::{c_int, c_uint, c_ulonglong};
+
 #[inline]
-pub fn ctz(mask: libc::c_uint) -> libc::c_int {
-    return mask.trailing_zeros() as i32;
+pub fn ctz(mask: c_uint) -> c_int {
+    mask.trailing_zeros() as i32
 }
 
 #[inline]
-pub fn clz(mask: libc::c_uint) -> libc::c_int {
-    return mask.leading_zeros() as i32;
+pub fn clz(mask: c_uint) -> c_int {
+    mask.leading_zeros() as i32
 }
 
 #[inline]
-pub fn clzll(mask: libc::c_ulonglong) -> libc::c_int {
-    return mask.leading_zeros() as i32;
+pub fn clzll(mask: c_ulonglong) -> c_int {
+    mask.leading_zeros() as i32
 }

--- a/include/common/intops.rs
+++ b/include/common/intops.rs
@@ -1,67 +1,86 @@
+use std::ffi::{c_int, c_uint, c_ulonglong};
+
 use crate::include::common::attributes::clz;
 use crate::include::common::attributes::clzll;
-use crate::include::stdint::int64_t;
-use crate::include::stdint::uint64_t;
 
 #[inline]
-pub fn imax(a: libc::c_int, b: libc::c_int) -> libc::c_int {
-    return if a > b { a } else { b };
-}
-
-#[inline]
-pub fn imin(a: libc::c_int, b: libc::c_int) -> libc::c_int {
-    return if a < b { a } else { b };
-}
-
-#[inline]
-pub fn umin(a: libc::c_uint, b: libc::c_uint) -> libc::c_uint {
-    return if a < b { a } else { b };
-}
-
-#[inline]
-pub fn iclip(
-    v: libc::c_int,
-    min: libc::c_int,
-    max: libc::c_int,
-) -> libc::c_int {
-    return if v < min { min } else if v > max { max } else { v };
-}
-
-#[inline]
-pub fn iclip_u8(v: libc::c_int) -> libc::c_int {
-    return iclip(v, 0 as libc::c_int, 255 as libc::c_int);
-}
-
-#[inline]
-pub fn apply_sign(v: libc::c_int, s: libc::c_int) -> libc::c_int {
-    return if s < 0 as libc::c_int { -v } else { v };
-}
-
-#[inline]
-pub fn apply_sign64(v: libc::c_int, s: int64_t) -> libc::c_int {
-    return if s < 0 { -v } else { v };
-}
-
-#[inline]
-pub fn ulog2(v: libc::c_uint) -> libc::c_int {
-    return 31 as libc::c_int - clz(v);
-}
-
-#[inline]
-pub fn u64log2(v: uint64_t) -> libc::c_int {
-    return 63 as libc::c_int - clzll(v as libc::c_ulonglong);
-}
-
-#[inline]
-pub fn inv_recenter(r: libc::c_uint, v: libc::c_uint) -> libc::c_uint {
-    if v > r << 1 as libc::c_int {
-        return v
-    } else if v & 1 as libc::c_int as libc::c_uint == 0 as libc::c_int as libc::c_uint {
-        return (v >> 1 as libc::c_int).wrapping_add(r)
+pub fn imax(a: c_int, b: c_int) -> c_int {
+    if a > b {
+        a
     } else {
-        return r
-            .wrapping_sub(
-                v.wrapping_add(1 as libc::c_int as libc::c_uint) >> 1 as libc::c_int,
-            )
-    };
+        b
+    }
+}
+
+#[inline]
+pub fn imin(a: c_int, b: c_int) -> c_int {
+    if a < b {
+        a
+    } else {
+        b
+    }
+}
+
+#[inline]
+pub fn umin(a: c_uint, b: c_uint) -> c_uint {
+    if a < b {
+        a
+    } else {
+        b
+    }
+}
+
+#[inline]
+pub fn iclip(v: c_int, min: c_int, max: c_int) -> c_int {
+    if v < min {
+        min
+    } else if v > max {
+        max
+    } else {
+        v
+    }
+}
+
+#[inline]
+pub fn iclip_u8(v: c_int) -> c_int {
+    iclip(v, 0, 255)
+}
+
+#[inline]
+pub fn apply_sign(v: c_int, s: c_int) -> c_int {
+    if s < 0 {
+        -v
+    } else {
+        v
+    }
+}
+
+#[inline]
+pub fn apply_sign64(v: c_int, s: i64) -> c_int {
+    if s < 0 {
+        -v
+    } else {
+        v
+    }
+}
+
+#[inline]
+pub fn ulog2(v: c_uint) -> c_int {
+    return 31 - clz(v);
+}
+
+#[inline]
+pub fn u64log2(v: u64) -> c_int {
+    return 63 - clzll(v as c_ulonglong);
+}
+
+#[inline]
+pub fn inv_recenter(r: c_uint, v: c_uint) -> c_uint {
+    if v > r << 1 {
+        v
+    } else if v & 1 == 0 {
+        (v >> 1).wrapping_add(r)
+    } else {
+        r.wrapping_sub(v.wrapping_add(1) >> 1)
+    }
 }

--- a/include/common/intops.rs
+++ b/include/common/intops.rs
@@ -4,22 +4,22 @@ use crate::include::stdint::int64_t;
 use crate::include::stdint::uint64_t;
 
 #[inline]
-pub unsafe extern "C" fn imax(a: libc::c_int, b: libc::c_int) -> libc::c_int {
+pub fn imax(a: libc::c_int, b: libc::c_int) -> libc::c_int {
     return if a > b { a } else { b };
 }
 
 #[inline]
-pub unsafe extern "C" fn imin(a: libc::c_int, b: libc::c_int) -> libc::c_int {
+pub fn imin(a: libc::c_int, b: libc::c_int) -> libc::c_int {
     return if a < b { a } else { b };
 }
 
 #[inline]
-pub unsafe extern "C" fn umin(a: libc::c_uint, b: libc::c_uint) -> libc::c_uint {
+pub fn umin(a: libc::c_uint, b: libc::c_uint) -> libc::c_uint {
     return if a < b { a } else { b };
 }
 
 #[inline]
-pub unsafe extern "C" fn iclip(
+pub fn iclip(
     v: libc::c_int,
     min: libc::c_int,
     max: libc::c_int,
@@ -28,32 +28,32 @@ pub unsafe extern "C" fn iclip(
 }
 
 #[inline]
-pub unsafe extern "C" fn iclip_u8(v: libc::c_int) -> libc::c_int {
+pub fn iclip_u8(v: libc::c_int) -> libc::c_int {
     return iclip(v, 0 as libc::c_int, 255 as libc::c_int);
 }
 
 #[inline]
-pub unsafe extern "C" fn apply_sign(v: libc::c_int, s: libc::c_int) -> libc::c_int {
+pub fn apply_sign(v: libc::c_int, s: libc::c_int) -> libc::c_int {
     return if s < 0 as libc::c_int { -v } else { v };
 }
 
 #[inline]
-pub unsafe extern "C" fn apply_sign64(v: libc::c_int, s: int64_t) -> libc::c_int {
+pub fn apply_sign64(v: libc::c_int, s: int64_t) -> libc::c_int {
     return if s < 0 { -v } else { v };
 }
 
 #[inline]
-pub unsafe extern "C" fn ulog2(v: libc::c_uint) -> libc::c_int {
+pub fn ulog2(v: libc::c_uint) -> libc::c_int {
     return 31 as libc::c_int - clz(v);
 }
 
 #[inline]
-pub unsafe extern "C" fn u64log2(v: uint64_t) -> libc::c_int {
+pub fn u64log2(v: uint64_t) -> libc::c_int {
     return 63 as libc::c_int - clzll(v as libc::c_ulonglong);
 }
 
 #[inline]
-pub unsafe extern "C" fn inv_recenter(r: libc::c_uint, v: libc::c_uint) -> libc::c_uint {
+pub fn inv_recenter(r: libc::c_uint, v: libc::c_uint) -> libc::c_uint {
     if v > r << 1 as libc::c_int {
         return v
     } else if v & 1 as libc::c_int as libc::c_uint == 0 as libc::c_int as libc::c_uint {


### PR DESCRIPTION
These functions are already safe, so I just removed the `unsafe` and `extern "C"` and cleaned them up a bit.  They're used all over the place, including in `decode_b` and its children.