### PR TITLE
Fix missing aligns

### DIFF
--- a/src/align.rs
+++ b/src/align.rs
@@ -8,122 +8,38 @@
 
 use std::ops::{Index, IndexMut};
 
-#[derive(Copy, Clone)]
-#[repr(C, align(64))]
-pub struct Align64<T>(pub T);
+macro_rules! def_align {
+    ($align:literal, $name:ident) => {
+        #[derive(Copy, Clone)]
+        #[repr(C, align($align))]
+        pub struct $name<T>(pub T);
 
-impl<T> From<T> for Align64<T> {
-    fn from(from: T) -> Self {
-        Align64(from)
-    }
+        impl<T> From<T> for $name<T> {
+            fn from(from: T) -> Self {
+                Self(from)
+            }
+        }
+
+        impl<T: Index<usize>> Index<usize> for $name<T> {
+            type Output = T::Output;
+
+            fn index(&self, index: usize) -> &Self::Output {
+                &self.0[index]
+            }
+        }
+
+        impl<T: IndexMut<usize>> IndexMut<usize> for $name<T> {
+            fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+                &mut self.0[index]
+            }
+        }
+    };
 }
 
-impl<T: Index<usize>> Index<usize> for Align64<T> {
-    type Output = T::Output;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        &self.0[index]
-    }
-}
-
-impl<T: IndexMut<usize>> IndexMut<usize> for Align64<T> {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.0[index]
-    }
-}
-
-#[derive(Copy, Clone)]
-#[repr(C, align(32))]
-pub struct Align32<T>(pub T);
-
-impl<T> From<T> for Align32<T> {
-    fn from(from: T) -> Self {
-        Align32(from)
-    }
-}
-
-impl<T: Index<usize>> Index<usize> for Align32<T> {
-    type Output = T::Output;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        &self.0[index]
-    }
-}
-
-impl<T: IndexMut<usize>> IndexMut<usize> for Align32<T> {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.0[index]
-    }
-}
-
-#[derive(Copy, Clone)]
-#[repr(C, align(16))]
-pub struct Align16<T>(pub T);
-
-impl<T> From<T> for Align16<T> {
-    fn from(from: T) -> Self {
-        Align16(from)
-    }
-}
-
-impl<T: Index<usize>> Index<usize> for Align16<T> {
-    type Output = T::Output;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        &self.0[index]
-    }
-}
-
-impl<T: IndexMut<usize>> IndexMut<usize> for Align16<T> {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.0[index]
-    }
-}
-
-#[derive(Copy, Clone)]
-#[repr(C, align(8))]
-pub struct Align8<T>(pub T);
-
-impl<T> From<T> for Align8<T> {
-    fn from(from: T) -> Self {
-        Align8(from)
-    }
-}
-
-impl<T: Index<usize>> Index<usize> for Align8<T> {
-    type Output = T::Output;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        &self.0[index]
-    }
-}
-
-impl<T: IndexMut<usize>> IndexMut<usize> for Align8<T> {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.0[index]
-    }
-}
-
-#[derive(Copy, Clone)]
-#[repr(C, align(4))]
-pub struct Align4<T>(pub T);
-
-impl<T> From<T> for Align4<T> {
-    fn from(from: T) -> Self {
-        Align4(from)
-    }
-}
-
-impl<T: Index<usize>> Index<usize> for Align4<T> {
-    type Output = T::Output;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        &self.0[index]
-    }
-}
-
-impl<T: IndexMut<usize>> IndexMut<usize> for Align4<T> {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.0[index]
-    }
-}
+def_align!(1, Align1);
+def_align!(2, Align2);
+def_align!(4, Align4);
+def_align!(8, Align8);
+def_align!(16, Align16);
+def_align!(32, Align32);
+def_align!(64, Align64);

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -4482,12 +4482,12 @@ pub fn default_mv_component_cdf() -> CdfMvComponent {
     };
     init
 }
