### PR TITLE
`fn add_temporal_candidate`: Cleanup and make almost safe

### DIFF
--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -418,15 +418,15 @@ unsafe fn add_temporal_candidate(
         }
         let mut n = 0;
         while n < last {
-            if mvstack[n as usize].mv.mv[0] == mv {
-                mvstack[n as usize].weight += 2;
+            if mvstack[n].mv.mv[0] == mv {
+                mvstack[n].weight += 2;
                 return;
             }
             n += 1;
         }
         if last < 8 {
-            mvstack[last as usize].mv.mv[0] = mv;
-            mvstack[last as usize].weight = 2;
+            mvstack[last].mv.mv[0] = mv;
+            mvstack[last].weight = 2;
             *cnt = last + 1;
         }
     } else {
@@ -441,17 +441,17 @@ unsafe fn add_temporal_candidate(
             ],
         };
         fix_mv_precision(&*rf.frm_hdr, &mut mvp.mv[1]);
-        let mut n_0 = 0;
-        while n_0 < last {
-            if mvstack[n_0 as usize].mv == mvp {
-                mvstack[n_0 as usize].weight += 2;
+        let mut n = 0;
+        while n < last {
+            if mvstack[n].mv == mvp {
+                mvstack[n].weight += 2;
                 return;
             }
-            n_0 += 1;
+            n += 1;
         }
         if last < 8 {
-            mvstack[last as usize].mv = mvp;
-            mvstack[last as usize].weight = 2;
+            mvstack[last].mv = mvp;
+            mvstack[last].weight = 2;
             *cnt = last + 1;
         }
     };

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -396,18 +396,18 @@ unsafe fn add_temporal_candidate(
     rf: &refmvs_frame,
     mvstack: &mut [refmvs_candidate],
     cnt: &mut usize,
-    rb: *const refmvs_temporal_block,
+    rb: &refmvs_temporal_block,
     r#ref: refmvs_refpair,
     globalmv_ctx: *mut libc::c_int,
     mut gmv: *const mv,
 ) {
-    if (*rb).mv == mv::INVALID {
+    if rb.mv == mv::INVALID {
         return;
     }
     let mut mv = mv_projection(
-        (*rb).mv,
+        rb.mv,
         rf.pocdiff[r#ref.r#ref[0] as usize - 1] as libc::c_int,
-        (*rb).r#ref as libc::c_int,
+        rb.r#ref as libc::c_int,
     );
     fix_mv_precision(&*rf.frm_hdr, &mut mv);
     let last = *cnt;
@@ -434,9 +434,9 @@ unsafe fn add_temporal_candidate(
             mv: [
                 mv,
                 mv_projection(
-                    (*rb).mv,
+                    rb.mv,
                     rf.pocdiff[r#ref.r#ref[1] as usize - 1] as libc::c_int,
-                    (*rb).r#ref as libc::c_int,
+                    rb.r#ref as libc::c_int,
                 ),
             ],
         };

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -393,7 +393,7 @@ fn mv_projection(mv: mv, num: libc::c_int, den: libc::c_int) -> mv {
 }
 
 unsafe fn add_temporal_candidate(
-    rf: *const refmvs_frame,
+    rf: &refmvs_frame,
     mvstack: &mut [refmvs_candidate],
     cnt: &mut usize,
     rb: *const refmvs_temporal_block,
@@ -406,10 +406,10 @@ unsafe fn add_temporal_candidate(
     }
     let mut mv = mv_projection(
         (*rb).mv,
-        (*rf).pocdiff[r#ref.r#ref[0] as usize - 1] as libc::c_int,
+        rf.pocdiff[r#ref.r#ref[0] as usize - 1] as libc::c_int,
         (*rb).r#ref as libc::c_int,
     );
-    fix_mv_precision(&*(*rf).frm_hdr, &mut mv);
+    fix_mv_precision(&*rf.frm_hdr, &mut mv);
     let last = *cnt;
     if r#ref.r#ref[1] == -1 {
         if !globalmv_ctx.is_null() {
@@ -435,12 +435,12 @@ unsafe fn add_temporal_candidate(
                 mv,
                 mv_projection(
                     (*rb).mv,
-                    (*rf).pocdiff[r#ref.r#ref[1] as usize - 1] as libc::c_int,
+                    rf.pocdiff[r#ref.r#ref[1] as usize - 1] as libc::c_int,
                     (*rb).r#ref as libc::c_int,
                 ),
             ],
         };
-        fix_mv_precision(&*(*rf).frm_hdr, &mut mvp.mv[1]);
+        fix_mv_precision(&*rf.frm_hdr, &mut mvp.mv[1]);
         let mut n_0 = 0;
         while n_0 < last {
             if mvstack[n_0 as usize].mv == mvp {

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -403,18 +403,21 @@ unsafe fn add_temporal_candidate(
     if rb.mv == mv::INVALID {
         return;
     }
+
     let mut mv = mv_projection(
         rb.mv,
         rf.pocdiff[r#ref.r#ref[0] as usize - 1] as libc::c_int,
         rb.r#ref as libc::c_int,
     );
     fix_mv_precision(&*rf.frm_hdr, &mut mv);
+
     let last = *cnt;
     if r#ref.r#ref[1] == -1 {
         if let Some((globalmv_ctx, gmv)) = globalmv {
             *globalmv_ctx =
                 ((mv.x - gmv[0].x).abs() | (mv.y - gmv[0].y).abs() >= 16) as libc::c_int;
         }
+
         for cand in &mut mvstack[..last] {
             if cand.mv.mv[0] == mv {
                 cand.weight += 2;
@@ -439,6 +442,7 @@ unsafe fn add_temporal_candidate(
             ],
         };
         fix_mv_precision(&*rf.frm_hdr, &mut mvp.mv[1]);
+        
         for cand in &mut mvstack[..last] {
             if cand.mv == mvp {
                 cand.weight += 2;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -416,13 +416,11 @@ unsafe fn add_temporal_candidate(
             *globalmv_ctx = ((mv.x - (*gmv.offset(0)).x).abs() | (mv.y - (*gmv.offset(0)).y).abs()
                 >= 16) as libc::c_int;
         }
-        let mut n = 0;
-        while n < last {
+        for n in 0..last {
             if mvstack[n].mv.mv[0] == mv {
                 mvstack[n].weight += 2;
                 return;
             }
-            n += 1;
         }
         if last < 8 {
             mvstack[last].mv.mv[0] = mv;
@@ -441,13 +439,11 @@ unsafe fn add_temporal_candidate(
             ],
         };
         fix_mv_precision(&*rf.frm_hdr, &mut mvp.mv[1]);
-        let mut n = 0;
-        while n < last {
+        for n in 0..last {
             if mvstack[n].mv == mvp {
                 mvstack[n].weight += 2;
                 return;
             }
-            n += 1;
         }
         if last < 8 {
             mvstack[last].mv = mvp;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -743,7 +743,7 @@ pub unsafe fn dav1d_refmvs_find(
                     if x | y == 0 {
                         &mut globalmv_ctx
                     } else {
-                        0 as *mut libc::c_int
+                        std::ptr::null_mut()
                     },
                     tgmv.as_ptr(),
                 );

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -398,7 +398,7 @@ unsafe fn add_temporal_candidate(
     cnt: &mut usize,
     rb: &refmvs_temporal_block,
     r#ref: refmvs_refpair,
-    globalmv_ctx: *mut libc::c_int,
+    globalmv_ctx: Option<&mut libc::c_int>,
     mut gmv: *const mv,
 ) {
     if rb.mv == mv::INVALID {
@@ -412,7 +412,7 @@ unsafe fn add_temporal_candidate(
     fix_mv_precision(&*rf.frm_hdr, &mut mv);
     let last = *cnt;
     if r#ref.r#ref[1] == -1 {
-        if !globalmv_ctx.is_null() {
+        if let Some(globalmv_ctx) = globalmv_ctx {
             *globalmv_ctx = ((mv.x - (*gmv.offset(0)).x).abs() | (mv.y - (*gmv.offset(0)).y).abs()
                 >= 16) as libc::c_int;
         }
@@ -741,9 +741,9 @@ pub unsafe fn dav1d_refmvs_find(
                     &*rb.offset(x as isize),
                     r#ref,
                     if x | y == 0 {
-                        &mut globalmv_ctx
+                        Some(&mut globalmv_ctx)
                     } else {
-                        std::ptr::null_mut()
+                        None
                     },
                     tgmv.as_ptr(),
                 );
@@ -763,7 +763,7 @@ pub unsafe fn dav1d_refmvs_find(
                     cnt,
                     &*rb.offset(-1),
                     r#ref,
-                    std::ptr::null_mut(),
+                    None,
                     std::ptr::null(),
                 );
             }
@@ -775,7 +775,7 @@ pub unsafe fn dav1d_refmvs_find(
                         cnt,
                         &*rb.offset(bw8 as isize),
                         r#ref,
-                        std::ptr::null_mut(),
+                        None,
                         std::ptr::null(),
                     );
                 }
@@ -786,7 +786,7 @@ pub unsafe fn dav1d_refmvs_find(
                         cnt,
                         &*rb.offset(bw8 as isize - stride),
                         r#ref,
-                        std::ptr::null_mut(),
+                        None,
                         std::ptr::null(),
                     );
                 }

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -404,39 +404,38 @@ unsafe fn add_temporal_candidate(
     if (*rb).mv == mv::INVALID {
         return;
     }
-    let mut mv: mv = mv_projection(
+    let mut mv = mv_projection(
         (*rb).mv,
-        (*rf).pocdiff[(r#ref.r#ref[0] as libc::c_int - 1) as usize] as libc::c_int,
+        (*rf).pocdiff[r#ref.r#ref[0] as usize - 1] as libc::c_int,
         (*rb).r#ref as libc::c_int,
     );
     fix_mv_precision(&*(*rf).frm_hdr, &mut mv);
     let last = *cnt;
-    if r#ref.r#ref[1] as libc::c_int == -(1 as libc::c_int) {
+    if r#ref.r#ref[1] == -1 {
         if !globalmv_ctx.is_null() {
-            *globalmv_ctx = ((mv.x as libc::c_int - (*gmv.offset(0)).x as libc::c_int).abs()
-                | (mv.y as libc::c_int - (*gmv.offset(0)).y as libc::c_int).abs()
+            *globalmv_ctx = ((mv.x - (*gmv.offset(0)).x).abs() | (mv.y - (*gmv.offset(0)).y).abs()
                 >= 16) as libc::c_int;
         }
         let mut n = 0;
         while n < last {
             if (*mvstack.offset(n as isize)).mv.mv[0] == mv {
-                (*mvstack.offset(n as isize)).weight += 2 as libc::c_int;
+                (*mvstack.offset(n as isize)).weight += 2;
                 return;
             }
             n += 1;
         }
         if last < 8 {
             (*mvstack.offset(last as isize)).mv.mv[0] = mv;
-            (*mvstack.offset(last as isize)).weight = 2 as libc::c_int;
+            (*mvstack.offset(last as isize)).weight = 2;
             *cnt = last + 1;
         }
     } else {
-        let mut mvp: refmvs_mvpair = refmvs_mvpair {
+        let mut mvp = refmvs_mvpair {
             mv: [
                 mv,
                 mv_projection(
                     (*rb).mv,
-                    (*rf).pocdiff[(r#ref.r#ref[1] as libc::c_int - 1) as usize] as libc::c_int,
+                    (*rf).pocdiff[r#ref.r#ref[1] as usize - 1] as libc::c_int,
                     (*rb).r#ref as libc::c_int,
                 ),
             ],
@@ -445,14 +444,14 @@ unsafe fn add_temporal_candidate(
         let mut n_0 = 0;
         while n_0 < last {
             if (*mvstack.offset(n_0 as isize)).mv == mvp {
-                (*mvstack.offset(n_0 as isize)).weight += 2 as libc::c_int;
+                (*mvstack.offset(n_0 as isize)).weight += 2;
                 return;
             }
             n_0 += 1;
         }
         if last < 8 {
             (*mvstack.offset(last as isize)).mv = mvp;
-            (*mvstack.offset(last as isize)).weight = 2 as libc::c_int;
+            (*mvstack.offset(last as isize)).weight = 2;
             *cnt = last + 1;
         }
     };

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -392,7 +392,7 @@ fn mv_projection(mv: mv, num: libc::c_int, den: libc::c_int) -> mv {
     };
 }
 
-unsafe extern "C" fn add_temporal_candidate(
+unsafe fn add_temporal_candidate(
     rf: *const refmvs_frame,
     mvstack: *mut refmvs_candidate,
     cnt: &mut usize,

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -416,9 +416,9 @@ unsafe fn add_temporal_candidate(
             *globalmv_ctx = ((mv.x - (*gmv.offset(0)).x).abs() | (mv.y - (*gmv.offset(0)).y).abs()
                 >= 16) as libc::c_int;
         }
-        for n in 0..last {
-            if mvstack[n].mv.mv[0] == mv {
-                mvstack[n].weight += 2;
+        for cand in &mut mvstack[..last] {
+            if cand.mv.mv[0] == mv {
+                cand.weight += 2;
                 return;
             }
         }
@@ -439,9 +439,9 @@ unsafe fn add_temporal_candidate(
             ],
         };
         fix_mv_precision(&*rf.frm_hdr, &mut mvp.mv[1]);
-        for n in 0..last {
-            if mvstack[n].mv == mvp {
-                mvstack[n].weight += 2;
+        for cand in &mut mvstack[..last] {
+            if cand.mv == mvp {
+                cand.weight += 2;
                 return;
             }
         }

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -423,8 +423,9 @@ unsafe fn add_temporal_candidate(
             }
         }
         if last < 8 {
-            mvstack[last].mv.mv[0] = mv;
-            mvstack[last].weight = 2;
+            let cand = &mut mvstack[last];
+            cand.mv.mv[0] = mv;
+            cand.weight = 2;
             *cnt = last + 1;
         }
     } else {
@@ -446,8 +447,9 @@ unsafe fn add_temporal_candidate(
             }
         }
         if last < 8 {
-            mvstack[last].mv = mvp;
-            mvstack[last].weight = 2;
+            let cand = &mut mvstack[last];
+            cand.mv = mvp;
+            cand.weight = 2;
             *cnt = last + 1;
         }
     };


### PR DESCRIPTION
The only unsafe thing left is `refmvs_frame`'s `frm_hdr: *const Dav1dFrameHeader` field.

Also, I wasn't sure about what to name `globalmv` in eb3704da52195fa3628dbee8f6ed703e94250492.