### PR TITLE
Add workflow for checking formatting and run one more formatting pass

### DIFF
--- a/.github/workflows/cargo-fmt.yml
+++ b/.github/workflows/cargo-fmt.yml
@@ -9,5 +9,4 @@ jobs:
         with:
           fetch-depth: 1
       - name: Check formatting
-        run: |
-          cargo fmt --check
+        run: cargo fmt --check

--- a/.github/workflows/cargo-fmt.yml
+++ b/.github/workflows/cargo-fmt.yml
@@ -1,0 +1,38 @@
+name: build and test on x86-64
+on: [push, pull_request]
+jobs:
+  cargo-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: install prerequisites
+        run: |
+          # make sure we don't silently continue
+          set -euo pipefail
+          sudo apt-get update --quiet=2
+          sudo apt-get install --yes meson nasm gcc-multilib
+        env:
+          DEBIAN_FRONTEND: noninteractive
+      - name: git checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: cache rust toolchain
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.rustup/toolchains
+            ~/.rustup/update-hashes
+            ~/.rustup/settings.toml
+          key: ${{ runner.os }}-rust-toolchain-${{ hashFiles('rust-toolchain', 'rust-toolchain.toml') }}
+      - name: cache rust crates
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Check formatting
+        run: cargo fmt --check

--- a/.github/workflows/cargo-fmt.yml
+++ b/.github/workflows/cargo-fmt.yml
@@ -8,5 +8,23 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
+      - name: cache rust toolchain
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.rustup/toolchains
+            ~/.rustup/update-hashes
+            ~/.rustup/settings.toml
+          key: ${{ runner.os }}-rust-toolchain-${{ hashFiles('rust-toolchain', 'rust-toolchain.toml') }}
+      - name: cache rust crates
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Check formatting
         run: cargo fmt --check

--- a/.github/workflows/cargo-fmt.yml
+++ b/.github/workflows/cargo-fmt.yml
@@ -4,37 +4,10 @@ jobs:
   cargo-fmt:
     runs-on: ubuntu-latest
     steps:
-      - name: install prerequisites
-        run: |
-          # make sure we don't silently continue
-          set -euo pipefail
-          sudo apt-get update --quiet=2
-          sudo apt-get install --yes meson nasm gcc-multilib
-        env:
-          DEBIAN_FRONTEND: noninteractive
       - name: git checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: cache rust toolchain
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.rustup/toolchains
-            ~/.rustup/update-hashes
-            ~/.rustup/settings.toml
-          key: ${{ runner.os }}-rust-toolchain-${{ hashFiles('rust-toolchain', 'rust-toolchain.toml') }}
-      - name: cache rust crates
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Check formatting
         run: |
-          rustup component add rustfmt
           cargo fmt --check

--- a/.github/workflows/cargo-fmt.yml
+++ b/.github/workflows/cargo-fmt.yml
@@ -35,4 +35,6 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Check formatting
-        run: cargo fmt --check
+        run: |
+          rustup component add rustfmt
+          cargo fmt --check

