### PR TITLE
`fn decomp_tx`: Cleanup and make mostly safe

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -108,3 +108,30 @@ pub unsafe fn case_set<D, F>(
         _ => {}
     }
 }
+
+#[inline]
+pub unsafe fn case_set_upto16<D, F>(
+    var: libc::c_int,
+    dir: &mut D,
+    diridx: usize,
+    off: isize,
+    set_ctx: &mut F,
+) where
+    F: FnMut(&mut D, usize, isize, u64, SetCtxFn),
+{
+    match var {
+        1 => set_ctx(dir, diridx, off, 0x01, set_ctx_rep1::<alias8>),
+        2 => set_ctx(dir, diridx, off, 0x0101, set_ctx_rep1::<alias16>),
+        4 => set_ctx(dir, diridx, off, 0x01010101, set_ctx_rep1::<alias32>),
+        8 => set_ctx(
+            dir,
+            diridx,
+            off,
+            0x0101010101010101,
+            set_ctx_rep1::<alias64>,
+        ),
+        16 => set_ctx(dir, diridx, off, 0x0101010101010101, set_ctx_rep2),
+
+        _ => {}
+    }
+}

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4907,7 +4907,7 @@ unsafe fn decode_b(
                 b.skip as libc::c_int,
                 bs,
                 ytx,
-                tx_split.as_ptr(),
+                &tx_split,
                 uvtx,
                 f.cur.p.layout,
                 &mut *((*t.a).tx_lpf_y.0).as_mut_ptr().offset(bx4 as isize),

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -61,16 +61,17 @@ pub struct Av1Restoration {
 unsafe fn decomp_tx(
     txa: *mut [[[u8; 32]; 32]; 2],
     from: RectTxfmSize,
-    depth: libc::c_int,
+    depth: usize,
     y_off: u8,
     x_off: u8,
     tx_masks: &[u16; 2],
 ) {
+    debug_assert!(depth <= 2);
     let t_dim = &dav1d_txfm_dimensions[from as usize];
     let is_split = if from == TX_4X4 || depth > 1 {
         false
     } else {
-        (tx_masks[depth as usize] >> (y_off * 4 + x_off)) & 1 != 0
+        (tx_masks[depth] >> (y_off * 4 + x_off)) & 1 != 0
     };
     if is_split {
         let sub = t_dim.sub as RectTxfmSize;
@@ -197,7 +198,7 @@ unsafe fn mask_edges_inter(
                 .as_mut_ptr()
                 .offset(x_0 as isize) as *mut u8 as *mut [[[u8; 32]; 32]; 2],
                 max_tx,
-                0 as libc::c_int,
+                0,
                 y_off,
                 x_off,
                 tx_masks,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -58,6 +58,14 @@ pub struct Av1Restoration {
     pub lr: [[Av1RestorationUnit; 4]; 3],
 }
 
+/// In `txa`, the array lengths represent from inner to outer:
+/// * `32`: `x`
+/// * `32`: `y`
+/// * `2`: `txsz`, `step`
+///
+/// (Note: This is added here in the docs vs. inline `/* */` comments
+/// at the array lengths because `rustfmt` deletes them
+/// (tracked in [rust-lang/rustfmt#5297](https://github.com/rust-lang/rustfmt/issues/5297))).
 unsafe fn decomp_tx(
     txa: *mut [[[u8; 32]; 32]; 2],
     from: RectTxfmSize,
@@ -77,6 +85,7 @@ unsafe fn decomp_tx(
         let sub = t_dim.sub as RectTxfmSize;
         let htw4 = t_dim.w >> 1;
         let hth4 = t_dim.h >> 1;
+
         decomp_tx(txa, sub, depth + 1, y_off * 2 + 0, x_off * 2 + 0, tx_masks);
         if t_dim.w >= t_dim.h {
             decomp_tx(
@@ -139,7 +148,6 @@ unsafe fn decomp_tx(
             0,
             &mut set_ctx,
         );
-
         let mut set_ctx = |_dir: &mut (), _diridx, off, mul, rep_macro: SetCtxFn| {
             rep_macro(
                 (*txa.offset(1))[1][0].as_mut_ptr(),

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -66,19 +66,18 @@ unsafe fn decomp_tx(
     x_off: libc::c_int,
     tx_masks: *const u16,
 ) {
-    let t_dim: *const TxfmInfo =
-        &*dav1d_txfm_dimensions.as_ptr().offset(from as isize) as *const TxfmInfo;
+    let t_dim = &dav1d_txfm_dimensions[from as usize];
     let is_split = if from as libc::c_uint == TX_4X4 as libc::c_int as libc::c_uint || depth > 1 {
         0 as libc::c_int
     } else {
         *tx_masks.offset(depth as isize) as libc::c_int >> y_off * 4 + x_off & 1
     };
     if is_split != 0 {
-        let sub: RectTxfmSize = (*t_dim).sub as RectTxfmSize;
-        let htw4 = (*t_dim).w as libc::c_int >> 1;
-        let hth4 = (*t_dim).h as libc::c_int >> 1;
+        let sub: RectTxfmSize = t_dim.sub as RectTxfmSize;
+        let htw4 = t_dim.w as libc::c_int >> 1;
+        let hth4 = t_dim.h as libc::c_int >> 1;
         decomp_tx(txa, sub, depth + 1, y_off * 2 + 0, x_off * 2 + 0, tx_masks);
-        if (*t_dim).w as libc::c_int >= (*t_dim).h as libc::c_int {
+        if t_dim.w as libc::c_int >= t_dim.h as libc::c_int {
             decomp_tx(
                 &mut *(*(*(*txa.offset(0)).as_mut_ptr().offset(0))
                     .as_mut_ptr()
@@ -92,7 +91,7 @@ unsafe fn decomp_tx(
                 tx_masks,
             );
         }
-        if (*t_dim).h as libc::c_int >= (*t_dim).w as libc::c_int {
+        if t_dim.h as libc::c_int >= t_dim.w as libc::c_int {
             decomp_tx(
                 &mut *(*(*(*txa.offset(0)).as_mut_ptr().offset(0))
                     .as_mut_ptr()
@@ -105,7 +104,7 @@ unsafe fn decomp_tx(
                 x_off * 2 + 0,
                 tx_masks,
             );
-            if (*t_dim).w as libc::c_int >= (*t_dim).h as libc::c_int {
+            if t_dim.w as libc::c_int >= t_dim.h as libc::c_int {
                 decomp_tx(
                     &mut *(*(*(*txa.offset(0)).as_mut_ptr().offset(0))
                         .as_mut_ptr()
@@ -122,12 +121,12 @@ unsafe fn decomp_tx(
             }
         }
     } else {
-        let lw = imin(2 as libc::c_int, (*t_dim).lw as libc::c_int);
-        let lh = imin(2 as libc::c_int, (*t_dim).lh as libc::c_int);
+        let lw = imin(2 as libc::c_int, t_dim.lw as libc::c_int);
+        let lh = imin(2 as libc::c_int, t_dim.lh as libc::c_int);
 
         let mut set_ctx = |_dir: &mut (), _diridx, off, mul, rep_macro: SetCtxFn| {
             let mut y = 0;
-            while y < (*t_dim).h as libc::c_int {
+            while y < t_dim.h as libc::c_int {
                 rep_macro(
                     (*txa.offset(0))[0][y as usize].as_mut_ptr(),
                     off,
@@ -138,13 +137,13 @@ unsafe fn decomp_tx(
                     off,
                     mul * lh as u64,
                 );
-                (*txa.offset(0))[1][y as usize][0] = (*t_dim).w;
+                (*txa.offset(0))[1][y as usize][0] = t_dim.w;
                 y += 1;
             }
         };
         case_set_upto16(
-            (*t_dim).w as libc::c_int,
-            &mut (), // Was nothing in C.
+            t_dim.w as libc::c_int,
+            &mut (),            // Was nothing in C.
             Default::default(), // Was nothing in C.
             0,
             &mut set_ctx,
@@ -154,12 +153,12 @@ unsafe fn decomp_tx(
             rep_macro(
                 (*txa.offset(1))[1][0].as_mut_ptr(),
                 off,
-                mul * (*t_dim).h as u64,
+                mul * t_dim.h as u64,
             );
         };
         case_set_upto16(
-            (*t_dim).w as libc::c_int,
-            &mut (), // Was nothing in C.
+            t_dim.w as libc::c_int,
+            &mut (),            // Was nothing in C.
             Default::default(), // Was nothing in C.
             0,
             &mut set_ctx,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -64,13 +64,13 @@ unsafe fn decomp_tx(
     depth: libc::c_int,
     y_off: libc::c_int,
     x_off: libc::c_int,
-    tx_masks: *const u16,
+    tx_masks: &[u16; 2],
 ) {
     let t_dim = &dav1d_txfm_dimensions[from as usize];
     let is_split = if from == TX_4X4 || depth > 1 {
         false
     } else {
-        (*tx_masks.offset(depth as isize) >> (y_off * 4 + x_off)) & 1 != 0
+        (tx_masks[depth as usize] >> (y_off * 4 + x_off)) & 1 != 0
     };
     if is_split {
         let sub = t_dim.sub as RectTxfmSize;
@@ -175,7 +175,7 @@ unsafe fn mask_edges_inter(
     h4: libc::c_int,
     skip: libc::c_int,
     max_tx: RectTxfmSize,
-    tx_masks: *const u16,
+    tx_masks: &[u16; 2],
     a: *mut u8,
     l: *mut u8,
 ) {
@@ -698,7 +698,7 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     skip: libc::c_int,
     bs: BlockSize,
     max_ytx: RectTxfmSize,
-    tx_masks: *const u16,
+    tx_masks: &[u16; 2],
     uvtx: RectTxfmSize,
     layout: Dav1dPixelLayout,
     ay: *mut u8,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -126,20 +126,10 @@ unsafe fn decomp_tx(
         let lh = std::cmp::min(2, t_dim.lh);
 
         let mut set_ctx = |_dir: &mut (), _diridx, off, mul, rep_macro: SetCtxFn| {
-            let mut y = 0;
-            while y < t_dim.h as libc::c_int {
-                rep_macro(
-                    (*txa.offset(0))[0][y as usize].as_mut_ptr(),
-                    off,
-                    mul * lw as u64,
-                );
-                rep_macro(
-                    (*txa.offset(1))[0][y as usize].as_mut_ptr(),
-                    off,
-                    mul * lh as u64,
-                );
-                (*txa.offset(0))[1][y as usize][0] = t_dim.w;
-                y += 1;
+            for y in 0..t_dim.h as usize {
+                rep_macro((*txa.offset(0))[0][y].as_mut_ptr(), off, mul * lw as u64);
+                rep_macro((*txa.offset(1))[0][y].as_mut_ptr(), off, mul * lh as u64);
+                (*txa.offset(0))[1][y][0] = t_dim.w;
             }
         };
         case_set_upto16(

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -11,6 +11,8 @@ use crate::src::ctx::alias16;
 use crate::src::ctx::alias32;
 use crate::src::ctx::alias64;
 use crate::src::ctx::alias8;
+use crate::src::ctx::case_set_upto16;
+use crate::src::ctx::SetCtxFn;
 use crate::src::levels::BlockSize;
 use crate::src::levels::RectTxfmSize;
 use crate::src::levels::TX_4X4;
@@ -122,180 +124,46 @@ unsafe fn decomp_tx(
     } else {
         let lw = imin(2 as libc::c_int, (*t_dim).lw as libc::c_int);
         let lh = imin(2 as libc::c_int, (*t_dim).lh as libc::c_int);
-        match (*t_dim).w as libc::c_int {
-            1 => {
-                let mut y = 0;
-                while y < (*t_dim).h as libc::c_int {
-                    (*(&mut *(*(*(*txa.offset(0)).as_mut_ptr().offset(0))
-                        .as_mut_ptr()
-                        .offset(y as isize))
-                    .as_mut_ptr()
-                    .offset(0) as *mut u8 as *mut alias8))
-                        .u8_0 = (0x1 * lw) as u8;
-                    (*(&mut *(*(*(*txa.offset(1)).as_mut_ptr().offset(0))
-                        .as_mut_ptr()
-                        .offset(y as isize))
-                    .as_mut_ptr()
-                    .offset(0) as *mut u8 as *mut alias8))
-                        .u8_0 = (0x1 * lh) as u8;
-                    (*txa.offset(0))[1][y as usize][0] = (*t_dim).w;
-                    y += 1;
-                }
+
+        let mut set_ctx = |_dir: &mut (), _diridx, off, mul, rep_macro: SetCtxFn| {
+            let mut y = 0;
+            while y < (*t_dim).h as libc::c_int {
+                rep_macro(
+                    (*txa.offset(0))[0][y as usize].as_mut_ptr(),
+                    off,
+                    mul * lw as u64,
+                );
+                rep_macro(
+                    (*txa.offset(1))[0][y as usize].as_mut_ptr(),
+                    off,
+                    mul * lh as u64,
+                );
+                (*txa.offset(0))[1][y as usize][0] = (*t_dim).w;
+                y += 1;
             }
-            2 => {
-                let mut y_0 = 0;
-                while y_0 < (*t_dim).h as libc::c_int {
-                    (*(&mut *(*(*(*txa.offset(0)).as_mut_ptr().offset(0))
-                        .as_mut_ptr()
-                        .offset(y_0 as isize))
-                    .as_mut_ptr()
-                    .offset(0) as *mut u8 as *mut alias16))
-                        .u16_0 = (0x101 * lw) as u16;
-                    (*(&mut *(*(*(*txa.offset(1)).as_mut_ptr().offset(0))
-                        .as_mut_ptr()
-                        .offset(y_0 as isize))
-                    .as_mut_ptr()
-                    .offset(0) as *mut u8 as *mut alias16))
-                        .u16_0 = (0x101 * lh) as u16;
-                    (*txa.offset(0))[1][y_0 as usize][0] = (*t_dim).w;
-                    y_0 += 1;
-                }
-            }
-            4 => {
-                let mut y_1 = 0;
-                while y_1 < (*t_dim).h as libc::c_int {
-                    (*(&mut *(*(*(*txa.offset(0)).as_mut_ptr().offset(0))
-                        .as_mut_ptr()
-                        .offset(y_1 as isize))
-                    .as_mut_ptr()
-                    .offset(0) as *mut u8 as *mut alias32))
-                        .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(lw as libc::c_uint);
-                    (*(&mut *(*(*(*txa.offset(1)).as_mut_ptr().offset(0))
-                        .as_mut_ptr()
-                        .offset(y_1 as isize))
-                    .as_mut_ptr()
-                    .offset(0) as *mut u8 as *mut alias32))
-                        .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul(lh as libc::c_uint);
-                    (*txa.offset(0))[1][y_1 as usize][0] = (*t_dim).w;
-                    y_1 += 1;
-                }
-            }
-            8 => {
-                let mut y_2 = 0;
-                while y_2 < (*t_dim).h as libc::c_int {
-                    (*(&mut *(*(*(*txa.offset(0)).as_mut_ptr().offset(0))
-                        .as_mut_ptr()
-                        .offset(y_2 as isize))
-                    .as_mut_ptr()
-                    .offset(0) as *mut u8 as *mut alias64))
-                        .u64_0 = (0x101010101010101 as libc::c_ulonglong)
-                        .wrapping_mul(lw as libc::c_ulonglong)
-                        as u64;
-                    (*(&mut *(*(*(*txa.offset(1)).as_mut_ptr().offset(0))
-                        .as_mut_ptr()
-                        .offset(y_2 as isize))
-                    .as_mut_ptr()
-                    .offset(0) as *mut u8 as *mut alias64))
-                        .u64_0 = (0x101010101010101 as libc::c_ulonglong)
-                        .wrapping_mul(lh as libc::c_ulonglong)
-                        as u64;
-                    (*txa.offset(0))[1][y_2 as usize][0] = (*t_dim).w;
-                    y_2 += 1;
-                }
-            }
-            16 => {
-                let mut y_3 = 0;
-                while y_3 < (*t_dim).h as libc::c_int {
-                    let const_val: u64 = (0x101010101010101 as libc::c_ulonglong)
-                        .wrapping_mul(lw as libc::c_ulonglong)
-                        as u64;
-                    (*(&mut *(*(*(*txa.offset(0)).as_mut_ptr().offset(0))
-                        .as_mut_ptr()
-                        .offset(y_3 as isize))
-                    .as_mut_ptr()
-                    .offset((0 + 0) as isize) as *mut u8 as *mut alias64))
-                        .u64_0 = const_val;
-                    (*(&mut *(*(*(*txa.offset(0)).as_mut_ptr().offset(0))
-                        .as_mut_ptr()
-                        .offset(y_3 as isize))
-                    .as_mut_ptr()
-                    .offset((0 + 8) as isize) as *mut u8 as *mut alias64))
-                        .u64_0 = const_val;
-                    let const_val_0: u64 = (0x101010101010101 as libc::c_ulonglong)
-                        .wrapping_mul(lh as libc::c_ulonglong)
-                        as u64;
-                    (*(&mut *(*(*(*txa.offset(1)).as_mut_ptr().offset(0))
-                        .as_mut_ptr()
-                        .offset(y_3 as isize))
-                    .as_mut_ptr()
-                    .offset((0 + 0) as isize) as *mut u8 as *mut alias64))
-                        .u64_0 = const_val_0;
-                    (*(&mut *(*(*(*txa.offset(1)).as_mut_ptr().offset(0))
-                        .as_mut_ptr()
-                        .offset(y_3 as isize))
-                    .as_mut_ptr()
-                    .offset((0 + 8) as isize) as *mut u8 as *mut alias64))
-                        .u64_0 = const_val_0;
-                    (*txa.offset(0))[1][y_3 as usize][0] = (*t_dim).w;
-                    y_3 += 1;
-                }
-            }
-            _ => {}
-        }
-        match (*t_dim).w as libc::c_int {
-            1 => {
-                (*(&mut *(*(*(*txa.offset(1)).as_mut_ptr().offset(1))
-                    .as_mut_ptr()
-                    .offset(0))
-                .as_mut_ptr()
-                .offset(0) as *mut u8 as *mut alias8))
-                    .u8_0 = (0x1 * (*t_dim).h as libc::c_int) as u8;
-            }
-            2 => {
-                (*(&mut *(*(*(*txa.offset(1)).as_mut_ptr().offset(1))
-                    .as_mut_ptr()
-                    .offset(0))
-                .as_mut_ptr()
-                .offset(0) as *mut u8 as *mut alias16))
-                    .u16_0 = (0x101 * (*t_dim).h as libc::c_int) as u16;
-            }
-            4 => {
-                (*(&mut *(*(*(*txa.offset(1)).as_mut_ptr().offset(1))
-                    .as_mut_ptr()
-                    .offset(0))
-                .as_mut_ptr()
-                .offset(0) as *mut u8 as *mut alias32))
-                    .u32_0 = (0x1010101 as libc::c_uint).wrapping_mul((*t_dim).h as libc::c_uint);
-            }
-            8 => {
-                (*(&mut *(*(*(*txa.offset(1)).as_mut_ptr().offset(1))
-                    .as_mut_ptr()
-                    .offset(0))
-                .as_mut_ptr()
-                .offset(0) as *mut u8 as *mut alias64))
-                    .u64_0 = (0x101010101010101 as libc::c_ulonglong)
-                    .wrapping_mul((*t_dim).h as libc::c_ulonglong)
-                    as u64;
-            }
-            16 => {
-                let const_val_1: u64 = (0x101010101010101 as libc::c_ulonglong)
-                    .wrapping_mul((*t_dim).h as libc::c_ulonglong)
-                    as u64;
-                (*(&mut *(*(*(*txa.offset(1)).as_mut_ptr().offset(1))
-                    .as_mut_ptr()
-                    .offset(0))
-                .as_mut_ptr()
-                .offset((0 + 0) as isize) as *mut u8 as *mut alias64))
-                    .u64_0 = const_val_1;
-                (*(&mut *(*(*(*txa.offset(1)).as_mut_ptr().offset(1))
-                    .as_mut_ptr()
-                    .offset(0))
-                .as_mut_ptr()
-                .offset((0 + 8) as isize) as *mut u8 as *mut alias64))
-                    .u64_0 = const_val_1;
-            }
-            _ => {}
-        }
+        };
+        case_set_upto16(
+            (*t_dim).w as libc::c_int,
+            &mut (), // Was nothing in C.
+            Default::default(), // Was nothing in C.
+            0,
+            &mut set_ctx,
+        );
+
+        let mut set_ctx = |_dir: &mut (), _diridx, off, mul, rep_macro: SetCtxFn| {
+            rep_macro(
+                (*txa.offset(1))[1][0].as_mut_ptr(),
+                off,
+                mul * (*t_dim).h as u64,
+            );
+        };
+        case_set_upto16(
+            (*t_dim).w as libc::c_int,
+            &mut (), // Was nothing in C.
+            Default::default(), // Was nothing in C.
+            0,
+            &mut set_ctx,
+        );
     };
 }
 

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -67,17 +67,17 @@ unsafe fn decomp_tx(
     tx_masks: *const u16,
 ) {
     let t_dim = &dav1d_txfm_dimensions[from as usize];
-    let is_split = if from as libc::c_uint == TX_4X4 as libc::c_int as libc::c_uint || depth > 1 {
-        0 as libc::c_int
+    let is_split = if from == TX_4X4 || depth > 1 {
+        0
     } else {
-        *tx_masks.offset(depth as isize) as libc::c_int >> y_off * 4 + x_off & 1
+        *tx_masks.offset(depth as isize) >> y_off * 4 + x_off & 1
     };
     if is_split != 0 {
-        let sub: RectTxfmSize = t_dim.sub as RectTxfmSize;
-        let htw4 = t_dim.w as libc::c_int >> 1;
-        let hth4 = t_dim.h as libc::c_int >> 1;
+        let sub = t_dim.sub as RectTxfmSize;
+        let htw4 = t_dim.w >> 1;
+        let hth4 = t_dim.h >> 1;
         decomp_tx(txa, sub, depth + 1, y_off * 2 + 0, x_off * 2 + 0, tx_masks);
-        if t_dim.w as libc::c_int >= t_dim.h as libc::c_int {
+        if t_dim.w >= t_dim.h {
             decomp_tx(
                 &mut *(*(*(*txa.offset(0)).as_mut_ptr().offset(0))
                     .as_mut_ptr()
@@ -91,7 +91,7 @@ unsafe fn decomp_tx(
                 tx_masks,
             );
         }
-        if t_dim.h as libc::c_int >= t_dim.w as libc::c_int {
+        if t_dim.h >= t_dim.w {
             decomp_tx(
                 &mut *(*(*(*txa.offset(0)).as_mut_ptr().offset(0))
                     .as_mut_ptr()
@@ -104,7 +104,7 @@ unsafe fn decomp_tx(
                 x_off * 2 + 0,
                 tx_masks,
             );
-            if t_dim.w as libc::c_int >= t_dim.h as libc::c_int {
+            if t_dim.w >= t_dim.h {
                 decomp_tx(
                     &mut *(*(*(*txa.offset(0)).as_mut_ptr().offset(0))
                         .as_mut_ptr()
@@ -121,8 +121,8 @@ unsafe fn decomp_tx(
             }
         }
     } else {
-        let lw = imin(2 as libc::c_int, t_dim.lw as libc::c_int);
-        let lh = imin(2 as libc::c_int, t_dim.lh as libc::c_int);
+        let lw = imin(2, t_dim.lw as libc::c_int);
+        let lh = imin(2, t_dim.lh as libc::c_int);
 
         let mut set_ctx = |_dir: &mut (), _diridx, off, mul, rep_macro: SetCtxFn| {
             let mut y = 0;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -121,8 +121,8 @@ unsafe fn decomp_tx(
             }
         }
     } else {
-        let lw = imin(2, t_dim.lw as libc::c_int);
-        let lh = imin(2, t_dim.lh as libc::c_int);
+        let lw = std::cmp::min(2, t_dim.lw);
+        let lh = std::cmp::min(2, t_dim.lh);
 
         let mut set_ctx = |_dir: &mut (), _diridx, off, mul, rep_macro: SetCtxFn| {
             let mut y = 0;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -68,11 +68,11 @@ unsafe fn decomp_tx(
 ) {
     let t_dim = &dav1d_txfm_dimensions[from as usize];
     let is_split = if from == TX_4X4 || depth > 1 {
-        0
+        false
     } else {
-        *tx_masks.offset(depth as isize) >> y_off * 4 + x_off & 1
+        (*tx_masks.offset(depth as isize) >> (y_off * 4 + x_off)) & 1 != 0
     };
-    if is_split != 0 {
+    if is_split {
         let sub = t_dim.sub as RectTxfmSize;
         let htw4 = t_dim.w >> 1;
         let hth4 = t_dim.h >> 1;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -62,8 +62,8 @@ unsafe fn decomp_tx(
     txa: *mut [[[u8; 32]; 32]; 2],
     from: RectTxfmSize,
     depth: libc::c_int,
-    y_off: libc::c_int,
-    x_off: libc::c_int,
+    y_off: u8,
+    x_off: u8,
     tx_masks: &[u16; 2],
 ) {
     let t_dim = &dav1d_txfm_dimensions[from as usize];


### PR DESCRIPTION
I still need to make `txa` a safe slice/array ref (see the discussion below), but doing so in the way it's done in C would be UB in Rust, so I'm going to change the implementation a bit to make it safe, as @fbossen suggested below in a follow-up PR.