### PR TITLE
`fn derive_warpmv`: Cleanup and make almost safe

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2336,11 +2336,11 @@ unsafe fn derive_warpmv(
     let mut mvd = [0; 8];
     let mut ret = 0;
     let thresh = 4 * iclip(imax(bw4, bh4), 4, 28);
-    for i in 0..np {
-        mvd[i] = (pts[i][1][0] - pts[i][0][0] - mv.x as libc::c_int).abs()
-            + (pts[i][1][1] - pts[i][0][1] - mv.y as libc::c_int).abs();
-        if mvd[i] > thresh {
-            mvd[i] = -1;
+    for (mvd, pts) in std::iter::zip(&mut mvd[..np], &pts[..np]) {
+        *mvd = (pts[1][0] - pts[0][0] - mv.x as i32).abs()
+            + (pts[1][1] - pts[0][1] - mv.y as i32).abs();
+        if *mvd > thresh {
+            *mvd = -1;
         } else {
             ret += 1;
         }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2272,7 +2272,7 @@ unsafe fn derive_warpmv(
     t: *const Dav1dTaskContext,
     bw4: libc::c_int,
     bh4: libc::c_int,
-    mut masks: *const uint64_t,
+    masks: &[u64; 2],
     mv: mv,
     wmp: *mut Dav1dWarpedMotionParams,
 ) {
@@ -2280,7 +2280,7 @@ unsafe fn derive_warpmv(
     let mut np = 0;
     let mut r =
         &*((*t).rt.r).as_ptr().offset((((*t).by & 31) + 5) as isize) as *const *mut refmvs_block;
-    if *masks.offset(0) as libc::c_uint == 1 && (*masks.offset(1)).wrapping_shr(32) == 0 {
+    if masks[0] as u32 == 1 && masks[1].wrapping_shr(32) == 0 {
         let off = (*t).bx
             & dav1d_block_dimensions[(*(*r.offset(-1)).offset((*t).bx as isize)).bs as usize][0]
                 as libc::c_int
@@ -2304,7 +2304,7 @@ unsafe fn derive_warpmv(
         np += 1;
     } else {
         let mut off_0 = 0 as libc::c_uint;
-        let mut xmask = *masks.offset(0) as uint32_t;
+        let mut xmask = masks[0] as u32;
         while np < 8 && xmask != 0 {
             let tz = ctz(xmask);
             off_0 = off_0.wrapping_add(tz as libc::c_uint);
@@ -2340,7 +2340,7 @@ unsafe fn derive_warpmv(
             xmask &= !1;
         }
     }
-    if np < 8 && *masks.offset(1) as libc::c_uint == 1 {
+    if np < 8 && masks[1] as u32 == 1 {
         let off_1 = (*t).by
             & dav1d_block_dimensions[(*(*r.offset(0)).offset(((*t).bx - 1) as isize)).bs as usize]
                 [1] as libc::c_int
@@ -2370,7 +2370,7 @@ unsafe fn derive_warpmv(
         np += 1;
     } else {
         let mut off_2 = 0 as libc::c_uint;
-        let mut ymask = *masks.offset(1) as uint32_t;
+        let mut ymask = masks[1] as u32;
         while np < 8 && ymask != 0 {
             let tz_0 = ctz(ymask);
             off_2 = off_2.wrapping_add(tz_0 as libc::c_uint);
@@ -2402,7 +2402,7 @@ unsafe fn derive_warpmv(
             ymask &= !1;
         }
     }
-    if np < 8 && (*masks.offset(1)).wrapping_shr(32) != 0 {
+    if np < 8 && masks[1].wrapping_shr(32) != 0 {
         pts[np][0][0] = 16
             * (2 * 0
                 + -1 * dav1d_block_dimensions
@@ -2421,7 +2421,7 @@ unsafe fn derive_warpmv(
             + (*(*r.offset(-1)).offset(((*t).bx - 1) as isize)).mv.mv[0].y as libc::c_int;
         np += 1;
     }
-    if np < 8 && (*masks.offset(0)).wrapping_shr(32) != 0 {
+    if np < 8 && masks[0].wrapping_shr(32) != 0 {
         pts[np][0][0] = 16
             * (2 * bw4
                 + 1 * dav1d_block_dimensions
@@ -8296,7 +8296,7 @@ unsafe fn decode_b(
                         t,
                         bw4,
                         bh4,
-                        mask.as_mut_ptr() as *const uint64_t,
+                        &mask,
                         b.c2rust_unnamed
                             .c2rust_unnamed_0
                             .c2rust_unnamed

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2332,9 +2332,7 @@ unsafe fn derive_warpmv(
     if np < 8 && masks[0] >> 32 != 0 {
         np = add_sample(np, bw4, 0, 1, -1, rp(-1, (*t).bx + bw4));
     }
-    if !(np > 0 && np <= 8) {
-        unreachable!();
-    }
+    assert!(np > 0 && np <= 8);
     let mut mvd = [0; 8];
     let mut ret = 0;
     let thresh = 4 * iclip(imax(bw4, bh4), 4, 28);
@@ -2362,9 +2360,7 @@ unsafe fn derive_warpmv(
             while mvd[j] == -1 {
                 j -= 1;
             }
-            if !(i_0 != j) {
-                unreachable!();
-            }
+            assert!(i_0 != j);
             if i_0 > j {
                 break;
             }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2371,12 +2371,12 @@ unsafe fn derive_warpmv(
             j -= 1;
         }
     }
-    if !dav1d_find_affine_int(&pts, ret, bw4, bh4, mv, &mut *wmp, (*t).bx, (*t).by)
+    (*wmp).type_0 = if !dav1d_find_affine_int(&pts, ret, bw4, bh4, mv, &mut *wmp, (*t).bx, (*t).by)
         && !dav1d_get_shear_params(&mut *wmp)
     {
-        (*wmp).type_0 = DAV1D_WM_TYPE_AFFINE;
+        DAV1D_WM_TYPE_AFFINE
     } else {
-        (*wmp).type_0 = DAV1D_WM_TYPE_IDENTITY;
+        DAV1D_WM_TYPE_IDENTITY
     };
 }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2267,7 +2267,8 @@ unsafe extern "C" fn find_matching_ref(
         *fresh7 = (*fresh7 as libc::c_ulonglong | (1 as libc::c_ulonglong) << 32) as uint64_t;
     }
 }
-unsafe extern "C" fn derive_warpmv(
+
+unsafe fn derive_warpmv(
     t: *const Dav1dTaskContext,
     bw4: libc::c_int,
     bh4: libc::c_int,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2285,145 +2285,74 @@ unsafe fn derive_warpmv(
         let offset = ((*t).by & 31) + 5;
         (*t).rt.r[(offset as isize + i) as usize]
     };
+
+    let mut add_sample = |np: usize, dx: i32, dy: i32, sx: i32, sy: i32, rp: *mut refmvs_block| {
+        pts[np][0][0] =
+            16 * (2 * dx + sx * dav1d_block_dimensions[(*rp).bs as usize][0] as i32) - 8;
+        pts[np][0][1] =
+            16 * (2 * dy + sy * dav1d_block_dimensions[(*rp).bs as usize][1] as i32) - 8;
+        pts[np][1][0] = pts[np][0][0] + (*rp).mv.mv[0].x as i32;
+        pts[np][1][1] = pts[np][0][1] + (*rp).mv.mv[0].y as i32;
+        np + 1
+    };
+
     if masks[0] as u32 == 1 && masks[1] >> 32 == 0 {
         let off = (*t).bx
-            & dav1d_block_dimensions[(*r(-1).offset((*t).bx as isize)).bs as usize][0]
-                as libc::c_int
-                - 1;
-        pts[np][0][0] = 16
-            * (2 * -off
-                + 1 * dav1d_block_dimensions[(*r(-1).offset((*t).bx as isize)).bs as usize][0]
-                    as libc::c_int)
-            - 8;
-        pts[np][0][1] = 16
-            * (2 * 0
-                + -1 * dav1d_block_dimensions[(*r(-1).offset((*t).bx as isize)).bs as usize][1]
-                    as libc::c_int)
-            - 8;
-        pts[np][1][0] = pts[np][0][0] + (*r(-1).offset((*t).bx as isize)).mv.mv[0].x as libc::c_int;
-        pts[np][1][1] = pts[np][0][1] + (*r(-1).offset((*t).bx as isize)).mv.mv[0].y as libc::c_int;
-        np += 1;
+            & dav1d_block_dimensions[(*r(-1).offset((*t).bx as isize)).bs as usize][0] as i32 - 1;
+        np = add_sample(np, -off, 0, 1, -1, r(-1).offset((*t).bx as isize));
     } else {
-        let mut off_0 = 0 as libc::c_uint;
+        let mut off_0 = 0;
         let mut xmask = masks[0] as u32;
         while np < 8 && xmask != 0 {
             let tz = ctz(xmask);
-            off_0 = off_0.wrapping_add(tz as libc::c_uint);
+            off_0 += tz;
             xmask >>= tz;
-            pts[np][0][0] = (16 as libc::c_uint)
-                .wrapping_mul(
-                    (2 as libc::c_uint).wrapping_mul(off_0).wrapping_add(
-                        (1 as libc::c_int
-                            * dav1d_block_dimensions[(*r(-1)
-                                .offset(((*t).bx as libc::c_uint).wrapping_add(off_0) as isize))
-                            .bs as usize][0] as libc::c_int)
-                            as libc::c_uint,
-                    ),
-                )
-                .wrapping_sub(8) as libc::c_int;
-            pts[np][0][1] = 16
-                * (2 * 0
-                    + -1 * dav1d_block_dimensions[(*r(-1)
-                        .offset(((*t).bx as libc::c_uint).wrapping_add(off_0) as isize))
-                    .bs as usize][1] as libc::c_int)
-                - 8;
-            pts[np][1][0] = pts[np][0][0]
-                + (*r(-1).offset(((*t).bx as libc::c_uint).wrapping_add(off_0) as isize))
-                    .mv
-                    .mv[0]
-                    .x as libc::c_int;
-            pts[np][1][1] = pts[np][0][1]
-                + (*r(-1).offset(((*t).bx as libc::c_uint).wrapping_add(off_0) as isize))
-                    .mv
-                    .mv[0]
-                    .y as libc::c_int;
-            np += 1;
+            np = add_sample(
+                np,
+                off_0,
+                0,
+                1,
+                -1,
+                r(-1).offset(((*t).bx + off_0) as isize),
+            );
             xmask &= !1;
         }
     }
     if np < 8 && masks[1] as u32 == 1 {
         let off_1 = (*t).by
-            & dav1d_block_dimensions[(*r(0).offset(((*t).bx - 1) as isize)).bs as usize][1]
-                as libc::c_int
+            & dav1d_block_dimensions[(*r(0).offset(((*t).bx - 1) as isize)).bs as usize][1] as i32
                 - 1;
-        pts[np][0][0] = 16
-            * (2 * 0
-                + -1 * dav1d_block_dimensions
-                    [(*r(-off_1 as isize).offset(((*t).bx - 1) as isize)).bs as usize][0]
-                    as libc::c_int)
-            - 8;
-        pts[np][0][1] = 16
-            * (2 * -off_1
-                + 1 * dav1d_block_dimensions
-                    [(*r(-off_1 as isize).offset(((*t).bx - 1) as isize)).bs as usize][1]
-                    as libc::c_int)
-            - 8;
-        pts[np][1][0] = pts[np][0][0]
-            + (*r(-off_1 as isize).offset(((*t).bx - 1) as isize)).mv.mv[0].x as libc::c_int;
-        pts[np][1][1] = pts[np][0][1]
-            + (*r(-off_1 as isize).offset(((*t).bx - 1) as isize)).mv.mv[0].y as libc::c_int;
-        np += 1;
+        np = add_sample(
+            np,
+            0,
+            -off_1,
+            -1,
+            1,
+            r(-off_1 as isize).offset(((*t).bx - 1) as isize),
+        );
     } else {
-        let mut off_2 = 0 as libc::c_uint;
+        let mut off_2 = 0;
         let mut ymask = masks[1] as u32;
         while np < 8 && ymask != 0 {
             let tz_0 = ctz(ymask);
-            off_2 = off_2.wrapping_add(tz_0 as libc::c_uint);
+            off_2 += tz_0;
             ymask >>= tz_0;
-            pts[np][0][0] = 16
-                * (2 * 0
-                    + -1 * dav1d_block_dimensions
-                        [(*r(off_2 as isize).offset(((*t).bx - 1) as isize)).bs as usize][0]
-                        as libc::c_int)
-                - 8;
-            pts[np][0][1] = (16 as libc::c_uint)
-                .wrapping_mul((2 as libc::c_uint).wrapping_mul(off_2).wrapping_add(
-                    (1 * dav1d_block_dimensions
-                        [(*r(off_2 as isize).offset(((*t).bx - 1) as isize)).bs as usize][1]
-                        as libc::c_int) as libc::c_uint,
-                ))
-                .wrapping_sub(8) as libc::c_int;
-            pts[np][1][0] = pts[np][0][0]
-                + (*r(off_2 as isize).offset(((*t).bx - 1) as isize)).mv.mv[0].x as libc::c_int;
-            pts[np][1][1] = pts[np][0][1]
-                + (*r(off_2 as isize).offset(((*t).bx - 1) as isize)).mv.mv[0].y as libc::c_int;
-            np += 1;
+            np = add_sample(
+                np,
+                0,
+                off_2,
+                -1,
+                1,
+                r(off_2 as isize).offset(((*t).bx - 1) as isize),
+            );
             ymask &= !1;
         }
     }
     if np < 8 && masks[1] >> 32 != 0 {
-        pts[np][0][0] = 16
-            * (2 * 0
-                + -1 * dav1d_block_dimensions[(*r(-1).offset(((*t).bx - 1) as isize)).bs as usize]
-                    [0] as libc::c_int)
-            - 8;
-        pts[np][0][1] = 16
-            * (2 * 0
-                + -1 * dav1d_block_dimensions[(*r(-1).offset(((*t).bx - 1) as isize)).bs as usize]
-                    [1] as libc::c_int)
-            - 8;
-        pts[np][1][0] =
-            pts[np][0][0] + (*r(-1).offset(((*t).bx - 1) as isize)).mv.mv[0].x as libc::c_int;
-        pts[np][1][1] =
-            pts[np][0][1] + (*r(-1).offset(((*t).bx - 1) as isize)).mv.mv[0].y as libc::c_int;
-        np += 1;
+        np = add_sample(np, 0, 0, -1, -1, r(-1).offset(((*t).bx - 1) as isize));
     }
     if np < 8 && masks[0] >> 32 != 0 {
-        pts[np][0][0] = 16
-            * (2 * bw4
-                + 1 * dav1d_block_dimensions[(*r(-1).offset(((*t).bx + bw4) as isize)).bs as usize]
-                    [0] as libc::c_int)
-            - 8;
-        pts[np][0][1] = 16
-            * (2 * 0
-                + -1 * dav1d_block_dimensions[(*r(-1).offset(((*t).bx + bw4) as isize)).bs as usize]
-                    [1] as libc::c_int)
-            - 8;
-        pts[np][1][0] =
-            pts[np][0][0] + (*r(-1).offset(((*t).bx + bw4) as isize)).mv.mv[0].x as libc::c_int;
-        pts[np][1][1] =
-            pts[np][0][1] + (*r(-1).offset(((*t).bx + bw4) as isize)).mv.mv[0].y as libc::c_int;
-        np += 1;
+        np = add_sample(np, bw4, 0, 1, -1, r(-1).offset(((*t).bx + bw4) as isize));
     }
     if !(np > 0 && np <= 8) {
         unreachable!();

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2336,8 +2336,7 @@ unsafe fn derive_warpmv(
     let mut mvd = [0; 8];
     let mut ret = 0;
     let thresh = 4 * iclip(imax(bw4, bh4), 4, 28);
-    let mut i = 0;
-    while i < np {
+    for i in 0..np {
         mvd[i] = (pts[i][1][0] - pts[i][0][0] - mv.x as libc::c_int).abs()
             + (pts[i][1][1] - pts[i][0][1] - mv.y as libc::c_int).abs();
         if mvd[i] > thresh {
@@ -2345,15 +2344,13 @@ unsafe fn derive_warpmv(
         } else {
             ret += 1;
         }
-        i += 1;
     }
     if ret == 0 {
         ret = 1;
     } else {
         let mut i_0 = 0;
         let mut j = np - 1;
-        let mut k = 0;
-        while k < np - ret {
+        for _ in 0..np - ret {
             while mvd[i_0] != -1 {
                 i_0 += 1;
             }
@@ -2370,7 +2367,6 @@ unsafe fn derive_warpmv(
                 pts[j].as_mut_ptr() as *const libc::c_void,
                 ::core::mem::size_of::<[[libc::c_int; 2]; 2]>() as libc::c_ulong,
             );
-            k += 1;
             i_0 += 1;
             j -= 1;
         }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2280,7 +2280,7 @@ unsafe fn derive_warpmv(
     let mut np = 0;
     let mut r =
         &*((*t).rt.r).as_ptr().offset((((*t).by & 31) + 5) as isize) as *const *mut refmvs_block;
-    if masks[0] as u32 == 1 && masks[1].wrapping_shr(32) == 0 {
+    if masks[0] as u32 == 1 && masks[1] >> 32 == 0 {
         let off = (*t).bx
             & dav1d_block_dimensions[(*(*r.offset(-1)).offset((*t).bx as isize)).bs as usize][0]
                 as libc::c_int
@@ -2402,7 +2402,7 @@ unsafe fn derive_warpmv(
             ymask &= !1;
         }
     }
-    if np < 8 && masks[1].wrapping_shr(32) != 0 {
+    if np < 8 && masks[1] >> 32 != 0 {
         pts[np][0][0] = 16
             * (2 * 0
                 + -1 * dav1d_block_dimensions
@@ -2421,7 +2421,7 @@ unsafe fn derive_warpmv(
             + (*(*r.offset(-1)).offset(((*t).bx - 1) as isize)).mv.mv[0].y as libc::c_int;
         np += 1;
     }
-    if np < 8 && masks[0].wrapping_shr(32) != 0 {
+    if np < 8 && masks[0] >> 32 != 0 {
         pts[np][0][0] = 16
             * (2 * bw4
                 + 1 * dav1d_block_dimensions

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2362,11 +2362,7 @@ unsafe fn derive_warpmv(
                 break;
             }
             mvd[i] = mvd[j];
-            memcpy(
-                pts[i].as_mut_ptr() as *mut libc::c_void,
-                pts[j].as_mut_ptr() as *const libc::c_void,
-                ::core::mem::size_of::<[[libc::c_int; 2]; 2]>() as libc::c_ulong,
-            );
+            pts[i] = pts[j];
             i += 1;
             j -= 1;
         }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2276,226 +2276,182 @@ unsafe fn derive_warpmv(
     mv: mv,
     wmp: *mut Dav1dWarpedMotionParams,
 ) {
-    let mut pts: [[[libc::c_int; 2]; 2]; 8] = [[[0; 2]; 2]; 8];
+    let mut pts = [[[0; 2]; 2]; 8];
     let mut np = 0;
-    let mut r: *const *mut refmvs_block =
+    let mut r =
         &*((*t).rt.r).as_ptr().offset((((*t).by & 31) + 5) as isize) as *const *mut refmvs_block;
-    if *masks.offset(0) as libc::c_uint == 1 as libc::c_uint
-        && (*masks.offset(1)).wrapping_shr(32) == 0
-    {
+    if *masks.offset(0) as libc::c_uint == 1 && (*masks.offset(1)).wrapping_shr(32) == 0 {
         let off = (*t).bx
-            & dav1d_block_dimensions
-                [(*(*r.offset(-(1 as libc::c_int) as isize)).offset((*t).bx as isize)).bs as usize]
-                [0] as libc::c_int
+            & dav1d_block_dimensions[(*(*r.offset(-1)).offset((*t).bx as isize)).bs as usize][0]
+                as libc::c_int
                 - 1;
-        pts[np as usize][0][0] = 16 as libc::c_int
+        pts[np][0][0] = 16
             * (2 * -off
-                + 1 * dav1d_block_dimensions[(*(*r.offset(-(1 as libc::c_int) as isize))
-                    .offset((*t).bx as isize))
-                .bs as usize][0] as libc::c_int)
+                + 1 * dav1d_block_dimensions
+                    [(*(*r.offset(-1)).offset((*t).bx as isize)).bs as usize][0]
+                    as libc::c_int)
             - 8;
-        pts[np as usize][0][1] = 16 as libc::c_int
+        pts[np][0][1] = 16
             * (2 * 0
-                + -(1 as libc::c_int)
-                    * dav1d_block_dimensions[(*(*r.offset(-(1 as libc::c_int) as isize))
-                        .offset((*t).bx as isize))
-                    .bs as usize][1] as libc::c_int)
+                + -1 * dav1d_block_dimensions
+                    [(*(*r.offset(-1)).offset((*t).bx as isize)).bs as usize][1]
+                    as libc::c_int)
             - 8;
-        pts[np as usize][1][0] = pts[np as usize][0][0]
-            + (*(*r.offset(-(1 as libc::c_int) as isize)).offset((*t).bx as isize))
-                .mv
-                .mv[0]
-                .x as libc::c_int;
-        pts[np as usize][1][1] = pts[np as usize][0][1]
-            + (*(*r.offset(-(1 as libc::c_int) as isize)).offset((*t).bx as isize))
-                .mv
-                .mv[0]
-                .y as libc::c_int;
+        pts[np][1][0] =
+            pts[np][0][0] + (*(*r.offset(-1)).offset((*t).bx as isize)).mv.mv[0].x as libc::c_int;
+        pts[np][1][1] =
+            pts[np][0][1] + (*(*r.offset(-1)).offset((*t).bx as isize)).mv.mv[0].y as libc::c_int;
         np += 1;
     } else {
-        let mut off_0: libc::c_uint = 0 as libc::c_int as libc::c_uint;
-        let mut xmask: libc::c_uint = *masks.offset(0) as uint32_t;
+        let mut off_0 = 0 as libc::c_uint;
+        let mut xmask = *masks.offset(0) as uint32_t;
         while np < 8 && xmask != 0 {
             let tz = ctz(xmask);
             off_0 = off_0.wrapping_add(tz as libc::c_uint);
             xmask >>= tz;
-            pts[np as usize][0][0] = (16 as libc::c_int as libc::c_uint)
+            pts[np][0][0] = (16 as libc::c_uint)
                 .wrapping_mul(
-                    (2 as libc::c_int as libc::c_uint)
-                        .wrapping_mul(off_0)
-                        .wrapping_add(
-                            (1 as libc::c_int
-                                * dav1d_block_dimensions[(*(*r
-                                    .offset(-(1 as libc::c_int) as isize))
+                    (2 as libc::c_uint).wrapping_mul(off_0).wrapping_add(
+                        (1 as libc::c_int
+                            * dav1d_block_dimensions[(*(*r.offset(-1))
                                 .offset(((*t).bx as libc::c_uint).wrapping_add(off_0) as isize))
-                                .bs
-                                    as usize][0] as libc::c_int)
-                                as libc::c_uint,
-                        ),
+                            .bs as usize][0] as libc::c_int)
+                            as libc::c_uint,
+                    ),
                 )
-                .wrapping_sub(8 as libc::c_int as libc::c_uint)
-                as libc::c_int;
-            pts[np as usize][0][1] = 16 as libc::c_int
+                .wrapping_sub(8) as libc::c_int;
+            pts[np][0][1] = 16
                 * (2 * 0
-                    + -(1 as libc::c_int)
-                        * dav1d_block_dimensions[(*(*r.offset(-(1 as libc::c_int) as isize))
-                            .offset(((*t).bx as libc::c_uint).wrapping_add(off_0) as isize))
-                        .bs as usize][1] as libc::c_int)
+                    + -1 * dav1d_block_dimensions[(*(*r.offset(-1))
+                        .offset(((*t).bx as libc::c_uint).wrapping_add(off_0) as isize))
+                    .bs as usize][1] as libc::c_int)
                 - 8;
-            pts[np as usize][1][0] = pts[np as usize][0][0]
-                + (*(*r.offset(-(1 as libc::c_int) as isize))
-                    .offset(((*t).bx as libc::c_uint).wrapping_add(off_0) as isize))
-                .mv
-                .mv[0]
+            pts[np][1][0] = pts[np][0][0]
+                + (*(*r.offset(-1)).offset(((*t).bx as libc::c_uint).wrapping_add(off_0) as isize))
+                    .mv
+                    .mv[0]
                     .x as libc::c_int;
-            pts[np as usize][1][1] = pts[np as usize][0][1]
-                + (*(*r.offset(-(1 as libc::c_int) as isize))
-                    .offset(((*t).bx as libc::c_uint).wrapping_add(off_0) as isize))
-                .mv
-                .mv[0]
+            pts[np][1][1] = pts[np][0][1]
+                + (*(*r.offset(-1)).offset(((*t).bx as libc::c_uint).wrapping_add(off_0) as isize))
+                    .mv
+                    .mv[0]
                     .y as libc::c_int;
             np += 1;
-            xmask &= !(1 as libc::c_int) as libc::c_uint;
+            xmask &= !1;
         }
     }
-    if np < 8 && *masks.offset(1) == 1 {
+    if np < 8 && *masks.offset(1) as libc::c_uint == 1 {
         let off_1 = (*t).by
             & dav1d_block_dimensions[(*(*r.offset(0)).offset(((*t).bx - 1) as isize)).bs as usize]
                 [1] as libc::c_int
                 - 1;
-        pts[np as usize][0][0] = 16 as libc::c_int
+        pts[np][0][0] = 16
             * (2 * 0
-                + -(1 as libc::c_int)
-                    * dav1d_block_dimensions
-                        [(*(*r.offset(-off_1 as isize)).offset(((*t).bx - 1) as isize)).bs as usize]
-                        [0] as libc::c_int)
+                + -1 * dav1d_block_dimensions
+                    [(*(*r.offset(-off_1 as isize)).offset(((*t).bx - 1) as isize)).bs as usize][0]
+                    as libc::c_int)
             - 8;
-        pts[np as usize][0][1] = 16 as libc::c_int
+        pts[np][0][1] = 16
             * (2 * -off_1
                 + 1 * dav1d_block_dimensions
                     [(*(*r.offset(-off_1 as isize)).offset(((*t).bx - 1) as isize)).bs as usize][1]
                     as libc::c_int)
             - 8;
-        pts[np as usize][1][0] = pts[np as usize][0][0]
+        pts[np][1][0] = pts[np][0][0]
             + (*(*r.offset(-off_1 as isize)).offset(((*t).bx - 1) as isize))
                 .mv
                 .mv[0]
                 .x as libc::c_int;
-        pts[np as usize][1][1] = pts[np as usize][0][1]
+        pts[np][1][1] = pts[np][0][1]
             + (*(*r.offset(-off_1 as isize)).offset(((*t).bx - 1) as isize))
                 .mv
                 .mv[0]
                 .y as libc::c_int;
         np += 1;
     } else {
-        let mut off_2: libc::c_uint = 0 as libc::c_int as libc::c_uint;
-        let mut ymask: libc::c_uint = *masks.offset(1) as uint32_t;
+        let mut off_2 = 0 as libc::c_uint;
+        let mut ymask = *masks.offset(1) as uint32_t;
         while np < 8 && ymask != 0 {
             let tz_0 = ctz(ymask);
             off_2 = off_2.wrapping_add(tz_0 as libc::c_uint);
             ymask >>= tz_0;
-            pts[np as usize][0][0] = 16 as libc::c_int
+            pts[np][0][0] = 16
                 * (2 * 0
-                    + -(1 as libc::c_int)
-                        * dav1d_block_dimensions[(*(*r.offset(off_2 as isize))
-                            .offset(((*t).bx - 1) as isize))
-                        .bs as usize][0] as libc::c_int)
+                    + -1 * dav1d_block_dimensions
+                        [(*(*r.offset(off_2 as isize)).offset(((*t).bx - 1) as isize)).bs as usize]
+                        [0] as libc::c_int)
                 - 8;
-            pts[np as usize][0][1] = (16 as libc::c_int as libc::c_uint)
-                .wrapping_mul(
-                    (2 as libc::c_int as libc::c_uint)
-                        .wrapping_mul(off_2)
-                        .wrapping_add(
-                            (1 as libc::c_int
-                                * dav1d_block_dimensions[(*(*r.offset(off_2 as isize))
-                                    .offset(((*t).bx - 1) as isize))
-                                .bs
-                                    as usize][1] as libc::c_int)
-                                as libc::c_uint,
-                        ),
-                )
-                .wrapping_sub(8 as libc::c_int as libc::c_uint)
-                as libc::c_int;
-            pts[np as usize][1][0] = pts[np as usize][0][0]
+            pts[np][0][1] = (16 as libc::c_uint)
+                .wrapping_mul((2 as libc::c_uint).wrapping_mul(off_2).wrapping_add(
+                    (1 * dav1d_block_dimensions
+                        [(*(*r.offset(off_2 as isize)).offset(((*t).bx - 1) as isize)).bs as usize]
+                        [1] as libc::c_int) as libc::c_uint,
+                ))
+                .wrapping_sub(8) as libc::c_int;
+            pts[np][1][0] = pts[np][0][0]
                 + (*(*r.offset(off_2 as isize)).offset(((*t).bx - 1) as isize))
                     .mv
                     .mv[0]
                     .x as libc::c_int;
-            pts[np as usize][1][1] = pts[np as usize][0][1]
+            pts[np][1][1] = pts[np][0][1]
                 + (*(*r.offset(off_2 as isize)).offset(((*t).bx - 1) as isize))
                     .mv
                     .mv[0]
                     .y as libc::c_int;
             np += 1;
-            ymask &= !(1 as libc::c_int) as libc::c_uint;
+            ymask &= !1;
         }
     }
     if np < 8 && (*masks.offset(1)).wrapping_shr(32) != 0 {
-        pts[np as usize][0][0] = 16 as libc::c_int
+        pts[np][0][0] = 16
             * (2 * 0
-                + -(1 as libc::c_int)
-                    * dav1d_block_dimensions[(*(*r.offset(-(1 as libc::c_int) as isize))
-                        .offset(((*t).bx - 1) as isize))
-                    .bs as usize][0] as libc::c_int)
+                + -1 * dav1d_block_dimensions
+                    [(*(*r.offset(-1)).offset(((*t).bx - 1) as isize)).bs as usize][0]
+                    as libc::c_int)
             - 8;
-        pts[np as usize][0][1] = 16 as libc::c_int
+        pts[np][0][1] = 16
             * (2 * 0
-                + -(1 as libc::c_int)
-                    * dav1d_block_dimensions[(*(*r.offset(-(1 as libc::c_int) as isize))
-                        .offset(((*t).bx - 1) as isize))
-                    .bs as usize][1] as libc::c_int)
+                + -1 * dav1d_block_dimensions
+                    [(*(*r.offset(-1)).offset(((*t).bx - 1) as isize)).bs as usize][1]
+                    as libc::c_int)
             - 8;
-        pts[np as usize][1][0] = pts[np as usize][0][0]
-            + (*(*r.offset(-(1 as libc::c_int) as isize)).offset(((*t).bx - 1) as isize))
-                .mv
-                .mv[0]
-                .x as libc::c_int;
-        pts[np as usize][1][1] = pts[np as usize][0][1]
-            + (*(*r.offset(-(1 as libc::c_int) as isize)).offset(((*t).bx - 1) as isize))
-                .mv
-                .mv[0]
-                .y as libc::c_int;
+        pts[np][1][0] = pts[np][0][0]
+            + (*(*r.offset(-1)).offset(((*t).bx - 1) as isize)).mv.mv[0].x as libc::c_int;
+        pts[np][1][1] = pts[np][0][1]
+            + (*(*r.offset(-1)).offset(((*t).bx - 1) as isize)).mv.mv[0].y as libc::c_int;
         np += 1;
     }
     if np < 8 && (*masks.offset(0)).wrapping_shr(32) != 0 {
-        pts[np as usize][0][0] = 16 as libc::c_int
+        pts[np][0][0] = 16
             * (2 * bw4
-                + 1 * dav1d_block_dimensions[(*(*r.offset(-(1 as libc::c_int) as isize))
-                    .offset(((*t).bx + bw4) as isize))
-                .bs as usize][0] as libc::c_int)
+                + 1 * dav1d_block_dimensions
+                    [(*(*r.offset(-1)).offset(((*t).bx + bw4) as isize)).bs as usize][0]
+                    as libc::c_int)
             - 8;
-        pts[np as usize][0][1] = 16 as libc::c_int
+        pts[np][0][1] = 16
             * (2 * 0
-                + -(1 as libc::c_int)
-                    * dav1d_block_dimensions[(*(*r.offset(-(1 as libc::c_int) as isize))
-                        .offset(((*t).bx + bw4) as isize))
-                    .bs as usize][1] as libc::c_int)
+                + -1 * dav1d_block_dimensions
+                    [(*(*r.offset(-1)).offset(((*t).bx + bw4) as isize)).bs as usize][1]
+                    as libc::c_int)
             - 8;
-        pts[np as usize][1][0] = pts[np as usize][0][0]
-            + (*(*r.offset(-(1 as libc::c_int) as isize)).offset(((*t).bx + bw4) as isize))
-                .mv
-                .mv[0]
-                .x as libc::c_int;
-        pts[np as usize][1][1] = pts[np as usize][0][1]
-            + (*(*r.offset(-(1 as libc::c_int) as isize)).offset(((*t).bx + bw4) as isize))
-                .mv
-                .mv[0]
-                .y as libc::c_int;
+        pts[np][1][0] = pts[np][0][0]
+            + (*(*r.offset(-1)).offset(((*t).bx + bw4) as isize)).mv.mv[0].x as libc::c_int;
+        pts[np][1][1] = pts[np][0][1]
+            + (*(*r.offset(-1)).offset(((*t).bx + bw4) as isize)).mv.mv[0].y as libc::c_int;
         np += 1;
     }
     if !(np > 0 && np <= 8) {
         unreachable!();
     }
-    let mut mvd: [libc::c_int; 8] = [0; 8];
+    let mut mvd = [0; 8];
     let mut ret = 0;
-    let thresh = 4 as libc::c_int * iclip(imax(bw4, bh4), 4 as libc::c_int, 28 as libc::c_int);
+    let thresh = 4 * iclip(imax(bw4, bh4), 4, 28);
     let mut i = 0;
     while i < np {
-        mvd[i as usize] = (pts[i as usize][1][0] - pts[i as usize][0][0] - mv.x as libc::c_int)
-            .abs()
-            + (pts[i as usize][1][1] - pts[i as usize][0][1] - mv.y as libc::c_int).abs();
-        if mvd[i as usize] > thresh {
-            mvd[i as usize] = -(1 as libc::c_int);
+        mvd[i] = (pts[i][1][0] - pts[i][0][0] - mv.x as libc::c_int).abs()
+            + (pts[i][1][1] - pts[i][0][1] - mv.y as libc::c_int).abs();
+        if mvd[i] > thresh {
+            mvd[i] = -1;
         } else {
             ret += 1;
         }
@@ -2508,10 +2464,10 @@ unsafe fn derive_warpmv(
         let mut j = np - 1;
         let mut k = 0;
         while k < np - ret {
-            while mvd[i_0 as usize] != -(1 as libc::c_int) {
+            while mvd[i_0] != -1 {
                 i_0 += 1;
             }
-            while mvd[j as usize] == -(1 as libc::c_int) {
+            while mvd[j] == -1 {
                 j -= 1;
             }
             if !(i_0 != j) {
@@ -2520,10 +2476,10 @@ unsafe fn derive_warpmv(
             if i_0 > j {
                 break;
             }
-            mvd[i_0 as usize] = mvd[j as usize];
+            mvd[i_0] = mvd[j];
             memcpy(
-                (pts[i_0 as usize]).as_mut_ptr() as *mut libc::c_void,
-                (pts[j as usize]).as_mut_ptr() as *const libc::c_void,
+                pts[i_0].as_mut_ptr() as *mut libc::c_void,
+                pts[j].as_mut_ptr() as *const libc::c_void,
                 ::core::mem::size_of::<[[libc::c_int; 2]; 2]>() as libc::c_ulong,
             );
             k += 1;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2286,19 +2286,18 @@ unsafe fn derive_warpmv(
         (*t).rt.r[(offset as isize + i) as usize]
     };
 
+    let bs = |rp: *mut refmvs_block| dav1d_block_dimensions[(*rp).bs as usize];
+
     let mut add_sample = |np: usize, dx: i32, dy: i32, sx: i32, sy: i32, rp: *mut refmvs_block| {
-        pts[np][0][0] =
-            16 * (2 * dx + sx * dav1d_block_dimensions[(*rp).bs as usize][0] as i32) - 8;
-        pts[np][0][1] =
-            16 * (2 * dy + sy * dav1d_block_dimensions[(*rp).bs as usize][1] as i32) - 8;
+        pts[np][0][0] = 16 * (2 * dx + sx * bs(rp)[0] as i32) - 8;
+        pts[np][0][1] = 16 * (2 * dy + sy * bs(rp)[1] as i32) - 8;
         pts[np][1][0] = pts[np][0][0] + (*rp).mv.mv[0].x as i32;
         pts[np][1][1] = pts[np][0][1] + (*rp).mv.mv[0].y as i32;
         np + 1
     };
 
     if masks[0] as u32 == 1 && masks[1] >> 32 == 0 {
-        let off = (*t).bx
-            & dav1d_block_dimensions[(*r(-1).offset((*t).bx as isize)).bs as usize][0] as i32 - 1;
+        let off = (*t).bx & bs(r(-1).offset((*t).bx as isize))[0] as i32 - 1;
         np = add_sample(np, -off, 0, 1, -1, r(-1).offset((*t).bx as isize));
     } else {
         let mut off_0 = 0;
@@ -2319,9 +2318,7 @@ unsafe fn derive_warpmv(
         }
     }
     if np < 8 && masks[1] as u32 == 1 {
-        let off_1 = (*t).by
-            & dav1d_block_dimensions[(*r(0).offset(((*t).bx - 1) as isize)).bs as usize][1] as i32
-                - 1;
+        let off_1 = (*t).by & bs(r(0).offset(((*t).bx - 1) as isize))[1] as i32 - 1;
         np = add_sample(
             np,
             0,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2281,7 +2281,7 @@ unsafe fn derive_warpmv(
     let r = |i: isize| {
         // Need to use a closure here vs. a slice because `i` can be negative
         // (and not just by a constant -1).
-        // See `off_1: i32` below.
+        // See `-off` below.
         let offset = ((*t).by & 31) + 5;
         (*t).rt.r[(offset as isize + i) as usize]
     };
@@ -2302,27 +2302,27 @@ unsafe fn derive_warpmv(
         let off = (*t).bx & bs(rp(-1, (*t).bx))[0] as i32 - 1;
         np = add_sample(np, -off, 0, 1, -1, rp(-1, (*t).bx));
     } else {
-        let mut off_0 = 0;
+        let mut off = 0;
         let mut xmask = masks[0] as u32;
         while np < 8 && xmask != 0 {
             let tz = ctz(xmask);
-            off_0 += tz;
+            off += tz;
             xmask >>= tz;
-            np = add_sample(np, off_0, 0, 1, -1, rp(-1, (*t).bx + off_0));
+            np = add_sample(np, off, 0, 1, -1, rp(-1, (*t).bx + off));
             xmask &= !1;
         }
     }
     if np < 8 && masks[1] as u32 == 1 {
-        let off_1 = (*t).by & bs(rp(0, (*t).bx - 1))[1] as i32 - 1;
-        np = add_sample(np, 0, -off_1, -1, 1, rp(-off_1, (*t).bx - 1));
+        let off = (*t).by & bs(rp(0, (*t).bx - 1))[1] as i32 - 1;
+        np = add_sample(np, 0, -off, -1, 1, rp(-off, (*t).bx - 1));
     } else {
-        let mut off_2 = 0;
+        let mut off = 0;
         let mut ymask = masks[1] as u32;
         while np < 8 && ymask != 0 {
-            let tz_0 = ctz(ymask);
-            off_2 += tz_0;
-            ymask >>= tz_0;
-            np = add_sample(np, 0, off_2, -1, 1, rp(off_2, (*t).bx - 1));
+            let tz = ctz(ymask);
+            off += tz;
+            ymask >>= tz;
+            np = add_sample(np, 0, off, -1, 1, rp(off, (*t).bx - 1));
             ymask &= !1;
         }
     }
@@ -2348,26 +2348,26 @@ unsafe fn derive_warpmv(
     if ret == 0 {
         ret = 1;
     } else {
-        let mut i_0 = 0;
+        let mut i = 0;
         let mut j = np - 1;
         for _ in 0..np - ret {
-            while mvd[i_0] != -1 {
-                i_0 += 1;
+            while mvd[i] != -1 {
+                i += 1;
             }
             while mvd[j] == -1 {
                 j -= 1;
             }
-            assert!(i_0 != j);
-            if i_0 > j {
+            assert!(i != j);
+            if i > j {
                 break;
             }
-            mvd[i_0] = mvd[j];
+            mvd[i] = mvd[j];
             memcpy(
-                pts[i_0].as_mut_ptr() as *mut libc::c_void,
+                pts[i].as_mut_ptr() as *mut libc::c_void,
                 pts[j].as_mut_ptr() as *const libc::c_void,
                 ::core::mem::size_of::<[[libc::c_int; 2]; 2]>() as libc::c_ulong,
             );
-            i_0 += 1;
+            i += 1;
             j -= 1;
         }
     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2286,11 +2286,11 @@ unsafe fn derive_warpmv(
         (*t).rt.r[(offset as isize + i) as usize]
     };
 
-    let rp = |i: i32, j: i32| r(i as isize).offset(j as isize);
+    let rp = |i: i32, j: i32| &*r(i as isize).offset(j as isize);
 
-    let bs = |rp: *mut refmvs_block| dav1d_block_dimensions[(*rp).bs as usize];
+    let bs = |rp: &refmvs_block| dav1d_block_dimensions[(*rp).bs as usize];
 
-    let mut add_sample = |np: usize, dx: i32, dy: i32, sx: i32, sy: i32, rp: *mut refmvs_block| {
+    let mut add_sample = |np: usize, dx: i32, dy: i32, sx: i32, sy: i32, rp: &refmvs_block| {
         pts[np][0][0] = 16 * (2 * dx + sx * bs(rp)[0] as i32) - 8;
         pts[np][0][1] = 16 * (2 * dy + sy * bs(rp)[1] as i32) - 8;
         pts[np][1][0] = pts[np][0][0] + (*rp).mv.mv[0].x as i32;


### PR DESCRIPTION
The remaining `unsafe` is in this line:

```rust
let rp = |i: i32, j: i32| &*r(i as isize).offset(j as size);
```

Some of the cleanups here were non-trivial to satisfy the borrow checker, such as:
* 9aac8c97254cb1a47cfdb40c618365c593a8fcdb
* 022d74c08a62ccf072630dee92109fa8b7b353e1

so I had to change some signatures.