### PR TITLE
`fn dav1d_msac_*`: Deduplicate declarations

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -158,36 +158,6 @@ extern "C" {
     fn dav1d_mc_dsp_init_8bpc(c: *mut Dav1dMCDSPContext);
     #[cfg(feature = "bitdepth_16")]
     fn dav1d_mc_dsp_init_16bpc(c: *mut Dav1dMCDSPContext);
-    fn dav1d_msac_init(
-        s: *mut MsacContext,
-        data: *const uint8_t,
-        sz: size_t,
-        disable_cdf_update_flag: libc::c_int,
-    );
-    fn dav1d_msac_decode_subexp(
-        s: *mut MsacContext,
-        r#ref: libc::c_int,
-        n: libc::c_int,
-        k: libc::c_uint,
-    ) -> libc::c_int;
-    fn dav1d_msac_decode_symbol_adapt4(
-        s: *mut MsacContext,
-        cdf: *mut uint16_t,
-        n_symbols: size_t,
-    ) -> libc::c_uint;
-    fn dav1d_msac_decode_symbol_adapt8(
-        s: *mut MsacContext,
-        cdf: *mut uint16_t,
-        n_symbols: size_t,
-    ) -> libc::c_uint;
-    fn dav1d_msac_decode_symbol_adapt16(
-        s: *mut MsacContext,
-        cdf: *mut uint16_t,
-        n_symbols: size_t,
-    ) -> libc::c_uint;
-    fn dav1d_msac_decode_bool_adapt(s: *mut MsacContext, cdf: *mut uint16_t) -> libc::c_uint;
-    fn dav1d_msac_decode_bool_equi(s: *mut MsacContext) -> libc::c_uint;
-    fn dav1d_msac_decode_bool(s: *mut MsacContext, f: libc::c_uint) -> libc::c_uint;
     fn dav1d_thread_picture_alloc(
         c: *mut Dav1dContext,
         f: *mut Dav1dFrameContext,
@@ -273,6 +243,14 @@ extern "C" {
 }
 
 use crate::src::dequant_tables::dav1d_dq_tbl;
+use crate::src::msac::dav1d_msac_decode_bool;
+use crate::src::msac::dav1d_msac_decode_bool_adapt;
+use crate::src::msac::dav1d_msac_decode_bool_equi;
+use crate::src::msac::dav1d_msac_decode_subexp;
+use crate::src::msac::dav1d_msac_decode_symbol_adapt16;
+use crate::src::msac::dav1d_msac_decode_symbol_adapt4;
+use crate::src::msac::dav1d_msac_decode_symbol_adapt8;
+use crate::src::msac::dav1d_msac_init;
 use crate::src::refmvs::dav1d_refmvs_find;
 use crate::src::tables::dav1d_al_part_ctx;
 use crate::src::tables::dav1d_block_dimensions;

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -145,7 +145,7 @@ unsafe extern "C" fn ctx_norm(s: *mut MsacContext, dif: ec_win, rng: libc::c_uin
     }
 }
 
-pub unsafe extern "C" fn dav1d_msac_decode_bool_equi_c(s: *mut MsacContext) -> libc::c_uint {
+pub unsafe fn dav1d_msac_decode_bool_equi_c(s: *mut MsacContext) -> libc::c_uint {
     let r: libc::c_uint = (*s).rng;
     let mut dif: ec_win = (*s).dif;
     if !(dif >> (::core::mem::size_of::<ec_win>() << 3).wrapping_sub(16) < r as size_t) {
@@ -164,10 +164,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool_equi_c(s: *mut MsacContext) -> l
     return (ret == 0) as libc::c_int as libc::c_uint;
 }
 
-pub unsafe extern "C" fn dav1d_msac_decode_bool_c(
-    s: *mut MsacContext,
-    f: libc::c_uint,
-) -> libc::c_uint {
+pub unsafe fn dav1d_msac_decode_bool_c(s: *mut MsacContext, f: libc::c_uint) -> libc::c_uint {
     let r: libc::c_uint = (*s).rng;
     let mut dif: ec_win = (*s).dif;
     if !(dif >> (::core::mem::size_of::<ec_win>() << 3).wrapping_sub(16) < r as size_t) {
@@ -187,7 +184,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool_c(
     return (ret == 0) as libc::c_int as libc::c_uint;
 }
 
-pub unsafe extern "C" fn dav1d_msac_decode_subexp(
+pub unsafe fn dav1d_msac_decode_subexp(
     s: *mut MsacContext,
     r#ref: libc::c_int,
     n: libc::c_int,
@@ -284,7 +281,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt_c(
     return val;
 }
 
-pub unsafe extern "C" fn dav1d_msac_decode_bool_adapt_c(
+pub unsafe fn dav1d_msac_decode_bool_adapt_c(
     s: *mut MsacContext,
     cdf: *mut uint16_t,
 ) -> libc::c_uint {
@@ -309,10 +306,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool_adapt_c(
     return bit;
 }
 
-pub unsafe extern "C" fn dav1d_msac_decode_hi_tok_c(
-    s: *mut MsacContext,
-    cdf: *mut uint16_t,
-) -> libc::c_uint {
+pub unsafe fn dav1d_msac_decode_hi_tok_c(s: *mut MsacContext, cdf: *mut uint16_t) -> libc::c_uint {
     let mut tok_br: libc::c_uint =
         dav1d_msac_decode_symbol_adapt4(s, cdf, 3 as libc::c_int as size_t);
     let mut tok: libc::c_uint = (3 as libc::c_int as libc::c_uint).wrapping_add(tok_br);
@@ -332,7 +326,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_hi_tok_c(
     return tok;
 }
 
-pub unsafe extern "C" fn dav1d_msac_init(
+pub unsafe fn dav1d_msac_init(
     s: *mut MsacContext,
     data: *const uint8_t,
     sz: size_t,
@@ -358,7 +352,7 @@ pub unsafe extern "C" fn dav1d_msac_init(
     }
 }
 
-pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt4(
+pub unsafe fn dav1d_msac_decode_symbol_adapt4(
     mut s: *mut MsacContext,
     mut cdf: *mut uint16_t,
     mut n_symbols: size_t,
@@ -374,7 +368,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt4(
     }
 }
 
-pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt8(
+pub unsafe fn dav1d_msac_decode_symbol_adapt8(
     mut s: *mut MsacContext,
     mut cdf: *mut uint16_t,
     mut n_symbols: size_t,
@@ -390,7 +384,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt8(
     }
 }
 
-pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt16(
+pub unsafe fn dav1d_msac_decode_symbol_adapt16(
     mut s: *mut MsacContext,
     mut cdf: *mut uint16_t,
     mut n_symbols: size_t,
@@ -406,7 +400,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt16(
     }
 }
 
-pub unsafe extern "C" fn dav1d_msac_decode_bool_adapt(
+pub unsafe fn dav1d_msac_decode_bool_adapt(
     mut s: *mut MsacContext,
     mut cdf: *mut uint16_t,
 ) -> libc::c_uint {
@@ -421,7 +415,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool_adapt(
     }
 }
 
-pub unsafe extern "C" fn dav1d_msac_decode_bool_equi(mut s: *mut MsacContext) -> libc::c_uint {
+pub unsafe fn dav1d_msac_decode_bool_equi(mut s: *mut MsacContext) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
             return dav1d_msac_decode_bool_equi_sse2(s);
@@ -433,10 +427,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool_equi(mut s: *mut MsacContext) ->
     }
 }
 
-pub unsafe extern "C" fn dav1d_msac_decode_bool(
-    mut s: *mut MsacContext,
-    mut f: libc::c_uint,
-) -> libc::c_uint {
+pub unsafe fn dav1d_msac_decode_bool(mut s: *mut MsacContext, mut f: libc::c_uint) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
             return dav1d_msac_decode_bool_sse2(s, f);
@@ -448,7 +439,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool(
     }
 }
 
-pub unsafe extern "C" fn dav1d_msac_decode_hi_tok(
+pub unsafe fn dav1d_msac_decode_hi_tok(
     mut s: *mut MsacContext,
     mut cdf: *mut uint16_t,
 ) -> libc::c_uint {

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -145,7 +145,6 @@ unsafe extern "C" fn ctx_norm(s: *mut MsacContext, dif: ec_win, rng: libc::c_uin
     }
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_bool_equi_c(s: *mut MsacContext) -> libc::c_uint {
     let r: libc::c_uint = (*s).rng;
     let mut dif: ec_win = (*s).dif;
@@ -165,7 +164,6 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool_equi_c(s: *mut MsacContext) -> l
     return (ret == 0) as libc::c_int as libc::c_uint;
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_bool_c(
     s: *mut MsacContext,
     f: libc::c_uint,
@@ -189,7 +187,6 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool_c(
     return (ret == 0) as libc::c_int as libc::c_uint;
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_subexp(
     s: *mut MsacContext,
     r#ref: libc::c_int,
@@ -217,7 +214,6 @@ pub unsafe extern "C" fn dav1d_msac_decode_subexp(
     return ret;
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt_c(
     s: *mut MsacContext,
     cdf: *mut uint16_t,
@@ -288,7 +284,6 @@ pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt_c(
     return val;
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_bool_adapt_c(
     s: *mut MsacContext,
     cdf: *mut uint16_t,
@@ -314,7 +309,6 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool_adapt_c(
     return bit;
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_hi_tok_c(
     s: *mut MsacContext,
     cdf: *mut uint16_t,
@@ -338,7 +332,6 @@ pub unsafe extern "C" fn dav1d_msac_decode_hi_tok_c(
     return tok;
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_init(
     s: *mut MsacContext,
     data: *const uint8_t,
@@ -365,7 +358,6 @@ pub unsafe extern "C" fn dav1d_msac_init(
     }
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt4(
     mut s: *mut MsacContext,
     mut cdf: *mut uint16_t,
@@ -382,7 +374,6 @@ pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt4(
     }
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt8(
     mut s: *mut MsacContext,
     mut cdf: *mut uint16_t,
@@ -399,7 +390,6 @@ pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt8(
     }
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt16(
     mut s: *mut MsacContext,
     mut cdf: *mut uint16_t,
@@ -416,7 +406,6 @@ pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt16(
     }
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_bool_adapt(
     mut s: *mut MsacContext,
     mut cdf: *mut uint16_t,
@@ -432,7 +421,6 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool_adapt(
     }
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_bool_equi(mut s: *mut MsacContext) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
@@ -445,7 +433,6 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool_equi(mut s: *mut MsacContext) ->
     }
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_bool(
     mut s: *mut MsacContext,
     mut f: libc::c_uint,
@@ -461,7 +448,6 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool(
     }
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_hi_tok(
     mut s: *mut MsacContext,
     mut cdf: *mut uint16_t,

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -211,7 +211,7 @@ pub unsafe fn dav1d_msac_decode_subexp(
     return ret;
 }
 
-pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt_c(
+unsafe fn dav1d_msac_decode_symbol_adapt_rust(
     s: *mut MsacContext,
     cdf: *mut uint16_t,
     n_symbols: size_t,
@@ -279,6 +279,14 @@ pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt_c(
             as uint16_t;
     }
     return val;
+}
+
+pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt_c(
+    s: *mut MsacContext,
+    cdf: *mut uint16_t,
+    n_symbols: size_t,
+) -> libc::c_uint {
+    dav1d_msac_decode_symbol_adapt_rust(s, cdf, n_symbols)
 }
 
 pub unsafe fn dav1d_msac_decode_bool_adapt_c(
@@ -363,7 +371,7 @@ pub unsafe fn dav1d_msac_decode_symbol_adapt4(
         } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
             return dav1d_msac_decode_symbol_adapt4_neon(s, cdf, n_symbols);
         } else {
-            return dav1d_msac_decode_symbol_adapt_c(s, cdf, n_symbols);
+            return dav1d_msac_decode_symbol_adapt_rust(s, cdf, n_symbols);
         }
     }
 }
@@ -379,7 +387,7 @@ pub unsafe fn dav1d_msac_decode_symbol_adapt8(
         } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
             return dav1d_msac_decode_symbol_adapt8_neon(s, cdf, n_symbols);
         } else {
-            return dav1d_msac_decode_symbol_adapt_c(s, cdf, n_symbols);
+            return dav1d_msac_decode_symbol_adapt_rust(s, cdf, n_symbols);
         }
     }
 }
@@ -395,7 +403,7 @@ pub unsafe fn dav1d_msac_decode_symbol_adapt16(
         } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
             return dav1d_msac_decode_symbol_adapt16_neon(s, cdf, n_symbols);
         } else {
-            return dav1d_msac_decode_symbol_adapt_c(s, cdf, n_symbols);
+            return dav1d_msac_decode_symbol_adapt_rust(s, cdf, n_symbols);
         }
     }
 }

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -145,7 +145,7 @@ unsafe extern "C" fn ctx_norm(s: *mut MsacContext, dif: ec_win, rng: libc::c_uin
     }
 }
 
-pub unsafe fn dav1d_msac_decode_bool_equi_rust(s: *mut MsacContext) -> libc::c_uint {
+unsafe fn dav1d_msac_decode_bool_equi_rust(s: *mut MsacContext) -> libc::c_uint {
     let r: libc::c_uint = (*s).rng;
     let mut dif: ec_win = (*s).dif;
     if !(dif >> (::core::mem::size_of::<ec_win>() << 3).wrapping_sub(16) < r as size_t) {
@@ -164,7 +164,7 @@ pub unsafe fn dav1d_msac_decode_bool_equi_rust(s: *mut MsacContext) -> libc::c_u
     return (ret == 0) as libc::c_int as libc::c_uint;
 }
 
-pub unsafe fn dav1d_msac_decode_bool_rust(s: *mut MsacContext, f: libc::c_uint) -> libc::c_uint {
+unsafe fn dav1d_msac_decode_bool_rust(s: *mut MsacContext, f: libc::c_uint) -> libc::c_uint {
     let r: libc::c_uint = (*s).rng;
     let mut dif: ec_win = (*s).dif;
     if !(dif >> (::core::mem::size_of::<ec_win>() << 3).wrapping_sub(16) < r as size_t) {
@@ -281,7 +281,7 @@ unsafe fn dav1d_msac_decode_symbol_adapt_rust(
     return val;
 }
 
-pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt_c(
+unsafe extern "C" fn dav1d_msac_decode_symbol_adapt_c(
     s: *mut MsacContext,
     cdf: *mut uint16_t,
     n_symbols: size_t,
@@ -289,7 +289,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt_c(
     dav1d_msac_decode_symbol_adapt_rust(s, cdf, n_symbols)
 }
 
-pub unsafe fn dav1d_msac_decode_bool_adapt_rust(
+unsafe fn dav1d_msac_decode_bool_adapt_rust(
     s: *mut MsacContext,
     cdf: *mut uint16_t,
 ) -> libc::c_uint {
@@ -314,7 +314,7 @@ pub unsafe fn dav1d_msac_decode_bool_adapt_rust(
     return bit;
 }
 
-pub unsafe fn dav1d_msac_decode_hi_tok_rust(s: *mut MsacContext, cdf: *mut uint16_t) -> libc::c_uint {
+unsafe fn dav1d_msac_decode_hi_tok_rust(s: *mut MsacContext, cdf: *mut uint16_t) -> libc::c_uint {
     let mut tok_br: libc::c_uint =
         dav1d_msac_decode_symbol_adapt4(s, cdf, 3 as libc::c_int as size_t);
     let mut tok: libc::c_uint = (3 as libc::c_int as libc::c_uint).wrapping_add(tok_br);

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -145,7 +145,7 @@ unsafe extern "C" fn ctx_norm(s: *mut MsacContext, dif: ec_win, rng: libc::c_uin
     }
 }
 
-pub unsafe fn dav1d_msac_decode_bool_equi_c(s: *mut MsacContext) -> libc::c_uint {
+pub unsafe fn dav1d_msac_decode_bool_equi_rust(s: *mut MsacContext) -> libc::c_uint {
     let r: libc::c_uint = (*s).rng;
     let mut dif: ec_win = (*s).dif;
     if !(dif >> (::core::mem::size_of::<ec_win>() << 3).wrapping_sub(16) < r as size_t) {
@@ -164,7 +164,7 @@ pub unsafe fn dav1d_msac_decode_bool_equi_c(s: *mut MsacContext) -> libc::c_uint
     return (ret == 0) as libc::c_int as libc::c_uint;
 }
 
-pub unsafe fn dav1d_msac_decode_bool_c(s: *mut MsacContext, f: libc::c_uint) -> libc::c_uint {
+pub unsafe fn dav1d_msac_decode_bool_rust(s: *mut MsacContext, f: libc::c_uint) -> libc::c_uint {
     let r: libc::c_uint = (*s).rng;
     let mut dif: ec_win = (*s).dif;
     if !(dif >> (::core::mem::size_of::<ec_win>() << 3).wrapping_sub(16) < r as size_t) {
@@ -289,7 +289,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt_c(
     dav1d_msac_decode_symbol_adapt_rust(s, cdf, n_symbols)
 }
 
-pub unsafe fn dav1d_msac_decode_bool_adapt_c(
+pub unsafe fn dav1d_msac_decode_bool_adapt_rust(
     s: *mut MsacContext,
     cdf: *mut uint16_t,
 ) -> libc::c_uint {
@@ -314,7 +314,7 @@ pub unsafe fn dav1d_msac_decode_bool_adapt_c(
     return bit;
 }
 
-pub unsafe fn dav1d_msac_decode_hi_tok_c(s: *mut MsacContext, cdf: *mut uint16_t) -> libc::c_uint {
+pub unsafe fn dav1d_msac_decode_hi_tok_rust(s: *mut MsacContext, cdf: *mut uint16_t) -> libc::c_uint {
     let mut tok_br: libc::c_uint =
         dav1d_msac_decode_symbol_adapt4(s, cdf, 3 as libc::c_int as size_t);
     let mut tok: libc::c_uint = (3 as libc::c_int as libc::c_uint).wrapping_add(tok_br);
@@ -418,7 +418,7 @@ pub unsafe fn dav1d_msac_decode_bool_adapt(
         } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
             return dav1d_msac_decode_bool_adapt_neon(s, cdf);
         } else {
-            return dav1d_msac_decode_bool_adapt_c(s, cdf);
+            return dav1d_msac_decode_bool_adapt_rust(s, cdf);
         }
     }
 }
@@ -430,7 +430,7 @@ pub unsafe fn dav1d_msac_decode_bool_equi(mut s: *mut MsacContext) -> libc::c_ui
         } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
             return dav1d_msac_decode_bool_equi_neon(s);
         } else {
-            return dav1d_msac_decode_bool_equi_c(s);
+            return dav1d_msac_decode_bool_equi_rust(s);
         }
     }
 }
@@ -442,7 +442,7 @@ pub unsafe fn dav1d_msac_decode_bool(mut s: *mut MsacContext, mut f: libc::c_uin
         } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
             return dav1d_msac_decode_bool_neon(s, f);
         } else {
-            return dav1d_msac_decode_bool_c(s, f);
+            return dav1d_msac_decode_bool_rust(s, f);
         }
     }
 }
@@ -457,7 +457,7 @@ pub unsafe fn dav1d_msac_decode_hi_tok(
         } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
             return dav1d_msac_decode_hi_tok_neon(s, cdf);
         } else {
-            return dav1d_msac_decode_hi_tok_c(s, cdf);
+            return dav1d_msac_decode_hi_tok_rust(s, cdf);
         }
     }
 }

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -130,6 +130,7 @@ unsafe extern "C" fn ctx_refill(s: *mut MsacContext) {
         .wrapping_sub(24 as libc::c_int as libc::c_ulong) as libc::c_int;
     (*s).buf_pos = buf_pos;
 }
+
 #[inline]
 unsafe extern "C" fn ctx_norm(s: *mut MsacContext, dif: ec_win, rng: libc::c_uint) {
     let d = 15 as libc::c_int ^ (31 as libc::c_int ^ clz(rng));
@@ -143,6 +144,7 @@ unsafe extern "C" fn ctx_norm(s: *mut MsacContext, dif: ec_win, rng: libc::c_uin
         ctx_refill(s);
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_bool_equi_c(s: *mut MsacContext) -> libc::c_uint {
     let r: libc::c_uint = (*s).rng;
@@ -162,6 +164,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool_equi_c(s: *mut MsacContext) -> l
     ctx_norm(s, dif, v);
     return (ret == 0) as libc::c_int as libc::c_uint;
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_bool_c(
     s: *mut MsacContext,
@@ -185,6 +188,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool_c(
     ctx_norm(s, dif, v);
     return (ret == 0) as libc::c_int as libc::c_uint;
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_subexp(
     s: *mut MsacContext,
@@ -212,6 +216,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_subexp(
     }) as libc::c_int;
     return ret;
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt_c(
     s: *mut MsacContext,
@@ -282,6 +287,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt_c(
     }
     return val;
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_bool_adapt_c(
     s: *mut MsacContext,
@@ -307,6 +313,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool_adapt_c(
     }
     return bit;
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_hi_tok_c(
     s: *mut MsacContext,
@@ -330,6 +337,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_hi_tok_c(
     }
     return tok;
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_init(
     s: *mut MsacContext,
@@ -356,6 +364,7 @@ pub unsafe extern "C" fn dav1d_msac_init(
         msac_init_x86(s);
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt4(
     mut s: *mut MsacContext,
@@ -372,6 +381,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt4(
         }
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt8(
     mut s: *mut MsacContext,
@@ -388,6 +398,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt8(
         }
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt16(
     mut s: *mut MsacContext,
@@ -404,6 +415,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_symbol_adapt16(
         }
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_bool_adapt(
     mut s: *mut MsacContext,
@@ -419,6 +431,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool_adapt(
         }
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_bool_equi(mut s: *mut MsacContext) -> libc::c_uint {
     cfg_if! {
@@ -431,6 +444,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool_equi(mut s: *mut MsacContext) ->
         }
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_bool(
     mut s: *mut MsacContext,
@@ -446,6 +460,7 @@ pub unsafe extern "C" fn dav1d_msac_decode_bool(
         }
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_msac_decode_hi_tok(
     mut s: *mut MsacContext,

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -10,24 +10,6 @@ extern "C" {
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::size_t) -> *mut libc::c_void;
     fn fprintf(_: *mut libc::FILE, _: *const libc::c_char, _: ...) -> libc::c_int;
     fn printf(_: *const libc::c_char, _: ...) -> libc::c_int;
-    fn dav1d_msac_decode_symbol_adapt4(
-        s: *mut MsacContext,
-        cdf: *mut uint16_t,
-        n_symbols: size_t,
-    ) -> libc::c_uint;
-    fn dav1d_msac_decode_symbol_adapt8(
-        s: *mut MsacContext,
-        cdf: *mut uint16_t,
-        n_symbols: size_t,
-    ) -> libc::c_uint;
-    fn dav1d_msac_decode_symbol_adapt16(
-        s: *mut MsacContext,
-        cdf: *mut uint16_t,
-        n_symbols: size_t,
-    ) -> libc::c_uint;
-    fn dav1d_msac_decode_bool_adapt(s: *mut MsacContext, cdf: *mut uint16_t) -> libc::c_uint;
-    fn dav1d_msac_decode_bool_equi(s: *mut MsacContext) -> libc::c_uint;
-    fn dav1d_msac_decode_hi_tok(s: *mut MsacContext, cdf: *mut uint16_t) -> libc::c_uint;
     fn dav1d_cdef_brow_16bpc(
         tc: *mut Dav1dTaskContext,
         p: *const *mut pixel,
@@ -76,6 +58,12 @@ extern "C" {
     static mut dav1d_ii_masks: [[[*const uint8_t; 4]; 3]; 22];
 }
 
+use crate::src::msac::dav1d_msac_decode_bool_adapt;
+use crate::src::msac::dav1d_msac_decode_bool_equi;
+use crate::src::msac::dav1d_msac_decode_hi_tok;
+use crate::src::msac::dav1d_msac_decode_symbol_adapt16;
+use crate::src::msac::dav1d_msac_decode_symbol_adapt4;
+use crate::src::msac::dav1d_msac_decode_symbol_adapt8;
 use crate::src::tables::dav1d_block_dimensions;
 use crate::src::tables::dav1d_filter_2d;
 use crate::src::tables::dav1d_filter_mode_to_y_mode;

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -10,24 +10,6 @@ extern "C" {
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::size_t) -> *mut libc::c_void;
     fn fprintf(_: *mut libc::FILE, _: *const libc::c_char, _: ...) -> libc::c_int;
     fn printf(_: *const libc::c_char, _: ...) -> libc::c_int;
-    fn dav1d_msac_decode_symbol_adapt4(
-        s: *mut MsacContext,
-        cdf: *mut uint16_t,
-        n_symbols: size_t,
-    ) -> libc::c_uint;
-    fn dav1d_msac_decode_symbol_adapt8(
-        s: *mut MsacContext,
-        cdf: *mut uint16_t,
-        n_symbols: size_t,
-    ) -> libc::c_uint;
-    fn dav1d_msac_decode_symbol_adapt16(
-        s: *mut MsacContext,
-        cdf: *mut uint16_t,
-        n_symbols: size_t,
-    ) -> libc::c_uint;
-    fn dav1d_msac_decode_bool_adapt(s: *mut MsacContext, cdf: *mut uint16_t) -> libc::c_uint;
-    fn dav1d_msac_decode_bool_equi(s: *mut MsacContext) -> libc::c_uint;
-    fn dav1d_msac_decode_hi_tok(s: *mut MsacContext, cdf: *mut uint16_t) -> libc::c_uint;
     fn dav1d_cdef_brow_8bpc(
         tc: *mut Dav1dTaskContext,
         p: *const *mut pixel,
@@ -75,6 +57,12 @@ extern "C" {
     static mut dav1d_ii_masks: [[[*const uint8_t; 4]; 3]; 22];
 }
 
+use crate::src::msac::dav1d_msac_decode_bool_adapt;
+use crate::src::msac::dav1d_msac_decode_bool_equi;
+use crate::src::msac::dav1d_msac_decode_hi_tok;
+use crate::src::msac::dav1d_msac_decode_symbol_adapt16;
+use crate::src::msac::dav1d_msac_decode_symbol_adapt4;
+use crate::src::msac::dav1d_msac_decode_symbol_adapt8;
 use crate::src::tables::dav1d_block_dimensions;
 use crate::src::tables::dav1d_filter_2d;
 use crate::src::tables::dav1d_filter_mode_to_y_mode;


### PR DESCRIPTION
This also removes `#[no_mangle]`s and `extern "C"`s, which can be done now that their declarations have been deduplicated into `use`s.  It also renames the `*_c` `fn` to `*_rust` now that they're in Rust.