### PR TITLE
Fix numerous alignment issues and enable most arm assembly routines

### DIFF
--- a/.github/workflows/build-and-test-arm7.yml
+++ b/.github/workflows/build-and-test-arm7.yml
@@ -37,8 +37,7 @@ jobs:
       - name: cargo build for armv7-unknown-linux-gnueabihf
         run: |
           rustup target add armv7-unknown-linux-gnueabihf
-          cargo build --release --target armv7-unknown-linux-gnueabihf \
-            --no-default-features  --features bitdepth_8,bitdepth_16
+          cargo build --release --target armv7-unknown-linux-gnueabihf
       - name: docker pull
         run: docker pull ghcr.io/immunant/rav1d/debian-bullseye-arm7:latest
       - name: build and run tests in docker

--- a/src/cdef_tmpl_8.rs
+++ b/src/cdef_tmpl_8.rs
@@ -1,5 +1,6 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
+use crate::src::align::Align16;
 use ::libc;
 use cfg_if::cfg_if;
 
@@ -908,8 +909,8 @@ unsafe extern "C" fn cdef_filter_8x8_neon(
     damping: libc::c_int,
     edges: CdefEdgeFlags,
 ) {
-    let mut tmp_buf = [0; 200];
-    let mut tmp = tmp_buf.as_mut_ptr().offset(2 * 16).offset(8);
+    let mut tmp_buf = Align16([0; 200]);
+    let mut tmp = tmp_buf.0.as_mut_ptr().offset(2 * 16).offset(8);
     dav1d_cdef_padding8_8bpc_neon(tmp, dst, stride, left, top, bottom, 8, edges);
     dav1d_cdef_filter8_8bpc_neon(
         dst,

--- a/src/ipred_tmpl_16.rs
+++ b/src/ipred_tmpl_16.rs
@@ -1158,9 +1158,9 @@ unsafe extern "C" fn ipred_smooth_c(
     _bitdepth_max: libc::c_int,
 ) {
     let weights_hor: *const uint8_t =
-        &*dav1d_sm_weights.as_ptr().offset(width as isize) as *const uint8_t;
+        &*dav1d_sm_weights.0.as_ptr().offset(width as isize) as *const uint8_t;
     let weights_ver: *const uint8_t =
-        &*dav1d_sm_weights.as_ptr().offset(height as isize) as *const uint8_t;
+        &*dav1d_sm_weights.0.as_ptr().offset(height as isize) as *const uint8_t;
     let right = *topleft.offset(width as isize) as libc::c_int;
     let bottom = *topleft.offset(-height as isize) as libc::c_int;
     let mut y = 0;
@@ -1192,7 +1192,7 @@ unsafe extern "C" fn ipred_smooth_v_c(
     _bitdepth_max: libc::c_int,
 ) {
     let weights_ver: *const uint8_t =
-        &*dav1d_sm_weights.as_ptr().offset(height as isize) as *const uint8_t;
+        &*dav1d_sm_weights.0.as_ptr().offset(height as isize) as *const uint8_t;
     let bottom = *topleft.offset(-height as isize) as libc::c_int;
     let mut y = 0;
     while y < height {
@@ -1220,7 +1220,7 @@ unsafe extern "C" fn ipred_smooth_h_c(
     _bitdepth_max: libc::c_int,
 ) {
     let weights_hor: *const uint8_t =
-        &*dav1d_sm_weights.as_ptr().offset(width as isize) as *const uint8_t;
+        &*dav1d_sm_weights.0.as_ptr().offset(width as isize) as *const uint8_t;
     let right = *topleft.offset(width as isize) as libc::c_int;
     let mut y = 0;
     while y < height {

--- a/src/ipred_tmpl_8.rs
+++ b/src/ipred_tmpl_8.rs
@@ -1185,9 +1185,9 @@ unsafe extern "C" fn ipred_smooth_c(
     _max_height: libc::c_int,
 ) {
     let weights_hor: *const uint8_t =
-        &*dav1d_sm_weights.as_ptr().offset(width as isize) as *const uint8_t;
+        &*dav1d_sm_weights.0.as_ptr().offset(width as isize) as *const uint8_t;
     let weights_ver: *const uint8_t =
-        &*dav1d_sm_weights.as_ptr().offset(height as isize) as *const uint8_t;
+        &*dav1d_sm_weights.0.as_ptr().offset(height as isize) as *const uint8_t;
     let right = *topleft.offset(width as isize) as libc::c_int;
     let bottom = *topleft.offset(-height as isize) as libc::c_int;
     let mut y = 0;
@@ -1218,7 +1218,7 @@ unsafe extern "C" fn ipred_smooth_v_c(
     _max_height: libc::c_int,
 ) {
     let weights_ver: *const uint8_t =
-        &*dav1d_sm_weights.as_ptr().offset(height as isize) as *const uint8_t;
+        &*dav1d_sm_weights.0.as_ptr().offset(height as isize) as *const uint8_t;
     let bottom = *topleft.offset(-height as isize) as libc::c_int;
     let mut y = 0;
     while y < height {
@@ -1245,7 +1245,7 @@ unsafe extern "C" fn ipred_smooth_h_c(
     _max_height: libc::c_int,
 ) {
     let weights_hor: *const uint8_t =
-        &*dav1d_sm_weights.as_ptr().offset(width as isize) as *const uint8_t;
+        &*dav1d_sm_weights.0.as_ptr().offset(width as isize) as *const uint8_t;
     let right = *topleft.offset(width as isize) as libc::c_int;
     let mut y = 0;
     while y < height {

--- a/src/ipred_tmpl_8.rs
+++ b/src/ipred_tmpl_8.rs
@@ -2058,8 +2058,11 @@ unsafe extern "C" fn intra_pred_dsp_init_arm(c: *mut Dav1dIntraPredDSPContext) {
     (*c).intra_pred[SMOOTH_PRED as usize] = Some(dav1d_ipred_smooth_8bpc_neon);
     (*c).intra_pred[SMOOTH_V_PRED as usize] = Some(dav1d_ipred_smooth_v_8bpc_neon);
     (*c).intra_pred[SMOOTH_H_PRED as usize] = Some(dav1d_ipred_smooth_h_8bpc_neon);
-    (*c).intra_pred[Z1_PRED as usize] = Some(ipred_z1_neon);
-    (*c).intra_pred[Z3_PRED as usize] = Some(ipred_z3_neon);
+    #[cfg(target_arch = "aarch64")]
+    {
+        (*c).intra_pred[Z1_PRED as usize] = Some(ipred_z1_neon);
+        (*c).intra_pred[Z3_PRED as usize] = Some(ipred_z3_neon);
+    }
     (*c).intra_pred[FILTER_PRED as usize] = Some(dav1d_ipred_filter_8bpc_neon);
 
     (*c).cfl_pred[DC_PRED as usize] = Some(dav1d_ipred_cfl_8bpc_neon);

--- a/src/looprestoration_tmpl_16.rs
+++ b/src/looprestoration_tmpl_16.rs
@@ -1093,8 +1093,16 @@ unsafe extern "C" fn loop_restoration_dsp_init_arm(
         return;
     }
 
-    (*c).wiener[0] = Some(dav1d_wiener_filter7_16bpc_neon);
-    (*c).wiener[1] = Some(dav1d_wiener_filter5_16bpc_neon);
+    cfg_if::cfg_if! {
+        if #[cfg(target_arch = "aarch64")] {
+            (*c).wiener[0] = Some(dav1d_wiener_filter7_16bpc_neon);
+            (*c).wiener[1] = Some(dav1d_wiener_filter5_16bpc_neon);
+        } else {
+            // TODO(perl): enable assembly routines here
+            // (*c).wiener[0] = Some(dav1d_wiener_filter_neon);
+            // (*c).wiener[1] = Some(dav1d_wiener_filter_neon);
+        }
+    }
 
     if bpc == 10 {
         (*c).sgr[0] = Some(sgr_filter_5x5_neon);

--- a/src/looprestoration_tmpl_16.rs
+++ b/src/looprestoration_tmpl_16.rs
@@ -1,5 +1,6 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
+use crate::src::align::Align16;
 use ::libc;
 use cfg_if::cfg_if;
 extern "C" {
@@ -1123,9 +1124,9 @@ unsafe extern "C" fn sgr_filter_3x3_neon(
     edges: LrEdgeFlags,
     bitdepth_max: libc::c_int,
 ) {
-    let mut tmp: [int16_t; 24576] = [0; 24576];
+    let mut tmp: Align16<[int16_t; 24576]> = Align16([0; 24576]);
     dav1d_sgr_filter1_neon(
-        tmp.as_mut_ptr(),
+        tmp.0.as_mut_ptr(),
         dst,
         stride,
         left,
@@ -1141,7 +1142,7 @@ unsafe extern "C" fn sgr_filter_3x3_neon(
         stride,
         dst,
         stride,
-        tmp.as_mut_ptr(),
+        tmp.0.as_mut_ptr(),
         w,
         h,
         (*params).sgr.w1 as libc::c_int,
@@ -1162,13 +1163,17 @@ unsafe extern "C" fn dav1d_sgr_filter1_neon(
     edges: LrEdgeFlags,
     bitdepth_max: libc::c_int,
 ) {
-    let mut sumsq_mem: [int32_t; 27208] = [0; 27208];
-    let sumsq: *mut int32_t =
-        &mut *sumsq_mem.as_mut_ptr().offset(((384 + 16) * 2 + 8) as isize) as *mut int32_t;
+    let mut sumsq_mem: Align16<[int32_t; 27208]> = Align16([0; 27208]);
+    let sumsq: *mut int32_t = &mut *sumsq_mem
+        .0
+        .as_mut_ptr()
+        .offset(((384 + 16) * 2 + 8) as isize) as *mut int32_t;
     let a: *mut int32_t = sumsq;
-    let mut sum_mem: [int16_t; 27216] = [0; 27216];
-    let sum: *mut int16_t =
-        &mut *sum_mem.as_mut_ptr().offset(((384 + 16) * 2 + 16) as isize) as *mut int16_t;
+    let mut sum_mem: Align16<[int16_t; 27216]> = Align16([0; 27216]);
+    let sum: *mut int16_t = &mut *sum_mem
+        .0
+        .as_mut_ptr()
+        .offset(((384 + 16) * 2 + 16) as isize) as *mut int16_t;
     let b: *mut int16_t = sum;
     dav1d_sgr_box3_h_16bpc_neon(sumsq, sum, left, src, stride, w, h, edges);
     if edges as libc::c_uint & LR_HAVE_TOP as libc::c_int as libc::c_uint != 0 {
@@ -1213,13 +1218,17 @@ unsafe extern "C" fn dav1d_sgr_filter2_neon(
     edges: LrEdgeFlags,
     bitdepth_max: libc::c_int,
 ) {
-    let mut sumsq_mem: [int32_t; 27208] = [0; 27208];
-    let sumsq: *mut int32_t =
-        &mut *sumsq_mem.as_mut_ptr().offset(((384 + 16) * 2 + 8) as isize) as *mut int32_t;
+    let mut sumsq_mem: Align16<[int32_t; 27208]> = Align16([0; 27208]);
+    let sumsq: *mut int32_t = &mut *sumsq_mem
+        .0
+        .as_mut_ptr()
+        .offset(((384 + 16) * 2 + 8) as isize) as *mut int32_t;
     let a: *mut int32_t = sumsq;
-    let mut sum_mem: [int16_t; 27216] = [0; 27216];
-    let sum: *mut int16_t =
-        &mut *sum_mem.as_mut_ptr().offset(((384 + 16) * 2 + 16) as isize) as *mut int16_t;
+    let mut sum_mem: Align16<[int16_t; 27216]> = Align16([0; 27216]);
+    let sum: *mut int16_t = &mut *sum_mem
+        .0
+        .as_mut_ptr()
+        .offset(((384 + 16) * 2 + 16) as isize) as *mut int16_t;
     let b: *mut int16_t = sum;
     dav1d_sgr_box5_h_16bpc_neon(sumsq, sum, left, src, stride, w, h, edges);
     if edges as libc::c_uint & LR_HAVE_TOP as libc::c_int as libc::c_uint != 0 {
@@ -1263,9 +1272,9 @@ unsafe extern "C" fn sgr_filter_5x5_neon(
     edges: LrEdgeFlags,
     bitdepth_max: libc::c_int,
 ) {
-    let mut tmp: [int16_t; 24576] = [0; 24576];
+    let mut tmp: Align16<[int16_t; 24576]> = Align16([0; 24576]);
     dav1d_sgr_filter2_neon(
-        tmp.as_mut_ptr(),
+        tmp.0.as_mut_ptr(),
         dst,
         stride,
         left,
@@ -1281,7 +1290,7 @@ unsafe extern "C" fn sgr_filter_5x5_neon(
         stride,
         dst,
         stride,
-        tmp.as_mut_ptr(),
+        tmp.0.as_mut_ptr(),
         w,
         h,
         (*params).sgr.w0 as libc::c_int,
@@ -1301,10 +1310,10 @@ unsafe extern "C" fn sgr_filter_mix_neon(
     edges: LrEdgeFlags,
     bitdepth_max: libc::c_int,
 ) {
-    let mut tmp1: [int16_t; 24576] = [0; 24576];
-    let mut tmp2: [int16_t; 24576] = [0; 24576];
+    let mut tmp1: Align16<[int16_t; 24576]> = Align16([0; 24576]);
+    let mut tmp2: Align16<[int16_t; 24576]> = Align16([0; 24576]);
     dav1d_sgr_filter2_neon(
-        tmp1.as_mut_ptr(),
+        tmp1.0.as_mut_ptr(),
         dst,
         stride,
         left,
@@ -1316,7 +1325,7 @@ unsafe extern "C" fn sgr_filter_mix_neon(
         bitdepth_max,
     );
     dav1d_sgr_filter1_neon(
-        tmp2.as_mut_ptr(),
+        tmp2.0.as_mut_ptr(),
         dst,
         stride,
         left,
@@ -1333,8 +1342,8 @@ unsafe extern "C" fn sgr_filter_mix_neon(
         stride,
         dst,
         stride,
-        tmp1.as_mut_ptr(),
-        tmp2.as_mut_ptr(),
+        tmp1.0.as_mut_ptr(),
+        tmp2.0.as_mut_ptr(),
         w,
         h,
         wt.as_ptr(),

--- a/src/looprestoration_tmpl_8.rs
+++ b/src/looprestoration_tmpl_8.rs
@@ -1,5 +1,6 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
+use crate::src::align::Align16;
 use ::libc;
 use ::libc::size_t;
 use cfg_if::cfg_if;
@@ -1086,13 +1087,17 @@ unsafe extern "C" fn dav1d_sgr_filter1_neon(
     strength: libc::c_int,
     edges: LrEdgeFlags,
 ) {
-    let mut sumsq_mem: [int32_t; 27208] = [0; 27208];
-    let sumsq: *mut int32_t =
-        &mut *sumsq_mem.as_mut_ptr().offset(((384 + 16) * 2 + 8) as isize) as *mut int32_t;
+    let mut sumsq_mem: Align16<[int32_t; 27208]> = Align16([0; 27208]);
+    let sumsq: *mut int32_t = &mut *sumsq_mem
+        .0
+        .as_mut_ptr()
+        .offset(((384 + 16) * 2 + 8) as isize) as *mut int32_t;
     let a: *mut int32_t = sumsq;
-    let mut sum_mem: [int16_t; 27216] = [0; 27216];
-    let sum: *mut int16_t =
-        &mut *sum_mem.as_mut_ptr().offset(((384 + 16) * 2 + 16) as isize) as *mut int16_t;
+    let mut sum_mem: Align16<[int16_t; 27216]> = Align16([0; 27216]);
+    let sum: *mut int16_t = &mut *sum_mem
+        .0
+        .as_mut_ptr()
+        .offset(((384 + 16) * 2 + 16) as isize) as *mut int16_t;
     let b: *mut int16_t = sum;
     dav1d_sgr_box3_h_8bpc_neon(sumsq, sum, left, src, stride, w, h, edges);
     if edges as libc::c_uint & LR_HAVE_TOP as libc::c_int as libc::c_uint != 0 {
@@ -1136,13 +1141,17 @@ unsafe extern "C" fn dav1d_sgr_filter2_neon(
     strength: libc::c_int,
     edges: LrEdgeFlags,
 ) {
-    let mut sumsq_mem: [int32_t; 27208] = [0; 27208];
-    let sumsq: *mut int32_t =
-        &mut *sumsq_mem.as_mut_ptr().offset(((384 + 16) * 2 + 8) as isize) as *mut int32_t;
+    let mut sumsq_mem: Align16<[int32_t; 27208]> = Align16([0; 27208]);
+    let sumsq: *mut int32_t = &mut *sumsq_mem
+        .0
+        .as_mut_ptr()
+        .offset(((384 + 16) * 2 + 8) as isize) as *mut int32_t;
     let a: *mut int32_t = sumsq;
-    let mut sum_mem: [int16_t; 27216] = [0; 27216];
-    let sum: *mut int16_t =
-        &mut *sum_mem.as_mut_ptr().offset(((384 + 16) * 2 + 16) as isize) as *mut int16_t;
+    let mut sum_mem: Align16<[int16_t; 27216]> = Align16([0; 27216]);
+    let sum: *mut int16_t = &mut *sum_mem
+        .0
+        .as_mut_ptr()
+        .offset(((384 + 16) * 2 + 16) as isize) as *mut int16_t;
     let b: *mut int16_t = sum;
     dav1d_sgr_box5_h_8bpc_neon(sumsq, sum, left, src, stride, w, h, edges);
     if edges as libc::c_uint & LR_HAVE_TOP as libc::c_int as libc::c_uint != 0 {
@@ -1185,9 +1194,9 @@ unsafe extern "C" fn sgr_filter_5x5_neon(
     params: *const LooprestorationParams,
     edges: LrEdgeFlags,
 ) {
-    let mut tmp: [int16_t; 24576] = [0; 24576];
+    let mut tmp: Align16<[int16_t; 24576]> = Align16([0; 24576]);
     dav1d_sgr_filter2_neon(
-        tmp.as_mut_ptr(),
+        tmp.0.as_mut_ptr(),
         dst,
         stride,
         left,
@@ -1202,7 +1211,7 @@ unsafe extern "C" fn sgr_filter_5x5_neon(
         stride,
         dst,
         stride,
-        tmp.as_mut_ptr(),
+        tmp.0.as_mut_ptr(),
         w,
         h,
         (*params).sgr.w0 as libc::c_int,
@@ -1220,9 +1229,9 @@ unsafe extern "C" fn sgr_filter_3x3_neon(
     params: *const LooprestorationParams,
     edges: LrEdgeFlags,
 ) {
-    let mut tmp: [int16_t; 24576] = [0; 24576];
+    let mut tmp: Align16<[int16_t; 24576]> = Align16([0; 24576]);
     dav1d_sgr_filter1_neon(
-        tmp.as_mut_ptr(),
+        tmp.0.as_mut_ptr(),
         dst,
         stride,
         left,
@@ -1237,7 +1246,7 @@ unsafe extern "C" fn sgr_filter_3x3_neon(
         stride,
         dst,
         stride,
-        tmp.as_mut_ptr(),
+        tmp.0.as_mut_ptr(),
         w,
         h,
         (*params).sgr.w1 as libc::c_int,
@@ -1255,10 +1264,10 @@ unsafe extern "C" fn sgr_filter_mix_neon(
     params: *const LooprestorationParams,
     edges: LrEdgeFlags,
 ) {
-    let mut tmp1: [int16_t; 24576] = [0; 24576];
-    let mut tmp2: [int16_t; 24576] = [0; 24576];
+    let mut tmp1: Align16<[int16_t; 24576]> = Align16([0; 24576]);
+    let mut tmp2: Align16<[int16_t; 24576]> = Align16([0; 24576]);
     dav1d_sgr_filter2_neon(
-        tmp1.as_mut_ptr(),
+        tmp1.0.as_mut_ptr(),
         dst,
         stride,
         left,
@@ -1269,7 +1278,7 @@ unsafe extern "C" fn sgr_filter_mix_neon(
         edges,
     );
     dav1d_sgr_filter1_neon(
-        tmp2.as_mut_ptr(),
+        tmp2.0.as_mut_ptr(),
         dst,
         stride,
         left,
@@ -1285,8 +1294,8 @@ unsafe extern "C" fn sgr_filter_mix_neon(
         stride,
         dst,
         stride,
-        tmp1.as_mut_ptr(),
-        tmp2.as_mut_ptr(),
+        tmp1.0.as_mut_ptr(),
+        tmp2.0.as_mut_ptr(),
         w,
         h,
         wt.as_ptr(),

--- a/src/looprestoration_tmpl_8.rs
+++ b/src/looprestoration_tmpl_8.rs
@@ -1058,8 +1058,16 @@ unsafe extern "C" fn loop_restoration_dsp_init_arm(
         return;
     }
 
-    (*c).wiener[0] = Some(dav1d_wiener_filter7_8bpc_neon);
-    (*c).wiener[1] = Some(dav1d_wiener_filter5_8bpc_neon);
+    cfg_if::cfg_if! {
+        if #[cfg(target_arch = "aarch64")] {
+            (*c).wiener[0] = Some(dav1d_wiener_filter7_8bpc_neon);
+            (*c).wiener[1] = Some(dav1d_wiener_filter5_8bpc_neon);
+        } else {
+            // TODO(perl): enable assembly routines here
+            // (*c).wiener[0] = Some(dav1d_wiener_filter_neon);
+            // (*c).wiener[1] = Some(dav1d_wiener_filter_neon);
+        }
+    }
 
     (*c).sgr[0] = Some(sgr_filter_5x5_neon);
     (*c).sgr[1] = Some(sgr_filter_3x3_neon);

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -4,7 +4,9 @@ use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
 use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
 use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
 use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+use crate::src::align::Align16;
 use crate::src::align::Align64;
+use crate::src::align::Align8;
 use crate::src::levels::BS_128x128;
 use crate::src::levels::BS_128x64;
 use crate::src::levels::BS_16x16;
@@ -763,7 +765,7 @@ pub static dav1d_sgr_x_by_x: Align64<[u8; 256]> = Align64([
 ]);
 
 #[no_mangle]
-pub static dav1d_mc_subpel_filters: [[[i8; 8]; 15]; 6] = [
+pub static dav1d_mc_subpel_filters: Align8<[[[i8; 8]; 15]; 6]> = Align8([
     [
         [0, 1, -3, 63, 4, -1, 0, 0],
         [0, 1, -5, 61, 9, -2, 0, 0],
@@ -866,7 +868,7 @@ pub static dav1d_mc_subpel_filters: [[[i8; 8]; 15]; 6] = [
         [0, 0, 0, 8, 56, 0, 0, 0],
         [0, 0, 0, 4, 60, 0, 0, 0],
     ],
-];
+]);
 
 #[no_mangle]
 pub static dav1d_mc_warp_filter: [[i8; 8]; 193] = [
@@ -1134,14 +1136,14 @@ pub static dav1d_resize_filter: [[i8; 8]; 64] = [
 ];
 
 #[no_mangle]
-pub static dav1d_sm_weights: [u8; 128] = [
+pub static dav1d_sm_weights: Align16<[u8; 128]> = Align16([
     0, 0, 255, 128, 255, 149, 85, 64, 255, 197, 146, 105, 73, 50, 37, 32, 255, 225, 196, 170, 145,
     123, 102, 84, 68, 54, 43, 33, 26, 20, 17, 16, 255, 240, 225, 210, 196, 182, 169, 157, 145, 133,
     122, 111, 101, 92, 83, 74, 66, 59, 52, 45, 39, 34, 29, 25, 21, 17, 14, 12, 10, 9, 8, 8, 255,
     248, 240, 233, 225, 218, 210, 203, 196, 189, 182, 176, 169, 163, 156, 150, 144, 138, 133, 127,
     121, 116, 111, 106, 101, 96, 91, 86, 82, 77, 73, 69, 65, 61, 57, 54, 50, 47, 44, 41, 38, 35,
     32, 29, 27, 25, 22, 20, 18, 16, 15, 13, 12, 10, 9, 8, 7, 6, 6, 5, 5, 4, 4, 4,
-];
+]);
 
 #[no_mangle]
 pub static dav1d_dr_intra_derivative: [u16; 44] = [


### PR DESCRIPTION
Still need to enable `wiener_filter_neon` and the assembly routines it calls but that can happen in a separate PR.