--- a/build.rs
+++ b/build.rs
@@ -33,7 +33,7 @@ fn build_nasm_files(x86_64: bool) {
     config_file
         .write(b"%define private_prefix dav1d\n")
         .unwrap();
-   if x86_64 {
+    if x86_64 {
         config_file.write(b"%define ARCH_X86_32 0\n").unwrap();
         config_file.write(b"%define ARCH_X86_64 1\n").unwrap();
         config_file.write(b"%define STACK_ALIGNMENT 16\n").unwrap();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2022-08-08"
-components = []
+components = ["rustfmt"]

--- a/src/cdef_tmpl_16.rs
+++ b/src/cdef_tmpl_16.rs
@@ -744,7 +744,8 @@ unsafe extern "C" fn cdef_dsp_init_x86(c: *mut Dav1dCdefDSPContext) {
 
     (*c).dir = Some(dav1d_cdef_dir_16bpc_sse4);
 
-    #[cfg(target_arch = "x86_64")] {
+    #[cfg(target_arch = "x86_64")]
+    {
         if flags & DAV1D_X86_CPU_FLAG_AVX2 == 0 {
             return;
         }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4065,7 +4065,9 @@ unsafe fn decode_b(
     }
 
     // skip_mode
-    if seg.map(|seg| seg.globalmv == 0 && seg.r#ref == -1 && seg.skip == 0).unwrap_or(true)
+    if seg
+        .map(|seg| seg.globalmv == 0 && seg.r#ref == -1 && seg.skip == 0)
+        .unwrap_or(true)
         && (*f.frame_hdr).skip_mode_enabled != 0
         && imin(bw4, bh4) > 1
     {
@@ -4087,10 +4089,9 @@ unsafe fn decode_b(
         b.skip = 1;
     } else {
         let sctx = (*t.a).skip[bx4 as usize] + t.l.skip[by4 as usize];
-        b.skip = dav1d_msac_decode_bool_adapt(
-            &mut ts.msac,
-            (ts.cdf.m.skip[sctx as usize]).as_mut_ptr(),
-        ) as uint8_t;
+        b.skip =
+            dav1d_msac_decode_bool_adapt(&mut ts.msac, (ts.cdf.m.skip[sctx as usize]).as_mut_ptr())
+                as uint8_t;
 
         if DEBUG_BLOCK_INFO(f, t) {
             println!("Post-skip[{}]: r={}", b.skip, ts.msac.rng);
@@ -4102,27 +4103,18 @@ unsafe fn decode_b(
         && (*f.frame_hdr).segmentation.update_map != 0
         && (*f.frame_hdr).segmentation.seg_data.preskip == 0
     {
-        if b.skip == 0 && (*f.frame_hdr).segmentation.temporal != 0
-            && {
-                let index = (*t.a).seg_pred[bx4 as usize] + t.l.seg_pred[by4 as usize];
-                seg_pred = dav1d_msac_decode_bool_adapt(
-                    &mut ts.msac,
-                    ts.cdf.m.seg_pred[index as usize].as_mut_ptr(),
-                ) as libc::c_int;
-                seg_pred != 0
-            }
-        {
+        if b.skip == 0 && (*f.frame_hdr).segmentation.temporal != 0 && {
+            let index = (*t.a).seg_pred[bx4 as usize] + t.l.seg_pred[by4 as usize];
+            seg_pred = dav1d_msac_decode_bool_adapt(
+                &mut ts.msac,
+                ts.cdf.m.seg_pred[index as usize].as_mut_ptr(),
+            ) as libc::c_int;
+            seg_pred != 0
+        } {
             // temporal predicted seg_id
             if !(f.prev_segmap).is_null() {
-                let mut seg_id = get_prev_frame_segid(
-                    f,
-                    t.by,
-                    t.bx,
-                    w4,
-                    h4,
-                    f.prev_segmap,
-                    f.b4_stride,
-                );
+                let mut seg_id =
+                    get_prev_frame_segid(f, t.by, t.bx, w4, h4, f.prev_segmap, f.b4_stride);
 
                 if seg_id >= DAV1D_MAX_SEGMENTS.into() {
                     return -1;
@@ -4152,10 +4144,7 @@ unsafe fn decode_b(
                     ts.cdf.m.seg_id[seg_ctx as usize].as_mut_ptr(),
                     (DAV1D_MAX_SEGMENTS - 1) as size_t,
                 );
-                let last_active_seg_id = (*f.frame_hdr)
-                    .segmentation
-                    .seg_data
-                    .last_active_segid;
+                let last_active_seg_id = (*f.frame_hdr).segmentation.seg_data.last_active_segid;
 
                 b.seg_id = neg_deinterleave(
                     diff as libc::c_int,
@@ -4189,8 +4178,7 @@ unsafe fn decode_b(
 
         if *(t.cur_sb_cdef_idx_ptr).offset(idx) == -1 {
             let v =
-                dav1d_msac_decode_bools(&mut ts.msac, frame_hdr.cdef.n_bits as libc::c_uint)
-                    as i8;
+                dav1d_msac_decode_bools(&mut ts.msac, frame_hdr.cdef.n_bits as libc::c_uint) as i8;
 
             *(t.cur_sb_cdef_idx_ptr).offset(idx) = v;
 
@@ -4340,10 +4328,8 @@ unsafe fn decode_b(
             }
         }
     } else if frame_hdr.allow_intrabc != 0 {
-        b.intra = (dav1d_msac_decode_bool_adapt(
-            &mut ts.msac,
-            ts.cdf.m.intrabc.0.as_mut_ptr(),
-        ) == 0)  as uint8_t;
+        b.intra = (dav1d_msac_decode_bool_adapt(&mut ts.msac, ts.cdf.m.intrabc.0.as_mut_ptr()) == 0)
+            as uint8_t;
 
         if DEBUG_BLOCK_INFO(f, t) {
             println!("Post-intrabcflag[{}]: r={}", b.intra, ts.msac.rng);
@@ -4357,10 +4343,7 @@ unsafe fn decode_b(
         let ymode_cdf = if frame_hdr.frame_type & 1 != 0 {
             ts.cdf.m.y_mode[dav1d_ymode_size_context[bs as usize] as usize].as_mut_ptr()
         } else {
-            ts
-                .cdf
-                .kfym
-                [dav1d_intra_mode_context[(*t.a).mode[bx4 as usize] as usize] as usize]
+            ts.cdf.kfym[dav1d_intra_mode_context[(*t.a).mode[bx4 as usize] as usize] as usize]
                 [dav1d_intra_mode_context[t.l.mode[by4 as usize] as usize] as usize]
                 .as_mut_ptr()
         };
@@ -4377,8 +4360,7 @@ unsafe fn decode_b(
 
         // angle delta
         if b_dim[2] + b_dim[3] >= 2
-            && b.c2rust_unnamed.c2rust_unnamed.y_mode as libc::c_int
-                >= VERT_PRED as libc::c_int
+            && b.c2rust_unnamed.c2rust_unnamed.y_mode as libc::c_int >= VERT_PRED as libc::c_int
             && b.c2rust_unnamed.c2rust_unnamed.y_mode as libc::c_int
                 <= VERT_LEFT_PRED as libc::c_int
         {
@@ -4495,8 +4477,7 @@ unsafe fn decode_b(
         }
         b.c2rust_unnamed.c2rust_unnamed.pal_sz[1] = 0 as libc::c_int as uint8_t;
         b.c2rust_unnamed.c2rust_unnamed.pal_sz[0] = b.c2rust_unnamed.c2rust_unnamed.pal_sz[1];
-        if frame_hdr.allow_screen_content_tools != 0 && imax(bw4, bh4) <= 16 && bw4 + bh4 >= 4
-        {
+        if frame_hdr.allow_screen_content_tools != 0 && imax(bw4, bh4) <= 16 && bw4 + bh4 >= 4 {
             let sz_ctx = (b_dim[2] + b_dim[3] - 2) as libc::c_int;
             if b.c2rust_unnamed.c2rust_unnamed.y_mode as libc::c_int == DC_PRED as libc::c_int {
                 let pal_ctx = ((*t.a).pal_sz[bx4 as usize] as libc::c_int > 0) as libc::c_int
@@ -4539,10 +4520,7 @@ unsafe fn decode_b(
         }
         if b.c2rust_unnamed.c2rust_unnamed.y_mode as libc::c_int == DC_PRED as libc::c_int
             && b.c2rust_unnamed.c2rust_unnamed.pal_sz[0] == 0
-            && imax(
-                b_dim[2] as libc::c_int,
-                b_dim[3] as libc::c_int,
-            ) <= 3
+            && imax(b_dim[2] as libc::c_int, b_dim[3] as libc::c_int) <= 3
             && (*f.seq_hdr).filter_intra != 0
         {
             let is_filter = dav1d_msac_decode_bool_adapt(
@@ -6558,8 +6536,7 @@ unsafe fn decode_b(
             1 => {
                 (*(&mut *(t.l.tx_intra).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                     as *mut alias8))
-                    .u8_0 = (0x1 * b_dim[2 + 1])
-                    as uint8_t;
+                    .u8_0 = (0x1 * b_dim[2 + 1]) as uint8_t;
                 (*(&mut *(t.l.mode).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * DC_PRED as libc::c_int) as uint8_t;
@@ -6586,7 +6563,7 @@ unsafe fn decode_b(
             2 => {
                 (*(&mut *(t.l.tx_intra).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                     as *mut alias16))
-                    .u16_0 = 0x101  * b_dim[2 + 1] as uint16_t;
+                    .u16_0 = 0x101 * b_dim[2 + 1] as uint16_t;
                 (*(&mut *(t.l.mode).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * DC_PRED as libc::c_int) as uint16_t;
@@ -6613,8 +6590,7 @@ unsafe fn decode_b(
             4 => {
                 (*(&mut *(t.l.tx_intra).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                     as *mut alias32))
-                    .u32_0 = (0x1010101 as libc::c_uint)
-                    .wrapping_mul(b_dim[2 + 1] as libc::c_uint);
+                    .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(b_dim[2 + 1] as libc::c_uint);
                 (*(&mut *(t.l.mode).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)
@@ -6926,8 +6902,7 @@ unsafe fn decode_b(
             4 => {
                 (*(&mut *((*t.a).tx_intra).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                     as *mut alias32))
-                    .u32_0 = (0x1010101 as libc::c_uint)
-                    .wrapping_mul(b_dim[2 + 0] as libc::c_uint);
+                    .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(b_dim[2 + 0] as libc::c_uint);
                 (*(&mut *((*t.a).mode).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)
@@ -8089,8 +8064,8 @@ unsafe fn decode_b(
                         frame_hdr,
                     );
                     has_subpel_filter = (imin(bw4, bh4) == 1
-                        || frame_hdr.gmv[b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as usize]
-                            .type_0 as libc::c_uint
+                        || frame_hdr.gmv[b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as usize].type_0
+                            as libc::c_uint
                             == DAV1D_WM_TYPE_TRANSLATION as libc::c_int as libc::c_uint)
                         as libc::c_int;
                 } else {
@@ -8344,8 +8319,8 @@ unsafe fn decode_b(
                 && !(frame_hdr.force_integer_mv == 0
                     && b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_int
                         == GLOBALMV as libc::c_int
-                    && frame_hdr.gmv[b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as usize]
-                        .type_0 as libc::c_uint
+                    && frame_hdr.gmv[b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as usize].type_0
+                        as libc::c_uint
                         > DAV1D_WM_TYPE_TRANSLATION as libc::c_int as libc::c_uint)
                 && (have_left != 0 && findoddzero(&t.l.intra[by4 as usize..][..h4 as usize])
                     || have_top != 0 && findoddzero(&(*t.a).intra[bx4 as usize..][..w4 as usize]))
@@ -8826,8 +8801,7 @@ unsafe fn decode_b(
                     .u32_0 = 0 as libc::c_int as uint32_t;
                 (*(&mut *(t.l.tx_intra).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                     as *mut alias32))
-                    .u32_0 = (0x1010101 as libc::c_uint)
-                    .wrapping_mul(b_dim[2 + 1] as libc::c_uint);
+                    .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(b_dim[2 + 1] as libc::c_uint);
                 (*(&mut *(t.l.comp_type).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)
@@ -9427,8 +9401,7 @@ unsafe fn decode_b(
                     .u32_0 = 0 as libc::c_int as uint32_t;
                 (*(&mut *((*t.a).tx_intra).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                     as *mut alias32))
-                    .u32_0 = (0x1010101 as libc::c_uint)
-                    .wrapping_mul(b_dim[2 + 0] as libc::c_uint);
+                    .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(b_dim[2 + 0] as libc::c_uint);
                 (*(&mut *((*t.a).comp_type).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)

--- a/src/filmgrain_tmpl_16.rs
+++ b/src/filmgrain_tmpl_16.rs
@@ -1408,15 +1408,21 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Dav1dFilmGrainDSPContext) {
         }
 
         (*c).generate_grain_y = Some(dav1d_generate_grain_y_16bpc_avx2);
-        (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(dav1d_generate_grain_uv_420_16bpc_avx2);
-        (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(dav1d_generate_grain_uv_422_16bpc_avx2);
-        (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(dav1d_generate_grain_uv_444_16bpc_avx2);
+        (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+            Some(dav1d_generate_grain_uv_420_16bpc_avx2);
+        (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+            Some(dav1d_generate_grain_uv_422_16bpc_avx2);
+        (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+            Some(dav1d_generate_grain_uv_444_16bpc_avx2);
 
         if flags & DAV1D_X86_CPU_FLAG_SLOW_GATHER == 0 {
             (*c).fgy_32x32xn = Some(dav1d_fgy_32x32xn_16bpc_avx2);
-            (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(dav1d_fguv_32x32xn_i420_16bpc_avx2);
-            (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(dav1d_fguv_32x32xn_i422_16bpc_avx2);
-            (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(dav1d_fguv_32x32xn_i444_16bpc_avx2);
+            (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+                Some(dav1d_fguv_32x32xn_i420_16bpc_avx2);
+            (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+                Some(dav1d_fguv_32x32xn_i422_16bpc_avx2);
+            (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+                Some(dav1d_fguv_32x32xn_i444_16bpc_avx2);
         }
 
         if flags & DAV1D_X86_CPU_FLAG_AVX512ICL == 0 {
@@ -1424,9 +1430,12 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Dav1dFilmGrainDSPContext) {
         }
 
         (*c).fgy_32x32xn = Some(dav1d_fgy_32x32xn_16bpc_avx512icl);
-        (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(dav1d_fguv_32x32xn_i420_16bpc_avx512icl);
-        (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(dav1d_fguv_32x32xn_i422_16bpc_avx512icl);
-        (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(dav1d_fguv_32x32xn_i444_16bpc_avx512icl);
+        (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+            Some(dav1d_fguv_32x32xn_i420_16bpc_avx512icl);
+        (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+            Some(dav1d_fguv_32x32xn_i422_16bpc_avx512icl);
+        (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+            Some(dav1d_fguv_32x32xn_i444_16bpc_avx512icl);
     }
 }
 

--- a/src/filmgrain_tmpl_8.rs
+++ b/src/filmgrain_tmpl_8.rs
@@ -1317,15 +1317,21 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Dav1dFilmGrainDSPContext) {
         }
 
         (*c).generate_grain_y = Some(dav1d_generate_grain_y_8bpc_avx2);
-        (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(dav1d_generate_grain_uv_420_8bpc_avx2);
-        (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(dav1d_generate_grain_uv_422_8bpc_avx2);
-        (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(dav1d_generate_grain_uv_444_8bpc_avx2);
+        (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+            Some(dav1d_generate_grain_uv_420_8bpc_avx2);
+        (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+            Some(dav1d_generate_grain_uv_422_8bpc_avx2);
+        (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+            Some(dav1d_generate_grain_uv_444_8bpc_avx2);
 
         if flags & DAV1D_X86_CPU_FLAG_SLOW_GATHER == 0 {
             (*c).fgy_32x32xn = Some(dav1d_fgy_32x32xn_8bpc_avx2);
-            (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(dav1d_fguv_32x32xn_i420_8bpc_avx2);
-            (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(dav1d_fguv_32x32xn_i422_8bpc_avx2);
-            (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(dav1d_fguv_32x32xn_i444_8bpc_avx2);
+            (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+                Some(dav1d_fguv_32x32xn_i420_8bpc_avx2);
+            (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+                Some(dav1d_fguv_32x32xn_i422_8bpc_avx2);
+            (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+                Some(dav1d_fguv_32x32xn_i444_8bpc_avx2);
         }
 
         if flags & DAV1D_X86_CPU_FLAG_AVX512ICL == 0 {
@@ -1333,9 +1339,12 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Dav1dFilmGrainDSPContext) {
         }
 
         (*c).fgy_32x32xn = Some(dav1d_fgy_32x32xn_8bpc_avx512icl);
-        (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(dav1d_fguv_32x32xn_i420_8bpc_avx512icl);
-        (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(dav1d_fguv_32x32xn_i422_8bpc_avx512icl);
-        (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(dav1d_fguv_32x32xn_i444_8bpc_avx512icl);
+        (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+            Some(dav1d_fguv_32x32xn_i420_8bpc_avx512icl);
+        (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+            Some(dav1d_fguv_32x32xn_i422_8bpc_avx512icl);
+        (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+            Some(dav1d_fguv_32x32xn_i444_8bpc_avx512icl);
     }
 }
 

--- a/src/ipred_tmpl_16.rs
+++ b/src/ipred_tmpl_16.rs
@@ -1997,9 +1997,12 @@ unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Dav1dIntraPredDSPContext) {
         (*c).cfl_pred[TOP_DC_PRED as usize] = Some(dav1d_ipred_cfl_top_16bpc_avx2);
         (*c).cfl_pred[LEFT_DC_PRED as usize] = Some(dav1d_ipred_cfl_left_16bpc_avx2);
 
-        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(dav1d_ipred_cfl_ac_420_16bpc_avx2);
-        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(dav1d_ipred_cfl_ac_422_16bpc_avx2);
-        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(dav1d_ipred_cfl_ac_444_16bpc_avx2);
+        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+            Some(dav1d_ipred_cfl_ac_420_16bpc_avx2);
+        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+            Some(dav1d_ipred_cfl_ac_422_16bpc_avx2);
+        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+            Some(dav1d_ipred_cfl_ac_444_16bpc_avx2);
 
         (*c).pal_pred = Some(dav1d_pal_pred_16bpc_avx2);
 

--- a/src/ipred_tmpl_8.rs
+++ b/src/ipred_tmpl_8.rs
@@ -1999,9 +1999,12 @@ unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Dav1dIntraPredDSPContext) {
         (*c).cfl_pred[TOP_DC_PRED as usize] = Some(dav1d_ipred_cfl_top_8bpc_avx2);
         (*c).cfl_pred[LEFT_DC_PRED as usize] = Some(dav1d_ipred_cfl_left_8bpc_avx2);
 
-        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(dav1d_ipred_cfl_ac_420_8bpc_avx2);
-        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(dav1d_ipred_cfl_ac_422_8bpc_avx2);
-        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(dav1d_ipred_cfl_ac_444_8bpc_avx2);
+        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+            Some(dav1d_ipred_cfl_ac_420_8bpc_avx2);
+        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+            Some(dav1d_ipred_cfl_ac_422_8bpc_avx2);
+        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+            Some(dav1d_ipred_cfl_ac_444_8bpc_avx2);
 
         (*c).pal_pred = Some(dav1d_pal_pred_8bpc_avx2);
 

--- a/src/mc_tmpl_16.rs
+++ b/src/mc_tmpl_16.rs
@@ -4745,53 +4745,84 @@ unsafe extern "C" fn mc_dsp_init_x86(c: *mut Dav1dMCDSPContext) {
         return;
     }
 
-    #[cfg(target_arch = "x86_64")] {
+    #[cfg(target_arch = "x86_64")]
+    {
         if flags & DAV1D_X86_CPU_FLAG_AVX2 == 0 {
             return;
         }
 
         (*c).mc[FILTER_2D_8TAP_REGULAR as usize] = Some(dav1d_put_8tap_regular_16bpc_avx2);
-        (*c).mc[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] = Some(dav1d_put_8tap_regular_smooth_16bpc_avx2);
-        (*c).mc[FILTER_2D_8TAP_REGULAR_SHARP as usize] = Some(dav1d_put_8tap_regular_sharp_16bpc_avx2);
-        (*c).mc[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] = Some(dav1d_put_8tap_smooth_regular_16bpc_avx2);
+        (*c).mc[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] =
+            Some(dav1d_put_8tap_regular_smooth_16bpc_avx2);
+        (*c).mc[FILTER_2D_8TAP_REGULAR_SHARP as usize] =
+            Some(dav1d_put_8tap_regular_sharp_16bpc_avx2);
+        (*c).mc[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] =
+            Some(dav1d_put_8tap_smooth_regular_16bpc_avx2);
         (*c).mc[FILTER_2D_8TAP_SMOOTH as usize] = Some(dav1d_put_8tap_smooth_16bpc_avx2);
-        (*c).mc[FILTER_2D_8TAP_SMOOTH_SHARP as usize] = Some(dav1d_put_8tap_smooth_sharp_16bpc_avx2);
-        (*c).mc[FILTER_2D_8TAP_SHARP_REGULAR as usize] = Some(dav1d_put_8tap_sharp_regular_16bpc_avx2);
-        (*c).mc[FILTER_2D_8TAP_SHARP_SMOOTH as usize] = Some(dav1d_put_8tap_sharp_smooth_16bpc_avx2);
+        (*c).mc[FILTER_2D_8TAP_SMOOTH_SHARP as usize] =
+            Some(dav1d_put_8tap_smooth_sharp_16bpc_avx2);
+        (*c).mc[FILTER_2D_8TAP_SHARP_REGULAR as usize] =
+            Some(dav1d_put_8tap_sharp_regular_16bpc_avx2);
+        (*c).mc[FILTER_2D_8TAP_SHARP_SMOOTH as usize] =
+            Some(dav1d_put_8tap_sharp_smooth_16bpc_avx2);
         (*c).mc[FILTER_2D_8TAP_SHARP as usize] = Some(dav1d_put_8tap_sharp_16bpc_avx2);
         (*c).mc[FILTER_2D_BILINEAR as usize] = Some(dav1d_put_bilin_16bpc_avx2);
 
         (*c).mct[FILTER_2D_8TAP_REGULAR as usize] = Some(dav1d_prep_8tap_regular_16bpc_avx2);
-        (*c).mct[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] = Some(dav1d_prep_8tap_regular_smooth_16bpc_avx2);
-        (*c).mct[FILTER_2D_8TAP_REGULAR_SHARP as usize] = Some(dav1d_prep_8tap_regular_sharp_16bpc_avx2);
-        (*c).mct[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] = Some(dav1d_prep_8tap_smooth_regular_16bpc_avx2);
+        (*c).mct[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] =
+            Some(dav1d_prep_8tap_regular_smooth_16bpc_avx2);
+        (*c).mct[FILTER_2D_8TAP_REGULAR_SHARP as usize] =
+            Some(dav1d_prep_8tap_regular_sharp_16bpc_avx2);
+        (*c).mct[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] =
+            Some(dav1d_prep_8tap_smooth_regular_16bpc_avx2);
         (*c).mct[FILTER_2D_8TAP_SMOOTH as usize] = Some(dav1d_prep_8tap_smooth_16bpc_avx2);
-        (*c).mct[FILTER_2D_8TAP_SMOOTH_SHARP as usize] = Some(dav1d_prep_8tap_smooth_sharp_16bpc_avx2);
-        (*c).mct[FILTER_2D_8TAP_SHARP_REGULAR as usize] = Some(dav1d_prep_8tap_sharp_regular_16bpc_avx2);
-        (*c).mct[FILTER_2D_8TAP_SHARP_SMOOTH as usize] = Some(dav1d_prep_8tap_sharp_smooth_16bpc_avx2);
+        (*c).mct[FILTER_2D_8TAP_SMOOTH_SHARP as usize] =
+            Some(dav1d_prep_8tap_smooth_sharp_16bpc_avx2);
+        (*c).mct[FILTER_2D_8TAP_SHARP_REGULAR as usize] =
+            Some(dav1d_prep_8tap_sharp_regular_16bpc_avx2);
+        (*c).mct[FILTER_2D_8TAP_SHARP_SMOOTH as usize] =
+            Some(dav1d_prep_8tap_sharp_smooth_16bpc_avx2);
         (*c).mct[FILTER_2D_8TAP_SHARP as usize] = Some(dav1d_prep_8tap_sharp_16bpc_avx2);
         (*c).mct[FILTER_2D_BILINEAR as usize] = Some(dav1d_prep_bilin_16bpc_avx2);
 
-        (*c).mc_scaled[FILTER_2D_8TAP_REGULAR as usize] = Some(dav1d_put_8tap_scaled_regular_16bpc_avx2);
-        (*c).mc_scaled[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] = Some(dav1d_put_8tap_scaled_regular_smooth_16bpc_avx2);
-        (*c).mc_scaled[FILTER_2D_8TAP_REGULAR_SHARP as usize] = Some(dav1d_put_8tap_scaled_regular_sharp_16bpc_avx2);
-        (*c).mc_scaled[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] = Some(dav1d_put_8tap_scaled_smooth_regular_16bpc_avx2);
-        (*c).mc_scaled[FILTER_2D_8TAP_SMOOTH as usize] = Some(dav1d_put_8tap_scaled_smooth_16bpc_avx2);
-        (*c).mc_scaled[FILTER_2D_8TAP_SMOOTH_SHARP as usize] = Some(dav1d_put_8tap_scaled_smooth_sharp_16bpc_avx2);
-        (*c).mc_scaled[FILTER_2D_8TAP_SHARP_REGULAR as usize] = Some(dav1d_put_8tap_scaled_sharp_regular_16bpc_avx2);
-        (*c).mc_scaled[FILTER_2D_8TAP_SHARP_SMOOTH as usize] = Some(dav1d_put_8tap_scaled_sharp_smooth_16bpc_avx2);
-        (*c).mc_scaled[FILTER_2D_8TAP_SHARP as usize] = Some(dav1d_put_8tap_scaled_sharp_16bpc_avx2);
+        (*c).mc_scaled[FILTER_2D_8TAP_REGULAR as usize] =
+            Some(dav1d_put_8tap_scaled_regular_16bpc_avx2);
+        (*c).mc_scaled[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] =
+            Some(dav1d_put_8tap_scaled_regular_smooth_16bpc_avx2);
+        (*c).mc_scaled[FILTER_2D_8TAP_REGULAR_SHARP as usize] =
+            Some(dav1d_put_8tap_scaled_regular_sharp_16bpc_avx2);
+        (*c).mc_scaled[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] =
+            Some(dav1d_put_8tap_scaled_smooth_regular_16bpc_avx2);
+        (*c).mc_scaled[FILTER_2D_8TAP_SMOOTH as usize] =
+            Some(dav1d_put_8tap_scaled_smooth_16bpc_avx2);
+        (*c).mc_scaled[FILTER_2D_8TAP_SMOOTH_SHARP as usize] =
+            Some(dav1d_put_8tap_scaled_smooth_sharp_16bpc_avx2);
+        (*c).mc_scaled[FILTER_2D_8TAP_SHARP_REGULAR as usize] =
+            Some(dav1d_put_8tap_scaled_sharp_regular_16bpc_avx2);
+        (*c).mc_scaled[FILTER_2D_8TAP_SHARP_SMOOTH as usize] =
+            Some(dav1d_put_8tap_scaled_sharp_smooth_16bpc_avx2);
+        (*c).mc_scaled[FILTER_2D_8TAP_SHARP as usize] =
+            Some(dav1d_put_8tap_scaled_sharp_16bpc_avx2);
         (*c).mc_scaled[FILTER_2D_BILINEAR as usize] = Some(dav1d_put_bilin_scaled_16bpc_avx2);
 
-        (*c).mct_scaled[FILTER_2D_8TAP_REGULAR as usize] = Some(dav1d_prep_8tap_scaled_regular_16bpc_avx2);
-        (*c).mct_scaled[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] = Some(dav1d_prep_8tap_scaled_regular_smooth_16bpc_avx2);
-        (*c).mct_scaled[FILTER_2D_8TAP_REGULAR_SHARP as usize] = Some(dav1d_prep_8tap_scaled_regular_sharp_16bpc_avx2);
-        (*c).mct_scaled[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] = Some(dav1d_prep_8tap_scaled_smooth_regular_16bpc_avx2);
-        (*c).mct_scaled[FILTER_2D_8TAP_SMOOTH as usize] = Some(dav1d_prep_8tap_scaled_smooth_16bpc_avx2);
-        (*c).mct_scaled[FILTER_2D_8TAP_SMOOTH_SHARP as usize] = Some(dav1d_prep_8tap_scaled_smooth_sharp_16bpc_avx2);
-        (*c).mct_scaled[FILTER_2D_8TAP_SHARP_REGULAR as usize] = Some(dav1d_prep_8tap_scaled_sharp_regular_16bpc_avx2);
-        (*c).mct_scaled[FILTER_2D_8TAP_SHARP_SMOOTH as usize] = Some(dav1d_prep_8tap_scaled_sharp_smooth_16bpc_avx2);
-        (*c).mct_scaled[FILTER_2D_8TAP_SHARP as usize] = Some(dav1d_prep_8tap_scaled_sharp_16bpc_avx2);
+        (*c).mct_scaled[FILTER_2D_8TAP_REGULAR as usize] =
+            Some(dav1d_prep_8tap_scaled_regular_16bpc_avx2);
+        (*c).mct_scaled[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] =
+            Some(dav1d_prep_8tap_scaled_regular_smooth_16bpc_avx2);
+        (*c).mct_scaled[FILTER_2D_8TAP_REGULAR_SHARP as usize] =
+            Some(dav1d_prep_8tap_scaled_regular_sharp_16bpc_avx2);
+        (*c).mct_scaled[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] =
+            Some(dav1d_prep_8tap_scaled_smooth_regular_16bpc_avx2);
+        (*c).mct_scaled[FILTER_2D_8TAP_SMOOTH as usize] =
+            Some(dav1d_prep_8tap_scaled_smooth_16bpc_avx2);
+        (*c).mct_scaled[FILTER_2D_8TAP_SMOOTH_SHARP as usize] =
+            Some(dav1d_prep_8tap_scaled_smooth_sharp_16bpc_avx2);
+        (*c).mct_scaled[FILTER_2D_8TAP_SHARP_REGULAR as usize] =
+            Some(dav1d_prep_8tap_scaled_sharp_regular_16bpc_avx2);
+        (*c).mct_scaled[FILTER_2D_8TAP_SHARP_SMOOTH as usize] =
+            Some(dav1d_prep_8tap_scaled_sharp_smooth_16bpc_avx2);
+        (*c).mct_scaled[FILTER_2D_8TAP_SHARP as usize] =
+            Some(dav1d_prep_8tap_scaled_sharp_16bpc_avx2);
         (*c).mct_scaled[FILTER_2D_BILINEAR as usize] = Some(dav1d_prep_bilin_scaled_16bpc_avx2);
 
         (*c).avg = Some(dav1d_avg_16bpc_avx2);
@@ -4815,24 +4846,36 @@ unsafe extern "C" fn mc_dsp_init_x86(c: *mut Dav1dMCDSPContext) {
         }
 
         (*c).mc[FILTER_2D_8TAP_REGULAR as usize] = Some(dav1d_put_8tap_regular_16bpc_avx512icl);
-        (*c).mc[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] = Some(dav1d_put_8tap_regular_smooth_16bpc_avx512icl);
-        (*c).mc[FILTER_2D_8TAP_REGULAR_SHARP as usize] = Some(dav1d_put_8tap_regular_sharp_16bpc_avx512icl);
-        (*c).mc[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] = Some(dav1d_put_8tap_smooth_regular_16bpc_avx512icl);
+        (*c).mc[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] =
+            Some(dav1d_put_8tap_regular_smooth_16bpc_avx512icl);
+        (*c).mc[FILTER_2D_8TAP_REGULAR_SHARP as usize] =
+            Some(dav1d_put_8tap_regular_sharp_16bpc_avx512icl);
+        (*c).mc[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] =
+            Some(dav1d_put_8tap_smooth_regular_16bpc_avx512icl);
         (*c).mc[FILTER_2D_8TAP_SMOOTH as usize] = Some(dav1d_put_8tap_smooth_16bpc_avx512icl);
-        (*c).mc[FILTER_2D_8TAP_SMOOTH_SHARP as usize] = Some(dav1d_put_8tap_smooth_sharp_16bpc_avx512icl);
-        (*c).mc[FILTER_2D_8TAP_SHARP_REGULAR as usize] = Some(dav1d_put_8tap_sharp_regular_16bpc_avx512icl);
-        (*c).mc[FILTER_2D_8TAP_SHARP_SMOOTH as usize] = Some(dav1d_put_8tap_sharp_smooth_16bpc_avx512icl);
+        (*c).mc[FILTER_2D_8TAP_SMOOTH_SHARP as usize] =
+            Some(dav1d_put_8tap_smooth_sharp_16bpc_avx512icl);
+        (*c).mc[FILTER_2D_8TAP_SHARP_REGULAR as usize] =
+            Some(dav1d_put_8tap_sharp_regular_16bpc_avx512icl);
+        (*c).mc[FILTER_2D_8TAP_SHARP_SMOOTH as usize] =
+            Some(dav1d_put_8tap_sharp_smooth_16bpc_avx512icl);
         (*c).mc[FILTER_2D_8TAP_SHARP as usize] = Some(dav1d_put_8tap_sharp_16bpc_avx512icl);
         (*c).mc[FILTER_2D_BILINEAR as usize] = Some(dav1d_put_bilin_16bpc_avx512icl);
 
         (*c).mct[FILTER_2D_8TAP_REGULAR as usize] = Some(dav1d_prep_8tap_regular_16bpc_avx512icl);
-        (*c).mct[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] = Some(dav1d_prep_8tap_regular_smooth_16bpc_avx512icl);
-        (*c).mct[FILTER_2D_8TAP_REGULAR_SHARP as usize] = Some(dav1d_prep_8tap_regular_sharp_16bpc_avx512icl);
-        (*c).mct[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] = Some(dav1d_prep_8tap_smooth_regular_16bpc_avx512icl);
+        (*c).mct[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] =
+            Some(dav1d_prep_8tap_regular_smooth_16bpc_avx512icl);
+        (*c).mct[FILTER_2D_8TAP_REGULAR_SHARP as usize] =
+            Some(dav1d_prep_8tap_regular_sharp_16bpc_avx512icl);
+        (*c).mct[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] =
+            Some(dav1d_prep_8tap_smooth_regular_16bpc_avx512icl);
         (*c).mct[FILTER_2D_8TAP_SMOOTH as usize] = Some(dav1d_prep_8tap_smooth_16bpc_avx512icl);
-        (*c).mct[FILTER_2D_8TAP_SMOOTH_SHARP as usize] = Some(dav1d_prep_8tap_smooth_sharp_16bpc_avx512icl);
-        (*c).mct[FILTER_2D_8TAP_SHARP_REGULAR as usize] = Some(dav1d_prep_8tap_sharp_regular_16bpc_avx512icl);
-        (*c).mct[FILTER_2D_8TAP_SHARP_SMOOTH as usize] = Some(dav1d_prep_8tap_sharp_smooth_16bpc_avx512icl);
+        (*c).mct[FILTER_2D_8TAP_SMOOTH_SHARP as usize] =
+            Some(dav1d_prep_8tap_smooth_sharp_16bpc_avx512icl);
+        (*c).mct[FILTER_2D_8TAP_SHARP_REGULAR as usize] =
+            Some(dav1d_prep_8tap_sharp_regular_16bpc_avx512icl);
+        (*c).mct[FILTER_2D_8TAP_SHARP_SMOOTH as usize] =
+            Some(dav1d_prep_8tap_sharp_smooth_16bpc_avx512icl);
         (*c).mct[FILTER_2D_8TAP_SHARP as usize] = Some(dav1d_prep_8tap_sharp_16bpc_avx512icl);
         (*c).mct[FILTER_2D_BILINEAR as usize] = Some(dav1d_prep_bilin_16bpc_avx512icl);
 

--- a/src/mc_tmpl_8.rs
+++ b/src/mc_tmpl_8.rs
@@ -4581,53 +4581,81 @@ unsafe extern "C" fn mc_dsp_init_x86(c: *mut Dav1dMCDSPContext) {
     (*c).warp8x8 = Some(dav1d_warp_affine_8x8_8bpc_sse4);
     (*c).warp8x8t = Some(dav1d_warp_affine_8x8t_8bpc_sse4);
 
-    #[cfg(target_arch = "x86_64")] {
+    #[cfg(target_arch = "x86_64")]
+    {
         if flags & DAV1D_X86_CPU_FLAG_AVX2 == 0 {
             return;
         }
 
         (*c).mc[FILTER_2D_8TAP_REGULAR as usize] = Some(dav1d_put_8tap_regular_8bpc_avx2);
-        (*c).mc[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] = Some(dav1d_put_8tap_regular_smooth_8bpc_avx2);
-        (*c).mc[FILTER_2D_8TAP_REGULAR_SHARP as usize] = Some(dav1d_put_8tap_regular_sharp_8bpc_avx2);
-        (*c).mc[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] = Some(dav1d_put_8tap_smooth_regular_8bpc_avx2);
+        (*c).mc[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] =
+            Some(dav1d_put_8tap_regular_smooth_8bpc_avx2);
+        (*c).mc[FILTER_2D_8TAP_REGULAR_SHARP as usize] =
+            Some(dav1d_put_8tap_regular_sharp_8bpc_avx2);
+        (*c).mc[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] =
+            Some(dav1d_put_8tap_smooth_regular_8bpc_avx2);
         (*c).mc[FILTER_2D_8TAP_SMOOTH as usize] = Some(dav1d_put_8tap_smooth_8bpc_avx2);
         (*c).mc[FILTER_2D_8TAP_SMOOTH_SHARP as usize] = Some(dav1d_put_8tap_smooth_sharp_8bpc_avx2);
-        (*c).mc[FILTER_2D_8TAP_SHARP_REGULAR as usize] = Some(dav1d_put_8tap_sharp_regular_8bpc_avx2);
+        (*c).mc[FILTER_2D_8TAP_SHARP_REGULAR as usize] =
+            Some(dav1d_put_8tap_sharp_regular_8bpc_avx2);
         (*c).mc[FILTER_2D_8TAP_SHARP_SMOOTH as usize] = Some(dav1d_put_8tap_sharp_smooth_8bpc_avx2);
         (*c).mc[FILTER_2D_8TAP_SHARP as usize] = Some(dav1d_put_8tap_sharp_8bpc_avx2);
         (*c).mc[FILTER_2D_BILINEAR as usize] = Some(dav1d_put_bilin_8bpc_avx2);
 
         (*c).mct[FILTER_2D_8TAP_REGULAR as usize] = Some(dav1d_prep_8tap_regular_8bpc_avx2);
-        (*c).mct[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] = Some(dav1d_prep_8tap_regular_smooth_8bpc_avx2);
-        (*c).mct[FILTER_2D_8TAP_REGULAR_SHARP as usize] = Some(dav1d_prep_8tap_regular_sharp_8bpc_avx2);
-        (*c).mct[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] = Some(dav1d_prep_8tap_smooth_regular_8bpc_avx2);
+        (*c).mct[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] =
+            Some(dav1d_prep_8tap_regular_smooth_8bpc_avx2);
+        (*c).mct[FILTER_2D_8TAP_REGULAR_SHARP as usize] =
+            Some(dav1d_prep_8tap_regular_sharp_8bpc_avx2);
+        (*c).mct[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] =
+            Some(dav1d_prep_8tap_smooth_regular_8bpc_avx2);
         (*c).mct[FILTER_2D_8TAP_SMOOTH as usize] = Some(dav1d_prep_8tap_smooth_8bpc_avx2);
-        (*c).mct[FILTER_2D_8TAP_SMOOTH_SHARP as usize] = Some(dav1d_prep_8tap_smooth_sharp_8bpc_avx2);
-        (*c).mct[FILTER_2D_8TAP_SHARP_REGULAR as usize] = Some(dav1d_prep_8tap_sharp_regular_8bpc_avx2);
-        (*c).mct[FILTER_2D_8TAP_SHARP_SMOOTH as usize] = Some(dav1d_prep_8tap_sharp_smooth_8bpc_avx2);
+        (*c).mct[FILTER_2D_8TAP_SMOOTH_SHARP as usize] =
+            Some(dav1d_prep_8tap_smooth_sharp_8bpc_avx2);
+        (*c).mct[FILTER_2D_8TAP_SHARP_REGULAR as usize] =
+            Some(dav1d_prep_8tap_sharp_regular_8bpc_avx2);
+        (*c).mct[FILTER_2D_8TAP_SHARP_SMOOTH as usize] =
+            Some(dav1d_prep_8tap_sharp_smooth_8bpc_avx2);
         (*c).mct[FILTER_2D_8TAP_SHARP as usize] = Some(dav1d_prep_8tap_sharp_8bpc_avx2);
         (*c).mct[FILTER_2D_BILINEAR as usize] = Some(dav1d_prep_bilin_8bpc_avx2);
 
-        (*c).mc_scaled[FILTER_2D_8TAP_REGULAR as usize] = Some(dav1d_put_8tap_scaled_regular_8bpc_avx2);
-        (*c).mc_scaled[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] = Some(dav1d_put_8tap_scaled_regular_smooth_8bpc_avx2);
-        (*c).mc_scaled[FILTER_2D_8TAP_REGULAR_SHARP as usize] = Some(dav1d_put_8tap_scaled_regular_sharp_8bpc_avx2);
-        (*c).mc_scaled[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] = Some(dav1d_put_8tap_scaled_smooth_regular_8bpc_avx2);
-        (*c).mc_scaled[FILTER_2D_8TAP_SMOOTH as usize] = Some(dav1d_put_8tap_scaled_smooth_8bpc_avx2);
-        (*c).mc_scaled[FILTER_2D_8TAP_SMOOTH_SHARP as usize] = Some(dav1d_put_8tap_scaled_smooth_sharp_8bpc_avx2);
-        (*c).mc_scaled[FILTER_2D_8TAP_SHARP_REGULAR as usize] = Some(dav1d_put_8tap_scaled_sharp_regular_8bpc_avx2);
-        (*c).mc_scaled[FILTER_2D_8TAP_SHARP_SMOOTH as usize] = Some(dav1d_put_8tap_scaled_sharp_smooth_8bpc_avx2);
+        (*c).mc_scaled[FILTER_2D_8TAP_REGULAR as usize] =
+            Some(dav1d_put_8tap_scaled_regular_8bpc_avx2);
+        (*c).mc_scaled[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] =
+            Some(dav1d_put_8tap_scaled_regular_smooth_8bpc_avx2);
+        (*c).mc_scaled[FILTER_2D_8TAP_REGULAR_SHARP as usize] =
+            Some(dav1d_put_8tap_scaled_regular_sharp_8bpc_avx2);
+        (*c).mc_scaled[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] =
+            Some(dav1d_put_8tap_scaled_smooth_regular_8bpc_avx2);
+        (*c).mc_scaled[FILTER_2D_8TAP_SMOOTH as usize] =
+            Some(dav1d_put_8tap_scaled_smooth_8bpc_avx2);
+        (*c).mc_scaled[FILTER_2D_8TAP_SMOOTH_SHARP as usize] =
+            Some(dav1d_put_8tap_scaled_smooth_sharp_8bpc_avx2);
+        (*c).mc_scaled[FILTER_2D_8TAP_SHARP_REGULAR as usize] =
+            Some(dav1d_put_8tap_scaled_sharp_regular_8bpc_avx2);
+        (*c).mc_scaled[FILTER_2D_8TAP_SHARP_SMOOTH as usize] =
+            Some(dav1d_put_8tap_scaled_sharp_smooth_8bpc_avx2);
         (*c).mc_scaled[FILTER_2D_8TAP_SHARP as usize] = Some(dav1d_put_8tap_scaled_sharp_8bpc_avx2);
         (*c).mc_scaled[FILTER_2D_BILINEAR as usize] = Some(dav1d_put_bilin_scaled_8bpc_avx2);
 
-        (*c).mct_scaled[FILTER_2D_8TAP_REGULAR as usize] = Some(dav1d_prep_8tap_scaled_regular_8bpc_avx2);
-        (*c).mct_scaled[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] = Some(dav1d_prep_8tap_scaled_regular_smooth_8bpc_avx2);
-        (*c).mct_scaled[FILTER_2D_8TAP_REGULAR_SHARP as usize] = Some(dav1d_prep_8tap_scaled_regular_sharp_8bpc_avx2);
-        (*c).mct_scaled[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] = Some(dav1d_prep_8tap_scaled_smooth_regular_8bpc_avx2);
-        (*c).mct_scaled[FILTER_2D_8TAP_SMOOTH as usize] = Some(dav1d_prep_8tap_scaled_smooth_8bpc_avx2);
-        (*c).mct_scaled[FILTER_2D_8TAP_SMOOTH_SHARP as usize] = Some(dav1d_prep_8tap_scaled_smooth_sharp_8bpc_avx2);
-        (*c).mct_scaled[FILTER_2D_8TAP_SHARP_REGULAR as usize] = Some(dav1d_prep_8tap_scaled_sharp_regular_8bpc_avx2);
-        (*c).mct_scaled[FILTER_2D_8TAP_SHARP_SMOOTH as usize] = Some(dav1d_prep_8tap_scaled_sharp_smooth_8bpc_avx2);
-        (*c).mct_scaled[FILTER_2D_8TAP_SHARP as usize] = Some(dav1d_prep_8tap_scaled_sharp_8bpc_avx2);
+        (*c).mct_scaled[FILTER_2D_8TAP_REGULAR as usize] =
+            Some(dav1d_prep_8tap_scaled_regular_8bpc_avx2);
+        (*c).mct_scaled[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] =
+            Some(dav1d_prep_8tap_scaled_regular_smooth_8bpc_avx2);
+        (*c).mct_scaled[FILTER_2D_8TAP_REGULAR_SHARP as usize] =
+            Some(dav1d_prep_8tap_scaled_regular_sharp_8bpc_avx2);
+        (*c).mct_scaled[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] =
+            Some(dav1d_prep_8tap_scaled_smooth_regular_8bpc_avx2);
+        (*c).mct_scaled[FILTER_2D_8TAP_SMOOTH as usize] =
+            Some(dav1d_prep_8tap_scaled_smooth_8bpc_avx2);
+        (*c).mct_scaled[FILTER_2D_8TAP_SMOOTH_SHARP as usize] =
+            Some(dav1d_prep_8tap_scaled_smooth_sharp_8bpc_avx2);
+        (*c).mct_scaled[FILTER_2D_8TAP_SHARP_REGULAR as usize] =
+            Some(dav1d_prep_8tap_scaled_sharp_regular_8bpc_avx2);
+        (*c).mct_scaled[FILTER_2D_8TAP_SHARP_SMOOTH as usize] =
+            Some(dav1d_prep_8tap_scaled_sharp_smooth_8bpc_avx2);
+        (*c).mct_scaled[FILTER_2D_8TAP_SHARP as usize] =
+            Some(dav1d_prep_8tap_scaled_sharp_8bpc_avx2);
         (*c).mct_scaled[FILTER_2D_BILINEAR as usize] = Some(dav1d_prep_bilin_scaled_8bpc_avx2);
 
         (*c).avg = Some(dav1d_avg_8bpc_avx2);
@@ -4651,24 +4679,36 @@ unsafe extern "C" fn mc_dsp_init_x86(c: *mut Dav1dMCDSPContext) {
         }
 
         (*c).mc[FILTER_2D_8TAP_REGULAR as usize] = Some(dav1d_put_8tap_regular_8bpc_avx512icl);
-        (*c).mc[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] = Some(dav1d_put_8tap_regular_smooth_8bpc_avx512icl);
-        (*c).mc[FILTER_2D_8TAP_REGULAR_SHARP as usize] = Some(dav1d_put_8tap_regular_sharp_8bpc_avx512icl);
-        (*c).mc[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] = Some(dav1d_put_8tap_smooth_regular_8bpc_avx512icl);
+        (*c).mc[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] =
+            Some(dav1d_put_8tap_regular_smooth_8bpc_avx512icl);
+        (*c).mc[FILTER_2D_8TAP_REGULAR_SHARP as usize] =
+            Some(dav1d_put_8tap_regular_sharp_8bpc_avx512icl);
+        (*c).mc[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] =
+            Some(dav1d_put_8tap_smooth_regular_8bpc_avx512icl);
         (*c).mc[FILTER_2D_8TAP_SMOOTH as usize] = Some(dav1d_put_8tap_smooth_8bpc_avx512icl);
-        (*c).mc[FILTER_2D_8TAP_SMOOTH_SHARP as usize] = Some(dav1d_put_8tap_smooth_sharp_8bpc_avx512icl);
-        (*c).mc[FILTER_2D_8TAP_SHARP_REGULAR as usize] = Some(dav1d_put_8tap_sharp_regular_8bpc_avx512icl);
-        (*c).mc[FILTER_2D_8TAP_SHARP_SMOOTH as usize] = Some(dav1d_put_8tap_sharp_smooth_8bpc_avx512icl);
+        (*c).mc[FILTER_2D_8TAP_SMOOTH_SHARP as usize] =
+            Some(dav1d_put_8tap_smooth_sharp_8bpc_avx512icl);
+        (*c).mc[FILTER_2D_8TAP_SHARP_REGULAR as usize] =
+            Some(dav1d_put_8tap_sharp_regular_8bpc_avx512icl);
+        (*c).mc[FILTER_2D_8TAP_SHARP_SMOOTH as usize] =
+            Some(dav1d_put_8tap_sharp_smooth_8bpc_avx512icl);
         (*c).mc[FILTER_2D_8TAP_SHARP as usize] = Some(dav1d_put_8tap_sharp_8bpc_avx512icl);
         (*c).mc[FILTER_2D_BILINEAR as usize] = Some(dav1d_put_bilin_8bpc_avx512icl);
 
         (*c).mct[FILTER_2D_8TAP_REGULAR as usize] = Some(dav1d_prep_8tap_regular_8bpc_avx512icl);
-        (*c).mct[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] = Some(dav1d_prep_8tap_regular_smooth_8bpc_avx512icl);
-        (*c).mct[FILTER_2D_8TAP_REGULAR_SHARP as usize] = Some(dav1d_prep_8tap_regular_sharp_8bpc_avx512icl);
-        (*c).mct[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] = Some(dav1d_prep_8tap_smooth_regular_8bpc_avx512icl);
+        (*c).mct[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] =
+            Some(dav1d_prep_8tap_regular_smooth_8bpc_avx512icl);
+        (*c).mct[FILTER_2D_8TAP_REGULAR_SHARP as usize] =
+            Some(dav1d_prep_8tap_regular_sharp_8bpc_avx512icl);
+        (*c).mct[FILTER_2D_8TAP_SMOOTH_REGULAR as usize] =
+            Some(dav1d_prep_8tap_smooth_regular_8bpc_avx512icl);
         (*c).mct[FILTER_2D_8TAP_SMOOTH as usize] = Some(dav1d_prep_8tap_smooth_8bpc_avx512icl);
-        (*c).mct[FILTER_2D_8TAP_SMOOTH_SHARP as usize] = Some(dav1d_prep_8tap_smooth_sharp_8bpc_avx512icl);
-        (*c).mct[FILTER_2D_8TAP_SHARP_REGULAR as usize] = Some(dav1d_prep_8tap_sharp_regular_8bpc_avx512icl);
-        (*c).mct[FILTER_2D_8TAP_SHARP_SMOOTH as usize] = Some(dav1d_prep_8tap_sharp_smooth_8bpc_avx512icl);
+        (*c).mct[FILTER_2D_8TAP_SMOOTH_SHARP as usize] =
+            Some(dav1d_prep_8tap_smooth_sharp_8bpc_avx512icl);
+        (*c).mct[FILTER_2D_8TAP_SHARP_REGULAR as usize] =
+            Some(dav1d_prep_8tap_sharp_regular_8bpc_avx512icl);
+        (*c).mct[FILTER_2D_8TAP_SHARP_SMOOTH as usize] =
+            Some(dav1d_prep_8tap_sharp_smooth_8bpc_avx512icl);
         (*c).mct[FILTER_2D_8TAP_SHARP as usize] = Some(dav1d_prep_8tap_sharp_8bpc_avx512icl);
         (*c).mct[FILTER_2D_BILINEAR as usize] = Some(dav1d_prep_bilin_8bpc_avx512icl);
 

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -266,7 +266,7 @@ unsafe fn scan_row(
     let first_cand_b_dim = &dav1d_block_dimensions[first_cand_bs as usize];
     let mut cand_bw4 = first_cand_b_dim[0] as libc::c_int;
     let mut len = imax(step, imin(bw4, cand_bw4));
-    
+
     if bw4 <= cand_bw4 {
         // FIXME weight can be higher for odd blocks (bx4 & 1), but then the
         // position of the first block has to be odd already, i.e. not just
@@ -335,7 +335,7 @@ unsafe fn scan_col(
     let first_cand_b_dim = &dav1d_block_dimensions[first_cand_bs as usize];
     let mut cand_bh4 = first_cand_b_dim[1] as libc::c_int;
     let mut len = imax(step, imin(bh4, cand_bh4));
-    
+
     if bh4 <= cand_bh4 {
         // FIXME weight can be higher for odd blocks (by4 & 1), but then the
         // position of the first block has to be odd already, i.e. not just


### PR DESCRIPTION
A few things have gotten mis-formatted as a result of bad merges since the initial formatting pass. This PR adds a new workflow to check formatting in CI, and does one final `cargo fmt` run over everything.