### PR TITLE
Backport refmvs changes from dav1d 1.2.0

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -2829,9 +2829,9 @@ int dav1d_decode_tile_sbrow(Dav1dTaskContext *const t) {
     if (ts->msac.cnt < -15) return 1;
 
     if (f->c->n_tc > 1 && f->frame_hdr->use_ref_frame_mvs) {
-        dav1d_refmvs_load_tmvs(&f->rf, ts->tiling.row,
-                               ts->tiling.col_start >> 1, ts->tiling.col_end >> 1,
-                               t->by >> 1, (t->by + sb_step) >> 1);
+        f->c->refmvs_dsp.load_tmvs(&f->rf, ts->tiling.row,
+                                   ts->tiling.col_start >> 1, ts->tiling.col_end >> 1,
+                                   t->by >> 1, (t->by + sb_step) >> 1);
     }
     memset(t->pal_sz_uv[1], 0, sizeof(*t->pal_sz_uv));
     const int sb128y = t->by >> 5;
@@ -2914,7 +2914,7 @@ int dav1d_decode_tile_sbrow(Dav1dTaskContext *const t) {
     }
 
     if (f->seq_hdr->ref_frame_mvs && f->c->n_tc > 1 && IS_INTER_OR_SWITCH(f->frame_hdr)) {
-        dav1d_refmvs_save_tmvs(&t->rt,
+        dav1d_refmvs_save_tmvs(&f->c->refmvs_dsp, &t->rt,
                                ts->tiling.col_start >> 1, ts->tiling.col_end >> 1,
                                t->by >> 1, (t->by + sb_step) >> 1);
     }
@@ -3394,15 +3394,16 @@ int dav1d_decode_frame_main(Dav1dFrameContext *const f) {
             t->by = sby << (4 + f->seq_hdr->sb128);
             const int by_end = (t->by + f->sb_step) >> 1;
             if (f->frame_hdr->use_ref_frame_mvs) {
-                dav1d_refmvs_load_tmvs(&f->rf, tile_row,
-                                       0, f->bw >> 1, t->by >> 1, by_end);
+                f->c->refmvs_dsp.load_tmvs(&f->rf, tile_row,
+                                           0, f->bw >> 1, t->by >> 1, by_end);
             }
             for (int tile_col = 0; tile_col < f->frame_hdr->tiling.cols; tile_col++) {
                 t->ts = &f->ts[tile_row * f->frame_hdr->tiling.cols + tile_col];
                 if (dav1d_decode_tile_sbrow(t)) goto error;
             }
             if (IS_INTER_OR_SWITCH(f->frame_hdr)) {
-                dav1d_refmvs_save_tmvs(&t->rt, 0, f->bw >> 1, t->by >> 1, by_end);
+                dav1d_refmvs_save_tmvs(&f->c->refmvs_dsp, &t->rt,
+                                       0, f->bw >> 1, t->by >> 1, by_end);
             }
 
             // loopfilter + cdef + restoration

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -6,7 +6,7 @@ use crate::src::align::Align16;
 use crate::src::cdf::{CdfContext, CdfMvComponent, CdfMvContext};
 use crate::src::ctx::{case_set, SetCtxFn};
 use crate::src::msac::MsacContext;
-use ::libc;
+use libc;
 
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
@@ -58,15 +58,8 @@ extern "C" {
         n_tile_threads: libc::c_int,
         n_frame_threads: libc::c_int,
     ) -> libc::c_int;
-    fn dav1d_refmvs_load_tmvs(
-        rf: *const refmvs_frame,
-        tile_row_idx: libc::c_int,
-        col_start8: libc::c_int,
-        col_end8: libc::c_int,
-        row_start8: libc::c_int,
-        row_end8: libc::c_int,
-    );
     fn dav1d_refmvs_save_tmvs(
+        dsp: *const Dav1dRefmvsDSPContext,
         rt: *const refmvs_tile,
         col_start8: libc::c_int,
         col_end8: libc::c_int,
@@ -8134,7 +8127,10 @@ pub unsafe extern "C" fn dav1d_decode_tile_sbrow(t: *mut Dav1dTaskContext) -> li
         return 1 as libc::c_int;
     }
     if (*(*f).c).n_tc > 1 as libc::c_uint && (*(*f).frame_hdr).use_ref_frame_mvs != 0 {
-        dav1d_refmvs_load_tmvs(
+        (*(*f).c)
+            .refmvs_dsp
+            .load_tmvs
+            .expect("non-null function pointer")(
             &(*f).rf,
             (*ts).tiling.row,
             (*ts).tiling.col_start >> 1,
@@ -8255,6 +8251,7 @@ pub unsafe extern "C" fn dav1d_decode_tile_sbrow(t: *mut Dav1dTaskContext) -> li
         && (*(*f).frame_hdr).frame_type as libc::c_uint & 1 as libc::c_uint != 0
     {
         dav1d_refmvs_save_tmvs(
+            &(*(*f).c).refmvs_dsp,
             &mut (*t).rt,
             (*ts).tiling.col_start >> 1,
             (*ts).tiling.col_end >> 1,
@@ -9550,7 +9547,10 @@ pub unsafe extern "C" fn dav1d_decode_frame_main(f: *mut Dav1dFrameContext) -> l
             (*t).by = sby << 4 + (*(*f).seq_hdr).sb128;
             let by_end = (*t).by + (*f).sb_step >> 1;
             if (*(*f).frame_hdr).use_ref_frame_mvs != 0 {
-                dav1d_refmvs_load_tmvs(
+                (*(*f).c)
+                    .refmvs_dsp
+                    .load_tmvs
+                    .expect("non-null function pointer")(
                     &mut (*f).rf,
                     tile_row,
                     0 as libc::c_int,
@@ -9572,6 +9572,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_main(f: *mut Dav1dFrameContext) -> l
             }
             if (*(*f).frame_hdr).frame_type as libc::c_uint & 1 as libc::c_uint != 0 {
                 dav1d_refmvs_save_tmvs(
+                    &(*(*f).c).refmvs_dsp,
                     &mut (*t).rt,
                     0 as libc::c_int,
                     (*f).bw >> 1,

--- a/src/refmvs.c
+++ b/src/refmvs.c
@@ -687,9 +687,9 @@ void dav1d_refmvs_tile_sbrow_init(refmvs_tile *const rt, const refmvs_frame *con
     rt->tile_col.end = imin(tile_col_end4, rf->iw4);
 }
 
-void dav1d_refmvs_load_tmvs(const refmvs_frame *const rf, int tile_row_idx,
-                            const int col_start8, const int col_end8,
-                            const int row_start8, int row_end8)
+static void load_tmvs_c(const refmvs_frame *const rf, int tile_row_idx,
+                        const int col_start8, const int col_end8,
+                        const int row_start8, int row_end8)
 {
     if (rf->n_tile_threads == 1) tile_row_idx = 0;
     assert(row_start8 >= 0);
@@ -760,22 +760,14 @@ void dav1d_refmvs_load_tmvs(const refmvs_frame *const rf, int tile_row_idx,
     }
 }
 
-void dav1d_refmvs_save_tmvs(const refmvs_tile *const rt,
-                            const int col_start8, int col_end8,
-                            const int row_start8, int row_end8)
+static void save_tmvs_c(refmvs_temporal_block *rp, const ptrdiff_t stride,
+                        refmvs_block *const *const rr,
+                        const uint8_t *const ref_sign,
+                        const int col_end8, const int row_end8,
+                        const int col_start8, const int row_start8)
 {
-    const refmvs_frame *const rf = rt->rf;
-
-    assert(row_start8 >= 0);
-    assert((unsigned) (row_end8 - row_start8) <= 16U);
-    row_end8 = imin(row_end8, rf->ih8);
-    col_end8 = imin(col_end8, rf->iw8);
-
-    const ptrdiff_t stride = rf->rp_stride;
-    const uint8_t *const ref_sign = rf->mfmv_sign;
-    refmvs_temporal_block *rp = &rf->rp[row_start8 * stride];
     for (int y = row_start8; y < row_end8; y++) {
-        const refmvs_block *const b = rt->r[6 + (y & 15) * 2];
+        const refmvs_block *const b = rr[(y & 15) * 2];
 
         for (int x = col_start8; x < col_end8;) {
             const refmvs_block *const cand_b = &b[x * 2 + 1];
@@ -932,6 +924,8 @@ static void splat_mv_c(refmvs_block **rr, const refmvs_block *const rmv,
 
 COLD void dav1d_refmvs_dsp_init(Dav1dRefmvsDSPContext *const c)
 {
+    c->load_tmvs = load_tmvs_c;
+    c->save_tmvs = save_tmvs_c;
     c->splat_mv = splat_mv_c;
 
 #if HAVE_ASM

--- a/src/refmvs.c
+++ b/src/refmvs.c
@@ -786,8 +786,10 @@ static void save_tmvs_c(refmvs_temporal_block *rp, const ptrdiff_t stride,
                     rp[x] = (refmvs_temporal_block) { .mv = cand_b->mv.mv[0],
                                                       .ref = cand_b->ref.ref[0] };
             } else {
-                for (int n = 0; n < bw8; n++, x++)
+                for (int n = 0; n < bw8; n++, x++) {
+                    rp[x].mv.n = 0;
                     rp[x].ref = 0; // "invalid"
+                }
             }
         }
         rp += stride;

--- a/src/refmvs.h
+++ b/src/refmvs.h
@@ -39,10 +39,10 @@
 
 #define INVALID_MV 0x80008000
 
-typedef struct refmvs_temporal_block {
+PACKED(typedef struct refmvs_temporal_block {
     mv mv;
     int8_t ref;
-} refmvs_temporal_block;
+}) refmvs_temporal_block;
 
 typedef union refmvs_refpair {
     int8_t ref[2]; // [0] = 0: intra=1, [1] = -1: comp=0

--- a/src/refmvs.h
+++ b/src/refmvs.h
@@ -96,11 +96,28 @@ typedef struct refmvs_candidate {
     int weight;
 } refmvs_candidate;
 
+// initialize temporal MVs; this can be done in any configuration, e.g. one
+// tile/sbrow at a time, where col_{start,end}8 are the tile boundaries; or
+// it can just be for the whole frame's sbrow, where col_{start,end}8 are the
+// frame boundaries. row_{start,end}8 are the superblock row boundaries.
+#define decl_load_tmvs_fn(name) \
+void (name)(const refmvs_frame *rf, int tile_row_idx, \
+            int col_start8, int col_end8, int row_start8, int row_end8)
+typedef decl_load_tmvs_fn(*load_tmvs_fn);
+
+#define decl_save_tmvs_fn(name) \
+void (name)(refmvs_temporal_block *rp, const ptrdiff_t stride, \
+            refmvs_block *const *const rr, const uint8_t *const ref_sign, \
+            int col_end8, int row_end8, int col_start8, int row_start8)
+typedef decl_save_tmvs_fn(*save_tmvs_fn);
+
 #define decl_splat_mv_fn(name) \
 void (name)(refmvs_block **rr, const refmvs_block *rmv, int bx4, int bw4, int bh4)
 typedef decl_splat_mv_fn(*splat_mv_fn);
 
 typedef struct Dav1dRefmvsDSPContext {
+    load_tmvs_fn load_tmvs;
+    save_tmvs_fn save_tmvs;
     splat_mv_fn splat_mv;
 } Dav1dRefmvsDSPContext;
 
@@ -118,19 +135,27 @@ int dav1d_refmvs_init_frame(refmvs_frame *rf,
                             /*const*/ refmvs_temporal_block *const rp_ref[7],
                             int n_tile_threads, int n_frame_threads);
 
-// initialize temporal MVs; this can be done in any configuration, e.g. one
-// tile/sbrow at a time, where col_{start,end}8 are the tile boundaries; or
-// it can just be for the whole frame's sbrow, where col_{start,end}8 are the
-// frame boundaries. row_{start,end}8 are the superblock row boundaries.
-void dav1d_refmvs_load_tmvs(const refmvs_frame *rf, int tile_row_idx,
-                            int col_start8, int col_end8,
-                            int row_start8, int row_end8);
-
 // cache the current tile/sbrow (or frame/sbrow)'s projectable motion vectors
 // into buffers for use in future frame's temporal MV prediction
-void dav1d_refmvs_save_tmvs(const refmvs_tile *rt,
-                            int col_start8, int col_end8,
-                            int row_start8, int row_end8);
+static inline void dav1d_refmvs_save_tmvs(const Dav1dRefmvsDSPContext *const dsp,
+                                          const refmvs_tile *const rt,
+                                          const int col_start8, int col_end8,
+                                          const int row_start8, int row_end8)
+{
+    const refmvs_frame *const rf = rt->rf;
+
+    assert(row_start8 >= 0);
+    assert((unsigned) (row_end8 - row_start8) <= 16U);
+    row_end8 = imin(row_end8, rf->ih8);
+    col_end8 = imin(col_end8, rf->iw8);
+
+    const ptrdiff_t stride = rf->rp_stride;
+    const uint8_t *const ref_sign = rf->mfmv_sign;
+    refmvs_temporal_block *rp = &rf->rp[row_start8 * stride];
+
+    dsp->save_tmvs(rp, stride, rt->r + 6, ref_sign,
+                   col_end8, row_end8, col_start8, row_start8);
+}
 
 // initialize tile boundaries and refmvs_block pointers for one tile/sbrow
 void dav1d_refmvs_tile_sbrow_init(refmvs_tile *rt, const refmvs_frame *rf,

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1,7 +1,7 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use ::libc;
 use cfg_if::cfg_if;
+use libc;
 extern "C" {
     fn free(_: *mut libc::c_void);
     fn posix_memalign(
@@ -67,7 +67,7 @@ use crate::src::levels::mv;
 use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
 
 #[derive(Copy, Clone)]
-#[repr(C)]
+#[repr(C, packed)]
 pub struct refmvs_temporal_block {
     pub mv: mv,
     pub r#ref: int8_t,
@@ -161,6 +161,28 @@ pub struct refmvs_candidate {
     pub mv: refmvs_mvpair,
     pub weight: libc::c_int,
 }
+pub type load_tmvs_fn = Option<
+    unsafe extern "C" fn(
+        *const refmvs_frame,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+    ) -> (),
+>;
+pub type save_tmvs_fn = Option<
+    unsafe extern "C" fn(
+        *mut refmvs_temporal_block,
+        ptrdiff_t,
+        *const *const refmvs_block,
+        *const u8,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+    ) -> (),
+>;
 pub type splat_mv_fn = Option<
     unsafe extern "C" fn(
         *mut *mut refmvs_block,
@@ -173,6 +195,8 @@ pub type splat_mv_fn = Option<
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dRefmvsDSPContext {
+    pub load_tmvs: load_tmvs_fn,
+    pub save_tmvs: save_tmvs_fn,
     pub splat_mv: splat_mv_fn,
 }
 
@@ -433,7 +457,7 @@ unsafe fn add_temporal_candidate(
     r#ref: refmvs_refpair,
     globalmv: Option<(&mut libc::c_int, &[mv; 2])>,
 ) {
-    if rb.mv == mv::INVALID {
+    if rb.mv.is_invalid() {
         return;
     }
 
@@ -1058,6 +1082,42 @@ pub unsafe fn dav1d_refmvs_find(
     *ctx = refmv_ctx << 4 | globalmv_ctx << 3 | newmv_ctx;
 }
 
+// cache the current tile/sbrow (or frame/sbrow)'s projectable motion vectors
+// into buffers for use in future frame's temporal MV prediction
+#[no_mangle]
+pub unsafe extern "C" fn dav1d_refmvs_save_tmvs(
+    dsp: *const Dav1dRefmvsDSPContext,
+    rt: *const refmvs_tile,
+    col_start8: libc::c_int,
+    mut col_end8: libc::c_int,
+    row_start8: libc::c_int,
+    mut row_end8: libc::c_int,
+) {
+    let rf: *const refmvs_frame = (*rt).rf;
+    if !(row_start8 >= 0) {
+        unreachable!();
+    }
+    if !((row_end8 - row_start8) as libc::c_uint <= 16 as libc::c_uint) {
+        unreachable!();
+    }
+    row_end8 = imin(row_end8, (*rf).ih8);
+    col_end8 = imin(col_end8, (*rf).iw8);
+    let stride: ptrdiff_t = (*rf).rp_stride;
+    let ref_sign: *const uint8_t = ((*rf).mfmv_sign).as_ptr();
+    let mut rp: *mut refmvs_temporal_block = (*rf).rp.offset(row_start8 as isize * stride);
+
+    (*dsp).save_tmvs.expect("non-null function pointer")(
+        rp,
+        stride,
+        (*rt).r.as_ptr().offset(6) as *const *const refmvs_block,
+        ref_sign,
+        col_end8,
+        row_end8,
+        col_start8,
+        row_start8,
+    );
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_refmvs_tile_sbrow_init(
     rt: *mut refmvs_tile,
@@ -1117,7 +1177,7 @@ pub unsafe extern "C" fn dav1d_refmvs_tile_sbrow_init(
     (*rt).tile_col.end = imin(tile_col_end4, (*rf).iw4);
 }
 #[no_mangle]
-pub unsafe extern "C" fn dav1d_refmvs_load_tmvs(
+pub unsafe extern "C" fn load_tmvs_c(
     rf: *const refmvs_frame,
     mut tile_row_idx: libc::c_int,
     col_start8: libc::c_int,
@@ -1203,7 +1263,8 @@ pub unsafe extern "C" fn dav1d_refmvs_load_tmvs(
                                         break;
                                     }
                                     rb = rb.offset(1);
-                                    if (*rb).r#ref as libc::c_int != b_ref || (*rb).mv != b_mv {
+                                    let rb_mv = (*rb).mv;
+                                    if (*rb).r#ref as libc::c_int != b_ref || rb_mv != b_mv {
                                         break;
                                     }
                                     pos_x += 1;
@@ -1215,7 +1276,8 @@ pub unsafe extern "C" fn dav1d_refmvs_load_tmvs(
                                         break;
                                     }
                                     rb = rb.offset(1);
-                                    if (*rb).r#ref as libc::c_int != b_ref || (*rb).mv != b_mv {
+                                    let rb_mv = (*rb).mv;
+                                    if (*rb).r#ref as libc::c_int != b_ref || rb_mv != b_mv {
                                         break;
                                     }
                                 }
@@ -1233,29 +1295,19 @@ pub unsafe extern "C" fn dav1d_refmvs_load_tmvs(
     }
 }
 #[no_mangle]
-pub unsafe extern "C" fn dav1d_refmvs_save_tmvs(
-    rt: *const refmvs_tile,
+pub unsafe extern "C" fn save_tmvs_c(
+    mut rp: *mut refmvs_temporal_block,
+    stride: ptrdiff_t,
+    rr: *const *const refmvs_block,
+    ref_sign: *const u8,
+    col_end8: libc::c_int,
+    row_end8: libc::c_int,
     col_start8: libc::c_int,
-    mut col_end8: libc::c_int,
     row_start8: libc::c_int,
-    mut row_end8: libc::c_int,
 ) {
-    let rf: *const refmvs_frame = (*rt).rf;
-    if !(row_start8 >= 0) {
-        unreachable!();
-    }
-    if !((row_end8 - row_start8) as libc::c_uint <= 16 as libc::c_uint) {
-        unreachable!();
-    }
-    row_end8 = imin(row_end8, (*rf).ih8);
-    col_end8 = imin(col_end8, (*rf).iw8);
-    let stride: ptrdiff_t = (*rf).rp_stride;
-    let ref_sign: *const uint8_t = ((*rf).mfmv_sign).as_ptr();
-    let mut rp: *mut refmvs_temporal_block =
-        &mut *((*rf).rp).offset(row_start8 as isize * stride) as *mut refmvs_temporal_block;
     let mut y = row_start8;
     while y < row_end8 {
-        let b: *const refmvs_block = (*rt).r[(6 + (y & 15) * 2) as usize];
+        let b: *const refmvs_block = *rr.offset(((y & 15) * 2) as isize);
         let mut x = col_start8;
         while x < col_end8 {
             let cand_b: *const refmvs_block =
@@ -1300,7 +1352,10 @@ pub unsafe extern "C" fn dav1d_refmvs_save_tmvs(
             } else {
                 let mut n_1 = 0;
                 while n_1 < bw8 {
-                    (*rp.offset(x as isize)).r#ref = 0 as libc::c_int as int8_t;
+                    *rp.offset(x as isize) = refmvs_temporal_block {
+                        mv: mv { x: 0, y: 0 },
+                        r#ref: 0,
+                    };
                     n_1 += 1;
                     x += 1;
                 }
@@ -1573,6 +1628,8 @@ unsafe extern "C" fn refmvs_dsp_init_arm(c: *mut Dav1dRefmvsDSPContext) {
 #[no_mangle]
 #[cold]
 pub unsafe extern "C" fn dav1d_refmvs_dsp_init(c: *mut Dav1dRefmvsDSPContext) {
+    (*c).load_tmvs = Some(load_tmvs_c);
+    (*c).save_tmvs = Some(save_tmvs_c);
     (*c).splat_mv = Some(
         splat_mv_c
             as unsafe extern "C" fn(

--- a/src/x86/refmvs.asm
+++ b/src/x86/refmvs.asm
@@ -51,15 +51,23 @@ splat_mv_shuf: db  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11,  0,  1,  2,  3
                db  4,  5,  6,  7,  8,  9, 10, 11,  0,  1,  2,  3,  4,  5,  6,  7
                db  8,  9, 10, 11,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11
                db  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11,  0,  1,  2,  3
+%endif
 save_pack0:    db  0,  1,  2,  3,  4,  0,  1,  2,  3,  4,  0,  1,  2,  3,  4,  0
                db  1,  2,  3,  4,  0,  1,  2,  3,  4,  0,  1,  2,  3,  4,  0,  1
 save_pack1:    db  2,  3,  4,  0,  1,  2,  3,  4,  0,  1,  2,  3,  4,  0,  1,  2
                db  3,  4,  0,  1,  2,  3,  4,  0,  1,  2,  3,  4,  0,  1,  2,  3
 save_ref_shuf: db  0, -1, -1, -1,  1, -1, -1, -1,  8, -1, -1, -1,  9, -1, -1, -1
-save_cond0:    db  0x80, 0x81, 0x82, 0x83, 0x89, 0x00, 0x00, 0x00
-save_cond1:    db  0x84, 0x85, 0x86, 0x87, 0x88, 0x00, 0x00, 0x00
-pb_128:        times 4 db 128
+save_cond0:    db  0x80, 0x81, 0x82, 0x83, 0x89, 0x84, 0x00, 0x00
+save_cond1:    db  0x84, 0x85, 0x86, 0x87, 0x88, 0x80, 0x00, 0x00
+pb_128:        times 16 db 128
 
+save_tmvs_ssse3_table: SAVE_TMVS_TABLE 2, 16, ssse3
+                       SAVE_TMVS_TABLE 4,  8, ssse3
+                       SAVE_TMVS_TABLE 4,  4, ssse3
+                       SAVE_TMVS_TABLE 5,  2, ssse3
+                       SAVE_TMVS_TABLE 7,  1, ssse3
+
+%if ARCH_X86_64
 save_tmvs_avx2_table: SAVE_TMVS_TABLE 2, 16, avx2
                       SAVE_TMVS_TABLE 4,  8, avx2
                       SAVE_TMVS_TABLE 4,  4, avx2
@@ -69,9 +77,188 @@ save_tmvs_avx2_table: SAVE_TMVS_TABLE 2, 16, avx2
 JMP_TABLE splat_mv_avx512icl, 1, 2, 4, 8, 16, 32
 JMP_TABLE splat_mv_avx2,      1, 2, 4, 8, 16, 32
 %endif
+
 JMP_TABLE splat_mv_sse2,      1, 2, 4, 8, 16, 32
 
 SECTION .text
+
+%macro movif32 2
+%if ARCH_X86_32
+    mov             %1, %2
+%endif
+%endmacro
+
+INIT_XMM ssse3
+; refmvs_temporal_block *rp, ptrdiff_t stride,
+; refmvs_block **rr, uint8_t *ref_sign,
+; int col_end8, int row_end8, int col_start8, int row_start8
+%if ARCH_X86_64
+cglobal save_tmvs, 4, 13, 11, rp, stride, rr, ref_sign, \
+                             xend, yend, xstart, ystart
+%define base_reg r12
+%else
+cglobal save_tmvs, 6, 7, 8, rp, stride, rr, ref_sign, \
+                            xend, yend, xstart, ystart
+    movq            m5, [ref_signq]
+    lea        strided, [strided*5]
+    mov        stridem, strided
+    mov             r3, xstartm
+    mov             r1, ystartm
+ DEFINE_ARGS b, ystart, rr, cand, xend, x
+%define stridemp r1m
+%define m8  [base+pb_128]
+%define m9  [base+save_pack0+ 0]
+%define m10 [base+save_pack0+16]
+%define base_reg r6
+%endif
+%define base base_reg-.write1
+    LEA       base_reg, .write1
+%if ARCH_X86_64
+    movifnidn    xendd, xendm
+    movifnidn    yendd, yendm
+    mov        xstartd, xstartm
+    mov        ystartd, ystartm
+    movq            m5, [ref_signq]
+%endif
+    movu            m4, [base+save_ref_shuf]
+    movddup         m6, [base+save_cond0]
+    movddup         m7, [base+save_cond1]
+%if ARCH_X86_64
+    mova            m8, [base+pb_128]
+    mova            m9, [base+save_pack0+ 0]
+    mova           m10, [base+save_pack0+16]
+%endif
+    psllq           m5, 8
+%if ARCH_X86_64
+    lea            r9d, [xendq*5]
+    lea        xstartd, [xstartq*5]
+    sub          yendd, ystartd
+    add        ystartd, ystartd
+    lea        strideq, [strideq*5]
+    sub        xstartq, r9
+    add          xendd, r9d
+    add            rpq, r9
+ DEFINE_ARGS rp, stride, rr, x, xend, h, xstart, ystart, b, cand
+%else
+    lea             r0, [xendd*5]   ; xend5
+    lea             r3, [r3*5]      ; xstart5
+    sub             r3, r0          ; -w5
+    mov            r6m, r3
+%define xstartq r6m
+    add          xendd, r0          ; xend6
+    add            r0m, r0          ; rp+xend5
+    mov          xendm, xendd
+    sub             r5, r1          ; h
+    add             r1, r1
+    mov            r7m, r1
+    mov            r5m, r5
+%define hd r5mp
+    jmp .loop_y_noload
+%endif
+.loop_y:
+    movif32    ystartd, r7m
+    movif32      xendd, xendm
+.loop_y_noload:
+    and        ystartd, 30
+    mov             xq, xstartq
+    mov             bq, [rrq+ystartq*gprsize]
+    add        ystartd, 2
+    movif32        r7m, ystartd
+    lea             bq, [bq+xendq*4]
+.loop_x:
+%if ARCH_X86_32
+%define rpq  r3
+%define r10  r1
+%define r10d r1
+%define r10w r1w
+%define r10b r1b
+%define r11  r4
+%define r11d r4
+%endif
+    imul         candq, xq, 0x9999  ; x / 5 * 3
+    sar          candq, 16
+    movzx         r10d, byte [bq+candq*8+22] ; cand_b->bs
+    movu            m0, [bq+candq*8+12]      ; cand_b
+    movzx         r11d, byte [base+save_tmvs_ssse3_table+r10*2+0]
+    movzx         r10d, byte [base+save_tmvs_ssse3_table+r10*2+1]
+    add            r10, base_reg
+    add          candq, r11
+    jge .calc
+    movu            m1, [bq+candq*8+12]
+    movzx         r11d, byte [bq+candq*8+22]
+    movzx         r11d, byte [base+save_tmvs_ssse3_table+r11*2+1]
+    add            r11, base_reg
+.calc:
+    movif32        rpq, r0m
+    ; ref check
+    punpckhqdq      m2, m0, m1
+    pshufb          m2, m4      ; b0.ref0 b0.ref1 b1.ref0 b1.ref1 | ...
+    pshufb          m3, m5, m2  ; ref > 0 && res_sign[ref - 1]
+    ; mv check
+    punpcklqdq      m2, m0, m1  ; b0.mv0 b0.mv1 b1.mv0 b1.mv1 | ...
+    pabsw           m2, m2
+    psrlw           m2, 12      ; (abs(mv.x) | abs(mv.y)) < 4096
+    ; res
+    pcmpgtd         m3, m2
+    pshufd          m2, m3, q2301
+    pand            m3, m6      ; b0c0 b0c1 b1c0 b1c1 | ...
+    pand            m2, m7      ; b0c1 b0c0 b1c1 b1c0 | ...
+    por             m3, m2      ; b0.shuf b1.shuf | ...
+    pxor            m3, m8      ; if cond0|cond1 == 0 => zero out
+    pshufb          m0, m3
+    pshufb          m1, m3
+    call           r10
+    jge .next_line
+    pshufd          m0, m1, q3232
+    call           r11
+    jl .loop_x
+.next_line:
+    add            rpq, stridemp
+    movif32        r0m, rpq
+    dec             hd
+    jg .loop_y
+    RET
+.write1:
+    movd    [rpq+xq+0], m0
+    psrlq           m0, 8
+    movd    [rpq+xq+1], m0
+    add             xq, 5*1
+    ret
+.write2:
+    movq    [rpq+xq+0], m0
+    psrlq           m0, 8
+    movd    [rpq+xq+6], m0
+    add             xq, 5*2
+    ret
+.write4:
+    pshufb          m0, m9
+    movu   [rpq+xq+ 0], m0
+    psrlq           m0, 8
+    movd   [rpq+xq+16], m0
+    add             xq, 5*4
+    ret
+.write8:
+    pshufb          m2, m0, m9
+    movu   [rpq+xq+ 0], m2
+    pshufb          m0, m10
+    movu   [rpq+xq+16], m0
+    psrldq          m2, 2
+    movq   [rpq+xq+32], m2
+    add             xq, 5*8
+    ret
+.write16:
+    pshufb          m2, m0, m9
+    movu   [rpq+xq+ 0], m2
+    pshufb          m0, m10
+    movu   [rpq+xq+16], m0
+    shufps          m2, m0, q1032
+    movu   [rpq+xq+48], m2
+    shufps          m2, m0, q2121
+    movu   [rpq+xq+32], m2
+    shufps          m0, m2, q1032
+    movu   [rpq+xq+64], m0
+    add             xq, 5*16
+    ret
 
 INIT_XMM sse2
 ; refmvs_block **rr, refmvs_block *a, int bx4, int bw4, int bh4

--- a/src/x86/refmvs.h
+++ b/src/x86/refmvs.h
@@ -30,6 +30,7 @@
 
 decl_save_tmvs_fn(dav1d_save_tmvs_ssse3);
 decl_save_tmvs_fn(dav1d_save_tmvs_avx2);
+decl_save_tmvs_fn(dav1d_save_tmvs_avx512icl);
 
 decl_splat_mv_fn(dav1d_splat_mv_sse2);
 decl_splat_mv_fn(dav1d_splat_mv_avx2);
@@ -54,6 +55,7 @@ static ALWAYS_INLINE void refmvs_dsp_init_x86(Dav1dRefmvsDSPContext *const c) {
 
     if (!(flags & DAV1D_X86_CPU_FLAG_AVX512ICL)) return;
 
+    c->save_tmvs = dav1d_save_tmvs_avx512icl;
     c->splat_mv = dav1d_splat_mv_avx512icl;
 #endif
 }

--- a/src/x86/refmvs.h
+++ b/src/x86/refmvs.h
@@ -28,6 +28,8 @@
 #include "src/cpu.h"
 #include "src/refmvs.h"
 
+decl_save_tmvs_fn(dav1d_save_tmvs_avx2);
+
 decl_splat_mv_fn(dav1d_splat_mv_sse2);
 decl_splat_mv_fn(dav1d_splat_mv_avx2);
 decl_splat_mv_fn(dav1d_splat_mv_avx512icl);
@@ -42,6 +44,7 @@ static ALWAYS_INLINE void refmvs_dsp_init_x86(Dav1dRefmvsDSPContext *const c) {
 #if ARCH_X86_64
     if (!(flags & DAV1D_X86_CPU_FLAG_AVX2)) return;
 
+    c->save_tmvs = dav1d_save_tmvs_avx2;
     c->splat_mv = dav1d_splat_mv_avx2;
 
     if (!(flags & DAV1D_X86_CPU_FLAG_AVX512ICL)) return;

--- a/src/x86/refmvs.h
+++ b/src/x86/refmvs.h
@@ -28,6 +28,7 @@
 #include "src/cpu.h"
 #include "src/refmvs.h"
 
+decl_save_tmvs_fn(dav1d_save_tmvs_ssse3);
 decl_save_tmvs_fn(dav1d_save_tmvs_avx2);
 
 decl_splat_mv_fn(dav1d_splat_mv_sse2);
@@ -40,6 +41,10 @@ static ALWAYS_INLINE void refmvs_dsp_init_x86(Dav1dRefmvsDSPContext *const c) {
     if (!(flags & DAV1D_X86_CPU_FLAG_SSE2)) return;
 
     c->splat_mv = dav1d_splat_mv_sse2;
+
+    if (!(flags & DAV1D_X86_CPU_FLAG_SSSE3)) return;
+
+    c->save_tmvs = dav1d_save_tmvs_ssse3;
 
 #if ARCH_X86_64
     if (!(flags & DAV1D_X86_CPU_FLAG_AVX2)) return;

--- a/tests/checkasm/refmvs.c
+++ b/tests/checkasm/refmvs.c
@@ -27,6 +27,84 @@
 #include "tests/checkasm/checkasm.h"
 #include "src/refmvs.h"
 
+#include <stdio.h>
+
+static void check_save_tmvs(const Dav1dRefmvsDSPContext *const c) {
+    refmvs_block *rr[31];
+    refmvs_block r[31 * 256];
+    ALIGN_STK_64(refmvs_temporal_block, c_rp, 128 * 16,);
+    ALIGN_STK_64(refmvs_temporal_block, a_rp, 128 * 16,);
+    uint8_t ref_sign[7];
+
+    for (int i = 0; i < 31; i++)
+        rr[i] = &r[i * 256];
+
+    declare_func(void, refmvs_temporal_block *rp, const ptrdiff_t stride,
+                 refmvs_block *const *const rr, const uint8_t *const ref_sign,
+                 int col_end8, int row_end8, int col_start8, int row_start8);
+
+    if (check_func(c->save_tmvs, "save_tmvs")) {
+        const int row_start8 = rnd() & 7;
+        const int row_end8 = 8 + (rnd() & 7);
+        const int col_start8 = rnd() & 31;
+        const int col_end8 = 96 + (rnd() & 31);
+
+        for (int i = 0; i < 7; i++)
+            ref_sign[i] = rnd() & 1;
+
+        for (int i = row_start8; i < row_end8; i++)
+            for (int j = col_start8; j < col_end8;) {
+                int bs = rnd() % N_BS_SIZES;
+                while (j + ((dav1d_block_dimensions[bs][0] + 1) >> 1) > col_end8)
+                    bs++;
+                rr[i * 2][j * 2 + 1] = (refmvs_block) {
+                    .mv.mv[0].x = -(rnd() & 1) * (rnd() & 8191),
+                    .mv.mv[0].y = -(rnd() & 1) * (rnd() & 8191),
+                    .mv.mv[1].x = -(rnd() & 1) * (rnd() & 8191),
+                    .mv.mv[1].y = -(rnd() & 1) * (rnd() & 8191),
+                    .ref.ref = { (rnd() % 9) - 1, (rnd() % 9) - 1 },
+                    .bs = bs
+                };
+                for (int k = 0; k < (dav1d_block_dimensions[bs][0] + 1) >> 1; k++, j++) {
+                    c_rp[i * 128 + j].mv.n = 0xdeadbeef;
+                    c_rp[i * 128 + j].ref = 0xdd;
+                }
+            }
+
+        call_ref(c_rp + row_start8 * 128, 128, rr, ref_sign,
+                 col_end8, row_end8, col_start8, row_start8);
+        call_new(a_rp + row_start8 * 128, 128, rr, ref_sign,
+                 col_end8, row_end8, col_start8, row_start8);
+        for (int i = row_start8; i < row_end8; i++)
+            for (int j = col_start8; j < col_end8; j++)
+                if (c_rp[i * 128 + j].mv.n != a_rp[i * 128 + j].mv.n ||
+                    c_rp[i * 128 + j].ref != a_rp[i * 128 + j].ref)
+                {
+                    if (fail()) {
+                        fprintf(stderr, "[%d][%d] c_rp.mv.x = 0x%x a_rp.mv.x = 0x%x\n",
+                                i, j, c_rp[i * 128 + j].mv.x, a_rp[i * 128 + j].mv.x);
+                        fprintf(stderr, "[%d][%d] c_rp.mv.y = 0x%x a_rp.mv.y = 0x%x\n",
+                                i, j, c_rp[i * 128 + j].mv.y, a_rp[i * 128 + j].mv.y);
+                        fprintf(stderr, "[%d][%d] c_rp.ref = %u a_rp.ref = %u\n",
+                                i, j, c_rp[i * 128 + j].ref, a_rp[i * 128 + j].ref);
+                    }
+                }
+
+        for (int bs = BS_4x4; bs < N_BS_SIZES; bs++) {
+            const int bw8 = (dav1d_block_dimensions[bs][0] + 1) >> 1;
+            for (int i = 0; i < 16; i++)
+                for (int j = 0; j < 128; j += bw8) {
+                    rr[i * 2][j * 2 + 1].ref.ref[0] = (rnd() % 9) - 1;
+                    rr[i * 2][j * 2 + 1].ref.ref[1] = (rnd() % 9) - 1;
+                    rr[i * 2][j * 2 + 1].bs = bs;
+                }
+            bench_new(alternate(c_rp, a_rp), 128, rr, ref_sign, 128, 16, 0, 0);
+        }
+    }
+
+    report("save_tmvs");
+}
+
 static void check_splat_mv(const Dav1dRefmvsDSPContext *const c) {
     ALIGN_STK_64(refmvs_block, c_buf, 32 * 32,);
     ALIGN_STK_64(refmvs_block, a_buf, 32 * 32,);
@@ -74,5 +152,6 @@ void checkasm_check_refmvs(void) {
     Dav1dRefmvsDSPContext c;
     dav1d_refmvs_dsp_init(&c);
 
+    check_save_tmvs(&c);
     check_splat_mv(&c);
 }


### PR DESCRIPTION
Make `refmvs_temporal_block` a packed structure and abstract functions for loading and saving it. Add asm functions for saving mvs. Partially addresses #225