### PR TITLE
`fn get_{top,left}_partition_ctx`: Cleanup and make safe

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1161,7 +1161,7 @@ unsafe fn gather_left_partition_prob(r#in: &[u16; 16], bl: BlockLevel) -> u32 {
     if bl != BL_128X128 {
         out += r#in[(PARTITION_H4 - 1) as usize] as i32 - r#in[PARTITION_H4 as usize] as i32;
     }
-    return out as u32;
+    out as u32
 }
 
 #[inline]
@@ -1173,7 +1173,7 @@ unsafe fn gather_top_partition_prob(r#in: &[u16; 16], bl: BlockLevel) -> u32 {
         out += r#in[(PARTITION_V4 - 1) as usize] as i32
             - r#in[PARTITION_T_RIGHT_SPLIT as usize] as i32;
     }
-    return out as u32;
+    out as u32
 }
 
 #[inline]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1154,7 +1154,7 @@ fn get_partition_ctx(
 }
 
 #[inline]
-unsafe fn gather_left_partition_prob(r#in: &[u16; 16], bl: BlockLevel) -> u32 {
+fn gather_left_partition_prob(r#in: &[u16; 16], bl: BlockLevel) -> u32 {
     let mut out = r#in[(PARTITION_H - 1) as usize] as i32 - r#in[PARTITION_H as usize] as i32;
     out +=
         r#in[(PARTITION_SPLIT - 1) as usize] as i32 - r#in[PARTITION_T_LEFT_SPLIT as usize] as i32;
@@ -1165,7 +1165,7 @@ unsafe fn gather_left_partition_prob(r#in: &[u16; 16], bl: BlockLevel) -> u32 {
 }
 
 #[inline]
-unsafe fn gather_top_partition_prob(r#in: &[u16; 16], bl: BlockLevel) -> u32 {
+fn gather_top_partition_prob(r#in: &[u16; 16], bl: BlockLevel) -> u32 {
     let mut out =
         r#in[(PARTITION_V - 1) as usize] as i32 - r#in[PARTITION_T_TOP_SPLIT as usize] as i32;
     out += r#in[(PARTITION_T_LEFT_SPLIT - 1) as usize] as i32;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1154,7 +1154,7 @@ fn get_partition_ctx(
 }
 
 #[inline]
-unsafe extern "C" fn gather_left_partition_prob(
+unsafe fn gather_left_partition_prob(
     in_0: *const uint16_t,
     bl: BlockLevel,
 ) -> libc::c_uint {
@@ -1176,8 +1176,9 @@ unsafe extern "C" fn gather_left_partition_prob(
     }
     return out;
 }
+
 #[inline]
-unsafe extern "C" fn gather_top_partition_prob(
+unsafe fn gather_top_partition_prob(
     in_0: *const uint16_t,
     bl: BlockLevel,
 ) -> libc::c_uint {
@@ -1197,6 +1198,7 @@ unsafe extern "C" fn gather_top_partition_prob(
     }
     return out;
 }
+
 #[inline]
 unsafe extern "C" fn get_filter_ctx(
     a: *const BlockContext,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1154,37 +1154,28 @@ fn get_partition_ctx(
 }
 
 #[inline]
-unsafe fn gather_left_partition_prob(in_0: *const uint16_t, bl: BlockLevel) -> libc::c_uint {
-    let mut out = (*in_0.offset((PARTITION_H - 1) as isize) as libc::c_int
-        - *in_0.offset(PARTITION_H as isize) as libc::c_int) as libc::c_uint;
-    out = out.wrapping_add(
-        (*in_0.offset((PARTITION_SPLIT - 1) as isize) as libc::c_int
-            - *in_0.offset(PARTITION_T_LEFT_SPLIT as isize) as libc::c_int) as libc::c_uint,
-    );
+unsafe fn gather_left_partition_prob(in_0: *const u16, bl: BlockLevel) -> u32 {
+    let mut out =
+        *in_0.offset((PARTITION_H - 1) as isize) as i32 - *in_0.offset(PARTITION_H as isize) as i32;
+    out += *in_0.offset((PARTITION_SPLIT - 1) as isize) as i32
+        - *in_0.offset(PARTITION_T_LEFT_SPLIT as isize) as i32;
     if bl != BL_128X128 {
-        out = out.wrapping_add(
-            (*in_0.offset((PARTITION_H4 - 1) as isize) as libc::c_int
-                - *in_0.offset(PARTITION_H4 as libc::c_int as isize) as libc::c_int)
-                as libc::c_uint,
-        );
+        out += *in_0.offset((PARTITION_H4 - 1) as isize) as i32
+            - *in_0.offset(PARTITION_H4 as libc::c_int as isize) as i32;
     }
-    return out;
+    return out as u32;
 }
 
 #[inline]
-unsafe fn gather_top_partition_prob(in_0: *const uint16_t, bl: BlockLevel) -> libc::c_uint {
-    let mut out = (*in_0.offset((PARTITION_V - 1) as isize) as libc::c_int
-        - *in_0.offset(PARTITION_T_TOP_SPLIT as isize) as libc::c_int)
-        as libc::c_uint;
-    out = out.wrapping_add(*in_0.offset((PARTITION_T_LEFT_SPLIT - 1) as isize) as libc::c_uint);
+unsafe fn gather_top_partition_prob(in_0: *const u16, bl: BlockLevel) -> u32 {
+    let mut out = *in_0.offset((PARTITION_V - 1) as isize) as i32
+        - *in_0.offset(PARTITION_T_TOP_SPLIT as isize) as i32;
+    out += *in_0.offset((PARTITION_T_LEFT_SPLIT - 1) as isize) as i32;
     if bl != BL_128X128 {
-        out = out.wrapping_add(
-            (*in_0.offset((PARTITION_V4 - 1) as isize) as libc::c_int
-                - *in_0.offset(PARTITION_T_RIGHT_SPLIT as isize) as libc::c_int)
-                as libc::c_uint,
-        );
+        out += *in_0.offset((PARTITION_V4 - 1) as isize) as i32
+            - *in_0.offset(PARTITION_T_RIGHT_SPLIT as isize) as i32;
     }
-    return out;
+    return out as u32;
 }
 
 #[inline]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1156,6 +1156,8 @@ fn get_partition_ctx(
 #[inline]
 fn gather_left_partition_prob(r#in: &[u16; 16], bl: BlockLevel) -> u32 {
     let mut out = r#in[(PARTITION_H - 1) as usize] as i32 - r#in[PARTITION_H as usize] as i32;
+    // Exploit the fact that cdfs for PARTITION_SPLIT, PARTITION_T_TOP_SPLIT,
+    // PARTITION_T_BOTTOM_SPLIT and PARTITION_T_LEFT_SPLIT are neighbors.
     out +=
         r#in[(PARTITION_SPLIT - 1) as usize] as i32 - r#in[PARTITION_T_LEFT_SPLIT as usize] as i32;
     if bl != BL_128X128 {
@@ -1166,8 +1168,14 @@ fn gather_left_partition_prob(r#in: &[u16; 16], bl: BlockLevel) -> u32 {
 
 #[inline]
 fn gather_top_partition_prob(r#in: &[u16; 16], bl: BlockLevel) -> u32 {
+    // Exploit the fact that cdfs for PARTITION_V, PARTITION_SPLIT and
+    // PARTITION_T_TOP_SPLIT are neighbors.
     let mut out =
         r#in[(PARTITION_V - 1) as usize] as i32 - r#in[PARTITION_T_TOP_SPLIT as usize] as i32;
+    // Exploit the facts that cdfs for PARTITION_T_LEFT_SPLIT and
+    // PARTITION_T_RIGHT_SPLIT are neighbors, the probability for
+    // PARTITION_V4 is always zero, and the probability for
+    // PARTITION_T_RIGHT_SPLIT is zero in 128x128 blocks.
     out += r#in[(PARTITION_T_LEFT_SPLIT - 1) as usize] as i32;
     if bl != BL_128X128 {
         out += r#in[(PARTITION_V4 - 1) as usize] as i32

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1154,26 +1154,26 @@ fn get_partition_ctx(
 }
 
 #[inline]
-unsafe fn gather_left_partition_prob(in_0: *const u16, bl: BlockLevel) -> u32 {
+unsafe fn gather_left_partition_prob(r#in: *const u16, bl: BlockLevel) -> u32 {
     let mut out =
-        *in_0.offset((PARTITION_H - 1) as isize) as i32 - *in_0.offset(PARTITION_H as isize) as i32;
-    out += *in_0.offset((PARTITION_SPLIT - 1) as isize) as i32
-        - *in_0.offset(PARTITION_T_LEFT_SPLIT as isize) as i32;
+        *r#in.offset((PARTITION_H - 1) as isize) as i32 - *r#in.offset(PARTITION_H as isize) as i32;
+    out += *r#in.offset((PARTITION_SPLIT - 1) as isize) as i32
+        - *r#in.offset(PARTITION_T_LEFT_SPLIT as isize) as i32;
     if bl != BL_128X128 {
-        out += *in_0.offset((PARTITION_H4 - 1) as isize) as i32
-            - *in_0.offset(PARTITION_H4 as libc::c_int as isize) as i32;
+        out += *r#in.offset((PARTITION_H4 - 1) as isize) as i32
+            - *r#in.offset(PARTITION_H4 as libc::c_int as isize) as i32;
     }
     return out as u32;
 }
 
 #[inline]
-unsafe fn gather_top_partition_prob(in_0: *const u16, bl: BlockLevel) -> u32 {
-    let mut out = *in_0.offset((PARTITION_V - 1) as isize) as i32
-        - *in_0.offset(PARTITION_T_TOP_SPLIT as isize) as i32;
-    out += *in_0.offset((PARTITION_T_LEFT_SPLIT - 1) as isize) as i32;
+unsafe fn gather_top_partition_prob(r#in: *const u16, bl: BlockLevel) -> u32 {
+    let mut out = *r#in.offset((PARTITION_V - 1) as isize) as i32
+        - *r#in.offset(PARTITION_T_TOP_SPLIT as isize) as i32;
+    out += *r#in.offset((PARTITION_T_LEFT_SPLIT - 1) as isize) as i32;
     if bl != BL_128X128 {
-        out += *in_0.offset((PARTITION_V4 - 1) as isize) as i32
-            - *in_0.offset(PARTITION_T_RIGHT_SPLIT as isize) as i32;
+        out += *r#in.offset((PARTITION_V4 - 1) as isize) as i32
+            - *r#in.offset(PARTITION_T_RIGHT_SPLIT as isize) as i32;
     }
     return out as u32;
 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1154,20 +1154,14 @@ fn get_partition_ctx(
 }
 
 #[inline]
-unsafe fn gather_left_partition_prob(
-    in_0: *const uint16_t,
-    bl: BlockLevel,
-) -> libc::c_uint {
-    let mut out: libc::c_uint = (*in_0.offset((PARTITION_H as libc::c_int - 1) as isize)
-        as libc::c_int
-        - *in_0.offset(PARTITION_H as libc::c_int as isize) as libc::c_int)
-        as libc::c_uint;
+unsafe fn gather_left_partition_prob(in_0: *const uint16_t, bl: BlockLevel) -> libc::c_uint {
+    let mut out = (*in_0.offset((PARTITION_H - 1) as isize) as libc::c_int
+        - *in_0.offset(PARTITION_H as isize) as libc::c_int) as libc::c_uint;
     out = out.wrapping_add(
-        (*in_0.offset((PARTITION_SPLIT as libc::c_int - 1) as isize) as libc::c_int
-            - *in_0.offset(PARTITION_T_LEFT_SPLIT as libc::c_int as isize) as libc::c_int)
-            as libc::c_uint,
+        (*in_0.offset((PARTITION_SPLIT - 1) as isize) as libc::c_int
+            - *in_0.offset(PARTITION_T_LEFT_SPLIT as isize) as libc::c_int) as libc::c_uint,
     );
-    if bl as libc::c_uint != BL_128X128 as libc::c_int as libc::c_uint {
+    if bl != BL_128X128 {
         out = out.wrapping_add(
             (*in_0.offset((PARTITION_H4 - 1) as isize) as libc::c_int
                 - *in_0.offset(PARTITION_H4 as libc::c_int as isize) as libc::c_int)
@@ -1178,21 +1172,15 @@ unsafe fn gather_left_partition_prob(
 }
 
 #[inline]
-unsafe fn gather_top_partition_prob(
-    in_0: *const uint16_t,
-    bl: BlockLevel,
-) -> libc::c_uint {
-    let mut out: libc::c_uint = (*in_0.offset((PARTITION_V as libc::c_int - 1) as isize)
-        as libc::c_int
-        - *in_0.offset(PARTITION_T_TOP_SPLIT as libc::c_int as isize) as libc::c_int)
+unsafe fn gather_top_partition_prob(in_0: *const uint16_t, bl: BlockLevel) -> libc::c_uint {
+    let mut out = (*in_0.offset((PARTITION_V - 1) as isize) as libc::c_int
+        - *in_0.offset(PARTITION_T_TOP_SPLIT as isize) as libc::c_int)
         as libc::c_uint;
-    out = out.wrapping_add(
-        *in_0.offset((PARTITION_T_LEFT_SPLIT as libc::c_int - 1) as isize) as libc::c_uint,
-    );
-    if bl as libc::c_uint != BL_128X128 as libc::c_int as libc::c_uint {
+    out = out.wrapping_add(*in_0.offset((PARTITION_T_LEFT_SPLIT - 1) as isize) as libc::c_uint);
+    if bl != BL_128X128 {
         out = out.wrapping_add(
             (*in_0.offset((PARTITION_V4 - 1) as isize) as libc::c_int
-                - *in_0.offset(PARTITION_T_RIGHT_SPLIT as libc::c_int as isize) as libc::c_int)
+                - *in_0.offset(PARTITION_T_RIGHT_SPLIT as isize) as libc::c_int)
                 as libc::c_uint,
         );
     }


### PR DESCRIPTION
fe804849ef1fd402c75e9032cb74fdd900572c3a is the only interesting commit here.  In the C, it was nullable, but since the guarding condition was pretty separate, making it an `Option` would be more unwieldy.  Instead, I just initialized to a zeroed array ref instead of null.  It doesn't matter what it's initialized to, as it'll never get rid.  Also, this `pc` var should just be `&` eventually, but `dav1d_msac_decode_symbol_adapt16` takes it as a `*mut` ptr (even though it doesn't actually mutate it), but I'll fix that when I clean up those functions.