### PR TITLE
`fn dav1d_find_affine_int`: Cleanup and make safe

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2501,7 +2501,7 @@ unsafe extern "C" fn derive_warpmv(
         i += 1;
     }
     if ret == 0 {
-        ret = 1 as libc::c_int;
+        ret = 1;
     } else {
         let mut i_0 = 0;
         let mut j = np - 1;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2531,7 +2531,7 @@ unsafe extern "C" fn derive_warpmv(
         }
     }
     if dav1d_find_affine_int(
-        pts.as_mut_ptr() as *const [[libc::c_int; 2]; 2],
+        &pts,
         ret,
         bw4,
         bh4,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2530,16 +2530,7 @@ unsafe extern "C" fn derive_warpmv(
             j -= 1;
         }
     }
-    if dav1d_find_affine_int(
-        &pts,
-        ret,
-        bw4,
-        bh4,
-        mv,
-        &mut *wmp,
-        (*t).bx,
-        (*t).by,
-    ) == 0
+    if !dav1d_find_affine_int(&pts, ret, bw4, bh4, mv, &mut *wmp, (*t).bx, (*t).by)
         && !dav1d_get_shear_params(&mut *wmp)
     {
         (*wmp).type_0 = DAV1D_WM_TYPE_AFFINE;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -270,16 +270,6 @@ extern "C" {
         cond_signal: libc::c_int,
     ) -> libc::c_int;
     fn dav1d_task_frame_init(f: *mut Dav1dFrameContext);
-    fn dav1d_find_affine_int(
-        pts: *const [[libc::c_int; 2]; 2],
-        np: libc::c_int,
-        bw4: libc::c_int,
-        bh4: libc::c_int,
-        mv: mv,
-        wm: *mut Dav1dWarpedMotionParams,
-        bx: libc::c_int,
-        by: libc::c_int,
-    ) -> libc::c_int;
 }
 
 use crate::src::dequant_tables::dav1d_dq_tbl;
@@ -297,6 +287,7 @@ use crate::src::tables::dav1d_sgr_params;
 use crate::src::tables::dav1d_txfm_dimensions;
 use crate::src::tables::dav1d_wedge_ctx_lut;
 use crate::src::tables::dav1d_ymode_size_context;
+use crate::src::warpmv::dav1d_find_affine_int;
 use crate::src::warpmv::dav1d_get_shear_params;
 use crate::src::warpmv::dav1d_set_affine_mv2d;
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2536,7 +2536,7 @@ unsafe extern "C" fn derive_warpmv(
         bw4,
         bh4,
         mv,
-        wmp,
+        &mut *wmp,
         (*t).bx,
         (*t).by,
     ) == 0

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -128,7 +128,7 @@ pub fn dav1d_set_affine_mv2d(
     );
 }
 
