### PR TITLE
`fn dav1d_get_shear_params`: Cleanup and make safe

### DIFF
--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -44,26 +44,28 @@ pub const DAV1D_WM_TYPE_IDENTITY: Dav1dWarpedMotionType = 0;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct Dav1dWarpedMotionParams_u_p {
-    pub alpha: i16,
-    pub beta: i16,
-    pub gamma: i16,
-    pub delta: i16,
-}
-
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub union Dav1dWarpedMotionParams_u {
-    pub p: Dav1dWarpedMotionParams_u_p,
-    pub abcd: [i16; 4],
-}
-
-#[derive(Copy, Clone)]
-#[repr(C)]
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
     pub matrix: [i32; 6],
-    pub u: Dav1dWarpedMotionParams_u,
+    pub abcd: [i16; 4],
+}
+
+impl Dav1dWarpedMotionParams {
+    pub const fn alpha(&self) -> i16 {
+        self.abcd[0]
+    }
+
+    pub const fn beta(&self) -> i16 {
+        self.abcd[1]
+    }
+
+    pub const fn gamma(&self) -> i16 {
+        self.abcd[2]
+    }
+
+    pub const fn delta(&self) -> i16 {
+        self.abcd[3]
+    }
 }
 
 pub type Dav1dPixelLayout = libc::c_uint;

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -1,6 +1,4 @@
 use crate::include::stddef::size_t;
-use crate::include::stdint::int16_t;
-use crate::include::stdint::int32_t;
 use crate::include::stdint::int8_t;
 use crate::include::stdint::uint16_t;
 use crate::include::stdint::uint32_t;
@@ -43,27 +41,31 @@ pub const DAV1D_WM_TYPE_AFFINE: Dav1dWarpedMotionType = 3;
 pub const DAV1D_WM_TYPE_ROT_ZOOM: Dav1dWarpedMotionType = 2;
 pub const DAV1D_WM_TYPE_TRANSLATION: Dav1dWarpedMotionType = 1;
 pub const DAV1D_WM_TYPE_IDENTITY: Dav1dWarpedMotionType = 0;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams_u_p {
-    pub alpha: int16_t,
-    pub beta: int16_t,
-    pub gamma: int16_t,
-    pub delta: int16_t,
+    pub alpha: i16,
+    pub beta: i16,
+    pub gamma: i16,
+    pub delta: i16,
 }
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union Dav1dWarpedMotionParams_u {
     pub p: Dav1dWarpedMotionParams_u_p,
-    pub abcd: [int16_t; 4],
+    pub abcd: [i16; 4],
 }
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
-    pub matrix: [int32_t; 6],
+    pub matrix: [i32; 6],
     pub u: Dav1dWarpedMotionParams_u,
 }
+
 pub type Dav1dPixelLayout = libc::c_uint;
 pub const DAV1D_PIXEL_LAYOUT_I444: Dav1dPixelLayout = 3;
 pub const DAV1D_PIXEL_LAYOUT_I422: Dav1dPixelLayout = 2;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2556,7 +2556,7 @@ unsafe extern "C" fn derive_warpmv(
         (*t).bx,
         (*t).by,
     ) == 0