-static mut default_mv_joint_cdf: [uint16_t; 4] = [
+static mut default_mv_joint_cdf: Align8<[uint16_t; 4]> = Align8([
     (32768 - 4096) as uint16_t,
     (32768 - 11264) as uint16_t,
     (32768 - 19328) as uint16_t,
     0,
-];
+]);
 static mut default_kf_y_mode_cdf: [[[uint16_t; 16]; 5]; 5] = [
     [
         [
@@ -23242,12 +23242,12 @@ pub unsafe extern "C" fn dav1d_cdf_thread_copy(dst: *mut CdfContext, src: *const
         (*dst).coef = av1_default_coef_cdf()[(*src).data.qcat as usize];
         memcpy(
             ((*dst).mv.joint.0).as_mut_ptr() as *mut libc::c_void,
-            default_mv_joint_cdf.as_ptr() as *const libc::c_void,
+            default_mv_joint_cdf.0.as_ptr() as *const libc::c_void,
             ::core::mem::size_of::<[uint16_t; 4]>() as libc::c_ulong,
         );
         memcpy(
             ((*dst).dmv.joint.0).as_mut_ptr() as *mut libc::c_void,
-            default_mv_joint_cdf.as_ptr() as *const libc::c_void,
+            default_mv_joint_cdf.0.as_ptr() as *const libc::c_void,
             ::core::mem::size_of::<[uint16_t; 4]>() as libc::c_ulong,
         );
         (*dst).dmv.comp[1] = default_mv_component_cdf();

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -4488,7 +4488,7 @@ static mut default_mv_joint_cdf: Align8<[uint16_t; 4]> = Align8([
     (32768 - 19328) as uint16_t,
     0,
 ]);
-static mut default_kf_y_mode_cdf: [[[uint16_t; 16]; 5]; 5] = [
+static mut default_kf_y_mode_cdf: Align32<[[[uint16_t; 16]; 5]; 5]> = Align32([
     [
         [
             (32768 - 15588) as uint16_t,
@@ -4949,7 +4949,7 @@ static mut default_kf_y_mode_cdf: [[[uint16_t; 16]; 5]; 5] = [
             0,
         ],
     ],
-];
+]);
 pub fn av1_default_coef_cdf() -> [CdfCoefContext; 4] {
     [
         {
@@ -23236,7 +23236,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_copy(dst: *mut CdfContext, src: *const
         (*dst).m = av1_default_cdf();
         memcpy(
             ((*dst).kfym.0).as_mut_ptr() as *mut libc::c_void,
-            default_kf_y_mode_cdf.as_ptr() as *const libc::c_void,
+            default_kf_y_mode_cdf.0.as_ptr() as *const libc::c_void,
             ::core::mem::size_of::<[[[uint16_t; 16]; 5]; 5]>() as libc::c_ulong,
         );
         (*dst).coef = av1_default_coef_cdf()[(*src).data.qcat as usize];

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1258,8 +1258,8 @@ unsafe extern "C" fn read_tx_tree(
     if depth < 2 && from as libc::c_uint > TX_4X4 as libc::c_int as libc::c_uint {
         let cat =
             2 as libc::c_int * (TX_64X64 as libc::c_int - (*t_dim).max as libc::c_int) - depth;
-        let a = (((*(*t).a).tx[bx4 as usize] as libc::c_int) < txw) as libc::c_int;
-        let l = (((*t).l.tx[by4 as usize] as libc::c_int) < txh) as libc::c_int;
+        let a = (((*(*t).a).tx.0[bx4 as usize] as libc::c_int) < txw) as libc::c_int;
+        let l = (((*t).l.tx.0[by4 as usize] as libc::c_int) < txh) as libc::c_int;
         is_split = dav1d_msac_decode_bool_adapt(
             &mut (*(*t).ts).msac,
             &mut (*(*t).ts).cdf.m.txpart[cat as usize][(a + l) as usize],
@@ -1297,7 +1297,7 @@ unsafe extern "C" fn read_tx_tree(
     } else {
         match (*t_dim).h as libc::c_int {
             1 => {
-                (*(&mut *((*t).l.tx).as_mut_ptr().offset(by4 as isize) as *mut int8_t
+                (*(&mut *((*t).l.tx.0).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                     as *mut alias8))
                     .u8_0 = (if is_split != 0 {
                     TX_4X4 as libc::c_int
@@ -1306,7 +1306,7 @@ unsafe extern "C" fn read_tx_tree(
                 }) as uint8_t;
             }
             2 => {
-                (*(&mut *((*t).l.tx).as_mut_ptr().offset(by4 as isize) as *mut int8_t
+                (*(&mut *((*t).l.tx.0).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                     as *mut alias16))
                     .u16_0 = (if is_split != 0 {
                     TX_4X4 as libc::c_int
@@ -1315,7 +1315,7 @@ unsafe extern "C" fn read_tx_tree(
                 }) as uint16_t;
             }
             4 => {
-                (*(&mut *((*t).l.tx).as_mut_ptr().offset(by4 as isize) as *mut int8_t
+                (*(&mut *((*t).l.tx.0).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                     as *mut alias32))
                     .u32_0 = if is_split != 0 {
                     TX_4X4 as libc::c_int as libc::c_uint
@@ -1324,7 +1324,7 @@ unsafe extern "C" fn read_tx_tree(
                 };
             }
             8 => {
-                (*(&mut *((*t).l.tx).as_mut_ptr().offset(by4 as isize) as *mut int8_t
+                (*(&mut *((*t).l.tx.0).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = (if is_split != 0 {
                     TX_4X4 as libc::c_int as libc::c_ulonglong
@@ -1338,10 +1338,10 @@ unsafe extern "C" fn read_tx_tree(
                 } else {
                     (0x101010101010101 as libc::c_ulonglong).wrapping_mul(txh as libc::c_ulonglong)
                 }) as uint64_t;
-                (*(&mut *((*t).l.tx).as_mut_ptr().offset((by4 + 0) as isize) as *mut int8_t
+                (*(&mut *((*t).l.tx.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val;
-                (*(&mut *((*t).l.tx).as_mut_ptr().offset((by4 + 8) as isize) as *mut int8_t
+                (*(&mut *((*t).l.tx.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val;
             }
@@ -1349,7 +1349,7 @@ unsafe extern "C" fn read_tx_tree(
         }
         match (*t_dim).w as libc::c_int {
             1 => {
-                (*(&mut *((*(*t).a).tx).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
+                (*(&mut *((*(*t).a).tx.0).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                     as *mut alias8))
                     .u8_0 = (if is_split != 0 {
                     TX_4X4 as libc::c_int
@@ -1358,7 +1358,7 @@ unsafe extern "C" fn read_tx_tree(
                 }) as uint8_t;
             }
             2 => {
-                (*(&mut *((*(*t).a).tx).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
+                (*(&mut *((*(*t).a).tx.0).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                     as *mut alias16))
                     .u16_0 = (if is_split != 0 {
                     TX_4X4 as libc::c_int
@@ -1367,7 +1367,7 @@ unsafe extern "C" fn read_tx_tree(
                 }) as uint16_t;
             }
             4 => {
-                (*(&mut *((*(*t).a).tx).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
+                (*(&mut *((*(*t).a).tx.0).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                     as *mut alias32))
                     .u32_0 = if is_split != 0 {
                     TX_4X4 as libc::c_int as libc::c_uint
@@ -1376,7 +1376,7 @@ unsafe extern "C" fn read_tx_tree(
                 };
             }
             8 => {
-                (*(&mut *((*(*t).a).tx).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
+                (*(&mut *((*(*t).a).tx.0).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = (if is_split != 0 {
                     TX_4X4 as libc::c_int as libc::c_ulonglong
@@ -1390,10 +1390,10 @@ unsafe extern "C" fn read_tx_tree(
                 } else {
                     (0x101010101010101 as libc::c_ulonglong).wrapping_mul(txw as libc::c_ulonglong)
                 }) as uint64_t;
-                (*(&mut *((*(*t).a).tx).as_mut_ptr().offset((bx4 + 0) as isize) as *mut int8_t
+                (*(&mut *((*(*t).a).tx.0).as_mut_ptr().offset((bx4 + 0) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_0;
-                (*(&mut *((*(*t).a).tx).as_mut_ptr().offset((bx4 + 8) as isize) as *mut int8_t
+                (*(&mut *((*(*t).a).tx.0).as_mut_ptr().offset((bx4 + 8) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_0;
             }
@@ -2192,46 +2192,46 @@ unsafe extern "C" fn read_vartx_tree(
         {
             match bh4 {
                 1 => {
-                    (*(&mut *((*t).l.tx).as_mut_ptr().offset(by4 as isize) as *mut int8_t
+                    (*(&mut *((*t).l.tx.0).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                         as *mut alias8))
                         .u8_0 = TX_4X4 as libc::c_int as uint8_t;
                 }
                 2 => {
-                    (*(&mut *((*t).l.tx).as_mut_ptr().offset(by4 as isize) as *mut int8_t
+                    (*(&mut *((*t).l.tx.0).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                         as *mut alias16))
                         .u16_0 = TX_4X4 as libc::c_int as uint16_t;
                 }
                 4 => {
-                    (*(&mut *((*t).l.tx).as_mut_ptr().offset(by4 as isize) as *mut int8_t
+                    (*(&mut *((*t).l.tx.0).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                         as *mut alias32))
                         .u32_0 = TX_4X4 as libc::c_int as uint32_t;
                 }
                 8 => {
-                    (*(&mut *((*t).l.tx).as_mut_ptr().offset(by4 as isize) as *mut int8_t
+                    (*(&mut *((*t).l.tx.0).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = TX_4X4 as libc::c_int as uint64_t;
                 }
                 16 => {
                     let const_val: uint64_t = TX_4X4 as libc::c_int as uint64_t;
-                    (*(&mut *((*t).l.tx).as_mut_ptr().offset((by4 + 0) as isize) as *mut int8_t
+                    (*(&mut *((*t).l.tx.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val;
-                    (*(&mut *((*t).l.tx).as_mut_ptr().offset((by4 + 8) as isize) as *mut int8_t
+                    (*(&mut *((*t).l.tx.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val;
                 }
                 32 => {
                     let const_val_0: uint64_t = TX_4X4 as libc::c_int as uint64_t;
-                    (*(&mut *((*t).l.tx).as_mut_ptr().offset((by4 + 0) as isize) as *mut int8_t
+                    (*(&mut *((*t).l.tx.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_0;
-                    (*(&mut *((*t).l.tx).as_mut_ptr().offset((by4 + 8) as isize) as *mut int8_t
+                    (*(&mut *((*t).l.tx.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_0;
-                    (*(&mut *((*t).l.tx).as_mut_ptr().offset((by4 + 16) as isize) as *mut int8_t
+                    (*(&mut *((*t).l.tx.0).as_mut_ptr().offset((by4 + 16) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_0;
-                    (*(&mut *((*t).l.tx).as_mut_ptr().offset((by4 + 24) as isize) as *mut int8_t
+                    (*(&mut *((*t).l.tx.0).as_mut_ptr().offset((by4 + 24) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_0;
                 }
@@ -2239,33 +2239,33 @@ unsafe extern "C" fn read_vartx_tree(
             }
             match bw4 {
                 1 => {
-                    (*(&mut *((*(*t).a).tx).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
+                    (*(&mut *((*(*t).a).tx.0).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                         as *mut alias8))
                         .u8_0 = TX_4X4 as libc::c_int as uint8_t;
                 }
                 2 => {
-                    (*(&mut *((*(*t).a).tx).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
+                    (*(&mut *((*(*t).a).tx.0).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                         as *mut alias16))
                         .u16_0 = TX_4X4 as libc::c_int as uint16_t;
                 }
                 4 => {
-                    (*(&mut *((*(*t).a).tx).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
+                    (*(&mut *((*(*t).a).tx.0).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                         as *mut alias32))
                         .u32_0 = TX_4X4 as libc::c_int as uint32_t;
                 }
                 8 => {
-                    (*(&mut *((*(*t).a).tx).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
+                    (*(&mut *((*(*t).a).tx.0).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = TX_4X4 as libc::c_int as uint64_t;
                 }
                 16 => {
                     let const_val_1: uint64_t = TX_4X4 as libc::c_int as uint64_t;
-                    (*(&mut *((*(*t).a).tx)
+                    (*(&mut *((*(*t).a).tx.0)
                         .as_mut_ptr()
                         .offset((bx4 + 0) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_1;
-                    (*(&mut *((*(*t).a).tx)
+                    (*(&mut *((*(*t).a).tx.0)
                         .as_mut_ptr()
                         .offset((bx4 + 8) as isize) as *mut int8_t
                         as *mut alias64))
@@ -2273,22 +2273,22 @@ unsafe extern "C" fn read_vartx_tree(
                 }
                 32 => {
                     let const_val_2: uint64_t = TX_4X4 as libc::c_int as uint64_t;
-                    (*(&mut *((*(*t).a).tx)
+                    (*(&mut *((*(*t).a).tx.0)
                         .as_mut_ptr()
                         .offset((bx4 + 0) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_2;
-                    (*(&mut *((*(*t).a).tx)
+                    (*(&mut *((*(*t).a).tx.0)
                         .as_mut_ptr()
                         .offset((bx4 + 8) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_2;
-                    (*(&mut *((*(*t).a).tx)
+                    (*(&mut *((*(*t).a).tx.0)
                         .as_mut_ptr()
                         .offset((bx4 + 16) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_2;
-                    (*(&mut *((*(*t).a).tx)
+                    (*(&mut *((*(*t).a).tx.0)
                         .as_mut_ptr()
                         .offset((bx4 + 24) as isize) as *mut int8_t
                         as *mut alias64))
@@ -2306,27 +2306,27 @@ unsafe extern "C" fn read_vartx_tree(
         {
             match bh4 {
                 1 => {
-                    (*(&mut *((*t).l.tx).as_mut_ptr().offset(by4 as isize) as *mut int8_t
+                    (*(&mut *((*t).l.tx.0).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                         as *mut alias8))
                         .u8_0 = (0x1 as libc::c_int
                         * *b_dim.offset((2 + 1) as isize) as libc::c_int)
                         as uint8_t;
                 }
                 2 => {
-                    (*(&mut *((*t).l.tx).as_mut_ptr().offset(by4 as isize) as *mut int8_t
+                    (*(&mut *((*t).l.tx.0).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                         as *mut alias16))
                         .u16_0 = (0x101 as libc::c_int
                         * *b_dim.offset((2 + 1) as isize) as libc::c_int)
                         as uint16_t;
                 }
                 4 => {
-                    (*(&mut *((*t).l.tx).as_mut_ptr().offset(by4 as isize) as *mut int8_t
+                    (*(&mut *((*t).l.tx.0).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                         as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint)
                         .wrapping_mul(*b_dim.offset((2 + 1) as isize) as libc::c_uint);
                 }
                 8 => {
-                    (*(&mut *((*t).l.tx).as_mut_ptr().offset(by4 as isize) as *mut int8_t
+                    (*(&mut *((*t).l.tx.0).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(*b_dim.offset((2 + 1) as isize) as libc::c_ulonglong)
@@ -2336,10 +2336,10 @@ unsafe extern "C" fn read_vartx_tree(
                     let const_val_3: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(*b_dim.offset((2 + 1) as isize) as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *((*t).l.tx).as_mut_ptr().offset((by4 + 0) as isize) as *mut int8_t
+                    (*(&mut *((*t).l.tx.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_3;
-                    (*(&mut *((*t).l.tx).as_mut_ptr().offset((by4 + 8) as isize) as *mut int8_t
+                    (*(&mut *((*t).l.tx.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_3;
                 }
@@ -2347,16 +2347,16 @@ unsafe extern "C" fn read_vartx_tree(
                     let const_val_4: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(*b_dim.offset((2 + 1) as isize) as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *((*t).l.tx).as_mut_ptr().offset((by4 + 0) as isize) as *mut int8_t
+                    (*(&mut *((*t).l.tx.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_4;
-                    (*(&mut *((*t).l.tx).as_mut_ptr().offset((by4 + 8) as isize) as *mut int8_t
+                    (*(&mut *((*t).l.tx.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_4;
-                    (*(&mut *((*t).l.tx).as_mut_ptr().offset((by4 + 16) as isize) as *mut int8_t
+                    (*(&mut *((*t).l.tx.0).as_mut_ptr().offset((by4 + 16) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_4;
-                    (*(&mut *((*t).l.tx).as_mut_ptr().offset((by4 + 24) as isize) as *mut int8_t
+                    (*(&mut *((*t).l.tx.0).as_mut_ptr().offset((by4 + 24) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_4;
                 }
@@ -2364,27 +2364,27 @@ unsafe extern "C" fn read_vartx_tree(
             }
             match bw4 {
                 1 => {
-                    (*(&mut *((*(*t).a).tx).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
+                    (*(&mut *((*(*t).a).tx.0).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                         as *mut alias8))
                         .u8_0 = (0x1 as libc::c_int
                         * *b_dim.offset((2 + 0) as isize) as libc::c_int)
                         as uint8_t;
                 }
                 2 => {
-                    (*(&mut *((*(*t).a).tx).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
+                    (*(&mut *((*(*t).a).tx.0).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                         as *mut alias16))
                         .u16_0 = (0x101 as libc::c_int
                         * *b_dim.offset((2 + 0) as isize) as libc::c_int)
                         as uint16_t;
                 }
                 4 => {
-                    (*(&mut *((*(*t).a).tx).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
+                    (*(&mut *((*(*t).a).tx.0).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                         as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint)
                         .wrapping_mul(*b_dim.offset((2 + 0) as isize) as libc::c_uint);
                 }
                 8 => {
-                    (*(&mut *((*(*t).a).tx).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
+                    (*(&mut *((*(*t).a).tx.0).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(*b_dim.offset((2 + 0) as isize) as libc::c_ulonglong)
@@ -2394,12 +2394,12 @@ unsafe extern "C" fn read_vartx_tree(
                     let const_val_5: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(*b_dim.offset((2 + 0) as isize) as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *((*(*t).a).tx)
+                    (*(&mut *((*(*t).a).tx.0)
                         .as_mut_ptr()
                         .offset((bx4 + 0) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_5;
-                    (*(&mut *((*(*t).a).tx)
+                    (*(&mut *((*(*t).a).tx.0)
                         .as_mut_ptr()
                         .offset((bx4 + 8) as isize) as *mut int8_t
                         as *mut alias64))
@@ -2409,22 +2409,22 @@ unsafe extern "C" fn read_vartx_tree(
                     let const_val_6: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(*b_dim.offset((2 + 0) as isize) as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *((*(*t).a).tx)
+                    (*(&mut *((*(*t).a).tx.0)
                         .as_mut_ptr()
                         .offset((bx4 + 0) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_6;
-                    (*(&mut *((*(*t).a).tx)
+                    (*(&mut *((*(*t).a).tx.0)
                         .as_mut_ptr()
                         .offset((bx4 + 8) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_6;
-                    (*(&mut *((*(*t).a).tx)
+                    (*(&mut *((*(*t).a).tx.0)
                         .as_mut_ptr()
                         .offset((bx4 + 16) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_6;
-                    (*(&mut *((*(*t).a).tx)
+                    (*(&mut *((*(*t).a).tx.0)
                         .as_mut_ptr()
                         .offset((bx4 + 24) as isize) as *mut int8_t
                         as *mut alias64))
@@ -3710,7 +3710,7 @@ unsafe fn decode_b(
                 off,
                 mul * lw_lh as u64,
             );
-            rep_macro(dir.tx.as_mut_ptr() as *mut u8, off, mul * lw_lh as u64);
+            rep_macro(dir.tx.0.as_mut_ptr() as *mut u8, off, mul * lw_lh as u64);
             rep_macro(dir.mode.0.as_mut_ptr(), off, mul * y_mode_nofilt as u64);
             rep_macro(dir.pal_sz.as_mut_ptr(), off, mul * b.pal_sz()[0] as u64);
             rep_macro(dir.seg_pred.0.as_mut_ptr(), off, mul * seg_pred as u64);
@@ -7819,7 +7819,7 @@ unsafe extern "C" fn reset_context(
         ::core::mem::size_of::<[int8_t; 32]>(),
     );
     memset(
-        ((*ctx).tx).as_mut_ptr() as *mut libc::c_void,
+        ((*ctx).tx.0).as_mut_ptr() as *mut libc::c_void,
         TX_64X64 as libc::c_int,
         ::core::mem::size_of::<[int8_t; 32]>(),
     );

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3084,10 +3084,10 @@ unsafe fn decode_b(
             seg = Some(&frame_hdr.segmentation.seg_data.d[b.seg_id as usize]);
         } else if frame_hdr.segmentation.seg_data.preskip != 0 {
             if frame_hdr.segmentation.temporal != 0 && {
-                let index = (*t.a).seg_pred[bx4 as usize] + t.l.seg_pred[by4 as usize];
+                let index = (*t.a).seg_pred.0[bx4 as usize] + t.l.seg_pred.0[by4 as usize];
                 seg_pred = dav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
-                    &mut ts.cdf.m.seg_pred[index as usize],
+                    &mut ts.cdf.m.seg_pred.0[index as usize],
                 ) as libc::c_int;
                 seg_pred != 0
             } {
@@ -3176,9 +3176,9 @@ unsafe fn decode_b(
         && (*f.frame_hdr).segmentation.seg_data.preskip == 0
     {
         if b.skip == 0 && (*f.frame_hdr).segmentation.temporal != 0 && {
-            let index = (*t.a).seg_pred[bx4 as usize] + t.l.seg_pred[by4 as usize];
+            let index = (*t.a).seg_pred.0[bx4 as usize] + t.l.seg_pred.0[by4 as usize];
             seg_pred =
-                dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.seg_pred[index as usize])
+                dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.seg_pred.0[index as usize])
                     as libc::c_int;
             seg_pred != 0
         } {
@@ -3713,7 +3713,7 @@ unsafe fn decode_b(
             rep_macro(dir.tx.as_mut_ptr() as *mut u8, off, mul * lw_lh as u64);
             rep_macro(dir.mode.0.as_mut_ptr(), off, mul * y_mode_nofilt as u64);
             rep_macro(dir.pal_sz.as_mut_ptr(), off, mul * b.pal_sz()[0] as u64);
-            rep_macro(dir.seg_pred.as_mut_ptr(), off, mul * seg_pred as u64);
+            rep_macro(dir.seg_pred.0.as_mut_ptr(), off, mul * seg_pred as u64);
             rep_macro(dir.skip_mode.as_mut_ptr(), off, 0);
             rep_macro(dir.intra.as_mut_ptr(), off, mul);
             rep_macro(dir.skip.as_mut_ptr(), off, mul * b.skip as u64);
@@ -3935,7 +3935,7 @@ unsafe fn decode_b(
             rep_macro(dir.pal_sz.as_mut_ptr(), off, 0);
             // see aomedia bug 2183 for why this is outside `if has_chroma {}`
             rep_macro(t.pal_sz_uv[diridx].as_mut_ptr(), off, 0);
-            rep_macro(dir.seg_pred.as_mut_ptr(), off, mul * seg_pred as u64);
+            rep_macro(dir.seg_pred.0.as_mut_ptr(), off, mul * seg_pred as u64);
             rep_macro(dir.skip_mode.as_mut_ptr(), off, 0);
             rep_macro(dir.intra.as_mut_ptr(), off, 0);
             rep_macro(dir.skip.as_mut_ptr(), off, mul * b.skip as u64)
@@ -5291,7 +5291,7 @@ unsafe fn decode_b(
         }
         match bh4 {
             1 => {
-                (*(&mut *(t.l.seg_pred).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.seg_pred.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * seg_pred) as uint8_t;
                 (*(&mut *(t.l.skip_mode).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
@@ -5349,7 +5349,7 @@ unsafe fn decode_b(
                     as uint8_t;
             }
             2 => {
-                (*(&mut *(t.l.seg_pred).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.seg_pred.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * seg_pred) as uint16_t;
                 (*(&mut *(t.l.skip_mode).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
@@ -5407,7 +5407,7 @@ unsafe fn decode_b(
                     as uint16_t;
             }
             4 => {
-                (*(&mut *(t.l.seg_pred).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.seg_pred.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(seg_pred as libc::c_uint);
                 (*(&mut *(t.l.skip_mode).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
@@ -5458,7 +5458,7 @@ unsafe fn decode_b(
                 );
             }
             8 => {
-                (*(&mut *(t.l.seg_pred).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.seg_pred.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(seg_pred as libc::c_ulonglong)
@@ -5527,10 +5527,10 @@ unsafe fn decode_b(
                 let const_val_123: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(seg_pred as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(t.l.seg_pred).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *(t.l.seg_pred.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_123;
-                (*(&mut *(t.l.seg_pred).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *(t.l.seg_pred.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_123;
                 let const_val_124: uint64_t = (0x101010101010101 as libc::c_ulonglong)
@@ -5660,16 +5660,16 @@ unsafe fn decode_b(
                 let const_val_136: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(seg_pred as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(t.l.seg_pred).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *(t.l.seg_pred.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_136;
-                (*(&mut *(t.l.seg_pred).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *(t.l.seg_pred.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_136;
-                (*(&mut *(t.l.seg_pred).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
+                (*(&mut *(t.l.seg_pred.0).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_136;
-                (*(&mut *(t.l.seg_pred).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
+                (*(&mut *(t.l.seg_pred.0).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_136;
                 let const_val_137: uint64_t = (0x101010101010101 as libc::c_ulonglong)
@@ -5891,7 +5891,7 @@ unsafe fn decode_b(
         }
         match bw4 {
             1 => {
-                (*(&mut *((*t.a).seg_pred).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).seg_pred.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * seg_pred) as uint8_t;
                 (*(&mut *((*t.a).skip_mode).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
@@ -5949,7 +5949,7 @@ unsafe fn decode_b(
                     as uint8_t;
             }
             2 => {
-                (*(&mut *((*t.a).seg_pred).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).seg_pred.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * seg_pred) as uint16_t;
                 (*(&mut *((*t.a).skip_mode).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
@@ -6007,7 +6007,7 @@ unsafe fn decode_b(
                     as uint16_t;
             }
             4 => {
-                (*(&mut *((*t.a).seg_pred).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).seg_pred.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(seg_pred as libc::c_uint);
                 (*(&mut *((*t.a).skip_mode).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
@@ -6058,7 +6058,7 @@ unsafe fn decode_b(
                 );
             }
             8 => {
-                (*(&mut *((*t.a).seg_pred).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).seg_pred.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(seg_pred as libc::c_ulonglong)
@@ -6127,12 +6127,12 @@ unsafe fn decode_b(
                 let const_val_149: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(seg_pred as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).seg_pred)
+                (*(&mut *((*t.a).seg_pred.0)
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_149;
-                (*(&mut *((*t.a).seg_pred)
+                (*(&mut *((*t.a).seg_pred.0)
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -6272,22 +6272,22 @@ unsafe fn decode_b(
                 let const_val_162: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(seg_pred as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).seg_pred)
+                (*(&mut *((*t.a).seg_pred.0)
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_162;
-                (*(&mut *((*t.a).seg_pred)
+                (*(&mut *((*t.a).seg_pred.0)
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_162;
-                (*(&mut *((*t.a).seg_pred)
+                (*(&mut *((*t.a).seg_pred.0)
                     .as_mut_ptr()
                     .offset((bx4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_162;
-                (*(&mut *((*t.a).seg_pred)
+                (*(&mut *((*t.a).seg_pred.0)
                     .as_mut_ptr()
                     .offset((bx4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -7856,7 +7856,7 @@ unsafe extern "C" fn reset_context(
         ::core::mem::size_of::<[[uint8_t; 32]; 2]>(),
     );
     memset(
-        ((*ctx).seg_pred).as_mut_ptr() as *mut libc::c_void,
+        ((*ctx).seg_pred.0).as_mut_ptr() as *mut libc::c_void,
         0 as libc::c_int,
         ::core::mem::size_of::<[uint8_t; 32]>(),
     );

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3670,12 +3670,12 @@ unsafe fn decode_b(
                 &mut (*t.a).tx_lpf_y.0[bx4 as usize],
                 &mut t.l.tx_lpf_y.0[by4 as usize],
                 if has_chroma {
-                    &mut (*t.a).tx_lpf_uv[cbx4 as usize]
+                    &mut (*t.a).tx_lpf_uv.0[cbx4 as usize]
                 } else {
                     std::ptr::null_mut()
                 },
                 if has_chroma {
-                    &mut t.l.tx_lpf_uv[cby4 as usize]
+                    &mut t.l.tx_lpf_uv.0[cby4 as usize]
                 } else {
                     std::ptr::null_mut()
                 },
@@ -5273,12 +5273,12 @@ unsafe fn decode_b(
                 &mut *((*t.a).tx_lpf_y.0).as_mut_ptr().offset(bx4 as isize),
                 &mut *(t.l.tx_lpf_y.0).as_mut_ptr().offset(by4 as isize),
                 if has_chroma {
-                    &mut *((*t.a).tx_lpf_uv).as_mut_ptr().offset(cbx4 as isize)
+                    &mut *((*t.a).tx_lpf_uv.0).as_mut_ptr().offset(cbx4 as isize)
                 } else {
                     0 as *mut uint8_t
                 },
                 if has_chroma {
-                    &mut *(t.l.tx_lpf_uv).as_mut_ptr().offset(cby4 as isize)
+                    &mut *(t.l.tx_lpf_uv.0).as_mut_ptr().offset(cby4 as isize)
                 } else {
                     0 as *mut uint8_t
                 },
@@ -7809,7 +7809,7 @@ unsafe extern "C" fn reset_context(
         ::core::mem::size_of::<[uint8_t; 32]>(),
     );
     memset(
-        ((*ctx).tx_lpf_uv).as_mut_ptr() as *mut libc::c_void,
+        ((*ctx).tx_lpf_uv.0).as_mut_ptr() as *mut libc::c_void,
         1 as libc::c_int,
         ::core::mem::size_of::<[uint8_t; 32]>(),
     );
@@ -8395,7 +8395,7 @@ pub unsafe extern "C" fn dav1d_decode_tile_sbrow(t: *mut Dav1dTaskContext) -> li
         &mut *(*((*f).lf.tx_lpf_right_edge).as_ptr().offset(1))
             .offset((align_h * tile_col + ((*t).by >> ss_ver_0)) as isize) as *mut uint8_t
             as *mut libc::c_void,
-        &mut *((*t).l.tx_lpf_uv)
+        &mut *((*t).l.tx_lpf_uv.0)
             .as_mut_ptr()
             .offset((((*t).by & 16) >> ss_ver_0) as isize) as *mut uint8_t
             as *const libc::c_void,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2283,15 +2283,11 @@ unsafe extern "C" fn read_vartx_tree(
                         .offset((bx4 + 8) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_2;
-                    (*(&mut *((*(*t).a).tx.0)
-                        .as_mut_ptr()
-                        .offset((bx4 + 16) as isize) as *mut int8_t
-                        as *mut alias64))
+                    (*(&mut *((*(*t).a).tx.0).as_mut_ptr().offset((bx4 + 16) as isize)
+                        as *mut int8_t as *mut alias64))
                         .u64_0 = const_val_2;
-                    (*(&mut *((*(*t).a).tx.0)
-                        .as_mut_ptr()
-                        .offset((bx4 + 24) as isize) as *mut int8_t
-                        as *mut alias64))
+                    (*(&mut *((*(*t).a).tx.0).as_mut_ptr().offset((bx4 + 24) as isize)
+                        as *mut int8_t as *mut alias64))
                         .u64_0 = const_val_2;
                 }
                 _ => {}
@@ -2419,15 +2415,11 @@ unsafe extern "C" fn read_vartx_tree(
                         .offset((bx4 + 8) as isize) as *mut int8_t
                         as *mut alias64))
                         .u64_0 = const_val_6;
-                    (*(&mut *((*(*t).a).tx.0)
-                        .as_mut_ptr()
-                        .offset((bx4 + 16) as isize) as *mut int8_t
-                        as *mut alias64))
+                    (*(&mut *((*(*t).a).tx.0).as_mut_ptr().offset((bx4 + 16) as isize)
+                        as *mut int8_t as *mut alias64))
                         .u64_0 = const_val_6;
-                    (*(&mut *((*(*t).a).tx.0)
-                        .as_mut_ptr()
-                        .offset((bx4 + 24) as isize) as *mut int8_t
-                        as *mut alias64))
+                    (*(&mut *((*(*t).a).tx.0).as_mut_ptr().offset((bx4 + 24) as isize)
+                        as *mut int8_t as *mut alias64))
                         .u64_0 = const_val_6;
                 }
                 _ => {}
@@ -3177,9 +3169,10 @@ unsafe fn decode_b(
     {
         if b.skip == 0 && (*f.frame_hdr).segmentation.temporal != 0 && {
             let index = (*t.a).seg_pred.0[bx4 as usize] + t.l.seg_pred.0[by4 as usize];
-            seg_pred =
-                dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.seg_pred.0[index as usize])
-                    as libc::c_int;
+            seg_pred = dav1d_msac_decode_bool_adapt(
+                &mut ts.msac,
+                &mut ts.cdf.m.seg_pred.0[index as usize],
+            ) as libc::c_int;
             seg_pred != 0
         } {
             // temporal predicted seg_id
@@ -3406,7 +3399,8 @@ unsafe fn decode_b(
         let ymode_cdf = if frame_hdr.frame_type & 1 != 0 {
             &mut ts.cdf.m.y_mode[dav1d_ymode_size_context[bs as usize] as usize]
         } else {
-            &mut ts.cdf.kfym[dav1d_intra_mode_context[(*t.a).mode.0[bx4 as usize] as usize] as usize]
+            &mut ts.cdf.kfym
+                [dav1d_intra_mode_context[(*t.a).mode.0[bx4 as usize] as usize] as usize]
                 [dav1d_intra_mode_context[t.l.mode.0[by4 as usize] as usize] as usize]
         };
 
@@ -6140,15 +6134,11 @@ unsafe fn decode_b(
                 let const_val_150: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.skip_mode as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).skip_mode.0)
-                    .as_mut_ptr()
-                    .offset((bx4 + 0) as isize) as *mut uint8_t
-                    as *mut alias64))
+                (*(&mut *((*t.a).skip_mode.0).as_mut_ptr().offset((bx4 + 0) as isize)
+                    as *mut uint8_t as *mut alias64))
                     .u64_0 = const_val_150;
-                (*(&mut *((*t.a).skip_mode.0)
-                    .as_mut_ptr()
-                    .offset((bx4 + 8) as isize) as *mut uint8_t
-                    as *mut alias64))
+                (*(&mut *((*t.a).skip_mode.0).as_mut_ptr().offset((bx4 + 8) as isize)
+                    as *mut uint8_t as *mut alias64))
                     .u64_0 = const_val_150;
                 let const_val_151: uint64_t = 0 as libc::c_int as uint64_t;
                 (*(&mut *((*t.a).intra.0).as_mut_ptr().offset((bx4 + 0) as isize) as *mut uint8_t
@@ -6196,15 +6186,11 @@ unsafe fn decode_b(
                 let const_val_156: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).comp_type.0)
-                    .as_mut_ptr()
-                    .offset((bx4 + 0) as isize) as *mut uint8_t
-                    as *mut alias64))
+                (*(&mut *((*t.a).comp_type.0).as_mut_ptr().offset((bx4 + 0) as isize)
+                    as *mut uint8_t as *mut alias64))
                     .u64_0 = const_val_156;
-                (*(&mut *((*t.a).comp_type.0)
-                    .as_mut_ptr()
-                    .offset((bx4 + 8) as isize) as *mut uint8_t
-                    as *mut alias64))
+                (*(&mut *((*t.a).comp_type.0).as_mut_ptr().offset((bx4 + 8) as isize)
+                    as *mut uint8_t as *mut alias64))
                     .u64_0 = const_val_156;
                 let const_val_157: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(filter_0[0] as libc::c_ulonglong)
@@ -6282,28 +6268,20 @@ unsafe fn decode_b(
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_162;
-                (*(&mut *((*t.a).seg_pred.0)
-                    .as_mut_ptr()
-                    .offset((bx4 + 16) as isize) as *mut uint8_t
-                    as *mut alias64))
+                (*(&mut *((*t.a).seg_pred.0).as_mut_ptr().offset((bx4 + 16) as isize)
+                    as *mut uint8_t as *mut alias64))
                     .u64_0 = const_val_162;
-                (*(&mut *((*t.a).seg_pred.0)
-                    .as_mut_ptr()
-                    .offset((bx4 + 24) as isize) as *mut uint8_t
-                    as *mut alias64))
+                (*(&mut *((*t.a).seg_pred.0).as_mut_ptr().offset((bx4 + 24) as isize)
+                    as *mut uint8_t as *mut alias64))
                     .u64_0 = const_val_162;
                 let const_val_163: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.skip_mode as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).skip_mode.0)
-                    .as_mut_ptr()
-                    .offset((bx4 + 0) as isize) as *mut uint8_t
-                    as *mut alias64))
+                (*(&mut *((*t.a).skip_mode.0).as_mut_ptr().offset((bx4 + 0) as isize)
+                    as *mut uint8_t as *mut alias64))
                     .u64_0 = const_val_163;
-                (*(&mut *((*t.a).skip_mode.0)
-                    .as_mut_ptr()
-                    .offset((bx4 + 8) as isize) as *mut uint8_t
-                    as *mut alias64))
+                (*(&mut *((*t.a).skip_mode.0).as_mut_ptr().offset((bx4 + 8) as isize)
+                    as *mut uint8_t as *mut alias64))
                     .u64_0 = const_val_163;
                 (*(&mut *((*t.a).skip_mode.0)
                     .as_mut_ptr()
@@ -6399,15 +6377,11 @@ unsafe fn decode_b(
                 let const_val_169: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).comp_type.0)
-                    .as_mut_ptr()
-                    .offset((bx4 + 0) as isize) as *mut uint8_t
-                    as *mut alias64))
+                (*(&mut *((*t.a).comp_type.0).as_mut_ptr().offset((bx4 + 0) as isize)
+                    as *mut uint8_t as *mut alias64))
                     .u64_0 = const_val_169;
-                (*(&mut *((*t.a).comp_type.0)
-                    .as_mut_ptr()
-                    .offset((bx4 + 8) as isize) as *mut uint8_t
-                    as *mut alias64))
+                (*(&mut *((*t.a).comp_type.0).as_mut_ptr().offset((bx4 + 8) as isize)
+                    as *mut uint8_t as *mut alias64))
                     .u64_0 = const_val_169;
                 (*(&mut *((*t.a).comp_type.0)
                     .as_mut_ptr()
@@ -6583,15 +6557,11 @@ unsafe fn decode_b(
                         .offset((cby4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_176;
-                    (*(&mut *(t.l.uvmode.0)
-                        .as_mut_ptr()
-                        .offset((cby4 + 16) as isize) as *mut uint8_t
-                        as *mut alias64))
+                    (*(&mut *(t.l.uvmode.0).as_mut_ptr().offset((cby4 + 16) as isize)
+                        as *mut uint8_t as *mut alias64))
                         .u64_0 = const_val_176;
-                    (*(&mut *(t.l.uvmode.0)
-                        .as_mut_ptr()
-                        .offset((cby4 + 24) as isize) as *mut uint8_t
-                        as *mut alias64))
+                    (*(&mut *(t.l.uvmode.0).as_mut_ptr().offset((cby4 + 24) as isize)
+                        as *mut uint8_t as *mut alias64))
                         .u64_0 = const_val_176;
                 }
                 _ => {}
@@ -7747,15 +7717,11 @@ unsafe extern "C" fn decode_sb(
                 let const_val_0: uint64_t = (0x101010101010101 as libc::c_ulonglong).wrapping_mul(
                     dav1d_al_part_ctx[1][bl as usize][bp as usize] as libc::c_ulonglong,
                 ) as uint64_t;
-                (*(&mut *((*t).l.partition.0)
-                    .as_mut_ptr()
-                    .offset((by8 + 0) as isize) as *mut uint8_t
-                    as *mut alias64))
+                (*(&mut *((*t).l.partition.0).as_mut_ptr().offset((by8 + 0) as isize)
+                    as *mut uint8_t as *mut alias64))
                     .u64_0 = const_val_0;
-                (*(&mut *((*t).l.partition.0)
-                    .as_mut_ptr()
-                    .offset((by8 + 8) as isize) as *mut uint8_t
-                    as *mut alias64))
+                (*(&mut *((*t).l.partition.0).as_mut_ptr().offset((by8 + 8) as isize)
+                    as *mut uint8_t as *mut alias64))
                     .u64_0 = const_val_0;
             }
             _ => {}

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3667,8 +3667,8 @@ unsafe fn decode_b(
                 b.tx() as RectTxfmSize,
                 b.uvtx as RectTxfmSize,
                 f.cur.p.layout,
-                &mut (*t.a).tx_lpf_y[bx4 as usize],
-                &mut t.l.tx_lpf_y[by4 as usize],
+                &mut (*t.a).tx_lpf_y.0[bx4 as usize],
+                &mut t.l.tx_lpf_y.0[by4 as usize],
                 if has_chroma {
                     &mut (*t.a).tx_lpf_uv[cbx4 as usize]
                 } else {
@@ -5270,8 +5270,8 @@ unsafe fn decode_b(
                 tx_split.as_ptr(),
                 uvtx,
                 f.cur.p.layout,
-                &mut *((*t.a).tx_lpf_y).as_mut_ptr().offset(bx4 as isize),
-                &mut *(t.l.tx_lpf_y).as_mut_ptr().offset(by4 as isize),
+                &mut *((*t.a).tx_lpf_y.0).as_mut_ptr().offset(bx4 as isize),
+                &mut *(t.l.tx_lpf_y.0).as_mut_ptr().offset(by4 as isize),
                 if has_chroma {
                     &mut *((*t.a).tx_lpf_uv).as_mut_ptr().offset(cbx4 as isize)
                 } else {
@@ -7804,7 +7804,7 @@ unsafe extern "C" fn reset_context(
         ::core::mem::size_of::<[uint8_t; 32]>(),
     );
     memset(
-        ((*ctx).tx_lpf_y).as_mut_ptr() as *mut libc::c_void,
+        ((*ctx).tx_lpf_y.0).as_mut_ptr() as *mut libc::c_void,
         2 as libc::c_int,
         ::core::mem::size_of::<[uint8_t; 32]>(),
     );
@@ -8382,7 +8382,7 @@ pub unsafe extern "C" fn dav1d_decode_tile_sbrow(t: *mut Dav1dTaskContext) -> li
         &mut *(*((*f).lf.tx_lpf_right_edge).as_ptr().offset(0))
             .offset((align_h * tile_col + (*t).by) as isize) as *mut uint8_t
             as *mut libc::c_void,
-        &mut *((*t).l.tx_lpf_y)
+        &mut *((*t).l.tx_lpf_y.0)
             .as_mut_ptr()
             .offset(((*t).by & 16) as isize) as *mut uint8_t as *const libc::c_void,
         sb_step as libc::c_ulong,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -7841,7 +7841,7 @@ unsafe extern "C" fn reset_context(
         );
     }
     memset(
-        ((*ctx).lcoef).as_mut_ptr() as *mut libc::c_void,
+        ((*ctx).lcoef.0).as_mut_ptr() as *mut libc::c_void,
         0x40 as libc::c_int,
         ::core::mem::size_of::<[uint8_t; 32]>(),
     );

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -7846,7 +7846,7 @@ unsafe extern "C" fn reset_context(
         ::core::mem::size_of::<[uint8_t; 32]>(),
     );
     memset(
-        ((*ctx).ccoef).as_mut_ptr() as *mut libc::c_void,
+        ((*ctx).ccoef.0).as_mut_ptr() as *mut libc::c_void,
         0x40 as libc::c_int,
         ::core::mem::size_of::<[[uint8_t; 32]; 2]>(),
     );

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3706,7 +3706,7 @@ unsafe fn decode_b(
             };
 
             rep_macro(
-                dir.tx_intra.as_mut_ptr() as *mut u8,
+                dir.tx_intra.0.as_mut_ptr() as *mut u8,
                 off,
                 mul * lw_lh as u64,
             );
@@ -3927,7 +3927,7 @@ unsafe fn decode_b(
 
         let mut set_ctx = |dir: &mut BlockContext, diridx: usize, off, mul, rep_macro: SetCtxFn| {
             rep_macro(
-                dir.tx_intra.as_mut_ptr() as *mut u8,
+                dir.tx_intra.0.as_mut_ptr() as *mut u8,
                 off,
                 mul * b_dim[2 + diridx] as u64,
             );
@@ -5310,7 +5310,7 @@ unsafe fn decode_b(
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut uint8_t as *mut alias8))
                     .u8_0 = 0 as libc::c_int as uint8_t;
-                (*(&mut *(t.l.tx_intra).as_mut_ptr().offset(by4 as isize) as *mut int8_t
+                (*(&mut *(t.l.tx_intra.0).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                     as *mut alias8))
                     .u8_0 = 0x1 * b_dim[2 + 1] as uint8_t;
                 (*(&mut *(t.l.comp_type.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
@@ -5368,7 +5368,7 @@ unsafe fn decode_b(
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut uint8_t as *mut alias16))
                     .u16_0 = 0 as libc::c_int as uint16_t;
-                (*(&mut *(t.l.tx_intra).as_mut_ptr().offset(by4 as isize) as *mut int8_t
+                (*(&mut *(t.l.tx_intra.0).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                     as *mut alias16))
                     .u16_0 = 0x101 * b_dim[2 + 1] as uint16_t;
                 (*(&mut *(t.l.comp_type.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
@@ -5426,7 +5426,7 @@ unsafe fn decode_b(
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut uint8_t as *mut alias32))
                     .u32_0 = 0 as libc::c_int as uint32_t;
-                (*(&mut *(t.l.tx_intra).as_mut_ptr().offset(by4 as isize) as *mut int8_t
+                (*(&mut *(t.l.tx_intra.0).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(b_dim[2 + 1] as libc::c_uint);
                 (*(&mut *(t.l.comp_type.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
@@ -5483,7 +5483,7 @@ unsafe fn decode_b(
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut uint8_t as *mut alias64))
                     .u64_0 = 0 as libc::c_int as uint64_t;
-                (*(&mut *(t.l.tx_intra).as_mut_ptr().offset(by4 as isize) as *mut int8_t
+                (*(&mut *(t.l.tx_intra.0).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b_dim[2 + 1] as libc::c_ulonglong)
@@ -5579,10 +5579,10 @@ unsafe fn decode_b(
                 let const_val_129: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b_dim[2 + 1] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(t.l.tx_intra).as_mut_ptr().offset((by4 + 0) as isize) as *mut int8_t
+                (*(&mut *(t.l.tx_intra.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_129;
-                (*(&mut *(t.l.tx_intra).as_mut_ptr().offset((by4 + 8) as isize) as *mut int8_t
+                (*(&mut *(t.l.tx_intra.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_129;
                 let const_val_130: uint64_t = (0x101010101010101 as libc::c_ulonglong)
@@ -5752,16 +5752,16 @@ unsafe fn decode_b(
                 let const_val_142: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b_dim[2 + 1] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(t.l.tx_intra).as_mut_ptr().offset((by4 + 0) as isize) as *mut int8_t
+                (*(&mut *(t.l.tx_intra.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_142;
-                (*(&mut *(t.l.tx_intra).as_mut_ptr().offset((by4 + 8) as isize) as *mut int8_t
+                (*(&mut *(t.l.tx_intra.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_142;
-                (*(&mut *(t.l.tx_intra).as_mut_ptr().offset((by4 + 16) as isize) as *mut int8_t
+                (*(&mut *(t.l.tx_intra.0).as_mut_ptr().offset((by4 + 16) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_142;
-                (*(&mut *(t.l.tx_intra).as_mut_ptr().offset((by4 + 24) as isize) as *mut int8_t
+                (*(&mut *(t.l.tx_intra.0).as_mut_ptr().offset((by4 + 24) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_142;
                 let const_val_143: uint64_t = (0x101010101010101 as libc::c_ulonglong)
@@ -5910,7 +5910,7 @@ unsafe fn decode_b(
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut uint8_t as *mut alias8))
                     .u8_0 = 0 as libc::c_int as uint8_t;
-                (*(&mut *((*t.a).tx_intra).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
+                (*(&mut *((*t.a).tx_intra.0).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                     as *mut alias8))
                     .u8_0 = 0x1 * b_dim[2 + 0];
                 (*(&mut *((*t.a).comp_type.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
@@ -5968,7 +5968,7 @@ unsafe fn decode_b(
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut uint8_t as *mut alias16))
                     .u16_0 = 0 as libc::c_int as uint16_t;
-                (*(&mut *((*t.a).tx_intra).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
+                (*(&mut *((*t.a).tx_intra.0).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                     as *mut alias16))
                     .u16_0 = 0x101 * b_dim[2 + 0] as uint16_t;
                 (*(&mut *((*t.a).comp_type.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
@@ -6026,7 +6026,7 @@ unsafe fn decode_b(
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut uint8_t as *mut alias32))
                     .u32_0 = 0 as libc::c_int as uint32_t;
-                (*(&mut *((*t.a).tx_intra).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
+                (*(&mut *((*t.a).tx_intra.0).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(b_dim[2 + 0] as libc::c_uint);
                 (*(&mut *((*t.a).comp_type.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
@@ -6083,7 +6083,7 @@ unsafe fn decode_b(
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut uint8_t as *mut alias64))
                     .u64_0 = 0 as libc::c_int as uint64_t;
-                (*(&mut *((*t.a).tx_intra).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
+                (*(&mut *((*t.a).tx_intra.0).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b_dim[2 + 0] as libc::c_ulonglong)
@@ -6187,10 +6187,10 @@ unsafe fn decode_b(
                 let const_val_155: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b_dim[2 + 0] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).tx_intra).as_mut_ptr().offset((bx4 + 0) as isize) as *mut int8_t
+                (*(&mut *((*t.a).tx_intra.0).as_mut_ptr().offset((bx4 + 0) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_155;
-                (*(&mut *((*t.a).tx_intra).as_mut_ptr().offset((bx4 + 8) as isize) as *mut int8_t
+                (*(&mut *((*t.a).tx_intra.0).as_mut_ptr().offset((bx4 + 8) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_155;
                 let const_val_156: uint64_t = (0x101010101010101 as libc::c_ulonglong)
@@ -6380,18 +6380,18 @@ unsafe fn decode_b(
                 let const_val_168: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b_dim[2 + 0] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).tx_intra).as_mut_ptr().offset((bx4 + 0) as isize) as *mut int8_t
+                (*(&mut *((*t.a).tx_intra.0).as_mut_ptr().offset((bx4 + 0) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_168;
-                (*(&mut *((*t.a).tx_intra).as_mut_ptr().offset((bx4 + 8) as isize) as *mut int8_t
+                (*(&mut *((*t.a).tx_intra.0).as_mut_ptr().offset((bx4 + 8) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_168;
-                (*(&mut *((*t.a).tx_intra)
+                (*(&mut *((*t.a).tx_intra.0)
                     .as_mut_ptr()
                     .offset((bx4 + 16) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_168;
-                (*(&mut *((*t.a).tx_intra)
+                (*(&mut *((*t.a).tx_intra.0)
                     .as_mut_ptr()
                     .offset((bx4 + 24) as isize) as *mut int8_t
                     as *mut alias64))
@@ -7814,7 +7814,7 @@ unsafe extern "C" fn reset_context(
         ::core::mem::size_of::<[uint8_t; 32]>(),
     );
     memset(
-        ((*ctx).tx_intra).as_mut_ptr() as *mut libc::c_void,
+        ((*ctx).tx_intra.0).as_mut_ptr() as *mut libc::c_void,
         -(1 as libc::c_int),
         ::core::mem::size_of::<[int8_t; 32]>(),
     );

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2968,7 +2968,7 @@ unsafe fn decode_b(
                 let mut set_ctx =
                     |dir: &mut BlockContext, _diridx, off, mul, rep_macro: SetCtxFn| {
                         rep_macro(
-                            dir.uvmode.as_mut_ptr(),
+                            dir.uvmode.0.as_mut_ptr(),
                             off,
                             mul * b.c2rust_unnamed.c2rust_unnamed.uv_mode as u64,
                         );
@@ -3045,7 +3045,7 @@ unsafe fn decode_b(
             if has_chroma {
                 let mut set_ctx =
                     |dir: &mut BlockContext, _diridx, off, mul, rep_macro: SetCtxFn| {
-                        rep_macro(dir.uvmode.as_mut_ptr(), off, mul * DC_PRED as u64);
+                        rep_macro(dir.uvmode.0.as_mut_ptr(), off, mul * DC_PRED as u64);
                     };
                 case_set(cbh4, &mut t.l, 1, cby4 as isize, &mut set_ctx);
                 case_set(cbw4, &mut *t.a, 0, cbx4 as isize, &mut set_ctx);
@@ -3774,7 +3774,7 @@ unsafe fn decode_b(
 
         if has_chroma {
             let mut set_ctx = |dir: &mut BlockContext, _diridx, off, mul, rep_macro: SetCtxFn| {
-                rep_macro(dir.uvmode.as_mut_ptr(), off, mul * b.uv_mode() as u64);
+                rep_macro(dir.uvmode.0.as_mut_ptr(), off, mul * b.uv_mode() as u64);
             };
             case_set(cbh4, &mut t.l, 1, cby4 as isize, &mut set_ctx);
             case_set(cbw4, &mut *t.a, 0, cbx4 as isize, &mut set_ctx);
@@ -3945,7 +3945,7 @@ unsafe fn decode_b(
 
         if has_chroma {
             let mut set_ctx = |dir: &mut BlockContext, _diridx, off, mul, rep_macro: SetCtxFn| {
-                rep_macro(dir.uvmode.as_mut_ptr(), off, mul * DC_PRED as u64);
+                rep_macro(dir.uvmode.0.as_mut_ptr(), off, mul * DC_PRED as u64);
             };
             case_set(cbh4, &mut t.l, 1, cby4 as isize, &mut set_ctx);
             case_set(cbw4, &mut *t.a, 0, cbx4 as isize, &mut set_ctx);
@@ -6532,23 +6532,23 @@ unsafe fn decode_b(
         if has_chroma {
             match cbh4 {
                 1 => {
-                    (*(&mut *(t.l.uvmode).as_mut_ptr().offset(cby4 as isize) as *mut uint8_t
+                    (*(&mut *(t.l.uvmode.0).as_mut_ptr().offset(cby4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * DC_PRED as libc::c_int) as uint8_t;
                 }
                 2 => {
-                    (*(&mut *(t.l.uvmode).as_mut_ptr().offset(cby4 as isize) as *mut uint8_t
+                    (*(&mut *(t.l.uvmode.0).as_mut_ptr().offset(cby4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * DC_PRED as libc::c_int) as uint16_t;
                 }
                 4 => {
-                    (*(&mut *(t.l.uvmode).as_mut_ptr().offset(cby4 as isize) as *mut uint8_t
+                    (*(&mut *(t.l.uvmode.0).as_mut_ptr().offset(cby4 as isize) as *mut uint8_t
                         as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint)
                         .wrapping_mul(DC_PRED as libc::c_int as libc::c_uint);
                 }
                 8 => {
-                    (*(&mut *(t.l.uvmode).as_mut_ptr().offset(cby4 as isize) as *mut uint8_t
+                    (*(&mut *(t.l.uvmode.0).as_mut_ptr().offset(cby4 as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(DC_PRED as libc::c_int as libc::c_ulonglong)
@@ -6558,12 +6558,12 @@ unsafe fn decode_b(
                     let const_val_175: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(DC_PRED as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(t.l.uvmode)
+                    (*(&mut *(t.l.uvmode.0)
                         .as_mut_ptr()
                         .offset((cby4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_175;
-                    (*(&mut *(t.l.uvmode)
+                    (*(&mut *(t.l.uvmode.0)
                         .as_mut_ptr()
                         .offset((cby4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -6573,22 +6573,22 @@ unsafe fn decode_b(
                     let const_val_176: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(DC_PRED as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(t.l.uvmode)
+                    (*(&mut *(t.l.uvmode.0)
                         .as_mut_ptr()
                         .offset((cby4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_176;
-                    (*(&mut *(t.l.uvmode)
+                    (*(&mut *(t.l.uvmode.0)
                         .as_mut_ptr()
                         .offset((cby4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_176;
-                    (*(&mut *(t.l.uvmode)
+                    (*(&mut *(t.l.uvmode.0)
                         .as_mut_ptr()
                         .offset((cby4 + 16) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_176;
-                    (*(&mut *(t.l.uvmode)
+                    (*(&mut *(t.l.uvmode.0)
                         .as_mut_ptr()
                         .offset((cby4 + 24) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -6598,23 +6598,23 @@ unsafe fn decode_b(
             }
             match cbw4 {
                 1 => {
-                    (*(&mut *((*t.a).uvmode).as_mut_ptr().offset(cbx4 as isize) as *mut uint8_t
+                    (*(&mut *((*t.a).uvmode.0).as_mut_ptr().offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * DC_PRED as libc::c_int) as uint8_t;
                 }
                 2 => {
-                    (*(&mut *((*t.a).uvmode).as_mut_ptr().offset(cbx4 as isize) as *mut uint8_t
+                    (*(&mut *((*t.a).uvmode.0).as_mut_ptr().offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * DC_PRED as libc::c_int) as uint16_t;
                 }
                 4 => {
-                    (*(&mut *((*t.a).uvmode).as_mut_ptr().offset(cbx4 as isize) as *mut uint8_t
+                    (*(&mut *((*t.a).uvmode.0).as_mut_ptr().offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint)
                         .wrapping_mul(DC_PRED as libc::c_int as libc::c_uint);
                 }
                 8 => {
-                    (*(&mut *((*t.a).uvmode).as_mut_ptr().offset(cbx4 as isize) as *mut uint8_t
+                    (*(&mut *((*t.a).uvmode.0).as_mut_ptr().offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(DC_PRED as libc::c_int as libc::c_ulonglong)
@@ -6624,10 +6624,10 @@ unsafe fn decode_b(
                     let const_val_177: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(DC_PRED as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *((*t.a).uvmode).as_mut_ptr().offset((cbx4 + 0) as isize)
+                    (*(&mut *((*t.a).uvmode.0).as_mut_ptr().offset((cbx4 + 0) as isize)
                         as *mut uint8_t as *mut alias64))
                         .u64_0 = const_val_177;
-                    (*(&mut *((*t.a).uvmode).as_mut_ptr().offset((cbx4 + 8) as isize)
+                    (*(&mut *((*t.a).uvmode.0).as_mut_ptr().offset((cbx4 + 8) as isize)
                         as *mut uint8_t as *mut alias64))
                         .u64_0 = const_val_177;
                 }
@@ -6635,16 +6635,16 @@ unsafe fn decode_b(
                     let const_val_178: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(DC_PRED as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *((*t.a).uvmode).as_mut_ptr().offset((cbx4 + 0) as isize)
+                    (*(&mut *((*t.a).uvmode.0).as_mut_ptr().offset((cbx4 + 0) as isize)
                         as *mut uint8_t as *mut alias64))
                         .u64_0 = const_val_178;
-                    (*(&mut *((*t.a).uvmode).as_mut_ptr().offset((cbx4 + 8) as isize)
+                    (*(&mut *((*t.a).uvmode.0).as_mut_ptr().offset((cbx4 + 8) as isize)
                         as *mut uint8_t as *mut alias64))
                         .u64_0 = const_val_178;
-                    (*(&mut *((*t.a).uvmode).as_mut_ptr().offset((cbx4 + 16) as isize)
+                    (*(&mut *((*t.a).uvmode.0).as_mut_ptr().offset((cbx4 + 16) as isize)
                         as *mut uint8_t as *mut alias64))
                         .u64_0 = const_val_178;
-                    (*(&mut *((*t.a).uvmode).as_mut_ptr().offset((cbx4 + 24) as isize)
+                    (*(&mut *((*t.a).uvmode.0).as_mut_ptr().offset((cbx4 + 24) as isize)
                         as *mut uint8_t as *mut alias64))
                         .u64_0 = const_val_178;
                 }
@@ -7774,7 +7774,7 @@ unsafe extern "C" fn reset_context(
         ::core::mem::size_of::<[uint8_t; 32]>(),
     );
     memset(
-        ((*ctx).uvmode).as_mut_ptr() as *mut libc::c_void,
+        ((*ctx).uvmode.0).as_mut_ptr() as *mut libc::c_void,
         DC_PRED as libc::c_int,
         ::core::mem::size_of::<[uint8_t; 32]>(),
     );

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5335,13 +5335,13 @@ unsafe fn decode_b(
                     .u8_0 = (0x1 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_int)
                     as uint8_t;
-                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(0))
+                (*(&mut *(*(t.l.r#ref.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut int8_t as *mut alias8))
                     .u8_0 = (0x1 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_int)
                     as uint8_t;
-                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(1))
+                (*(&mut *(*(t.l.r#ref.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut int8_t as *mut alias8))
                     .u8_0 = (0x1 as libc::c_int
@@ -5393,13 +5393,13 @@ unsafe fn decode_b(
                     .u16_0 = (0x101 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_int)
                     as uint16_t;
-                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(0))
+                (*(&mut *(*(t.l.r#ref.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut int8_t as *mut alias16))
                     .u16_0 = (0x101 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_int)
                     as uint16_t;
-                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(1))
+                (*(&mut *(*(t.l.r#ref.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut int8_t as *mut alias16))
                     .u16_0 = (0x101 as libc::c_int
@@ -5445,12 +5445,12 @@ unsafe fn decode_b(
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_uint);
-                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(0))
+                (*(&mut *(*(t.l.r#ref.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut int8_t as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_uint);
-                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(1))
+                (*(&mut *(*(t.l.r#ref.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut int8_t as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(
@@ -5510,13 +5510,13 @@ unsafe fn decode_b(
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(0))
+                (*(&mut *(*(t.l.r#ref.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut int8_t as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(1))
+                (*(&mut *(*(t.l.r#ref.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut int8_t as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong).wrapping_mul(
@@ -5632,12 +5632,12 @@ unsafe fn decode_b(
                 let const_val_134: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(0))
+                (*(&mut *(*(t.l.r#ref.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((by4 + 0) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_134;
-                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(0))
+                (*(&mut *(*(t.l.r#ref.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((by4 + 8) as isize) as *mut int8_t
                     as *mut alias64))
@@ -5645,12 +5645,12 @@ unsafe fn decode_b(
                 let const_val_135: uint64_t = (0x101010101010101 as libc::c_ulonglong).wrapping_mul(
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] as uint8_t as libc::c_ulonglong,
                 ) as uint64_t;
-                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(1))
+                (*(&mut *(*(t.l.r#ref.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((by4 + 0) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_135;
-                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(1))
+                (*(&mut *(*(t.l.r#ref.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((by4 + 8) as isize) as *mut int8_t
                     as *mut alias64))
@@ -5843,22 +5843,22 @@ unsafe fn decode_b(
                 let const_val_147: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(0))
+                (*(&mut *(*(t.l.r#ref.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((by4 + 0) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_147;
-                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(0))
+                (*(&mut *(*(t.l.r#ref.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((by4 + 8) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_147;
-                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(0))
+                (*(&mut *(*(t.l.r#ref.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((by4 + 16) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_147;
-                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(0))
+                (*(&mut *(*(t.l.r#ref.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((by4 + 24) as isize) as *mut int8_t
                     as *mut alias64))
@@ -5866,22 +5866,22 @@ unsafe fn decode_b(
                 let const_val_148: uint64_t = (0x101010101010101 as libc::c_ulonglong).wrapping_mul(
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] as uint8_t as libc::c_ulonglong,
                 ) as uint64_t;
-                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(1))
+                (*(&mut *(*(t.l.r#ref.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((by4 + 0) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_148;
-                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(1))
+                (*(&mut *(*(t.l.r#ref.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((by4 + 8) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_148;
-                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(1))
+                (*(&mut *(*(t.l.r#ref.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((by4 + 16) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_148;
-                (*(&mut *(*(t.l.r#ref).as_mut_ptr().offset(1))
+                (*(&mut *(*(t.l.r#ref.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((by4 + 24) as isize) as *mut int8_t
                     as *mut alias64))
@@ -5935,13 +5935,13 @@ unsafe fn decode_b(
                     .u8_0 = (0x1 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_int)
                     as uint8_t;
-                (*(&mut *(*((*t.a).r#ref).as_mut_ptr().offset(0))
+                (*(&mut *(*((*t.a).r#ref.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut int8_t as *mut alias8))
                     .u8_0 = (0x1 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_int)
                     as uint8_t;
-                (*(&mut *(*((*t.a).r#ref).as_mut_ptr().offset(1))
+                (*(&mut *(*((*t.a).r#ref.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut int8_t as *mut alias8))
                     .u8_0 = (0x1 as libc::c_int
@@ -5993,13 +5993,13 @@ unsafe fn decode_b(
                     .u16_0 = (0x101 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_int)
                     as uint16_t;
-                (*(&mut *(*((*t.a).r#ref).as_mut_ptr().offset(0))
+                (*(&mut *(*((*t.a).r#ref.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut int8_t as *mut alias16))
                     .u16_0 = (0x101 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_int)
                     as uint16_t;
-                (*(&mut *(*((*t.a).r#ref).as_mut_ptr().offset(1))
+                (*(&mut *(*((*t.a).r#ref.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut int8_t as *mut alias16))
                     .u16_0 = (0x101 as libc::c_int
@@ -6045,12 +6045,12 @@ unsafe fn decode_b(
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_uint);
-                (*(&mut *(*((*t.a).r#ref).as_mut_ptr().offset(0))
+                (*(&mut *(*((*t.a).r#ref.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut int8_t as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_uint);
-                (*(&mut *(*((*t.a).r#ref).as_mut_ptr().offset(1))
+                (*(&mut *(*((*t.a).r#ref.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut int8_t as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(
@@ -6110,13 +6110,13 @@ unsafe fn decode_b(
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(*((*t.a).r#ref).as_mut_ptr().offset(0))
+                (*(&mut *(*((*t.a).r#ref.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut int8_t as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(*((*t.a).r#ref).as_mut_ptr().offset(1))
+                (*(&mut *(*((*t.a).r#ref.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut int8_t as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong).wrapping_mul(
@@ -6244,12 +6244,12 @@ unsafe fn decode_b(
                 let const_val_160: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(*((*t.a).r#ref).as_mut_ptr().offset(0))
+                (*(&mut *(*((*t.a).r#ref.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_160;
-                (*(&mut *(*((*t.a).r#ref).as_mut_ptr().offset(0))
+                (*(&mut *(*((*t.a).r#ref.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut int8_t
                     as *mut alias64))
@@ -6257,12 +6257,12 @@ unsafe fn decode_b(
                 let const_val_161: uint64_t = (0x101010101010101 as libc::c_ulonglong).wrapping_mul(
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] as uint8_t as libc::c_ulonglong,
                 ) as uint64_t;
-                (*(&mut *(*((*t.a).r#ref).as_mut_ptr().offset(1))
+                (*(&mut *(*((*t.a).r#ref.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_161;
-                (*(&mut *(*((*t.a).r#ref).as_mut_ptr().offset(1))
+                (*(&mut *(*((*t.a).r#ref.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut int8_t
                     as *mut alias64))
@@ -6483,22 +6483,22 @@ unsafe fn decode_b(
                 let const_val_173: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(*((*t.a).r#ref).as_mut_ptr().offset(0))
+                (*(&mut *(*((*t.a).r#ref.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_173;
-                (*(&mut *(*((*t.a).r#ref).as_mut_ptr().offset(0))
+                (*(&mut *(*((*t.a).r#ref.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_173;
-                (*(&mut *(*((*t.a).r#ref).as_mut_ptr().offset(0))
+                (*(&mut *(*((*t.a).r#ref.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((bx4 + 16) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_173;
-                (*(&mut *(*((*t.a).r#ref).as_mut_ptr().offset(0))
+                (*(&mut *(*((*t.a).r#ref.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((bx4 + 24) as isize) as *mut int8_t
                     as *mut alias64))
@@ -6506,22 +6506,22 @@ unsafe fn decode_b(
                 let const_val_174: uint64_t = (0x101010101010101 as libc::c_ulonglong).wrapping_mul(
                     b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] as uint8_t as libc::c_ulonglong,
                 ) as uint64_t;
-                (*(&mut *(*((*t.a).r#ref).as_mut_ptr().offset(1))
+                (*(&mut *(*((*t.a).r#ref.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_174;
-                (*(&mut *(*((*t.a).r#ref).as_mut_ptr().offset(1))
+                (*(&mut *(*((*t.a).r#ref.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_174;
-                (*(&mut *(*((*t.a).r#ref).as_mut_ptr().offset(1))
+                (*(&mut *(*((*t.a).r#ref.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((bx4 + 16) as isize) as *mut int8_t
                     as *mut alias64))
                     .u64_0 = const_val_174;
-                (*(&mut *(*((*t.a).r#ref).as_mut_ptr().offset(1))
+                (*(&mut *(*((*t.a).r#ref.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((bx4 + 24) as isize) as *mut int8_t
                     as *mut alias64))
@@ -7825,7 +7825,7 @@ unsafe extern "C" fn reset_context(
     );
     if keyframe == 0 {
         memset(
-            ((*ctx).r#ref).as_mut_ptr() as *mut libc::c_void,
+            ((*ctx).r#ref.0).as_mut_ptr() as *mut libc::c_void,
             -(1 as libc::c_int),
             ::core::mem::size_of::<[[int8_t; 32]; 2]>(),
         );

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1738,14 +1738,14 @@ unsafe extern "C" fn read_pal_plane(
     let mut l_cache = if pl != 0 {
         (*t).pal_sz_uv[1][by4 as usize] as libc::c_int
     } else {
-        (*t).l.pal_sz[by4 as usize] as libc::c_int
+        (*t).l.pal_sz.0[by4 as usize] as libc::c_int
     };
     let mut n_cache = 0;
     let mut a_cache = if by4 & 15 != 0 {
         if pl != 0 {
             (*t).pal_sz_uv[0][bx4 as usize] as libc::c_int
         } else {
-            (*(*t).a).pal_sz[bx4 as usize] as libc::c_int
+            (*(*t).a).pal_sz.0[bx4 as usize] as libc::c_int
         }
     } else {
         0 as libc::c_int
@@ -3513,8 +3513,8 @@ unsafe fn decode_b(
         if frame_hdr.allow_screen_content_tools != 0 && imax(bw4, bh4) <= 16 && bw4 + bh4 >= 4 {
             let sz_ctx = b_dim[2] + b_dim[3] - 2;
             if b.y_mode() == DC_PRED as u8 {
-                let pal_ctx = ((*t.a).pal_sz[bx4 as usize] > 0) as usize
-                    + (t.l.pal_sz[by4 as usize] > 0) as usize;
+                let pal_ctx = ((*t.a).pal_sz.0[bx4 as usize] > 0) as usize
+                    + (t.l.pal_sz.0[by4 as usize] > 0) as usize;
                 let use_y_pal = dav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
                     &mut ts.cdf.m.pal_y[sz_ctx as usize][pal_ctx],
@@ -3712,7 +3712,7 @@ unsafe fn decode_b(
             );
             rep_macro(dir.tx.0.as_mut_ptr() as *mut u8, off, mul * lw_lh as u64);
             rep_macro(dir.mode.0.as_mut_ptr(), off, mul * y_mode_nofilt as u64);
-            rep_macro(dir.pal_sz.as_mut_ptr(), off, mul * b.pal_sz()[0] as u64);
+            rep_macro(dir.pal_sz.0.as_mut_ptr(), off, mul * b.pal_sz()[0] as u64);
             rep_macro(dir.seg_pred.0.as_mut_ptr(), off, mul * seg_pred as u64);
             rep_macro(dir.skip_mode.0.as_mut_ptr(), off, 0);
             rep_macro(dir.intra.0.as_mut_ptr(), off, mul);
@@ -3932,7 +3932,7 @@ unsafe fn decode_b(
                 mul * b_dim[2 + diridx] as u64,
             );
             rep_macro(dir.mode.0.as_mut_ptr(), off, mul * DC_PRED as u64);
-            rep_macro(dir.pal_sz.as_mut_ptr(), off, 0);
+            rep_macro(dir.pal_sz.0.as_mut_ptr(), off, 0);
             // see aomedia bug 2183 for why this is outside `if has_chroma {}`
             rep_macro(t.pal_sz_uv[diridx].as_mut_ptr(), off, 0);
             rep_macro(dir.seg_pred.0.as_mut_ptr(), off, mul * seg_pred as u64);
@@ -5303,7 +5303,7 @@ unsafe fn decode_b(
                 (*(&mut *(t.l.skip.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * b.skip as libc::c_int) as uint8_t;
-                (*(&mut *(t.l.pal_sz).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.pal_sz.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = 0 as libc::c_int as uint8_t;
                 (*(&mut *(*(t.pal_sz_uv).as_mut_ptr().offset(1))
@@ -5361,7 +5361,7 @@ unsafe fn decode_b(
                 (*(&mut *(t.l.skip.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * b.skip as libc::c_int) as uint16_t;
-                (*(&mut *(t.l.pal_sz).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.pal_sz.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = 0 as libc::c_int as uint16_t;
                 (*(&mut *(*(t.pal_sz_uv).as_mut_ptr().offset(1))
@@ -5419,7 +5419,7 @@ unsafe fn decode_b(
                 (*(&mut *(t.l.skip.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(b.skip as libc::c_uint);
-                (*(&mut *(t.l.pal_sz).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.pal_sz.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = 0 as libc::c_int as uint32_t;
                 (*(&mut *(*(t.pal_sz_uv).as_mut_ptr().offset(1))
@@ -5476,7 +5476,7 @@ unsafe fn decode_b(
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.skip as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(t.l.pal_sz).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.pal_sz.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = 0 as libc::c_int as uint64_t;
                 (*(&mut *(*(t.pal_sz_uv).as_mut_ptr().offset(1))
@@ -5559,10 +5559,10 @@ unsafe fn decode_b(
                     as *mut alias64))
                     .u64_0 = const_val_126;
                 let const_val_127: uint64_t = 0 as libc::c_int as uint64_t;
-                (*(&mut *(t.l.pal_sz).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *(t.l.pal_sz.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_127;
-                (*(&mut *(t.l.pal_sz).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *(t.l.pal_sz.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_127;
                 let const_val_128: uint64_t = 0 as libc::c_int as uint64_t;
@@ -5716,16 +5716,16 @@ unsafe fn decode_b(
                     as *mut alias64))
                     .u64_0 = const_val_139;
                 let const_val_140: uint64_t = 0 as libc::c_int as uint64_t;
-                (*(&mut *(t.l.pal_sz).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *(t.l.pal_sz.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_140;
-                (*(&mut *(t.l.pal_sz).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *(t.l.pal_sz.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_140;
-                (*(&mut *(t.l.pal_sz).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
+                (*(&mut *(t.l.pal_sz.0).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_140;
-                (*(&mut *(t.l.pal_sz).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
+                (*(&mut *(t.l.pal_sz.0).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_140;
                 let const_val_141: uint64_t = 0 as libc::c_int as uint64_t;
@@ -5903,7 +5903,7 @@ unsafe fn decode_b(
                 (*(&mut *((*t.a).skip.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * b.skip as libc::c_int) as uint8_t;
-                (*(&mut *((*t.a).pal_sz).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).pal_sz.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = 0 as libc::c_int as uint8_t;
                 (*(&mut *(*(t.pal_sz_uv).as_mut_ptr().offset(0))
@@ -5961,7 +5961,7 @@ unsafe fn decode_b(
                 (*(&mut *((*t.a).skip.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * b.skip as libc::c_int) as uint16_t;
-                (*(&mut *((*t.a).pal_sz).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).pal_sz.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = 0 as libc::c_int as uint16_t;
                 (*(&mut *(*(t.pal_sz_uv).as_mut_ptr().offset(0))
@@ -6019,7 +6019,7 @@ unsafe fn decode_b(
                 (*(&mut *((*t.a).skip.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(b.skip as libc::c_uint);
-                (*(&mut *((*t.a).pal_sz).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).pal_sz.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = 0 as libc::c_int as uint32_t;
                 (*(&mut *(*(t.pal_sz_uv).as_mut_ptr().offset(0))
@@ -6076,7 +6076,7 @@ unsafe fn decode_b(
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.skip as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).pal_sz).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).pal_sz.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = 0 as libc::c_int as uint64_t;
                 (*(&mut *(*(t.pal_sz_uv).as_mut_ptr().offset(0))
@@ -6167,10 +6167,10 @@ unsafe fn decode_b(
                     as *mut alias64))
                     .u64_0 = const_val_152;
                 let const_val_153: uint64_t = 0 as libc::c_int as uint64_t;
-                (*(&mut *((*t.a).pal_sz).as_mut_ptr().offset((bx4 + 0) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).pal_sz.0).as_mut_ptr().offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_153;
-                (*(&mut *((*t.a).pal_sz).as_mut_ptr().offset((bx4 + 8) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).pal_sz.0).as_mut_ptr().offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_153;
                 let const_val_154: uint64_t = 0 as libc::c_int as uint64_t;
@@ -6344,16 +6344,16 @@ unsafe fn decode_b(
                     as *mut alias64))
                     .u64_0 = const_val_165;
                 let const_val_166: uint64_t = 0 as libc::c_int as uint64_t;
-                (*(&mut *((*t.a).pal_sz).as_mut_ptr().offset((bx4 + 0) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).pal_sz.0).as_mut_ptr().offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_166;
-                (*(&mut *((*t.a).pal_sz).as_mut_ptr().offset((bx4 + 8) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).pal_sz.0).as_mut_ptr().offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_166;
-                (*(&mut *((*t.a).pal_sz).as_mut_ptr().offset((bx4 + 16) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).pal_sz.0).as_mut_ptr().offset((bx4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_166;
-                (*(&mut *((*t.a).pal_sz).as_mut_ptr().offset((bx4 + 24) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).pal_sz.0).as_mut_ptr().offset((bx4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_166;
                 let const_val_167: uint64_t = 0 as libc::c_int as uint64_t;
@@ -7861,7 +7861,7 @@ unsafe extern "C" fn reset_context(
         ::core::mem::size_of::<[uint8_t; 32]>(),
     );
     memset(
-        ((*ctx).pal_sz).as_mut_ptr() as *mut libc::c_void,
+        ((*ctx).pal_sz.0).as_mut_ptr() as *mut libc::c_void,
         0 as libc::c_int,
         ::core::mem::size_of::<[uint8_t; 32]>(),
     );

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3145,9 +3145,9 @@ unsafe fn decode_b(
         && (*f.frame_hdr).skip_mode_enabled != 0
         && imin(bw4, bh4) > 1
     {
-        let smctx = (*t.a).skip_mode[bx4 as usize] + t.l.skip_mode[by4 as usize];
+        let smctx = (*t.a).skip_mode.0[bx4 as usize] + t.l.skip_mode.0[by4 as usize];
         b.skip_mode =
-            dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.skip_mode[smctx as usize])
+            dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.skip_mode.0[smctx as usize])
                 as uint8_t;
 
         if DEBUG_BLOCK_INFO(f, t) {
@@ -3714,7 +3714,7 @@ unsafe fn decode_b(
             rep_macro(dir.mode.0.as_mut_ptr(), off, mul * y_mode_nofilt as u64);
             rep_macro(dir.pal_sz.as_mut_ptr(), off, mul * b.pal_sz()[0] as u64);
             rep_macro(dir.seg_pred.0.as_mut_ptr(), off, mul * seg_pred as u64);
-            rep_macro(dir.skip_mode.as_mut_ptr(), off, 0);
+            rep_macro(dir.skip_mode.0.as_mut_ptr(), off, 0);
             rep_macro(dir.intra.as_mut_ptr(), off, mul);
             rep_macro(dir.skip.0.as_mut_ptr(), off, mul * b.skip as u64);
             // see aomedia bug 2183 for why we use luma coordinates here
@@ -3936,7 +3936,7 @@ unsafe fn decode_b(
             // see aomedia bug 2183 for why this is outside `if has_chroma {}`
             rep_macro(t.pal_sz_uv[diridx].as_mut_ptr(), off, 0);
             rep_macro(dir.seg_pred.0.as_mut_ptr(), off, mul * seg_pred as u64);
-            rep_macro(dir.skip_mode.as_mut_ptr(), off, 0);
+            rep_macro(dir.skip_mode.0.as_mut_ptr(), off, 0);
             rep_macro(dir.intra.as_mut_ptr(), off, 0);
             rep_macro(dir.skip.0.as_mut_ptr(), off, mul * b.skip as u64)
         };
@@ -5294,7 +5294,7 @@ unsafe fn decode_b(
                 (*(&mut *(t.l.seg_pred.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * seg_pred) as uint8_t;
-                (*(&mut *(t.l.skip_mode).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.skip_mode.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * b.skip_mode as libc::c_int) as uint8_t;
                 (*(&mut *(t.l.intra).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
@@ -5352,7 +5352,7 @@ unsafe fn decode_b(
                 (*(&mut *(t.l.seg_pred.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * seg_pred) as uint16_t;
-                (*(&mut *(t.l.skip_mode).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.skip_mode.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * b.skip_mode as libc::c_int) as uint16_t;
                 (*(&mut *(t.l.intra).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
@@ -5410,7 +5410,7 @@ unsafe fn decode_b(
                 (*(&mut *(t.l.seg_pred.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(seg_pred as libc::c_uint);
-                (*(&mut *(t.l.skip_mode).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.skip_mode.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(b.skip_mode as libc::c_uint);
                 (*(&mut *(t.l.intra).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
@@ -5463,7 +5463,7 @@ unsafe fn decode_b(
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(seg_pred as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(t.l.skip_mode).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.skip_mode.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.skip_mode as libc::c_ulonglong)
@@ -5536,10 +5536,10 @@ unsafe fn decode_b(
                 let const_val_124: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.skip_mode as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(t.l.skip_mode).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *(t.l.skip_mode.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_124;
-                (*(&mut *(t.l.skip_mode).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *(t.l.skip_mode.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_124;
                 let const_val_125: uint64_t = 0 as libc::c_int as uint64_t;
@@ -5675,16 +5675,16 @@ unsafe fn decode_b(
                 let const_val_137: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.skip_mode as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(t.l.skip_mode).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *(t.l.skip_mode.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_137;
-                (*(&mut *(t.l.skip_mode).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *(t.l.skip_mode.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_137;
-                (*(&mut *(t.l.skip_mode).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
+                (*(&mut *(t.l.skip_mode.0).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_137;
-                (*(&mut *(t.l.skip_mode).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
+                (*(&mut *(t.l.skip_mode.0).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_137;
                 let const_val_138: uint64_t = 0 as libc::c_int as uint64_t;
@@ -5894,7 +5894,7 @@ unsafe fn decode_b(
                 (*(&mut *((*t.a).seg_pred.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * seg_pred) as uint8_t;
-                (*(&mut *((*t.a).skip_mode).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).skip_mode.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * b.skip_mode as libc::c_int) as uint8_t;
                 (*(&mut *((*t.a).intra).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
@@ -5952,7 +5952,7 @@ unsafe fn decode_b(
                 (*(&mut *((*t.a).seg_pred.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * seg_pred) as uint16_t;
-                (*(&mut *((*t.a).skip_mode).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).skip_mode.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * b.skip_mode as libc::c_int) as uint16_t;
                 (*(&mut *((*t.a).intra).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
@@ -6010,7 +6010,7 @@ unsafe fn decode_b(
                 (*(&mut *((*t.a).seg_pred.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(seg_pred as libc::c_uint);
-                (*(&mut *((*t.a).skip_mode).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).skip_mode.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(b.skip_mode as libc::c_uint);
                 (*(&mut *((*t.a).intra).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
@@ -6063,7 +6063,7 @@ unsafe fn decode_b(
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(seg_pred as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).skip_mode).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).skip_mode.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.skip_mode as libc::c_ulonglong)
@@ -6140,12 +6140,12 @@ unsafe fn decode_b(
                 let const_val_150: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.skip_mode as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).skip_mode)
+                (*(&mut *((*t.a).skip_mode.0)
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_150;
-                (*(&mut *((*t.a).skip_mode)
+                (*(&mut *((*t.a).skip_mode.0)
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -6295,22 +6295,22 @@ unsafe fn decode_b(
                 let const_val_163: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.skip_mode as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).skip_mode)
+                (*(&mut *((*t.a).skip_mode.0)
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_163;
-                (*(&mut *((*t.a).skip_mode)
+                (*(&mut *((*t.a).skip_mode.0)
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_163;
-                (*(&mut *((*t.a).skip_mode)
+                (*(&mut *((*t.a).skip_mode.0)
                     .as_mut_ptr()
                     .offset((bx4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_163;
-                (*(&mut *((*t.a).skip_mode)
+                (*(&mut *((*t.a).skip_mode.0)
                     .as_mut_ptr()
                     .offset((bx4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -7799,7 +7799,7 @@ unsafe extern "C" fn reset_context(
         ::core::mem::size_of::<[uint8_t; 32]>(),
     );
     memset(
-        ((*ctx).skip_mode).as_mut_ptr() as *mut libc::c_void,
+        ((*ctx).skip_mode.0).as_mut_ptr() as *mut libc::c_void,
         0 as libc::c_int,
         ::core::mem::size_of::<[uint8_t; 32]>(),
     );

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2942,7 +2942,7 @@ unsafe fn decode_b(
 
             let mut set_ctx = |dir: &mut BlockContext, _diridx, off, mul, rep_macro: SetCtxFn| {
                 rep_macro(dir.mode.0.as_mut_ptr(), off, mul * y_mode_nofilt as u64);
-                rep_macro(dir.intra.as_mut_ptr(), off, mul);
+                rep_macro(dir.intra.0.as_mut_ptr(), off, mul);
             };
             case_set(bh4, &mut t.l, 1, by4 as isize, &mut set_ctx);
             case_set(bw4, &mut *t.a, 0, bx4 as isize, &mut set_ctx);
@@ -3019,7 +3019,7 @@ unsafe fn decode_b(
             let mut set_ctx = |dir: &mut BlockContext, _diridx, off, mul, rep_macro: SetCtxFn| {
                 rep_macro(dir.filter[0].as_mut_ptr(), off, mul * filter[0] as u64);
                 rep_macro(dir.filter[1].as_mut_ptr(), off, mul * filter[1] as u64);
-                rep_macro(dir.intra.as_mut_ptr(), off, 0);
+                rep_macro(dir.intra.0.as_mut_ptr(), off, 0);
             };
             case_set(bh4, &mut t.l, 1, by4 as isize, &mut set_ctx);
             case_set(bw4, &mut *t.a, 0, bx4 as isize, &mut set_ctx);
@@ -3715,7 +3715,7 @@ unsafe fn decode_b(
             rep_macro(dir.pal_sz.as_mut_ptr(), off, mul * b.pal_sz()[0] as u64);
             rep_macro(dir.seg_pred.0.as_mut_ptr(), off, mul * seg_pred as u64);
             rep_macro(dir.skip_mode.0.as_mut_ptr(), off, 0);
-            rep_macro(dir.intra.as_mut_ptr(), off, mul);
+            rep_macro(dir.intra.0.as_mut_ptr(), off, mul);
             rep_macro(dir.skip.0.as_mut_ptr(), off, mul * b.skip as u64);
             // see aomedia bug 2183 for why we use luma coordinates here
             rep_macro(
@@ -3937,7 +3937,7 @@ unsafe fn decode_b(
             rep_macro(t.pal_sz_uv[diridx].as_mut_ptr(), off, 0);
             rep_macro(dir.seg_pred.0.as_mut_ptr(), off, mul * seg_pred as u64);
             rep_macro(dir.skip_mode.0.as_mut_ptr(), off, 0);
-            rep_macro(dir.intra.as_mut_ptr(), off, 0);
+            rep_macro(dir.intra.0.as_mut_ptr(), off, 0);
             rep_macro(dir.skip.0.as_mut_ptr(), off, mul * b.skip as u64)
         };
         case_set(bh4, &mut t.l, 1, by4 as isize, &mut set_ctx);
@@ -4952,8 +4952,8 @@ unsafe fn decode_b(
                     && frame_hdr.gmv[b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as usize].type_0
                         as libc::c_uint
                         > DAV1D_WM_TYPE_TRANSLATION as libc::c_int as libc::c_uint)
-                && (have_left && findoddzero(&t.l.intra[by4 as usize..][..h4 as usize])
-                    || have_top && findoddzero(&(*t.a).intra[bx4 as usize..][..w4 as usize]))
+                && (have_left && findoddzero(&t.l.intra.0[by4 as usize..][..h4 as usize])
+                    || have_top && findoddzero(&(*t.a).intra.0[bx4 as usize..][..w4 as usize]))
             {
                 let mut mask: [uint64_t; 2] =
                     [0 as libc::c_int as uint64_t, 0 as libc::c_int as uint64_t];
@@ -5297,7 +5297,7 @@ unsafe fn decode_b(
                 (*(&mut *(t.l.skip_mode.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * b.skip_mode as libc::c_int) as uint8_t;
-                (*(&mut *(t.l.intra).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.intra.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = 0 as libc::c_int as uint8_t;
                 (*(&mut *(t.l.skip.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
@@ -5355,7 +5355,7 @@ unsafe fn decode_b(
                 (*(&mut *(t.l.skip_mode.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * b.skip_mode as libc::c_int) as uint16_t;
-                (*(&mut *(t.l.intra).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.intra.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = 0 as libc::c_int as uint16_t;
                 (*(&mut *(t.l.skip.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
@@ -5413,7 +5413,7 @@ unsafe fn decode_b(
                 (*(&mut *(t.l.skip_mode.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(b.skip_mode as libc::c_uint);
-                (*(&mut *(t.l.intra).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.intra.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = 0 as libc::c_int as uint32_t;
                 (*(&mut *(t.l.skip.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
@@ -5468,7 +5468,7 @@ unsafe fn decode_b(
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.skip_mode as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(t.l.intra).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.intra.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = 0 as libc::c_int as uint64_t;
                 (*(&mut *(t.l.skip.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
@@ -5543,10 +5543,10 @@ unsafe fn decode_b(
                     as *mut alias64))
                     .u64_0 = const_val_124;
                 let const_val_125: uint64_t = 0 as libc::c_int as uint64_t;
-                (*(&mut *(t.l.intra).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *(t.l.intra.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_125;
-                (*(&mut *(t.l.intra).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *(t.l.intra.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_125;
                 let const_val_126: uint64_t = (0x101010101010101 as libc::c_ulonglong)
@@ -5688,16 +5688,16 @@ unsafe fn decode_b(
                     as *mut alias64))
                     .u64_0 = const_val_137;
                 let const_val_138: uint64_t = 0 as libc::c_int as uint64_t;
-                (*(&mut *(t.l.intra).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *(t.l.intra.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_138;
-                (*(&mut *(t.l.intra).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *(t.l.intra.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_138;
-                (*(&mut *(t.l.intra).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
+                (*(&mut *(t.l.intra.0).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_138;
-                (*(&mut *(t.l.intra).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
+                (*(&mut *(t.l.intra.0).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_138;
                 let const_val_139: uint64_t = (0x101010101010101 as libc::c_ulonglong)
@@ -5897,7 +5897,7 @@ unsafe fn decode_b(
                 (*(&mut *((*t.a).skip_mode.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * b.skip_mode as libc::c_int) as uint8_t;
-                (*(&mut *((*t.a).intra).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).intra.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = 0 as libc::c_int as uint8_t;
                 (*(&mut *((*t.a).skip.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
@@ -5955,7 +5955,7 @@ unsafe fn decode_b(
                 (*(&mut *((*t.a).skip_mode.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * b.skip_mode as libc::c_int) as uint16_t;
-                (*(&mut *((*t.a).intra).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).intra.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = 0 as libc::c_int as uint16_t;
                 (*(&mut *((*t.a).skip.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
@@ -6013,7 +6013,7 @@ unsafe fn decode_b(
                 (*(&mut *((*t.a).skip_mode.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(b.skip_mode as libc::c_uint);
-                (*(&mut *((*t.a).intra).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).intra.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = 0 as libc::c_int as uint32_t;
                 (*(&mut *((*t.a).skip.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
@@ -6068,7 +6068,7 @@ unsafe fn decode_b(
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.skip_mode as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).intra).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).intra.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = 0 as libc::c_int as uint64_t;
                 (*(&mut *((*t.a).skip.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
@@ -6151,10 +6151,10 @@ unsafe fn decode_b(
                     as *mut alias64))
                     .u64_0 = const_val_150;
                 let const_val_151: uint64_t = 0 as libc::c_int as uint64_t;
-                (*(&mut *((*t.a).intra).as_mut_ptr().offset((bx4 + 0) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).intra.0).as_mut_ptr().offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_151;
-                (*(&mut *((*t.a).intra).as_mut_ptr().offset((bx4 + 8) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).intra.0).as_mut_ptr().offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_151;
                 let const_val_152: uint64_t = (0x101010101010101 as libc::c_ulonglong)
@@ -6316,16 +6316,16 @@ unsafe fn decode_b(
                     as *mut alias64))
                     .u64_0 = const_val_163;
                 let const_val_164: uint64_t = 0 as libc::c_int as uint64_t;
-                (*(&mut *((*t.a).intra).as_mut_ptr().offset((bx4 + 0) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).intra.0).as_mut_ptr().offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_164;
-                (*(&mut *((*t.a).intra).as_mut_ptr().offset((bx4 + 8) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).intra.0).as_mut_ptr().offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_164;
-                (*(&mut *((*t.a).intra).as_mut_ptr().offset((bx4 + 16) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).intra.0).as_mut_ptr().offset((bx4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_164;
-                (*(&mut *((*t.a).intra).as_mut_ptr().offset((bx4 + 24) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).intra.0).as_mut_ptr().offset((bx4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_164;
                 let const_val_165: uint64_t = (0x101010101010101 as libc::c_ulonglong)
@@ -7769,7 +7769,7 @@ unsafe extern "C" fn reset_context(
     pass: libc::c_int,
 ) {
     memset(
-        ((*ctx).intra).as_mut_ptr() as *mut libc::c_void,
+        ((*ctx).intra.0).as_mut_ptr() as *mut libc::c_void,
         keyframe,
         ::core::mem::size_of::<[uint8_t; 32]>(),
     );

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3017,8 +3017,8 @@ unsafe fn decode_b(
             let filter = &dav1d_filter_dir[b.filter2d() as usize];
 
             let mut set_ctx = |dir: &mut BlockContext, _diridx, off, mul, rep_macro: SetCtxFn| {
-                rep_macro(dir.filter[0].as_mut_ptr(), off, mul * filter[0] as u64);
-                rep_macro(dir.filter[1].as_mut_ptr(), off, mul * filter[1] as u64);
+                rep_macro(dir.filter.0[0].as_mut_ptr(), off, mul * filter[0] as u64);
+                rep_macro(dir.filter.0[1].as_mut_ptr(), off, mul * filter[1] as u64);
                 rep_macro(dir.intra.0.as_mut_ptr(), off, 0);
             };
             case_set(bh4, &mut t.l, 1, by4 as isize, &mut set_ctx);
@@ -3740,12 +3740,12 @@ unsafe fn decode_b(
                     mul * u8::MAX as u64,
                 );
                 rep_macro(
-                    dir.filter[0].as_mut_ptr(),
+                    dir.filter.0[0].as_mut_ptr(),
                     off,
                     mul * DAV1D_N_SWITCHABLE_FILTERS as u64,
                 );
                 rep_macro(
-                    dir.filter[1].as_mut_ptr(),
+                    dir.filter.0[1].as_mut_ptr(),
                     off,
                     mul * DAV1D_N_SWITCHABLE_FILTERS as u64,
                 );
@@ -5162,7 +5162,7 @@ unsafe fn decode_b(
                 );
                 filter_0[0] = dav1d_msac_decode_symbol_adapt4(
                     &mut ts.msac,
-                    &mut ts.cdf.m.filter[0][ctx1_1 as usize],
+                    &mut ts.cdf.m.filter.0[0][ctx1_1 as usize],
                     (DAV1D_N_SWITCHABLE_FILTERS as libc::c_int - 1) as size_t,
                 ) as Dav1dFilterMode;
                 if (*f.seq_hdr).dual_filter != 0 {
@@ -5186,7 +5186,7 @@ unsafe fn decode_b(
                     }
                     filter_0[1] = dav1d_msac_decode_symbol_adapt4(
                         &mut ts.msac,
-                        &mut ts.cdf.m.filter[1][ctx2_3 as usize],
+                        &mut ts.cdf.m.filter.0[1][ctx2_3 as usize],
                         (DAV1D_N_SWITCHABLE_FILTERS as libc::c_int - 1) as size_t,
                     ) as Dav1dFilterMode;
                     if DEBUG_BLOCK_INFO(f, t) {
@@ -5318,13 +5318,13 @@ unsafe fn decode_b(
                     .u8_0 = (0x1 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_int)
                     as uint8_t;
-                (*(&mut *(*(t.l.filter).as_mut_ptr().offset(0))
+                (*(&mut *(*(t.l.filter.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut uint8_t as *mut alias8))
                     .u8_0 = (0x1 as libc::c_int as libc::c_uint)
                     .wrapping_mul(filter_0[0] as libc::c_uint)
                     as uint8_t;
-                (*(&mut *(*(t.l.filter).as_mut_ptr().offset(1))
+                (*(&mut *(*(t.l.filter.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut uint8_t as *mut alias8))
                     .u8_0 = (0x1 as libc::c_int as libc::c_uint)
@@ -5376,13 +5376,13 @@ unsafe fn decode_b(
                     .u16_0 = (0x101 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_int)
                     as uint16_t;
-                (*(&mut *(*(t.l.filter).as_mut_ptr().offset(0))
+                (*(&mut *(*(t.l.filter.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut uint8_t as *mut alias16))
                     .u16_0 = (0x101 as libc::c_int as libc::c_uint)
                     .wrapping_mul(filter_0[0] as libc::c_uint)
                     as uint16_t;
-                (*(&mut *(*(t.l.filter).as_mut_ptr().offset(1))
+                (*(&mut *(*(t.l.filter.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut uint8_t as *mut alias16))
                     .u16_0 = (0x101 as libc::c_int as libc::c_uint)
@@ -5433,11 +5433,11 @@ unsafe fn decode_b(
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_uint);
-                (*(&mut *(*(t.l.filter).as_mut_ptr().offset(0))
+                (*(&mut *(*(t.l.filter.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut uint8_t as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(filter_0[0] as libc::c_uint);
-                (*(&mut *(*(t.l.filter).as_mut_ptr().offset(1))
+                (*(&mut *(*(t.l.filter.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut uint8_t as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(filter_0[1] as libc::c_uint);
@@ -5493,13 +5493,13 @@ unsafe fn decode_b(
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(*(t.l.filter).as_mut_ptr().offset(0))
+                (*(&mut *(*(t.l.filter.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut uint8_t as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(filter_0[0] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(*(t.l.filter).as_mut_ptr().offset(1))
+                (*(&mut *(*(t.l.filter.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut uint8_t as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
@@ -5597,12 +5597,12 @@ unsafe fn decode_b(
                 let const_val_131: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(filter_0[0] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(*(t.l.filter).as_mut_ptr().offset(0))
+                (*(&mut *(*(t.l.filter.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_131;
-                (*(&mut *(*(t.l.filter).as_mut_ptr().offset(0))
+                (*(&mut *(*(t.l.filter.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -5610,12 +5610,12 @@ unsafe fn decode_b(
                 let const_val_132: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(filter_0[1] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(*(t.l.filter).as_mut_ptr().offset(1))
+                (*(&mut *(*(t.l.filter.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_132;
-                (*(&mut *(*(t.l.filter).as_mut_ptr().offset(1))
+                (*(&mut *(*(t.l.filter.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -5782,22 +5782,22 @@ unsafe fn decode_b(
                 let const_val_144: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(filter_0[0] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(*(t.l.filter).as_mut_ptr().offset(0))
+                (*(&mut *(*(t.l.filter.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_144;
-                (*(&mut *(*(t.l.filter).as_mut_ptr().offset(0))
+                (*(&mut *(*(t.l.filter.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_144;
-                (*(&mut *(*(t.l.filter).as_mut_ptr().offset(0))
+                (*(&mut *(*(t.l.filter.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((by4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_144;
-                (*(&mut *(*(t.l.filter).as_mut_ptr().offset(0))
+                (*(&mut *(*(t.l.filter.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((by4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -5805,22 +5805,22 @@ unsafe fn decode_b(
                 let const_val_145: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(filter_0[1] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(*(t.l.filter).as_mut_ptr().offset(1))
+                (*(&mut *(*(t.l.filter.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_145;
-                (*(&mut *(*(t.l.filter).as_mut_ptr().offset(1))
+                (*(&mut *(*(t.l.filter.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_145;
-                (*(&mut *(*(t.l.filter).as_mut_ptr().offset(1))
+                (*(&mut *(*(t.l.filter.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((by4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_145;
-                (*(&mut *(*(t.l.filter).as_mut_ptr().offset(1))
+                (*(&mut *(*(t.l.filter.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((by4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -5918,13 +5918,13 @@ unsafe fn decode_b(
                     .u8_0 = (0x1 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_int)
                     as uint8_t;
-                (*(&mut *(*((*t.a).filter).as_mut_ptr().offset(0))
+                (*(&mut *(*((*t.a).filter.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut uint8_t as *mut alias8))
                     .u8_0 = (0x1 as libc::c_int as libc::c_uint)
                     .wrapping_mul(filter_0[0] as libc::c_uint)
                     as uint8_t;
-                (*(&mut *(*((*t.a).filter).as_mut_ptr().offset(1))
+                (*(&mut *(*((*t.a).filter.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut uint8_t as *mut alias8))
                     .u8_0 = (0x1 as libc::c_int as libc::c_uint)
@@ -5976,13 +5976,13 @@ unsafe fn decode_b(
                     .u16_0 = (0x101 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_int)
                     as uint16_t;
-                (*(&mut *(*((*t.a).filter).as_mut_ptr().offset(0))
+                (*(&mut *(*((*t.a).filter.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut uint8_t as *mut alias16))
                     .u16_0 = (0x101 as libc::c_int as libc::c_uint)
                     .wrapping_mul(filter_0[0] as libc::c_uint)
                     as uint16_t;
-                (*(&mut *(*((*t.a).filter).as_mut_ptr().offset(1))
+                (*(&mut *(*((*t.a).filter.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut uint8_t as *mut alias16))
                     .u16_0 = (0x101 as libc::c_int as libc::c_uint)
@@ -6033,11 +6033,11 @@ unsafe fn decode_b(
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_uint);
-                (*(&mut *(*((*t.a).filter).as_mut_ptr().offset(0))
+                (*(&mut *(*((*t.a).filter.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut uint8_t as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(filter_0[0] as libc::c_uint);
-                (*(&mut *(*((*t.a).filter).as_mut_ptr().offset(1))
+                (*(&mut *(*((*t.a).filter.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut uint8_t as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(filter_0[1] as libc::c_uint);
@@ -6093,13 +6093,13 @@ unsafe fn decode_b(
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(*((*t.a).filter).as_mut_ptr().offset(0))
+                (*(&mut *(*((*t.a).filter.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut uint8_t as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(filter_0[0] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(*((*t.a).filter).as_mut_ptr().offset(1))
+                (*(&mut *(*((*t.a).filter.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut uint8_t as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
@@ -6209,12 +6209,12 @@ unsafe fn decode_b(
                 let const_val_157: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(filter_0[0] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(*((*t.a).filter).as_mut_ptr().offset(0))
+                (*(&mut *(*((*t.a).filter.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_157;
-                (*(&mut *(*((*t.a).filter).as_mut_ptr().offset(0))
+                (*(&mut *(*((*t.a).filter.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -6222,12 +6222,12 @@ unsafe fn decode_b(
                 let const_val_158: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(filter_0[1] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(*((*t.a).filter).as_mut_ptr().offset(1))
+                (*(&mut *(*((*t.a).filter.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_158;
-                (*(&mut *(*((*t.a).filter).as_mut_ptr().offset(1))
+                (*(&mut *(*((*t.a).filter.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -6422,22 +6422,22 @@ unsafe fn decode_b(
                 let const_val_170: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(filter_0[0] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(*((*t.a).filter).as_mut_ptr().offset(0))
+                (*(&mut *(*((*t.a).filter.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_170;
-                (*(&mut *(*((*t.a).filter).as_mut_ptr().offset(0))
+                (*(&mut *(*((*t.a).filter.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_170;
-                (*(&mut *(*((*t.a).filter).as_mut_ptr().offset(0))
+                (*(&mut *(*((*t.a).filter.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((bx4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_170;
-                (*(&mut *(*((*t.a).filter).as_mut_ptr().offset(0))
+                (*(&mut *(*((*t.a).filter.0).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset((bx4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -6445,22 +6445,22 @@ unsafe fn decode_b(
                 let const_val_171: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(filter_0[1] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(*((*t.a).filter).as_mut_ptr().offset(1))
+                (*(&mut *(*((*t.a).filter.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_171;
-                (*(&mut *(*((*t.a).filter).as_mut_ptr().offset(1))
+                (*(&mut *(*((*t.a).filter.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_171;
-                (*(&mut *(*((*t.a).filter).as_mut_ptr().offset(1))
+                (*(&mut *(*((*t.a).filter.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((bx4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_171;
-                (*(&mut *(*((*t.a).filter).as_mut_ptr().offset(1))
+                (*(&mut *(*((*t.a).filter.0).as_mut_ptr().offset(1))
                     .as_mut_ptr()
                     .offset((bx4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -7851,7 +7851,7 @@ unsafe extern "C" fn reset_context(
         ::core::mem::size_of::<[[uint8_t; 32]; 2]>(),
     );
     memset(
-        ((*ctx).filter).as_mut_ptr() as *mut libc::c_void,
+        ((*ctx).filter.0).as_mut_ptr() as *mut libc::c_void,
         DAV1D_N_SWITCHABLE_FILTERS as libc::c_int,
         ::core::mem::size_of::<[[uint8_t; 32]; 2]>(),
     );

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3716,7 +3716,7 @@ unsafe fn decode_b(
             rep_macro(dir.seg_pred.0.as_mut_ptr(), off, mul * seg_pred as u64);
             rep_macro(dir.skip_mode.as_mut_ptr(), off, 0);
             rep_macro(dir.intra.as_mut_ptr(), off, mul);
-            rep_macro(dir.skip.as_mut_ptr(), off, mul * b.skip as u64);
+            rep_macro(dir.skip.0.as_mut_ptr(), off, mul * b.skip as u64);
             // see aomedia bug 2183 for why we use luma coordinates here
             rep_macro(
                 t.pal_sz_uv[diridx].as_mut_ptr(),
@@ -3938,7 +3938,7 @@ unsafe fn decode_b(
             rep_macro(dir.seg_pred.0.as_mut_ptr(), off, mul * seg_pred as u64);
             rep_macro(dir.skip_mode.as_mut_ptr(), off, 0);
             rep_macro(dir.intra.as_mut_ptr(), off, 0);
-            rep_macro(dir.skip.as_mut_ptr(), off, mul * b.skip as u64)
+            rep_macro(dir.skip.0.as_mut_ptr(), off, mul * b.skip as u64)
         };
         case_set(bh4, &mut t.l, 1, by4 as isize, &mut set_ctx);
         case_set(bw4, &mut *t.a, 0, bx4 as isize, &mut set_ctx);
@@ -5300,7 +5300,7 @@ unsafe fn decode_b(
                 (*(&mut *(t.l.intra).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = 0 as libc::c_int as uint8_t;
-                (*(&mut *(t.l.skip).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.skip.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * b.skip as libc::c_int) as uint8_t;
                 (*(&mut *(t.l.pal_sz).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
@@ -5358,7 +5358,7 @@ unsafe fn decode_b(
                 (*(&mut *(t.l.intra).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = 0 as libc::c_int as uint16_t;
-                (*(&mut *(t.l.skip).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.skip.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * b.skip as libc::c_int) as uint16_t;
                 (*(&mut *(t.l.pal_sz).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
@@ -5416,7 +5416,7 @@ unsafe fn decode_b(
                 (*(&mut *(t.l.intra).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = 0 as libc::c_int as uint32_t;
-                (*(&mut *(t.l.skip).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.skip.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(b.skip as libc::c_uint);
                 (*(&mut *(t.l.pal_sz).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
@@ -5471,7 +5471,7 @@ unsafe fn decode_b(
                 (*(&mut *(t.l.intra).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = 0 as libc::c_int as uint64_t;
-                (*(&mut *(t.l.skip).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.skip.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.skip as libc::c_ulonglong)
@@ -5552,10 +5552,10 @@ unsafe fn decode_b(
                 let const_val_126: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.skip as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(t.l.skip).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *(t.l.skip.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_126;
-                (*(&mut *(t.l.skip).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *(t.l.skip.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_126;
                 let const_val_127: uint64_t = 0 as libc::c_int as uint64_t;
@@ -5703,16 +5703,16 @@ unsafe fn decode_b(
                 let const_val_139: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.skip as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(t.l.skip).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *(t.l.skip.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_139;
-                (*(&mut *(t.l.skip).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *(t.l.skip.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_139;
-                (*(&mut *(t.l.skip).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
+                (*(&mut *(t.l.skip.0).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_139;
-                (*(&mut *(t.l.skip).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
+                (*(&mut *(t.l.skip.0).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_139;
                 let const_val_140: uint64_t = 0 as libc::c_int as uint64_t;
@@ -5900,7 +5900,7 @@ unsafe fn decode_b(
                 (*(&mut *((*t.a).intra).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = 0 as libc::c_int as uint8_t;
-                (*(&mut *((*t.a).skip).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).skip.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * b.skip as libc::c_int) as uint8_t;
                 (*(&mut *((*t.a).pal_sz).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
@@ -5958,7 +5958,7 @@ unsafe fn decode_b(
                 (*(&mut *((*t.a).intra).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = 0 as libc::c_int as uint16_t;
-                (*(&mut *((*t.a).skip).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).skip.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * b.skip as libc::c_int) as uint16_t;
                 (*(&mut *((*t.a).pal_sz).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
@@ -6016,7 +6016,7 @@ unsafe fn decode_b(
                 (*(&mut *((*t.a).intra).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = 0 as libc::c_int as uint32_t;
-                (*(&mut *((*t.a).skip).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).skip.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(b.skip as libc::c_uint);
                 (*(&mut *((*t.a).pal_sz).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
@@ -6071,7 +6071,7 @@ unsafe fn decode_b(
                 (*(&mut *((*t.a).intra).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = 0 as libc::c_int as uint64_t;
-                (*(&mut *((*t.a).skip).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).skip.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.skip as libc::c_ulonglong)
@@ -6160,10 +6160,10 @@ unsafe fn decode_b(
                 let const_val_152: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.skip as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).skip).as_mut_ptr().offset((bx4 + 0) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).skip.0).as_mut_ptr().offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_152;
-                (*(&mut *((*t.a).skip).as_mut_ptr().offset((bx4 + 8) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).skip.0).as_mut_ptr().offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_152;
                 let const_val_153: uint64_t = 0 as libc::c_int as uint64_t;
@@ -6331,16 +6331,16 @@ unsafe fn decode_b(
                 let const_val_165: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.skip as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).skip).as_mut_ptr().offset((bx4 + 0) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).skip.0).as_mut_ptr().offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_165;
-                (*(&mut *((*t.a).skip).as_mut_ptr().offset((bx4 + 8) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).skip.0).as_mut_ptr().offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_165;
-                (*(&mut *((*t.a).skip).as_mut_ptr().offset((bx4 + 16) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).skip.0).as_mut_ptr().offset((bx4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_165;
-                (*(&mut *((*t.a).skip).as_mut_ptr().offset((bx4 + 24) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).skip.0).as_mut_ptr().offset((bx4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_165;
                 let const_val_166: uint64_t = 0 as libc::c_int as uint64_t;
@@ -7794,7 +7794,7 @@ unsafe extern "C" fn reset_context(
         ::core::mem::size_of::<[uint8_t; 16]>(),
     );
     memset(
-        ((*ctx).skip).as_mut_ptr() as *mut libc::c_void,
+        ((*ctx).skip.0).as_mut_ptr() as *mut libc::c_void,
         0 as libc::c_int,
         ::core::mem::size_of::<[uint8_t; 32]>(),
     );

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2941,7 +2941,7 @@ unsafe fn decode_b(
             };
 
             let mut set_ctx = |dir: &mut BlockContext, _diridx, off, mul, rep_macro: SetCtxFn| {
-                rep_macro(dir.mode.as_mut_ptr(), off, mul * y_mode_nofilt as u64);
+                rep_macro(dir.mode.0.as_mut_ptr(), off, mul * y_mode_nofilt as u64);
                 rep_macro(dir.intra.as_mut_ptr(), off, mul);
             };
             case_set(bh4, &mut t.l, 1, by4 as isize, &mut set_ctx);
@@ -3406,8 +3406,8 @@ unsafe fn decode_b(
         let ymode_cdf = if frame_hdr.frame_type & 1 != 0 {
             &mut ts.cdf.m.y_mode[dav1d_ymode_size_context[bs as usize] as usize]
         } else {
-            &mut ts.cdf.kfym[dav1d_intra_mode_context[(*t.a).mode[bx4 as usize] as usize] as usize]
-                [dav1d_intra_mode_context[t.l.mode[by4 as usize] as usize] as usize]
+            &mut ts.cdf.kfym[dav1d_intra_mode_context[(*t.a).mode.0[bx4 as usize] as usize] as usize]
+                [dav1d_intra_mode_context[t.l.mode.0[by4 as usize] as usize] as usize]
         };
 
         *b.y_mode_mut() = dav1d_msac_decode_symbol_adapt16(
@@ -3711,7 +3711,7 @@ unsafe fn decode_b(
                 mul * lw_lh as u64,
             );
             rep_macro(dir.tx.as_mut_ptr() as *mut u8, off, mul * lw_lh as u64);
-            rep_macro(dir.mode.as_mut_ptr(), off, mul * y_mode_nofilt as u64);
+            rep_macro(dir.mode.0.as_mut_ptr(), off, mul * y_mode_nofilt as u64);
             rep_macro(dir.pal_sz.as_mut_ptr(), off, mul * b.pal_sz()[0] as u64);
             rep_macro(dir.seg_pred.as_mut_ptr(), off, mul * seg_pred as u64);
             rep_macro(dir.skip_mode.as_mut_ptr(), off, 0);
@@ -3931,7 +3931,7 @@ unsafe fn decode_b(
                 off,
                 mul * b_dim[2 + diridx] as u64,
             );
-            rep_macro(dir.mode.as_mut_ptr(), off, mul * DC_PRED as u64);
+            rep_macro(dir.mode.0.as_mut_ptr(), off, mul * DC_PRED as u64);
             rep_macro(dir.pal_sz.as_mut_ptr(), off, 0);
             // see aomedia bug 2183 for why this is outside `if has_chroma {}`
             rep_macro(t.pal_sz_uv[diridx].as_mut_ptr(), off, 0);
@@ -5330,7 +5330,7 @@ unsafe fn decode_b(
                     .u8_0 = (0x1 as libc::c_int as libc::c_uint)
                     .wrapping_mul(filter_0[1] as libc::c_uint)
                     as uint8_t;
-                (*(&mut *(t.l.mode).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.mode.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_int)
@@ -5388,7 +5388,7 @@ unsafe fn decode_b(
                     .u16_0 = (0x101 as libc::c_int as libc::c_uint)
                     .wrapping_mul(filter_0[1] as libc::c_uint)
                     as uint16_t;
-                (*(&mut *(t.l.mode).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.mode.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_int)
@@ -5441,7 +5441,7 @@ unsafe fn decode_b(
                     .as_mut_ptr()
                     .offset(by4 as isize) as *mut uint8_t as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(filter_0[1] as libc::c_uint);
-                (*(&mut *(t.l.mode).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.mode.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_uint);
@@ -5505,7 +5505,7 @@ unsafe fn decode_b(
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(filter_0[1] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(t.l.mode).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.mode.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_ulonglong)
@@ -5623,10 +5623,10 @@ unsafe fn decode_b(
                 let const_val_133: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(t.l.mode).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *(t.l.mode.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_133;
-                (*(&mut *(t.l.mode).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *(t.l.mode.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_133;
                 let const_val_134: uint64_t = (0x101010101010101 as libc::c_ulonglong)
@@ -5828,16 +5828,16 @@ unsafe fn decode_b(
                 let const_val_146: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(t.l.mode).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *(t.l.mode.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_146;
-                (*(&mut *(t.l.mode).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *(t.l.mode.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_146;
-                (*(&mut *(t.l.mode).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
+                (*(&mut *(t.l.mode.0).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_146;
-                (*(&mut *(t.l.mode).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
+                (*(&mut *(t.l.mode.0).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_146;
                 let const_val_147: uint64_t = (0x101010101010101 as libc::c_ulonglong)
@@ -5930,7 +5930,7 @@ unsafe fn decode_b(
                     .u8_0 = (0x1 as libc::c_int as libc::c_uint)
                     .wrapping_mul(filter_0[1] as libc::c_uint)
                     as uint8_t;
-                (*(&mut *((*t.a).mode).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).mode.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_int)
@@ -5988,7 +5988,7 @@ unsafe fn decode_b(
                     .u16_0 = (0x101 as libc::c_int as libc::c_uint)
                     .wrapping_mul(filter_0[1] as libc::c_uint)
                     as uint16_t;
-                (*(&mut *((*t.a).mode).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).mode.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_int)
@@ -6041,7 +6041,7 @@ unsafe fn decode_b(
                     .as_mut_ptr()
                     .offset(bx4 as isize) as *mut uint8_t as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(filter_0[1] as libc::c_uint);
-                (*(&mut *((*t.a).mode).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).mode.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_uint);
@@ -6105,7 +6105,7 @@ unsafe fn decode_b(
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(filter_0[1] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).mode).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).mode.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_ulonglong)
@@ -6235,10 +6235,10 @@ unsafe fn decode_b(
                 let const_val_159: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).mode).as_mut_ptr().offset((bx4 + 0) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).mode.0).as_mut_ptr().offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_159;
-                (*(&mut *((*t.a).mode).as_mut_ptr().offset((bx4 + 8) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).mode.0).as_mut_ptr().offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_159;
                 let const_val_160: uint64_t = (0x101010101010101 as libc::c_ulonglong)
@@ -6468,16 +6468,16 @@ unsafe fn decode_b(
                 let const_val_172: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).mode).as_mut_ptr().offset((bx4 + 0) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).mode.0).as_mut_ptr().offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_172;
-                (*(&mut *((*t.a).mode).as_mut_ptr().offset((bx4 + 8) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).mode.0).as_mut_ptr().offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_172;
-                (*(&mut *((*t.a).mode).as_mut_ptr().offset((bx4 + 16) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).mode.0).as_mut_ptr().offset((bx4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_172;
-                (*(&mut *((*t.a).mode).as_mut_ptr().offset((bx4 + 24) as isize) as *mut uint8_t
+                (*(&mut *((*t.a).mode.0).as_mut_ptr().offset((bx4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_172;
                 let const_val_173: uint64_t = (0x101010101010101 as libc::c_ulonglong)
@@ -7780,7 +7780,7 @@ unsafe extern "C" fn reset_context(
     );
     if keyframe != 0 {
         memset(
-            ((*ctx).mode).as_mut_ptr() as *mut libc::c_void,
+            ((*ctx).mode.0).as_mut_ptr() as *mut libc::c_void,
             DC_PRED as libc::c_int,
             ::core::mem::size_of::<[uint8_t; 32]>(),
         );
@@ -7835,7 +7835,7 @@ unsafe extern "C" fn reset_context(
             ::core::mem::size_of::<[uint8_t; 32]>(),
         );
         memset(
-            ((*ctx).mode).as_mut_ptr() as *mut libc::c_void,
+            ((*ctx).mode.0).as_mut_ptr() as *mut libc::c_void,
             NEARESTMV as libc::c_int,
             ::core::mem::size_of::<[uint8_t; 32]>(),
         );

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -7685,46 +7685,46 @@ unsafe extern "C" fn decode_sb(
     {
         match hsz {
             1 => {
-                (*(&mut *((*(*t).a).partition).as_mut_ptr().offset(bx8 as isize) as *mut uint8_t
+                (*(&mut *((*(*t).a).partition.0).as_mut_ptr().offset(bx8 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 as libc::c_int
                     * dav1d_al_part_ctx[0][bl as usize][bp as usize] as libc::c_int)
                     as uint8_t;
-                (*(&mut *((*t).l.partition).as_mut_ptr().offset(by8 as isize) as *mut uint8_t
+                (*(&mut *((*t).l.partition.0).as_mut_ptr().offset(by8 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 as libc::c_int
                     * dav1d_al_part_ctx[1][bl as usize][bp as usize] as libc::c_int)
                     as uint8_t;
             }
             2 => {
-                (*(&mut *((*(*t).a).partition).as_mut_ptr().offset(bx8 as isize) as *mut uint8_t
+                (*(&mut *((*(*t).a).partition.0).as_mut_ptr().offset(bx8 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 as libc::c_int
                     * dav1d_al_part_ctx[0][bl as usize][bp as usize] as libc::c_int)
                     as uint16_t;
-                (*(&mut *((*t).l.partition).as_mut_ptr().offset(by8 as isize) as *mut uint8_t
+                (*(&mut *((*t).l.partition.0).as_mut_ptr().offset(by8 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 as libc::c_int
                     * dav1d_al_part_ctx[1][bl as usize][bp as usize] as libc::c_int)
                     as uint16_t;
             }
             4 => {
-                (*(&mut *((*(*t).a).partition).as_mut_ptr().offset(bx8 as isize) as *mut uint8_t
+                (*(&mut *((*(*t).a).partition.0).as_mut_ptr().offset(bx8 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)
                     .wrapping_mul(dav1d_al_part_ctx[0][bl as usize][bp as usize] as libc::c_uint);
-                (*(&mut *((*t).l.partition).as_mut_ptr().offset(by8 as isize) as *mut uint8_t
+                (*(&mut *((*t).l.partition.0).as_mut_ptr().offset(by8 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)
                     .wrapping_mul(dav1d_al_part_ctx[1][bl as usize][bp as usize] as libc::c_uint);
             }
             8 => {
-                (*(&mut *((*(*t).a).partition).as_mut_ptr().offset(bx8 as isize) as *mut uint8_t
+                (*(&mut *((*(*t).a).partition.0).as_mut_ptr().offset(bx8 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong).wrapping_mul(
                     dav1d_al_part_ctx[0][bl as usize][bp as usize] as libc::c_ulonglong,
                 ) as uint64_t;
-                (*(&mut *((*t).l.partition).as_mut_ptr().offset(by8 as isize) as *mut uint8_t
+                (*(&mut *((*t).l.partition.0).as_mut_ptr().offset(by8 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong).wrapping_mul(
                     dav1d_al_part_ctx[1][bl as usize][bp as usize] as libc::c_ulonglong,
@@ -7734,12 +7734,12 @@ unsafe extern "C" fn decode_sb(
                 let const_val: uint64_t = (0x101010101010101 as libc::c_ulonglong).wrapping_mul(
                     dav1d_al_part_ctx[0][bl as usize][bp as usize] as libc::c_ulonglong,
                 ) as uint64_t;
-                (*(&mut *((*(*t).a).partition)
+                (*(&mut *((*(*t).a).partition.0)
                     .as_mut_ptr()
                     .offset((bx8 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val;
-                (*(&mut *((*(*t).a).partition)
+                (*(&mut *((*(*t).a).partition.0)
                     .as_mut_ptr()
                     .offset((bx8 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -7747,12 +7747,12 @@ unsafe extern "C" fn decode_sb(
                 let const_val_0: uint64_t = (0x101010101010101 as libc::c_ulonglong).wrapping_mul(
                     dav1d_al_part_ctx[1][bl as usize][bp as usize] as libc::c_ulonglong,
                 ) as uint64_t;
-                (*(&mut *((*t).l.partition)
+                (*(&mut *((*t).l.partition.0)
                     .as_mut_ptr()
                     .offset((by8 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_0;
-                (*(&mut *((*t).l.partition)
+                (*(&mut *((*t).l.partition.0)
                     .as_mut_ptr()
                     .offset((by8 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -7789,7 +7789,7 @@ unsafe extern "C" fn reset_context(
         return;
     }
     memset(
-        ((*ctx).partition).as_mut_ptr() as *mut libc::c_void,
+        ((*ctx).partition.0).as_mut_ptr() as *mut libc::c_void,
         0 as libc::c_int,
         ::core::mem::size_of::<[uint8_t; 16]>(),
     );

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3725,7 +3725,7 @@ unsafe fn decode_b(
             );
             if is_inter_or_switch(frame_hdr) {
                 rep_macro(
-                    dir.comp_type.as_mut_ptr(),
+                    dir.comp_type.0.as_mut_ptr(),
                     off,
                     mul * COMP_INTER_NONE as u64,
                 );
@@ -4438,9 +4438,9 @@ unsafe fn decode_b(
                                 == COMP_INTER_AVG as libc::c_int)
                                 as libc::c_int,
                             jnt_ctx as libc::c_int,
-                            (*t.a).comp_type[bx4 as usize] as libc::c_int,
+                            (*t.a).comp_type.0[bx4 as usize] as libc::c_int,
                             (*t.a).r#ref[0][bx4 as usize] as libc::c_int,
-                            t.l.comp_type[by4 as usize] as libc::c_int,
+                            t.l.comp_type.0[by4 as usize] as libc::c_int,
                             t.l.r#ref[0][by4 as usize] as libc::c_int,
                             ts.msac.rng,
                         );
@@ -5313,7 +5313,7 @@ unsafe fn decode_b(
                 (*(&mut *(t.l.tx_intra).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                     as *mut alias8))
                     .u8_0 = 0x1 * b_dim[2 + 1] as uint8_t;
-                (*(&mut *(t.l.comp_type).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.comp_type.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_int)
@@ -5371,7 +5371,7 @@ unsafe fn decode_b(
                 (*(&mut *(t.l.tx_intra).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                     as *mut alias16))
                     .u16_0 = 0x101 * b_dim[2 + 1] as uint16_t;
-                (*(&mut *(t.l.comp_type).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.comp_type.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_int)
@@ -5429,7 +5429,7 @@ unsafe fn decode_b(
                 (*(&mut *(t.l.tx_intra).as_mut_ptr().offset(by4 as isize) as *mut int8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(b_dim[2 + 1] as libc::c_uint);
-                (*(&mut *(t.l.comp_type).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.comp_type.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_uint);
@@ -5488,7 +5488,7 @@ unsafe fn decode_b(
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b_dim[2 + 1] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(t.l.comp_type).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *(t.l.comp_type.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_ulonglong)
@@ -5588,10 +5588,10 @@ unsafe fn decode_b(
                 let const_val_130: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(t.l.comp_type).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *(t.l.comp_type.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_130;
-                (*(&mut *(t.l.comp_type).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *(t.l.comp_type.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_130;
                 let const_val_131: uint64_t = (0x101010101010101 as libc::c_ulonglong)
@@ -5767,16 +5767,16 @@ unsafe fn decode_b(
                 let const_val_143: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *(t.l.comp_type).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *(t.l.comp_type.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_143;
-                (*(&mut *(t.l.comp_type).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *(t.l.comp_type.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_143;
-                (*(&mut *(t.l.comp_type).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
+                (*(&mut *(t.l.comp_type.0).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_143;
-                (*(&mut *(t.l.comp_type).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
+                (*(&mut *(t.l.comp_type.0).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_143;
                 let const_val_144: uint64_t = (0x101010101010101 as libc::c_ulonglong)
@@ -5913,7 +5913,7 @@ unsafe fn decode_b(
                 (*(&mut *((*t.a).tx_intra).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                     as *mut alias8))
                     .u8_0 = 0x1 * b_dim[2 + 0];
-                (*(&mut *((*t.a).comp_type).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).comp_type.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_int)
@@ -5971,7 +5971,7 @@ unsafe fn decode_b(
                 (*(&mut *((*t.a).tx_intra).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                     as *mut alias16))
                     .u16_0 = 0x101 * b_dim[2 + 0] as uint16_t;
-                (*(&mut *((*t.a).comp_type).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).comp_type.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 as libc::c_int
                     * b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_int)
@@ -6029,7 +6029,7 @@ unsafe fn decode_b(
                 (*(&mut *((*t.a).tx_intra).as_mut_ptr().offset(bx4 as isize) as *mut int8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(b_dim[2 + 0] as libc::c_uint);
-                (*(&mut *((*t.a).comp_type).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).comp_type.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 = (0x1010101 as libc::c_uint)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_uint);
@@ -6088,7 +6088,7 @@ unsafe fn decode_b(
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b_dim[2 + 0] as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).comp_type).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*t.a).comp_type.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_ulonglong)
@@ -6196,12 +6196,12 @@ unsafe fn decode_b(
                 let const_val_156: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).comp_type)
+                (*(&mut *((*t.a).comp_type.0)
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_156;
-                (*(&mut *((*t.a).comp_type)
+                (*(&mut *((*t.a).comp_type.0)
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -6399,22 +6399,22 @@ unsafe fn decode_b(
                 let const_val_169: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(b.c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t.a).comp_type)
+                (*(&mut *((*t.a).comp_type.0)
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_169;
-                (*(&mut *((*t.a).comp_type)
+                (*(&mut *((*t.a).comp_type.0)
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_169;
-                (*(&mut *((*t.a).comp_type)
+                (*(&mut *((*t.a).comp_type.0)
                     .as_mut_ptr()
                     .offset((bx4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_169;
-                (*(&mut *((*t.a).comp_type)
+                (*(&mut *((*t.a).comp_type.0)
                     .as_mut_ptr()
                     .offset((bx4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -7830,7 +7830,7 @@ unsafe extern "C" fn reset_context(
             ::core::mem::size_of::<[[int8_t; 32]; 2]>(),
         );
         memset(
-            ((*ctx).comp_type).as_mut_ptr() as *mut libc::c_void,
+            ((*ctx).comp_type.0).as_mut_ptr() as *mut libc::c_void,
             0 as libc::c_int,
             ::core::mem::size_of::<[uint8_t; 32]>(),
         );

--- a/src/env.rs
+++ b/src/env.rs
@@ -51,7 +51,7 @@ pub struct BlockContext {
     pub tx_intra: Align8<[int8_t; 32]>,
     pub tx: Align8<[int8_t; 32]>,
     pub tx_lpf_y: Align8<[uint8_t; 32]>,
-    pub tx_lpf_uv: [uint8_t; 32],
+    pub tx_lpf_uv: Align8<[uint8_t; 32]>,
     pub partition: [uint8_t; 16],
     pub uvmode: [uint8_t; 32],
     pub pal_sz: [uint8_t; 32],

--- a/src/env.rs
+++ b/src/env.rs
@@ -46,7 +46,7 @@ pub struct BlockContext {
     pub skip_mode: Align8<[uint8_t; 32]>,
     pub intra: Align8<[uint8_t; 32]>,
     pub comp_type: Align8<[uint8_t; 32]>,
-    pub r#ref: [[int8_t; 32]; 2],
+    pub r#ref: Align8<[[int8_t; 32]; 2]>,
     pub filter: [[uint8_t; 32]; 2],
     pub tx_intra: [int8_t; 32],
     pub tx: [int8_t; 32],

--- a/src/env.rs
+++ b/src/env.rs
@@ -43,7 +43,7 @@ pub struct BlockContext {
     pub ccoef: Align8<[[uint8_t; 32]; 2]>,
     pub seg_pred: Align8<[uint8_t; 32]>,
     pub skip: Align8<[uint8_t; 32]>,
-    pub skip_mode: [uint8_t; 32],
+    pub skip_mode: Align8<[uint8_t; 32]>,
     pub intra: [uint8_t; 32],
     pub comp_type: [uint8_t; 32],
     pub r#ref: [[int8_t; 32]; 2],

--- a/src/env.rs
+++ b/src/env.rs
@@ -40,7 +40,7 @@ use crate::src::tables::TxfmInfo;
 pub struct BlockContext {
     pub mode: Align8<[uint8_t; 32]>,
     pub lcoef: Align8<[uint8_t; 32]>,
-    pub ccoef: [[uint8_t; 32]; 2],
+    pub ccoef: Align8<[[uint8_t; 32]; 2]>,
     pub seg_pred: [uint8_t; 32],
     pub skip: [uint8_t; 32],
     pub skip_mode: [uint8_t; 32],

--- a/src/env.rs
+++ b/src/env.rs
@@ -52,7 +52,7 @@ pub struct BlockContext {
     pub tx: Align8<[int8_t; 32]>,
     pub tx_lpf_y: Align8<[uint8_t; 32]>,
     pub tx_lpf_uv: Align8<[uint8_t; 32]>,
-    pub partition: [uint8_t; 16],
+    pub partition: Align8<[uint8_t; 16]>,
     pub uvmode: [uint8_t; 32],
     pub pal_sz: [uint8_t; 32],
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -49,7 +49,7 @@ pub struct BlockContext {
     pub r#ref: Align8<[[int8_t; 32]; 2]>,
     pub filter: Align8<[[uint8_t; 32]; 2]>,
     pub tx_intra: Align8<[int8_t; 32]>,
-    pub tx: [int8_t; 32],
+    pub tx: Align8<[int8_t; 32]>,
     pub tx_lpf_y: [uint8_t; 32],
     pub tx_lpf_uv: [uint8_t; 32],
     pub partition: [uint8_t; 16],

--- a/src/env.rs
+++ b/src/env.rs
@@ -42,7 +42,7 @@ pub struct BlockContext {
     pub lcoef: Align8<[uint8_t; 32]>,
     pub ccoef: Align8<[[uint8_t; 32]; 2]>,
     pub seg_pred: Align8<[uint8_t; 32]>,
-    pub skip: [uint8_t; 32],
+    pub skip: Align8<[uint8_t; 32]>,
     pub skip_mode: [uint8_t; 32],
     pub intra: [uint8_t; 32],
     pub comp_type: [uint8_t; 32],

--- a/src/env.rs
+++ b/src/env.rs
@@ -48,7 +48,7 @@ pub struct BlockContext {
     pub comp_type: Align8<[uint8_t; 32]>,
     pub r#ref: Align8<[[int8_t; 32]; 2]>,
     pub filter: Align8<[[uint8_t; 32]; 2]>,
-    pub tx_intra: [int8_t; 32],
+    pub tx_intra: Align8<[int8_t; 32]>,
     pub tx: [int8_t; 32],
     pub tx_lpf_y: [uint8_t; 32],
     pub tx_lpf_uv: [uint8_t; 32],

--- a/src/env.rs
+++ b/src/env.rs
@@ -7,6 +7,7 @@ use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
 use crate::include::stddef::ptrdiff_t;
 use crate::include::stdint::int8_t;
 use crate::include::stdint::uint8_t;
+use crate::src::align::Align8;
 use crate::src::levels::mv;
 use crate::src::levels::BlockLevel;
 use crate::src::levels::TxfmSize;
@@ -37,7 +38,7 @@ use crate::src::tables::TxfmInfo;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct BlockContext {
-    pub mode: [uint8_t; 32],
+    pub mode: Align8<[uint8_t; 32]>,
     pub lcoef: [uint8_t; 32],
     pub ccoef: [[uint8_t; 32]; 2],
     pub seg_pred: [uint8_t; 32],

--- a/src/env.rs
+++ b/src/env.rs
@@ -44,7 +44,7 @@ pub struct BlockContext {
     pub seg_pred: Align8<[uint8_t; 32]>,
     pub skip: Align8<[uint8_t; 32]>,
     pub skip_mode: Align8<[uint8_t; 32]>,
-    pub intra: [uint8_t; 32],
+    pub intra: Align8<[uint8_t; 32]>,
     pub comp_type: [uint8_t; 32],
     pub r#ref: [[int8_t; 32]; 2],
     pub filter: [[uint8_t; 32]; 2],

--- a/src/env.rs
+++ b/src/env.rs
@@ -47,7 +47,7 @@ pub struct BlockContext {
     pub intra: Align8<[uint8_t; 32]>,
     pub comp_type: Align8<[uint8_t; 32]>,
     pub r#ref: Align8<[[int8_t; 32]; 2]>,
-    pub filter: [[uint8_t; 32]; 2],
+    pub filter: Align8<[[uint8_t; 32]; 2]>,
     pub tx_intra: [int8_t; 32],
     pub tx: [int8_t; 32],
     pub tx_lpf_y: [uint8_t; 32],

--- a/src/env.rs
+++ b/src/env.rs
@@ -53,7 +53,7 @@ pub struct BlockContext {
     pub tx_lpf_y: Align8<[uint8_t; 32]>,
     pub tx_lpf_uv: Align8<[uint8_t; 32]>,
     pub partition: Align8<[uint8_t; 16]>,
-    pub uvmode: [uint8_t; 32],
+    pub uvmode: Align8<[uint8_t; 32]>,
     pub pal_sz: [uint8_t; 32],
 }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -50,7 +50,7 @@ pub struct BlockContext {
     pub filter: Align8<[[uint8_t; 32]; 2]>,
     pub tx_intra: Align8<[int8_t; 32]>,
     pub tx: Align8<[int8_t; 32]>,
-    pub tx_lpf_y: [uint8_t; 32],
+    pub tx_lpf_y: Align8<[uint8_t; 32]>,
     pub tx_lpf_uv: [uint8_t; 32],
     pub partition: [uint8_t; 16],
     pub uvmode: [uint8_t; 32],

--- a/src/env.rs
+++ b/src/env.rs
@@ -39,7 +39,7 @@ use crate::src::tables::TxfmInfo;
 #[repr(C)]
 pub struct BlockContext {
     pub mode: Align8<[uint8_t; 32]>,
-    pub lcoef: [uint8_t; 32],
+    pub lcoef: Align8<[uint8_t; 32]>,
     pub ccoef: [[uint8_t; 32]; 2],
     pub seg_pred: [uint8_t; 32],
     pub skip: [uint8_t; 32],

--- a/src/env.rs
+++ b/src/env.rs
@@ -45,7 +45,7 @@ pub struct BlockContext {
     pub skip: Align8<[uint8_t; 32]>,
     pub skip_mode: Align8<[uint8_t; 32]>,
     pub intra: Align8<[uint8_t; 32]>,
-    pub comp_type: [uint8_t; 32],
+    pub comp_type: Align8<[uint8_t; 32]>,
     pub r#ref: [[int8_t; 32]; 2],
     pub filter: [[uint8_t; 32]; 2],
     pub tx_intra: [int8_t; 32],

--- a/src/env.rs
+++ b/src/env.rs
@@ -54,7 +54,7 @@ pub struct BlockContext {
     pub tx_lpf_uv: Align8<[uint8_t; 32]>,
     pub partition: Align8<[uint8_t; 16]>,
     pub uvmode: Align8<[uint8_t; 32]>,
-    pub pal_sz: [uint8_t; 32],
+    pub pal_sz: Align8<[uint8_t; 32]>,
 }
 
 #[inline]

--- a/src/env.rs
+++ b/src/env.rs
@@ -41,7 +41,7 @@ pub struct BlockContext {
     pub mode: Align8<[uint8_t; 32]>,
     pub lcoef: Align8<[uint8_t; 32]>,
     pub ccoef: Align8<[[uint8_t; 32]; 2]>,
-    pub seg_pred: [uint8_t; 32],
+    pub seg_pred: Align8<[uint8_t; 32]>,
     pub skip: [uint8_t; 32],
     pub skip_mode: [uint8_t; 32],
     pub intra: [uint8_t; 32],

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -270,7 +270,7 @@ pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
 }
 
 #[derive(Copy, Clone)]
-#[repr(C)]
+#[repr(C, align(64))]
 pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,

--- a/src/mc_tmpl_16.rs
+++ b/src/mc_tmpl_16.rs
@@ -4122,7 +4122,7 @@ unsafe extern "C" fn blend_v_c(
     w: libc::c_int,
     mut h: libc::c_int,
 ) {
-    let mask: *const uint8_t = &*dav1d_obmc_masks.as_ptr().offset(w as isize) as *const uint8_t;
+    let mask: *const uint8_t = &*dav1d_obmc_masks.0.as_ptr().offset(w as isize) as *const uint8_t;
     loop {
         let mut x = 0;
         while x < w * 3 >> 2 {
@@ -4148,7 +4148,8 @@ unsafe extern "C" fn blend_h_c(
     w: libc::c_int,
     mut h: libc::c_int,
 ) {
-    let mut mask: *const uint8_t = &*dav1d_obmc_masks.as_ptr().offset(h as isize) as *const uint8_t;
+    let mut mask: *const uint8_t =
+        &*dav1d_obmc_masks.0.as_ptr().offset(h as isize) as *const uint8_t;
     h = h * 3 >> 2;
     loop {
         let fresh0 = mask;

--- a/src/mc_tmpl_8.rs
+++ b/src/mc_tmpl_8.rs
@@ -3958,7 +3958,7 @@ unsafe extern "C" fn blend_v_c(
     w: libc::c_int,
     mut h: libc::c_int,
 ) {
-    let mask: *const uint8_t = &*dav1d_obmc_masks.as_ptr().offset(w as isize) as *const uint8_t;
+    let mask: *const uint8_t = &*dav1d_obmc_masks.0.as_ptr().offset(w as isize) as *const uint8_t;
     loop {
         let mut x = 0;
         while x < w * 3 >> 2 {
@@ -3984,7 +3984,8 @@ unsafe extern "C" fn blend_h_c(
     w: libc::c_int,
     mut h: libc::c_int,
 ) {
-    let mut mask: *const uint8_t = &*dav1d_obmc_masks.as_ptr().offset(h as isize) as *const uint8_t;
+    let mut mask: *const uint8_t =
+        &*dav1d_obmc_masks.0.as_ptr().offset(h as isize) as *const uint8_t;
     h = h * 3 >> 2;
     loop {
         let fresh0 = mask;

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -2962,37 +2962,37 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
         if has_chroma != 0 {
             match cbh4 {
                 1 => {
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
                 }
                 2 => {
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
                 }
                 4 => {
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias32))
@@ -3000,14 +3000,14 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                         .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
                 }
                 8 => {
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias64))
@@ -3019,12 +3019,12 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                     let const_val_3: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_3;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -3032,12 +3032,12 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                     let const_val_4: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_4;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -3047,22 +3047,22 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                     let const_val_5: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_5;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_5;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 16) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_5;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 24) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -3070,22 +3070,22 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                     let const_val_6: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_6;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_6;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 16) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_6;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 24) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -3095,37 +3095,37 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
             }
             match cbw4 {
                 1 => {
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
                 }
                 2 => {
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
                 }
                 4 => {
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias32))
@@ -3133,14 +3133,14 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                         .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
                 }
                 8 => {
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias64))
@@ -3152,12 +3152,12 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                     let const_val_7: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_7;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -3165,12 +3165,12 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                     let const_val_8: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_8;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -3180,22 +3180,22 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                     let const_val_9: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_9;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_9;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 16) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_9;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 24) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -3203,22 +3203,22 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                     let const_val_10: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_10;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_10;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 16) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_10;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 24) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -3474,10 +3474,10 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                 (*cbi_0.offset((*t).bx as isize)).eob[(1 + pl) as usize];
                             *fresh5 = decode_coefs(
                                 t,
-                                &mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(pl as isize))
+                                &mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(pl as isize))
                                     .as_mut_ptr()
                                     .offset((cbx4 + x) as isize),
-                                &mut *(*((*t).l.ccoef).as_mut_ptr().offset(pl as isize))
+                                &mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl as isize))
                                     .as_mut_ptr()
                                     .offset((cby4 + y) as isize),
                                 (*b).uvtx as RectTxfmSize,
@@ -3519,7 +3519,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                 (*f).bh - (*t).by + ss_ver >> ss_ver,
                             ) {
                                 1 => {
-                                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(pl as isize))
+                                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl as isize))
                                         .as_mut_ptr()
                                         .offset((cby4 + y) as isize)
                                         as *mut uint8_t
@@ -3527,7 +3527,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                         .u8_0 = (0x1 * cf_ctx_0 as libc::c_int) as uint8_t;
                                 }
                                 2 => {
-                                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(pl as isize))
+                                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl as isize))
                                         .as_mut_ptr()
                                         .offset((cby4 + y) as isize)
                                         as *mut uint8_t
@@ -3535,7 +3535,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                         .u16_0 = (0x101 * cf_ctx_0 as libc::c_int) as uint16_t;
                                 }
                                 4 => {
-                                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(pl as isize))
+                                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl as isize))
                                         .as_mut_ptr()
                                         .offset((cby4 + y) as isize)
                                         as *mut uint8_t
@@ -3544,7 +3544,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                         .wrapping_mul(cf_ctx_0 as libc::c_uint);
                                 }
                                 8 => {
-                                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(pl as isize))
+                                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl as isize))
                                         .as_mut_ptr()
                                         .offset((cby4 + y) as isize)
                                         as *mut uint8_t
@@ -3558,13 +3558,13 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                         as libc::c_ulonglong)
                                         .wrapping_mul(cf_ctx_0 as libc::c_ulonglong)
                                         as uint64_t;
-                                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(pl as isize))
+                                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl as isize))
                                         .as_mut_ptr()
                                         .offset((cby4 + y + 0) as isize)
                                         as *mut uint8_t
                                         as *mut alias64))
                                         .u64_0 = const_val_13;
-                                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(pl as isize))
+                                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl as isize))
                                         .as_mut_ptr()
                                         .offset((cby4 + y + 8) as isize)
                                         as *mut uint8_t
@@ -3573,7 +3573,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                 }
                                 _ => {
                                     memset(
-                                        &mut *(*((*t).l.ccoef).as_mut_ptr().offset(pl as isize))
+                                        &mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl as isize))
                                             .as_mut_ptr()
                                             .offset((cby4 + y) as isize)
                                             as *mut uint8_t
@@ -3591,7 +3591,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                 (*f).bw - (*t).bx + ss_hor >> ss_hor,
                             ) {
                                 1 => {
-                                    (*(&mut *(*((*(*t).a).ccoef)
+                                    (*(&mut *(*((*(*t).a).ccoef.0)
                                         .as_mut_ptr()
                                         .offset(pl as isize))
                                         .as_mut_ptr()
@@ -3601,7 +3601,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                         as uint8_t;
                                 }
                                 2 => {
-                                    (*(&mut *(*((*(*t).a).ccoef)
+                                    (*(&mut *(*((*(*t).a).ccoef.0)
                                         .as_mut_ptr()
                                         .offset(pl as isize))
                                         .as_mut_ptr()
@@ -3611,7 +3611,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                         as uint16_t;
                                 }
                                 4 => {
-                                    (*(&mut *(*((*(*t).a).ccoef)
+                                    (*(&mut *(*((*(*t).a).ccoef.0)
                                         .as_mut_ptr()
                                         .offset(pl as isize))
                                         .as_mut_ptr()
@@ -3621,7 +3621,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                         .wrapping_mul(cf_ctx_0 as libc::c_uint);
                                 }
                                 8 => {
-                                    (*(&mut *(*((*(*t).a).ccoef)
+                                    (*(&mut *(*((*(*t).a).ccoef.0)
                                         .as_mut_ptr()
                                         .offset(pl as isize))
                                         .as_mut_ptr()
@@ -3635,14 +3635,14 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                         as libc::c_ulonglong)
                                         .wrapping_mul(cf_ctx_0 as libc::c_ulonglong)
                                         as uint64_t;
-                                    (*(&mut *(*((*(*t).a).ccoef)
+                                    (*(&mut *(*((*(*t).a).ccoef.0)
                                         .as_mut_ptr()
                                         .offset(pl as isize))
                                         .as_mut_ptr()
                                         .offset((cbx4 + x + 0) as isize)
                                         as *mut uint8_t as *mut alias64))
                                         .u64_0 = const_val_14;
-                                    (*(&mut *(*((*(*t).a).ccoef)
+                                    (*(&mut *(*((*(*t).a).ccoef.0)
                                         .as_mut_ptr()
                                         .offset(pl as isize))
                                         .as_mut_ptr()
@@ -3652,7 +3652,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                 }
                                 _ => {
                                     memset(
-                                        &mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(pl as isize))
+                                        &mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(pl as isize))
                                             .as_mut_ptr()
                                             .offset((cbx4 + x) as isize)
                                             as *mut uint8_t
@@ -5103,12 +5103,12 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                     cf_0 = ((*t).c2rust_unnamed.cf_16bpc).as_mut_ptr();
                                     eob_0 = decode_coefs(
                                         t,
-                                        &mut *(*((*(*t).a).ccoef)
+                                        &mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
                                         .offset((cbx4 + x) as isize),
-                                        &mut *(*((*t).l.ccoef).as_mut_ptr().offset(pl_0 as isize))
+                                        &mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl_0 as isize))
                                             .as_mut_ptr()
                                             .offset((cby4 + y) as isize),
                                         (*b).uvtx as RectTxfmSize,
@@ -5144,7 +5144,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                         (*f).bh - (*t).by + ss_ver >> ss_ver,
                                     ) {
                                         1 => {
-                                            (*(&mut *(*((*t).l.ccoef)
+                                            (*(&mut *(*((*t).l.ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5154,7 +5154,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                                 .u8_0 = (0x1 * cf_ctx_0 as libc::c_int) as uint8_t;
                                         }
                                         2 => {
-                                            (*(&mut *(*((*t).l.ccoef)
+                                            (*(&mut *(*((*t).l.ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5165,7 +5165,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                                 (0x101 * cf_ctx_0 as libc::c_int) as uint16_t;
                                         }
                                         4 => {
-                                            (*(&mut *(*((*t).l.ccoef)
+                                            (*(&mut *(*((*t).l.ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5176,7 +5176,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                                 .wrapping_mul(cf_ctx_0 as libc::c_uint);
                                         }
                                         8 => {
-                                            (*(&mut *(*((*t).l.ccoef)
+                                            (*(&mut *(*((*t).l.ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5192,7 +5192,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                                 as libc::c_ulonglong)
                                                 .wrapping_mul(cf_ctx_0 as libc::c_ulonglong)
                                                 as uint64_t;
-                                            (*(&mut *(*((*t).l.ccoef)
+                                            (*(&mut *(*((*t).l.ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5200,7 +5200,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                                 as *mut uint8_t
                                                 as *mut alias64))
                                                 .u64_0 = const_val_3;
-                                            (*(&mut *(*((*t).l.ccoef)
+                                            (*(&mut *(*((*t).l.ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5211,7 +5211,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                         }
                                         _ => {
                                             memset(
-                                                &mut *(*((*t).l.ccoef)
+                                                &mut *(*((*t).l.ccoef.0)
                                                     .as_mut_ptr()
                                                     .offset(pl_0 as isize))
                                                 .as_mut_ptr()
@@ -5232,7 +5232,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                         (*f).bw - (*t).bx + ss_hor >> ss_hor,
                                     ) {
                                         1 => {
-                                            (*(&mut *(*((*(*t).a).ccoef)
+                                            (*(&mut *(*((*(*t).a).ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5242,7 +5242,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                                 .u8_0 = (0x1 * cf_ctx_0 as libc::c_int) as uint8_t;
                                         }
                                         2 => {
-                                            (*(&mut *(*((*(*t).a).ccoef)
+                                            (*(&mut *(*((*(*t).a).ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5253,7 +5253,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                                 (0x101 * cf_ctx_0 as libc::c_int) as uint16_t;
                                         }
                                         4 => {
-                                            (*(&mut *(*((*(*t).a).ccoef)
+                                            (*(&mut *(*((*(*t).a).ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5264,7 +5264,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                                 .wrapping_mul(cf_ctx_0 as libc::c_uint);
                                         }
                                         8 => {
-                                            (*(&mut *(*((*(*t).a).ccoef)
+                                            (*(&mut *(*((*(*t).a).ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5280,7 +5280,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                                 as libc::c_ulonglong)
                                                 .wrapping_mul(cf_ctx_0 as libc::c_ulonglong)
                                                 as uint64_t;
-                                            (*(&mut *(*((*(*t).a).ccoef)
+                                            (*(&mut *(*((*(*t).a).ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5288,7 +5288,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                                 as *mut uint8_t
                                                 as *mut alias64))
                                                 .u64_0 = const_val_4;
-                                            (*(&mut *(*((*(*t).a).ccoef)
+                                            (*(&mut *(*((*(*t).a).ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5299,7 +5299,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                         }
                                         _ => {
                                             memset(
-                                                &mut *(*((*(*t).a).ccoef)
+                                                &mut *(*((*(*t).a).ccoef.0)
                                                     .as_mut_ptr()
                                                     .offset(pl_0 as isize))
                                                 .as_mut_ptr()
@@ -5361,7 +5361,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                             } else if (*t).frame_thread.pass == 0 {
                                 match (*uv_t_dim).h as libc::c_int {
                                     1 => {
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5371,7 +5371,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                             .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
                                     }
                                     2 => {
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5381,7 +5381,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                             .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
                                     }
                                     4 => {
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5392,7 +5392,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                             .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
                                     }
                                     8 => {
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5408,7 +5408,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                             as libc::c_ulonglong)
                                             .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                                             as uint64_t;
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5416,7 +5416,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                             as *mut uint8_t
                                             as *mut alias64))
                                             .u64_0 = const_val_5;
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5429,7 +5429,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                 }
                                 match (*uv_t_dim).w as libc::c_int {
                                     1 => {
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5439,7 +5439,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                             .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
                                     }
                                     2 => {
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5449,7 +5449,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                             .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
                                     }
                                     4 => {
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5460,7 +5460,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                             .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
                                     }
                                     8 => {
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5476,7 +5476,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                             as libc::c_ulonglong)
                                             .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                                             as uint64_t;
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5484,7 +5484,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                             as *mut uint8_t
                                             as *mut alias64))
                                             .u64_0 = const_val_6;
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -6698,37 +6698,37 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
         if has_chroma != 0 {
             match cbh4 {
                 1 => {
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
                 }
                 2 => {
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
                 }
                 4 => {
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias32))
@@ -6736,14 +6736,14 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                         .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
                 }
                 8 => {
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias64))
@@ -6755,12 +6755,12 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                     let const_val_3: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_3;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -6768,12 +6768,12 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                     let const_val_4: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_4;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -6783,22 +6783,22 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                     let const_val_5: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_5;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_5;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 16) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_5;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 24) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -6806,22 +6806,22 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                     let const_val_6: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_6;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_6;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 16) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_6;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 24) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -6831,37 +6831,37 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
             }
             match cbw4 {
                 1 => {
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
                 }
                 2 => {
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
                 }
                 4 => {
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias32))
@@ -6869,14 +6869,14 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                         .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
                 }
                 8 => {
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias64))
@@ -6888,12 +6888,12 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                     let const_val_7: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_7;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -6901,12 +6901,12 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                     let const_val_8: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_8;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -6916,22 +6916,22 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                     let const_val_9: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_9;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_9;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 16) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_9;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 24) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -6939,22 +6939,22 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                     let const_val_10: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_10;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_10;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 16) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_10;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 24) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -7055,10 +7055,10 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                     as TxfmType;
                                 eob = decode_coefs(
                                     t,
-                                    &mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(pl_8 as isize))
+                                    &mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(pl_8 as isize))
                                         .as_mut_ptr()
                                         .offset((cbx4 + x_0) as isize),
-                                    &mut *(*((*t).l.ccoef).as_mut_ptr().offset(pl_8 as isize))
+                                    &mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl_8 as isize))
                                         .as_mut_ptr()
                                         .offset((cby4 + y) as isize),
                                     (*b).uvtx as RectTxfmSize,
@@ -7093,7 +7093,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                     (*f).bh - (*t).by + ss_ver >> ss_ver,
                                 ) {
                                     1 => {
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7103,7 +7103,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                             .u8_0 = (0x1 * cf_ctx as libc::c_int) as uint8_t;
                                     }
                                     2 => {
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7113,7 +7113,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                             .u16_0 = (0x101 * cf_ctx as libc::c_int) as uint16_t;
                                     }
                                     4 => {
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7124,7 +7124,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                             .wrapping_mul(cf_ctx as libc::c_uint);
                                     }
                                     8 => {
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7140,7 +7140,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                             as libc::c_ulonglong)
                                             .wrapping_mul(cf_ctx as libc::c_ulonglong)
                                             as uint64_t;
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7148,7 +7148,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                             as *mut uint8_t
                                             as *mut alias64))
                                             .u64_0 = const_val_11;
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7159,7 +7159,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                     }
                                     _ => {
                                         memset(
-                                            &mut *(*((*t).l.ccoef)
+                                            &mut *(*((*t).l.ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_8 as isize))
                                             .as_mut_ptr()
@@ -7179,7 +7179,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                     (*f).bw - (*t).bx + ss_hor >> ss_hor,
                                 ) {
                                     1 => {
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7189,7 +7189,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                             .u8_0 = (0x1 * cf_ctx as libc::c_int) as uint8_t;
                                     }
                                     2 => {
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7199,7 +7199,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                             .u16_0 = (0x101 * cf_ctx as libc::c_int) as uint16_t;
                                     }
                                     4 => {
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7210,7 +7210,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                             .wrapping_mul(cf_ctx as libc::c_uint);
                                     }
                                     8 => {
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7226,7 +7226,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                             as libc::c_ulonglong)
                                             .wrapping_mul(cf_ctx as libc::c_ulonglong)
                                             as uint64_t;
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7234,7 +7234,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                             as *mut uint8_t
                                             as *mut alias64))
                                             .u64_0 = const_val_12;
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7245,7 +7245,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                     }
                                     _ => {
                                         memset(
-                                            &mut *(*((*(*t).a).ccoef)
+                                            &mut *(*((*(*t).a).ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_8 as isize))
                                             .as_mut_ptr()

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -2630,15 +2630,11 @@ unsafe extern "C" fn read_coef_tree(
                     let const_val: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(cf_ctx as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *((*t).l.lcoef.0)
-                        .as_mut_ptr()
-                        .offset((by4 + 0) as isize) as *mut uint8_t
-                        as *mut alias64))
+                    (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 0) as isize)
+                        as *mut uint8_t as *mut alias64))
                         .u64_0 = const_val;
-                    (*(&mut *((*t).l.lcoef.0)
-                        .as_mut_ptr()
-                        .offset((by4 + 8) as isize) as *mut uint8_t
-                        as *mut alias64))
+                    (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 8) as isize)
+                        as *mut uint8_t as *mut alias64))
                         .u64_0 = const_val;
                 }
                 _ => {
@@ -2946,15 +2942,11 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_2;
-                (*(&mut *((*(*t).a).lcoef.0)
-                    .as_mut_ptr()
-                    .offset((bx4 + 16) as isize) as *mut uint8_t
-                    as *mut alias64))
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset((bx4 + 16) as isize)
+                    as *mut uint8_t as *mut alias64))
                     .u64_0 = const_val_2;
-                (*(&mut *((*(*t).a).lcoef.0)
-                    .as_mut_ptr()
-                    .offset((bx4 + 24) as isize) as *mut uint8_t
-                    as *mut alias64))
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset((bx4 + 24) as isize)
+                    as *mut uint8_t as *mut alias64))
                     .u64_0 = const_val_2;
             }
             _ => {}
@@ -3360,12 +3352,14 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                 (*(&mut *((*t).l.lcoef.0)
                                     .as_mut_ptr()
                                     .offset((by4 + y + 0) as isize)
-                                    as *mut uint8_t as *mut alias64))
+                                    as *mut uint8_t
+                                    as *mut alias64))
                                     .u64_0 = const_val_11;
                                 (*(&mut *((*t).l.lcoef.0)
                                     .as_mut_ptr()
                                     .offset((by4 + y + 8) as isize)
-                                    as *mut uint8_t as *mut alias64))
+                                    as *mut uint8_t
+                                    as *mut alias64))
                                     .u64_0 = const_val_11;
                             }
                             _ => {
@@ -3430,7 +3424,9 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                             }
                             _ => {
                                 memset(
-                                    &mut *((*(*t).a).lcoef.0).as_mut_ptr().offset((bx4 + x) as isize)
+                                    &mut *((*(*t).a).lcoef.0)
+                                        .as_mut_ptr()
+                                        .offset((bx4 + x) as isize)
                                         as *mut uint8_t
                                         as *mut libc::c_void,
                                     cf_ctx as libc::c_int,
@@ -3652,9 +3648,11 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                 }
                                 _ => {
                                     memset(
-                                        &mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(pl as isize))
+                                        &mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
-                                            .offset((cbx4 + x) as isize)
+                                            .offset(pl as isize))
+                                        .as_mut_ptr()
+                                        .offset((cbx4 + x) as isize)
                                             as *mut uint8_t
                                             as *mut libc::c_void,
                                         cf_ctx_0 as libc::c_int,
@@ -4452,22 +4450,24 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                 1 => {
                                     (*(&mut *((*t).l.lcoef.0)
                                         .as_mut_ptr()
-                                        .offset((by4 + y) as isize) as *mut uint8_t as *mut alias8))
-                                        .u8_0 = (0x1 * cf_ctx as libc::c_int)
-                                        as uint8_t;
+                                        .offset((by4 + y) as isize)
+                                        as *mut uint8_t
+                                        as *mut alias8))
+                                        .u8_0 = (0x1 * cf_ctx as libc::c_int) as uint8_t;
                                 }
                                 2 => {
                                     (*(&mut *((*t).l.lcoef.0)
                                         .as_mut_ptr()
-                                        .offset((by4 + y) as isize) as *mut uint8_t
+                                        .offset((by4 + y) as isize)
+                                        as *mut uint8_t
                                         as *mut alias16))
-                                        .u16_0 = (0x101 * cf_ctx as libc::c_int)
-                                        as uint16_t;
+                                        .u16_0 = (0x101 * cf_ctx as libc::c_int) as uint16_t;
                                 }
                                 4 => {
                                     (*(&mut *((*t).l.lcoef.0)
                                         .as_mut_ptr()
-                                        .offset((by4 + y) as isize) as *mut uint8_t
+                                        .offset((by4 + y) as isize)
+                                        as *mut uint8_t
                                         as *mut alias32))
                                         .u32_0 = (0x1010101 as libc::c_uint)
                                         .wrapping_mul(cf_ctx as libc::c_uint);
@@ -4475,10 +4475,12 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                 8 => {
                                     (*(&mut *((*t).l.lcoef.0)
                                         .as_mut_ptr()
-                                        .offset((by4 + y) as isize) as *mut uint8_t
+                                        .offset((by4 + y) as isize)
+                                        as *mut uint8_t
                                         as *mut alias64))
                                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
-                                        .wrapping_mul(cf_ctx as libc::c_ulonglong) as uint64_t;
+                                        .wrapping_mul(cf_ctx as libc::c_ulonglong)
+                                        as uint64_t;
                                 }
                                 16 => {
                                     let const_val: uint64_t = (0x101010101010101
@@ -4500,7 +4502,9 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                 }
                                 _ => {
                                     memset(
-                                        &mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
+                                        &mut *((*t).l.lcoef.0)
+                                            .as_mut_ptr()
+                                            .offset((by4 + y) as isize)
                                             as *mut uint8_t
                                             as *mut libc::c_void,
                                         cf_ctx as libc::c_int,
@@ -4656,12 +4660,14 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                 (*(&mut *((*t).l.lcoef.0)
                                     .as_mut_ptr()
                                     .offset((by4 + y + 0) as isize)
-                                    as *mut uint8_t as *mut alias64))
+                                    as *mut uint8_t
+                                    as *mut alias64))
                                     .u64_0 = const_val_1;
                                 (*(&mut *((*t).l.lcoef.0)
                                     .as_mut_ptr()
                                     .offset((by4 + y + 8) as isize)
-                                    as *mut uint8_t as *mut alias64))
+                                    as *mut uint8_t
+                                    as *mut alias64))
                                     .u64_0 = const_val_1;
                             }
                             _ => {}
@@ -5108,9 +5114,11 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
                                         .offset((cbx4 + x) as isize),
-                                        &mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl_0 as isize))
+                                        &mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
-                                            .offset((cby4 + y) as isize),
+                                            .offset(pl_0 as isize))
+                                        .as_mut_ptr()
+                                        .offset((cby4 + y) as isize),
                                         (*b).uvtx as RectTxfmSize,
                                         bs,
                                         b,
@@ -6682,15 +6690,11 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_2;
-                (*(&mut *((*(*t).a).lcoef.0)
-                    .as_mut_ptr()
-                    .offset((bx4 + 16) as isize) as *mut uint8_t
-                    as *mut alias64))
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset((bx4 + 16) as isize)
+                    as *mut uint8_t as *mut alias64))
                     .u64_0 = const_val_2;
-                (*(&mut *((*(*t).a).lcoef.0)
-                    .as_mut_ptr()
-                    .offset((bx4 + 24) as isize) as *mut uint8_t
-                    as *mut alias64))
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset((bx4 + 24) as isize)
+                    as *mut uint8_t as *mut alias64))
                     .u64_0 = const_val_2;
             }
             _ => {}

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -2576,8 +2576,8 @@ unsafe extern "C" fn read_coef_tree(
         if (*t).frame_thread.pass != 2 as libc::c_int {
             eob = decode_coefs(
                 t,
-                &mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize),
-                &mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize),
+                &mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize),
+                &mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize),
                 ytx,
                 bs,
                 b,
@@ -2605,22 +2605,22 @@ unsafe extern "C" fn read_coef_tree(
             }
             match imin(txh, (*f).bh - (*t).by) {
                 1 => {
-                    (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                    (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * cf_ctx as libc::c_int) as uint8_t;
                 }
                 2 => {
-                    (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                    (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * cf_ctx as libc::c_int) as uint16_t;
                 }
                 4 => {
-                    (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                    (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                         as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(cf_ctx as libc::c_uint);
                 }
                 8 => {
-                    (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                    (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(cf_ctx as libc::c_ulonglong)
@@ -2630,12 +2630,12 @@ unsafe extern "C" fn read_coef_tree(
                     let const_val: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(cf_ctx as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *((*t).l.lcoef)
+                    (*(&mut *((*t).l.lcoef.0)
                         .as_mut_ptr()
                         .offset((by4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val;
-                    (*(&mut *((*t).l.lcoef)
+                    (*(&mut *((*t).l.lcoef.0)
                         .as_mut_ptr()
                         .offset((by4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -2643,7 +2643,7 @@ unsafe extern "C" fn read_coef_tree(
                 }
                 _ => {
                     memset(
-                        &mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                        &mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                             as *mut libc::c_void,
                         cf_ctx as libc::c_int,
                         imin(txh, (*f).bh - (*t).by) as size_t,
@@ -2652,22 +2652,22 @@ unsafe extern "C" fn read_coef_tree(
             }
             match imin(txw, (*f).bw - (*t).bx) {
                 1 => {
-                    (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                    (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * cf_ctx as libc::c_int) as uint8_t;
                 }
                 2 => {
-                    (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                    (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * cf_ctx as libc::c_int) as uint16_t;
                 }
                 4 => {
-                    (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                    (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                         as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(cf_ctx as libc::c_uint);
                 }
                 8 => {
-                    (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                    (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(cf_ctx as libc::c_ulonglong)
@@ -2677,16 +2677,16 @@ unsafe extern "C" fn read_coef_tree(
                     let const_val_0: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(cf_ctx as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset((bx4 + 0) as isize)
+                    (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset((bx4 + 0) as isize)
                         as *mut uint8_t as *mut alias64))
                         .u64_0 = const_val_0;
-                    (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset((bx4 + 8) as isize)
+                    (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset((bx4 + 8) as isize)
                         as *mut uint8_t as *mut alias64))
                         .u64_0 = const_val_0;
                 }
                 _ => {
                     memset(
-                        &mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                        &mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                             as *mut libc::c_void,
                         cf_ctx as libc::c_int,
                         imin(txw, (*f).bw - (*t).bx) as size_t,
@@ -2841,23 +2841,23 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
     if (*b).skip != 0 {
         match bh4 {
             1 => {
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
             }
             2 => {
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
             }
             4 => {
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 =
                     (0x1010101 as libc::c_uint).wrapping_mul(0x40 as libc::c_int as libc::c_uint);
             }
             8 => {
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
@@ -2867,10 +2867,10 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                 let const_val: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val;
             }
@@ -2878,16 +2878,16 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                 let const_val_0: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_0;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_0;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_0;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_0;
             }
@@ -2895,23 +2895,23 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
         }
         match bw4 {
             1 => {
-                (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
             }
             2 => {
-                (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
             }
             4 => {
-                (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 =
                     (0x1010101 as libc::c_uint).wrapping_mul(0x40 as libc::c_int as libc::c_uint);
             }
             8 => {
-                (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
@@ -2921,12 +2921,12 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                 let const_val_1: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_1;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -2936,22 +2936,22 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                 let const_val_2: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_2;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_2;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_2;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -3290,8 +3290,8 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                         let ref mut fresh4 = (*cbi.offset((*t).bx as isize)).eob[0];
                         *fresh4 = decode_coefs(
                             t,
-                            &mut *((*(*t).a).lcoef).as_mut_ptr().offset((bx4 + x) as isize),
-                            &mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize),
+                            &mut *((*(*t).a).lcoef.0).as_mut_ptr().offset((bx4 + x) as isize),
+                            &mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize),
                             (*b).c2rust_unnamed.c2rust_unnamed.tx as RectTxfmSize,
                             bs,
                             b,
@@ -3326,26 +3326,26 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                         );
                         match imin((*t_dim).h as libc::c_int, (*f).bh - (*t).by) {
                             1 => {
-                                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize)
+                                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
                                     as *mut uint8_t
                                     as *mut alias8))
                                     .u8_0 = (0x1 * cf_ctx as libc::c_int) as uint8_t;
                             }
                             2 => {
-                                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize)
+                                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
                                     as *mut uint8_t
                                     as *mut alias16))
                                     .u16_0 = (0x101 * cf_ctx as libc::c_int) as uint16_t;
                             }
                             4 => {
-                                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize)
+                                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
                                     as *mut uint8_t
                                     as *mut alias32))
                                     .u32_0 = (0x1010101 as libc::c_uint)
                                     .wrapping_mul(cf_ctx as libc::c_uint);
                             }
                             8 => {
-                                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize)
+                                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
                                     as *mut uint8_t
                                     as *mut alias64))
                                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
@@ -3357,12 +3357,12 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                     as libc::c_ulonglong)
                                     .wrapping_mul(cf_ctx as libc::c_ulonglong)
                                     as uint64_t;
-                                (*(&mut *((*t).l.lcoef)
+                                (*(&mut *((*t).l.lcoef.0)
                                     .as_mut_ptr()
                                     .offset((by4 + y + 0) as isize)
                                     as *mut uint8_t as *mut alias64))
                                     .u64_0 = const_val_11;
-                                (*(&mut *((*t).l.lcoef)
+                                (*(&mut *((*t).l.lcoef.0)
                                     .as_mut_ptr()
                                     .offset((by4 + y + 8) as isize)
                                     as *mut uint8_t as *mut alias64))
@@ -3370,7 +3370,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                             }
                             _ => {
                                 memset(
-                                    &mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize)
+                                    &mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
                                         as *mut uint8_t
                                         as *mut libc::c_void,
                                     cf_ctx as libc::c_int,
@@ -3380,14 +3380,14 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                         }
                         match imin((*t_dim).w as libc::c_int, (*f).bw - (*t).bx) {
                             1 => {
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x) as isize) as *mut uint8_t as *mut alias8))
                                     .u8_0 = (0x1 * cf_ctx as libc::c_int)
                                     as uint8_t;
                             }
                             2 => {
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x) as isize) as *mut uint8_t
                                     as *mut alias16))
@@ -3395,7 +3395,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                     as uint16_t;
                             }
                             4 => {
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x) as isize) as *mut uint8_t
                                     as *mut alias32))
@@ -3403,7 +3403,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                     .wrapping_mul(cf_ctx as libc::c_uint);
                             }
                             8 => {
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x) as isize) as *mut uint8_t
                                     as *mut alias64))
@@ -3415,13 +3415,13 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                     as libc::c_ulonglong)
                                     .wrapping_mul(cf_ctx as libc::c_ulonglong)
                                     as uint64_t;
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x + 0) as isize)
                                     as *mut uint8_t
                                     as *mut alias64))
                                     .u64_0 = const_val_12;
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x + 8) as isize)
                                     as *mut uint8_t
@@ -3430,7 +3430,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                             }
                             _ => {
                                 memset(
-                                    &mut *((*(*t).a).lcoef).as_mut_ptr().offset((bx4 + x) as isize)
+                                    &mut *((*(*t).a).lcoef.0).as_mut_ptr().offset((bx4 + x) as isize)
                                         as *mut uint8_t
                                         as *mut libc::c_void,
                                     cf_ctx as libc::c_int,
@@ -4421,8 +4421,8 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                             cf = ((*t).c2rust_unnamed.cf_16bpc).as_mut_ptr();
                             eob = decode_coefs(
                                 t,
-                                &mut *((*(*t).a).lcoef).as_mut_ptr().offset((bx4 + x) as isize),
-                                &mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize),
+                                &mut *((*(*t).a).lcoef.0).as_mut_ptr().offset((bx4 + x) as isize),
+                                &mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize),
                                 (*b).c2rust_unnamed.c2rust_unnamed.tx as RectTxfmSize,
                                 bs,
                                 b,
@@ -4450,14 +4450,14 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                             }
                             match imin((*t_dim).h as libc::c_int, (*f).bh - (*t).by) {
                                 1 => {
-                                    (*(&mut *((*t).l.lcoef)
+                                    (*(&mut *((*t).l.lcoef.0)
                                         .as_mut_ptr()
                                         .offset((by4 + y) as isize) as *mut uint8_t as *mut alias8))
                                         .u8_0 = (0x1 * cf_ctx as libc::c_int)
                                         as uint8_t;
                                 }
                                 2 => {
-                                    (*(&mut *((*t).l.lcoef)
+                                    (*(&mut *((*t).l.lcoef.0)
                                         .as_mut_ptr()
                                         .offset((by4 + y) as isize) as *mut uint8_t
                                         as *mut alias16))
@@ -4465,7 +4465,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                         as uint16_t;
                                 }
                                 4 => {
-                                    (*(&mut *((*t).l.lcoef)
+                                    (*(&mut *((*t).l.lcoef.0)
                                         .as_mut_ptr()
                                         .offset((by4 + y) as isize) as *mut uint8_t
                                         as *mut alias32))
@@ -4473,7 +4473,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                         .wrapping_mul(cf_ctx as libc::c_uint);
                                 }
                                 8 => {
-                                    (*(&mut *((*t).l.lcoef)
+                                    (*(&mut *((*t).l.lcoef.0)
                                         .as_mut_ptr()
                                         .offset((by4 + y) as isize) as *mut uint8_t
                                         as *mut alias64))
@@ -4485,13 +4485,13 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                         as libc::c_ulonglong)
                                         .wrapping_mul(cf_ctx as libc::c_ulonglong)
                                         as uint64_t;
-                                    (*(&mut *((*t).l.lcoef)
+                                    (*(&mut *((*t).l.lcoef.0)
                                         .as_mut_ptr()
                                         .offset((by4 + y + 0) as isize)
                                         as *mut uint8_t
                                         as *mut alias64))
                                         .u64_0 = const_val;
-                                    (*(&mut *((*t).l.lcoef)
+                                    (*(&mut *((*t).l.lcoef.0)
                                         .as_mut_ptr()
                                         .offset((by4 + y + 8) as isize)
                                         as *mut uint8_t
@@ -4500,7 +4500,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                 }
                                 _ => {
                                     memset(
-                                        &mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize)
+                                        &mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
                                             as *mut uint8_t
                                             as *mut libc::c_void,
                                         cf_ctx as libc::c_int,
@@ -4511,7 +4511,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                             }
                             match imin((*t_dim).w as libc::c_int, (*f).bw - (*t).bx) {
                                 1 => {
-                                    (*(&mut *((*(*t).a).lcoef)
+                                    (*(&mut *((*(*t).a).lcoef.0)
                                         .as_mut_ptr()
                                         .offset((bx4 + x) as isize)
                                         as *mut uint8_t
@@ -4519,7 +4519,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                         .u8_0 = (0x1 * cf_ctx as libc::c_int) as uint8_t;
                                 }
                                 2 => {
-                                    (*(&mut *((*(*t).a).lcoef)
+                                    (*(&mut *((*(*t).a).lcoef.0)
                                         .as_mut_ptr()
                                         .offset((bx4 + x) as isize)
                                         as *mut uint8_t
@@ -4527,7 +4527,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                         .u16_0 = (0x101 * cf_ctx as libc::c_int) as uint16_t;
                                 }
                                 4 => {
-                                    (*(&mut *((*(*t).a).lcoef)
+                                    (*(&mut *((*(*t).a).lcoef.0)
                                         .as_mut_ptr()
                                         .offset((bx4 + x) as isize)
                                         as *mut uint8_t
@@ -4536,7 +4536,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                         .wrapping_mul(cf_ctx as libc::c_uint);
                                 }
                                 8 => {
-                                    (*(&mut *((*(*t).a).lcoef)
+                                    (*(&mut *((*(*t).a).lcoef.0)
                                         .as_mut_ptr()
                                         .offset((bx4 + x) as isize)
                                         as *mut uint8_t
@@ -4550,13 +4550,13 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                         as libc::c_ulonglong)
                                         .wrapping_mul(cf_ctx as libc::c_ulonglong)
                                         as uint64_t;
-                                    (*(&mut *((*(*t).a).lcoef)
+                                    (*(&mut *((*(*t).a).lcoef.0)
                                         .as_mut_ptr()
                                         .offset((bx4 + x + 0) as isize)
                                         as *mut uint8_t
                                         as *mut alias64))
                                         .u64_0 = const_val_0;
-                                    (*(&mut *((*(*t).a).lcoef)
+                                    (*(&mut *((*(*t).a).lcoef.0)
                                         .as_mut_ptr()
                                         .offset((bx4 + x + 8) as isize)
                                         as *mut uint8_t
@@ -4565,7 +4565,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                 }
                                 _ => {
                                     memset(
-                                        &mut *((*(*t).a).lcoef)
+                                        &mut *((*(*t).a).lcoef.0)
                                             .as_mut_ptr()
                                             .offset((bx4 + x) as isize)
                                             as *mut uint8_t
@@ -4623,26 +4623,26 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                     } else if (*t).frame_thread.pass == 0 {
                         match (*t_dim).h as libc::c_int {
                             1 => {
-                                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize)
+                                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
                                     as *mut uint8_t
                                     as *mut alias8))
                                     .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
                             }
                             2 => {
-                                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize)
+                                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
                                     as *mut uint8_t
                                     as *mut alias16))
                                     .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
                             }
                             4 => {
-                                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize)
+                                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
                                     as *mut uint8_t
                                     as *mut alias32))
                                     .u32_0 = (0x1010101 as libc::c_uint)
                                     .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
                             }
                             8 => {
-                                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize)
+                                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
                                     as *mut uint8_t
                                     as *mut alias64))
                                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
@@ -4653,12 +4653,12 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                 let const_val_1: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                                     as uint64_t;
-                                (*(&mut *((*t).l.lcoef)
+                                (*(&mut *((*t).l.lcoef.0)
                                     .as_mut_ptr()
                                     .offset((by4 + y + 0) as isize)
                                     as *mut uint8_t as *mut alias64))
                                     .u64_0 = const_val_1;
-                                (*(&mut *((*t).l.lcoef)
+                                (*(&mut *((*t).l.lcoef.0)
                                     .as_mut_ptr()
                                     .offset((by4 + y + 8) as isize)
                                     as *mut uint8_t as *mut alias64))
@@ -4668,14 +4668,14 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                         }
                         match (*t_dim).w as libc::c_int {
                             1 => {
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x) as isize) as *mut uint8_t as *mut alias8))
                                     .u8_0 = (0x1 * 0x40 as libc::c_int)
                                     as uint8_t;
                             }
                             2 => {
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x) as isize) as *mut uint8_t
                                     as *mut alias16))
@@ -4683,7 +4683,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                     as uint16_t;
                             }
                             4 => {
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x) as isize) as *mut uint8_t
                                     as *mut alias32))
@@ -4691,7 +4691,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                     .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
                             }
                             8 => {
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x) as isize) as *mut uint8_t
                                     as *mut alias64))
@@ -4703,13 +4703,13 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                 let const_val_2: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                                     as uint64_t;
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x + 0) as isize)
                                     as *mut uint8_t
                                     as *mut alias64))
                                     .u64_0 = const_val_2;
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x + 8) as isize)
                                     as *mut uint8_t
@@ -6577,23 +6577,23 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
     if (*b).skip != 0 {
         match bh4 {
             1 => {
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
             }
             2 => {
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
             }
             4 => {
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 =
                     (0x1010101 as libc::c_uint).wrapping_mul(0x40 as libc::c_int as libc::c_uint);
             }
             8 => {
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
@@ -6603,10 +6603,10 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                 let const_val: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val;
             }
@@ -6614,16 +6614,16 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                 let const_val_0: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_0;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_0;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_0;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_0;
             }
@@ -6631,23 +6631,23 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
         }
         match bw4 {
             1 => {
-                (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
             }
             2 => {
-                (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
             }
             4 => {
-                (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 =
                     (0x1010101 as libc::c_uint).wrapping_mul(0x40 as libc::c_int as libc::c_uint);
             }
             8 => {
-                (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
@@ -6657,12 +6657,12 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                 let const_val_1: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_1;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -6672,22 +6672,22 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                 let const_val_2: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_2;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_2;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_2;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -2791,8 +2791,8 @@ unsafe extern "C" fn read_coef_tree(
         if (*t).frame_thread.pass != 2 as libc::c_int {
             eob = decode_coefs(
                 t,
-                &mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize),
-                &mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize),
+                &mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize),
+                &mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize),
                 ytx,
                 bs,
                 b,
@@ -2820,22 +2820,22 @@ unsafe extern "C" fn read_coef_tree(
             }
             match imin(txh, (*f).bh - (*t).by) {
                 1 => {
-                    (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                    (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * cf_ctx as libc::c_int) as uint8_t;
                 }
                 2 => {
-                    (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                    (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * cf_ctx as libc::c_int) as uint16_t;
                 }
                 4 => {
-                    (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                    (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                         as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(cf_ctx as libc::c_uint);
                 }
                 8 => {
-                    (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                    (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(cf_ctx as libc::c_ulonglong)
@@ -2845,12 +2845,12 @@ unsafe extern "C" fn read_coef_tree(
                     let const_val: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(cf_ctx as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *((*t).l.lcoef)
+                    (*(&mut *((*t).l.lcoef.0)
                         .as_mut_ptr()
                         .offset((by4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val;
-                    (*(&mut *((*t).l.lcoef)
+                    (*(&mut *((*t).l.lcoef.0)
                         .as_mut_ptr()
                         .offset((by4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -2858,7 +2858,7 @@ unsafe extern "C" fn read_coef_tree(
                 }
                 _ => {
                     memset(
-                        &mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                        &mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                             as *mut libc::c_void,
                         cf_ctx as libc::c_int,
                         imin(txh, (*f).bh - (*t).by) as size_t,
@@ -2867,22 +2867,22 @@ unsafe extern "C" fn read_coef_tree(
             }
             match imin(txw, (*f).bw - (*t).bx) {
                 1 => {
-                    (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                    (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * cf_ctx as libc::c_int) as uint8_t;
                 }
                 2 => {
-                    (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                    (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * cf_ctx as libc::c_int) as uint16_t;
                 }
                 4 => {
-                    (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                    (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                         as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(cf_ctx as libc::c_uint);
                 }
                 8 => {
-                    (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                    (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(cf_ctx as libc::c_ulonglong)
@@ -2892,16 +2892,16 @@ unsafe extern "C" fn read_coef_tree(
                     let const_val_0: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(cf_ctx as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset((bx4 + 0) as isize)
+                    (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset((bx4 + 0) as isize)
                         as *mut uint8_t as *mut alias64))
                         .u64_0 = const_val_0;
-                    (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset((bx4 + 8) as isize)
+                    (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset((bx4 + 8) as isize)
                         as *mut uint8_t as *mut alias64))
                         .u64_0 = const_val_0;
                 }
                 _ => {
                     memset(
-                        &mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                        &mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                             as *mut libc::c_void,
                         cf_ctx as libc::c_int,
                         imin(txw, (*f).bw - (*t).bx) as size_t,
@@ -3052,23 +3052,23 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
     if (*b).skip != 0 {
         match bh4 {
             1 => {
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
             }
             2 => {
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
             }
             4 => {
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 =
                     (0x1010101 as libc::c_uint).wrapping_mul(0x40 as libc::c_int as libc::c_uint);
             }
             8 => {
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
@@ -3078,10 +3078,10 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                 let const_val: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val;
             }
@@ -3089,16 +3089,16 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                 let const_val_0: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_0;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_0;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_0;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_0;
             }
@@ -3106,23 +3106,23 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
         }
         match bw4 {
             1 => {
-                (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
             }
             2 => {
-                (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
             }
             4 => {
-                (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 =
                     (0x1010101 as libc::c_uint).wrapping_mul(0x40 as libc::c_int as libc::c_uint);
             }
             8 => {
-                (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
@@ -3132,12 +3132,12 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                 let const_val_1: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_1;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -3147,22 +3147,22 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                 let const_val_2: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_2;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_2;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_2;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -3501,8 +3501,8 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                         let ref mut fresh4 = (*cbi.offset((*t).bx as isize)).eob[0];
                         *fresh4 = decode_coefs(
                             t,
-                            &mut *((*(*t).a).lcoef).as_mut_ptr().offset((bx4 + x) as isize),
-                            &mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize),
+                            &mut *((*(*t).a).lcoef.0).as_mut_ptr().offset((bx4 + x) as isize),
+                            &mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize),
                             (*b).c2rust_unnamed.c2rust_unnamed.tx as RectTxfmSize,
                             bs,
                             b,
@@ -3537,26 +3537,26 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                         );
                         match imin((*t_dim).h as libc::c_int, (*f).bh - (*t).by) {
                             1 => {
-                                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize)
+                                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
                                     as *mut uint8_t
                                     as *mut alias8))
                                     .u8_0 = (0x1 * cf_ctx as libc::c_int) as uint8_t;
                             }
                             2 => {
-                                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize)
+                                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
                                     as *mut uint8_t
                                     as *mut alias16))
                                     .u16_0 = (0x101 * cf_ctx as libc::c_int) as uint16_t;
                             }
                             4 => {
-                                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize)
+                                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
                                     as *mut uint8_t
                                     as *mut alias32))
                                     .u32_0 = (0x1010101 as libc::c_uint)
                                     .wrapping_mul(cf_ctx as libc::c_uint);
                             }
                             8 => {
-                                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize)
+                                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
                                     as *mut uint8_t
                                     as *mut alias64))
                                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
@@ -3568,12 +3568,12 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                     as libc::c_ulonglong)
                                     .wrapping_mul(cf_ctx as libc::c_ulonglong)
                                     as uint64_t;
-                                (*(&mut *((*t).l.lcoef)
+                                (*(&mut *((*t).l.lcoef.0)
                                     .as_mut_ptr()
                                     .offset((by4 + y + 0) as isize)
                                     as *mut uint8_t as *mut alias64))
                                     .u64_0 = const_val_11;
-                                (*(&mut *((*t).l.lcoef)
+                                (*(&mut *((*t).l.lcoef.0)
                                     .as_mut_ptr()
                                     .offset((by4 + y + 8) as isize)
                                     as *mut uint8_t as *mut alias64))
@@ -3581,7 +3581,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                             }
                             _ => {
                                 memset(
-                                    &mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize)
+                                    &mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
                                         as *mut uint8_t
                                         as *mut libc::c_void,
                                     cf_ctx as libc::c_int,
@@ -3591,14 +3591,14 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                         }
                         match imin((*t_dim).w as libc::c_int, (*f).bw - (*t).bx) {
                             1 => {
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x) as isize) as *mut uint8_t as *mut alias8))
                                     .u8_0 = (0x1 * cf_ctx as libc::c_int)
                                     as uint8_t;
                             }
                             2 => {
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x) as isize) as *mut uint8_t
                                     as *mut alias16))
@@ -3606,7 +3606,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                     as uint16_t;
                             }
                             4 => {
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x) as isize) as *mut uint8_t
                                     as *mut alias32))
@@ -3614,7 +3614,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                     .wrapping_mul(cf_ctx as libc::c_uint);
                             }
                             8 => {
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x) as isize) as *mut uint8_t
                                     as *mut alias64))
@@ -3626,13 +3626,13 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                     as libc::c_ulonglong)
                                     .wrapping_mul(cf_ctx as libc::c_ulonglong)
                                     as uint64_t;
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x + 0) as isize)
                                     as *mut uint8_t
                                     as *mut alias64))
                                     .u64_0 = const_val_12;
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x + 8) as isize)
                                     as *mut uint8_t
@@ -3641,7 +3641,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                             }
                             _ => {
                                 memset(
-                                    &mut *((*(*t).a).lcoef).as_mut_ptr().offset((bx4 + x) as isize)
+                                    &mut *((*(*t).a).lcoef.0).as_mut_ptr().offset((bx4 + x) as isize)
                                         as *mut uint8_t
                                         as *mut libc::c_void,
                                     cf_ctx as libc::c_int,
@@ -4618,8 +4618,8 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                             cf = ((*t).c2rust_unnamed.cf_8bpc).as_mut_ptr();
                             eob = decode_coefs(
                                 t,
-                                &mut *((*(*t).a).lcoef).as_mut_ptr().offset((bx4 + x) as isize),
-                                &mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize),
+                                &mut *((*(*t).a).lcoef.0).as_mut_ptr().offset((bx4 + x) as isize),
+                                &mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize),
                                 (*b).c2rust_unnamed.c2rust_unnamed.tx as RectTxfmSize,
                                 bs,
                                 b,
@@ -4647,14 +4647,14 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                             }
                             match imin((*t_dim).h as libc::c_int, (*f).bh - (*t).by) {
                                 1 => {
-                                    (*(&mut *((*t).l.lcoef)
+                                    (*(&mut *((*t).l.lcoef.0)
                                         .as_mut_ptr()
                                         .offset((by4 + y) as isize) as *mut uint8_t as *mut alias8))
                                         .u8_0 = (0x1 * cf_ctx as libc::c_int)
                                         as uint8_t;
                                 }
                                 2 => {
-                                    (*(&mut *((*t).l.lcoef)
+                                    (*(&mut *((*t).l.lcoef.0)
                                         .as_mut_ptr()
                                         .offset((by4 + y) as isize) as *mut uint8_t
                                         as *mut alias16))
@@ -4662,7 +4662,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                         as uint16_t;
                                 }
                                 4 => {
-                                    (*(&mut *((*t).l.lcoef)
+                                    (*(&mut *((*t).l.lcoef.0)
                                         .as_mut_ptr()
                                         .offset((by4 + y) as isize) as *mut uint8_t
                                         as *mut alias32))
@@ -4670,7 +4670,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                         .wrapping_mul(cf_ctx as libc::c_uint);
                                 }
                                 8 => {
-                                    (*(&mut *((*t).l.lcoef)
+                                    (*(&mut *((*t).l.lcoef.0)
                                         .as_mut_ptr()
                                         .offset((by4 + y) as isize) as *mut uint8_t
                                         as *mut alias64))
@@ -4682,13 +4682,13 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                         as libc::c_ulonglong)
                                         .wrapping_mul(cf_ctx as libc::c_ulonglong)
                                         as uint64_t;
-                                    (*(&mut *((*t).l.lcoef)
+                                    (*(&mut *((*t).l.lcoef.0)
                                         .as_mut_ptr()
                                         .offset((by4 + y + 0) as isize)
                                         as *mut uint8_t
                                         as *mut alias64))
                                         .u64_0 = const_val;
-                                    (*(&mut *((*t).l.lcoef)
+                                    (*(&mut *((*t).l.lcoef.0)
                                         .as_mut_ptr()
                                         .offset((by4 + y + 8) as isize)
                                         as *mut uint8_t
@@ -4697,7 +4697,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                 }
                                 _ => {
                                     memset(
-                                        &mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize)
+                                        &mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
                                             as *mut uint8_t
                                             as *mut libc::c_void,
                                         cf_ctx as libc::c_int,
@@ -4708,7 +4708,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                             }
                             match imin((*t_dim).w as libc::c_int, (*f).bw - (*t).bx) {
                                 1 => {
-                                    (*(&mut *((*(*t).a).lcoef)
+                                    (*(&mut *((*(*t).a).lcoef.0)
                                         .as_mut_ptr()
                                         .offset((bx4 + x) as isize)
                                         as *mut uint8_t
@@ -4716,7 +4716,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                         .u8_0 = (0x1 * cf_ctx as libc::c_int) as uint8_t;
                                 }
                                 2 => {
-                                    (*(&mut *((*(*t).a).lcoef)
+                                    (*(&mut *((*(*t).a).lcoef.0)
                                         .as_mut_ptr()
                                         .offset((bx4 + x) as isize)
                                         as *mut uint8_t
@@ -4724,7 +4724,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                         .u16_0 = (0x101 * cf_ctx as libc::c_int) as uint16_t;
                                 }
                                 4 => {
-                                    (*(&mut *((*(*t).a).lcoef)
+                                    (*(&mut *((*(*t).a).lcoef.0)
                                         .as_mut_ptr()
                                         .offset((bx4 + x) as isize)
                                         as *mut uint8_t
@@ -4733,7 +4733,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                         .wrapping_mul(cf_ctx as libc::c_uint);
                                 }
                                 8 => {
-                                    (*(&mut *((*(*t).a).lcoef)
+                                    (*(&mut *((*(*t).a).lcoef.0)
                                         .as_mut_ptr()
                                         .offset((bx4 + x) as isize)
                                         as *mut uint8_t
@@ -4747,13 +4747,13 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                         as libc::c_ulonglong)
                                         .wrapping_mul(cf_ctx as libc::c_ulonglong)
                                         as uint64_t;
-                                    (*(&mut *((*(*t).a).lcoef)
+                                    (*(&mut *((*(*t).a).lcoef.0)
                                         .as_mut_ptr()
                                         .offset((bx4 + x + 0) as isize)
                                         as *mut uint8_t
                                         as *mut alias64))
                                         .u64_0 = const_val_0;
-                                    (*(&mut *((*(*t).a).lcoef)
+                                    (*(&mut *((*(*t).a).lcoef.0)
                                         .as_mut_ptr()
                                         .offset((bx4 + x + 8) as isize)
                                         as *mut uint8_t
@@ -4762,7 +4762,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                 }
                                 _ => {
                                     memset(
-                                        &mut *((*(*t).a).lcoef)
+                                        &mut *((*(*t).a).lcoef.0)
                                             .as_mut_ptr()
                                             .offset((bx4 + x) as isize)
                                             as *mut uint8_t
@@ -4819,26 +4819,26 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                     } else if (*t).frame_thread.pass == 0 {
                         match (*t_dim).h as libc::c_int {
                             1 => {
-                                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize)
+                                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
                                     as *mut uint8_t
                                     as *mut alias8))
                                     .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
                             }
                             2 => {
-                                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize)
+                                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
                                     as *mut uint8_t
                                     as *mut alias16))
                                     .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
                             }
                             4 => {
-                                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize)
+                                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
                                     as *mut uint8_t
                                     as *mut alias32))
                                     .u32_0 = (0x1010101 as libc::c_uint)
                                     .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
                             }
                             8 => {
-                                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + y) as isize)
+                                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
                                     as *mut uint8_t
                                     as *mut alias64))
                                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
@@ -4849,12 +4849,12 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                 let const_val_1: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                                     as uint64_t;
-                                (*(&mut *((*t).l.lcoef)
+                                (*(&mut *((*t).l.lcoef.0)
                                     .as_mut_ptr()
                                     .offset((by4 + y + 0) as isize)
                                     as *mut uint8_t as *mut alias64))
                                     .u64_0 = const_val_1;
-                                (*(&mut *((*t).l.lcoef)
+                                (*(&mut *((*t).l.lcoef.0)
                                     .as_mut_ptr()
                                     .offset((by4 + y + 8) as isize)
                                     as *mut uint8_t as *mut alias64))
@@ -4864,14 +4864,14 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                         }
                         match (*t_dim).w as libc::c_int {
                             1 => {
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x) as isize) as *mut uint8_t as *mut alias8))
                                     .u8_0 = (0x1 * 0x40 as libc::c_int)
                                     as uint8_t;
                             }
                             2 => {
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x) as isize) as *mut uint8_t
                                     as *mut alias16))
@@ -4879,7 +4879,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                     as uint16_t;
                             }
                             4 => {
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x) as isize) as *mut uint8_t
                                     as *mut alias32))
@@ -4887,7 +4887,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                     .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
                             }
                             8 => {
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x) as isize) as *mut uint8_t
                                     as *mut alias64))
@@ -4899,13 +4899,13 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                 let const_val_2: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                                     as uint64_t;
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x + 0) as isize)
                                     as *mut uint8_t
                                     as *mut alias64))
                                     .u64_0 = const_val_2;
-                                (*(&mut *((*(*t).a).lcoef)
+                                (*(&mut *((*(*t).a).lcoef.0)
                                     .as_mut_ptr()
                                     .offset((bx4 + x + 8) as isize)
                                     as *mut uint8_t
@@ -6748,23 +6748,23 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
     if (*b).skip != 0 {
         match bh4 {
             1 => {
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
             }
             2 => {
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
             }
             4 => {
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 =
                     (0x1010101 as libc::c_uint).wrapping_mul(0x40 as libc::c_int as libc::c_uint);
             }
             8 => {
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset(by4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
@@ -6774,10 +6774,10 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                 let const_val: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val;
             }
@@ -6785,16 +6785,16 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                 let const_val_0: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_0;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_0;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_0;
-                (*(&mut *((*t).l.lcoef).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
+                (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_0;
             }
@@ -6802,23 +6802,23 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
         }
         match bw4 {
             1 => {
-                (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias8))
                     .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
             }
             2 => {
-                (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias16))
                     .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
             }
             4 => {
-                (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias32))
                     .u32_0 =
                     (0x1010101 as libc::c_uint).wrapping_mul(0x40 as libc::c_int as libc::c_uint);
             }
             8 => {
-                (*(&mut *((*(*t).a).lcoef).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset(bx4 as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
@@ -6828,12 +6828,12 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                 let const_val_1: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_1;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
@@ -6843,22 +6843,22 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                 let const_val_2: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                     .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                     as uint64_t;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 0) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_2;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_2;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 16) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_2;
-                (*(&mut *((*(*t).a).lcoef)
+                (*(&mut *((*(*t).a).lcoef.0)
                     .as_mut_ptr()
                     .offset((bx4 + 24) as isize) as *mut uint8_t
                     as *mut alias64))

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -3173,37 +3173,37 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
         if has_chroma != 0 {
             match cbh4 {
                 1 => {
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
                 }
                 2 => {
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
                 }
                 4 => {
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias32))
@@ -3211,14 +3211,14 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                         .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
                 }
                 8 => {
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias64))
@@ -3230,12 +3230,12 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                     let const_val_3: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_3;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -3243,12 +3243,12 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                     let const_val_4: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_4;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -3258,22 +3258,22 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                     let const_val_5: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_5;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_5;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 16) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_5;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 24) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -3281,22 +3281,22 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                     let const_val_6: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_6;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_6;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 16) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_6;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 24) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -3306,37 +3306,37 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
             }
             match cbw4 {
                 1 => {
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
                 }
                 2 => {
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
                 }
                 4 => {
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias32))
@@ -3344,14 +3344,14 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                         .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
                 }
                 8 => {
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias64))
@@ -3363,12 +3363,12 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                     let const_val_7: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_7;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -3376,12 +3376,12 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                     let const_val_8: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_8;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -3391,22 +3391,22 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                     let const_val_9: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_9;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_9;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 16) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_9;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 24) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -3414,22 +3414,22 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                     let const_val_10: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_10;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_10;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 16) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_10;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 24) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -3685,10 +3685,10 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                 (*cbi_0.offset((*t).bx as isize)).eob[(1 + pl) as usize];
                             *fresh5 = decode_coefs(
                                 t,
-                                &mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(pl as isize))
+                                &mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(pl as isize))
                                     .as_mut_ptr()
                                     .offset((cbx4 + x) as isize),
-                                &mut *(*((*t).l.ccoef).as_mut_ptr().offset(pl as isize))
+                                &mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl as isize))
                                     .as_mut_ptr()
                                     .offset((cby4 + y) as isize),
                                 (*b).uvtx as RectTxfmSize,
@@ -3730,7 +3730,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                 (*f).bh - (*t).by + ss_ver >> ss_ver,
                             ) {
                                 1 => {
-                                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(pl as isize))
+                                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl as isize))
                                         .as_mut_ptr()
                                         .offset((cby4 + y) as isize)
                                         as *mut uint8_t
@@ -3738,7 +3738,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                         .u8_0 = (0x1 * cf_ctx_0 as libc::c_int) as uint8_t;
                                 }
                                 2 => {
-                                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(pl as isize))
+                                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl as isize))
                                         .as_mut_ptr()
                                         .offset((cby4 + y) as isize)
                                         as *mut uint8_t
@@ -3746,7 +3746,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                         .u16_0 = (0x101 * cf_ctx_0 as libc::c_int) as uint16_t;
                                 }
                                 4 => {
-                                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(pl as isize))
+                                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl as isize))
                                         .as_mut_ptr()
                                         .offset((cby4 + y) as isize)
                                         as *mut uint8_t
@@ -3755,7 +3755,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                         .wrapping_mul(cf_ctx_0 as libc::c_uint);
                                 }
                                 8 => {
-                                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(pl as isize))
+                                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl as isize))
                                         .as_mut_ptr()
                                         .offset((cby4 + y) as isize)
                                         as *mut uint8_t
@@ -3769,13 +3769,13 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                         as libc::c_ulonglong)
                                         .wrapping_mul(cf_ctx_0 as libc::c_ulonglong)
                                         as uint64_t;
-                                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(pl as isize))
+                                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl as isize))
                                         .as_mut_ptr()
                                         .offset((cby4 + y + 0) as isize)
                                         as *mut uint8_t
                                         as *mut alias64))
                                         .u64_0 = const_val_13;
-                                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(pl as isize))
+                                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl as isize))
                                         .as_mut_ptr()
                                         .offset((cby4 + y + 8) as isize)
                                         as *mut uint8_t
@@ -3784,7 +3784,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                 }
                                 _ => {
                                     memset(
-                                        &mut *(*((*t).l.ccoef).as_mut_ptr().offset(pl as isize))
+                                        &mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl as isize))
                                             .as_mut_ptr()
                                             .offset((cby4 + y) as isize)
                                             as *mut uint8_t
@@ -3802,7 +3802,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                 (*f).bw - (*t).bx + ss_hor >> ss_hor,
                             ) {
                                 1 => {
-                                    (*(&mut *(*((*(*t).a).ccoef)
+                                    (*(&mut *(*((*(*t).a).ccoef.0)
                                         .as_mut_ptr()
                                         .offset(pl as isize))
                                         .as_mut_ptr()
@@ -3812,7 +3812,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                         as uint8_t;
                                 }
                                 2 => {
-                                    (*(&mut *(*((*(*t).a).ccoef)
+                                    (*(&mut *(*((*(*t).a).ccoef.0)
                                         .as_mut_ptr()
                                         .offset(pl as isize))
                                         .as_mut_ptr()
@@ -3822,7 +3822,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                         as uint16_t;
                                 }
                                 4 => {
-                                    (*(&mut *(*((*(*t).a).ccoef)
+                                    (*(&mut *(*((*(*t).a).ccoef.0)
                                         .as_mut_ptr()
                                         .offset(pl as isize))
                                         .as_mut_ptr()
@@ -3832,7 +3832,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                         .wrapping_mul(cf_ctx_0 as libc::c_uint);
                                 }
                                 8 => {
-                                    (*(&mut *(*((*(*t).a).ccoef)
+                                    (*(&mut *(*((*(*t).a).ccoef.0)
                                         .as_mut_ptr()
                                         .offset(pl as isize))
                                         .as_mut_ptr()
@@ -3846,14 +3846,14 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                         as libc::c_ulonglong)
                                         .wrapping_mul(cf_ctx_0 as libc::c_ulonglong)
                                         as uint64_t;
-                                    (*(&mut *(*((*(*t).a).ccoef)
+                                    (*(&mut *(*((*(*t).a).ccoef.0)
                                         .as_mut_ptr()
                                         .offset(pl as isize))
                                         .as_mut_ptr()
                                         .offset((cbx4 + x + 0) as isize)
                                         as *mut uint8_t as *mut alias64))
                                         .u64_0 = const_val_14;
-                                    (*(&mut *(*((*(*t).a).ccoef)
+                                    (*(&mut *(*((*(*t).a).ccoef.0)
                                         .as_mut_ptr()
                                         .offset(pl as isize))
                                         .as_mut_ptr()
@@ -3863,7 +3863,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                 }
                                 _ => {
                                     memset(
-                                        &mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(pl as isize))
+                                        &mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(pl as isize))
                                             .as_mut_ptr()
                                             .offset((cbx4 + x) as isize)
                                             as *mut uint8_t
@@ -5291,12 +5291,12 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                     cf_0 = ((*t).c2rust_unnamed.cf_8bpc).as_mut_ptr();
                                     eob_0 = decode_coefs(
                                         t,
-                                        &mut *(*((*(*t).a).ccoef)
+                                        &mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
                                         .offset((cbx4 + x) as isize),
-                                        &mut *(*((*t).l.ccoef).as_mut_ptr().offset(pl_0 as isize))
+                                        &mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl_0 as isize))
                                             .as_mut_ptr()
                                             .offset((cby4 + y) as isize),
                                         (*b).uvtx as RectTxfmSize,
@@ -5332,7 +5332,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                         (*f).bh - (*t).by + ss_ver >> ss_ver,
                                     ) {
                                         1 => {
-                                            (*(&mut *(*((*t).l.ccoef)
+                                            (*(&mut *(*((*t).l.ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5342,7 +5342,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                                 .u8_0 = (0x1 * cf_ctx_0 as libc::c_int) as uint8_t;
                                         }
                                         2 => {
-                                            (*(&mut *(*((*t).l.ccoef)
+                                            (*(&mut *(*((*t).l.ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5353,7 +5353,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                                 (0x101 * cf_ctx_0 as libc::c_int) as uint16_t;
                                         }
                                         4 => {
-                                            (*(&mut *(*((*t).l.ccoef)
+                                            (*(&mut *(*((*t).l.ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5364,7 +5364,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                                 .wrapping_mul(cf_ctx_0 as libc::c_uint);
                                         }
                                         8 => {
-                                            (*(&mut *(*((*t).l.ccoef)
+                                            (*(&mut *(*((*t).l.ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5380,7 +5380,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                                 as libc::c_ulonglong)
                                                 .wrapping_mul(cf_ctx_0 as libc::c_ulonglong)
                                                 as uint64_t;
-                                            (*(&mut *(*((*t).l.ccoef)
+                                            (*(&mut *(*((*t).l.ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5388,7 +5388,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                                 as *mut uint8_t
                                                 as *mut alias64))
                                                 .u64_0 = const_val_3;
-                                            (*(&mut *(*((*t).l.ccoef)
+                                            (*(&mut *(*((*t).l.ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5399,7 +5399,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                         }
                                         _ => {
                                             memset(
-                                                &mut *(*((*t).l.ccoef)
+                                                &mut *(*((*t).l.ccoef.0)
                                                     .as_mut_ptr()
                                                     .offset(pl_0 as isize))
                                                 .as_mut_ptr()
@@ -5420,7 +5420,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                         (*f).bw - (*t).bx + ss_hor >> ss_hor,
                                     ) {
                                         1 => {
-                                            (*(&mut *(*((*(*t).a).ccoef)
+                                            (*(&mut *(*((*(*t).a).ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5430,7 +5430,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                                 .u8_0 = (0x1 * cf_ctx_0 as libc::c_int) as uint8_t;
                                         }
                                         2 => {
-                                            (*(&mut *(*((*(*t).a).ccoef)
+                                            (*(&mut *(*((*(*t).a).ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5441,7 +5441,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                                 (0x101 * cf_ctx_0 as libc::c_int) as uint16_t;
                                         }
                                         4 => {
-                                            (*(&mut *(*((*(*t).a).ccoef)
+                                            (*(&mut *(*((*(*t).a).ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5452,7 +5452,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                                 .wrapping_mul(cf_ctx_0 as libc::c_uint);
                                         }
                                         8 => {
-                                            (*(&mut *(*((*(*t).a).ccoef)
+                                            (*(&mut *(*((*(*t).a).ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5468,7 +5468,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                                 as libc::c_ulonglong)
                                                 .wrapping_mul(cf_ctx_0 as libc::c_ulonglong)
                                                 as uint64_t;
-                                            (*(&mut *(*((*(*t).a).ccoef)
+                                            (*(&mut *(*((*(*t).a).ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5476,7 +5476,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                                 as *mut uint8_t
                                                 as *mut alias64))
                                                 .u64_0 = const_val_4;
-                                            (*(&mut *(*((*(*t).a).ccoef)
+                                            (*(&mut *(*((*(*t).a).ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_0 as isize))
                                             .as_mut_ptr()
@@ -5487,7 +5487,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                         }
                                         _ => {
                                             memset(
-                                                &mut *(*((*(*t).a).ccoef)
+                                                &mut *(*((*(*t).a).ccoef.0)
                                                     .as_mut_ptr()
                                                     .offset(pl_0 as isize))
                                                 .as_mut_ptr()
@@ -5545,7 +5545,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                             } else if (*t).frame_thread.pass == 0 {
                                 match (*uv_t_dim).h as libc::c_int {
                                     1 => {
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5555,7 +5555,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                             .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
                                     }
                                     2 => {
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5565,7 +5565,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                             .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
                                     }
                                     4 => {
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5576,7 +5576,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                             .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
                                     }
                                     8 => {
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5592,7 +5592,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                             as libc::c_ulonglong)
                                             .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                                             as uint64_t;
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5600,7 +5600,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                             as *mut uint8_t
                                             as *mut alias64))
                                             .u64_0 = const_val_5;
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5613,7 +5613,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                 }
                                 match (*uv_t_dim).w as libc::c_int {
                                     1 => {
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5623,7 +5623,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                             .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
                                     }
                                     2 => {
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5633,7 +5633,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                             .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
                                     }
                                     4 => {
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5644,7 +5644,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                             .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
                                     }
                                     8 => {
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5660,7 +5660,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                             as libc::c_ulonglong)
                                             .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                                             as uint64_t;
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -5668,7 +5668,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                             as *mut uint8_t
                                             as *mut alias64))
                                             .u64_0 = const_val_6;
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
@@ -6869,37 +6869,37 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
         if has_chroma != 0 {
             match cbh4 {
                 1 => {
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
                 }
                 2 => {
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
                 }
                 4 => {
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias32))
@@ -6907,14 +6907,14 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                         .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
                 }
                 8 => {
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cby4 as isize) as *mut uint8_t
                         as *mut alias64))
@@ -6926,12 +6926,12 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                     let const_val_3: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_3;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -6939,12 +6939,12 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                     let const_val_4: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_4;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -6954,22 +6954,22 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                     let const_val_5: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_5;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_5;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 16) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_5;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cby4 + 24) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -6977,22 +6977,22 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                     let const_val_6: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_6;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_6;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 16) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_6;
-                    (*(&mut *(*((*t).l.ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cby4 + 24) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -7002,37 +7002,37 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
             }
             match cbw4 {
                 1 => {
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias8))
                         .u8_0 = (0x1 * 0x40 as libc::c_int) as uint8_t;
                 }
                 2 => {
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias16))
                         .u16_0 = (0x101 * 0x40 as libc::c_int) as uint16_t;
                 }
                 4 => {
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias32))
                         .u32_0 = (0x1010101 as libc::c_uint)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias32))
@@ -7040,14 +7040,14 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                         .wrapping_mul(0x40 as libc::c_int as libc::c_uint);
                 }
                 8 => {
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset(cbx4 as isize) as *mut uint8_t
                         as *mut alias64))
@@ -7059,12 +7059,12 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                     let const_val_7: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_7;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -7072,12 +7072,12 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                     let const_val_8: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_8;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -7087,22 +7087,22 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                     let const_val_9: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_9;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_9;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 16) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_9;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(0))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(0))
                         .as_mut_ptr()
                         .offset((cbx4 + 24) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -7110,22 +7110,22 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                     let const_val_10: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(0x40 as libc::c_int as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 0) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_10;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 8) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_10;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 16) as isize) as *mut uint8_t
                         as *mut alias64))
                         .u64_0 = const_val_10;
-                    (*(&mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(1))
+                    (*(&mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(1))
                         .as_mut_ptr()
                         .offset((cbx4 + 24) as isize) as *mut uint8_t
                         as *mut alias64))
@@ -7224,10 +7224,10 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                     as TxfmType;
                                 eob = decode_coefs(
                                     t,
-                                    &mut *(*((*(*t).a).ccoef).as_mut_ptr().offset(pl_8 as isize))
+                                    &mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(pl_8 as isize))
                                         .as_mut_ptr()
                                         .offset((cbx4 + x_0) as isize),
-                                    &mut *(*((*t).l.ccoef).as_mut_ptr().offset(pl_8 as isize))
+                                    &mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl_8 as isize))
                                         .as_mut_ptr()
                                         .offset((cby4 + y) as isize),
                                     (*b).uvtx as RectTxfmSize,
@@ -7262,7 +7262,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                     (*f).bh - (*t).by + ss_ver >> ss_ver,
                                 ) {
                                     1 => {
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7272,7 +7272,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                             .u8_0 = (0x1 * cf_ctx as libc::c_int) as uint8_t;
                                     }
                                     2 => {
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7282,7 +7282,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                             .u16_0 = (0x101 * cf_ctx as libc::c_int) as uint16_t;
                                     }
                                     4 => {
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7293,7 +7293,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                             .wrapping_mul(cf_ctx as libc::c_uint);
                                     }
                                     8 => {
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7309,7 +7309,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                             as libc::c_ulonglong)
                                             .wrapping_mul(cf_ctx as libc::c_ulonglong)
                                             as uint64_t;
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7317,7 +7317,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                             as *mut uint8_t
                                             as *mut alias64))
                                             .u64_0 = const_val_11;
-                                        (*(&mut *(*((*t).l.ccoef)
+                                        (*(&mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7328,7 +7328,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                     }
                                     _ => {
                                         memset(
-                                            &mut *(*((*t).l.ccoef)
+                                            &mut *(*((*t).l.ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_8 as isize))
                                             .as_mut_ptr()
@@ -7348,7 +7348,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                     (*f).bw - (*t).bx + ss_hor >> ss_hor,
                                 ) {
                                     1 => {
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7358,7 +7358,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                             .u8_0 = (0x1 * cf_ctx as libc::c_int) as uint8_t;
                                     }
                                     2 => {
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7368,7 +7368,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                             .u16_0 = (0x101 * cf_ctx as libc::c_int) as uint16_t;
                                     }
                                     4 => {
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7379,7 +7379,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                             .wrapping_mul(cf_ctx as libc::c_uint);
                                     }
                                     8 => {
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7395,7 +7395,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                             as libc::c_ulonglong)
                                             .wrapping_mul(cf_ctx as libc::c_ulonglong)
                                             as uint64_t;
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7403,7 +7403,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                             as *mut uint8_t
                                             as *mut alias64))
                                             .u64_0 = const_val_12;
-                                        (*(&mut *(*((*(*t).a).ccoef)
+                                        (*(&mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
                                             .offset(pl_8 as isize))
                                         .as_mut_ptr()
@@ -7414,7 +7414,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                     }
                                     _ => {
                                         memset(
-                                            &mut *(*((*(*t).a).ccoef)
+                                            &mut *(*((*(*t).a).ccoef.0)
                                                 .as_mut_ptr()
                                                 .offset(pl_8 as isize))
                                             .as_mut_ptr()

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -2845,15 +2845,11 @@ unsafe extern "C" fn read_coef_tree(
                     let const_val: uint64_t = (0x101010101010101 as libc::c_ulonglong)
                         .wrapping_mul(cf_ctx as libc::c_ulonglong)
                         as uint64_t;
-                    (*(&mut *((*t).l.lcoef.0)
-                        .as_mut_ptr()
-                        .offset((by4 + 0) as isize) as *mut uint8_t
-                        as *mut alias64))
+                    (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 0) as isize)
+                        as *mut uint8_t as *mut alias64))
                         .u64_0 = const_val;
-                    (*(&mut *((*t).l.lcoef.0)
-                        .as_mut_ptr()
-                        .offset((by4 + 8) as isize) as *mut uint8_t
-                        as *mut alias64))
+                    (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + 8) as isize)
+                        as *mut uint8_t as *mut alias64))
                         .u64_0 = const_val;
                 }
                 _ => {
@@ -3157,15 +3153,11 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_2;
-                (*(&mut *((*(*t).a).lcoef.0)
-                    .as_mut_ptr()
-                    .offset((bx4 + 16) as isize) as *mut uint8_t
-                    as *mut alias64))
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset((bx4 + 16) as isize)
+                    as *mut uint8_t as *mut alias64))
                     .u64_0 = const_val_2;
-                (*(&mut *((*(*t).a).lcoef.0)
-                    .as_mut_ptr()
-                    .offset((bx4 + 24) as isize) as *mut uint8_t
-                    as *mut alias64))
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset((bx4 + 24) as isize)
+                    as *mut uint8_t as *mut alias64))
                     .u64_0 = const_val_2;
             }
             _ => {}
@@ -3571,12 +3563,14 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                 (*(&mut *((*t).l.lcoef.0)
                                     .as_mut_ptr()
                                     .offset((by4 + y + 0) as isize)
-                                    as *mut uint8_t as *mut alias64))
+                                    as *mut uint8_t
+                                    as *mut alias64))
                                     .u64_0 = const_val_11;
                                 (*(&mut *((*t).l.lcoef.0)
                                     .as_mut_ptr()
                                     .offset((by4 + y + 8) as isize)
-                                    as *mut uint8_t as *mut alias64))
+                                    as *mut uint8_t
+                                    as *mut alias64))
                                     .u64_0 = const_val_11;
                             }
                             _ => {
@@ -3641,7 +3635,9 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                             }
                             _ => {
                                 memset(
-                                    &mut *((*(*t).a).lcoef.0).as_mut_ptr().offset((bx4 + x) as isize)
+                                    &mut *((*(*t).a).lcoef.0)
+                                        .as_mut_ptr()
+                                        .offset((bx4 + x) as isize)
                                         as *mut uint8_t
                                         as *mut libc::c_void,
                                     cf_ctx as libc::c_int,
@@ -3863,9 +3859,11 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                 }
                                 _ => {
                                     memset(
-                                        &mut *(*((*(*t).a).ccoef.0).as_mut_ptr().offset(pl as isize))
+                                        &mut *(*((*(*t).a).ccoef.0)
                                             .as_mut_ptr()
-                                            .offset((cbx4 + x) as isize)
+                                            .offset(pl as isize))
+                                        .as_mut_ptr()
+                                        .offset((cbx4 + x) as isize)
                                             as *mut uint8_t
                                             as *mut libc::c_void,
                                         cf_ctx_0 as libc::c_int,
@@ -4649,22 +4647,24 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                 1 => {
                                     (*(&mut *((*t).l.lcoef.0)
                                         .as_mut_ptr()
-                                        .offset((by4 + y) as isize) as *mut uint8_t as *mut alias8))
-                                        .u8_0 = (0x1 * cf_ctx as libc::c_int)
-                                        as uint8_t;
+                                        .offset((by4 + y) as isize)
+                                        as *mut uint8_t
+                                        as *mut alias8))
+                                        .u8_0 = (0x1 * cf_ctx as libc::c_int) as uint8_t;
                                 }
                                 2 => {
                                     (*(&mut *((*t).l.lcoef.0)
                                         .as_mut_ptr()
-                                        .offset((by4 + y) as isize) as *mut uint8_t
+                                        .offset((by4 + y) as isize)
+                                        as *mut uint8_t
                                         as *mut alias16))
-                                        .u16_0 = (0x101 * cf_ctx as libc::c_int)
-                                        as uint16_t;
+                                        .u16_0 = (0x101 * cf_ctx as libc::c_int) as uint16_t;
                                 }
                                 4 => {
                                     (*(&mut *((*t).l.lcoef.0)
                                         .as_mut_ptr()
-                                        .offset((by4 + y) as isize) as *mut uint8_t
+                                        .offset((by4 + y) as isize)
+                                        as *mut uint8_t
                                         as *mut alias32))
                                         .u32_0 = (0x1010101 as libc::c_uint)
                                         .wrapping_mul(cf_ctx as libc::c_uint);
@@ -4672,10 +4672,12 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                 8 => {
                                     (*(&mut *((*t).l.lcoef.0)
                                         .as_mut_ptr()
-                                        .offset((by4 + y) as isize) as *mut uint8_t
+                                        .offset((by4 + y) as isize)
+                                        as *mut uint8_t
                                         as *mut alias64))
                                         .u64_0 = (0x101010101010101 as libc::c_ulonglong)
-                                        .wrapping_mul(cf_ctx as libc::c_ulonglong) as uint64_t;
+                                        .wrapping_mul(cf_ctx as libc::c_ulonglong)
+                                        as uint64_t;
                                 }
                                 16 => {
                                     let const_val: uint64_t = (0x101010101010101
@@ -4697,7 +4699,9 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                 }
                                 _ => {
                                     memset(
-                                        &mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
+                                        &mut *((*t).l.lcoef.0)
+                                            .as_mut_ptr()
+                                            .offset((by4 + y) as isize)
                                             as *mut uint8_t
                                             as *mut libc::c_void,
                                         cf_ctx as libc::c_int,
@@ -4852,12 +4856,14 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                 (*(&mut *((*t).l.lcoef.0)
                                     .as_mut_ptr()
                                     .offset((by4 + y + 0) as isize)
-                                    as *mut uint8_t as *mut alias64))
+                                    as *mut uint8_t
+                                    as *mut alias64))
                                     .u64_0 = const_val_1;
                                 (*(&mut *((*t).l.lcoef.0)
                                     .as_mut_ptr()
                                     .offset((by4 + y + 8) as isize)
-                                    as *mut uint8_t as *mut alias64))
+                                    as *mut uint8_t
+                                    as *mut alias64))
                                     .u64_0 = const_val_1;
                             }
                             _ => {}
@@ -5296,9 +5302,11 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                             .offset(pl_0 as isize))
                                         .as_mut_ptr()
                                         .offset((cbx4 + x) as isize),
-                                        &mut *(*((*t).l.ccoef.0).as_mut_ptr().offset(pl_0 as isize))
+                                        &mut *(*((*t).l.ccoef.0)
                                             .as_mut_ptr()
-                                            .offset((cby4 + y) as isize),
+                                            .offset(pl_0 as isize))
+                                        .as_mut_ptr()
+                                        .offset((cby4 + y) as isize),
                                         (*b).uvtx as RectTxfmSize,
                                         bs,
                                         b,
@@ -6853,15 +6861,11 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                     .offset((bx4 + 8) as isize) as *mut uint8_t
                     as *mut alias64))
                     .u64_0 = const_val_2;
-                (*(&mut *((*(*t).a).lcoef.0)
-                    .as_mut_ptr()
-                    .offset((bx4 + 16) as isize) as *mut uint8_t
-                    as *mut alias64))
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset((bx4 + 16) as isize)
+                    as *mut uint8_t as *mut alias64))
                     .u64_0 = const_val_2;
-                (*(&mut *((*(*t).a).lcoef.0)
-                    .as_mut_ptr()
-                    .offset((bx4 + 24) as isize) as *mut uint8_t
-                    as *mut alias64))
+                (*(&mut *((*(*t).a).lcoef.0).as_mut_ptr().offset((bx4 + 24) as isize)
+                    as *mut uint8_t as *mut alias64))
                     .u64_0 = const_val_2;
             }
             _ => {}

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,7 +1,8 @@
 use crate::include::stdint::*;
+use crate::src::align::Align32;
 use ::libc;
 
-static mut scan_4x4: [uint16_t; 16] = [
+static mut scan_4x4: Align32<[uint16_t; 16]> = Align32([
     0 as libc::c_int as uint16_t,
     4 as libc::c_int as uint16_t,
     1 as libc::c_int as uint16_t,
@@ -18,8 +19,8 @@ static mut scan_4x4: [uint16_t; 16] = [
     14 as libc::c_int as uint16_t,
     11 as libc::c_int as uint16_t,
     15 as libc::c_int as uint16_t,
-];
-static mut scan_4x8: [uint16_t; 32] = [
+]);
+static mut scan_4x8: Align32<[uint16_t; 32]> = Align32([
     0 as libc::c_int as uint16_t,
     8 as libc::c_int as uint16_t,
     1 as libc::c_int as uint16_t,
@@ -52,8 +53,8 @@ static mut scan_4x8: [uint16_t; 32] = [
     30 as libc::c_int as uint16_t,
     23 as libc::c_int as uint16_t,
     31 as libc::c_int as uint16_t,
-];
-static mut scan_4x16: [uint16_t; 64] = [
+]);
+static mut scan_4x16: Align32<[uint16_t; 64]> = Align32([
     0 as libc::c_int as uint16_t,
     16 as libc::c_int as uint16_t,
     1 as libc::c_int as uint16_t,
@@ -118,8 +119,8 @@ static mut scan_4x16: [uint16_t; 64] = [
     62 as libc::c_int as uint16_t,
     47 as libc::c_int as uint16_t,
     63 as libc::c_int as uint16_t,
-];
-static mut scan_8x4: [uint16_t; 32] = [
+]);
+static mut scan_8x4: Align32<[uint16_t; 32]> = Align32([
     0 as libc::c_int as uint16_t,
     1 as libc::c_int as uint16_t,
     4 as libc::c_int as uint16_t,
@@ -152,8 +153,8 @@ static mut scan_8x4: [uint16_t; 32] = [
     27 as libc::c_int as uint16_t,
     30 as libc::c_int as uint16_t,
     31 as libc::c_int as uint16_t,
-];
-static mut scan_8x8: [uint16_t; 64] = [
+]);
+static mut scan_8x8: Align32<[uint16_t; 64]> = Align32([
     0 as libc::c_int as uint16_t,
     8 as libc::c_int as uint16_t,
     1 as libc::c_int as uint16_t,
@@ -218,8 +219,8 @@ static mut scan_8x8: [uint16_t; 64] = [
     62 as libc::c_int as uint16_t,
     55 as libc::c_int as uint16_t,
     63 as libc::c_int as uint16_t,
-];
-static mut scan_8x16: [uint16_t; 128] = [
+]);
+static mut scan_8x16: Align32<[uint16_t; 128]> = Align32([
     0 as libc::c_int as uint16_t,
     16 as libc::c_int as uint16_t,
     1 as libc::c_int as uint16_t,
@@ -348,8 +349,8 @@ static mut scan_8x16: [uint16_t; 128] = [
     126 as libc::c_int as uint16_t,
     111 as libc::c_int as uint16_t,
     127 as libc::c_int as uint16_t,
-];
-static mut scan_8x32: [uint16_t; 256] = [
+]);
+static mut scan_8x32: Align32<[uint16_t; 256]> = Align32([
     0 as libc::c_int as uint16_t,
     32 as libc::c_int as uint16_t,
     1 as libc::c_int as uint16_t,
@@ -606,8 +607,8 @@ static mut scan_8x32: [uint16_t; 256] = [
     254 as libc::c_int as uint16_t,
     223 as libc::c_int as uint16_t,
     255 as libc::c_int as uint16_t,
-];
-static mut scan_16x4: [uint16_t; 64] = [
+]);
+static mut scan_16x4: Align32<[uint16_t; 64]> = Align32([
     0 as libc::c_int as uint16_t,
     1 as libc::c_int as uint16_t,
     4 as libc::c_int as uint16_t,
@@ -672,8 +673,8 @@ static mut scan_16x4: [uint16_t; 64] = [
     59 as libc::c_int as uint16_t,
     62 as libc::c_int as uint16_t,
     63 as libc::c_int as uint16_t,
-];
-static mut scan_16x8: [uint16_t; 128] = [
+]);
+static mut scan_16x8: Align32<[uint16_t; 128]> = Align32([
     0 as libc::c_int as uint16_t,
     1 as libc::c_int as uint16_t,
     8 as libc::c_int as uint16_t,
@@ -802,8 +803,8 @@ static mut scan_16x8: [uint16_t; 128] = [
     119 as libc::c_int as uint16_t,
     126 as libc::c_int as uint16_t,
     127 as libc::c_int as uint16_t,
-];
-static mut scan_16x16: [uint16_t; 256] = [
+]);
+static mut scan_16x16: Align32<[uint16_t; 256]> = Align32([
     0 as libc::c_int as uint16_t,
     16 as libc::c_int as uint16_t,
     1 as libc::c_int as uint16_t,
@@ -1060,8 +1061,8 @@ static mut scan_16x16: [uint16_t; 256] = [
     254 as libc::c_int as uint16_t,
     239 as libc::c_int as uint16_t,
     255 as libc::c_int as uint16_t,
-];
-static mut scan_16x32: [uint16_t; 512] = [
+]);
+static mut scan_16x32: Align32<[uint16_t; 512]> = Align32([
     0 as libc::c_int as uint16_t,
     32 as libc::c_int as uint16_t,
     1 as libc::c_int as uint16_t,
@@ -1574,8 +1575,8 @@ static mut scan_16x32: [uint16_t; 512] = [
     510 as libc::c_int as uint16_t,
     479 as libc::c_int as uint16_t,
     511 as libc::c_int as uint16_t,
-];
-static mut scan_32x8: [uint16_t; 256] = [
+]);
+static mut scan_32x8: Align32<[uint16_t; 256]> = Align32([
     0 as libc::c_int as uint16_t,
     1 as libc::c_int as uint16_t,
     8 as libc::c_int as uint16_t,
@@ -1832,8 +1833,8 @@ static mut scan_32x8: [uint16_t; 256] = [
     247 as libc::c_int as uint16_t,
     254 as libc::c_int as uint16_t,
     255 as libc::c_int as uint16_t,
-];
-static mut scan_32x16: [uint16_t; 512] = [
+]);
+static mut scan_32x16: Align32<[uint16_t; 512]> = Align32([
     0 as libc::c_int as uint16_t,
     1 as libc::c_int as uint16_t,
     16 as libc::c_int as uint16_t,
@@ -2346,8 +2347,8 @@ static mut scan_32x16: [uint16_t; 512] = [
     495 as libc::c_int as uint16_t,
     510 as libc::c_int as uint16_t,
     511 as libc::c_int as uint16_t,
-];
-static mut scan_32x32: [uint16_t; 1024] = [
+]);
+static mut scan_32x32: Align32<[uint16_t; 1024]> = Align32([
     0 as libc::c_int as uint16_t,
     32 as libc::c_int as uint16_t,
     1 as libc::c_int as uint16_t,
@@ -3372,28 +3373,28 @@ static mut scan_32x32: [uint16_t; 1024] = [
     1022 as libc::c_int as uint16_t,
     991 as libc::c_int as uint16_t,
     1023 as libc::c_int as uint16_t,
-];
+]);
 #[no_mangle]
 pub static mut dav1d_scans: [*const uint16_t; 19] = unsafe {
     [
-        scan_4x4.as_ptr(),
-        scan_8x8.as_ptr(),
-        scan_16x16.as_ptr(),
-        scan_32x32.as_ptr(),
-        scan_32x32.as_ptr(),
-        scan_4x8.as_ptr(),
-        scan_8x4.as_ptr(),
-        scan_8x16.as_ptr(),
-        scan_16x8.as_ptr(),
-        scan_16x32.as_ptr(),
-        scan_32x16.as_ptr(),
-        scan_32x32.as_ptr(),
-        scan_32x32.as_ptr(),
-        scan_4x16.as_ptr(),
-        scan_16x4.as_ptr(),
-        scan_8x32.as_ptr(),
-        scan_32x8.as_ptr(),
-        scan_16x32.as_ptr(),
-        scan_32x16.as_ptr(),
+        scan_4x4.0.as_ptr(),
+        scan_8x8.0.as_ptr(),
+        scan_16x16.0.as_ptr(),
+        scan_32x32.0.as_ptr(),
+        scan_32x32.0.as_ptr(),
+        scan_4x8.0.as_ptr(),
+        scan_8x4.0.as_ptr(),
+        scan_8x16.0.as_ptr(),
+        scan_16x8.0.as_ptr(),
+        scan_16x32.0.as_ptr(),
+        scan_32x16.0.as_ptr(),
+        scan_32x32.0.as_ptr(),
+        scan_32x32.0.as_ptr(),
+        scan_4x16.0.as_ptr(),
+        scan_16x4.0.as_ptr(),
+        scan_8x32.0.as_ptr(),
+        scan_32x8.0.as_ptr(),
+        scan_16x32.0.as_ptr(),
+        scan_32x16.0.as_ptr(),
     ]
 };

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -1263,11 +1263,11 @@ pub static dav1d_filter_intra_taps: Align64<[[i8; 64]; 5]> = Align64([
 ]);
 
 #[no_mangle]
-pub static dav1d_obmc_masks: [u8; 64] = [
+pub static dav1d_obmc_masks: Align16<[u8; 64]> = Align16([
     0, 0, 19, 0, 25, 14, 5, 0, 28, 22, 16, 11, 7, 3, 0, 0, 30, 27, 24, 21, 18, 15, 12, 10, 8, 6, 4,
     3, 0, 0, 0, 0, 31, 29, 28, 26, 24, 23, 21, 20, 19, 17, 16, 14, 13, 12, 11, 9, 8, 7, 6, 5, 4, 4,
     3, 2, 0, 0, 0, 0, 0, 0, 0, 0,
-];
+]);
 
 #[no_mangle]
 pub static dav1d_gaussian_sequence: [i16; 2048] = [

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -1069,7 +1069,7 @@ pub static dav1d_mc_warp_filter: Align8<[[i8; 8]; 193]> = Align8([
 ]);
 
 #[no_mangle]
-pub static dav1d_resize_filter: [[i8; 8]; 64] = [
+pub static dav1d_resize_filter: Align8<[[i8; 8]; 64]> = Align8([
     [0, 0, 0, -128, 0, 0, 0, 0],
     [0, 0, 1, -128, -2, 1, 0, 0],
     [0, -1, 3, -127, -4, 2, -1, 0],
@@ -1134,7 +1134,7 @@ pub static dav1d_resize_filter: [[i8; 8]; 64] = [
     [0, -1, 3, -6, -127, 4, -1, 0],
     [0, -1, 2, -4, -127, 3, -1, 0],
     [0, 0, 1, -2, -128, 1, 0, 0],
-];
+]);
 
 #[no_mangle]
 pub static dav1d_sm_weights: Align16<[u8; 128]> = Align16([

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -5,6 +5,7 @@ use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
 use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
 use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
 use crate::src::align::Align16;
+use crate::src::align::Align4;
 use crate::src::align::Align64;
 use crate::src::align::Align8;
 use crate::src::levels::BS_128x128;
@@ -732,7 +733,7 @@ pub static dav1d_cdef_directions: [[i8; 2]; 12] = [
     [0 * 12 + 1, -1 * 12 + 2],
 ];
 
-pub static dav1d_sgr_params: [[u16; 2]; 16] = [
+pub static dav1d_sgr_params: Align4<[[u16; 2]; 16]> = Align4([
     [140, 3236],
     [112, 2158],
     [93, 1618],
@@ -749,7 +750,7 @@ pub static dav1d_sgr_params: [[u16; 2]; 16] = [
     [0, 925],
     [56, 0],
     [22, 0],
-];
+]);
 
 #[no_mangle]
 pub static dav1d_sgr_x_by_x: Align64<[u8; 256]> = Align64([

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -872,7 +872,7 @@ pub static dav1d_mc_subpel_filters: Align8<[[[i8; 8]; 15]; 6]> = Align8([
 ]);
 
 #[no_mangle]
-pub static dav1d_mc_warp_filter: [[i8; 8]; 193] = [
+pub static dav1d_mc_warp_filter: Align8<[[i8; 8]; 193]> = Align8([
     [0, 0, 127, 1, 0, 0, 0, 0],
     [0, -1, 127, 2, 0, 0, 0, 0],
     [1, -3, 127, 4, -1, 0, 0, 0],
@@ -1066,7 +1066,7 @@ pub static dav1d_mc_warp_filter: [[i8; 8]; 193] = [
     [0, 0, 0, -1, 4, 127, -3, 1],
     [0, 0, 0, 0, 2, 127, -1, 0],
     [0, 0, 0, 0, 2, 127, -1, 0],
-];
+]);
 
 #[no_mangle]
 pub static dav1d_resize_filter: [[i8; 8]; 64] = [

--- a/src/wedge.rs
+++ b/src/wedge.rs
@@ -1,4 +1,6 @@
 use crate::include::stdint::*;
+use crate::src::align::Align16;
+use crate::src::align::Align32;
 use crate::src::align::Align64;
 use ::libc;
 extern "C" {
@@ -882,16 +884,16 @@ pub unsafe extern "C" fn dav1d_init_wedge_masks() {
         0x7bfb as libc::c_int as libc::c_uint,
     );
 }
-static mut ii_dc_mask: [uint8_t; 1024] = [0; 1024];
-static mut ii_nondc_mask_32x32: [[uint8_t; 1024]; 3] = [[0; 1024]; 3];
-static mut ii_nondc_mask_16x32: [[uint8_t; 512]; 3] = [[0; 512]; 3];
-static mut ii_nondc_mask_16x16: [[uint8_t; 256]; 3] = [[0; 256]; 3];
-static mut ii_nondc_mask_8x32: [[uint8_t; 256]; 3] = [[0; 256]; 3];
-static mut ii_nondc_mask_8x16: [[uint8_t; 128]; 3] = [[0; 128]; 3];
-static mut ii_nondc_mask_8x8: [[uint8_t; 64]; 3] = [[0; 64]; 3];
-static mut ii_nondc_mask_4x16: [[uint8_t; 64]; 3] = [[0; 64]; 3];
-static mut ii_nondc_mask_4x8: [[uint8_t; 32]; 3] = [[0; 32]; 3];
-static mut ii_nondc_mask_4x4: [[uint8_t; 16]; 3] = [[0; 16]; 3];
+static mut ii_dc_mask: Align64<[uint8_t; 1024]> = Align64([0; 1024]);
+static mut ii_nondc_mask_32x32: Align64<[[uint8_t; 1024]; 3]> = Align64([[0; 1024]; 3]);
+static mut ii_nondc_mask_16x32: Align64<[[uint8_t; 512]; 3]> = Align64([[0; 512]; 3]);
+static mut ii_nondc_mask_16x16: Align64<[[uint8_t; 256]; 3]> = Align64([[0; 256]; 3]);
+static mut ii_nondc_mask_8x32: Align64<[[uint8_t; 256]; 3]> = Align64([[0; 256]; 3]);
+static mut ii_nondc_mask_8x16: Align64<[[uint8_t; 128]; 3]> = Align64([[0; 128]; 3]);
+static mut ii_nondc_mask_8x8: Align64<[[uint8_t; 64]; 3]> = Align64([[0; 64]; 3]);
+static mut ii_nondc_mask_4x16: Align64<[[uint8_t; 64]; 3]> = Align64([[0; 64]; 3]);
+static mut ii_nondc_mask_4x8: Align32<[[uint8_t; 32]; 3]> = Align32([[0; 32]; 3]);
+static mut ii_nondc_mask_4x4: Align16<[[uint8_t; 16]; 3]> = Align16([[0; 16]; 3]);
 #[no_mangle]
 pub static mut dav1d_ii_masks: [[[*const uint8_t; 4]; 3]; 22] = [[[0 as *const uint8_t; 4]; 3]; 22];
 #[cold]
@@ -959,7 +961,7 @@ unsafe extern "C" fn build_nondc_ii_masks(
 #[cold]
 pub unsafe extern "C" fn dav1d_init_interintra_masks() {
     memset(
-        ii_dc_mask.as_mut_ptr() as *mut libc::c_void,
+        ii_dc_mask.0.as_mut_ptr() as *mut libc::c_void,
         32 as libc::c_int,
         (32 * 32) as libc::c_ulong,
     );
@@ -1047,7 +1049,7 @@ unsafe extern "C" fn run_static_initializers() {
         [[0 as *const uint8_t; 4]; 3],
         [
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_32x32[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_32x32[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
@@ -1056,7 +1058,7 @@ unsafe extern "C" fn run_static_initializers() {
                     as *const uint8_t,
             ],
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_16x32[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_16x32[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
@@ -1065,7 +1067,7 @@ unsafe extern "C" fn run_static_initializers() {
                     as *const uint8_t,
             ],
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_16x16[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_16x16[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
@@ -1076,7 +1078,7 @@ unsafe extern "C" fn run_static_initializers() {
         ],
         [
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_32x32[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_32x32[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
@@ -1085,7 +1087,7 @@ unsafe extern "C" fn run_static_initializers() {
                     as *const uint8_t,
             ],
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_16x16[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_16x16[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
@@ -1094,7 +1096,7 @@ unsafe extern "C" fn run_static_initializers() {
                     as *const uint8_t,
             ],
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_16x16[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_16x16[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
@@ -1107,7 +1109,7 @@ unsafe extern "C" fn run_static_initializers() {
         [[0 as *const uint8_t; 4]; 3],
         [
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_16x32[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_16x32[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
@@ -1116,7 +1118,7 @@ unsafe extern "C" fn run_static_initializers() {
                     as *const uint8_t,
             ],
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_8x32[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_8x32[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
@@ -1125,7 +1127,7 @@ unsafe extern "C" fn run_static_initializers() {
                     as *const uint8_t,
             ],
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_8x16[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_8x16[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
@@ -1136,7 +1138,7 @@ unsafe extern "C" fn run_static_initializers() {
         ],
         [
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_16x16[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_16x16[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
@@ -1145,7 +1147,7 @@ unsafe extern "C" fn run_static_initializers() {
                     as *const uint8_t,
             ],
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_8x16[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_8x16[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
@@ -1154,7 +1156,7 @@ unsafe extern "C" fn run_static_initializers() {
                     as *const uint8_t,
             ],
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_8x8[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_8x8[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
@@ -1165,7 +1167,7 @@ unsafe extern "C" fn run_static_initializers() {
         ],
         [
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_16x16[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_16x16[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
@@ -1174,7 +1176,7 @@ unsafe extern "C" fn run_static_initializers() {
                     as *const uint8_t,
             ],
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_8x8[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_8x8[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
@@ -1183,7 +1185,7 @@ unsafe extern "C" fn run_static_initializers() {
                     as *const uint8_t,
             ],
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_8x8[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_8x8[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
@@ -1196,7 +1198,7 @@ unsafe extern "C" fn run_static_initializers() {
         [[0 as *const uint8_t; 4]; 3],
         [
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_8x16[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_8x16[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
@@ -1205,7 +1207,7 @@ unsafe extern "C" fn run_static_initializers() {
                     as *const uint8_t,
             ],
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_4x16[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_4x16[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
@@ -1214,7 +1216,7 @@ unsafe extern "C" fn run_static_initializers() {
                     as *const uint8_t,
             ],
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_4x8[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_4x8[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
@@ -1225,7 +1227,7 @@ unsafe extern "C" fn run_static_initializers() {
         ],
         [
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_8x8[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_8x8[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
@@ -1234,7 +1236,7 @@ unsafe extern "C" fn run_static_initializers() {
                     as *const uint8_t,
             ],
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_4x8[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_4x8[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
@@ -1243,7 +1245,7 @@ unsafe extern "C" fn run_static_initializers() {
                     as *const uint8_t,
             ],
             [
-                ii_dc_mask.as_mut_ptr() as *const uint8_t,
+                ii_dc_mask.0.as_mut_ptr() as *const uint8_t,
                 (ii_nondc_mask_4x4[(II_VERT_PRED as libc::c_int - 1) as usize]).as_mut_ptr()
                     as *const uint8_t,
                 (ii_nondc_mask_4x4[(II_HOR_PRED as libc::c_int - 1) as usize]).as_mut_ptr()


### PR DESCRIPTION
Fixes #122.

This aligns all remaining statics, fields, and variables that use `dav1d`'s C `ALIGN` macro to specify their alignment.