### PR TITLE
`fn splat_*`: Cleanup and make mostly safe

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2120,9 +2120,7 @@ unsafe fn splat_tworef_mv(
     bw4: libc::c_int,
     bh4: libc::c_int,
 ) {
-    if !(bw4 >= 2 && bh4 >= 2) {
-        unreachable!();
-    }
+    assert!(bw4 >= 2 && bh4 >= 2);
     let mode = b.inter_mode() as CompInterPredMode;
     let tmpl = Align16(refmvs_block(refmvs_block_unaligned {
         mv: refmvs_mvpair { mv: *b.mv() },

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2077,7 +2077,7 @@ unsafe fn splat_oneref_mv(
         mf: (mode == GLOBALMV && std::cmp::min(bw4, bh4) >= 2) as u8 | (mode == NEWMV) as u8 * 2,
     }));
     c.refmvs_dsp.splat_mv(
-        t.rt.r[((t.by & 31) + 5) as usize..].as_mut_ptr(),
+        &mut t.rt.r[((t.by & 31) + 5) as usize..],
         &tmpl.0,
         t.bx,
         bw4,
@@ -2103,7 +2103,7 @@ unsafe fn splat_intrabc_mv(
         mf: 0,
     }));
     c.refmvs_dsp.splat_mv(
-        t.rt.r[((t.by & 31) + 5) as usize..].as_mut_ptr(),
+        &mut t.rt.r[((t.by & 31) + 5) as usize..],
         &tmpl.0,
         t.bx,
         bw4,
@@ -2131,7 +2131,7 @@ unsafe fn splat_tworef_mv(
         mf: (mode == GLOBALMV_GLOBALMV) as u8 | (1 << mode & 0xbc != 0) as u8 * 2,
     }));
     c.refmvs_dsp.splat_mv(
-        t.rt.r[((t.by & 31) + 5) as usize..].as_mut_ptr(),
+        &mut t.rt.r[((t.by & 31) + 5) as usize..],
         &tmpl.0,
         t.bx,
         bw4,
@@ -2156,7 +2156,7 @@ unsafe fn splat_intraref(
         mf: 0,
     }));
     c.refmvs_dsp.splat_mv(
-        t.rt.r[((t.by & 31) + 5) as usize..].as_mut_ptr(),
+        &mut t.rt.r[((t.by & 31) + 5) as usize..],
         &tmpl.0,
         t.bx,
         bw4,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2054,7 +2054,7 @@ unsafe fn get_prev_frame_segid(
 }
 
 #[inline]
-unsafe extern "C" fn splat_oneref_mv(
+unsafe fn splat_oneref_mv(
     c: *const Dav1dContext,
     t: *mut Dav1dTaskContext,
     bs: BlockSize,
@@ -2103,8 +2103,9 @@ unsafe extern "C" fn splat_oneref_mv(
         bh4,
     );
 }
+
 #[inline]
-unsafe extern "C" fn splat_intrabc_mv(
+unsafe fn splat_intrabc_mv(
     c: *const Dav1dContext,
     t: *mut Dav1dTaskContext,
     bs: BlockSize,
@@ -2142,8 +2143,9 @@ unsafe extern "C" fn splat_intrabc_mv(
         bh4,
     );
 }
+
 #[inline]
-unsafe extern "C" fn splat_tworef_mv(
+unsafe fn splat_tworef_mv(
     c: *const Dav1dContext,
     t: *mut Dav1dTaskContext,
     bs: BlockSize,
@@ -2197,8 +2199,9 @@ unsafe extern "C" fn splat_tworef_mv(
         bh4,
     );
 }
+
 #[inline]
-unsafe extern "C" fn splat_intraref(
+unsafe fn splat_intraref(
     c: *const Dav1dContext,
     t: *mut Dav1dTaskContext,
     bs: BlockSize,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2063,34 +2063,31 @@ unsafe fn splat_oneref_mv(
     bh4: libc::c_int,
 ) {
     let mode = b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as InterPredMode;
-    let tmpl = {
-        let mut init = refmvs_block(refmvs_block_unaligned {
-            mv: refmvs_mvpair {
-                mv: [
-                    b.c2rust_unnamed
-                        .c2rust_unnamed_0
-                        .c2rust_unnamed
-                        .c2rust_unnamed
-                        .mv[0],
-                    mv::ZERO,
-                ],
-            },
-            r#ref: refmvs_refpair {
-                r#ref: [
-                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] + 1,
-                    if b.c2rust_unnamed.c2rust_unnamed_0.interintra_type != 0 {
-                        0
-                    } else {
-                        -1
-                    },
-                ],
-            },
-            bs: bs as u8,
-            mf: ((mode == GLOBALMV && imin(bw4, bh4) >= 2) as libc::c_int
-                | (mode == NEWMV) as libc::c_int * 2) as u8,
-        });
-        Align16(init)
-    };
+    let tmpl = Align16(refmvs_block(refmvs_block_unaligned {
+        mv: refmvs_mvpair {
+            mv: [
+                b.c2rust_unnamed
+                    .c2rust_unnamed_0
+                    .c2rust_unnamed
+                    .c2rust_unnamed
+                    .mv[0],
+                mv::ZERO,
+            ],
+        },
+        r#ref: refmvs_refpair {
+            r#ref: [
+                b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] + 1,
+                if b.c2rust_unnamed.c2rust_unnamed_0.interintra_type != 0 {
+                    0
+                } else {
+                    -1
+                },
+            ],
+        },
+        bs: bs as u8,
+        mf: ((mode == GLOBALMV && imin(bw4, bh4) >= 2) as libc::c_int
+            | (mode == NEWMV) as libc::c_int * 2) as u8,
+    }));
     (c.refmvs_dsp.splat_mv).expect("non-null function pointer")(
         &mut *(t.rt.r).as_mut_ptr().offset(((t.by & 31) + 5) as isize),
         &tmpl.0,
@@ -2109,24 +2106,21 @@ unsafe fn splat_intrabc_mv(
     bw4: libc::c_int,
     bh4: libc::c_int,
 ) {
-    let tmpl = {
-        let mut init = refmvs_block(refmvs_block_unaligned {
-            mv: refmvs_mvpair {
-                mv: [
-                    b.c2rust_unnamed
-                        .c2rust_unnamed_0
-                        .c2rust_unnamed
-                        .c2rust_unnamed
-                        .mv[0],
-                    mv::ZERO,
-                ],
-            },
-            r#ref: refmvs_refpair { r#ref: [0, -1] },
-            bs: bs as u8,
-            mf: 0,
-        });
-        Align16(init)
-    };
+    let tmpl = Align16(refmvs_block(refmvs_block_unaligned {
+        mv: refmvs_mvpair {
+            mv: [
+                b.c2rust_unnamed
+                    .c2rust_unnamed_0
+                    .c2rust_unnamed
+                    .c2rust_unnamed
+                    .mv[0],
+                mv::ZERO,
+            ],
+        },
+        r#ref: refmvs_refpair { r#ref: [0, -1] },
+        bs: bs as u8,
+        mf: 0,
+    }));
     (c.refmvs_dsp.splat_mv).expect("non-null function pointer")(
         &mut *(t.rt.r).as_mut_ptr().offset(((t.by & 31) + 5) as isize),
         &tmpl.0,
@@ -2149,34 +2143,31 @@ unsafe fn splat_tworef_mv(
         unreachable!();
     }
     let mode = b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as CompInterPredMode;
-    let tmpl = {
-        let mut init = refmvs_block(refmvs_block_unaligned {
-            mv: refmvs_mvpair {
-                mv: [
-                    b.c2rust_unnamed
-                        .c2rust_unnamed_0
-                        .c2rust_unnamed
-                        .c2rust_unnamed
-                        .mv[0],
-                    b.c2rust_unnamed
-                        .c2rust_unnamed_0
-                        .c2rust_unnamed
-                        .c2rust_unnamed
-                        .mv[1],
-                ],
-            },
-            r#ref: refmvs_refpair {
-                r#ref: [
-                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] + 1,
-                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] + 1,
-                ],
-            },
-            bs: bs as u8,
-            mf: ((mode == GLOBALMV_GLOBALMV) as libc::c_int
-                | (1 << mode & 0xbc != 0) as libc::c_int * 2) as u8,
-        });
-        Align16(init)
-    };
+    let tmpl = Align16(refmvs_block(refmvs_block_unaligned {
+        mv: refmvs_mvpair {
+            mv: [
+                b.c2rust_unnamed
+                    .c2rust_unnamed_0
+                    .c2rust_unnamed
+                    .c2rust_unnamed
+                    .mv[0],
+                b.c2rust_unnamed
+                    .c2rust_unnamed_0
+                    .c2rust_unnamed
+                    .c2rust_unnamed
+                    .mv[1],
+            ],
+        },
+        r#ref: refmvs_refpair {
+            r#ref: [
+                b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] + 1,
+                b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] + 1,
+            ],
+        },
+        bs: bs as u8,
+        mf: ((mode == GLOBALMV_GLOBALMV) as libc::c_int
+            | (1 << mode & 0xbc != 0) as libc::c_int * 2) as u8,
+    }));
     (c.refmvs_dsp.splat_mv).expect("non-null function pointer")(
         &mut *(t.rt.r).as_mut_ptr().offset(((t.by & 31) + 5) as isize),
         &tmpl.0,
@@ -2194,17 +2185,14 @@ unsafe fn splat_intraref(
     bw4: libc::c_int,
     bh4: libc::c_int,
 ) {
-    let tmpl = {
-        let mut init = refmvs_block(refmvs_block_unaligned {
-            mv: refmvs_mvpair {
-                mv: [mv::INVALID, mv::ZERO],
-            },
-            r#ref: refmvs_refpair { r#ref: [0, -1] },
-            bs: bs as u8,
-            mf: 0,
-        });
-        Align16(init)
-    };
+    let tmpl = Align16(refmvs_block(refmvs_block_unaligned {
+        mv: refmvs_mvpair {
+            mv: [mv::INVALID, mv::ZERO],
+        },
+        r#ref: refmvs_refpair { r#ref: [0, -1] },
+        bs: bs as u8,
+        mf: 0,
+    }));
     (c.refmvs_dsp.splat_mv).expect("non-null function pointer")(
         &mut *(t.rt.r).as_mut_ptr().offset(((t.by & 31) + 5) as isize),
         &tmpl.0,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2062,26 +2062,15 @@ unsafe fn splat_oneref_mv(
     bw4: libc::c_int,
     bh4: libc::c_int,
 ) {
-    let mode = b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as InterPredMode;
+    let mode = b.inter_mode() as InterPredMode;
     let tmpl = Align16(refmvs_block(refmvs_block_unaligned {
         mv: refmvs_mvpair {
-            mv: [
-                b.c2rust_unnamed
-                    .c2rust_unnamed_0
-                    .c2rust_unnamed
-                    .c2rust_unnamed
-                    .mv[0],
-                mv::ZERO,
-            ],
+            mv: [b.mv()[0], mv::ZERO],
         },
         r#ref: refmvs_refpair {
             r#ref: [
-                b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] + 1,
-                if b.c2rust_unnamed.c2rust_unnamed_0.interintra_type != 0 {
-                    0
-                } else {
-                    -1
-                },
+                b.r#ref()[0] + 1,
+                if b.interintra_type() != 0 { 0 } else { -1 },
             ],
         },
         bs: bs as u8,
@@ -2108,14 +2097,7 @@ unsafe fn splat_intrabc_mv(
 ) {
     let tmpl = Align16(refmvs_block(refmvs_block_unaligned {
         mv: refmvs_mvpair {
-            mv: [
-                b.c2rust_unnamed
-                    .c2rust_unnamed_0
-                    .c2rust_unnamed
-                    .c2rust_unnamed
-                    .mv[0],
-                mv::ZERO,
-            ],
+            mv: [b.mv()[0], mv::ZERO],
         },
         r#ref: refmvs_refpair { r#ref: [0, -1] },
         bs: bs as u8,
@@ -2142,27 +2124,11 @@ unsafe fn splat_tworef_mv(
     if !(bw4 >= 2 && bh4 >= 2) {
         unreachable!();
     }
-    let mode = b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as CompInterPredMode;
+    let mode = b.inter_mode() as CompInterPredMode;
     let tmpl = Align16(refmvs_block(refmvs_block_unaligned {
-        mv: refmvs_mvpair {
-            mv: [
-                b.c2rust_unnamed
-                    .c2rust_unnamed_0
-                    .c2rust_unnamed
-                    .c2rust_unnamed
-                    .mv[0],
-                b.c2rust_unnamed
-                    .c2rust_unnamed_0
-                    .c2rust_unnamed
-                    .c2rust_unnamed
-                    .mv[1],
-            ],
-        },
+        mv: refmvs_mvpair { mv: *b.mv() },
         r#ref: refmvs_refpair {
-            r#ref: [
-                b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] + 1,
-                b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] + 1,
-            ],
+            r#ref: [b.r#ref()[0] + 1, b.r#ref()[1] + 1],
         },
         bs: bs as u8,
         mf: ((mode == GLOBALMV_GLOBALMV) as libc::c_int

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2058,16 +2058,16 @@ unsafe fn splat_oneref_mv(
     c: &Dav1dContext,
     t: &mut Dav1dTaskContext,
     bs: BlockSize,
-    b: *const Av1Block,
+    b: &Av1Block,
     bw4: libc::c_int,
     bh4: libc::c_int,
 ) {
-    let mode: InterPredMode = (*b).c2rust_unnamed.c2rust_unnamed_0.inter_mode as InterPredMode;
+    let mode: InterPredMode = b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as InterPredMode;
     let tmpl: Align16<refmvs_block> = {
         let mut init = refmvs_block(refmvs_block_unaligned {
             mv: refmvs_mvpair {
                 mv: [
-                    (*b).c2rust_unnamed
+                    b.c2rust_unnamed
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
@@ -2077,8 +2077,8 @@ unsafe fn splat_oneref_mv(
             },
             r#ref: refmvs_refpair {
                 r#ref: [
-                    ((*b).c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_int + 1) as int8_t,
-                    (if (*b).c2rust_unnamed.c2rust_unnamed_0.interintra_type as libc::c_int != 0 {
+                    (b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_int + 1) as int8_t,
+                    (if b.c2rust_unnamed.c2rust_unnamed_0.interintra_type as libc::c_int != 0 {
                         0 as libc::c_int
                     } else {
                         -(1 as libc::c_int)
@@ -2107,7 +2107,7 @@ unsafe fn splat_intrabc_mv(
     c: &Dav1dContext,
     t: &mut Dav1dTaskContext,
     bs: BlockSize,
-    b: *const Av1Block,
+    b: &Av1Block,
     bw4: libc::c_int,
     bh4: libc::c_int,
 ) {
@@ -2115,7 +2115,7 @@ unsafe fn splat_intrabc_mv(
         let mut init = refmvs_block(refmvs_block_unaligned {
             mv: refmvs_mvpair {
                 mv: [
-                    (*b).c2rust_unnamed
+                    b.c2rust_unnamed
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
@@ -2145,25 +2145,24 @@ unsafe fn splat_tworef_mv(
     c: &Dav1dContext,
     t: &mut Dav1dTaskContext,
     bs: BlockSize,
-    b: *const Av1Block,
+    b: &Av1Block,
     bw4: libc::c_int,
     bh4: libc::c_int,
 ) {
     if !(bw4 >= 2 && bh4 >= 2) {
         unreachable!();
     }
-    let mode: CompInterPredMode =
-        (*b).c2rust_unnamed.c2rust_unnamed_0.inter_mode as CompInterPredMode;
+    let mode: CompInterPredMode = b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as CompInterPredMode;
     let tmpl: Align16<refmvs_block> = {
         let mut init = refmvs_block(refmvs_block_unaligned {
             mv: refmvs_mvpair {
                 mv: [
-                    (*b).c2rust_unnamed
+                    b.c2rust_unnamed
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
                         .mv[0],
-                    (*b).c2rust_unnamed
+                    b.c2rust_unnamed
                         .c2rust_unnamed_0
                         .c2rust_unnamed
                         .c2rust_unnamed
@@ -2172,8 +2171,8 @@ unsafe fn splat_tworef_mv(
             },
             r#ref: refmvs_refpair {
                 r#ref: [
-                    ((*b).c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_int + 1) as int8_t,
-                    ((*b).c2rust_unnamed.c2rust_unnamed_0.r#ref[1] as libc::c_int + 1) as int8_t,
+                    (b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_int + 1) as int8_t,
+                    (b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] as libc::c_int + 1) as int8_t,
                 ],
             },
             bs: bs as uint8_t,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2062,8 +2062,8 @@ unsafe fn splat_oneref_mv(
     bw4: libc::c_int,
     bh4: libc::c_int,
 ) {
-    let mode: InterPredMode = b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as InterPredMode;
-    let tmpl: Align16<refmvs_block> = {
+    let mode = b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as InterPredMode;
+    let tmpl = {
         let mut init = refmvs_block(refmvs_block_unaligned {
             mv: refmvs_mvpair {
                 mv: [
@@ -2077,19 +2077,17 @@ unsafe fn splat_oneref_mv(
             },
             r#ref: refmvs_refpair {
                 r#ref: [
-                    (b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_int + 1) as int8_t,
-                    (if b.c2rust_unnamed.c2rust_unnamed_0.interintra_type as libc::c_int != 0 {
-                        0 as libc::c_int
+                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] + 1,
+                    if b.c2rust_unnamed.c2rust_unnamed_0.interintra_type != 0 {
+                        0
                     } else {
-                        -(1 as libc::c_int)
-                    }) as int8_t,
+                        -1
+                    },
                 ],
             },
-            bs: bs as uint8_t,
-            mf: ((mode as libc::c_uint == GLOBALMV as libc::c_int as libc::c_uint
-                && imin(bw4, bh4) >= 2) as libc::c_int
-                | (mode as libc::c_uint == NEWMV as libc::c_int as libc::c_uint) as libc::c_int * 2)
-                as uint8_t,
+            bs: bs as u8,
+            mf: ((mode == GLOBALMV && imin(bw4, bh4) >= 2) as libc::c_int
+                | (mode == NEWMV) as libc::c_int * 2) as u8,
         });
         Align16(init)
     };
@@ -2111,7 +2109,7 @@ unsafe fn splat_intrabc_mv(
     bw4: libc::c_int,
     bh4: libc::c_int,
 ) {
-    let tmpl: Align16<refmvs_block> = {
+    let tmpl = {
         let mut init = refmvs_block(refmvs_block_unaligned {
             mv: refmvs_mvpair {
                 mv: [
@@ -2123,11 +2121,9 @@ unsafe fn splat_intrabc_mv(
                     mv::ZERO,
                 ],
             },
-            r#ref: refmvs_refpair {
-                r#ref: [0 as libc::c_int as int8_t, -(1 as libc::c_int) as int8_t],
-            },
-            bs: bs as uint8_t,
-            mf: 0 as libc::c_int as uint8_t,
+            r#ref: refmvs_refpair { r#ref: [0, -1] },
+            bs: bs as u8,
+            mf: 0,
         });
         Align16(init)
     };
@@ -2152,8 +2148,8 @@ unsafe fn splat_tworef_mv(
     if !(bw4 >= 2 && bh4 >= 2) {
         unreachable!();
     }
-    let mode: CompInterPredMode = b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as CompInterPredMode;
-    let tmpl: Align16<refmvs_block> = {
+    let mode = b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as CompInterPredMode;
+    let tmpl = {
         let mut init = refmvs_block(refmvs_block_unaligned {
             mv: refmvs_mvpair {
                 mv: [
@@ -2171,16 +2167,13 @@ unsafe fn splat_tworef_mv(
             },
             r#ref: refmvs_refpair {
                 r#ref: [
-                    (b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as libc::c_int + 1) as int8_t,
-                    (b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] as libc::c_int + 1) as int8_t,
+                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] + 1,
+                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] + 1,
                 ],
             },
-            bs: bs as uint8_t,
-            mf: ((mode as libc::c_uint == GLOBALMV_GLOBALMV as libc::c_int as libc::c_uint)
-                as libc::c_int
-                | ((1 as libc::c_int) << mode as libc::c_uint & 0xbc as libc::c_int != 0)
-                    as libc::c_int
-                    * 2) as uint8_t,
+            bs: bs as u8,
+            mf: ((mode == GLOBALMV_GLOBALMV) as libc::c_int
+                | (1 << mode & 0xbc != 0) as libc::c_int * 2) as u8,
         });
         Align16(init)
     };
@@ -2201,16 +2194,14 @@ unsafe fn splat_intraref(
     bw4: libc::c_int,
     bh4: libc::c_int,
 ) {
-    let tmpl: Align16<refmvs_block> = {
+    let tmpl = {
         let mut init = refmvs_block(refmvs_block_unaligned {
             mv: refmvs_mvpair {
                 mv: [mv::INVALID, mv::ZERO],
             },
-            r#ref: refmvs_refpair {
-                r#ref: [0 as libc::c_int as int8_t, -(1 as libc::c_int) as int8_t],
-            },
-            bs: bs as uint8_t,
-            mf: 0 as libc::c_int as uint8_t,
+            r#ref: refmvs_refpair { r#ref: [0, -1] },
+            bs: bs as u8,
+            mf: 0,
         });
         Align16(init)
     };

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2076,7 +2076,7 @@ unsafe fn splat_oneref_mv(
         bs: bs as u8,
         mf: (mode == GLOBALMV && std::cmp::min(bw4, bh4) >= 2) as u8 | (mode == NEWMV) as u8 * 2,
     }));
-    (c.refmvs_dsp.splat_mv).expect("non-null function pointer")(
+    c.refmvs_dsp.splat_mv(
         &mut *(t.rt.r).as_mut_ptr().offset(((t.by & 31) + 5) as isize),
         &tmpl.0,
         t.bx,
@@ -2102,7 +2102,7 @@ unsafe fn splat_intrabc_mv(
         bs: bs as u8,
         mf: 0,
     }));
-    (c.refmvs_dsp.splat_mv).expect("non-null function pointer")(
+    c.refmvs_dsp.splat_mv(
         &mut *(t.rt.r).as_mut_ptr().offset(((t.by & 31) + 5) as isize),
         &tmpl.0,
         t.bx,
@@ -2130,7 +2130,7 @@ unsafe fn splat_tworef_mv(
         bs: bs as u8,
         mf: (mode == GLOBALMV_GLOBALMV) as u8 | (1 << mode & 0xbc != 0) as u8 * 2,
     }));
-    (c.refmvs_dsp.splat_mv).expect("non-null function pointer")(
+    c.refmvs_dsp.splat_mv(
         &mut *(t.rt.r).as_mut_ptr().offset(((t.by & 31) + 5) as isize),
         &tmpl.0,
         t.bx,
@@ -2155,7 +2155,7 @@ unsafe fn splat_intraref(
         bs: bs as u8,
         mf: 0,
     }));
-    (c.refmvs_dsp.splat_mv).expect("non-null function pointer")(
+    c.refmvs_dsp.splat_mv(
         &mut *(t.rt.r).as_mut_ptr().offset(((t.by & 31) + 5) as isize),
         &tmpl.0,
         t.bx,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2056,7 +2056,7 @@ unsafe fn get_prev_frame_segid(
 #[inline]
 unsafe fn splat_oneref_mv(
     c: &Dav1dContext,
-    t: *mut Dav1dTaskContext,
+    t: &mut Dav1dTaskContext,
     bs: BlockSize,
     b: *const Av1Block,
     bw4: libc::c_int,
@@ -2094,11 +2094,9 @@ unsafe fn splat_oneref_mv(
         Align16(init)
     };
     (c.refmvs_dsp.splat_mv).expect("non-null function pointer")(
-        &mut *((*t).rt.r)
-            .as_mut_ptr()
-            .offset((((*t).by & 31) + 5) as isize),
+        &mut *(t.rt.r).as_mut_ptr().offset(((t.by & 31) + 5) as isize),
         &tmpl.0,
-        (*t).bx,
+        t.bx,
         bw4,
         bh4,
     );
@@ -2107,7 +2105,7 @@ unsafe fn splat_oneref_mv(
 #[inline]
 unsafe fn splat_intrabc_mv(
     c: &Dav1dContext,
-    t: *mut Dav1dTaskContext,
+    t: &mut Dav1dTaskContext,
     bs: BlockSize,
     b: *const Av1Block,
     bw4: libc::c_int,
@@ -2134,11 +2132,9 @@ unsafe fn splat_intrabc_mv(
         Align16(init)
     };
     (c.refmvs_dsp.splat_mv).expect("non-null function pointer")(
-        &mut *((*t).rt.r)
-            .as_mut_ptr()
-            .offset((((*t).by & 31) + 5) as isize),
+        &mut *(t.rt.r).as_mut_ptr().offset(((t.by & 31) + 5) as isize),
         &tmpl.0,
-        (*t).bx,
+        t.bx,
         bw4,
         bh4,
     );
@@ -2147,7 +2143,7 @@ unsafe fn splat_intrabc_mv(
 #[inline]
 unsafe fn splat_tworef_mv(
     c: &Dav1dContext,
-    t: *mut Dav1dTaskContext,
+    t: &mut Dav1dTaskContext,
     bs: BlockSize,
     b: *const Av1Block,
     bw4: libc::c_int,
@@ -2190,11 +2186,9 @@ unsafe fn splat_tworef_mv(
         Align16(init)
     };
     (c.refmvs_dsp.splat_mv).expect("non-null function pointer")(
-        &mut *((*t).rt.r)
-            .as_mut_ptr()
-            .offset((((*t).by & 31) + 5) as isize),
+        &mut *(t.rt.r).as_mut_ptr().offset(((t.by & 31) + 5) as isize),
         &tmpl.0,
-        (*t).bx,
+        t.bx,
         bw4,
         bh4,
     );
@@ -2203,7 +2197,7 @@ unsafe fn splat_tworef_mv(
 #[inline]
 unsafe fn splat_intraref(
     c: &Dav1dContext,
-    t: *mut Dav1dTaskContext,
+    t: &mut Dav1dTaskContext,
     bs: BlockSize,
     bw4: libc::c_int,
     bh4: libc::c_int,
@@ -2222,11 +2216,9 @@ unsafe fn splat_intraref(
         Align16(init)
     };
     (c.refmvs_dsp.splat_mv).expect("non-null function pointer")(
-        &mut *((*t).rt.r)
-            .as_mut_ptr()
-            .offset((((*t).by & 31) + 5) as isize),
+        &mut *(t.rt.r).as_mut_ptr().offset(((t.by & 31) + 5) as isize),
         &tmpl.0,
-        (*t).bx,
+        t.bx,
         bw4,
         bh4,
     );

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2077,7 +2077,7 @@ unsafe fn splat_oneref_mv(
         mf: (mode == GLOBALMV && std::cmp::min(bw4, bh4) >= 2) as u8 | (mode == NEWMV) as u8 * 2,
     }));
     c.refmvs_dsp.splat_mv(
-        &mut *(t.rt.r).as_mut_ptr().offset(((t.by & 31) + 5) as isize),
+        t.rt.r[((t.by & 31) + 5) as usize..].as_mut_ptr(),
         &tmpl.0,
         t.bx,
         bw4,
@@ -2103,7 +2103,7 @@ unsafe fn splat_intrabc_mv(
         mf: 0,
     }));
     c.refmvs_dsp.splat_mv(
-        &mut *(t.rt.r).as_mut_ptr().offset(((t.by & 31) + 5) as isize),
+        t.rt.r[((t.by & 31) + 5) as usize..].as_mut_ptr(),
         &tmpl.0,
         t.bx,
         bw4,
@@ -2131,7 +2131,7 @@ unsafe fn splat_tworef_mv(
         mf: (mode == GLOBALMV_GLOBALMV) as u8 | (1 << mode & 0xbc != 0) as u8 * 2,
     }));
     c.refmvs_dsp.splat_mv(
-        &mut *(t.rt.r).as_mut_ptr().offset(((t.by & 31) + 5) as isize),
+        t.rt.r[((t.by & 31) + 5) as usize..].as_mut_ptr(),
         &tmpl.0,
         t.bx,
         bw4,
@@ -2156,7 +2156,7 @@ unsafe fn splat_intraref(
         mf: 0,
     }));
     c.refmvs_dsp.splat_mv(
-        &mut *(t.rt.r).as_mut_ptr().offset(((t.by & 31) + 5) as isize),
+        t.rt.r[((t.by & 31) + 5) as usize..].as_mut_ptr(),
         &tmpl.0,
         t.bx,
         bw4,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2074,8 +2074,7 @@ unsafe fn splat_oneref_mv(
             ],
         },
         bs: bs as u8,
-        mf: ((mode == GLOBALMV && imin(bw4, bh4) >= 2) as libc::c_int
-            | (mode == NEWMV) as libc::c_int * 2) as u8,
+        mf: (mode == GLOBALMV && imin(bw4, bh4) >= 2) as u8 | (mode == NEWMV) as u8 * 2,
     }));
     (c.refmvs_dsp.splat_mv).expect("non-null function pointer")(
         &mut *(t.rt.r).as_mut_ptr().offset(((t.by & 31) + 5) as isize),
@@ -2131,8 +2130,7 @@ unsafe fn splat_tworef_mv(
             r#ref: [b.r#ref()[0] + 1, b.r#ref()[1] + 1],
         },
         bs: bs as u8,
-        mf: ((mode == GLOBALMV_GLOBALMV) as libc::c_int
-            | (1 << mode & 0xbc != 0) as libc::c_int * 2) as u8,
+        mf: (mode == GLOBALMV_GLOBALMV) as u8 | (1 << mode & 0xbc != 0) as u8 * 2,
     }));
     (c.refmvs_dsp.splat_mv).expect("non-null function pointer")(
         &mut *(t.rt.r).as_mut_ptr().offset(((t.by & 31) + 5) as isize),

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2055,7 +2055,7 @@ unsafe fn get_prev_frame_segid(
 
 #[inline]
 unsafe fn splat_oneref_mv(
-    c: *const Dav1dContext,
+    c: &Dav1dContext,
     t: *mut Dav1dTaskContext,
     bs: BlockSize,
     b: *const Av1Block,
@@ -2093,7 +2093,7 @@ unsafe fn splat_oneref_mv(
         });
         Align16(init)
     };
-    ((*c).refmvs_dsp.splat_mv).expect("non-null function pointer")(
+    (c.refmvs_dsp.splat_mv).expect("non-null function pointer")(
         &mut *((*t).rt.r)
             .as_mut_ptr()
             .offset((((*t).by & 31) + 5) as isize),
@@ -2106,7 +2106,7 @@ unsafe fn splat_oneref_mv(
 
 #[inline]
 unsafe fn splat_intrabc_mv(
-    c: *const Dav1dContext,
+    c: &Dav1dContext,
     t: *mut Dav1dTaskContext,
     bs: BlockSize,
     b: *const Av1Block,
@@ -2133,7 +2133,7 @@ unsafe fn splat_intrabc_mv(
         });
         Align16(init)
     };
-    ((*c).refmvs_dsp.splat_mv).expect("non-null function pointer")(
+    (c.refmvs_dsp.splat_mv).expect("non-null function pointer")(
         &mut *((*t).rt.r)
             .as_mut_ptr()
             .offset((((*t).by & 31) + 5) as isize),
@@ -2146,7 +2146,7 @@ unsafe fn splat_intrabc_mv(
 
 #[inline]
 unsafe fn splat_tworef_mv(
-    c: *const Dav1dContext,
+    c: &Dav1dContext,
     t: *mut Dav1dTaskContext,
     bs: BlockSize,
     b: *const Av1Block,
@@ -2189,7 +2189,7 @@ unsafe fn splat_tworef_mv(
         });
         Align16(init)
     };
-    ((*c).refmvs_dsp.splat_mv).expect("non-null function pointer")(
+    (c.refmvs_dsp.splat_mv).expect("non-null function pointer")(
         &mut *((*t).rt.r)
             .as_mut_ptr()
             .offset((((*t).by & 31) + 5) as isize),
@@ -2202,7 +2202,7 @@ unsafe fn splat_tworef_mv(
 
 #[inline]
 unsafe fn splat_intraref(
-    c: *const Dav1dContext,
+    c: &Dav1dContext,
     t: *mut Dav1dTaskContext,
     bs: BlockSize,
     bw4: libc::c_int,
@@ -2221,7 +2221,7 @@ unsafe fn splat_intraref(
         });
         Align16(init)
     };
-    ((*c).refmvs_dsp.splat_mv).expect("non-null function pointer")(
+    (c.refmvs_dsp.splat_mv).expect("non-null function pointer")(
         &mut *((*t).rt.r)
             .as_mut_ptr()
             .offset((((*t).by & 31) + 5) as isize),
@@ -3297,7 +3297,7 @@ unsafe fn decode_b(
         }
 
         if is_inter_or_switch(frame_hdr) || frame_hdr.allow_intrabc != 0 {
-            splat_intraref(f.c, t, bs, bw4, bh4);
+            splat_intraref(&*f.c, t, bs, bw4, bh4);
         }
     } else if is_key_or_intra(frame_hdr) {
         // intra block copy
@@ -3419,7 +3419,7 @@ unsafe fn decode_b(
             return -1;
         }
 
-        splat_intrabc_mv(f.c, t, bs, b, bw4, bh4);
+        splat_intrabc_mv(&*f.c, t, bs, b, bw4, bh4);
 
         let mut set_ctx = |dir: &mut BlockContext, diridx: usize, off, mul, rep_macro: SetCtxFn| {
             rep_macro(
@@ -4507,9 +4507,9 @@ unsafe fn decode_b(
             );
         }
         if is_comp {
-            splat_tworef_mv(f.c, t, bs, b, bw4, bh4);
+            splat_tworef_mv(&*f.c, t, bs, b, bw4, bh4);
         } else {
-            splat_oneref_mv(f.c, t, bs, b, bw4, bh4);
+            splat_oneref_mv(&*f.c, t, bs, b, bw4, bh4);
         }
         match bh4 {
             1 => {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2074,7 +2074,7 @@ unsafe fn splat_oneref_mv(
             ],
         },
         bs: bs as u8,
-        mf: (mode == GLOBALMV && imin(bw4, bh4) >= 2) as u8 | (mode == NEWMV) as u8 * 2,
+        mf: (mode == GLOBALMV && std::cmp::min(bw4, bh4) >= 2) as u8 | (mode == NEWMV) as u8 * 2,
     }));
     (c.refmvs_dsp.splat_mv).expect("non-null function pointer")(
         &mut *(t.rt.r).as_mut_ptr().offset(((t.by & 31) + 5) as isize),

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -493,4 +493,8 @@ impl Av1Block {
     pub unsafe fn max_ytx_mut(&mut self) -> &mut u8 {
         &mut self.c2rust_unnamed.c2rust_unnamed_0.max_ytx
     }
+
+    pub unsafe fn interintra_type(&self) -> u8 {
+        self.c2rust_unnamed.c2rust_unnamed_0.interintra_type
+    }
 }

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -224,6 +224,19 @@ pub struct Dav1dRefmvsDSPContext {
     pub splat_mv: splat_mv_fn,
 }
 
+impl Dav1dRefmvsDSPContext {
+    pub unsafe fn splat_mv(
+        &self,
+        rr: *mut *mut refmvs_block,
+        rmv: *const refmvs_block,
+        bx4: libc::c_int,
+        bw4: libc::c_int,
+        bh4: libc::c_int,
+    ) {
+        self.splat_mv.expect("non-null function pointer")(rr, rmv, bx4, bw4, bh4);
+    }
+}
+
 use crate::include::common::intops::apply_sign;
 use crate::include::common::intops::iclip;
 use crate::include::common::intops::imax;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -227,13 +227,13 @@ pub struct Dav1dRefmvsDSPContext {
 impl Dav1dRefmvsDSPContext {
     pub unsafe fn splat_mv(
         &self,
-        rr: *mut *mut refmvs_block,
-        rmv: *const refmvs_block,
+        rr: &mut [*mut refmvs_block],
+        rmv: &refmvs_block,
         bx4: libc::c_int,
         bw4: libc::c_int,
         bh4: libc::c_int,
     ) {
-        self.splat_mv.expect("non-null function pointer")(rr, rmv, bx4, bw4, bh4);
+        self.splat_mv.expect("non-null function pointer")(rr.as_mut_ptr(), rmv, bx4, bw4, bh4);
     }
 }
 


### PR DESCRIPTION
This is the last of the functions before `decode_b` that I've now cleaned up (though many are still `unsafe`, and there are other functions in other modules, too).