### PR TITLE
`fn get_prev_frame_segid`: Cleanup and make mostly safe

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2605,14 +2605,14 @@ unsafe fn get_prev_frame_segid(
     h4: libc::c_int,
     mut ref_seg_map: *const uint8_t,
     stride: ptrdiff_t,
-) -> libc::c_uint {
+) -> u8 {
     assert!((*(*f).frame_hdr).primary_ref_frame != 7);
 
     let mut prev_seg_id = 8;
     ref_seg_map = ref_seg_map.offset((by as isize * stride + bx as isize) as isize);
     for _ in 0..h4 {
         for &seg_id in std::slice::from_raw_parts(ref_seg_map, w4 as usize) {
-            prev_seg_id = std::cmp::min(prev_seg_id, seg_id as libc::c_uint);
+            prev_seg_id = std::cmp::min(prev_seg_id, seg_id);
         }
         ref_seg_map = ref_seg_map.offset(stride as isize);
         if prev_seg_id == 0 {
@@ -3160,7 +3160,7 @@ unsafe fn decode_b(
                     return -1;
                 }
 
-                b.seg_id = seg_id as uint8_t;
+                b.seg_id = seg_id;
             } else {
                 b.seg_id = 0;
             }
@@ -3183,7 +3183,7 @@ unsafe fn decode_b(
                         return -1;
                     }
 
-                    b.seg_id = seg_id as uint8_t;
+                    b.seg_id = seg_id;
                 } else {
                     b.seg_id = 0;
                 }
@@ -3278,7 +3278,7 @@ unsafe fn decode_b(
                     return -1;
                 }
 
-                b.seg_id = seg_id as uint8_t;
+                b.seg_id = seg_id;
             } else {
                 b.seg_id = 0;
             }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2607,6 +2607,7 @@ unsafe fn get_prev_frame_segid(
     stride: ptrdiff_t,
 ) -> libc::c_uint {
     assert!((*(*f).frame_hdr).primary_ref_frame != 7);
+
     let mut seg_id = 8;
     ref_seg_map = ref_seg_map.offset((by as isize * stride + bx as isize) as isize);
     loop {
@@ -2625,6 +2626,7 @@ unsafe fn get_prev_frame_segid(
         }
     }
     assert!(seg_id < 8);
+
     return seg_id;
 }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2608,23 +2608,23 @@ unsafe fn get_prev_frame_segid(
 ) -> libc::c_uint {
     assert!((*(*f).frame_hdr).primary_ref_frame != 7);
 
-    let mut seg_id = 8;
+    let mut prev_seg_id = 8;
     ref_seg_map = ref_seg_map.offset((by as isize * stride + bx as isize) as isize);
     for _ in 0..h4 {
-        for x in 0..w4 {
-            seg_id = imin(
+        for &seg_id in std::slice::from_raw_parts(ref_seg_map, w4 as usize) {
+            prev_seg_id = imin(
+                prev_seg_id as libc::c_int,
                 seg_id as libc::c_int,
-                *ref_seg_map.offset(x as isize) as libc::c_int,
             ) as libc::c_uint;
         }
         ref_seg_map = ref_seg_map.offset(stride as isize);
-        if seg_id == 0 {
+        if prev_seg_id == 0 {
             break;
         }
     }
-    assert!(seg_id < 8);
+    assert!(prev_seg_id < 8);
 
-    return seg_id;
+    return prev_seg_id;
 }
 
 #[inline]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2612,10 +2612,7 @@ unsafe fn get_prev_frame_segid(
     ref_seg_map = ref_seg_map.offset((by as isize * stride + bx as isize) as isize);
     for _ in 0..h4 {
         for &seg_id in std::slice::from_raw_parts(ref_seg_map, w4 as usize) {
-            prev_seg_id = imin(
-                prev_seg_id as libc::c_int,
-                seg_id as libc::c_int,
-            ) as libc::c_uint;
+            prev_seg_id = std::cmp::min(prev_seg_id, seg_id as libc::c_uint);
         }
         ref_seg_map = ref_seg_map.offset(stride as isize);
         if prev_seg_id == 0 {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2595,8 +2595,9 @@ unsafe extern "C" fn read_vartx_tree(
     (*b).c2rust_unnamed.c2rust_unnamed_0.tx_split0 = tx_split[0] as uint8_t;
     (*b).c2rust_unnamed.c2rust_unnamed_0.tx_split1 = tx_split[1];
 }
+
 #[inline]
-unsafe extern "C" fn get_prev_frame_segid(
+unsafe fn get_prev_frame_segid(
     f: *const Dav1dFrameContext,
     by: libc::c_int,
     bx: libc::c_int,
@@ -2630,6 +2631,7 @@ unsafe extern "C" fn get_prev_frame_segid(
     }
     return seg_id;
 }
+
 #[inline]
 unsafe extern "C" fn splat_oneref_mv(
     c: *const Dav1dContext,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2606,10 +2606,10 @@ unsafe fn get_prev_frame_segid(
     mut ref_seg_map: *const uint8_t,
     stride: ptrdiff_t,
 ) -> libc::c_uint {
-    if !((*(*f).frame_hdr).primary_ref_frame != 7 as libc::c_int) {
+    if !((*(*f).frame_hdr).primary_ref_frame != 7) {
         unreachable!();
     }
-    let mut seg_id: libc::c_uint = 8 as libc::c_int as libc::c_uint;
+    let mut seg_id = 8;
     ref_seg_map = ref_seg_map.offset((by as isize * stride + bx as isize) as isize);
     loop {
         let mut x = 0;
@@ -2626,7 +2626,7 @@ unsafe fn get_prev_frame_segid(
             break;
         }
     }
-    if !(seg_id < 8 as libc::c_uint) {
+    if !(seg_id < 8) {
         unreachable!();
     }
     return seg_id;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2611,9 +2611,10 @@ unsafe fn get_prev_frame_segid(
     let mut prev_seg_id = 8;
     ref_seg_map = ref_seg_map.offset((by as isize * stride + bx as isize) as isize);
     for _ in 0..h4 {
-        for &seg_id in std::slice::from_raw_parts(ref_seg_map, w4 as usize) {
-            prev_seg_id = std::cmp::min(prev_seg_id, seg_id);
-        }
+        prev_seg_id = std::slice::from_raw_parts(ref_seg_map, w4 as usize)
+            .iter()
+            .copied()
+            .fold(prev_seg_id, std::cmp::min);
         ref_seg_map = ref_seg_map.offset(stride as isize);
         if prev_seg_id == 0 {
             break;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2598,7 +2598,7 @@ unsafe extern "C" fn read_vartx_tree(
 
 #[inline]
 unsafe fn get_prev_frame_segid(
-    f: *const Dav1dFrameContext,
+    f: &Dav1dFrameContext,
     by: libc::c_int,
     bx: libc::c_int,
     w4: libc::c_int,
@@ -2606,7 +2606,7 @@ unsafe fn get_prev_frame_segid(
     mut ref_seg_map: *const uint8_t,
     stride: ptrdiff_t,
 ) -> u8 {
-    assert!((*(*f).frame_hdr).primary_ref_frame != 7);
+    assert!((*f.frame_hdr).primary_ref_frame != 7);
 
     let mut prev_seg_id = 8;
     ref_seg_map = ref_seg_map.offset((by as isize * stride + bx as isize) as isize);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2606,9 +2606,7 @@ unsafe fn get_prev_frame_segid(
     mut ref_seg_map: *const uint8_t,
     stride: ptrdiff_t,
 ) -> libc::c_uint {
-    if !((*(*f).frame_hdr).primary_ref_frame != 7) {
-        unreachable!();
-    }
+    assert!((*(*f).frame_hdr).primary_ref_frame != 7);
     let mut seg_id = 8;
     ref_seg_map = ref_seg_map.offset((by as isize * stride + bx as isize) as isize);
     loop {
@@ -2626,9 +2624,7 @@ unsafe fn get_prev_frame_segid(
             break;
         }
     }
-    if !(seg_id < 8) {
-        unreachable!();
-    }
+    assert!(seg_id < 8);
     return seg_id;
 }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2611,13 +2611,11 @@ unsafe fn get_prev_frame_segid(
     let mut seg_id = 8;
     ref_seg_map = ref_seg_map.offset((by as isize * stride + bx as isize) as isize);
     loop {
-        let mut x = 0;
-        while x < w4 {
+        for x in 0..w4 {
             seg_id = imin(
                 seg_id as libc::c_int,
                 *ref_seg_map.offset(x as isize) as libc::c_int,
             ) as libc::c_uint;
-            x += 1;
         }
         ref_seg_map = ref_seg_map.offset(stride as isize);
         h4 -= 1;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2602,7 +2602,7 @@ unsafe fn get_prev_frame_segid(
     by: libc::c_int,
     bx: libc::c_int,
     w4: libc::c_int,
-    mut h4: libc::c_int,
+    h4: libc::c_int,
     mut ref_seg_map: *const uint8_t,
     stride: ptrdiff_t,
 ) -> libc::c_uint {
@@ -2610,7 +2610,7 @@ unsafe fn get_prev_frame_segid(
 
     let mut seg_id = 8;
     ref_seg_map = ref_seg_map.offset((by as isize * stride + bx as isize) as isize);
-    loop {
+    for _ in 0..h4 {
         for x in 0..w4 {
             seg_id = imin(
                 seg_id as libc::c_int,
@@ -2618,8 +2618,7 @@ unsafe fn get_prev_frame_segid(
             ) as libc::c_uint;
         }
         ref_seg_map = ref_seg_map.offset(stride as isize);
-        h4 -= 1;
-        if !(h4 > 0 && seg_id != 0) {
+        if seg_id == 0 {
             break;
         }
     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2613,19 +2613,19 @@ unsafe fn get_prev_frame_segid(
     let w4 = usize::try_from(w4).unwrap();
     let h4 = usize::try_from(h4).unwrap();
     let stride = usize::try_from(stride).unwrap();
-
+    
     let mut prev_seg_id = 8;
     let mut ref_seg_map = std::slice::from_raw_parts(
         ref_seg_map.offset(by as isize * stride as isize + bx as isize),
         h4 * stride,
     );
 
-    for _ in 0..h4 {
+    assert!(w4 <= stride);
+    for ref_seg_map in ref_seg_map.chunks_exact(stride) {
         prev_seg_id = ref_seg_map[..w4]
             .iter()
             .copied()
             .fold(prev_seg_id, std::cmp::min);
-        ref_seg_map = &ref_seg_map[stride..];
         if prev_seg_id == 0 {
             break;
         }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2632,7 +2632,7 @@ unsafe fn get_prev_frame_segid(
     }
     assert!(prev_seg_id < 8);
 
-    return prev_seg_id;
+    prev_seg_id
 }
 
 #[inline]


### PR DESCRIPTION
This cleans up most of the function body in terms of safety, but just like #201 where `cur_seg_map` was difficult to make a safe slice, here `ref_seg_map` is similarly difficult to make a safe slice for the same reason.  That said, from the function body, we can tell how long `ref_seg_map` is assumed to be at maximum, and then immediately convert it to a slice (unsafely with `std::slice::from_raw_parts`), so at least the rest of the function is safe.