### PR TITLE
Cleanup and make safe `fn affine_lowest_px*`

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4241,7 +4241,7 @@ fn mc_lowest_px(
 
 #[inline(always)]
 unsafe fn affine_lowest_px(
-    t: *mut Dav1dTaskContext,
+    t: &Dav1dTaskContext,
     dst: &mut libc::c_int,
     b_dim: *const uint8_t,
     wmp: &Dav1dWarpedMotionParams,
@@ -4256,11 +4256,11 @@ unsafe fn affine_lowest_px(
     }
     let mat = wmp.matrix.as_ptr();
     let y = *b_dim.offset(1) as libc::c_int * v_mul - 8;
-    let src_y = (*t).by * 4 + ((y + 4) << ss_ver);
+    let src_y = t.by * 4 + ((y + 4) << ss_ver);
     let mat5_y = *mat.offset(5) as int64_t * src_y as int64_t + *mat.offset(1) as int64_t;
     let mut x = 0;
     while x < *b_dim.offset(0) as libc::c_int * h_mul {
-        let src_x = (*t).bx * 4 + ((x + 4) << ss_hor);
+        let src_x = t.bx * 4 + ((x + 4) << ss_hor);
         let mvy = *mat.offset(4) as int64_t * src_x as int64_t + mat5_y >> ss_ver;
         let dy = (mvy >> 16) as libc::c_int - 4;
         *dst = imax(*dst, dy + 4 + 8);
@@ -4270,7 +4270,7 @@ unsafe fn affine_lowest_px(
 
 #[inline(never)]
 unsafe fn affine_lowest_px_luma(
-    t: *mut Dav1dTaskContext,
+    t: &Dav1dTaskContext,
     dst: &mut libc::c_int,
     b_dim: *const uint8_t,
     wmp: &Dav1dWarpedMotionParams,
@@ -4280,12 +4280,12 @@ unsafe fn affine_lowest_px_luma(
 
 #[inline(never)]
 unsafe fn affine_lowest_px_chroma(
-    t: *mut Dav1dTaskContext,
+    t: &Dav1dTaskContext,
     dst: &mut libc::c_int,
     b_dim: *const uint8_t,
     wmp: &Dav1dWarpedMotionParams,
 ) {
-    let f = (*t).f;
+    let f = t.f;
     if !((*f).cur.p.layout != DAV1D_PIXEL_LAYOUT_I400) {
         unreachable!();
     }
@@ -13181,7 +13181,7 @@ unsafe fn decode_b(
                     if b.c2rust_unnamed.c2rust_unnamed_0.motion_mode as libc::c_int
                         == MM_WARP as libc::c_int
                     {
-                        &mut t.warpmv
+                        &t.warpmv
                     } else {
                         &mut *((*f.frame_hdr).gmv)
                             .as_mut_ptr()
@@ -13433,7 +13433,7 @@ unsafe fn decode_b(
                         if b.c2rust_unnamed.c2rust_unnamed_0.motion_mode
                             as libc::c_int == MM_WARP as libc::c_int
                         {
-                            &mut t.warpmv
+                            &t.warpmv
                         } else {
                             &mut *((*f.frame_hdr).gmv)
                                 .as_mut_ptr()

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4242,7 +4242,7 @@ fn mc_lowest_px(
 #[inline(always)]
 unsafe fn affine_lowest_px(
     t: *mut Dav1dTaskContext,
-    dst: *mut libc::c_int,
+    dst: &mut libc::c_int,
     b_dim: *const uint8_t,
     wmp: *const Dav1dWarpedMotionParams,
     ss_ver: libc::c_int,
@@ -4271,7 +4271,7 @@ unsafe fn affine_lowest_px(
 #[inline(never)]
 unsafe fn affine_lowest_px_luma(
     t: *mut Dav1dTaskContext,
-    dst: *mut libc::c_int,
+    dst: &mut libc::c_int,
     b_dim: *const uint8_t,
     wmp: *const Dav1dWarpedMotionParams,
 ) {
@@ -4281,7 +4281,7 @@ unsafe fn affine_lowest_px_luma(
 #[inline(never)]
 unsafe fn affine_lowest_px_chroma(
     t: *mut Dav1dTaskContext,
-    dst: *mut libc::c_int,
+    dst: &mut libc::c_int,
     b_dim: *const uint8_t,
     wmp: *const Dav1dWarpedMotionParams,
 ) {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4244,7 +4244,7 @@ unsafe fn affine_lowest_px(
     t: *mut Dav1dTaskContext,
     dst: &mut libc::c_int,
     b_dim: *const uint8_t,
-    wmp: *const Dav1dWarpedMotionParams,
+    wmp: &Dav1dWarpedMotionParams,
     ss_ver: libc::c_int,
     ss_hor: libc::c_int,
 ) {
@@ -4254,7 +4254,7 @@ unsafe fn affine_lowest_px(
         && *b_dim.offset(1) as libc::c_int * v_mul & 7 == 0) {
         unreachable!();
     }
-    let mat = ((*wmp).matrix).as_ptr();
+    let mat = wmp.matrix.as_ptr();
     let y = *b_dim.offset(1) as libc::c_int * v_mul - 8;
     let src_y = (*t).by * 4 + ((y + 4) << ss_ver);
     let mat5_y = *mat.offset(5) as int64_t * src_y as int64_t + *mat.offset(1) as int64_t;
@@ -4273,7 +4273,7 @@ unsafe fn affine_lowest_px_luma(
     t: *mut Dav1dTaskContext,
     dst: &mut libc::c_int,
     b_dim: *const uint8_t,
-    wmp: *const Dav1dWarpedMotionParams,
+    wmp: &Dav1dWarpedMotionParams,
 ) {
     affine_lowest_px(t, dst, b_dim, wmp, 0, 0);
 }
@@ -4283,7 +4283,7 @@ unsafe fn affine_lowest_px_chroma(
     t: *mut Dav1dTaskContext,
     dst: &mut libc::c_int,
     b_dim: *const uint8_t,
-    wmp: *const Dav1dWarpedMotionParams,
+    wmp: &Dav1dWarpedMotionParams,
 ) {
     let f = (*t).f;
     if !((*f).cur.p.layout != DAV1D_PIXEL_LAYOUT_I400) {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4250,10 +4250,8 @@ fn affine_lowest_px(
 ) {
     let h_mul = 4 >> ss_hor;
     let v_mul = 4 >> ss_ver;
-    if !(b_dim[0] as libc::c_int * h_mul & 7 == 0
-        && b_dim[1] as libc::c_int * v_mul & 7 == 0) {
-        unreachable!();
-    }
+    assert!(!(b_dim[0] as libc::c_int * h_mul & 7 == 0
+        && b_dim[1] as libc::c_int * v_mul & 7 == 0));
     let mat = &wmp.matrix;
     let y = b_dim[1] as libc::c_int * v_mul - 8;
     let src_y = t.by * 4 + ((y + 4) << ss_ver);
@@ -4286,9 +4284,7 @@ unsafe fn affine_lowest_px_chroma(
     wmp: &Dav1dWarpedMotionParams,
 ) {
     let f = &*t.f;
-    if !(f.cur.p.layout != DAV1D_PIXEL_LAYOUT_I400) {
-        unreachable!();
-    }
+    assert!(!(f.cur.p.layout != DAV1D_PIXEL_LAYOUT_I400));
     if f.cur.p.layout == DAV1D_PIXEL_LAYOUT_I444 {
         affine_lowest_px_luma(t, dst, b_dim, wmp);
     } else {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4254,14 +4254,14 @@ unsafe fn affine_lowest_px(
         && *b_dim.offset(1) as libc::c_int * v_mul & 7 == 0) {
         unreachable!();
     }
-    let mat = wmp.matrix.as_ptr();
+    let mat = &wmp.matrix;
     let y = *b_dim.offset(1) as libc::c_int * v_mul - 8;
     let src_y = t.by * 4 + ((y + 4) << ss_ver);
-    let mat5_y = *mat.offset(5) as int64_t * src_y as int64_t + *mat.offset(1) as int64_t;
+    let mat5_y = mat[5] as int64_t * src_y as int64_t + mat[1] as int64_t;
     let mut x = 0;
     while x < *b_dim.offset(0) as libc::c_int * h_mul {
         let src_x = t.bx * 4 + ((x + 4) << ss_hor);
-        let mvy = *mat.offset(4) as int64_t * src_x as int64_t + mat5_y >> ss_ver;
+        let mvy = mat[4] as int64_t * src_x as int64_t + mat5_y >> ss_ver;
         let dy = (mvy >> 16) as libc::c_int - 4;
         *dst = imax(*dst, dy + 4 + 8);
         x += imax(8, *b_dim.offset(0) as libc::c_int * h_mul - 8);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4240,7 +4240,7 @@ fn mc_lowest_px(
 }
 
 #[inline(always)]
-unsafe fn affine_lowest_px(
+fn affine_lowest_px(
     t: &Dav1dTaskContext,
     dst: &mut libc::c_int,
     b_dim: &[u8; 4],
@@ -4269,7 +4269,7 @@ unsafe fn affine_lowest_px(
 }
 
 #[inline(never)]
-unsafe fn affine_lowest_px_luma(
+fn affine_lowest_px_luma(
     t: &Dav1dTaskContext,
     dst: &mut libc::c_int,
     b_dim: &[u8; 4],

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4240,7 +4240,7 @@ fn mc_lowest_px(
 }
 
 #[inline(always)]
-unsafe extern "C" fn affine_lowest_px(
+unsafe fn affine_lowest_px(
     t: *mut Dav1dTaskContext,
     dst: *mut libc::c_int,
     b_dim: *const uint8_t,
@@ -4269,7 +4269,7 @@ unsafe extern "C" fn affine_lowest_px(
 }
 
 #[inline(never)]
-unsafe extern "C" fn affine_lowest_px_luma(
+unsafe fn affine_lowest_px_luma(
     t: *mut Dav1dTaskContext,
     dst: *mut libc::c_int,
     b_dim: *const uint8_t,
@@ -4279,7 +4279,7 @@ unsafe extern "C" fn affine_lowest_px_luma(
 }
 
 #[inline(never)]
-unsafe extern "C" fn affine_lowest_px_chroma(
+unsafe fn affine_lowest_px_chroma(
     t: *mut Dav1dTaskContext,
     dst: *mut libc::c_int,
     b_dim: *const uint8_t,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4285,11 +4285,11 @@ unsafe fn affine_lowest_px_chroma(
     b_dim: *const uint8_t,
     wmp: &Dav1dWarpedMotionParams,
 ) {
-    let f = t.f;
-    if !((*f).cur.p.layout != DAV1D_PIXEL_LAYOUT_I400) {
+    let f = &*t.f;
+    if !(f.cur.p.layout != DAV1D_PIXEL_LAYOUT_I400) {
         unreachable!();
     }
-    if (*f).cur.p.layout == DAV1D_PIXEL_LAYOUT_I444 {
+    if f.cur.p.layout == DAV1D_PIXEL_LAYOUT_I444 {
         affine_lowest_px_luma(t, dst, b_dim, wmp);
     } else {
         affine_lowest_px(
@@ -4297,7 +4297,7 @@ unsafe fn affine_lowest_px_chroma(
             dst,
             b_dim,
             wmp,
-            ((*f).cur.p.layout & DAV1D_PIXEL_LAYOUT_I420) as libc::c_int,
+            (f.cur.p.layout & DAV1D_PIXEL_LAYOUT_I420) as libc::c_int,
             1,
         );
     };


### PR DESCRIPTION
`fn affine_lowest_px` and `fn affine_lowest_px_luma` are made safe, but not yet `fn affine_lowest_px_chroma`, because it contains a `&*t.f` deref.  I'll wait until `Dav1dTaskContext::f: *const Dav1dFrameContext` is made a ref to fix that.

In updating the call sites, I passed `b_dim` as an array ref vs. a raw ptr, but since updating all the use sites in `decode_b` would be a lot, I didn't do that yet to not interfere too much with @randomPoison's work in `decode_b`.