### PR TITLE
`src/msac.rs`: Cleanup `fn`s and make mostly safe

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -8032,44 +8032,44 @@ unsafe extern "C" fn read_restoration_info(
         } else {
             dav1d_msac_decode_subexp(
                 &mut (*ts).msac,
-                (*(*ts).lr_ref[p as usize]).filter_v[0] as libc::c_int + 5,
-                16 as libc::c_int,
-                1 as libc::c_int as libc::c_uint,
+                ((*(*ts).lr_ref[p as usize]).filter_v[0] + 5) as libc::c_uint,
+                16,
+                1,
             ) - 5
         }) as int8_t;
         (*lr).filter_v[1] = (dav1d_msac_decode_subexp(
             &mut (*ts).msac,
-            (*(*ts).lr_ref[p as usize]).filter_v[1] as libc::c_int + 23,
-            32 as libc::c_int,
-            2 as libc::c_int as libc::c_uint,
+            ((*(*ts).lr_ref[p as usize]).filter_v[1] + 23) as libc::c_uint,
+            32,
+            2,
         ) - 23) as int8_t;
         (*lr).filter_v[2] = (dav1d_msac_decode_subexp(
             &mut (*ts).msac,
-            (*(*ts).lr_ref[p as usize]).filter_v[2] as libc::c_int + 17,
-            64 as libc::c_int,
-            3 as libc::c_int as libc::c_uint,
+            ((*(*ts).lr_ref[p as usize]).filter_v[2] + 17) as libc::c_uint,
+            64,
+            3,
         ) - 17) as int8_t;
         (*lr).filter_h[0] = (if p != 0 {
             0 as libc::c_int
         } else {
             dav1d_msac_decode_subexp(
                 &mut (*ts).msac,
-                (*(*ts).lr_ref[p as usize]).filter_h[0] as libc::c_int + 5,
-                16 as libc::c_int,
-                1 as libc::c_int as libc::c_uint,
+                ((*(*ts).lr_ref[p as usize]).filter_h[0] + 5) as libc::c_uint,
+                16,
+                1,
             ) - 5
         }) as int8_t;
         (*lr).filter_h[1] = (dav1d_msac_decode_subexp(
             &mut (*ts).msac,
-            (*(*ts).lr_ref[p as usize]).filter_h[1] as libc::c_int + 23,
-            32 as libc::c_int,
-            2 as libc::c_int as libc::c_uint,
+            ((*(*ts).lr_ref[p as usize]).filter_h[1] + 23) as libc::c_uint,
+            32,
+            2,
         ) - 23) as int8_t;
         (*lr).filter_h[2] = (dav1d_msac_decode_subexp(
             &mut (*ts).msac,
-            (*(*ts).lr_ref[p as usize]).filter_h[2] as libc::c_int + 17,
-            64 as libc::c_int,
-            3 as libc::c_int as libc::c_uint,
+            ((*(*ts).lr_ref[p as usize]).filter_h[2] + 17) as libc::c_uint,
+            64,
+            3,
         ) - 17) as int8_t;
         memcpy(
             ((*lr).sgr_weights).as_mut_ptr() as *mut libc::c_void,
@@ -8105,9 +8105,9 @@ unsafe extern "C" fn read_restoration_info(
         (*lr).sgr_weights[0] = (if *sgr_params.offset(0) as libc::c_int != 0 {
             dav1d_msac_decode_subexp(
                 &mut (*ts).msac,
-                (*(*ts).lr_ref[p as usize]).sgr_weights[0] as libc::c_int + 96,
-                128 as libc::c_int,
-                4 as libc::c_int as libc::c_uint,
+                ((*(*ts).lr_ref[p as usize]).sgr_weights[0] + 96) as libc::c_uint,
+                128,
+                4,
             ) - 96
         } else {
             0 as libc::c_int
@@ -8115,9 +8115,9 @@ unsafe extern "C" fn read_restoration_info(
         (*lr).sgr_weights[1] = (if *sgr_params.offset(1) as libc::c_int != 0 {
             dav1d_msac_decode_subexp(
                 &mut (*ts).msac,
-                (*(*ts).lr_ref[p as usize]).sgr_weights[1] as libc::c_int + 32,
-                128 as libc::c_int,
-                4 as libc::c_int as libc::c_uint,
+                ((*(*ts).lr_ref[p as usize]).sgr_weights[1] + 32) as libc::c_uint,
+                128,
+                4,
             ) - 32
         } else {
             95 as libc::c_int

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -7907,7 +7907,7 @@ unsafe extern "C" fn setup_tile(
         &mut (*ts).msac,
         data,
         sz,
-        (*(*f).frame_hdr).disable_cdf_update,
+        (*(*f).frame_hdr).disable_cdf_update != 0,
     );
     (*ts).tiling.row = tile_row;
     (*ts).tiling.col = tile_col;

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -88,14 +88,14 @@ pub unsafe fn dav1d_msac_decode_bools(s: &mut MsacContext, n: libc::c_uint) -> l
 
 #[inline]
 pub unsafe fn dav1d_msac_decode_uniform(s: &mut MsacContext, n: libc::c_uint) -> libc::c_int {
-    if !(n > 0 as libc::c_uint) {
+    if !(n > 0) {
         unreachable!();
     }
     let l = ulog2(n) + 1;
     if !(l > 1) {
         unreachable!();
     }
-    let m = (((1 as libc::c_int) << l) as libc::c_uint).wrapping_sub(n);
+    let m = ((1 << l) as libc::c_uint).wrapping_sub(n);
     let v = dav1d_msac_decode_bools(s, (l - 1) as libc::c_uint);
     return (if v < m {
         v
@@ -113,13 +113,13 @@ unsafe extern "C" fn msac_init_x86(s: &mut MsacContext) {
     use crate::src::x86::cpu::DAV1D_X86_CPU_FLAG_SSE2;
 
     let flags = dav1d_get_cpu_flags();
-    if flags & DAV1D_X86_CPU_FLAG_SSE2 as libc::c_int as libc::c_uint != 0 {
+    if flags & DAV1D_X86_CPU_FLAG_SSE2 != 0 {
         s.symbol_adapt16 = Some(
             dav1d_msac_decode_symbol_adapt16_sse2
                 as unsafe extern "C" fn(*mut MsacContext, *mut uint16_t, size_t) -> libc::c_uint,
         );
     }
-    if flags & DAV1D_X86_CPU_FLAG_AVX2 as libc::c_int as libc::c_uint != 0 {
+    if flags & DAV1D_X86_CPU_FLAG_AVX2 != 0 {
         s.symbol_adapt16 = Some(
             dav1d_msac_decode_symbol_adapt16_avx2
                 as unsafe extern "C" fn(*mut MsacContext, *mut uint16_t, size_t) -> libc::c_uint,
@@ -142,7 +142,7 @@ unsafe extern "C" fn ctx_refill(s: &mut MsacContext) {
         let fresh1 = buf_pos;
         buf_pos = buf_pos.offset(1);
         dif ^= (*fresh1 as ec_win) << c;
-        c -= 8 as libc::c_int;
+        c -= 8;
     }
     s.dif = dif;
     s.cnt = EC_WIN_SIZE.wrapping_sub(c as usize).wrapping_sub(24) as libc::c_int;
@@ -151,8 +151,8 @@ unsafe extern "C" fn ctx_refill(s: &mut MsacContext) {
 
 #[inline]
 unsafe extern "C" fn ctx_norm(s: &mut MsacContext, dif: ec_win, rng: libc::c_uint) {
-    let d = 15 as libc::c_int ^ (31 as libc::c_int ^ clz(rng));
-    if !(rng <= 65535 as libc::c_uint) {
+    let d = 15 ^ (31 ^ clz(rng));
+    if !(rng <= 65535) {
         unreachable!();
     }
     s.cnt -= d;
@@ -169,15 +169,13 @@ unsafe fn dav1d_msac_decode_bool_equi_rust(s: &mut MsacContext) -> libc::c_uint 
     if !(dif >> EC_WIN_SIZE.wrapping_sub(16) < r as size_t) {
         unreachable!();
     }
-    let mut v = ((r >> 8) << 7).wrapping_add(4 as libc::c_int as libc::c_uint);
+    let mut v = ((r >> 8) << 7).wrapping_add(4);
     let vw = (v as ec_win) << EC_WIN_SIZE.wrapping_sub(16);
-    let ret = (dif >= vw) as libc::c_int as libc::c_uint;
+    let ret = (dif >= vw) as libc::c_uint;
     dif = dif.wrapping_sub((ret as size_t).wrapping_mul(vw)) as ec_win as ec_win;
-    v = v.wrapping_add(
-        ret.wrapping_mul(r.wrapping_sub((2 as libc::c_int as libc::c_uint).wrapping_mul(v))),
-    );
+    v = v.wrapping_add(ret.wrapping_mul(r.wrapping_sub((2 as libc::c_uint).wrapping_mul(v))));
     ctx_norm(s, dif, v);
-    return (ret == 0) as libc::c_int as libc::c_uint;
+    return (ret == 0) as libc::c_uint;
 }
 
 unsafe fn dav1d_msac_decode_bool_rust(s: &mut MsacContext, f: libc::c_uint) -> libc::c_uint {
@@ -186,16 +184,13 @@ unsafe fn dav1d_msac_decode_bool_rust(s: &mut MsacContext, f: libc::c_uint) -> l
     if !(dif >> EC_WIN_SIZE.wrapping_sub(16) < r as size_t) {
         unreachable!();
     }
-    let mut v =
-        ((r >> 8).wrapping_mul(f >> 6) >> 7 - 6).wrapping_add(4 as libc::c_int as libc::c_uint);
+    let mut v = ((r >> 8).wrapping_mul(f >> 6) >> 7 - 6).wrapping_add(4);
     let vw = (v as ec_win) << EC_WIN_SIZE.wrapping_sub(16);
-    let ret = (dif >= vw) as libc::c_int as libc::c_uint;
+    let ret = (dif >= vw) as libc::c_uint;
     dif = (dif).wrapping_sub((ret as size_t).wrapping_mul(vw)) as ec_win as ec_win;
-    v = v.wrapping_add(
-        ret.wrapping_mul(r.wrapping_sub((2 as libc::c_int as libc::c_uint).wrapping_mul(v))),
-    );
+    v = v.wrapping_add(ret.wrapping_mul(r.wrapping_sub((2 as libc::c_uint).wrapping_mul(v))));
     ctx_norm(s, dif, v);
-    return (ret == 0) as libc::c_int as libc::c_uint;
+    return (ret == 0) as libc::c_uint;
 }
 
 pub unsafe fn dav1d_msac_decode_subexp(
@@ -207,14 +202,12 @@ pub unsafe fn dav1d_msac_decode_subexp(
     if !(n >> k == 8) {
         unreachable!();
     }
-    let mut a = 0 as libc::c_int as libc::c_uint;
+    let mut a = 0;
     if dav1d_msac_decode_bool_equi(s) != 0 {
         if dav1d_msac_decode_bool_equi(s) != 0 {
-            k = k.wrapping_add(
-                (dav1d_msac_decode_bool_equi(s)).wrapping_add(1 as libc::c_int as libc::c_uint),
-            );
+            k = k.wrapping_add((dav1d_msac_decode_bool_equi(s)).wrapping_add(1));
         }
-        a = ((1 as libc::c_int) << k) as libc::c_uint;
+        a = 1 << k;
     }
     let v = (dav1d_msac_decode_bools(s, k)).wrapping_add(a);
     let ret = (if r#ref * 2 <= n {
@@ -238,17 +231,16 @@ unsafe fn dav1d_msac_decode_symbol_adapt_rust(
     if !(n_symbols <= 15) {
         unreachable!();
     }
-    if !(cdf[n_symbols] as libc::c_int <= 32) {
+    if !(cdf[n_symbols] <= 32) {
         unreachable!();
     }
     loop {
         val = val.wrapping_add(1);
         u = v;
-        v = r.wrapping_mul((cdf[val as usize] as libc::c_int >> 6) as libc::c_uint);
+        v = r.wrapping_mul((cdf[val as usize] >> 6) as libc::c_uint);
         v >>= 7 - 6;
         v = v.wrapping_add(
-            (4 as libc::c_int as libc::c_uint)
-                .wrapping_mul((n_symbols as libc::c_uint).wrapping_sub(val)),
+            (4 as libc::c_uint).wrapping_mul((n_symbols as libc::c_uint).wrapping_sub(val)),
         );
         if !(c < v) {
             break;
@@ -264,21 +256,19 @@ unsafe fn dav1d_msac_decode_symbol_adapt_rust(
     );
     if s.allow_update_cdf != 0 {
         let count = cdf[n_symbols] as libc::c_uint;
-        let rate = (4 as libc::c_int as libc::c_uint)
+        let rate = (4 as libc::c_uint)
             .wrapping_add(count >> 4)
             .wrapping_add((n_symbols > 2) as u32);
         let mut i = 0;
         while i < val {
-            cdf[i as usize] += (32768 - cdf[i as usize] as libc::c_int >> rate) as uint16_t;
+            cdf[i as usize] += 32768 - cdf[i as usize] >> rate;
             i = i.wrapping_add(1);
         }
         while (i as size_t) < n_symbols {
-            cdf[i as usize] -= (cdf[i as usize] as libc::c_int >> rate) as uint16_t;
+            cdf[i as usize] -= cdf[i as usize] >> rate;
             i = i.wrapping_add(1);
         }
-        cdf[n_symbols] = count
-            .wrapping_add((count < 32 as libc::c_uint) as libc::c_int as libc::c_uint)
-            as uint16_t;
+        cdf[n_symbols] = count.wrapping_add((count < 32) as libc::c_uint) as uint16_t;
     }
     return val;
 }
@@ -306,31 +296,28 @@ unsafe fn dav1d_msac_decode_bool_adapt_rust(
     let bit = dav1d_msac_decode_bool(s, cdf[0] as libc::c_uint);
     if s.allow_update_cdf != 0 {
         let count = cdf[1] as libc::c_uint;
-        let rate = (4 as libc::c_int as libc::c_uint).wrapping_add(count >> 4) as libc::c_int;
+        let rate = (4 as libc::c_uint).wrapping_add(count >> 4) as libc::c_int;
         if bit != 0 {
-            cdf[0] += (32768 as libc::c_int - cdf[0] as libc::c_int >> rate) as uint16_t;
+            cdf[0] += 32768 - cdf[0] >> rate;
         } else {
-            cdf[0] -= (cdf[0] as libc::c_int >> rate) as uint16_t;
+            cdf[0] -= cdf[0] >> rate;
         }
-        cdf[1] = count.wrapping_add((count < 32 as libc::c_uint) as libc::c_int as libc::c_uint)
-            as uint16_t;
+        cdf[1] = count.wrapping_add((count < 32) as libc::c_uint) as uint16_t;
     }
     return bit;
 }
 
 unsafe fn dav1d_msac_decode_hi_tok_rust(s: &mut MsacContext, cdf: &mut [u16; 4]) -> libc::c_uint {
-    let mut tok_br = dav1d_msac_decode_symbol_adapt4(s, cdf, 3 as libc::c_int as size_t);
-    let mut tok = (3 as libc::c_int as libc::c_uint).wrapping_add(tok_br);
-    if tok_br == 3 as libc::c_uint {
-        tok_br = dav1d_msac_decode_symbol_adapt4(s, cdf, 3 as libc::c_int as size_t);
-        tok = (6 as libc::c_int as libc::c_uint).wrapping_add(tok_br);
-        if tok_br == 3 as libc::c_uint {
-            tok_br = dav1d_msac_decode_symbol_adapt4(s, cdf, 3 as libc::c_int as size_t);
-            tok = (9 as libc::c_int as libc::c_uint).wrapping_add(tok_br);
-            if tok_br == 3 as libc::c_uint {
-                tok = (12 as libc::c_int as libc::c_uint).wrapping_add(
-                    dav1d_msac_decode_symbol_adapt4(s, cdf, 3 as libc::c_int as size_t),
-                );
+    let mut tok_br = dav1d_msac_decode_symbol_adapt4(s, cdf, 3);
+    let mut tok = (3 as libc::c_uint).wrapping_add(tok_br);
+    if tok_br == 3 {
+        tok_br = dav1d_msac_decode_symbol_adapt4(s, cdf, 3);
+        tok = (6 as libc::c_uint).wrapping_add(tok_br);
+        if tok_br == 3 {
+            tok_br = dav1d_msac_decode_symbol_adapt4(s, cdf, 3);
+            tok = (9 as libc::c_uint).wrapping_add(tok_br);
+            if tok_br == 3 {
+                tok = (12 as libc::c_uint).wrapping_add(dav1d_msac_decode_symbol_adapt4(s, cdf, 3));
             }
         }
     }
@@ -345,9 +332,9 @@ pub unsafe fn dav1d_msac_init(
 ) {
     s.buf_pos = data;
     s.buf_end = data.offset(sz as isize);
-    s.dif = ((1 as libc::c_int as ec_win) << EC_WIN_SIZE.wrapping_sub(1)).wrapping_sub(1);
-    s.rng = 0x8000 as libc::c_int as libc::c_uint;
-    s.cnt = -(15 as libc::c_int);
+    s.dif = ((1 as ec_win) << EC_WIN_SIZE.wrapping_sub(1)).wrapping_sub(1);
+    s.rng = 0x8000;
+    s.cnt = -15;
     s.allow_update_cdf = (disable_cdf_update_flag == 0) as libc::c_int;
     ctx_refill(s);
 

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -170,11 +170,13 @@ unsafe fn dav1d_msac_decode_bool_equi_rust(s: &mut MsacContext) -> libc::c_uint 
     assert!(dif >> EC_WIN_SIZE.wrapping_sub(16) < r as size_t);
     let mut v = ((r >> 8) << 7).wrapping_add(EC_MIN_PROB);
     let vw = (v as ec_win) << EC_WIN_SIZE.wrapping_sub(16);
-    let ret = (dif >= vw) as libc::c_uint;
+    let ret = dif >= vw;
     dif = dif.wrapping_sub((ret as size_t).wrapping_mul(vw)) as ec_win as ec_win;
-    v = v.wrapping_add(ret.wrapping_mul(r.wrapping_sub((2 as libc::c_uint).wrapping_mul(v))));
+    v = v.wrapping_add(
+        (ret as libc::c_uint).wrapping_mul(r.wrapping_sub((2 as libc::c_uint).wrapping_mul(v))),
+    );
     ctx_norm(s, dif, v);
-    (ret == 0) as libc::c_uint
+    !ret as libc::c_uint
 }
 
 unsafe fn dav1d_msac_decode_bool_rust(s: &mut MsacContext, f: libc::c_uint) -> libc::c_uint {
@@ -184,11 +186,13 @@ unsafe fn dav1d_msac_decode_bool_rust(s: &mut MsacContext, f: libc::c_uint) -> l
     let mut v = ((r >> 8).wrapping_mul(f >> EC_PROB_SHIFT) >> (7 - EC_PROB_SHIFT))
         .wrapping_add(EC_MIN_PROB);
     let vw = (v as ec_win) << EC_WIN_SIZE.wrapping_sub(16);
-    let ret = (dif >= vw) as libc::c_uint;
+    let ret = dif >= vw;
     dif = (dif).wrapping_sub((ret as size_t).wrapping_mul(vw)) as ec_win as ec_win;
-    v = v.wrapping_add(ret.wrapping_mul(r.wrapping_sub((2 as libc::c_uint).wrapping_mul(v))));
+    v = v.wrapping_add(
+        (ret as libc::c_uint).wrapping_mul(r.wrapping_sub((2 as libc::c_uint).wrapping_mul(v))),
+    );
     ctx_norm(s, dif, v);
-    (ret == 0) as libc::c_uint
+    !ret as libc::c_uint
 }
 
 pub unsafe fn dav1d_msac_decode_subexp(

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -203,15 +203,15 @@ pub unsafe fn dav1d_msac_decode_subexp(
     let mut a = 0;
     if dav1d_msac_decode_bool_equi(s) != 0 {
         if dav1d_msac_decode_bool_equi(s) != 0 {
-            k = k.wrapping_add((dav1d_msac_decode_bool_equi(s)).wrapping_add(1));
+            k += dav1d_msac_decode_bool_equi(s) + 1;
         }
         a = 1 << k;
     }
-    let v = (dav1d_msac_decode_bools(s, k)).wrapping_add(a);
+    let v = dav1d_msac_decode_bools(s, k) + a;
     (if r#ref * 2 <= n {
         inv_recenter(r#ref as libc::c_uint, v)
     } else {
-        ((n - 1) as libc::c_uint).wrapping_sub(inv_recenter((n - 1 - r#ref) as libc::c_uint, v))
+        ((n - 1) as libc::c_uint) - inv_recenter((n - 1 - r#ref) as libc::c_uint, v)
     }) as libc::c_int
 }
 

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -166,7 +166,7 @@ unsafe fn dav1d_msac_decode_bool_equi_rust(s: &mut MsacContext) -> libc::c_uint 
     let r = s.rng;
     let mut dif = s.dif;
     assert!(dif >> (EC_WIN_SIZE - 16) < r as size_t);
-    let mut v = ((r >> 8) << 7).wrapping_add(EC_MIN_PROB);
+    let mut v = (r >> 8 << 7) + EC_MIN_PROB;
     let vw = (v as ec_win) << (EC_WIN_SIZE - 16);
     let ret = dif >= vw;
     dif = dif.wrapping_sub((ret as size_t).wrapping_mul(vw)) as ec_win;
@@ -181,8 +181,7 @@ unsafe fn dav1d_msac_decode_bool_rust(s: &mut MsacContext, f: libc::c_uint) -> l
     let r = s.rng;
     let mut dif = s.dif;
     assert!(dif >> (EC_WIN_SIZE - 16) < r as size_t);
-    let mut v = ((r >> 8).wrapping_mul(f >> EC_PROB_SHIFT) >> (7 - EC_PROB_SHIFT))
-        .wrapping_add(EC_MIN_PROB);
+    let mut v = ((r >> 8) * (f >> EC_PROB_SHIFT) >> (7 - EC_PROB_SHIFT)) + EC_MIN_PROB;
     let vw = (v as ec_win) << (EC_WIN_SIZE - 16);
     let ret = dif >= vw;
     dif = (dif).wrapping_sub((ret as size_t).wrapping_mul(vw)) as ec_win;

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -1,10 +1,10 @@
-use std::mem;
-
+use crate::include::common::attributes::clz;
+use crate::include::common::intops::inv_recenter;
 use crate::include::common::intops::ulog2;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use ::libc;
 use cfg_if::cfg_if;
+use std::mem;
 
 #[cfg(all(feature = "asm", target_arch = "x86_64"))]
 extern "C" {
@@ -60,7 +60,9 @@ extern "C" {
     static mut dav1d_cpu_flags_mask: libc::c_uint;
     static mut dav1d_cpu_flags: libc::c_uint;
 }
+
 pub type ec_win = size_t;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct MsacContext {
@@ -74,8 +76,6 @@ pub struct MsacContext {
     pub symbol_adapt16:
         Option<unsafe extern "C" fn(*mut MsacContext, *mut uint16_t, size_t) -> libc::c_uint>,
 }
-use crate::include::common::attributes::clz;
-use crate::include::common::intops::inv_recenter;
 
 #[inline]
 pub unsafe fn dav1d_msac_decode_bools(s: &mut MsacContext, n: libc::c_uint) -> libc::c_uint {

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -320,14 +320,14 @@ pub unsafe fn dav1d_msac_init(
     s: &mut MsacContext,
     data: *const uint8_t,
     sz: size_t,
-    disable_cdf_update_flag: libc::c_int,
+    disable_cdf_update_flag: bool,
 ) {
     s.buf_pos = data;
     s.buf_end = data.offset(sz as isize);
     s.dif = ((1 as ec_win) << EC_WIN_SIZE.wrapping_sub(1)).wrapping_sub(1);
     s.rng = 0x8000;
     s.cnt = -15;
-    s.set_allow_update_cdf(disable_cdf_update_flag == 0);
+    s.set_allow_update_cdf(!disable_cdf_update_flag);
     ctx_refill(s);
 
     #[cfg(all(feature = "asm", target_arch = "x86_64"))]

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -140,9 +140,8 @@ unsafe extern "C" fn ctx_refill(s: &mut MsacContext) {
     let mut c = (EC_WIN_SIZE as libc::c_int) - 24 - s.cnt;
     let mut dif = s.dif;
     while c >= 0 && buf_pos < buf_end {
-        let fresh1 = buf_pos;
+        dif ^= (*buf_pos as ec_win) << c;
         buf_pos = buf_pos.offset(1);
-        dif ^= (*fresh1 as ec_win) << c;
         c -= 8;
     }
     s.dif = dif;

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -174,7 +174,7 @@ unsafe fn dav1d_msac_decode_bool_equi_rust(s: &mut MsacContext) -> libc::c_uint 
     dif = dif.wrapping_sub((ret as size_t).wrapping_mul(vw)) as ec_win as ec_win;
     v = v.wrapping_add(ret.wrapping_mul(r.wrapping_sub((2 as libc::c_uint).wrapping_mul(v))));
     ctx_norm(s, dif, v);
-    return (ret == 0) as libc::c_uint;
+    (ret == 0) as libc::c_uint
 }
 
 unsafe fn dav1d_msac_decode_bool_rust(s: &mut MsacContext, f: libc::c_uint) -> libc::c_uint {
@@ -188,7 +188,7 @@ unsafe fn dav1d_msac_decode_bool_rust(s: &mut MsacContext, f: libc::c_uint) -> l
     dif = (dif).wrapping_sub((ret as size_t).wrapping_mul(vw)) as ec_win as ec_win;
     v = v.wrapping_add(ret.wrapping_mul(r.wrapping_sub((2 as libc::c_uint).wrapping_mul(v))));
     ctx_norm(s, dif, v);
-    return (ret == 0) as libc::c_uint;
+    (ret == 0) as libc::c_uint
 }
 
 pub unsafe fn dav1d_msac_decode_subexp(
@@ -206,12 +206,11 @@ pub unsafe fn dav1d_msac_decode_subexp(
         a = 1 << k;
     }
     let v = (dav1d_msac_decode_bools(s, k)).wrapping_add(a);
-    let ret = (if r#ref * 2 <= n {
+    (if r#ref * 2 <= n {
         inv_recenter(r#ref as libc::c_uint, v)
     } else {
         ((n - 1) as libc::c_uint).wrapping_sub(inv_recenter((n - 1 - r#ref) as libc::c_uint, v))
-    }) as libc::c_int;
-    return ret;
+    }) as libc::c_int
 }
 
 unsafe fn dav1d_msac_decode_symbol_adapt_rust(
@@ -258,7 +257,7 @@ unsafe fn dav1d_msac_decode_symbol_adapt_rust(
         }
         cdf[n_symbols] = count.wrapping_add((count < 32) as libc::c_uint) as uint16_t;
     }
-    return val;
+    val
 }
 
 unsafe extern "C" fn dav1d_msac_decode_symbol_adapt_c(
@@ -292,7 +291,7 @@ unsafe fn dav1d_msac_decode_bool_adapt_rust(
         }
         cdf[1] = count.wrapping_add((count < 32) as libc::c_uint) as uint16_t;
     }
-    return bit;
+    bit
 }
 
 unsafe fn dav1d_msac_decode_hi_tok_rust(s: &mut MsacContext, cdf: &mut [u16; 4]) -> libc::c_uint {
@@ -309,7 +308,7 @@ unsafe fn dav1d_msac_decode_hi_tok_rust(s: &mut MsacContext, cdf: &mut [u16; 4])
             }
         }
     }
-    return tok;
+    tok
 }
 
 pub unsafe fn dav1d_msac_init(

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -242,11 +242,11 @@ unsafe fn dav1d_msac_decode_symbol_adapt_rust(
         let count = cdf[n_symbols];
         let rate = 4 + (count >> 4) + (n_symbols > 2) as u16;
         let val = val as usize;
-        for i in 0..val {
-            cdf[i] += (1 << 15) - cdf[i] >> rate;
+        for cdf in &mut cdf[..val] {
+            *cdf += (1 << 15) - *cdf >> rate;
         }
-        for i in val..n_symbols {
-            cdf[i] -= cdf[i] >> rate;
+        for cdf in &mut cdf[val..n_symbols] {
+            *cdf -= *cdf >> rate;
         }
         cdf[n_symbols] = count + (count < 32) as u16;
     }

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -155,7 +155,7 @@ unsafe extern "C" fn ctx_norm(s: &mut MsacContext, dif: ec_win, rng: libc::c_uin
     let d = 15 ^ (31 ^ clz(rng));
     assert!(rng <= 65535);
     s.cnt -= d;
-    s.dif = (dif.wrapping_add(1) << d).wrapping_sub(1);
+    s.dif = ((dif + 1) << d) - 1;
     s.rng = rng << d;
     if s.cnt < 0 {
         ctx_refill(s);

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -250,14 +250,11 @@ unsafe fn dav1d_msac_decode_symbol_adapt_rust(
         let rate = (4 as libc::c_uint)
             .wrapping_add(count >> 4)
             .wrapping_add((n_symbols > 2) as u32);
-        let mut i = 0;
-        while i < val {
+        for i in 0..val {
             cdf[i as usize] += (1 << 15) - cdf[i as usize] >> rate;
-            i = i.wrapping_add(1);
         }
-        while (i as size_t) < n_symbols {
+        for i in val..n_symbols as libc::c_uint {
             cdf[i as usize] -= cdf[i as usize] >> rate;
-            i = i.wrapping_add(1);
         }
         cdf[n_symbols] = count.wrapping_add((count < 32) as libc::c_uint) as uint16_t;
     }

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -295,15 +295,15 @@ unsafe fn dav1d_msac_decode_bool_adapt_rust(
 
 unsafe fn dav1d_msac_decode_hi_tok_rust(s: &mut MsacContext, cdf: &mut [u16; 4]) -> libc::c_uint {
     let mut tok_br = dav1d_msac_decode_symbol_adapt4(s, cdf, 3);
-    let mut tok = (3 as libc::c_uint).wrapping_add(tok_br);
+    let mut tok = 3 + tok_br;
     if tok_br == 3 {
         tok_br = dav1d_msac_decode_symbol_adapt4(s, cdf, 3);
-        tok = (6 as libc::c_uint).wrapping_add(tok_br);
+        tok = 6 + tok_br;
         if tok_br == 3 {
             tok_br = dav1d_msac_decode_symbol_adapt4(s, cdf, 3);
-            tok = (9 as libc::c_uint).wrapping_add(tok_br);
+            tok = 9 + tok_br;
             if tok_br == 3 {
-                tok = (12 as libc::c_uint).wrapping_add(dav1d_msac_decode_symbol_adapt4(s, cdf, 3));
+                tok = 12 + dav1d_msac_decode_symbol_adapt4(s, cdf, 3);
             }
         }
     }

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -99,17 +99,15 @@ pub unsafe fn dav1d_msac_decode_bools(s: &mut MsacContext, n: libc::c_uint) -> l
 #[inline]
 pub unsafe fn dav1d_msac_decode_uniform(s: &mut MsacContext, n: libc::c_uint) -> libc::c_int {
     assert!(n > 0);
-    let l = ulog2(n) + 1;
+    let l = ulog2(n) as libc::c_uint + 1;
     assert!(l > 1);
-    let m = ((1 << l) as libc::c_uint).wrapping_sub(n);
-    let v = dav1d_msac_decode_bools(s, (l - 1) as libc::c_uint);
-    return (if v < m {
+    let m = (1 << l) - n;
+    let v = dav1d_msac_decode_bools(s, l - 1);
+    (if v < m {
         v
     } else {
-        (v << 1)
-            .wrapping_sub(m)
-            .wrapping_add(dav1d_msac_decode_bool_equi(s))
-    }) as libc::c_int;
+        (v << 1) - m + dav1d_msac_decode_bool_equi(s)
+    }) as libc::c_int
 }
 
 #[cfg(all(feature = "asm", target_arch = "x86_64"))]

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -112,7 +112,7 @@ pub unsafe fn dav1d_msac_decode_uniform(s: &mut MsacContext, n: libc::c_uint) ->
 
 #[cfg(all(feature = "asm", target_arch = "x86_64"))]
 #[inline(always)]
-unsafe extern "C" fn msac_init_x86(s: &mut MsacContext) {
+unsafe fn msac_init_x86(s: &mut MsacContext) {
     use crate::src::x86::cpu::DAV1D_X86_CPU_FLAG_AVX2;
     use crate::src::x86::cpu::DAV1D_X86_CPU_FLAG_SSE2;
 

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -219,11 +219,10 @@ unsafe fn dav1d_msac_decode_symbol_adapt_rust(
     let r = s.rng >> 8;
     let mut u = 0;
     let mut v = s.rng;
-    let mut val = -(1 as libc::c_int) as libc::c_uint;
+    let mut val = 0;
     assert!(n_symbols <= 15);
     assert!(cdf[n_symbols] <= 32);
     loop {
-        val = val.wrapping_add(1);
         u = v;
         v = r * ((cdf[val as usize] >> EC_PROB_SHIFT) as libc::c_uint);
         v >>= 7 - EC_PROB_SHIFT;
@@ -231,6 +230,7 @@ unsafe fn dav1d_msac_decode_symbol_adapt_rust(
         if !(c < v) {
             break;
         }
+        val += 1;
     }
     assert!(u <= s.rng);
     ctx_norm(

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -252,7 +252,7 @@ unsafe fn dav1d_msac_decode_symbol_adapt_rust(
             .wrapping_add((n_symbols > 2) as u32);
         let mut i = 0;
         while i < val {
-            cdf[i as usize] += 32768 - cdf[i as usize] >> rate;
+            cdf[i as usize] += (1 << 15) - cdf[i as usize] >> rate;
             i = i.wrapping_add(1);
         }
         while (i as size_t) < n_symbols {
@@ -289,7 +289,7 @@ unsafe fn dav1d_msac_decode_bool_adapt_rust(
         let count = cdf[1] as libc::c_uint;
         let rate = (4 as libc::c_uint).wrapping_add(count >> 4) as libc::c_int;
         if bit != 0 {
-            cdf[0] += 32768 - cdf[0] >> rate;
+            cdf[0] += (1 << 15) - cdf[0] >> rate;
         } else {
             cdf[0] -= cdf[0] >> rate;
         }

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -195,8 +195,8 @@ unsafe fn dav1d_msac_decode_bool_rust(s: &mut MsacContext, f: libc::c_uint) -> l
 
 pub unsafe fn dav1d_msac_decode_subexp(
     s: &mut MsacContext,
-    r#ref: libc::c_int,
-    n: libc::c_int,
+    r#ref: libc::c_uint,
+    n: libc::c_uint,
     mut k: libc::c_uint,
 ) -> libc::c_int {
     assert!(n >> k == 8);
@@ -209,9 +209,9 @@ pub unsafe fn dav1d_msac_decode_subexp(
     }
     let v = dav1d_msac_decode_bools(s, k) + a;
     (if r#ref * 2 <= n {
-        inv_recenter(r#ref as libc::c_uint, v)
+        inv_recenter(r#ref, v)
     } else {
-        ((n - 1) as libc::c_uint) - inv_recenter((n - 1 - r#ref) as libc::c_uint, v)
+        n - 1 - inv_recenter(n - 1 - r#ref, v)
     }) as libc::c_int
 }
 

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -88,13 +88,9 @@ pub unsafe fn dav1d_msac_decode_bools(s: &mut MsacContext, n: libc::c_uint) -> l
 
 #[inline]
 pub unsafe fn dav1d_msac_decode_uniform(s: &mut MsacContext, n: libc::c_uint) -> libc::c_int {
-    if !(n > 0) {
-        unreachable!();
-    }
+    assert!(n > 0);
     let l = ulog2(n) + 1;
-    if !(l > 1) {
-        unreachable!();
-    }
+    assert!(l > 1);
     let m = ((1 << l) as libc::c_uint).wrapping_sub(n);
     let v = dav1d_msac_decode_bools(s, (l - 1) as libc::c_uint);
     return (if v < m {
@@ -152,9 +148,7 @@ unsafe extern "C" fn ctx_refill(s: &mut MsacContext) {
 #[inline]
 unsafe extern "C" fn ctx_norm(s: &mut MsacContext, dif: ec_win, rng: libc::c_uint) {
     let d = 15 ^ (31 ^ clz(rng));
-    if !(rng <= 65535) {
-        unreachable!();
-    }
+    assert!(rng <= 65535);
     s.cnt -= d;
     s.dif = (dif.wrapping_add(1) << d).wrapping_sub(1);
     s.rng = rng << d;
@@ -166,9 +160,7 @@ unsafe extern "C" fn ctx_norm(s: &mut MsacContext, dif: ec_win, rng: libc::c_uin
 unsafe fn dav1d_msac_decode_bool_equi_rust(s: &mut MsacContext) -> libc::c_uint {
     let r = s.rng;
     let mut dif = s.dif;
-    if !(dif >> EC_WIN_SIZE.wrapping_sub(16) < r as size_t) {
-        unreachable!();
-    }
+    assert!(dif >> EC_WIN_SIZE.wrapping_sub(16) < r as size_t);
     let mut v = ((r >> 8) << 7).wrapping_add(4);
     let vw = (v as ec_win) << EC_WIN_SIZE.wrapping_sub(16);
     let ret = (dif >= vw) as libc::c_uint;
@@ -181,9 +173,7 @@ unsafe fn dav1d_msac_decode_bool_equi_rust(s: &mut MsacContext) -> libc::c_uint 
 unsafe fn dav1d_msac_decode_bool_rust(s: &mut MsacContext, f: libc::c_uint) -> libc::c_uint {
     let r = s.rng;
     let mut dif = s.dif;
-    if !(dif >> EC_WIN_SIZE.wrapping_sub(16) < r as size_t) {
-        unreachable!();
-    }
+    assert!(dif >> EC_WIN_SIZE.wrapping_sub(16) < r as size_t);
     let mut v = ((r >> 8).wrapping_mul(f >> 6) >> 7 - 6).wrapping_add(4);
     let vw = (v as ec_win) << EC_WIN_SIZE.wrapping_sub(16);
     let ret = (dif >= vw) as libc::c_uint;
@@ -199,9 +189,7 @@ pub unsafe fn dav1d_msac_decode_subexp(
     n: libc::c_int,
     mut k: libc::c_uint,
 ) -> libc::c_int {
-    if !(n >> k == 8) {
-        unreachable!();
-    }
+    assert!(n >> k == 8);
     let mut a = 0;
     if dav1d_msac_decode_bool_equi(s) != 0 {
         if dav1d_msac_decode_bool_equi(s) != 0 {
@@ -228,12 +216,8 @@ unsafe fn dav1d_msac_decode_symbol_adapt_rust(
     let mut u = 0;
     let mut v = s.rng;
     let mut val = -(1 as libc::c_int) as libc::c_uint;
-    if !(n_symbols <= 15) {
-        unreachable!();
-    }
-    if !(cdf[n_symbols] <= 32) {
-        unreachable!();
-    }
+    assert!(n_symbols <= 15);
+    assert!(cdf[n_symbols] <= 32);
     loop {
         val = val.wrapping_add(1);
         u = v;
@@ -246,9 +230,7 @@ unsafe fn dav1d_msac_decode_symbol_adapt_rust(
             break;
         }
     }
-    if !(u <= s.rng) {
-        unreachable!();
-    }
+    assert!(u <= s.rng);
     ctx_norm(
         s,
         (s.dif).wrapping_sub((v as ec_win) << EC_WIN_SIZE.wrapping_sub(16)),

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -246,11 +246,12 @@ unsafe fn dav1d_msac_decode_symbol_adapt_rust(
     if s.allow_update_cdf() {
         let count = cdf[n_symbols];
         let rate = 4 + (count >> 4) + (n_symbols > 2) as u16;
+        let val = val as usize;
         for i in 0..val {
-            cdf[i as usize] += (1 << 15) - cdf[i as usize] >> rate;
+            cdf[i] += (1 << 15) - cdf[i] >> rate;
         }
-        for i in val..n_symbols as libc::c_uint {
-            cdf[i as usize] -= cdf[i as usize] >> rate;
+        for i in val..n_symbols {
+            cdf[i] -= cdf[i] >> rate;
         }
         cdf[n_symbols] = count + (count < 32) as u16;
     }

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -134,7 +134,7 @@ const EC_MIN_PROB: libc::c_uint = 4; // must be <= (1 << EC_PROB_SHIFT) / 16
 const EC_WIN_SIZE: usize = mem::size_of::<ec_win>() << 3;
 
 #[inline]
-unsafe extern "C" fn ctx_refill(s: &mut MsacContext) {
+unsafe fn ctx_refill(s: &mut MsacContext) {
     let mut buf_pos = s.buf_pos;
     let mut buf_end = s.buf_end;
     let mut c = (EC_WIN_SIZE as libc::c_int) - 24 - s.cnt;
@@ -150,7 +150,7 @@ unsafe extern "C" fn ctx_refill(s: &mut MsacContext) {
 }
 
 #[inline]
-unsafe extern "C" fn ctx_norm(s: &mut MsacContext, dif: ec_win, rng: libc::c_uint) {
+unsafe fn ctx_norm(s: &mut MsacContext, dif: ec_win, rng: libc::c_uint) {
     let d = 15 ^ (31 ^ clz(rng));
     assert!(rng <= 65535);
     s.cnt -= d;

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -95,8 +95,8 @@ pub unsafe fn dav1d_msac_decode_uniform(s: &mut MsacContext, n: libc::c_uint) ->
     if !(l > 1) {
         unreachable!();
     }
-    let m: libc::c_uint = (((1 as libc::c_int) << l) as libc::c_uint).wrapping_sub(n);
-    let v: libc::c_uint = dav1d_msac_decode_bools(s, (l - 1) as libc::c_uint);
+    let m = (((1 as libc::c_int) << l) as libc::c_uint).wrapping_sub(n);
+    let v = dav1d_msac_decode_bools(s, (l - 1) as libc::c_uint);
     return (if v < m {
         v
     } else {
@@ -112,7 +112,7 @@ unsafe extern "C" fn msac_init_x86(s: &mut MsacContext) {
     use crate::src::x86::cpu::DAV1D_X86_CPU_FLAG_AVX2;
     use crate::src::x86::cpu::DAV1D_X86_CPU_FLAG_SSE2;
 
-    let flags: libc::c_uint = dav1d_get_cpu_flags();
+    let flags = dav1d_get_cpu_flags();
     if flags & DAV1D_X86_CPU_FLAG_SSE2 as libc::c_int as libc::c_uint != 0 {
         s.symbol_adapt16 = Some(
             dav1d_msac_decode_symbol_adapt16_sse2
@@ -134,10 +134,10 @@ const EC_WIN_SIZE: usize = mem::size_of::<ec_win>() << 3;
 
 #[inline]
 unsafe extern "C" fn ctx_refill(s: &mut MsacContext) {
-    let mut buf_pos: *const uint8_t = s.buf_pos;
-    let mut buf_end: *const uint8_t = s.buf_end;
+    let mut buf_pos = s.buf_pos;
+    let mut buf_end = s.buf_end;
     let mut c = EC_WIN_SIZE.wrapping_sub(s.cnt as usize).wrapping_sub(24) as libc::c_int;
-    let mut dif: ec_win = s.dif;
+    let mut dif = s.dif;
     while c >= 0 && buf_pos < buf_end {
         let fresh1 = buf_pos;
         buf_pos = buf_pos.offset(1);
@@ -164,14 +164,14 @@ unsafe extern "C" fn ctx_norm(s: &mut MsacContext, dif: ec_win, rng: libc::c_uin
 }
 
 unsafe fn dav1d_msac_decode_bool_equi_rust(s: &mut MsacContext) -> libc::c_uint {
-    let r: libc::c_uint = s.rng;
-    let mut dif: ec_win = s.dif;
+    let r = s.rng;
+    let mut dif = s.dif;
     if !(dif >> EC_WIN_SIZE.wrapping_sub(16) < r as size_t) {
         unreachable!();
     }
-    let mut v: libc::c_uint = ((r >> 8) << 7).wrapping_add(4 as libc::c_int as libc::c_uint);
-    let vw: ec_win = (v as ec_win) << EC_WIN_SIZE.wrapping_sub(16);
-    let ret: libc::c_uint = (dif >= vw) as libc::c_int as libc::c_uint;
+    let mut v = ((r >> 8) << 7).wrapping_add(4 as libc::c_int as libc::c_uint);
+    let vw = (v as ec_win) << EC_WIN_SIZE.wrapping_sub(16);
+    let ret = (dif >= vw) as libc::c_int as libc::c_uint;
     dif = dif.wrapping_sub((ret as size_t).wrapping_mul(vw)) as ec_win as ec_win;
     v = v.wrapping_add(
         ret.wrapping_mul(r.wrapping_sub((2 as libc::c_int as libc::c_uint).wrapping_mul(v))),
@@ -181,15 +181,15 @@ unsafe fn dav1d_msac_decode_bool_equi_rust(s: &mut MsacContext) -> libc::c_uint 
 }
 
 unsafe fn dav1d_msac_decode_bool_rust(s: &mut MsacContext, f: libc::c_uint) -> libc::c_uint {
-    let r: libc::c_uint = s.rng;
-    let mut dif: ec_win = s.dif;
+    let r = s.rng;
+    let mut dif = s.dif;
     if !(dif >> EC_WIN_SIZE.wrapping_sub(16) < r as size_t) {
         unreachable!();
     }
-    let mut v: libc::c_uint =
+    let mut v =
         ((r >> 8).wrapping_mul(f >> 6) >> 7 - 6).wrapping_add(4 as libc::c_int as libc::c_uint);
-    let vw: ec_win = (v as ec_win) << EC_WIN_SIZE.wrapping_sub(16);
-    let ret: libc::c_uint = (dif >= vw) as libc::c_int as libc::c_uint;
+    let vw = (v as ec_win) << EC_WIN_SIZE.wrapping_sub(16);
+    let ret = (dif >= vw) as libc::c_int as libc::c_uint;
     dif = (dif).wrapping_sub((ret as size_t).wrapping_mul(vw)) as ec_win as ec_win;
     v = v.wrapping_add(
         ret.wrapping_mul(r.wrapping_sub((2 as libc::c_int as libc::c_uint).wrapping_mul(v))),
@@ -207,7 +207,7 @@ pub unsafe fn dav1d_msac_decode_subexp(
     if !(n >> k == 8) {
         unreachable!();
     }
-    let mut a: libc::c_uint = 0 as libc::c_int as libc::c_uint;
+    let mut a = 0 as libc::c_int as libc::c_uint;
     if dav1d_msac_decode_bool_equi(s) != 0 {
         if dav1d_msac_decode_bool_equi(s) != 0 {
             k = k.wrapping_add(
@@ -216,7 +216,7 @@ pub unsafe fn dav1d_msac_decode_subexp(
         }
         a = ((1 as libc::c_int) << k) as libc::c_uint;
     }
-    let v: libc::c_uint = (dav1d_msac_decode_bools(s, k)).wrapping_add(a);
+    let v = (dav1d_msac_decode_bools(s, k)).wrapping_add(a);
     let ret = (if r#ref * 2 <= n {
         inv_recenter(r#ref as libc::c_uint, v)
     } else {
@@ -230,11 +230,11 @@ unsafe fn dav1d_msac_decode_symbol_adapt_rust(
     cdf: &mut [u16],
     n_symbols: size_t,
 ) -> libc::c_uint {
-    let c: libc::c_uint = (s.dif >> EC_WIN_SIZE.wrapping_sub(16)) as libc::c_uint;
-    let r: libc::c_uint = s.rng >> 8;
-    let mut u: libc::c_uint = 0;
-    let mut v: libc::c_uint = s.rng;
-    let mut val: libc::c_uint = -(1 as libc::c_int) as libc::c_uint;
+    let c = (s.dif >> EC_WIN_SIZE.wrapping_sub(16)) as libc::c_uint;
+    let r = s.rng >> 8;
+    let mut u = 0;
+    let mut v = s.rng;
+    let mut val = -(1 as libc::c_int) as libc::c_uint;
     if !(n_symbols <= 15) {
         unreachable!();
     }
@@ -263,11 +263,11 @@ unsafe fn dav1d_msac_decode_symbol_adapt_rust(
         u.wrapping_sub(v),
     );
     if s.allow_update_cdf != 0 {
-        let count: libc::c_uint = cdf[n_symbols] as libc::c_uint;
-        let rate: libc::c_uint = (4 as libc::c_int as libc::c_uint)
+        let count = cdf[n_symbols] as libc::c_uint;
+        let rate = (4 as libc::c_int as libc::c_uint)
             .wrapping_add(count >> 4)
             .wrapping_add((n_symbols > 2) as u32);
-        let mut i: libc::c_uint = 0;
+        let mut i = 0;
         while i < val {
             cdf[i as usize] += (32768 - cdf[i as usize] as libc::c_int >> rate) as uint16_t;
             i = i.wrapping_add(1);
@@ -303,9 +303,9 @@ unsafe fn dav1d_msac_decode_bool_adapt_rust(
     s: &mut MsacContext,
     cdf: &mut [u16; 2],
 ) -> libc::c_uint {
-    let bit: libc::c_uint = dav1d_msac_decode_bool(s, cdf[0] as libc::c_uint);
+    let bit = dav1d_msac_decode_bool(s, cdf[0] as libc::c_uint);
     if s.allow_update_cdf != 0 {
-        let count: libc::c_uint = cdf[1] as libc::c_uint;
+        let count = cdf[1] as libc::c_uint;
         let rate = (4 as libc::c_int as libc::c_uint).wrapping_add(count >> 4) as libc::c_int;
         if bit != 0 {
             cdf[0] += (32768 as libc::c_int - cdf[0] as libc::c_int >> rate) as uint16_t;
@@ -319,9 +319,8 @@ unsafe fn dav1d_msac_decode_bool_adapt_rust(
 }
 
 unsafe fn dav1d_msac_decode_hi_tok_rust(s: &mut MsacContext, cdf: &mut [u16; 4]) -> libc::c_uint {
-    let mut tok_br: libc::c_uint =
-        dav1d_msac_decode_symbol_adapt4(s, cdf, 3 as libc::c_int as size_t);
-    let mut tok: libc::c_uint = (3 as libc::c_int as libc::c_uint).wrapping_add(tok_br);
+    let mut tok_br = dav1d_msac_decode_symbol_adapt4(s, cdf, 3 as libc::c_int as size_t);
+    let mut tok = (3 as libc::c_int as libc::c_uint).wrapping_add(tok_br);
     if tok_br == 3 as libc::c_uint {
         tok_br = dav1d_msac_decode_symbol_adapt4(s, cdf, 3 as libc::c_int as size_t);
         tok = (6 as libc::c_int as libc::c_uint).wrapping_add(tok_br);

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -165,13 +165,13 @@ unsafe extern "C" fn ctx_norm(s: &mut MsacContext, dif: ec_win, rng: libc::c_uin
 unsafe fn dav1d_msac_decode_bool_equi_rust(s: &mut MsacContext) -> libc::c_uint {
     let r = s.rng;
     let mut dif = s.dif;
-    assert!(dif >> (EC_WIN_SIZE - 16) < r as size_t);
+    assert!(dif >> (EC_WIN_SIZE - 16) < r as ec_win);
     let mut v = (r >> 8 << 7) + EC_MIN_PROB;
     let vw = (v as ec_win) << (EC_WIN_SIZE - 16);
     let ret = dif >= vw;
-    dif = dif.wrapping_sub((ret as size_t).wrapping_mul(vw)) as ec_win;
+    dif = dif.wrapping_sub((ret as ec_win) * vw);
     v = v.wrapping_add(
-        (ret as libc::c_uint).wrapping_mul(r.wrapping_sub((2 as libc::c_uint).wrapping_mul(v))),
+        (ret as libc::c_uint) * (r.wrapping_sub((2 as libc::c_uint).wrapping_mul(v))),
     );
     ctx_norm(s, dif, v);
     !ret as libc::c_uint
@@ -180,13 +180,13 @@ unsafe fn dav1d_msac_decode_bool_equi_rust(s: &mut MsacContext) -> libc::c_uint 
 unsafe fn dav1d_msac_decode_bool_rust(s: &mut MsacContext, f: libc::c_uint) -> libc::c_uint {
     let r = s.rng;
     let mut dif = s.dif;
-    assert!(dif >> (EC_WIN_SIZE - 16) < r as size_t);
+    assert!(dif >> (EC_WIN_SIZE - 16) < r as ec_win);
     let mut v = ((r >> 8) * (f >> EC_PROB_SHIFT) >> (7 - EC_PROB_SHIFT)) + EC_MIN_PROB;
     let vw = (v as ec_win) << (EC_WIN_SIZE - 16);
     let ret = dif >= vw;
-    dif = (dif).wrapping_sub((ret as size_t).wrapping_mul(vw)) as ec_win;
+    dif = dif.wrapping_sub((ret as ec_win) * vw);
     v = v.wrapping_add(
-        (ret as libc::c_uint).wrapping_mul(r.wrapping_sub((2 as libc::c_uint).wrapping_mul(v))),
+        (ret as libc::c_uint) * (r.wrapping_sub((2 as libc::c_uint).wrapping_mul(v))),
     );
     ctx_norm(s, dif, v);
     !ret as libc::c_uint

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -113,6 +113,7 @@ pub unsafe fn dav1d_msac_decode_uniform(s: &mut MsacContext, n: libc::c_uint) ->
 #[cfg(all(feature = "asm", target_arch = "x86_64"))]
 #[inline(always)]
 unsafe fn msac_init_x86(s: &mut MsacContext) {
+    use crate::src::cpu::dav1d_get_cpu_flags;
     use crate::src::x86::cpu::DAV1D_X86_CPU_FLAG_AVX2;
     use crate::src::x86::cpu::DAV1D_X86_CPU_FLAG_SSE2;
 
@@ -124,9 +125,6 @@ unsafe fn msac_init_x86(s: &mut MsacContext) {
         s.symbol_adapt16 = Some(dav1d_msac_decode_symbol_adapt16_avx2);
     }
 }
-
-#[cfg(all(feature = "asm", target_arch = "x86_64"))]
-use crate::src::cpu::dav1d_get_cpu_flags;
 
 const EC_PROB_SHIFT: libc::c_uint = 6;
 const EC_MIN_PROB: libc::c_uint = 4; // must be <= (1 << EC_PROB_SHIFT) / 16

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -169,7 +169,7 @@ unsafe fn dav1d_msac_decode_bool_equi_rust(s: &mut MsacContext) -> libc::c_uint 
     let mut v = (r >> 8 << 7) + EC_MIN_PROB;
     let vw = (v as ec_win) << (EC_WIN_SIZE - 16);
     let ret = dif >= vw;
-    dif = dif.wrapping_sub((ret as ec_win) * vw);
+    dif -= (ret as ec_win) * vw;
     v = v.wrapping_add(
         (ret as libc::c_uint) * (r.wrapping_sub((2 as libc::c_uint).wrapping_mul(v))),
     );
@@ -184,7 +184,7 @@ unsafe fn dav1d_msac_decode_bool_rust(s: &mut MsacContext, f: libc::c_uint) -> l
     let mut v = ((r >> 8) * (f >> EC_PROB_SHIFT) >> (7 - EC_PROB_SHIFT)) + EC_MIN_PROB;
     let vw = (v as ec_win) << (EC_WIN_SIZE - 16);
     let ret = dif >= vw;
-    dif = dif.wrapping_sub((ret as ec_win) * vw);
+    dif -= (ret as ec_win) * vw;
     v = v.wrapping_add(
         (ret as libc::c_uint) * (r.wrapping_sub((2 as libc::c_uint).wrapping_mul(v))),
     );

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -120,16 +120,10 @@ unsafe extern "C" fn msac_init_x86(s: &mut MsacContext) {
 
     let flags = dav1d_get_cpu_flags();
     if flags & DAV1D_X86_CPU_FLAG_SSE2 != 0 {
-        s.symbol_adapt16 = Some(
-            dav1d_msac_decode_symbol_adapt16_sse2
-                as unsafe extern "C" fn(*mut MsacContext, *mut uint16_t, size_t) -> libc::c_uint,
-        );
+        s.symbol_adapt16 = Some(dav1d_msac_decode_symbol_adapt16_sse2);
     }
     if flags & DAV1D_X86_CPU_FLAG_AVX2 != 0 {
-        s.symbol_adapt16 = Some(
-            dav1d_msac_decode_symbol_adapt16_avx2
-                as unsafe extern "C" fn(*mut MsacContext, *mut uint16_t, size_t) -> libc::c_uint,
-        );
+        s.symbol_adapt16 = Some(dav1d_msac_decode_symbol_adapt16_avx2);
     }
 }
 
@@ -332,10 +326,7 @@ pub unsafe fn dav1d_msac_init(
 
     #[cfg(all(feature = "asm", target_arch = "x86_64"))]
     {
-        s.symbol_adapt16 = Some(
-            dav1d_msac_decode_symbol_adapt_c
-                as unsafe extern "C" fn(*mut MsacContext, *mut uint16_t, size_t) -> libc::c_uint,
-        );
+        s.symbol_adapt16 = Some(dav1d_msac_decode_symbol_adapt_c);
         msac_init_x86(s);
     }
 }

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -246,17 +246,15 @@ unsafe fn dav1d_msac_decode_symbol_adapt_rust(
         u.wrapping_sub(v),
     );
     if s.allow_update_cdf() {
-        let count = cdf[n_symbols] as libc::c_uint;
-        let rate = (4 as libc::c_uint)
-            .wrapping_add(count >> 4)
-            .wrapping_add((n_symbols > 2) as u32);
+        let count = cdf[n_symbols];
+        let rate = 4 + (count >> 4) + (n_symbols > 2) as u16;
         for i in 0..val {
             cdf[i as usize] += (1 << 15) - cdf[i as usize] >> rate;
         }
         for i in val..n_symbols as libc::c_uint {
             cdf[i as usize] -= cdf[i as usize] >> rate;
         }
-        cdf[n_symbols] = count.wrapping_add((count < 32) as libc::c_uint) as uint16_t;
+        cdf[n_symbols] = count + (count < 32) as u16;
     }
     val
 }
@@ -283,14 +281,14 @@ unsafe fn dav1d_msac_decode_bool_adapt_rust(
 ) -> libc::c_uint {
     let bit = dav1d_msac_decode_bool(s, cdf[0] as libc::c_uint);
     if s.allow_update_cdf() {
-        let count = cdf[1] as libc::c_uint;
-        let rate = (4 as libc::c_uint).wrapping_add(count >> 4) as libc::c_int;
+        let count = cdf[1];
+        let rate = 4 + (count >> 4);
         if bit != 0 {
             cdf[0] += (1 << 15) - cdf[0] >> rate;
         } else {
             cdf[0] -= cdf[0] >> rate;
         }
-        cdf[1] = count.wrapping_add((count < 32) as libc::c_uint) as uint16_t;
+        cdf[1] = count + (count < 32) as u16;
     }
     bit
 }


### PR DESCRIPTION
The remaining significant unsafe part around `MsacContext::buf_{pos,end}` will be fixed in a separate PR (#222), as it's a bit more complex.