-        && dav1d_get_shear_params(wmp) == 0
+        && dav1d_get_shear_params(&mut *wmp) == 0
     {
         (*wmp).type_0 = DAV1D_WM_TYPE_AFFINE;
     } else {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3918,10 +3918,10 @@ unsafe fn decode_b(
                             SignAbs(t.warpmv.matrix[3]),
                             SignAbs(t.warpmv.matrix[4]),
                             SignAbs(t.warpmv.matrix[5]),
-                            SignAbs(t.warpmv.u.p.alpha.into()),
-                            SignAbs(t.warpmv.u.p.beta.into()),
-                            SignAbs(t.warpmv.u.p.gamma.into()),
-                            SignAbs(t.warpmv.u.p.delta.into()),
+                            SignAbs(t.warpmv.alpha().into()),
+                            SignAbs(t.warpmv.beta().into()),
+                            SignAbs(t.warpmv.gamma().into()),
+                            SignAbs(t.warpmv.delta().into()),
                             b.mv2d().y,
                             b.mv2d().x,
                         );
@@ -8424,33 +8424,33 @@ unsafe fn decode_b(
                                 ' ' as i32
                             },
                             (t.warpmv.matrix[5]).abs(),
-                            if (t.warpmv.u.p.alpha as libc::c_int) < 0
+                            if (t.warpmv.alpha() as libc::c_int) < 0
                             {
                                 '-' as i32
                             } else {
                                 ' ' as i32
                             },
-                            (t.warpmv.u.p.alpha as libc::c_int).abs(),
-                            if (t.warpmv.u.p.beta as libc::c_int) < 0 {
+                            (t.warpmv.alpha() as libc::c_int).abs(),
+                            if (t.warpmv.beta() as libc::c_int) < 0 {
                                 '-' as i32
                             } else {
                                 ' ' as i32
                             },
-                            (t.warpmv.u.p.beta as libc::c_int).abs(),
-                            if (t.warpmv.u.p.gamma as libc::c_int) < 0
+                            (t.warpmv.beta() as libc::c_int).abs(),
+                            if (t.warpmv.gamma() as libc::c_int) < 0
                             {
                                 '-' as i32
                             } else {
                                 ' ' as i32
                             },
-                            (t.warpmv.u.p.gamma as libc::c_int).abs(),
-                            if (t.warpmv.u.p.delta as libc::c_int) < 0
+                            (t.warpmv.gamma() as libc::c_int).abs(),
+                            if (t.warpmv.delta() as libc::c_int) < 0
                             {
                                 '-' as i32
                             } else {
                                 ' ' as i32
                             },
-                            (t.warpmv.u.p.delta as libc::c_int).abs(),
+                            (t.warpmv.delta() as libc::c_int).abs(),
                             b
                                 .c2rust_unnamed
                                 .c2rust_unnamed_0

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2556,7 +2556,7 @@ unsafe extern "C" fn derive_warpmv(
         (*t).bx,
         (*t).by,
     ) == 0
-        && dav1d_get_shear_params(&mut *wmp) == 0
+        && !dav1d_get_shear_params(&mut *wmp)
     {
         (*wmp).type_0 = DAV1D_WM_TYPE_AFFINE;
     } else {
@@ -13510,11 +13510,11 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                                     ((*(*f).frame_hdr).gmv[i as usize].type_0 as libc::c_uint
                                         > DAV1D_WM_TYPE_TRANSLATION as libc::c_int as libc::c_uint
                                         && (*(*f).frame_hdr).force_integer_mv == 0
-                                        && dav1d_get_shear_params(
+                                        && !dav1d_get_shear_params(
                                             &mut *((*(*f).frame_hdr).gmv)
                                                 .as_mut_ptr()
                                                 .offset(i as isize),
-                                        ) == 0
+                                        )
                                         && (*f).svc[i as usize][0].scale == 0)
                                         as libc::c_int
                                         as uint8_t;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -270,7 +270,6 @@ extern "C" {
         cond_signal: libc::c_int,
     ) -> libc::c_int;
     fn dav1d_task_frame_init(f: *mut Dav1dFrameContext);
-    fn dav1d_get_shear_params(wm: *mut Dav1dWarpedMotionParams) -> libc::c_int;
     fn dav1d_find_affine_int(
         pts: *const [[libc::c_int; 2]; 2],
         np: libc::c_int,
@@ -306,6 +305,7 @@ use crate::src::tables::dav1d_sgr_params;
 use crate::src::tables::dav1d_txfm_dimensions;
 use crate::src::tables::dav1d_wedge_ctx_lut;
 use crate::src::tables::dav1d_ymode_size_context;
+use crate::src::warpmv::dav1d_get_shear_params;
 
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
@@ -4065,7 +4065,9 @@ unsafe fn decode_b(
     }
 
     // skip_mode
-    if seg.map(|seg| seg.globalmv == 0 && seg.r#ref == -1 && seg.skip == 0).unwrap_or(true)
+    if seg
+        .map(|seg| seg.globalmv == 0 && seg.r#ref == -1 && seg.skip == 0)
+        .unwrap_or(true)
         && (*f.frame_hdr).skip_mode_enabled != 0
         && imin(bw4, bh4) > 1
     {
@@ -4087,10 +4089,9 @@ unsafe fn decode_b(
         b.skip = 1;
     } else {
         let sctx = (*t.a).skip[bx4 as usize] + t.l.skip[by4 as usize];
-        b.skip = dav1d_msac_decode_bool_adapt(
-            &mut ts.msac,
-            (ts.cdf.m.skip[sctx as usize]).as_mut_ptr(),
-        ) as uint8_t;
+        b.skip =
+            dav1d_msac_decode_bool_adapt(&mut ts.msac, (ts.cdf.m.skip[sctx as usize]).as_mut_ptr())
+                as uint8_t;
 
         if DEBUG_BLOCK_INFO(f, t) {
             println!("Post-skip[{}]: r={}", b.skip, ts.msac.rng);
@@ -4102,27 +4103,18 @@ unsafe fn decode_b(
         && (*f.frame_hdr).segmentation.update_map != 0
         && (*f.frame_hdr).segmentation.seg_data.preskip == 0
     {
-        if b.skip == 0 && (*f.frame_hdr).segmentation.temporal != 0
-            && {
-                let index = (*t.a).seg_pred[bx4 as usize] + t.l.seg_pred[by4 as usize];
-                seg_pred = dav1d_msac_decode_bool_adapt(
-                    &mut ts.msac,
-                    ts.cdf.m.seg_pred[index as usize].as_mut_ptr(),
-                ) as libc::c_int;
-                seg_pred != 0
-            }
-        {
+        if b.skip == 0 && (*f.frame_hdr).segmentation.temporal != 0 && {
+            let index = (*t.a).seg_pred[bx4 as usize] + t.l.seg_pred[by4 as usize];
+            seg_pred = dav1d_msac_decode_bool_adapt(
+                &mut ts.msac,
+                ts.cdf.m.seg_pred[index as usize].as_mut_ptr(),
+            ) as libc::c_int;
+            seg_pred != 0
+        } {
             // temporal predicted seg_id
             if !(f.prev_segmap).is_null() {
-                let mut seg_id = get_prev_frame_segid(
-                    f,
-                    t.by,
-                    t.bx,
-                    w4,
-                    h4,
-                    f.prev_segmap,
-                    f.b4_stride,
-                );
+                let mut seg_id =
+                    get_prev_frame_segid(f, t.by, t.bx, w4, h4, f.prev_segmap, f.b4_stride);
 
                 if seg_id >= DAV1D_MAX_SEGMENTS.into() {
                     return -1;
@@ -4152,10 +4144,7 @@ unsafe fn decode_b(
                     ts.cdf.m.seg_id[seg_ctx as usize].as_mut_ptr(),
                     (DAV1D_MAX_SEGMENTS - 1) as size_t,
                 );
-                let last_active_seg_id = (*f.frame_hdr)
-                    .segmentation
-                    .seg_data
-                    .last_active_segid;
+                let last_active_seg_id = (*f.frame_hdr).segmentation.seg_data.last_active_segid;
 
                 b.seg_id = neg_deinterleave(
                     diff as libc::c_int,
@@ -4189,8 +4178,7 @@ unsafe fn decode_b(
 
         if *(t.cur_sb_cdef_idx_ptr).offset(idx) == -1 {
             let v =
-                dav1d_msac_decode_bools(&mut ts.msac, frame_hdr.cdef.n_bits as libc::c_uint)
-                    as i8;
+                dav1d_msac_decode_bools(&mut ts.msac, frame_hdr.cdef.n_bits as libc::c_uint) as i8;
 
             *(t.cur_sb_cdef_idx_ptr).offset(idx) = v;
 
@@ -4340,10 +4328,8 @@ unsafe fn decode_b(
             }
         }
     } else if frame_hdr.allow_intrabc != 0 {
-        b.intra = (dav1d_msac_decode_bool_adapt(
-            &mut ts.msac,
-            ts.cdf.m.intrabc.0.as_mut_ptr(),
-        ) == 0)  as uint8_t;
+        b.intra = (dav1d_msac_decode_bool_adapt(&mut ts.msac, ts.cdf.m.intrabc.0.as_mut_ptr()) == 0)
+            as uint8_t;
 
         if DEBUG_BLOCK_INFO(f, t) {
             println!("Post-intrabcflag[{}]: r={}", b.intra, ts.msac.rng);
@@ -4357,10 +4343,7 @@ unsafe fn decode_b(
         let ymode_cdf = if frame_hdr.frame_type & 1 != 0 {
             ts.cdf.m.y_mode[dav1d_ymode_size_context[bs as usize] as usize].as_mut_ptr()
         } else {
-            ts
-                .cdf
-                .kfym
-                [dav1d_intra_mode_context[(*t.a).mode[bx4 as usize] as usize] as usize]
+            ts.cdf.kfym[dav1d_intra_mode_context[(*t.a).mode[bx4 as usize] as usize] as usize]
                 [dav1d_intra_mode_context[t.l.mode[by4 as usize] as usize] as usize]
                 .as_mut_ptr()
         };
@@ -4377,8 +4360,7 @@ unsafe fn decode_b(
 
         // angle delta
         if b_dim[2] + b_dim[3] >= 2
-            && b.c2rust_unnamed.c2rust_unnamed.y_mode as libc::c_int
-                >= VERT_PRED as libc::c_int
+            && b.c2rust_unnamed.c2rust_unnamed.y_mode as libc::c_int >= VERT_PRED as libc::c_int
             && b.c2rust_unnamed.c2rust_unnamed.y_mode as libc::c_int
                 <= VERT_LEFT_PRED as libc::c_int
         {
@@ -4495,8 +4477,7 @@ unsafe fn decode_b(
         }
         b.c2rust_unnamed.c2rust_unnamed.pal_sz[1] = 0 as libc::c_int as uint8_t;
         b.c2rust_unnamed.c2rust_unnamed.pal_sz[0] = b.c2rust_unnamed.c2rust_unnamed.pal_sz[1];
-        if frame_hdr.allow_screen_content_tools != 0 && imax(bw4, bh4) <= 16 && bw4 + bh4 >= 4
-        {
+        if frame_hdr.allow_screen_content_tools != 0 && imax(bw4, bh4) <= 16 && bw4 + bh4 >= 4 {
             let sz_ctx = (b_dim[2] + b_dim[3] - 2) as libc::c_int;
             if b.c2rust_unnamed.c2rust_unnamed.y_mode as libc::c_int == DC_PRED as libc::c_int {
                 let pal_ctx = ((*t.a).pal_sz[bx4 as usize] as libc::c_int > 0) as libc::c_int
@@ -4539,10 +4520,7 @@ unsafe fn decode_b(
         }
         if b.c2rust_unnamed.c2rust_unnamed.y_mode as libc::c_int == DC_PRED as libc::c_int
             && b.c2rust_unnamed.c2rust_unnamed.pal_sz[0] == 0
-            && imax(
-                b_dim[2] as libc::c_int,
-                b_dim[3] as libc::c_int,
-            ) <= 3
+            && imax(b_dim[2] as libc::c_int, b_dim[3] as libc::c_int) <= 3
             && (*f.seq_hdr).filter_intra != 0
         {
             let is_filter = dav1d_msac_decode_bool_adapt(
@@ -6558,8 +6536,7 @@ unsafe fn decode_b(
             1 => {
                 (*(&mut *(t.l.tx_intra).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                     as *mut alias8))
-                    .u8_0 = (0x1 * b_dim[2 + 1])
-                    as uint8_t;
+                    .u8_0 = (0x1 * b_dim[2 + 1]) as uint8_t;
                 (*(&mut *(t.l.mode).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * DC_PRED as libc::c_int) as uint8_t;
@@ -6586,7 +6563,7 @@ unsafe fn decode_b(
             2 => {
                 (*(&mut *(t.l.tx_intra).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                     as *mut alias16))
-                    .u16_0 = 0x101  * b_dim[2 + 1] as uint16_t;
+                    .u16_0 = 0x101 * b_dim[2 + 1] as uint16_t;
                 (*(&mut *(t.l.mode).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * DC_PRED as libc::c_int) as uint16_t;
@@ -6613,8 +6590,7 @@ unsafe fn decode_b(
             4 => {
                 (*(&mut *(t.l.tx_intra).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                     as *mut alias32))
-                    .u32_0 = (0x1010101 as libc::c_uint)
-                    .wrapping_mul(b_dim[2 + 1] as libc::c_uint);
+                    .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(b_dim[2 + 1] as libc::c_uint);
                 (*(&mut *(t.l.mode).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)
@@ -6926,8 +6902,7 @@ unsafe fn decode_b(
             4 => {
                 (*(&mut *((*t.a).tx_intra).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                     as *mut alias32))
-                    .u32_0 = (0x1010101 as libc::c_uint)
-                    .wrapping_mul(b_dim[2 + 0] as libc::c_uint);
+                    .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(b_dim[2 + 0] as libc::c_uint);
                 (*(&mut *((*t.a).mode).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)
@@ -8089,8 +8064,8 @@ unsafe fn decode_b(
                         frame_hdr,
                     );
                     has_subpel_filter = (imin(bw4, bh4) == 1
-                        || frame_hdr.gmv[b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as usize]
-                            .type_0 as libc::c_uint
+                        || frame_hdr.gmv[b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as usize].type_0
+                            as libc::c_uint
                             == DAV1D_WM_TYPE_TRANSLATION as libc::c_int as libc::c_uint)
                         as libc::c_int;
                 } else {
@@ -8344,8 +8319,8 @@ unsafe fn decode_b(
                 && !(frame_hdr.force_integer_mv == 0
                     && b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_int
                         == GLOBALMV as libc::c_int
-                    && frame_hdr.gmv[b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as usize]
-                        .type_0 as libc::c_uint
+                    && frame_hdr.gmv[b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as usize].type_0
+                        as libc::c_uint
                         > DAV1D_WM_TYPE_TRANSLATION as libc::c_int as libc::c_uint)
                 && (have_left != 0 && findoddzero(&t.l.intra[by4 as usize..][..h4 as usize])
                     || have_top != 0 && findoddzero(&(*t.a).intra[bx4 as usize..][..w4 as usize]))
@@ -8826,8 +8801,7 @@ unsafe fn decode_b(
                     .u32_0 = 0 as libc::c_int as uint32_t;
                 (*(&mut *(t.l.tx_intra).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                     as *mut alias32))
-                    .u32_0 = (0x1010101 as libc::c_uint)
-                    .wrapping_mul(b_dim[2 + 1] as libc::c_uint);
+                    .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(b_dim[2 + 1] as libc::c_uint);
                 (*(&mut *(t.l.comp_type).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)
@@ -9427,8 +9401,7 @@ unsafe fn decode_b(
                     .u32_0 = 0 as libc::c_int as uint32_t;
                 (*(&mut *((*t.a).tx_intra).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                     as *mut alias32))
-                    .u32_0 = (0x1010101 as libc::c_uint)
-                    .wrapping_mul(b_dim[2 + 0] as libc::c_uint);
+                    .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(b_dim[2 + 0] as libc::c_uint);
                 (*(&mut *((*t.a).comp_type).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -4120,13 +4120,13 @@ unsafe extern "C" fn warp_affine(
             let mvy: int64_t = *mat.offset(4) as int64_t * src_x as int64_t + mat5_y >> ss_ver;
             let dx = (mvx >> 16) as libc::c_int - 4;
             let mx = (mvx as libc::c_int & 0xffff as libc::c_int)
-                - (*wmp).u.p.alpha as libc::c_int * 4
-                - (*wmp).u.p.beta as libc::c_int * 7
+                - (*wmp).alpha() as libc::c_int * 4
+                - (*wmp).beta() as libc::c_int * 7
                 & !(0x3f as libc::c_int);
             let dy = (mvy >> 16) as libc::c_int - 4;
             let my = (mvy as libc::c_int & 0xffff as libc::c_int)
-                - (*wmp).u.p.gamma as libc::c_int * 4
-                - (*wmp).u.p.delta as libc::c_int * 4
+                - (*wmp).gamma() as libc::c_int * 4
+                - (*wmp).delta() as libc::c_int * 4
                 & !(0x3f as libc::c_int);
             let mut ref_ptr: *const pixel = 0 as *const pixel;
             let mut ref_stride: ptrdiff_t = (*refp).p.stride[(pl != 0) as libc::c_int as usize];
@@ -4162,7 +4162,7 @@ unsafe extern "C" fn warp_affine(
                     dstride,
                     ref_ptr,
                     ref_stride,
-                    ((*wmp).u.abcd).as_ptr(),
+                    ((*wmp).abcd).as_ptr(),
                     mx,
                     my,
                     (*f).bitdepth_max,
@@ -4173,7 +4173,7 @@ unsafe extern "C" fn warp_affine(
                     dstride,
                     ref_ptr,
                     ref_stride,
-                    ((*wmp).u.abcd).as_ptr(),
+                    ((*wmp).abcd).as_ptr(),
                     mx,
                     my,
                     (*f).bitdepth_max,

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -4322,13 +4322,13 @@ unsafe extern "C" fn warp_affine(
             let mvy: int64_t = *mat.offset(4) as int64_t * src_x as int64_t + mat5_y >> ss_ver;
             let dx = (mvx >> 16) as libc::c_int - 4;
             let mx = (mvx as libc::c_int & 0xffff as libc::c_int)
-                - (*wmp).u.p.alpha as libc::c_int * 4
-                - (*wmp).u.p.beta as libc::c_int * 7
+                - (*wmp).alpha() as libc::c_int * 4
+                - (*wmp).beta() as libc::c_int * 7
                 & !(0x3f as libc::c_int);
             let dy = (mvy >> 16) as libc::c_int - 4;
             let my = (mvy as libc::c_int & 0xffff as libc::c_int)
-                - (*wmp).u.p.gamma as libc::c_int * 4
-                - (*wmp).u.p.delta as libc::c_int * 4
+                - (*wmp).gamma() as libc::c_int * 4
+                - (*wmp).delta() as libc::c_int * 4
                 & !(0x3f as libc::c_int);
             let mut ref_ptr: *const pixel = 0 as *const pixel;
             let mut ref_stride: ptrdiff_t = (*refp).p.stride[(pl != 0) as libc::c_int as usize];
@@ -4364,7 +4364,7 @@ unsafe extern "C" fn warp_affine(
                     dstride,
                     ref_ptr,
                     ref_stride,
-                    ((*wmp).u.abcd).as_ptr(),
+                    ((*wmp).abcd).as_ptr(),
                     mx,
                     my,
                 );
@@ -4374,7 +4374,7 @@ unsafe extern "C" fn warp_affine(
                     dstride,
                     ref_ptr,
                     ref_stride,
-                    ((*wmp).u.abcd).as_ptr(),
+                    ((*wmp).abcd).as_ptr(),
                     mx,
                     my,
                 );

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -1,6 +1,4 @@
 use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
-use crate::include::dav1d::headers::Dav1dWarpedMotionParams_u;
-use crate::include::dav1d::headers::Dav1dWarpedMotionParams_u_p;
 use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
 use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
 use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
@@ -672,23 +670,10 @@ pub static dav1d_wedge_ctx_lut: [u8; 22] = [
     0, 0, 0, 0, 0, 0, 0, 6, 5, 8, 0, 4, 3, 2, 0, 7, 1, 0, 0, 0, 0, 0,
 ];
 
-pub static dav1d_default_wm_params: Dav1dWarpedMotionParams = {
-    let mut init = Dav1dWarpedMotionParams {
-        type_0: DAV1D_WM_TYPE_IDENTITY,
-        matrix: [0, 0, 1 << 16, 0, 0, 1 << 16],
-        u: Dav1dWarpedMotionParams_u {
-            p: {
-                let mut init = Dav1dWarpedMotionParams_u_p {
-                    alpha: 0,
-                    beta: 0,
-                    gamma: 0,
-                    delta: 0,
-                };
-                init
-            },
-        },
-    };
-    init
+pub static dav1d_default_wm_params: Dav1dWarpedMotionParams = Dav1dWarpedMotionParams {
+    type_0: DAV1D_WM_TYPE_IDENTITY,
+    matrix: [0, 0, 1 << 16, 0, 0, 1 << 16],
+    abcd: [0; 4],
 };
 
 pub static dav1d_cdef_directions: [[i8; 2]; 12] = [

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -55,29 +55,23 @@ pub unsafe fn dav1d_get_shear_params(wm: &mut Dav1dWarpedMotionParams) -> libc::
     if mat[2] <= 0 {
         return 1;
     }
-    wm.u.p.alpha = iclip_wmp(mat[2] - 0x10000) as int16_t;
-    wm.u.p.beta = iclip_wmp(mat[3]) as int16_t;
+    wm.u.p.alpha = iclip_wmp(mat[2] - 0x10000) as i16;
+    wm.u.p.beta = iclip_wmp(mat[3]) as i16;
     let (mut shift, y) = resolve_divisor_32((mat[2]).abs() as u32);
     let y = apply_sign(y, mat[2]);
-    let v1 = mat[4] as int64_t * 0x10000 * y as int64_t;
+    let v1 = mat[4] as i64 * 0x10000 * y as i64;
     let rnd = 1 << shift >> 1;
     wm.u.p.gamma = iclip_wmp(apply_sign64(
-        (v1.abs() + rnd as libc::c_longlong >> shift) as libc::c_int,
+        (v1.abs() + rnd as i64 >> shift) as libc::c_int,
         v1,
-    )) as int16_t;
-    let v2 = mat[3] as int64_t * mat[4] as int64_t * y as int64_t;
+    )) as i16;
+    let v2 = mat[3] as i64 * mat[4] as i64 * y as i64;
     wm.u.p.delta = iclip_wmp(
-        mat[5]
-            - apply_sign64(
-                (v2.abs() + rnd as libc::c_longlong >> shift) as libc::c_int,
-                v2,
-            )
-            - 0x10000,
-    ) as int16_t;
-    return (4 * (wm.u.p.alpha as libc::c_int).abs() + 7 * (wm.u.p.beta as libc::c_int).abs()
-        >= 0x10000
-        || 4 * (wm.u.p.gamma as libc::c_int).abs() + 4 * (wm.u.p.delta as libc::c_int).abs()
-            >= 0x10000) as libc::c_int;
+        mat[5] - apply_sign64((v2.abs() + rnd as i64 >> shift) as libc::c_int, v2) - 0x10000,
+    ) as i16;
+    return (4 * (wm.u.p.alpha as i32).abs() + 7 * (wm.u.p.beta as i32).abs() >= 0x10000
+        || 4 * (wm.u.p.gamma as i32).abs() + 4 * (wm.u.p.delta as i32).abs() >= 0x10000)
+        as libc::c_int;
 }
 
 fn resolve_divisor_64(d: u64) -> (libc::c_int, libc::c_int) {

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -50,23 +50,23 @@ fn resolve_divisor_32(d: u32) -> (libc::c_int, libc::c_int) {
     (shift + 14, div_lut[f as usize] as libc::c_int)
 }
 
-pub unsafe fn dav1d_get_shear_params(wm: *mut Dav1dWarpedMotionParams) -> libc::c_int {
-    let mat: *const int32_t = ((*wm).matrix).as_mut_ptr();
+pub unsafe fn dav1d_get_shear_params(wm: &mut Dav1dWarpedMotionParams) -> libc::c_int {
+    let mat: *const int32_t = (wm.matrix).as_mut_ptr();
     if *mat.offset(2) <= 0 {
         return 1 as libc::c_int;
     }
-    (*wm).u.p.alpha = iclip_wmp(*mat.offset(2) - 0x10000 as libc::c_int) as int16_t;
-    (*wm).u.p.beta = iclip_wmp(*mat.offset(3)) as int16_t;
+    wm.u.p.alpha = iclip_wmp(*mat.offset(2) - 0x10000 as libc::c_int) as int16_t;
+    wm.u.p.beta = iclip_wmp(*mat.offset(3)) as int16_t;
     let (mut shift, y) = resolve_divisor_32((*mat.offset(2)).abs() as u32);
     let y = apply_sign(y, *mat.offset(2));
     let v1: int64_t = *mat.offset(4) as int64_t * 0x10000 * y as int64_t;
     let rnd = (1 as libc::c_int) << shift >> 1;
-    (*wm).u.p.gamma = iclip_wmp(apply_sign64(
+    wm.u.p.gamma = iclip_wmp(apply_sign64(
         ((v1 as libc::c_longlong).abs() + rnd as libc::c_longlong >> shift) as libc::c_int,
         v1,
     )) as int16_t;
     let v2: int64_t = *mat.offset(3) as int64_t * *mat.offset(4) as int64_t * y as int64_t;
-    (*wm).u.p.delta = iclip_wmp(
+    wm.u.p.delta = iclip_wmp(
         *mat.offset(5)
             - apply_sign64(
                 ((v2 as libc::c_longlong).abs() + rnd as libc::c_longlong >> shift) as libc::c_int,
@@ -74,9 +74,9 @@ pub unsafe fn dav1d_get_shear_params(wm: *mut Dav1dWarpedMotionParams) -> libc::
             )
             - 0x10000 as libc::c_int,
     ) as int16_t;
-    return (4 * ((*wm).u.p.alpha as libc::c_int).abs() + 7 * ((*wm).u.p.beta as libc::c_int).abs()
+    return (4 * (wm.u.p.alpha as libc::c_int).abs() + 7 * (wm.u.p.beta as libc::c_int).abs()
         >= 0x10000 as libc::c_int
-        || 4 * ((*wm).u.p.gamma as libc::c_int).abs() + 4 * ((*wm).u.p.delta as libc::c_int).abs()
+        || 4 * (wm.u.p.gamma as libc::c_int).abs() + 4 * (wm.u.p.delta as libc::c_int).abs()
             >= 0x10000 as libc::c_int) as libc::c_int;
 }
 

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -52,11 +52,14 @@ fn resolve_divisor_32(d: u32) -> (libc::c_int, libc::c_int) {
 
 pub fn dav1d_get_shear_params(wm: &mut Dav1dWarpedMotionParams) -> bool {
     let mat = &wm.matrix;
+
     if mat[2] <= 0 {
         return true;
     }
+
     let alpha = iclip_wmp(mat[2] - 0x10000) as i16;
     let beta = iclip_wmp(mat[3]) as i16;
+
     let (mut shift, y) = resolve_divisor_32((mat[2]).abs() as u32);
     let y = apply_sign(y, mat[2]);
     let v1 = mat[4] as i64 * 0x10000 * y as i64;
@@ -70,6 +73,7 @@ pub fn dav1d_get_shear_params(wm: &mut Dav1dWarpedMotionParams) -> bool {
         mat[5] - apply_sign64((v2.abs() + rnd as i64 >> shift) as libc::c_int, v2) - 0x10000,
     ) as i16;
     wm.abcd = [alpha, beta, gamma, delta];
+
     4 * (alpha as i32).abs() + 7 * (beta as i32).abs() >= 0x10000
         || 4 * (gamma as i32).abs() + 4 * (delta as i32).abs() >= 0x10000
 }

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -50,8 +50,7 @@ fn resolve_divisor_32(d: u32) -> (libc::c_int, libc::c_int) {
     (shift + 14, div_lut[f as usize] as libc::c_int)
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_get_shear_params(wm: *mut Dav1dWarpedMotionParams) -> libc::c_int {
+pub unsafe fn dav1d_get_shear_params(wm: *mut Dav1dWarpedMotionParams) -> libc::c_int {
     let mat: *const int32_t = ((*wm).matrix).as_mut_ptr();
     if *mat.offset(2) <= 0 {
         return 1 as libc::c_int;

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -50,10 +50,10 @@ fn resolve_divisor_32(d: u32) -> (libc::c_int, libc::c_int) {
     (shift + 14, div_lut[f as usize] as libc::c_int)
 }
 
-pub unsafe fn dav1d_get_shear_params(wm: &mut Dav1dWarpedMotionParams) -> libc::c_int {
+pub unsafe fn dav1d_get_shear_params(wm: &mut Dav1dWarpedMotionParams) -> bool {
     let mat = &wm.matrix;
     if mat[2] <= 0 {
-        return 1;
+        return true;
     }
     wm.u.p.alpha = iclip_wmp(mat[2] - 0x10000) as i16;
     wm.u.p.beta = iclip_wmp(mat[3]) as i16;
@@ -69,9 +69,8 @@ pub unsafe fn dav1d_get_shear_params(wm: &mut Dav1dWarpedMotionParams) -> libc::
     wm.u.p.delta = iclip_wmp(
         mat[5] - apply_sign64((v2.abs() + rnd as i64 >> shift) as libc::c_int, v2) - 0x10000,
     ) as i16;
-    return (4 * (wm.u.p.alpha as i32).abs() + 7 * (wm.u.p.beta as i32).abs() >= 0x10000
-        || 4 * (wm.u.p.gamma as i32).abs() + 4 * (wm.u.p.delta as i32).abs() >= 0x10000)
-        as libc::c_int;
+    4 * (wm.u.p.alpha as i32).abs() + 7 * (wm.u.p.beta as i32).abs() >= 0x10000
+        || 4 * (wm.u.p.gamma as i32).abs() + 4 * (wm.u.p.delta as i32).abs() >= 0x10000
 }
 
 fn resolve_divisor_64(d: u64) -> (libc::c_int, libc::c_int) {

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -51,23 +51,23 @@ fn resolve_divisor_32(d: u32) -> (libc::c_int, libc::c_int) {
 }
 
 pub unsafe fn dav1d_get_shear_params(wm: &mut Dav1dWarpedMotionParams) -> libc::c_int {
-    let mat = (wm.matrix).as_mut_ptr();
-    if *mat.offset(2) <= 0 {
+    let mat = &wm.matrix;
+    if mat[2] <= 0 {
         return 1;
     }
-    wm.u.p.alpha = iclip_wmp(*mat.offset(2) - 0x10000) as int16_t;
-    wm.u.p.beta = iclip_wmp(*mat.offset(3)) as int16_t;
-    let (mut shift, y) = resolve_divisor_32((*mat.offset(2)).abs() as u32);
-    let y = apply_sign(y, *mat.offset(2));
-    let v1 = *mat.offset(4) as int64_t * 0x10000 * y as int64_t;
+    wm.u.p.alpha = iclip_wmp(mat[2] - 0x10000) as int16_t;
+    wm.u.p.beta = iclip_wmp(mat[3]) as int16_t;
+    let (mut shift, y) = resolve_divisor_32((mat[2]).abs() as u32);
+    let y = apply_sign(y, mat[2]);
+    let v1 = mat[4] as int64_t * 0x10000 * y as int64_t;
     let rnd = 1 << shift >> 1;
     wm.u.p.gamma = iclip_wmp(apply_sign64(
         (v1.abs() + rnd as libc::c_longlong >> shift) as libc::c_int,
         v1,
     )) as int16_t;
-    let v2 = *mat.offset(3) as int64_t * *mat.offset(4) as int64_t * y as int64_t;
+    let v2 = mat[3] as int64_t * mat[4] as int64_t * y as int64_t;
     wm.u.p.delta = iclip_wmp(
-        *mat.offset(5)
+        mat[5]
             - apply_sign64(
                 (v2.abs() + rnd as libc::c_longlong >> shift) as libc::c_int,
                 v2,

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -55,22 +55,23 @@ pub unsafe fn dav1d_get_shear_params(wm: &mut Dav1dWarpedMotionParams) -> bool {
     if mat[2] <= 0 {
         return true;
     }
-    wm.u.p.alpha = iclip_wmp(mat[2] - 0x10000) as i16;
-    wm.u.p.beta = iclip_wmp(mat[3]) as i16;
+    let alpha = iclip_wmp(mat[2] - 0x10000) as i16;
+    let beta = iclip_wmp(mat[3]) as i16;
     let (mut shift, y) = resolve_divisor_32((mat[2]).abs() as u32);
     let y = apply_sign(y, mat[2]);
     let v1 = mat[4] as i64 * 0x10000 * y as i64;
     let rnd = 1 << shift >> 1;
-    wm.u.p.gamma = iclip_wmp(apply_sign64(
+    let gamma = iclip_wmp(apply_sign64(
         (v1.abs() + rnd as i64 >> shift) as libc::c_int,
         v1,
     )) as i16;
     let v2 = mat[3] as i64 * mat[4] as i64 * y as i64;
-    wm.u.p.delta = iclip_wmp(
+    let delta = iclip_wmp(
         mat[5] - apply_sign64((v2.abs() + rnd as i64 >> shift) as libc::c_int, v2) - 0x10000,
     ) as i16;
-    4 * (wm.u.p.alpha as i32).abs() + 7 * (wm.u.p.beta as i32).abs() >= 0x10000
-        || 4 * (wm.u.p.gamma as i32).abs() + 4 * (wm.u.p.delta as i32).abs() >= 0x10000
+    wm.abcd = [alpha, beta, gamma, delta];
+    4 * (alpha as i32).abs() + 7 * (beta as i32).abs() >= 0x10000
+        || 4 * (gamma as i32).abs() + 4 * (delta as i32).abs() >= 0x10000
 }
 
 fn resolve_divisor_64(d: u64) -> (libc::c_int, libc::c_int) {

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -51,33 +51,33 @@ fn resolve_divisor_32(d: u32) -> (libc::c_int, libc::c_int) {
 }
 
 pub unsafe fn dav1d_get_shear_params(wm: &mut Dav1dWarpedMotionParams) -> libc::c_int {
-    let mat: *const int32_t = (wm.matrix).as_mut_ptr();
+    let mat = (wm.matrix).as_mut_ptr();
     if *mat.offset(2) <= 0 {
-        return 1 as libc::c_int;
+        return 1;
     }
-    wm.u.p.alpha = iclip_wmp(*mat.offset(2) - 0x10000 as libc::c_int) as int16_t;
+    wm.u.p.alpha = iclip_wmp(*mat.offset(2) - 0x10000) as int16_t;
     wm.u.p.beta = iclip_wmp(*mat.offset(3)) as int16_t;
     let (mut shift, y) = resolve_divisor_32((*mat.offset(2)).abs() as u32);
     let y = apply_sign(y, *mat.offset(2));
-    let v1: int64_t = *mat.offset(4) as int64_t * 0x10000 * y as int64_t;
-    let rnd = (1 as libc::c_int) << shift >> 1;
+    let v1 = *mat.offset(4) as int64_t * 0x10000 * y as int64_t;
+    let rnd = 1 << shift >> 1;
     wm.u.p.gamma = iclip_wmp(apply_sign64(
-        ((v1 as libc::c_longlong).abs() + rnd as libc::c_longlong >> shift) as libc::c_int,
+        (v1.abs() + rnd as libc::c_longlong >> shift) as libc::c_int,
         v1,
     )) as int16_t;
-    let v2: int64_t = *mat.offset(3) as int64_t * *mat.offset(4) as int64_t * y as int64_t;
+    let v2 = *mat.offset(3) as int64_t * *mat.offset(4) as int64_t * y as int64_t;
     wm.u.p.delta = iclip_wmp(
         *mat.offset(5)
             - apply_sign64(
-                ((v2 as libc::c_longlong).abs() + rnd as libc::c_longlong >> shift) as libc::c_int,
+                (v2.abs() + rnd as libc::c_longlong >> shift) as libc::c_int,
                 v2,
             )
-            - 0x10000 as libc::c_int,
+            - 0x10000,
     ) as int16_t;
     return (4 * (wm.u.p.alpha as libc::c_int).abs() + 7 * (wm.u.p.beta as libc::c_int).abs()
-        >= 0x10000 as libc::c_int
+        >= 0x10000
         || 4 * (wm.u.p.gamma as libc::c_int).abs() + 4 * (wm.u.p.delta as libc::c_int).abs()
-            >= 0x10000 as libc::c_int) as libc::c_int;
+            >= 0x10000) as libc::c_int;
 }
 
 fn resolve_divisor_64(d: u64) -> (libc::c_int, libc::c_int) {

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -50,7 +50,7 @@ fn resolve_divisor_32(d: u32) -> (libc::c_int, libc::c_int) {
     (shift + 14, div_lut[f as usize] as libc::c_int)
 }
 
-pub unsafe fn dav1d_get_shear_params(wm: &mut Dav1dWarpedMotionParams) -> bool {
+pub fn dav1d_get_shear_params(wm: &mut Dav1dWarpedMotionParams) -> bool {
     let mat = &wm.matrix;
     if mat[2] <= 0 {
         return true;


### PR DESCRIPTION
This also removes the unsafe `union Dav1dWarpedMotionParams_u` in d8e01670d48b2ab26503afd575d9e3f48393af5b.