-pub unsafe fn dav1d_find_affine_int(
+pub fn dav1d_find_affine_int(
     pts: &[[[libc::c_int; 2]; 2]; 8],
     np: usize,
     bw4: libc::c_int,

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -138,13 +138,10 @@ pub unsafe fn dav1d_find_affine_int(
     bx4: libc::c_int,
     by4: libc::c_int,
 ) -> libc::c_int {
-    let mat: *mut int32_t = ((*wm).matrix).as_mut_ptr();
-    let mut a: [[libc::c_int; 2]; 2] = [
-        [0 as libc::c_int, 0 as libc::c_int],
-        [0 as libc::c_int, 0 as libc::c_int],
-    ];
-    let mut bx: [libc::c_int; 2] = [0 as libc::c_int, 0 as libc::c_int];
-    let mut by: [libc::c_int; 2] = [0 as libc::c_int, 0 as libc::c_int];
+    let mat = ((*wm).matrix).as_mut_ptr();
+    let mut a = [[0, 0], [0, 0]];
+    let mut bx = [0, 0];
+    let mut by = [0, 0];
     let rsuy = 2 * bh4 - 1;
     let rsux = 2 * bw4 - 1;
     let suy = rsuy * 8;
@@ -170,17 +167,16 @@ pub unsafe fn dav1d_find_affine_int(
         }
         i += 1;
     }
-    let det: int64_t =
-        a[0][0] as int64_t * a[1][1] as int64_t - a[0][1] as int64_t * a[0][1] as int64_t;
+    let det = a[0][0] as int64_t * a[1][1] as int64_t - a[0][1] as int64_t * a[0][1] as int64_t;
     if det == 0 {
-        return 1 as libc::c_int;
+        return 1;
     }
-    let (mut shift, idet) = resolve_divisor_64((det as libc::c_longlong).abs() as u64);
+    let (mut shift, idet) = resolve_divisor_64(det.abs() as u64);
     let mut idet = apply_sign64(idet, det);
-    shift -= 16 as libc::c_int;
+    shift -= 16;
     if shift < 0 {
         idet <<= -shift;
-        shift = 0 as libc::c_int;
+        shift = 0;
     }
     *mat.offset(2) = get_mult_shift_diag(
         a[1][1] as int64_t * bx[0] as int64_t - a[0][1] as int64_t * bx[1] as int64_t,
@@ -203,16 +199,14 @@ pub unsafe fn dav1d_find_affine_int(
         shift,
     );
     *mat.offset(0) = iclip(
-        mv.x as libc::c_int * 0x2000 as libc::c_int
-            - (isux * (*mat.offset(2) - 0x10000 as libc::c_int) + isuy * *mat.offset(3)),
-        -(0x800000 as libc::c_int),
-        0x7fffff as libc::c_int,
+        mv.x as libc::c_int * 0x2000 - (isux * (*mat.offset(2) - 0x10000) + isuy * *mat.offset(3)),
+        -0x800000,
+        0x7fffff,
     );
     *mat.offset(1) = iclip(
-        mv.y as libc::c_int * 0x2000 as libc::c_int
-            - (isux * *mat.offset(4) + isuy * (*mat.offset(5) - 0x10000 as libc::c_int)),
-        -(0x800000 as libc::c_int),
-        0x7fffff as libc::c_int,
+        mv.y as libc::c_int * 0x2000 - (isux * *mat.offset(4) + isuy * (*mat.offset(5) - 0x10000)),
+        -0x800000,
+        0x7fffff,
     );
-    return 0 as libc::c_int;
+    return 0;
 }

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -150,8 +150,7 @@ pub unsafe fn dav1d_find_affine_int(
     let dux = sux + mv.x as libc::c_int;
     let isuy = by4 * 4 + rsuy;
     let isux = bx4 * 4 + rsux;
-    let mut i = 0;
-    while i < np {
+    for i in 0..np {
         let dx = pts[i as usize][1][0] - dux;
         let dy = pts[i as usize][1][1] - duy;
         let sx = pts[i as usize][0][0] - sux;
@@ -165,7 +164,6 @@ pub unsafe fn dav1d_find_affine_int(
             by[0] += (sx * dy >> 2) + sx + dy + 4;
             by[1] += (sy * dy >> 2) + sy + dy + 8;
         }
-        i += 1;
     }
     let det = a[0][0] as int64_t * a[1][1] as int64_t - a[0][1] as int64_t * a[0][1] as int64_t;
     if det == 0 {

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -128,8 +128,7 @@ pub fn dav1d_set_affine_mv2d(
     );
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_find_affine_int(
+pub unsafe fn dav1d_find_affine_int(
     mut pts: *const [[libc::c_int; 2]; 2],
     np: libc::c_int,
     bw4: libc::c_int,

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -130,7 +130,7 @@ pub fn dav1d_set_affine_mv2d(
 
 pub unsafe fn dav1d_find_affine_int(
     pts: &[[[libc::c_int; 2]; 2]; 8],
-    np: libc::c_int,
+    np: usize,
     bw4: libc::c_int,
     bh4: libc::c_int,
     mv: mv,
@@ -151,10 +151,10 @@ pub unsafe fn dav1d_find_affine_int(
     let isuy = by4 * 4 + rsuy;
     let isux = bx4 * 4 + rsux;
     for i in 0..np {
-        let dx = pts[i as usize][1][0] - dux;
-        let dy = pts[i as usize][1][1] - duy;
-        let sx = pts[i as usize][0][0] - sux;
-        let sy = pts[i as usize][0][1] - suy;
+        let dx = pts[i][1][0] - dux;
+        let dy = pts[i][1][1] - duy;
+        let sx = pts[i][0][0] - sux;
+        let sy = pts[i][0][1] - suy;
         if (sx - dx).abs() < 256 && (sy - dy).abs() < 256 {
             a[0][0] += (sx * sx >> 2) + sx * 2 + 8;
             a[0][1] += (sx * sy >> 2) + sx + sy + 4;

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -138,7 +138,7 @@ pub unsafe fn dav1d_find_affine_int(
     bx4: libc::c_int,
     by4: libc::c_int,
 ) -> libc::c_int {
-    let mat = wm.matrix.as_mut_ptr();
+    let mat = &mut wm.matrix;
     let mut a = [[0, 0], [0, 0]];
     let mut bx = [0, 0];
     let mut by = [0, 0];
@@ -178,33 +178,33 @@ pub unsafe fn dav1d_find_affine_int(
         idet <<= -shift;
         shift = 0;
     }
-    *mat.offset(2) = get_mult_shift_diag(
+    mat[2] = get_mult_shift_diag(
         a[1][1] as int64_t * bx[0] as int64_t - a[0][1] as int64_t * bx[1] as int64_t,
         idet,
         shift,
     );
-    *mat.offset(3) = get_mult_shift_ndiag(
+    mat[3] = get_mult_shift_ndiag(
         a[0][0] as int64_t * bx[1] as int64_t - a[0][1] as int64_t * bx[0] as int64_t,
         idet,
         shift,
     );
-    *mat.offset(4) = get_mult_shift_ndiag(
+    mat[4] = get_mult_shift_ndiag(
         a[1][1] as int64_t * by[0] as int64_t - a[0][1] as int64_t * by[1] as int64_t,
         idet,
         shift,
     );
-    *mat.offset(5) = get_mult_shift_diag(
+    mat[5] = get_mult_shift_diag(
         a[0][0] as int64_t * by[1] as int64_t - a[0][1] as int64_t * by[0] as int64_t,
         idet,
         shift,
     );
-    *mat.offset(0) = iclip(
-        mv.x as libc::c_int * 0x2000 - (isux * (*mat.offset(2) - 0x10000) + isuy * *mat.offset(3)),
+    mat[0] = iclip(
+        mv.x as libc::c_int * 0x2000 - (isux * (mat[2] - 0x10000) + isuy * mat[3]),
         -0x800000,
         0x7fffff,
     );
-    *mat.offset(1) = iclip(
-        mv.y as libc::c_int * 0x2000 - (isux * *mat.offset(4) + isuy * (*mat.offset(5) - 0x10000)),
+    mat[1] = iclip(
+        mv.y as libc::c_int * 0x2000 - (isux * mat[4] + isuy * (mat[5] - 0x10000)),
         -0x800000,
         0x7fffff,
     );

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -209,5 +209,5 @@ pub fn dav1d_find_affine_int(
         0x7fffff,
     );
 
-    return false;
+    false
 }

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -129,7 +129,7 @@ pub fn dav1d_set_affine_mv2d(
 }
 
 pub unsafe fn dav1d_find_affine_int(
-    mut pts: *const [[libc::c_int; 2]; 2],
+    pts: &[[[libc::c_int; 2]; 2]; 8],
     np: libc::c_int,
     bw4: libc::c_int,
     bh4: libc::c_int,
@@ -152,10 +152,10 @@ pub unsafe fn dav1d_find_affine_int(
     let isux = bx4 * 4 + rsux;
     let mut i = 0;
     while i < np {
-        let dx = (*pts.offset(i as isize))[1][0] - dux;
-        let dy = (*pts.offset(i as isize))[1][1] - duy;
-        let sx = (*pts.offset(i as isize))[0][0] - sux;
-        let sy = (*pts.offset(i as isize))[0][1] - suy;
+        let dx = pts[i as usize][1][0] - dux;
+        let dy = pts[i as usize][1][1] - duy;
+        let sx = pts[i as usize][0][0] - sux;
+        let sy = pts[i as usize][0][1] - suy;
         if (sx - dx).abs() < 256 && (sy - dy).abs() < 256 {
             a[0][0] += (sx * sx >> 2) + sx * 2 + 8;
             a[0][1] += (sx * sy >> 2) + sx + sy + 4;

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -1,13 +1,10 @@
-use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
-use crate::include::stdint::*;
-use crate::src::levels::mv;
-use ::libc;
-
 use crate::include::common::intops::apply_sign;
 use crate::include::common::intops::apply_sign64;
 use crate::include::common::intops::iclip;
 use crate::include::common::intops::u64log2;
 use crate::include::common::intops::ulog2;
+use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
+use crate::src::levels::mv;
 
 static div_lut: [u16; 257] = [
     16384, 16320, 16257, 16194, 16132, 16070, 16009, 15948, 15888, 15828, 15768, 15709, 15650,
@@ -165,7 +162,7 @@ pub fn dav1d_find_affine_int(
             by[1] += (sy * dy >> 2) + sy + dy + 8;
         }
     }
-    let det = a[0][0] as int64_t * a[1][1] as int64_t - a[0][1] as int64_t * a[0][1] as int64_t;
+    let det = a[0][0] as i64 * a[1][1] as i64 - a[0][1] as i64 * a[0][1] as i64;
     if det == 0 {
         return true;
     }
@@ -177,32 +174,32 @@ pub fn dav1d_find_affine_int(
         shift = 0;
     }
     mat[2] = get_mult_shift_diag(
-        a[1][1] as int64_t * bx[0] as int64_t - a[0][1] as int64_t * bx[1] as int64_t,
+        a[1][1] as i64 * bx[0] as i64 - a[0][1] as i64 * bx[1] as i64,
         idet,
         shift,
     );
     mat[3] = get_mult_shift_ndiag(
-        a[0][0] as int64_t * bx[1] as int64_t - a[0][1] as int64_t * bx[0] as int64_t,
+        a[0][0] as i64 * bx[1] as i64 - a[0][1] as i64 * bx[0] as i64,
         idet,
         shift,
     );
     mat[4] = get_mult_shift_ndiag(
-        a[1][1] as int64_t * by[0] as int64_t - a[0][1] as int64_t * by[1] as int64_t,
+        a[1][1] as i64 * by[0] as i64 - a[0][1] as i64 * by[1] as i64,
         idet,
         shift,
     );
     mat[5] = get_mult_shift_diag(
-        a[0][0] as int64_t * by[1] as int64_t - a[0][1] as int64_t * by[0] as int64_t,
+        a[0][0] as i64 * by[1] as i64 - a[0][1] as i64 * by[0] as i64,
         idet,
         shift,
     );
     mat[0] = iclip(
-        mv.x as libc::c_int * 0x2000 - (isux * (mat[2] - 0x10000) + isuy * mat[3]),
+        mv.x as i32 * 0x2000 - (isux * (mat[2] - 0x10000) + isuy * mat[3]),
         -0x800000,
         0x7fffff,
     );
     mat[1] = iclip(
-        mv.y as libc::c_int * 0x2000 - (isux * mat[4] + isuy * (mat[5] - 0x10000)),
+        mv.y as i32 * 0x2000 - (isux * mat[4] + isuy * (mat[5] - 0x10000)),
         -0x800000,
         0x7fffff,
     );

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -150,11 +150,11 @@ pub unsafe fn dav1d_find_affine_int(
     let dux = sux + mv.x as libc::c_int;
     let isuy = by4 * 4 + rsuy;
     let isux = bx4 * 4 + rsux;
-    for i in 0..np {
-        let dx = pts[i][1][0] - dux;
-        let dy = pts[i][1][1] - duy;
-        let sx = pts[i][0][0] - sux;
-        let sy = pts[i][0][1] - suy;
+    for pts in &pts[..np] {
+        let dx = pts[1][0] - dux;
+        let dy = pts[1][1] - duy;
+        let sx = pts[0][0] - sux;
+        let sy = pts[0][1] - suy;
         if (sx - dx).abs() < 256 && (sy - dy).abs() < 256 {
             a[0][0] += (sx * sx >> 2) + sx * 2 + 8;
             a[0][1] += (sx * sy >> 2) + sx + sy + 4;

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -134,11 +134,11 @@ pub unsafe fn dav1d_find_affine_int(
     bw4: libc::c_int,
     bh4: libc::c_int,
     mv: mv,
-    wm: *mut Dav1dWarpedMotionParams,
+    wm: &mut Dav1dWarpedMotionParams,
     bx4: libc::c_int,
     by4: libc::c_int,
 ) -> libc::c_int {
-    let mat = ((*wm).matrix).as_mut_ptr();
+    let mat = wm.matrix.as_mut_ptr();
     let mut a = [[0, 0], [0, 0]];
     let mut bx = [0, 0];
     let mut by = [0, 0];

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -147,6 +147,7 @@ pub fn dav1d_find_affine_int(
     let dux = sux + mv.x as libc::c_int;
     let isuy = by4 * 4 + rsuy;
     let isux = bx4 * 4 + rsux;
+
     for pts in &pts[..np] {
         let dx = pts[1][0] - dux;
         let dy = pts[1][1] - duy;
@@ -162,6 +163,8 @@ pub fn dav1d_find_affine_int(
             by[1] += (sy * dy >> 2) + sy + dy + 8;
         }
     }
+
+    // compute determinant of a
     let det = a[0][0] as i64 * a[1][1] as i64 - a[0][1] as i64 * a[0][1] as i64;
     if det == 0 {
         return true;
@@ -173,6 +176,8 @@ pub fn dav1d_find_affine_int(
         idet <<= -shift;
         shift = 0;
     }
+
+    // solve the least-squares
     mat[2] = get_mult_shift_diag(
         a[1][1] as i64 * bx[0] as i64 - a[0][1] as i64 * bx[1] as i64,
         idet,
@@ -203,5 +208,6 @@ pub fn dav1d_find_affine_int(
         -0x800000,
         0x7fffff,
     );
+
     return false;
 }

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -137,7 +137,7 @@ pub fn dav1d_find_affine_int(
     wm: &mut Dav1dWarpedMotionParams,
     bx4: libc::c_int,
     by4: libc::c_int,
-) -> libc::c_int {
+) -> bool {
     let mat = &mut wm.matrix;
     let mut a = [[0, 0], [0, 0]];
     let mut bx = [0, 0];
@@ -167,7 +167,7 @@ pub fn dav1d_find_affine_int(
     }
     let det = a[0][0] as int64_t * a[1][1] as int64_t - a[0][1] as int64_t * a[0][1] as int64_t;
     if det == 0 {
-        return 1;
+        return true;
     }
     let (mut shift, idet) = resolve_divisor_64(det.abs() as u64);
     let mut idet = apply_sign64(idet, det);
@@ -206,5 +206,5 @@ pub fn dav1d_find_affine_int(
         -0x800000,
         0x7fffff,
     );
-    return 0;
+    return false;
 }


### PR DESCRIPTION
After this, `warpmv.rs` is now entirely safe!