### PR TITLE
`fn read_pal_plane`: Cleanup and make mostly safe

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1549,7 +1549,7 @@ fn findoddzero(buf: &[u8]) -> bool {
         .is_some()
 }
 
-unsafe extern "C" fn read_pal_plane(
+unsafe fn read_pal_plane(
     t: *mut Dav1dTaskContext,
     b: *mut Av1Block,
     pl: libc::c_int,
@@ -1763,6 +1763,7 @@ unsafe extern "C" fn read_pal_plane(
         printf(b"]\n\0" as *const u8 as *const libc::c_char);
     }
 }
+
 unsafe extern "C" fn read_pal_uv(
     t: *mut Dav1dTaskContext,
     b: *mut Av1Block,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1583,36 +1583,37 @@ unsafe fn read_pal_plane(
     } else {
         0
     };
-    let mut l = t.al_pal[1][by4 as usize][pl as usize].as_mut_ptr();
-    let mut a = t.al_pal[0][bx4 as usize][pl as usize].as_mut_ptr();
+    let [a, l] = &mut t.al_pal;
+    let mut l = &mut l[by4 as usize][pl as usize][..];
+    let mut a = &mut a[bx4 as usize][pl as usize][..];
     while l_cache != 0 && a_cache != 0 {
-        if *l < *a {
-            if n_cache == 0 || cache[n_cache - 1] != *l {
-                cache[n_cache] = *l;
+        if l[0] < a[0] {
+            if n_cache == 0 || cache[n_cache - 1] != l[0] {
+                cache[n_cache] = l[0];
                 n_cache += 1;
             }
-            l = l.offset(1);
+            l = &mut l[1..];
             l_cache -= 1;
         } else {
-            if *a == *l {
-                l = l.offset(1);
+            if a[0] == l[0] {
+                l = &mut l[1..];
                 l_cache -= 1;
             }
-            if n_cache == 0 || cache[n_cache - 1] != *a {
-                cache[n_cache] = *a;
+            if n_cache == 0 || cache[n_cache - 1] != a[0] {
+                cache[n_cache] = a[0];
                 n_cache += 1;
             }
-            a = a.offset(1);
+            a = &mut a[1..];
             a_cache -= 1;
         }
     }
     if l_cache != 0 {
         loop {
-            if n_cache == 0 || cache[n_cache - 1] != *l {
-                cache[n_cache] = *l;
+            if n_cache == 0 || cache[n_cache - 1] != l[0] {
+                cache[n_cache] = l[0];
                 n_cache += 1;
             }
-            l = l.offset(1);
+            l = &mut l[1..];
             l_cache -= 1;
             if !(l_cache > 0) {
                 break;
@@ -1620,11 +1621,11 @@ unsafe fn read_pal_plane(
         }
     } else if a_cache != 0 {
         loop {
-            if n_cache == 0 || cache[n_cache - 1] != *a {
-                cache[n_cache] = *a;
+            if n_cache == 0 || cache[n_cache - 1] != a[0] {
+                cache[n_cache] = a[0];
                 n_cache += 1;
             }
-            a = a.offset(1);
+            a = &mut a[1..];
             a_cache -= 1;
             if !(a_cache > 0) {
                 break;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1676,9 +1676,8 @@ unsafe fn read_pal_plane(
                 prev = pal[i] as libc::c_int;
                 i += 1;
                 if prev + not_pl >= max {
-                    while i < pal_sz {
+                    for i in i..pal_sz {
                         pal[i] = max as uint16_t;
-                        i += 1;
                     }
                     break;
                 } else {
@@ -1691,8 +1690,7 @@ unsafe fn read_pal_plane(
         }
         let mut n = 0;
         let mut m = n_used_cache;
-        i = 0;
-        while i < pal_sz {
+        for i in 0..pal_sz {
             if n < n_used_cache && (m >= pal_sz || used_cache[n] <= pal[m]) {
                 pal[i] = used_cache[n];
                 n += 1;
@@ -1701,7 +1699,6 @@ unsafe fn read_pal_plane(
                 pal[i] = pal[m];
                 m += 1;
             }
-            i += 1;
         }
     } else {
         pal[..n_used_cache].copy_from_slice(&used_cache[..n_used_cache]);
@@ -1711,16 +1708,12 @@ unsafe fn read_pal_plane(
             "Post-pal[pl={},sz={},cache_size={},used_cache={}]: r={}, cache=",
             pli, pal_sz, n_cache, n_used_cache, ts.msac.rng
         );
-        let mut n = 0;
-        while n < n_cache {
+        for n in 0..n_cache {
             print!("{}{:02x}", if n != 0 { ' ' } else { '[' }, cache[n]);
-            n += 1;
         }
         print!("{}, pal=", if n_cache != 0 { "]" } else { "[]" });
-        let mut n = 0;
-        while n < pal_sz {
+        for n in 0..pal_sz {
             print!("{}{:02x}", if n != 0 { ' ' } else { '[' }, pal[n]);
-            n += 1;
         }
         println!("]");
     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1554,8 +1554,8 @@ unsafe fn read_pal_plane(
     b: &mut Av1Block,
     pl: libc::c_int,
     sz_ctx: u8,
-    bx4: libc::c_int,
-    by4: libc::c_int,
+    bx4: usize,
+    by4: usize,
 ) {
     let ts = &mut *t.ts;
     let f = &*t.f;
@@ -1569,23 +1569,23 @@ unsafe fn read_pal_plane(
     let mut cache: [uint16_t; 16] = [0; 16];
     let mut used_cache: [uint16_t; 8] = [0; 8];
     let mut l_cache = if pl != 0 {
-        t.pal_sz_uv[1][by4 as usize] as libc::c_int
+        t.pal_sz_uv[1][by4] as libc::c_int
     } else {
-        t.l.pal_sz.0[by4 as usize] as libc::c_int
+        t.l.pal_sz.0[by4] as libc::c_int
     };
     let mut n_cache = 0;
     let mut a_cache = if by4 & 15 != 0 {
         (if pl != 0 {
-            t.pal_sz_uv[0][bx4 as usize]
+            t.pal_sz_uv[0][bx4]
         } else {
-            (*t.a).pal_sz.0[bx4 as usize]
+            (*t.a).pal_sz.0[bx4]
         }) as libc::c_int
     } else {
         0
     };
     let [a, l] = &mut t.al_pal;
-    let mut l = &mut l[by4 as usize][pl as usize][..];
-    let mut a = &mut a[bx4 as usize][pl as usize][..];
+    let mut l = &mut l[by4][pl as usize][..];
+    let mut a = &mut a[bx4][pl as usize][..];
     while l_cache != 0 && a_cache != 0 {
         if l[0] < a[0] {
             if n_cache == 0 || cache[n_cache - 1] != l[0] {
@@ -1741,8 +1741,8 @@ unsafe extern "C" fn read_pal_uv(
     t: *mut Dav1dTaskContext,
     b: *mut Av1Block,
     sz_ctx: u8,
-    bx4: libc::c_int,
-    by4: libc::c_int,
+    bx4: usize,
+    by4: usize,
 ) {
     read_pal_plane(&mut *t, &mut *b, 1 as libc::c_int, sz_ctx, bx4, by4);
     let ts: *mut Dav1dTileState = (*t).ts;
@@ -3289,7 +3289,7 @@ unsafe fn decode_b(
                 }
 
                 if use_y_pal {
-                    read_pal_plane(t, b, 0, sz_ctx, bx4, by4);
+                    read_pal_plane(t, b, 0, sz_ctx, bx4 as usize, by4 as usize);
                 }
             }
 
@@ -3305,7 +3305,7 @@ unsafe fn decode_b(
                 }
 
                 if use_uv_pal {
-                    read_pal_uv(t, b, sz_ctx, bx4, by4);
+                    read_pal_uv(t, b, sz_ctx, bx4 as usize, by4 as usize);
                 }
             }
         }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1695,7 +1695,6 @@ unsafe fn read_pal_plane(
                 pal[i] = used_cache[n];
                 n += 1;
             } else {
-                assert!(m < pal.len());
                 pal[i] = pal[m];
                 m += 1;
             }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1676,9 +1676,7 @@ unsafe fn read_pal_plane(
                 pal[i] = prev;
                 i += 1;
                 if prev + not_pl >= max {
-                    for pal in &mut pal[i..] {
-                        *pal = max;
-                    }
+                    pal[i..].fill(max);
                     break;
                 } else {
                     bits = std::cmp::min(bits, 1 + ulog2((max - prev - not_pl) as u32) as u32);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1562,10 +1562,9 @@ unsafe fn read_pal_plane(
     b.c2rust_unnamed.c2rust_unnamed.pal_sz[pl as usize] = (dav1d_msac_decode_symbol_adapt8(
         &mut ts.msac,
         &mut ts.cdf.m.pal_sz[pl as usize][sz_ctx as usize],
-        6 as libc::c_int as size_t,
+        6,
     ))
-    .wrapping_add(2 as libc::c_int as libc::c_uint)
-        as uint8_t;
+    .wrapping_add(2) as uint8_t;
     let pal_sz = b.c2rust_unnamed.c2rust_unnamed.pal_sz[pl as usize] as libc::c_int;
     let mut cache: [uint16_t; 16] = [0; 16];
     let mut used_cache: [uint16_t; 8] = [0; 8];
@@ -1576,19 +1575,19 @@ unsafe fn read_pal_plane(
     };
     let mut n_cache = 0;
     let mut a_cache = if by4 & 15 != 0 {
-        if pl != 0 {
-            t.pal_sz_uv[0][bx4 as usize] as libc::c_int
+        (if pl != 0 {
+            t.pal_sz_uv[0][bx4 as usize]
         } else {
-            (*t.a).pal_sz.0[bx4 as usize] as libc::c_int
-        }
+            (*t.a).pal_sz.0[bx4 as usize]
+        }) as libc::c_int
     } else {
-        0 as libc::c_int
+        0
     };
-    let mut l: *const uint16_t = (t.al_pal[1][by4 as usize][pl as usize]).as_mut_ptr();
-    let mut a: *const uint16_t = (t.al_pal[0][bx4 as usize][pl as usize]).as_mut_ptr();
+    let mut l = t.al_pal[1][by4 as usize][pl as usize].as_mut_ptr();
+    let mut a = t.al_pal[0][bx4 as usize][pl as usize].as_mut_ptr();
     while l_cache != 0 && a_cache != 0 {
-        if (*l as libc::c_int) < *a as libc::c_int {
-            if n_cache == 0 || cache[(n_cache - 1) as usize] as libc::c_int != *l as libc::c_int {
+        if *l < *a {
+            if n_cache == 0 || cache[(n_cache - 1) as usize] != *l {
                 let fresh8 = n_cache;
                 n_cache = n_cache + 1;
                 cache[fresh8 as usize] = *l;
@@ -1596,11 +1595,11 @@ unsafe fn read_pal_plane(
             l = l.offset(1);
             l_cache -= 1;
         } else {
-            if *a as libc::c_int == *l as libc::c_int {
+            if *a == *l {
                 l = l.offset(1);
                 l_cache -= 1;
             }
-            if n_cache == 0 || cache[(n_cache - 1) as usize] as libc::c_int != *a as libc::c_int {
+            if n_cache == 0 || cache[(n_cache - 1) as usize] != *a {
                 let fresh9 = n_cache;
                 n_cache = n_cache + 1;
                 cache[fresh9 as usize] = *a;
@@ -1611,7 +1610,7 @@ unsafe fn read_pal_plane(
     }
     if l_cache != 0 {
         loop {
-            if n_cache == 0 || cache[(n_cache - 1) as usize] as libc::c_int != *l as libc::c_int {
+            if n_cache == 0 || cache[(n_cache - 1) as usize] != *l {
                 let fresh10 = n_cache;
                 n_cache = n_cache + 1;
                 cache[fresh10 as usize] = *l;
@@ -1624,7 +1623,7 @@ unsafe fn read_pal_plane(
         }
     } else if a_cache != 0 {
         loop {
-            if n_cache == 0 || cache[(n_cache - 1) as usize] as libc::c_int != *a as libc::c_int {
+            if n_cache == 0 || cache[(n_cache - 1) as usize] != *a {
                 let fresh11 = n_cache;
                 n_cache = n_cache + 1;
                 cache[fresh11 as usize] = *a;
@@ -1647,14 +1646,14 @@ unsafe fn read_pal_plane(
         n += 1;
     }
     let n_used_cache = i;
-    let pal: *mut uint16_t = if t.frame_thread.pass != 0 {
-        ((*(f.frame_thread.pal).offset(
+    let pal = if t.frame_thread.pass != 0 {
+        (*(f.frame_thread.pal).offset(
             (((t.by >> 1) + (t.bx & 1)) as isize * (f.b4_stride >> 1)
                 + ((t.bx >> 1) + (t.by & 1)) as isize) as isize,
-        ))[pl as usize])
+        ))[pl as usize]
             .as_mut_ptr()
     } else {
-        (t.scratch.c2rust_unnamed_0.pal[pl as usize]).as_mut_ptr()
+        t.scratch.c2rust_unnamed_0.pal[pl as usize].as_mut_ptr()
     };
     if i < pal_sz {
         let fresh13 = i;
@@ -1663,10 +1662,10 @@ unsafe fn read_pal_plane(
         *fresh14 = dav1d_msac_decode_bools(&mut ts.msac, f.cur.p.bpc as libc::c_uint) as uint16_t;
         let mut prev = *fresh14 as libc::c_int;
         if i < pal_sz {
-            let mut bits = ((f.cur.p.bpc - 3) as libc::c_uint).wrapping_add(
-                dav1d_msac_decode_bools(&mut ts.msac, 2 as libc::c_int as libc::c_uint),
-            ) as libc::c_int;
-            let max = ((1 as libc::c_int) << f.cur.p.bpc) - 1;
+            let mut bits = ((f.cur.p.bpc - 3) as libc::c_uint)
+                .wrapping_add(dav1d_msac_decode_bools(&mut ts.msac, 2))
+                as libc::c_int;
+            let max = (1 << f.cur.p.bpc) - 1;
             loop {
                 let delta =
                     dav1d_msac_decode_bools(&mut ts.msac, bits as libc::c_uint) as libc::c_int;
@@ -1684,8 +1683,7 @@ unsafe fn read_pal_plane(
                 } else {
                     bits = imin(
                         bits,
-                        1 as libc::c_int
-                            + ulog2((max - prev - (pl == 0) as libc::c_int) as libc::c_uint),
+                        1 + ulog2((max - prev - (pl == 0) as libc::c_int) as libc::c_uint),
                     );
                     if !(i < pal_sz) {
                         break;
@@ -1695,12 +1693,10 @@ unsafe fn read_pal_plane(
         }
         let mut n_0 = 0;
         let mut m = n_used_cache;
-        i = 0 as libc::c_int;
+        i = 0;
         while i < pal_sz {
             if n_0 < n_used_cache
-                && (m >= pal_sz
-                    || used_cache[n_0 as usize] as libc::c_int
-                        <= *pal.offset(m as isize) as libc::c_int)
+                && (m >= pal_sz || used_cache[n_0 as usize] <= *pal.offset(m as isize))
             {
                 let fresh17 = n_0;
                 n_0 = n_0 + 1;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1551,7 +1551,7 @@ fn findoddzero(buf: &[u8]) -> bool {
 
 unsafe fn read_pal_plane(
     t: &mut Dav1dTaskContext,
-    b: *mut Av1Block,
+    b: &mut Av1Block,
     pl: libc::c_int,
     sz_ctx: libc::c_int,
     bx4: libc::c_int,
@@ -1559,14 +1559,14 @@ unsafe fn read_pal_plane(
 ) {
     let ts: *mut Dav1dTileState = t.ts;
     let f: *const Dav1dFrameContext = t.f;
-    (*b).c2rust_unnamed.c2rust_unnamed.pal_sz[pl as usize] = (dav1d_msac_decode_symbol_adapt8(
+    b.c2rust_unnamed.c2rust_unnamed.pal_sz[pl as usize] = (dav1d_msac_decode_symbol_adapt8(
         &mut (*ts).msac,
         &mut (*ts).cdf.m.pal_sz[pl as usize][sz_ctx as usize],
         6 as libc::c_int as size_t,
     ))
     .wrapping_add(2 as libc::c_int as libc::c_uint)
         as uint8_t;
-    let pal_sz = (*b).c2rust_unnamed.c2rust_unnamed.pal_sz[pl as usize] as libc::c_int;
+    let pal_sz = b.c2rust_unnamed.c2rust_unnamed.pal_sz[pl as usize] as libc::c_int;
     let mut cache: [uint16_t; 16] = [0; 16];
     let mut used_cache: [uint16_t; 8] = [0; 8];
     let mut l_cache = if pl != 0 {
@@ -1771,7 +1771,7 @@ unsafe extern "C" fn read_pal_uv(
     bx4: libc::c_int,
     by4: libc::c_int,
 ) {
-    read_pal_plane(&mut *t, b, 1 as libc::c_int, sz_ctx, bx4, by4);
+    read_pal_plane(&mut *t, &mut *b, 1 as libc::c_int, sz_ctx, bx4, by4);
     let ts: *mut Dav1dTileState = (*t).ts;
     let f: *const Dav1dFrameContext = (*t).f;
     let pal: *mut uint16_t = if (*t).frame_thread.pass != 0 {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1557,15 +1557,16 @@ unsafe fn read_pal_plane(
     bx4: usize,
     by4: usize,
 ) {
+    let pli = pl as usize;
     let ts = &mut *t.ts;
     let f = &*t.f;
-    b.c2rust_unnamed.c2rust_unnamed.pal_sz[pl as usize] = (dav1d_msac_decode_symbol_adapt8(
+    b.c2rust_unnamed.c2rust_unnamed.pal_sz[pli] = (dav1d_msac_decode_symbol_adapt8(
         &mut ts.msac,
-        &mut ts.cdf.m.pal_sz[pl as usize][sz_ctx as usize],
+        &mut ts.cdf.m.pal_sz[pli][sz_ctx as usize],
         6,
     ))
     .wrapping_add(2) as uint8_t;
-    let pal_sz = b.c2rust_unnamed.c2rust_unnamed.pal_sz[pl as usize] as libc::c_int;
+    let pal_sz = b.c2rust_unnamed.c2rust_unnamed.pal_sz[pli] as libc::c_int;
     let mut cache: [uint16_t; 16] = [0; 16];
     let mut used_cache: [uint16_t; 8] = [0; 8];
     let mut l_cache = if pl {
@@ -1584,8 +1585,8 @@ unsafe fn read_pal_plane(
         0
     };
     let [a, l] = &mut t.al_pal;
-    let mut l = &mut l[by4][pl as usize][..];
-    let mut a = &mut a[bx4][pl as usize][..];
+    let mut l = &mut l[by4][pli][..];
+    let mut a = &mut a[bx4][pli][..];
     while l_cache != 0 && a_cache != 0 {
         if l[0] < a[0] {
             if n_cache == 0 || cache[n_cache - 1] != l[0] {
@@ -1646,10 +1647,10 @@ unsafe fn read_pal_plane(
         (*(f.frame_thread.pal).offset(
             (((t.by >> 1) + (t.bx & 1)) as isize * (f.b4_stride >> 1)
                 + ((t.bx >> 1) + (t.by & 1)) as isize) as isize,
-        ))[pl as usize]
+        ))[pli]
             .as_mut_ptr()
     } else {
-        t.scratch.c2rust_unnamed_0.pal[pl as usize].as_mut_ptr()
+        t.scratch.c2rust_unnamed_0.pal[pli].as_mut_ptr()
     };
     if i < pal_sz {
         *pal.offset(i as isize) =
@@ -1664,8 +1665,7 @@ unsafe fn read_pal_plane(
             loop {
                 let delta =
                     dav1d_msac_decode_bools(&mut ts.msac, bits as libc::c_uint) as libc::c_int;
-                *pal.offset(i as isize) =
-                    imin(prev + delta + !pl as libc::c_int, max) as uint16_t;
+                *pal.offset(i as isize) = imin(prev + delta + !pl as libc::c_int, max) as uint16_t;
                 prev = *pal.offset(i as isize) as libc::c_int;
                 i += 1;
                 if prev + !pl as libc::c_int >= max {
@@ -1712,7 +1712,7 @@ unsafe fn read_pal_plane(
     if DEBUG_BLOCK_INFO(f, t) {
         print!(
             "Post-pal[pl={},sz={},cache_size={},used_cache={}]: r={}, cache=",
-            pl, pal_sz, n_cache, n_used_cache, ts.msac.rng
+            pli, pal_sz, n_cache, n_used_cache, ts.msac.rng
         );
         let mut n_1 = 0;
         while n_1 < n_cache {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1560,12 +1560,12 @@ unsafe fn read_pal_plane(
     let pli = pl as usize;
     let ts = &mut *t.ts;
     let f = &*t.f;
-    b.c2rust_unnamed.c2rust_unnamed.pal_sz[pli] = (dav1d_msac_decode_symbol_adapt8(
+    b.c2rust_unnamed.c2rust_unnamed.pal_sz[pli] = dav1d_msac_decode_symbol_adapt8(
         &mut ts.msac,
         &mut ts.cdf.m.pal_sz[pli][sz_ctx as usize],
         6,
-    ))
-    .wrapping_add(2) as uint8_t;
+    ) as u8
+        + 2;
     let pal_sz = b.c2rust_unnamed.c2rust_unnamed.pal_sz[pli] as libc::c_int;
     let mut cache: [uint16_t; 16] = [0; 16];
     let mut used_cache: [uint16_t; 8] = [0; 8];
@@ -1658,9 +1658,8 @@ unsafe fn read_pal_plane(
         let mut prev = *pal.offset(i as isize) as libc::c_int;
         i += 1;
         if i < pal_sz {
-            let mut bits = ((f.cur.p.bpc - 3) as libc::c_uint)
-                .wrapping_add(dav1d_msac_decode_bools(&mut ts.msac, 2))
-                as libc::c_int;
+            let mut bits =
+                f.cur.p.bpc - 3 + dav1d_msac_decode_bools(&mut ts.msac, 2) as libc::c_int;
             let max = (1 << f.cur.p.bpc) - 1;
             loop {
                 let delta =

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1600,6 +1600,7 @@ unsafe fn read_pal_plane(
     let mut a = &a[bx4][pli][..];
 
     // fill/sort cache
+    // TODO: This logic could be replaced with `itertools`' `.merge` and `.dedup`, which would elide bounds checks.
     while l_cache != 0 && a_cache != 0 {
         if l[0] < a[0] {
             if n_cache == 0 || cache[n_cache - 1] != l[0] {
@@ -1649,6 +1650,7 @@ unsafe fn read_pal_plane(
     let cache = &cache[..n_cache];
 
     // find reused cache entries
+    // TODO: Bounds checks could be elided with more complex iterators.
     let mut i = 0;
     for cache in cache {
         if !(i < pal_sz) {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1702,9 +1702,7 @@ unsafe fn read_pal_plane(
                 n_0 = n_0 + 1;
                 *pal.offset(i as isize) = used_cache[fresh17 as usize];
             } else {
-                if !(m < pal_sz) {
-                    unreachable!();
-                }
+                assert!(m < pal_sz);
                 let fresh18 = m;
                 m = m + 1;
                 *pal.offset(i as isize) = *pal.offset(fresh18 as isize);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1662,11 +1662,12 @@ unsafe fn read_pal_plane(
     } else {
         &mut t.scratch.c2rust_unnamed_0.pal[pli]
     };
-    if i < pal_sz {
+    let pal = &mut pal[..pal_sz];
+    if i < pal.len() {
         let mut prev = dav1d_msac_decode_bools(&mut ts.msac, f.cur.p.bpc as u32) as u16;
         pal[i] = prev;
         i += 1;
-        if i < pal_sz {
+        if i < pal.len() {
             let mut bits = f.cur.p.bpc as u32 + dav1d_msac_decode_bools(&mut ts.msac, 2) - 3;
             let max = (1 << f.cur.p.bpc) - 1;
             loop {
@@ -1675,13 +1676,13 @@ unsafe fn read_pal_plane(
                 pal[i] = prev;
                 i += 1;
                 if prev + not_pl >= max {
-                    for pal in &mut pal[i..pal_sz] {
+                    for pal in &mut pal[i..] {
                         *pal = max;
                     }
                     break;
                 } else {
                     bits = std::cmp::min(bits, 1 + ulog2((max - prev - not_pl) as u32) as u32);
-                    if !(i < pal_sz) {
+                    if !(i < pal.len()) {
                         break;
                     }
                 }
@@ -1689,12 +1690,12 @@ unsafe fn read_pal_plane(
         }
         let mut n = 0;
         let mut m = n_used_cache;
-        for i in 0..pal_sz {
-            if n < n_used_cache && (m >= pal_sz || used_cache[n] <= pal[m]) {
+        for i in 0..pal.len() {
+            if n < n_used_cache && (m >= pal.len() || used_cache[n] <= pal[m]) {
                 pal[i] = used_cache[n];
                 n += 1;
             } else {
-                assert!(m < pal_sz);
+                assert!(m < pal.len());
                 pal[i] = pal[m];
                 m += 1;
             }
@@ -1711,7 +1712,7 @@ unsafe fn read_pal_plane(
             print!("{}{:02x}", if n != 0 { ' ' } else { '[' }, cache);
         }
         print!("{}, pal=", if n_cache != 0 { "]" } else { "[]" });
-        for (n, pal) in pal[..pal_sz].iter().enumerate() {
+        for (n, pal) in pal.iter().enumerate() {
             print!("{}{:02x}", if n != 0 { ' ' } else { '[' }, pal);
         }
         println!("]");

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1558,6 +1558,8 @@ unsafe fn read_pal_plane(
     by4: usize,
 ) {
     let pli = pl as usize;
+    let not_pl = !pl as libc::c_int;
+
     let ts = &mut *t.ts;
     let f = &*t.f;
 
@@ -1670,20 +1672,17 @@ unsafe fn read_pal_plane(
             loop {
                 let delta =
                     dav1d_msac_decode_bools(&mut ts.msac, bits as libc::c_uint) as libc::c_int;
-                pal[i] = imin(prev + delta + !pl as libc::c_int, max) as uint16_t;
+                pal[i] = imin(prev + delta + not_pl, max) as uint16_t;
                 prev = pal[i] as libc::c_int;
                 i += 1;
-                if prev + !pl as libc::c_int >= max {
+                if prev + not_pl >= max {
                     while i < pal_sz {
                         pal[i] = max as uint16_t;
                         i += 1;
                     }
                     break;
                 } else {
-                    bits = imin(
-                        bits,
-                        1 + ulog2((max - prev - !pl as libc::c_int) as libc::c_uint),
-                    );
+                    bits = imin(bits, 1 + ulog2((max - prev - not_pl) as libc::c_uint));
                     if !(i < pal_sz) {
                         break;
                     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1577,8 +1577,8 @@ unsafe fn read_pal_plane(
         + 2;
     b.pal_sz_mut()[pli] = pal_sz;
     let pal_sz = pal_sz as usize;
-    let mut cache: [uint16_t; 16] = [0; 16];
-    let mut used_cache: [uint16_t; 8] = [0; 8];
+    let mut cache = <[u16; 16]>::default();
+    let mut used_cache = <[u16; 8]>::default();
     let mut l_cache = if pl {
         t.pal_sz_uv[1][by4]
     } else {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1676,8 +1676,8 @@ unsafe fn read_pal_plane(
                 prev = pal[i] as libc::c_int;
                 i += 1;
                 if prev + not_pl >= max {
-                    for i in i..pal_sz {
-                        pal[i] = max as uint16_t;
+                    for pal in &mut pal[i..pal_sz] {
+                        *pal = max as u16;
                     }
                     break;
                 } else {
@@ -1708,12 +1708,12 @@ unsafe fn read_pal_plane(
             "Post-pal[pl={},sz={},cache_size={},used_cache={}]: r={}, cache=",
             pli, pal_sz, n_cache, n_used_cache, ts.msac.rng
         );
-        for n in 0..n_cache {
-            print!("{}{:02x}", if n != 0 { ' ' } else { '[' }, cache[n]);
+        for (n, cache) in cache[..n_cache].iter().enumerate() {
+            print!("{}{:02x}", if n != 0 { ' ' } else { '[' }, cache);
         }
         print!("{}, pal=", if n_cache != 0 { "]" } else { "[]" });
-        for n in 0..pal_sz {
-            print!("{}{:02x}", if n != 0 { ' ' } else { '[' }, pal[n]);
+        for (n, pal) in pal[..pal_sz].iter().enumerate() {
+            print!("{}{:02x}", if n != 0 { ' ' } else { '[' }, pal);
         }
         println!("]");
     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1653,7 +1653,7 @@ unsafe fn read_pal_plane(
             i += 1;
         }
     }
-    let n_used_cache = i;
+    let used_cache = &used_cache[..i];
     let pal = if t.frame_thread.pass != 0 {
         &mut (*(f.frame_thread.pal).offset(
             ((t.by >> 1) + (t.bx & 1)) as isize * (f.b4_stride >> 1)
@@ -1687,9 +1687,9 @@ unsafe fn read_pal_plane(
             }
         }
         let mut n = 0;
-        let mut m = n_used_cache;
+        let mut m = used_cache.len();
         for i in 0..pal.len() {
-            if n < n_used_cache && (m >= pal.len() || used_cache[n] <= pal[m]) {
+            if n < used_cache.len() && (m >= pal.len() || used_cache[n] <= pal[m]) {
                 pal[i] = used_cache[n];
                 n += 1;
             } else {
@@ -1698,12 +1698,16 @@ unsafe fn read_pal_plane(
             }
         }
     } else {
-        pal[..n_used_cache].copy_from_slice(&used_cache[..n_used_cache]);
+        pal[..used_cache.len()].copy_from_slice(&used_cache);
     }
     if dbg {
         print!(
             "Post-pal[pl={},sz={},cache_size={},used_cache={}]: r={}, cache=",
-            pli, pal_sz, n_cache, n_used_cache, ts.msac.rng
+            pli,
+            pal_sz,
+            n_cache,
+            used_cache.len(),
+            ts.msac.rng
         );
         for (n, cache) in cache[..n_cache].iter().enumerate() {
             print!("{}{:02x}", if n != 0 { ' ' } else { '[' }, cache);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1560,20 +1560,20 @@ unsafe fn read_pal_plane(
     let pli = pl as usize;
     let ts = &mut *t.ts;
     let f = &*t.f;
-    
+
     // Must come before `pal`, which mutably borrows `t`.
     // TODO: `DEBUG_BLOCK_INFO` really should take a subset of `f` and `t`,
     // i.e. only the fields it needs, as this would solve the bitdepth-dependence problem
     // as well as the borrowck error here if `dbg` is not hoisted.
     let dbg = DEBUG_BLOCK_INFO(f, t);
 
-    b.c2rust_unnamed.c2rust_unnamed.pal_sz[pli] = dav1d_msac_decode_symbol_adapt8(
+    b.pal_sz_mut()[pli] = dav1d_msac_decode_symbol_adapt8(
         &mut ts.msac,
         &mut ts.cdf.m.pal_sz[pli][sz_ctx as usize],
         6,
     ) as u8
         + 2;
-    let pal_sz = b.c2rust_unnamed.c2rust_unnamed.pal_sz[pli] as libc::c_int;
+    let pal_sz = b.pal_sz()[pli] as libc::c_int;
     let mut cache: [uint16_t; 16] = [0; 16];
     let mut used_cache: [uint16_t; 8] = [0; 8];
     let mut l_cache = if pl {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1720,42 +1720,30 @@ unsafe fn read_pal_plane(
         );
     }
     if DEBUG_BLOCK_INFO(f, t) {
-        printf(
-            b"Post-pal[pl=%d,sz=%d,cache_size=%d,used_cache=%d]: r=%d, cache=\0" as *const u8
-                as *const libc::c_char,
-            pl,
-            pal_sz,
-            n_cache,
-            n_used_cache,
-            ts.msac.rng,
+        print!(
+            "Post-pal[pl={},sz={},cache_size={},used_cache={}]: r={}, cache=",
+            pl, pal_sz, n_cache, n_used_cache, ts.msac.rng
         );
         let mut n_1 = 0;
         while n_1 < n_cache {
-            printf(
-                b"%c%02x\0" as *const u8 as *const libc::c_char,
-                if n_1 != 0 { ' ' as i32 } else { '[' as i32 },
-                cache[n_1 as usize] as libc::c_int,
+            print!(
+                "{}{:02x}",
+                if n_1 != 0 { ' ' } else { '[' },
+                cache[n_1 as usize]
             );
             n_1 += 1;
         }
-        printf(
-            b"%s, pal=\0" as *const u8 as *const libc::c_char,
-            if n_cache != 0 {
-                b"]\0" as *const u8 as *const libc::c_char
-            } else {
-                b"[]\0" as *const u8 as *const libc::c_char
-            },
-        );
+        print!("{}, pal=", if n_cache != 0 { "]" } else { "[]" });
         let mut n_2 = 0;
         while n_2 < pal_sz {
-            printf(
-                b"%c%02x\0" as *const u8 as *const libc::c_char,
-                if n_2 != 0 { ' ' as i32 } else { '[' as i32 },
-                *pal.offset(n_2 as isize) as libc::c_int,
+            print!(
+                "{}{:02x}",
+                if n_2 != 0 { ' ' } else { '[' },
+                *pal.offset(n_2 as isize)
             );
             n_2 += 1;
         }
-        printf(b"]\n\0" as *const u8 as *const libc::c_char);
+        println!("]");
     }
 }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1595,26 +1595,26 @@ unsafe fn read_pal_plane(
         0
     };
     let [a, l] = &mut t.al_pal;
-    let mut l = &mut l[by4][pli][..];
-    let mut a = &mut a[bx4][pli][..];
+    let mut l = &l[by4][pli][..];
+    let mut a = &a[bx4][pli][..];
     while l_cache != 0 && a_cache != 0 {
         if l[0] < a[0] {
             if n_cache == 0 || cache[n_cache - 1] != l[0] {
                 cache[n_cache] = l[0];
                 n_cache += 1;
             }
-            l = &mut l[1..];
+            l = &l[1..];
             l_cache -= 1;
         } else {
             if a[0] == l[0] {
-                l = &mut l[1..];
+                l = &l[1..];
                 l_cache -= 1;
             }
             if n_cache == 0 || cache[n_cache - 1] != a[0] {
                 cache[n_cache] = a[0];
                 n_cache += 1;
             }
-            a = &mut a[1..];
+            a = &a[1..];
             a_cache -= 1;
         }
     }
@@ -1624,7 +1624,7 @@ unsafe fn read_pal_plane(
                 cache[n_cache] = l[0];
                 n_cache += 1;
             }
-            l = &mut l[1..];
+            l = &l[1..];
             l_cache -= 1;
             if !(l_cache > 0) {
                 break;
@@ -1636,7 +1636,7 @@ unsafe fn read_pal_plane(
                 cache[n_cache] = a[0];
                 n_cache += 1;
             }
-            a = &mut a[1..];
+            a = &a[1..];
             a_cache -= 1;
             if !(a_cache > 0) {
                 break;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1587,8 +1587,8 @@ unsafe fn read_pal_plane(
     let mut a = t.al_pal[0][bx4 as usize][pl as usize].as_mut_ptr();
     while l_cache != 0 && a_cache != 0 {
         if *l < *a {
-            if n_cache == 0 || cache[(n_cache - 1) as usize] != *l {
-                cache[n_cache as usize] = *l;
+            if n_cache == 0 || cache[n_cache - 1] != *l {
+                cache[n_cache] = *l;
                 n_cache += 1;
             }
             l = l.offset(1);
@@ -1598,8 +1598,8 @@ unsafe fn read_pal_plane(
                 l = l.offset(1);
                 l_cache -= 1;
             }
-            if n_cache == 0 || cache[(n_cache - 1) as usize] != *a {
-                cache[n_cache as usize] = *a;
+            if n_cache == 0 || cache[n_cache - 1] != *a {
+                cache[n_cache] = *a;
                 n_cache += 1;
             }
             a = a.offset(1);
@@ -1608,8 +1608,8 @@ unsafe fn read_pal_plane(
     }
     if l_cache != 0 {
         loop {
-            if n_cache == 0 || cache[(n_cache - 1) as usize] != *l {
-                cache[n_cache as usize] = *l;
+            if n_cache == 0 || cache[n_cache - 1] != *l {
+                cache[n_cache] = *l;
                 n_cache += 1;
             }
             l = l.offset(1);
@@ -1620,8 +1620,8 @@ unsafe fn read_pal_plane(
         }
     } else if a_cache != 0 {
         loop {
-            if n_cache == 0 || cache[(n_cache - 1) as usize] != *a {
-                cache[n_cache as usize] = *a;
+            if n_cache == 0 || cache[n_cache - 1] != *a {
+                cache[n_cache] = *a;
                 n_cache += 1;
             }
             a = a.offset(1);
@@ -1635,7 +1635,7 @@ unsafe fn read_pal_plane(
     let mut n = 0;
     while n < n_cache && i < pal_sz {
         if dav1d_msac_decode_bool_equi(&mut ts.msac) {
-            used_cache[i as usize] = cache[n as usize];
+            used_cache[i as usize] = cache[n];
             i += 1;
         }
         n += 1;
@@ -1718,7 +1718,7 @@ unsafe fn read_pal_plane(
             print!(
                 "{}{:02x}",
                 if n_1 != 0 { ' ' } else { '[' },
-                cache[n_1 as usize]
+                cache[n_1]
             );
             n_1 += 1;
         }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1588,9 +1588,8 @@ unsafe fn read_pal_plane(
     while l_cache != 0 && a_cache != 0 {
         if *l < *a {
             if n_cache == 0 || cache[(n_cache - 1) as usize] != *l {
-                let fresh8 = n_cache;
-                n_cache = n_cache + 1;
-                cache[fresh8 as usize] = *l;
+                cache[n_cache as usize] = *l;
+                n_cache += 1;
             }
             l = l.offset(1);
             l_cache -= 1;
@@ -1600,9 +1599,8 @@ unsafe fn read_pal_plane(
                 l_cache -= 1;
             }
             if n_cache == 0 || cache[(n_cache - 1) as usize] != *a {
-                let fresh9 = n_cache;
-                n_cache = n_cache + 1;
-                cache[fresh9 as usize] = *a;
+                cache[n_cache as usize] = *a;
+                n_cache += 1;
             }
             a = a.offset(1);
             a_cache -= 1;
@@ -1611,9 +1609,8 @@ unsafe fn read_pal_plane(
     if l_cache != 0 {
         loop {
             if n_cache == 0 || cache[(n_cache - 1) as usize] != *l {
-                let fresh10 = n_cache;
-                n_cache = n_cache + 1;
-                cache[fresh10 as usize] = *l;
+                cache[n_cache as usize] = *l;
+                n_cache += 1;
             }
             l = l.offset(1);
             l_cache -= 1;
@@ -1624,9 +1621,8 @@ unsafe fn read_pal_plane(
     } else if a_cache != 0 {
         loop {
             if n_cache == 0 || cache[(n_cache - 1) as usize] != *a {
-                let fresh11 = n_cache;
-                n_cache = n_cache + 1;
-                cache[fresh11 as usize] = *a;
+                cache[n_cache as usize] = *a;
+                n_cache += 1;
             }
             a = a.offset(1);
             a_cache -= 1;
@@ -1639,9 +1635,8 @@ unsafe fn read_pal_plane(
     let mut n = 0;
     while n < n_cache && i < pal_sz {
         if dav1d_msac_decode_bool_equi(&mut ts.msac) {
-            let fresh12 = i;
-            i = i + 1;
-            used_cache[fresh12 as usize] = cache[n as usize];
+            used_cache[i as usize] = cache[n as usize];
+            i += 1;
         }
         n += 1;
     }
@@ -1656,11 +1651,10 @@ unsafe fn read_pal_plane(
         t.scratch.c2rust_unnamed_0.pal[pl as usize].as_mut_ptr()
     };
     if i < pal_sz {
-        let fresh13 = i;
-        i = i + 1;
-        let ref mut fresh14 = *pal.offset(fresh13 as isize);
-        *fresh14 = dav1d_msac_decode_bools(&mut ts.msac, f.cur.p.bpc as libc::c_uint) as uint16_t;
-        let mut prev = *fresh14 as libc::c_int;
+        *pal.offset(i as isize) =
+            dav1d_msac_decode_bools(&mut ts.msac, f.cur.p.bpc as libc::c_uint) as uint16_t;
+        let mut prev = *pal.offset(i as isize) as libc::c_int;
+        i += 1;
         if i < pal_sz {
             let mut bits = ((f.cur.p.bpc - 3) as libc::c_uint)
                 .wrapping_add(dav1d_msac_decode_bools(&mut ts.msac, 2))
@@ -1669,11 +1663,10 @@ unsafe fn read_pal_plane(
             loop {
                 let delta =
                     dav1d_msac_decode_bools(&mut ts.msac, bits as libc::c_uint) as libc::c_int;
-                let fresh15 = i;
-                i = i + 1;
-                let ref mut fresh16 = *pal.offset(fresh15 as isize);
-                *fresh16 = imin(prev + delta + (pl == 0) as libc::c_int, max) as uint16_t;
-                prev = *fresh16 as libc::c_int;
+                *pal.offset(i as isize) =
+                    imin(prev + delta + (pl == 0) as libc::c_int, max) as uint16_t;
+                prev = *pal.offset(i as isize) as libc::c_int;
+                i += 1;
                 if prev + (pl == 0) as libc::c_int >= max {
                     while i < pal_sz {
                         *pal.offset(i as isize) = max as uint16_t;
@@ -1698,14 +1691,12 @@ unsafe fn read_pal_plane(
             if n_0 < n_used_cache
                 && (m >= pal_sz || used_cache[n_0 as usize] <= *pal.offset(m as isize))
             {
-                let fresh17 = n_0;
-                n_0 = n_0 + 1;
-                *pal.offset(i as isize) = used_cache[fresh17 as usize];
+                *pal.offset(i as isize) = used_cache[n_0 as usize];
+                n_0 += 1;
             } else {
                 assert!(m < pal_sz);
-                let fresh18 = m;
-                m = m + 1;
-                *pal.offset(i as isize) = *pal.offset(fresh18 as isize);
+                *pal.offset(i as isize) = *pal.offset(m as isize);
+                m += 1;
             }
             i += 1;
         }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1644,13 +1644,14 @@ unsafe fn read_pal_plane(
         }
     }
     let mut i = 0;
-    let mut n = 0;
-    while n < n_cache && i < pal_sz {
+    for cache in &cache[..n_cache] {
+        if !(i < pal_sz) {
+            break;
+        }
         if dav1d_msac_decode_bool_equi(&mut ts.msac) {
-            used_cache[i] = cache[n];
+            used_cache[i] = *cache;
             i += 1;
         }
-        n += 1;
     }
     let n_used_cache = i;
     let pal = if t.frame_thread.pass != 0 {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1684,15 +1684,15 @@ unsafe fn read_pal_plane(
                 }
             }
         }
-        let mut n_0 = 0;
+        let mut n = 0;
         let mut m = n_used_cache;
         i = 0;
         while i < pal_sz {
-            if n_0 < n_used_cache
-                && (m >= pal_sz || used_cache[n_0 as usize] <= *pal.offset(m as isize))
+            if n < n_used_cache
+                && (m >= pal_sz || used_cache[n as usize] <= *pal.offset(m as isize))
             {
-                *pal.offset(i as isize) = used_cache[n_0 as usize];
-                n_0 += 1;
+                *pal.offset(i as isize) = used_cache[n as usize];
+                n += 1;
             } else {
                 assert!(m < pal_sz);
                 *pal.offset(i as isize) = *pal.offset(m as isize);
@@ -1713,24 +1713,20 @@ unsafe fn read_pal_plane(
             "Post-pal[pl={},sz={},cache_size={},used_cache={}]: r={}, cache=",
             pli, pal_sz, n_cache, n_used_cache, ts.msac.rng
         );
-        let mut n_1 = 0;
-        while n_1 < n_cache {
-            print!(
-                "{}{:02x}",
-                if n_1 != 0 { ' ' } else { '[' },
-                cache[n_1]
-            );
-            n_1 += 1;
+        let mut n = 0;
+        while n < n_cache {
+            print!("{}{:02x}", if n != 0 { ' ' } else { '[' }, cache[n]);
+            n += 1;
         }
         print!("{}, pal=", if n_cache != 0 { "]" } else { "[]" });
-        let mut n_2 = 0;
-        while n_2 < pal_sz {
+        let mut n = 0;
+        while n < pal_sz {
             print!(
                 "{}{:02x}",
-                if n_2 != 0 { ' ' } else { '[' },
-                *pal.offset(n_2 as isize)
+                if n != 0 { ' ' } else { '[' },
+                *pal.offset(n as isize)
             );
-            n_2 += 1;
+            n += 1;
         }
         println!("]");
     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1557,11 +1557,11 @@ unsafe fn read_pal_plane(
     bx4: libc::c_int,
     by4: libc::c_int,
 ) {
-    let ts: *mut Dav1dTileState = t.ts;
+    let ts = &mut *t.ts;
     let f: *const Dav1dFrameContext = t.f;
     b.c2rust_unnamed.c2rust_unnamed.pal_sz[pl as usize] = (dav1d_msac_decode_symbol_adapt8(
-        &mut (*ts).msac,
-        &mut (*ts).cdf.m.pal_sz[pl as usize][sz_ctx as usize],
+        &mut ts.msac,
+        &mut ts.cdf.m.pal_sz[pl as usize][sz_ctx as usize],
         6 as libc::c_int as size_t,
     ))
     .wrapping_add(2 as libc::c_int as libc::c_uint)
@@ -1639,7 +1639,7 @@ unsafe fn read_pal_plane(
     let mut i = 0;
     let mut n = 0;
     while n < n_cache && i < pal_sz {
-        if dav1d_msac_decode_bool_equi(&mut (*ts).msac) {
+        if dav1d_msac_decode_bool_equi(&mut ts.msac) {
             let fresh12 = i;
             i = i + 1;
             used_cache[fresh12 as usize] = cache[n as usize];
@@ -1661,16 +1661,16 @@ unsafe fn read_pal_plane(
         i = i + 1;
         let ref mut fresh14 = *pal.offset(fresh13 as isize);
         *fresh14 =
-            dav1d_msac_decode_bools(&mut (*ts).msac, (*f).cur.p.bpc as libc::c_uint) as uint16_t;
+            dav1d_msac_decode_bools(&mut ts.msac, (*f).cur.p.bpc as libc::c_uint) as uint16_t;
         let mut prev = *fresh14 as libc::c_int;
         if i < pal_sz {
             let mut bits = (((*f).cur.p.bpc - 3) as libc::c_uint).wrapping_add(
-                dav1d_msac_decode_bools(&mut (*ts).msac, 2 as libc::c_int as libc::c_uint),
+                dav1d_msac_decode_bools(&mut ts.msac, 2 as libc::c_int as libc::c_uint),
             ) as libc::c_int;
             let max = ((1 as libc::c_int) << (*f).cur.p.bpc) - 1;
             loop {
                 let delta =
-                    dav1d_msac_decode_bools(&mut (*ts).msac, bits as libc::c_uint) as libc::c_int;
+                    dav1d_msac_decode_bools(&mut ts.msac, bits as libc::c_uint) as libc::c_int;
                 let fresh15 = i;
                 i = i + 1;
                 let ref mut fresh16 = *pal.offset(fresh15 as isize);
@@ -1732,7 +1732,7 @@ unsafe fn read_pal_plane(
             pal_sz,
             n_cache,
             n_used_cache,
-            (*ts).msac.rng,
+            ts.msac.rng,
         );
         let mut n_1 = 0;
         while n_1 < n_cache {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1643,8 +1643,9 @@ unsafe fn read_pal_plane(
             }
         }
     }
+    let cache = &cache[..n_cache];
     let mut i = 0;
-    for cache in &cache[..n_cache] {
+    for cache in cache {
         if !(i < pal_sz) {
             break;
         }
@@ -1705,14 +1706,14 @@ unsafe fn read_pal_plane(
             "Post-pal[pl={},sz={},cache_size={},used_cache={}]: r={}, cache=",
             pli,
             pal_sz,
-            n_cache,
+            cache.len(),
             used_cache.len(),
             ts.msac.rng
         );
-        for (n, cache) in cache[..n_cache].iter().enumerate() {
+        for (n, cache) in cache.iter().enumerate() {
             print!("{}{:02x}", if n != 0 { ' ' } else { '[' }, cache);
         }
-        print!("{}, pal=", if n_cache != 0 { "]" } else { "[]" });
+        print!("{}, pal=", if cache.len() != 0 { "]" } else { "[]" });
         for (n, pal) in pal.iter().enumerate() {
             print!("{}{:02x}", if n != 0 { ' ' } else { '[' }, pal);
         }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1553,7 +1553,7 @@ unsafe fn read_pal_plane(
     t: &mut Dav1dTaskContext,
     b: &mut Av1Block,
     pl: libc::c_int,
-    sz_ctx: libc::c_int,
+    sz_ctx: u8,
     bx4: libc::c_int,
     by4: libc::c_int,
 ) {
@@ -1740,7 +1740,7 @@ unsafe fn read_pal_plane(
 unsafe extern "C" fn read_pal_uv(
     t: *mut Dav1dTaskContext,
     b: *mut Av1Block,
-    sz_ctx: libc::c_int,
+    sz_ctx: u8,
     bx4: libc::c_int,
     by4: libc::c_int,
 ) {
@@ -3289,7 +3289,7 @@ unsafe fn decode_b(
                 }
 
                 if use_y_pal {
-                    read_pal_plane(t, b, 0, sz_ctx as i32, bx4, by4);
+                    read_pal_plane(t, b, 0, sz_ctx, bx4, by4);
                 }
             }
 
@@ -3305,7 +3305,7 @@ unsafe fn decode_b(
                 }
 
                 if use_uv_pal {
-                    read_pal_uv(t, b, sz_ctx as i32, bx4, by4);
+                    read_pal_uv(t, b, sz_ctx, bx4, by4);
                 }
             }
         }


### PR DESCRIPTION
There are a couple more cleanups we could do here to elide bounds checks (like they were previously with `unsafe`), which I left `TODO` comments for.  For one of them, the iterator version is much more complex, so I left it out for now.  And for the other, it'd replace a large chunk of logic with `itertools`' `.merge` and `.dedup`, so it'd be simple, but add an `itertools` dependency (which might be something we want to do, eventually).