### PR TITLE
`fn resolve_divisor_{32,64}`: Cleanup and make safe

### DIFF
--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -46,6 +46,7 @@ fn resolve_divisor_32(d: u32) -> (libc::c_int, libc::c_int) {
     } else {
         e << 8 - shift
     };
+    // Use f as lookup into the precomputed table of multipliers
     (shift + 14, div_lut[f as usize] as libc::c_int)
 }
 
@@ -88,6 +89,7 @@ fn resolve_divisor_64(d: u64) -> (libc::c_int, libc::c_int) {
     } else {
         e << 8 - shift
     };
+    // Use f as lookup into the precomputed table of multipliers
     (shift + 14, div_lut[f as usize] as libc::c_int)
 }
 

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -47,7 +47,7 @@ fn resolve_divisor_32(d: libc::c_uint, shift: &mut libc::c_int) -> libc::c_int {
         e << 8 - *shift
     };
     assert!(f <= 256);
-    *shift += 14 as libc::c_int;
+    *shift += 14;
     return div_lut[f as usize] as libc::c_int;
 }
 
@@ -87,16 +87,16 @@ pub unsafe extern "C" fn dav1d_get_shear_params(wm: *mut Dav1dWarpedMotionParams
 
 fn resolve_divisor_64(d: uint64_t, shift: &mut libc::c_int) -> libc::c_int {
     *shift = u64log2(d);
-    let e: int64_t = (d as libc::c_ulonglong)
+    let e = (d as libc::c_ulonglong)
         .wrapping_sub(((1 as libc::c_longlong) << *shift) as libc::c_ulonglong)
         as int64_t;
-    let f: int64_t = (if *shift > 8 {
+    let f = (if *shift > 8 {
         e as libc::c_longlong + ((1 as libc::c_longlong) << *shift - 9) >> *shift - 8
     } else {
         (e << 8 - *shift) as libc::c_longlong
     }) as int64_t;
     assert!(f <= 256);
-    *shift += 14 as libc::c_int;
+    *shift += 14;
     return div_lut[f as usize] as libc::c_int;
 }
 

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -38,11 +38,11 @@ fn iclip_wmp(v: libc::c_int) -> libc::c_int {
 }
 
 #[inline]
-fn resolve_divisor_32(d: libc::c_uint, shift: &mut libc::c_int) -> libc::c_int {
+fn resolve_divisor_32(d: u32, shift: &mut libc::c_int) -> libc::c_int {
     *shift = ulog2(d);
-    let e = d.wrapping_sub(((1 as libc::c_int) << *shift) as libc::c_uint) as libc::c_int;
+    let e = d.wrapping_sub((1i32 << *shift) as u32) as i32;
     let f = if *shift > 8 {
-        e + ((1 as libc::c_int) << *shift - 9) >> *shift - 8
+        e + (1i32 << *shift - 9) >> *shift - 8
     } else {
         e << 8 - *shift
     };
@@ -85,16 +85,14 @@ pub unsafe extern "C" fn dav1d_get_shear_params(wm: *mut Dav1dWarpedMotionParams
             >= 0x10000 as libc::c_int) as libc::c_int;
 }
 
-fn resolve_divisor_64(d: uint64_t, shift: &mut libc::c_int) -> libc::c_int {
+fn resolve_divisor_64(d: u64, shift: &mut libc::c_int) -> libc::c_int {
     *shift = u64log2(d);
-    let e = (d as libc::c_ulonglong)
-        .wrapping_sub(((1 as libc::c_longlong) << *shift) as libc::c_ulonglong)
-        as int64_t;
-    let f = (if *shift > 8 {
-        e as libc::c_longlong + ((1 as libc::c_longlong) << *shift - 9) >> *shift - 8
+    let e = d.wrapping_sub((1i64 << *shift) as u64) as i64;
+    let f = if *shift > 8 {
+        e + (1i64 << *shift - 9) >> *shift - 8
     } else {
-        (e << 8 - *shift) as libc::c_longlong
-    }) as int64_t;
+        e << 8 - *shift
+    };
     assert!(f <= 256);
     *shift += 14;
     return div_lut[f as usize] as libc::c_int;

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -38,7 +38,7 @@ fn iclip_wmp(v: libc::c_int) -> libc::c_int {
 }
 
 #[inline]
-unsafe extern "C" fn resolve_divisor_32(d: libc::c_uint, shift: *mut libc::c_int) -> libc::c_int {
+unsafe fn resolve_divisor_32(d: libc::c_uint, shift: *mut libc::c_int) -> libc::c_int {
     *shift = ulog2(d);
     let e = d.wrapping_sub(((1 as libc::c_int) << *shift) as libc::c_uint) as libc::c_int;
     let f = if *shift > 8 {
@@ -52,6 +52,7 @@ unsafe extern "C" fn resolve_divisor_32(d: libc::c_uint, shift: *mut libc::c_int
     *shift += 14 as libc::c_int;
     return div_lut[f as usize] as libc::c_int;
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_get_shear_params(wm: *mut Dav1dWarpedMotionParams) -> libc::c_int {
     let mat: *const int32_t = ((*wm).matrix).as_mut_ptr();
@@ -85,7 +86,8 @@ pub unsafe extern "C" fn dav1d_get_shear_params(wm: *mut Dav1dWarpedMotionParams
         || 4 * ((*wm).u.p.gamma as libc::c_int).abs() + 4 * ((*wm).u.p.delta as libc::c_int).abs()
             >= 0x10000 as libc::c_int) as libc::c_int;
 }
-unsafe extern "C" fn resolve_divisor_64(d: uint64_t, shift: *mut libc::c_int) -> libc::c_int {
+
+unsafe fn resolve_divisor_64(d: uint64_t, shift: *mut libc::c_int) -> libc::c_int {
     *shift = u64log2(d);
     let e: int64_t = (d as libc::c_ulonglong)
         .wrapping_sub(((1 as libc::c_longlong) << *shift) as libc::c_ulonglong)
@@ -101,6 +103,7 @@ unsafe extern "C" fn resolve_divisor_64(d: uint64_t, shift: *mut libc::c_int) ->
     *shift += 14 as libc::c_int;
     return div_lut[f as usize] as libc::c_int;
 }
+
 unsafe extern "C" fn get_mult_shift_ndiag(
     px: int64_t,
     idet: libc::c_int,

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -46,9 +46,7 @@ unsafe fn resolve_divisor_32(d: libc::c_uint, shift: *mut libc::c_int) -> libc::
     } else {
         e << 8 - *shift
     };
-    if !(f <= 256) {
-        unreachable!();
-    }
+    assert!(f <= 256);
     *shift += 14 as libc::c_int;
     return div_lut[f as usize] as libc::c_int;
 }
@@ -97,9 +95,7 @@ unsafe fn resolve_divisor_64(d: uint64_t, shift: *mut libc::c_int) -> libc::c_in
     } else {
         (e << 8 - *shift) as libc::c_longlong
     }) as int64_t;
-    if !(f <= 256) {
-        unreachable!();
-    }
+    assert!(f <= 256);
     *shift += 14 as libc::c_int;
     return div_lut[f as usize] as libc::c_int;
 }

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -40,7 +40,7 @@ fn iclip_wmp(v: libc::c_int) -> libc::c_int {
 #[inline]
 fn resolve_divisor_32(d: u32, shift: &mut libc::c_int) -> libc::c_int {
     *shift = ulog2(d);
-    let e = d.wrapping_sub(1u32 << *shift) as i32;
+    let e = d - (1 << *shift);
     let f = if *shift > 8 {
         e + (1 << *shift - 9) >> *shift - 8
     } else {
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn dav1d_get_shear_params(wm: *mut Dav1dWarpedMotionParams
 
 fn resolve_divisor_64(d: u64, shift: &mut libc::c_int) -> libc::c_int {
     *shift = u64log2(d);
-    let e = d.wrapping_sub(1u64 << *shift) as i64;
+    let e = d - (1 << *shift);
     let f = if *shift > 8 {
         e + (1 << *shift - 9) >> *shift - 8
     } else {

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -38,7 +38,7 @@ fn iclip_wmp(v: libc::c_int) -> libc::c_int {
 }
 
 #[inline]
-unsafe fn resolve_divisor_32(d: libc::c_uint, shift: &mut libc::c_int) -> libc::c_int {
+fn resolve_divisor_32(d: libc::c_uint, shift: &mut libc::c_int) -> libc::c_int {
     *shift = ulog2(d);
     let e = d.wrapping_sub(((1 as libc::c_int) << *shift) as libc::c_uint) as libc::c_int;
     let f = if *shift > 8 {
@@ -85,7 +85,7 @@ pub unsafe extern "C" fn dav1d_get_shear_params(wm: *mut Dav1dWarpedMotionParams
             >= 0x10000 as libc::c_int) as libc::c_int;
 }
 
-unsafe fn resolve_divisor_64(d: uint64_t, shift: &mut libc::c_int) -> libc::c_int {
+fn resolve_divisor_64(d: uint64_t, shift: &mut libc::c_int) -> libc::c_int {
     *shift = u64log2(d);
     let e: int64_t = (d as libc::c_ulonglong)
         .wrapping_sub(((1 as libc::c_longlong) << *shift) as libc::c_ulonglong)

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -46,7 +46,6 @@ fn resolve_divisor_32(d: u32, shift: &mut libc::c_int) -> libc::c_int {
     } else {
         e << 8 - *shift
     };
-    assert!(f <= 256);
     *shift += 14;
     return div_lut[f as usize] as libc::c_int;
 }
@@ -93,7 +92,6 @@ fn resolve_divisor_64(d: u64, shift: &mut libc::c_int) -> libc::c_int {
     } else {
         e << 8 - *shift
     };
-    assert!(f <= 256);
     *shift += 14;
     return div_lut[f as usize] as libc::c_int;
 }

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -40,9 +40,9 @@ fn iclip_wmp(v: libc::c_int) -> libc::c_int {
 #[inline]
 fn resolve_divisor_32(d: u32, shift: &mut libc::c_int) -> libc::c_int {
     *shift = ulog2(d);
-    let e = d.wrapping_sub((1i32 << *shift) as u32) as i32;
+    let e = d.wrapping_sub(1u32 << *shift) as i32;
     let f = if *shift > 8 {
-        e + (1i32 << *shift - 9) >> *shift - 8
+        e + (1 << *shift - 9) >> *shift - 8
     } else {
         e << 8 - *shift
     };
@@ -87,9 +87,9 @@ pub unsafe extern "C" fn dav1d_get_shear_params(wm: *mut Dav1dWarpedMotionParams
 
 fn resolve_divisor_64(d: u64, shift: &mut libc::c_int) -> libc::c_int {
     *shift = u64log2(d);
-    let e = d.wrapping_sub((1i64 << *shift) as u64) as i64;
+    let e = d.wrapping_sub(1u64 << *shift) as i64;
     let f = if *shift > 8 {
-        e + (1i64 << *shift - 9) >> *shift - 8
+        e + (1 << *shift - 9) >> *shift - 8
     } else {
         e << 8 - *shift
     };

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -38,7 +38,7 @@ fn iclip_wmp(v: libc::c_int) -> libc::c_int {
 }
 
 #[inline]
-unsafe fn resolve_divisor_32(d: libc::c_uint, shift: *mut libc::c_int) -> libc::c_int {
+unsafe fn resolve_divisor_32(d: libc::c_uint, shift: &mut libc::c_int) -> libc::c_int {
     *shift = ulog2(d);
     let e = d.wrapping_sub(((1 as libc::c_int) << *shift) as libc::c_uint) as libc::c_int;
     let f = if *shift > 8 {
@@ -85,7 +85,7 @@ pub unsafe extern "C" fn dav1d_get_shear_params(wm: *mut Dav1dWarpedMotionParams
             >= 0x10000 as libc::c_int) as libc::c_int;
 }
 
-unsafe fn resolve_divisor_64(d: uint64_t, shift: *mut libc::c_int) -> libc::c_int {
+unsafe fn resolve_divisor_64(d: uint64_t, shift: &mut libc::c_int) -> libc::c_int {
     *shift = u64log2(d);
     let e: int64_t = (d as libc::c_ulonglong)
         .wrapping_sub(((1 as libc::c_longlong) << *shift) as libc::c_ulonglong)


### PR DESCRIPTION
These could be further cleaned up by parameterizing over `u32` and `u64`, but it's not that important yet.  I would like to replace the `ulog2` and `u64log2` calls with `{u32, u64}::ilog2`, but `ilog2` was stabilized in Rust `1.67`, and our pinned nightly is a bit behind that.  Would it be a good idea to upgrade that to something newer?  Unfortunately, we'll have to stay on nightly for a while longer until we finish getting rid of varargs, extern types, and intrinsic calls.