### PR TITLE
`fn order_palette`: Cleanup and make mostly safe

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2044,7 +2044,7 @@ unsafe fn order_palette(
     i: libc::c_int,
     first: libc::c_int,
     last: libc::c_int,
-    order: *mut [uint8_t; 8],
+    order: &mut [[u8; 8]; 64],
     ctx: &mut [u8; 64],
 ) {
     let mut have_top = i > first;
@@ -2063,7 +2063,7 @@ unsafe fn order_palette(
             assert!((v as libc::c_uint) < 8);
             let fresh21 = o_idx;
             o_idx = o_idx + 1;
-            (*order.offset(n as isize))[fresh21 as usize] = v as uint8_t;
+            order[n as usize][fresh21 as usize] = v as uint8_t;
             mask |= (1 << v) as libc::c_uint;
         } else if !have_top {
             ctx[n as usize] = 0;
@@ -2071,7 +2071,7 @@ unsafe fn order_palette(
             assert!((v_0 as libc::c_uint) < 8);
             let fresh22 = o_idx;
             o_idx = o_idx + 1;
-            (*order.offset(n as isize))[fresh22 as usize] = v_0 as uint8_t;
+            order[n as usize][fresh22 as usize] = v_0 as uint8_t;
             mask |= (1 << v_0) as libc::c_uint;
         } else {
             let l = *pal_idx.offset(-1) as libc::c_int;
@@ -2087,7 +2087,7 @@ unsafe fn order_palette(
                 assert!((v_1 as libc::c_uint) < 8);
                 let fresh23 = o_idx;
                 o_idx = o_idx + 1;
-                (*order.offset(n as isize))[fresh23 as usize] = v_1 as uint8_t;
+                order[n as usize][fresh23 as usize] = v_1 as uint8_t;
                 mask |= (1 << v_1) as libc::c_uint;
             } else if same_t_l != 0 {
                 ctx[n as usize] = 3;
@@ -2095,13 +2095,13 @@ unsafe fn order_palette(
                 assert!((v_2 as libc::c_uint) < 8);
                 let fresh24 = o_idx;
                 o_idx = o_idx + 1;
-                (*order.offset(n as isize))[fresh24 as usize] = v_2 as uint8_t;
+                order[n as usize][fresh24 as usize] = v_2 as uint8_t;
                 mask |= (1 << v_2) as libc::c_uint;
                 let v_3 = tl;
                 assert!((v_3 as libc::c_uint) < 8);
                 let fresh25 = o_idx;
                 o_idx = o_idx + 1;
-                (*order.offset(n as isize))[fresh25 as usize] = v_3 as uint8_t;
+                order[n as usize][fresh25 as usize] = v_3 as uint8_t;
                 mask |= (1 << v_3) as libc::c_uint;
             } else if same_t_tl | same_l_tl != 0 {
                 ctx[n as usize] = 2;
@@ -2109,13 +2109,13 @@ unsafe fn order_palette(
                 assert!((v_4 as libc::c_uint) < 8);
                 let fresh26 = o_idx;
                 o_idx = o_idx + 1;
-                (*order.offset(n as isize))[fresh26 as usize] = v_4 as uint8_t;
+                order[n as usize][fresh26 as usize] = v_4 as uint8_t;
                 mask |= (1 << v_4) as libc::c_uint;
                 let v_5 = if same_t_tl != 0 { l } else { t };
                 assert!((v_5 as libc::c_uint) < 8);
                 let fresh27 = o_idx;
                 o_idx = o_idx + 1;
-                (*order.offset(n as isize))[fresh27 as usize] = v_5 as uint8_t;
+                order[n as usize][fresh27 as usize] = v_5 as uint8_t;
                 mask |= (1 << v_5) as libc::c_uint;
             } else {
                 ctx[n as usize] = 1;
@@ -2123,19 +2123,19 @@ unsafe fn order_palette(
                 assert!((v_6 as libc::c_uint) < 8);
                 let fresh28 = o_idx;
                 o_idx = o_idx + 1;
-                (*order.offset(n as isize))[fresh28 as usize] = v_6 as uint8_t;
+                order[n as usize][fresh28 as usize] = v_6 as uint8_t;
                 mask |= (1 << v_6) as libc::c_uint;
                 let v_7 = imax(t, l);
                 assert!((v_7 as libc::c_uint) < 8);
                 let fresh29 = o_idx;
                 o_idx = o_idx + 1;
-                (*order.offset(n as isize))[fresh29 as usize] = v_7 as uint8_t;
+                order[n as usize][fresh29 as usize] = v_7 as uint8_t;
                 mask |= (1 << v_7) as libc::c_uint;
                 let v_8 = tl;
                 assert!((v_8 as libc::c_uint) < 8);
                 let fresh30 = o_idx;
                 o_idx = o_idx + 1;
-                (*order.offset(n as isize))[fresh30 as usize] = v_8 as uint8_t;
+                order[n as usize][fresh30 as usize] = v_8 as uint8_t;
                 mask |= (1 << v_8) as libc::c_uint;
             }
         }
@@ -2145,7 +2145,7 @@ unsafe fn order_palette(
             if mask & m == 0 {
                 let fresh31 = o_idx;
                 o_idx = o_idx + 1;
-                (*order.offset(n as isize))[fresh31 as usize] = bit as uint8_t;
+                order[n as usize][fresh31 as usize] = bit as uint8_t;
             }
             m <<= 1;
             bit = bit.wrapping_add(1);
@@ -2180,13 +2180,12 @@ unsafe extern "C" fn read_pal_indices(
     let color_map_cdf: *mut [uint16_t; 8] = ((*ts).cdf.m.color_map[pl as usize]
         [((*b).c2rust_unnamed.c2rust_unnamed.pal_sz[pl as usize] as libc::c_int - 2) as usize])
         .as_mut_ptr();
-    let order: *mut [uint8_t; 8] = ((*t)
+    let order = &mut (*t)
         .scratch
         .c2rust_unnamed_0
         .c2rust_unnamed
         .c2rust_unnamed
-        .pal_order)
-        .as_mut_ptr();
+        .pal_order;
     let ctx = &mut (*t)
         .scratch
         .c2rust_unnamed_0
@@ -2208,7 +2207,7 @@ unsafe extern "C" fn read_pal_indices(
                     as size_t,
             ) as libc::c_int;
             *pal_idx.offset(((i - j) as isize * stride + j as isize) as isize) =
-                (*order.offset(m as isize))[color_idx as usize];
+                order[m as usize][color_idx as usize];
             j -= 1;
             m += 1;
         }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2062,7 +2062,7 @@ unsafe fn order_palette(
         let mut o_idx = 0;
         let mut add = |v: u8| {
             assert!(v < 8);
-            order[o_idx as usize] = v;
+            order[o_idx] = v;
             o_idx += 1;
             mask |= 1 << v;
         };
@@ -2103,7 +2103,7 @@ unsafe fn order_palette(
         let mut bit = 0;
         while m < 0x100 {
             if mask & m == 0 {
-                order[o_idx as usize] = bit;
+                order[o_idx] = bit;
                 o_idx += 1;
             }
             m <<= 1;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2107,7 +2107,7 @@ unsafe fn order_palette(
                 o_idx += 1;
             }
             m <<= 1;
-            bit = bit.wrapping_add(1);
+            bit += 1;
         }
         assert!(o_idx == 8);
         have_top = true;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2047,17 +2047,17 @@ unsafe fn order_palette(
     order: *mut [uint8_t; 8],
     ctx: *mut uint8_t,
 ) {
-    let mut have_top = (i > first) as libc::c_int;
+    let mut have_top = i > first;
     assert!(!pal_idx.is_null());
     pal_idx = pal_idx.offset(first as isize + (i - first) as isize * stride);
     let mut j = first;
     let mut n = 0;
     while j >= last {
-        let have_left = (j > 0) as libc::c_int;
-        assert!(have_left != 0 || have_top != 0);
+        let have_left = j > 0;
+        assert!(have_left || have_top);
         let mut mask = 0 as libc::c_uint;
         let mut o_idx = 0;
-        if have_left == 0 {
+        if !have_left {
             *ctx.offset(n as isize) = 0;
             let v = *pal_idx.offset(-stride) as libc::c_int;
             assert!((v as libc::c_uint) < 8);
@@ -2065,7 +2065,7 @@ unsafe fn order_palette(
             o_idx = o_idx + 1;
             (*order.offset(n as isize))[fresh21 as usize] = v as uint8_t;
             mask |= (1 << v) as libc::c_uint;
-        } else if have_top == 0 {
+        } else if !have_top {
             *ctx.offset(n as isize) = 0;
             let v_0 = *pal_idx.offset(-1) as libc::c_int;
             assert!((v_0 as libc::c_uint) < 8);
@@ -2151,7 +2151,7 @@ unsafe fn order_palette(
             bit = bit.wrapping_add(1);
         }
         assert!(o_idx == 8);
-        have_top = 1;
+        have_top = true;
         j -= 1;
         n += 1;
         pal_idx = pal_idx.offset(stride - 1);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2057,24 +2057,22 @@ unsafe fn order_palette(
     {
         let have_left = j > 0;
         assert!(have_left || have_top);
+
         let mut mask = 0 as libc::c_uint;
         let mut o_idx = 0;
+        let mut add = |v: libc::c_int| {
+            assert!((v as libc::c_uint) < 8);
+            order[o_idx as usize] = v as u8;
+            o_idx += 1;
+            mask |= (1 << v) as libc::c_uint;
+        };
+
         if !have_left {
             *ctx = 0;
-            let v = *pal_idx.offset(-stride) as libc::c_int;
-            assert!((v as libc::c_uint) < 8);
-            let fresh21 = o_idx;
-            o_idx = o_idx + 1;
-            order[fresh21 as usize] = v as uint8_t;
-            mask |= (1 << v) as libc::c_uint;
+            add(*pal_idx.offset(-stride) as libc::c_int);
         } else if !have_top {
             *ctx = 0;
-            let v_0 = *pal_idx.offset(-1) as libc::c_int;
-            assert!((v_0 as libc::c_uint) < 8);
-            let fresh22 = o_idx;
-            o_idx = o_idx + 1;
-            order[fresh22 as usize] = v_0 as uint8_t;
-            mask |= (1 << v_0) as libc::c_uint;
+            add(*pal_idx.offset(-1) as libc::c_int);
         } else {
             let l = *pal_idx.offset(-1) as libc::c_int;
             let t = *pal_idx.offset(-stride) as libc::c_int;
@@ -2085,69 +2083,28 @@ unsafe fn order_palette(
             let same_all = same_t_l & same_t_tl & same_l_tl;
             if same_all != 0 {
                 *ctx = 4;
-                let v_1 = t;
-                assert!((v_1 as libc::c_uint) < 8);
-                let fresh23 = o_idx;
-                o_idx = o_idx + 1;
-                order[fresh23 as usize] = v_1 as uint8_t;
-                mask |= (1 << v_1) as libc::c_uint;
+                add(t);
             } else if same_t_l != 0 {
                 *ctx = 3;
-                let v_2 = t;
-                assert!((v_2 as libc::c_uint) < 8);
-                let fresh24 = o_idx;
-                o_idx = o_idx + 1;
-                order[fresh24 as usize] = v_2 as uint8_t;
-                mask |= (1 << v_2) as libc::c_uint;
-                let v_3 = tl;
-                assert!((v_3 as libc::c_uint) < 8);
-                let fresh25 = o_idx;
-                o_idx = o_idx + 1;
-                order[fresh25 as usize] = v_3 as uint8_t;
-                mask |= (1 << v_3) as libc::c_uint;
+                add(t);
+                add(tl);
             } else if same_t_tl | same_l_tl != 0 {
                 *ctx = 2;
-                let v_4 = tl;
-                assert!((v_4 as libc::c_uint) < 8);
-                let fresh26 = o_idx;
-                o_idx = o_idx + 1;
-                order[fresh26 as usize] = v_4 as uint8_t;
-                mask |= (1 << v_4) as libc::c_uint;
-                let v_5 = if same_t_tl != 0 { l } else { t };
-                assert!((v_5 as libc::c_uint) < 8);
-                let fresh27 = o_idx;
-                o_idx = o_idx + 1;
-                order[fresh27 as usize] = v_5 as uint8_t;
-                mask |= (1 << v_5) as libc::c_uint;
+                add(tl);
+                add(if same_t_tl != 0 { l } else { t });
             } else {
                 *ctx = 1;
-                let v_6 = imin(t, l);
-                assert!((v_6 as libc::c_uint) < 8);
-                let fresh28 = o_idx;
-                o_idx = o_idx + 1;
-                order[fresh28 as usize] = v_6 as uint8_t;
-                mask |= (1 << v_6) as libc::c_uint;
-                let v_7 = imax(t, l);
-                assert!((v_7 as libc::c_uint) < 8);
-                let fresh29 = o_idx;
-                o_idx = o_idx + 1;
-                order[fresh29 as usize] = v_7 as uint8_t;
-                mask |= (1 << v_7) as libc::c_uint;
-                let v_8 = tl;
-                assert!((v_8 as libc::c_uint) < 8);
-                let fresh30 = o_idx;
-                o_idx = o_idx + 1;
-                order[fresh30 as usize] = v_8 as uint8_t;
-                mask |= (1 << v_8) as libc::c_uint;
+                add(imin(t, l));
+                add(imax(t, l));
+                add(tl);
             }
         }
         let mut m = 1 as libc::c_uint;
         let mut bit = 0 as libc::c_uint;
         while m < 0x100 {
             if mask & m == 0 {
-                let fresh31 = o_idx;
-                o_idx = o_idx + 1;
-                order[fresh31 as usize] = bit as uint8_t;
+                order[o_idx as usize] = bit as uint8_t;
+                o_idx += 1;
             }
             m <<= 1;
             bit = bit.wrapping_add(1);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2050,26 +2050,30 @@ unsafe fn order_palette(
     let mut have_top = i > first;
     assert!(!pal_idx.is_null());
     pal_idx = pal_idx.offset(first as isize + (i - first) as isize * stride);
-    for (n, j) in (last..=first).rev().enumerate() {
+    for ((ctx, order), j) in ctx
+        .iter_mut()
+        .zip(order.iter_mut())
+        .zip((last..=first).rev())
+    {
         let have_left = j > 0;
         assert!(have_left || have_top);
         let mut mask = 0 as libc::c_uint;
         let mut o_idx = 0;
         if !have_left {
-            ctx[n] = 0;
+            *ctx = 0;
             let v = *pal_idx.offset(-stride) as libc::c_int;
             assert!((v as libc::c_uint) < 8);
             let fresh21 = o_idx;
             o_idx = o_idx + 1;
-            order[n][fresh21 as usize] = v as uint8_t;
+            order[fresh21 as usize] = v as uint8_t;
             mask |= (1 << v) as libc::c_uint;
         } else if !have_top {
-            ctx[n] = 0;
+            *ctx = 0;
             let v_0 = *pal_idx.offset(-1) as libc::c_int;
             assert!((v_0 as libc::c_uint) < 8);
             let fresh22 = o_idx;
             o_idx = o_idx + 1;
-            order[n][fresh22 as usize] = v_0 as uint8_t;
+            order[fresh22 as usize] = v_0 as uint8_t;
             mask |= (1 << v_0) as libc::c_uint;
         } else {
             let l = *pal_idx.offset(-1) as libc::c_int;
@@ -2080,60 +2084,60 @@ unsafe fn order_palette(
             let same_l_tl = (l == tl) as libc::c_int;
             let same_all = same_t_l & same_t_tl & same_l_tl;
             if same_all != 0 {
-                ctx[n] = 4;
+                *ctx = 4;
                 let v_1 = t;
                 assert!((v_1 as libc::c_uint) < 8);
                 let fresh23 = o_idx;
                 o_idx = o_idx + 1;
-                order[n][fresh23 as usize] = v_1 as uint8_t;
+                order[fresh23 as usize] = v_1 as uint8_t;
                 mask |= (1 << v_1) as libc::c_uint;
             } else if same_t_l != 0 {
-                ctx[n] = 3;
+                *ctx = 3;
                 let v_2 = t;
                 assert!((v_2 as libc::c_uint) < 8);
                 let fresh24 = o_idx;
                 o_idx = o_idx + 1;
-                order[n][fresh24 as usize] = v_2 as uint8_t;
+                order[fresh24 as usize] = v_2 as uint8_t;
                 mask |= (1 << v_2) as libc::c_uint;
                 let v_3 = tl;
                 assert!((v_3 as libc::c_uint) < 8);
                 let fresh25 = o_idx;
                 o_idx = o_idx + 1;
-                order[n][fresh25 as usize] = v_3 as uint8_t;
+                order[fresh25 as usize] = v_3 as uint8_t;
                 mask |= (1 << v_3) as libc::c_uint;
             } else if same_t_tl | same_l_tl != 0 {
-                ctx[n] = 2;
+                *ctx = 2;
                 let v_4 = tl;
                 assert!((v_4 as libc::c_uint) < 8);
                 let fresh26 = o_idx;
                 o_idx = o_idx + 1;
-                order[n][fresh26 as usize] = v_4 as uint8_t;
+                order[fresh26 as usize] = v_4 as uint8_t;
                 mask |= (1 << v_4) as libc::c_uint;
                 let v_5 = if same_t_tl != 0 { l } else { t };
                 assert!((v_5 as libc::c_uint) < 8);
                 let fresh27 = o_idx;
                 o_idx = o_idx + 1;
-                order[n][fresh27 as usize] = v_5 as uint8_t;
+                order[fresh27 as usize] = v_5 as uint8_t;
                 mask |= (1 << v_5) as libc::c_uint;
             } else {
-                ctx[n] = 1;
+                *ctx = 1;
                 let v_6 = imin(t, l);
                 assert!((v_6 as libc::c_uint) < 8);
                 let fresh28 = o_idx;
                 o_idx = o_idx + 1;
-                order[n][fresh28 as usize] = v_6 as uint8_t;
+                order[fresh28 as usize] = v_6 as uint8_t;
                 mask |= (1 << v_6) as libc::c_uint;
                 let v_7 = imax(t, l);
                 assert!((v_7 as libc::c_uint) < 8);
                 let fresh29 = o_idx;
                 o_idx = o_idx + 1;
-                order[n][fresh29 as usize] = v_7 as uint8_t;
+                order[fresh29 as usize] = v_7 as uint8_t;
                 mask |= (1 << v_7) as libc::c_uint;
                 let v_8 = tl;
                 assert!((v_8 as libc::c_uint) < 8);
                 let fresh30 = o_idx;
                 o_idx = o_idx + 1;
-                order[n][fresh30 as usize] = v_8 as uint8_t;
+                order[fresh30 as usize] = v_8 as uint8_t;
                 mask |= (1 << v_8) as libc::c_uint;
             }
         }
@@ -2143,7 +2147,7 @@ unsafe fn order_palette(
             if mask & m == 0 {
                 let fresh31 = o_idx;
                 o_idx = o_idx + 1;
-                order[n][fresh31 as usize] = bit as uint8_t;
+                order[fresh31 as usize] = bit as uint8_t;
             }
             m <<= 1;
             bit = bit.wrapping_add(1);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2058,25 +2058,25 @@ unsafe fn order_palette(
         let have_left = j > 0;
         assert!(have_left || have_top);
 
-        let mut mask = 0 as libc::c_uint;
+        let mut mask = 0u32;
         let mut o_idx = 0;
-        let mut add = |v: libc::c_int| {
-            assert!((v as libc::c_uint) < 8);
-            order[o_idx as usize] = v as u8;
+        let mut add = |v: u8| {
+            assert!(v < 8);
+            order[o_idx as usize] = v;
             o_idx += 1;
-            mask |= (1 << v) as libc::c_uint;
+            mask |= 1 << v;
         };
 
         if !have_left {
             *ctx = 0;
-            add(*pal_idx.offset(-stride) as libc::c_int);
+            add(*pal_idx.offset(-stride));
         } else if !have_top {
             *ctx = 0;
-            add(*pal_idx.offset(-1) as libc::c_int);
+            add(*pal_idx.offset(-1));
         } else {
-            let l = *pal_idx.offset(-1) as libc::c_int;
-            let t = *pal_idx.offset(-stride) as libc::c_int;
-            let tl = *pal_idx.offset(-(stride + 1)) as libc::c_int;
+            let l = *pal_idx.offset(-1);
+            let t = *pal_idx.offset(-stride);
+            let tl = *pal_idx.offset(-(stride + 1));
             let same_t_l = t == l;
             let same_t_tl = t == tl;
             let same_l_tl = l == tl;
@@ -2094,16 +2094,16 @@ unsafe fn order_palette(
                 add(if same_t_tl { l } else { t });
             } else {
                 *ctx = 1;
-                add(imin(t, l));
-                add(imax(t, l));
+                add(std::cmp::min(t, l));
+                add(std::cmp::max(t, l));
                 add(tl);
             }
         }
-        let mut m = 1 as libc::c_uint;
-        let mut bit = 0 as libc::c_uint;
+        let mut m = 1;
+        let mut bit = 0;
         while m < 0x100 {
             if mask & m == 0 {
-                order[o_idx as usize] = bit as uint8_t;
+                order[o_idx as usize] = bit;
                 o_idx += 1;
             }
             m <<= 1;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2048,6 +2048,7 @@ unsafe fn order_palette(
     ctx: &mut [u8; 64],
 ) {
     let mut have_top = i > first;
+
     assert!(!pal_idx.is_null());
     pal_idx = pal_idx.offset(first as isize + (i - first) as isize * stride);
     for ((ctx, order), j) in ctx
@@ -2056,6 +2057,7 @@ unsafe fn order_palette(
         .zip((last..=first).rev())
     {
         let have_left = j > 0;
+
         assert!(have_left || have_top);
 
         let mut mask = 0u8;
@@ -2081,6 +2083,7 @@ unsafe fn order_palette(
             let same_t_tl = t == tl;
             let same_l_tl = l == tl;
             let same_all = same_t_l & same_t_tl & same_l_tl;
+
             if same_all {
                 *ctx = 4;
                 add(t);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2058,7 +2058,7 @@ unsafe fn order_palette(
         let have_left = j > 0;
         assert!(have_left || have_top);
 
-        let mut mask = 0u32;
+        let mut mask = 0u8;
         let mut o_idx = 0;
         let mut add = |v: u8| {
             assert!(v < 8);
@@ -2099,15 +2099,11 @@ unsafe fn order_palette(
                 add(tl);
             }
         }
-        let mut m = 1;
-        let mut bit = 0;
-        while m < 0x100 {
-            if mask & m == 0 {
+        for bit in 0..u8::BITS as u8 {
+            if mask & (1 << bit) == 0 {
                 order[o_idx] = bit;
                 o_idx += 1;
             }
-            m <<= 1;
-            bit += 1;
         }
         assert!(o_idx == 8);
         have_top = true;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2050,28 +2050,26 @@ unsafe fn order_palette(
     let mut have_top = i > first;
     assert!(!pal_idx.is_null());
     pal_idx = pal_idx.offset(first as isize + (i - first) as isize * stride);
-    let mut j = first;
-    let mut n = 0;
-    while j >= last {
+    for (n, j) in (last..=first).rev().enumerate() {
         let have_left = j > 0;
         assert!(have_left || have_top);
         let mut mask = 0 as libc::c_uint;
         let mut o_idx = 0;
         if !have_left {
-            ctx[n as usize] = 0;
+            ctx[n] = 0;
             let v = *pal_idx.offset(-stride) as libc::c_int;
             assert!((v as libc::c_uint) < 8);
             let fresh21 = o_idx;
             o_idx = o_idx + 1;
-            order[n as usize][fresh21 as usize] = v as uint8_t;
+            order[n][fresh21 as usize] = v as uint8_t;
             mask |= (1 << v) as libc::c_uint;
         } else if !have_top {
-            ctx[n as usize] = 0;
+            ctx[n] = 0;
             let v_0 = *pal_idx.offset(-1) as libc::c_int;
             assert!((v_0 as libc::c_uint) < 8);
             let fresh22 = o_idx;
             o_idx = o_idx + 1;
-            order[n as usize][fresh22 as usize] = v_0 as uint8_t;
+            order[n][fresh22 as usize] = v_0 as uint8_t;
             mask |= (1 << v_0) as libc::c_uint;
         } else {
             let l = *pal_idx.offset(-1) as libc::c_int;
@@ -2082,60 +2080,60 @@ unsafe fn order_palette(
             let same_l_tl = (l == tl) as libc::c_int;
             let same_all = same_t_l & same_t_tl & same_l_tl;
             if same_all != 0 {
-                ctx[n as usize] = 4;
+                ctx[n] = 4;
                 let v_1 = t;
                 assert!((v_1 as libc::c_uint) < 8);
                 let fresh23 = o_idx;
                 o_idx = o_idx + 1;
-                order[n as usize][fresh23 as usize] = v_1 as uint8_t;
+                order[n][fresh23 as usize] = v_1 as uint8_t;
                 mask |= (1 << v_1) as libc::c_uint;
             } else if same_t_l != 0 {
-                ctx[n as usize] = 3;
+                ctx[n] = 3;
                 let v_2 = t;
                 assert!((v_2 as libc::c_uint) < 8);
                 let fresh24 = o_idx;
                 o_idx = o_idx + 1;
-                order[n as usize][fresh24 as usize] = v_2 as uint8_t;
+                order[n][fresh24 as usize] = v_2 as uint8_t;
                 mask |= (1 << v_2) as libc::c_uint;
                 let v_3 = tl;
                 assert!((v_3 as libc::c_uint) < 8);
                 let fresh25 = o_idx;
                 o_idx = o_idx + 1;
-                order[n as usize][fresh25 as usize] = v_3 as uint8_t;
+                order[n][fresh25 as usize] = v_3 as uint8_t;
                 mask |= (1 << v_3) as libc::c_uint;
             } else if same_t_tl | same_l_tl != 0 {
-                ctx[n as usize] = 2;
+                ctx[n] = 2;
                 let v_4 = tl;
                 assert!((v_4 as libc::c_uint) < 8);
                 let fresh26 = o_idx;
                 o_idx = o_idx + 1;
-                order[n as usize][fresh26 as usize] = v_4 as uint8_t;
+                order[n][fresh26 as usize] = v_4 as uint8_t;
                 mask |= (1 << v_4) as libc::c_uint;
                 let v_5 = if same_t_tl != 0 { l } else { t };
                 assert!((v_5 as libc::c_uint) < 8);
                 let fresh27 = o_idx;
                 o_idx = o_idx + 1;
-                order[n as usize][fresh27 as usize] = v_5 as uint8_t;
+                order[n][fresh27 as usize] = v_5 as uint8_t;
                 mask |= (1 << v_5) as libc::c_uint;
             } else {
-                ctx[n as usize] = 1;
+                ctx[n] = 1;
                 let v_6 = imin(t, l);
                 assert!((v_6 as libc::c_uint) < 8);
                 let fresh28 = o_idx;
                 o_idx = o_idx + 1;
-                order[n as usize][fresh28 as usize] = v_6 as uint8_t;
+                order[n][fresh28 as usize] = v_6 as uint8_t;
                 mask |= (1 << v_6) as libc::c_uint;
                 let v_7 = imax(t, l);
                 assert!((v_7 as libc::c_uint) < 8);
                 let fresh29 = o_idx;
                 o_idx = o_idx + 1;
-                order[n as usize][fresh29 as usize] = v_7 as uint8_t;
+                order[n][fresh29 as usize] = v_7 as uint8_t;
                 mask |= (1 << v_7) as libc::c_uint;
                 let v_8 = tl;
                 assert!((v_8 as libc::c_uint) < 8);
                 let fresh30 = o_idx;
                 o_idx = o_idx + 1;
-                order[n as usize][fresh30 as usize] = v_8 as uint8_t;
+                order[n][fresh30 as usize] = v_8 as uint8_t;
                 mask |= (1 << v_8) as libc::c_uint;
             }
         }
@@ -2145,15 +2143,13 @@ unsafe fn order_palette(
             if mask & m == 0 {
                 let fresh31 = o_idx;
                 o_idx = o_idx + 1;
-                order[n as usize][fresh31 as usize] = bit as uint8_t;
+                order[n][fresh31 as usize] = bit as uint8_t;
             }
             m <<= 1;
             bit = bit.wrapping_add(1);
         }
         assert!(o_idx == 8);
         have_top = true;
-        j -= 1;
-        n += 1;
         pal_idx = pal_idx.offset(stride - 1);
     }
 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2037,7 +2037,8 @@ unsafe extern "C" fn read_pal_uv(
         printf(b"]\n\0" as *const u8 as *const libc::c_char);
     }
 }
-unsafe extern "C" fn order_palette(
+
+unsafe fn order_palette(
     mut pal_idx: *const uint8_t,
     stride: ptrdiff_t,
     i: libc::c_int,
@@ -2182,6 +2183,7 @@ unsafe extern "C" fn order_palette(
         pal_idx = pal_idx.offset((stride - 1) as isize);
     }
 }
+
 unsafe extern "C" fn read_pal_indices(
     t: *mut Dav1dTaskContext,
     pal_idx: *mut uint8_t,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2044,7 +2044,7 @@ unsafe fn order_palette(
     i: libc::c_int,
     first: libc::c_int,
     last: libc::c_int,
-    order: &mut [[u8; 8]; 64],
+    order: &mut [[u8; u8::BITS as usize]; 64],
     ctx: &mut [u8; 64],
 ) {
     let mut have_top = i > first;
@@ -2061,7 +2061,7 @@ unsafe fn order_palette(
         let mut mask = 0u8;
         let mut o_idx = 0;
         let mut add = |v: u8| {
-            assert!(v < 8);
+            assert!(v < u8::BITS as u8);
             order[o_idx] = v;
             o_idx += 1;
             mask |= 1 << v;
@@ -2105,7 +2105,7 @@ unsafe fn order_palette(
                 o_idx += 1;
             }
         }
-        assert!(o_idx == 8);
+        assert!(o_idx == u8::BITS as usize);
         have_top = true;
         pal_idx = pal_idx.offset(stride - 1);
     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2049,99 +2049,99 @@ unsafe fn order_palette(
 ) {
     let mut have_top = (i > first) as libc::c_int;
     assert!(!pal_idx.is_null());
-    pal_idx = pal_idx.offset((first as isize + (i - first) as isize * stride) as isize);
+    pal_idx = pal_idx.offset(first as isize + (i - first) as isize * stride);
     let mut j = first;
     let mut n = 0;
     while j >= last {
         let have_left = (j > 0) as libc::c_int;
         assert!(have_left != 0 || have_top != 0);
-        let mut mask: libc::c_uint = 0 as libc::c_int as libc::c_uint;
+        let mut mask = 0 as libc::c_uint;
         let mut o_idx = 0;
         if have_left == 0 {
-            *ctx.offset(n as isize) = 0 as libc::c_int as uint8_t;
-            let v = *pal_idx.offset(-stride as isize) as libc::c_int;
-            assert!((v as libc::c_uint) < 8 as libc::c_uint);
+            *ctx.offset(n as isize) = 0;
+            let v = *pal_idx.offset(-stride) as libc::c_int;
+            assert!((v as libc::c_uint) < 8);
             let fresh21 = o_idx;
             o_idx = o_idx + 1;
             (*order.offset(n as isize))[fresh21 as usize] = v as uint8_t;
-            mask |= ((1 as libc::c_int) << v) as libc::c_uint;
+            mask |= (1 << v) as libc::c_uint;
         } else if have_top == 0 {
-            *ctx.offset(n as isize) = 0 as libc::c_int as uint8_t;
-            let v_0 = *pal_idx.offset(-(1 as libc::c_int) as isize) as libc::c_int;
-            assert!((v_0 as libc::c_uint) < 8 as libc::c_uint);
+            *ctx.offset(n as isize) = 0;
+            let v_0 = *pal_idx.offset(-1) as libc::c_int;
+            assert!((v_0 as libc::c_uint) < 8);
             let fresh22 = o_idx;
             o_idx = o_idx + 1;
             (*order.offset(n as isize))[fresh22 as usize] = v_0 as uint8_t;
-            mask |= ((1 as libc::c_int) << v_0) as libc::c_uint;
+            mask |= (1 << v_0) as libc::c_uint;
         } else {
-            let l = *pal_idx.offset(-(1 as libc::c_int) as isize) as libc::c_int;
-            let t = *pal_idx.offset(-stride as isize) as libc::c_int;
-            let tl = *pal_idx.offset(-(stride + 1) as isize) as libc::c_int;
+            let l = *pal_idx.offset(-1) as libc::c_int;
+            let t = *pal_idx.offset(-stride) as libc::c_int;
+            let tl = *pal_idx.offset(-(stride + 1)) as libc::c_int;
             let same_t_l = (t == l) as libc::c_int;
             let same_t_tl = (t == tl) as libc::c_int;
             let same_l_tl = (l == tl) as libc::c_int;
             let same_all = same_t_l & same_t_tl & same_l_tl;
             if same_all != 0 {
-                *ctx.offset(n as isize) = 4 as libc::c_int as uint8_t;
+                *ctx.offset(n as isize) = 4;
                 let v_1 = t;
-                assert!((v_1 as libc::c_uint) < 8 as libc::c_uint);
+                assert!((v_1 as libc::c_uint) < 8);
                 let fresh23 = o_idx;
                 o_idx = o_idx + 1;
                 (*order.offset(n as isize))[fresh23 as usize] = v_1 as uint8_t;
-                mask |= ((1 as libc::c_int) << v_1) as libc::c_uint;
+                mask |= (1 << v_1) as libc::c_uint;
             } else if same_t_l != 0 {
-                *ctx.offset(n as isize) = 3 as libc::c_int as uint8_t;
+                *ctx.offset(n as isize) = 3;
                 let v_2 = t;
-                assert!((v_2 as libc::c_uint) < 8 as libc::c_uint);
+                assert!((v_2 as libc::c_uint) < 8);
                 let fresh24 = o_idx;
                 o_idx = o_idx + 1;
                 (*order.offset(n as isize))[fresh24 as usize] = v_2 as uint8_t;
-                mask |= ((1 as libc::c_int) << v_2) as libc::c_uint;
+                mask |= (1 << v_2) as libc::c_uint;
                 let v_3 = tl;
-                assert!((v_3 as libc::c_uint) < 8 as libc::c_uint);
+                assert!((v_3 as libc::c_uint) < 8);
                 let fresh25 = o_idx;
                 o_idx = o_idx + 1;
                 (*order.offset(n as isize))[fresh25 as usize] = v_3 as uint8_t;
-                mask |= ((1 as libc::c_int) << v_3) as libc::c_uint;
+                mask |= (1 << v_3) as libc::c_uint;
             } else if same_t_tl | same_l_tl != 0 {
-                *ctx.offset(n as isize) = 2 as libc::c_int as uint8_t;
+                *ctx.offset(n as isize) = 2;
                 let v_4 = tl;
-                assert!((v_4 as libc::c_uint) < 8 as libc::c_uint);
+                assert!((v_4 as libc::c_uint) < 8);
                 let fresh26 = o_idx;
                 o_idx = o_idx + 1;
                 (*order.offset(n as isize))[fresh26 as usize] = v_4 as uint8_t;
-                mask |= ((1 as libc::c_int) << v_4) as libc::c_uint;
+                mask |= (1 << v_4) as libc::c_uint;
                 let v_5 = if same_t_tl != 0 { l } else { t };
-                assert!((v_5 as libc::c_uint) < 8 as libc::c_uint);
+                assert!((v_5 as libc::c_uint) < 8);
                 let fresh27 = o_idx;
                 o_idx = o_idx + 1;
                 (*order.offset(n as isize))[fresh27 as usize] = v_5 as uint8_t;
-                mask |= ((1 as libc::c_int) << v_5) as libc::c_uint;
+                mask |= (1 << v_5) as libc::c_uint;
             } else {
-                *ctx.offset(n as isize) = 1 as libc::c_int as uint8_t;
+                *ctx.offset(n as isize) = 1;
                 let v_6 = imin(t, l);
-                assert!((v_6 as libc::c_uint) < 8 as libc::c_uint);
+                assert!((v_6 as libc::c_uint) < 8);
                 let fresh28 = o_idx;
                 o_idx = o_idx + 1;
                 (*order.offset(n as isize))[fresh28 as usize] = v_6 as uint8_t;
-                mask |= ((1 as libc::c_int) << v_6) as libc::c_uint;
+                mask |= (1 << v_6) as libc::c_uint;
                 let v_7 = imax(t, l);
-                assert!((v_7 as libc::c_uint) < 8 as libc::c_uint);
+                assert!((v_7 as libc::c_uint) < 8);
                 let fresh29 = o_idx;
                 o_idx = o_idx + 1;
                 (*order.offset(n as isize))[fresh29 as usize] = v_7 as uint8_t;
-                mask |= ((1 as libc::c_int) << v_7) as libc::c_uint;
+                mask |= (1 << v_7) as libc::c_uint;
                 let v_8 = tl;
-                assert!((v_8 as libc::c_uint) < 8 as libc::c_uint);
+                assert!((v_8 as libc::c_uint) < 8);
                 let fresh30 = o_idx;
                 o_idx = o_idx + 1;
                 (*order.offset(n as isize))[fresh30 as usize] = v_8 as uint8_t;
-                mask |= ((1 as libc::c_int) << v_8) as libc::c_uint;
+                mask |= (1 << v_8) as libc::c_uint;
             }
         }
-        let mut m: libc::c_uint = 1 as libc::c_int as libc::c_uint;
-        let mut bit: libc::c_uint = 0 as libc::c_int as libc::c_uint;
-        while m < 0x100 as libc::c_int as libc::c_uint {
+        let mut m = 1 as libc::c_uint;
+        let mut bit = 0 as libc::c_uint;
+        while m < 0x100 {
             if mask & m == 0 {
                 let fresh31 = o_idx;
                 o_idx = o_idx + 1;
@@ -2151,10 +2151,10 @@ unsafe fn order_palette(
             bit = bit.wrapping_add(1);
         }
         assert!(o_idx == 8);
-        have_top = 1 as libc::c_int;
+        have_top = 1;
         j -= 1;
         n += 1;
-        pal_idx = pal_idx.offset((stride - 1) as isize);
+        pal_idx = pal_idx.offset(stride - 1);
     }
 }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2077,21 +2077,21 @@ unsafe fn order_palette(
             let l = *pal_idx.offset(-1) as libc::c_int;
             let t = *pal_idx.offset(-stride) as libc::c_int;
             let tl = *pal_idx.offset(-(stride + 1)) as libc::c_int;
-            let same_t_l = (t == l) as libc::c_int;
-            let same_t_tl = (t == tl) as libc::c_int;
-            let same_l_tl = (l == tl) as libc::c_int;
+            let same_t_l = t == l;
+            let same_t_tl = t == tl;
+            let same_l_tl = l == tl;
             let same_all = same_t_l & same_t_tl & same_l_tl;
-            if same_all != 0 {
+            if same_all {
                 *ctx = 4;
                 add(t);
-            } else if same_t_l != 0 {
+            } else if same_t_l {
                 *ctx = 3;
                 add(t);
                 add(tl);
-            } else if same_t_tl | same_l_tl != 0 {
+            } else if same_t_tl | same_l_tl {
                 *ctx = 2;
                 add(tl);
-                add(if same_t_tl != 0 { l } else { t });
+                add(if same_t_tl { l } else { t });
             } else {
                 *ctx = 1;
                 add(imin(t, l));

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2048,25 +2048,19 @@ unsafe fn order_palette(
     ctx: *mut uint8_t,
 ) {
     let mut have_top = (i > first) as libc::c_int;
-    if pal_idx.is_null() {
-        unreachable!();
-    }
+    assert!(!pal_idx.is_null());
     pal_idx = pal_idx.offset((first as isize + (i - first) as isize * stride) as isize);
     let mut j = first;
     let mut n = 0;
     while j >= last {
         let have_left = (j > 0) as libc::c_int;
-        if !(have_left != 0 || have_top != 0) {
-            unreachable!();
-        }
+        assert!(have_left != 0 || have_top != 0);
         let mut mask: libc::c_uint = 0 as libc::c_int as libc::c_uint;
         let mut o_idx = 0;
         if have_left == 0 {
             *ctx.offset(n as isize) = 0 as libc::c_int as uint8_t;
             let v = *pal_idx.offset(-stride as isize) as libc::c_int;
-            if !((v as libc::c_uint) < 8 as libc::c_uint) {
-                unreachable!();
-            }
+            assert!((v as libc::c_uint) < 8 as libc::c_uint);
             let fresh21 = o_idx;
             o_idx = o_idx + 1;
             (*order.offset(n as isize))[fresh21 as usize] = v as uint8_t;
@@ -2074,9 +2068,7 @@ unsafe fn order_palette(
         } else if have_top == 0 {
             *ctx.offset(n as isize) = 0 as libc::c_int as uint8_t;
             let v_0 = *pal_idx.offset(-(1 as libc::c_int) as isize) as libc::c_int;
-            if !((v_0 as libc::c_uint) < 8 as libc::c_uint) {
-                unreachable!();
-            }
+            assert!((v_0 as libc::c_uint) < 8 as libc::c_uint);
             let fresh22 = o_idx;
             o_idx = o_idx + 1;
             (*order.offset(n as isize))[fresh22 as usize] = v_0 as uint8_t;
@@ -2092,9 +2084,7 @@ unsafe fn order_palette(
             if same_all != 0 {
                 *ctx.offset(n as isize) = 4 as libc::c_int as uint8_t;
                 let v_1 = t;
-                if !((v_1 as libc::c_uint) < 8 as libc::c_uint) {
-                    unreachable!();
-                }
+                assert!((v_1 as libc::c_uint) < 8 as libc::c_uint);
                 let fresh23 = o_idx;
                 o_idx = o_idx + 1;
                 (*order.offset(n as isize))[fresh23 as usize] = v_1 as uint8_t;
@@ -2102,17 +2092,13 @@ unsafe fn order_palette(
             } else if same_t_l != 0 {
                 *ctx.offset(n as isize) = 3 as libc::c_int as uint8_t;
                 let v_2 = t;
-                if !((v_2 as libc::c_uint) < 8 as libc::c_uint) {
-                    unreachable!();
-                }
+                assert!((v_2 as libc::c_uint) < 8 as libc::c_uint);
                 let fresh24 = o_idx;
                 o_idx = o_idx + 1;
                 (*order.offset(n as isize))[fresh24 as usize] = v_2 as uint8_t;
                 mask |= ((1 as libc::c_int) << v_2) as libc::c_uint;
                 let v_3 = tl;
-                if !((v_3 as libc::c_uint) < 8 as libc::c_uint) {
-                    unreachable!();
-                }
+                assert!((v_3 as libc::c_uint) < 8 as libc::c_uint);
                 let fresh25 = o_idx;
                 o_idx = o_idx + 1;
                 (*order.offset(n as isize))[fresh25 as usize] = v_3 as uint8_t;
@@ -2120,17 +2106,13 @@ unsafe fn order_palette(
             } else if same_t_tl | same_l_tl != 0 {
                 *ctx.offset(n as isize) = 2 as libc::c_int as uint8_t;
                 let v_4 = tl;
-                if !((v_4 as libc::c_uint) < 8 as libc::c_uint) {
-                    unreachable!();
-                }
+                assert!((v_4 as libc::c_uint) < 8 as libc::c_uint);
                 let fresh26 = o_idx;
                 o_idx = o_idx + 1;
                 (*order.offset(n as isize))[fresh26 as usize] = v_4 as uint8_t;
                 mask |= ((1 as libc::c_int) << v_4) as libc::c_uint;
                 let v_5 = if same_t_tl != 0 { l } else { t };
-                if !((v_5 as libc::c_uint) < 8 as libc::c_uint) {
-                    unreachable!();
-                }
+                assert!((v_5 as libc::c_uint) < 8 as libc::c_uint);
                 let fresh27 = o_idx;
                 o_idx = o_idx + 1;
                 (*order.offset(n as isize))[fresh27 as usize] = v_5 as uint8_t;
@@ -2138,25 +2120,19 @@ unsafe fn order_palette(
             } else {
                 *ctx.offset(n as isize) = 1 as libc::c_int as uint8_t;
                 let v_6 = imin(t, l);
-                if !((v_6 as libc::c_uint) < 8 as libc::c_uint) {
-                    unreachable!();
-                }
+                assert!((v_6 as libc::c_uint) < 8 as libc::c_uint);
                 let fresh28 = o_idx;
                 o_idx = o_idx + 1;
                 (*order.offset(n as isize))[fresh28 as usize] = v_6 as uint8_t;
                 mask |= ((1 as libc::c_int) << v_6) as libc::c_uint;
                 let v_7 = imax(t, l);
-                if !((v_7 as libc::c_uint) < 8 as libc::c_uint) {
-                    unreachable!();
-                }
+                assert!((v_7 as libc::c_uint) < 8 as libc::c_uint);
                 let fresh29 = o_idx;
                 o_idx = o_idx + 1;
                 (*order.offset(n as isize))[fresh29 as usize] = v_7 as uint8_t;
                 mask |= ((1 as libc::c_int) << v_7) as libc::c_uint;
                 let v_8 = tl;
-                if !((v_8 as libc::c_uint) < 8 as libc::c_uint) {
-                    unreachable!();
-                }
+                assert!((v_8 as libc::c_uint) < 8 as libc::c_uint);
                 let fresh30 = o_idx;
                 o_idx = o_idx + 1;
                 (*order.offset(n as isize))[fresh30 as usize] = v_8 as uint8_t;
@@ -2174,9 +2150,7 @@ unsafe fn order_palette(
             m <<= 1;
             bit = bit.wrapping_add(1);
         }
-        if !(o_idx == 8) {
-            unreachable!();
-        }
+        assert!(o_idx == 8);
         have_top = 1 as libc::c_int;
         j -= 1;
         n += 1;


### PR DESCRIPTION
The `pal_idx` arg remains a raw ptr and unsafe, and it can be made safe, but since the changes to `pal_idx` propagate significantly throughout the code, I'll save it for a separate PR.