### PR TITLE
`fn get_cur_frame_segid`: Cleanup

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3194,16 +3194,8 @@ unsafe fn decode_b(
                     b.seg_id = 0;
                 }
             } else {
-                let mut seg_ctx = 0;
-                let pred_seg_id = get_cur_frame_segid(
-                    t.by,
-                    t.bx,
-                    have_top,
-                    have_left,
-                    &mut seg_ctx,
-                    f.cur_segmap,
-                    f.b4_stride,
-                );
+                let (pred_seg_id, seg_ctx) =
+                    get_cur_frame_segid(t.by, t.bx, have_top, have_left, f.cur_segmap, f.b4_stride);
                 let diff = dav1d_msac_decode_symbol_adapt8(
                     &mut ts.msac,
                     (ts.cdf.m.seg_id[seg_ctx as usize]).as_mut_ptr(),
@@ -3297,16 +3289,8 @@ unsafe fn decode_b(
                 b.seg_id = 0;
             }
         } else {
-            let mut seg_ctx = 0;
-            let pred_seg_id = get_cur_frame_segid(
-                t.by,
-                t.bx,
-                have_top,
-                have_left,
-                &mut seg_ctx,
-                f.cur_segmap,
-                f.b4_stride,
-            );
+            let (pred_seg_id, seg_ctx) =
+                get_cur_frame_segid(t.by, t.bx, have_top, have_left, f.cur_segmap, f.b4_stride);
 
             if b.skip != 0 {
                 b.seg_id = pred_seg_id as uint8_t;

--- a/src/env.rs
+++ b/src/env.rs
@@ -631,17 +631,17 @@ pub unsafe fn get_cur_frame_segid(
         } else {
             *seg_ctx = 0;
         }
-        return (if a == al { a } else { l }) as libc::c_uint;
+        (if a == al { a } else { l }) as libc::c_uint
     } else {
         *seg_ctx = 0;
-        return (if have_left {
+        (if have_left {
             *cur_seg_map.offset(-1)
         } else if have_top {
             *cur_seg_map.offset(-stride as isize)
         } else {
             0
-        }) as libc::c_uint;
-    };
+        }) as libc::c_uint
+    }
 }
 
 #[inline]

--- a/src/env.rs
+++ b/src/env.rs
@@ -615,32 +615,33 @@ pub unsafe fn get_cur_frame_segid(
     bx: libc::c_int,
     have_top: bool,
     have_left: bool,
-    seg_ctx: *mut libc::c_int,
     mut cur_seg_map: *const uint8_t,
     stride: ptrdiff_t,
-) -> libc::c_uint {
+) -> (libc::c_uint, libc::c_int) {
     cur_seg_map = cur_seg_map.offset(bx as isize + by as isize * stride);
     if have_left && have_top {
         let l = *cur_seg_map.offset(-1);
         let a = *cur_seg_map.offset(-stride as isize);
         let al = *cur_seg_map.offset(-(stride + 1) as isize);
-        if l == a && al == l {
-            *seg_ctx = 2;
+        let seg_ctx = if l == a && al == l {
+            2
         } else if l == a || al == l || a == al {
-            *seg_ctx = 1;
+            1
         } else {
-            *seg_ctx = 0;
-        }
-        (if a == al { a } else { l }) as libc::c_uint
+            0
+        };
+        let seg_id = if a == al { a } else { l } as libc::c_uint;
+        (seg_id, seg_ctx)
     } else {
-        *seg_ctx = 0;
-        (if have_left {
+        let seg_ctx = 0;
+        let seg_id = if have_left {
             *cur_seg_map.offset(-1)
         } else if have_top {
             *cur_seg_map.offset(-stride as isize)
         } else {
             0
-        }) as libc::c_uint
+        } as libc::c_uint;
+        (seg_id, seg_ctx)
     }
 }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -621,25 +621,25 @@ pub unsafe fn get_cur_frame_segid(
 ) -> libc::c_uint {
     cur_seg_map = cur_seg_map.offset(bx as isize + by as isize * stride);
     if have_left && have_top {
-        let l = *cur_seg_map.offset(-(1 as libc::c_int) as isize) as libc::c_int;
-        let a = *cur_seg_map.offset(-stride as isize) as libc::c_int;
-        let al = *cur_seg_map.offset(-(stride + 1) as isize) as libc::c_int;
+        let l = *cur_seg_map.offset(-1);
+        let a = *cur_seg_map.offset(-stride as isize);
+        let al = *cur_seg_map.offset(-(stride + 1) as isize);
         if l == a && al == l {
-            *seg_ctx = 2 as libc::c_int;
+            *seg_ctx = 2;
         } else if l == a || al == l || a == al {
-            *seg_ctx = 1 as libc::c_int;
+            *seg_ctx = 1;
         } else {
-            *seg_ctx = 0 as libc::c_int;
+            *seg_ctx = 0;
         }
         return (if a == al { a } else { l }) as libc::c_uint;
     } else {
-        *seg_ctx = 0 as libc::c_int;
+        *seg_ctx = 0;
         return (if have_left {
-            *cur_seg_map.offset(-(1 as libc::c_int) as isize) as libc::c_int
+            *cur_seg_map.offset(-1)
         } else if have_top {
-            *cur_seg_map.offset(-stride as isize) as libc::c_int
+            *cur_seg_map.offset(-stride as isize)
         } else {
-            0 as libc::c_int
+            0
         }) as libc::c_uint;
     };
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -617,7 +617,7 @@ pub unsafe fn get_cur_frame_segid(
     have_left: bool,
     mut cur_seg_map: *const uint8_t,
     stride: ptrdiff_t,
-) -> (libc::c_uint, libc::c_int) {
+) -> (u8, u8) {
     cur_seg_map = cur_seg_map.offset(bx as isize + by as isize * stride);
     if have_left && have_top {
         let l = *cur_seg_map.offset(-1);
@@ -630,7 +630,7 @@ pub unsafe fn get_cur_frame_segid(
         } else {
             0
         };
-        let seg_id = if a == al { a } else { l } as libc::c_uint;
+        let seg_id = if a == al { a } else { l };
         (seg_id, seg_ctx)
     } else {
         let seg_ctx = 0;
@@ -640,7 +640,7 @@ pub unsafe fn get_cur_frame_segid(
             *cur_seg_map.offset(-stride as isize)
         } else {
             0
-        } as libc::c_uint;
+        };
         (seg_id, seg_ctx)
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -615,7 +615,12 @@ pub unsafe fn get_cur_frame_segid(
     bx: libc::c_int,
     have_top: bool,
     have_left: bool,
-    mut cur_seg_map: *const uint8_t,
+    // It's very difficult to make this safe (a slice),
+    // as it is negatively indexed
+    // and it comes from [`Dav1dFrameContext::cur_segmap`],
+    // which is set to [`Dav1dFrameContext::cur_segmap_ref`] and [`Dav1dFrameContext::prev_segmap_ref`],
+    // which are [`Dav1dRef`]s, which have no size and are refcounted.
+    mut cur_seg_map: *const u8,
     stride: ptrdiff_t,
 ) -> (u8, u8) {
     cur_seg_map = cur_seg_map.offset(bx as isize + by as isize * stride);


### PR DESCRIPTION
See d21d91d6532e012fc3e8c5a6d68aa39cc1bcc184 for why it's going to be difficult to make this safe for a while until we clean up a lot more things and understand the dataflow better.