### PR TITLE
`fn DEBUG_BLOCK_INFO`: Deduplicate and cleanup

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1887,7 +1887,7 @@ unsafe extern "C" fn read_pal_plane(
                 .wrapping_mul(::core::mem::size_of::<uint16_t>() as libc::c_ulong),
         );
     }
-    if DEBUG_BLOCK_INFO(f, t) {
+    if DEBUG_BLOCK_INFO(&*f, &*t) {
         printf(
             b"Post-pal[pl=%d,sz=%d,cache_size=%d,used_cache=%d]: r=%d, cache=\0" as *const u8
                 as *const libc::c_char,
@@ -1976,7 +1976,7 @@ unsafe extern "C" fn read_pal_uv(
             i_0 += 1;
         }
     }
-    if DEBUG_BLOCK_INFO(f, t) {
+    if DEBUG_BLOCK_INFO(&*f, &*t) {
         printf(
             b"Post-pal[pl=2]: r=%d \0" as *const u8 as *const libc::c_char,
             (*ts).msac.rng,
@@ -2451,7 +2451,7 @@ unsafe extern "C" fn read_vartx_tree(
             y_off += 1;
         }
         (*t).by -= y;
-        if DEBUG_BLOCK_INFO(f, t) {
+        if DEBUG_BLOCK_INFO(&*f, &*t) {
             printf(
                 b"Post-vartxtree[%x/%x]: r=%d\n\0" as *const u8 as *const libc::c_char,
                 tx_split[0] as libc::c_int,
@@ -6869,7 +6869,7 @@ unsafe extern "C" fn decode_sb(
             {
                 return 1 as libc::c_int;
             }
-            if DEBUG_BLOCK_INFO(f, t) {
+            if DEBUG_BLOCK_INFO(&*f, &*t) {
                 printf(
                     b"poc=%d,y=%d,x=%d,bl=%d,ctx=%d,bp=%d: r=%d\n\0" as *const u8
                         as *const libc::c_char,
@@ -7286,7 +7286,7 @@ unsafe extern "C" fn decode_sb(
         } else {
             is_split = dav1d_msac_decode_bool(&mut (*ts).msac, gather_top_partition_prob(pc, bl))
                 as libc::c_uint;
-            if DEBUG_BLOCK_INFO(f, t) {
+            if DEBUG_BLOCK_INFO(&*f, &*t) {
                 printf(
                     b"poc=%d,y=%d,x=%d,bl=%d,ctx=%d,bp=%d: r=%d\n\0" as *const u8
                         as *const libc::c_char,
@@ -7361,7 +7361,7 @@ unsafe extern "C" fn decode_sb(
             {
                 return 1 as libc::c_int;
             }
-            if DEBUG_BLOCK_INFO(f, t) {
+            if DEBUG_BLOCK_INFO(&*f, &*t) {
                 printf(
                     b"poc=%d,y=%d,x=%d,bl=%d,ctx=%d,bp=%d: r=%d\n\0" as *const u8
                         as *const libc::c_char,
@@ -7824,7 +7824,7 @@ unsafe extern "C" fn read_restoration_info(
             ::core::mem::size_of::<[int8_t; 2]>() as libc::c_ulong,
         );
         (*ts).lr_ref[p as usize] = lr;
-        if DEBUG_BLOCK_INFO(f, t) {
+        if DEBUG_BLOCK_INFO(&*f, &*t) {
             printf(
                 b"Post-lr_wiener[pl=%d,v[%d,%d,%d],h[%d,%d,%d]]: r=%d\n\0" as *const u8
                     as *const libc::c_char,
@@ -7874,7 +7874,7 @@ unsafe extern "C" fn read_restoration_info(
             ::core::mem::size_of::<[int8_t; 3]>() as libc::c_ulong,
         );
         (*ts).lr_ref[p as usize] = lr;
-        if DEBUG_BLOCK_INFO(f, t) {
+        if DEBUG_BLOCK_INFO(&*f, &*t) {
             printf(
                 b"Post-lr_sgrproj[pl=%d,idx=%d,w[%d,%d]]: r=%d\n\0" as *const u8
                     as *const libc::c_char,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1887,13 +1887,7 @@ unsafe extern "C" fn read_pal_plane(
                 .wrapping_mul(::core::mem::size_of::<uint16_t>() as libc::c_ulong),
         );
     }
-    if 0 as libc::c_int != 0
-        && (*(*f).frame_hdr).frame_offset == 2
-        && (*t).by >= 0
-        && (*t).by < 4
-        && (*t).bx >= 8
-        && (*t).bx < 12
-    {
+    if DEBUG_BLOCK_INFO(f, t) {
         printf(
             b"Post-pal[pl=%d,sz=%d,cache_size=%d,used_cache=%d]: r=%d, cache=\0" as *const u8
                 as *const libc::c_char,
@@ -1982,13 +1976,7 @@ unsafe extern "C" fn read_pal_uv(
             i_0 += 1;
         }
     }
-    if 0 as libc::c_int != 0
-        && (*(*f).frame_hdr).frame_offset == 2
-        && (*t).by >= 0
-        && (*t).by < 4
-        && (*t).bx >= 8
-        && (*t).bx < 12
-    {
+    if DEBUG_BLOCK_INFO(f, t) {
         printf(
             b"Post-pal[pl=2]: r=%d \0" as *const u8 as *const libc::c_char,
             (*ts).msac.rng,
@@ -2463,13 +2451,7 @@ unsafe extern "C" fn read_vartx_tree(
             y_off += 1;
         }
         (*t).by -= y;
-        if 0 as libc::c_int != 0
-            && (*(*f).frame_hdr).frame_offset == 2
-            && (*t).by >= 0
-            && (*t).by < 4
-            && (*t).bx >= 8
-            && (*t).bx < 12
-        {
+        if DEBUG_BLOCK_INFO(f, t) {
             printf(
                 b"Post-vartxtree[%x/%x]: r=%d\n\0" as *const u8 as *const libc::c_char,
                 tx_split[0] as libc::c_int,
@@ -7842,13 +7824,7 @@ unsafe extern "C" fn read_restoration_info(
             ::core::mem::size_of::<[int8_t; 2]>() as libc::c_ulong,
         );
         (*ts).lr_ref[p as usize] = lr;
-        if 0 as libc::c_int != 0
-            && (*(*f).frame_hdr).frame_offset == 2
-            && (*t).by >= 0
-            && (*t).by < 4
-            && (*t).bx >= 8
-            && (*t).bx < 12
-        {
+        if DEBUG_BLOCK_INFO(f, t) {
             printf(
                 b"Post-lr_wiener[pl=%d,v[%d,%d,%d],h[%d,%d,%d]]: r=%d\n\0" as *const u8
                     as *const libc::c_char,
@@ -7898,13 +7874,7 @@ unsafe extern "C" fn read_restoration_info(
             ::core::mem::size_of::<[int8_t; 3]>() as libc::c_ulong,
         );
         (*ts).lr_ref[p as usize] = lr;
-        if 0 as libc::c_int != 0
-            && (*(*f).frame_hdr).frame_offset == 2
-            && (*t).by >= 0
-            && (*t).by < 4
-            && (*t).bx >= 8
-            && (*t).bx < 12
-        {
+        if DEBUG_BLOCK_INFO(f, t) {
             printf(
                 b"Post-lr_sgrproj[pl=%d,idx=%d,w[%d,%d]]: r=%d\n\0" as *const u8
                     as *const libc::c_char,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1115,6 +1115,10 @@ use crate::src::env::get_tx_ctx;
 use crate::src::msac::dav1d_msac_decode_bools;
 use crate::src::msac::dav1d_msac_decode_uniform;
 
+use crate::src::recon::define_DEBUG_BLOCK_INFO;
+
+define_DEBUG_BLOCK_INFO!();
+
 fn init_quant_tables(
     seq_hdr: &Dav1dSequenceHeader,
     frame_hdr: &Dav1dFrameHeader,
@@ -2846,20 +2850,6 @@ unsafe fn obmc_lowest_px(
             y += imax(l_b_dim[1] as libc::c_int, 2);
         }
     }
-}
-
-/* NOTE: DEBUG_BLOCK_INFO is a macro in recon.h so it should probably live in
- * one of the rust files generated from recon_tmpl.c once deduplicated.
- */
-unsafe fn DEBUG_BLOCK_INFO(f: *const Dav1dFrameContext, t: *const Dav1dTaskContext) -> bool {
-    /* TODO: add feature and compile-time guard around this code */
-    0 != 0
-        && (*(*f).frame_hdr).frame_offset == 2
-        && (*t).by >= 0
-        && (*t).by < 4
-        && (*t).bx >= 8
-        && (*t).bx < 12
-    // true
 }
 
 unsafe fn decode_b(

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -1,6 +1,29 @@
 use crate::src::msac::dav1d_msac_decode_bool_equi;
 use crate::src::msac::MsacContext;
 
+/// This is a macro that defines a function
+/// because it takes `Dav1dFrameContext` and `Dav1dTaskContext` as arguments,
+/// which have not yet been deduplicated/genericized over bitdepth.
+macro_rules! define_DEBUG_BLOCK_INFO {
+    () => {
+        unsafe fn DEBUG_BLOCK_INFO(
+            f: *const Dav1dFrameContext,
+            t: *const Dav1dTaskContext,
+        ) -> bool {
+            /* TODO: add feature and compile-time guard around this code */
+            0 != 0
+                && (*(*f).frame_hdr).frame_offset == 2
+                && (*t).by >= 0
+                && (*t).by < 4
+                && (*t).bx >= 8
+                && (*t).bx < 12
+            // true
+        }
+    };
+}
+
+pub(crate) use define_DEBUG_BLOCK_INFO;
+
 #[inline]
 pub unsafe extern "C" fn read_golomb(msac: &mut MsacContext) -> libc::c_uint {
     let mut len = 0;

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -7,16 +7,13 @@ use crate::src::msac::MsacContext;
 macro_rules! define_DEBUG_BLOCK_INFO {
     () => {
         /// TODO: add feature and compile-time guard around this code
-        unsafe fn DEBUG_BLOCK_INFO(
-            f: *const Dav1dFrameContext,
-            t: *const Dav1dTaskContext,
-        ) -> bool {
+        unsafe fn DEBUG_BLOCK_INFO(f: &Dav1dFrameContext, t: &Dav1dTaskContext) -> bool {
             false
-                && (*(*f).frame_hdr).frame_offset == 2
-                && (*t).by >= 0
-                && (*t).by < 4
-                && (*t).bx >= 8
-                && (*t).bx < 12
+                && (*f.frame_hdr).frame_offset == 2
+                && t.by >= 0
+                && t.by < 4
+                && t.bx >= 8
+                && t.bx < 12
         }
     };
 }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -6,18 +6,17 @@ use crate::src::msac::MsacContext;
 /// which have not yet been deduplicated/genericized over bitdepth.
 macro_rules! define_DEBUG_BLOCK_INFO {
     () => {
+        /// TODO: add feature and compile-time guard around this code
         unsafe fn DEBUG_BLOCK_INFO(
             f: *const Dav1dFrameContext,
             t: *const Dav1dTaskContext,
         ) -> bool {
-            /* TODO: add feature and compile-time guard around this code */
-            0 != 0
+            false
                 && (*(*f).frame_hdr).frame_offset == 2
                 && (*t).by >= 0
                 && (*t).by < 4
                 && (*t).bx >= 8
                 && (*t).bx < 12
-            // true
         }
     };
 }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -4,6 +4,11 @@ use crate::src::msac::MsacContext;
 /// This is a macro that defines a function
 /// because it takes `Dav1dFrameContext` and `Dav1dTaskContext` as arguments,
 /// which have not yet been deduplicated/genericized over bitdepth.
+///
+/// TODO: This should not remain a macro.
+/// It should either be a `fn` generic over bitdepth
+/// or take `struct` arguments that are the subset of fields that are actually used in this `fn`,
+/// as this would also solve some borrowck errors that had to be worked around.
 macro_rules! define_DEBUG_BLOCK_INFO {
     () => {
         /// TODO: add feature and compile-time guard around this code

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -808,6 +808,11 @@ use crate::src::ctx::alias32;
 use crate::src::ctx::alias64;
 use crate::src::ctx::alias8;
 use crate::src::tables::TxfmInfo;
+
+use crate::src::recon::define_DEBUG_BLOCK_INFO;
+
+define_DEBUG_BLOCK_INFO!();
+
 #[inline]
 unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     if x & 1 != 0 {
@@ -1263,14 +1268,7 @@ unsafe extern "C" fn decode_coefs(
     let lossless = (*(*f).frame_hdr).segmentation.lossless[(*b).seg_id as usize];
     let t_dim: *const TxfmInfo =
         &*dav1d_txfm_dimensions.as_ptr().offset(tx as isize) as *const TxfmInfo;
-    let dbg = (0 as libc::c_int != 0
-        && (*(*f).frame_hdr).frame_offset == 2
-        && (*t).by >= 0
-        && (*t).by < 4
-        && (*t).bx >= 8
-        && (*t).bx < 12
-        && plane != 0
-        && 0 != 0) as libc::c_int;
+    let dbg = DEBUG_BLOCK_INFO(f, t) as libc::c_int;
     if dbg != 0 {
         printf(
             b"Start: r=%d\n\0" as *const u8 as *const libc::c_char,
@@ -2587,13 +2585,7 @@ unsafe extern "C" fn read_coef_tree(
                 &mut txtp,
                 &mut cf_ctx,
             );
-            if 0 as libc::c_int != 0
-                && (*(*f).frame_hdr).frame_offset == 2
-                && (*t).by >= 0
-                && (*t).by < 4
-                && (*t).bx >= 8
-                && (*t).bx < 12
-            {
+            if DEBUG_BLOCK_INFO(f, t) {
                 printf(
                     b"Post-y-cf-blk[tx=%d,txtp=%d,eob=%d]: r=%d\n\0" as *const u8
                         as *const libc::c_char,
@@ -2766,14 +2758,7 @@ unsafe extern "C" fn read_coef_tree(
                 unreachable!();
             }
             if eob >= 0 {
-                if 0 as libc::c_int != 0
-                    && (*(*f).frame_hdr).frame_offset == 2
-                    && (*t).by >= 0
-                    && (*t).by < 4
-                    && (*t).bx >= 8
-                    && (*t).bx < 12
-                    && 0 != 0
-                {
+                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                     coef_dump(
                         cf,
                         imin((*t_dim).h as libc::c_int, 8 as libc::c_int) * 4,
@@ -2790,14 +2775,7 @@ unsafe extern "C" fn read_coef_tree(
                     eob,
                     (*f).bitdepth_max,
                 );
-                if 0 as libc::c_int != 0
-                    && (*(*f).frame_hdr).frame_offset == 2
-                    && (*t).by >= 0
-                    && (*t).by < 4
-                    && (*t).bx >= 8
-                    && (*t).bx < 12
-                    && 0 != 0
-                {
+                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                     hex_dump(
                         dst,
                         (*f).cur.stride[0],
@@ -3294,13 +3272,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                             &mut cf_ctx,
                         ) as int16_t;
                         let eob = *fresh4 as libc::c_int;
-                        if 0 as libc::c_int != 0
-                            && (*(*f).frame_hdr).frame_offset == 2
-                            && (*t).by >= 0
-                            && (*t).by < 4
-                            && (*t).bx >= 8
-                            && (*t).bx < 12
-                        {
+                        if DEBUG_BLOCK_INFO(f, t) {
                             printf(
                                 b"Post-y-cf-blk[tx=%d,txtp=%d,eob=%d]: r=%d\n\0" as *const u8
                                     as *const libc::c_char,
@@ -3486,13 +3458,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                 &mut cf_ctx_0,
                             ) as int16_t;
                             let eob_0 = *fresh5 as libc::c_int;
-                            if 0 as libc::c_int != 0
-                                && (*(*f).frame_hdr).frame_offset == 2
-                                && (*t).by >= 0
-                                && (*t).by < 4
-                                && (*t).bx >= 8
-                                && (*t).bx < 12
-                            {
+                            if DEBUG_BLOCK_INFO(f, t) {
                                 printf(
                                     b"Post-uv-cf-blk[pl=%d,tx=%d,txtp=%d,eob=%d]: r=%d\n\0"
                                         as *const u8
@@ -3811,13 +3777,7 @@ unsafe extern "C" fn mc(
         let top = pos_y >> 10;
         let right = (pos_x + (bw4 * h_mul - 1) * (*f).svc[refidx as usize][0].step >> 10) + 1;
         let bottom = (pos_y + (bh4 * v_mul - 1) * (*f).svc[refidx as usize][1].step >> 10) + 1;
-        if 0 as libc::c_int != 0
-            && (*(*f).frame_hdr).frame_offset == 2
-            && (*t).by >= 0
-            && (*t).by < 4
-            && (*t).bx >= 8
-            && (*t).bx < 12
-        {
+        if DEBUG_BLOCK_INFO(f, t) {
             printf(
                 b"Off %dx%d [%d,%d,%d], size %dx%d [%d,%d]\n\0" as *const u8 as *const libc::c_char,
                 left,
@@ -3854,13 +3814,7 @@ unsafe extern "C" fn mc(
             ref_stride = (320 as libc::c_int as libc::c_ulong)
                 .wrapping_mul(::core::mem::size_of::<pixel>() as libc::c_ulong)
                 as ptrdiff_t;
-            if 0 as libc::c_int != 0
-                && (*(*f).frame_hdr).frame_offset == 2
-                && (*t).by >= 0
-                && (*t).by < 4
-                && (*t).bx >= 8
-                && (*t).bx < 12
-            {
+            if DEBUG_BLOCK_INFO(f, t) {
                 printf(b"Emu\n\0" as *const u8 as *const libc::c_char);
             }
         } else {
@@ -4252,14 +4206,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                     bw4 * 4,
                     bh4 * 4,
                 );
-                if 0 as libc::c_int != 0
-                    && (*(*f).frame_hdr).frame_offset == 2
-                    && (*t).by >= 0
-                    && (*t).by < 4
-                    && (*t).bx >= 8
-                    && (*t).bx < 12
-                    && 0 != 0
-                {
+                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                     hex_dump(
                         dst,
                         PXSTRIDE((*f).cur.stride[0]),
@@ -4357,14 +4304,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                             4 * (*f).bh - 4 * (*t).by,
                             (*f).bitdepth_max,
                         );
-                        if 0 as libc::c_int != 0
-                            && (*(*f).frame_hdr).frame_offset == 2
-                            && (*t).by >= 0
-                            && (*t).by < 4
-                            && (*t).bx >= 8
-                            && (*t).bx < 12
-                            && 0 != 0
-                        {
+                        if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                             hex_dump(
                                 edge.offset(-(((*t_dim).h as libc::c_int * 4) as isize)),
                                 ((*t_dim).h as libc::c_int * 4) as ptrdiff_t,
@@ -4430,13 +4370,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                 &mut txtp,
                                 &mut cf_ctx,
                             );
-                            if 0 as libc::c_int != 0
-                                && (*(*f).frame_hdr).frame_offset == 2
-                                && (*t).by >= 0
-                                && (*t).by < 4
-                                && (*t).bx >= 8
-                                && (*t).bx < 12
-                            {
+                            if DEBUG_BLOCK_INFO(f, t) {
                                 printf(
                                     b"Post-y-cf-blk[tx=%d,txtp=%d,eob=%d]: r=%d\n\0" as *const u8
                                         as *const libc::c_char,
@@ -4582,14 +4516,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                             }
                         }
                         if eob >= 0 {
-                            if 0 as libc::c_int != 0
-                                && (*(*f).frame_hdr).frame_offset == 2
-                                && (*t).by >= 0
-                                && (*t).by < 4
-                                && (*t).bx >= 8
-                                && (*t).bx < 12
-                                && 0 != 0
-                            {
+                            if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                                 coef_dump(
                                     cf,
                                     imin((*t_dim).h as libc::c_int, 8 as libc::c_int) * 4,
@@ -4607,14 +4534,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                 eob,
                                 (*f).bitdepth_max,
                             );
-                            if 0 as libc::c_int != 0
-                                && (*(*f).frame_hdr).frame_offset == 2
-                                && (*t).by >= 0
-                                && (*t).by < 4
-                                && (*t).bx >= 8
-                                && (*t).bx < 12
-                                && 0 != 0
-                            {
+                            if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                                 hex_dump(
                                     dst_0,
                                     (*f).cur.stride[0],
@@ -4821,14 +4741,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                         }
                         pl += 1;
                     }
-                    if 0 as libc::c_int != 0
-                        && (*(*f).frame_hdr).frame_offset == 2
-                        && (*t).by >= 0
-                        && (*t).by < 4
-                        && (*t).bx >= 8
-                        && (*t).bx < 12
-                        && 0 != 0
-                    {
+                    if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                         ac_dump(
                             ac,
                             4 * cbw4,
@@ -4895,14 +4808,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                         cbw4 * 4,
                         cbh4 * 4,
                     );
-                    if 0 as libc::c_int != 0
-                        && (*(*f).frame_hdr).frame_offset == 2
-                        && (*t).by >= 0
-                        && (*t).by < 4
-                        && (*t).bx >= 8
-                        && (*t).bx < 12
-                        && 0 != 0
-                    {
+                    if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                         hex_dump(
                             ((*f).cur.data[1] as *mut pixel).offset(uv_dstoff as isize),
                             PXSTRIDE((*f).cur.stride[1]),
@@ -5040,14 +4946,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                     4 * (*f).bh + ss_ver - 4 * ((*t).by & !ss_ver) >> ss_ver,
                                     (*f).bitdepth_max,
                                 );
-                                if 0 as libc::c_int != 0
-                                    && (*(*f).frame_hdr).frame_offset == 2
-                                    && (*t).by >= 0
-                                    && (*t).by < 4
-                                    && (*t).bx >= 8
-                                    && (*t).bx < 12
-                                    && 0 != 0
-                                {
+                                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                                     hex_dump(
                                         edge.offset(-(((*uv_t_dim).h as libc::c_int * 4) as isize)),
                                         ((*uv_t_dim).h as libc::c_int * 4) as ptrdiff_t,
@@ -5128,13 +5027,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                         &mut txtp_0,
                                         &mut cf_ctx_0,
                                     );
-                                    if 0 as libc::c_int != 0
-                                        && (*(*f).frame_hdr).frame_offset == 2
-                                        && (*t).by >= 0
-                                        && (*t).by < 4
-                                        && (*t).bx >= 8
-                                        && (*t).bx < 12
-                                    {
+                                    if DEBUG_BLOCK_INFO(f, t) {
                                         printf(
                                             b"Post-uv-cf-blk[pl=%d,tx=%d,txtp=%d,eob=%d]: r=%d [x=%d,cbx4=%d]\n\0"
                                                 as *const u8 as *const libc::c_char,
@@ -5325,14 +5218,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                     }
                                 }
                                 if eob_0 >= 0 {
-                                    if 0 as libc::c_int != 0
-                                        && (*(*f).frame_hdr).frame_offset == 2
-                                        && (*t).by >= 0
-                                        && (*t).by < 4
-                                        && (*t).bx >= 8
-                                        && (*t).bx < 12
-                                        && 0 != 0
-                                    {
+                                    if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                                         coef_dump(
                                             cf_0,
                                             (*uv_t_dim).h as libc::c_int * 4,
@@ -5349,14 +5235,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                         eob_0,
                                         (*f).bitdepth_max,
                                     );
-                                    if 0 as libc::c_int != 0
-                                        && (*(*f).frame_hdr).frame_offset == 2
-                                        && (*t).by >= 0
-                                        && (*t).by < 4
-                                        && (*t).bx >= 8
-                                        && (*t).bx < 12
-                                        && 0 != 0
-                                    {
+                                    if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                                         hex_dump(
                                             dst_1,
                                             stride,
@@ -6548,14 +6427,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
             }
         }
     }
-    if 0 as libc::c_int != 0
-        && (*(*f).frame_hdr).frame_offset == 2
-        && (*t).by >= 0
-        && (*t).by < 4
-        && (*t).bx >= 8
-        && (*t).bx < 12
-        && 0 != 0
-    {
+    if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
         hex_dump(
             dst,
             (*f).cur.stride[0],
@@ -7074,13 +6946,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                     &mut txtp,
                                     &mut cf_ctx,
                                 );
-                                if 0 as libc::c_int != 0
-                                    && (*(*f).frame_hdr).frame_offset == 2
-                                    && (*t).by >= 0
-                                    && (*t).by < 4
-                                    && (*t).bx >= 8
-                                    && (*t).bx < 12
-                                {
+                                if DEBUG_BLOCK_INFO(f, t) {
                                     printf(
                                         b"Post-uv-cf-blk[pl=%d,tx=%d,txtp=%d,eob=%d]: r=%d\n\0"
                                             as *const u8
@@ -7266,14 +7132,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                 }
                             }
                             if eob >= 0 {
-                                if 0 as libc::c_int != 0
-                                    && (*(*f).frame_hdr).frame_offset == 2
-                                    && (*t).by >= 0
-                                    && (*t).by < 4
-                                    && (*t).bx >= 8
-                                    && (*t).bx < 12
-                                    && 0 != 0
-                                {
+                                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                                     coef_dump(
                                         cf,
                                         (*uvtx).h as libc::c_int * 4,
@@ -7290,14 +7149,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                     eob,
                                     (*f).bitdepth_max,
                                 );
-                                if 0 as libc::c_int != 0
-                                    && (*(*f).frame_hdr).frame_offset == 2
-                                    && (*t).by >= 0
-                                    && (*t).by < 4
-                                    && (*t).bx >= 8
-                                    && (*t).bx < 12
-                                    && 0 != 0
-                                {
+                                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                                     hex_dump(
                                         &mut *uvdst_1.offset((4 * x_0) as isize),
                                         (*f).cur.stride[1],

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1268,7 +1268,7 @@ unsafe extern "C" fn decode_coefs(
     let lossless = (*(*f).frame_hdr).segmentation.lossless[(*b).seg_id as usize];
     let t_dim: *const TxfmInfo =
         &*dav1d_txfm_dimensions.as_ptr().offset(tx as isize) as *const TxfmInfo;
-    let dbg = DEBUG_BLOCK_INFO(f, t) as libc::c_int;
+    let dbg = DEBUG_BLOCK_INFO(&*f, &*t) as libc::c_int;
     if dbg != 0 {
         printf(
             b"Start: r=%d\n\0" as *const u8 as *const libc::c_char,
@@ -2585,7 +2585,7 @@ unsafe extern "C" fn read_coef_tree(
                 &mut txtp,
                 &mut cf_ctx,
             );
-            if DEBUG_BLOCK_INFO(f, t) {
+            if DEBUG_BLOCK_INFO(&*f, &*t) {
                 printf(
                     b"Post-y-cf-blk[tx=%d,txtp=%d,eob=%d]: r=%d\n\0" as *const u8
                         as *const libc::c_char,
@@ -2758,7 +2758,7 @@ unsafe extern "C" fn read_coef_tree(
                 unreachable!();
             }
             if eob >= 0 {
-                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                     coef_dump(
                         cf,
                         imin((*t_dim).h as libc::c_int, 8 as libc::c_int) * 4,
@@ -2775,7 +2775,7 @@ unsafe extern "C" fn read_coef_tree(
                     eob,
                     (*f).bitdepth_max,
                 );
-                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                     hex_dump(
                         dst,
                         (*f).cur.stride[0],
@@ -3272,7 +3272,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                             &mut cf_ctx,
                         ) as int16_t;
                         let eob = *fresh4 as libc::c_int;
-                        if DEBUG_BLOCK_INFO(f, t) {
+                        if DEBUG_BLOCK_INFO(&*f, &*t) {
                             printf(
                                 b"Post-y-cf-blk[tx=%d,txtp=%d,eob=%d]: r=%d\n\0" as *const u8
                                     as *const libc::c_char,
@@ -3458,7 +3458,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                 &mut cf_ctx_0,
                             ) as int16_t;
                             let eob_0 = *fresh5 as libc::c_int;
-                            if DEBUG_BLOCK_INFO(f, t) {
+                            if DEBUG_BLOCK_INFO(&*f, &*t) {
                                 printf(
                                     b"Post-uv-cf-blk[pl=%d,tx=%d,txtp=%d,eob=%d]: r=%d\n\0"
                                         as *const u8
@@ -3777,7 +3777,7 @@ unsafe extern "C" fn mc(
         let top = pos_y >> 10;
         let right = (pos_x + (bw4 * h_mul - 1) * (*f).svc[refidx as usize][0].step >> 10) + 1;
         let bottom = (pos_y + (bh4 * v_mul - 1) * (*f).svc[refidx as usize][1].step >> 10) + 1;
-        if DEBUG_BLOCK_INFO(f, t) {
+        if DEBUG_BLOCK_INFO(&*f, &*t) {
             printf(
                 b"Off %dx%d [%d,%d,%d], size %dx%d [%d,%d]\n\0" as *const u8 as *const libc::c_char,
                 left,
@@ -3814,7 +3814,7 @@ unsafe extern "C" fn mc(
             ref_stride = (320 as libc::c_int as libc::c_ulong)
                 .wrapping_mul(::core::mem::size_of::<pixel>() as libc::c_ulong)
                 as ptrdiff_t;
-            if DEBUG_BLOCK_INFO(f, t) {
+            if DEBUG_BLOCK_INFO(&*f, &*t) {
                 printf(b"Emu\n\0" as *const u8 as *const libc::c_char);
             }
         } else {
@@ -4206,7 +4206,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                     bw4 * 4,
                     bh4 * 4,
                 );
-                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                     hex_dump(
                         dst,
                         PXSTRIDE((*f).cur.stride[0]),
@@ -4304,7 +4304,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                             4 * (*f).bh - 4 * (*t).by,
                             (*f).bitdepth_max,
                         );
-                        if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                        if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                             hex_dump(
                                 edge.offset(-(((*t_dim).h as libc::c_int * 4) as isize)),
                                 ((*t_dim).h as libc::c_int * 4) as ptrdiff_t,
@@ -4370,7 +4370,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                 &mut txtp,
                                 &mut cf_ctx,
                             );
-                            if DEBUG_BLOCK_INFO(f, t) {
+                            if DEBUG_BLOCK_INFO(&*f, &*t) {
                                 printf(
                                     b"Post-y-cf-blk[tx=%d,txtp=%d,eob=%d]: r=%d\n\0" as *const u8
                                         as *const libc::c_char,
@@ -4516,7 +4516,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                             }
                         }
                         if eob >= 0 {
-                            if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                            if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                                 coef_dump(
                                     cf,
                                     imin((*t_dim).h as libc::c_int, 8 as libc::c_int) * 4,
@@ -4534,7 +4534,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                 eob,
                                 (*f).bitdepth_max,
                             );
-                            if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                            if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                                 hex_dump(
                                     dst_0,
                                     (*f).cur.stride[0],
@@ -4741,7 +4741,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                         }
                         pl += 1;
                     }
-                    if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                    if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                         ac_dump(
                             ac,
                             4 * cbw4,
@@ -4808,7 +4808,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                         cbw4 * 4,
                         cbh4 * 4,
                     );
-                    if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                    if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                         hex_dump(
                             ((*f).cur.data[1] as *mut pixel).offset(uv_dstoff as isize),
                             PXSTRIDE((*f).cur.stride[1]),
@@ -4946,7 +4946,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                     4 * (*f).bh + ss_ver - 4 * ((*t).by & !ss_ver) >> ss_ver,
                                     (*f).bitdepth_max,
                                 );
-                                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                                if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                                     hex_dump(
                                         edge.offset(-(((*uv_t_dim).h as libc::c_int * 4) as isize)),
                                         ((*uv_t_dim).h as libc::c_int * 4) as ptrdiff_t,
@@ -5027,7 +5027,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                         &mut txtp_0,
                                         &mut cf_ctx_0,
                                     );
-                                    if DEBUG_BLOCK_INFO(f, t) {
+                                    if DEBUG_BLOCK_INFO(&*f, &*t) {
                                         printf(
                                             b"Post-uv-cf-blk[pl=%d,tx=%d,txtp=%d,eob=%d]: r=%d [x=%d,cbx4=%d]\n\0"
                                                 as *const u8 as *const libc::c_char,
@@ -5218,7 +5218,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                     }
                                 }
                                 if eob_0 >= 0 {
-                                    if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                                    if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                                         coef_dump(
                                             cf_0,
                                             (*uv_t_dim).h as libc::c_int * 4,
@@ -5235,7 +5235,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                         eob_0,
                                         (*f).bitdepth_max,
                                     );
-                                    if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                                    if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                                         hex_dump(
                                             dst_1,
                                             stride,
@@ -6427,7 +6427,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
             }
         }
     }
-    if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+    if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
         hex_dump(
             dst,
             (*f).cur.stride[0],
@@ -6946,7 +6946,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                     &mut txtp,
                                     &mut cf_ctx,
                                 );
-                                if DEBUG_BLOCK_INFO(f, t) {
+                                if DEBUG_BLOCK_INFO(&*f, &*t) {
                                     printf(
                                         b"Post-uv-cf-blk[pl=%d,tx=%d,txtp=%d,eob=%d]: r=%d\n\0"
                                             as *const u8
@@ -7132,7 +7132,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                 }
                             }
                             if eob >= 0 {
-                                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                                if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                                     coef_dump(
                                         cf,
                                         (*uvtx).h as libc::c_int * 4,
@@ -7149,7 +7149,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                     eob,
                                     (*f).bitdepth_max,
                                 );
-                                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                                if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                                     hex_dump(
                                         &mut *uvdst_1.offset((4 * x_0) as isize),
                                         (*f).cur.stride[1],

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1479,7 +1479,7 @@ unsafe extern "C" fn decode_coefs(
     let lossless = (*(*f).frame_hdr).segmentation.lossless[(*b).seg_id as usize];
     let t_dim: *const TxfmInfo =
         &*dav1d_txfm_dimensions.as_ptr().offset(tx as isize) as *const TxfmInfo;
-    let dbg = DEBUG_BLOCK_INFO(f, t) as libc::c_int;
+    let dbg = DEBUG_BLOCK_INFO(&*f, &*t) as libc::c_int;
     if dbg != 0 {
         printf(
             b"Start: r=%d\n\0" as *const u8 as *const libc::c_char,
@@ -2800,7 +2800,7 @@ unsafe extern "C" fn read_coef_tree(
                 &mut txtp,
                 &mut cf_ctx,
             );
-            if DEBUG_BLOCK_INFO(f, t) {
+            if DEBUG_BLOCK_INFO(&*f, &*t) {
                 printf(
                     b"Post-y-cf-blk[tx=%d,txtp=%d,eob=%d]: r=%d\n\0" as *const u8
                         as *const libc::c_char,
@@ -2973,7 +2973,7 @@ unsafe extern "C" fn read_coef_tree(
                 unreachable!();
             }
             if eob >= 0 {
-                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                     coef_dump(
                         cf,
                         imin((*t_dim).h as libc::c_int, 8 as libc::c_int) * 4,
@@ -2986,7 +2986,7 @@ unsafe extern "C" fn read_coef_tree(
                     .expect("non-null function pointer")(
                     dst, (*f).cur.stride[0], cf, eob
                 );
-                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                     hex_dump(
                         dst,
                         (*f).cur.stride[0],
@@ -3483,7 +3483,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                             &mut cf_ctx,
                         ) as int16_t;
                         let eob = *fresh4 as libc::c_int;
-                        if DEBUG_BLOCK_INFO(f, t) {
+                        if DEBUG_BLOCK_INFO(&*f, &*t) {
                             printf(
                                 b"Post-y-cf-blk[tx=%d,txtp=%d,eob=%d]: r=%d\n\0" as *const u8
                                     as *const libc::c_char,
@@ -3669,7 +3669,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                 &mut cf_ctx_0,
                             ) as int16_t;
                             let eob_0 = *fresh5 as libc::c_int;
-                            if DEBUG_BLOCK_INFO(f, t) {
+                            if DEBUG_BLOCK_INFO(&*f, &*t) {
                                 printf(
                                     b"Post-uv-cf-blk[pl=%d,tx=%d,txtp=%d,eob=%d]: r=%d\n\0"
                                         as *const u8
@@ -3986,7 +3986,7 @@ unsafe extern "C" fn mc(
         let top = pos_y >> 10;
         let right = (pos_x + (bw4 * h_mul - 1) * (*f).svc[refidx as usize][0].step >> 10) + 1;
         let bottom = (pos_y + (bh4 * v_mul - 1) * (*f).svc[refidx as usize][1].step >> 10) + 1;
-        if DEBUG_BLOCK_INFO(f, t) {
+        if DEBUG_BLOCK_INFO(&*f, &*t) {
             printf(
                 b"Off %dx%d [%d,%d,%d], size %dx%d [%d,%d]\n\0" as *const u8 as *const libc::c_char,
                 left,
@@ -4023,7 +4023,7 @@ unsafe extern "C" fn mc(
             ref_stride = (320 as libc::c_int as libc::c_ulong)
                 .wrapping_mul(::core::mem::size_of::<pixel>() as libc::c_ulong)
                 as ptrdiff_t;
-            if DEBUG_BLOCK_INFO(f, t) {
+            if DEBUG_BLOCK_INFO(&*f, &*t) {
                 printf(b"Emu\n\0" as *const u8 as *const libc::c_char);
             }
         } else {
@@ -4405,7 +4405,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                     bw4 * 4,
                     bh4 * 4,
                 );
-                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                     hex_dump(
                         dst,
                         (*f).cur.stride[0],
@@ -4501,7 +4501,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                             4 * (*f).bw - 4 * (*t).bx,
                             4 * (*f).bh - 4 * (*t).by,
                         );
-                        if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                        if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                             hex_dump(
                                 edge.offset(-(((*t_dim).h as libc::c_int * 4) as isize)),
                                 ((*t_dim).h as libc::c_int * 4) as ptrdiff_t,
@@ -4567,7 +4567,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                 &mut txtp,
                                 &mut cf_ctx,
                             );
-                            if DEBUG_BLOCK_INFO(f, t) {
+                            if DEBUG_BLOCK_INFO(&*f, &*t) {
                                 printf(
                                     b"Post-y-cf-blk[tx=%d,txtp=%d,eob=%d]: r=%d\n\0" as *const u8
                                         as *const libc::c_char,
@@ -4713,7 +4713,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                             }
                         }
                         if eob >= 0 {
-                            if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                            if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                                 coef_dump(
                                     cf,
                                     imin((*t_dim).h as libc::c_int, 8 as libc::c_int) * 4,
@@ -4730,7 +4730,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                 cf,
                                 eob,
                             );
-                            if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                            if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                                 hex_dump(
                                     dst_0,
                                     (*f).cur.stride[0],
@@ -4931,7 +4931,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                         }
                         pl += 1;
                     }
-                    if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                    if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                         ac_dump(
                             ac,
                             4 * cbw4,
@@ -4998,7 +4998,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                         cbw4 * 4,
                         cbh4 * 4,
                     );
-                    if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                    if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                         hex_dump(
                             ((*f).cur.data[1] as *mut pixel).offset(uv_dstoff as isize),
                             (*f).cur.stride[1],
@@ -5134,7 +5134,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                     4 * (*f).bw + ss_hor - 4 * ((*t).bx & !ss_hor) >> ss_hor,
                                     4 * (*f).bh + ss_ver - 4 * ((*t).by & !ss_ver) >> ss_ver,
                                 );
-                                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                                if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                                     hex_dump(
                                         edge.offset(-(((*uv_t_dim).h as libc::c_int * 4) as isize)),
                                         ((*uv_t_dim).h as libc::c_int * 4) as ptrdiff_t,
@@ -5215,7 +5215,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                         &mut txtp_0,
                                         &mut cf_ctx_0,
                                     );
-                                    if DEBUG_BLOCK_INFO(f, t) {
+                                    if DEBUG_BLOCK_INFO(&*f, &*t) {
                                         printf(
                                             b"Post-uv-cf-blk[pl=%d,tx=%d,txtp=%d,eob=%d]: r=%d [x=%d,cbx4=%d]\n\0"
                                                 as *const u8 as *const libc::c_char,
@@ -5406,7 +5406,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                     }
                                 }
                                 if eob_0 >= 0 {
-                                    if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                                    if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                                         coef_dump(
                                             cf_0,
                                             (*uv_t_dim).h as libc::c_int * 4,
@@ -5419,7 +5419,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                         .expect("non-null function pointer")(
                                         dst_1, stride, cf_0, eob_0,
                                     );
-                                    if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                                    if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                                         hex_dump(
                                             dst_1,
                                             stride,
@@ -6598,7 +6598,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
             }
         }
     }
-    if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+    if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
         hex_dump(
             dst,
             (*f).cur.stride[0],
@@ -7115,7 +7115,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                     &mut txtp,
                                     &mut cf_ctx,
                                 );
-                                if DEBUG_BLOCK_INFO(f, t) {
+                                if DEBUG_BLOCK_INFO(&*f, &*t) {
                                     printf(
                                         b"Post-uv-cf-blk[pl=%d,tx=%d,txtp=%d,eob=%d]: r=%d\n\0"
                                             as *const u8
@@ -7301,7 +7301,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                 }
                             }
                             if eob >= 0 {
-                                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                                if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                                     coef_dump(
                                         cf,
                                         (*uvtx).h as libc::c_int * 4,
@@ -7317,7 +7317,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                     cf,
                                     eob,
                                 );
-                                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
+                                if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                                     hex_dump(
                                         &mut *uvdst_1.offset((4 * x_0) as isize),
                                         (*f).cur.stride[1],

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -786,6 +786,11 @@ use crate::src::ctx::alias32;
 use crate::src::ctx::alias64;
 use crate::src::ctx::alias8;
 use crate::src::tables::TxfmInfo;
+
+use crate::src::recon::define_DEBUG_BLOCK_INFO;
+
+define_DEBUG_BLOCK_INFO!();
+
 #[inline]
 unsafe extern "C" fn hex_fdump(
     mut out: *mut libc::FILE,
@@ -1474,14 +1479,7 @@ unsafe extern "C" fn decode_coefs(
     let lossless = (*(*f).frame_hdr).segmentation.lossless[(*b).seg_id as usize];
     let t_dim: *const TxfmInfo =
         &*dav1d_txfm_dimensions.as_ptr().offset(tx as isize) as *const TxfmInfo;
-    let dbg = (0 as libc::c_int != 0
-        && (*(*f).frame_hdr).frame_offset == 2
-        && (*t).by >= 0
-        && (*t).by < 4
-        && (*t).bx >= 8
-        && (*t).bx < 12
-        && plane != 0
-        && 0 != 0) as libc::c_int;
+    let dbg = DEBUG_BLOCK_INFO(f, t) as libc::c_int;
     if dbg != 0 {
         printf(
             b"Start: r=%d\n\0" as *const u8 as *const libc::c_char,
@@ -2802,13 +2800,7 @@ unsafe extern "C" fn read_coef_tree(
                 &mut txtp,
                 &mut cf_ctx,
             );
-            if 0 as libc::c_int != 0
-                && (*(*f).frame_hdr).frame_offset == 2
-                && (*t).by >= 0
-                && (*t).by < 4
-                && (*t).bx >= 8
-                && (*t).bx < 12
-            {
+            if DEBUG_BLOCK_INFO(f, t) {
                 printf(
                     b"Post-y-cf-blk[tx=%d,txtp=%d,eob=%d]: r=%d\n\0" as *const u8
                         as *const libc::c_char,
@@ -2981,14 +2973,7 @@ unsafe extern "C" fn read_coef_tree(
                 unreachable!();
             }
             if eob >= 0 {
-                if 0 as libc::c_int != 0
-                    && (*(*f).frame_hdr).frame_offset == 2
-                    && (*t).by >= 0
-                    && (*t).by < 4
-                    && (*t).bx >= 8
-                    && (*t).bx < 12
-                    && 0 != 0
-                {
+                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                     coef_dump(
                         cf,
                         imin((*t_dim).h as libc::c_int, 8 as libc::c_int) * 4,
@@ -3001,14 +2986,7 @@ unsafe extern "C" fn read_coef_tree(
                     .expect("non-null function pointer")(
                     dst, (*f).cur.stride[0], cf, eob
                 );
-                if 0 as libc::c_int != 0
-                    && (*(*f).frame_hdr).frame_offset == 2
-                    && (*t).by >= 0
-                    && (*t).by < 4
-                    && (*t).bx >= 8
-                    && (*t).bx < 12
-                    && 0 != 0
-                {
+                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                     hex_dump(
                         dst,
                         (*f).cur.stride[0],
@@ -3505,13 +3483,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                             &mut cf_ctx,
                         ) as int16_t;
                         let eob = *fresh4 as libc::c_int;
-                        if 0 as libc::c_int != 0
-                            && (*(*f).frame_hdr).frame_offset == 2
-                            && (*t).by >= 0
-                            && (*t).by < 4
-                            && (*t).bx >= 8
-                            && (*t).bx < 12
-                        {
+                        if DEBUG_BLOCK_INFO(f, t) {
                             printf(
                                 b"Post-y-cf-blk[tx=%d,txtp=%d,eob=%d]: r=%d\n\0" as *const u8
                                     as *const libc::c_char,
@@ -3697,13 +3669,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                 &mut cf_ctx_0,
                             ) as int16_t;
                             let eob_0 = *fresh5 as libc::c_int;
-                            if 0 as libc::c_int != 0
-                                && (*(*f).frame_hdr).frame_offset == 2
-                                && (*t).by >= 0
-                                && (*t).by < 4
-                                && (*t).bx >= 8
-                                && (*t).bx < 12
-                            {
+                            if DEBUG_BLOCK_INFO(f, t) {
                                 printf(
                                     b"Post-uv-cf-blk[pl=%d,tx=%d,txtp=%d,eob=%d]: r=%d\n\0"
                                         as *const u8
@@ -4020,13 +3986,7 @@ unsafe extern "C" fn mc(
         let top = pos_y >> 10;
         let right = (pos_x + (bw4 * h_mul - 1) * (*f).svc[refidx as usize][0].step >> 10) + 1;
         let bottom = (pos_y + (bh4 * v_mul - 1) * (*f).svc[refidx as usize][1].step >> 10) + 1;
-        if 0 as libc::c_int != 0
-            && (*(*f).frame_hdr).frame_offset == 2
-            && (*t).by >= 0
-            && (*t).by < 4
-            && (*t).bx >= 8
-            && (*t).bx < 12
-        {
+        if DEBUG_BLOCK_INFO(f, t) {
             printf(
                 b"Off %dx%d [%d,%d,%d], size %dx%d [%d,%d]\n\0" as *const u8 as *const libc::c_char,
                 left,
@@ -4063,13 +4023,7 @@ unsafe extern "C" fn mc(
             ref_stride = (320 as libc::c_int as libc::c_ulong)
                 .wrapping_mul(::core::mem::size_of::<pixel>() as libc::c_ulong)
                 as ptrdiff_t;
-            if 0 as libc::c_int != 0
-                && (*(*f).frame_hdr).frame_offset == 2
-                && (*t).by >= 0
-                && (*t).by < 4
-                && (*t).bx >= 8
-                && (*t).bx < 12
-            {
+            if DEBUG_BLOCK_INFO(f, t) {
                 printf(b"Emu\n\0" as *const u8 as *const libc::c_char);
             }
         } else {
@@ -4451,14 +4405,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                     bw4 * 4,
                     bh4 * 4,
                 );
-                if 0 as libc::c_int != 0
-                    && (*(*f).frame_hdr).frame_offset == 2
-                    && (*t).by >= 0
-                    && (*t).by < 4
-                    && (*t).bx >= 8
-                    && (*t).bx < 12
-                    && 0 != 0
-                {
+                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                     hex_dump(
                         dst,
                         (*f).cur.stride[0],
@@ -4554,14 +4501,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                             4 * (*f).bw - 4 * (*t).bx,
                             4 * (*f).bh - 4 * (*t).by,
                         );
-                        if 0 as libc::c_int != 0
-                            && (*(*f).frame_hdr).frame_offset == 2
-                            && (*t).by >= 0
-                            && (*t).by < 4
-                            && (*t).bx >= 8
-                            && (*t).bx < 12
-                            && 0 != 0
-                        {
+                        if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                             hex_dump(
                                 edge.offset(-(((*t_dim).h as libc::c_int * 4) as isize)),
                                 ((*t_dim).h as libc::c_int * 4) as ptrdiff_t,
@@ -4627,13 +4567,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                 &mut txtp,
                                 &mut cf_ctx,
                             );
-                            if 0 as libc::c_int != 0
-                                && (*(*f).frame_hdr).frame_offset == 2
-                                && (*t).by >= 0
-                                && (*t).by < 4
-                                && (*t).bx >= 8
-                                && (*t).bx < 12
-                            {
+                            if DEBUG_BLOCK_INFO(f, t) {
                                 printf(
                                     b"Post-y-cf-blk[tx=%d,txtp=%d,eob=%d]: r=%d\n\0" as *const u8
                                         as *const libc::c_char,
@@ -4779,14 +4713,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                             }
                         }
                         if eob >= 0 {
-                            if 0 as libc::c_int != 0
-                                && (*(*f).frame_hdr).frame_offset == 2
-                                && (*t).by >= 0
-                                && (*t).by < 4
-                                && (*t).bx >= 8
-                                && (*t).bx < 12
-                                && 0 != 0
-                            {
+                            if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                                 coef_dump(
                                     cf,
                                     imin((*t_dim).h as libc::c_int, 8 as libc::c_int) * 4,
@@ -4803,14 +4730,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                 cf,
                                 eob,
                             );
-                            if 0 as libc::c_int != 0
-                                && (*(*f).frame_hdr).frame_offset == 2
-                                && (*t).by >= 0
-                                && (*t).by < 4
-                                && (*t).bx >= 8
-                                && (*t).bx < 12
-                                && 0 != 0
-                            {
+                            if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                                 hex_dump(
                                     dst_0,
                                     (*f).cur.stride[0],
@@ -5011,14 +4931,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                         }
                         pl += 1;
                     }
-                    if 0 as libc::c_int != 0
-                        && (*(*f).frame_hdr).frame_offset == 2
-                        && (*t).by >= 0
-                        && (*t).by < 4
-                        && (*t).bx >= 8
-                        && (*t).bx < 12
-                        && 0 != 0
-                    {
+                    if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                         ac_dump(
                             ac,
                             4 * cbw4,
@@ -5085,14 +4998,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                         cbw4 * 4,
                         cbh4 * 4,
                     );
-                    if 0 as libc::c_int != 0
-                        && (*(*f).frame_hdr).frame_offset == 2
-                        && (*t).by >= 0
-                        && (*t).by < 4
-                        && (*t).bx >= 8
-                        && (*t).bx < 12
-                        && 0 != 0
-                    {
+                    if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                         hex_dump(
                             ((*f).cur.data[1] as *mut pixel).offset(uv_dstoff as isize),
                             (*f).cur.stride[1],
@@ -5228,14 +5134,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                     4 * (*f).bw + ss_hor - 4 * ((*t).bx & !ss_hor) >> ss_hor,
                                     4 * (*f).bh + ss_ver - 4 * ((*t).by & !ss_ver) >> ss_ver,
                                 );
-                                if 0 as libc::c_int != 0
-                                    && (*(*f).frame_hdr).frame_offset == 2
-                                    && (*t).by >= 0
-                                    && (*t).by < 4
-                                    && (*t).bx >= 8
-                                    && (*t).bx < 12
-                                    && 0 != 0
-                                {
+                                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                                     hex_dump(
                                         edge.offset(-(((*uv_t_dim).h as libc::c_int * 4) as isize)),
                                         ((*uv_t_dim).h as libc::c_int * 4) as ptrdiff_t,
@@ -5316,13 +5215,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                         &mut txtp_0,
                                         &mut cf_ctx_0,
                                     );
-                                    if 0 as libc::c_int != 0
-                                        && (*(*f).frame_hdr).frame_offset == 2
-                                        && (*t).by >= 0
-                                        && (*t).by < 4
-                                        && (*t).bx >= 8
-                                        && (*t).bx < 12
-                                    {
+                                    if DEBUG_BLOCK_INFO(f, t) {
                                         printf(
                                             b"Post-uv-cf-blk[pl=%d,tx=%d,txtp=%d,eob=%d]: r=%d [x=%d,cbx4=%d]\n\0"
                                                 as *const u8 as *const libc::c_char,
@@ -5513,14 +5406,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                     }
                                 }
                                 if eob_0 >= 0 {
-                                    if 0 as libc::c_int != 0
-                                        && (*(*f).frame_hdr).frame_offset == 2
-                                        && (*t).by >= 0
-                                        && (*t).by < 4
-                                        && (*t).bx >= 8
-                                        && (*t).bx < 12
-                                        && 0 != 0
-                                    {
+                                    if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                                         coef_dump(
                                             cf_0,
                                             (*uv_t_dim).h as libc::c_int * 4,
@@ -5533,14 +5419,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                         .expect("non-null function pointer")(
                                         dst_1, stride, cf_0, eob_0,
                                     );
-                                    if 0 as libc::c_int != 0
-                                        && (*(*f).frame_hdr).frame_offset == 2
-                                        && (*t).by >= 0
-                                        && (*t).by < 4
-                                        && (*t).bx >= 8
-                                        && (*t).bx < 12
-                                        && 0 != 0
-                                    {
+                                    if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                                         hex_dump(
                                             dst_1,
                                             stride,
@@ -6719,14 +6598,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
             }
         }
     }
-    if 0 as libc::c_int != 0
-        && (*(*f).frame_hdr).frame_offset == 2
-        && (*t).by >= 0
-        && (*t).by < 4
-        && (*t).bx >= 8
-        && (*t).bx < 12
-        && 0 != 0
-    {
+    if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
         hex_dump(
             dst,
             (*f).cur.stride[0],
@@ -7243,13 +7115,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                     &mut txtp,
                                     &mut cf_ctx,
                                 );
-                                if 0 as libc::c_int != 0
-                                    && (*(*f).frame_hdr).frame_offset == 2
-                                    && (*t).by >= 0
-                                    && (*t).by < 4
-                                    && (*t).bx >= 8
-                                    && (*t).bx < 12
-                                {
+                                if DEBUG_BLOCK_INFO(f, t) {
                                     printf(
                                         b"Post-uv-cf-blk[pl=%d,tx=%d,txtp=%d,eob=%d]: r=%d\n\0"
                                             as *const u8
@@ -7435,14 +7301,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                 }
                             }
                             if eob >= 0 {
-                                if 0 as libc::c_int != 0
-                                    && (*(*f).frame_hdr).frame_offset == 2
-                                    && (*t).by >= 0
-                                    && (*t).by < 4
-                                    && (*t).bx >= 8
-                                    && (*t).bx < 12
-                                    && 0 != 0
-                                {
+                                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                                     coef_dump(
                                         cf,
                                         (*uvtx).h as libc::c_int * 4,
@@ -7458,14 +7317,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                     cf,
                                     eob,
                                 );
-                                if 0 as libc::c_int != 0
-                                    && (*(*f).frame_hdr).frame_offset == 2
-                                    && (*t).by >= 0
-                                    && (*t).by < 4
-                                    && (*t).bx >= 8
-                                    && (*t).bx < 12
-                                    && 0 != 0
-                                {
+                                if DEBUG_BLOCK_INFO(f, t) && 0 != 0 {
                                     hex_dump(
                                         &mut *uvdst_1.offset((4 * x_0) as isize),
                                         (*f).cur.stride[1],


### PR DESCRIPTION
Since `fn DEBUG_BLOCK_INFO` depends on types (`Dav1dFrameContext`, `Dav1dTaskContext`) that haven't been deduplicated/genericized over bitdepth yet, we can't have a single definition for it, even though it only uses fields that are not bitdepth-dependent.  Thus, I defined a macro that defines the `fn` in each module that uses it.  Once we do bitdepth genericization or split out the non-bitdepth-dependent parts of these types, we can consolidate the `fn`-defining macro into just a normal `fn`.

Also, making some other functions safe requires `DEBUG_BLOCK_INFO` to take refs instead of raw ptrs, which is why I decided to fully deduplicate and clean this up now.