### PR TITLE
Cleanup remaining trivial redundant casts (after `cargo fmt`)

### DIFF
--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -1242,28 +1242,28 @@ pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
                         bit ^= 1 as libc::c_int;
                         last_skip = 0 as libc::c_int;
                     }
-                    bptrs[0 as libc::c_int as usize] = (bptrs[0]).offset(8);
-                    bptrs[1 as libc::c_int as usize] = (bptrs[1]).offset((8 >> ss_hor) as isize);
-                    bptrs[2 as libc::c_int as usize] = (bptrs[2]).offset((8 >> ss_hor) as isize);
+                    bptrs[0] = (bptrs[0]).offset(8);
+                    bptrs[1] = (bptrs[1]).offset((8 >> ss_hor) as isize);
+                    bptrs[2] = (bptrs[2]).offset((8 >> ss_hor) as isize);
                     bx += 2 as libc::c_int;
                     edges = ::core::mem::transmute::<libc::c_uint, CdefEdgeFlags>(
                         edges as libc::c_uint | CDEF_HAVE_LEFT as libc::c_int as libc::c_uint,
                     );
                 }
             }
-            iptrs[0 as libc::c_int as usize] = (iptrs[0]).offset((sbsz * 4) as isize);
-            iptrs[1 as libc::c_int as usize] = (iptrs[1]).offset((sbsz * 4 >> ss_hor) as isize);
-            iptrs[2 as libc::c_int as usize] = (iptrs[2]).offset((sbsz * 4 >> ss_hor) as isize);
+            iptrs[0] = (iptrs[0]).offset((sbsz * 4) as isize);
+            iptrs[1] = (iptrs[1]).offset((sbsz * 4 >> ss_hor) as isize);
+            iptrs[2] = (iptrs[2]).offset((sbsz * 4 >> ss_hor) as isize);
             sbx += 1;
             edges = ::core::mem::transmute::<libc::c_uint, CdefEdgeFlags>(
                 edges as libc::c_uint | CDEF_HAVE_LEFT as libc::c_int as libc::c_uint,
             );
         }
-        ptrs[0 as libc::c_int as usize] =
+        ptrs[0] =
             (ptrs[0]).offset((8 * PXSTRIDE((*f).cur.stride[0])) as isize);
-        ptrs[1 as libc::c_int as usize] =
+        ptrs[1] =
             (ptrs[1]).offset((8 * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize);
-        ptrs[2 as libc::c_int as usize] =
+        ptrs[2] =
             (ptrs[2]).offset((8 * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize);
         (*tc).top_pre_cdef_toggle ^= 1 as libc::c_int;
         by += 2 as libc::c_int;

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -1259,12 +1259,9 @@ pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
                 edges as libc::c_uint | CDEF_HAVE_LEFT as libc::c_int as libc::c_uint,
             );
         }
-        ptrs[0] =
-            (ptrs[0]).offset((8 * PXSTRIDE((*f).cur.stride[0])) as isize);
-        ptrs[1] =
-            (ptrs[1]).offset((8 * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize);
-        ptrs[2] =
-            (ptrs[2]).offset((8 * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize);
+        ptrs[0] = (ptrs[0]).offset((8 * PXSTRIDE((*f).cur.stride[0])) as isize);
+        ptrs[1] = (ptrs[1]).offset((8 * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize);
+        ptrs[2] = (ptrs[2]).offset((8 * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize);
         (*tc).top_pre_cdef_toggle ^= 1 as libc::c_int;
         by += 2 as libc::c_int;
         edges = ::core::mem::transmute::<libc::c_uint, CdefEdgeFlags>(

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -1211,27 +1211,27 @@ pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
                         bit ^= 1 as libc::c_int;
                         last_skip = 0 as libc::c_int;
                     }
-                    bptrs[0 as libc::c_int as usize] = (bptrs[0]).offset(8);
-                    bptrs[1 as libc::c_int as usize] = (bptrs[1]).offset((8 >> ss_hor) as isize);
-                    bptrs[2 as libc::c_int as usize] = (bptrs[2]).offset((8 >> ss_hor) as isize);
+                    bptrs[0] = (bptrs[0]).offset(8);
+                    bptrs[1] = (bptrs[1]).offset((8 >> ss_hor) as isize);
+                    bptrs[2] = (bptrs[2]).offset((8 >> ss_hor) as isize);
                     bx += 2 as libc::c_int;
                     edges = ::core::mem::transmute::<libc::c_uint, CdefEdgeFlags>(
                         edges as libc::c_uint | CDEF_HAVE_LEFT as libc::c_int as libc::c_uint,
                     );
                 }
             }
-            iptrs[0 as libc::c_int as usize] = (iptrs[0]).offset((sbsz * 4) as isize);
-            iptrs[1 as libc::c_int as usize] = (iptrs[1]).offset((sbsz * 4 >> ss_hor) as isize);
-            iptrs[2 as libc::c_int as usize] = (iptrs[2]).offset((sbsz * 4 >> ss_hor) as isize);
+            iptrs[0] = (iptrs[0]).offset((sbsz * 4) as isize);
+            iptrs[1] = (iptrs[1]).offset((sbsz * 4 >> ss_hor) as isize);
+            iptrs[2] = (iptrs[2]).offset((sbsz * 4 >> ss_hor) as isize);
             sbx += 1;
             edges = ::core::mem::transmute::<libc::c_uint, CdefEdgeFlags>(
                 edges as libc::c_uint | CDEF_HAVE_LEFT as libc::c_int as libc::c_uint,
             );
         }
-        ptrs[0 as libc::c_int as usize] = (ptrs[0]).offset((8 * (*f).cur.stride[0]) as isize);
-        ptrs[1 as libc::c_int as usize] =
+        ptrs[0] = (ptrs[0]).offset((8 * (*f).cur.stride[0]) as isize);
+        ptrs[1] =
             (ptrs[1]).offset((8 * (*f).cur.stride[1] >> ss_ver) as isize);
-        ptrs[2 as libc::c_int as usize] =
+        ptrs[2] =
             (ptrs[2]).offset((8 * (*f).cur.stride[1] >> ss_ver) as isize);
         (*tc).top_pre_cdef_toggle ^= 1 as libc::c_int;
         by += 2 as libc::c_int;

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -1229,10 +1229,8 @@ pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
             );
         }
         ptrs[0] = (ptrs[0]).offset((8 * (*f).cur.stride[0]) as isize);
