### PR TITLE
`fn *_ctx`: Cleanup (minimally) and make safe

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -6489,7 +6489,7 @@ unsafe fn decode_b(
             && frame_hdr.switchable_comp_refs != 0
             && imin(bw4, bh4) > 1
         {
-            let ctx_2 = get_comp_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
+            let ctx_2 = get_comp_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
             is_comp = dav1d_msac_decode_bool_adapt(
                 &mut ts.msac,
                 (ts.cdf.m.comp[ctx_2 as usize]).as_mut_ptr(),
@@ -6579,19 +6579,19 @@ unsafe fn decode_b(
                 );
             }
         } else if is_comp != 0 {
-            let dir_ctx = get_comp_dir_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
+            let dir_ctx = get_comp_dir_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
             if dav1d_msac_decode_bool_adapt(
                 &mut ts.msac,
                 (ts.cdf.m.comp_dir[dir_ctx as usize]).as_mut_ptr(),
             ) != 0
             {
-                let ctx1 = av1_get_fwd_ref_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
+                let ctx1 = av1_get_fwd_ref_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
                 if dav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
                     (ts.cdf.m.comp_fwd_ref[0][ctx1 as usize]).as_mut_ptr(),
                 ) != 0
                 {
-                    let ctx2 = av1_get_fwd_ref_2_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
+                    let ctx2 = av1_get_fwd_ref_2_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] = (2 as libc::c_int as libc::c_uint)
                         .wrapping_add(dav1d_msac_decode_bool_adapt(
                             &mut ts.msac,
@@ -6599,14 +6599,13 @@ unsafe fn decode_b(
                         ))
                         as int8_t;
                 } else {
-                    let ctx2_0 =
-                        av1_get_fwd_ref_1_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
+                    let ctx2_0 = av1_get_fwd_ref_1_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] = dav1d_msac_decode_bool_adapt(
                         &mut ts.msac,
                         (ts.cdf.m.comp_fwd_ref[1][ctx2_0 as usize]).as_mut_ptr(),
                     ) as int8_t;
                 }
-                let ctx3 = av1_get_bwd_ref_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
+                let ctx3 = av1_get_bwd_ref_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
                 if dav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
                     (ts.cdf.m.comp_bwd_ref[0][ctx3 as usize]).as_mut_ptr(),
@@ -6614,7 +6613,7 @@ unsafe fn decode_b(
                 {
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] = 6 as libc::c_int as int8_t;
                 } else {
-                    let ctx4 = av1_get_bwd_ref_1_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
+                    let ctx4 = av1_get_bwd_ref_1_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] = (4 as libc::c_int as libc::c_uint)
                         .wrapping_add(dav1d_msac_decode_bool_adapt(
                             &mut ts.msac,
@@ -6623,7 +6622,7 @@ unsafe fn decode_b(
                         as int8_t;
                 }
             } else {
-                let uctx_p = av1_get_ref_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
+                let uctx_p = av1_get_ref_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
                 if dav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
                     (ts.cdf.m.comp_uni_ref[0][uctx_p as usize]).as_mut_ptr(),
@@ -6632,7 +6631,7 @@ unsafe fn decode_b(
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] = 4 as libc::c_int as int8_t;
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] = 6 as libc::c_int as int8_t;
                 } else {
-                    let uctx_p1 = av1_get_uni_p1_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
+                    let uctx_p1 = av1_get_uni_p1_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] = 0 as libc::c_int as int8_t;
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] = (1 as libc::c_int as libc::c_uint)
                         .wrapping_add(dav1d_msac_decode_bool_adapt(
@@ -6642,7 +6641,7 @@ unsafe fn decode_b(
                         as int8_t;
                     if b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] as libc::c_int == 2 {
                         let uctx_p2 =
-                            av1_get_fwd_ref_2_ctx(t.a, &mut t.l, by4, bx4, have_top, have_left);
+                            av1_get_fwd_ref_2_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
                         b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] =
                             (b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] as libc::c_uint)
                                 .wrapping_add(dav1d_msac_decode_bool_adapt(
@@ -6923,7 +6922,7 @@ unsafe fn decode_b(
             }
             let mut is_segwedge = 0;
             if (*f.seq_hdr).masked_compound != 0 {
-                let mask_ctx = get_mask_comp_ctx(t.a, &mut t.l, by4, bx4);
+                let mask_ctx = get_mask_comp_ctx(&*t.a, &t.l, by4, bx4);
                 is_segwedge = dav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
                     (ts.cdf.m.mask_comp[mask_ctx as usize]).as_mut_ptr(),
@@ -6951,8 +6950,8 @@ unsafe fn decode_b(
                             .p
                             .frame_hdr)
                             .frame_offset as libc::c_uint,
-                        t.a,
-                        &mut t.l,
+                        &*t.a,
+                        &t.l,
                         by4,
                         bx4,
                     );
@@ -7052,8 +7051,8 @@ unsafe fn decode_b(
                     .r#ref[0] = 0 as libc::c_int as int8_t;
             } else {
                 let ctx1_0 = av1_get_ref_ctx(
-                    t.a,
-                    &mut t.l,
+                    &*t.a,
+                    &t.l,
                     by4,
                     bx4,
                     have_top,
@@ -7066,8 +7065,8 @@ unsafe fn decode_b(
                 ) != 0
                 {
                     let ctx2_1 = av1_get_bwd_ref_ctx(
-                        t.a,
-                        &mut t.l,
+                        &*t.a,
+                        &t.l,
                         by4,
                         bx4,
                         have_top,
@@ -7086,8 +7085,8 @@ unsafe fn decode_b(
                             as usize] = 6 as libc::c_int as int8_t;
                     } else {
                         let ctx3_0 = av1_get_bwd_ref_1_ctx(
-                            t.a,
-                            &mut t.l,
+                            &*t.a,
+                            &t.l,
                             by4,
                             bx4,
                             have_top,
@@ -7111,8 +7110,8 @@ unsafe fn decode_b(
                     }
                 } else {
                     let ctx2_2 = av1_get_fwd_ref_ctx(
-                        t.a,
-                        &mut t.l,
+                        &*t.a,
+                        &t.l,
                         by4,
                         bx4,
                         have_top,
@@ -7125,8 +7124,8 @@ unsafe fn decode_b(
                     ) != 0
                     {
                         let ctx3_1 = av1_get_fwd_ref_2_ctx(
-                            t.a,
-                            &mut t.l,
+                            &*t.a,
+                            &t.l,
                             by4,
                             bx4,
                             have_top,
@@ -7149,8 +7148,8 @@ unsafe fn decode_b(
                             ) as int8_t;
                     } else {
                         let ctx3_2 = av1_get_fwd_ref_1_ctx(
-                            t.a,
-                            &mut t.l,
+                            &*t.a,
+                            &t.l,
                             by4,
                             bx4,
                             have_top,
@@ -7694,8 +7693,8 @@ unsafe fn decode_b(
                 let comp = (b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_int
                     != COMP_INTER_NONE as libc::c_int) as libc::c_int;
                 let ctx1_1 = get_filter_ctx(
-                    t.a,
-                    &mut t.l,
+                    &*t.a,
+                    &t.l,
                     comp,
                     0 as libc::c_int,
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_int,
@@ -7709,8 +7708,8 @@ unsafe fn decode_b(
                 ) as Dav1dFilterMode;
                 if (*f.seq_hdr).dual_filter != 0 {
                     let ctx2_3 = get_filter_ctx(
-                        t.a,
-                        &mut t.l,
+                        &*t.a,
+                        &t.l,
                         comp,
                         1 as libc::c_int,
                         b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_int,

--- a/src/env.rs
+++ b/src/env.rs
@@ -151,25 +151,25 @@ pub fn get_uv_inter_txtp(uvt_dim: &TxfmInfo, ytxtp: TxfmType) -> TxfmType {
 
 #[inline]
 pub unsafe fn get_filter_ctx(
-    a: *const BlockContext,
-    l: *const BlockContext,
+    a: &BlockContext,
+    l: &BlockContext,
     comp: libc::c_int,
     dir: libc::c_int,
     r#ref: libc::c_int,
     yb4: libc::c_int,
     xb4: libc::c_int,
 ) -> libc::c_int {
-    let a_filter = if (*a).r#ref[0][xb4 as usize] as libc::c_int == r#ref
-        || (*a).r#ref[1][xb4 as usize] as libc::c_int == r#ref
+    let a_filter = if a.r#ref[0][xb4 as usize] as libc::c_int == r#ref
+        || a.r#ref[1][xb4 as usize] as libc::c_int == r#ref
     {
-        (*a).filter[dir as usize][xb4 as usize] as libc::c_int
+        a.filter[dir as usize][xb4 as usize] as libc::c_int
     } else {
         DAV1D_N_SWITCHABLE_FILTERS as libc::c_int
     };
-    let l_filter = if (*l).r#ref[0][yb4 as usize] as libc::c_int == r#ref
-        || (*l).r#ref[1][yb4 as usize] as libc::c_int == r#ref
+    let l_filter = if l.r#ref[0][yb4 as usize] as libc::c_int == r#ref
+        || l.r#ref[1][yb4 as usize] as libc::c_int == r#ref
     {
-        (*l).filter[dir as usize][yb4 as usize] as libc::c_int
+        l.filter[dir as usize][yb4 as usize] as libc::c_int
     } else {
         DAV1D_N_SWITCHABLE_FILTERS as libc::c_int
     };
@@ -186,8 +186,8 @@ pub unsafe fn get_filter_ctx(
 
 #[inline]
 pub unsafe fn get_comp_ctx(
-    a: *const BlockContext,
-    l: *const BlockContext,
+    a: &BlockContext,
+    l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
     have_top: libc::c_int,
@@ -195,34 +195,34 @@ pub unsafe fn get_comp_ctx(
 ) -> libc::c_int {
     if have_top != 0 {
         if have_left != 0 {
-            if (*a).comp_type[xb4 as usize] != 0 {
-                if (*l).comp_type[yb4 as usize] != 0 {
+            if a.comp_type[xb4 as usize] != 0 {
+                if l.comp_type[yb4 as usize] != 0 {
                     return 4 as libc::c_int;
                 } else {
                     return 2 as libc::c_int
-                        + ((*l).r#ref[0][yb4 as usize] as libc::c_uint >= 4 as libc::c_uint)
+                        + (l.r#ref[0][yb4 as usize] as libc::c_uint >= 4 as libc::c_uint)
                             as libc::c_int;
                 }
-            } else if (*l).comp_type[yb4 as usize] != 0 {
+            } else if l.comp_type[yb4 as usize] != 0 {
                 return 2 as libc::c_int
-                    + ((*a).r#ref[0][xb4 as usize] as libc::c_uint >= 4 as libc::c_uint)
+                    + (a.r#ref[0][xb4 as usize] as libc::c_uint >= 4 as libc::c_uint)
                         as libc::c_int;
             } else {
-                return ((*l).r#ref[0][yb4 as usize] as libc::c_int >= 4) as libc::c_int
-                    ^ ((*a).r#ref[0][xb4 as usize] as libc::c_int >= 4) as libc::c_int;
+                return (l.r#ref[0][yb4 as usize] as libc::c_int >= 4) as libc::c_int
+                    ^ (a.r#ref[0][xb4 as usize] as libc::c_int >= 4) as libc::c_int;
             }
         } else {
-            return if (*a).comp_type[xb4 as usize] as libc::c_int != 0 {
+            return if a.comp_type[xb4 as usize] as libc::c_int != 0 {
                 3 as libc::c_int
             } else {
-                ((*a).r#ref[0][xb4 as usize] as libc::c_int >= 4) as libc::c_int
+                (a.r#ref[0][xb4 as usize] as libc::c_int >= 4) as libc::c_int
             };
         }
     } else if have_left != 0 {
-        return if (*l).comp_type[yb4 as usize] as libc::c_int != 0 {
+        return if l.comp_type[yb4 as usize] as libc::c_int != 0 {
             3 as libc::c_int
         } else {
-            ((*l).r#ref[0][yb4 as usize] as libc::c_int >= 4) as libc::c_int
+            (l.r#ref[0][yb4 as usize] as libc::c_int >= 4) as libc::c_int
         };
     } else {
         return 1 as libc::c_int;
@@ -231,16 +231,16 @@ pub unsafe fn get_comp_ctx(
 
 #[inline]
 pub unsafe fn get_comp_dir_ctx(
-    a: *const BlockContext,
-    l: *const BlockContext,
+    a: &BlockContext,
+    l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
     have_top: libc::c_int,
     have_left: libc::c_int,
 ) -> libc::c_int {
     if have_top != 0 && have_left != 0 {
-        let a_intra = (*a).intra[xb4 as usize] as libc::c_int;
-        let l_intra = (*l).intra[yb4 as usize] as libc::c_int;
+        let a_intra = a.intra[xb4 as usize] as libc::c_int;
+        let l_intra = l.intra[yb4 as usize] as libc::c_int;
         if a_intra != 0 && l_intra != 0 {
             return 2 as libc::c_int;
         }
@@ -255,12 +255,12 @@ pub unsafe fn get_comp_dir_ctx(
                     == (((*edge).r#ref[1][off as usize] as libc::c_int) < 4) as libc::c_int)
                     as libc::c_int;
         }
-        let a_comp = ((*a).comp_type[xb4 as usize] as libc::c_int != COMP_INTER_NONE as libc::c_int)
+        let a_comp = (a.comp_type[xb4 as usize] as libc::c_int != COMP_INTER_NONE as libc::c_int)
             as libc::c_int;
-        let l_comp = ((*l).comp_type[yb4 as usize] as libc::c_int != COMP_INTER_NONE as libc::c_int)
+        let l_comp = (l.comp_type[yb4 as usize] as libc::c_int != COMP_INTER_NONE as libc::c_int)
             as libc::c_int;
-        let a_ref0 = (*a).r#ref[0][xb4 as usize] as libc::c_int;
-        let l_ref0 = (*l).r#ref[0][yb4 as usize] as libc::c_int;
+        let a_ref0 = a.r#ref[0][xb4 as usize] as libc::c_int;
+        let l_ref0 = l.r#ref[0][yb4 as usize] as libc::c_int;
         if a_comp == 0 && l_comp == 0 {
             return 1 as libc::c_int
                 + 2 * ((a_ref0 >= 4) as libc::c_int == (l_ref0 >= 4) as libc::c_int)
@@ -276,11 +276,11 @@ pub unsafe fn get_comp_dir_ctx(
             return 3 as libc::c_int
                 + ((a_ref0 >= 4) as libc::c_int == (l_ref0 >= 4) as libc::c_int) as libc::c_int;
         } else {
-            let a_uni = ((((*a).r#ref[0][xb4 as usize] as libc::c_int) < 4) as libc::c_int
-                == (((*a).r#ref[1][xb4 as usize] as libc::c_int) < 4) as libc::c_int)
+            let a_uni = (((a.r#ref[0][xb4 as usize] as libc::c_int) < 4) as libc::c_int
+                == ((a.r#ref[1][xb4 as usize] as libc::c_int) < 4) as libc::c_int)
                 as libc::c_int;
-            let l_uni = ((((*l).r#ref[0][yb4 as usize] as libc::c_int) < 4) as libc::c_int
-                == (((*l).r#ref[1][yb4 as usize] as libc::c_int) < 4) as libc::c_int)
+            let l_uni = (((l.r#ref[0][yb4 as usize] as libc::c_int) < 4) as libc::c_int
+                == ((l.r#ref[1][yb4 as usize] as libc::c_int) < 4) as libc::c_int)
                 as libc::c_int;
             if a_uni == 0 && l_uni == 0 {
                 return 0 as libc::c_int;
@@ -329,8 +329,8 @@ pub unsafe fn get_jnt_comp_ctx(
     poc: libc::c_uint,
     ref0poc: libc::c_uint,
     ref1poc: libc::c_uint,
-    a: *const BlockContext,
-    l: *const BlockContext,
+    a: &BlockContext,
+    l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
 ) -> libc::c_int {
@@ -347,30 +347,30 @@ pub unsafe fn get_jnt_comp_ctx(
     )
     .abs() as libc::c_uint;
     let offset = (d0 == d1) as libc::c_int;
-    let a_ctx = ((*a).comp_type[xb4 as usize] as libc::c_int >= COMP_INTER_AVG as libc::c_int
-        || (*a).r#ref[0][xb4 as usize] as libc::c_int == 6) as libc::c_int;
-    let l_ctx = ((*l).comp_type[yb4 as usize] as libc::c_int >= COMP_INTER_AVG as libc::c_int
-        || (*l).r#ref[0][yb4 as usize] as libc::c_int == 6) as libc::c_int;
+    let a_ctx = (a.comp_type[xb4 as usize] as libc::c_int >= COMP_INTER_AVG as libc::c_int
+        || a.r#ref[0][xb4 as usize] as libc::c_int == 6) as libc::c_int;
+    let l_ctx = (l.comp_type[yb4 as usize] as libc::c_int >= COMP_INTER_AVG as libc::c_int
+        || l.r#ref[0][yb4 as usize] as libc::c_int == 6) as libc::c_int;
     return 3 * offset + a_ctx + l_ctx;
 }
 
 #[inline]
 pub unsafe fn get_mask_comp_ctx(
-    a: *const BlockContext,
-    l: *const BlockContext,
+    a: &BlockContext,
+    l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
 ) -> libc::c_int {
-    let a_ctx = if (*a).comp_type[xb4 as usize] as libc::c_int >= COMP_INTER_SEG as libc::c_int {
+    let a_ctx = if a.comp_type[xb4 as usize] as libc::c_int >= COMP_INTER_SEG as libc::c_int {
         1 as libc::c_int
-    } else if (*a).r#ref[0][xb4 as usize] as libc::c_int == 6 {
+    } else if a.r#ref[0][xb4 as usize] as libc::c_int == 6 {
         3 as libc::c_int
     } else {
         0 as libc::c_int
     };
-    let l_ctx = if (*l).comp_type[yb4 as usize] as libc::c_int >= COMP_INTER_SEG as libc::c_int {
+    let l_ctx = if l.comp_type[yb4 as usize] as libc::c_int >= COMP_INTER_SEG as libc::c_int {
         1 as libc::c_int
-    } else if (*l).r#ref[0][yb4 as usize] as libc::c_int == 6 {
+    } else if l.r#ref[0][yb4 as usize] as libc::c_int == 6 {
         3 as libc::c_int
     } else {
         0 as libc::c_int
@@ -380,24 +380,24 @@ pub unsafe fn get_mask_comp_ctx(
 
 #[inline]
 pub unsafe fn av1_get_ref_ctx(
-    a: *const BlockContext,
-    l: *const BlockContext,
+    a: &BlockContext,
+    l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
     mut have_top: libc::c_int,
     mut have_left: libc::c_int,
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 2] = [0 as libc::c_int, 0];
-    if have_top != 0 && (*a).intra[xb4 as usize] == 0 {
-        cnt[((*a).r#ref[0][xb4 as usize] as libc::c_int >= 4) as libc::c_int as usize] += 1;
-        if (*a).comp_type[xb4 as usize] != 0 {
-            cnt[((*a).r#ref[1][xb4 as usize] as libc::c_int >= 4) as libc::c_int as usize] += 1;
+    if have_top != 0 && a.intra[xb4 as usize] == 0 {
+        cnt[(a.r#ref[0][xb4 as usize] as libc::c_int >= 4) as libc::c_int as usize] += 1;
+        if a.comp_type[xb4 as usize] != 0 {
+            cnt[(a.r#ref[1][xb4 as usize] as libc::c_int >= 4) as libc::c_int as usize] += 1;
         }
     }
-    if have_left != 0 && (*l).intra[yb4 as usize] == 0 {
-        cnt[((*l).r#ref[0][yb4 as usize] as libc::c_int >= 4) as libc::c_int as usize] += 1;
-        if (*l).comp_type[yb4 as usize] != 0 {
-            cnt[((*l).r#ref[1][yb4 as usize] as libc::c_int >= 4) as libc::c_int as usize] += 1;
+    if have_left != 0 && l.intra[yb4 as usize] == 0 {
+        cnt[(l.r#ref[0][yb4 as usize] as libc::c_int >= 4) as libc::c_int as usize] += 1;
+        if l.comp_type[yb4 as usize] != 0 {
+            cnt[(l.r#ref[1][yb4 as usize] as libc::c_int >= 4) as libc::c_int as usize] += 1;
         }
     }
     return if cnt[0] == cnt[1] {
@@ -411,32 +411,32 @@ pub unsafe fn av1_get_ref_ctx(
 
 #[inline]
 pub unsafe fn av1_get_fwd_ref_ctx(
-    a: *const BlockContext,
-    l: *const BlockContext,
+    a: &BlockContext,
+    l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
     have_top: libc::c_int,
     have_left: libc::c_int,
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 4] = [0 as libc::c_int, 0, 0, 0];
-    if have_top != 0 && (*a).intra[xb4 as usize] == 0 {
-        if ((*a).r#ref[0][xb4 as usize] as libc::c_int) < 4 {
-            cnt[(*a).r#ref[0][xb4 as usize] as usize] += 1;
+    if have_top != 0 && a.intra[xb4 as usize] == 0 {
+        if (a.r#ref[0][xb4 as usize] as libc::c_int) < 4 {
+            cnt[a.r#ref[0][xb4 as usize] as usize] += 1;
         }
-        if (*a).comp_type[xb4 as usize] as libc::c_int != 0
-            && ((*a).r#ref[1][xb4 as usize] as libc::c_int) < 4
+        if a.comp_type[xb4 as usize] as libc::c_int != 0
+            && (a.r#ref[1][xb4 as usize] as libc::c_int) < 4
         {
-            cnt[(*a).r#ref[1][xb4 as usize] as usize] += 1;
+            cnt[a.r#ref[1][xb4 as usize] as usize] += 1;
         }
     }
-    if have_left != 0 && (*l).intra[yb4 as usize] == 0 {
-        if ((*l).r#ref[0][yb4 as usize] as libc::c_int) < 4 {
-            cnt[(*l).r#ref[0][yb4 as usize] as usize] += 1;
+    if have_left != 0 && l.intra[yb4 as usize] == 0 {
+        if (l.r#ref[0][yb4 as usize] as libc::c_int) < 4 {
+            cnt[l.r#ref[0][yb4 as usize] as usize] += 1;
         }
-        if (*l).comp_type[yb4 as usize] as libc::c_int != 0
-            && ((*l).r#ref[1][yb4 as usize] as libc::c_int) < 4
+        if l.comp_type[yb4 as usize] as libc::c_int != 0
+            && (l.r#ref[1][yb4 as usize] as libc::c_int) < 4
         {
-            cnt[(*l).r#ref[1][yb4 as usize] as usize] += 1;
+            cnt[l.r#ref[1][yb4 as usize] as usize] += 1;
         }
     }
     cnt[0] += cnt[1];
@@ -452,32 +452,32 @@ pub unsafe fn av1_get_fwd_ref_ctx(
 
 #[inline]
 pub unsafe fn av1_get_fwd_ref_1_ctx(
-    a: *const BlockContext,
-    l: *const BlockContext,
+    a: &BlockContext,
+    l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
     have_top: libc::c_int,
     have_left: libc::c_int,
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 2] = [0 as libc::c_int, 0];
-    if have_top != 0 && (*a).intra[xb4 as usize] == 0 {
-        if ((*a).r#ref[0][xb4 as usize] as libc::c_int) < 2 {
-            cnt[(*a).r#ref[0][xb4 as usize] as usize] += 1;
+    if have_top != 0 && a.intra[xb4 as usize] == 0 {
+        if (a.r#ref[0][xb4 as usize] as libc::c_int) < 2 {
+            cnt[a.r#ref[0][xb4 as usize] as usize] += 1;
         }
-        if (*a).comp_type[xb4 as usize] as libc::c_int != 0
-            && ((*a).r#ref[1][xb4 as usize] as libc::c_int) < 2
+        if a.comp_type[xb4 as usize] as libc::c_int != 0
+            && (a.r#ref[1][xb4 as usize] as libc::c_int) < 2
         {
-            cnt[(*a).r#ref[1][xb4 as usize] as usize] += 1;
+            cnt[a.r#ref[1][xb4 as usize] as usize] += 1;
         }
     }
-    if have_left != 0 && (*l).intra[yb4 as usize] == 0 {
-        if ((*l).r#ref[0][yb4 as usize] as libc::c_int) < 2 {
-            cnt[(*l).r#ref[0][yb4 as usize] as usize] += 1;
+    if have_left != 0 && l.intra[yb4 as usize] == 0 {
+        if (l.r#ref[0][yb4 as usize] as libc::c_int) < 2 {
+            cnt[l.r#ref[0][yb4 as usize] as usize] += 1;
         }
-        if (*l).comp_type[yb4 as usize] as libc::c_int != 0
-            && ((*l).r#ref[1][yb4 as usize] as libc::c_int) < 2
+        if l.comp_type[yb4 as usize] as libc::c_int != 0
+            && (l.r#ref[1][yb4 as usize] as libc::c_int) < 2
         {
-            cnt[(*l).r#ref[1][yb4 as usize] as usize] += 1;
+            cnt[l.r#ref[1][yb4 as usize] as usize] += 1;
         }
     }
     return if cnt[0] == cnt[1] {
@@ -491,32 +491,32 @@ pub unsafe fn av1_get_fwd_ref_1_ctx(
 
 #[inline]
 pub unsafe fn av1_get_fwd_ref_2_ctx(
-    a: *const BlockContext,
-    l: *const BlockContext,
+    a: &BlockContext,
+    l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
     have_top: libc::c_int,
     have_left: libc::c_int,
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 2] = [0 as libc::c_int, 0];
-    if have_top != 0 && (*a).intra[xb4 as usize] == 0 {
-        if ((*a).r#ref[0][xb4 as usize] as libc::c_uint ^ 2 as libc::c_uint) < 2 as libc::c_uint {
-            cnt[((*a).r#ref[0][xb4 as usize] as libc::c_int - 2) as usize] += 1;
+    if have_top != 0 && a.intra[xb4 as usize] == 0 {
+        if (a.r#ref[0][xb4 as usize] as libc::c_uint ^ 2 as libc::c_uint) < 2 as libc::c_uint {
+            cnt[(a.r#ref[0][xb4 as usize] as libc::c_int - 2) as usize] += 1;
         }
-        if (*a).comp_type[xb4 as usize] as libc::c_int != 0
-            && ((*a).r#ref[1][xb4 as usize] as libc::c_uint ^ 2 as libc::c_uint) < 2 as libc::c_uint
+        if a.comp_type[xb4 as usize] as libc::c_int != 0
+            && (a.r#ref[1][xb4 as usize] as libc::c_uint ^ 2 as libc::c_uint) < 2 as libc::c_uint
         {
-            cnt[((*a).r#ref[1][xb4 as usize] as libc::c_int - 2) as usize] += 1;
+            cnt[(a.r#ref[1][xb4 as usize] as libc::c_int - 2) as usize] += 1;
         }
     }
-    if have_left != 0 && (*l).intra[yb4 as usize] == 0 {
-        if ((*l).r#ref[0][yb4 as usize] as libc::c_uint ^ 2 as libc::c_uint) < 2 as libc::c_uint {
-            cnt[((*l).r#ref[0][yb4 as usize] as libc::c_int - 2) as usize] += 1;
+    if have_left != 0 && l.intra[yb4 as usize] == 0 {
+        if (l.r#ref[0][yb4 as usize] as libc::c_uint ^ 2 as libc::c_uint) < 2 as libc::c_uint {
+            cnt[(l.r#ref[0][yb4 as usize] as libc::c_int - 2) as usize] += 1;
         }
-        if (*l).comp_type[yb4 as usize] as libc::c_int != 0
-            && ((*l).r#ref[1][yb4 as usize] as libc::c_uint ^ 2 as libc::c_uint) < 2 as libc::c_uint
+        if l.comp_type[yb4 as usize] as libc::c_int != 0
+            && (l.r#ref[1][yb4 as usize] as libc::c_uint ^ 2 as libc::c_uint) < 2 as libc::c_uint
         {
-            cnt[((*l).r#ref[1][yb4 as usize] as libc::c_int - 2) as usize] += 1;
+            cnt[(l.r#ref[1][yb4 as usize] as libc::c_int - 2) as usize] += 1;
         }
     }
     return if cnt[0] == cnt[1] {
@@ -530,32 +530,32 @@ pub unsafe fn av1_get_fwd_ref_2_ctx(
 
 #[inline]
 pub unsafe fn av1_get_bwd_ref_ctx(
-    a: *const BlockContext,
-    l: *const BlockContext,
+    a: &BlockContext,
+    l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
     have_top: libc::c_int,
     have_left: libc::c_int,
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 3] = [0 as libc::c_int, 0, 0];
-    if have_top != 0 && (*a).intra[xb4 as usize] == 0 {
-        if (*a).r#ref[0][xb4 as usize] as libc::c_int >= 4 {
-            cnt[((*a).r#ref[0][xb4 as usize] as libc::c_int - 4) as usize] += 1;
+    if have_top != 0 && a.intra[xb4 as usize] == 0 {
+        if a.r#ref[0][xb4 as usize] as libc::c_int >= 4 {
+            cnt[(a.r#ref[0][xb4 as usize] as libc::c_int - 4) as usize] += 1;
         }
-        if (*a).comp_type[xb4 as usize] as libc::c_int != 0
-            && (*a).r#ref[1][xb4 as usize] as libc::c_int >= 4
+        if a.comp_type[xb4 as usize] as libc::c_int != 0
+            && a.r#ref[1][xb4 as usize] as libc::c_int >= 4
         {
-            cnt[((*a).r#ref[1][xb4 as usize] as libc::c_int - 4) as usize] += 1;
+            cnt[(a.r#ref[1][xb4 as usize] as libc::c_int - 4) as usize] += 1;
         }
     }
-    if have_left != 0 && (*l).intra[yb4 as usize] == 0 {
-        if (*l).r#ref[0][yb4 as usize] as libc::c_int >= 4 {
-            cnt[((*l).r#ref[0][yb4 as usize] as libc::c_int - 4) as usize] += 1;
+    if have_left != 0 && l.intra[yb4 as usize] == 0 {
+        if l.r#ref[0][yb4 as usize] as libc::c_int >= 4 {
+            cnt[(l.r#ref[0][yb4 as usize] as libc::c_int - 4) as usize] += 1;
         }
-        if (*l).comp_type[yb4 as usize] as libc::c_int != 0
-            && (*l).r#ref[1][yb4 as usize] as libc::c_int >= 4
+        if l.comp_type[yb4 as usize] as libc::c_int != 0
+            && l.r#ref[1][yb4 as usize] as libc::c_int >= 4
         {
-            cnt[((*l).r#ref[1][yb4 as usize] as libc::c_int - 4) as usize] += 1;
+            cnt[(l.r#ref[1][yb4 as usize] as libc::c_int - 4) as usize] += 1;
         }
     }
     cnt[1] += cnt[0];
@@ -570,32 +570,32 @@ pub unsafe fn av1_get_bwd_ref_ctx(
 
 #[inline]
 pub unsafe fn av1_get_bwd_ref_1_ctx(
-    a: *const BlockContext,
-    l: *const BlockContext,
+    a: &BlockContext,
+    l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
     have_top: libc::c_int,
     have_left: libc::c_int,
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 3] = [0 as libc::c_int, 0, 0];
-    if have_top != 0 && (*a).intra[xb4 as usize] == 0 {
-        if (*a).r#ref[0][xb4 as usize] as libc::c_int >= 4 {
-            cnt[((*a).r#ref[0][xb4 as usize] as libc::c_int - 4) as usize] += 1;
+    if have_top != 0 && a.intra[xb4 as usize] == 0 {
+        if a.r#ref[0][xb4 as usize] as libc::c_int >= 4 {
+            cnt[(a.r#ref[0][xb4 as usize] as libc::c_int - 4) as usize] += 1;
         }
-        if (*a).comp_type[xb4 as usize] as libc::c_int != 0
-            && (*a).r#ref[1][xb4 as usize] as libc::c_int >= 4
+        if a.comp_type[xb4 as usize] as libc::c_int != 0
+            && a.r#ref[1][xb4 as usize] as libc::c_int >= 4
         {
-            cnt[((*a).r#ref[1][xb4 as usize] as libc::c_int - 4) as usize] += 1;
+            cnt[(a.r#ref[1][xb4 as usize] as libc::c_int - 4) as usize] += 1;
         }
     }
-    if have_left != 0 && (*l).intra[yb4 as usize] == 0 {
-        if (*l).r#ref[0][yb4 as usize] as libc::c_int >= 4 {
-            cnt[((*l).r#ref[0][yb4 as usize] as libc::c_int - 4) as usize] += 1;
+    if have_left != 0 && l.intra[yb4 as usize] == 0 {
+        if l.r#ref[0][yb4 as usize] as libc::c_int >= 4 {
+            cnt[(l.r#ref[0][yb4 as usize] as libc::c_int - 4) as usize] += 1;
         }
-        if (*l).comp_type[yb4 as usize] as libc::c_int != 0
-            && (*l).r#ref[1][yb4 as usize] as libc::c_int >= 4
+        if l.comp_type[yb4 as usize] as libc::c_int != 0
+            && l.r#ref[1][yb4 as usize] as libc::c_int >= 4
         {
-            cnt[((*l).r#ref[1][yb4 as usize] as libc::c_int - 4) as usize] += 1;
+            cnt[(l.r#ref[1][yb4 as usize] as libc::c_int - 4) as usize] += 1;
         }
     }
     return if cnt[0] == cnt[1] {
@@ -609,38 +609,38 @@ pub unsafe fn av1_get_bwd_ref_1_ctx(
 
 #[inline]
 pub unsafe fn av1_get_uni_p1_ctx(
-    a: *const BlockContext,
-    l: *const BlockContext,
+    a: &BlockContext,
+    l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
     have_top: libc::c_int,
     have_left: libc::c_int,
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 3] = [0 as libc::c_int, 0, 0];
-    if have_top != 0 && (*a).intra[xb4 as usize] == 0 {
-        if ((*a).r#ref[0][xb4 as usize] as libc::c_uint).wrapping_sub(1 as libc::c_uint)
+    if have_top != 0 && a.intra[xb4 as usize] == 0 {
+        if (a.r#ref[0][xb4 as usize] as libc::c_uint).wrapping_sub(1 as libc::c_uint)
             < 3 as libc::c_uint
         {
-            cnt[((*a).r#ref[0][xb4 as usize] as libc::c_int - 1) as usize] += 1;
+            cnt[(a.r#ref[0][xb4 as usize] as libc::c_int - 1) as usize] += 1;
         }
-        if (*a).comp_type[xb4 as usize] as libc::c_int != 0
-            && ((*a).r#ref[1][xb4 as usize] as libc::c_uint).wrapping_sub(1 as libc::c_uint)
+        if a.comp_type[xb4 as usize] as libc::c_int != 0
+            && (a.r#ref[1][xb4 as usize] as libc::c_uint).wrapping_sub(1 as libc::c_uint)
                 < 3 as libc::c_uint
         {
-            cnt[((*a).r#ref[1][xb4 as usize] as libc::c_int - 1) as usize] += 1;
+            cnt[(a.r#ref[1][xb4 as usize] as libc::c_int - 1) as usize] += 1;
         }
     }
-    if have_left != 0 && (*l).intra[yb4 as usize] == 0 {
-        if ((*l).r#ref[0][yb4 as usize] as libc::c_uint).wrapping_sub(1 as libc::c_uint)
+    if have_left != 0 && l.intra[yb4 as usize] == 0 {
+        if (l.r#ref[0][yb4 as usize] as libc::c_uint).wrapping_sub(1 as libc::c_uint)
             < 3 as libc::c_uint
         {
-            cnt[((*l).r#ref[0][yb4 as usize] as libc::c_int - 1) as usize] += 1;
+            cnt[(l.r#ref[0][yb4 as usize] as libc::c_int - 1) as usize] += 1;
         }
-        if (*l).comp_type[yb4 as usize] as libc::c_int != 0
-            && ((*l).r#ref[1][yb4 as usize] as libc::c_uint).wrapping_sub(1 as libc::c_uint)
+        if l.comp_type[yb4 as usize] as libc::c_int != 0
+            && (l.r#ref[1][yb4 as usize] as libc::c_uint).wrapping_sub(1 as libc::c_uint)
                 < 3 as libc::c_uint
         {
-            cnt[((*l).r#ref[1][yb4 as usize] as libc::c_int - 1) as usize] += 1;
+            cnt[(l.r#ref[1][yb4 as usize] as libc::c_int - 1) as usize] += 1;
         }
     }
     cnt[1] += cnt[2];

--- a/src/env.rs
+++ b/src/env.rs
@@ -190,11 +190,11 @@ pub unsafe fn get_comp_ctx(
     l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
-    have_top: libc::c_int,
-    have_left: libc::c_int,
+    have_top: bool,
+    have_left: bool,
 ) -> libc::c_int {
-    if have_top != 0 {
-        if have_left != 0 {
+    if have_top {
+        if have_left {
             if a.comp_type[xb4 as usize] != 0 {
                 if l.comp_type[yb4 as usize] != 0 {
                     return 4 as libc::c_int;
@@ -218,7 +218,7 @@ pub unsafe fn get_comp_ctx(
                 (a.r#ref[0][xb4 as usize] as libc::c_int >= 4) as libc::c_int
             };
         }
-    } else if have_left != 0 {
+    } else if have_left {
         return if l.comp_type[yb4 as usize] as libc::c_int != 0 {
             3 as libc::c_int
         } else {
@@ -235,10 +235,10 @@ pub unsafe fn get_comp_dir_ctx(
     l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
-    have_top: libc::c_int,
-    have_left: libc::c_int,
+    have_top: bool,
+    have_left: bool,
 ) -> libc::c_int {
-    if have_top != 0 && have_left != 0 {
+    if have_top && have_left {
         let a_intra = a.intra[xb4 as usize] as libc::c_int;
         let l_intra = l.intra[yb4 as usize] as libc::c_int;
         if a_intra != 0 && l_intra != 0 {
@@ -291,9 +291,9 @@ pub unsafe fn get_comp_dir_ctx(
             return 3 as libc::c_int
                 + ((a_ref0 == 4) as libc::c_int == (l_ref0 == 4) as libc::c_int) as libc::c_int;
         }
-    } else if have_top != 0 || have_left != 0 {
-        let edge_1: *const BlockContext = if have_left != 0 { l } else { a };
-        let off_1 = if have_left != 0 { yb4 } else { xb4 };
+    } else if have_top || have_left {
+        let edge_1: *const BlockContext = if have_left { l } else { a };
+        let off_1 = if have_left { yb4 } else { xb4 };
         if (*edge_1).intra[off_1 as usize] != 0 {
             return 2 as libc::c_int;
         }
@@ -384,17 +384,17 @@ pub unsafe fn av1_get_ref_ctx(
     l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
-    mut have_top: libc::c_int,
-    mut have_left: libc::c_int,
+    mut have_top: bool,
+    mut have_left: bool,
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 2] = [0 as libc::c_int, 0];
-    if have_top != 0 && a.intra[xb4 as usize] == 0 {
+    if have_top && a.intra[xb4 as usize] == 0 {
         cnt[(a.r#ref[0][xb4 as usize] as libc::c_int >= 4) as libc::c_int as usize] += 1;
         if a.comp_type[xb4 as usize] != 0 {
             cnt[(a.r#ref[1][xb4 as usize] as libc::c_int >= 4) as libc::c_int as usize] += 1;
         }
     }
-    if have_left != 0 && l.intra[yb4 as usize] == 0 {
+    if have_left && l.intra[yb4 as usize] == 0 {
         cnt[(l.r#ref[0][yb4 as usize] as libc::c_int >= 4) as libc::c_int as usize] += 1;
         if l.comp_type[yb4 as usize] != 0 {
             cnt[(l.r#ref[1][yb4 as usize] as libc::c_int >= 4) as libc::c_int as usize] += 1;
@@ -415,11 +415,11 @@ pub unsafe fn av1_get_fwd_ref_ctx(
     l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
-    have_top: libc::c_int,
-    have_left: libc::c_int,
+    have_top: bool,
+    have_left: bool,
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 4] = [0 as libc::c_int, 0, 0, 0];
-    if have_top != 0 && a.intra[xb4 as usize] == 0 {
+    if have_top && a.intra[xb4 as usize] == 0 {
         if (a.r#ref[0][xb4 as usize] as libc::c_int) < 4 {
             cnt[a.r#ref[0][xb4 as usize] as usize] += 1;
         }
@@ -429,7 +429,7 @@ pub unsafe fn av1_get_fwd_ref_ctx(
             cnt[a.r#ref[1][xb4 as usize] as usize] += 1;
         }
     }
-    if have_left != 0 && l.intra[yb4 as usize] == 0 {
+    if have_left && l.intra[yb4 as usize] == 0 {
         if (l.r#ref[0][yb4 as usize] as libc::c_int) < 4 {
             cnt[l.r#ref[0][yb4 as usize] as usize] += 1;
         }
@@ -456,11 +456,11 @@ pub unsafe fn av1_get_fwd_ref_1_ctx(
     l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
-    have_top: libc::c_int,
-    have_left: libc::c_int,
+    have_top: bool,
+    have_left: bool,
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 2] = [0 as libc::c_int, 0];
-    if have_top != 0 && a.intra[xb4 as usize] == 0 {
+    if have_top && a.intra[xb4 as usize] == 0 {
         if (a.r#ref[0][xb4 as usize] as libc::c_int) < 2 {
             cnt[a.r#ref[0][xb4 as usize] as usize] += 1;
         }
@@ -470,7 +470,7 @@ pub unsafe fn av1_get_fwd_ref_1_ctx(
             cnt[a.r#ref[1][xb4 as usize] as usize] += 1;
         }
     }
-    if have_left != 0 && l.intra[yb4 as usize] == 0 {
+    if have_left && l.intra[yb4 as usize] == 0 {
         if (l.r#ref[0][yb4 as usize] as libc::c_int) < 2 {
             cnt[l.r#ref[0][yb4 as usize] as usize] += 1;
         }
@@ -495,11 +495,11 @@ pub unsafe fn av1_get_fwd_ref_2_ctx(
     l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
-    have_top: libc::c_int,
-    have_left: libc::c_int,
+    have_top: bool,
+    have_left: bool,
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 2] = [0 as libc::c_int, 0];
-    if have_top != 0 && a.intra[xb4 as usize] == 0 {
+    if have_top && a.intra[xb4 as usize] == 0 {
         if (a.r#ref[0][xb4 as usize] as libc::c_uint ^ 2 as libc::c_uint) < 2 as libc::c_uint {
             cnt[(a.r#ref[0][xb4 as usize] as libc::c_int - 2) as usize] += 1;
         }
@@ -509,7 +509,7 @@ pub unsafe fn av1_get_fwd_ref_2_ctx(
             cnt[(a.r#ref[1][xb4 as usize] as libc::c_int - 2) as usize] += 1;
         }
     }
-    if have_left != 0 && l.intra[yb4 as usize] == 0 {
+    if have_left && l.intra[yb4 as usize] == 0 {
         if (l.r#ref[0][yb4 as usize] as libc::c_uint ^ 2 as libc::c_uint) < 2 as libc::c_uint {
             cnt[(l.r#ref[0][yb4 as usize] as libc::c_int - 2) as usize] += 1;
         }
@@ -534,11 +534,11 @@ pub unsafe fn av1_get_bwd_ref_ctx(
     l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
-    have_top: libc::c_int,
-    have_left: libc::c_int,
+    have_top: bool,
+    have_left: bool,
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 3] = [0 as libc::c_int, 0, 0];
-    if have_top != 0 && a.intra[xb4 as usize] == 0 {
+    if have_top && a.intra[xb4 as usize] == 0 {
         if a.r#ref[0][xb4 as usize] as libc::c_int >= 4 {
             cnt[(a.r#ref[0][xb4 as usize] as libc::c_int - 4) as usize] += 1;
         }
@@ -548,7 +548,7 @@ pub unsafe fn av1_get_bwd_ref_ctx(
             cnt[(a.r#ref[1][xb4 as usize] as libc::c_int - 4) as usize] += 1;
         }
     }
-    if have_left != 0 && l.intra[yb4 as usize] == 0 {
+    if have_left && l.intra[yb4 as usize] == 0 {
         if l.r#ref[0][yb4 as usize] as libc::c_int >= 4 {
             cnt[(l.r#ref[0][yb4 as usize] as libc::c_int - 4) as usize] += 1;
         }
@@ -574,11 +574,11 @@ pub unsafe fn av1_get_bwd_ref_1_ctx(
     l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
-    have_top: libc::c_int,
-    have_left: libc::c_int,
+    have_top: bool,
+    have_left: bool,
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 3] = [0 as libc::c_int, 0, 0];
-    if have_top != 0 && a.intra[xb4 as usize] == 0 {
+    if have_top && a.intra[xb4 as usize] == 0 {
         if a.r#ref[0][xb4 as usize] as libc::c_int >= 4 {
             cnt[(a.r#ref[0][xb4 as usize] as libc::c_int - 4) as usize] += 1;
         }
@@ -588,7 +588,7 @@ pub unsafe fn av1_get_bwd_ref_1_ctx(
             cnt[(a.r#ref[1][xb4 as usize] as libc::c_int - 4) as usize] += 1;
         }
     }
-    if have_left != 0 && l.intra[yb4 as usize] == 0 {
+    if have_left && l.intra[yb4 as usize] == 0 {
         if l.r#ref[0][yb4 as usize] as libc::c_int >= 4 {
             cnt[(l.r#ref[0][yb4 as usize] as libc::c_int - 4) as usize] += 1;
         }
@@ -613,11 +613,11 @@ pub unsafe fn av1_get_uni_p1_ctx(
     l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
-    have_top: libc::c_int,
-    have_left: libc::c_int,
+    have_top: bool,
+    have_left: bool,
 ) -> libc::c_int {
     let mut cnt: [libc::c_int; 3] = [0 as libc::c_int, 0, 0];
-    if have_top != 0 && a.intra[xb4 as usize] == 0 {
+    if have_top && a.intra[xb4 as usize] == 0 {
         if (a.r#ref[0][xb4 as usize] as libc::c_uint).wrapping_sub(1 as libc::c_uint)
             < 3 as libc::c_uint
         {
@@ -630,7 +630,7 @@ pub unsafe fn av1_get_uni_p1_ctx(
             cnt[(a.r#ref[1][xb4 as usize] as libc::c_int - 1) as usize] += 1;
         }
     }
-    if have_left != 0 && l.intra[yb4 as usize] == 0 {
+    if have_left && l.intra[yb4 as usize] == 0 {
         if (l.r#ref[0][yb4 as usize] as libc::c_uint).wrapping_sub(1 as libc::c_uint)
             < 3 as libc::c_uint
         {
@@ -668,14 +668,14 @@ pub fn get_drl_context(ref_mv_stack: &[refmvs_candidate; 8], ref_idx: usize) -> 
 pub unsafe fn get_cur_frame_segid(
     by: libc::c_int,
     bx: libc::c_int,
-    have_top: libc::c_int,
-    have_left: libc::c_int,
+    have_top: bool,
+    have_left: bool,
     seg_ctx: *mut libc::c_int,
     mut cur_seg_map: *const uint8_t,
     stride: ptrdiff_t,
 ) -> libc::c_uint {
     cur_seg_map = cur_seg_map.offset(bx as isize + by as isize * stride);
-    if have_left != 0 && have_top != 0 {
+    if have_left && have_top {
         let l = *cur_seg_map.offset(-(1 as libc::c_int) as isize) as libc::c_int;
         let a = *cur_seg_map.offset(-stride as isize) as libc::c_int;
         let al = *cur_seg_map.offset(-(stride + 1) as isize) as libc::c_int;
@@ -689,9 +689,9 @@ pub unsafe fn get_cur_frame_segid(
         return (if a == al { a } else { l }) as libc::c_uint;
     } else {
         *seg_ctx = 0 as libc::c_int;
-        return (if have_left != 0 {
+        return (if have_left {
             *cur_seg_map.offset(-(1 as libc::c_int) as isize) as libc::c_int
-        } else if have_top != 0 {
+        } else if have_top {
             *cur_seg_map.offset(-stride as isize) as libc::c_int
         } else {
             0 as libc::c_int

--- a/src/env.rs
+++ b/src/env.rs
@@ -150,7 +150,7 @@ pub fn get_uv_inter_txtp(uvt_dim: &TxfmInfo, ytxtp: TxfmType) -> TxfmType {
 }
 
 #[inline]
-pub unsafe fn get_filter_ctx(
+pub fn get_filter_ctx(
     a: &BlockContext,
     l: &BlockContext,
     comp: libc::c_int,
@@ -185,7 +185,7 @@ pub unsafe fn get_filter_ctx(
 }
 
 #[inline]
-pub unsafe fn get_comp_ctx(
+pub fn get_comp_ctx(
     a: &BlockContext,
     l: &BlockContext,
     yb4: libc::c_int,
@@ -230,7 +230,7 @@ pub unsafe fn get_comp_ctx(
 }
 
 #[inline]
-pub unsafe fn get_comp_dir_ctx(
+pub fn get_comp_dir_ctx(
     a: &BlockContext,
     l: &BlockContext,
     yb4: libc::c_int,
@@ -324,7 +324,7 @@ pub fn get_poc_diff(
 }
 
 #[inline]
-pub unsafe fn get_jnt_comp_ctx(
+pub fn get_jnt_comp_ctx(
     order_hint_n_bits: libc::c_int,
     poc: libc::c_uint,
     ref0poc: libc::c_uint,
@@ -355,7 +355,7 @@ pub unsafe fn get_jnt_comp_ctx(
 }
 
 #[inline]
-pub unsafe fn get_mask_comp_ctx(
+pub fn get_mask_comp_ctx(
     a: &BlockContext,
     l: &BlockContext,
     yb4: libc::c_int,
@@ -379,7 +379,7 @@ pub unsafe fn get_mask_comp_ctx(
 }
 
 #[inline]
-pub unsafe fn av1_get_ref_ctx(
+pub fn av1_get_ref_ctx(
     a: &BlockContext,
     l: &BlockContext,
     yb4: libc::c_int,
@@ -410,7 +410,7 @@ pub unsafe fn av1_get_ref_ctx(
 }
 
 #[inline]
-pub unsafe fn av1_get_fwd_ref_ctx(
+pub fn av1_get_fwd_ref_ctx(
     a: &BlockContext,
     l: &BlockContext,
     yb4: libc::c_int,
@@ -451,7 +451,7 @@ pub unsafe fn av1_get_fwd_ref_ctx(
 }
 
 #[inline]
-pub unsafe fn av1_get_fwd_ref_1_ctx(
+pub fn av1_get_fwd_ref_1_ctx(
     a: &BlockContext,
     l: &BlockContext,
     yb4: libc::c_int,
@@ -490,7 +490,7 @@ pub unsafe fn av1_get_fwd_ref_1_ctx(
 }
 
 #[inline]
-pub unsafe fn av1_get_fwd_ref_2_ctx(
+pub fn av1_get_fwd_ref_2_ctx(
     a: &BlockContext,
     l: &BlockContext,
     yb4: libc::c_int,
@@ -529,7 +529,7 @@ pub unsafe fn av1_get_fwd_ref_2_ctx(
 }
 
 #[inline]
-pub unsafe fn av1_get_bwd_ref_ctx(
+pub fn av1_get_bwd_ref_ctx(
     a: &BlockContext,
     l: &BlockContext,
     yb4: libc::c_int,
@@ -569,7 +569,7 @@ pub unsafe fn av1_get_bwd_ref_ctx(
 }
 
 #[inline]
-pub unsafe fn av1_get_bwd_ref_1_ctx(
+pub fn av1_get_bwd_ref_1_ctx(
     a: &BlockContext,
     l: &BlockContext,
     yb4: libc::c_int,
@@ -608,7 +608,7 @@ pub unsafe fn av1_get_bwd_ref_1_ctx(
 }
 
 #[inline]
-pub unsafe fn av1_get_uni_p1_ctx(
+pub fn av1_get_uni_p1_ctx(
     a: &BlockContext,
     l: &BlockContext,
     yb4: libc::c_int,

--- a/src/env.rs
+++ b/src/env.rs
@@ -245,14 +245,14 @@ pub unsafe fn get_comp_dir_ctx(
             return 2 as libc::c_int;
         }
         if a_intra != 0 || l_intra != 0 {
-            let edge: *const BlockContext = if a_intra != 0 { l } else { a };
+            let edge = if a_intra != 0 { l } else { a };
             let off = if a_intra != 0 { yb4 } else { xb4 };
-            if (*edge).comp_type[off as usize] as libc::c_int == COMP_INTER_NONE as libc::c_int {
+            if edge.comp_type[off as usize] as libc::c_int == COMP_INTER_NONE as libc::c_int {
                 return 2 as libc::c_int;
             }
             return 1 as libc::c_int
-                + 2 * ((((*edge).r#ref[0][off as usize] as libc::c_int) < 4) as libc::c_int
-                    == (((*edge).r#ref[1][off as usize] as libc::c_int) < 4) as libc::c_int)
+                + 2 * (((edge.r#ref[0][off as usize] as libc::c_int) < 4) as libc::c_int
+                    == ((edge.r#ref[1][off as usize] as libc::c_int) < 4) as libc::c_int)
                     as libc::c_int;
         }
         let a_comp = (a.comp_type[xb4 as usize] as libc::c_int != COMP_INTER_NONE as libc::c_int)
@@ -266,10 +266,10 @@ pub unsafe fn get_comp_dir_ctx(
                 + 2 * ((a_ref0 >= 4) as libc::c_int == (l_ref0 >= 4) as libc::c_int)
                     as libc::c_int;
         } else if a_comp == 0 || l_comp == 0 {
-            let edge_0: *const BlockContext = if a_comp != 0 { a } else { l };
+            let edge_0 = if a_comp != 0 { a } else { l };
             let off_0 = if a_comp != 0 { xb4 } else { yb4 };
-            if !((((*edge_0).r#ref[0][off_0 as usize] as libc::c_int) < 4) as libc::c_int
-                == (((*edge_0).r#ref[1][off_0 as usize] as libc::c_int) < 4) as libc::c_int)
+            if !(((edge_0.r#ref[0][off_0 as usize] as libc::c_int) < 4) as libc::c_int
+                == ((edge_0.r#ref[1][off_0 as usize] as libc::c_int) < 4) as libc::c_int)
             {
                 return 1 as libc::c_int;
             }
@@ -292,17 +292,17 @@ pub unsafe fn get_comp_dir_ctx(
                 + ((a_ref0 == 4) as libc::c_int == (l_ref0 == 4) as libc::c_int) as libc::c_int;
         }
     } else if have_top || have_left {
-        let edge_1: *const BlockContext = if have_left { l } else { a };
+        let edge_1 = if have_left { l } else { a };
         let off_1 = if have_left { yb4 } else { xb4 };
-        if (*edge_1).intra[off_1 as usize] != 0 {
+        if edge_1.intra[off_1 as usize] != 0 {
             return 2 as libc::c_int;
         }
-        if (*edge_1).comp_type[off_1 as usize] as libc::c_int == COMP_INTER_NONE as libc::c_int {
+        if edge_1.comp_type[off_1 as usize] as libc::c_int == COMP_INTER_NONE as libc::c_int {
             return 2 as libc::c_int;
         }
         return 4 as libc::c_int
-            * ((((*edge_1).r#ref[0][off_1 as usize] as libc::c_int) < 4) as libc::c_int
-                == (((*edge_1).r#ref[1][off_1 as usize] as libc::c_int) < 4) as libc::c_int)
+            * (((edge_1.r#ref[0][off_1 as usize] as libc::c_int) < 4) as libc::c_int
+                == ((edge_1.r#ref[1][off_1 as usize] as libc::c_int) < 4) as libc::c_int)
                 as libc::c_int;
     } else {
         return 2 as libc::c_int;


### PR DESCRIPTION
This does just the simplest cleanups (that apply equally to args of all `fn`s) and makes all the `fn`s safe.  There are still lots of little things to clean up in these functions (e.x. redundant casts), but they're all safe now.