### PR TITLE
Rename all `ref_0`s to `r#ref`

### DIFF
--- a/include/dav1d/common.rs
+++ b/include/dav1d/common.rs
@@ -7,7 +7,7 @@ use crate::src::r#ref::Dav1dRef;
 #[repr(C)]
 pub struct Dav1dUserData {
     pub data: *const uint8_t,
-    pub ref_0: *mut Dav1dRef,
+    pub r#ref: *mut Dav1dRef,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/include/dav1d/data.rs
+++ b/include/dav1d/data.rs
@@ -8,6 +8,6 @@ use crate::src::r#ref::Dav1dRef;
 pub struct Dav1dData {
     pub data: *const uint8_t,
     pub sz: size_t,
-    pub ref_0: *mut Dav1dRef,
+    pub r#ref: *mut Dav1dRef,
     pub m: Dav1dDataProps,
 }

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -236,7 +236,7 @@ pub struct Dav1dSegmentationData {
     pub delta_lf_y_h: libc::c_int,
     pub delta_lf_u: libc::c_int,
     pub delta_lf_v: libc::c_int,
-    pub ref_0: libc::c_int,
+    pub r#ref: libc::c_int,
     pub skip: libc::c_int,
     pub globalmv: libc::c_int,
 }

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -37,7 +37,7 @@ pub struct Dav1dPicture {
     pub mastering_display_ref: *mut Dav1dRef,
     pub itut_t35_ref: *mut Dav1dRef,
     pub reserved_ref: [uintptr_t; 4],
-    pub ref_0: *mut Dav1dRef,
+    pub r#ref: *mut Dav1dRef,
     pub allocator_data: *mut libc::c_void,
 }
 

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -329,7 +329,7 @@ pub struct CdfModeContext {
     pub jnt_comp: Align4<[[uint16_t; 2]; 6]>,
     pub mask_comp: Align4<[[uint16_t; 2]; 6]>,
     pub wedge_comp: Align4<[[uint16_t; 2]; 9]>,
-    pub ref_0: Align4<[[[uint16_t; 2]; 3]; 6]>,
+    pub r#ref: Align4<[[[uint16_t; 2]; 3]; 6]>,
     pub comp_fwd_ref: Align4<[[[uint16_t; 2]; 3]; 3]>,
     pub comp_bwd_ref: Align4<[[[uint16_t; 2]; 3]; 2]>,
     pub comp_uni_ref: Align4<[[[uint16_t; 2]; 3]; 3]>,
@@ -791,7 +791,7 @@ pub type generate_grain_y_fn = Option::<
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct CdfThreadContext {
-    pub ref_0: *mut Dav1dRef,
+    pub r#ref: *mut Dav1dRef,
     pub data: CdfThreadContext_data,
     pub progress: *mut atomic_uint,
 }
@@ -4320,7 +4320,7 @@ pub fn av1_default_cdf() -> CdfModeContext {
             [(32768 as libc::c_int - 11820 as libc::c_int) as uint16_t, 0],
             [(32768 as libc::c_int - 7701 as libc::c_int) as uint16_t, 0],
         ].into(),
-        ref_0: [
+        r#ref: [
             [
                 [(32768 as libc::c_int - 4897 as libc::c_int) as uint16_t, 0],
                 [(32768 as libc::c_int - 16973 as libc::c_int) as uint16_t, 0],
@@ -23450,15 +23450,15 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
         while i_20 < 3 as libc::c_int {
             (*dst)
                 .m
-                .ref_0[j_30
+                .r#ref[j_30
                 as usize][i_20
                 as usize][0 as libc::c_int
                 as usize] = (*src)
                 .m
-                .ref_0[j_30 as usize][i_20 as usize][0 as libc::c_int as usize];
+                .r#ref[j_30 as usize][i_20 as usize][0 as libc::c_int as usize];
             (*dst)
                 .m
-                .ref_0[j_30
+                .r#ref[j_30
                 as usize][i_20
                 as usize][1 as libc::c_int as usize] = 0 as libc::c_int as uint16_t;
             i_20 += 1;
@@ -23734,7 +23734,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_init_static(
     cdf: *mut CdfThreadContext,
     qidx: libc::c_int,
 ) {
-    (*cdf).ref_0 = 0 as *mut Dav1dRef;
+    (*cdf).r#ref = 0 as *mut Dav1dRef;
     (*cdf).data.qcat = get_qcat_idx(qidx) as libc::c_uint;
 }
 #[no_mangle]
@@ -23742,7 +23742,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_copy(
     dst: *mut CdfContext,
     src: *const CdfThreadContext,
 ) {
-    if !((*src).ref_0).is_null() {
+    if !((*src).r#ref).is_null() {
         memcpy(
             dst as *mut libc::c_void,
             (*src).data.cdf as *const libc::c_void,
@@ -23787,15 +23787,15 @@ pub unsafe extern "C" fn dav1d_cdf_thread_alloc(
     have_frame_mt: libc::c_int,
 ) -> libc::c_int {
     (*cdf)
-        .ref_0 = dav1d_ref_create_using_pool(
+        .r#ref = dav1d_ref_create_using_pool(
         (*c).cdf_pool,
         (::core::mem::size_of::<CdfContext>())
             .wrapping_add(::core::mem::size_of::<atomic_uint>()),
     );
-    if ((*cdf).ref_0).is_null() {
+    if ((*cdf).r#ref).is_null() {
         return -(12 as libc::c_int);
     }
-    (*cdf).data.cdf = (*(*cdf).ref_0).data as *mut CdfContext;
+    (*cdf).data.cdf = (*(*cdf).r#ref).data as *mut CdfContext;
     if have_frame_mt != 0 {
         (*cdf)
             .progress = &mut *((*cdf).data.cdf).offset(1 as libc::c_int as isize)
@@ -23810,8 +23810,8 @@ pub unsafe extern "C" fn dav1d_cdf_thread_ref(
     src: *mut CdfThreadContext,
 ) {
     *dst = *src;
-    if !((*src).ref_0).is_null() {
-        dav1d_ref_inc((*src).ref_0);
+    if !((*src).r#ref).is_null() {
+        dav1d_ref_inc((*src).r#ref);
     }
 }
 #[no_mangle]
@@ -23822,5 +23822,5 @@ pub unsafe extern "C" fn dav1d_cdf_thread_unref(cdf: *mut CdfThreadContext) {
         (::core::mem::size_of::<CdfThreadContext>() as libc::c_ulong)
             .wrapping_sub(8 as libc::c_ulong),
     );
-    dav1d_ref_dec(&mut (*cdf).ref_0);
+    dav1d_ref_dec(&mut (*cdf).r#ref);
 }

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -18,7 +18,7 @@ extern "C" {
         pool: *mut Dav1dMemPool,
         size: size_t,
     ) -> *mut Dav1dRef;
-    fn dav1d_ref_dec(ref_0: *mut *mut Dav1dRef);
+    fn dav1d_ref_dec(r#ref: *mut *mut Dav1dRef);
     static dav1d_partition_type_count: [uint8_t; 5];
 }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -48,15 +48,15 @@ pub unsafe extern "C" fn dav1d_data_create_internal(
     {
         return 0 as *mut uint8_t;
     }
-    (*buf).ref_0 = dav1d_ref_create(sz);
-    if ((*buf).ref_0).is_null() {
+    (*buf).r#ref = dav1d_ref_create(sz);
+    if ((*buf).r#ref).is_null() {
         return 0 as *mut uint8_t;
     }
-    (*buf).data = (*(*buf).ref_0).const_data as *const uint8_t;
+    (*buf).data = (*(*buf).r#ref).const_data as *const uint8_t;
     (*buf).sz = sz;
     dav1d_data_props_set_defaults(&mut (*buf).m);
     (*buf).m.size = sz;
-    return (*(*buf).ref_0).data as *mut uint8_t;
+    return (*(*buf).r#ref).data as *mut uint8_t;
 }
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_data_wrap_internal(
@@ -110,8 +110,8 @@ pub unsafe extern "C" fn dav1d_data_wrap_internal(
         );
         return -(22 as libc::c_int);
     }
-    (*buf).ref_0 = dav1d_ref_wrap(ptr, free_callback, cookie);
-    if ((*buf).ref_0).is_null() {
+    (*buf).r#ref = dav1d_ref_wrap(ptr, free_callback, cookie);
+    if ((*buf).r#ref).is_null() {
         return -(12 as libc::c_int);
     }
     (*buf).data = ptr;
@@ -157,8 +157,8 @@ pub unsafe extern "C" fn dav1d_data_wrap_user_data_internal(
         );
         return -(22 as libc::c_int);
     }
-    (*buf).m.user_data.ref_0 = dav1d_ref_wrap(user_data, free_callback, cookie);
-    if ((*buf).m.user_data.ref_0).is_null() {
+    (*buf).m.user_data.r#ref = dav1d_ref_wrap(user_data, free_callback, cookie);
+    if ((*buf).m.user_data.r#ref).is_null() {
         return -(12 as libc::c_int);
     }
     (*buf).m.user_data.data = user_data;
@@ -208,7 +208,7 @@ pub unsafe extern "C" fn dav1d_data_ref(dst: *mut Dav1dData, src: *const Dav1dDa
         );
         return;
     }
-    if !((*src).ref_0).is_null() {
+    if !((*src).r#ref).is_null() {
         if ((*src).data).is_null() {
             fprintf(
                 stderr,
@@ -223,10 +223,10 @@ pub unsafe extern "C" fn dav1d_data_ref(dst: *mut Dav1dData, src: *const Dav1dDa
             );
             return;
         }
-        dav1d_ref_inc((*src).ref_0);
+        dav1d_ref_inc((*src).r#ref);
     }
-    if !((*src).m.user_data.ref_0).is_null() {
-        dav1d_ref_inc((*src).m.user_data.ref_0);
+    if !((*src).m.user_data.r#ref).is_null() {
+        dav1d_ref_inc((*src).m.user_data.r#ref);
     }
     *dst = *src;
 }
@@ -241,10 +241,10 @@ pub unsafe extern "C" fn dav1d_data_props_copy(
     if src.is_null() {
         unreachable!();
     }
-    dav1d_ref_dec(&mut (*dst).user_data.ref_0);
+    dav1d_ref_dec(&mut (*dst).user_data.r#ref);
     *dst = *src;
-    if !((*dst).user_data.ref_0).is_null() {
-        dav1d_ref_inc((*dst).user_data.ref_0);
+    if !((*dst).user_data.r#ref).is_null() {
+        dav1d_ref_inc((*dst).user_data.r#ref);
     }
 }
 #[no_mangle]
@@ -276,7 +276,7 @@ pub unsafe extern "C" fn dav1d_data_props_unref_internal(props: *mut Dav1dDataPr
         );
         return;
     }
-    let mut user_data_ref: *mut Dav1dRef = (*props).user_data.ref_0;
+    let mut user_data_ref: *mut Dav1dRef = (*props).user_data.r#ref;
     dav1d_data_props_set_defaults(props);
     dav1d_ref_dec(&mut user_data_ref);
 }
@@ -296,8 +296,8 @@ pub unsafe extern "C" fn dav1d_data_unref_internal(buf: *mut Dav1dData) {
         );
         return;
     }
-    let mut user_data_ref: *mut Dav1dRef = (*buf).m.user_data.ref_0;
-    if !((*buf).ref_0).is_null() {
+    let mut user_data_ref: *mut Dav1dRef = (*buf).m.user_data.r#ref;
+    if !((*buf).r#ref).is_null() {
         if ((*buf).data).is_null() {
             fprintf(
                 stderr,
@@ -312,7 +312,7 @@ pub unsafe extern "C" fn dav1d_data_unref_internal(buf: *mut Dav1dData) {
             );
             return;
         }
-        dav1d_ref_dec(&mut (*buf).ref_0);
+        dav1d_ref_dec(&mut (*buf).r#ref);
     }
     memset(
         buf as *mut libc::c_void,

--- a/src/data.rs
+++ b/src/data.rs
@@ -9,7 +9,7 @@ extern "C" {
         _: libc::c_ulong,
     ) -> *mut libc::c_void;
     fn fprintf(_: *mut libc::FILE, _: *const libc::c_char, _: ...) -> libc::c_int;
-    fn dav1d_ref_dec(ref_0: *mut *mut Dav1dRef);
+    fn dav1d_ref_dec(r#ref: *mut *mut Dav1dRef);
     fn dav1d_ref_wrap(
         ptr: *const uint8_t,
         free_callback: Option::<

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1352,17 +1352,17 @@ unsafe extern "C" fn get_filter_ctx(
     yb4: libc::c_int,
     xb4: libc::c_int,
 ) -> libc::c_int {
-    let a_filter: libc::c_int = if (*a).ref_0[0 as libc::c_int as usize][xb4 as usize]
+    let a_filter: libc::c_int = if (*a).r#ref[0 as libc::c_int as usize][xb4 as usize]
         as libc::c_int == ref_0
-        || (*a).ref_0[1 as libc::c_int as usize][xb4 as usize] as libc::c_int == ref_0
+        || (*a).r#ref[1 as libc::c_int as usize][xb4 as usize] as libc::c_int == ref_0
     {
         (*a).filter[dir as usize][xb4 as usize] as libc::c_int
     } else {
         DAV1D_N_SWITCHABLE_FILTERS as libc::c_int
     };
-    let l_filter: libc::c_int = if (*l).ref_0[0 as libc::c_int as usize][yb4 as usize]
+    let l_filter: libc::c_int = if (*l).r#ref[0 as libc::c_int as usize][yb4 as usize]
         as libc::c_int == ref_0
-        || (*l).ref_0[1 as libc::c_int as usize][yb4 as usize] as libc::c_int == ref_0
+        || (*l).r#ref[1 as libc::c_int as usize][yb4 as usize] as libc::c_int == ref_0
     {
         (*l).filter[dir as usize][yb4 as usize] as libc::c_int
     } else {
@@ -1394,24 +1394,24 @@ unsafe extern "C" fn get_comp_ctx(
                     return 4 as libc::c_int
                 } else {
                     return 2 as libc::c_int
-                        + ((*l).ref_0[0 as libc::c_int as usize][yb4 as usize]
+                        + ((*l).r#ref[0 as libc::c_int as usize][yb4 as usize]
                             as libc::c_uint >= 4 as libc::c_uint) as libc::c_int
                 }
             } else if (*l).comp_type[yb4 as usize] != 0 {
                 return 2 as libc::c_int
-                    + ((*a).ref_0[0 as libc::c_int as usize][xb4 as usize]
+                    + ((*a).r#ref[0 as libc::c_int as usize][xb4 as usize]
                         as libc::c_uint >= 4 as libc::c_uint) as libc::c_int
             } else {
-                return ((*l).ref_0[0 as libc::c_int as usize][yb4 as usize]
+                return ((*l).r#ref[0 as libc::c_int as usize][yb4 as usize]
                     as libc::c_int >= 4 as libc::c_int) as libc::c_int
-                    ^ ((*a).ref_0[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
+                    ^ ((*a).r#ref[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
                         >= 4 as libc::c_int) as libc::c_int
             }
         } else {
             return if (*a).comp_type[xb4 as usize] as libc::c_int != 0 {
                 3 as libc::c_int
             } else {
-                ((*a).ref_0[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
+                ((*a).r#ref[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
                     >= 4 as libc::c_int) as libc::c_int
             }
         }
@@ -1419,7 +1419,7 @@ unsafe extern "C" fn get_comp_ctx(
         return if (*l).comp_type[yb4 as usize] as libc::c_int != 0 {
             3 as libc::c_int
         } else {
-            ((*l).ref_0[0 as libc::c_int as usize][yb4 as usize] as libc::c_int
+            ((*l).r#ref[0 as libc::c_int as usize][yb4 as usize] as libc::c_int
                 >= 4 as libc::c_int) as libc::c_int
         }
     } else {
@@ -1451,9 +1451,9 @@ unsafe extern "C" fn get_comp_dir_ctx(
             }
             return 1 as libc::c_int
                 + 2 as libc::c_int
-                    * ((((*edge).ref_0[0 as libc::c_int as usize][off as usize]
+                    * ((((*edge).r#ref[0 as libc::c_int as usize][off as usize]
                         as libc::c_int) < 4 as libc::c_int) as libc::c_int
-                        == (((*edge).ref_0[1 as libc::c_int as usize][off as usize]
+                        == (((*edge).r#ref[1 as libc::c_int as usize][off as usize]
                             as libc::c_int) < 4 as libc::c_int) as libc::c_int)
                         as libc::c_int;
         }
@@ -1461,9 +1461,9 @@ unsafe extern "C" fn get_comp_dir_ctx(
             != COMP_INTER_NONE as libc::c_int) as libc::c_int;
         let l_comp: libc::c_int = ((*l).comp_type[yb4 as usize] as libc::c_int
             != COMP_INTER_NONE as libc::c_int) as libc::c_int;
-        let a_ref0: libc::c_int = (*a).ref_0[0 as libc::c_int as usize][xb4 as usize]
+        let a_ref0: libc::c_int = (*a).r#ref[0 as libc::c_int as usize][xb4 as usize]
             as libc::c_int;
-        let l_ref0: libc::c_int = (*l).ref_0[0 as libc::c_int as usize][yb4 as usize]
+        let l_ref0: libc::c_int = (*l).r#ref[0 as libc::c_int as usize][yb4 as usize]
             as libc::c_int;
         if a_comp == 0 && l_comp == 0 {
             return 1 as libc::c_int
@@ -1473,9 +1473,9 @@ unsafe extern "C" fn get_comp_dir_ctx(
         } else if a_comp == 0 || l_comp == 0 {
             let edge_0: *const BlockContext = if a_comp != 0 { a } else { l };
             let off_0: libc::c_int = if a_comp != 0 { xb4 } else { yb4 };
-            if !((((*edge_0).ref_0[0 as libc::c_int as usize][off_0 as usize]
+            if !((((*edge_0).r#ref[0 as libc::c_int as usize][off_0 as usize]
                 as libc::c_int) < 4 as libc::c_int) as libc::c_int
-                == (((*edge_0).ref_0[1 as libc::c_int as usize][off_0 as usize]
+                == (((*edge_0).r#ref[1 as libc::c_int as usize][off_0 as usize]
                     as libc::c_int) < 4 as libc::c_int) as libc::c_int)
             {
                 return 1 as libc::c_int;
@@ -1485,14 +1485,14 @@ unsafe extern "C" fn get_comp_dir_ctx(
                     == (l_ref0 >= 4 as libc::c_int) as libc::c_int) as libc::c_int;
         } else {
             let a_uni: libc::c_int = ((((*a)
-                .ref_0[0 as libc::c_int as usize][xb4 as usize] as libc::c_int)
+                .r#ref[0 as libc::c_int as usize][xb4 as usize] as libc::c_int)
                 < 4 as libc::c_int) as libc::c_int
-                == (((*a).ref_0[1 as libc::c_int as usize][xb4 as usize] as libc::c_int)
+                == (((*a).r#ref[1 as libc::c_int as usize][xb4 as usize] as libc::c_int)
                     < 4 as libc::c_int) as libc::c_int) as libc::c_int;
             let l_uni: libc::c_int = ((((*l)
-                .ref_0[0 as libc::c_int as usize][yb4 as usize] as libc::c_int)
+                .r#ref[0 as libc::c_int as usize][yb4 as usize] as libc::c_int)
                 < 4 as libc::c_int) as libc::c_int
-                == (((*l).ref_0[1 as libc::c_int as usize][yb4 as usize] as libc::c_int)
+                == (((*l).r#ref[1 as libc::c_int as usize][yb4 as usize] as libc::c_int)
                     < 4 as libc::c_int) as libc::c_int) as libc::c_int;
             if a_uni == 0 && l_uni == 0 {
                 return 0 as libc::c_int;
@@ -1516,9 +1516,9 @@ unsafe extern "C" fn get_comp_dir_ctx(
             return 2 as libc::c_int;
         }
         return 4 as libc::c_int
-            * ((((*edge_1).ref_0[0 as libc::c_int as usize][off_1 as usize]
+            * ((((*edge_1).r#ref[0 as libc::c_int as usize][off_1 as usize]
                 as libc::c_int) < 4 as libc::c_int) as libc::c_int
-                == (((*edge_1).ref_0[1 as libc::c_int as usize][off_1 as usize]
+                == (((*edge_1).r#ref[1 as libc::c_int as usize][off_1 as usize]
                     as libc::c_int) < 4 as libc::c_int) as libc::c_int) as libc::c_int;
     } else {
         return 2 as libc::c_int
@@ -1541,11 +1541,11 @@ unsafe extern "C" fn get_jnt_comp_ctx(
     let offset: libc::c_int = (d0 == d1) as libc::c_int;
     let a_ctx: libc::c_int = ((*a).comp_type[xb4 as usize] as libc::c_int
         >= COMP_INTER_AVG as libc::c_int
-        || (*a).ref_0[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
+        || (*a).r#ref[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
             == 6 as libc::c_int) as libc::c_int;
     let l_ctx: libc::c_int = ((*l).comp_type[yb4 as usize] as libc::c_int
         >= COMP_INTER_AVG as libc::c_int
-        || (*l).ref_0[0 as libc::c_int as usize][yb4 as usize] as libc::c_int
+        || (*l).r#ref[0 as libc::c_int as usize][yb4 as usize] as libc::c_int
             == 6 as libc::c_int) as libc::c_int;
     return 3 as libc::c_int * offset + a_ctx + l_ctx;
 }
@@ -1560,7 +1560,7 @@ unsafe extern "C" fn get_mask_comp_ctx(
         >= COMP_INTER_SEG as libc::c_int
     {
         1 as libc::c_int
-    } else if (*a).ref_0[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
+    } else if (*a).r#ref[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
         == 6 as libc::c_int
     {
         3 as libc::c_int
@@ -1571,7 +1571,7 @@ unsafe extern "C" fn get_mask_comp_ctx(
         >= COMP_INTER_SEG as libc::c_int
     {
         1 as libc::c_int
-    } else if (*l).ref_0[0 as libc::c_int as usize][yb4 as usize] as libc::c_int
+    } else if (*l).r#ref[0 as libc::c_int as usize][yb4 as usize] as libc::c_int
         == 6 as libc::c_int
     {
         3 as libc::c_int
@@ -1591,18 +1591,18 @@ unsafe extern "C" fn av1_get_ref_ctx(
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 2] = [0 as libc::c_int, 0];
     if have_top != 0 && (*a).intra[xb4 as usize] == 0 {
-        cnt[((*a).ref_0[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
+        cnt[((*a).r#ref[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
             >= 4 as libc::c_int) as libc::c_int as usize] += 1;
         if (*a).comp_type[xb4 as usize] != 0 {
-            cnt[((*a).ref_0[1 as libc::c_int as usize][xb4 as usize] as libc::c_int
+            cnt[((*a).r#ref[1 as libc::c_int as usize][xb4 as usize] as libc::c_int
                 >= 4 as libc::c_int) as libc::c_int as usize] += 1;
         }
     }
     if have_left != 0 && (*l).intra[yb4 as usize] == 0 {
-        cnt[((*l).ref_0[0 as libc::c_int as usize][yb4 as usize] as libc::c_int
+        cnt[((*l).r#ref[0 as libc::c_int as usize][yb4 as usize] as libc::c_int
             >= 4 as libc::c_int) as libc::c_int as usize] += 1;
         if (*l).comp_type[yb4 as usize] != 0 {
-            cnt[((*l).ref_0[1 as libc::c_int as usize][yb4 as usize] as libc::c_int
+            cnt[((*l).r#ref[1 as libc::c_int as usize][yb4 as usize] as libc::c_int
                 >= 4 as libc::c_int) as libc::c_int as usize] += 1;
         }
     }
@@ -1625,29 +1625,29 @@ unsafe extern "C" fn av1_get_fwd_ref_ctx(
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 4] = [0 as libc::c_int, 0, 0, 0];
     if have_top != 0 && (*a).intra[xb4 as usize] == 0 {
-        if ((*a).ref_0[0 as libc::c_int as usize][xb4 as usize] as libc::c_int)
+        if ((*a).r#ref[0 as libc::c_int as usize][xb4 as usize] as libc::c_int)
             < 4 as libc::c_int
         {
-            cnt[(*a).ref_0[0 as libc::c_int as usize][xb4 as usize] as usize] += 1;
+            cnt[(*a).r#ref[0 as libc::c_int as usize][xb4 as usize] as usize] += 1;
         }
         if (*a).comp_type[xb4 as usize] as libc::c_int != 0
-            && ((*a).ref_0[1 as libc::c_int as usize][xb4 as usize] as libc::c_int)
+            && ((*a).r#ref[1 as libc::c_int as usize][xb4 as usize] as libc::c_int)
                 < 4 as libc::c_int
         {
-            cnt[(*a).ref_0[1 as libc::c_int as usize][xb4 as usize] as usize] += 1;
+            cnt[(*a).r#ref[1 as libc::c_int as usize][xb4 as usize] as usize] += 1;
         }
     }
     if have_left != 0 && (*l).intra[yb4 as usize] == 0 {
-        if ((*l).ref_0[0 as libc::c_int as usize][yb4 as usize] as libc::c_int)
+        if ((*l).r#ref[0 as libc::c_int as usize][yb4 as usize] as libc::c_int)
             < 4 as libc::c_int
         {
-            cnt[(*l).ref_0[0 as libc::c_int as usize][yb4 as usize] as usize] += 1;
+            cnt[(*l).r#ref[0 as libc::c_int as usize][yb4 as usize] as usize] += 1;
         }
         if (*l).comp_type[yb4 as usize] as libc::c_int != 0
-            && ((*l).ref_0[1 as libc::c_int as usize][yb4 as usize] as libc::c_int)
+            && ((*l).r#ref[1 as libc::c_int as usize][yb4 as usize] as libc::c_int)
                 < 4 as libc::c_int
         {
-            cnt[(*l).ref_0[1 as libc::c_int as usize][yb4 as usize] as usize] += 1;
+            cnt[(*l).r#ref[1 as libc::c_int as usize][yb4 as usize] as usize] += 1;
         }
     }
     cnt[0 as libc::c_int as usize] += cnt[1 as libc::c_int as usize];
@@ -1671,29 +1671,29 @@ unsafe extern "C" fn av1_get_fwd_ref_1_ctx(
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 2] = [0 as libc::c_int, 0];
     if have_top != 0 && (*a).intra[xb4 as usize] == 0 {
-        if ((*a).ref_0[0 as libc::c_int as usize][xb4 as usize] as libc::c_int)
+        if ((*a).r#ref[0 as libc::c_int as usize][xb4 as usize] as libc::c_int)
             < 2 as libc::c_int
         {
-            cnt[(*a).ref_0[0 as libc::c_int as usize][xb4 as usize] as usize] += 1;
+            cnt[(*a).r#ref[0 as libc::c_int as usize][xb4 as usize] as usize] += 1;
         }
         if (*a).comp_type[xb4 as usize] as libc::c_int != 0
-            && ((*a).ref_0[1 as libc::c_int as usize][xb4 as usize] as libc::c_int)
+            && ((*a).r#ref[1 as libc::c_int as usize][xb4 as usize] as libc::c_int)
                 < 2 as libc::c_int
         {
-            cnt[(*a).ref_0[1 as libc::c_int as usize][xb4 as usize] as usize] += 1;
+            cnt[(*a).r#ref[1 as libc::c_int as usize][xb4 as usize] as usize] += 1;
         }
     }
     if have_left != 0 && (*l).intra[yb4 as usize] == 0 {
-        if ((*l).ref_0[0 as libc::c_int as usize][yb4 as usize] as libc::c_int)
+        if ((*l).r#ref[0 as libc::c_int as usize][yb4 as usize] as libc::c_int)
             < 2 as libc::c_int
         {
-            cnt[(*l).ref_0[0 as libc::c_int as usize][yb4 as usize] as usize] += 1;
+            cnt[(*l).r#ref[0 as libc::c_int as usize][yb4 as usize] as usize] += 1;
         }
         if (*l).comp_type[yb4 as usize] as libc::c_int != 0
-            && ((*l).ref_0[1 as libc::c_int as usize][yb4 as usize] as libc::c_int)
+            && ((*l).r#ref[1 as libc::c_int as usize][yb4 as usize] as libc::c_int)
                 < 2 as libc::c_int
         {
-            cnt[(*l).ref_0[1 as libc::c_int as usize][yb4 as usize] as usize] += 1;
+            cnt[(*l).r#ref[1 as libc::c_int as usize][yb4 as usize] as usize] += 1;
         }
     }
     return if cnt[0 as libc::c_int as usize] == cnt[1 as libc::c_int as usize] {
@@ -1715,32 +1715,32 @@ unsafe extern "C" fn av1_get_fwd_ref_2_ctx(
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 2] = [0 as libc::c_int, 0];
     if have_top != 0 && (*a).intra[xb4 as usize] == 0 {
-        if ((*a).ref_0[0 as libc::c_int as usize][xb4 as usize] as libc::c_uint
+        if ((*a).r#ref[0 as libc::c_int as usize][xb4 as usize] as libc::c_uint
             ^ 2 as libc::c_uint) < 2 as libc::c_int as libc::c_uint
         {
-            cnt[((*a).ref_0[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
+            cnt[((*a).r#ref[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
                 - 2 as libc::c_int) as usize] += 1;
         }
         if (*a).comp_type[xb4 as usize] as libc::c_int != 0
-            && ((*a).ref_0[1 as libc::c_int as usize][xb4 as usize] as libc::c_uint
+            && ((*a).r#ref[1 as libc::c_int as usize][xb4 as usize] as libc::c_uint
                 ^ 2 as libc::c_uint) < 2 as libc::c_int as libc::c_uint
         {
-            cnt[((*a).ref_0[1 as libc::c_int as usize][xb4 as usize] as libc::c_int
+            cnt[((*a).r#ref[1 as libc::c_int as usize][xb4 as usize] as libc::c_int
                 - 2 as libc::c_int) as usize] += 1;
         }
     }
     if have_left != 0 && (*l).intra[yb4 as usize] == 0 {
-        if ((*l).ref_0[0 as libc::c_int as usize][yb4 as usize] as libc::c_uint
+        if ((*l).r#ref[0 as libc::c_int as usize][yb4 as usize] as libc::c_uint
             ^ 2 as libc::c_uint) < 2 as libc::c_int as libc::c_uint
         {
-            cnt[((*l).ref_0[0 as libc::c_int as usize][yb4 as usize] as libc::c_int
+            cnt[((*l).r#ref[0 as libc::c_int as usize][yb4 as usize] as libc::c_int
                 - 2 as libc::c_int) as usize] += 1;
         }
         if (*l).comp_type[yb4 as usize] as libc::c_int != 0
-            && ((*l).ref_0[1 as libc::c_int as usize][yb4 as usize] as libc::c_uint
+            && ((*l).r#ref[1 as libc::c_int as usize][yb4 as usize] as libc::c_uint
                 ^ 2 as libc::c_uint) < 2 as libc::c_int as libc::c_uint
         {
-            cnt[((*l).ref_0[1 as libc::c_int as usize][yb4 as usize] as libc::c_int
+            cnt[((*l).r#ref[1 as libc::c_int as usize][yb4 as usize] as libc::c_int
                 - 2 as libc::c_int) as usize] += 1;
         }
     }
@@ -1763,32 +1763,32 @@ unsafe extern "C" fn av1_get_bwd_ref_ctx(
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 3] = [0 as libc::c_int, 0, 0];
     if have_top != 0 && (*a).intra[xb4 as usize] == 0 {
-        if (*a).ref_0[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
+        if (*a).r#ref[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
             >= 4 as libc::c_int
         {
-            cnt[((*a).ref_0[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
+            cnt[((*a).r#ref[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
                 - 4 as libc::c_int) as usize] += 1;
         }
         if (*a).comp_type[xb4 as usize] as libc::c_int != 0
-            && (*a).ref_0[1 as libc::c_int as usize][xb4 as usize] as libc::c_int
+            && (*a).r#ref[1 as libc::c_int as usize][xb4 as usize] as libc::c_int
                 >= 4 as libc::c_int
         {
-            cnt[((*a).ref_0[1 as libc::c_int as usize][xb4 as usize] as libc::c_int
+            cnt[((*a).r#ref[1 as libc::c_int as usize][xb4 as usize] as libc::c_int
                 - 4 as libc::c_int) as usize] += 1;
         }
     }
     if have_left != 0 && (*l).intra[yb4 as usize] == 0 {
-        if (*l).ref_0[0 as libc::c_int as usize][yb4 as usize] as libc::c_int
+        if (*l).r#ref[0 as libc::c_int as usize][yb4 as usize] as libc::c_int
             >= 4 as libc::c_int
         {
-            cnt[((*l).ref_0[0 as libc::c_int as usize][yb4 as usize] as libc::c_int
+            cnt[((*l).r#ref[0 as libc::c_int as usize][yb4 as usize] as libc::c_int
                 - 4 as libc::c_int) as usize] += 1;
         }
         if (*l).comp_type[yb4 as usize] as libc::c_int != 0
-            && (*l).ref_0[1 as libc::c_int as usize][yb4 as usize] as libc::c_int
+            && (*l).r#ref[1 as libc::c_int as usize][yb4 as usize] as libc::c_int
                 >= 4 as libc::c_int
         {
-            cnt[((*l).ref_0[1 as libc::c_int as usize][yb4 as usize] as libc::c_int
+            cnt[((*l).r#ref[1 as libc::c_int as usize][yb4 as usize] as libc::c_int
                 - 4 as libc::c_int) as usize] += 1;
         }
     }
@@ -1812,32 +1812,32 @@ unsafe extern "C" fn av1_get_bwd_ref_1_ctx(
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 3] = [0 as libc::c_int, 0, 0];
     if have_top != 0 && (*a).intra[xb4 as usize] == 0 {
-        if (*a).ref_0[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
+        if (*a).r#ref[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
             >= 4 as libc::c_int
         {
-            cnt[((*a).ref_0[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
+            cnt[((*a).r#ref[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
                 - 4 as libc::c_int) as usize] += 1;
         }
         if (*a).comp_type[xb4 as usize] as libc::c_int != 0
-            && (*a).ref_0[1 as libc::c_int as usize][xb4 as usize] as libc::c_int
+            && (*a).r#ref[1 as libc::c_int as usize][xb4 as usize] as libc::c_int
                 >= 4 as libc::c_int
         {
-            cnt[((*a).ref_0[1 as libc::c_int as usize][xb4 as usize] as libc::c_int
+            cnt[((*a).r#ref[1 as libc::c_int as usize][xb4 as usize] as libc::c_int
                 - 4 as libc::c_int) as usize] += 1;
         }
     }
     if have_left != 0 && (*l).intra[yb4 as usize] == 0 {
-        if (*l).ref_0[0 as libc::c_int as usize][yb4 as usize] as libc::c_int
+        if (*l).r#ref[0 as libc::c_int as usize][yb4 as usize] as libc::c_int
             >= 4 as libc::c_int
         {
-            cnt[((*l).ref_0[0 as libc::c_int as usize][yb4 as usize] as libc::c_int
+            cnt[((*l).r#ref[0 as libc::c_int as usize][yb4 as usize] as libc::c_int
                 - 4 as libc::c_int) as usize] += 1;
         }
         if (*l).comp_type[yb4 as usize] as libc::c_int != 0
-            && (*l).ref_0[1 as libc::c_int as usize][yb4 as usize] as libc::c_int
+            && (*l).r#ref[1 as libc::c_int as usize][yb4 as usize] as libc::c_int
                 >= 4 as libc::c_int
         {
-            cnt[((*l).ref_0[1 as libc::c_int as usize][yb4 as usize] as libc::c_int
+            cnt[((*l).r#ref[1 as libc::c_int as usize][yb4 as usize] as libc::c_int
                 - 4 as libc::c_int) as usize] += 1;
         }
     }
@@ -1860,32 +1860,32 @@ unsafe extern "C" fn av1_get_uni_p1_ctx(
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 3] = [0 as libc::c_int, 0, 0];
     if have_top != 0 && (*a).intra[xb4 as usize] == 0 {
-        if ((*a).ref_0[0 as libc::c_int as usize][xb4 as usize] as libc::c_uint)
+        if ((*a).r#ref[0 as libc::c_int as usize][xb4 as usize] as libc::c_uint)
             .wrapping_sub(1 as libc::c_uint) < 3 as libc::c_int as libc::c_uint
         {
-            cnt[((*a).ref_0[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
+            cnt[((*a).r#ref[0 as libc::c_int as usize][xb4 as usize] as libc::c_int
                 - 1 as libc::c_int) as usize] += 1;
         }
         if (*a).comp_type[xb4 as usize] as libc::c_int != 0
-            && ((*a).ref_0[1 as libc::c_int as usize][xb4 as usize] as libc::c_uint)
+            && ((*a).r#ref[1 as libc::c_int as usize][xb4 as usize] as libc::c_uint)
                 .wrapping_sub(1 as libc::c_uint) < 3 as libc::c_int as libc::c_uint
         {
-            cnt[((*a).ref_0[1 as libc::c_int as usize][xb4 as usize] as libc::c_int
+            cnt[((*a).r#ref[1 as libc::c_int as usize][xb4 as usize] as libc::c_int
                 - 1 as libc::c_int) as usize] += 1;
         }
     }
     if have_left != 0 && (*l).intra[yb4 as usize] == 0 {
-        if ((*l).ref_0[0 as libc::c_int as usize][yb4 as usize] as libc::c_uint)
+        if ((*l).r#ref[0 as libc::c_int as usize][yb4 as usize] as libc::c_uint)
             .wrapping_sub(1 as libc::c_uint) < 3 as libc::c_int as libc::c_uint
         {
-            cnt[((*l).ref_0[0 as libc::c_int as usize][yb4 as usize] as libc::c_int
+            cnt[((*l).r#ref[0 as libc::c_int as usize][yb4 as usize] as libc::c_int
                 - 1 as libc::c_int) as usize] += 1;
         }
         if (*l).comp_type[yb4 as usize] as libc::c_int != 0
-            && ((*l).ref_0[1 as libc::c_int as usize][yb4 as usize] as libc::c_uint)
+            && ((*l).r#ref[1 as libc::c_int as usize][yb4 as usize] as libc::c_uint)
                 .wrapping_sub(1 as libc::c_uint) < 3 as libc::c_int as libc::c_uint
         {
-            cnt[((*l).ref_0[1 as libc::c_int as usize][yb4 as usize] as libc::c_int
+            cnt[((*l).r#ref[1 as libc::c_int as usize][yb4 as usize] as libc::c_int
                 - 1 as libc::c_int) as usize] += 1;
         }
     }
@@ -2382,9 +2382,9 @@ unsafe extern "C" fn find_matching_ref(
     if have_top != 0 {
         let mut r2: *const refmvs_block = &mut *(*r.offset(-(1 as libc::c_int) as isize))
             .offset((*t).bx as isize) as *mut refmvs_block;
-        if (*r2).ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
+        if (*r2).r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
             == ref_0 + 1 as libc::c_int
-            && (*r2).ref_0.r#ref[1 as libc::c_int as usize] as libc::c_int
+            && (*r2).r#ref.r#ref[1 as libc::c_int as usize] as libc::c_int
                 == -(1 as libc::c_int)
         {
             let ref mut fresh2 = *masks.offset(0 as libc::c_int as isize);
@@ -2406,9 +2406,9 @@ unsafe extern "C" fn find_matching_ref(
             let mut x: libc::c_int = aw4;
             while x < w4 {
                 r2 = r2.offset(aw4 as isize);
-                if (*r2).ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
+                if (*r2).r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
                     == ref_0 + 1 as libc::c_int
-                    && (*r2).ref_0.r#ref[1 as libc::c_int as usize] as libc::c_int
+                    && (*r2).r#ref.r#ref[1 as libc::c_int as usize] as libc::c_int
                         == -(1 as libc::c_int)
                 {
                     let ref mut fresh3 = *masks.offset(0 as libc::c_int as isize);
@@ -2429,11 +2429,11 @@ unsafe extern "C" fn find_matching_ref(
         let mut r2_0: *const *mut refmvs_block = r;
         if (*(*r2_0.offset(0 as libc::c_int as isize))
             .offset(((*t).bx - 1 as libc::c_int) as isize))
-            .ref_0
+            .r#ref
             .r#ref[0 as libc::c_int as usize] as libc::c_int == ref_0 + 1 as libc::c_int
             && (*(*r2_0.offset(0 as libc::c_int as isize))
                 .offset(((*t).bx - 1 as libc::c_int) as isize))
-                .ref_0
+                .r#ref
                 .r#ref[1 as libc::c_int as usize] as libc::c_int == -(1 as libc::c_int)
         {
             let ref mut fresh4 = *masks.offset(1 as libc::c_int as isize);
@@ -2458,12 +2458,12 @@ unsafe extern "C" fn find_matching_ref(
                 r2_0 = r2_0.offset(lh4 as isize);
                 if (*(*r2_0.offset(0 as libc::c_int as isize))
                     .offset(((*t).bx - 1 as libc::c_int) as isize))
-                    .ref_0
+                    .r#ref
                     .r#ref[0 as libc::c_int as usize] as libc::c_int
                     == ref_0 + 1 as libc::c_int
                     && (*(*r2_0.offset(0 as libc::c_int as isize))
                         .offset(((*t).bx - 1 as libc::c_int) as isize))
-                        .ref_0
+                        .r#ref
                         .r#ref[1 as libc::c_int as usize] as libc::c_int
                         == -(1 as libc::c_int)
                 {
@@ -2485,11 +2485,11 @@ unsafe extern "C" fn find_matching_ref(
     if have_topleft != 0
         && ((*(*r.offset(-(1 as libc::c_int) as isize))
             .offset(((*t).bx - 1 as libc::c_int) as isize))
-            .ref_0
+            .r#ref
             .r#ref[0 as libc::c_int as usize] as libc::c_int == ref_0 + 1 as libc::c_int
             && (*(*r.offset(-(1 as libc::c_int) as isize))
                 .offset(((*t).bx - 1 as libc::c_int) as isize))
-                .ref_0
+                .r#ref
                 .r#ref[1 as libc::c_int as usize] as libc::c_int == -(1 as libc::c_int))
     {
         let ref mut fresh6 = *masks.offset(1 as libc::c_int as isize);
@@ -2502,11 +2502,11 @@ unsafe extern "C" fn find_matching_ref(
     }
     if have_topright != 0
         && ((*(*r.offset(-(1 as libc::c_int) as isize)).offset(((*t).bx + bw4) as isize))
-            .ref_0
+            .r#ref
             .r#ref[0 as libc::c_int as usize] as libc::c_int == ref_0 + 1 as libc::c_int
             && (*(*r.offset(-(1 as libc::c_int) as isize))
                 .offset(((*t).bx + bw4) as isize))
-                .ref_0
+                .r#ref
                 .r#ref[1 as libc::c_int as usize] as libc::c_int == -(1 as libc::c_int))
     {
         let ref mut fresh7 = *masks.offset(0 as libc::c_int as isize);
@@ -3952,7 +3952,7 @@ unsafe extern "C" fn splat_oneref_mv(
                     mv::ZERO,
                 ],
             },
-            ref_0: refmvs_refpair {
+            r#ref: refmvs_refpair {
                 r#ref: [
                     ((*b)
                         .c2rust_unnamed
@@ -4011,7 +4011,7 @@ unsafe extern "C" fn splat_intrabc_mv(
                     mv::ZERO,
                 ],
             },
-            ref_0: refmvs_refpair {
+            r#ref: refmvs_refpair {
                 r#ref: [0 as libc::c_int as int8_t, -(1 as libc::c_int) as int8_t],
             },
             bs: bs as uint8_t,
@@ -4064,7 +4064,7 @@ unsafe extern "C" fn splat_tworef_mv(
                         .mv[1 as libc::c_int as usize],
                 ],
             },
-            ref_0: refmvs_refpair {
+            r#ref: refmvs_refpair {
                 r#ref: [
                     ((*b)
                         .c2rust_unnamed
@@ -4115,7 +4115,7 @@ unsafe extern "C" fn splat_intraref(
                     mv::ZERO,
                 ],
             },
-            ref_0: refmvs_refpair {
+            r#ref: refmvs_refpair {
                 r#ref: [0 as libc::c_int as int8_t, -(1 as libc::c_int) as int8_t],
             },
             bs: bs as uint8_t,
@@ -4268,7 +4268,7 @@ unsafe extern "C" fn obmc_lowest_px(
                 .offset(((*t).bx + x + 1 as libc::c_int) as isize) as *mut refmvs_block;
             let a_b_dim: *const uint8_t = (dav1d_block_dimensions[(*a_r).bs as usize])
                 .as_ptr();
-            if (*a_r).ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
+            if (*a_r).r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
                 > 0 as libc::c_int
             {
                 let oh4: libc::c_int = imin(
@@ -4278,7 +4278,7 @@ unsafe extern "C" fn obmc_lowest_px(
                 mc_lowest_px(
                     &mut *(*dst
                         .offset(
-                            (*((*a_r).ref_0.r#ref)
+                            (*((*a_r).r#ref.r#ref)
                                 .as_ptr()
                                 .offset(0 as libc::c_int as isize) as libc::c_int
                                 - 1 as libc::c_int) as isize,
@@ -4292,7 +4292,7 @@ unsafe extern "C" fn obmc_lowest_px(
                     &*(*((*f).svc)
                         .as_ptr()
                         .offset(
-                            (*((*a_r).ref_0.r#ref)
+                            (*((*a_r).r#ref.r#ref)
                                 .as_ptr()
                                 .offset(0 as libc::c_int as isize) as libc::c_int
                                 - 1 as libc::c_int) as isize,
@@ -4324,7 +4324,7 @@ unsafe extern "C" fn obmc_lowest_px(
                 .offset(((*t).bx - 1 as libc::c_int) as isize) as *mut refmvs_block;
             let l_b_dim: *const uint8_t = (dav1d_block_dimensions[(*l_r).bs as usize])
                 .as_ptr();
-            if (*l_r).ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
+            if (*l_r).r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
                 > 0 as libc::c_int
             {
                 let oh4_0: libc::c_int = iclip(
@@ -4335,7 +4335,7 @@ unsafe extern "C" fn obmc_lowest_px(
                 mc_lowest_px(
                     &mut *(*dst
                         .offset(
-                            (*((*l_r).ref_0.r#ref)
+                            (*((*l_r).r#ref.r#ref)
                                 .as_ptr()
                                 .offset(0 as libc::c_int as isize) as libc::c_int
                                 - 1 as libc::c_int) as isize,
@@ -4349,7 +4349,7 @@ unsafe extern "C" fn obmc_lowest_px(
                     &*(*((*f).svc)
                         .as_ptr()
                         .offset(
-                            (*((*l_r).ref_0.r#ref)
+                            (*((*l_r).r#ref.r#ref)
                                 .as_ptr()
                                 .offset(0 as libc::c_int as isize) as libc::c_int
                                 - 1 as libc::c_int) as isize,
@@ -4455,14 +4455,14 @@ unsafe fn decode_b(
                     .offset(t.bx as isize);
                 for x in 0..bw4 {
                     let block = &mut *r.offset(x as isize);
-                    block.ref_0.r#ref[0] = 0;
+                    block.r#ref.r#ref[0] = 0;
                     block.bs = bs as uint8_t;
                 }
 
                 let mut rr = &t.rt.r[((t.by & 31) + 5) as usize..];
                 for y in 0..bh4 - 1 {
                     let block = &mut *rr[y as usize].offset((t.bx + bw4 - 1) as isize);
-                    block.ref_0.r#ref[0] = 0;
+                    block.r#ref.r#ref[0] = 0;
                     block.bs = bs as uint8_t;
                 }
             }
@@ -4540,7 +4540,7 @@ unsafe fn decode_b(
                     .r[((t.by & 31) + 5 + bh4 - 1) as usize]
                     .offset(t.bx as isize);
                 for x in 0..bw4 as isize {
-                    (*r.offset(x)).ref_0.r#ref[0] = b.r#ref()[0] + 1;
+                    (*r.offset(x)).r#ref.r#ref[0] = b.r#ref()[0] + 1;
                     (*r.offset(x)).mv.mv[0] = b.mv()[0];
                     (*r.offset(x)).bs = bs as uint8_t;
                 }
@@ -4548,7 +4548,7 @@ unsafe fn decode_b(
                 let mut rr: &[*mut refmvs_block] = &t.rt.r[((t.by & 31) + 5) as usize..];
                 for y in 0..bh4 as usize - 1 {
                     let r = &mut *rr[y].offset((t.bx + bw4 - 1) as isize);
-                    r.ref_0.r#ref[0] = b.r#ref()[0] + 1;
+                    r.r#ref.r#ref[0] = b.r#ref()[0] + 1;
                     r.mv.mv[0] = b.mv()[0];
                     r.bs = bs as uint8_t;
                 }
@@ -4676,7 +4676,7 @@ unsafe fn decode_b(
         b.seg_id = 0 as libc::c_int as uint8_t;
     }
 
-    if seg.map(|seg| seg.globalmv == 0 && seg.ref_0 == -1 && seg.skip == 0).unwrap_or(true)
+    if seg.map(|seg| seg.globalmv == 0 && seg.r#ref == -1 && seg.skip == 0).unwrap_or(true)
         && (*f.frame_hdr).skip_mode_enabled != 0
         && imin(bw4, bh4) > 1
     {
@@ -5010,8 +5010,8 @@ unsafe fn decode_b(
     } else if (*f.frame_hdr).frame_type as libc::c_uint
         & 1 as libc::c_int as libc::c_uint != 0
     {
-        if let Some(seg) = seg && (seg.ref_0 >= 0 || seg.globalmv != 0) {
-            b.intra = (seg.ref_0 == 0) as uint8_t;
+        if let Some(seg) = seg && (seg.r#ref >= 0 || seg.globalmv != 0) {
+            b.intra = (seg.r#ref == 0) as uint8_t;
         } else {
             let ictx: libc::c_int = get_intra_ctx(
                 t.a,
@@ -5581,14 +5581,14 @@ unsafe fn decode_b(
                         as *mut uint8_t as *mut alias8))
                         .u8_0 = (0x1 as libc::c_int * COMP_INTER_NONE as libc::c_int)
                         as uint8_t;
-                    (*(&mut *(*(t.l.ref_0)
+                    (*(&mut *(*(t.l.r#ref)
                         .as_mut_ptr()
                         .offset(0 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset(by4 as isize) as *mut int8_t as *mut alias8))
                         .u8_0 = (0x1 as libc::c_int
                         * -(1 as libc::c_int) as uint8_t as libc::c_int) as uint8_t;
-                    (*(&mut *(*(t.l.ref_0)
+                    (*(&mut *(*(t.l.r#ref)
                         .as_mut_ptr()
                         .offset(1 as libc::c_int as isize))
                         .as_mut_ptr()
@@ -5667,14 +5667,14 @@ unsafe fn decode_b(
                         as *mut uint8_t as *mut alias16))
                         .u16_0 = (0x101 as libc::c_int * COMP_INTER_NONE as libc::c_int)
                         as uint16_t;
-                    (*(&mut *(*(t.l.ref_0)
+                    (*(&mut *(*(t.l.r#ref)
                         .as_mut_ptr()
                         .offset(0 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset(by4 as isize) as *mut int8_t as *mut alias16))
                         .u16_0 = (0x101 as libc::c_int
                         * -(1 as libc::c_int) as uint8_t as libc::c_int) as uint16_t;
-                    (*(&mut *(*(t.l.ref_0)
+                    (*(&mut *(*(t.l.r#ref)
                         .as_mut_ptr()
                         .offset(1 as libc::c_int as isize))
                         .as_mut_ptr()
@@ -5762,14 +5762,14 @@ unsafe fn decode_b(
                         as *mut uint8_t as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint)
                         .wrapping_mul(COMP_INTER_NONE as libc::c_int as libc::c_uint);
-                    (*(&mut *(*(t.l.ref_0)
+                    (*(&mut *(*(t.l.r#ref)
                         .as_mut_ptr()
                         .offset(0 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset(by4 as isize) as *mut int8_t as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint)
                         .wrapping_mul(-(1 as libc::c_int) as uint8_t as libc::c_uint);
-                    (*(&mut *(*(t.l.ref_0)
+                    (*(&mut *(*(t.l.r#ref)
                         .as_mut_ptr()
                         .offset(1 as libc::c_int as isize))
                         .as_mut_ptr()
@@ -5863,7 +5863,7 @@ unsafe fn decode_b(
                         .wrapping_mul(
                             COMP_INTER_NONE as libc::c_int as libc::c_ulonglong,
                         ) as uint64_t;
-                    (*(&mut *(*(t.l.ref_0)
+                    (*(&mut *(*(t.l.r#ref)
                         .as_mut_ptr()
                         .offset(0 as libc::c_int as isize))
                         .as_mut_ptr()
@@ -5872,7 +5872,7 @@ unsafe fn decode_b(
                         .wrapping_mul(
                             -(1 as libc::c_int) as uint8_t as libc::c_ulonglong,
                         ) as uint64_t;
-                    (*(&mut *(*(t.l.ref_0)
+                    (*(&mut *(*(t.l.r#ref)
                         .as_mut_ptr()
                         .offset(1 as libc::c_int as isize))
                         .as_mut_ptr()
@@ -6056,14 +6056,14 @@ unsafe fn decode_b(
                         .wrapping_mul(
                             -(1 as libc::c_int) as uint8_t as libc::c_ulonglong,
                         ) as uint64_t;
-                    (*(&mut *(*(t.l.ref_0)
+                    (*(&mut *(*(t.l.r#ref)
                         .as_mut_ptr()
                         .offset(0 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset((by4 + 0 as libc::c_int) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_37;
-                    (*(&mut *(*(t.l.ref_0)
+                    (*(&mut *(*(t.l.r#ref)
                         .as_mut_ptr()
                         .offset(0 as libc::c_int as isize))
                         .as_mut_ptr()
@@ -6074,14 +6074,14 @@ unsafe fn decode_b(
                         .wrapping_mul(
                             -(1 as libc::c_int) as uint8_t as libc::c_ulonglong,
                         ) as uint64_t;
-                    (*(&mut *(*(t.l.ref_0)
+                    (*(&mut *(*(t.l.r#ref)
                         .as_mut_ptr()
                         .offset(1 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset((by4 + 0 as libc::c_int) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_38;
-                    (*(&mut *(*(t.l.ref_0)
+                    (*(&mut *(*(t.l.r#ref)
                         .as_mut_ptr()
                         .offset(1 as libc::c_int as isize))
                         .as_mut_ptr()
@@ -6385,28 +6385,28 @@ unsafe fn decode_b(
                         .wrapping_mul(
                             -(1 as libc::c_int) as uint8_t as libc::c_ulonglong,
                         ) as uint64_t;
-                    (*(&mut *(*(t.l.ref_0)
+                    (*(&mut *(*(t.l.r#ref)
                         .as_mut_ptr()
                         .offset(0 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset((by4 + 0 as libc::c_int) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_51;
-                    (*(&mut *(*(t.l.ref_0)
+                    (*(&mut *(*(t.l.r#ref)
                         .as_mut_ptr()
                         .offset(0 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset((by4 + 8 as libc::c_int) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_51;
-                    (*(&mut *(*(t.l.ref_0)
+                    (*(&mut *(*(t.l.r#ref)
                         .as_mut_ptr()
                         .offset(0 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset((by4 + 16 as libc::c_int) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_51;
-                    (*(&mut *(*(t.l.ref_0)
+                    (*(&mut *(*(t.l.r#ref)
                         .as_mut_ptr()
                         .offset(0 as libc::c_int as isize))
                         .as_mut_ptr()
@@ -6417,28 +6417,28 @@ unsafe fn decode_b(
                         .wrapping_mul(
                             -(1 as libc::c_int) as uint8_t as libc::c_ulonglong,
                         ) as uint64_t;
-                    (*(&mut *(*(t.l.ref_0)
+                    (*(&mut *(*(t.l.r#ref)
                         .as_mut_ptr()
                         .offset(1 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset((by4 + 0 as libc::c_int) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_52;
-                    (*(&mut *(*(t.l.ref_0)
+                    (*(&mut *(*(t.l.r#ref)
                         .as_mut_ptr()
                         .offset(1 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset((by4 + 8 as libc::c_int) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_52;
-                    (*(&mut *(*(t.l.ref_0)
+                    (*(&mut *(*(t.l.r#ref)
                         .as_mut_ptr()
                         .offset(1 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset((by4 + 16 as libc::c_int) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_52;
-                    (*(&mut *(*(t.l.ref_0)
+                    (*(&mut *(*(t.l.r#ref)
                         .as_mut_ptr()
                         .offset(1 as libc::c_int as isize))
                         .as_mut_ptr()
@@ -6571,14 +6571,14 @@ unsafe fn decode_b(
                         as *mut uint8_t as *mut alias8))
                         .u8_0 = (0x1 as libc::c_int * COMP_INTER_NONE as libc::c_int)
                         as uint8_t;
-                    (*(&mut *(*((*t.a).ref_0)
+                    (*(&mut *(*((*t.a).r#ref)
                         .as_mut_ptr()
                         .offset(0 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset(bx4 as isize) as *mut int8_t as *mut alias8))
                         .u8_0 = (0x1 as libc::c_int
                         * -(1 as libc::c_int) as uint8_t as libc::c_int) as uint8_t;
-                    (*(&mut *(*((*t.a).ref_0)
+                    (*(&mut *(*((*t.a).r#ref)
                         .as_mut_ptr()
                         .offset(1 as libc::c_int as isize))
                         .as_mut_ptr()
@@ -6657,14 +6657,14 @@ unsafe fn decode_b(
                         as *mut uint8_t as *mut alias16))
                         .u16_0 = (0x101 as libc::c_int * COMP_INTER_NONE as libc::c_int)
                         as uint16_t;
-                    (*(&mut *(*((*t.a).ref_0)
+                    (*(&mut *(*((*t.a).r#ref)
                         .as_mut_ptr()
                         .offset(0 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset(bx4 as isize) as *mut int8_t as *mut alias16))
                         .u16_0 = (0x101 as libc::c_int
                         * -(1 as libc::c_int) as uint8_t as libc::c_int) as uint16_t;
-                    (*(&mut *(*((*t.a).ref_0)
+                    (*(&mut *(*((*t.a).r#ref)
                         .as_mut_ptr()
                         .offset(1 as libc::c_int as isize))
                         .as_mut_ptr()
@@ -6752,14 +6752,14 @@ unsafe fn decode_b(
                         as *mut uint8_t as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint)
                         .wrapping_mul(COMP_INTER_NONE as libc::c_int as libc::c_uint);
-                    (*(&mut *(*((*t.a).ref_0)
+                    (*(&mut *(*((*t.a).r#ref)
                         .as_mut_ptr()
                         .offset(0 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset(bx4 as isize) as *mut int8_t as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint)
                         .wrapping_mul(-(1 as libc::c_int) as uint8_t as libc::c_uint);
-                    (*(&mut *(*((*t.a).ref_0)
+                    (*(&mut *(*((*t.a).r#ref)
                         .as_mut_ptr()
                         .offset(1 as libc::c_int as isize))
                         .as_mut_ptr()
@@ -6853,7 +6853,7 @@ unsafe fn decode_b(
                         .wrapping_mul(
                             COMP_INTER_NONE as libc::c_int as libc::c_ulonglong,
                         ) as uint64_t;
-                    (*(&mut *(*((*t.a).ref_0)
+                    (*(&mut *(*((*t.a).r#ref)
                         .as_mut_ptr()
                         .offset(0 as libc::c_int as isize))
                         .as_mut_ptr()
@@ -6862,7 +6862,7 @@ unsafe fn decode_b(
                         .wrapping_mul(
                             -(1 as libc::c_int) as uint8_t as libc::c_ulonglong,
                         ) as uint64_t;
-                    (*(&mut *(*((*t.a).ref_0)
+                    (*(&mut *(*((*t.a).r#ref)
                         .as_mut_ptr()
                         .offset(1 as libc::c_int as isize))
                         .as_mut_ptr()
@@ -7046,14 +7046,14 @@ unsafe fn decode_b(
                         .wrapping_mul(
                             -(1 as libc::c_int) as uint8_t as libc::c_ulonglong,
                         ) as uint64_t;
-                    (*(&mut *(*((*t.a).ref_0)
+                    (*(&mut *(*((*t.a).r#ref)
                         .as_mut_ptr()
                         .offset(0 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset((bx4 + 0 as libc::c_int) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_65;
-                    (*(&mut *(*((*t.a).ref_0)
+                    (*(&mut *(*((*t.a).r#ref)
                         .as_mut_ptr()
                         .offset(0 as libc::c_int as isize))
                         .as_mut_ptr()
@@ -7064,14 +7064,14 @@ unsafe fn decode_b(
                         .wrapping_mul(
                             -(1 as libc::c_int) as uint8_t as libc::c_ulonglong,
                         ) as uint64_t;
-                    (*(&mut *(*((*t.a).ref_0)
+                    (*(&mut *(*((*t.a).r#ref)
                         .as_mut_ptr()
                         .offset(1 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset((bx4 + 0 as libc::c_int) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_66;
-                    (*(&mut *(*((*t.a).ref_0)
+                    (*(&mut *(*((*t.a).r#ref)
                         .as_mut_ptr()
                         .offset(1 as libc::c_int as isize))
                         .as_mut_ptr()
@@ -7375,28 +7375,28 @@ unsafe fn decode_b(
                         .wrapping_mul(
                             -(1 as libc::c_int) as uint8_t as libc::c_ulonglong,
                         ) as uint64_t;
-                    (*(&mut *(*((*t.a).ref_0)
+                    (*(&mut *(*((*t.a).r#ref)
                         .as_mut_ptr()
                         .offset(0 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset((bx4 + 0 as libc::c_int) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_79;
-                    (*(&mut *(*((*t.a).ref_0)
+                    (*(&mut *(*((*t.a).r#ref)
                         .as_mut_ptr()
                         .offset(0 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset((bx4 + 8 as libc::c_int) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_79;
-                    (*(&mut *(*((*t.a).ref_0)
+                    (*(&mut *(*((*t.a).r#ref)
                         .as_mut_ptr()
                         .offset(0 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset((bx4 + 16 as libc::c_int) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_79;
-                    (*(&mut *(*((*t.a).ref_0)
+                    (*(&mut *(*((*t.a).r#ref)
                         .as_mut_ptr()
                         .offset(0 as libc::c_int as isize))
                         .as_mut_ptr()
@@ -7407,28 +7407,28 @@ unsafe fn decode_b(
                         .wrapping_mul(
                             -(1 as libc::c_int) as uint8_t as libc::c_ulonglong,
                         ) as uint64_t;
-                    (*(&mut *(*((*t.a).ref_0)
+                    (*(&mut *(*((*t.a).r#ref)
                         .as_mut_ptr()
                         .offset(1 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset((bx4 + 0 as libc::c_int) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_80;
-                    (*(&mut *(*((*t.a).ref_0)
+                    (*(&mut *(*((*t.a).r#ref)
                         .as_mut_ptr()
                         .offset(1 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset((bx4 + 8 as libc::c_int) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_80;
-                    (*(&mut *(*((*t.a).ref_0)
+                    (*(&mut *(*((*t.a).r#ref)
                         .as_mut_ptr()
                         .offset(1 as libc::c_int as isize))
                         .as_mut_ptr()
                         .offset((bx4 + 16 as libc::c_int) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_80;
-                    (*(&mut *(*((*t.a).ref_0)
+                    (*(&mut *(*((*t.a).r#ref)
                         .as_mut_ptr()
                         .offset(1 as libc::c_int as isize))
                         .as_mut_ptr()
@@ -8968,7 +8968,7 @@ unsafe fn decode_b(
             is_comp = 1 as libc::c_int;
         } else if
             seg
-                .map(|seg| seg.ref_0 == -1 && seg.globalmv == 0 && seg.skip == 0)
+                .map(|seg| seg.r#ref == -1 && seg.globalmv == 0 && seg.skip == 0)
                 .unwrap_or(true)
             && (*f.frame_hdr).switchable_comp_refs != 0
             && imin(bw4, bh4) > 1
@@ -9802,10 +9802,10 @@ unsafe fn decode_b(
                                 as libc::c_int,
                             jnt_ctx,
                             (*t.a).comp_type[bx4 as usize] as libc::c_int,
-                            (*t.a).ref_0[0 as libc::c_int as usize][bx4 as usize]
+                            (*t.a).r#ref[0 as libc::c_int as usize][bx4 as usize]
                                 as libc::c_int,
                             t.l.comp_type[by4 as usize] as libc::c_int,
-                            t.l.ref_0[0 as libc::c_int as usize][by4 as usize]
+                            t.l.r#ref[0 as libc::c_int as usize][by4 as usize]
                                 as libc::c_int,
                             ts.msac.rng,
                         );
@@ -9887,12 +9887,12 @@ unsafe fn decode_b(
                 .c2rust_unnamed
                 .c2rust_unnamed_0
                 .comp_type = COMP_INTER_NONE as libc::c_int as uint8_t;
-            if let Some(seg) = seg && seg.ref_0 > 0 {
+            if let Some(seg) = seg && seg.r#ref > 0 {
                 b
                     .c2rust_unnamed
                     .c2rust_unnamed_0
                     .r#ref[0 as libc::c_int
-                    as usize] = seg.ref_0 as i8 - 1;
+                    as usize] = seg.r#ref as i8 - 1;
             } else if let Some(seg) = seg && (seg.globalmv != 0 || seg.skip != 0) {
                 b
                     .c2rust_unnamed
@@ -9909,7 +9909,7 @@ unsafe fn decode_b(
                 );
                 if dav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
-                    (ts.cdf.m.ref_0[0 as libc::c_int as usize][ctx1_0 as usize])
+                    (ts.cdf.m.r#ref[0 as libc::c_int as usize][ctx1_0 as usize])
                         .as_mut_ptr(),
                 ) != 0
                 {
@@ -9923,7 +9923,7 @@ unsafe fn decode_b(
                     );
                     if dav1d_msac_decode_bool_adapt(
                         &mut ts.msac,
-                        (ts.cdf.m.ref_0[1 as libc::c_int as usize][ctx2_1 as usize])
+                        (ts.cdf.m.r#ref[1 as libc::c_int as usize][ctx2_1 as usize])
                             .as_mut_ptr(),
                     ) != 0
                     {
@@ -9952,7 +9952,7 @@ unsafe fn decode_b(
                                     (ts
                                         .cdf
                                         .m
-                                        .ref_0[5 as libc::c_int as usize][ctx3_0 as usize])
+                                        .r#ref[5 as libc::c_int as usize][ctx3_0 as usize])
                                         .as_mut_ptr(),
                                 ),
                             ) as int8_t;
@@ -9968,7 +9968,7 @@ unsafe fn decode_b(
                     );
                     if dav1d_msac_decode_bool_adapt(
                         &mut ts.msac,
-                        (ts.cdf.m.ref_0[2 as libc::c_int as usize][ctx2_2 as usize])
+                        (ts.cdf.m.r#ref[2 as libc::c_int as usize][ctx2_2 as usize])
                             .as_mut_ptr(),
                     ) != 0
                     {
@@ -9991,7 +9991,7 @@ unsafe fn decode_b(
                                     (ts
                                         .cdf
                                         .m
-                                        .ref_0[4 as libc::c_int as usize][ctx3_1 as usize])
+                                        .r#ref[4 as libc::c_int as usize][ctx3_1 as usize])
                                         .as_mut_ptr(),
                                 ),
                             ) as int8_t;
@@ -10013,7 +10013,7 @@ unsafe fn decode_b(
                             (ts
                                 .cdf
                                 .m
-                                .ref_0[3 as libc::c_int as usize][ctx3_2 as usize])
+                                .r#ref[3 as libc::c_int as usize][ctx3_2 as usize])
                                 .as_mut_ptr(),
                         ) as int8_t;
                     }
@@ -10921,7 +10921,7 @@ unsafe fn decode_b(
                     .u8_0 = (0x1 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_int)
                     as uint8_t;
-                (*(&mut *(*(t.l.ref_0).as_mut_ptr().offset(0 as libc::c_int as isize))
+                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(0 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut int8_t as *mut alias8))
                     .u8_0 = (0x1 as libc::c_int
@@ -10929,7 +10929,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed
                         .c2rust_unnamed_0
                         .r#ref[0 as libc::c_int as usize] as libc::c_int) as uint8_t;
-                (*(&mut *(*(t.l.ref_0).as_mut_ptr().offset(1 as libc::c_int as isize))
+                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(1 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut int8_t as *mut alias8))
                     .u8_0 = (0x1 as libc::c_int
@@ -10994,7 +10994,7 @@ unsafe fn decode_b(
                     .u16_0 = (0x101 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_int)
                     as uint16_t;
-                (*(&mut *(*(t.l.ref_0).as_mut_ptr().offset(0 as libc::c_int as isize))
+                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(0 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut int8_t as *mut alias16))
                     .u16_0 = (0x101 as libc::c_int
@@ -11002,7 +11002,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed
                         .c2rust_unnamed_0
                         .r#ref[0 as libc::c_int as usize] as libc::c_int) as uint16_t;
-                (*(&mut *(*(t.l.ref_0).as_mut_ptr().offset(1 as libc::c_int as isize))
+                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(1 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut int8_t as *mut alias16))
                     .u16_0 = (0x101 as libc::c_int
@@ -11070,7 +11070,7 @@ unsafe fn decode_b(
                     .wrapping_mul(
                         b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_uint,
                     );
-                (*(&mut *(*(t.l.ref_0).as_mut_ptr().offset(0 as libc::c_int as isize))
+                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(0 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut int8_t as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)
@@ -11080,7 +11080,7 @@ unsafe fn decode_b(
                             .c2rust_unnamed_0
                             .r#ref[0 as libc::c_int as usize] as libc::c_uint,
                     );
-                (*(&mut *(*(t.l.ref_0).as_mut_ptr().offset(1 as libc::c_int as isize))
+                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(1 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut int8_t as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)
@@ -11155,7 +11155,7 @@ unsafe fn decode_b(
                         b.c2rust_unnamed.c2rust_unnamed_0.inter_mode
                             as libc::c_ulonglong,
                     ) as uint64_t;
-                (*(&mut *(*(t.l.ref_0).as_mut_ptr().offset(0 as libc::c_int as isize))
+                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(0 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut int8_t as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
@@ -11165,7 +11165,7 @@ unsafe fn decode_b(
                             .c2rust_unnamed_0
                             .r#ref[0 as libc::c_int as usize] as libc::c_ulonglong,
                     ) as uint64_t;
-                (*(&mut *(*(t.l.ref_0).as_mut_ptr().offset(1 as libc::c_int as isize))
+                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(1 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut int8_t as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
@@ -11339,12 +11339,12 @@ unsafe fn decode_b(
                             .c2rust_unnamed_0
                             .r#ref[0 as libc::c_int as usize] as libc::c_ulonglong,
                     ) as uint64_t;
-                (*(&mut *(*(t.l.ref_0).as_mut_ptr().offset(0 as libc::c_int as isize))
+                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(0 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset((by4 + 0 as libc::c_int) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_134;
-                (*(&mut *(*(t.l.ref_0).as_mut_ptr().offset(0 as libc::c_int as isize))
+                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(0 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset((by4 + 8 as libc::c_int) as isize) as *mut int8_t
                     as *mut alias64))
@@ -11357,12 +11357,12 @@ unsafe fn decode_b(
                             .r#ref[1 as libc::c_int as usize] as uint8_t
                             as libc::c_ulonglong,
                     ) as uint64_t;
-                (*(&mut *(*(t.l.ref_0).as_mut_ptr().offset(1 as libc::c_int as isize))
+                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(1 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset((by4 + 0 as libc::c_int) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_135;
-                (*(&mut *(*(t.l.ref_0).as_mut_ptr().offset(1 as libc::c_int as isize))
+                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(1 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset((by4 + 8 as libc::c_int) as isize) as *mut int8_t
                     as *mut alias64))
@@ -11652,22 +11652,22 @@ unsafe fn decode_b(
                             .c2rust_unnamed_0
                             .r#ref[0 as libc::c_int as usize] as libc::c_ulonglong,
                     ) as uint64_t;
-                (*(&mut *(*(t.l.ref_0).as_mut_ptr().offset(0 as libc::c_int as isize))
+                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(0 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset((by4 + 0 as libc::c_int) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_147;
-                (*(&mut *(*(t.l.ref_0).as_mut_ptr().offset(0 as libc::c_int as isize))
+                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(0 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset((by4 + 8 as libc::c_int) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_147;
-                (*(&mut *(*(t.l.ref_0).as_mut_ptr().offset(0 as libc::c_int as isize))
+                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(0 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset((by4 + 16 as libc::c_int) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_147;
-                (*(&mut *(*(t.l.ref_0).as_mut_ptr().offset(0 as libc::c_int as isize))
+                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(0 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset((by4 + 24 as libc::c_int) as isize) as *mut int8_t
                     as *mut alias64))
@@ -11680,22 +11680,22 @@ unsafe fn decode_b(
                             .r#ref[1 as libc::c_int as usize] as uint8_t
                             as libc::c_ulonglong,
                     ) as uint64_t;
-                (*(&mut *(*(t.l.ref_0).as_mut_ptr().offset(1 as libc::c_int as isize))
+                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(1 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset((by4 + 0 as libc::c_int) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_148;
-                (*(&mut *(*(t.l.ref_0).as_mut_ptr().offset(1 as libc::c_int as isize))
+                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(1 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset((by4 + 8 as libc::c_int) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_148;
-                (*(&mut *(*(t.l.ref_0).as_mut_ptr().offset(1 as libc::c_int as isize))
+                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(1 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset((by4 + 16 as libc::c_int) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_148;
-                (*(&mut *(*(t.l.ref_0).as_mut_ptr().offset(1 as libc::c_int as isize))
+                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(1 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset((by4 + 24 as libc::c_int) as isize) as *mut int8_t
                     as *mut alias64))
@@ -11758,7 +11758,7 @@ unsafe fn decode_b(
                     .u8_0 = (0x1 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_int)
                     as uint8_t;
-                (*(&mut *(*((*t.a).ref_0)
+                (*(&mut *(*((*t.a).r#ref)
                     .as_mut_ptr()
                     .offset(0 as libc::c_int as isize))
                     .as_mut_ptr()
@@ -11768,7 +11768,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed
                         .c2rust_unnamed_0
                         .r#ref[0 as libc::c_int as usize] as libc::c_int) as uint8_t;
-                (*(&mut *(*((*t.a).ref_0)
+                (*(&mut *(*((*t.a).r#ref)
                     .as_mut_ptr()
                     .offset(1 as libc::c_int as isize))
                     .as_mut_ptr()
@@ -11835,7 +11835,7 @@ unsafe fn decode_b(
                     .u16_0 = (0x101 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_int)
                     as uint16_t;
-                (*(&mut *(*((*t.a).ref_0)
+                (*(&mut *(*((*t.a).r#ref)
                     .as_mut_ptr()
                     .offset(0 as libc::c_int as isize))
                     .as_mut_ptr()
@@ -11845,7 +11845,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed
                         .c2rust_unnamed_0
                         .r#ref[0 as libc::c_int as usize] as libc::c_int) as uint16_t;
-                (*(&mut *(*((*t.a).ref_0)
+                (*(&mut *(*((*t.a).r#ref)
                     .as_mut_ptr()
                     .offset(1 as libc::c_int as isize))
                     .as_mut_ptr()
@@ -11915,7 +11915,7 @@ unsafe fn decode_b(
                     .wrapping_mul(
                         b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_uint,
                     );
-                (*(&mut *(*((*t.a).ref_0)
+                (*(&mut *(*((*t.a).r#ref)
                     .as_mut_ptr()
                     .offset(0 as libc::c_int as isize))
                     .as_mut_ptr()
@@ -11927,7 +11927,7 @@ unsafe fn decode_b(
                             .c2rust_unnamed_0
                             .r#ref[0 as libc::c_int as usize] as libc::c_uint,
                     );
-                (*(&mut *(*((*t.a).ref_0)
+                (*(&mut *(*((*t.a).r#ref)
                     .as_mut_ptr()
                     .offset(1 as libc::c_int as isize))
                     .as_mut_ptr()
@@ -12004,7 +12004,7 @@ unsafe fn decode_b(
                         b.c2rust_unnamed.c2rust_unnamed_0.inter_mode
                             as libc::c_ulonglong,
                     ) as uint64_t;
-                (*(&mut *(*((*t.a).ref_0)
+                (*(&mut *(*((*t.a).r#ref)
                     .as_mut_ptr()
                     .offset(0 as libc::c_int as isize))
                     .as_mut_ptr()
@@ -12016,7 +12016,7 @@ unsafe fn decode_b(
                             .c2rust_unnamed_0
                             .r#ref[0 as libc::c_int as usize] as libc::c_ulonglong,
                     ) as uint64_t;
-                (*(&mut *(*((*t.a).ref_0)
+                (*(&mut *(*((*t.a).r#ref)
                     .as_mut_ptr()
                     .offset(1 as libc::c_int as isize))
                     .as_mut_ptr()
@@ -12192,14 +12192,14 @@ unsafe fn decode_b(
                             .c2rust_unnamed_0
                             .r#ref[0 as libc::c_int as usize] as libc::c_ulonglong,
                     ) as uint64_t;
-                (*(&mut *(*((*t.a).ref_0)
+                (*(&mut *(*((*t.a).r#ref)
                     .as_mut_ptr()
                     .offset(0 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset((bx4 + 0 as libc::c_int) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_160;
-                (*(&mut *(*((*t.a).ref_0)
+                (*(&mut *(*((*t.a).r#ref)
                     .as_mut_ptr()
                     .offset(0 as libc::c_int as isize))
                     .as_mut_ptr()
@@ -12214,14 +12214,14 @@ unsafe fn decode_b(
                             .r#ref[1 as libc::c_int as usize] as uint8_t
                             as libc::c_ulonglong,
                     ) as uint64_t;
-                (*(&mut *(*((*t.a).ref_0)
+                (*(&mut *(*((*t.a).r#ref)
                     .as_mut_ptr()
                     .offset(1 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset((bx4 + 0 as libc::c_int) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_161;
-                (*(&mut *(*((*t.a).ref_0)
+                (*(&mut *(*((*t.a).r#ref)
                     .as_mut_ptr()
                     .offset(1 as libc::c_int as isize))
                     .as_mut_ptr()
@@ -12513,28 +12513,28 @@ unsafe fn decode_b(
                             .c2rust_unnamed_0
                             .r#ref[0 as libc::c_int as usize] as libc::c_ulonglong,
                     ) as uint64_t;
-                (*(&mut *(*((*t.a).ref_0)
+                (*(&mut *(*((*t.a).r#ref)
                     .as_mut_ptr()
                     .offset(0 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset((bx4 + 0 as libc::c_int) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_173;
-                (*(&mut *(*((*t.a).ref_0)
+                (*(&mut *(*((*t.a).r#ref)
                     .as_mut_ptr()
                     .offset(0 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset((bx4 + 8 as libc::c_int) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_173;
-                (*(&mut *(*((*t.a).ref_0)
+                (*(&mut *(*((*t.a).r#ref)
                     .as_mut_ptr()
                     .offset(0 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset((bx4 + 16 as libc::c_int) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_173;
-                (*(&mut *(*((*t.a).ref_0)
+                (*(&mut *(*((*t.a).r#ref)
                     .as_mut_ptr()
                     .offset(0 as libc::c_int as isize))
                     .as_mut_ptr()
@@ -12549,28 +12549,28 @@ unsafe fn decode_b(
                             .r#ref[1 as libc::c_int as usize] as uint8_t
                             as libc::c_ulonglong,
                     ) as uint64_t;
-                (*(&mut *(*((*t.a).ref_0)
+                (*(&mut *(*((*t.a).r#ref)
                     .as_mut_ptr()
                     .offset(1 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset((bx4 + 0 as libc::c_int) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_174;
-                (*(&mut *(*((*t.a).ref_0)
+                (*(&mut *(*((*t.a).r#ref)
                     .as_mut_ptr()
                     .offset(1 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset((bx4 + 8 as libc::c_int) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_174;
-                (*(&mut *(*((*t.a).ref_0)
+                (*(&mut *(*((*t.a).r#ref)
                     .as_mut_ptr()
                     .offset(1 as libc::c_int as isize))
                     .as_mut_ptr()
                     .offset((bx4 + 16 as libc::c_int) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_174;
-                (*(&mut *(*((*t.a).ref_0)
+                (*(&mut *(*((*t.a).r#ref)
                     .as_mut_ptr()
                     .offset(1 as libc::c_int as isize))
                     .as_mut_ptr()
@@ -12953,7 +12953,7 @@ unsafe fn decode_b(
                         is_sub8x8
                             &= ((*(*r_1.offset(0 as libc::c_int as isize))
                                 .offset((t.bx - 1 as libc::c_int) as isize))
-                                .ref_0
+                                .r#ref
                                 .r#ref[0 as libc::c_int as usize] as libc::c_int
                                 > 0 as libc::c_int) as libc::c_int;
                     }
@@ -12961,7 +12961,7 @@ unsafe fn decode_b(
                         is_sub8x8
                             &= ((*(*r_1.offset(-(1 as libc::c_int) as isize))
                                 .offset(t.bx as isize))
-                                .ref_0
+                                .r#ref
                                 .r#ref[0 as libc::c_int as usize] as libc::c_int
                                 > 0 as libc::c_int) as libc::c_int;
                     }
@@ -12969,7 +12969,7 @@ unsafe fn decode_b(
                         is_sub8x8
                             &= ((*(*r_1.offset(-(1 as libc::c_int) as isize))
                                 .offset((t.bx - 1 as libc::c_int) as isize))
-                                .ref_0
+                                .r#ref
                                 .r#ref[0 as libc::c_int as usize] as libc::c_int
                                 > 0 as libc::c_int) as libc::c_int;
                     }
@@ -12986,7 +12986,7 @@ unsafe fn decode_b(
                         mc_lowest_px(
                             &mut *(*lowest_px
                                 .offset(
-                                    (*((*rr_1).ref_0.r#ref)
+                                    (*((*rr_1).r#ref.r#ref)
                                         .as_ptr()
                                         .offset(0 as libc::c_int as isize) as libc::c_int
                                         - 1 as libc::c_int) as isize,
@@ -13001,7 +13001,7 @@ unsafe fn decode_b(
                             &*(*(f.svc)
                                 .as_ptr()
                                 .offset(
-                                    (*((*rr_1).ref_0.r#ref)
+                                    (*((*rr_1).r#ref.r#ref)
                                         .as_ptr()
                                         .offset(0 as libc::c_int as isize) as libc::c_int
                                         - 1 as libc::c_int) as isize,
@@ -13018,7 +13018,7 @@ unsafe fn decode_b(
                         mc_lowest_px(
                             &mut *(*lowest_px
                                 .offset(
-                                    (*((*rr_2).ref_0.r#ref)
+                                    (*((*rr_2).r#ref.r#ref)
                                         .as_ptr()
                                         .offset(0 as libc::c_int as isize) as libc::c_int
                                         - 1 as libc::c_int) as isize,
@@ -13033,7 +13033,7 @@ unsafe fn decode_b(
                             &*(*(f.svc)
                                 .as_ptr()
                                 .offset(
-                                    (*((*rr_2).ref_0.r#ref)
+                                    (*((*rr_2).r#ref.r#ref)
                                         .as_ptr()
                                         .offset(0 as libc::c_int as isize) as libc::c_int
                                         - 1 as libc::c_int) as isize,
@@ -13049,7 +13049,7 @@ unsafe fn decode_b(
                         mc_lowest_px(
                             &mut *(*lowest_px
                                 .offset(
-                                    (*((*rr_3).ref_0.r#ref)
+                                    (*((*rr_3).r#ref.r#ref)
                                         .as_ptr()
                                         .offset(0 as libc::c_int as isize) as libc::c_int
                                         - 1 as libc::c_int) as isize,
@@ -13064,7 +13064,7 @@ unsafe fn decode_b(
                             &*(*(f.svc)
                                 .as_ptr()
                                 .offset(
-                                    (*((*rr_3).ref_0.r#ref)
+                                    (*((*rr_3).r#ref.r#ref)
                                         .as_ptr()
                                         .offset(0 as libc::c_int as isize) as libc::c_int
                                         - 1 as libc::c_int) as isize,
@@ -14154,7 +14154,7 @@ unsafe extern "C" fn reset_context(
     );
     if keyframe == 0 {
         memset(
-            ((*ctx).ref_0).as_mut_ptr() as *mut libc::c_void,
+            ((*ctx).r#ref).as_mut_ptr() as *mut libc::c_void,
             -(1 as libc::c_int),
             ::core::mem::size_of::<[[int8_t; 32]; 2]>(),
         );

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -47,7 +47,7 @@ extern "C" {
         pool: *mut Dav1dMemPool,
         size: size_t,
     ) -> *mut Dav1dRef;
-    fn dav1d_ref_dec(ref_0: *mut *mut Dav1dRef);
+    fn dav1d_ref_dec(r#ref: *mut *mut Dav1dRef);
     fn dav1d_cdf_thread_init_static(cdf: *mut CdfThreadContext, qidx: libc::c_int);
     fn dav1d_cdf_thread_alloc(
         c: *mut Dav1dContext,
@@ -119,7 +119,7 @@ extern "C" {
         mvstack: *mut refmvs_candidate,
         cnt: *mut libc::c_int,
         ctx: *mut libc::c_int,
-        ref_0: refmvs_refpair,
+        r#ref: refmvs_refpair,
         bs: BlockSize,
         edge_flags: EdgeFlags,
         by4: libc::c_int,
@@ -207,7 +207,7 @@ extern "C" {
     );
     fn dav1d_msac_decode_subexp(
         s: *mut MsacContext,
-        ref_0: libc::c_int,
+        r#ref: libc::c_int,
         n: libc::c_int,
         k: libc::c_uint,
     ) -> libc::c_int;
@@ -1348,21 +1348,21 @@ unsafe extern "C" fn get_filter_ctx(
     l: *const BlockContext,
     comp: libc::c_int,
     dir: libc::c_int,
-    ref_0: libc::c_int,
+    r#ref: libc::c_int,
     yb4: libc::c_int,
     xb4: libc::c_int,
 ) -> libc::c_int {
     let a_filter: libc::c_int = if (*a).r#ref[0 as libc::c_int as usize][xb4 as usize]
-        as libc::c_int == ref_0
-        || (*a).r#ref[1 as libc::c_int as usize][xb4 as usize] as libc::c_int == ref_0
+        as libc::c_int == r#ref
+        || (*a).r#ref[1 as libc::c_int as usize][xb4 as usize] as libc::c_int == r#ref
     {
         (*a).filter[dir as usize][xb4 as usize] as libc::c_int
     } else {
         DAV1D_N_SWITCHABLE_FILTERS as libc::c_int
     };
     let l_filter: libc::c_int = if (*l).r#ref[0 as libc::c_int as usize][yb4 as usize]
-        as libc::c_int == ref_0
-        || (*l).r#ref[1 as libc::c_int as usize][yb4 as usize] as libc::c_int == ref_0
+        as libc::c_int == r#ref
+        || (*l).r#ref[1 as libc::c_int as usize][yb4 as usize] as libc::c_int == r#ref
     {
         (*l).filter[dir as usize][yb4 as usize] as libc::c_int
     } else {
@@ -2365,7 +2365,7 @@ unsafe extern "C" fn find_matching_ref(
     h4: libc::c_int,
     have_left: libc::c_int,
     have_top: libc::c_int,
-    ref_0: libc::c_int,
+    r#ref: libc::c_int,
     mut masks: *mut uint64_t,
 ) {
     let mut r: *const *mut refmvs_block = &*((*t).rt.r)
@@ -2383,7 +2383,7 @@ unsafe extern "C" fn find_matching_ref(
         let mut r2: *const refmvs_block = &mut *(*r.offset(-(1 as libc::c_int) as isize))
             .offset((*t).bx as isize) as *mut refmvs_block;
         if (*r2).r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
-            == ref_0 + 1 as libc::c_int
+            == r#ref + 1 as libc::c_int
             && (*r2).r#ref.r#ref[1 as libc::c_int as usize] as libc::c_int
                 == -(1 as libc::c_int)
         {
@@ -2407,7 +2407,7 @@ unsafe extern "C" fn find_matching_ref(
             while x < w4 {
                 r2 = r2.offset(aw4 as isize);
                 if (*r2).r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
-                    == ref_0 + 1 as libc::c_int
+                    == r#ref + 1 as libc::c_int
                     && (*r2).r#ref.r#ref[1 as libc::c_int as usize] as libc::c_int
                         == -(1 as libc::c_int)
                 {
@@ -2430,7 +2430,7 @@ unsafe extern "C" fn find_matching_ref(
         if (*(*r2_0.offset(0 as libc::c_int as isize))
             .offset(((*t).bx - 1 as libc::c_int) as isize))
             .r#ref
-            .r#ref[0 as libc::c_int as usize] as libc::c_int == ref_0 + 1 as libc::c_int
+            .r#ref[0 as libc::c_int as usize] as libc::c_int == r#ref + 1 as libc::c_int
             && (*(*r2_0.offset(0 as libc::c_int as isize))
                 .offset(((*t).bx - 1 as libc::c_int) as isize))
                 .r#ref
@@ -2460,7 +2460,7 @@ unsafe extern "C" fn find_matching_ref(
                     .offset(((*t).bx - 1 as libc::c_int) as isize))
                     .r#ref
                     .r#ref[0 as libc::c_int as usize] as libc::c_int
-                    == ref_0 + 1 as libc::c_int
+                    == r#ref + 1 as libc::c_int
                     && (*(*r2_0.offset(0 as libc::c_int as isize))
                         .offset(((*t).bx - 1 as libc::c_int) as isize))
                         .r#ref
@@ -2486,7 +2486,7 @@ unsafe extern "C" fn find_matching_ref(
         && ((*(*r.offset(-(1 as libc::c_int) as isize))
             .offset(((*t).bx - 1 as libc::c_int) as isize))
             .r#ref
-            .r#ref[0 as libc::c_int as usize] as libc::c_int == ref_0 + 1 as libc::c_int
+            .r#ref[0 as libc::c_int as usize] as libc::c_int == r#ref + 1 as libc::c_int
             && (*(*r.offset(-(1 as libc::c_int) as isize))
                 .offset(((*t).bx - 1 as libc::c_int) as isize))
                 .r#ref
@@ -2503,7 +2503,7 @@ unsafe extern "C" fn find_matching_ref(
     if have_topright != 0
         && ((*(*r.offset(-(1 as libc::c_int) as isize)).offset(((*t).bx + bw4) as isize))
             .r#ref
-            .r#ref[0 as libc::c_int as usize] as libc::c_int == ref_0 + 1 as libc::c_int
+            .r#ref[0 as libc::c_int as usize] as libc::c_int == r#ref + 1 as libc::c_int
             && (*(*r.offset(-(1 as libc::c_int) as isize))
                 .offset(((*t).bx + bw4) as isize))
                 .r#ref
@@ -7830,7 +7830,7 @@ unsafe fn decode_b(
                 .mv[0 as libc::c_int as usize]
                 .x = 0 as libc::c_int as int16_t;
         }
-        let ref_0: mv = b
+        let r#ref: mv = b
             .c2rust_unnamed
             .c2rust_unnamed_0
             .c2rust_unnamed
@@ -7941,8 +7941,8 @@ unsafe fn decode_b(
                     .c2rust_unnamed
                     .mv[0 as libc::c_int as usize]
                     .x as libc::c_int,
-                ref_0.y as libc::c_int,
-                ref_0.x as libc::c_int,
+                r#ref.y as libc::c_int,
+                r#ref.x as libc::c_int,
                 mvstack[0 as libc::c_int as usize]
                     .mv
                     .mv[0 as libc::c_int as usize]

--- a/src/env.rs
+++ b/src/env.rs
@@ -27,7 +27,7 @@ pub struct BlockContext {
     pub skip_mode: [uint8_t; 32],
     pub intra: [uint8_t; 32],
     pub comp_type: [uint8_t; 32],
-    pub ref_0: [[int8_t; 32]; 2],
+    pub r#ref: [[int8_t; 32]; 2],
     pub filter: [[uint8_t; 32]; 2],
     pub tx_intra: [int8_t; 32],
     pub tx: [int8_t; 32],

--- a/src/getbits.rs
+++ b/src/getbits.rs
@@ -167,7 +167,7 @@ pub unsafe extern "C" fn dav1d_get_vlc(c: *mut GetBits) -> libc::c_uint {
 }
 unsafe extern "C" fn get_bits_subexp_u(
     c: *mut GetBits,
-    ref_0: libc::c_uint,
+    r#ref: libc::c_uint,
     n: libc::c_uint,
 ) -> libc::c_uint {
     let mut v: libc::c_uint = 0 as libc::c_int as libc::c_uint;
@@ -200,21 +200,21 @@ unsafe extern "C" fn get_bits_subexp_u(
             i += 1;
         }
     }
-    return if ref_0.wrapping_mul(2 as libc::c_int as libc::c_uint) <= n {
-        inv_recenter(ref_0, v)
+    return if r#ref.wrapping_mul(2 as libc::c_int as libc::c_uint) <= n {
+        inv_recenter(r#ref, v)
     } else {
-        n.wrapping_sub(inv_recenter(n.wrapping_sub(ref_0), v))
+        n.wrapping_sub(inv_recenter(n.wrapping_sub(r#ref), v))
     };
 }
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_get_bits_subexp(
     c: *mut GetBits,
-    ref_0: libc::c_int,
+    r#ref: libc::c_int,
     n: libc::c_uint,
 ) -> libc::c_int {
     return get_bits_subexp_u(
         c,
-        (ref_0 + ((1 as libc::c_int) << n)) as libc::c_uint,
+        (r#ref + ((1 as libc::c_int) << n)) as libc::c_uint,
         ((2 as libc::c_int) << n) as libc::c_uint,
     ) as libc::c_int - ((1 as libc::c_int) << n);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1584,7 +1584,7 @@ pub unsafe extern "C" fn dav1d_parse_sequence_header(
         let mut init = Dav1dData {
             data: 0 as *const uint8_t,
             sz: 0,
-            ref_0: 0 as *mut Dav1dRef,
+            r#ref: 0 as *mut Dav1dRef,
             m: Dav1dDataProps {
                 timestamp: 0,
                 duration: 0,
@@ -1592,7 +1592,7 @@ pub unsafe extern "C" fn dav1d_parse_sequence_header(
                 size: 0,
                 user_data: Dav1dUserData {
                     data: 0 as *const uint8_t,
-                    ref_0: 0 as *mut Dav1dRef,
+                    r#ref: 0 as *mut Dav1dRef,
                 },
             },
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ extern "C" {
     fn dav1d_refmvs_clear(rf: *mut refmvs_frame);
     fn dav1d_cdf_thread_unref(cdf: *mut CdfThreadContext);
     fn dav1d_thread_picture_unref(p: *mut Dav1dThreadPicture);
-    fn dav1d_ref_dec(ref_0: *mut *mut Dav1dRef);
+    fn dav1d_ref_dec(r#ref: *mut *mut Dav1dRef);
     fn dav1d_mem_pool_end(pool: *mut Dav1dMemPool);
     fn pthread_attr_destroy(__attr: *mut pthread_attr_t) -> libc::c_int;
     fn dav1d_default_picture_alloc(

--- a/src/mc_tmpl_16.rs
+++ b/src/mc_tmpl_16.rs
@@ -5060,10 +5060,10 @@ unsafe extern "C" fn emu_edge_c(
     y: intptr_t,
     mut dst: *mut pixel,
     dst_stride: ptrdiff_t,
-    mut ref_0: *const pixel,
+    mut r#ref: *const pixel,
     ref_stride: ptrdiff_t,
 ) {
-    ref_0 = ref_0
+    r#ref = r#ref
         .offset(
             iclip(
                 y as libc::c_int,
@@ -5110,7 +5110,7 @@ unsafe extern "C" fn emu_edge_c(
     while y_0 < center_h {
         memcpy(
             blk.offset(left_ext as isize) as *mut libc::c_void,
-            ref_0 as *const libc::c_void,
+            r#ref as *const libc::c_void,
             (center_w << 1 as libc::c_int) as libc::c_ulong,
         );
         if left_ext != 0 {
@@ -5124,7 +5124,7 @@ unsafe extern "C" fn emu_edge_c(
                 right_ext,
             );
         }
-        ref_0 = ref_0.offset(PXSTRIDE(ref_stride) as isize);
+        r#ref = r#ref.offset(PXSTRIDE(ref_stride) as isize);
         blk = blk.offset(PXSTRIDE(dst_stride) as isize);
         y_0 += 1;
     }

--- a/src/mc_tmpl_8.rs
+++ b/src/mc_tmpl_8.rs
@@ -4850,10 +4850,10 @@ unsafe extern "C" fn emu_edge_c(
     y: intptr_t,
     mut dst: *mut pixel,
     dst_stride: ptrdiff_t,
-    mut ref_0: *const pixel,
+    mut r#ref: *const pixel,
     ref_stride: ptrdiff_t,
 ) {
-    ref_0 = ref_0
+    r#ref = r#ref
         .offset(
             (iclip(
                 y as libc::c_int,
@@ -4902,7 +4902,7 @@ unsafe extern "C" fn emu_edge_c(
     while y_0 < center_h {
         memcpy(
             blk.offset(left_ext as isize) as *mut libc::c_void,
-            ref_0 as *const libc::c_void,
+            r#ref as *const libc::c_void,
             center_w as libc::c_ulong,
         );
         if left_ext != 0 {
@@ -4921,7 +4921,7 @@ unsafe extern "C" fn emu_edge_c(
                 right_ext as libc::c_ulong,
             );
         }
-        ref_0 = ref_0.offset(ref_stride as isize);
+        r#ref = r#ref.offset(ref_stride as isize);
         blk = blk.offset(dst_stride as isize);
         y_0 += 1;
     }

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -230,7 +230,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool_c(
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_subexp(
     s: *mut MsacContext,
-    ref_0: libc::c_int,
+    r#ref: libc::c_int,
     n: libc::c_int,
     mut k: libc::c_uint,
 ) -> libc::c_int {
@@ -249,12 +249,12 @@ pub unsafe extern "C" fn dav1d_msac_decode_subexp(
         a = ((1 as libc::c_int) << k) as libc::c_uint;
     }
     let v: libc::c_uint = (dav1d_msac_decode_bools(s, k)).wrapping_add(a);
-    let ret = (if ref_0 * 2 as libc::c_int <= n {
-        inv_recenter(ref_0 as libc::c_uint, v)
+    let ret = (if r#ref * 2 as libc::c_int <= n {
+        inv_recenter(r#ref as libc::c_uint, v)
     } else {
         ((n - 1 as libc::c_int) as libc::c_uint)
             .wrapping_sub(
-                inv_recenter((n - 1 as libc::c_int - ref_0) as libc::c_uint, v),
+                inv_recenter((n - 1 as libc::c_int - r#ref) as libc::c_uint, v),
             )
     }) as libc::c_int;
     return ret;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2110,12 +2110,12 @@ unsafe extern "C" fn parse_frame_hdr(
                                     }
                                     if dav1d_get_bit(gb) != 0 {
                                         (*seg)
-                                            .ref_0 = dav1d_get_bits(gb, 3 as libc::c_int)
+                                            .r#ref = dav1d_get_bits(gb, 3 as libc::c_int)
                                             as libc::c_int;
                                         (*hdr).segmentation.seg_data.last_active_segid = i_10;
                                         (*hdr).segmentation.seg_data.preskip = 1 as libc::c_int;
                                     } else {
-                                        (*seg).ref_0 = -(1 as libc::c_int);
+                                        (*seg).r#ref = -(1 as libc::c_int);
                                     }
                                     (*seg).skip = dav1d_get_bit(gb) as libc::c_int;
                                     if (*seg).skip != 0 {
@@ -2160,7 +2160,7 @@ unsafe extern "C" fn parse_frame_hdr(
                                     .segmentation
                                     .seg_data
                                     .d[i_11 as usize]
-                                    .ref_0 = -(1 as libc::c_int);
+                                    .r#ref = -(1 as libc::c_int);
                                 i_11 += 1;
                             }
                             current_block = 8075351136037156718;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -27,7 +27,7 @@ extern "C" {
         pool: *mut Dav1dMemPool,
         size: size_t,
     ) -> *mut Dav1dRef;
-    fn dav1d_ref_dec(ref_0: *mut *mut Dav1dRef);
+    fn dav1d_ref_dec(r#ref: *mut *mut Dav1dRef);
     fn dav1d_cdf_thread_ref(dst: *mut CdfThreadContext, src: *mut CdfThreadContext);
     fn dav1d_cdf_thread_unref(cdf: *mut CdfThreadContext);
     fn dav1d_data_ref(dst: *mut Dav1dData, src: *const Dav1dData);
@@ -49,7 +49,7 @@ extern "C" {
     fn dav1d_get_vlc(c: *mut GetBits) -> libc::c_uint;
     fn dav1d_get_bits_subexp(
         c: *mut GetBits,
-        ref_0: libc::c_int,
+        r#ref: libc::c_int,
         n: libc::c_uint,
     ) -> libc::c_int;
     fn dav1d_bytealign_get_bits(c: *mut GetBits);
@@ -1242,22 +1242,22 @@ unsafe extern "C" fn read_frame_size(
         let mut i: libc::c_int = 0 as libc::c_int;
         while i < 7 as libc::c_int {
             if dav1d_get_bit(gb) != 0 {
-                let ref_0: *const Dav1dThreadPicture = &mut (*((*c).refs)
+                let r#ref: *const Dav1dThreadPicture = &mut (*((*c).refs)
                     .as_mut_ptr()
                     .offset(
                         *((*(*c).frame_hdr).refidx).as_mut_ptr().offset(i as isize)
                             as isize,
                     ))
                     .p;
-                if ((*ref_0).p.frame_hdr).is_null() {
+                if ((*r#ref).p.frame_hdr).is_null() {
                     return -(1 as libc::c_int);
                 }
                 (*hdr)
                     .width[1 as libc::c_int
-                    as usize] = (*(*ref_0).p.frame_hdr).width[1 as libc::c_int as usize];
-                (*hdr).height = (*(*ref_0).p.frame_hdr).height;
-                (*hdr).render_width = (*(*ref_0).p.frame_hdr).render_width;
-                (*hdr).render_height = (*(*ref_0).p.frame_hdr).render_height;
+                    as usize] = (*(*r#ref).p.frame_hdr).width[1 as libc::c_int as usize];
+                (*hdr).height = (*(*r#ref).p.frame_hdr).height;
+                (*hdr).render_width = (*(*r#ref).p.frame_hdr).render_width;
+                (*hdr).render_height = (*(*r#ref).p.frame_hdr).render_height;
                 (*hdr)
                     .super_res
                     .enabled = ((*seqhdr).super_res != 0 && dav1d_get_bit(gb) != 0)
@@ -1714,12 +1714,12 @@ unsafe extern "C" fn parse_frame_hdr(
                             i_6 += 1;
                         }
                         earliest_frame_offset = 2147483647 as libc::c_int;
-                        let mut ref_0: libc::c_int = -(1 as libc::c_int);
+                        let mut r#ref: libc::c_int = -(1 as libc::c_int);
                         let mut i_7: libc::c_int = 0 as libc::c_int;
                         while i_7 < 8 as libc::c_int {
                             let hint_3: libc::c_int = shifted_frame_offset[i_7 as usize];
                             if hint_3 < earliest_frame_offset {
-                                ref_0 = i_7;
+                                r#ref = i_7;
                                 earliest_frame_offset = hint_3;
                             }
                             i_7 += 1;
@@ -1727,7 +1727,7 @@ unsafe extern "C" fn parse_frame_hdr(
                         let mut i_8: libc::c_int = 0 as libc::c_int;
                         while i_8 < 7 as libc::c_int {
                             if (*hdr).refidx[i_8 as usize] < 0 as libc::c_int {
-                                (*hdr).refidx[i_8 as usize] = ref_0;
+                                (*hdr).refidx[i_8 as usize] = r#ref;
                             }
                             i_8 += 1;
                         }
@@ -3180,21 +3180,21 @@ pub unsafe extern "C" fn dav1d_parse_obus(
             }
             match type_0 as libc::c_uint {
                 1 => {
-                    let mut ref_0: *mut Dav1dRef = dav1d_ref_create_using_pool(
+                    let mut r#ref: *mut Dav1dRef = dav1d_ref_create_using_pool(
                         (*c).seq_hdr_pool,
                         ::core::mem::size_of::<Dav1dSequenceHeader>(),
                     );
-                    if ref_0.is_null() {
+                    if r#ref.is_null() {
                         return -(12 as libc::c_int);
                     }
-                    let mut seq_hdr: *mut Dav1dSequenceHeader = (*ref_0).data
+                    let mut seq_hdr: *mut Dav1dSequenceHeader = (*r#ref).data
                         as *mut Dav1dSequenceHeader;
                     res = parse_seq_hdr(c, &mut gb, seq_hdr);
                     if res < 0 as libc::c_int {
-                        dav1d_ref_dec(&mut ref_0);
+                        dav1d_ref_dec(&mut r#ref);
                         current_block = 2084488458830559219;
                     } else if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
-                        dav1d_ref_dec(&mut ref_0);
+                        dav1d_ref_dec(&mut r#ref);
                         current_block = 2084488458830559219;
                     } else {
                         if ((*c).seq_hdr).is_null() {
@@ -3265,7 +3265,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                             );
                         }
                         dav1d_ref_dec(&mut (*c).seq_hdr_ref);
-                        (*c).seq_hdr_ref = ref_0;
+                        (*c).seq_hdr_ref = r#ref;
                         (*c).seq_hdr = seq_hdr;
                         current_block = 2704538829018177290;
                     }

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -900,14 +900,14 @@ unsafe extern "C" fn picture_alloc_with_edges(
     (*pic_ctx).allocator = *p_allocator;
     (*pic_ctx).pic = *p;
     (*p)
-        .ref_0 = dav1d_ref_wrap(
+        .r#ref = dav1d_ref_wrap(
         (*p).data[0 as libc::c_int as usize] as *const uint8_t,
         Some(
             free_buffer as unsafe extern "C" fn(*const uint8_t, *mut libc::c_void) -> (),
         ),
         pic_ctx as *mut libc::c_void,
     );
-    if ((*p).ref_0).is_null() {
+    if ((*p).r#ref).is_null() {
         ((*p_allocator).release_picture_callback)
             .expect("non-null function pointer")(p, (*p_allocator).cookie);
         free(pic_ctx as *mut libc::c_void);
@@ -1016,7 +1016,7 @@ pub unsafe extern "C" fn dav1d_picture_alloc_copy(
     w: libc::c_int,
     src: *const Dav1dPicture,
 ) -> libc::c_int {
-    let pic_ctx: *mut pic_ctx_context = (*(*src).ref_0).user_data
+    let pic_ctx: *mut pic_ctx_context = (*(*src).r#ref).user_data
         as *mut pic_ctx_context;
     let res: libc::c_int = picture_alloc_with_edges(
         c,
@@ -1088,7 +1088,7 @@ pub unsafe extern "C" fn dav1d_picture_ref(
         );
         return;
     }
-    if !((*src).ref_0).is_null() {
+    if !((*src).r#ref).is_null() {
         if ((*src).data[0 as libc::c_int as usize]).is_null() {
             fprintf(
                 stderr,
@@ -1103,7 +1103,7 @@ pub unsafe extern "C" fn dav1d_picture_ref(
             );
             return;
         }
-        dav1d_ref_inc((*src).ref_0);
+        dav1d_ref_inc((*src).r#ref);
     }
     if !((*src).frame_hdr_ref).is_null() {
         dav1d_ref_inc((*src).frame_hdr_ref);
@@ -1111,8 +1111,8 @@ pub unsafe extern "C" fn dav1d_picture_ref(
     if !((*src).seq_hdr_ref).is_null() {
         dav1d_ref_inc((*src).seq_hdr_ref);
     }
-    if !((*src).m.user_data.ref_0).is_null() {
-        dav1d_ref_inc((*src).m.user_data.ref_0);
+    if !((*src).m.user_data.r#ref).is_null() {
+        dav1d_ref_inc((*src).m.user_data.r#ref);
     }
     if !((*src).content_light_ref).is_null() {
         dav1d_ref_inc((*src).content_light_ref);
@@ -1172,7 +1172,7 @@ pub unsafe extern "C" fn dav1d_picture_move_ref(
         );
         return;
     }
-    if !((*src).ref_0).is_null() {
+    if !((*src).r#ref).is_null() {
         if ((*src).data[0 as libc::c_int as usize]).is_null() {
             fprintf(
                 stderr,
@@ -1238,7 +1238,7 @@ pub unsafe extern "C" fn dav1d_picture_unref_internal(p: *mut Dav1dPicture) {
         );
         return;
     }
-    if !((*p).ref_0).is_null() {
+    if !((*p).r#ref).is_null() {
         if ((*p).data[0 as libc::c_int as usize]).is_null() {
             fprintf(
                 stderr,
@@ -1253,11 +1253,11 @@ pub unsafe extern "C" fn dav1d_picture_unref_internal(p: *mut Dav1dPicture) {
             );
             return;
         }
-        dav1d_ref_dec(&mut (*p).ref_0);
+        dav1d_ref_dec(&mut (*p).r#ref);
     }
     dav1d_ref_dec(&mut (*p).seq_hdr_ref);
     dav1d_ref_dec(&mut (*p).frame_hdr_ref);
-    dav1d_ref_dec(&mut (*p).m.user_data.ref_0);
+    dav1d_ref_dec(&mut (*p).m.user_data.r#ref);
     dav1d_ref_dec(&mut (*p).content_light_ref);
     dav1d_ref_dec(&mut (*p).mastering_display_ref);
     dav1d_ref_dec(&mut (*p).itut_t35_ref);

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -26,7 +26,7 @@ extern "C" {
         >,
         user_data: *mut libc::c_void,
     ) -> *mut Dav1dRef;
-    fn dav1d_ref_dec(ref_0: *mut *mut Dav1dRef);
+    fn dav1d_ref_dec(r#ref: *mut *mut Dav1dRef);
     fn dav1d_data_props_copy(dst: *mut Dav1dDataProps, src: *const Dav1dDataProps);
     fn dav1d_data_props_set_defaults(props: *mut Dav1dDataProps);
     fn dav1d_log(c: *mut Dav1dContext, format: *const libc::c_char, _: ...);

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -4456,7 +4456,7 @@ unsafe extern "C" fn obmc(
                 2 as libc::c_int,
                 16 as libc::c_int,
             );
-            if (*a_r).ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
+            if (*a_r).r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
                 > 0 as libc::c_int
             {
                 let ow4: libc::c_int = imin(
@@ -4483,12 +4483,12 @@ unsafe extern "C" fn obmc(
                     &*((*f).refp)
                         .as_ptr()
                         .offset(
-                            (*((*a_r).ref_0.r#ref)
+                            (*((*a_r).r#ref.r#ref)
                                 .as_ptr()
                                 .offset(0 as libc::c_int as isize) as libc::c_int
                                 - 1 as libc::c_int) as isize,
                         ),
-                    (*a_r).ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
+                    (*a_r).r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
                         - 1 as libc::c_int,
                     dav1d_filter_2d[(*(*t).a)
                         .filter[1 as libc::c_int
@@ -4536,7 +4536,7 @@ unsafe extern "C" fn obmc(
                 2 as libc::c_int,
                 16 as libc::c_int,
             );
-            if (*l_r).ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
+            if (*l_r).r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
                 > 0 as libc::c_int
             {
                 let ow4_0: libc::c_int = imin(
@@ -4563,12 +4563,12 @@ unsafe extern "C" fn obmc(
                     &*((*f).refp)
                         .as_ptr()
                         .offset(
-                            (*((*l_r).ref_0.r#ref)
+                            (*((*l_r).r#ref.r#ref)
                                 .as_ptr()
                                 .offset(0 as libc::c_int as isize) as libc::c_int
                                 - 1 as libc::c_int) as isize,
                         ),
-                    (*l_r).ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
+                    (*l_r).r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
                         - 1 as libc::c_int,
                     dav1d_filter_2d[(*t)
                         .l
@@ -6495,7 +6495,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                     is_sub8x8
                         &= ((*(*r.offset(0 as libc::c_int as isize))
                             .offset(((*t).bx - 1 as libc::c_int) as isize))
-                            .ref_0
+                            .r#ref
                             .r#ref[0 as libc::c_int as usize] as libc::c_int
                             > 0 as libc::c_int) as libc::c_int;
                 }
@@ -6503,7 +6503,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                     is_sub8x8
                         &= ((*(*r.offset(-(1 as libc::c_int) as isize))
                             .offset((*t).bx as isize))
-                            .ref_0
+                            .r#ref
                             .r#ref[0 as libc::c_int as usize] as libc::c_int
                             > 0 as libc::c_int) as libc::c_int;
                 }
@@ -6511,7 +6511,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                     is_sub8x8
                         &= ((*(*r.offset(-(1 as libc::c_int) as isize))
                             .offset(((*t).bx - 1 as libc::c_int) as isize))
-                            .ref_0
+                            .r#ref
                             .r#ref[0 as libc::c_int as usize] as libc::c_int
                             > 0 as libc::c_int) as libc::c_int;
                 }
@@ -6546,7 +6546,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                 .offset(
                                     (*((*(*r.offset(-(1 as libc::c_int) as isize))
                                         .offset(((*t).bx - 1 as libc::c_int) as isize))
-                                        .ref_0
+                                        .r#ref
                                         .r#ref)
                                         .as_mut_ptr()
                                         .offset(0 as libc::c_int as isize) as libc::c_int
@@ -6554,7 +6554,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                 ),
                             (*(*r.offset(-(1 as libc::c_int) as isize))
                                 .offset(((*t).bx - 1 as libc::c_int) as isize))
-                                .ref_0
+                                .r#ref
                                 .r#ref[0 as libc::c_int as usize] as libc::c_int
                                 - 1 as libc::c_int,
                             (if (*t).frame_thread.pass != 2 as libc::c_int {
@@ -6609,7 +6609,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                 .offset(
                                     (*((*(*r.offset(0 as libc::c_int as isize))
                                         .offset(((*t).bx - 1 as libc::c_int) as isize))
-                                        .ref_0
+                                        .r#ref
                                         .r#ref)
                                         .as_mut_ptr()
                                         .offset(0 as libc::c_int as isize) as libc::c_int
@@ -6617,7 +6617,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                 ),
                             (*(*r.offset(0 as libc::c_int as isize))
                                 .offset(((*t).bx - 1 as libc::c_int) as isize))
-                                .ref_0
+                                .r#ref
                                 .r#ref[0 as libc::c_int as usize] as libc::c_int
                                 - 1 as libc::c_int,
                             (if (*t).frame_thread.pass != 2 as libc::c_int {
@@ -6671,7 +6671,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                 .offset(
                                     (*((*(*r.offset(-(1 as libc::c_int) as isize))
                                         .offset((*t).bx as isize))
-                                        .ref_0
+                                        .r#ref
                                         .r#ref)
                                         .as_mut_ptr()
                                         .offset(0 as libc::c_int as isize) as libc::c_int
@@ -6679,7 +6679,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                 ),
                             (*(*r.offset(-(1 as libc::c_int) as isize))
                                 .offset((*t).bx as isize))
-                                .ref_0
+                                .r#ref
                                 .r#ref[0 as libc::c_int as usize] as libc::c_int
                                 - 1 as libc::c_int,
                             (if (*t).frame_thread.pass != 2 as libc::c_int {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -4175,7 +4175,7 @@ unsafe extern "C" fn mc(
     let mx: libc::c_int = mvx & 15 as libc::c_int >> (ss_hor == 0) as libc::c_int;
     let my: libc::c_int = mvy & 15 as libc::c_int >> (ss_ver == 0) as libc::c_int;
     let mut ref_stride: ptrdiff_t = (*refp).p.stride[(pl != 0) as libc::c_int as usize];
-    let mut ref_0: *const pixel = 0 as *const pixel;
+    let mut r#ref: *const pixel = 0 as *const pixel;
     if (*refp).p.p.w == (*f).cur.p.w && (*refp).p.p.h == (*f).cur.p.h {
         let dx: libc::c_int = bx * h_mul + (mvx >> 3 as libc::c_int + ss_hor);
         let dy: libc::c_int = by * v_mul + (mvy >> 3 as libc::c_int + ss_ver);
@@ -4218,7 +4218,7 @@ unsafe extern "C" fn mc(
                 (*refp).p.data[pl as usize] as *const pixel,
                 ref_stride,
             );
-            ref_0 = &mut *emu_edge_buf
+            r#ref = &mut *emu_edge_buf
                 .offset(
                     (192 as libc::c_int * (my != 0) as libc::c_int * 3 as libc::c_int
                         + (mx != 0) as libc::c_int * 3 as libc::c_int) as isize,
@@ -4227,7 +4227,7 @@ unsafe extern "C" fn mc(
                 .wrapping_mul(::core::mem::size_of::<pixel>() as libc::c_ulong)
                 as ptrdiff_t;
         } else {
-            ref_0 = ((*refp).p.data[pl as usize] as *mut pixel)
+            r#ref = ((*refp).p.data[pl as usize] as *mut pixel)
                 .offset(PXSTRIDE(ref_stride) * dy as isize)
                 .offset(dx as isize);
         }
@@ -4238,7 +4238,7 @@ unsafe extern "C" fn mc(
                 )(
                 dst8,
                 dst_stride,
-                ref_0,
+                r#ref,
                 ref_stride,
                 bw4 * h_mul,
                 bh4 * v_mul,
@@ -4252,7 +4252,7 @@ unsafe extern "C" fn mc(
                     "non-null function pointer",
                 )(
                 dst16,
-                ref_0,
+                r#ref,
                 ref_stride,
                 bw4 * h_mul,
                 bh4 * v_mul,
@@ -4345,7 +4345,7 @@ unsafe extern "C" fn mc(
                 (*refp).p.data[pl as usize] as *const pixel,
                 ref_stride,
             );
-            ref_0 = &mut *emu_edge_buf_0
+            r#ref = &mut *emu_edge_buf_0
                 .offset(
                     (320 as libc::c_int * 3 as libc::c_int + 3 as libc::c_int) as isize,
                 ) as *mut pixel;
@@ -4360,7 +4360,7 @@ unsafe extern "C" fn mc(
                 printf(b"Emu\n\0" as *const u8 as *const libc::c_char);
             }
         } else {
-            ref_0 = ((*refp).p.data[pl as usize] as *mut pixel)
+            r#ref = ((*refp).p.data[pl as usize] as *mut pixel)
                 .offset(PXSTRIDE(ref_stride) * top as isize)
                 .offset(left as isize);
         }
@@ -4371,7 +4371,7 @@ unsafe extern "C" fn mc(
                 )(
                 dst8,
                 dst_stride,
-                ref_0,
+                r#ref,
                 ref_stride,
                 bw4 * h_mul,
                 bh4 * v_mul,
@@ -4387,7 +4387,7 @@ unsafe extern "C" fn mc(
                     "non-null function pointer",
                 )(
                 dst16,
-                ref_0,
+                r#ref,
                 ref_stride,
                 bw4 * h_mul,
                 bh4 * v_mul,

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -4448,7 +4448,7 @@ unsafe extern "C" fn mc(
     let mx: libc::c_int = mvx & 15 as libc::c_int >> (ss_hor == 0) as libc::c_int;
     let my: libc::c_int = mvy & 15 as libc::c_int >> (ss_ver == 0) as libc::c_int;
     let mut ref_stride: ptrdiff_t = (*refp).p.stride[(pl != 0) as libc::c_int as usize];
-    let mut ref_0: *const pixel = 0 as *const pixel;
+    let mut r#ref: *const pixel = 0 as *const pixel;
     if (*refp).p.p.w == (*f).cur.p.w && (*refp).p.p.h == (*f).cur.p.h {
         let dx: libc::c_int = bx * h_mul + (mvx >> 3 as libc::c_int + ss_hor);
         let dy: libc::c_int = by * v_mul + (mvy >> 3 as libc::c_int + ss_ver);
@@ -4491,7 +4491,7 @@ unsafe extern "C" fn mc(
                 (*refp).p.data[pl as usize] as *const pixel,
                 ref_stride,
             );
-            ref_0 = &mut *emu_edge_buf
+            r#ref = &mut *emu_edge_buf
                 .offset(
                     (192 as libc::c_int * (my != 0) as libc::c_int * 3 as libc::c_int
                         + (mx != 0) as libc::c_int * 3 as libc::c_int) as isize,
@@ -4500,7 +4500,7 @@ unsafe extern "C" fn mc(
                 .wrapping_mul(::core::mem::size_of::<pixel>() as libc::c_ulong)
                 as ptrdiff_t;
         } else {
-            ref_0 = ((*refp).p.data[pl as usize] as *mut pixel)
+            r#ref = ((*refp).p.data[pl as usize] as *mut pixel)
                 .offset((ref_stride * dy as isize) as isize)
                 .offset(dx as isize);
         }
@@ -4511,7 +4511,7 @@ unsafe extern "C" fn mc(
                 )(
                 dst8,
                 dst_stride,
-                ref_0,
+                r#ref,
                 ref_stride,
                 bw4 * h_mul,
                 bh4 * v_mul,
@@ -4524,7 +4524,7 @@ unsafe extern "C" fn mc(
                     "non-null function pointer",
                 )(
                 dst16,
-                ref_0,
+                r#ref,
                 ref_stride,
                 bw4 * h_mul,
                 bh4 * v_mul,
@@ -4616,7 +4616,7 @@ unsafe extern "C" fn mc(
                 (*refp).p.data[pl as usize] as *const pixel,
                 ref_stride,
             );
-            ref_0 = &mut *emu_edge_buf_0
+            r#ref = &mut *emu_edge_buf_0
                 .offset(
                     (320 as libc::c_int * 3 as libc::c_int + 3 as libc::c_int) as isize,
                 ) as *mut pixel;
@@ -4631,7 +4631,7 @@ unsafe extern "C" fn mc(
                 printf(b"Emu\n\0" as *const u8 as *const libc::c_char);
             }
         } else {
-            ref_0 = ((*refp).p.data[pl as usize] as *mut pixel)
+            r#ref = ((*refp).p.data[pl as usize] as *mut pixel)
                 .offset((ref_stride * top as isize) as isize)
                 .offset(left as isize);
         }
@@ -4642,7 +4642,7 @@ unsafe extern "C" fn mc(
                 )(
                 dst8,
                 dst_stride,
-                ref_0,
+                r#ref,
                 ref_stride,
                 bw4 * h_mul,
                 bh4 * v_mul,
@@ -4657,7 +4657,7 @@ unsafe extern "C" fn mc(
                     "non-null function pointer",
                 )(
                 dst16,
-                ref_0,
+                r#ref,
                 ref_stride,
                 bw4 * h_mul,
                 bh4 * v_mul,

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -4725,7 +4725,7 @@ unsafe extern "C" fn obmc(
                 2 as libc::c_int,
                 16 as libc::c_int,
             );
-            if (*a_r).ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
+            if (*a_r).r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
                 > 0 as libc::c_int
             {
                 let ow4: libc::c_int = imin(
@@ -4752,12 +4752,12 @@ unsafe extern "C" fn obmc(
                     &*((*f).refp)
                         .as_ptr()
                         .offset(
-                            (*((*a_r).ref_0.r#ref)
+                            (*((*a_r).r#ref.r#ref)
                                 .as_ptr()
                                 .offset(0 as libc::c_int as isize) as libc::c_int
                                 - 1 as libc::c_int) as isize,
                         ),
-                    (*a_r).ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
+                    (*a_r).r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
                         - 1 as libc::c_int,
                     dav1d_filter_2d[(*(*t).a)
                         .filter[1 as libc::c_int
@@ -4805,7 +4805,7 @@ unsafe extern "C" fn obmc(
                 2 as libc::c_int,
                 16 as libc::c_int,
             );
-            if (*l_r).ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
+            if (*l_r).r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
                 > 0 as libc::c_int
             {
                 let ow4_0: libc::c_int = imin(
@@ -4832,12 +4832,12 @@ unsafe extern "C" fn obmc(
                     &*((*f).refp)
                         .as_ptr()
                         .offset(
-                            (*((*l_r).ref_0.r#ref)
+                            (*((*l_r).r#ref.r#ref)
                                 .as_ptr()
                                 .offset(0 as libc::c_int as isize) as libc::c_int
                                 - 1 as libc::c_int) as isize,
                         ),
-                    (*l_r).ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
+                    (*l_r).r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
                         - 1 as libc::c_int,
                     dav1d_filter_2d[(*t)
                         .l
@@ -6747,7 +6747,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                     is_sub8x8
                         &= ((*(*r.offset(0 as libc::c_int as isize))
                             .offset(((*t).bx - 1 as libc::c_int) as isize))
-                            .ref_0
+                            .r#ref
                             .r#ref[0 as libc::c_int as usize] as libc::c_int
                             > 0 as libc::c_int) as libc::c_int;
                 }
@@ -6755,7 +6755,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                     is_sub8x8
                         &= ((*(*r.offset(-(1 as libc::c_int) as isize))
                             .offset((*t).bx as isize))
-                            .ref_0
+                            .r#ref
                             .r#ref[0 as libc::c_int as usize] as libc::c_int
                             > 0 as libc::c_int) as libc::c_int;
                 }
@@ -6763,7 +6763,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                     is_sub8x8
                         &= ((*(*r.offset(-(1 as libc::c_int) as isize))
                             .offset(((*t).bx - 1 as libc::c_int) as isize))
-                            .ref_0
+                            .r#ref
                             .r#ref[0 as libc::c_int as usize] as libc::c_int
                             > 0 as libc::c_int) as libc::c_int;
                 }
@@ -6798,7 +6798,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                 .offset(
                                     (*((*(*r.offset(-(1 as libc::c_int) as isize))
                                         .offset(((*t).bx - 1 as libc::c_int) as isize))
-                                        .ref_0
+                                        .r#ref
                                         .r#ref)
                                         .as_mut_ptr()
                                         .offset(0 as libc::c_int as isize) as libc::c_int
@@ -6806,7 +6806,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                 ),
                             (*(*r.offset(-(1 as libc::c_int) as isize))
                                 .offset(((*t).bx - 1 as libc::c_int) as isize))
-                                .ref_0
+                                .r#ref
                                 .r#ref[0 as libc::c_int as usize] as libc::c_int
                                 - 1 as libc::c_int,
                             (if (*t).frame_thread.pass != 2 as libc::c_int {
@@ -6860,7 +6860,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                 .offset(
                                     (*((*(*r.offset(0 as libc::c_int as isize))
                                         .offset(((*t).bx - 1 as libc::c_int) as isize))
-                                        .ref_0
+                                        .r#ref
                                         .r#ref)
                                         .as_mut_ptr()
                                         .offset(0 as libc::c_int as isize) as libc::c_int
@@ -6868,7 +6868,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                 ),
                             (*(*r.offset(0 as libc::c_int as isize))
                                 .offset(((*t).bx - 1 as libc::c_int) as isize))
-                                .ref_0
+                                .r#ref
                                 .r#ref[0 as libc::c_int as usize] as libc::c_int
                                 - 1 as libc::c_int,
                             (if (*t).frame_thread.pass != 2 as libc::c_int {
@@ -6921,7 +6921,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                 .offset(
                                     (*((*(*r.offset(-(1 as libc::c_int) as isize))
                                         .offset((*t).bx as isize))
-                                        .ref_0
+                                        .r#ref
                                         .r#ref)
                                         .as_mut_ptr()
                                         .offset(0 as libc::c_int as isize) as libc::c_int
@@ -6929,7 +6929,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                 ),
                             (*(*r.offset(-(1 as libc::c_int) as isize))
                                 .offset((*t).bx as isize))
-                                .ref_0
+                                .r#ref
                                 .r#ref[0 as libc::c_int as usize] as libc::c_int
                                 - 1 as libc::c_int,
                             (if (*t).frame_thread.pass != 2 as libc::c_int {

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -35,8 +35,8 @@ use crate::src::mem::dav1d_alloc_aligned;
 use crate::src::mem::dav1d_free_aligned;
 
 #[inline]
-pub unsafe extern "C" fn dav1d_ref_inc(ref_0: *mut Dav1dRef) {
-    ::core::intrinsics::atomic_xadd_relaxed(&mut (*ref_0).ref_cnt, 1 as libc::c_int);
+pub unsafe extern "C" fn dav1d_ref_inc(r#ref: *mut Dav1dRef) {
+    ::core::intrinsics::atomic_xadd_relaxed(&mut (*r#ref).ref_cnt, 1 as libc::c_int);
 }
 
 unsafe extern "C" fn default_free_callback(
@@ -139,29 +139,29 @@ pub unsafe extern "C" fn dav1d_ref_dec(pref: *mut *mut Dav1dRef) {
     if pref.is_null() {
         unreachable!();
     }
-    let ref_0: *mut Dav1dRef = *pref;
-    if ref_0.is_null() {
+    let r#ref: *mut Dav1dRef = *pref;
+    if r#ref.is_null() {
         return;
     }
     *pref = 0 as *mut Dav1dRef;
     if ::core::intrinsics::atomic_xsub_seqcst(
-        &mut (*ref_0).ref_cnt as *mut atomic_int,
+        &mut (*r#ref).ref_cnt as *mut atomic_int,
         1 as libc::c_int,
     ) == 1 as libc::c_int
     {
-        let free_ref: libc::c_int = (*ref_0).free_ref;
-        ((*ref_0).free_callback)
+        let free_ref: libc::c_int = (*r#ref).free_ref;
+        ((*r#ref).free_callback)
             .expect(
                 "non-null function pointer",
-            )((*ref_0).const_data as *const uint8_t, (*ref_0).user_data);
+            )((*r#ref).const_data as *const uint8_t, (*r#ref).user_data);
         if free_ref != 0 {
-            free(ref_0 as *mut libc::c_void);
+            free(r#ref as *mut libc::c_void);
         }
     }
 }
 #[no_mangle]
-pub unsafe extern "C" fn dav1d_ref_is_writable(ref_0: *mut Dav1dRef) -> libc::c_int {
+pub unsafe extern "C" fn dav1d_ref_is_writable(r#ref: *mut Dav1dRef) -> libc::c_int {
     return (::core::intrinsics::atomic_load_seqcst(
-        &mut (*ref_0).ref_cnt as *mut atomic_int,
-    ) == 1 as libc::c_int && !((*ref_0).data).is_null()) as libc::c_int;
+        &mut (*r#ref).ref_cnt as *mut atomic_int,
+    ) == 1 as libc::c_int && !((*r#ref).data).is_null()) as libc::c_int;
 }

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -177,7 +177,7 @@ unsafe extern "C" fn add_spatial_candidate(
     cnt: *mut libc::c_int,
     weight: libc::c_int,
     b: *const refmvs_block,
-    ref_0: refmvs_refpair,
+    r#ref: refmvs_refpair,
     mut gmv: *const mv,
     have_newmv_match: *mut libc::c_int,
     have_refmv_match: *mut libc::c_int,
@@ -185,11 +185,11 @@ unsafe extern "C" fn add_spatial_candidate(
     if (*b).mv.mv[0].is_invalid() {
         return;
     }
-    if ref_0.r#ref[1 as libc::c_int as usize] as libc::c_int == -(1 as libc::c_int) {
+    if r#ref.r#ref[1 as libc::c_int as usize] as libc::c_int == -(1 as libc::c_int) {
         let mut n: libc::c_int = 0 as libc::c_int;
         while n < 2 as libc::c_int {
             if (*b).r#ref.r#ref[n as usize] as libc::c_int
-                == ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
+                == r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
             {
                 let cand_mv: mv = if (*b).mf as libc::c_int & 1 as libc::c_int != 0
                     && (*gmv.offset(0)) != mv::INVALID {
@@ -219,7 +219,7 @@ unsafe extern "C" fn add_spatial_candidate(
             }
             n += 1;
         }
-    } else if (*b).r#ref == ref_0 {
+    } else if (*b).r#ref == r#ref {
         let cand_mv_0: refmvs_mvpair = refmvs_mvpair {
             mv: [
                 if (*b).mf as libc::c_int & 1 as libc::c_int != 0
@@ -257,7 +257,7 @@ unsafe extern "C" fn add_spatial_candidate(
 unsafe extern "C" fn scan_row(
     mvstack: *mut refmvs_candidate,
     cnt: *mut libc::c_int,
-    ref_0: refmvs_refpair,
+    r#ref: refmvs_refpair,
     mut gmv: *const mv,
     mut b: *const refmvs_block,
     bw4: libc::c_int,
@@ -292,7 +292,7 @@ unsafe extern "C" fn scan_row(
             cnt,
             len * weight,
             cand_b,
-            ref_0,
+            r#ref,
             gmv,
             have_newmv_match,
             have_refmv_match,
@@ -306,7 +306,7 @@ unsafe extern "C" fn scan_row(
             cnt,
             len * 2 as libc::c_int,
             cand_b,
-            ref_0,
+            r#ref,
             gmv,
             have_newmv_match,
             have_refmv_match,
@@ -327,7 +327,7 @@ unsafe extern "C" fn scan_row(
 unsafe extern "C" fn scan_col(
     mvstack: *mut refmvs_candidate,
     cnt: *mut libc::c_int,
-    ref_0: refmvs_refpair,
+    r#ref: refmvs_refpair,
     mut gmv: *const mv,
     mut b: *const *mut refmvs_block,
     bh4: libc::c_int,
@@ -364,7 +364,7 @@ unsafe extern "C" fn scan_col(
             cnt,
             len * weight,
             cand_b,
-            ref_0,
+            r#ref,
             gmv,
             have_newmv_match,
             have_refmv_match,
@@ -378,7 +378,7 @@ unsafe extern "C" fn scan_col(
             cnt,
             len * 2 as libc::c_int,
             cand_b,
-            ref_0,
+            r#ref,
             gmv,
             have_newmv_match,
             have_refmv_match,
@@ -451,7 +451,7 @@ unsafe extern "C" fn add_temporal_candidate(
     mvstack: *mut refmvs_candidate,
     cnt: *mut libc::c_int,
     rb: *const refmvs_temporal_block,
-    ref_0: refmvs_refpair,
+    r#ref: refmvs_refpair,
     globalmv_ctx: *mut libc::c_int,
     mut gmv: *const mv,
 ) {
@@ -461,13 +461,13 @@ unsafe extern "C" fn add_temporal_candidate(
     let mut mv: mv = mv_projection(
         (*rb).mv,
         (*rf)
-            .pocdiff[(ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
+            .pocdiff[(r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
             - 1 as libc::c_int) as usize] as libc::c_int,
         (*rb).r#ref as libc::c_int,
     );
     fix_mv_precision((*rf).frm_hdr, &mut mv);
     let last: libc::c_int = *cnt;
-    if ref_0.r#ref[1 as libc::c_int as usize] as libc::c_int == -(1 as libc::c_int) {
+    if r#ref.r#ref[1 as libc::c_int as usize] as libc::c_int == -(1 as libc::c_int) {
         if !globalmv_ctx.is_null() {
             *globalmv_ctx = ((mv.x as libc::c_int - (*gmv.offset(0)).x as libc::c_int).abs()
                 | (mv.y as libc::c_int - (*gmv.offset(0)).y as libc::c_int).abs() >= 16 as libc::c_int) as libc::c_int;
@@ -492,7 +492,7 @@ unsafe extern "C" fn add_temporal_candidate(
                 mv_projection(
                     (*rb).mv,
                     (*rf)
-                        .pocdiff[(ref_0.r#ref[1 as libc::c_int as usize] as libc::c_int
+                        .pocdiff[(r#ref.r#ref[1 as libc::c_int as usize] as libc::c_int
                         - 1 as libc::c_int) as usize] as libc::c_int,
                     (*rb).r#ref as libc::c_int,
                 ),
@@ -523,7 +523,7 @@ unsafe extern "C" fn add_compound_extended_candidate(
     cand_b: *const refmvs_block,
     sign0: libc::c_int,
     sign1: libc::c_int,
-    ref_0: refmvs_refpair,
+    r#ref: refmvs_refpair,
     sign_bias: *const uint8_t,
 ) {
     let diff: *mut refmvs_candidate = &mut *same.offset(2 as libc::c_int as isize)
@@ -537,7 +537,7 @@ unsafe extern "C" fn add_compound_extended_candidate(
             break;
         }
         let mut cand_mv: mv = (*cand_b).mv.mv[n as usize];
-        if cand_ref == ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int {
+        if cand_ref == r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int {
             if *same_count.offset(0 as libc::c_int as isize) < 2 as libc::c_int {
                 let ref mut fresh0 = *same_count.offset(0 as libc::c_int as isize);
                 let fresh1 = *fresh0;
@@ -563,7 +563,7 @@ unsafe extern "C" fn add_compound_extended_candidate(
                     .mv
                     .mv[1 as libc::c_int as usize] = cand_mv;
             }
-        } else if cand_ref == ref_0.r#ref[1 as libc::c_int as usize] as libc::c_int {
+        } else if cand_ref == r#ref.r#ref[1 as libc::c_int as usize] as libc::c_int {
             if *same_count.offset(1 as libc::c_int as isize) < 2 as libc::c_int {
                 let ref mut fresh4 = *same_count.offset(1 as libc::c_int as isize);
                 let fresh5 = *fresh4;
@@ -674,7 +674,7 @@ pub unsafe extern "C" fn dav1d_refmvs_find(
     mut mvstack: *mut refmvs_candidate,
     cnt: *mut libc::c_int,
     ctx: *mut libc::c_int,
-    ref_0: refmvs_refpair,
+    r#ref: refmvs_refpair,
     bs: BlockSize,
     edge_flags: EdgeFlags,
     by4: libc::c_int,
@@ -689,20 +689,20 @@ pub unsafe extern "C" fn dav1d_refmvs_find(
     let mut gmv: [mv; 2] = [mv::ZERO; 2];
     let mut tgmv: [mv; 2] = [mv::ZERO; 2];
     *cnt = 0 as libc::c_int;
-    if !(ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int >= 0 as libc::c_int
-        && ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int <= 8 as libc::c_int
-        && ref_0.r#ref[1 as libc::c_int as usize] as libc::c_int >= -(1 as libc::c_int)
-        && ref_0.r#ref[1 as libc::c_int as usize] as libc::c_int <= 8 as libc::c_int)
+    if !(r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int >= 0 as libc::c_int
+        && r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int <= 8 as libc::c_int
+        && r#ref.r#ref[1 as libc::c_int as usize] as libc::c_int >= -(1 as libc::c_int)
+        && r#ref.r#ref[1 as libc::c_int as usize] as libc::c_int <= 8 as libc::c_int)
     {
         unreachable!();
     }
-    if ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int > 0 as libc::c_int {
+    if r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int > 0 as libc::c_int {
         tgmv[0 as libc::c_int
             as usize] = get_gmv_2d(
             &*((*(*rf).frm_hdr).gmv)
                 .as_ptr()
                 .offset(
-                    (*(ref_0.r#ref).as_ptr().offset(0 as libc::c_int as isize)
+                    (*(r#ref.r#ref).as_ptr().offset(0 as libc::c_int as isize)
                         as libc::c_int - 1 as libc::c_int) as isize,
                 ),
             bx4,
@@ -713,7 +713,7 @@ pub unsafe extern "C" fn dav1d_refmvs_find(
         );
         gmv[0 as libc::c_int
             as usize] = if (*(*rf).frm_hdr)
-            .gmv[(ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
+            .gmv[(r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
                 - 1 as libc::c_int) as usize]
             .type_0 as libc::c_uint
             > DAV1D_WM_TYPE_TRANSLATION as libc::c_int as libc::c_uint
@@ -726,13 +726,13 @@ pub unsafe extern "C" fn dav1d_refmvs_find(
         tgmv[0] = mv::ZERO;
         gmv[0] = mv::INVALID;
     }
-    if ref_0.r#ref[1 as libc::c_int as usize] as libc::c_int > 0 as libc::c_int {
+    if r#ref.r#ref[1 as libc::c_int as usize] as libc::c_int > 0 as libc::c_int {
         tgmv[1 as libc::c_int
             as usize] = get_gmv_2d(
             &*((*(*rf).frm_hdr).gmv)
                 .as_ptr()
                 .offset(
-                    (*(ref_0.r#ref).as_ptr().offset(1 as libc::c_int as isize)
+                    (*(r#ref.r#ref).as_ptr().offset(1 as libc::c_int as isize)
                         as libc::c_int - 1 as libc::c_int) as isize,
                 ),
             bx4,
@@ -743,7 +743,7 @@ pub unsafe extern "C" fn dav1d_refmvs_find(
         );
         gmv[1 as libc::c_int
             as usize] = if (*(*rf).frm_hdr)
-            .gmv[(ref_0.r#ref[1 as libc::c_int as usize] as libc::c_int
+            .gmv[(r#ref.r#ref[1 as libc::c_int as usize] as libc::c_int
                 - 1 as libc::c_int) as usize]
             .type_0 as libc::c_uint
             > DAV1D_WM_TYPE_TRANSLATION as libc::c_int as libc::c_uint
@@ -774,7 +774,7 @@ pub unsafe extern "C" fn dav1d_refmvs_find(
         n_rows = scan_row(
             mvstack,
             cnt,
-            ref_0,
+            r#ref,
             gmv.as_mut_ptr() as *const mv,
             b_top,
             bw4,
@@ -800,7 +800,7 @@ pub unsafe extern "C" fn dav1d_refmvs_find(
         n_cols = scan_col(
             mvstack,
             cnt,
-            ref_0,
+            r#ref,
             gmv.as_mut_ptr() as *const mv,
             b_left,
             bh4,
@@ -822,7 +822,7 @@ pub unsafe extern "C" fn dav1d_refmvs_find(
             cnt,
             4 as libc::c_int,
             &*b_top.offset(bw4 as isize),
-            ref_0,
+            r#ref,
             gmv.as_mut_ptr() as *const mv,
             &mut have_newmv,
             &mut have_row_mvs,
@@ -871,7 +871,7 @@ pub unsafe extern "C" fn dav1d_refmvs_find(
                     mvstack,
                     cnt,
                     &*rb.offset(x as isize),
-                    ref_0,
+                    r#ref,
                     if x | y == 0 { &mut globalmv_ctx } else { 0 as *mut libc::c_int },
                     tgmv.as_mut_ptr() as *const mv,
                 );
@@ -902,7 +902,7 @@ pub unsafe extern "C" fn dav1d_refmvs_find(
                     mvstack,
                     cnt,
                     &*rb.offset(-(1 as libc::c_int) as isize),
-                    ref_0,
+                    r#ref,
                     0 as *mut libc::c_int,
                     0 as *const mv,
                 );
@@ -919,7 +919,7 @@ pub unsafe extern "C" fn dav1d_refmvs_find(
                         mvstack,
                         cnt,
                         &*rb.offset(bw8 as isize),
-                        ref_0,
+                        r#ref,
                         0 as *mut libc::c_int,
                         0 as *const mv,
                     );
@@ -935,7 +935,7 @@ pub unsafe extern "C" fn dav1d_refmvs_find(
                         mvstack,
                         cnt,
                         &*rb.offset(bw8 as isize - stride),
-                        ref_0,
+                        r#ref,
                         0 as *mut libc::c_int,
                         0 as *const mv,
                     );
@@ -953,7 +953,7 @@ pub unsafe extern "C" fn dav1d_refmvs_find(
             cnt,
             4 as libc::c_int,
             &*b_top.offset(-(1 as libc::c_int) as isize),
-            ref_0,
+            r#ref,
             gmv.as_mut_ptr() as *const mv,
             &mut have_dummy_newmv_match,
             &mut have_row_mvs,
@@ -967,7 +967,7 @@ pub unsafe extern "C" fn dav1d_refmvs_find(
                     scan_row(
                         mvstack,
                         cnt,
-                        ref_0,
+                        r#ref,
                         gmv.as_mut_ptr() as *const mv,
                         &mut *(*((*rt).r)
                             .as_ptr()
@@ -998,7 +998,7 @@ pub unsafe extern "C" fn dav1d_refmvs_find(
                     scan_col(
                         mvstack,
                         cnt,
-                        ref_0,
+                        r#ref,
                         gmv.as_mut_ptr() as *const mv,
                         &*((*rt).r)
                             .as_ptr()
@@ -1088,13 +1088,13 @@ pub unsafe extern "C" fn dav1d_refmvs_find(
         }
         len = last_0;
     }
-    if ref_0.r#ref[1 as libc::c_int as usize] as libc::c_int > 0 as libc::c_int {
+    if r#ref.r#ref[1 as libc::c_int as usize] as libc::c_int > 0 as libc::c_int {
         if *cnt < 2 as libc::c_int {
             let sign0: libc::c_int = (*rf)
-                .sign_bias[(ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
+                .sign_bias[(r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
                 - 1 as libc::c_int) as usize] as libc::c_int;
             let sign1: libc::c_int = (*rf)
-                .sign_bias[(ref_0.r#ref[1 as libc::c_int as usize] as libc::c_int
+                .sign_bias[(r#ref.r#ref[1 as libc::c_int as usize] as libc::c_int
                 - 1 as libc::c_int) as usize] as libc::c_int;
             let sz4: libc::c_int = imin(w4, h4);
             let same: *mut refmvs_candidate = &mut *mvstack.offset(*cnt as isize)
@@ -1111,7 +1111,7 @@ pub unsafe extern "C" fn dav1d_refmvs_find(
                         cand_b,
                         sign0,
                         sign1,
-                        ref_0,
+                        r#ref,
                         ((*rf).sign_bias).as_ptr(),
                     );
                     x_0
@@ -1131,7 +1131,7 @@ pub unsafe extern "C" fn dav1d_refmvs_find(
                         cand_b_0,
                         sign0,
                         sign1,
-                        ref_0,
+                        r#ref,
                         ((*rf).sign_bias).as_ptr(),
                     );
                     y_0
@@ -1283,10 +1283,10 @@ pub unsafe extern "C" fn dav1d_refmvs_find(
         return;
     } else {
         if *cnt < 2 as libc::c_int
-            && ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int > 0 as libc::c_int
+            && r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int > 0 as libc::c_int
         {
             let sign: libc::c_int = (*rf)
-                .sign_bias[(ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
+                .sign_bias[(r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
                 - 1 as libc::c_int) as usize] as libc::c_int;
             let sz4_0: libc::c_int = imin(w4, h4);
             if n_rows != !(0 as libc::c_uint) {
@@ -1492,10 +1492,10 @@ pub unsafe extern "C" fn dav1d_refmvs_load_tmvs(
     while n < (*rf).n_mfmvs {
         let ref2cur: libc::c_int = (*rf).mfmv_ref2cur[n as usize];
         if !(ref2cur == -(2147483647 as libc::c_int) - 1 as libc::c_int) {
-            let ref_0: libc::c_int = (*rf).mfmv_ref[n as usize] as libc::c_int;
-            let ref_sign: libc::c_int = ref_0 - 4 as libc::c_int;
+            let r#ref: libc::c_int = (*rf).mfmv_ref[n as usize] as libc::c_int;
+            let ref_sign: libc::c_int = r#ref - 4 as libc::c_int;
             let mut r: *const refmvs_temporal_block = &mut *(*((*rf).rp_ref)
-                .offset(ref_0 as isize))
+                .offset(r#ref as isize))
                 .offset(row_start8 as isize * stride)
                 as *mut refmvs_temporal_block;
             let mut y_0: libc::c_int = row_start8;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -69,11 +69,12 @@ use crate::src::levels::mv;
 use crate::src::intra_edge::EdgeFlags;
 
 use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct refmvs_temporal_block {
     pub mv: mv,
-    pub ref_0: int8_t,
+    pub r#ref: int8_t,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -92,10 +93,11 @@ pub struct refmvs_mvpair {
 #[repr(C, packed)]
 pub struct refmvs_block {
     pub mv: refmvs_mvpair,
-    pub ref_0: refmvs_refpair,
+    pub r#ref: refmvs_refpair,
     pub bs: uint8_t,
     pub mf: uint8_t,
 }
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct refmvs_frame {
@@ -186,7 +188,7 @@ unsafe extern "C" fn add_spatial_candidate(
     if ref_0.r#ref[1 as libc::c_int as usize] as libc::c_int == -(1 as libc::c_int) {
         let mut n: libc::c_int = 0 as libc::c_int;
         while n < 2 as libc::c_int {
-            if (*b).ref_0.r#ref[n as usize] as libc::c_int
+            if (*b).r#ref.r#ref[n as usize] as libc::c_int
                 == ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
             {
                 let cand_mv: mv = if (*b).mf as libc::c_int & 1 as libc::c_int != 0
@@ -217,7 +219,7 @@ unsafe extern "C" fn add_spatial_candidate(
             }
             n += 1;
         }
-    } else if (*b).ref_0 == ref_0 {
+    } else if (*b).r#ref == ref_0 {
         let cand_mv_0: refmvs_mvpair = refmvs_mvpair {
             mv: [
                 if (*b).mf as libc::c_int & 1 as libc::c_int != 0
@@ -461,7 +463,7 @@ unsafe extern "C" fn add_temporal_candidate(
         (*rf)
             .pocdiff[(ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
             - 1 as libc::c_int) as usize] as libc::c_int,
-        (*rb).ref_0 as libc::c_int,
+        (*rb).r#ref as libc::c_int,
     );
     fix_mv_precision((*rf).frm_hdr, &mut mv);
     let last: libc::c_int = *cnt;
@@ -492,7 +494,7 @@ unsafe extern "C" fn add_temporal_candidate(
                     (*rf)
                         .pocdiff[(ref_0.r#ref[1 as libc::c_int as usize] as libc::c_int
                         - 1 as libc::c_int) as usize] as libc::c_int,
-                    (*rb).ref_0 as libc::c_int,
+                    (*rb).r#ref as libc::c_int,
                 ),
             ],
         };
@@ -530,7 +532,7 @@ unsafe extern "C" fn add_compound_extended_candidate(
         as *mut libc::c_int;
     let mut n: libc::c_int = 0 as libc::c_int;
     while n < 2 as libc::c_int {
-        let cand_ref: libc::c_int = (*cand_b).ref_0.r#ref[n as usize] as libc::c_int;
+        let cand_ref: libc::c_int = (*cand_b).r#ref.r#ref[n as usize] as libc::c_int;
         if cand_ref <= 0 as libc::c_int {
             break;
         }
@@ -635,7 +637,7 @@ unsafe extern "C" fn add_single_extended_candidate(
 ) {
     let mut n: libc::c_int = 0 as libc::c_int;
     while n < 2 as libc::c_int {
-        let cand_ref: libc::c_int = (*cand_b).ref_0.r#ref[n as usize] as libc::c_int;
+        let cand_ref: libc::c_int = (*cand_b).r#ref.r#ref[n as usize] as libc::c_int;
         if cand_ref <= 0 as libc::c_int {
             break;
         }
@@ -1508,7 +1510,7 @@ pub unsafe extern "C" fn dav1d_refmvs_load_tmvs(
                 while x_0 < col_end8i {
                     let mut rb: *const refmvs_temporal_block = &*r.offset(x_0 as isize)
                         as *const refmvs_temporal_block;
-                    let b_ref: libc::c_int = (*rb).ref_0 as libc::c_int;
+                    let b_ref: libc::c_int = (*rb).r#ref as libc::c_int;
                     if !(b_ref == 0) {
                         let ref2ref: libc::c_int = (*rf)
                             .mfmv_ref2ref[n
@@ -1538,14 +1540,14 @@ pub unsafe extern "C" fn dav1d_refmvs_load_tmvs(
                                         (*rp_proj.offset(pos + pos_x as isize))
                                             .mv = (*rb).mv;
                                         (*rp_proj.offset(pos + pos_x as isize))
-                                            .ref_0 = ref2ref as int8_t;
+                                            .r#ref = ref2ref as int8_t;
                                     }
                                     x_0 += 1;
                                     if x_0 >= col_end8i {
                                         break;
                                     }
                                     rb = rb.offset(1);
-                                    if (*rb).ref_0 as libc::c_int != b_ref || (*rb).mv != b_mv {
+                                    if (*rb).r#ref as libc::c_int != b_ref || (*rb).mv != b_mv {
                                         break;
                                     }
                                     pos_x += 1;
@@ -1557,7 +1559,7 @@ pub unsafe extern "C" fn dav1d_refmvs_load_tmvs(
                                         break;
                                     }
                                     rb = rb.offset(1);
-                                    if (*rb).ref_0 as libc::c_int != b_ref || (*rb).mv != b_mv {
+                                    if (*rb).r#ref as libc::c_int != b_ref || (*rb).mv != b_mv {
                                         break;
                                     }
                                 }
@@ -1608,11 +1610,11 @@ pub unsafe extern "C" fn dav1d_refmvs_save_tmvs(
             let bw8: libc::c_int = dav1d_block_dimensions[(*cand_b).bs
                 as usize][0 as libc::c_int as usize] as libc::c_int + 1 as libc::c_int
                 >> 1 as libc::c_int;
-            if (*cand_b).ref_0.r#ref[1 as libc::c_int as usize] as libc::c_int
+            if (*cand_b).r#ref.r#ref[1 as libc::c_int as usize] as libc::c_int
                 > 0 as libc::c_int
                 && *ref_sign
                     .offset(
-                        ((*cand_b).ref_0.r#ref[1 as libc::c_int as usize] as libc::c_int
+                        ((*cand_b).r#ref.r#ref[1 as libc::c_int as usize] as libc::c_int
                             - 1 as libc::c_int) as isize,
                     ) as libc::c_int != 0
                 && (*cand_b).mv.mv[1].y.abs() | (*cand_b).mv.mv[1].x.abs() < 4096 {
@@ -1624,18 +1626,18 @@ pub unsafe extern "C" fn dav1d_refmvs_save_tmvs(
                         ) = {
                         let mut init = refmvs_temporal_block {
                             mv: (*cand_b).mv.mv[1 as libc::c_int as usize],
-                            ref_0: (*cand_b).ref_0.r#ref[1 as libc::c_int as usize],
+                            r#ref: (*cand_b).r#ref.r#ref[1 as libc::c_int as usize],
                         };
                         init
                     };
                     n += 1;
                     x += 1;
                 }
-            } else if (*cand_b).ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
+            } else if (*cand_b).r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
                 > 0 as libc::c_int
                 && *ref_sign
                     .offset(
-                        ((*cand_b).ref_0.r#ref[0 as libc::c_int as usize] as libc::c_int
+                        ((*cand_b).r#ref.r#ref[0 as libc::c_int as usize] as libc::c_int
                             - 1 as libc::c_int) as isize,
                     ) as libc::c_int != 0
                 && (*cand_b).mv.mv[0].y.abs() | (*cand_b).mv.mv[0].x.abs() < 4096 {
@@ -1647,7 +1649,7 @@ pub unsafe extern "C" fn dav1d_refmvs_save_tmvs(
                         ) = {
                         let mut init = refmvs_temporal_block {
                             mv: (*cand_b).mv.mv[0 as libc::c_int as usize],
-                            ref_0: (*cand_b).ref_0.r#ref[0 as libc::c_int as usize],
+                            r#ref: (*cand_b).r#ref.r#ref[0 as libc::c_int as usize],
                         };
                         init
                     };
@@ -1657,7 +1659,7 @@ pub unsafe extern "C" fn dav1d_refmvs_save_tmvs(
             } else {
                 let mut n_1: libc::c_int = 0 as libc::c_int;
                 while n_1 < bw8 {
-                    (*rp.offset(x as isize)).ref_0 = 0 as libc::c_int as int8_t;
+                    (*rp.offset(x as isize)).r#ref = 0 as libc::c_int as int8_t;
                     n_1 += 1;
                     x += 1;
                 }

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -407,7 +407,7 @@ unsafe fn main_0(argc: libc::c_int, argv: *const *mut libc::c_char) -> libc::c_i
             size: 0,
             user_data: Dav1dUserData {
                 data: 0 as *const uint8_t,
-                ref_0: 0 as *mut Dav1dRef,
+                r#ref: 0 as *mut Dav1dRef,
             },
         },
         content_light: 0 as *mut Dav1dContentLightLevel,
@@ -420,14 +420,14 @@ unsafe fn main_0(argc: libc::c_int, argv: *const *mut libc::c_char) -> libc::c_i
         mastering_display_ref: 0 as *mut Dav1dRef,
         itut_t35_ref: 0 as *mut Dav1dRef,
         reserved_ref: [0; 4],
-        ref_0: 0 as *mut Dav1dRef,
+        r#ref: 0 as *mut Dav1dRef,
         allocator_data: 0 as *mut libc::c_void,
     };
     let mut c: *mut Dav1dContext = 0 as *mut Dav1dContext;
     let mut data: Dav1dData = Dav1dData {
         data: 0 as *const uint8_t,
         sz: 0,
-        ref_0: 0 as *mut Dav1dRef,
+        r#ref: 0 as *mut Dav1dRef,
         m: Dav1dDataProps {
             timestamp: 0,
             duration: 0,
@@ -435,7 +435,7 @@ unsafe fn main_0(argc: libc::c_int, argv: *const *mut libc::c_char) -> libc::c_i
             size: 0,
             user_data: Dav1dUserData {
                 data: 0 as *const uint8_t,
-                ref_0: 0 as *mut Dav1dRef,
+                r#ref: 0 as *mut Dav1dRef,
             },
         },
     };


### PR DESCRIPTION
We've started to do this already to individual fields, so this just does it for them all.