-        ptrs[1] =
-            (ptrs[1]).offset((8 * (*f).cur.stride[1] >> ss_ver) as isize);
-        ptrs[2] =
-            (ptrs[2]).offset((8 * (*f).cur.stride[1] >> ss_ver) as isize);
+        ptrs[1] = (ptrs[1]).offset((8 * (*f).cur.stride[1] >> ss_ver) as isize);
+        ptrs[2] = (ptrs[2]).offset((8 * (*f).cur.stride[1] >> ss_ver) as isize);
         (*tc).top_pre_cdef_toggle ^= 1 as libc::c_int;
         by += 2 as libc::c_int;
         edges = ::core::mem::transmute::<libc::c_uint, CdefEdgeFlags>(

--- a/src/cdef_tmpl_16.rs
+++ b/src/cdef_tmpl_16.rs
@@ -625,13 +625,13 @@ unsafe extern "C" fn cdef_find_dir_c(
         while x < 8 {
             let px = (*img.offset(x as isize) as libc::c_int >> bitdepth_min_8) - 128;
             partial_sum_diag[0][(y + x) as usize] += px;
-            partial_sum_alt[0 as libc::c_int as usize][(y + (x >> 1)) as usize] += px;
+            partial_sum_alt[0][(y + (x >> 1)) as usize] += px;
             partial_sum_hv[0][y as usize] += px;
-            partial_sum_alt[1 as libc::c_int as usize][(3 + y - (x >> 1)) as usize] += px;
-            partial_sum_diag[1 as libc::c_int as usize][(7 + y - x) as usize] += px;
-            partial_sum_alt[2 as libc::c_int as usize][(3 - (y >> 1) + x) as usize] += px;
+            partial_sum_alt[1][(3 + y - (x >> 1)) as usize] += px;
+            partial_sum_diag[1][(7 + y - x) as usize] += px;
+            partial_sum_alt[2][(3 - (y >> 1) + x) as usize] += px;
             partial_sum_hv[1][x as usize] += px;
-            partial_sum_alt[3 as libc::c_int as usize][((y >> 1) + x) as usize] += px;
+            partial_sum_alt[3][((y >> 1) + x) as usize] += px;
             x += 1;
         }
         img = img.offset(PXSTRIDE(stride) as isize);
@@ -640,16 +640,16 @@ unsafe extern "C" fn cdef_find_dir_c(
     let mut cost: [libc::c_uint; 8] = [0 as libc::c_int as libc::c_uint, 0, 0, 0, 0, 0, 0, 0];
     let mut n = 0;
     while n < 8 {
-        cost[2 as libc::c_int as usize] = (cost[2]).wrapping_add(
+        cost[2] = (cost[2]).wrapping_add(
             (partial_sum_hv[0][n as usize] * partial_sum_hv[0][n as usize]) as libc::c_uint,
         );
-        cost[6 as libc::c_int as usize] = (cost[6]).wrapping_add(
+        cost[6] = (cost[6]).wrapping_add(
             (partial_sum_hv[1][n as usize] * partial_sum_hv[1][n as usize]) as libc::c_uint,
         );
         n += 1;
     }
-    cost[2 as libc::c_int as usize] = (cost[2]).wrapping_mul(105 as libc::c_int as libc::c_uint);
-    cost[6 as libc::c_int as usize] = (cost[6]).wrapping_mul(105 as libc::c_int as libc::c_uint);
+    cost[2] = (cost[2]).wrapping_mul(105 as libc::c_int as libc::c_uint);
+    cost[6] = (cost[6]).wrapping_mul(105 as libc::c_int as libc::c_uint);
     static mut div_table: [uint16_t; 7] = [
         840 as libc::c_int as uint16_t,
         420 as libc::c_int as uint16_t,
@@ -662,23 +662,23 @@ unsafe extern "C" fn cdef_find_dir_c(
     let mut n_0 = 0;
     while n_0 < 7 {
         let d = div_table[n_0 as usize] as libc::c_int;
-        cost[0 as libc::c_int as usize] = (cost[0]).wrapping_add(
+        cost[0] = (cost[0]).wrapping_add(
             ((partial_sum_diag[0][n_0 as usize] * partial_sum_diag[0][n_0 as usize]
-                + partial_sum_diag[0 as libc::c_int as usize][(14 - n_0) as usize]
-                    * partial_sum_diag[0 as libc::c_int as usize][(14 - n_0) as usize])
+                + partial_sum_diag[0][(14 - n_0) as usize]
+                    * partial_sum_diag[0][(14 - n_0) as usize])
                 * d) as libc::c_uint,
         );
-        cost[4 as libc::c_int as usize] = (cost[4]).wrapping_add(
+        cost[4] = (cost[4]).wrapping_add(
             ((partial_sum_diag[1][n_0 as usize] * partial_sum_diag[1][n_0 as usize]
-                + partial_sum_diag[1 as libc::c_int as usize][(14 - n_0) as usize]
-                    * partial_sum_diag[1 as libc::c_int as usize][(14 - n_0) as usize])
+                + partial_sum_diag[1][(14 - n_0) as usize]
+                    * partial_sum_diag[1][(14 - n_0) as usize])
                 * d) as libc::c_uint,
         );
         n_0 += 1;
     }
-    cost[0 as libc::c_int as usize] = (cost[0])
+    cost[0] = (cost[0])
         .wrapping_add((partial_sum_diag[0][7] * partial_sum_diag[0][7] * 105) as libc::c_uint);
-    cost[4 as libc::c_int as usize] = (cost[4])
+    cost[4] = (cost[4])
         .wrapping_add((partial_sum_diag[1][7] * partial_sum_diag[1][7] * 105) as libc::c_uint);
     let mut n_1 = 0;
     while n_1 < 4 {

--- a/src/cdef_tmpl_8.rs
+++ b/src/cdef_tmpl_8.rs
@@ -664,13 +664,13 @@ unsafe extern "C" fn cdef_find_dir_c(
         while x < 8 {
             let px = (*img.offset(x as isize) as libc::c_int >> bitdepth_min_8) - 128;
             partial_sum_diag[0][(y + x) as usize] += px;
-            partial_sum_alt[0 as libc::c_int as usize][(y + (x >> 1)) as usize] += px;
+            partial_sum_alt[0][(y + (x >> 1)) as usize] += px;
             partial_sum_hv[0][y as usize] += px;
-            partial_sum_alt[1 as libc::c_int as usize][(3 + y - (x >> 1)) as usize] += px;
-            partial_sum_diag[1 as libc::c_int as usize][(7 + y - x) as usize] += px;
-            partial_sum_alt[2 as libc::c_int as usize][(3 - (y >> 1) + x) as usize] += px;
+            partial_sum_alt[1][(3 + y - (x >> 1)) as usize] += px;
+            partial_sum_diag[1][(7 + y - x) as usize] += px;
+            partial_sum_alt[2][(3 - (y >> 1) + x) as usize] += px;
             partial_sum_hv[1][x as usize] += px;
-            partial_sum_alt[3 as libc::c_int as usize][((y >> 1) + x) as usize] += px;
+            partial_sum_alt[3][((y >> 1) + x) as usize] += px;
             x += 1;
         }
         img = img.offset(stride as isize);
@@ -679,16 +679,16 @@ unsafe extern "C" fn cdef_find_dir_c(
     let mut cost: [libc::c_uint; 8] = [0 as libc::c_int as libc::c_uint, 0, 0, 0, 0, 0, 0, 0];
     let mut n = 0;
     while n < 8 {
-        cost[2 as libc::c_int as usize] = (cost[2]).wrapping_add(
+        cost[2] = (cost[2]).wrapping_add(
             (partial_sum_hv[0][n as usize] * partial_sum_hv[0][n as usize]) as libc::c_uint,
         );
-        cost[6 as libc::c_int as usize] = (cost[6]).wrapping_add(
+        cost[6] = (cost[6]).wrapping_add(
             (partial_sum_hv[1][n as usize] * partial_sum_hv[1][n as usize]) as libc::c_uint,
         );
         n += 1;
     }
-    cost[2 as libc::c_int as usize] = (cost[2]).wrapping_mul(105 as libc::c_int as libc::c_uint);
-    cost[6 as libc::c_int as usize] = (cost[6]).wrapping_mul(105 as libc::c_int as libc::c_uint);
+    cost[2] = (cost[2]).wrapping_mul(105 as libc::c_int as libc::c_uint);
+    cost[6] = (cost[6]).wrapping_mul(105 as libc::c_int as libc::c_uint);
     static mut div_table: [uint16_t; 7] = [
         840 as libc::c_int as uint16_t,
         420 as libc::c_int as uint16_t,
@@ -701,23 +701,23 @@ unsafe extern "C" fn cdef_find_dir_c(
     let mut n_0 = 0;
     while n_0 < 7 {
         let d = div_table[n_0 as usize] as libc::c_int;
-        cost[0 as libc::c_int as usize] = (cost[0]).wrapping_add(
+        cost[0] = (cost[0]).wrapping_add(
             ((partial_sum_diag[0][n_0 as usize] * partial_sum_diag[0][n_0 as usize]
-                + partial_sum_diag[0 as libc::c_int as usize][(14 - n_0) as usize]
-                    * partial_sum_diag[0 as libc::c_int as usize][(14 - n_0) as usize])
+                + partial_sum_diag[0][(14 - n_0) as usize]
+                    * partial_sum_diag[0][(14 - n_0) as usize])
                 * d) as libc::c_uint,
         );
-        cost[4 as libc::c_int as usize] = (cost[4]).wrapping_add(
+        cost[4] = (cost[4]).wrapping_add(
             ((partial_sum_diag[1][n_0 as usize] * partial_sum_diag[1][n_0 as usize]
-                + partial_sum_diag[1 as libc::c_int as usize][(14 - n_0) as usize]
-                    * partial_sum_diag[1 as libc::c_int as usize][(14 - n_0) as usize])
+                + partial_sum_diag[1][(14 - n_0) as usize]
+                    * partial_sum_diag[1][(14 - n_0) as usize])
                 * d) as libc::c_uint,
         );
         n_0 += 1;
     }
-    cost[0 as libc::c_int as usize] = (cost[0])
+    cost[0] = (cost[0])
         .wrapping_add((partial_sum_diag[0][7] * partial_sum_diag[0][7] * 105) as libc::c_uint);
-    cost[4 as libc::c_int as usize] = (cost[4])
+    cost[4] = (cost[4])
         .wrapping_add((partial_sum_diag[1][7] * partial_sum_diag[1][7] * 105) as libc::c_uint);
     let mut n_1 = 0;
     while n_1 < 4 {

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -22476,7 +22476,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
 ) {
     let mut i = 0;
     while i < N_BS_SIZES as libc::c_int {
-        (*dst).m.use_filter_intra[i as usize][0 as libc::c_int as usize] =
+        (*dst).m.use_filter_intra[i as usize][0] =
             (*src).m.use_filter_intra[i as usize][0];
         (*dst).m.use_filter_intra[i as usize][1] = 0 as libc::c_int as uint16_t;
         i += 1;
@@ -22560,7 +22560,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     }
     let mut i_0 = 0;
     while i_0 < 3 {
-        (*dst).m.skip[i_0 as usize][0 as libc::c_int as usize] = (*src).m.skip[i_0 as usize][0];
+        (*dst).m.skip[i_0 as usize][0] = (*src).m.skip[i_0 as usize][0];
         (*dst).m.skip[i_0 as usize][1] = 0 as libc::c_int as uint16_t;
         i_0 += 1;
     }
@@ -22583,7 +22583,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     while j_5 < N_TX_SIZES as libc::c_int {
         let mut i_1 = 0;
         while i_1 < 13 {
-            (*dst).coef.skip[j_5 as usize][i_1 as usize][0 as libc::c_int as usize] =
+            (*dst).coef.skip[j_5 as usize][i_1 as usize][0] =
                 (*src).coef.skip[j_5 as usize][i_1 as usize][0];
             (*dst).coef.skip[j_5 as usize][i_1 as usize][1] = 0 as libc::c_int as uint16_t;
             i_1 += 1;
@@ -22697,7 +22697,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
             let mut i_2 = 0;
             while i_2 < 11 {
                 (*dst).coef.eob_hi_bit[k_9 as usize][j_13 as usize][i_2 as usize]
-                    [0 as libc::c_int as usize] =
+                    [0] =
                     (*src).coef.eob_hi_bit[k_9 as usize][j_13 as usize][i_2 as usize][0];
                 (*dst).coef.eob_hi_bit[k_9 as usize][j_13 as usize][i_2 as usize][1] =
                     0 as libc::c_int as uint16_t;
@@ -22753,7 +22753,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     while j_16 < 2 {
         let mut i_3 = 0;
         while i_3 < 3 {
-            (*dst).coef.dc_sign[j_16 as usize][i_3 as usize][0 as libc::c_int as usize] =
+            (*dst).coef.dc_sign[j_16 as usize][i_3 as usize][0] =
                 (*src).coef.dc_sign[j_16 as usize][i_3 as usize][0];
             (*dst).coef.dc_sign[j_16 as usize][i_3 as usize][1] = 0 as libc::c_int as uint16_t;
             i_3 += 1;
@@ -22807,9 +22807,9 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
         (*dst).m.cfl_alpha[j_19 as usize][15] = 0 as libc::c_int as uint16_t;
         j_19 += 1;
     }
-    (*dst).m.restore_wiener[0 as libc::c_int as usize] = (*src).m.restore_wiener[0];
+    (*dst).m.restore_wiener[0] = (*src).m.restore_wiener[0];
     (*dst).m.restore_wiener[1] = 0 as libc::c_int as uint16_t;
-    (*dst).m.restore_sgrproj[0 as libc::c_int as usize] = (*src).m.restore_sgrproj[0];
+    (*dst).m.restore_sgrproj[0] = (*src).m.restore_sgrproj[0];
     (*dst).m.restore_sgrproj[1] = 0 as libc::c_int as uint16_t;
     memcpy(
         ((*dst).m.restore_switchable).0.as_mut_ptr() as *mut libc::c_void,
@@ -22837,7 +22837,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     while j_21 < 7 {
         let mut i_4 = 0;
         while i_4 < 3 {
-            (*dst).m.pal_y[j_21 as usize][i_4 as usize][0 as libc::c_int as usize] =
+            (*dst).m.pal_y[j_21 as usize][i_4 as usize][0] =
                 (*src).m.pal_y[j_21 as usize][i_4 as usize][0];
             (*dst).m.pal_y[j_21 as usize][i_4 as usize][1] = 0 as libc::c_int as uint16_t;
             i_4 += 1;
@@ -22846,7 +22846,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     }
     let mut i_5 = 0;
     while i_5 < 2 {
-        (*dst).m.pal_uv[i_5 as usize][0 as libc::c_int as usize] = (*src).m.pal_uv[i_5 as usize][0];
+        (*dst).m.pal_uv[i_5 as usize][0] = (*src).m.pal_uv[i_5 as usize][0];
         (*dst).m.pal_uv[i_5 as usize][1] = 0 as libc::c_int as uint16_t;
         i_5 += 1;
     }
@@ -22889,7 +22889,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     while j_24 < 7 {
         let mut i_6 = 0;
         while i_6 < 3 {
-            (*dst).m.txpart[j_24 as usize][i_6 as usize][0 as libc::c_int as usize] =
+            (*dst).m.txpart[j_24 as usize][i_6 as usize][0] =
                 (*src).m.txpart[j_24 as usize][i_6 as usize][0];
             (*dst).m.txpart[j_24 as usize][i_6 as usize][1] = 0 as libc::c_int as uint16_t;
             i_6 += 1;
@@ -22914,13 +22914,13 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     (*dst).m.txtp_inter2[11] = 0 as libc::c_int as uint16_t;
     let mut i_7 = 0;
     while i_7 < 4 {
-        (*dst).m.txtp_inter3[i_7 as usize][0 as libc::c_int as usize] =
+        (*dst).m.txtp_inter3[i_7 as usize][0] =
             (*src).m.txtp_inter3[i_7 as usize][0];
         (*dst).m.txtp_inter3[i_7 as usize][1] = 0 as libc::c_int as uint16_t;
         i_7 += 1;
     }
     if (*hdr).frame_type as libc::c_uint & 1 as libc::c_uint == 0 {
-        (*dst).m.intrabc[0 as libc::c_int as usize] = (*src).m.intrabc[0];
+        (*dst).m.intrabc[0] = (*src).m.intrabc[0];
         (*dst).m.intrabc[1] = 0 as libc::c_int as uint16_t;
         memcpy(
             ((*dst).dmv.joint.0).as_mut_ptr() as *mut libc::c_void,
@@ -22936,18 +22936,18 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
                 ::core::mem::size_of::<[uint16_t; 16]>() as libc::c_ulong,
             );
             (*dst).dmv.comp[k_15 as usize].classes[10] = 0 as libc::c_int as uint16_t;
-            (*dst).dmv.comp[k_15 as usize].class0[0 as libc::c_int as usize] =
+            (*dst).dmv.comp[k_15 as usize].class0[0] =
                 (*src).dmv.comp[k_15 as usize].class0[0];
             (*dst).dmv.comp[k_15 as usize].class0[1] = 0 as libc::c_int as uint16_t;
             let mut i_8 = 0;
             while i_8 < 10 {
-                (*dst).dmv.comp[k_15 as usize].classN[i_8 as usize][0 as libc::c_int as usize] =
+                (*dst).dmv.comp[k_15 as usize].classN[i_8 as usize][0] =
                     (*src).dmv.comp[k_15 as usize].classN[i_8 as usize][0];
                 (*dst).dmv.comp[k_15 as usize].classN[i_8 as usize][1] =
                     0 as libc::c_int as uint16_t;
                 i_8 += 1;
             }
-            (*dst).dmv.comp[k_15 as usize].sign[0 as libc::c_int as usize] =
+            (*dst).dmv.comp[k_15 as usize].sign[0] =
                 (*src).dmv.comp[k_15 as usize].sign[0];
             (*dst).dmv.comp[k_15 as usize].sign[1] = 0 as libc::c_int as uint16_t;
             k_15 += 1;
@@ -22956,7 +22956,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     }
     let mut i_9 = 0;
     while i_9 < 3 {
-        (*dst).m.skip_mode.0[i_9 as usize][0 as libc::c_int as usize] =
+        (*dst).m.skip_mode.0[i_9 as usize][0] =
             (*src).m.skip_mode.0[i_9 as usize][0];
         (*dst).m.skip_mode.0[i_9 as usize][1] = 0 as libc::c_int as uint16_t;
         i_9 += 1;
@@ -22990,28 +22990,28 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     }
     let mut i_10 = 0;
     while i_10 < 6 {
-        (*dst).m.newmv_mode.0[i_10 as usize][0 as libc::c_int as usize] =
+        (*dst).m.newmv_mode.0[i_10 as usize][0] =
             (*src).m.newmv_mode.0[i_10 as usize][0];
         (*dst).m.newmv_mode.0[i_10 as usize][1] = 0 as libc::c_int as uint16_t;
         i_10 += 1;
     }
     let mut i_11 = 0;
     while i_11 < 2 {
-        (*dst).m.globalmv_mode.0[i_11 as usize][0 as libc::c_int as usize] =
+        (*dst).m.globalmv_mode.0[i_11 as usize][0] =
             (*src).m.globalmv_mode.0[i_11 as usize][0];
         (*dst).m.globalmv_mode.0[i_11 as usize][1] = 0 as libc::c_int as uint16_t;
         i_11 += 1;
     }
     let mut i_12 = 0;
     while i_12 < 6 {
-        (*dst).m.refmv_mode.0[i_12 as usize][0 as libc::c_int as usize] =
+        (*dst).m.refmv_mode.0[i_12 as usize][0] =
             (*src).m.refmv_mode.0[i_12 as usize][0];
         (*dst).m.refmv_mode.0[i_12 as usize][1] = 0 as libc::c_int as uint16_t;
         i_12 += 1;
     }
     let mut i_13 = 0;
     while i_13 < 3 {
-        (*dst).m.drl_bit.0[i_13 as usize][0 as libc::c_int as usize] =
+        (*dst).m.drl_bit.0[i_13 as usize][0] =
             (*src).m.drl_bit.0[i_13 as usize][0];
         (*dst).m.drl_bit.0[i_13 as usize][1] = 0 as libc::c_int as uint16_t;
         i_13 += 1;
@@ -23029,42 +23029,42 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     }
     let mut i_14 = 0;
     while i_14 < 4 {
-        (*dst).m.intra.0[i_14 as usize][0 as libc::c_int as usize] =
+        (*dst).m.intra.0[i_14 as usize][0] =
             (*src).m.intra.0[i_14 as usize][0];
         (*dst).m.intra.0[i_14 as usize][1] = 0 as libc::c_int as uint16_t;
         i_14 += 1;
     }
     let mut i_15 = 0;
     while i_15 < 5 {
-        (*dst).m.comp.0[i_15 as usize][0 as libc::c_int as usize] =
+        (*dst).m.comp.0[i_15 as usize][0] =
             (*src).m.comp.0[i_15 as usize][0];
         (*dst).m.comp.0[i_15 as usize][1] = 0 as libc::c_int as uint16_t;
         i_15 += 1;
     }
     let mut i_16 = 0;
     while i_16 < 5 {
-        (*dst).m.comp_dir.0[i_16 as usize][0 as libc::c_int as usize] =
+        (*dst).m.comp_dir.0[i_16 as usize][0] =
             (*src).m.comp_dir.0[i_16 as usize][0];
         (*dst).m.comp_dir.0[i_16 as usize][1] = 0 as libc::c_int as uint16_t;
         i_16 += 1;
     }
     let mut i_17 = 0;
     while i_17 < 6 {
-        (*dst).m.jnt_comp.0[i_17 as usize][0 as libc::c_int as usize] =
+        (*dst).m.jnt_comp.0[i_17 as usize][0] =
             (*src).m.jnt_comp.0[i_17 as usize][0];
         (*dst).m.jnt_comp.0[i_17 as usize][1] = 0 as libc::c_int as uint16_t;
         i_17 += 1;
     }
     let mut i_18 = 0;
     while i_18 < 6 {
-        (*dst).m.mask_comp.0[i_18 as usize][0 as libc::c_int as usize] =
+        (*dst).m.mask_comp.0[i_18 as usize][0] =
             (*src).m.mask_comp.0[i_18 as usize][0];
         (*dst).m.mask_comp.0[i_18 as usize][1] = 0 as libc::c_int as uint16_t;
         i_18 += 1;
     }
     let mut i_19 = 0;
     while i_19 < 9 {
-        (*dst).m.wedge_comp.0[i_19 as usize][0 as libc::c_int as usize] =
+        (*dst).m.wedge_comp.0[i_19 as usize][0] =
             (*src).m.wedge_comp.0[i_19 as usize][0];
         (*dst).m.wedge_comp.0[i_19 as usize][1] = 0 as libc::c_int as uint16_t;
         i_19 += 1;
@@ -23083,7 +23083,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     while j_30 < 6 {
         let mut i_20 = 0;
         while i_20 < 3 {
-            (*dst).m.r#ref[j_30 as usize][i_20 as usize][0 as libc::c_int as usize] =
+            (*dst).m.r#ref[j_30 as usize][i_20 as usize][0] =
                 (*src).m.r#ref[j_30 as usize][i_20 as usize][0];
             (*dst).m.r#ref[j_30 as usize][i_20 as usize][1] = 0 as libc::c_int as uint16_t;
             i_20 += 1;
@@ -23094,7 +23094,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     while j_31 < 3 {
         let mut i_21 = 0;
         while i_21 < 3 {
-            (*dst).m.comp_fwd_ref[j_31 as usize][i_21 as usize][0 as libc::c_int as usize] =
+            (*dst).m.comp_fwd_ref[j_31 as usize][i_21 as usize][0] =
                 (*src).m.comp_fwd_ref[j_31 as usize][i_21 as usize][0];
             (*dst).m.comp_fwd_ref[j_31 as usize][i_21 as usize][1] = 0 as libc::c_int as uint16_t;
             i_21 += 1;
@@ -23105,7 +23105,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     while j_32 < 2 {
         let mut i_22 = 0;
         while i_22 < 3 {
-            (*dst).m.comp_bwd_ref[j_32 as usize][i_22 as usize][0 as libc::c_int as usize] =
+            (*dst).m.comp_bwd_ref[j_32 as usize][i_22 as usize][0] =
                 (*src).m.comp_bwd_ref[j_32 as usize][i_22 as usize][0];
             (*dst).m.comp_bwd_ref[j_32 as usize][i_22 as usize][1] = 0 as libc::c_int as uint16_t;
             i_22 += 1;
@@ -23116,7 +23116,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     while j_33 < 3 {
         let mut i_23 = 0;
         while i_23 < 3 {
-            (*dst).m.comp_uni_ref[j_33 as usize][i_23 as usize][0 as libc::c_int as usize] =
+            (*dst).m.comp_uni_ref[j_33 as usize][i_23 as usize][0] =
                 (*src).m.comp_uni_ref[j_33 as usize][i_23 as usize][0];
             (*dst).m.comp_uni_ref[j_33 as usize][i_23 as usize][1] = 0 as libc::c_int as uint16_t;
             i_23 += 1;
@@ -23125,21 +23125,21 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     }
     let mut i_24 = 0;
     while i_24 < 3 {
-        (*dst).m.seg_pred[i_24 as usize][0 as libc::c_int as usize] =
+        (*dst).m.seg_pred[i_24 as usize][0] =
             (*src).m.seg_pred[i_24 as usize][0];
         (*dst).m.seg_pred[i_24 as usize][1] = 0 as libc::c_int as uint16_t;
         i_24 += 1;
     }
     let mut i_25 = 0;
     while i_25 < 4 {
-        (*dst).m.interintra[i_25 as usize][0 as libc::c_int as usize] =
+        (*dst).m.interintra[i_25 as usize][0] =
             (*src).m.interintra[i_25 as usize][0];
         (*dst).m.interintra[i_25 as usize][1] = 0 as libc::c_int as uint16_t;
         i_25 += 1;
     }
     let mut i_26 = 0;
     while i_26 < 7 {
-        (*dst).m.interintra_wedge[i_26 as usize][0 as libc::c_int as usize] =
+        (*dst).m.interintra_wedge[i_26 as usize][0] =
             (*src).m.interintra_wedge[i_26 as usize][0];
         (*dst).m.interintra_wedge[i_26 as usize][1] = 0 as libc::c_int as uint16_t;
         i_26 += 1;
@@ -23166,7 +23166,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     }
     let mut i_27 = 0;
     while i_27 < N_BS_SIZES as libc::c_int {
-        (*dst).m.obmc[i_27 as usize][0 as libc::c_int as usize] = (*src).m.obmc[i_27 as usize][0];
+        (*dst).m.obmc[i_27 as usize][0] = (*src).m.obmc[i_27 as usize][0];
         (*dst).m.obmc[i_27 as usize][1] = 0 as libc::c_int as uint16_t;
         i_27 += 1;
     }
@@ -23184,12 +23184,12 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
             ::core::mem::size_of::<[uint16_t; 16]>() as libc::c_ulong,
         );
         (*dst).mv.comp[k_17 as usize].classes[10] = 0 as libc::c_int as uint16_t;
-        (*dst).mv.comp[k_17 as usize].class0[0 as libc::c_int as usize] =
+        (*dst).mv.comp[k_17 as usize].class0[0] =
             (*src).mv.comp[k_17 as usize].class0[0];
         (*dst).mv.comp[k_17 as usize].class0[1] = 0 as libc::c_int as uint16_t;
         let mut i_28 = 0;
         while i_28 < 10 {
-            (*dst).mv.comp[k_17 as usize].classN[i_28 as usize][0 as libc::c_int as usize] =
+            (*dst).mv.comp[k_17 as usize].classN[i_28 as usize][0] =
                 (*src).mv.comp[k_17 as usize].classN[i_28 as usize][0];
             (*dst).mv.comp[k_17 as usize].classN[i_28 as usize][1] = 0 as libc::c_int as uint16_t;
             i_28 += 1;
@@ -23213,13 +23213,13 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
             ::core::mem::size_of::<[uint16_t; 4]>() as libc::c_ulong,
         );
         (*dst).mv.comp[k_17 as usize].classN_fp[3] = 0 as libc::c_int as uint16_t;
-        (*dst).mv.comp[k_17 as usize].class0_hp[0 as libc::c_int as usize] =
+        (*dst).mv.comp[k_17 as usize].class0_hp[0] =
             (*src).mv.comp[k_17 as usize].class0_hp[0];
         (*dst).mv.comp[k_17 as usize].class0_hp[1] = 0 as libc::c_int as uint16_t;
-        (*dst).mv.comp[k_17 as usize].classN_hp[0 as libc::c_int as usize] =
+        (*dst).mv.comp[k_17 as usize].classN_hp[0] =
             (*src).mv.comp[k_17 as usize].classN_hp[0];
         (*dst).mv.comp[k_17 as usize].classN_hp[1] = 0 as libc::c_int as uint16_t;
-        (*dst).mv.comp[k_17 as usize].sign[0 as libc::c_int as usize] =
+        (*dst).mv.comp[k_17 as usize].sign[0] =
             (*src).mv.comp[k_17 as usize].sign[0];
         (*dst).mv.comp[k_17 as usize].sign[1] = 0 as libc::c_int as uint16_t;
         k_17 += 1;
@@ -23273,8 +23273,8 @@ pub unsafe extern "C" fn dav1d_cdf_thread_copy(dst: *mut CdfContext, src: *const
             ::core::mem::size_of::<[uint16_t; 4]>() as libc::c_ulong,
         );
         (*dst).dmv.comp[1] = default_mv_component_cdf();
-        (*dst).dmv.comp[0 as libc::c_int as usize] = (*dst).dmv.comp[1];
-        (*dst).mv.comp[1 as libc::c_int as usize] = (*dst).dmv.comp[0];
+        (*dst).dmv.comp[0] = (*dst).dmv.comp[1];
+        (*dst).mv.comp[1] = (*dst).dmv.comp[0];
         (*dst).mv.comp[0] = (*dst).mv.comp[1];
     };
 }

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -22476,8 +22476,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
 ) {
     let mut i = 0;
     while i < N_BS_SIZES as libc::c_int {
-        (*dst).m.use_filter_intra[i as usize][0] =
-            (*src).m.use_filter_intra[i as usize][0];
+        (*dst).m.use_filter_intra[i as usize][0] = (*src).m.use_filter_intra[i as usize][0];
         (*dst).m.use_filter_intra[i as usize][1] = 0 as libc::c_int as uint16_t;
         i += 1;
     }
@@ -22696,8 +22695,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
         while j_13 < 2 {
             let mut i_2 = 0;
             while i_2 < 11 {
-                (*dst).coef.eob_hi_bit[k_9 as usize][j_13 as usize][i_2 as usize]
-                    [0] =
+                (*dst).coef.eob_hi_bit[k_9 as usize][j_13 as usize][i_2 as usize][0] =
                     (*src).coef.eob_hi_bit[k_9 as usize][j_13 as usize][i_2 as usize][0];
                 (*dst).coef.eob_hi_bit[k_9 as usize][j_13 as usize][i_2 as usize][1] =
                     0 as libc::c_int as uint16_t;
@@ -22914,8 +22912,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     (*dst).m.txtp_inter2[11] = 0 as libc::c_int as uint16_t;
     let mut i_7 = 0;
     while i_7 < 4 {
-        (*dst).m.txtp_inter3[i_7 as usize][0] =
-            (*src).m.txtp_inter3[i_7 as usize][0];
+        (*dst).m.txtp_inter3[i_7 as usize][0] = (*src).m.txtp_inter3[i_7 as usize][0];
         (*dst).m.txtp_inter3[i_7 as usize][1] = 0 as libc::c_int as uint16_t;
         i_7 += 1;
     }
@@ -22936,8 +22933,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
                 ::core::mem::size_of::<[uint16_t; 16]>() as libc::c_ulong,
             );
             (*dst).dmv.comp[k_15 as usize].classes[10] = 0 as libc::c_int as uint16_t;
-            (*dst).dmv.comp[k_15 as usize].class0[0] =
-                (*src).dmv.comp[k_15 as usize].class0[0];
+            (*dst).dmv.comp[k_15 as usize].class0[0] = (*src).dmv.comp[k_15 as usize].class0[0];
             (*dst).dmv.comp[k_15 as usize].class0[1] = 0 as libc::c_int as uint16_t;
             let mut i_8 = 0;
             while i_8 < 10 {
@@ -22947,8 +22943,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
                     0 as libc::c_int as uint16_t;
                 i_8 += 1;
             }
-            (*dst).dmv.comp[k_15 as usize].sign[0] =
-                (*src).dmv.comp[k_15 as usize].sign[0];
+            (*dst).dmv.comp[k_15 as usize].sign[0] = (*src).dmv.comp[k_15 as usize].sign[0];
             (*dst).dmv.comp[k_15 as usize].sign[1] = 0 as libc::c_int as uint16_t;
             k_15 += 1;
         }
@@ -22956,8 +22951,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     }
     let mut i_9 = 0;
     while i_9 < 3 {
-        (*dst).m.skip_mode.0[i_9 as usize][0] =
-            (*src).m.skip_mode.0[i_9 as usize][0];
+        (*dst).m.skip_mode.0[i_9 as usize][0] = (*src).m.skip_mode.0[i_9 as usize][0];
         (*dst).m.skip_mode.0[i_9 as usize][1] = 0 as libc::c_int as uint16_t;
         i_9 += 1;
     }
@@ -22990,29 +22984,25 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     }
     let mut i_10 = 0;
     while i_10 < 6 {
-        (*dst).m.newmv_mode.0[i_10 as usize][0] =
-            (*src).m.newmv_mode.0[i_10 as usize][0];
+        (*dst).m.newmv_mode.0[i_10 as usize][0] = (*src).m.newmv_mode.0[i_10 as usize][0];
         (*dst).m.newmv_mode.0[i_10 as usize][1] = 0 as libc::c_int as uint16_t;
         i_10 += 1;
     }
     let mut i_11 = 0;
     while i_11 < 2 {
-        (*dst).m.globalmv_mode.0[i_11 as usize][0] =
-            (*src).m.globalmv_mode.0[i_11 as usize][0];
+        (*dst).m.globalmv_mode.0[i_11 as usize][0] = (*src).m.globalmv_mode.0[i_11 as usize][0];
         (*dst).m.globalmv_mode.0[i_11 as usize][1] = 0 as libc::c_int as uint16_t;
         i_11 += 1;
     }
     let mut i_12 = 0;
     while i_12 < 6 {
-        (*dst).m.refmv_mode.0[i_12 as usize][0] =
-            (*src).m.refmv_mode.0[i_12 as usize][0];
+        (*dst).m.refmv_mode.0[i_12 as usize][0] = (*src).m.refmv_mode.0[i_12 as usize][0];
         (*dst).m.refmv_mode.0[i_12 as usize][1] = 0 as libc::c_int as uint16_t;
         i_12 += 1;
     }
     let mut i_13 = 0;
     while i_13 < 3 {
-        (*dst).m.drl_bit.0[i_13 as usize][0] =
-            (*src).m.drl_bit.0[i_13 as usize][0];
+        (*dst).m.drl_bit.0[i_13 as usize][0] = (*src).m.drl_bit.0[i_13 as usize][0];
         (*dst).m.drl_bit.0[i_13 as usize][1] = 0 as libc::c_int as uint16_t;
         i_13 += 1;
     }
@@ -23029,43 +23019,37 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     }
     let mut i_14 = 0;
     while i_14 < 4 {
-        (*dst).m.intra.0[i_14 as usize][0] =
-            (*src).m.intra.0[i_14 as usize][0];
+        (*dst).m.intra.0[i_14 as usize][0] = (*src).m.intra.0[i_14 as usize][0];
         (*dst).m.intra.0[i_14 as usize][1] = 0 as libc::c_int as uint16_t;
         i_14 += 1;
     }
     let mut i_15 = 0;
     while i_15 < 5 {
-        (*dst).m.comp.0[i_15 as usize][0] =
-            (*src).m.comp.0[i_15 as usize][0];
+        (*dst).m.comp.0[i_15 as usize][0] = (*src).m.comp.0[i_15 as usize][0];
         (*dst).m.comp.0[i_15 as usize][1] = 0 as libc::c_int as uint16_t;
         i_15 += 1;
     }
     let mut i_16 = 0;
     while i_16 < 5 {
-        (*dst).m.comp_dir.0[i_16 as usize][0] =
-            (*src).m.comp_dir.0[i_16 as usize][0];
+        (*dst).m.comp_dir.0[i_16 as usize][0] = (*src).m.comp_dir.0[i_16 as usize][0];
         (*dst).m.comp_dir.0[i_16 as usize][1] = 0 as libc::c_int as uint16_t;
         i_16 += 1;
     }
     let mut i_17 = 0;
     while i_17 < 6 {
-        (*dst).m.jnt_comp.0[i_17 as usize][0] =
-            (*src).m.jnt_comp.0[i_17 as usize][0];
+        (*dst).m.jnt_comp.0[i_17 as usize][0] = (*src).m.jnt_comp.0[i_17 as usize][0];
         (*dst).m.jnt_comp.0[i_17 as usize][1] = 0 as libc::c_int as uint16_t;
         i_17 += 1;
     }
     let mut i_18 = 0;
     while i_18 < 6 {
-        (*dst).m.mask_comp.0[i_18 as usize][0] =
-            (*src).m.mask_comp.0[i_18 as usize][0];
+        (*dst).m.mask_comp.0[i_18 as usize][0] = (*src).m.mask_comp.0[i_18 as usize][0];
         (*dst).m.mask_comp.0[i_18 as usize][1] = 0 as libc::c_int as uint16_t;
         i_18 += 1;
     }
     let mut i_19 = 0;
     while i_19 < 9 {
-        (*dst).m.wedge_comp.0[i_19 as usize][0] =
-            (*src).m.wedge_comp.0[i_19 as usize][0];
+        (*dst).m.wedge_comp.0[i_19 as usize][0] = (*src).m.wedge_comp.0[i_19 as usize][0];
         (*dst).m.wedge_comp.0[i_19 as usize][1] = 0 as libc::c_int as uint16_t;
         i_19 += 1;
     }
@@ -23125,22 +23109,19 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
     }
     let mut i_24 = 0;
     while i_24 < 3 {
-        (*dst).m.seg_pred[i_24 as usize][0] =
-            (*src).m.seg_pred[i_24 as usize][0];
+        (*dst).m.seg_pred[i_24 as usize][0] = (*src).m.seg_pred[i_24 as usize][0];
         (*dst).m.seg_pred[i_24 as usize][1] = 0 as libc::c_int as uint16_t;
         i_24 += 1;
     }
     let mut i_25 = 0;
     while i_25 < 4 {
-        (*dst).m.interintra[i_25 as usize][0] =
-            (*src).m.interintra[i_25 as usize][0];
+        (*dst).m.interintra[i_25 as usize][0] = (*src).m.interintra[i_25 as usize][0];
         (*dst).m.interintra[i_25 as usize][1] = 0 as libc::c_int as uint16_t;
         i_25 += 1;
     }
     let mut i_26 = 0;
     while i_26 < 7 {
-        (*dst).m.interintra_wedge[i_26 as usize][0] =
-            (*src).m.interintra_wedge[i_26 as usize][0];
+        (*dst).m.interintra_wedge[i_26 as usize][0] = (*src).m.interintra_wedge[i_26 as usize][0];
         (*dst).m.interintra_wedge[i_26 as usize][1] = 0 as libc::c_int as uint16_t;
         i_26 += 1;
     }
@@ -23184,8 +23165,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
             ::core::mem::size_of::<[uint16_t; 16]>() as libc::c_ulong,
         );
         (*dst).mv.comp[k_17 as usize].classes[10] = 0 as libc::c_int as uint16_t;
-        (*dst).mv.comp[k_17 as usize].class0[0] =
-            (*src).mv.comp[k_17 as usize].class0[0];
+        (*dst).mv.comp[k_17 as usize].class0[0] = (*src).mv.comp[k_17 as usize].class0[0];
         (*dst).mv.comp[k_17 as usize].class0[1] = 0 as libc::c_int as uint16_t;
         let mut i_28 = 0;
         while i_28 < 10 {
@@ -23213,14 +23193,11 @@ pub unsafe extern "C" fn dav1d_cdf_thread_update(
             ::core::mem::size_of::<[uint16_t; 4]>() as libc::c_ulong,
         );
         (*dst).mv.comp[k_17 as usize].classN_fp[3] = 0 as libc::c_int as uint16_t;
-        (*dst).mv.comp[k_17 as usize].class0_hp[0] =
-            (*src).mv.comp[k_17 as usize].class0_hp[0];
+        (*dst).mv.comp[k_17 as usize].class0_hp[0] = (*src).mv.comp[k_17 as usize].class0_hp[0];
         (*dst).mv.comp[k_17 as usize].class0_hp[1] = 0 as libc::c_int as uint16_t;
-        (*dst).mv.comp[k_17 as usize].classN_hp[0] =
-            (*src).mv.comp[k_17 as usize].classN_hp[0];
+        (*dst).mv.comp[k_17 as usize].classN_hp[0] = (*src).mv.comp[k_17 as usize].classN_hp[0];
         (*dst).mv.comp[k_17 as usize].classN_hp[1] = 0 as libc::c_int as uint16_t;
-        (*dst).mv.comp[k_17 as usize].sign[0] =
-            (*src).mv.comp[k_17 as usize].sign[0];
+        (*dst).mv.comp[k_17 as usize].sign[0] = (*src).mv.comp[k_17 as usize].sign[0];
         (*dst).mv.comp[k_17 as usize].sign[1] = 0 as libc::c_int as uint16_t;
         k_17 += 1;
     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1374,7 +1374,8 @@ unsafe extern "C" fn get_comp_dir_ctx(
         let l_ref0 = (*l).r#ref[0][yb4 as usize] as libc::c_int;
         if a_comp == 0 && l_comp == 0 {
             return 1 as libc::c_int
-                + 2 * ((a_ref0 >= 4) as libc::c_int == (l_ref0 >= 4) as libc::c_int) as libc::c_int;
+                + 2 * ((a_ref0 >= 4) as libc::c_int == (l_ref0 >= 4) as libc::c_int)
+                    as libc::c_int;
         } else if a_comp == 0 || l_comp == 0 {
             let edge_0: *const BlockContext = if a_comp != 0 { a } else { l };
             let off_0 = if a_comp != 0 { xb4 } else { yb4 };
@@ -2317,14 +2318,12 @@ unsafe extern "C" fn derive_warpmv(
                         .offset((*t).bx as isize))
                     .bs as usize][1] as libc::c_int)
             - 8;
-        pts[np as usize][1][0] = pts[np as usize]
-            [0][0]
+        pts[np as usize][1][0] = pts[np as usize][0][0]
             + (*(*r.offset(-(1 as libc::c_int) as isize)).offset((*t).bx as isize))
                 .mv
                 .mv[0]
                 .x as libc::c_int;
-        pts[np as usize][1][1] = pts[np as usize]
-            [0][1]
+        pts[np as usize][1][1] = pts[np as usize][0][1]
             + (*(*r.offset(-(1 as libc::c_int) as isize)).offset((*t).bx as isize))
                 .mv
                 .mv[0]
@@ -2337,40 +2336,36 @@ unsafe extern "C" fn derive_warpmv(
             let tz = ctz(xmask);
             off_0 = off_0.wrapping_add(tz as libc::c_uint);
             xmask >>= tz;
-            pts[np as usize][0][0] =
-                (16 as libc::c_int as libc::c_uint)
-                    .wrapping_mul(
-                        (2 as libc::c_int as libc::c_uint)
-                            .wrapping_mul(off_0)
-                            .wrapping_add(
-                                (1 as libc::c_int
-                                    * dav1d_block_dimensions[(*(*r
-                                        .offset(-(1 as libc::c_int) as isize))
-                                    .offset(((*t).bx as libc::c_uint).wrapping_add(off_0) as isize))
-                                    .bs
-                                        as usize][0]
-                                        as libc::c_int)
-                                    as libc::c_uint,
-                            ),
-                    )
-                    .wrapping_sub(8 as libc::c_int as libc::c_uint) as libc::c_int;
-            pts[np as usize][0][1] = 16
-                as libc::c_int
+            pts[np as usize][0][0] = (16 as libc::c_int as libc::c_uint)
+                .wrapping_mul(
+                    (2 as libc::c_int as libc::c_uint)
+                        .wrapping_mul(off_0)
+                        .wrapping_add(
+                            (1 as libc::c_int
+                                * dav1d_block_dimensions[(*(*r
+                                    .offset(-(1 as libc::c_int) as isize))
+                                .offset(((*t).bx as libc::c_uint).wrapping_add(off_0) as isize))
+                                .bs
+                                    as usize][0] as libc::c_int)
+                                as libc::c_uint,
+                        ),
+                )
+                .wrapping_sub(8 as libc::c_int as libc::c_uint)
+                as libc::c_int;
+            pts[np as usize][0][1] = 16 as libc::c_int
                 * (2 * 0
                     + -(1 as libc::c_int)
                         * dav1d_block_dimensions[(*(*r.offset(-(1 as libc::c_int) as isize))
                             .offset(((*t).bx as libc::c_uint).wrapping_add(off_0) as isize))
                         .bs as usize][1] as libc::c_int)
                 - 8;
-            pts[np as usize][1][0] = pts
-                [np as usize][0][0]
+            pts[np as usize][1][0] = pts[np as usize][0][0]
                 + (*(*r.offset(-(1 as libc::c_int) as isize))
                     .offset(((*t).bx as libc::c_uint).wrapping_add(off_0) as isize))
                 .mv
                 .mv[0]
                     .x as libc::c_int;
-            pts[np as usize][1][1] = pts
-                [np as usize][0][1]
+            pts[np as usize][1][1] = pts[np as usize][0][1]
                 + (*(*r.offset(-(1 as libc::c_int) as isize))
                     .offset(((*t).bx as libc::c_uint).wrapping_add(off_0) as isize))
                 .mv
@@ -2398,14 +2393,12 @@ unsafe extern "C" fn derive_warpmv(
                     [(*(*r.offset(-off_1 as isize)).offset(((*t).bx - 1) as isize)).bs as usize][1]
                     as libc::c_int)
             - 8;
-        pts[np as usize][1][0] = pts[np as usize]
-            [0][0]
+        pts[np as usize][1][0] = pts[np as usize][0][0]
             + (*(*r.offset(-off_1 as isize)).offset(((*t).bx - 1) as isize))
                 .mv
                 .mv[0]
                 .x as libc::c_int;
-        pts[np as usize][1][1] = pts[np as usize]
-            [0][1]
+        pts[np as usize][1][1] = pts[np as usize][0][1]
             + (*(*r.offset(-off_1 as isize)).offset(((*t).bx - 1) as isize))
                 .mv
                 .mv[0]
@@ -2418,38 +2411,34 @@ unsafe extern "C" fn derive_warpmv(
             let tz_0 = ctz(ymask);
             off_2 = off_2.wrapping_add(tz_0 as libc::c_uint);
             ymask >>= tz_0;
-            pts[np as usize][0][0] = 16
-                as libc::c_int
+            pts[np as usize][0][0] = 16 as libc::c_int
                 * (2 * 0
                     + -(1 as libc::c_int)
                         * dav1d_block_dimensions[(*(*r.offset(off_2 as isize))
                             .offset(((*t).bx - 1) as isize))
                         .bs as usize][0] as libc::c_int)
                 - 8;
-            pts[np as usize][0][1] =
-                (16 as libc::c_int as libc::c_uint)
-                    .wrapping_mul(
-                        (2 as libc::c_int as libc::c_uint)
-                            .wrapping_mul(off_2)
-                            .wrapping_add(
-                                (1 as libc::c_int
-                                    * dav1d_block_dimensions[(*(*r.offset(off_2 as isize))
-                                        .offset(((*t).bx - 1) as isize))
-                                    .bs
-                                        as usize][1]
-                                        as libc::c_int)
-                                    as libc::c_uint,
-                            ),
-                    )
-                    .wrapping_sub(8 as libc::c_int as libc::c_uint) as libc::c_int;
-            pts[np as usize][1][0] = pts
-                [np as usize][0][0]
+            pts[np as usize][0][1] = (16 as libc::c_int as libc::c_uint)
+                .wrapping_mul(
+                    (2 as libc::c_int as libc::c_uint)
+                        .wrapping_mul(off_2)
+                        .wrapping_add(
+                            (1 as libc::c_int
+                                * dav1d_block_dimensions[(*(*r.offset(off_2 as isize))
+                                    .offset(((*t).bx - 1) as isize))
+                                .bs
+                                    as usize][1] as libc::c_int)
+                                as libc::c_uint,
+                        ),
+                )
+                .wrapping_sub(8 as libc::c_int as libc::c_uint)
+                as libc::c_int;
+            pts[np as usize][1][0] = pts[np as usize][0][0]
                 + (*(*r.offset(off_2 as isize)).offset(((*t).bx - 1) as isize))
                     .mv
                     .mv[0]
                     .x as libc::c_int;
-            pts[np as usize][1][1] = pts
-                [np as usize][0][1]
+            pts[np as usize][1][1] = pts[np as usize][0][1]
                 + (*(*r.offset(off_2 as isize)).offset(((*t).bx - 1) as isize))
                     .mv
                     .mv[0]
@@ -2473,14 +2462,12 @@ unsafe extern "C" fn derive_warpmv(
                         .offset(((*t).bx - 1) as isize))
                     .bs as usize][1] as libc::c_int)
             - 8;
-        pts[np as usize][1][0] = pts[np as usize]
-            [0][0]
+        pts[np as usize][1][0] = pts[np as usize][0][0]
             + (*(*r.offset(-(1 as libc::c_int) as isize)).offset(((*t).bx - 1) as isize))
                 .mv
                 .mv[0]
                 .x as libc::c_int;
-        pts[np as usize][1][1] = pts[np as usize]
-            [0][1]
+        pts[np as usize][1][1] = pts[np as usize][0][1]
             + (*(*r.offset(-(1 as libc::c_int) as isize)).offset(((*t).bx - 1) as isize))
                 .mv
                 .mv[0]
@@ -2501,14 +2488,12 @@ unsafe extern "C" fn derive_warpmv(
                         .offset(((*t).bx + bw4) as isize))
                     .bs as usize][1] as libc::c_int)
             - 8;
-        pts[np as usize][1][0] = pts[np as usize]
-            [0][0]
+        pts[np as usize][1][0] = pts[np as usize][0][0]
             + (*(*r.offset(-(1 as libc::c_int) as isize)).offset(((*t).bx + bw4) as isize))
                 .mv
                 .mv[0]
                 .x as libc::c_int;
-        pts[np as usize][1][1] = pts[np as usize]
-            [0][1]
+        pts[np as usize][1][1] = pts[np as usize][0][1]
             + (*(*r.offset(-(1 as libc::c_int) as isize)).offset(((*t).bx + bw4) as isize))
                 .mv
                 .mv[0]
@@ -4479,8 +4464,7 @@ unsafe fn decode_b(
                                 as int8_t;
                     }
                 } else {
-                    b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[0] =
-                        0 as libc::c_int as int8_t;
+                    b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[0] = 0 as libc::c_int as int8_t;
                 }
                 if sign_v != 0 {
                     let ctx_0 = (sign_v == 2) as libc::c_int * 3 + sign_u;
@@ -4498,8 +4482,7 @@ unsafe fn decode_b(
                                 as int8_t;
                     }
                 } else {
-                    b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[1] =
-                        0 as libc::c_int as int8_t;
+                    b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[1] = 0 as libc::c_int as int8_t;
                 }
                 if DEBUG_BLOCK_INFO(f, t) {
                     printf(
@@ -4529,8 +4512,7 @@ unsafe fn decode_b(
             }
         }
         b.c2rust_unnamed.c2rust_unnamed.pal_sz[1] = 0 as libc::c_int as uint8_t;
-        b.c2rust_unnamed.c2rust_unnamed.pal_sz[0] =
-            b.c2rust_unnamed.c2rust_unnamed.pal_sz[1];
+        b.c2rust_unnamed.c2rust_unnamed.pal_sz[0] = b.c2rust_unnamed.c2rust_unnamed.pal_sz[1];
         if (*f.frame_hdr).allow_screen_content_tools != 0 && imax(bw4, bh4) <= 16 && bw4 + bh4 >= 4
         {
             let sz_ctx = *b_dim.offset(2) as libc::c_int + *b_dim.offset(3) as libc::c_int - 2;
@@ -6223,8 +6205,7 @@ unsafe fn decode_b(
             let mut x_1 = 0;
             while x_1 < bw4 {
                 memcpy(
-                    ((*t).al_pal[0][(bx4 + x_1) as usize][0]).as_mut_ptr()
-                        as *mut libc::c_void,
+                    ((*t).al_pal[0][(bx4 + x_1) as usize][0]).as_mut_ptr() as *mut libc::c_void,
                     pal as *const libc::c_void,
                     16 as libc::c_int as libc::c_ulong,
                 );
@@ -6233,8 +6214,7 @@ unsafe fn decode_b(
             let mut y_1 = 0;
             while y_1 < bh4 {
                 memcpy(
-                    ((*t).al_pal[1][(by4 + y_1) as usize][0]).as_mut_ptr()
-                        as *mut libc::c_void,
+                    ((*t).al_pal[1][(by4 + y_1) as usize][0]).as_mut_ptr() as *mut libc::c_void,
                     pal as *const libc::c_void,
                     16 as libc::c_int as libc::c_ulong,
                 );
@@ -6385,9 +6365,8 @@ unsafe fn decode_b(
                     let mut x_2 = 0;
                     while x_2 < bw4 {
                         memcpy(
-                            ((*t).al_pal[0][(bx4 + x_2) as usize]
-                                [pl as usize])
-                                .as_mut_ptr() as *mut libc::c_void,
+                            ((*t).al_pal[0][(bx4 + x_2) as usize][pl as usize]).as_mut_ptr()
+                                as *mut libc::c_void,
                             (*pal_0.offset(pl as isize)).as_ptr() as *const libc::c_void,
                             16 as libc::c_int as libc::c_ulong,
                         );
@@ -6396,9 +6375,8 @@ unsafe fn decode_b(
                     let mut y_2 = 0;
                     while y_2 < bh4 {
                         memcpy(
-                            ((*t).al_pal[1][(by4 + y_2) as usize]
-                                [pl as usize])
-                                .as_mut_ptr() as *mut libc::c_void,
+                            ((*t).al_pal[1][(by4 + y_2) as usize][pl as usize]).as_mut_ptr()
+                                as *mut libc::c_void,
                             (*pal_0.offset(pl as isize)).as_ptr() as *const libc::c_void,
                             16 as libc::c_int as libc::c_ulong,
                         );
@@ -7401,10 +7379,8 @@ unsafe fn decode_b(
             is_comp = 0 as libc::c_int;
         }
         if b.skip_mode != 0 {
-            b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] =
-                (*f.frame_hdr).skip_mode_refs[0] as int8_t;
-            b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] =
-                (*f.frame_hdr).skip_mode_refs[1] as int8_t;
+            b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] = (*f.frame_hdr).skip_mode_refs[0] as int8_t;
+            b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] = (*f.frame_hdr).skip_mode_refs[1] as int8_t;
             b.c2rust_unnamed.c2rust_unnamed_0.comp_type = COMP_INTER_AVG as libc::c_int as uint8_t;
             b.c2rust_unnamed.c2rust_unnamed_0.inter_mode =
                 NEARESTMV_NEARESTMV as libc::c_int as uint8_t;
@@ -7490,21 +7466,19 @@ unsafe fn decode_b(
                 ) != 0
                 {
                     let ctx2 = av1_get_fwd_ref_2_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
-                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] =
-                        (2 as libc::c_int as libc::c_uint).wrapping_add(
-                            dav1d_msac_decode_bool_adapt(
-                                &mut ts.msac,
-                                (ts.cdf.m.comp_fwd_ref[2][ctx2 as usize]).as_mut_ptr(),
-                            ),
-                        ) as int8_t;
+                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] = (2 as libc::c_int as libc::c_uint)
+                        .wrapping_add(dav1d_msac_decode_bool_adapt(
+                            &mut ts.msac,
+                            (ts.cdf.m.comp_fwd_ref[2][ctx2 as usize]).as_mut_ptr(),
+                        ))
+                        as int8_t;
                 } else {
                     let ctx2_0 =
                         av1_get_fwd_ref_1_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
-                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] =
-                        dav1d_msac_decode_bool_adapt(
-                            &mut ts.msac,
-                            (ts.cdf.m.comp_fwd_ref[1][ctx2_0 as usize]).as_mut_ptr(),
-                        ) as int8_t;
+                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] = dav1d_msac_decode_bool_adapt(
+                        &mut ts.msac,
+                        (ts.cdf.m.comp_fwd_ref[1][ctx2_0 as usize]).as_mut_ptr(),
+                    ) as int8_t;
                 }
                 let ctx3 = av1_get_bwd_ref_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
                 if dav1d_msac_decode_bool_adapt(
@@ -7515,13 +7489,12 @@ unsafe fn decode_b(
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] = 6 as libc::c_int as int8_t;
                 } else {
                     let ctx4 = av1_get_bwd_ref_1_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
-                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] =
-                        (4 as libc::c_int as libc::c_uint).wrapping_add(
-                            dav1d_msac_decode_bool_adapt(
-                                &mut ts.msac,
-                                (ts.cdf.m.comp_bwd_ref[1][ctx4 as usize]).as_mut_ptr(),
-                            ),
-                        ) as int8_t;
+                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] = (4 as libc::c_int as libc::c_uint)
+                        .wrapping_add(dav1d_msac_decode_bool_adapt(
+                            &mut ts.msac,
+                            (ts.cdf.m.comp_bwd_ref[1][ctx4 as usize]).as_mut_ptr(),
+                        ))
+                        as int8_t;
                 }
             } else {
                 let uctx_p = av1_get_ref_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
@@ -7535,13 +7508,12 @@ unsafe fn decode_b(
                 } else {
                     let uctx_p1 = av1_get_uni_p1_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] = 0 as libc::c_int as int8_t;
-                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] =
-                        (1 as libc::c_int as libc::c_uint).wrapping_add(
-                            dav1d_msac_decode_bool_adapt(
-                                &mut ts.msac,
-                                (ts.cdf.m.comp_uni_ref[1][uctx_p1 as usize]).as_mut_ptr(),
-                            ),
-                        ) as int8_t;
+                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] = (1 as libc::c_int as libc::c_uint)
+                        .wrapping_add(dav1d_msac_decode_bool_adapt(
+                            &mut ts.msac,
+                            (ts.cdf.m.comp_uni_ref[1][uctx_p1 as usize]).as_mut_ptr(),
+                        ))
+                        as int8_t;
                     if b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] as libc::c_int == 2 {
                         let uctx_p2 =
                             av1_get_fwd_ref_2_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
@@ -7690,8 +7662,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
-                        .mv[0] = mvstack_1
-                        [b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as usize]
+                        .mv[0] = mvstack_1[b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as usize]
                         .mv
                         .mv[0];
                     fix_mv_precision(&*f.frame_hdr, &mut b.mv_mut()[0]);
@@ -7720,8 +7691,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
-                        .mv[0] = mvstack_1
-                        [b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as usize]
+                        .mv[0] = mvstack_1[b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as usize]
                         .mv
                         .mv[0];
                     read_mv_residual(
@@ -7746,8 +7716,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
-                        .mv[1] = mvstack_1
-                        [b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as usize]
+                        .mv[1] = mvstack_1[b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as usize]
                         .mv
                         .mv[1];
                     fix_mv_precision(&*f.frame_hdr, &mut b.mv_mut()[1]);
@@ -7776,8 +7745,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
-                        .mv[1] = mvstack_1
-                        [b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as usize]
+                        .mv[1] = mvstack_1[b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as usize]
                         .mv
                         .mv[1];
                     read_mv_residual(
@@ -8198,8 +8166,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
-                        .mv[0] = mvstack_2
-                        [b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as usize]
+                        .mv[0] = mvstack_2[b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as usize]
                         .mv
                         .mv[0];
                     if (b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as libc::c_int)
@@ -8269,8 +8236,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
-                        .mv[0] = mvstack_2
-                        [b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as usize]
+                        .mv[0] = mvstack_2[b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as usize]
                         .mv
                         .mv[0];
                 } else {
@@ -8578,8 +8544,7 @@ unsafe fn decode_b(
                                 .c2rust_unnamed_0
                                 .c2rust_unnamed
                                 .c2rust_unnamed_0
-                                .matrix[0] =
-                                (-(32767 as libc::c_int) - 1) as int16_t;
+                                .matrix[0] = (-(32767 as libc::c_int) - 1) as int16_t;
                         }
                     }
                 }
@@ -10202,8 +10167,7 @@ unsafe fn decode_b(
             (*noskip_mask)[bx_idx as usize] =
                 ((*noskip_mask)[bx_idx as usize] as libc::c_uint | mask_0) as uint16_t;
             if bw4 == 32 {
-                (*noskip_mask)[1] =
-                    ((*noskip_mask)[1] as libc::c_uint | mask_0) as uint16_t;
+                (*noskip_mask)[1] = ((*noskip_mask)[1] as libc::c_uint | mask_0) as uint16_t;
             }
             y_9 += 2 as libc::c_int;
             noskip_mask = noskip_mask.offset(1);
@@ -11145,58 +11109,51 @@ unsafe extern "C" fn decode_sb(
                 (*(&mut *((*(*t).a).partition).as_mut_ptr().offset(bx8 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 as libc::c_int
-                    * dav1d_al_part_ctx[0][bl as usize][bp as usize]
-                        as libc::c_int) as uint8_t;
+                    * dav1d_al_part_ctx[0][bl as usize][bp as usize] as libc::c_int)
+                    as uint8_t;
                 (*(&mut *((*t).l.partition).as_mut_ptr().offset(by8 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 as libc::c_int
-                    * dav1d_al_part_ctx[1][bl as usize][bp as usize]
-                        as libc::c_int) as uint8_t;
+                    * dav1d_al_part_ctx[1][bl as usize][bp as usize] as libc::c_int)
+                    as uint8_t;
             }
             2 => {
                 (*(&mut *((*(*t).a).partition).as_mut_ptr().offset(bx8 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 as libc::c_int
-                    * dav1d_al_part_ctx[0][bl as usize][bp as usize]
-                        as libc::c_int) as uint16_t;
+                    * dav1d_al_part_ctx[0][bl as usize][bp as usize] as libc::c_int)
+                    as uint16_t;
                 (*(&mut *((*t).l.partition).as_mut_ptr().offset(by8 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 as libc::c_int
-                    * dav1d_al_part_ctx[1][bl as usize][bp as usize]
-                        as libc::c_int) as uint16_t;
+                    * dav1d_al_part_ctx[1][bl as usize][bp as usize] as libc::c_int)
+                    as uint16_t;
             }
             4 => {
                 (*(&mut *((*(*t).a).partition).as_mut_ptr().offset(bx8 as isize) as *mut uint8_t
                     as *mut alias32))
-                    .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(
-                    dav1d_al_part_ctx[0][bl as usize][bp as usize]
-                        as libc::c_uint,
-                );
+                    .u32_0 = (0x1010101 as libc::c_uint)
+                    .wrapping_mul(dav1d_al_part_ctx[0][bl as usize][bp as usize] as libc::c_uint);
                 (*(&mut *((*t).l.partition).as_mut_ptr().offset(by8 as isize) as *mut uint8_t
                     as *mut alias32))
-                    .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(
-                    dav1d_al_part_ctx[1][bl as usize][bp as usize]
-                        as libc::c_uint,
-                );
+                    .u32_0 = (0x1010101 as libc::c_uint)
+                    .wrapping_mul(dav1d_al_part_ctx[1][bl as usize][bp as usize] as libc::c_uint);
             }
             8 => {
                 (*(&mut *((*(*t).a).partition).as_mut_ptr().offset(bx8 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong).wrapping_mul(
-                    dav1d_al_part_ctx[0][bl as usize][bp as usize]
-                        as libc::c_ulonglong,
+                    dav1d_al_part_ctx[0][bl as usize][bp as usize] as libc::c_ulonglong,
                 ) as uint64_t;
                 (*(&mut *((*t).l.partition).as_mut_ptr().offset(by8 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong).wrapping_mul(
-                    dav1d_al_part_ctx[1][bl as usize][bp as usize]
-                        as libc::c_ulonglong,
+                    dav1d_al_part_ctx[1][bl as usize][bp as usize] as libc::c_ulonglong,
                 ) as uint64_t;
             }
             16 => {
                 let const_val: uint64_t = (0x101010101010101 as libc::c_ulonglong).wrapping_mul(
-                    dav1d_al_part_ctx[0][bl as usize][bp as usize]
-                        as libc::c_ulonglong,
+                    dav1d_al_part_ctx[0][bl as usize][bp as usize] as libc::c_ulonglong,
                 ) as uint64_t;
                 (*(&mut *((*(*t).a).partition)
                     .as_mut_ptr()
@@ -11209,8 +11166,7 @@ unsafe extern "C" fn decode_sb(
                     as *mut alias64))
                     .u64_0 = const_val;
                 let const_val_0: uint64_t = (0x101010101010101 as libc::c_ulonglong).wrapping_mul(
-                    dav1d_al_part_ctx[1][bl as usize][bp as usize]
-                        as libc::c_ulonglong,
+                    dav1d_al_part_ctx[1][bl as usize][bp as usize] as libc::c_ulonglong,
                 ) as uint64_t;
                 (*(&mut *((*t).l.partition)
                     .as_mut_ptr()
@@ -11443,22 +11399,14 @@ unsafe extern "C" fn setup_tile(
             match current_block_31 {
                 2370887241019905314 => {}
                 _ => {
-                    (*(*ts).lr_ref[p_0 as usize]).filter_v[0] =
-                        3 as libc::c_int as int8_t;
-                    (*(*ts).lr_ref[p_0 as usize]).filter_v[1] =
-                        -(7 as libc::c_int) as int8_t;
-                    (*(*ts).lr_ref[p_0 as usize]).filter_v[2] =
-                        15 as libc::c_int as int8_t;
-                    (*(*ts).lr_ref[p_0 as usize]).filter_h[0] =
-                        3 as libc::c_int as int8_t;
-                    (*(*ts).lr_ref[p_0 as usize]).filter_h[1] =
-                        -(7 as libc::c_int) as int8_t;
-                    (*(*ts).lr_ref[p_0 as usize]).filter_h[2] =
-                        15 as libc::c_int as int8_t;
-                    (*(*ts).lr_ref[p_0 as usize]).sgr_weights[0] =
-                        -(32 as libc::c_int) as int8_t;
-                    (*(*ts).lr_ref[p_0 as usize]).sgr_weights[1] =
-                        31 as libc::c_int as int8_t;
+                    (*(*ts).lr_ref[p_0 as usize]).filter_v[0] = 3 as libc::c_int as int8_t;
+                    (*(*ts).lr_ref[p_0 as usize]).filter_v[1] = -(7 as libc::c_int) as int8_t;
+                    (*(*ts).lr_ref[p_0 as usize]).filter_v[2] = 15 as libc::c_int as int8_t;
+                    (*(*ts).lr_ref[p_0 as usize]).filter_h[0] = 3 as libc::c_int as int8_t;
+                    (*(*ts).lr_ref[p_0 as usize]).filter_h[1] = -(7 as libc::c_int) as int8_t;
+                    (*(*ts).lr_ref[p_0 as usize]).filter_h[2] = 15 as libc::c_int as int8_t;
+                    (*(*ts).lr_ref[p_0 as usize]).sgr_weights[0] = -(32 as libc::c_int) as int8_t;
+                    (*(*ts).lr_ref[p_0 as usize]).sgr_weights[1] = 31 as libc::c_int as int8_t;
                 }
             }
         }
@@ -11588,8 +11536,7 @@ unsafe extern "C" fn read_restoration_info(
             dav1d_msac_decode_bools(&mut (*ts).msac, 4 as libc::c_int as libc::c_uint);
         let sgr_params: *const uint16_t = (dav1d_sgr_params[idx as usize]).as_ptr();
         (*lr).sgr_idx = idx as uint8_t;
-        (*lr).sgr_weights[0] = (if *sgr_params.offset(0) as libc::c_int != 0
-        {
+        (*lr).sgr_weights[0] = (if *sgr_params.offset(0) as libc::c_int != 0 {
             dav1d_msac_decode_subexp(
                 &mut (*ts).msac,
                 (*(*ts).lr_ref[p as usize]).sgr_weights[0] as libc::c_int + 96,
@@ -11599,8 +11546,7 @@ unsafe extern "C" fn read_restoration_info(
         } else {
             0 as libc::c_int
         }) as int8_t;
-        (*lr).sgr_weights[1] = (if *sgr_params.offset(1) as libc::c_int != 0
-        {
+        (*lr).sgr_weights[1] = (if *sgr_params.offset(1) as libc::c_int != 0 {
             dav1d_msac_decode_subexp(
                 &mut (*ts).msac,
                 (*(*ts).lr_ref[p as usize]).sgr_weights[1] as libc::c_int + 32,
@@ -12266,33 +12212,28 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                             as *mut uint8_t;
                                         let mut ptr: *mut uint8_t = (*f).lf.cdef_line_buf;
                                         if ptr.is_null() {
-                                            (*f).lf.cdef_buf_plane_sz[1] =
-                                                0 as libc::c_int;
+                                            (*f).lf.cdef_buf_plane_sz[1] = 0 as libc::c_int;
                                             (*f).lf.cdef_buf_plane_sz[0] =
                                                 (*f).lf.cdef_buf_plane_sz[1];
                                             current_block = 13495985911605184990;
                                         } else {
                                             ptr = ptr.offset(32);
                                             if y_stride < 0 {
-                                                (*f).lf.cdef_line[0]
-                                                    [0] = ptr.offset(
+                                                (*f).lf.cdef_line[0][0] = ptr.offset(
                                                     -((y_stride * ((*f).sbh * 4 - 1) as isize)
                                                         as isize),
                                                 )
                                                     as *mut libc::c_void;
-                                                (*f).lf.cdef_line[1]
-                                                    [0] = ptr.offset(
+                                                (*f).lf.cdef_line[1][0] = ptr.offset(
                                                     -((y_stride * ((*f).sbh * 4 - 3) as isize)
                                                         as isize),
                                                 )
                                                     as *mut libc::c_void;
                                             } else {
-                                                (*f).lf.cdef_line[0]
-                                                    [0] = ptr
+                                                (*f).lf.cdef_line[0][0] = ptr
                                                     .offset((y_stride * 0) as isize)
                                                     as *mut libc::c_void;
-                                                (*f).lf.cdef_line[1]
-                                                    [0] = ptr
+                                                (*f).lf.cdef_line[1][0] = ptr
                                                     .offset((y_stride * 2) as isize)
                                                     as *mut libc::c_void;
                                             }
@@ -12303,45 +12244,37 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                                     as isize,
                                             );
                                             if uv_stride < 0 {
-                                                (*f).lf.cdef_line[0]
-                                                    [1] = ptr.offset(
+                                                (*f).lf.cdef_line[0][1] = ptr.offset(
                                                     -((uv_stride * ((*f).sbh * 8 - 1) as isize)
                                                         as isize),
                                                 )
                                                     as *mut libc::c_void;
-                                                (*f).lf.cdef_line[0]
-                                                    [2] = ptr.offset(
+                                                (*f).lf.cdef_line[0][2] = ptr.offset(
                                                     -((uv_stride * ((*f).sbh * 8 - 3) as isize)
                                                         as isize),
                                                 )
                                                     as *mut libc::c_void;
-                                                (*f).lf.cdef_line[1]
-                                                    [1] = ptr.offset(
+                                                (*f).lf.cdef_line[1][1] = ptr.offset(
                                                     -((uv_stride * ((*f).sbh * 8 - 5) as isize)
                                                         as isize),
                                                 )
                                                     as *mut libc::c_void;
-                                                (*f).lf.cdef_line[1]
-                                                    [2] = ptr.offset(
+                                                (*f).lf.cdef_line[1][2] = ptr.offset(
                                                     -((uv_stride * ((*f).sbh * 8 - 7) as isize)
                                                         as isize),
                                                 )
                                                     as *mut libc::c_void;
                                             } else {
-                                                (*f).lf.cdef_line[0]
-                                                    [1] = ptr
+                                                (*f).lf.cdef_line[0][1] = ptr
                                                     .offset((uv_stride * 0) as isize)
                                                     as *mut libc::c_void;
-                                                (*f).lf.cdef_line[0]
-                                                    [2] = ptr
+                                                (*f).lf.cdef_line[0][2] = ptr
                                                     .offset((uv_stride * 2) as isize)
                                                     as *mut libc::c_void;
-                                                (*f).lf.cdef_line[1]
-                                                    [1] = ptr
+                                                (*f).lf.cdef_line[1][1] = ptr
                                                     .offset((uv_stride * 4) as isize)
                                                     as *mut libc::c_void;
-                                                (*f).lf.cdef_line[1]
-                                                    [2] = ptr
+                                                (*f).lf.cdef_line[1][2] = ptr
                                                     .offset((uv_stride * 6) as isize)
                                                     as *mut libc::c_void;
                                             }
@@ -12353,15 +12286,13 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                                         as isize,
                                                 );
                                                 if y_stride < 0 {
-                                                    (*f).lf.cdef_lpf_line
-                                                        [0] = ptr.offset(
+                                                    (*f).lf.cdef_lpf_line[0] = ptr.offset(
                                                         -((y_stride * ((*f).sbh * 4 - 1) as isize)
                                                             as isize),
                                                     )
                                                         as *mut libc::c_void;
                                                 } else {
-                                                    (*f).lf.cdef_lpf_line
-                                                        [0] =
+                                                    (*f).lf.cdef_lpf_line[0] =
                                                         ptr as *mut libc::c_void;
                                                 }
                                                 ptr = ptr.offset(
@@ -12371,24 +12302,20 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                                         as isize,
                                                 );
                                                 if uv_stride < 0 {
-                                                    (*f).lf.cdef_lpf_line
-                                                        [1] = ptr.offset(
+                                                    (*f).lf.cdef_lpf_line[1] = ptr.offset(
                                                         -((uv_stride * ((*f).sbh * 4 - 1) as isize)
                                                             as isize),
                                                     )
                                                         as *mut libc::c_void;
-                                                    (*f).lf.cdef_lpf_line
-                                                        [2] = ptr.offset(
+                                                    (*f).lf.cdef_lpf_line[2] = ptr.offset(
                                                         -((uv_stride * ((*f).sbh * 8 - 1) as isize)
                                                             as isize),
                                                     )
                                                         as *mut libc::c_void;
                                                 } else {
-                                                    (*f).lf.cdef_lpf_line
-                                                        [1] =
+                                                    (*f).lf.cdef_lpf_line[1] =
                                                         ptr as *mut libc::c_void;
-                                                    (*f).lf.cdef_lpf_line
-                                                        [2] = ptr.offset(
+                                                    (*f).lf.cdef_lpf_line[2] = ptr.offset(
                                                         (uv_stride * (*f).sbh as isize * 4)
                                                             as isize,
                                                     )
@@ -12445,27 +12372,20 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                                     as *mut uint8_t;
                                                 let mut ptr_0: *mut uint8_t = (*f).lf.lr_line_buf;
                                                 if ptr_0.is_null() {
-                                                    (*f).lf.lr_buf_plane_sz
-                                                        [1] =
-                                                        0 as libc::c_int;
-                                                    (*f).lf.lr_buf_plane_sz
-                                                        [0] =
+                                                    (*f).lf.lr_buf_plane_sz[1] = 0 as libc::c_int;
+                                                    (*f).lf.lr_buf_plane_sz[0] =
                                                         (*f).lf.lr_buf_plane_sz[1];
                                                     current_block = 13495985911605184990;
                                                 } else {
                                                     ptr_0 = ptr_0.offset(64);
                                                     if y_stride < 0 {
-                                                        (*f).lf.lr_lpf_line
-                                                            [0] = ptr_0
-                                                            .offset(
-                                                                -((y_stride
-                                                                    * (num_lines - 1) as isize)
-                                                                    as isize),
-                                                            )
+                                                        (*f).lf.lr_lpf_line[0] = ptr_0.offset(
+                                                            -((y_stride * (num_lines - 1) as isize)
+                                                                as isize),
+                                                        )
                                                             as *mut libc::c_void;
                                                     } else {
-                                                        (*f).lf.lr_lpf_line
-                                                            [0] =
+                                                        (*f).lf.lr_lpf_line[0] =
                                                             ptr_0 as *mut libc::c_void;
                                                     }
                                                     ptr_0 = ptr_0.offset(
@@ -12474,39 +12394,30 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                                             as isize,
                                                     );
                                                     if uv_stride < 0 {
-                                                        (*f).lf.lr_lpf_line
-                                                            [1] = ptr_0
-                                                            .offset(
-                                                                -((uv_stride
-                                                                    * (num_lines * 1 - 1) as isize)
-                                                                    as isize),
-                                                            )
+                                                        (*f).lf.lr_lpf_line[1] = ptr_0.offset(
+                                                            -((uv_stride
+                                                                * (num_lines * 1 - 1) as isize)
+                                                                as isize),
+                                                        )
                                                             as *mut libc::c_void;
-                                                        (*f).lf.lr_lpf_line
-                                                            [2] = ptr_0
-                                                            .offset(
-                                                                -((uv_stride
-                                                                    * (num_lines * 2 - 1) as isize)
-                                                                    as isize),
-                                                            )
+                                                        (*f).lf.lr_lpf_line[2] = ptr_0.offset(
+                                                            -((uv_stride
+                                                                * (num_lines * 2 - 1) as isize)
+                                                                as isize),
+                                                        )
                                                             as *mut libc::c_void;
                                                     } else {
-                                                        (*f).lf.lr_lpf_line
-                                                            [1] =
+                                                        (*f).lf.lr_lpf_line[1] =
                                                             ptr_0 as *mut libc::c_void;
-                                                        (*f).lf.lr_lpf_line
-                                                            [2] = ptr_0
-                                                            .offset(
-                                                                (uv_stride * num_lines as isize)
-                                                                    as isize,
-                                                            )
+                                                        (*f).lf.lr_lpf_line[2] = ptr_0.offset(
+                                                            (uv_stride * num_lines as isize)
+                                                                as isize,
+                                                        )
                                                             as *mut libc::c_void;
                                                     }
-                                                    (*f).lf.lr_buf_plane_sz
-                                                        [0] =
+                                                    (*f).lf.lr_buf_plane_sz[0] =
                                                         y_stride as libc::c_int * num_lines;
-                                                    (*f).lf.lr_buf_plane_sz
-                                                        [1] =
+                                                    (*f).lf.lr_buf_plane_sz[1] =
                                                         uv_stride as libc::c_int * num_lines * 2;
                                                     current_block = 15456862084301247793;
                                                 }
@@ -13769,10 +13680,9 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                                                 if (*(*f).frame_hdr).width[0]
                                                     != (*(*f).frame_hdr).width[1]
                                                 {
-                                                    (*f).resize_step[0] =
-                                                        (((*f).cur.p.w << 14)
-                                                            + ((*f).sr_cur.p.p.w >> 1))
-                                                            / (*f).sr_cur.p.p.w;
+                                                    (*f).resize_step[0] = (((*f).cur.p.w << 14)
+                                                        + ((*f).sr_cur.p.p.w >> 1))
+                                                        / (*f).sr_cur.p.p.w;
                                                     let ss_hor = ((*f).cur.p.layout as libc::c_uint
                                                         != DAV1D_PIXEL_LAYOUT_I444 as libc::c_int
                                                             as libc::c_uint)
@@ -13782,18 +13692,16 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                                                         (*f).sr_cur.p.p.w + ss_hor >> ss_hor;
                                                     (*f).resize_step[1] =
                                                         ((in_cw << 14) + (out_cw >> 1)) / out_cw;
-                                                    (*f).resize_start[0] =
-                                                        get_upscale_x0(
-                                                            (*f).cur.p.w,
-                                                            (*f).sr_cur.p.p.w,
-                                                            (*f).resize_step[0],
-                                                        );
-                                                    (*f).resize_start[1] =
-                                                        get_upscale_x0(
-                                                            in_cw,
-                                                            out_cw,
-                                                            (*f).resize_step[1],
-                                                        );
+                                                    (*f).resize_start[0] = get_upscale_x0(
+                                                        (*f).cur.p.w,
+                                                        (*f).sr_cur.p.p.w,
+                                                        (*f).resize_step[0],
+                                                    );
+                                                    (*f).resize_start[1] = get_upscale_x0(
+                                                        in_cw,
+                                                        out_cw,
+                                                        (*f).resize_step[1],
+                                                    );
                                                 }
                                                 if (*c).n_fc == 1 as libc::c_uint {
                                                     if (*(*f).frame_hdr).show_frame != 0

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2304,26 +2304,26 @@ unsafe extern "C" fn derive_warpmv(
                 [(*(*r.offset(-(1 as libc::c_int) as isize)).offset((*t).bx as isize)).bs as usize]
                 [0] as libc::c_int
                 - 1;
-        pts[np as usize][0 as libc::c_int as usize][0 as libc::c_int as usize] = 16 as libc::c_int
+        pts[np as usize][0][0] = 16 as libc::c_int
             * (2 * -off
                 + 1 * dav1d_block_dimensions[(*(*r.offset(-(1 as libc::c_int) as isize))
                     .offset((*t).bx as isize))
                 .bs as usize][0] as libc::c_int)
             - 8;
-        pts[np as usize][0 as libc::c_int as usize][1 as libc::c_int as usize] = 16 as libc::c_int
+        pts[np as usize][0][1] = 16 as libc::c_int
             * (2 * 0
                 + -(1 as libc::c_int)
                     * dav1d_block_dimensions[(*(*r.offset(-(1 as libc::c_int) as isize))
                         .offset((*t).bx as isize))
                     .bs as usize][1] as libc::c_int)
             - 8;
-        pts[np as usize][1 as libc::c_int as usize][0 as libc::c_int as usize] = pts[np as usize]
+        pts[np as usize][1][0] = pts[np as usize]
             [0][0]
             + (*(*r.offset(-(1 as libc::c_int) as isize)).offset((*t).bx as isize))
                 .mv
                 .mv[0]
                 .x as libc::c_int;
-        pts[np as usize][1 as libc::c_int as usize][1 as libc::c_int as usize] = pts[np as usize]
+        pts[np as usize][1][1] = pts[np as usize]
             [0][1]
             + (*(*r.offset(-(1 as libc::c_int) as isize)).offset((*t).bx as isize))
                 .mv
@@ -2337,7 +2337,7 @@ unsafe extern "C" fn derive_warpmv(
             let tz = ctz(xmask);
             off_0 = off_0.wrapping_add(tz as libc::c_uint);
             xmask >>= tz;
-            pts[np as usize][0 as libc::c_int as usize][0 as libc::c_int as usize] =
+            pts[np as usize][0][0] =
                 (16 as libc::c_int as libc::c_uint)
                     .wrapping_mul(
                         (2 as libc::c_int as libc::c_uint)
@@ -2354,7 +2354,7 @@ unsafe extern "C" fn derive_warpmv(
                             ),
                     )
                     .wrapping_sub(8 as libc::c_int as libc::c_uint) as libc::c_int;
-            pts[np as usize][0 as libc::c_int as usize][1 as libc::c_int as usize] = 16
+            pts[np as usize][0][1] = 16
                 as libc::c_int
                 * (2 * 0
                     + -(1 as libc::c_int)
@@ -2362,14 +2362,14 @@ unsafe extern "C" fn derive_warpmv(
                             .offset(((*t).bx as libc::c_uint).wrapping_add(off_0) as isize))
                         .bs as usize][1] as libc::c_int)
                 - 8;
-            pts[np as usize][1 as libc::c_int as usize][0 as libc::c_int as usize] = pts
+            pts[np as usize][1][0] = pts
                 [np as usize][0][0]
                 + (*(*r.offset(-(1 as libc::c_int) as isize))
                     .offset(((*t).bx as libc::c_uint).wrapping_add(off_0) as isize))
                 .mv
                 .mv[0]
                     .x as libc::c_int;
-            pts[np as usize][1 as libc::c_int as usize][1 as libc::c_int as usize] = pts
+            pts[np as usize][1][1] = pts
                 [np as usize][0][1]
                 + (*(*r.offset(-(1 as libc::c_int) as isize))
                     .offset(((*t).bx as libc::c_uint).wrapping_add(off_0) as isize))
@@ -2385,26 +2385,26 @@ unsafe extern "C" fn derive_warpmv(
             & dav1d_block_dimensions[(*(*r.offset(0)).offset(((*t).bx - 1) as isize)).bs as usize]
                 [1] as libc::c_int
                 - 1;
-        pts[np as usize][0 as libc::c_int as usize][0 as libc::c_int as usize] = 16 as libc::c_int
+        pts[np as usize][0][0] = 16 as libc::c_int
             * (2 * 0
                 + -(1 as libc::c_int)
                     * dav1d_block_dimensions
                         [(*(*r.offset(-off_1 as isize)).offset(((*t).bx - 1) as isize)).bs as usize]
                         [0] as libc::c_int)
             - 8;
-        pts[np as usize][0 as libc::c_int as usize][1 as libc::c_int as usize] = 16 as libc::c_int
+        pts[np as usize][0][1] = 16 as libc::c_int
             * (2 * -off_1
                 + 1 * dav1d_block_dimensions
                     [(*(*r.offset(-off_1 as isize)).offset(((*t).bx - 1) as isize)).bs as usize][1]
                     as libc::c_int)
             - 8;
-        pts[np as usize][1 as libc::c_int as usize][0 as libc::c_int as usize] = pts[np as usize]
+        pts[np as usize][1][0] = pts[np as usize]
             [0][0]
             + (*(*r.offset(-off_1 as isize)).offset(((*t).bx - 1) as isize))
                 .mv
                 .mv[0]
                 .x as libc::c_int;
-        pts[np as usize][1 as libc::c_int as usize][1 as libc::c_int as usize] = pts[np as usize]
+        pts[np as usize][1][1] = pts[np as usize]
             [0][1]
             + (*(*r.offset(-off_1 as isize)).offset(((*t).bx - 1) as isize))
                 .mv
@@ -2418,7 +2418,7 @@ unsafe extern "C" fn derive_warpmv(
             let tz_0 = ctz(ymask);
             off_2 = off_2.wrapping_add(tz_0 as libc::c_uint);
             ymask >>= tz_0;
-            pts[np as usize][0 as libc::c_int as usize][0 as libc::c_int as usize] = 16
+            pts[np as usize][0][0] = 16
                 as libc::c_int
                 * (2 * 0
                     + -(1 as libc::c_int)
@@ -2426,7 +2426,7 @@ unsafe extern "C" fn derive_warpmv(
                             .offset(((*t).bx - 1) as isize))
                         .bs as usize][0] as libc::c_int)
                 - 8;
-            pts[np as usize][0 as libc::c_int as usize][1 as libc::c_int as usize] =
+            pts[np as usize][0][1] =
                 (16 as libc::c_int as libc::c_uint)
                     .wrapping_mul(
                         (2 as libc::c_int as libc::c_uint)
@@ -2442,13 +2442,13 @@ unsafe extern "C" fn derive_warpmv(
                             ),
                     )
                     .wrapping_sub(8 as libc::c_int as libc::c_uint) as libc::c_int;
-            pts[np as usize][1 as libc::c_int as usize][0 as libc::c_int as usize] = pts
+            pts[np as usize][1][0] = pts
                 [np as usize][0][0]
                 + (*(*r.offset(off_2 as isize)).offset(((*t).bx - 1) as isize))
                     .mv
                     .mv[0]
                     .x as libc::c_int;
-            pts[np as usize][1 as libc::c_int as usize][1 as libc::c_int as usize] = pts
+            pts[np as usize][1][1] = pts
                 [np as usize][0][1]
                 + (*(*r.offset(off_2 as isize)).offset(((*t).bx - 1) as isize))
                     .mv
@@ -2459,27 +2459,27 @@ unsafe extern "C" fn derive_warpmv(
         }
     }
     if np < 8 && (*masks.offset(1)).wrapping_shr(32) != 0 {
-        pts[np as usize][0 as libc::c_int as usize][0 as libc::c_int as usize] = 16 as libc::c_int
+        pts[np as usize][0][0] = 16 as libc::c_int
             * (2 * 0
                 + -(1 as libc::c_int)
                     * dav1d_block_dimensions[(*(*r.offset(-(1 as libc::c_int) as isize))
                         .offset(((*t).bx - 1) as isize))
                     .bs as usize][0] as libc::c_int)
             - 8;
-        pts[np as usize][0 as libc::c_int as usize][1 as libc::c_int as usize] = 16 as libc::c_int
+        pts[np as usize][0][1] = 16 as libc::c_int
             * (2 * 0
                 + -(1 as libc::c_int)
                     * dav1d_block_dimensions[(*(*r.offset(-(1 as libc::c_int) as isize))
                         .offset(((*t).bx - 1) as isize))
                     .bs as usize][1] as libc::c_int)
             - 8;
-        pts[np as usize][1 as libc::c_int as usize][0 as libc::c_int as usize] = pts[np as usize]
+        pts[np as usize][1][0] = pts[np as usize]
             [0][0]
             + (*(*r.offset(-(1 as libc::c_int) as isize)).offset(((*t).bx - 1) as isize))
                 .mv
                 .mv[0]
                 .x as libc::c_int;
-        pts[np as usize][1 as libc::c_int as usize][1 as libc::c_int as usize] = pts[np as usize]
+        pts[np as usize][1][1] = pts[np as usize]
             [0][1]
             + (*(*r.offset(-(1 as libc::c_int) as isize)).offset(((*t).bx - 1) as isize))
                 .mv
@@ -2488,26 +2488,26 @@ unsafe extern "C" fn derive_warpmv(
         np += 1;
     }
     if np < 8 && (*masks.offset(0)).wrapping_shr(32) != 0 {
-        pts[np as usize][0 as libc::c_int as usize][0 as libc::c_int as usize] = 16 as libc::c_int
+        pts[np as usize][0][0] = 16 as libc::c_int
             * (2 * bw4
                 + 1 * dav1d_block_dimensions[(*(*r.offset(-(1 as libc::c_int) as isize))
                     .offset(((*t).bx + bw4) as isize))
                 .bs as usize][0] as libc::c_int)
             - 8;
-        pts[np as usize][0 as libc::c_int as usize][1 as libc::c_int as usize] = 16 as libc::c_int
+        pts[np as usize][0][1] = 16 as libc::c_int
             * (2 * 0
                 + -(1 as libc::c_int)
                     * dav1d_block_dimensions[(*(*r.offset(-(1 as libc::c_int) as isize))
                         .offset(((*t).bx + bw4) as isize))
                     .bs as usize][1] as libc::c_int)
             - 8;
-        pts[np as usize][1 as libc::c_int as usize][0 as libc::c_int as usize] = pts[np as usize]
+        pts[np as usize][1][0] = pts[np as usize]
             [0][0]
             + (*(*r.offset(-(1 as libc::c_int) as isize)).offset(((*t).bx + bw4) as isize))
                 .mv
                 .mv[0]
                 .x as libc::c_int;
-        pts[np as usize][1 as libc::c_int as usize][1 as libc::c_int as usize] = pts[np as usize]
+        pts[np as usize][1][1] = pts[np as usize]
             [0][1]
             + (*(*r.offset(-(1 as libc::c_int) as isize)).offset(((*t).bx + bw4) as isize))
                 .mv
@@ -4465,7 +4465,7 @@ unsafe fn decode_b(
                 }
                 if sign_u != 0 {
                     let ctx = (sign_u == 2) as libc::c_int * 3 + sign_v;
-                    b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[0 as libc::c_int as usize] =
+                    b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[0] =
                         (dav1d_msac_decode_symbol_adapt16(
                             &mut ts.msac,
                             (ts.cdf.m.cfl_alpha[ctx as usize]).as_mut_ptr(),
@@ -4474,17 +4474,17 @@ unsafe fn decode_b(
                         .wrapping_add(1 as libc::c_int as libc::c_uint)
                             as int8_t;
                     if sign_u == 1 {
-                        b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[0 as libc::c_int as usize] =
+                        b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[0] =
                             -(b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[0] as libc::c_int)
                                 as int8_t;
                     }
                 } else {
-                    b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[0 as libc::c_int as usize] =
+                    b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[0] =
                         0 as libc::c_int as int8_t;
                 }
                 if sign_v != 0 {
                     let ctx_0 = (sign_v == 2) as libc::c_int * 3 + sign_u;
-                    b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[1 as libc::c_int as usize] =
+                    b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[1] =
                         (dav1d_msac_decode_symbol_adapt16(
                             &mut ts.msac,
                             (ts.cdf.m.cfl_alpha[ctx_0 as usize]).as_mut_ptr(),
@@ -4493,12 +4493,12 @@ unsafe fn decode_b(
                         .wrapping_add(1 as libc::c_int as libc::c_uint)
                             as int8_t;
                     if sign_v == 1 {
-                        b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[1 as libc::c_int as usize] =
+                        b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[1] =
                             -(b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[1] as libc::c_int)
                                 as int8_t;
                     }
                 } else {
-                    b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[1 as libc::c_int as usize] =
+                    b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[1] =
                         0 as libc::c_int as int8_t;
                 }
                 if DEBUG_BLOCK_INFO(f, t) {
@@ -4529,7 +4529,7 @@ unsafe fn decode_b(
             }
         }
         b.c2rust_unnamed.c2rust_unnamed.pal_sz[1] = 0 as libc::c_int as uint8_t;
-        b.c2rust_unnamed.c2rust_unnamed.pal_sz[0 as libc::c_int as usize] =
+        b.c2rust_unnamed.c2rust_unnamed.pal_sz[0] =
             b.c2rust_unnamed.c2rust_unnamed.pal_sz[1];
         if (*f.frame_hdr).allow_screen_content_tools != 0 && imax(bw4, bh4) <= 16 && bw4 + bh4 >= 4
         {
@@ -6223,7 +6223,7 @@ unsafe fn decode_b(
             let mut x_1 = 0;
             while x_1 < bw4 {
                 memcpy(
-                    ((*t).al_pal[0 as libc::c_int as usize][(bx4 + x_1) as usize][0]).as_mut_ptr()
+                    ((*t).al_pal[0][(bx4 + x_1) as usize][0]).as_mut_ptr()
                         as *mut libc::c_void,
                     pal as *const libc::c_void,
                     16 as libc::c_int as libc::c_ulong,
@@ -6233,7 +6233,7 @@ unsafe fn decode_b(
             let mut y_1 = 0;
             while y_1 < bh4 {
                 memcpy(
-                    ((*t).al_pal[1 as libc::c_int as usize][(by4 + y_1) as usize][0]).as_mut_ptr()
+                    ((*t).al_pal[1][(by4 + y_1) as usize][0]).as_mut_ptr()
                         as *mut libc::c_void,
                     pal as *const libc::c_void,
                     16 as libc::c_int as libc::c_ulong,
@@ -6385,7 +6385,7 @@ unsafe fn decode_b(
                     let mut x_2 = 0;
                     while x_2 < bw4 {
                         memcpy(
-                            ((*t).al_pal[0 as libc::c_int as usize][(bx4 + x_2) as usize]
+                            ((*t).al_pal[0][(bx4 + x_2) as usize]
                                 [pl as usize])
                                 .as_mut_ptr() as *mut libc::c_void,
                             (*pal_0.offset(pl as isize)).as_ptr() as *const libc::c_void,
@@ -6396,7 +6396,7 @@ unsafe fn decode_b(
                     let mut y_2 = 0;
                     while y_2 < bh4 {
                         memcpy(
-                            ((*t).al_pal[1 as libc::c_int as usize][(by4 + y_2) as usize]
+                            ((*t).al_pal[1][(by4 + y_2) as usize]
                                 [pl as usize])
                                 .as_mut_ptr() as *mut libc::c_void,
                             (*pal_0.offset(pl as isize)).as_ptr() as *const libc::c_void,
@@ -6438,13 +6438,13 @@ unsafe fn decode_b(
                 .c2rust_unnamed_0
                 .c2rust_unnamed
                 .c2rust_unnamed
-                .mv[0 as libc::c_int as usize] = mvstack[0].mv.mv[0];
+                .mv[0] = mvstack[0].mv.mv[0];
         } else if mvstack[1].mv.mv[0] != mv::ZERO {
             b.c2rust_unnamed
                 .c2rust_unnamed_0
                 .c2rust_unnamed
                 .c2rust_unnamed
-                .mv[0 as libc::c_int as usize] = mvstack[1].mv.mv[0];
+                .mv[0] = mvstack[1].mv.mv[0];
         } else if t.by - ((16 as libc::c_int) << (*f.seq_hdr).sb128) < ts.tiling.row_start {
             b.c2rust_unnamed
                 .c2rust_unnamed_0
@@ -7401,9 +7401,9 @@ unsafe fn decode_b(
             is_comp = 0 as libc::c_int;
         }
         if b.skip_mode != 0 {
-            b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0 as libc::c_int as usize] =
+            b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] =
                 (*f.frame_hdr).skip_mode_refs[0] as int8_t;
-            b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1 as libc::c_int as usize] =
+            b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] =
                 (*f.frame_hdr).skip_mode_refs[1] as int8_t;
             b.c2rust_unnamed.c2rust_unnamed_0.comp_type = COMP_INTER_AVG as libc::c_int as uint8_t;
             b.c2rust_unnamed.c2rust_unnamed_0.inter_mode =
@@ -7436,12 +7436,12 @@ unsafe fn decode_b(
                 .c2rust_unnamed_0
                 .c2rust_unnamed
                 .c2rust_unnamed
-                .mv[0 as libc::c_int as usize] = mvstack_0[0].mv.mv[0];
+                .mv[0] = mvstack_0[0].mv.mv[0];
             b.c2rust_unnamed
                 .c2rust_unnamed_0
                 .c2rust_unnamed
                 .c2rust_unnamed
-                .mv[1 as libc::c_int as usize] = mvstack_0[0].mv.mv[1];
+                .mv[1] = mvstack_0[0].mv.mv[1];
             fix_mv_precision(&*f.frame_hdr, &mut b.mv_mut()[0]);
             fix_mv_precision(&*f.frame_hdr, &mut b.mv_mut()[1]);
             if DEBUG_BLOCK_INFO(f, t) {
@@ -7490,7 +7490,7 @@ unsafe fn decode_b(
                 ) != 0
                 {
                     let ctx2 = av1_get_fwd_ref_2_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
-                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0 as libc::c_int as usize] =
+                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] =
                         (2 as libc::c_int as libc::c_uint).wrapping_add(
                             dav1d_msac_decode_bool_adapt(
                                 &mut ts.msac,
@@ -7500,7 +7500,7 @@ unsafe fn decode_b(
                 } else {
                     let ctx2_0 =
                         av1_get_fwd_ref_1_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
-                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0 as libc::c_int as usize] =
+                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] =
                         dav1d_msac_decode_bool_adapt(
                             &mut ts.msac,
                             (ts.cdf.m.comp_fwd_ref[1][ctx2_0 as usize]).as_mut_ptr(),
@@ -7515,7 +7515,7 @@ unsafe fn decode_b(
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] = 6 as libc::c_int as int8_t;
                 } else {
                     let ctx4 = av1_get_bwd_ref_1_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
-                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1 as libc::c_int as usize] =
+                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] =
                         (4 as libc::c_int as libc::c_uint).wrapping_add(
                             dav1d_msac_decode_bool_adapt(
                                 &mut ts.msac,
@@ -7535,7 +7535,7 @@ unsafe fn decode_b(
                 } else {
                     let uctx_p1 = av1_get_uni_p1_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] = 0 as libc::c_int as int8_t;
-                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1 as libc::c_int as usize] =
+                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] =
                         (1 as libc::c_int as libc::c_uint).wrapping_add(
                             dav1d_msac_decode_bool_adapt(
                                 &mut ts.msac,
@@ -7545,7 +7545,7 @@ unsafe fn decode_b(
                     if b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] as libc::c_int == 2 {
                         let uctx_p2 =
                             av1_get_fwd_ref_2_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
-                        b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1 as libc::c_int as usize] =
+                        b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] =
                             (b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] as libc::c_uint)
                                 .wrapping_add(dav1d_msac_decode_bool_adapt(
                                     &mut ts.msac,
@@ -7690,7 +7690,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
-                        .mv[0 as libc::c_int as usize] = mvstack_1
+                        .mv[0] = mvstack_1
                         [b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as usize]
                         .mv
                         .mv[0];
@@ -7706,7 +7706,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
-                        .mv[0 as libc::c_int as usize] = get_gmv_2d(
+                        .mv[0] = get_gmv_2d(
                         &(*f.frame_hdr).gmv[b.r#ref()[0] as usize],
                         t.bx,
                         t.by,
@@ -7720,7 +7720,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
-                        .mv[0 as libc::c_int as usize] = mvstack_1
+                        .mv[0] = mvstack_1
                         [b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as usize]
                         .mv
                         .mv[0];
@@ -7746,7 +7746,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
-                        .mv[1 as libc::c_int as usize] = mvstack_1
+                        .mv[1] = mvstack_1
                         [b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as usize]
                         .mv
                         .mv[1];
@@ -7762,7 +7762,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
-                        .mv[1 as libc::c_int as usize] = get_gmv_2d(
+                        .mv[1] = get_gmv_2d(
                         &(*f.frame_hdr).gmv[b.r#ref()[1] as usize],
                         t.bx,
                         t.by,
@@ -7776,7 +7776,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
-                        .mv[1 as libc::c_int as usize] = mvstack_1
+                        .mv[1] = mvstack_1
                         [b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as usize]
                         .mv
                         .mv[1];
@@ -8133,7 +8133,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
-                        .mv[0 as libc::c_int as usize] = get_gmv_2d(
+                        .mv[0] = get_gmv_2d(
                         &(*f.frame_hdr).gmv[b.r#ref()[0] as usize],
                         t.bx,
                         t.by,
@@ -8198,7 +8198,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
-                        .mv[0 as libc::c_int as usize] = mvstack_2
+                        .mv[0] = mvstack_2
                         [b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as usize]
                         .mv
                         .mv[0];
@@ -8269,7 +8269,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
-                        .mv[0 as libc::c_int as usize] = mvstack_2
+                        .mv[0] = mvstack_2
                         [b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as usize]
                         .mv
                         .mv[0];
@@ -8281,7 +8281,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
-                        .mv[0 as libc::c_int as usize] = mvstack_2[0].mv.mv[0];
+                        .mv[0] = mvstack_2[0].mv.mv[0];
                     fix_mv_precision(&*f.frame_hdr, &mut b.mv_mut()[0]);
                 }
                 if DEBUG_BLOCK_INFO(f, t) {
@@ -8555,30 +8555,30 @@ unsafe fn decode_b(
                                 .c2rust_unnamed_0
                                 .c2rust_unnamed
                                 .c2rust_unnamed_0
-                                .matrix[0 as libc::c_int as usize] =
+                                .matrix[0] =
                                 (t.warpmv.matrix[2] - 0x10000 as libc::c_int) as int16_t;
                             b.c2rust_unnamed
                                 .c2rust_unnamed_0
                                 .c2rust_unnamed
                                 .c2rust_unnamed_0
-                                .matrix[1 as libc::c_int as usize] = t.warpmv.matrix[3] as int16_t;
+                                .matrix[1] = t.warpmv.matrix[3] as int16_t;
                             b.c2rust_unnamed
                                 .c2rust_unnamed_0
                                 .c2rust_unnamed
                                 .c2rust_unnamed_0
-                                .matrix[2 as libc::c_int as usize] = t.warpmv.matrix[4] as int16_t;
+                                .matrix[2] = t.warpmv.matrix[4] as int16_t;
                             b.c2rust_unnamed
                                 .c2rust_unnamed_0
                                 .c2rust_unnamed
                                 .c2rust_unnamed_0
-                                .matrix[3 as libc::c_int as usize] =
+                                .matrix[3] =
                                 (t.warpmv.matrix[5] - 0x10000 as libc::c_int) as int16_t;
                         } else {
                             b.c2rust_unnamed
                                 .c2rust_unnamed_0
                                 .c2rust_unnamed
                                 .c2rust_unnamed_0
-                                .matrix[0 as libc::c_int as usize] =
+                                .matrix[0] =
                                 (-(32767 as libc::c_int) - 1) as int16_t;
                         }
                     }
@@ -8614,7 +8614,7 @@ unsafe fn decode_b(
                     by4,
                     bx4,
                 );
-                filter_0[0 as libc::c_int as usize] = dav1d_msac_decode_symbol_adapt4(
+                filter_0[0] = dav1d_msac_decode_symbol_adapt4(
                     &mut ts.msac,
                     (ts.cdf.m.filter[0][ctx1_1 as usize]).as_mut_ptr(),
                     (DAV1D_N_SWITCHABLE_FILTERS as libc::c_int - 1) as size_t,
@@ -8638,7 +8638,7 @@ unsafe fn decode_b(
                             ts.msac.rng,
                         );
                     }
-                    filter_0[1 as libc::c_int as usize] = dav1d_msac_decode_symbol_adapt4(
+                    filter_0[1] = dav1d_msac_decode_symbol_adapt4(
                         &mut ts.msac,
                         (ts.cdf.m.filter[1][ctx2_3 as usize]).as_mut_ptr(),
                         (DAV1D_N_SWITCHABLE_FILTERS as libc::c_int - 1) as size_t,
@@ -8653,7 +8653,7 @@ unsafe fn decode_b(
                         );
                     }
                 } else {
-                    filter_0[1 as libc::c_int as usize] = filter_0[0];
+                    filter_0[1] = filter_0[0];
                     if DEBUG_BLOCK_INFO(f, t) {
                         printf(
                             b"Post-subpel_filter[%d,ctx=%d]: r=%d\n\0" as *const u8
@@ -8666,7 +8666,7 @@ unsafe fn decode_b(
                 }
             } else {
                 filter_0[1] = DAV1D_FILTER_8TAP_REGULAR;
-                filter_0[0 as libc::c_int as usize] = filter_0[1];
+                filter_0[0] = filter_0[1];
             }
         } else {
             filter_0[1] = (*f.frame_hdr).subpel_filter_mode;
@@ -10202,7 +10202,7 @@ unsafe fn decode_b(
             (*noskip_mask)[bx_idx as usize] =
                 ((*noskip_mask)[bx_idx as usize] as libc::c_uint | mask_0) as uint16_t;
             if bw4 == 32 {
-                (*noskip_mask)[1 as libc::c_int as usize] =
+                (*noskip_mask)[1] =
                     ((*noskip_mask)[1] as libc::c_uint | mask_0) as uint16_t;
             }
             y_9 += 2 as libc::c_int;
@@ -11145,37 +11145,37 @@ unsafe extern "C" fn decode_sb(
                 (*(&mut *((*(*t).a).partition).as_mut_ptr().offset(bx8 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 as libc::c_int
-                    * dav1d_al_part_ctx[0 as libc::c_int as usize][bl as usize][bp as usize]
+                    * dav1d_al_part_ctx[0][bl as usize][bp as usize]
                         as libc::c_int) as uint8_t;
                 (*(&mut *((*t).l.partition).as_mut_ptr().offset(by8 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 as libc::c_int
-                    * dav1d_al_part_ctx[1 as libc::c_int as usize][bl as usize][bp as usize]
+                    * dav1d_al_part_ctx[1][bl as usize][bp as usize]
                         as libc::c_int) as uint8_t;
             }
             2 => {
                 (*(&mut *((*(*t).a).partition).as_mut_ptr().offset(bx8 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 as libc::c_int
-                    * dav1d_al_part_ctx[0 as libc::c_int as usize][bl as usize][bp as usize]
+                    * dav1d_al_part_ctx[0][bl as usize][bp as usize]
                         as libc::c_int) as uint16_t;
                 (*(&mut *((*t).l.partition).as_mut_ptr().offset(by8 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 as libc::c_int
-                    * dav1d_al_part_ctx[1 as libc::c_int as usize][bl as usize][bp as usize]
+                    * dav1d_al_part_ctx[1][bl as usize][bp as usize]
                         as libc::c_int) as uint16_t;
             }
             4 => {
                 (*(&mut *((*(*t).a).partition).as_mut_ptr().offset(bx8 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(
-                    dav1d_al_part_ctx[0 as libc::c_int as usize][bl as usize][bp as usize]
+                    dav1d_al_part_ctx[0][bl as usize][bp as usize]
                         as libc::c_uint,
                 );
                 (*(&mut *((*t).l.partition).as_mut_ptr().offset(by8 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(
-                    dav1d_al_part_ctx[1 as libc::c_int as usize][bl as usize][bp as usize]
+                    dav1d_al_part_ctx[1][bl as usize][bp as usize]
                         as libc::c_uint,
                 );
             }
@@ -11183,19 +11183,19 @@ unsafe extern "C" fn decode_sb(
                 (*(&mut *((*(*t).a).partition).as_mut_ptr().offset(bx8 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong).wrapping_mul(
-                    dav1d_al_part_ctx[0 as libc::c_int as usize][bl as usize][bp as usize]
+                    dav1d_al_part_ctx[0][bl as usize][bp as usize]
                         as libc::c_ulonglong,
                 ) as uint64_t;
                 (*(&mut *((*t).l.partition).as_mut_ptr().offset(by8 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong).wrapping_mul(
-                    dav1d_al_part_ctx[1 as libc::c_int as usize][bl as usize][bp as usize]
+                    dav1d_al_part_ctx[1][bl as usize][bp as usize]
                         as libc::c_ulonglong,
                 ) as uint64_t;
             }
             16 => {
                 let const_val: uint64_t = (0x101010101010101 as libc::c_ulonglong).wrapping_mul(
-                    dav1d_al_part_ctx[0 as libc::c_int as usize][bl as usize][bp as usize]
+                    dav1d_al_part_ctx[0][bl as usize][bp as usize]
                         as libc::c_ulonglong,
                 ) as uint64_t;
                 (*(&mut *((*(*t).a).partition)
@@ -11209,7 +11209,7 @@ unsafe extern "C" fn decode_sb(
                     as *mut alias64))
                     .u64_0 = const_val;
                 let const_val_0: uint64_t = (0x101010101010101 as libc::c_ulonglong).wrapping_mul(
-                    dav1d_al_part_ctx[1 as libc::c_int as usize][bl as usize][bp as usize]
+                    dav1d_al_part_ctx[1][bl as usize][bp as usize]
                         as libc::c_ulonglong,
                 ) as uint64_t;
                 (*(&mut *((*t).l.partition)
@@ -11443,21 +11443,21 @@ unsafe extern "C" fn setup_tile(
             match current_block_31 {
                 2370887241019905314 => {}
                 _ => {
-                    (*(*ts).lr_ref[p_0 as usize]).filter_v[0 as libc::c_int as usize] =
+                    (*(*ts).lr_ref[p_0 as usize]).filter_v[0] =
                         3 as libc::c_int as int8_t;
-                    (*(*ts).lr_ref[p_0 as usize]).filter_v[1 as libc::c_int as usize] =
+                    (*(*ts).lr_ref[p_0 as usize]).filter_v[1] =
                         -(7 as libc::c_int) as int8_t;
-                    (*(*ts).lr_ref[p_0 as usize]).filter_v[2 as libc::c_int as usize] =
+                    (*(*ts).lr_ref[p_0 as usize]).filter_v[2] =
                         15 as libc::c_int as int8_t;
-                    (*(*ts).lr_ref[p_0 as usize]).filter_h[0 as libc::c_int as usize] =
+                    (*(*ts).lr_ref[p_0 as usize]).filter_h[0] =
                         3 as libc::c_int as int8_t;
-                    (*(*ts).lr_ref[p_0 as usize]).filter_h[1 as libc::c_int as usize] =
+                    (*(*ts).lr_ref[p_0 as usize]).filter_h[1] =
                         -(7 as libc::c_int) as int8_t;
-                    (*(*ts).lr_ref[p_0 as usize]).filter_h[2 as libc::c_int as usize] =
+                    (*(*ts).lr_ref[p_0 as usize]).filter_h[2] =
                         15 as libc::c_int as int8_t;
-                    (*(*ts).lr_ref[p_0 as usize]).sgr_weights[0 as libc::c_int as usize] =
+                    (*(*ts).lr_ref[p_0 as usize]).sgr_weights[0] =
                         -(32 as libc::c_int) as int8_t;
-                    (*(*ts).lr_ref[p_0 as usize]).sgr_weights[1 as libc::c_int as usize] =
+                    (*(*ts).lr_ref[p_0 as usize]).sgr_weights[1] =
                         31 as libc::c_int as int8_t;
                 }
             }
@@ -11513,7 +11513,7 @@ unsafe extern "C" fn read_restoration_info(
         }) as uint8_t;
     }
     if (*lr).type_0 as libc::c_int == DAV1D_RESTORATION_WIENER as libc::c_int {
-        (*lr).filter_v[0 as libc::c_int as usize] = (if p != 0 {
+        (*lr).filter_v[0] = (if p != 0 {
             0 as libc::c_int
         } else {
             dav1d_msac_decode_subexp(
@@ -11523,19 +11523,19 @@ unsafe extern "C" fn read_restoration_info(
                 1 as libc::c_int as libc::c_uint,
             ) - 5
         }) as int8_t;
-        (*lr).filter_v[1 as libc::c_int as usize] = (dav1d_msac_decode_subexp(
+        (*lr).filter_v[1] = (dav1d_msac_decode_subexp(
             &mut (*ts).msac,
             (*(*ts).lr_ref[p as usize]).filter_v[1] as libc::c_int + 23,
             32 as libc::c_int,
             2 as libc::c_int as libc::c_uint,
         ) - 23) as int8_t;
-        (*lr).filter_v[2 as libc::c_int as usize] = (dav1d_msac_decode_subexp(
+        (*lr).filter_v[2] = (dav1d_msac_decode_subexp(
             &mut (*ts).msac,
             (*(*ts).lr_ref[p as usize]).filter_v[2] as libc::c_int + 17,
             64 as libc::c_int,
             3 as libc::c_int as libc::c_uint,
         ) - 17) as int8_t;
-        (*lr).filter_h[0 as libc::c_int as usize] = (if p != 0 {
+        (*lr).filter_h[0] = (if p != 0 {
             0 as libc::c_int
         } else {
             dav1d_msac_decode_subexp(
@@ -11545,13 +11545,13 @@ unsafe extern "C" fn read_restoration_info(
                 1 as libc::c_int as libc::c_uint,
             ) - 5
         }) as int8_t;
-        (*lr).filter_h[1 as libc::c_int as usize] = (dav1d_msac_decode_subexp(
+        (*lr).filter_h[1] = (dav1d_msac_decode_subexp(
             &mut (*ts).msac,
             (*(*ts).lr_ref[p as usize]).filter_h[1] as libc::c_int + 23,
             32 as libc::c_int,
             2 as libc::c_int as libc::c_uint,
         ) - 23) as int8_t;
-        (*lr).filter_h[2 as libc::c_int as usize] = (dav1d_msac_decode_subexp(
+        (*lr).filter_h[2] = (dav1d_msac_decode_subexp(
             &mut (*ts).msac,
             (*(*ts).lr_ref[p as usize]).filter_h[2] as libc::c_int + 17,
             64 as libc::c_int,
@@ -11588,7 +11588,7 @@ unsafe extern "C" fn read_restoration_info(
             dav1d_msac_decode_bools(&mut (*ts).msac, 4 as libc::c_int as libc::c_uint);
         let sgr_params: *const uint16_t = (dav1d_sgr_params[idx as usize]).as_ptr();
         (*lr).sgr_idx = idx as uint8_t;
-        (*lr).sgr_weights[0 as libc::c_int as usize] = (if *sgr_params.offset(0) as libc::c_int != 0
+        (*lr).sgr_weights[0] = (if *sgr_params.offset(0) as libc::c_int != 0
         {
             dav1d_msac_decode_subexp(
                 &mut (*ts).msac,
@@ -11599,7 +11599,7 @@ unsafe extern "C" fn read_restoration_info(
         } else {
             0 as libc::c_int
         }) as int8_t;
-        (*lr).sgr_weights[1 as libc::c_int as usize] = (if *sgr_params.offset(1) as libc::c_int != 0
+        (*lr).sgr_weights[1] = (if *sgr_params.offset(1) as libc::c_int != 0
         {
             dav1d_msac_decode_subexp(
                 &mut (*ts).msac,
@@ -12266,33 +12266,33 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                             as *mut uint8_t;
                                         let mut ptr: *mut uint8_t = (*f).lf.cdef_line_buf;
                                         if ptr.is_null() {
-                                            (*f).lf.cdef_buf_plane_sz[1 as libc::c_int as usize] =
+                                            (*f).lf.cdef_buf_plane_sz[1] =
                                                 0 as libc::c_int;
-                                            (*f).lf.cdef_buf_plane_sz[0 as libc::c_int as usize] =
+                                            (*f).lf.cdef_buf_plane_sz[0] =
                                                 (*f).lf.cdef_buf_plane_sz[1];
                                             current_block = 13495985911605184990;
                                         } else {
                                             ptr = ptr.offset(32);
                                             if y_stride < 0 {
-                                                (*f).lf.cdef_line[0 as libc::c_int as usize]
-                                                    [0 as libc::c_int as usize] = ptr.offset(
+                                                (*f).lf.cdef_line[0]
+                                                    [0] = ptr.offset(
                                                     -((y_stride * ((*f).sbh * 4 - 1) as isize)
                                                         as isize),
                                                 )
                                                     as *mut libc::c_void;
-                                                (*f).lf.cdef_line[1 as libc::c_int as usize]
-                                                    [0 as libc::c_int as usize] = ptr.offset(
+                                                (*f).lf.cdef_line[1]
+                                                    [0] = ptr.offset(
                                                     -((y_stride * ((*f).sbh * 4 - 3) as isize)
                                                         as isize),
                                                 )
                                                     as *mut libc::c_void;
                                             } else {
-                                                (*f).lf.cdef_line[0 as libc::c_int as usize]
-                                                    [0 as libc::c_int as usize] = ptr
+                                                (*f).lf.cdef_line[0]
+                                                    [0] = ptr
                                                     .offset((y_stride * 0) as isize)
                                                     as *mut libc::c_void;
-                                                (*f).lf.cdef_line[1 as libc::c_int as usize]
-                                                    [0 as libc::c_int as usize] = ptr
+                                                (*f).lf.cdef_line[1]
+                                                    [0] = ptr
                                                     .offset((y_stride * 2) as isize)
                                                     as *mut libc::c_void;
                                             }
@@ -12303,45 +12303,45 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                                     as isize,
                                             );
                                             if uv_stride < 0 {
-                                                (*f).lf.cdef_line[0 as libc::c_int as usize]
-                                                    [1 as libc::c_int as usize] = ptr.offset(
+                                                (*f).lf.cdef_line[0]
+                                                    [1] = ptr.offset(
                                                     -((uv_stride * ((*f).sbh * 8 - 1) as isize)
                                                         as isize),
                                                 )
                                                     as *mut libc::c_void;
-                                                (*f).lf.cdef_line[0 as libc::c_int as usize]
-                                                    [2 as libc::c_int as usize] = ptr.offset(
+                                                (*f).lf.cdef_line[0]
+                                                    [2] = ptr.offset(
                                                     -((uv_stride * ((*f).sbh * 8 - 3) as isize)
                                                         as isize),
                                                 )
                                                     as *mut libc::c_void;
-                                                (*f).lf.cdef_line[1 as libc::c_int as usize]
-                                                    [1 as libc::c_int as usize] = ptr.offset(
+                                                (*f).lf.cdef_line[1]
+                                                    [1] = ptr.offset(
                                                     -((uv_stride * ((*f).sbh * 8 - 5) as isize)
                                                         as isize),
                                                 )
                                                     as *mut libc::c_void;
-                                                (*f).lf.cdef_line[1 as libc::c_int as usize]
-                                                    [2 as libc::c_int as usize] = ptr.offset(
+                                                (*f).lf.cdef_line[1]
+                                                    [2] = ptr.offset(
                                                     -((uv_stride * ((*f).sbh * 8 - 7) as isize)
                                                         as isize),
                                                 )
                                                     as *mut libc::c_void;
                                             } else {
-                                                (*f).lf.cdef_line[0 as libc::c_int as usize]
-                                                    [1 as libc::c_int as usize] = ptr
+                                                (*f).lf.cdef_line[0]
+                                                    [1] = ptr
                                                     .offset((uv_stride * 0) as isize)
                                                     as *mut libc::c_void;
-                                                (*f).lf.cdef_line[0 as libc::c_int as usize]
-                                                    [2 as libc::c_int as usize] = ptr
+                                                (*f).lf.cdef_line[0]
+                                                    [2] = ptr
                                                     .offset((uv_stride * 2) as isize)
                                                     as *mut libc::c_void;
-                                                (*f).lf.cdef_line[1 as libc::c_int as usize]
-                                                    [1 as libc::c_int as usize] = ptr
+                                                (*f).lf.cdef_line[1]
+                                                    [1] = ptr
                                                     .offset((uv_stride * 4) as isize)
                                                     as *mut libc::c_void;
-                                                (*f).lf.cdef_line[1 as libc::c_int as usize]
-                                                    [2 as libc::c_int as usize] = ptr
+                                                (*f).lf.cdef_line[1]
+                                                    [2] = ptr
                                                     .offset((uv_stride * 6) as isize)
                                                     as *mut libc::c_void;
                                             }
@@ -12354,14 +12354,14 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                                 );
                                                 if y_stride < 0 {
                                                     (*f).lf.cdef_lpf_line
-                                                        [0 as libc::c_int as usize] = ptr.offset(
+                                                        [0] = ptr.offset(
                                                         -((y_stride * ((*f).sbh * 4 - 1) as isize)
                                                             as isize),
                                                     )
                                                         as *mut libc::c_void;
                                                 } else {
                                                     (*f).lf.cdef_lpf_line
-                                                        [0 as libc::c_int as usize] =
+                                                        [0] =
                                                         ptr as *mut libc::c_void;
                                                 }
                                                 ptr = ptr.offset(
@@ -12372,32 +12372,32 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                                 );
                                                 if uv_stride < 0 {
                                                     (*f).lf.cdef_lpf_line
-                                                        [1 as libc::c_int as usize] = ptr.offset(
+                                                        [1] = ptr.offset(
                                                         -((uv_stride * ((*f).sbh * 4 - 1) as isize)
                                                             as isize),
                                                     )
                                                         as *mut libc::c_void;
                                                     (*f).lf.cdef_lpf_line
-                                                        [2 as libc::c_int as usize] = ptr.offset(
+                                                        [2] = ptr.offset(
                                                         -((uv_stride * ((*f).sbh * 8 - 1) as isize)
                                                             as isize),
                                                     )
                                                         as *mut libc::c_void;
                                                 } else {
                                                     (*f).lf.cdef_lpf_line
-                                                        [1 as libc::c_int as usize] =
+                                                        [1] =
                                                         ptr as *mut libc::c_void;
                                                     (*f).lf.cdef_lpf_line
-                                                        [2 as libc::c_int as usize] = ptr.offset(
+                                                        [2] = ptr.offset(
                                                         (uv_stride * (*f).sbh as isize * 4)
                                                             as isize,
                                                     )
                                                         as *mut libc::c_void;
                                                 }
                                             }
-                                            (*f).lf.cdef_buf_plane_sz[0 as libc::c_int as usize] =
+                                            (*f).lf.cdef_buf_plane_sz[0] =
                                                 y_stride as libc::c_int * (*f).sbh * 4;
-                                            (*f).lf.cdef_buf_plane_sz[1 as libc::c_int as usize] =
+                                            (*f).lf.cdef_buf_plane_sz[1] =
                                                 uv_stride as libc::c_int * (*f).sbh * 8;
                                             (*f).lf.need_cdef_lpf_copy = need_cdef_lpf_copy;
                                             (*f).lf.cdef_buf_sbh = (*f).sbh;
@@ -12446,17 +12446,17 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                                 let mut ptr_0: *mut uint8_t = (*f).lf.lr_line_buf;
                                                 if ptr_0.is_null() {
                                                     (*f).lf.lr_buf_plane_sz
-                                                        [1 as libc::c_int as usize] =
+                                                        [1] =
                                                         0 as libc::c_int;
                                                     (*f).lf.lr_buf_plane_sz
-                                                        [0 as libc::c_int as usize] =
+                                                        [0] =
                                                         (*f).lf.lr_buf_plane_sz[1];
                                                     current_block = 13495985911605184990;
                                                 } else {
                                                     ptr_0 = ptr_0.offset(64);
                                                     if y_stride < 0 {
                                                         (*f).lf.lr_lpf_line
-                                                            [0 as libc::c_int as usize] = ptr_0
+                                                            [0] = ptr_0
                                                             .offset(
                                                                 -((y_stride
                                                                     * (num_lines - 1) as isize)
@@ -12465,7 +12465,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                                             as *mut libc::c_void;
                                                     } else {
                                                         (*f).lf.lr_lpf_line
-                                                            [0 as libc::c_int as usize] =
+                                                            [0] =
                                                             ptr_0 as *mut libc::c_void;
                                                     }
                                                     ptr_0 = ptr_0.offset(
@@ -12475,7 +12475,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                                     );
                                                     if uv_stride < 0 {
                                                         (*f).lf.lr_lpf_line
-                                                            [1 as libc::c_int as usize] = ptr_0
+                                                            [1] = ptr_0
                                                             .offset(
                                                                 -((uv_stride
                                                                     * (num_lines * 1 - 1) as isize)
@@ -12483,7 +12483,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                                             )
                                                             as *mut libc::c_void;
                                                         (*f).lf.lr_lpf_line
-                                                            [2 as libc::c_int as usize] = ptr_0
+                                                            [2] = ptr_0
                                                             .offset(
                                                                 -((uv_stride
                                                                     * (num_lines * 2 - 1) as isize)
@@ -12492,10 +12492,10 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                                             as *mut libc::c_void;
                                                     } else {
                                                         (*f).lf.lr_lpf_line
-                                                            [1 as libc::c_int as usize] =
+                                                            [1] =
                                                             ptr_0 as *mut libc::c_void;
                                                         (*f).lf.lr_lpf_line
-                                                            [2 as libc::c_int as usize] = ptr_0
+                                                            [2] = ptr_0
                                                             .offset(
                                                                 (uv_stride * num_lines as isize)
                                                                     as isize,
@@ -12503,10 +12503,10 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                                             as *mut libc::c_void;
                                                     }
                                                     (*f).lf.lr_buf_plane_sz
-                                                        [0 as libc::c_int as usize] =
+                                                        [0] =
                                                         y_stride as libc::c_int * num_lines;
                                                     (*f).lf.lr_buf_plane_sz
-                                                        [1 as libc::c_int as usize] =
+                                                        [1] =
                                                         uv_stride as libc::c_int * num_lines * 2;
                                                     current_block = 15456862084301247793;
                                                 }
@@ -13769,7 +13769,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                                                 if (*(*f).frame_hdr).width[0]
                                                     != (*(*f).frame_hdr).width[1]
                                                 {
-                                                    (*f).resize_step[0 as libc::c_int as usize] =
+                                                    (*f).resize_step[0] =
                                                         (((*f).cur.p.w << 14)
                                                             + ((*f).sr_cur.p.p.w >> 1))
                                                             / (*f).sr_cur.p.p.w;
@@ -13780,15 +13780,15 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                                                     let in_cw = (*f).cur.p.w + ss_hor >> ss_hor;
                                                     let out_cw =
                                                         (*f).sr_cur.p.p.w + ss_hor >> ss_hor;
-                                                    (*f).resize_step[1 as libc::c_int as usize] =
+                                                    (*f).resize_step[1] =
                                                         ((in_cw << 14) + (out_cw >> 1)) / out_cw;
-                                                    (*f).resize_start[0 as libc::c_int as usize] =
+                                                    (*f).resize_start[0] =
                                                         get_upscale_x0(
                                                             (*f).cur.p.w,
                                                             (*f).sr_cur.p.p.w,
                                                             (*f).resize_step[0],
                                                         );
-                                                    (*f).resize_start[1 as libc::c_int as usize] =
+                                                    (*f).resize_start[1] =
                                                         get_upscale_x0(
                                                             in_cw,
                                                             out_cw,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3042,7 +3042,7 @@ unsafe extern "C" fn read_pal_indices(
     if pal_idx.is_null() {
         unreachable!();
     }
-    *pal_idx.offset(0 as libc::c_int as isize) = dav1d_msac_decode_uniform(
+    *pal_idx.offset(0) = dav1d_msac_decode_uniform(
         &mut (*ts).msac,
         (*b).c2rust_unnamed.c2rust_unnamed.pal_sz[pl as usize] as libc::c_uint,
     ) as uint8_t;

--- a/src/filmgrain_tmpl_16.rs
+++ b/src/filmgrain_tmpl_16.rs
@@ -680,13 +680,13 @@ unsafe extern "C" fn fgy_32x32xn_c(
         if (*data).overlap_flag != 0 && bx != 0 {
             let mut i_0 = 0;
             while i_0 < rows {
-                offsets[1 as libc::c_int as usize][i_0 as usize] = offsets[0][i_0 as usize];
+                offsets[1][i_0 as usize] = offsets[0][i_0 as usize];
                 i_0 += 1;
             }
         }
         let mut i_1 = 0;
         while i_1 < rows {
-            offsets[0 as libc::c_int as usize][i_1 as usize] = get_random_number(
+            offsets[0][i_1 as usize] = get_random_number(
                 8 as libc::c_int,
                 &mut *seed.as_mut_ptr().offset(i_1 as isize),
             );
@@ -959,13 +959,13 @@ unsafe extern "C" fn fguv_32x32xn_c(
         if (*data).overlap_flag != 0 && bx != 0 {
             let mut i_0 = 0;
             while i_0 < rows {
-                offsets[1 as libc::c_int as usize][i_0 as usize] = offsets[0][i_0 as usize];
+                offsets[1][i_0 as usize] = offsets[0][i_0 as usize];
                 i_0 += 1;
             }
         }
         let mut i_1 = 0;
         while i_1 < rows {
-            offsets[0 as libc::c_int as usize][i_1 as usize] = get_random_number(
+            offsets[0][i_1 as usize] = get_random_number(
                 8 as libc::c_int,
                 &mut *seed.as_mut_ptr().offset(i_1 as isize),
             );
@@ -1492,13 +1492,13 @@ unsafe extern "C" fn fgy_32x32xn_neon(
         if (*data).overlap_flag != 0 && bx != 0 {
             let mut i_0 = 0;
             while i_0 < rows {
-                offsets[1 as libc::c_int as usize][i_0 as usize] = offsets[0][i_0 as usize];
+                offsets[1][i_0 as usize] = offsets[0][i_0 as usize];
                 i_0 += 1;
             }
         }
         let mut i_1 = 0;
         while i_1 < rows {
-            offsets[0 as libc::c_int as usize][i_1 as usize] = get_random_number(
+            offsets[0][i_1 as usize] = get_random_number(
                 8 as libc::c_int,
                 &mut *seed.as_mut_ptr().offset(i_1 as isize),
             );
@@ -1560,13 +1560,13 @@ unsafe extern "C" fn fguv_32x32xn_420_neon(
         if (*data).overlap_flag != 0 && bx != 0 {
             let mut i_0 = 0;
             while i_0 < rows {
-                offsets[1 as libc::c_int as usize][i_0 as usize] = offsets[0][i_0 as usize];
+                offsets[1][i_0 as usize] = offsets[0][i_0 as usize];
                 i_0 += 1;
             }
         }
         let mut i_1 = 0;
         while i_1 < rows {
-            offsets[0 as libc::c_int as usize][i_1 as usize] = get_random_number(
+            offsets[0][i_1 as usize] = get_random_number(
                 8 as libc::c_int,
                 &mut *seed.as_mut_ptr().offset(i_1 as isize),
             );
@@ -1634,13 +1634,13 @@ unsafe extern "C" fn fguv_32x32xn_422_neon(
         if (*data).overlap_flag != 0 && bx != 0 {
             let mut i_0 = 0;
             while i_0 < rows {
-                offsets[1 as libc::c_int as usize][i_0 as usize] = offsets[0][i_0 as usize];
+                offsets[1][i_0 as usize] = offsets[0][i_0 as usize];
                 i_0 += 1;
             }
         }
         let mut i_1 = 0;
         while i_1 < rows {
-            offsets[0 as libc::c_int as usize][i_1 as usize] = get_random_number(
+            offsets[0][i_1 as usize] = get_random_number(
                 8 as libc::c_int,
                 &mut *seed.as_mut_ptr().offset(i_1 as isize),
             );
@@ -1708,13 +1708,13 @@ unsafe extern "C" fn fguv_32x32xn_444_neon(
         if (*data).overlap_flag != 0 && bx != 0 {
             let mut i_0 = 0;
             while i_0 < rows {
-                offsets[1 as libc::c_int as usize][i_0 as usize] = offsets[0][i_0 as usize];
+                offsets[1][i_0 as usize] = offsets[0][i_0 as usize];
                 i_0 += 1;
             }
         }
         let mut i_1 = 0;
         while i_1 < rows {
-            offsets[0 as libc::c_int as usize][i_1 as usize] = get_random_number(
+            offsets[0][i_1 as usize] = get_random_number(
                 8 as libc::c_int,
                 &mut *seed.as_mut_ptr().offset(i_1 as isize),
             );

--- a/src/filmgrain_tmpl_8.rs
+++ b/src/filmgrain_tmpl_8.rs
@@ -607,13 +607,13 @@ unsafe extern "C" fn fgy_32x32xn_c(
         if (*data).overlap_flag != 0 && bx != 0 {
             let mut i_0 = 0;
             while i_0 < rows {
-                offsets[1 as libc::c_int as usize][i_0 as usize] = offsets[0][i_0 as usize];
+                offsets[1][i_0 as usize] = offsets[0][i_0 as usize];
                 i_0 += 1;
             }
         }
         let mut i_1 = 0;
         while i_1 < rows {
-            offsets[0 as libc::c_int as usize][i_1 as usize] = get_random_number(
+            offsets[0][i_1 as usize] = get_random_number(
                 8 as libc::c_int,
                 &mut *seed.as_mut_ptr().offset(i_1 as isize),
             );
@@ -885,13 +885,13 @@ unsafe extern "C" fn fguv_32x32xn_c(
         if (*data).overlap_flag != 0 && bx != 0 {
             let mut i_0 = 0;
             while i_0 < rows {
-                offsets[1 as libc::c_int as usize][i_0 as usize] = offsets[0][i_0 as usize];
+                offsets[1][i_0 as usize] = offsets[0][i_0 as usize];
                 i_0 += 1;
             }
         }
         let mut i_1 = 0;
         while i_1 < rows {
-            offsets[0 as libc::c_int as usize][i_1 as usize] = get_random_number(
+            offsets[0][i_1 as usize] = get_random_number(
                 8 as libc::c_int,
                 &mut *seed.as_mut_ptr().offset(i_1 as isize),
             );
@@ -1400,13 +1400,13 @@ unsafe extern "C" fn fgy_32x32xn_neon(
         if (*data).overlap_flag != 0 && bx != 0 {
             let mut i_0 = 0;
             while i_0 < rows {
-                offsets[1 as libc::c_int as usize][i_0 as usize] = offsets[0][i_0 as usize];
+                offsets[1][i_0 as usize] = offsets[0][i_0 as usize];
                 i_0 += 1;
             }
         }
         let mut i_1 = 0;
         while i_1 < rows {
-            offsets[0 as libc::c_int as usize][i_1 as usize] = get_random_number(
+            offsets[0][i_1 as usize] = get_random_number(
                 8 as libc::c_int,
                 &mut *seed.as_mut_ptr().offset(i_1 as isize),
             );
@@ -1466,13 +1466,13 @@ unsafe extern "C" fn fguv_32x32xn_420_neon(
         if (*data).overlap_flag != 0 && bx != 0 {
             let mut i_0 = 0;
             while i_0 < rows {
-                offsets[1 as libc::c_int as usize][i_0 as usize] = offsets[0][i_0 as usize];
+                offsets[1][i_0 as usize] = offsets[0][i_0 as usize];
                 i_0 += 1;
             }
         }
         let mut i_1 = 0;
         while i_1 < rows {
-            offsets[0 as libc::c_int as usize][i_1 as usize] = get_random_number(
+            offsets[0][i_1 as usize] = get_random_number(
                 8 as libc::c_int,
                 &mut *seed.as_mut_ptr().offset(i_1 as isize),
             );
@@ -1538,13 +1538,13 @@ unsafe extern "C" fn fguv_32x32xn_422_neon(
         if (*data).overlap_flag != 0 && bx != 0 {
             let mut i_0 = 0;
             while i_0 < rows {
-                offsets[1 as libc::c_int as usize][i_0 as usize] = offsets[0][i_0 as usize];
+                offsets[1][i_0 as usize] = offsets[0][i_0 as usize];
                 i_0 += 1;
             }
         }
         let mut i_1 = 0;
         while i_1 < rows {
-            offsets[0 as libc::c_int as usize][i_1 as usize] = get_random_number(
+            offsets[0][i_1 as usize] = get_random_number(
                 8 as libc::c_int,
                 &mut *seed.as_mut_ptr().offset(i_1 as isize),
             );
@@ -1610,13 +1610,13 @@ unsafe extern "C" fn fguv_32x32xn_444_neon(
         if (*data).overlap_flag != 0 && bx != 0 {
             let mut i_0 = 0;
             while i_0 < rows {
-                offsets[1 as libc::c_int as usize][i_0 as usize] = offsets[0][i_0 as usize];
+                offsets[1][i_0 as usize] = offsets[0][i_0 as usize];
                 i_0 += 1;
             }
         }
         let mut i_1 = 0;
         while i_1 < rows {
-            offsets[0 as libc::c_int as usize][i_1 as usize] = get_random_number(
+            offsets[0][i_1 as usize] = get_random_number(
                 8 as libc::c_int,
                 &mut *seed.as_mut_ptr().offset(i_1 as isize),
             );

--- a/src/intra_edge.rs
+++ b/src/intra_edge.rs
@@ -76,8 +76,7 @@ unsafe extern "C" fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags:
             | EDGE_I420_TOP_HAS_RIGHT as libc::c_int
             | (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int))
-            as EdgeFlags;
+                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int)) as EdgeFlags;
         (*nt).split[1] = (edge_flags as libc::c_uint
             & (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
@@ -121,8 +120,7 @@ unsafe extern "C" fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags:
             as EdgeFlags;
         (*nwc).h4[2] = (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
             | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
-            | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int)
-            as EdgeFlags;
+            | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as EdgeFlags;
         (*nwc).h4[1] = (*nwc).h4[2];
         (*nwc).h4[3] = (edge_flags as libc::c_uint
             & (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
@@ -143,8 +141,7 @@ unsafe extern "C" fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags:
             as EdgeFlags;
         (*nwc).v4[2] = (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
             | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
-            | EDGE_I420_TOP_HAS_RIGHT as libc::c_int)
-            as EdgeFlags;
+            | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as EdgeFlags;
         (*nwc).v4[1] = (*nwc).v4[2];
         (*nwc).v4[3] = (edge_flags as libc::c_uint
             & (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
@@ -165,8 +162,7 @@ unsafe extern "C" fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags:
             | EDGE_I420_TOP_HAS_RIGHT as libc::c_int
             | (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int))
-            as EdgeFlags;
+                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int)) as EdgeFlags;
         (*nwc).tls[1] = (edge_flags as libc::c_uint
             & (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
@@ -193,8 +189,7 @@ unsafe extern "C" fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags:
             | EDGE_I420_TOP_HAS_RIGHT as libc::c_int
             | (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int))
-            as EdgeFlags;
+                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int)) as EdgeFlags;
         (*nwc).tts[1] = (edge_flags as libc::c_uint
             & (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I422_TOP_HAS_RIGHT as libc::c_int

--- a/src/intra_edge.rs
+++ b/src/intra_edge.rs
@@ -48,111 +48,111 @@ unsafe extern "C" fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags:
     (*node).o = edge_flags;
     if bl as libc::c_uint == BL_8X8 as libc::c_int as libc::c_uint {
         let nt: *mut EdgeTip = node as *mut EdgeTip;
-        (*node).h[0 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*node).h[0] = (edge_flags as libc::c_uint
             | (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
             as EdgeFlags;
-        (*node).h[1 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*node).h[1] = (edge_flags as libc::c_uint
             & (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)
             as EdgeFlags;
-        (*node).v[0 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*node).v[0] = (edge_flags as libc::c_uint
             | (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)
             as EdgeFlags;
-        (*node).v[1 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*node).v[1] = (edge_flags as libc::c_uint
             & (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I420_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
             as EdgeFlags;
-        (*nt).split[0 as libc::c_int as usize] = (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
+        (*nt).split[0] = (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
             | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
             | EDGE_I420_TOP_HAS_RIGHT as libc::c_int
             | (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int))
             as EdgeFlags;
-        (*nt).split[1 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*nt).split[1] = (edge_flags as libc::c_uint
             & (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint
             | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int as libc::c_uint)
             as EdgeFlags;
-        (*nt).split[2 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*nt).split[2] = (edge_flags as libc::c_uint
             | EDGE_I444_TOP_HAS_RIGHT as libc::c_int as libc::c_uint)
             as EdgeFlags;
-        (*nt).split[3 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*nt).split[3] = (edge_flags as libc::c_uint
             & (EDGE_I420_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
             as EdgeFlags;
     } else {
         let nwc: *mut EdgeBranch = node as *mut EdgeBranch;
-        (*node).h[0 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*node).h[0] = (edge_flags as libc::c_uint
             | (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
             as EdgeFlags;
-        (*node).h[1 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*node).h[1] = (edge_flags as libc::c_uint
             & (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
             as EdgeFlags;
-        (*node).v[0 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*node).v[0] = (edge_flags as libc::c_uint
             | (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)
             as EdgeFlags;
-        (*node).v[1 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*node).v[1] = (edge_flags as libc::c_uint
             & (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)
             as EdgeFlags;
-        (*nwc).h4[0 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*nwc).h4[0] = (edge_flags as libc::c_uint
             | (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
             as EdgeFlags;
-        (*nwc).h4[2 as libc::c_int as usize] = (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
+        (*nwc).h4[2] = (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
             | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
             | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int)
             as EdgeFlags;
         (*nwc).h4[1] = (*nwc).h4[2];
-        (*nwc).h4[3 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*nwc).h4[3] = (edge_flags as libc::c_uint
             & (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
             as EdgeFlags;
         if bl as libc::c_uint == BL_16X16 as libc::c_int as libc::c_uint {
-            (*nwc).h4[1 as libc::c_int as usize] = ::core::mem::transmute::<libc::c_uint, EdgeFlags>(
+            (*nwc).h4[1] = ::core::mem::transmute::<libc::c_uint, EdgeFlags>(
                 (*nwc).h4[1] as libc::c_uint
                     | edge_flags as libc::c_uint
                         & EDGE_I420_TOP_HAS_RIGHT as libc::c_int as libc::c_uint,
             );
         }
-        (*nwc).v4[0 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*nwc).v4[0] = (edge_flags as libc::c_uint
             | (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)
             as EdgeFlags;
-        (*nwc).v4[2 as libc::c_int as usize] = (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
+        (*nwc).v4[2] = (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
             | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
             | EDGE_I420_TOP_HAS_RIGHT as libc::c_int)
             as EdgeFlags;
         (*nwc).v4[1] = (*nwc).v4[2];
-        (*nwc).v4[3 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*nwc).v4[3] = (edge_flags as libc::c_uint
             & (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)
             as EdgeFlags;
         if bl as libc::c_uint == BL_16X16 as libc::c_int as libc::c_uint {
-            (*nwc).v4[1 as libc::c_int as usize] = ::core::mem::transmute::<libc::c_uint, EdgeFlags>(
+            (*nwc).v4[1] = ::core::mem::transmute::<libc::c_uint, EdgeFlags>(
                 (*nwc).v4[1] as libc::c_uint
                     | edge_flags as libc::c_uint
                         & (EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int
@@ -160,57 +160,57 @@ unsafe extern "C" fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags:
                             as libc::c_uint,
             );
         }
-        (*nwc).tls[0 as libc::c_int as usize] = (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
+        (*nwc).tls[0] = (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
             | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
             | EDGE_I420_TOP_HAS_RIGHT as libc::c_int
             | (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int))
             as EdgeFlags;
-        (*nwc).tls[1 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*nwc).tls[1] = (edge_flags as libc::c_uint
             & (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
             as EdgeFlags;
-        (*nwc).tls[2 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*nwc).tls[2] = (edge_flags as libc::c_uint
             & (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)
             as EdgeFlags;
-        (*nwc).trs[0 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*nwc).trs[0] = (edge_flags as libc::c_uint
             | (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)
             as EdgeFlags;
-        (*nwc).trs[1 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*nwc).trs[1] = (edge_flags as libc::c_uint
             | (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
             as EdgeFlags;
         (*nwc).trs[2] = 0 as EdgeFlags;
-        (*nwc).tts[0 as libc::c_int as usize] = (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
+        (*nwc).tts[0] = (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
             | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
             | EDGE_I420_TOP_HAS_RIGHT as libc::c_int
             | (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int))
             as EdgeFlags;
-        (*nwc).tts[1 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*nwc).tts[1] = (edge_flags as libc::c_uint
             & (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)
             as EdgeFlags;
-        (*nwc).tts[2 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*nwc).tts[2] = (edge_flags as libc::c_uint
             & (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
             as EdgeFlags;
-        (*nwc).tbs[0 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*nwc).tbs[0] = (edge_flags as libc::c_uint
             | (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
                 | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
             as EdgeFlags;
-        (*nwc).tbs[1 as libc::c_int as usize] = (edge_flags as libc::c_uint
+        (*nwc).tbs[1] = (edge_flags as libc::c_uint
             | (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
                 | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)

--- a/src/ipred_tmpl_8.rs
+++ b/src/ipred_tmpl_8.rs
@@ -2094,7 +2094,7 @@ unsafe extern "C" fn ipred_z3_neon(
         0 as libc::c_int
     };
     if upsample_left != 0 {
-        flipped[0 as libc::c_int as usize] = *topleft_in.offset(0);
+        flipped[0] = *topleft_in.offset(0);
         dav1d_ipred_reverse_8bpc_neon(
             &mut *flipped.as_mut_ptr().offset(1),
             &*topleft_in.offset(0),
@@ -2115,7 +2115,7 @@ unsafe extern "C" fn ipred_z3_neon(
             0 as libc::c_int
         };
         if filter_strength != 0 {
-            flipped[0 as libc::c_int as usize] = *topleft_in.offset(0);
+            flipped[0] = *topleft_in.offset(0);
             dav1d_ipred_reverse_8bpc_neon(
                 &mut *flipped.as_mut_ptr().offset(1),
                 &*topleft_in.offset(0),

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -1010,18 +1010,18 @@ unsafe extern "C" fn filter_plane_cols_y(
         if !(have_left == 0 && x == 0) {
             let mut hmask: [uint32_t; 4] = [0; 4];
             if starty4 == 0 {
-                hmask[0 as libc::c_int as usize] = (*mask.offset(x as isize))[0][0] as uint32_t;
-                hmask[1 as libc::c_int as usize] = (*mask.offset(x as isize))[1][0] as uint32_t;
-                hmask[2 as libc::c_int as usize] = (*mask.offset(x as isize))[2][0] as uint32_t;
+                hmask[0] = (*mask.offset(x as isize))[0][0] as uint32_t;
+                hmask[1] = (*mask.offset(x as isize))[1][0] as uint32_t;
+                hmask[2] = (*mask.offset(x as isize))[2][0] as uint32_t;
                 if endy4 > 16 {
                     hmask[0] |= ((*mask.offset(x as isize))[0][1] as libc::c_uint) << 16;
                     hmask[1] |= ((*mask.offset(x as isize))[1][1] as libc::c_uint) << 16;
                     hmask[2] |= ((*mask.offset(x as isize))[2][1] as libc::c_uint) << 16;
                 }
             } else {
-                hmask[0 as libc::c_int as usize] = (*mask.offset(x as isize))[0][1] as uint32_t;
-                hmask[1 as libc::c_int as usize] = (*mask.offset(x as isize))[1][1] as uint32_t;
-                hmask[2 as libc::c_int as usize] = (*mask.offset(x as isize))[2][1] as uint32_t;
+                hmask[0] = (*mask.offset(x as isize))[0][1] as uint32_t;
+                hmask[1] = (*mask.offset(x as isize))[1][1] as uint32_t;
+                hmask[2] = (*mask.offset(x as isize))[2][1] as uint32_t;
             }
             hmask[3] = 0 as libc::c_int as uint32_t;
             ((*dsp).lf.loop_filter_sb[0][0]).expect("non-null function pointer")(
@@ -1102,8 +1102,8 @@ unsafe extern "C" fn filter_plane_cols_uv(
         if !(have_left == 0 && x == 0) {
             let mut hmask: [uint32_t; 3] = [0; 3];
             if starty4 == 0 {
-                hmask[0 as libc::c_int as usize] = (*mask.offset(x as isize))[0][0] as uint32_t;
-                hmask[1 as libc::c_int as usize] = (*mask.offset(x as isize))[1][0] as uint32_t;
+                hmask[0] = (*mask.offset(x as isize))[0][0] as uint32_t;
+                hmask[1] = (*mask.offset(x as isize))[1][0] as uint32_t;
                 if endy4 > 16 >> ss_ver {
                     hmask[0] |=
                         ((*mask.offset(x as isize))[0][1] as libc::c_uint) << (16 >> ss_ver);
@@ -1111,8 +1111,8 @@ unsafe extern "C" fn filter_plane_cols_uv(
                         ((*mask.offset(x as isize))[1][1] as libc::c_uint) << (16 >> ss_ver);
                 }
             } else {
-                hmask[0 as libc::c_int as usize] = (*mask.offset(x as isize))[0][1] as uint32_t;
-                hmask[1 as libc::c_int as usize] = (*mask.offset(x as isize))[1][1] as uint32_t;
+                hmask[0] = (*mask.offset(x as isize))[0][1] as uint32_t;
+                hmask[1] = (*mask.offset(x as isize))[1][1] as uint32_t;
             }
             hmask[2] = 0 as libc::c_int as uint32_t;
             ((*dsp).lf.loop_filter_sb[1][0]).expect("non-null function pointer")(

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -954,18 +954,18 @@ unsafe extern "C" fn filter_plane_cols_y(
         if !(have_left == 0 && x == 0) {
             let mut hmask: [uint32_t; 4] = [0; 4];
             if starty4 == 0 {
-                hmask[0 as libc::c_int as usize] = (*mask.offset(x as isize))[0][0] as uint32_t;
-                hmask[1 as libc::c_int as usize] = (*mask.offset(x as isize))[1][0] as uint32_t;
-                hmask[2 as libc::c_int as usize] = (*mask.offset(x as isize))[2][0] as uint32_t;
+                hmask[0] = (*mask.offset(x as isize))[0][0] as uint32_t;
+                hmask[1] = (*mask.offset(x as isize))[1][0] as uint32_t;
+                hmask[2] = (*mask.offset(x as isize))[2][0] as uint32_t;
                 if endy4 > 16 {
                     hmask[0] |= ((*mask.offset(x as isize))[0][1] as libc::c_uint) << 16;
                     hmask[1] |= ((*mask.offset(x as isize))[1][1] as libc::c_uint) << 16;
                     hmask[2] |= ((*mask.offset(x as isize))[2][1] as libc::c_uint) << 16;
                 }
             } else {
-                hmask[0 as libc::c_int as usize] = (*mask.offset(x as isize))[0][1] as uint32_t;
-                hmask[1 as libc::c_int as usize] = (*mask.offset(x as isize))[1][1] as uint32_t;
-                hmask[2 as libc::c_int as usize] = (*mask.offset(x as isize))[2][1] as uint32_t;
+                hmask[0] = (*mask.offset(x as isize))[0][1] as uint32_t;
+                hmask[1] = (*mask.offset(x as isize))[1][1] as uint32_t;
+                hmask[2] = (*mask.offset(x as isize))[2][1] as uint32_t;
             }
             hmask[3] = 0 as libc::c_int as uint32_t;
             ((*dsp).lf.loop_filter_sb[0][0]).expect("non-null function pointer")(
@@ -1044,8 +1044,8 @@ unsafe extern "C" fn filter_plane_cols_uv(
         if !(have_left == 0 && x == 0) {
             let mut hmask: [uint32_t; 3] = [0; 3];
             if starty4 == 0 {
-                hmask[0 as libc::c_int as usize] = (*mask.offset(x as isize))[0][0] as uint32_t;
-                hmask[1 as libc::c_int as usize] = (*mask.offset(x as isize))[1][0] as uint32_t;
+                hmask[0] = (*mask.offset(x as isize))[0][0] as uint32_t;
+                hmask[1] = (*mask.offset(x as isize))[1][0] as uint32_t;
                 if endy4 > 16 >> ss_ver {
                     hmask[0] |=
                         ((*mask.offset(x as isize))[0][1] as libc::c_uint) << (16 >> ss_ver);
@@ -1053,8 +1053,8 @@ unsafe extern "C" fn filter_plane_cols_uv(
                         ((*mask.offset(x as isize))[1][1] as libc::c_uint) << (16 >> ss_ver);
                 }
             } else {
-                hmask[0 as libc::c_int as usize] = (*mask.offset(x as isize))[0][1] as uint32_t;
-                hmask[1 as libc::c_int as usize] = (*mask.offset(x as isize))[1][1] as uint32_t;
+                hmask[0] = (*mask.offset(x as isize))[0][1] as uint32_t;
+                hmask[1] = (*mask.offset(x as isize))[1][1] as uint32_t;
             }
             hmask[2] = 0 as libc::c_int as uint32_t;
             ((*dsp).lf.loop_filter_sb[1][0]).expect("non-null function pointer")(

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -142,8 +142,7 @@ unsafe extern "C" fn decomp_tx(
                     .as_mut_ptr()
                     .offset(0) as *mut uint8_t as *mut alias8))
                         .u8_0 = (0x1 * lh) as uint8_t;
-                    (*txa.offset(0))[1]
-                        [y as usize][0] = (*t_dim).w;
+                    (*txa.offset(0))[1][y as usize][0] = (*t_dim).w;
                     y += 1;
                 }
             }
@@ -162,8 +161,7 @@ unsafe extern "C" fn decomp_tx(
                     .as_mut_ptr()
                     .offset(0) as *mut uint8_t as *mut alias16))
                         .u16_0 = (0x101 * lh) as uint16_t;
-                    (*txa.offset(0))[1]
-                        [y_0 as usize][0] = (*t_dim).w;
+                    (*txa.offset(0))[1][y_0 as usize][0] = (*t_dim).w;
                     y_0 += 1;
                 }
             }
@@ -182,8 +180,7 @@ unsafe extern "C" fn decomp_tx(
                     .as_mut_ptr()
                     .offset(0) as *mut uint8_t as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(lh as libc::c_uint);
-                    (*txa.offset(0))[1]
-                        [y_1 as usize][0] = (*t_dim).w;
+                    (*txa.offset(0))[1][y_1 as usize][0] = (*t_dim).w;
                     y_1 += 1;
                 }
             }
@@ -206,8 +203,7 @@ unsafe extern "C" fn decomp_tx(
                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(lh as libc::c_ulonglong)
                         as uint64_t;
-                    (*txa.offset(0))[1]
-                        [y_2 as usize][0] = (*t_dim).w;
+                    (*txa.offset(0))[1][y_2 as usize][0] = (*t_dim).w;
                     y_2 += 1;
                 }
             }
@@ -248,8 +244,7 @@ unsafe extern "C" fn decomp_tx(
                     .offset((0 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_0;
-                    (*txa.offset(0))[1]
-                        [y_3 as usize][0] = (*t_dim).w;
+                    (*txa.offset(0))[1][y_3 as usize][0] = (*t_dim).w;
                     y_3 += 1;
                 }
             }
@@ -362,8 +357,7 @@ unsafe extern "C" fn mask_edges_inter(
         let ref mut fresh0 = (*masks.offset(0))[bx4 as usize][imin(
             txa[0][0][y as usize][0] as libc::c_int,
             *l.offset(y as isize) as libc::c_int,
-        )
-            as usize][sidx as usize];
+        ) as usize][sidx as usize];
         *fresh0 = (*fresh0 as libc::c_uint | smask) as uint16_t;
         y += 1;
         mask <<= 1;
@@ -376,8 +370,7 @@ unsafe extern "C" fn mask_edges_inter(
         let ref mut fresh1 = (*masks.offset(1))[by4 as usize][imin(
             txa[1][0][0][x as usize] as libc::c_int,
             *a.offset(x as isize) as libc::c_int,
-        )
-            as usize][sidx_0 as usize];
+        ) as usize][sidx_0 as usize];
         *fresh1 = (*fresh1 as libc::c_uint | smask_0) as uint16_t;
         x += 1;
         mask <<= 1;
@@ -388,10 +381,8 @@ unsafe extern "C" fn mask_edges_inter(
         while y < h4 {
             let sidx_1 = (mask >= 0x10000 as libc::c_uint) as libc::c_int;
             let smask_1: libc::c_uint = mask >> (sidx_1 << 4);
-            let mut ltx = txa[0][0][y as usize][0]
-                as libc::c_int;
-            let mut step = txa[0][1][y as usize][0]
-                as libc::c_int;
+            let mut ltx = txa[0][0][y as usize][0] as libc::c_int;
+            let mut step = txa[0][1][y as usize][0] as libc::c_int;
             x = step;
             while x < w4 {
                 let rtx = txa[0][0][y as usize][x as usize] as libc::c_int;
@@ -410,10 +401,8 @@ unsafe extern "C" fn mask_edges_inter(
         while x < w4 {
             let sidx_2 = (mask >= 0x10000 as libc::c_uint) as libc::c_int;
             let smask_2: libc::c_uint = mask >> (sidx_2 << 4);
-            let mut ttx = txa[1][0][0][x as usize]
-                as libc::c_int;
-            let mut step_0 = txa[1][1][0]
-                [x as usize] as libc::c_int;
+            let mut ttx = txa[1][0][0][x as usize] as libc::c_int;
+            let mut step_0 = txa[1][1][0][x as usize] as libc::c_int;
             y = step_0;
             while y < h4 {
                 let btx = txa[1][0][y as usize][x as usize] as libc::c_int;
@@ -430,8 +419,7 @@ unsafe extern "C" fn mask_edges_inter(
     }
     y = 0 as libc::c_int;
     while y < h4 {
-        *l.offset(y as isize) = txa[0][0]
-            [y as usize][(w4 - 1) as usize];
+        *l.offset(y as isize) = txa[0][0][y as usize][(w4 - 1) as usize];
         y += 1;
     }
     memcpy(
@@ -490,13 +478,11 @@ unsafe extern "C" fn mask_edges_intra(
     x = hstep;
     while x < w4 {
         if inner1 != 0 {
-            let ref mut fresh6 =
-                (*masks.offset(0))[(bx4 + x) as usize][twl4c as usize][0];
+            let ref mut fresh6 = (*masks.offset(0))[(bx4 + x) as usize][twl4c as usize][0];
             *fresh6 = (*fresh6 as libc::c_uint | inner1) as uint16_t;
         }
         if inner2 != 0 {
-            let ref mut fresh7 =
-                (*masks.offset(0))[(bx4 + x) as usize][twl4c as usize][1];
+            let ref mut fresh7 = (*masks.offset(0))[(bx4 + x) as usize][twl4c as usize][1];
             *fresh7 = (*fresh7 as libc::c_uint | inner2) as uint16_t;
         }
         x += hstep;
@@ -509,13 +495,11 @@ unsafe extern "C" fn mask_edges_intra(
     y = vstep;
     while y < h4 {
         if inner1 != 0 {
-            let ref mut fresh8 =
-                (*masks.offset(1))[(by4 + y) as usize][thl4c as usize][0];
+            let ref mut fresh8 = (*masks.offset(1))[(by4 + y) as usize][thl4c as usize][0];
             *fresh8 = (*fresh8 as libc::c_uint | inner1) as uint16_t;
         }
         if inner2 != 0 {
-            let ref mut fresh9 =
-                (*masks.offset(1))[(by4 + y) as usize][thl4c as usize][1];
+            let ref mut fresh9 = (*masks.offset(1))[(by4 + y) as usize][thl4c as usize][1];
             *fresh9 = (*fresh9 as libc::c_uint | inner2) as uint16_t;
         }
         y += vstep;
@@ -664,13 +648,11 @@ unsafe extern "C" fn mask_edges_chroma(
         x = hstep;
         while x < cw4 {
             if inner1 != 0 {
-                let ref mut fresh12 = (*masks.offset(0))
-                    [(cbx4 + x) as usize][twl4c as usize][0];
+                let ref mut fresh12 = (*masks.offset(0))[(cbx4 + x) as usize][twl4c as usize][0];
                 *fresh12 = (*fresh12 as libc::c_uint | inner1) as uint16_t;
             }
             if inner2 != 0 {
-                let ref mut fresh13 = (*masks.offset(0))
-                    [(cbx4 + x) as usize][twl4c as usize][1];
+                let ref mut fresh13 = (*masks.offset(0))[(cbx4 + x) as usize][twl4c as usize][1];
                 *fresh13 = (*fresh13 as libc::c_uint | inner2) as uint16_t;
             }
             x += hstep;
@@ -683,13 +665,11 @@ unsafe extern "C" fn mask_edges_chroma(
         y = vstep;
         while y < ch4 {
             if inner1 != 0 {
-                let ref mut fresh14 = (*masks.offset(1))
-                    [(cby4 + y) as usize][thl4c as usize][0];
+                let ref mut fresh14 = (*masks.offset(1))[(cby4 + y) as usize][thl4c as usize][0];
                 *fresh14 = (*fresh14 as libc::c_uint | inner1) as uint16_t;
             }
             if inner2 != 0 {
-                let ref mut fresh15 = (*masks.offset(1))
-                    [(cby4 + y) as usize][thl4c as usize][1];
+                let ref mut fresh15 = (*masks.offset(1))[(cby4 + y) as usize][thl4c as usize][1];
                 *fresh15 = (*fresh15 as libc::c_uint | inner2) as uint16_t;
             }
             y += vstep;
@@ -812,10 +792,8 @@ pub unsafe extern "C" fn dav1d_create_lf_mask_intra(
         while y < bh4 {
             let mut x = 0;
             while x < bw4 {
-                (*level_cache_ptr.offset(x as isize))[0] =
-                    (*filter_level.offset(0))[0][0];
-                (*level_cache_ptr.offset(x as isize))[1] =
-                    (*filter_level.offset(1))[0][0];
+                (*level_cache_ptr.offset(x as isize))[0] = (*filter_level.offset(0))[0][0];
+                (*level_cache_ptr.offset(x as isize))[1] = (*filter_level.offset(1))[0][0];
                 x += 1;
             }
             level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
@@ -859,10 +837,8 @@ pub unsafe extern "C" fn dav1d_create_lf_mask_intra(
     while y_0 < cbh4 {
         let mut x_0 = 0;
         while x_0 < cbw4 {
-            (*level_cache_ptr_0.offset(x_0 as isize))[2] =
-                (*filter_level.offset(2))[0][0];
-            (*level_cache_ptr_0.offset(x_0 as isize))[3] =
-                (*filter_level.offset(3))[0][0];
+            (*level_cache_ptr_0.offset(x_0 as isize))[2] = (*filter_level.offset(2))[0][0];
+            (*level_cache_ptr_0.offset(x_0 as isize))[3] = (*filter_level.offset(3))[0][0];
             x_0 += 1;
         }
         level_cache_ptr_0 = level_cache_ptr_0.offset(b4_stride as isize);
@@ -916,10 +892,8 @@ pub unsafe extern "C" fn dav1d_create_lf_mask_inter(
         while y < bh4 {
             let mut x = 0;
             while x < bw4 {
-                (*level_cache_ptr.offset(x as isize))[0] =
-                    (*filter_level.offset(0))[0][0];
-                (*level_cache_ptr.offset(x as isize))[1] =
-                    (*filter_level.offset(1))[0][0];
+                (*level_cache_ptr.offset(x as isize))[0] = (*filter_level.offset(0))[0][0];
+                (*level_cache_ptr.offset(x as isize))[1] = (*filter_level.offset(1))[0][0];
                 x += 1;
             }
             level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
@@ -965,10 +939,8 @@ pub unsafe extern "C" fn dav1d_create_lf_mask_inter(
     while y_0 < cbh4 {
         let mut x_0 = 0;
         while x_0 < cbw4 {
-            (*level_cache_ptr_0.offset(x_0 as isize))[2] =
-                (*filter_level.offset(2))[0][0];
-            (*level_cache_ptr_0.offset(x_0 as isize))[3] =
-                (*filter_level.offset(3))[0][0];
+            (*level_cache_ptr_0.offset(x_0 as isize))[2] = (*filter_level.offset(2))[0][0];
+            (*level_cache_ptr_0.offset(x_0 as isize))[3] = (*filter_level.offset(3))[0][0];
             x_0 += 1;
         }
         level_cache_ptr_0 = level_cache_ptr_0.offset(b4_stride as isize);

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -142,7 +142,7 @@ unsafe extern "C" fn decomp_tx(
                     .as_mut_ptr()
                     .offset(0) as *mut uint8_t as *mut alias8))
                         .u8_0 = (0x1 * lh) as uint8_t;
-                    (*txa.offset(0 as libc::c_int as isize))[1 as libc::c_int as usize]
+                    (*txa.offset(0 as libc::c_int as isize))[1]
                         [y as usize][0] = (*t_dim).w;
                     y += 1;
                 }
@@ -162,7 +162,7 @@ unsafe extern "C" fn decomp_tx(
                     .as_mut_ptr()
                     .offset(0) as *mut uint8_t as *mut alias16))
                         .u16_0 = (0x101 * lh) as uint16_t;
-                    (*txa.offset(0 as libc::c_int as isize))[1 as libc::c_int as usize]
+                    (*txa.offset(0 as libc::c_int as isize))[1]
                         [y_0 as usize][0] = (*t_dim).w;
                     y_0 += 1;
                 }
@@ -182,7 +182,7 @@ unsafe extern "C" fn decomp_tx(
                     .as_mut_ptr()
                     .offset(0) as *mut uint8_t as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(lh as libc::c_uint);
-                    (*txa.offset(0 as libc::c_int as isize))[1 as libc::c_int as usize]
+                    (*txa.offset(0 as libc::c_int as isize))[1]
                         [y_1 as usize][0] = (*t_dim).w;
                     y_1 += 1;
                 }
@@ -206,7 +206,7 @@ unsafe extern "C" fn decomp_tx(
                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(lh as libc::c_ulonglong)
                         as uint64_t;
-                    (*txa.offset(0 as libc::c_int as isize))[1 as libc::c_int as usize]
+                    (*txa.offset(0 as libc::c_int as isize))[1]
                         [y_2 as usize][0] = (*t_dim).w;
                     y_2 += 1;
                 }
@@ -248,7 +248,7 @@ unsafe extern "C" fn decomp_tx(
                     .offset((0 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_0;
-                    (*txa.offset(0 as libc::c_int as isize))[1 as libc::c_int as usize]
+                    (*txa.offset(0 as libc::c_int as isize))[1]
                         [y_3 as usize][0] = (*t_dim).w;
                     y_3 += 1;
                 }
@@ -360,7 +360,7 @@ unsafe extern "C" fn mask_edges_inter(
         let sidx = (mask >= 0x10000 as libc::c_int as libc::c_uint) as libc::c_int;
         let smask: libc::c_uint = mask >> (sidx << 4);
         let ref mut fresh0 = (*masks.offset(0 as libc::c_int as isize))[bx4 as usize][imin(
-            txa[0 as libc::c_int as usize][0 as libc::c_int as usize][y as usize][0] as libc::c_int,
+            txa[0][0][y as usize][0] as libc::c_int,
             *l.offset(y as isize) as libc::c_int,
         )
             as usize][sidx as usize];
@@ -374,7 +374,7 @@ unsafe extern "C" fn mask_edges_inter(
         let sidx_0 = (mask >= 0x10000 as libc::c_int as libc::c_uint) as libc::c_int;
         let smask_0: libc::c_uint = mask >> (sidx_0 << 4);
         let ref mut fresh1 = (*masks.offset(1 as libc::c_int as isize))[by4 as usize][imin(
-            txa[1 as libc::c_int as usize][0 as libc::c_int as usize][0][x as usize] as libc::c_int,
+            txa[1][0][0][x as usize] as libc::c_int,
             *a.offset(x as isize) as libc::c_int,
         )
             as usize][sidx_0 as usize];
@@ -388,18 +388,18 @@ unsafe extern "C" fn mask_edges_inter(
         while y < h4 {
             let sidx_1 = (mask >= 0x10000 as libc::c_uint) as libc::c_int;
             let smask_1: libc::c_uint = mask >> (sidx_1 << 4);
-            let mut ltx = txa[0 as libc::c_int as usize][0 as libc::c_int as usize][y as usize][0]
+            let mut ltx = txa[0][0][y as usize][0]
                 as libc::c_int;
-            let mut step = txa[0 as libc::c_int as usize][1 as libc::c_int as usize][y as usize][0]
+            let mut step = txa[0][1][y as usize][0]
                 as libc::c_int;
             x = step;
             while x < w4 {
-                let rtx = txa[0 as libc::c_int as usize][0][y as usize][x as usize] as libc::c_int;
+                let rtx = txa[0][0][y as usize][x as usize] as libc::c_int;
                 let ref mut fresh2 = (*masks.offset(0 as libc::c_int as isize))[(bx4 + x) as usize]
                     [imin(rtx, ltx) as usize][sidx_1 as usize];
                 *fresh2 = (*fresh2 as libc::c_uint | smask_1) as uint16_t;
                 ltx = rtx;
-                step = txa[0 as libc::c_int as usize][1][y as usize][x as usize] as libc::c_int;
+                step = txa[0][1][y as usize][x as usize] as libc::c_int;
                 x += step;
             }
             y += 1;
@@ -410,18 +410,18 @@ unsafe extern "C" fn mask_edges_inter(
         while x < w4 {
             let sidx_2 = (mask >= 0x10000 as libc::c_uint) as libc::c_int;
             let smask_2: libc::c_uint = mask >> (sidx_2 << 4);
-            let mut ttx = txa[1 as libc::c_int as usize][0 as libc::c_int as usize][0][x as usize]
+            let mut ttx = txa[1][0][0][x as usize]
                 as libc::c_int;
-            let mut step_0 = txa[1 as libc::c_int as usize][1 as libc::c_int as usize][0]
+            let mut step_0 = txa[1][1][0]
                 [x as usize] as libc::c_int;
             y = step_0;
             while y < h4 {
-                let btx = txa[1 as libc::c_int as usize][0][y as usize][x as usize] as libc::c_int;
+                let btx = txa[1][0][y as usize][x as usize] as libc::c_int;
                 let ref mut fresh3 = (*masks.offset(1 as libc::c_int as isize))[(by4 + y) as usize]
                     [imin(ttx, btx) as usize][sidx_2 as usize];
                 *fresh3 = (*fresh3 as libc::c_uint | smask_2) as uint16_t;
                 ttx = btx;
-                step_0 = txa[1 as libc::c_int as usize][1][y as usize][x as usize] as libc::c_int;
+                step_0 = txa[1][1][y as usize][x as usize] as libc::c_int;
                 y += step_0;
             }
             x += 1;
@@ -430,13 +430,13 @@ unsafe extern "C" fn mask_edges_inter(
     }
     y = 0 as libc::c_int;
     while y < h4 {
-        *l.offset(y as isize) = txa[0 as libc::c_int as usize][0 as libc::c_int as usize]
+        *l.offset(y as isize) = txa[0][0]
             [y as usize][(w4 - 1) as usize];
         y += 1;
     }
     memcpy(
         a as *mut libc::c_void,
-        (txa[1 as libc::c_int as usize][0][(h4 - 1) as usize]).as_mut_ptr() as *const libc::c_void,
+        (txa[1][0][(h4 - 1) as usize]).as_mut_ptr() as *const libc::c_void,
         w4 as libc::c_ulong,
     );
 }
@@ -812,9 +812,9 @@ pub unsafe extern "C" fn dav1d_create_lf_mask_intra(
         while y < bh4 {
             let mut x = 0;
             while x < bw4 {
-                (*level_cache_ptr.offset(x as isize))[0 as libc::c_int as usize] =
+                (*level_cache_ptr.offset(x as isize))[0] =
                     (*filter_level.offset(0 as libc::c_int as isize))[0][0];
-                (*level_cache_ptr.offset(x as isize))[1 as libc::c_int as usize] =
+                (*level_cache_ptr.offset(x as isize))[1] =
                     (*filter_level.offset(1 as libc::c_int as isize))[0][0];
                 x += 1;
             }
@@ -859,9 +859,9 @@ pub unsafe extern "C" fn dav1d_create_lf_mask_intra(
     while y_0 < cbh4 {
         let mut x_0 = 0;
         while x_0 < cbw4 {
-            (*level_cache_ptr_0.offset(x_0 as isize))[2 as libc::c_int as usize] =
+            (*level_cache_ptr_0.offset(x_0 as isize))[2] =
                 (*filter_level.offset(2 as libc::c_int as isize))[0][0];
-            (*level_cache_ptr_0.offset(x_0 as isize))[3 as libc::c_int as usize] =
+            (*level_cache_ptr_0.offset(x_0 as isize))[3] =
                 (*filter_level.offset(3 as libc::c_int as isize))[0][0];
             x_0 += 1;
         }
@@ -916,9 +916,9 @@ pub unsafe extern "C" fn dav1d_create_lf_mask_inter(
         while y < bh4 {
             let mut x = 0;
             while x < bw4 {
-                (*level_cache_ptr.offset(x as isize))[0 as libc::c_int as usize] =
+                (*level_cache_ptr.offset(x as isize))[0] =
                     (*filter_level.offset(0 as libc::c_int as isize))[0][0];
-                (*level_cache_ptr.offset(x as isize))[1 as libc::c_int as usize] =
+                (*level_cache_ptr.offset(x as isize))[1] =
                     (*filter_level.offset(1 as libc::c_int as isize))[0][0];
                 x += 1;
             }
@@ -965,9 +965,9 @@ pub unsafe extern "C" fn dav1d_create_lf_mask_inter(
     while y_0 < cbh4 {
         let mut x_0 = 0;
         while x_0 < cbw4 {
-            (*level_cache_ptr_0.offset(x_0 as isize))[2 as libc::c_int as usize] =
+            (*level_cache_ptr_0.offset(x_0 as isize))[2] =
                 (*filter_level.offset(2 as libc::c_int as isize))[0][0];
-            (*level_cache_ptr_0.offset(x_0 as isize))[3 as libc::c_int as usize] =
+            (*level_cache_ptr_0.offset(x_0 as isize))[3] =
                 (*filter_level.offset(3 as libc::c_int as isize))[0][0];
             x_0 += 1;
         }
@@ -1003,8 +1003,8 @@ pub unsafe extern "C" fn dav1d_calc_eih(lim_lut: *mut Av1FilterLUT, filter_sharp
         (*lim_lut).e[level as usize] = (2 * (level + 2) + limit) as uint8_t;
         level += 1;
     }
-    (*lim_lut).sharp[0 as libc::c_int as usize] = (sharp + 3 >> 2) as uint64_t;
-    (*lim_lut).sharp[1 as libc::c_int as usize] = (if sharp != 0 {
+    (*lim_lut).sharp[0] = (sharp + 3 >> 2) as uint64_t;
+    (*lim_lut).sharp[1] = (if sharp != 0 {
         9 - sharp
     } else {
         0xff as libc::c_int

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -142,7 +142,7 @@ unsafe extern "C" fn decomp_tx(
                     .as_mut_ptr()
                     .offset(0) as *mut uint8_t as *mut alias8))
                         .u8_0 = (0x1 * lh) as uint8_t;
-                    (*txa.offset(0 as libc::c_int as isize))[1]
+                    (*txa.offset(0))[1]
                         [y as usize][0] = (*t_dim).w;
                     y += 1;
                 }
@@ -162,7 +162,7 @@ unsafe extern "C" fn decomp_tx(
                     .as_mut_ptr()
                     .offset(0) as *mut uint8_t as *mut alias16))
                         .u16_0 = (0x101 * lh) as uint16_t;
-                    (*txa.offset(0 as libc::c_int as isize))[1]
+                    (*txa.offset(0))[1]
                         [y_0 as usize][0] = (*t_dim).w;
                     y_0 += 1;
                 }
@@ -182,7 +182,7 @@ unsafe extern "C" fn decomp_tx(
                     .as_mut_ptr()
                     .offset(0) as *mut uint8_t as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(lh as libc::c_uint);
-                    (*txa.offset(0 as libc::c_int as isize))[1]
+                    (*txa.offset(0))[1]
                         [y_1 as usize][0] = (*t_dim).w;
                     y_1 += 1;
                 }
@@ -206,7 +206,7 @@ unsafe extern "C" fn decomp_tx(
                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(lh as libc::c_ulonglong)
                         as uint64_t;
-                    (*txa.offset(0 as libc::c_int as isize))[1]
+                    (*txa.offset(0))[1]
                         [y_2 as usize][0] = (*t_dim).w;
                     y_2 += 1;
                 }
@@ -248,7 +248,7 @@ unsafe extern "C" fn decomp_tx(
                     .offset((0 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_0;
-                    (*txa.offset(0 as libc::c_int as isize))[1]
+                    (*txa.offset(0))[1]
                         [y_3 as usize][0] = (*t_dim).w;
                     y_3 += 1;
                 }
@@ -359,7 +359,7 @@ unsafe extern "C" fn mask_edges_inter(
     while y < h4 {
         let sidx = (mask >= 0x10000 as libc::c_int as libc::c_uint) as libc::c_int;
         let smask: libc::c_uint = mask >> (sidx << 4);
-        let ref mut fresh0 = (*masks.offset(0 as libc::c_int as isize))[bx4 as usize][imin(
+        let ref mut fresh0 = (*masks.offset(0))[bx4 as usize][imin(
             txa[0][0][y as usize][0] as libc::c_int,
             *l.offset(y as isize) as libc::c_int,
         )
@@ -373,7 +373,7 @@ unsafe extern "C" fn mask_edges_inter(
     while x < w4 {
         let sidx_0 = (mask >= 0x10000 as libc::c_int as libc::c_uint) as libc::c_int;
         let smask_0: libc::c_uint = mask >> (sidx_0 << 4);
-        let ref mut fresh1 = (*masks.offset(1 as libc::c_int as isize))[by4 as usize][imin(
+        let ref mut fresh1 = (*masks.offset(1))[by4 as usize][imin(
             txa[1][0][0][x as usize] as libc::c_int,
             *a.offset(x as isize) as libc::c_int,
         )
@@ -395,7 +395,7 @@ unsafe extern "C" fn mask_edges_inter(
             x = step;
             while x < w4 {
                 let rtx = txa[0][0][y as usize][x as usize] as libc::c_int;
-                let ref mut fresh2 = (*masks.offset(0 as libc::c_int as isize))[(bx4 + x) as usize]
+                let ref mut fresh2 = (*masks.offset(0))[(bx4 + x) as usize]
                     [imin(rtx, ltx) as usize][sidx_1 as usize];
                 *fresh2 = (*fresh2 as libc::c_uint | smask_1) as uint16_t;
                 ltx = rtx;
@@ -417,7 +417,7 @@ unsafe extern "C" fn mask_edges_inter(
             y = step_0;
             while y < h4 {
                 let btx = txa[1][0][y as usize][x as usize] as libc::c_int;
-                let ref mut fresh3 = (*masks.offset(1 as libc::c_int as isize))[(by4 + y) as usize]
+                let ref mut fresh3 = (*masks.offset(1))[(by4 + y) as usize]
                     [imin(ttx, btx) as usize][sidx_2 as usize];
                 *fresh3 = (*fresh3 as libc::c_uint | smask_2) as uint16_t;
                 ttx = btx;
@@ -464,7 +464,7 @@ unsafe extern "C" fn mask_edges_intra(
     while y < h4 {
         let sidx = (mask >= 0x10000 as libc::c_int as libc::c_uint) as libc::c_int;
         let smask: libc::c_uint = mask >> (sidx << 4);
-        let ref mut fresh4 = (*masks.offset(0 as libc::c_int as isize))[bx4 as usize]
+        let ref mut fresh4 = (*masks.offset(0))[bx4 as usize]
             [imin(twl4c, *l.offset(y as isize) as libc::c_int) as usize][sidx as usize];
         *fresh4 = (*fresh4 as libc::c_uint | smask) as uint16_t;
         y += 1;
@@ -475,7 +475,7 @@ unsafe extern "C" fn mask_edges_intra(
     while x < w4 {
         let sidx_0 = (mask >= 0x10000 as libc::c_int as libc::c_uint) as libc::c_int;
         let smask_0: libc::c_uint = mask >> (sidx_0 << 4);
-        let ref mut fresh5 = (*masks.offset(1 as libc::c_int as isize))[by4 as usize]
+        let ref mut fresh5 = (*masks.offset(1))[by4 as usize]
             [imin(thl4c, *a.offset(x as isize) as libc::c_int) as usize][sidx_0 as usize];
         *fresh5 = (*fresh5 as libc::c_uint | smask_0) as uint16_t;
         x += 1;
@@ -491,12 +491,12 @@ unsafe extern "C" fn mask_edges_intra(
     while x < w4 {
         if inner1 != 0 {
             let ref mut fresh6 =
-                (*masks.offset(0 as libc::c_int as isize))[(bx4 + x) as usize][twl4c as usize][0];
+                (*masks.offset(0))[(bx4 + x) as usize][twl4c as usize][0];
             *fresh6 = (*fresh6 as libc::c_uint | inner1) as uint16_t;
         }
         if inner2 != 0 {
             let ref mut fresh7 =
-                (*masks.offset(0 as libc::c_int as isize))[(bx4 + x) as usize][twl4c as usize][1];
+                (*masks.offset(0))[(bx4 + x) as usize][twl4c as usize][1];
             *fresh7 = (*fresh7 as libc::c_uint | inner2) as uint16_t;
         }
         x += hstep;
@@ -510,12 +510,12 @@ unsafe extern "C" fn mask_edges_intra(
     while y < h4 {
         if inner1 != 0 {
             let ref mut fresh8 =
-                (*masks.offset(1 as libc::c_int as isize))[(by4 + y) as usize][thl4c as usize][0];
+                (*masks.offset(1))[(by4 + y) as usize][thl4c as usize][0];
             *fresh8 = (*fresh8 as libc::c_uint | inner1) as uint16_t;
         }
         if inner2 != 0 {
             let ref mut fresh9 =
-                (*masks.offset(1 as libc::c_int as isize))[(by4 + y) as usize][thl4c as usize][1];
+                (*masks.offset(1))[(by4 + y) as usize][thl4c as usize][1];
             *fresh9 = (*fresh9 as libc::c_uint | inner2) as uint16_t;
         }
         y += vstep;
@@ -637,7 +637,7 @@ unsafe extern "C" fn mask_edges_chroma(
     while y < ch4 {
         let sidx = (mask >= vmax) as libc::c_int;
         let smask: libc::c_uint = mask >> (sidx << vbits);
-        let ref mut fresh10 = (*masks.offset(0 as libc::c_int as isize))[cbx4 as usize]
+        let ref mut fresh10 = (*masks.offset(0))[cbx4 as usize]
             [imin(twl4c, *l.offset(y as isize) as libc::c_int) as usize][sidx as usize];
         *fresh10 = (*fresh10 as libc::c_uint | smask) as uint16_t;
         y += 1;
@@ -648,7 +648,7 @@ unsafe extern "C" fn mask_edges_chroma(
     while x < cw4 {
         let sidx_0 = (mask >= hmax) as libc::c_int;
         let smask_0: libc::c_uint = mask >> (sidx_0 << hbits);
-        let ref mut fresh11 = (*masks.offset(1 as libc::c_int as isize))[cby4 as usize]
+        let ref mut fresh11 = (*masks.offset(1))[cby4 as usize]
             [imin(thl4c, *a.offset(x as isize) as libc::c_int) as usize][sidx_0 as usize];
         *fresh11 = (*fresh11 as libc::c_uint | smask_0) as uint16_t;
         x += 1;
@@ -664,12 +664,12 @@ unsafe extern "C" fn mask_edges_chroma(
         x = hstep;
         while x < cw4 {
             if inner1 != 0 {
-                let ref mut fresh12 = (*masks.offset(0 as libc::c_int as isize))
+                let ref mut fresh12 = (*masks.offset(0))
                     [(cbx4 + x) as usize][twl4c as usize][0];
                 *fresh12 = (*fresh12 as libc::c_uint | inner1) as uint16_t;
             }
             if inner2 != 0 {
-                let ref mut fresh13 = (*masks.offset(0 as libc::c_int as isize))
+                let ref mut fresh13 = (*masks.offset(0))
                     [(cbx4 + x) as usize][twl4c as usize][1];
                 *fresh13 = (*fresh13 as libc::c_uint | inner2) as uint16_t;
             }
@@ -683,12 +683,12 @@ unsafe extern "C" fn mask_edges_chroma(
         y = vstep;
         while y < ch4 {
             if inner1 != 0 {
-                let ref mut fresh14 = (*masks.offset(1 as libc::c_int as isize))
+                let ref mut fresh14 = (*masks.offset(1))
                     [(cby4 + y) as usize][thl4c as usize][0];
                 *fresh14 = (*fresh14 as libc::c_uint | inner1) as uint16_t;
             }
             if inner2 != 0 {
-                let ref mut fresh15 = (*masks.offset(1 as libc::c_int as isize))
+                let ref mut fresh15 = (*masks.offset(1))
                     [(cby4 + y) as usize][thl4c as usize][1];
                 *fresh15 = (*fresh15 as libc::c_uint | inner2) as uint16_t;
             }
@@ -813,9 +813,9 @@ pub unsafe extern "C" fn dav1d_create_lf_mask_intra(
             let mut x = 0;
             while x < bw4 {
                 (*level_cache_ptr.offset(x as isize))[0] =
-                    (*filter_level.offset(0 as libc::c_int as isize))[0][0];
+                    (*filter_level.offset(0))[0][0];
                 (*level_cache_ptr.offset(x as isize))[1] =
-                    (*filter_level.offset(1 as libc::c_int as isize))[0][0];
+                    (*filter_level.offset(1))[0][0];
                 x += 1;
             }
             level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
@@ -860,9 +860,9 @@ pub unsafe extern "C" fn dav1d_create_lf_mask_intra(
         let mut x_0 = 0;
         while x_0 < cbw4 {
             (*level_cache_ptr_0.offset(x_0 as isize))[2] =
-                (*filter_level.offset(2 as libc::c_int as isize))[0][0];
+                (*filter_level.offset(2))[0][0];
             (*level_cache_ptr_0.offset(x_0 as isize))[3] =
-                (*filter_level.offset(3 as libc::c_int as isize))[0][0];
+                (*filter_level.offset(3))[0][0];
             x_0 += 1;
         }
         level_cache_ptr_0 = level_cache_ptr_0.offset(b4_stride as isize);
@@ -917,9 +917,9 @@ pub unsafe extern "C" fn dav1d_create_lf_mask_inter(
             let mut x = 0;
             while x < bw4 {
                 (*level_cache_ptr.offset(x as isize))[0] =
-                    (*filter_level.offset(0 as libc::c_int as isize))[0][0];
+                    (*filter_level.offset(0))[0][0];
                 (*level_cache_ptr.offset(x as isize))[1] =
-                    (*filter_level.offset(1 as libc::c_int as isize))[0][0];
+                    (*filter_level.offset(1))[0][0];
                 x += 1;
             }
             level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
@@ -966,9 +966,9 @@ pub unsafe extern "C" fn dav1d_create_lf_mask_inter(
         let mut x_0 = 0;
         while x_0 < cbw4 {
             (*level_cache_ptr_0.offset(x_0 as isize))[2] =
-                (*filter_level.offset(2 as libc::c_int as isize))[0][0];
+                (*filter_level.offset(2))[0][0];
             (*level_cache_ptr_0.offset(x_0 as isize))[3] =
-                (*filter_level.offset(3 as libc::c_int as isize))[0][0];
+                (*filter_level.offset(3))[0][0];
             x_0 += 1;
         }
         level_cache_ptr_0 = level_cache_ptr_0.offset(b4_stride as isize);

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -757,7 +757,7 @@ unsafe extern "C" fn lr_stripe(
         let ref mut fresh2 = (*filter.offset(0))[4];
         *fresh2 = (*lr).filter_h[2] as int16_t;
         (*filter.offset(0))[2] = *fresh2;
-        (*filter.offset(0 as libc::c_int as isize))[3] =
+        (*filter.offset(0))[3] =
             (-((*filter.offset(0))[0] as libc::c_int
                 + (*filter.offset(0))[1] as libc::c_int
                 + (*filter.offset(0))[2] as libc::c_int)
@@ -773,7 +773,7 @@ unsafe extern "C" fn lr_stripe(
         let ref mut fresh6 = (*filter.offset(1))[4];
         *fresh6 = (*lr).filter_v[2] as int16_t;
         (*filter.offset(1))[2] = *fresh6;
-        (*filter.offset(1 as libc::c_int as isize))[3] =
+        (*filter.offset(1))[3] =
             (128 as libc::c_int
                 - ((*filter.offset(1))[0] as libc::c_int
                     + (*filter.offset(1))[1] as libc::c_int

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -757,11 +757,10 @@ unsafe extern "C" fn lr_stripe(
         let ref mut fresh2 = (*filter.offset(0))[4];
         *fresh2 = (*lr).filter_h[2] as int16_t;
         (*filter.offset(0))[2] = *fresh2;
-        (*filter.offset(0))[3] =
-            (-((*filter.offset(0))[0] as libc::c_int
-                + (*filter.offset(0))[1] as libc::c_int
-                + (*filter.offset(0))[2] as libc::c_int)
-                * 2) as int16_t;
+        (*filter.offset(0))[3] = (-((*filter.offset(0))[0] as libc::c_int
+            + (*filter.offset(0))[1] as libc::c_int
+            + (*filter.offset(0))[2] as libc::c_int)
+            * 2) as int16_t;
         let ref mut fresh3 = (*filter.offset(0))[3];
         *fresh3 = (*fresh3 + 128) as int16_t;
         let ref mut fresh4 = (*filter.offset(1))[6];
@@ -773,12 +772,11 @@ unsafe extern "C" fn lr_stripe(
         let ref mut fresh6 = (*filter.offset(1))[4];
         *fresh6 = (*lr).filter_v[2] as int16_t;
         (*filter.offset(1))[2] = *fresh6;
-        (*filter.offset(1))[3] =
-            (128 as libc::c_int
-                - ((*filter.offset(1))[0] as libc::c_int
-                    + (*filter.offset(1))[1] as libc::c_int
-                    + (*filter.offset(1))[2] as libc::c_int)
-                    * 2) as int16_t;
+        (*filter.offset(1))[3] = (128 as libc::c_int
+            - ((*filter.offset(1))[0] as libc::c_int
+                + (*filter.offset(1))[1] as libc::c_int
+                + (*filter.offset(1))[2] as libc::c_int)
+                * 2) as int16_t;
         lr_fn = (*dsp).lr.wiener[((*filter.offset(0))[0] as libc::c_int
             | (*filter.offset(1))[0] as libc::c_int
             == 0) as libc::c_int as usize];

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -757,7 +757,7 @@ unsafe extern "C" fn lr_stripe(
         let ref mut fresh2 = (*filter.offset(0))[4];
         *fresh2 = (*lr).filter_h[2] as int16_t;
         (*filter.offset(0))[2] = *fresh2;
-        (*filter.offset(0 as libc::c_int as isize))[3 as libc::c_int as usize] =
+        (*filter.offset(0 as libc::c_int as isize))[3] =
             (-((*filter.offset(0))[0] as libc::c_int
                 + (*filter.offset(0))[1] as libc::c_int
                 + (*filter.offset(0))[2] as libc::c_int)
@@ -773,7 +773,7 @@ unsafe extern "C" fn lr_stripe(
         let ref mut fresh6 = (*filter.offset(1))[4];
         *fresh6 = (*lr).filter_v[2] as int16_t;
         (*filter.offset(1))[2] = *fresh6;
-        (*filter.offset(1 as libc::c_int as isize))[3 as libc::c_int as usize] =
+        (*filter.offset(1 as libc::c_int as isize))[3] =
             (128 as libc::c_int
                 - ((*filter.offset(1))[0] as libc::c_int
                     + (*filter.offset(1))[1] as libc::c_int
@@ -884,7 +884,7 @@ unsafe extern "C" fn lr_sbrow(
     aligned_unit_pos <<= ss_ver;
     let sb_idx = (aligned_unit_pos >> 7) * (*f).sr_sb128w;
     let unit_idx = (aligned_unit_pos >> 6 & 1) << 1;
-    lr[0 as libc::c_int as usize] = &mut *(*((*((*f).lf.lr_mask).offset(sb_idx as isize)).lr)
+    lr[0] = &mut *(*((*((*f).lf.lr_mask).offset(sb_idx as isize)).lr)
         .as_mut_ptr()
         .offset(plane as isize))
     .as_mut_ptr()

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -731,11 +731,10 @@ unsafe extern "C" fn lr_stripe(
         let ref mut fresh2 = (*filter.offset(0))[4];
         *fresh2 = (*lr).filter_h[2] as int16_t;
         (*filter.offset(0))[2] = *fresh2;
-        (*filter.offset(0))[3] =
-            (-((*filter.offset(0))[0] as libc::c_int
-                + (*filter.offset(0))[1] as libc::c_int
-                + (*filter.offset(0))[2] as libc::c_int)
-                * 2) as int16_t;
+        (*filter.offset(0))[3] = (-((*filter.offset(0))[0] as libc::c_int
+            + (*filter.offset(0))[1] as libc::c_int
+            + (*filter.offset(0))[2] as libc::c_int)
+            * 2) as int16_t;
         let ref mut fresh3 = (*filter.offset(1))[6];
         *fresh3 = (*lr).filter_v[0] as int16_t;
         (*filter.offset(1))[0] = *fresh3;
@@ -745,12 +744,11 @@ unsafe extern "C" fn lr_stripe(
         let ref mut fresh5 = (*filter.offset(1))[4];
         *fresh5 = (*lr).filter_v[2] as int16_t;
         (*filter.offset(1))[2] = *fresh5;
-        (*filter.offset(1))[3] =
-            (128 as libc::c_int
-                - ((*filter.offset(1))[0] as libc::c_int
-                    + (*filter.offset(1))[1] as libc::c_int
-                    + (*filter.offset(1))[2] as libc::c_int)
-                    * 2) as int16_t;
+        (*filter.offset(1))[3] = (128 as libc::c_int
+            - ((*filter.offset(1))[0] as libc::c_int
+                + (*filter.offset(1))[1] as libc::c_int
+                + (*filter.offset(1))[2] as libc::c_int)
+                * 2) as int16_t;
         lr_fn = (*dsp).lr.wiener[((*filter.offset(0))[0] as libc::c_int
             | (*filter.offset(1))[0] as libc::c_int
             == 0) as libc::c_int as usize];

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -731,7 +731,7 @@ unsafe extern "C" fn lr_stripe(
         let ref mut fresh2 = (*filter.offset(0))[4];
         *fresh2 = (*lr).filter_h[2] as int16_t;
         (*filter.offset(0))[2] = *fresh2;
-        (*filter.offset(0 as libc::c_int as isize))[3 as libc::c_int as usize] =
+        (*filter.offset(0 as libc::c_int as isize))[3] =
             (-((*filter.offset(0))[0] as libc::c_int
                 + (*filter.offset(0))[1] as libc::c_int
                 + (*filter.offset(0))[2] as libc::c_int)
@@ -745,7 +745,7 @@ unsafe extern "C" fn lr_stripe(
         let ref mut fresh5 = (*filter.offset(1))[4];
         *fresh5 = (*lr).filter_v[2] as int16_t;
         (*filter.offset(1))[2] = *fresh5;
-        (*filter.offset(1 as libc::c_int as isize))[3 as libc::c_int as usize] =
+        (*filter.offset(1 as libc::c_int as isize))[3] =
             (128 as libc::c_int
                 - ((*filter.offset(1))[0] as libc::c_int
                     + (*filter.offset(1))[1] as libc::c_int
@@ -855,7 +855,7 @@ unsafe extern "C" fn lr_sbrow(
     aligned_unit_pos <<= ss_ver;
     let sb_idx = (aligned_unit_pos >> 7) * (*f).sr_sb128w;
     let unit_idx = (aligned_unit_pos >> 6 & 1) << 1;
-    lr[0 as libc::c_int as usize] = &mut *(*((*((*f).lf.lr_mask).offset(sb_idx as isize)).lr)
+    lr[0] = &mut *(*((*((*f).lf.lr_mask).offset(sb_idx as isize)).lr)
         .as_mut_ptr()
         .offset(plane as isize))
     .as_mut_ptr()

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -731,7 +731,7 @@ unsafe extern "C" fn lr_stripe(
         let ref mut fresh2 = (*filter.offset(0))[4];
         *fresh2 = (*lr).filter_h[2] as int16_t;
         (*filter.offset(0))[2] = *fresh2;
-        (*filter.offset(0 as libc::c_int as isize))[3] =
+        (*filter.offset(0))[3] =
             (-((*filter.offset(0))[0] as libc::c_int
                 + (*filter.offset(0))[1] as libc::c_int
                 + (*filter.offset(0))[2] as libc::c_int)
@@ -745,7 +745,7 @@ unsafe extern "C" fn lr_stripe(
         let ref mut fresh5 = (*filter.offset(1))[4];
         *fresh5 = (*lr).filter_v[2] as int16_t;
         (*filter.offset(1))[2] = *fresh5;
-        (*filter.offset(1 as libc::c_int as isize))[3] =
+        (*filter.offset(1))[3] =
             (128 as libc::c_int
                 - ((*filter.offset(1))[0] as libc::c_int
                     + (*filter.offset(1))[1] as libc::c_int

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -301,7 +301,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool_adapt_c(
             *fresh5 =
                 (*fresh5 as libc::c_int - (*cdf.offset(0) as libc::c_int >> rate)) as uint16_t;
         }
-        *cdf.offset(1 as libc::c_int as isize) = count
+        *cdf.offset(1) = count
             .wrapping_add((count < 32 as libc::c_uint) as libc::c_int as libc::c_uint)
             as uint16_t;
     }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1139,7 +1139,7 @@ unsafe extern "C" fn read_frame_size(
                 if ((*r#ref).p.frame_hdr).is_null() {
                     return -(1 as libc::c_int);
                 }
-                (*hdr).width[1 as libc::c_int as usize] = (*(*r#ref).p.frame_hdr).width[1];
+                (*hdr).width[1] = (*(*r#ref).p.frame_hdr).width[1];
                 (*hdr).height = (*(*r#ref).p.frame_hdr).height;
                 (*hdr).render_width = (*(*r#ref).p.frame_hdr).render_width;
                 (*hdr).render_height = (*(*r#ref).p.frame_hdr).render_height;
@@ -1150,13 +1150,13 @@ unsafe extern "C" fn read_frame_size(
                         .wrapping_add(dav1d_get_bits(gb, 3 as libc::c_int))
                         as libc::c_int;
                     let d = (*hdr).super_res.width_scale_denominator;
-                    (*hdr).width[0 as libc::c_int as usize] = imax(
+                    (*hdr).width[0] = imax(
                         ((*hdr).width[1] * 8 + (d >> 1)) / d,
                         imin(16 as libc::c_int, (*hdr).width[1]),
                     );
                 } else {
                     (*hdr).super_res.width_scale_denominator = 8 as libc::c_int;
-                    (*hdr).width[0 as libc::c_int as usize] = (*hdr).width[1];
+                    (*hdr).width[0] = (*hdr).width[1];
                 }
                 return 0 as libc::c_int;
             }
@@ -1164,7 +1164,7 @@ unsafe extern "C" fn read_frame_size(
         }
     }
     if (*hdr).frame_size_override != 0 {
-        (*hdr).width[1 as libc::c_int as usize] = (dav1d_get_bits(gb, (*seqhdr).width_n_bits))
+        (*hdr).width[1] = (dav1d_get_bits(gb, (*seqhdr).width_n_bits))
             .wrapping_add(1 as libc::c_int as libc::c_uint)
             as libc::c_int;
         (*hdr).height = (dav1d_get_bits(gb, (*seqhdr).height_n_bits))
@@ -1179,7 +1179,7 @@ unsafe extern "C" fn read_frame_size(
             .wrapping_add(dav1d_get_bits(gb, 3 as libc::c_int))
             as libc::c_int;
         let d_0 = (*hdr).super_res.width_scale_denominator;
-        (*hdr).width[0 as libc::c_int as usize] = imax(
+        (*hdr).width[0] = imax(
             ((*hdr).width[1] * 8 + (d_0 >> 1)) / d_0,
             imin(16 as libc::c_int, (*hdr).width[1]),
         );
@@ -1412,15 +1412,15 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             (*hdr).frame_ref_short_signaling =
                 ((*seqhdr).order_hint != 0 && dav1d_get_bit(gb) != 0) as libc::c_int;
             if (*hdr).frame_ref_short_signaling != 0 {
-                (*hdr).refidx[0 as libc::c_int as usize] =
+                (*hdr).refidx[0] =
                     dav1d_get_bits(gb, 3 as libc::c_int) as libc::c_int;
                 (*hdr).refidx[2] = -(1 as libc::c_int);
-                (*hdr).refidx[1 as libc::c_int as usize] = (*hdr).refidx[2];
-                (*hdr).refidx[3 as libc::c_int as usize] =
+                (*hdr).refidx[1] = (*hdr).refidx[2];
+                (*hdr).refidx[3] =
                     dav1d_get_bits(gb, 3 as libc::c_int) as libc::c_int;
                 (*hdr).refidx[6] = -(1 as libc::c_int);
-                (*hdr).refidx[5 as libc::c_int as usize] = (*hdr).refidx[6];
-                (*hdr).refidx[4 as libc::c_int as usize] = (*hdr).refidx[5];
+                (*hdr).refidx[5] = (*hdr).refidx[6];
+                (*hdr).refidx[4] = (*hdr).refidx[5];
                 let mut shifted_frame_offset: [libc::c_int; 8] = [0; 8];
                 let current_frame_offset = (1 as libc::c_int) << (*seqhdr).order_hint_n_bits - 1;
                 let mut i_2 = 0;
@@ -1940,7 +1940,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                 }
                                 if (*hdr).all_lossless != 0 || (*hdr).allow_intrabc != 0 {
                                     (*hdr).loopfilter.level_y[1] = 0 as libc::c_int;
-                                    (*hdr).loopfilter.level_y[0 as libc::c_int as usize] =
+                                    (*hdr).loopfilter.level_y[0] =
                                         (*hdr).loopfilter.level_y[1];
                                     (*hdr).loopfilter.level_v = 0 as libc::c_int;
                                     (*hdr).loopfilter.level_u = (*hdr).loopfilter.level_v;
@@ -1950,9 +1950,9 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                     (*hdr).loopfilter.mode_ref_deltas = default_mode_ref_deltas;
                                     current_block = 1424623445371442388;
                                 } else {
-                                    (*hdr).loopfilter.level_y[0 as libc::c_int as usize] =
+                                    (*hdr).loopfilter.level_y[0] =
                                         dav1d_get_bits(gb, 6 as libc::c_int) as libc::c_int;
-                                    (*hdr).loopfilter.level_y[1 as libc::c_int as usize] =
+                                    (*hdr).loopfilter.level_y[1] =
                                         dav1d_get_bits(gb, 6 as libc::c_int) as libc::c_int;
                                     if (*seqhdr).monochrome == 0
                                         && ((*hdr).loopfilter.level_y[0] != 0
@@ -2059,23 +2059,23 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                             && (*seqhdr).restoration != 0
                                             && (*hdr).allow_intrabc == 0
                                         {
-                                            (*hdr).restoration.type_0[0 as libc::c_int as usize] =
+                                            (*hdr).restoration.type_0[0] =
                                                 dav1d_get_bits(gb, 2 as libc::c_int)
                                                     as Dav1dRestorationType;
                                             if (*seqhdr).monochrome == 0 {
                                                 (*hdr).restoration.type_0
-                                                    [1 as libc::c_int as usize] =
+                                                    [1] =
                                                     dav1d_get_bits(gb, 2 as libc::c_int)
                                                         as Dav1dRestorationType;
                                                 (*hdr).restoration.type_0
-                                                    [2 as libc::c_int as usize] =
+                                                    [2] =
                                                     dav1d_get_bits(gb, 2 as libc::c_int)
                                                         as Dav1dRestorationType;
                                             } else {
                                                 (*hdr).restoration.type_0[2] =
                                                     DAV1D_RESTORATION_NONE;
                                                 (*hdr).restoration.type_0
-                                                    [1 as libc::c_int as usize] =
+                                                    [1] =
                                                     (*hdr).restoration.type_0[2];
                                             }
                                             if (*hdr).restoration.type_0[0] as libc::c_uint != 0
@@ -2083,13 +2083,13 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                                 || (*hdr).restoration.type_0[2] as libc::c_uint != 0
                                             {
                                                 (*hdr).restoration.unit_size
-                                                    [0 as libc::c_int as usize] =
+                                                    [0] =
                                                     6 + (*seqhdr).sb128;
                                                 if dav1d_get_bit(gb) != 0 {
                                                     (*hdr).restoration.unit_size[0] += 1;
                                                     if (*seqhdr).sb128 == 0 {
                                                         (*hdr).restoration.unit_size
-                                                            [0 as libc::c_int as usize] =
+                                                            [0] =
                                                             ((*hdr).restoration.unit_size[0]
                                                                 as libc::c_uint)
                                                                 .wrapping_add(dav1d_get_bit(gb))
@@ -2098,7 +2098,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                                     }
                                                 }
                                                 (*hdr).restoration.unit_size
-                                                    [1 as libc::c_int as usize] =
+                                                    [1] =
                                                     (*hdr).restoration.unit_size[0];
                                                 if ((*hdr).restoration.type_0[1] as libc::c_uint
                                                     != 0
@@ -2108,7 +2108,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                                     && (*seqhdr).ss_ver == 1
                                                 {
                                                     (*hdr).restoration.unit_size
-                                                        [1 as libc::c_int as usize] =
+                                                        [1] =
                                                         ((*hdr).restoration.unit_size[1]
                                                             as libc::c_uint)
                                                             .wrapping_sub(dav1d_get_bit(gb))
@@ -2213,10 +2213,10 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                                         && off_after != -(1 as libc::c_int)
                                                     {
                                                         (*hdr).skip_mode_refs
-                                                            [0 as libc::c_int as usize] =
+                                                            [0] =
                                                             imin(off_before_idx, off_after_idx);
                                                         (*hdr).skip_mode_refs
-                                                            [1 as libc::c_int as usize] =
+                                                            [1] =
                                                             imax(off_before_idx, off_after_idx);
                                                         (*hdr).skip_mode_allowed = 1 as libc::c_int;
                                                         current_block = 2126221883176060805;
@@ -3039,16 +3039,16 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                 let mut i_1 = 0;
                                 while i_1 < 3 {
                                     (*mastering_display).primaries[i_1 as usize]
-                                        [0 as libc::c_int as usize] =
+                                        [0] =
                                         dav1d_get_bits(&mut gb, 16 as libc::c_int) as uint16_t;
                                     (*mastering_display).primaries[i_1 as usize]
-                                        [1 as libc::c_int as usize] =
+                                        [1] =
                                         dav1d_get_bits(&mut gb, 16 as libc::c_int) as uint16_t;
                                     i_1 += 1;
                                 }
-                                (*mastering_display).white_point[0 as libc::c_int as usize] =
+                                (*mastering_display).white_point[0] =
                                     dav1d_get_bits(&mut gb, 16 as libc::c_int) as uint16_t;
-                                (*mastering_display).white_point[1 as libc::c_int as usize] =
+                                (*mastering_display).white_point[1] =
                                     dav1d_get_bits(&mut gb, 16 as libc::c_int) as uint16_t;
                                 (*mastering_display).max_luminance =
                                     dav1d_get_bits(&mut gb, 32 as libc::c_int);

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1412,12 +1412,10 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             (*hdr).frame_ref_short_signaling =
                 ((*seqhdr).order_hint != 0 && dav1d_get_bit(gb) != 0) as libc::c_int;
             if (*hdr).frame_ref_short_signaling != 0 {
-                (*hdr).refidx[0] =
-                    dav1d_get_bits(gb, 3 as libc::c_int) as libc::c_int;
+                (*hdr).refidx[0] = dav1d_get_bits(gb, 3 as libc::c_int) as libc::c_int;
                 (*hdr).refidx[2] = -(1 as libc::c_int);
                 (*hdr).refidx[1] = (*hdr).refidx[2];
-                (*hdr).refidx[3] =
-                    dav1d_get_bits(gb, 3 as libc::c_int) as libc::c_int;
+                (*hdr).refidx[3] = dav1d_get_bits(gb, 3 as libc::c_int) as libc::c_int;
                 (*hdr).refidx[6] = -(1 as libc::c_int);
                 (*hdr).refidx[5] = (*hdr).refidx[6];
                 (*hdr).refidx[4] = (*hdr).refidx[5];
@@ -1940,8 +1938,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                 }
                                 if (*hdr).all_lossless != 0 || (*hdr).allow_intrabc != 0 {
                                     (*hdr).loopfilter.level_y[1] = 0 as libc::c_int;
-                                    (*hdr).loopfilter.level_y[0] =
-                                        (*hdr).loopfilter.level_y[1];
+                                    (*hdr).loopfilter.level_y[0] = (*hdr).loopfilter.level_y[1];
                                     (*hdr).loopfilter.level_v = 0 as libc::c_int;
                                     (*hdr).loopfilter.level_u = (*hdr).loopfilter.level_v;
                                     (*hdr).loopfilter.sharpness = 0 as libc::c_int;
@@ -2063,33 +2060,28 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                                 dav1d_get_bits(gb, 2 as libc::c_int)
                                                     as Dav1dRestorationType;
                                             if (*seqhdr).monochrome == 0 {
-                                                (*hdr).restoration.type_0
-                                                    [1] =
+                                                (*hdr).restoration.type_0[1] =
                                                     dav1d_get_bits(gb, 2 as libc::c_int)
                                                         as Dav1dRestorationType;
-                                                (*hdr).restoration.type_0
-                                                    [2] =
+                                                (*hdr).restoration.type_0[2] =
                                                     dav1d_get_bits(gb, 2 as libc::c_int)
                                                         as Dav1dRestorationType;
                                             } else {
                                                 (*hdr).restoration.type_0[2] =
                                                     DAV1D_RESTORATION_NONE;
-                                                (*hdr).restoration.type_0
-                                                    [1] =
+                                                (*hdr).restoration.type_0[1] =
                                                     (*hdr).restoration.type_0[2];
                                             }
                                             if (*hdr).restoration.type_0[0] as libc::c_uint != 0
                                                 || (*hdr).restoration.type_0[1] as libc::c_uint != 0
                                                 || (*hdr).restoration.type_0[2] as libc::c_uint != 0
                                             {
-                                                (*hdr).restoration.unit_size
-                                                    [0] =
+                                                (*hdr).restoration.unit_size[0] =
                                                     6 + (*seqhdr).sb128;
                                                 if dav1d_get_bit(gb) != 0 {
                                                     (*hdr).restoration.unit_size[0] += 1;
                                                     if (*seqhdr).sb128 == 0 {
-                                                        (*hdr).restoration.unit_size
-                                                            [0] =
+                                                        (*hdr).restoration.unit_size[0] =
                                                             ((*hdr).restoration.unit_size[0]
                                                                 as libc::c_uint)
                                                                 .wrapping_add(dav1d_get_bit(gb))
@@ -2097,8 +2089,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                                                 as libc::c_int;
                                                     }
                                                 }
-                                                (*hdr).restoration.unit_size
-                                                    [1] =
+                                                (*hdr).restoration.unit_size[1] =
                                                     (*hdr).restoration.unit_size[0];
                                                 if ((*hdr).restoration.type_0[1] as libc::c_uint
                                                     != 0
@@ -2107,8 +2098,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                                     && (*seqhdr).ss_hor == 1
                                                     && (*seqhdr).ss_ver == 1
                                                 {
-                                                    (*hdr).restoration.unit_size
-                                                        [1] =
+                                                    (*hdr).restoration.unit_size[1] =
                                                         ((*hdr).restoration.unit_size[1]
                                                             as libc::c_uint)
                                                             .wrapping_sub(dav1d_get_bit(gb))
@@ -2212,11 +2202,9 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                                     if off_before != 0xffffffff as libc::c_uint
                                                         && off_after != -(1 as libc::c_int)
                                                     {
-                                                        (*hdr).skip_mode_refs
-                                                            [0] =
+                                                        (*hdr).skip_mode_refs[0] =
                                                             imin(off_before_idx, off_after_idx);
-                                                        (*hdr).skip_mode_refs
-                                                            [1] =
+                                                        (*hdr).skip_mode_refs[1] =
                                                             imax(off_before_idx, off_after_idx);
                                                         (*hdr).skip_mode_allowed = 1 as libc::c_int;
                                                         current_block = 2126221883176060805;
@@ -3038,11 +3026,9 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                     (*ref_2).data as *mut Dav1dMasteringDisplay;
                                 let mut i_1 = 0;
                                 while i_1 < 3 {
-                                    (*mastering_display).primaries[i_1 as usize]
-                                        [0] =
+                                    (*mastering_display).primaries[i_1 as usize][0] =
                                         dav1d_get_bits(&mut gb, 16 as libc::c_int) as uint16_t;
-                                    (*mastering_display).primaries[i_1 as usize]
-                                        [1] =
+                                    (*mastering_display).primaries[i_1 as usize][1] =
                                         dav1d_get_bits(&mut gb, 16 as libc::c_int) as uint16_t;
                                     i_1 += 1;
                                 }

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -771,12 +771,12 @@ pub unsafe extern "C" fn dav1d_default_picture_alloc(
     (*p).allocator_data = buf as *mut libc::c_void;
     let data: *mut uint8_t = (*buf).data as *mut uint8_t;
     (*p).data[0] = data as *mut libc::c_void;
-    (*p).data[1 as libc::c_int as usize] = (if has_chroma != 0 {
+    (*p).data[1] = (if has_chroma != 0 {
         data.offset(y_sz as isize)
     } else {
         0 as *mut uint8_t
     }) as *mut libc::c_void;
-    (*p).data[2 as libc::c_int as usize] = (if has_chroma != 0 {
+    (*p).data[2] = (if has_chroma != 0 {
         data.offset(y_sz as isize).offset(uv_sz as isize)
     } else {
         0 as *mut uint8_t

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -3990,10 +3990,9 @@ unsafe extern "C" fn obmc(
                         (*((*a_r).r#ref.r#ref).as_ptr().offset(0) as libc::c_int - 1) as isize,
                     ),
                     (*a_r).r#ref.r#ref[0] as libc::c_int - 1,
-                    dav1d_filter_2d[(*(*t).a).filter[1]
-                        [(bx4 + x + 1) as usize] as usize][(*(*t).a).filter
-                        [0][(bx4 + x + 1) as usize]
-                        as usize] as Filter2d,
+                    dav1d_filter_2d[(*(*t).a).filter[1][(bx4 + x + 1) as usize] as usize]
+                        [(*(*t).a).filter[0][(bx4 + x + 1) as usize] as usize]
+                        as Filter2d,
                 );
                 if res != 0 {
                     return res;
@@ -4043,8 +4042,7 @@ unsafe extern "C" fn obmc(
                         (*((*l_r).r#ref.r#ref).as_ptr().offset(0) as libc::c_int - 1) as isize,
                     ),
                     (*l_r).r#ref.r#ref[0] as libc::c_int - 1,
-                    dav1d_filter_2d
-                        [(*t).l.filter[1][(by4 + y + 1) as usize] as usize]
+                    dav1d_filter_2d[(*t).l.filter[1][(by4 + y + 1) as usize] as usize]
                         [(*t).l.filter[0][(by4 + y + 1) as usize] as usize]
                         as Filter2d,
                 );
@@ -5800,16 +5798,14 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                     .c2rust_unnamed_0
                     .c2rust_unnamed
                     .c2rust_unnamed
-                    .interintra_mode
-                    as usize]
+                    .interintra_mode as usize]
             } else {
-                dav1d_wedge_masks[bs as usize][0][0]
-                    [(*b)
-                        .c2rust_unnamed
-                        .c2rust_unnamed_0
-                        .c2rust_unnamed
-                        .c2rust_unnamed
-                        .wedge_idx as usize]
+                dav1d_wedge_masks[bs as usize][0][0][(*b)
+                    .c2rust_unnamed
+                    .c2rust_unnamed_0
+                    .c2rust_unnamed
+                    .c2rust_unnamed
+                    .wedge_idx as usize]
             };
             ((*dsp).mc.blend).expect("non-null function pointer")(
                 dst,
@@ -6142,8 +6138,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                 .interintra_mode
                                 as usize]
                         } else {
-                            dav1d_wedge_masks[bs as usize][chr_layout_idx as usize]
-                                [0][(*b)
+                            dav1d_wedge_masks[bs as usize][chr_layout_idx as usize][0][(*b)
                                 .c2rust_unnamed
                                 .c2rust_unnamed_0
                                 .c2rust_unnamed
@@ -6379,13 +6374,13 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                 mask = seg_mask;
             }
             4 => {
-                mask = dav1d_wedge_masks[bs as usize][0]
-                    [0][(*b)
+                mask = dav1d_wedge_masks[bs as usize][0][0][(*b)
                     .c2rust_unnamed
                     .c2rust_unnamed_0
                     .c2rust_unnamed
                     .c2rust_unnamed
-                    .wedge_idx as usize];
+                    .wedge_idx
+                    as usize];
                 ((*dsp).mc.mask).expect("non-null function pointer")(
                     dst,
                     (*f).cur.stride[0],

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -2330,7 +2330,7 @@ unsafe extern "C" fn decode_coefs(
             cul_level = dc_tok;
             dc_dq >>= dq_shift;
             dc_dq = umin(dc_dq as libc::c_uint, (cf_max + dc_sign) as libc::c_uint) as libc::c_int;
-            *cf.offset(0 as libc::c_int as isize) = if dc_sign != 0 { -dc_dq } else { dc_dq };
+            *cf.offset(0) = if dc_sign != 0 { -dc_dq } else { dc_dq };
             if rc != 0 {
                 current_block = 1669574575799829731;
             } else {
@@ -2361,7 +2361,7 @@ unsafe extern "C" fn decode_coefs(
                 }
             }
             cul_level = dc_tok;
-            *cf.offset(0 as libc::c_int as isize) = if dc_sign != 0 { -dc_dq } else { dc_dq };
+            *cf.offset(0) = if dc_sign != 0 { -dc_dq } else { dc_dq };
             if rc != 0 {
                 current_block = 2404388531445638768;
             } else {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -3990,9 +3990,9 @@ unsafe extern "C" fn obmc(
                         (*((*a_r).r#ref.r#ref).as_ptr().offset(0) as libc::c_int - 1) as isize,
                     ),
                     (*a_r).r#ref.r#ref[0] as libc::c_int - 1,
-                    dav1d_filter_2d[(*(*t).a).filter[1 as libc::c_int as usize]
+                    dav1d_filter_2d[(*(*t).a).filter[1]
                         [(bx4 + x + 1) as usize] as usize][(*(*t).a).filter
-                        [0 as libc::c_int as usize][(bx4 + x + 1) as usize]
+                        [0][(bx4 + x + 1) as usize]
                         as usize] as Filter2d,
                 );
                 if res != 0 {
@@ -4044,8 +4044,8 @@ unsafe extern "C" fn obmc(
                     ),
                     (*l_r).r#ref.r#ref[0] as libc::c_int - 1,
                     dav1d_filter_2d
-                        [(*t).l.filter[1 as libc::c_int as usize][(by4 + y + 1) as usize] as usize]
-                        [(*t).l.filter[0 as libc::c_int as usize][(by4 + y + 1) as usize] as usize]
+                        [(*t).l.filter[1][(by4 + y + 1) as usize] as usize]
+                        [(*t).l.filter[0][(by4 + y + 1) as usize] as usize]
                         as Filter2d,
                 );
                 if res != 0 {
@@ -5795,7 +5795,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                 as libc::c_int
                 == INTER_INTRA_BLEND as libc::c_int
             {
-                dav1d_ii_masks[bs as usize][0 as libc::c_int as usize][(*b)
+                dav1d_ii_masks[bs as usize][0][(*b)
                     .c2rust_unnamed
                     .c2rust_unnamed_0
                     .c2rust_unnamed
@@ -5803,7 +5803,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                     .interintra_mode
                     as usize]
             } else {
-                dav1d_wedge_masks[bs as usize][0 as libc::c_int as usize][0 as libc::c_int as usize]
+                dav1d_wedge_masks[bs as usize][0][0]
                     [(*b)
                         .c2rust_unnamed
                         .c2rust_unnamed_0
@@ -6143,7 +6143,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                 as usize]
                         } else {
                             dav1d_wedge_masks[bs as usize][chr_layout_idx as usize]
-                                [0 as libc::c_int as usize][(*b)
+                                [0][(*b)
                                 .c2rust_unnamed
                                 .c2rust_unnamed_0
                                 .c2rust_unnamed
@@ -6379,8 +6379,8 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                 mask = seg_mask;
             }
             4 => {
-                mask = dav1d_wedge_masks[bs as usize][0 as libc::c_int as usize]
-                    [0 as libc::c_int as usize][(*b)
+                mask = dav1d_wedge_masks[bs as usize][0]
+                    [0][(*b)
                     .c2rust_unnamed
                     .c2rust_unnamed_0
                     .c2rust_unnamed

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -2546,8 +2546,7 @@ unsafe extern "C" fn decode_coefs(
             cul_level = dc_tok;
             dc_dq >>= dq_shift;
             dc_dq = umin(dc_dq as libc::c_uint, (cf_max + dc_sign) as libc::c_uint) as libc::c_int;
-            *cf.offset(0) =
-                (if dc_sign != 0 { -dc_dq } else { dc_dq }) as coef;
+            *cf.offset(0) = (if dc_sign != 0 { -dc_dq } else { dc_dq }) as coef;
             if rc != 0 {
                 current_block = 10687245492419339872;
             } else {
@@ -2578,8 +2577,7 @@ unsafe extern "C" fn decode_coefs(
                 }
             }
             cul_level = dc_tok;
-            *cf.offset(0) =
-                (if dc_sign != 0 { -dc_dq } else { dc_dq }) as coef;
+            *cf.offset(0) = (if dc_sign != 0 { -dc_dq } else { dc_dq }) as coef;
             if rc != 0 {
                 current_block = 16948539754621368774;
             } else {
@@ -4200,10 +4198,9 @@ unsafe extern "C" fn obmc(
                         (*((*a_r).r#ref.r#ref).as_ptr().offset(0) as libc::c_int - 1) as isize,
                     ),
                     (*a_r).r#ref.r#ref[0] as libc::c_int - 1,
-                    dav1d_filter_2d[(*(*t).a).filter[1]
-                        [(bx4 + x + 1) as usize] as usize][(*(*t).a).filter
-                        [0][(bx4 + x + 1) as usize]
-                        as usize] as Filter2d,
+                    dav1d_filter_2d[(*(*t).a).filter[1][(bx4 + x + 1) as usize] as usize]
+                        [(*(*t).a).filter[0][(bx4 + x + 1) as usize] as usize]
+                        as Filter2d,
                 );
                 if res != 0 {
                     return res;
@@ -4253,8 +4250,7 @@ unsafe extern "C" fn obmc(
                         (*((*l_r).r#ref.r#ref).as_ptr().offset(0) as libc::c_int - 1) as isize,
                     ),
                     (*l_r).r#ref.r#ref[0] as libc::c_int - 1,
-                    dav1d_filter_2d
-                        [(*t).l.filter[1][(by4 + y + 1) as usize] as usize]
+                    dav1d_filter_2d[(*t).l.filter[1][(by4 + y + 1) as usize] as usize]
                         [(*t).l.filter[0][(by4 + y + 1) as usize] as usize]
                         as Filter2d,
                 );
@@ -5983,16 +5979,14 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                     .c2rust_unnamed_0
                     .c2rust_unnamed
                     .c2rust_unnamed
-                    .interintra_mode
-                    as usize]
+                    .interintra_mode as usize]
             } else {
-                dav1d_wedge_masks[bs as usize][0][0]
-                    [(*b)
-                        .c2rust_unnamed
-                        .c2rust_unnamed_0
-                        .c2rust_unnamed
-                        .c2rust_unnamed
-                        .wedge_idx as usize]
+                dav1d_wedge_masks[bs as usize][0][0][(*b)
+                    .c2rust_unnamed
+                    .c2rust_unnamed_0
+                    .c2rust_unnamed
+                    .c2rust_unnamed
+                    .wedge_idx as usize]
             };
             ((*dsp).mc.blend).expect("non-null function pointer")(
                 dst,
@@ -6325,8 +6319,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                 .interintra_mode
                                 as usize]
                         } else {
-                            dav1d_wedge_masks[bs as usize][chr_layout_idx as usize]
-                                [0][(*b)
+                            dav1d_wedge_masks[bs as usize][chr_layout_idx as usize][0][(*b)
                                 .c2rust_unnamed
                                 .c2rust_unnamed_0
                                 .c2rust_unnamed
@@ -6557,13 +6550,13 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                 mask = seg_mask;
             }
             4 => {
-                mask = dav1d_wedge_masks[bs as usize][0]
-                    [0][(*b)
+                mask = dav1d_wedge_masks[bs as usize][0][0][(*b)
                     .c2rust_unnamed
                     .c2rust_unnamed_0
                     .c2rust_unnamed
                     .c2rust_unnamed
-                    .wedge_idx as usize];
+                    .wedge_idx
+                    as usize];
                 ((*dsp).mc.mask).expect("non-null function pointer")(
                     dst,
                     (*f).cur.stride[0],

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -2546,7 +2546,7 @@ unsafe extern "C" fn decode_coefs(
             cul_level = dc_tok;
             dc_dq >>= dq_shift;
             dc_dq = umin(dc_dq as libc::c_uint, (cf_max + dc_sign) as libc::c_uint) as libc::c_int;
-            *cf.offset(0 as libc::c_int as isize) =
+            *cf.offset(0) =
                 (if dc_sign != 0 { -dc_dq } else { dc_dq }) as coef;
             if rc != 0 {
                 current_block = 10687245492419339872;
@@ -2578,7 +2578,7 @@ unsafe extern "C" fn decode_coefs(
                 }
             }
             cul_level = dc_tok;
-            *cf.offset(0 as libc::c_int as isize) =
+            *cf.offset(0) =
                 (if dc_sign != 0 { -dc_dq } else { dc_dq }) as coef;
             if rc != 0 {
                 current_block = 16948539754621368774;

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -4200,9 +4200,9 @@ unsafe extern "C" fn obmc(
                         (*((*a_r).r#ref.r#ref).as_ptr().offset(0) as libc::c_int - 1) as isize,
                     ),
                     (*a_r).r#ref.r#ref[0] as libc::c_int - 1,
-                    dav1d_filter_2d[(*(*t).a).filter[1 as libc::c_int as usize]
+                    dav1d_filter_2d[(*(*t).a).filter[1]
                         [(bx4 + x + 1) as usize] as usize][(*(*t).a).filter
-                        [0 as libc::c_int as usize][(bx4 + x + 1) as usize]
+                        [0][(bx4 + x + 1) as usize]
                         as usize] as Filter2d,
                 );
                 if res != 0 {
@@ -4254,8 +4254,8 @@ unsafe extern "C" fn obmc(
                     ),
                     (*l_r).r#ref.r#ref[0] as libc::c_int - 1,
                     dav1d_filter_2d
-                        [(*t).l.filter[1 as libc::c_int as usize][(by4 + y + 1) as usize] as usize]
-                        [(*t).l.filter[0 as libc::c_int as usize][(by4 + y + 1) as usize] as usize]
+                        [(*t).l.filter[1][(by4 + y + 1) as usize] as usize]
+                        [(*t).l.filter[0][(by4 + y + 1) as usize] as usize]
                         as Filter2d,
                 );
                 if res != 0 {
@@ -5978,7 +5978,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                 as libc::c_int
                 == INTER_INTRA_BLEND as libc::c_int
             {
-                dav1d_ii_masks[bs as usize][0 as libc::c_int as usize][(*b)
+                dav1d_ii_masks[bs as usize][0][(*b)
                     .c2rust_unnamed
                     .c2rust_unnamed_0
                     .c2rust_unnamed
@@ -5986,7 +5986,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                     .interintra_mode
                     as usize]
             } else {
-                dav1d_wedge_masks[bs as usize][0 as libc::c_int as usize][0 as libc::c_int as usize]
+                dav1d_wedge_masks[bs as usize][0][0]
                     [(*b)
                         .c2rust_unnamed
                         .c2rust_unnamed_0
@@ -6326,7 +6326,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                 as usize]
                         } else {
                             dav1d_wedge_masks[bs as usize][chr_layout_idx as usize]
-                                [0 as libc::c_int as usize][(*b)
+                                [0][(*b)
                                 .c2rust_unnamed
                                 .c2rust_unnamed_0
                                 .c2rust_unnamed
@@ -6557,8 +6557,8 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                 mask = seg_mask;
             }
             4 => {
-                mask = dav1d_wedge_masks[bs as usize][0 as libc::c_int as usize]
-                    [0 as libc::c_int as usize][(*b)
+                mask = dav1d_wedge_masks[bs as usize][0]
+                    [0][(*b)
                     .c2rust_unnamed
                     .c2rust_unnamed_0
                     .c2rust_unnamed

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -378,13 +378,13 @@ pub unsafe extern "C" fn dav1d_set_affine_mv2d(
     let rsux = 2 * bw4 - 1;
     let isuy = by4 * 4 + rsuy;
     let isux = bx4 * 4 + rsux;
-    *mat.offset(0 as libc::c_int as isize) = iclip(
+    *mat.offset(0) = iclip(
         mv.x as libc::c_int * 0x2000 as libc::c_int
             - (isux * (*mat.offset(2) - 0x10000 as libc::c_int) + isuy * *mat.offset(3)),
         -(0x800000 as libc::c_int),
         0x7fffff as libc::c_int,
     );
-    *mat.offset(1 as libc::c_int as isize) = iclip(
+    *mat.offset(1) = iclip(
         mv.y as libc::c_int * 0x2000 as libc::c_int
             - (isux * *mat.offset(4) + isuy * (*mat.offset(5) - 0x10000 as libc::c_int)),
         -(0x800000 as libc::c_int),
@@ -449,33 +449,33 @@ pub unsafe extern "C" fn dav1d_find_affine_int(
         idet <<= -shift;
         shift = 0 as libc::c_int;
     }
-    *mat.offset(2 as libc::c_int as isize) = get_mult_shift_diag(
+    *mat.offset(2) = get_mult_shift_diag(
         a[1][1] as int64_t * bx[0] as int64_t - a[0][1] as int64_t * bx[1] as int64_t,
         idet,
         shift,
     );
-    *mat.offset(3 as libc::c_int as isize) = get_mult_shift_ndiag(
+    *mat.offset(3) = get_mult_shift_ndiag(
         a[0][0] as int64_t * bx[1] as int64_t - a[0][1] as int64_t * bx[0] as int64_t,
         idet,
         shift,
     );
-    *mat.offset(4 as libc::c_int as isize) = get_mult_shift_ndiag(
+    *mat.offset(4) = get_mult_shift_ndiag(
         a[1][1] as int64_t * by[0] as int64_t - a[0][1] as int64_t * by[1] as int64_t,
         idet,
         shift,
     );
-    *mat.offset(5 as libc::c_int as isize) = get_mult_shift_diag(
+    *mat.offset(5) = get_mult_shift_diag(
         a[0][0] as int64_t * by[1] as int64_t - a[0][1] as int64_t * by[0] as int64_t,
         idet,
         shift,
     );
-    *mat.offset(0 as libc::c_int as isize) = iclip(
+    *mat.offset(0) = iclip(
         mv.x as libc::c_int * 0x2000 as libc::c_int
             - (isux * (*mat.offset(2) - 0x10000 as libc::c_int) + isuy * *mat.offset(3)),
         -(0x800000 as libc::c_int),
         0x7fffff as libc::c_int,
     );
-    *mat.offset(1 as libc::c_int as isize) = iclip(
+    *mat.offset(1) = iclip(
         mv.y as libc::c_int * 0x2000 as libc::c_int
             - (isux * *mat.offset(4) + isuy * (*mat.offset(5) - 0x10000 as libc::c_int)),
         -(0x800000 as libc::c_int),

--- a/src/wedge.rs
+++ b/src/wedge.rs
@@ -628,32 +628,25 @@ unsafe extern "C" fn fill2d_16x2(
     let mut n_1 = 0;
     while n_1 < 16 {
         let sign = (signs >> n_1 & 1 as libc::c_uint) as libc::c_int;
-        dav1d_wedge_masks[bs as usize][0][0]
-            [n_1 as usize] =
+        dav1d_wedge_masks[bs as usize][0][0][n_1 as usize] =
             &mut *masks_444.offset((sign * sign_stride_444) as isize) as *mut uint8_t;
-        dav1d_wedge_masks[bs as usize][0][1]
-            [n_1 as usize] =
+        dav1d_wedge_masks[bs as usize][0][1][n_1 as usize] =
             &mut *masks_444.offset((sign * sign_stride_444) as isize) as *mut uint8_t;
-        dav1d_wedge_masks[bs as usize][1][0]
-            [n_1 as usize] =
+        dav1d_wedge_masks[bs as usize][1][0][n_1 as usize] =
             &mut *masks_422.offset((sign * sign_stride_422) as isize) as *mut uint8_t;
-        dav1d_wedge_masks[bs as usize][1][1]
-            [n_1 as usize] = &mut *masks_422
+        dav1d_wedge_masks[bs as usize][1][1][n_1 as usize] = &mut *masks_422
             .offset(((sign == 0) as libc::c_int * sign_stride_422) as isize)
             as *mut uint8_t;
-        dav1d_wedge_masks[bs as usize][2][0]
-            [n_1 as usize] =
+        dav1d_wedge_masks[bs as usize][2][0][n_1 as usize] =
             &mut *masks_420.offset((sign * sign_stride_420) as isize) as *mut uint8_t;
-        dav1d_wedge_masks[bs as usize][2][1]
-            [n_1 as usize] = &mut *masks_420
+        dav1d_wedge_masks[bs as usize][2][1][n_1 as usize] = &mut *masks_420
             .offset(((sign == 0) as libc::c_int * sign_stride_420) as isize)
             as *mut uint8_t;
         masks_444 = masks_444.offset(n_stride_444 as isize);
         masks_422 = masks_422.offset(n_stride_422 as isize);
         masks_420 = masks_420.offset(n_stride_420 as isize);
         init_chroma(
-            dav1d_wedge_masks[bs as usize][1][0][n_1 as usize]
-                as *mut uint8_t,
+            dav1d_wedge_masks[bs as usize][1][0][n_1 as usize] as *mut uint8_t,
             dav1d_wedge_masks[bs as usize][0][0][n_1 as usize],
             0 as libc::c_int,
             w,
@@ -661,8 +654,7 @@ unsafe extern "C" fn fill2d_16x2(
             0 as libc::c_int,
         );
         init_chroma(
-            dav1d_wedge_masks[bs as usize][1][1][n_1 as usize]
-                as *mut uint8_t,
+            dav1d_wedge_masks[bs as usize][1][1][n_1 as usize] as *mut uint8_t,
             dav1d_wedge_masks[bs as usize][0][0][n_1 as usize],
             1 as libc::c_int,
             w,
@@ -670,8 +662,7 @@ unsafe extern "C" fn fill2d_16x2(
             0 as libc::c_int,
         );
         init_chroma(
-            dav1d_wedge_masks[bs as usize][2][0][n_1 as usize]
-                as *mut uint8_t,
+            dav1d_wedge_masks[bs as usize][2][0][n_1 as usize] as *mut uint8_t,
             dav1d_wedge_masks[bs as usize][0][0][n_1 as usize],
             0 as libc::c_int,
             w,
@@ -679,8 +670,7 @@ unsafe extern "C" fn fill2d_16x2(
             1 as libc::c_int,
         );
         init_chroma(
-            dav1d_wedge_masks[bs as usize][2][1][n_1 as usize]
-                as *mut uint8_t,
+            dav1d_wedge_masks[bs as usize][2][1][n_1 as usize] as *mut uint8_t,
             dav1d_wedge_masks[bs as usize][0][0][n_1 as usize],
             1 as libc::c_int,
             w,

--- a/src/wedge.rs
+++ b/src/wedge.rs
@@ -628,23 +628,23 @@ unsafe extern "C" fn fill2d_16x2(
     let mut n_1 = 0;
     while n_1 < 16 {
         let sign = (signs >> n_1 & 1 as libc::c_uint) as libc::c_int;
-        dav1d_wedge_masks[bs as usize][0 as libc::c_int as usize][0 as libc::c_int as usize]
+        dav1d_wedge_masks[bs as usize][0][0]
             [n_1 as usize] =
             &mut *masks_444.offset((sign * sign_stride_444) as isize) as *mut uint8_t;
-        dav1d_wedge_masks[bs as usize][0 as libc::c_int as usize][1 as libc::c_int as usize]
+        dav1d_wedge_masks[bs as usize][0][1]
             [n_1 as usize] =
             &mut *masks_444.offset((sign * sign_stride_444) as isize) as *mut uint8_t;
-        dav1d_wedge_masks[bs as usize][1 as libc::c_int as usize][0 as libc::c_int as usize]
+        dav1d_wedge_masks[bs as usize][1][0]
             [n_1 as usize] =
             &mut *masks_422.offset((sign * sign_stride_422) as isize) as *mut uint8_t;
-        dav1d_wedge_masks[bs as usize][1 as libc::c_int as usize][1 as libc::c_int as usize]
+        dav1d_wedge_masks[bs as usize][1][1]
             [n_1 as usize] = &mut *masks_422
             .offset(((sign == 0) as libc::c_int * sign_stride_422) as isize)
             as *mut uint8_t;
-        dav1d_wedge_masks[bs as usize][2 as libc::c_int as usize][0 as libc::c_int as usize]
+        dav1d_wedge_masks[bs as usize][2][0]
             [n_1 as usize] =
             &mut *masks_420.offset((sign * sign_stride_420) as isize) as *mut uint8_t;
-        dav1d_wedge_masks[bs as usize][2 as libc::c_int as usize][1 as libc::c_int as usize]
+        dav1d_wedge_masks[bs as usize][2][1]
             [n_1 as usize] = &mut *masks_420
             .offset(((sign == 0) as libc::c_int * sign_stride_420) as isize)
             as *mut uint8_t;
@@ -652,36 +652,36 @@ unsafe extern "C" fn fill2d_16x2(
         masks_422 = masks_422.offset(n_stride_422 as isize);
         masks_420 = masks_420.offset(n_stride_420 as isize);
         init_chroma(
-            dav1d_wedge_masks[bs as usize][1 as libc::c_int as usize][0][n_1 as usize]
+            dav1d_wedge_masks[bs as usize][1][0][n_1 as usize]
                 as *mut uint8_t,
-            dav1d_wedge_masks[bs as usize][0 as libc::c_int as usize][0][n_1 as usize],
+            dav1d_wedge_masks[bs as usize][0][0][n_1 as usize],
             0 as libc::c_int,
             w,
             h,
             0 as libc::c_int,
         );
         init_chroma(
-            dav1d_wedge_masks[bs as usize][1 as libc::c_int as usize][1][n_1 as usize]
+            dav1d_wedge_masks[bs as usize][1][1][n_1 as usize]
                 as *mut uint8_t,
-            dav1d_wedge_masks[bs as usize][0 as libc::c_int as usize][0][n_1 as usize],
+            dav1d_wedge_masks[bs as usize][0][0][n_1 as usize],
             1 as libc::c_int,
             w,
             h,
             0 as libc::c_int,
         );
         init_chroma(
-            dav1d_wedge_masks[bs as usize][2 as libc::c_int as usize][0][n_1 as usize]
+            dav1d_wedge_masks[bs as usize][2][0][n_1 as usize]
                 as *mut uint8_t,
-            dav1d_wedge_masks[bs as usize][0 as libc::c_int as usize][0][n_1 as usize],
+            dav1d_wedge_masks[bs as usize][0][0][n_1 as usize],
             0 as libc::c_int,
             w,
             h,
             1 as libc::c_int,
         );
         init_chroma(
-            dav1d_wedge_masks[bs as usize][2 as libc::c_int as usize][1][n_1 as usize]
+            dav1d_wedge_masks[bs as usize][2][1][n_1 as usize]
                 as *mut uint8_t,
-            dav1d_wedge_masks[bs as usize][0 as libc::c_int as usize][0][n_1 as usize],
+            dav1d_wedge_masks[bs as usize][0][0][n_1 as usize],
             1 as libc::c_int,
             w,
             h,

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -303,16 +303,16 @@ unsafe extern "C" fn picture_alloc(p: *mut Dav1dPicture, _: *mut libc::c_void) -
     (*p).allocator_data = buf as *mut libc::c_void;
     let align_m1: ptrdiff_t = (64 - 1) as ptrdiff_t;
     let data: *mut uint8_t = (buf as ptrdiff_t + align_m1 & !align_m1) as *mut uint8_t;
-    (*p).data[0 as libc::c_int as usize] =
+    (*p).data[0] =
         data.offset(y_sz as isize).offset(-(y_stride as isize)) as *mut libc::c_void;
-    (*p).data[1 as libc::c_int as usize] = (if has_chroma != 0 {
+    (*p).data[1] = (if has_chroma != 0 {
         data.offset(y_sz as isize)
             .offset(uv_sz.wrapping_mul(1) as isize)
             .offset(-(uv_stride as isize))
     } else {
         0 as *mut uint8_t
     }) as *mut libc::c_void;
-    (*p).data[2 as libc::c_int as usize] = (if has_chroma != 0 {
+    (*p).data[2] = (if has_chroma != 0 {
         data.offset(y_sz as isize)
             .offset(uv_sz.wrapping_mul(2) as isize)
             .offset(-(uv_stride as isize))

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -303,8 +303,7 @@ unsafe extern "C" fn picture_alloc(p: *mut Dav1dPicture, _: *mut libc::c_void) -
     (*p).allocator_data = buf as *mut libc::c_void;
     let align_m1: ptrdiff_t = (64 - 1) as ptrdiff_t;
     let data: *mut uint8_t = (buf as ptrdiff_t + align_m1 & !align_m1) as *mut uint8_t;
-    (*p).data[0] =
-        data.offset(y_sz as isize).offset(-(y_stride as isize)) as *mut libc::c_void;
+    (*p).data[0] = data.offset(y_sz as isize).offset(-(y_stride as isize)) as *mut libc::c_void;
     (*p).data[1] = (if has_chroma != 0 {
         data.offset(y_sz as isize)
             .offset(uv_sz.wrapping_mul(1) as isize)

--- a/tools/input/ivf.rs
+++ b/tools/input/ivf.rs
@@ -152,8 +152,8 @@ unsafe extern "C" fn ivf_open(
             }
         }
     }
-    *timebase.offset(0 as libc::c_int as isize) = rl32(&mut *hdr.as_mut_ptr().offset(16));
-    *timebase.offset(1 as libc::c_int as isize) = rl32(&mut *hdr.as_mut_ptr().offset(20));
+    *timebase.offset(0) = rl32(&mut *hdr.as_mut_ptr().offset(16));
+    *timebase.offset(1) = rl32(&mut *hdr.as_mut_ptr().offset(20));
     let duration: libc::c_uint = rl32(&mut *hdr.as_mut_ptr().offset(24));
     let mut data: [uint8_t; 8] = [0; 8];
     (*c).broken = 0 as libc::c_int;

--- a/tools/output/md5.rs
+++ b/tools/output/md5.rs
@@ -544,13 +544,13 @@ unsafe extern "C" fn md5_body(md5: *mut MD5Context, data: *const uint32_t) {
             .wrapping_add(*data.offset((5 - 60 & 15) as isize)),
         21 as libc::c_int,
     ));
-    (*md5).abcd[0 as libc::c_int as usize] =
+    (*md5).abcd[0] =
         ((*md5).abcd[0] as libc::c_uint).wrapping_add(a) as uint32_t as uint32_t;
-    (*md5).abcd[1 as libc::c_int as usize] =
+    (*md5).abcd[1] =
         ((*md5).abcd[1] as libc::c_uint).wrapping_add(b) as uint32_t as uint32_t;
-    (*md5).abcd[2 as libc::c_int as usize] =
+    (*md5).abcd[2] =
         ((*md5).abcd[2] as libc::c_uint).wrapping_add(c) as uint32_t as uint32_t;
-    (*md5).abcd[3 as libc::c_int as usize] =
+    (*md5).abcd[3] =
         ((*md5).abcd[3] as libc::c_uint).wrapping_add(d) as uint32_t as uint32_t;
 }
 unsafe extern "C" fn md5_update(

--- a/tools/output/md5.rs
+++ b/tools/output/md5.rs
@@ -544,14 +544,10 @@ unsafe extern "C" fn md5_body(md5: *mut MD5Context, data: *const uint32_t) {
             .wrapping_add(*data.offset((5 - 60 & 15) as isize)),
         21 as libc::c_int,
     ));
-    (*md5).abcd[0] =
-        ((*md5).abcd[0] as libc::c_uint).wrapping_add(a) as uint32_t as uint32_t;
-    (*md5).abcd[1] =
-        ((*md5).abcd[1] as libc::c_uint).wrapping_add(b) as uint32_t as uint32_t;
-    (*md5).abcd[2] =
-        ((*md5).abcd[2] as libc::c_uint).wrapping_add(c) as uint32_t as uint32_t;
-    (*md5).abcd[3] =
-        ((*md5).abcd[3] as libc::c_uint).wrapping_add(d) as uint32_t as uint32_t;
+    (*md5).abcd[0] = ((*md5).abcd[0] as libc::c_uint).wrapping_add(a) as uint32_t as uint32_t;
+    (*md5).abcd[1] = ((*md5).abcd[1] as libc::c_uint).wrapping_add(b) as uint32_t as uint32_t;
+    (*md5).abcd[2] = ((*md5).abcd[2] as libc::c_uint).wrapping_add(c) as uint32_t as uint32_t;
+    (*md5).abcd[3] = ((*md5).abcd[3] as libc::c_uint).wrapping_add(d) as uint32_t as uint32_t;
 }
 unsafe extern "C" fn md5_update(
     md5: *mut MD5Context,


### PR DESCRIPTION
`cargo fmt`ing (#177) makes the regexes from #166 pickup a lot more.