### PR TITLE
`fn dav1d_msac_*`: Cleanup and make args safe

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1147,27 +1147,25 @@ unsafe extern "C" fn read_mv_component_diff(
     let ts: *mut Dav1dTileState = (*t).ts;
     let f: *const Dav1dFrameContext = (*t).f;
     let have_hp = (*(*f).frame_hdr).hp;
-    let sign = dav1d_msac_decode_bool_adapt(&mut (*ts).msac, ((*mv_comp).sign.0).as_mut_ptr())
-        as libc::c_int;
+    let sign = dav1d_msac_decode_bool_adapt(&mut (*ts).msac, &mut (*mv_comp).sign.0) as libc::c_int;
     let cl = dav1d_msac_decode_symbol_adapt16(
         &mut (*ts).msac,
-        ((*mv_comp).classes.0).as_mut_ptr(),
+        &mut (*mv_comp).classes.0,
         10 as libc::c_int as size_t,
     ) as libc::c_int;
     let mut up = 0;
     let mut fp = 0;
     let mut hp = 0;
     if cl == 0 {
-        up = dav1d_msac_decode_bool_adapt(&mut (*ts).msac, ((*mv_comp).class0.0).as_mut_ptr())
-            as libc::c_int;
+        up = dav1d_msac_decode_bool_adapt(&mut (*ts).msac, &mut (*mv_comp).class0.0) as libc::c_int;
         if have_fp != 0 {
             fp = dav1d_msac_decode_symbol_adapt4(
                 &mut (*ts).msac,
-                ((*mv_comp).class0_fp[up as usize]).as_mut_ptr(),
+                &mut (*mv_comp).class0_fp[up as usize],
                 3 as libc::c_int as size_t,
             ) as libc::c_int;
             hp = (if have_hp != 0 {
-                dav1d_msac_decode_bool_adapt(&mut (*ts).msac, ((*mv_comp).class0_hp.0).as_mut_ptr())
+                dav1d_msac_decode_bool_adapt(&mut (*ts).msac, &mut (*mv_comp).class0_hp.0)
             } else {
                 1 as libc::c_int as libc::c_uint
             }) as libc::c_int;
@@ -1180,20 +1178,18 @@ unsafe extern "C" fn read_mv_component_diff(
         let mut n = 0;
         while n < cl {
             up = (up as libc::c_uint
-                | dav1d_msac_decode_bool_adapt(
-                    &mut (*ts).msac,
-                    ((*mv_comp).classN[n as usize]).as_mut_ptr(),
-                ) << n) as libc::c_int;
+                | dav1d_msac_decode_bool_adapt(&mut (*ts).msac, &mut (*mv_comp).classN[n as usize])
+                    << n) as libc::c_int;
             n += 1;
         }
         if have_fp != 0 {
             fp = dav1d_msac_decode_symbol_adapt4(
                 &mut (*ts).msac,
-                ((*mv_comp).classN_fp.0).as_mut_ptr(),
+                &mut (*mv_comp).classN_fp.0,
                 3 as libc::c_int as size_t,
             ) as libc::c_int;
             hp = (if have_hp != 0 {
-                dav1d_msac_decode_bool_adapt(&mut (*ts).msac, ((*mv_comp).classN_hp.0).as_mut_ptr())
+                dav1d_msac_decode_bool_adapt(&mut (*ts).msac, &mut (*mv_comp).classN_hp.0)
             } else {
                 1 as libc::c_int as libc::c_uint
             }) as libc::c_int;
@@ -1213,7 +1209,7 @@ unsafe extern "C" fn read_mv_residual(
 ) {
     match dav1d_msac_decode_symbol_adapt4(
         &mut (*(*t).ts).msac,
-        ((*(*t).ts).cdf.mv.joint.0).as_mut_ptr(),
+        &mut (*(*t).ts).cdf.mv.joint.0,
         (N_MV_JOINTS as libc::c_int - 1) as size_t,
     ) {
         3 => {
@@ -1256,7 +1252,7 @@ unsafe extern "C" fn read_tx_tree(
         let l = (((*t).l.tx[by4 as usize] as libc::c_int) < txh) as libc::c_int;
         is_split = dav1d_msac_decode_bool_adapt(
             &mut (*(*t).ts).msac,
-            ((*(*t).ts).cdf.m.txpart[cat as usize][(a + l) as usize]).as_mut_ptr(),
+            &mut (*(*t).ts).cdf.m.txpart[cat as usize][(a + l) as usize],
         ) as libc::c_int;
         if is_split != 0 {
             let ref mut fresh1 = *masks.offset(depth as isize);
@@ -1713,7 +1709,7 @@ unsafe extern "C" fn read_pal_plane(
     let f: *const Dav1dFrameContext = (*t).f;
     (*b).c2rust_unnamed.c2rust_unnamed.pal_sz[pl as usize] = (dav1d_msac_decode_symbol_adapt8(
         &mut (*ts).msac,
-        ((*ts).cdf.m.pal_sz[pl as usize][sz_ctx as usize]).as_mut_ptr(),
+        &mut (*ts).cdf.m.pal_sz[pl as usize][sz_ctx as usize],
         6 as libc::c_int as size_t,
     ))
     .wrapping_add(2 as libc::c_int as libc::c_uint)
@@ -2115,7 +2111,7 @@ unsafe extern "C" fn read_pal_indices(
         while j >= last {
             let color_idx = dav1d_msac_decode_symbol_adapt8(
                 &mut (*ts).msac,
-                (*color_map_cdf.offset(ctx[m as usize] as isize)).as_mut_ptr(),
+                &mut *color_map_cdf.offset(ctx[m as usize] as isize),
                 ((*b).c2rust_unnamed.c2rust_unnamed.pal_sz[pl as usize] as libc::c_int - 1)
                     as size_t,
             ) as libc::c_int;
@@ -3071,7 +3067,7 @@ unsafe fn decode_b(
                 let index = (*t.a).seg_pred[bx4 as usize] + t.l.seg_pred[by4 as usize];
                 seg_pred = dav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
-                    ts.cdf.m.seg_pred[index as usize].as_mut_ptr(),
+                    &mut ts.cdf.m.seg_pred[index as usize],
                 ) as libc::c_int;
                 seg_pred != 0
             } {
@@ -3092,7 +3088,7 @@ unsafe fn decode_b(
                     get_cur_frame_segid(t.by, t.bx, have_top, have_left, f.cur_segmap, f.b4_stride);
                 let diff = dav1d_msac_decode_symbol_adapt8(
                     &mut ts.msac,
-                    (ts.cdf.m.seg_id[seg_ctx as usize]).as_mut_ptr(),
+                    &mut ts.cdf.m.seg_id[seg_ctx as usize],
                     (DAV1D_MAX_SEGMENTS - 1) as size_t,
                 );
                 let last_active_seg_id = frame_hdr.segmentation.seg_data.last_active_segid;
@@ -3130,10 +3126,9 @@ unsafe fn decode_b(
         && imin(bw4, bh4) > 1
     {
         let smctx = (*t.a).skip_mode[bx4 as usize] + t.l.skip_mode[by4 as usize];
-        b.skip_mode = dav1d_msac_decode_bool_adapt(
-            &mut ts.msac,
-            (ts.cdf.m.skip_mode[smctx as usize]).as_mut_ptr(),
-        ) as uint8_t;
+        b.skip_mode =
+            dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.skip_mode[smctx as usize])
+                as uint8_t;
 
         if DEBUG_BLOCK_INFO(f, t) {
             println!("Post-skipmode[{}]: r={}", b.skip_mode, ts.msac.rng);
@@ -3147,9 +3142,8 @@ unsafe fn decode_b(
         b.skip = 1;
     } else {
         let sctx = (*t.a).skip[bx4 as usize] + t.l.skip[by4 as usize];
-        b.skip =
-            dav1d_msac_decode_bool_adapt(&mut ts.msac, (ts.cdf.m.skip[sctx as usize]).as_mut_ptr())
-                as uint8_t;
+        b.skip = dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.skip[sctx as usize])
+            as uint8_t;
 
         if DEBUG_BLOCK_INFO(f, t) {
             println!("Post-skip[{}]: r={}", b.skip, ts.msac.rng);
@@ -3163,10 +3157,9 @@ unsafe fn decode_b(
     {
         if b.skip == 0 && (*f.frame_hdr).segmentation.temporal != 0 && {
             let index = (*t.a).seg_pred[bx4 as usize] + t.l.seg_pred[by4 as usize];
-            seg_pred = dav1d_msac_decode_bool_adapt(
-                &mut ts.msac,
-                ts.cdf.m.seg_pred[index as usize].as_mut_ptr(),
-            ) as libc::c_int;
+            seg_pred =
+                dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.seg_pred[index as usize])
+                    as libc::c_int;
             seg_pred != 0
         } {
             // temporal predicted seg_id
@@ -3191,7 +3184,7 @@ unsafe fn decode_b(
             } else {
                 let diff = dav1d_msac_decode_symbol_adapt8(
                     &mut ts.msac,
-                    ts.cdf.m.seg_id[seg_ctx as usize].as_mut_ptr(),
+                    &mut ts.cdf.m.seg_id[seg_ctx as usize],
                     (DAV1D_MAX_SEGMENTS - 1) as size_t,
                 );
                 let last_active_seg_id = (*f.frame_hdr).segmentation.seg_data.last_active_segid;
@@ -3269,7 +3262,7 @@ unsafe fn decode_b(
 
         if have_delta_q {
             let mut delta_q =
-                dav1d_msac_decode_symbol_adapt4(&mut ts.msac, (ts.cdf.m.delta_q.0).as_mut_ptr(), 3)
+                dav1d_msac_decode_symbol_adapt4(&mut ts.msac, &mut ts.cdf.m.delta_q.0, 3)
                     as libc::c_int;
 
             if delta_q == 3 {
@@ -3309,7 +3302,7 @@ unsafe fn decode_b(
                     let delta_lf_index = i + frame_hdr.delta.lf.multi as usize;
                     let mut delta_lf = dav1d_msac_decode_symbol_adapt4(
                         &mut ts.msac,
-                        ts.cdf.m.delta_lf[delta_lf_index].as_mut_ptr(),
+                        &mut ts.cdf.m.delta_lf[delta_lf_index],
                         3,
                     ) as libc::c_int;
 
@@ -3370,7 +3363,7 @@ unsafe fn decode_b(
             let ictx = get_intra_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
             b.intra = (dav1d_msac_decode_bool_adapt(
                 &mut ts.msac,
-                ts.cdf.m.intra[ictx.into()].as_mut_ptr(),
+                &mut ts.cdf.m.intra[ictx.into()],
             ) == 0) as uint8_t;
 
             if DEBUG_BLOCK_INFO(f, t) {
@@ -3378,8 +3371,8 @@ unsafe fn decode_b(
             }
         }
     } else if frame_hdr.allow_intrabc != 0 {
-        b.intra = (dav1d_msac_decode_bool_adapt(&mut ts.msac, ts.cdf.m.intrabc.0.as_mut_ptr()) == 0)
-            as uint8_t;
+        b.intra =
+            (dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.intrabc.0) == 0) as uint8_t;
 
         if DEBUG_BLOCK_INFO(f, t) {
             println!("Post-intrabcflag[{}]: r={}", b.intra, ts.msac.rng);
@@ -3391,11 +3384,10 @@ unsafe fn decode_b(
     // intra/inter-specific stuff
     if b.intra != 0 {
         let ymode_cdf = if frame_hdr.frame_type & 1 != 0 {
-            ts.cdf.m.y_mode[dav1d_ymode_size_context[bs as usize] as usize].as_mut_ptr()
+            &mut ts.cdf.m.y_mode[dav1d_ymode_size_context[bs as usize] as usize]
         } else {
-            ts.cdf.kfym[dav1d_intra_mode_context[(*t.a).mode[bx4 as usize] as usize] as usize]
+            &mut ts.cdf.kfym[dav1d_intra_mode_context[(*t.a).mode[bx4 as usize] as usize] as usize]
                 [dav1d_intra_mode_context[t.l.mode[by4 as usize] as usize] as usize]
-                .as_mut_ptr()
         };
 
         *b.y_mode_mut() = dav1d_msac_decode_symbol_adapt16(
@@ -3414,7 +3406,7 @@ unsafe fn decode_b(
             && b.y_mode() as IntraPredMode <= VERT_LEFT_PRED
         {
             let acdf = &mut ts.cdf.m.angle_delta[b.y_mode() as usize - VERT_PRED as usize];
-            let angle = dav1d_msac_decode_symbol_adapt8(&mut ts.msac, acdf.as_mut_ptr(), 6);
+            let angle = dav1d_msac_decode_symbol_adapt8(&mut ts.msac, acdf, 6);
             *b.y_angle_mut() = angle as int8_t - 3;
         } else {
             *b.y_angle_mut() = 0;
@@ -3430,7 +3422,7 @@ unsafe fn decode_b(
             let uvmode_cdf = &mut ts.cdf.m.uv_mode[cfl_allowed as usize][b.y_mode() as usize];
             *b.uv_mode_mut() = dav1d_msac_decode_symbol_adapt16(
                 &mut ts.msac,
-                uvmode_cdf.as_mut_ptr(),
+                uvmode_cdf,
                 N_UV_INTRA_PRED_MODES as size_t - 1 - (!cfl_allowed) as size_t,
             ) as uint8_t;
 
@@ -3440,11 +3432,8 @@ unsafe fn decode_b(
 
             *b.uv_angle_mut() = 0;
             if b.uv_mode() == CFL_PRED as u8 {
-                let sign = dav1d_msac_decode_symbol_adapt8(
-                    &mut ts.msac,
-                    ts.cdf.m.cfl_sign.0.as_mut_ptr(),
-                    7,
-                ) + 1;
+                let sign =
+                    dav1d_msac_decode_symbol_adapt8(&mut ts.msac, &mut ts.cdf.m.cfl_sign.0, 7) + 1;
                 let sign_u = sign * 0x56 >> 8;
                 let sign_v = sign - sign_u * 3;
 
@@ -3454,7 +3443,7 @@ unsafe fn decode_b(
                     let ctx = (sign_u == 2) as usize * 3 + sign_v as usize;
                     b.cfl_alpha_mut()[0] = dav1d_msac_decode_symbol_adapt16(
                         &mut ts.msac,
-                        ts.cdf.m.cfl_alpha[ctx].as_mut_ptr(),
+                        &mut ts.cdf.m.cfl_alpha[ctx],
                         15,
                     ) as i8
                         + 1;
@@ -3470,7 +3459,7 @@ unsafe fn decode_b(
                     let ctx = (sign_v == 2) as usize * 3 + sign_u as usize;
                     b.cfl_alpha_mut()[1] = dav1d_msac_decode_symbol_adapt16(
                         &mut ts.msac,
-                        (ts.cdf.m.cfl_alpha[ctx]).as_mut_ptr(),
+                        &mut ts.cdf.m.cfl_alpha[ctx],
                         15,
                     ) as i8
                         + 1;
@@ -3495,8 +3484,7 @@ unsafe fn decode_b(
                 && b.uv_mode() <= VERT_LEFT_PRED as u8
             {
                 let acdf = &mut ts.cdf.m.angle_delta[b.uv_mode() as usize - VERT_PRED as usize];
-                let angle = dav1d_msac_decode_symbol_adapt8(&mut ts.msac, acdf.as_mut_ptr(), 6)
-                    as libc::c_int;
+                let angle = dav1d_msac_decode_symbol_adapt8(&mut ts.msac, acdf, 6) as libc::c_int;
                 *b.uv_angle_mut() = (angle - 3) as int8_t;
             }
         }
@@ -3509,7 +3497,7 @@ unsafe fn decode_b(
                     + (t.l.pal_sz[by4 as usize] > 0) as usize;
                 let use_y_pal = dav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
-                    ts.cdf.m.pal_y[sz_ctx as usize][pal_ctx].as_mut_ptr(),
+                    &mut ts.cdf.m.pal_y[sz_ctx as usize][pal_ctx],
                 ) != 0;
 
                 if DEBUG_BLOCK_INFO(f, t) {
@@ -3525,7 +3513,7 @@ unsafe fn decode_b(
                 let pal_ctx = b.pal_sz()[0] > 0;
                 let use_uv_pal = dav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
-                    ts.cdf.m.pal_uv[pal_ctx as usize].as_mut_ptr(),
+                    &mut ts.cdf.m.pal_uv[pal_ctx as usize],
                 ) != 0;
 
                 if DEBUG_BLOCK_INFO(f, t) {
@@ -3545,16 +3533,14 @@ unsafe fn decode_b(
         {
             let is_filter = dav1d_msac_decode_bool_adapt(
                 &mut ts.msac,
-                ts.cdf.m.use_filter_intra[bs as usize].as_mut_ptr(),
+                &mut ts.cdf.m.use_filter_intra[bs as usize],
             ) != 0;
 
             if is_filter {
                 *b.y_mode_mut() = FILTER_PRED as uint8_t;
-                *b.y_angle_mut() = dav1d_msac_decode_symbol_adapt4(
-                    &mut ts.msac,
-                    (ts.cdf.m.filter_intra.0).as_mut_ptr(),
-                    4,
-                ) as int8_t;
+                *b.y_angle_mut() =
+                    dav1d_msac_decode_symbol_adapt4(&mut ts.msac, &mut ts.cdf.m.filter_intra.0, 4)
+                        as int8_t;
             }
 
             if DEBUG_BLOCK_INFO(f, t) {
@@ -3625,7 +3611,7 @@ unsafe fn decode_b(
                 let tx_cdf = &mut ts.cdf.m.txsz[(t_dim.max - 1) as usize][tctx as usize];
                 let mut depth = dav1d_msac_decode_symbol_adapt4(
                     &mut ts.msac,
-                    tx_cdf.as_mut_ptr(),
+                    tx_cdf,
                     imin(t_dim.max as libc::c_int, 2 as libc::c_int) as size_t,
                 ) as libc::c_int;
 
@@ -6321,10 +6307,8 @@ unsafe fn decode_b(
             && imin(bw4, bh4) > 1
         {
             let ctx_2 = get_comp_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
-            is_comp = dav1d_msac_decode_bool_adapt(
-                &mut ts.msac,
-                (ts.cdf.m.comp[ctx_2 as usize]).as_mut_ptr(),
-            ) as libc::c_int;
+            is_comp = dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.comp[ctx_2 as usize])
+                as libc::c_int;
             if DEBUG_BLOCK_INFO(f, t) {
                 printf(
                     b"Post-compflag[%d]: r=%d\n\0" as *const u8 as *const libc::c_char,
@@ -6411,35 +6395,33 @@ unsafe fn decode_b(
             }
         } else if is_comp != 0 {
             let dir_ctx = get_comp_dir_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
-            if dav1d_msac_decode_bool_adapt(
-                &mut ts.msac,
-                (ts.cdf.m.comp_dir[dir_ctx as usize]).as_mut_ptr(),
-            ) != 0
+            if dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.comp_dir[dir_ctx as usize])
+                != 0
             {
                 let ctx1 = av1_get_fwd_ref_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
                 if dav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
-                    (ts.cdf.m.comp_fwd_ref[0][ctx1 as usize]).as_mut_ptr(),
+                    &mut ts.cdf.m.comp_fwd_ref[0][ctx1 as usize],
                 ) != 0
                 {
                     let ctx2 = av1_get_fwd_ref_2_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] = (2 as libc::c_int as libc::c_uint)
                         .wrapping_add(dav1d_msac_decode_bool_adapt(
                             &mut ts.msac,
-                            (ts.cdf.m.comp_fwd_ref[2][ctx2 as usize]).as_mut_ptr(),
+                            &mut ts.cdf.m.comp_fwd_ref[2][ctx2 as usize],
                         ))
                         as int8_t;
                 } else {
                     let ctx2_0 = av1_get_fwd_ref_1_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] = dav1d_msac_decode_bool_adapt(
                         &mut ts.msac,
-                        (ts.cdf.m.comp_fwd_ref[1][ctx2_0 as usize]).as_mut_ptr(),
+                        &mut ts.cdf.m.comp_fwd_ref[1][ctx2_0 as usize],
                     ) as int8_t;
                 }
                 let ctx3 = av1_get_bwd_ref_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
                 if dav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
-                    (ts.cdf.m.comp_bwd_ref[0][ctx3 as usize]).as_mut_ptr(),
+                    &mut ts.cdf.m.comp_bwd_ref[0][ctx3 as usize],
                 ) != 0
                 {
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] = 6 as libc::c_int as int8_t;
@@ -6448,7 +6430,7 @@ unsafe fn decode_b(
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] = (4 as libc::c_int as libc::c_uint)
                         .wrapping_add(dav1d_msac_decode_bool_adapt(
                             &mut ts.msac,
-                            (ts.cdf.m.comp_bwd_ref[1][ctx4 as usize]).as_mut_ptr(),
+                            &mut ts.cdf.m.comp_bwd_ref[1][ctx4 as usize],
                         ))
                         as int8_t;
                 }
@@ -6456,7 +6438,7 @@ unsafe fn decode_b(
                 let uctx_p = av1_get_ref_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
                 if dav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
-                    (ts.cdf.m.comp_uni_ref[0][uctx_p as usize]).as_mut_ptr(),
+                    &mut ts.cdf.m.comp_uni_ref[0][uctx_p as usize],
                 ) != 0
                 {
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] = 4 as libc::c_int as int8_t;
@@ -6467,7 +6449,7 @@ unsafe fn decode_b(
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] = (1 as libc::c_int as libc::c_uint)
                         .wrapping_add(dav1d_msac_decode_bool_adapt(
                             &mut ts.msac,
-                            (ts.cdf.m.comp_uni_ref[1][uctx_p1 as usize]).as_mut_ptr(),
+                            &mut ts.cdf.m.comp_uni_ref[1][uctx_p1 as usize],
                         ))
                         as int8_t;
                     if b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] as libc::c_int == 2 {
@@ -6477,7 +6459,7 @@ unsafe fn decode_b(
                             (b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] as libc::c_uint)
                                 .wrapping_add(dav1d_msac_decode_bool_adapt(
                                     &mut ts.msac,
-                                    (ts.cdf.m.comp_uni_ref[2][uctx_p2 as usize]).as_mut_ptr(),
+                                    &mut ts.cdf.m.comp_uni_ref[2][uctx_p2 as usize],
                                 )) as int8_t as int8_t;
                     }
                 }
@@ -6514,7 +6496,7 @@ unsafe fn decode_b(
             );
             b.c2rust_unnamed.c2rust_unnamed_0.inter_mode = dav1d_msac_decode_symbol_adapt8(
                 &mut ts.msac,
-                (ts.cdf.m.comp_inter_mode[ctx_4 as usize]).as_mut_ptr(),
+                &mut ts.cdf.m.comp_inter_mode[ctx_4 as usize],
                 (N_COMP_INTER_PRED_MODES as libc::c_int - 1) as size_t,
             ) as uint8_t;
             if DEBUG_BLOCK_INFO(f, t) {
@@ -6540,7 +6522,7 @@ unsafe fn decode_b(
                         (b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as libc::c_uint).wrapping_add(
                             dav1d_msac_decode_bool_adapt(
                                 &mut ts.msac,
-                                (ts.cdf.m.drl_bit[drl_ctx_v1 as usize]).as_mut_ptr(),
+                                &mut ts.cdf.m.drl_bit[drl_ctx_v1 as usize],
                             ),
                         ) as uint8_t as uint8_t;
                     if b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as libc::c_int
@@ -6552,7 +6534,7 @@ unsafe fn decode_b(
                             (b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as libc::c_uint)
                                 .wrapping_add(dav1d_msac_decode_bool_adapt(
                                     &mut ts.msac,
-                                    (ts.cdf.m.drl_bit[drl_ctx_v2 as usize]).as_mut_ptr(),
+                                    &mut ts.cdf.m.drl_bit[drl_ctx_v2 as usize],
                                 )) as uint8_t as uint8_t;
                     }
                     if DEBUG_BLOCK_INFO(f, t) {
@@ -6575,7 +6557,7 @@ unsafe fn decode_b(
                         (b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as libc::c_uint).wrapping_add(
                             dav1d_msac_decode_bool_adapt(
                                 &mut ts.msac,
-                                (ts.cdf.m.drl_bit[drl_ctx_v2_0 as usize]).as_mut_ptr(),
+                                &mut ts.cdf.m.drl_bit[drl_ctx_v2_0 as usize],
                             ),
                         ) as uint8_t as uint8_t;
                     if b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as libc::c_int
@@ -6587,7 +6569,7 @@ unsafe fn decode_b(
                             (b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as libc::c_uint)
                                 .wrapping_add(dav1d_msac_decode_bool_adapt(
                                     &mut ts.msac,
-                                    (ts.cdf.m.drl_bit[drl_ctx_v3 as usize]).as_mut_ptr(),
+                                    &mut ts.cdf.m.drl_bit[drl_ctx_v3 as usize],
                                 )) as uint8_t as uint8_t;
                     }
                     if DEBUG_BLOCK_INFO(f, t) {
@@ -6756,7 +6738,7 @@ unsafe fn decode_b(
                 let mask_ctx = get_mask_comp_ctx(&*t.a, &t.l, by4, bx4);
                 is_segwedge = dav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
-                    (ts.cdf.m.mask_comp[mask_ctx as usize]).as_mut_ptr(),
+                    &mut ts.cdf.m.mask_comp[mask_ctx as usize],
                 ) as libc::c_int;
                 if DEBUG_BLOCK_INFO(f, t) {
                     printf(
@@ -6790,7 +6772,7 @@ unsafe fn decode_b(
                         (COMP_INTER_WEIGHTED_AVG as libc::c_int as libc::c_uint).wrapping_add(
                             dav1d_msac_decode_bool_adapt(
                                 &mut ts.msac,
-                                (ts.cdf.m.jnt_comp[jnt_ctx as usize]).as_mut_ptr(),
+                                &mut ts.cdf.m.jnt_comp[jnt_ctx as usize],
                             ),
                         ) as uint8_t;
                     if DEBUG_BLOCK_INFO(f, t) {
@@ -6821,7 +6803,7 @@ unsafe fn decode_b(
                         as libc::c_uint)
                         .wrapping_sub(dav1d_msac_decode_bool_adapt(
                             &mut ts.msac,
-                            (ts.cdf.m.wedge_comp[ctx_5 as usize]).as_mut_ptr(),
+                            &mut ts.cdf.m.wedge_comp[ctx_5 as usize],
                         ))
                         as uint8_t;
                     if b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_int
@@ -6833,7 +6815,7 @@ unsafe fn decode_b(
                             .c2rust_unnamed
                             .wedge_idx = dav1d_msac_decode_symbol_adapt16(
                             &mut ts.msac,
-                            (ts.cdf.m.wedge_idx[ctx_5 as usize]).as_mut_ptr(),
+                            &mut ts.cdf.m.wedge_idx[ctx_5 as usize],
                             15 as libc::c_int as size_t,
                         ) as uint8_t;
                     }
@@ -6891,8 +6873,7 @@ unsafe fn decode_b(
                 );
                 if dav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
-                    (ts.cdf.m.r#ref[0][ctx1_0 as usize])
-                        .as_mut_ptr(),
+                    &mut ts.cdf.m.r#ref[0][ctx1_0 as usize],
                 ) != 0
                 {
                     let ctx2_1 = av1_get_bwd_ref_ctx(
@@ -6905,8 +6886,7 @@ unsafe fn decode_b(
                     );
                     if dav1d_msac_decode_bool_adapt(
                         &mut ts.msac,
-                        (ts.cdf.m.r#ref[1][ctx2_1 as usize])
-                            .as_mut_ptr(),
+                        &mut ts.cdf.m.r#ref[1][ctx2_1 as usize],
                     ) != 0
                     {
                         b
@@ -6931,11 +6911,10 @@ unsafe fn decode_b(
                             .wrapping_add(
                                 dav1d_msac_decode_bool_adapt(
                                     &mut ts.msac,
-                                    (ts
+                                    &mut ts
                                         .cdf
                                         .m
-                                        .r#ref[5][ctx3_0 as usize])
-                                        .as_mut_ptr(),
+                                        .r#ref[5][ctx3_0 as usize],
                                 ),
                             ) as int8_t;
                     }
@@ -6950,8 +6929,7 @@ unsafe fn decode_b(
                     );
                     if dav1d_msac_decode_bool_adapt(
                         &mut ts.msac,
-                        (ts.cdf.m.r#ref[2][ctx2_2 as usize])
-                            .as_mut_ptr(),
+                        &mut ts.cdf.m.r#ref[2][ctx2_2 as usize],
                     ) != 0
                     {
                         let ctx3_1 = av1_get_fwd_ref_2_ctx(
@@ -6970,11 +6948,10 @@ unsafe fn decode_b(
                             .wrapping_add(
                                 dav1d_msac_decode_bool_adapt(
                                     &mut ts.msac,
-                                    (ts
+                                    &mut ts
                                         .cdf
                                         .m
-                                        .r#ref[4][ctx3_1 as usize])
-                                        .as_mut_ptr(),
+                                        .r#ref[4][ctx3_1 as usize],
                                 ),
                             ) as int8_t;
                     } else {
@@ -6992,11 +6969,10 @@ unsafe fn decode_b(
                             .r#ref[0 as libc::c_int
                             as usize] = dav1d_msac_decode_bool_adapt(
                             &mut ts.msac,
-                            (ts
+                            &mut ts
                                 .cdf
                                 .m
-                                .r#ref[3][ctx3_2 as usize])
-                                .as_mut_ptr(),
+                                .r#ref[3][ctx3_2 as usize],
                         ) as int8_t;
                     }
                 }
@@ -7040,7 +7016,7 @@ unsafe fn decode_b(
                 .unwrap_or(false)
                 || dav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
-                    (ts.cdf.m.newmv_mode[(ctx_6 & 7) as usize]).as_mut_ptr(),
+                    &mut ts.cdf.m.newmv_mode[(ctx_6 & 7) as usize],
                 ) != 0
             {
                 if seg
@@ -7048,7 +7024,7 @@ unsafe fn decode_b(
                     .unwrap_or(false)
                     || dav1d_msac_decode_bool_adapt(
                         &mut ts.msac,
-                        (ts.cdf.m.globalmv_mode[(ctx_6 >> 3 & 1) as usize]).as_mut_ptr(),
+                        &mut ts.cdf.m.globalmv_mode[(ctx_6 >> 3 & 1) as usize],
                     ) == 0
                 {
                     b.c2rust_unnamed.c2rust_unnamed_0.inter_mode =
@@ -7074,7 +7050,7 @@ unsafe fn decode_b(
                     has_subpel_filter = 1 as libc::c_int;
                     if dav1d_msac_decode_bool_adapt(
                         &mut ts.msac,
-                        (ts.cdf.m.refmv_mode[(ctx_6 >> 4 & 15) as usize]).as_mut_ptr(),
+                        &mut ts.cdf.m.refmv_mode[(ctx_6 >> 4 & 15) as usize],
                     ) != 0
                     {
                         b.c2rust_unnamed.c2rust_unnamed_0.inter_mode =
@@ -7087,7 +7063,7 @@ unsafe fn decode_b(
                                 (b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as libc::c_uint)
                                     .wrapping_add(dav1d_msac_decode_bool_adapt(
                                         &mut ts.msac,
-                                        (ts.cdf.m.drl_bit[drl_ctx_v2_1 as usize]).as_mut_ptr(),
+                                        &mut ts.cdf.m.drl_bit[drl_ctx_v2_1 as usize],
                                     )) as uint8_t as uint8_t;
                             if b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as libc::c_int
                                 == NEAR_DRL as libc::c_int
@@ -7098,7 +7074,7 @@ unsafe fn decode_b(
                                     (b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as libc::c_uint)
                                         .wrapping_add(dav1d_msac_decode_bool_adapt(
                                             &mut ts.msac,
-                                            (ts.cdf.m.drl_bit[drl_ctx_v3_0 as usize]).as_mut_ptr(),
+                                            &mut ts.cdf.m.drl_bit[drl_ctx_v3_0 as usize],
                                         )) as uint8_t
                                         as uint8_t;
                             }
@@ -7161,7 +7137,7 @@ unsafe fn decode_b(
                         (b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as libc::c_uint).wrapping_add(
                             dav1d_msac_decode_bool_adapt(
                                 &mut ts.msac,
-                                (ts.cdf.m.drl_bit[drl_ctx_v1_0 as usize]).as_mut_ptr(),
+                                &mut ts.cdf.m.drl_bit[drl_ctx_v1_0 as usize],
                             ),
                         ) as uint8_t as uint8_t;
                     if b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as libc::c_int
@@ -7173,7 +7149,7 @@ unsafe fn decode_b(
                             (b.c2rust_unnamed.c2rust_unnamed_0.drl_idx as libc::c_uint)
                                 .wrapping_add(dav1d_msac_decode_bool_adapt(
                                     &mut ts.msac,
-                                    (ts.cdf.m.drl_bit[drl_ctx_v2_2 as usize]).as_mut_ptr(),
+                                    &mut ts.cdf.m.drl_bit[drl_ctx_v2_2 as usize],
                                 )) as uint8_t as uint8_t;
                     }
                 }
@@ -7251,7 +7227,7 @@ unsafe fn decode_b(
                     != 0
                 && dav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
-                    (ts.cdf.m.interintra[ii_sz_grp as usize]).as_mut_ptr(),
+                    &mut ts.cdf.m.interintra[ii_sz_grp as usize],
                 ) != 0
             {
                 b.c2rust_unnamed
@@ -7260,7 +7236,7 @@ unsafe fn decode_b(
                     .c2rust_unnamed
                     .interintra_mode = dav1d_msac_decode_symbol_adapt4(
                     &mut ts.msac,
-                    (ts.cdf.m.interintra_mode[ii_sz_grp as usize]).as_mut_ptr(),
+                    &mut ts.cdf.m.interintra_mode[ii_sz_grp as usize],
                     (N_INTER_INTRA_PRED_MODES as libc::c_int - 1) as size_t,
                 ) as uint8_t;
                 let wedge_ctx = dav1d_wedge_ctx_lut[bs as usize] as libc::c_int;
@@ -7268,7 +7244,7 @@ unsafe fn decode_b(
                     (INTER_INTRA_BLEND as libc::c_int as libc::c_uint).wrapping_add(
                         dav1d_msac_decode_bool_adapt(
                             &mut ts.msac,
-                            (ts.cdf.m.interintra_wedge[wedge_ctx as usize]).as_mut_ptr(),
+                            &mut ts.cdf.m.interintra_wedge[wedge_ctx as usize],
                         ),
                     ) as uint8_t;
                 if b.c2rust_unnamed.c2rust_unnamed_0.interintra_type as libc::c_int
@@ -7280,7 +7256,7 @@ unsafe fn decode_b(
                         .c2rust_unnamed
                         .wedge_idx = dav1d_msac_decode_symbol_adapt16(
                         &mut ts.msac,
-                        (ts.cdf.m.wedge_idx[wedge_ctx as usize]).as_mut_ptr(),
+                        &mut ts.cdf.m.wedge_idx[wedge_ctx as usize],
                         15 as libc::c_int as size_t,
                     ) as uint8_t;
                 }
@@ -7346,14 +7322,11 @@ unsafe fn decode_b(
                 b.c2rust_unnamed.c2rust_unnamed_0.motion_mode = (if allow_warp != 0 {
                     dav1d_msac_decode_symbol_adapt4(
                         &mut ts.msac,
-                        (ts.cdf.m.motion_mode[bs as usize]).as_mut_ptr(),
+                        &mut ts.cdf.m.motion_mode[bs as usize],
                         2 as libc::c_int as size_t,
                     )
                 } else {
-                    dav1d_msac_decode_bool_adapt(
-                        &mut ts.msac,
-                        (ts.cdf.m.obmc[bs as usize]).as_mut_ptr(),
-                    )
+                    dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.obmc[bs as usize])
                 }) as uint8_t;
                 if b.c2rust_unnamed.c2rust_unnamed_0.motion_mode as libc::c_int
                     == MM_WARP as libc::c_int
@@ -7534,7 +7507,7 @@ unsafe fn decode_b(
                 );
                 filter_0[0] = dav1d_msac_decode_symbol_adapt4(
                     &mut ts.msac,
-                    (ts.cdf.m.filter[0][ctx1_1 as usize]).as_mut_ptr(),
+                    &mut ts.cdf.m.filter[0][ctx1_1 as usize],
                     (DAV1D_N_SWITCHABLE_FILTERS as libc::c_int - 1) as size_t,
                 ) as Dav1dFilterMode;
                 if (*f.seq_hdr).dual_filter != 0 {
@@ -7558,7 +7531,7 @@ unsafe fn decode_b(
                     }
                     filter_0[1] = dav1d_msac_decode_symbol_adapt4(
                         &mut ts.msac,
-                        (ts.cdf.m.filter[1][ctx2_3 as usize]).as_mut_ptr(),
+                        &mut ts.cdf.m.filter[1][ctx2_3 as usize],
                         (DAV1D_N_SWITCHABLE_FILTERS as libc::c_int - 1) as size_t,
                     ) as Dav1dFilterMode;
                     if DEBUG_BLOCK_INFO(f, t) {
@@ -9488,7 +9461,7 @@ unsafe extern "C" fn decode_sb(
         } else {
             bp = dav1d_msac_decode_symbol_adapt16(
                 &mut (*ts).msac,
-                pc.as_mut_ptr(),
+                pc,
                 dav1d_partition_type_count[bl as usize] as size_t,
             ) as BlockPartition;
             if (*f).cur.p.layout as libc::c_uint
@@ -10379,7 +10352,7 @@ unsafe extern "C" fn read_restoration_info(
     if frame_type as libc::c_uint == DAV1D_RESTORATION_SWITCHABLE as libc::c_int as libc::c_uint {
         let filter = dav1d_msac_decode_symbol_adapt4(
             &mut (*ts).msac,
-            ((*ts).cdf.m.restore_switchable.0).as_mut_ptr(),
+            &mut (*ts).cdf.m.restore_switchable.0,
             2 as libc::c_int as size_t,
         ) as libc::c_int;
         (*lr).type_0 = (if filter != 0 {
@@ -10396,9 +10369,9 @@ unsafe extern "C" fn read_restoration_info(
             &mut (*ts).msac,
             if frame_type as libc::c_uint == DAV1D_RESTORATION_WIENER as libc::c_int as libc::c_uint
             {
-                ((*ts).cdf.m.restore_wiener.0).as_mut_ptr()
+                &mut (*ts).cdf.m.restore_wiener.0
             } else {
-                ((*ts).cdf.m.restore_sgrproj.0).as_mut_ptr()
+                &mut (*ts).cdf.m.restore_sgrproj.0
             },
         );
         (*lr).type_0 = (if type_0 != 0 {

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -379,9 +379,9 @@ pub unsafe fn dav1d_msac_init(
 }
 
 pub unsafe fn dav1d_msac_decode_symbol_adapt4(
-    mut s: *mut MsacContext,
-    mut cdf: *mut uint16_t,
-    mut n_symbols: size_t,
+    s: *mut MsacContext,
+    cdf: *mut uint16_t,
+    n_symbols: size_t,
 ) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
@@ -395,9 +395,9 @@ pub unsafe fn dav1d_msac_decode_symbol_adapt4(
 }
 
 pub unsafe fn dav1d_msac_decode_symbol_adapt8(
-    mut s: *mut MsacContext,
-    mut cdf: *mut uint16_t,
-    mut n_symbols: size_t,
+    s: *mut MsacContext,
+    cdf: *mut uint16_t,
+    n_symbols: size_t,
 ) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
@@ -411,9 +411,9 @@ pub unsafe fn dav1d_msac_decode_symbol_adapt8(
 }
 
 pub unsafe fn dav1d_msac_decode_symbol_adapt16(
-    mut s: *mut MsacContext,
-    mut cdf: *mut uint16_t,
-    mut n_symbols: size_t,
+    s: *mut MsacContext,
+    cdf: *mut uint16_t,
+    n_symbols: size_t,
 ) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
@@ -427,8 +427,8 @@ pub unsafe fn dav1d_msac_decode_symbol_adapt16(
 }
 
 pub unsafe fn dav1d_msac_decode_bool_adapt(
-    mut s: *mut MsacContext,
-    mut cdf: *mut uint16_t,
+    s: *mut MsacContext,
+    cdf: *mut uint16_t,
 ) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
@@ -441,7 +441,7 @@ pub unsafe fn dav1d_msac_decode_bool_adapt(
     }
 }
 
-pub unsafe fn dav1d_msac_decode_bool_equi(mut s: *mut MsacContext) -> libc::c_uint {
+pub unsafe fn dav1d_msac_decode_bool_equi(s: *mut MsacContext) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
              dav1d_msac_decode_bool_equi_sse2(s)
@@ -453,7 +453,7 @@ pub unsafe fn dav1d_msac_decode_bool_equi(mut s: *mut MsacContext) -> libc::c_ui
     }
 }
 
-pub unsafe fn dav1d_msac_decode_bool(mut s: *mut MsacContext, mut f: libc::c_uint) -> libc::c_uint {
+pub unsafe fn dav1d_msac_decode_bool(s: *mut MsacContext, f: libc::c_uint) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
              dav1d_msac_decode_bool_sse2(s, f)
@@ -465,10 +465,7 @@ pub unsafe fn dav1d_msac_decode_bool(mut s: *mut MsacContext, mut f: libc::c_uin
     }
 }
 
-pub unsafe fn dav1d_msac_decode_hi_tok(
-    mut s: *mut MsacContext,
-    mut cdf: *mut uint16_t,
-) -> libc::c_uint {
+pub unsafe fn dav1d_msac_decode_hi_tok(s: *mut MsacContext, cdf: *mut uint16_t) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
              dav1d_msac_decode_hi_tok_sse2(s, cdf)

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -310,7 +310,10 @@ unsafe extern "C" fn dav1d_msac_decode_symbol_adapt_c(
     dav1d_msac_decode_symbol_adapt_rust(&mut *s, cdf, n_symbols)
 }
 
-unsafe fn dav1d_msac_decode_bool_adapt_rust(s: &mut MsacContext, cdf: &mut [u16]) -> libc::c_uint {
+unsafe fn dav1d_msac_decode_bool_adapt_rust(
+    s: &mut MsacContext,
+    cdf: &mut [u16; 2],
+) -> libc::c_uint {
     let bit: libc::c_uint = dav1d_msac_decode_bool(s, cdf[0] as libc::c_uint);
     if s.allow_update_cdf != 0 {
         let count: libc::c_uint = cdf[1] as libc::c_uint;
@@ -326,7 +329,7 @@ unsafe fn dav1d_msac_decode_bool_adapt_rust(s: &mut MsacContext, cdf: &mut [u16]
     return bit;
 }
 
-unsafe fn dav1d_msac_decode_hi_tok_rust(s: &mut MsacContext, cdf: &mut [u16]) -> libc::c_uint {
+unsafe fn dav1d_msac_decode_hi_tok_rust(s: &mut MsacContext, cdf: &mut [u16; 4]) -> libc::c_uint {
     let mut tok_br: libc::c_uint =
         dav1d_msac_decode_symbol_adapt4(s, cdf, 3 as libc::c_int as size_t);
     let mut tok: libc::c_uint = (3 as libc::c_int as libc::c_uint).wrapping_add(tok_br);
@@ -421,7 +424,10 @@ pub unsafe fn dav1d_msac_decode_symbol_adapt16(
     }
 }
 
-pub unsafe fn dav1d_msac_decode_bool_adapt(s: &mut MsacContext, cdf: &mut [u16]) -> libc::c_uint {
+pub unsafe fn dav1d_msac_decode_bool_adapt(
+    s: &mut MsacContext,
+    cdf: &mut [u16; 2],
+) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
             dav1d_msac_decode_bool_adapt_sse2(s, cdf.as_mut_ptr())
@@ -457,7 +463,7 @@ pub unsafe fn dav1d_msac_decode_bool(s: &mut MsacContext, f: libc::c_uint) -> li
     }
 }
 
-pub unsafe fn dav1d_msac_decode_hi_tok(s: &mut MsacContext, cdf: &mut [u16]) -> libc::c_uint {
+pub unsafe fn dav1d_msac_decode_hi_tok(s: &mut MsacContext, cdf: &mut [u16; 4]) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
              dav1d_msac_decode_hi_tok_sse2(s, cdf.as_mut_ptr())

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -76,7 +76,7 @@ use crate::include::common::attributes::clz;
 use crate::include::common::intops::inv_recenter;
 
 #[inline]
-pub unsafe fn dav1d_msac_decode_bools(s: *mut MsacContext, n: libc::c_uint) -> libc::c_uint {
+pub unsafe fn dav1d_msac_decode_bools(s: &mut MsacContext, n: libc::c_uint) -> libc::c_uint {
     let mut v = 0;
     for _ in 0..n {
         v = v << 1 | dav1d_msac_decode_bool_equi(s);
@@ -85,7 +85,7 @@ pub unsafe fn dav1d_msac_decode_bools(s: *mut MsacContext, n: libc::c_uint) -> l
 }
 
 #[inline]
-pub unsafe fn dav1d_msac_decode_uniform(s: *mut MsacContext, n: libc::c_uint) -> libc::c_int {
+pub unsafe fn dav1d_msac_decode_uniform(s: &mut MsacContext, n: libc::c_uint) -> libc::c_int {
     if !(n > 0 as libc::c_uint) {
         unreachable!();
     }
@@ -106,19 +106,19 @@ pub unsafe fn dav1d_msac_decode_uniform(s: *mut MsacContext, n: libc::c_uint) ->
 
 #[cfg(all(feature = "asm", target_arch = "x86_64"))]
 #[inline(always)]
-unsafe extern "C" fn msac_init_x86(s: *mut MsacContext) {
+unsafe extern "C" fn msac_init_x86(s: &mut MsacContext) {
     use crate::src::x86::cpu::DAV1D_X86_CPU_FLAG_AVX2;
     use crate::src::x86::cpu::DAV1D_X86_CPU_FLAG_SSE2;
 
     let flags: libc::c_uint = dav1d_get_cpu_flags();
     if flags & DAV1D_X86_CPU_FLAG_SSE2 as libc::c_int as libc::c_uint != 0 {
-        (*s).symbol_adapt16 = Some(
+        s.symbol_adapt16 = Some(
             dav1d_msac_decode_symbol_adapt16_sse2
                 as unsafe extern "C" fn(*mut MsacContext, *mut uint16_t, size_t) -> libc::c_uint,
         );
     }
     if flags & DAV1D_X86_CPU_FLAG_AVX2 as libc::c_int as libc::c_uint != 0 {
-        (*s).symbol_adapt16 = Some(
+        s.symbol_adapt16 = Some(
             dav1d_msac_decode_symbol_adapt16_avx2
                 as unsafe extern "C" fn(*mut MsacContext, *mut uint16_t, size_t) -> libc::c_uint,
         );
@@ -129,43 +129,43 @@ unsafe extern "C" fn msac_init_x86(s: *mut MsacContext) {
 use crate::src::cpu::dav1d_get_cpu_flags;
 
 #[inline]
-unsafe extern "C" fn ctx_refill(s: *mut MsacContext) {
-    let mut buf_pos: *const uint8_t = (*s).buf_pos;
-    let mut buf_end: *const uint8_t = (*s).buf_end;
+unsafe extern "C" fn ctx_refill(s: &mut MsacContext) {
+    let mut buf_pos: *const uint8_t = s.buf_pos;
+    let mut buf_end: *const uint8_t = s.buf_end;
     let mut c = ((::core::mem::size_of::<ec_win>() as libc::c_ulong) << 3)
-        .wrapping_sub((*s).cnt as libc::c_ulong)
+        .wrapping_sub(s.cnt as libc::c_ulong)
         .wrapping_sub(24 as libc::c_int as libc::c_ulong) as libc::c_int;
-    let mut dif: ec_win = (*s).dif;
+    let mut dif: ec_win = s.dif;
     while c >= 0 && buf_pos < buf_end {
         let fresh1 = buf_pos;
         buf_pos = buf_pos.offset(1);
         dif ^= (*fresh1 as ec_win) << c;
         c -= 8 as libc::c_int;
     }
-    (*s).dif = dif;
-    (*s).cnt = ((::core::mem::size_of::<ec_win>() as libc::c_ulong) << 3)
+    s.dif = dif;
+    s.cnt = ((::core::mem::size_of::<ec_win>() as libc::c_ulong) << 3)
         .wrapping_sub(c as libc::c_ulong)
         .wrapping_sub(24 as libc::c_int as libc::c_ulong) as libc::c_int;
-    (*s).buf_pos = buf_pos;
+    s.buf_pos = buf_pos;
 }
 
 #[inline]
-unsafe extern "C" fn ctx_norm(s: *mut MsacContext, dif: ec_win, rng: libc::c_uint) {
+unsafe extern "C" fn ctx_norm(s: &mut MsacContext, dif: ec_win, rng: libc::c_uint) {
     let d = 15 as libc::c_int ^ (31 as libc::c_int ^ clz(rng));
     if !(rng <= 65535 as libc::c_uint) {
         unreachable!();
     }
-    (*s).cnt -= d;
-    (*s).dif = (dif.wrapping_add(1) << d).wrapping_sub(1);
-    (*s).rng = rng << d;
-    if (*s).cnt < 0 {
+    s.cnt -= d;
+    s.dif = (dif.wrapping_add(1) << d).wrapping_sub(1);
+    s.rng = rng << d;
+    if s.cnt < 0 {
         ctx_refill(s);
     }
 }
 
-unsafe fn dav1d_msac_decode_bool_equi_rust(s: *mut MsacContext) -> libc::c_uint {
-    let r: libc::c_uint = (*s).rng;
-    let mut dif: ec_win = (*s).dif;
+unsafe fn dav1d_msac_decode_bool_equi_rust(s: &mut MsacContext) -> libc::c_uint {
+    let r: libc::c_uint = s.rng;
+    let mut dif: ec_win = s.dif;
     if !(dif >> (::core::mem::size_of::<ec_win>() << 3).wrapping_sub(16) < r as size_t) {
         unreachable!();
     }
@@ -182,9 +182,9 @@ unsafe fn dav1d_msac_decode_bool_equi_rust(s: *mut MsacContext) -> libc::c_uint 
     return (ret == 0) as libc::c_int as libc::c_uint;
 }
 
-unsafe fn dav1d_msac_decode_bool_rust(s: *mut MsacContext, f: libc::c_uint) -> libc::c_uint {
-    let r: libc::c_uint = (*s).rng;
-    let mut dif: ec_win = (*s).dif;
+unsafe fn dav1d_msac_decode_bool_rust(s: &mut MsacContext, f: libc::c_uint) -> libc::c_uint {
+    let r: libc::c_uint = s.rng;
+    let mut dif: ec_win = s.dif;
     if !(dif >> (::core::mem::size_of::<ec_win>() << 3).wrapping_sub(16) < r as size_t) {
         unreachable!();
     }
@@ -203,7 +203,7 @@ unsafe fn dav1d_msac_decode_bool_rust(s: *mut MsacContext, f: libc::c_uint) -> l
 }
 
 pub unsafe fn dav1d_msac_decode_subexp(
-    s: *mut MsacContext,
+    s: &mut MsacContext,
     r#ref: libc::c_int,
     n: libc::c_int,
     mut k: libc::c_uint,
@@ -230,17 +230,17 @@ pub unsafe fn dav1d_msac_decode_subexp(
 }
 
 unsafe fn dav1d_msac_decode_symbol_adapt_rust(
-    s: *mut MsacContext,
+    s: &mut MsacContext,
     cdf: *mut uint16_t,
     n_symbols: size_t,
 ) -> libc::c_uint {
-    let c: libc::c_uint = ((*s).dif
+    let c: libc::c_uint = (s.dif
         >> ((::core::mem::size_of::<ec_win>() as libc::c_ulong) << 3)
             .wrapping_sub(16 as libc::c_int as libc::c_ulong))
         as libc::c_uint;
-    let r: libc::c_uint = (*s).rng >> 8;
+    let r: libc::c_uint = s.rng >> 8;
     let mut u: libc::c_uint = 0;
-    let mut v: libc::c_uint = (*s).rng;
+    let mut v: libc::c_uint = s.rng;
     let mut val: libc::c_uint = -(1 as libc::c_int) as libc::c_uint;
     if !(n_symbols <= 15) {
         unreachable!();
@@ -261,19 +261,19 @@ unsafe fn dav1d_msac_decode_symbol_adapt_rust(
             break;
         }
     }
-    if !(u <= (*s).rng) {
+    if !(u <= s.rng) {
         unreachable!();
     }
     ctx_norm(
         s,
-        ((*s).dif).wrapping_sub(
+        (s.dif).wrapping_sub(
             (v as ec_win)
                 << ((::core::mem::size_of::<ec_win>() as libc::c_ulong) << 3)
                     .wrapping_sub(16 as libc::c_int as libc::c_ulong),
         ),
         u.wrapping_sub(v),
     );
-    if (*s).allow_update_cdf != 0 {
+    if s.allow_update_cdf != 0 {
         let count: libc::c_uint = *cdf.offset(n_symbols as isize) as libc::c_uint;
         let rate: libc::c_uint = (4 as libc::c_int as libc::c_uint)
             .wrapping_add(count >> 4)
@@ -304,15 +304,15 @@ unsafe extern "C" fn dav1d_msac_decode_symbol_adapt_c(
     cdf: *mut uint16_t,
     n_symbols: size_t,
 ) -> libc::c_uint {
-    dav1d_msac_decode_symbol_adapt_rust(s, cdf, n_symbols)
+    dav1d_msac_decode_symbol_adapt_rust(&mut *s, cdf, n_symbols)
 }
 
 unsafe fn dav1d_msac_decode_bool_adapt_rust(
-    s: *mut MsacContext,
+    s: &mut MsacContext,
     cdf: *mut uint16_t,
 ) -> libc::c_uint {
     let bit: libc::c_uint = dav1d_msac_decode_bool(s, *cdf as libc::c_uint);
-    if (*s).allow_update_cdf != 0 {
+    if s.allow_update_cdf != 0 {
         let count: libc::c_uint = *cdf.offset(1) as libc::c_uint;
         let rate = (4 as libc::c_int as libc::c_uint).wrapping_add(count >> 4) as libc::c_int;
         if bit != 0 {
@@ -332,7 +332,7 @@ unsafe fn dav1d_msac_decode_bool_adapt_rust(
     return bit;
 }
 
-unsafe fn dav1d_msac_decode_hi_tok_rust(s: *mut MsacContext, cdf: *mut uint16_t) -> libc::c_uint {
+unsafe fn dav1d_msac_decode_hi_tok_rust(s: &mut MsacContext, cdf: *mut uint16_t) -> libc::c_uint {
     let mut tok_br: libc::c_uint =
         dav1d_msac_decode_symbol_adapt4(s, cdf, 3 as libc::c_int as size_t);
     let mut tok: libc::c_uint = (3 as libc::c_int as libc::c_uint).wrapping_add(tok_br);
@@ -353,24 +353,24 @@ unsafe fn dav1d_msac_decode_hi_tok_rust(s: *mut MsacContext, cdf: *mut uint16_t)
 }
 
 pub unsafe fn dav1d_msac_init(
-    s: *mut MsacContext,
+    s: &mut MsacContext,
     data: *const uint8_t,
     sz: size_t,
     disable_cdf_update_flag: libc::c_int,
 ) {
-    (*s).buf_pos = data;
-    (*s).buf_end = data.offset(sz as isize);
-    (*s).dif = ((1 as libc::c_int as ec_win)
+    s.buf_pos = data;
+    s.buf_end = data.offset(sz as isize);
+    s.dif = ((1 as libc::c_int as ec_win)
         << ((::core::mem::size_of::<ec_win>()) << 3).wrapping_sub(1))
     .wrapping_sub(1);
-    (*s).rng = 0x8000 as libc::c_int as libc::c_uint;
-    (*s).cnt = -(15 as libc::c_int);
-    (*s).allow_update_cdf = (disable_cdf_update_flag == 0) as libc::c_int;
+    s.rng = 0x8000 as libc::c_int as libc::c_uint;
+    s.cnt = -(15 as libc::c_int);
+    s.allow_update_cdf = (disable_cdf_update_flag == 0) as libc::c_int;
     ctx_refill(s);
 
     #[cfg(all(feature = "asm", target_arch = "x86_64"))]
     {
-        (*s).symbol_adapt16 = Some(
+        s.symbol_adapt16 = Some(
             dav1d_msac_decode_symbol_adapt_c
                 as unsafe extern "C" fn(*mut MsacContext, *mut uint16_t, size_t) -> libc::c_uint,
         );
@@ -379,7 +379,7 @@ pub unsafe fn dav1d_msac_init(
 }
 
 pub unsafe fn dav1d_msac_decode_symbol_adapt4(
-    s: *mut MsacContext,
+    s: &mut MsacContext,
     cdf: *mut uint16_t,
     n_symbols: size_t,
 ) -> libc::c_uint {
@@ -395,7 +395,7 @@ pub unsafe fn dav1d_msac_decode_symbol_adapt4(
 }
 
 pub unsafe fn dav1d_msac_decode_symbol_adapt8(
-    s: *mut MsacContext,
+    s: &mut MsacContext,
     cdf: *mut uint16_t,
     n_symbols: size_t,
 ) -> libc::c_uint {
@@ -411,13 +411,13 @@ pub unsafe fn dav1d_msac_decode_symbol_adapt8(
 }
 
 pub unsafe fn dav1d_msac_decode_symbol_adapt16(
-    s: *mut MsacContext,
+    s: &mut MsacContext,
     cdf: *mut uint16_t,
     n_symbols: size_t,
 ) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
-            ((*s).symbol_adapt16).expect("non-null function pointer")(s, cdf, n_symbols)
+            (s.symbol_adapt16).expect("non-null function pointer")(s, cdf, n_symbols)
         } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
             dav1d_msac_decode_symbol_adapt16_neon(s, cdf, n_symbols)
         } else {
@@ -427,7 +427,7 @@ pub unsafe fn dav1d_msac_decode_symbol_adapt16(
 }
 
 pub unsafe fn dav1d_msac_decode_bool_adapt(
-    s: *mut MsacContext,
+    s: &mut MsacContext,
     cdf: *mut uint16_t,
 ) -> libc::c_uint {
     cfg_if! {
@@ -441,7 +441,7 @@ pub unsafe fn dav1d_msac_decode_bool_adapt(
     }
 }
 
-pub unsafe fn dav1d_msac_decode_bool_equi(s: *mut MsacContext) -> libc::c_uint {
+pub unsafe fn dav1d_msac_decode_bool_equi(s: &mut MsacContext) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
              dav1d_msac_decode_bool_equi_sse2(s)
@@ -453,7 +453,7 @@ pub unsafe fn dav1d_msac_decode_bool_equi(s: *mut MsacContext) -> libc::c_uint {
     }
 }
 
-pub unsafe fn dav1d_msac_decode_bool(s: *mut MsacContext, f: libc::c_uint) -> libc::c_uint {
+pub unsafe fn dav1d_msac_decode_bool(s: &mut MsacContext, f: libc::c_uint) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
              dav1d_msac_decode_bool_sse2(s, f)
@@ -465,7 +465,7 @@ pub unsafe fn dav1d_msac_decode_bool(s: *mut MsacContext, f: libc::c_uint) -> li
     }
 }
 
-pub unsafe fn dav1d_msac_decode_hi_tok(s: *mut MsacContext, cdf: *mut uint16_t) -> libc::c_uint {
+pub unsafe fn dav1d_msac_decode_hi_tok(s: &mut MsacContext, cdf: *mut uint16_t) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
              dav1d_msac_decode_hi_tok_sse2(s, cdf)

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -385,11 +385,11 @@ pub unsafe fn dav1d_msac_decode_symbol_adapt4(
 ) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
-            return dav1d_msac_decode_symbol_adapt4_sse2(s, cdf, n_symbols);
+            dav1d_msac_decode_symbol_adapt4_sse2(s, cdf, n_symbols)
         } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
-            return dav1d_msac_decode_symbol_adapt4_neon(s, cdf, n_symbols);
+            dav1d_msac_decode_symbol_adapt4_neon(s, cdf, n_symbols)
         } else {
-            return dav1d_msac_decode_symbol_adapt_rust(s, cdf, n_symbols);
+            dav1d_msac_decode_symbol_adapt_rust(s, cdf, n_symbols)
         }
     }
 }
@@ -401,11 +401,11 @@ pub unsafe fn dav1d_msac_decode_symbol_adapt8(
 ) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
-            return dav1d_msac_decode_symbol_adapt8_sse2(s, cdf, n_symbols);
+             dav1d_msac_decode_symbol_adapt8_sse2(s, cdf, n_symbols)
         } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
-            return dav1d_msac_decode_symbol_adapt8_neon(s, cdf, n_symbols);
+             dav1d_msac_decode_symbol_adapt8_neon(s, cdf, n_symbols)
         } else {
-            return dav1d_msac_decode_symbol_adapt_rust(s, cdf, n_symbols);
+             dav1d_msac_decode_symbol_adapt_rust(s, cdf, n_symbols)
         }
     }
 }
@@ -417,11 +417,11 @@ pub unsafe fn dav1d_msac_decode_symbol_adapt16(
 ) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
-            return ((*s).symbol_adapt16).expect("non-null function pointer")(s, cdf, n_symbols);
+            ((*s).symbol_adapt16).expect("non-null function pointer")(s, cdf, n_symbols)
         } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
-            return dav1d_msac_decode_symbol_adapt16_neon(s, cdf, n_symbols);
+            dav1d_msac_decode_symbol_adapt16_neon(s, cdf, n_symbols)
         } else {
-            return dav1d_msac_decode_symbol_adapt_rust(s, cdf, n_symbols);
+            dav1d_msac_decode_symbol_adapt_rust(s, cdf, n_symbols)
         }
     }
 }
@@ -432,11 +432,11 @@ pub unsafe fn dav1d_msac_decode_bool_adapt(
 ) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
-            return dav1d_msac_decode_bool_adapt_sse2(s, cdf);
+            dav1d_msac_decode_bool_adapt_sse2(s, cdf)
         } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
-            return dav1d_msac_decode_bool_adapt_neon(s, cdf);
+            dav1d_msac_decode_bool_adapt_neon(s, cdf)
         } else {
-            return dav1d_msac_decode_bool_adapt_rust(s, cdf);
+            dav1d_msac_decode_bool_adapt_rust(s, cdf)
         }
     }
 }
@@ -444,11 +444,11 @@ pub unsafe fn dav1d_msac_decode_bool_adapt(
 pub unsafe fn dav1d_msac_decode_bool_equi(mut s: *mut MsacContext) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
-            return dav1d_msac_decode_bool_equi_sse2(s);
+             dav1d_msac_decode_bool_equi_sse2(s)
         } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
-            return dav1d_msac_decode_bool_equi_neon(s);
+             dav1d_msac_decode_bool_equi_neon(s)
         } else {
-            return dav1d_msac_decode_bool_equi_rust(s);
+             dav1d_msac_decode_bool_equi_rust(s)
         }
     }
 }
@@ -456,11 +456,11 @@ pub unsafe fn dav1d_msac_decode_bool_equi(mut s: *mut MsacContext) -> libc::c_ui
 pub unsafe fn dav1d_msac_decode_bool(mut s: *mut MsacContext, mut f: libc::c_uint) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
-            return dav1d_msac_decode_bool_sse2(s, f);
+             dav1d_msac_decode_bool_sse2(s, f)
         } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
-            return dav1d_msac_decode_bool_neon(s, f);
+             dav1d_msac_decode_bool_neon(s, f)
         } else {
-            return dav1d_msac_decode_bool_rust(s, f);
+             dav1d_msac_decode_bool_rust(s, f)
         }
     }
 }
@@ -471,11 +471,11 @@ pub unsafe fn dav1d_msac_decode_hi_tok(
 ) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
-            return dav1d_msac_decode_hi_tok_sse2(s, cdf);
+             dav1d_msac_decode_hi_tok_sse2(s, cdf)
         } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
-            return dav1d_msac_decode_hi_tok_neon(s, cdf);
+             dav1d_msac_decode_hi_tok_neon(s, cdf)
         } else {
-            return dav1d_msac_decode_hi_tok_rust(s, cdf);
+             dav1d_msac_decode_hi_tok_rust(s, cdf)
         }
     }
 }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2,7 +2,7 @@ use crate::src::msac::dav1d_msac_decode_bool_equi;
 use crate::src::msac::MsacContext;
 
 #[inline]
-pub unsafe extern "C" fn read_golomb(msac: *mut MsacContext) -> libc::c_uint {
+pub unsafe extern "C" fn read_golomb(msac: &mut MsacContext) -> libc::c_uint {
     let mut len = 0;
     let mut val: libc::c_uint = 1 as libc::c_int as libc::c_uint;
     while dav1d_msac_decode_bool_equi(msac) == 0 && len < 32 {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1254,7 +1254,6 @@ unsafe extern "C" fn decode_coefs(
     mut res_ctx: *mut uint8_t,
 ) -> libc::c_int {
     let mut dc_sign_ctx = 0;
-    let mut dc_sign_cdf: *mut uint16_t = 0 as *mut uint16_t;
     let mut dc_sign = 0;
     let mut dc_dq = 0;
     let mut current_block: u64;
@@ -1281,7 +1280,7 @@ unsafe extern "C" fn decode_coefs(
     let sctx = get_skip_ctx(t_dim, bs, a, l, chroma, (*f).cur.p.layout) as libc::c_int;
     let all_skip = dav1d_msac_decode_bool_adapt(
         &mut (*ts).msac,
-        ((*ts).cdf.coef.skip[(*t_dim).ctx as usize][sctx as usize]).as_mut_ptr(),
+        &mut (*ts).cdf.coef.skip[(*t_dim).ctx as usize][sctx as usize],
     ) as libc::c_int;
     if dbg != 0 {
         printf(
@@ -1330,8 +1329,7 @@ unsafe extern "C" fn decode_coefs(
             {
                 idx = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
-                    ((*ts).cdf.m.txtp_intra2[(*t_dim).min as usize][y_mode_nofilt as usize])
-                        .as_mut_ptr(),
+                    &mut (*ts).cdf.m.txtp_intra2[(*t_dim).min as usize][y_mode_nofilt as usize],
                     4 as libc::c_int as size_t,
                 );
                 *txtp = dav1d_tx_types_per_set
@@ -1340,8 +1338,7 @@ unsafe extern "C" fn decode_coefs(
             } else {
                 idx = dav1d_msac_decode_symbol_adapt8(
                     &mut (*ts).msac,
-                    ((*ts).cdf.m.txtp_intra1[(*t_dim).min as usize][y_mode_nofilt as usize])
-                        .as_mut_ptr(),
+                    &mut (*ts).cdf.m.txtp_intra1[(*t_dim).min as usize][y_mode_nofilt as usize],
                     6 as libc::c_int as size_t,
                 );
                 *txtp = dav1d_tx_types_per_set
@@ -1366,14 +1363,14 @@ unsafe extern "C" fn decode_coefs(
             {
                 idx = dav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
-                    ((*ts).cdf.m.txtp_inter3[(*t_dim).min as usize]).as_mut_ptr(),
+                    &mut (*ts).cdf.m.txtp_inter3[(*t_dim).min as usize],
                 );
                 *txtp = (idx.wrapping_sub(1 as libc::c_int as libc::c_uint)
                     & IDTX as libc::c_int as libc::c_uint) as TxfmType;
             } else if (*t_dim).min as libc::c_int == TX_16X16 as libc::c_int {
                 idx = dav1d_msac_decode_symbol_adapt16(
                     &mut (*ts).msac,
-                    ((*ts).cdf.m.txtp_inter2.0).as_mut_ptr(),
+                    &mut (*ts).cdf.m.txtp_inter2.0,
                     11 as libc::c_int as size_t,
                 );
                 *txtp = dav1d_tx_types_per_set
@@ -1382,7 +1379,7 @@ unsafe extern "C" fn decode_coefs(
             } else {
                 idx = dav1d_msac_decode_symbol_adapt16(
                     &mut (*ts).msac,
-                    ((*ts).cdf.m.txtp_inter1[(*t_dim).min as usize]).as_mut_ptr(),
+                    &mut (*ts).cdf.m.txtp_inter1[(*t_dim).min as usize],
                     15 as libc::c_int as size_t,
                 );
                 *txtp = dav1d_tx_types_per_set
@@ -1410,50 +1407,43 @@ unsafe extern "C" fn decode_coefs(
         (tx_class as libc::c_uint != TX_CLASS_2D as libc::c_int as libc::c_uint) as libc::c_int;
     match tx2dszctx {
         0 => {
-            let eob_bin_cdf: *mut uint16_t =
-                ((*ts).cdf.coef.eob_bin_16[chroma as usize][is_1d as usize]).as_mut_ptr();
+            let eob_bin_cdf = &mut (*ts).cdf.coef.eob_bin_16[chroma as usize][is_1d as usize];
             eob_bin =
                 dav1d_msac_decode_symbol_adapt4(&mut (*ts).msac, eob_bin_cdf, (4 + 0) as size_t)
                     as libc::c_int;
         }
         1 => {
-            let eob_bin_cdf_0: *mut uint16_t =
-                ((*ts).cdf.coef.eob_bin_32[chroma as usize][is_1d as usize]).as_mut_ptr();
+            let eob_bin_cdf_0 = &mut (*ts).cdf.coef.eob_bin_32[chroma as usize][is_1d as usize];
             eob_bin =
                 dav1d_msac_decode_symbol_adapt8(&mut (*ts).msac, eob_bin_cdf_0, (4 + 1) as size_t)
                     as libc::c_int;
         }
         2 => {
-            let eob_bin_cdf_1: *mut uint16_t =
-                ((*ts).cdf.coef.eob_bin_64[chroma as usize][is_1d as usize]).as_mut_ptr();
+            let eob_bin_cdf_1 = &mut (*ts).cdf.coef.eob_bin_64[chroma as usize][is_1d as usize];
             eob_bin =
                 dav1d_msac_decode_symbol_adapt8(&mut (*ts).msac, eob_bin_cdf_1, (4 + 2) as size_t)
                     as libc::c_int;
         }
         3 => {
-            let eob_bin_cdf_2: *mut uint16_t =
-                ((*ts).cdf.coef.eob_bin_128[chroma as usize][is_1d as usize]).as_mut_ptr();
+            let eob_bin_cdf_2 = &mut (*ts).cdf.coef.eob_bin_128[chroma as usize][is_1d as usize];
             eob_bin =
                 dav1d_msac_decode_symbol_adapt8(&mut (*ts).msac, eob_bin_cdf_2, (4 + 3) as size_t)
                     as libc::c_int;
         }
         4 => {
-            let eob_bin_cdf_3: *mut uint16_t =
-                ((*ts).cdf.coef.eob_bin_256[chroma as usize][is_1d as usize]).as_mut_ptr();
+            let eob_bin_cdf_3 = &mut (*ts).cdf.coef.eob_bin_256[chroma as usize][is_1d as usize];
             eob_bin =
                 dav1d_msac_decode_symbol_adapt16(&mut (*ts).msac, eob_bin_cdf_3, (4 + 4) as size_t)
                     as libc::c_int;
         }
         5 => {
-            let eob_bin_cdf_4: *mut uint16_t =
-                ((*ts).cdf.coef.eob_bin_512[chroma as usize]).as_mut_ptr();
+            let eob_bin_cdf_4 = &mut (*ts).cdf.coef.eob_bin_512[chroma as usize];
             eob_bin =
                 dav1d_msac_decode_symbol_adapt16(&mut (*ts).msac, eob_bin_cdf_4, (4 + 5) as size_t)
                     as libc::c_int;
         }
         6 => {
-            let eob_bin_cdf_5: *mut uint16_t =
-                ((*ts).cdf.coef.eob_bin_1024[chroma as usize]).as_mut_ptr();
+            let eob_bin_cdf_5 = &mut (*ts).cdf.coef.eob_bin_1024[chroma as usize];
             eob_bin =
                 dav1d_msac_decode_symbol_adapt16(&mut (*ts).msac, eob_bin_cdf_5, (4 + 6) as size_t)
                     as libc::c_int;
@@ -1472,9 +1462,8 @@ unsafe extern "C" fn decode_coefs(
     }
     let mut eob = 0;
     if eob_bin > 1 {
-        let eob_hi_bit_cdf: *mut uint16_t = ((*ts).cdf.coef.eob_hi_bit[(*t_dim).ctx as usize]
-            [chroma as usize][eob_bin as usize])
-            .as_mut_ptr();
+        let eob_hi_bit_cdf = &mut (*ts).cdf.coef.eob_hi_bit[(*t_dim).ctx as usize][chroma as usize]
+            [eob_bin as usize];
         let eob_hi_bit =
             dav1d_msac_decode_bool_adapt(&mut (*ts).msac, eob_hi_bit_cdf) as libc::c_int;
         if dbg != 0 {
@@ -1523,7 +1512,7 @@ unsafe extern "C" fn decode_coefs(
             as libc::c_uint;
         let mut eob_tok = dav1d_msac_decode_symbol_adapt4(
             &mut (*ts).msac,
-            (*eob_cdf.offset(ctx as isize)).as_mut_ptr(),
+            &mut *eob_cdf.offset(ctx as isize),
             2 as libc::c_int as size_t,
         ) as libc::c_int;
         let mut tok = eob_tok + 1;
@@ -1593,7 +1582,7 @@ unsafe extern "C" fn decode_coefs(
                     }) as libc::c_uint;
                     tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
-                        (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
+                        &mut *hi_cdf.offset(ctx as isize),
                     ) as libc::c_int;
                     level_tok = tok + ((3 as libc::c_int) << 6);
                     if dbg != 0 {
@@ -1638,7 +1627,7 @@ unsafe extern "C" fn decode_coefs(
                     }
                     tok = dav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
-                        (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
+                        &mut *lo_cdf.offset(ctx as isize),
                         3 as libc::c_int as size_t,
                     ) as libc::c_int;
                     if dbg != 0 {
@@ -1671,7 +1660,7 @@ unsafe extern "C" fn decode_coefs(
                             });
                         tok = dav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
-                            (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
+                            &mut *hi_cdf.offset(ctx as isize),
                         ) as libc::c_int;
                         if dbg != 0 {
                             printf(
@@ -1717,7 +1706,7 @@ unsafe extern "C" fn decode_coefs(
                 };
                 dc_tok = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
-                    (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
+                    &mut *lo_cdf.offset(ctx as isize),
                     3 as libc::c_int as size_t,
                 );
                 if dbg != 0 {
@@ -1746,7 +1735,7 @@ unsafe extern "C" fn decode_coefs(
                     };
                     dc_tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
-                        (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
+                        &mut *hi_cdf.offset(ctx as isize),
                     );
                     if dbg != 0 {
                         printf(
@@ -1812,7 +1801,7 @@ unsafe extern "C" fn decode_coefs(
                     }) as libc::c_uint;
                     tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
-                        (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
+                        &mut *hi_cdf.offset(ctx as isize),
                     ) as libc::c_int;
                     level_tok = tok + ((3 as libc::c_int) << 6);
                     if dbg != 0 {
@@ -1867,7 +1856,7 @@ unsafe extern "C" fn decode_coefs(
                     }
                     tok = dav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
-                        (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
+                        &mut *lo_cdf.offset(ctx as isize),
                         3 as libc::c_int as size_t,
                     ) as libc::c_int;
                     if dbg != 0 {
@@ -1900,7 +1889,7 @@ unsafe extern "C" fn decode_coefs(
                             });
                         tok = dav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
-                            (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
+                            &mut *hi_cdf.offset(ctx as isize),
                         ) as libc::c_int;
                         if dbg != 0 {
                             printf(
@@ -1946,7 +1935,7 @@ unsafe extern "C" fn decode_coefs(
                 };
                 dc_tok = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
-                    (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
+                    &mut *lo_cdf.offset(ctx as isize),
                     3 as libc::c_int as size_t,
                 );
                 if dbg != 0 {
@@ -1975,7 +1964,7 @@ unsafe extern "C" fn decode_coefs(
                     };
                     dc_tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
-                        (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
+                        &mut *hi_cdf.offset(ctx as isize),
                     );
                     if dbg != 0 {
                         printf(
@@ -2041,7 +2030,7 @@ unsafe extern "C" fn decode_coefs(
                     }) as libc::c_uint;
                     tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
-                        (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
+                        &mut *hi_cdf.offset(ctx as isize),
                     ) as libc::c_int;
                     level_tok = tok + ((3 as libc::c_int) << 6);
                     if dbg != 0 {
@@ -2096,7 +2085,7 @@ unsafe extern "C" fn decode_coefs(
                     }
                     tok = dav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
-                        (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
+                        &mut *lo_cdf.offset(ctx as isize),
                         3 as libc::c_int as size_t,
                     ) as libc::c_int;
                     if dbg != 0 {
@@ -2129,7 +2118,7 @@ unsafe extern "C" fn decode_coefs(
                             });
                         tok = dav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
-                            (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
+                            &mut *hi_cdf.offset(ctx as isize),
                         ) as libc::c_int;
                         if dbg != 0 {
                             printf(
@@ -2175,7 +2164,7 @@ unsafe extern "C" fn decode_coefs(
                 };
                 dc_tok = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
-                    (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
+                    &mut *lo_cdf.offset(ctx as isize),
                     3 as libc::c_int as size_t,
                 );
                 if dbg != 0 {
@@ -2204,7 +2193,7 @@ unsafe extern "C" fn decode_coefs(
                     };
                     dc_tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
-                        (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
+                        &mut *hi_cdf.offset(ctx as isize),
                     );
                     if dbg != 0 {
                         printf(
@@ -2227,7 +2216,7 @@ unsafe extern "C" fn decode_coefs(
     } else {
         let mut tok_br = dav1d_msac_decode_symbol_adapt4(
             &mut (*ts).msac,
-            (*eob_cdf.offset(0)).as_mut_ptr(),
+            &mut *eob_cdf.offset(0),
             2 as libc::c_int as size_t,
         ) as libc::c_int;
         dc_tok = (1 + tok_br) as libc::c_uint;
@@ -2242,7 +2231,7 @@ unsafe extern "C" fn decode_coefs(
             );
         }
         if tok_br == 2 {
-            dc_tok = dav1d_msac_decode_hi_tok(&mut (*ts).msac, (*hi_cdf.offset(0)).as_mut_ptr());
+            dc_tok = dav1d_msac_decode_hi_tok(&mut (*ts).msac, &mut *hi_cdf.offset(0));
             if dbg != 0 {
                 printf(
                     b"Post-dc_hi_tok[%d][%d][0][%d]: r=%d\n\0" as *const u8 as *const libc::c_char,
@@ -2281,7 +2270,7 @@ unsafe extern "C" fn decode_coefs(
         }
     } else {
         dc_sign_ctx = get_dc_sign_ctx(tx as libc::c_int, a, l) as libc::c_int;
-        dc_sign_cdf = ((*ts).cdf.coef.dc_sign[chroma as usize][dc_sign_ctx as usize]).as_mut_ptr();
+        let dc_sign_cdf = &mut (*ts).cdf.coef.dc_sign[chroma as usize][dc_sign_ctx as usize];
         dc_sign = dav1d_msac_decode_bool_adapt(&mut (*ts).msac, dc_sign_cdf) as libc::c_int;
         if dbg != 0 {
             printf(

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1465,7 +1465,6 @@ unsafe extern "C" fn decode_coefs(
     mut res_ctx: *mut uint8_t,
 ) -> libc::c_int {
     let mut dc_sign_ctx = 0;
-    let mut dc_sign_cdf: *mut uint16_t = 0 as *mut uint16_t;
     let mut dc_sign = 0;
     let mut dc_dq = 0;
     let mut current_block: u64;
@@ -1492,7 +1491,7 @@ unsafe extern "C" fn decode_coefs(
     let sctx = get_skip_ctx(t_dim, bs, a, l, chroma, (*f).cur.p.layout) as libc::c_int;
     let all_skip = dav1d_msac_decode_bool_adapt(
         &mut (*ts).msac,
-        ((*ts).cdf.coef.skip[(*t_dim).ctx as usize][sctx as usize]).as_mut_ptr(),
+        &mut (*ts).cdf.coef.skip[(*t_dim).ctx as usize][sctx as usize],
     ) as libc::c_int;
     if dbg != 0 {
         printf(
@@ -1541,8 +1540,7 @@ unsafe extern "C" fn decode_coefs(
             {
                 idx = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
-                    ((*ts).cdf.m.txtp_intra2[(*t_dim).min as usize][y_mode_nofilt as usize])
-                        .as_mut_ptr(),
+                    &mut (*ts).cdf.m.txtp_intra2[(*t_dim).min as usize][y_mode_nofilt as usize],
                     4 as libc::c_int as size_t,
                 );
                 *txtp = dav1d_tx_types_per_set
@@ -1551,8 +1549,7 @@ unsafe extern "C" fn decode_coefs(
             } else {
                 idx = dav1d_msac_decode_symbol_adapt8(
                     &mut (*ts).msac,
-                    ((*ts).cdf.m.txtp_intra1[(*t_dim).min as usize][y_mode_nofilt as usize])
-                        .as_mut_ptr(),
+                    &mut (*ts).cdf.m.txtp_intra1[(*t_dim).min as usize][y_mode_nofilt as usize],
                     6 as libc::c_int as size_t,
                 );
                 *txtp = dav1d_tx_types_per_set
@@ -1577,14 +1574,14 @@ unsafe extern "C" fn decode_coefs(
             {
                 idx = dav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
-                    ((*ts).cdf.m.txtp_inter3[(*t_dim).min as usize]).as_mut_ptr(),
+                    &mut (*ts).cdf.m.txtp_inter3[(*t_dim).min as usize],
                 );
                 *txtp = (idx.wrapping_sub(1 as libc::c_int as libc::c_uint)
                     & IDTX as libc::c_int as libc::c_uint) as TxfmType;
             } else if (*t_dim).min as libc::c_int == TX_16X16 as libc::c_int {
                 idx = dav1d_msac_decode_symbol_adapt16(
                     &mut (*ts).msac,
-                    ((*ts).cdf.m.txtp_inter2.0).as_mut_ptr(),
+                    &mut (*ts).cdf.m.txtp_inter2.0,
                     11 as libc::c_int as size_t,
                 );
                 *txtp = dav1d_tx_types_per_set
@@ -1593,7 +1590,7 @@ unsafe extern "C" fn decode_coefs(
             } else {
                 idx = dav1d_msac_decode_symbol_adapt16(
                     &mut (*ts).msac,
-                    ((*ts).cdf.m.txtp_inter1[(*t_dim).min as usize]).as_mut_ptr(),
+                    &mut (*ts).cdf.m.txtp_inter1[(*t_dim).min as usize],
                     15 as libc::c_int as size_t,
                 );
                 *txtp = dav1d_tx_types_per_set
@@ -1621,50 +1618,43 @@ unsafe extern "C" fn decode_coefs(
         (tx_class as libc::c_uint != TX_CLASS_2D as libc::c_int as libc::c_uint) as libc::c_int;
     match tx2dszctx {
         0 => {
-            let eob_bin_cdf: *mut uint16_t =
-                ((*ts).cdf.coef.eob_bin_16[chroma as usize][is_1d as usize]).as_mut_ptr();
+            let eob_bin_cdf = &mut (*ts).cdf.coef.eob_bin_16[chroma as usize][is_1d as usize];
             eob_bin =
                 dav1d_msac_decode_symbol_adapt4(&mut (*ts).msac, eob_bin_cdf, (4 + 0) as size_t)
                     as libc::c_int;
         }
         1 => {
-            let eob_bin_cdf_0: *mut uint16_t =
-                ((*ts).cdf.coef.eob_bin_32[chroma as usize][is_1d as usize]).as_mut_ptr();
+            let eob_bin_cdf_0 = &mut (*ts).cdf.coef.eob_bin_32[chroma as usize][is_1d as usize];
             eob_bin =
                 dav1d_msac_decode_symbol_adapt8(&mut (*ts).msac, eob_bin_cdf_0, (4 + 1) as size_t)
                     as libc::c_int;
         }
         2 => {
-            let eob_bin_cdf_1: *mut uint16_t =
-                ((*ts).cdf.coef.eob_bin_64[chroma as usize][is_1d as usize]).as_mut_ptr();
+            let eob_bin_cdf_1 = &mut (*ts).cdf.coef.eob_bin_64[chroma as usize][is_1d as usize];
             eob_bin =
                 dav1d_msac_decode_symbol_adapt8(&mut (*ts).msac, eob_bin_cdf_1, (4 + 2) as size_t)
                     as libc::c_int;
         }
         3 => {
-            let eob_bin_cdf_2: *mut uint16_t =
-                ((*ts).cdf.coef.eob_bin_128[chroma as usize][is_1d as usize]).as_mut_ptr();
+            let eob_bin_cdf_2 = &mut (*ts).cdf.coef.eob_bin_128[chroma as usize][is_1d as usize];
             eob_bin =
                 dav1d_msac_decode_symbol_adapt8(&mut (*ts).msac, eob_bin_cdf_2, (4 + 3) as size_t)
                     as libc::c_int;
         }
         4 => {
-            let eob_bin_cdf_3: *mut uint16_t =
-                ((*ts).cdf.coef.eob_bin_256[chroma as usize][is_1d as usize]).as_mut_ptr();
+            let eob_bin_cdf_3 = &mut (*ts).cdf.coef.eob_bin_256[chroma as usize][is_1d as usize];
             eob_bin =
                 dav1d_msac_decode_symbol_adapt16(&mut (*ts).msac, eob_bin_cdf_3, (4 + 4) as size_t)
                     as libc::c_int;
         }
         5 => {
-            let eob_bin_cdf_4: *mut uint16_t =
-                ((*ts).cdf.coef.eob_bin_512[chroma as usize]).as_mut_ptr();
+            let eob_bin_cdf_4 = &mut (*ts).cdf.coef.eob_bin_512[chroma as usize];
             eob_bin =
                 dav1d_msac_decode_symbol_adapt16(&mut (*ts).msac, eob_bin_cdf_4, (4 + 5) as size_t)
                     as libc::c_int;
         }
         6 => {
-            let eob_bin_cdf_5: *mut uint16_t =
-                ((*ts).cdf.coef.eob_bin_1024[chroma as usize]).as_mut_ptr();
+            let eob_bin_cdf_5 = &mut (*ts).cdf.coef.eob_bin_1024[chroma as usize];
             eob_bin =
                 dav1d_msac_decode_symbol_adapt16(&mut (*ts).msac, eob_bin_cdf_5, (4 + 6) as size_t)
                     as libc::c_int;
@@ -1683,9 +1673,8 @@ unsafe extern "C" fn decode_coefs(
     }
     let mut eob = 0;
     if eob_bin > 1 {
-        let eob_hi_bit_cdf: *mut uint16_t = ((*ts).cdf.coef.eob_hi_bit[(*t_dim).ctx as usize]
-            [chroma as usize][eob_bin as usize])
-            .as_mut_ptr();
+        let eob_hi_bit_cdf = &mut (*ts).cdf.coef.eob_hi_bit[(*t_dim).ctx as usize][chroma as usize]
+            [eob_bin as usize];
         let eob_hi_bit =
             dav1d_msac_decode_bool_adapt(&mut (*ts).msac, eob_hi_bit_cdf) as libc::c_int;
         if dbg != 0 {
@@ -1734,7 +1723,7 @@ unsafe extern "C" fn decode_coefs(
             as libc::c_uint;
         let mut eob_tok = dav1d_msac_decode_symbol_adapt4(
             &mut (*ts).msac,
-            (*eob_cdf.offset(ctx as isize)).as_mut_ptr(),
+            &mut *eob_cdf.offset(ctx as isize),
             2 as libc::c_int as size_t,
         ) as libc::c_int;
         let mut tok = eob_tok + 1;
@@ -1804,7 +1793,7 @@ unsafe extern "C" fn decode_coefs(
                     }) as libc::c_uint;
                     tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
-                        (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
+                        &mut *hi_cdf.offset(ctx as isize),
                     ) as libc::c_int;
                     level_tok = tok + ((3 as libc::c_int) << 6);
                     if dbg != 0 {
@@ -1851,7 +1840,7 @@ unsafe extern "C" fn decode_coefs(
                     }
                     tok = dav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
-                        (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
+                        &mut *lo_cdf.offset(ctx as isize),
                         3 as libc::c_int as size_t,
                     ) as libc::c_int;
                     if dbg != 0 {
@@ -1884,7 +1873,7 @@ unsafe extern "C" fn decode_coefs(
                             });
                         tok = dav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
-                            (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
+                            &mut *hi_cdf.offset(ctx as isize),
                         ) as libc::c_int;
                         if dbg != 0 {
                             printf(
@@ -1930,7 +1919,7 @@ unsafe extern "C" fn decode_coefs(
                 };
                 dc_tok = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
-                    (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
+                    &mut *lo_cdf.offset(ctx as isize),
                     3 as libc::c_int as size_t,
                 );
                 if dbg != 0 {
@@ -1959,7 +1948,7 @@ unsafe extern "C" fn decode_coefs(
                     };
                     dc_tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
-                        (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
+                        &mut *hi_cdf.offset(ctx as isize),
                     );
                     if dbg != 0 {
                         printf(
@@ -2025,7 +2014,7 @@ unsafe extern "C" fn decode_coefs(
                     }) as libc::c_uint;
                     tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
-                        (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
+                        &mut *hi_cdf.offset(ctx as isize),
                     ) as libc::c_int;
                     level_tok = tok + ((3 as libc::c_int) << 6);
                     if dbg != 0 {
@@ -2081,7 +2070,7 @@ unsafe extern "C" fn decode_coefs(
                     }
                     tok = dav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
-                        (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
+                        &mut *lo_cdf.offset(ctx as isize),
                         3 as libc::c_int as size_t,
                     ) as libc::c_int;
                     if dbg != 0 {
@@ -2114,7 +2103,7 @@ unsafe extern "C" fn decode_coefs(
                             });
                         tok = dav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
-                            (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
+                            &mut *hi_cdf.offset(ctx as isize),
                         ) as libc::c_int;
                         if dbg != 0 {
                             printf(
@@ -2160,7 +2149,7 @@ unsafe extern "C" fn decode_coefs(
                 };
                 dc_tok = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
-                    (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
+                    &mut *lo_cdf.offset(ctx as isize),
                     3 as libc::c_int as size_t,
                 );
                 if dbg != 0 {
@@ -2189,7 +2178,7 @@ unsafe extern "C" fn decode_coefs(
                     };
                     dc_tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
-                        (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
+                        &mut *hi_cdf.offset(ctx as isize),
                     );
                     if dbg != 0 {
                         printf(
@@ -2255,7 +2244,7 @@ unsafe extern "C" fn decode_coefs(
                     }) as libc::c_uint;
                     tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
-                        (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
+                        &mut *hi_cdf.offset(ctx as isize),
                     ) as libc::c_int;
                     level_tok = tok + ((3 as libc::c_int) << 6);
                     if dbg != 0 {
@@ -2311,7 +2300,7 @@ unsafe extern "C" fn decode_coefs(
                     }
                     tok = dav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
-                        (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
+                        &mut *lo_cdf.offset(ctx as isize),
                         3 as libc::c_int as size_t,
                     ) as libc::c_int;
                     if dbg != 0 {
@@ -2344,7 +2333,7 @@ unsafe extern "C" fn decode_coefs(
                             });
                         tok = dav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
-                            (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
+                            &mut *hi_cdf.offset(ctx as isize),
                         ) as libc::c_int;
                         if dbg != 0 {
                             printf(
@@ -2390,7 +2379,7 @@ unsafe extern "C" fn decode_coefs(
                 };
                 dc_tok = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
-                    (*lo_cdf.offset(ctx as isize)).as_mut_ptr(),
+                    &mut *lo_cdf.offset(ctx as isize),
                     3 as libc::c_int as size_t,
                 );
                 if dbg != 0 {
@@ -2419,7 +2408,7 @@ unsafe extern "C" fn decode_coefs(
                     };
                     dc_tok = dav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
-                        (*hi_cdf.offset(ctx as isize)).as_mut_ptr(),
+                        &mut *hi_cdf.offset(ctx as isize),
                     );
                     if dbg != 0 {
                         printf(
@@ -2442,7 +2431,7 @@ unsafe extern "C" fn decode_coefs(
     } else {
         let mut tok_br = dav1d_msac_decode_symbol_adapt4(
             &mut (*ts).msac,
-            (*eob_cdf.offset(0)).as_mut_ptr(),
+            &mut *eob_cdf.offset(0),
             2 as libc::c_int as size_t,
         ) as libc::c_int;
         dc_tok = (1 + tok_br) as libc::c_uint;
@@ -2457,7 +2446,7 @@ unsafe extern "C" fn decode_coefs(
             );
         }
         if tok_br == 2 {
-            dc_tok = dav1d_msac_decode_hi_tok(&mut (*ts).msac, (*hi_cdf.offset(0)).as_mut_ptr());
+            dc_tok = dav1d_msac_decode_hi_tok(&mut (*ts).msac, &mut *hi_cdf.offset(0));
             if dbg != 0 {
                 printf(
                     b"Post-dc_hi_tok[%d][%d][0][%d]: r=%d\n\0" as *const u8 as *const libc::c_char,
@@ -2496,7 +2485,7 @@ unsafe extern "C" fn decode_coefs(
         }
     } else {
         dc_sign_ctx = get_dc_sign_ctx(tx as libc::c_int, a, l) as libc::c_int;
-        dc_sign_cdf = ((*ts).cdf.coef.dc_sign[chroma as usize][dc_sign_ctx as usize]).as_mut_ptr();
+        let dc_sign_cdf = &mut (*ts).cdf.coef.dc_sign[chroma as usize][dc_sign_ctx as usize];
         dc_sign = dav1d_msac_decode_bool_adapt(&mut (*ts).msac, dc_sign_cdf) as libc::c_int;
         if dbg != 0 {
             printf(


### PR DESCRIPTION
The major refactor here is making the `cdf: *mut u16` a `&mut [u16]` slice.  All call sites are array refs, so this works nicely (though there are quite a lot of these, ~155).

For `fn dav1d_msac_decode_symbol_adapt_rust`, however, this is trickier, as `cdf` must round-trip through FFI and perhaps an asm call, so slices can't be used.  `cdf.len()` could be added as an extra arg, but that may require changing asm slightly, which I don't want to do at all.  However, `n_symbols` is the last index accessed in `cdf`, so `n_symbols + 1` should be a valid length, possibly smaller.  Thus, an `assert!(n_symbols < cdf.len())` before the `s.symbol_adapt16` call ensures that in `fn dav1d_msac_decode_symbol_adapt_c`, this still holds true, and thus we can safely reconstruct the slice (or a subset) with `unsafe { std::slice::from_raw_parts_mut(cdf, n_symbols + 1) }`.

Since `n_symbols + ` is the length of `cdf` accessed in all of these functions, I could also eliminate the `n_symbols` arg and instead pass it as the `cdf` slice's length, with an array slice at the call sites.  Maybe this is something we should eventually do (or at least an `assert!(n_symbols < cdf.len())`, or `debug_assert!` at least), but for now, I left the `n_symbols` arg to stay closer to the C.  Passing it through the slice would be safer, though, in terms of guarantees when we call asm (the `assert!` would be equally safe, but have a runtime perf cost).