### PR TITLE
Update to latest nightly, `nightly-2023-05-10`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,9 @@
 [toolchain]
 channel = "nightly-2023-05-10"
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "i686-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "armv7-unknown-linux-gnueabihf",
+]
 components = ["rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-08-08"
+channel = "nightly-2023-05-10"
 components = ["rustfmt"]

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -929,7 +929,7 @@ pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
                 layout,
             );
         }
-        let mut lr_bak: [[[[pixel; 2]; 8]; 3]; 2] = [[[[0; 2]; 8]; 3]; 2];
+        let mut lr_bak: Align16<[[[[pixel; 2]; 8]; 3]; 2]> = Align16([[[[0; 2]; 8]; 3]; 2]);
         let mut iptrs: [*mut pixel; 3] = [ptrs[0], ptrs[1], ptrs[2]];
         edges = ::core::mem::transmute::<libc::c_uint, CdefEdgeFlags>(
             edges as libc::c_uint & !(CDEF_HAVE_LEFT as libc::c_int) as libc::c_uint,

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -902,7 +902,7 @@ pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
                 layout,
             );
         }
-        let mut lr_bak: [[[[pixel; 2]; 8]; 3]; 2] = [[[[0; 2]; 8]; 3]; 2];
+        let mut lr_bak: Align16<[[[[pixel; 2]; 8]; 3]; 2]> = Align16([[[[0; 2]; 8]; 3]; 2]);
         let mut iptrs: [*mut pixel; 3] = [ptrs[0], ptrs[1], ptrs[2]];
         edges = ::core::mem::transmute::<libc::c_uint, CdefEdgeFlags>(
             edges as libc::c_uint & !(CDEF_HAVE_LEFT as libc::c_int) as libc::c_uint,

--- a/src/cdef_tmpl_8.rs
+++ b/src/cdef_tmpl_8.rs
@@ -845,8 +845,8 @@ unsafe extern "C" fn cdef_filter_4x4_neon(
     damping: libc::c_int,
     edges: CdefEdgeFlags,
 ) {
-    let mut tmp_buf = [0; 104];
-    let mut tmp = tmp_buf.as_mut_ptr().offset(2 * 8).offset(8);
+    let mut tmp_buf = Align16([0; 104]);
+    let mut tmp = tmp_buf.0.as_mut_ptr().offset(2 * 8).offset(8);
     dav1d_cdef_padding4_8bpc_neon(tmp, dst, stride, left, top, bottom, 4, edges);
     dav1d_cdef_filter4_8bpc_neon(
         dst,
@@ -875,8 +875,8 @@ unsafe extern "C" fn cdef_filter_4x8_neon(
     damping: libc::c_int,
     edges: CdefEdgeFlags,
 ) {
-    let mut tmp_buf = [0; 104];
-    let mut tmp = tmp_buf.as_mut_ptr().offset(2 * 8).offset(8);
+    let mut tmp_buf = Align16([0; 104]);
+    let mut tmp = tmp_buf.0.as_mut_ptr().offset(2 * 8).offset(8);
     dav1d_cdef_padding4_8bpc_neon(tmp, dst, stride, left, top, bottom, 8, edges);
     dav1d_cdef_filter4_8bpc_neon(
         dst,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3335,7 +3335,7 @@ unsafe fn decode_b(
     if b.skip_mode != 0 {
         b.intra = 0;
     } else if is_inter_or_switch(frame_hdr) {
-        if let Some(seg) = seg && (seg.r#ref >= 0 || seg.globalmv != 0) {
+        if let Some(seg) = seg.filter(|seg| seg.r#ref >= 0 || seg.globalmv != 0) {
             b.intra = (seg.r#ref == 0) as uint8_t;
         } else {
             let ictx = get_intra_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
@@ -4266,13 +4266,13 @@ unsafe fn decode_b(
             }
         } else {
             b.c2rust_unnamed.c2rust_unnamed_0.comp_type = COMP_INTER_NONE as libc::c_int as uint8_t;
-            if let Some(seg) = seg && seg.r#ref > 0 {
+            if let Some(seg) = seg.filter(|seg| seg.r#ref > 0) {
                 b
                     .c2rust_unnamed
                     .c2rust_unnamed_0
                     .r#ref[0 as libc::c_int
                     as usize] = seg.r#ref as i8 - 1;
-            } else if let Some(seg) = seg && (seg.globalmv != 0 || seg.skip != 0) {
+            } else if let Some(_) = seg.filter(|seg| seg.globalmv != 0 || seg.skip != 0) {
                 b
                     .c2rust_unnamed
                     .c2rust_unnamed_0

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3339,10 +3339,9 @@ unsafe fn decode_b(
             b.intra = (seg.r#ref == 0) as uint8_t;
         } else {
             let ictx = get_intra_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
-            b.intra = (!dav1d_msac_decode_bool_adapt(
-                &mut ts.msac,
-                &mut ts.cdf.m.intra[ictx.into()],
-            )) as uint8_t;
+            b.intra =
+                (!dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.intra[ictx.into()]))
+                    as uint8_t;
 
             if DEBUG_BLOCK_INFO(f, t) {
                 println!("Post-intra[{}]: r={}", b.intra, ts.msac.rng);
@@ -4267,138 +4266,63 @@ unsafe fn decode_b(
         } else {
             b.c2rust_unnamed.c2rust_unnamed_0.comp_type = COMP_INTER_NONE as libc::c_int as uint8_t;
             if let Some(seg) = seg.filter(|seg| seg.r#ref > 0) {
-                b
-                    .c2rust_unnamed
-                    .c2rust_unnamed_0
-                    .r#ref[0 as libc::c_int
-                    as usize] = seg.r#ref as i8 - 1;
+                b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0 as libc::c_int as usize] =
+                    seg.r#ref as i8 - 1;
             } else if let Some(_) = seg.filter(|seg| seg.globalmv != 0 || seg.skip != 0) {
-                b
-                    .c2rust_unnamed
-                    .c2rust_unnamed_0
-                    .r#ref[0] = 0 as libc::c_int as int8_t;
+                b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] = 0 as libc::c_int as int8_t;
             } else {
-                let ctx1_0 = av1_get_ref_ctx(
-                    &*t.a,
-                    &t.l,
-                    by4,
-                    bx4,
-                    have_top,
-                    have_left,
-                );
+                let ctx1_0 = av1_get_ref_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
                 if dav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
                     &mut ts.cdf.m.r#ref[0][ctx1_0 as usize],
-                )
-                {
-                    let ctx2_1 = av1_get_bwd_ref_ctx(
-                        &*t.a,
-                        &t.l,
-                        by4,
-                        bx4,
-                        have_top,
-                        have_left,
-                    );
+                ) {
+                    let ctx2_1 = av1_get_bwd_ref_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
                     if dav1d_msac_decode_bool_adapt(
                         &mut ts.msac,
                         &mut ts.cdf.m.r#ref[1][ctx2_1 as usize],
-                    )
-                    {
-                        b
-                            .c2rust_unnamed
-                            .c2rust_unnamed_0
-                            .r#ref[0 as libc::c_int
-                            as usize] = 6 as libc::c_int as int8_t;
+                    ) {
+                        b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0 as libc::c_int as usize] =
+                            6 as libc::c_int as int8_t;
                     } else {
-                        let ctx3_0 = av1_get_bwd_ref_1_ctx(
-                            &*t.a,
-                            &t.l,
-                            by4,
-                            bx4,
-                            have_top,
-                            have_left,
-                        );
-                        b
-                            .c2rust_unnamed
-                            .c2rust_unnamed_0
-                            .r#ref[0 as libc::c_int
-                            as usize] = (4 as libc::c_int as libc::c_uint)
-                            .wrapping_add(
+                        let ctx3_0 =
+                            av1_get_bwd_ref_1_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
+                        b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0 as libc::c_int as usize] =
+                            (4 as libc::c_int as libc::c_uint).wrapping_add(
                                 dav1d_msac_decode_bool_adapt(
                                     &mut ts.msac,
-                                    &mut ts
-                                        .cdf
-                                        .m
-                                        .r#ref[5][ctx3_0 as usize],
+                                    &mut ts.cdf.m.r#ref[5][ctx3_0 as usize],
                                 ) as libc::c_uint,
                             ) as int8_t;
                     }
                 } else {
-                    let ctx2_2 = av1_get_fwd_ref_ctx(
-                        &*t.a,
-                        &t.l,
-                        by4,
-                        bx4,
-                        have_top,
-                        have_left,
-                    );
+                    let ctx2_2 = av1_get_fwd_ref_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
                     if dav1d_msac_decode_bool_adapt(
                         &mut ts.msac,
                         &mut ts.cdf.m.r#ref[2][ctx2_2 as usize],
-                    )
-                    {
-                        let ctx3_1 = av1_get_fwd_ref_2_ctx(
-                            &*t.a,
-                            &t.l,
-                            by4,
-                            bx4,
-                            have_top,
-                            have_left,
-                        );
-                        b
-                            .c2rust_unnamed
-                            .c2rust_unnamed_0
-                            .r#ref[0 as libc::c_int
-                            as usize] = (2 as libc::c_int as libc::c_uint)
-                            .wrapping_add(
+                    ) {
+                        let ctx3_1 =
+                            av1_get_fwd_ref_2_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
+                        b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0 as libc::c_int as usize] =
+                            (2 as libc::c_int as libc::c_uint).wrapping_add(
                                 dav1d_msac_decode_bool_adapt(
                                     &mut ts.msac,
-                                    &mut ts
-                                        .cdf
-                                        .m
-                                        .r#ref[4][ctx3_1 as usize],
+                                    &mut ts.cdf.m.r#ref[4][ctx3_1 as usize],
                                 ) as libc::c_uint,
                             ) as int8_t;
                     } else {
-                        let ctx3_2 = av1_get_fwd_ref_1_ctx(
-                            &*t.a,
-                            &t.l,
-                            by4,
-                            bx4,
-                            have_top,
-                            have_left,
-                        );
-                        b
-                            .c2rust_unnamed
-                            .c2rust_unnamed_0
-                            .r#ref[0 as libc::c_int
-                            as usize] = dav1d_msac_decode_bool_adapt(
-                            &mut ts.msac,
-                            &mut ts
-                                .cdf
-                                .m
-                                .r#ref[3][ctx3_2 as usize],
-                        ) as int8_t;
+                        let ctx3_2 =
+                            av1_get_fwd_ref_1_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
+                        b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0 as libc::c_int as usize] =
+                            dav1d_msac_decode_bool_adapt(
+                                &mut ts.msac,
+                                &mut ts.cdf.m.r#ref[3][ctx3_2 as usize],
+                            ) as int8_t;
                     }
                 }
-                if DEBUG_BLOCK_INFO(f, t)
-                {
+                if DEBUG_BLOCK_INFO(f, t) {
                     printf(
                         b"Post-ref[%d]: r=%d\n\0" as *const u8 as *const libc::c_char,
-                        b
-                            .c2rust_unnamed
-                            .c2rust_unnamed_0
-                            .r#ref[0] as libc::c_int,
+                        b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_int,
                         ts.msac.rng,
                     );
                 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -578,9 +578,10 @@ pub fn av1_get_uni_p1_ctx(
         if let Some(cnt) = cnt.get_mut((a.r#ref[0][xb4 as usize] - 1) as usize) {
             *cnt += 1;
         }
-        if a.comp_type[xb4 as usize] != 0
-                && let Some(cnt) = cnt.get_mut((a.r#ref[1][xb4 as usize] - 1) as usize) {
-            *cnt += 1;
+        if a.comp_type[xb4 as usize] != 0 {
+            if let Some(cnt) = cnt.get_mut((a.r#ref[1][xb4 as usize] - 1) as usize) {
+                *cnt += 1;
+            }
         }
     }
 
@@ -588,9 +589,10 @@ pub fn av1_get_uni_p1_ctx(
         if let Some(cnt) = cnt.get_mut((l.r#ref[0][yb4 as usize] - 1) as usize) {
             *cnt += 1;
         }
-        if l.comp_type[yb4 as usize] != 0
-                && let Some(cnt) = cnt.get_mut((l.r#ref[1][yb4 as usize] - 1) as usize) {
-            *cnt += 1;
+        if l.comp_type[yb4 as usize] != 0 {
+            if let Some(cnt) = cnt.get_mut((l.r#ref[1][yb4 as usize] - 1) as usize) {
+                *cnt += 1;
+            }
         }
     }
 

--- a/src/fg_apply_tmpl_16.rs
+++ b/src/fg_apply_tmpl_16.rs
@@ -1,6 +1,6 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use crate::src::align::{Align16, Align64};
+use crate::src::align::{Align1, Align16};
 use ::libc;
 extern "C" {
     pub type Dav1dRef;
@@ -392,7 +392,7 @@ pub unsafe extern "C" fn dav1d_apply_grain_16bpc(
     in_0: *const Dav1dPicture,
 ) {
     let mut grain_lut = Align16([[[0; 82]; 74]; 3]);
-    let mut scaling = Align64([[0; 4096]; 3]);
+    let mut scaling = Align1([[0; 4096]; 3]);
     let rows = (*out).p.h + 31 >> 5;
     dav1d_prep_grain_16bpc(
         dsp,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -60,6 +60,9 @@ use crate::include::common::intops::iclip;
 use crate::include::common::intops::imax;
 use crate::include::common::intops::imin;
 use crate::src::tables::TxfmInfo;
+
+use crate::src::align::Align16;
+
 unsafe extern "C" fn decomp_tx(
     txa: *mut [[[uint8_t; 32]; 32]; 2],
     from: RectTxfmSize,
@@ -324,7 +327,7 @@ unsafe extern "C" fn mask_edges_inter(
         &*dav1d_txfm_dimensions.as_ptr().offset(max_tx as isize) as *const TxfmInfo;
     let mut y = 0;
     let mut x = 0;
-    let mut txa: [[[[uint8_t; 32]; 32]; 2]; 2] = [[[[0; 32]; 32]; 2]; 2];
+    let mut txa: Align16<[[[[uint8_t; 32]; 32]; 2]; 2]> = Align16([[[[0; 32]; 32]; 2]; 2]);
     let mut y_off = 0;
     let mut y_0 = 0;
     while y_0 < h4 {
@@ -332,7 +335,7 @@ unsafe extern "C" fn mask_edges_inter(
         let mut x_0 = 0;
         while x_0 < w4 {
             decomp_tx(
-                &mut *(*(*(*txa.as_mut_ptr().offset(0)).as_mut_ptr().offset(0))
+                &mut *(*(*(*txa.0.as_mut_ptr().offset(0)).as_mut_ptr().offset(0))
                     .as_mut_ptr()
                     .offset(y_0 as isize))
                 .as_mut_ptr()

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -869,7 +869,7 @@ unsafe extern "C" fn lr_sbrow(
     let max_unit_size = unit_size + half_unit_size;
     let row_y = y + (8 >> ss_ver) * (y != 0) as libc::c_int;
     let shift_hor = 7 - ss_hor;
-    let mut pre_lr_border: [[[pixel; 4]; 136]; 2] = [[[0; 4]; 136]; 2];
+    let mut pre_lr_border: Align16<[[[pixel; 4]; 136]; 2]> = Align16([[[0; 4]; 136]; 2]);
     let mut lr: [*const Av1RestorationUnit; 2] = [0 as *const Av1RestorationUnit; 2];
     let mut edges: LrEdgeFlags = ((if y > 0 {
         LR_HAVE_TOP as libc::c_int

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -840,7 +840,7 @@ unsafe extern "C" fn lr_sbrow(
     let max_unit_size = unit_size + half_unit_size;
     let row_y = y + (8 >> ss_ver) * (y != 0) as libc::c_int;
     let shift_hor = 7 - ss_hor;
-    let mut pre_lr_border: [[[pixel; 4]; 136]; 2] = [[[0; 4]; 136]; 2];
+    let mut pre_lr_border: Align16<[[[pixel; 4]; 136]; 2]> = Align16([[[0; 4]; 136]; 2]);
     let mut lr: [*const Av1RestorationUnit; 2] = [0 as *const Av1RestorationUnit; 2];
     let mut edges: LrEdgeFlags = ((if y > 0 {
         LR_HAVE_TOP as libc::c_int


### PR DESCRIPTION
There are some newly stabilized things that we want to use to replace C versions.  `ilog2` from #184 and other cleanups was one of them, and there were some other ones I came across as well.

Also, `#![feature(let_chains)]` became unstable again as it was implemented incorrectly, so I've removed their few uses and manually desugared them or used `Option::filter` instead.

Also, upgrading the toolchain seems to cause test failures now because of stricter checks.  Raw pointer dereferences are now checked for alignment (in debug builds it seems), and that's now uncovering further errors.  Unaligned references are UB in Rust, so we need to fix these.  Tracked in #250.  This is another great reason to upgrade the toolchain, as this is a really useful check.

Update: #251 has been merged into this PR, fixing the crashes explained above.