### PR TITLE
`fn mask_edges_inter`: Cleanup and make mostly safe

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4910,8 +4910,8 @@ unsafe fn decode_b(
                 &tx_split,
                 uvtx,
                 f.cur.p.layout,
-                &mut *((*t.a).tx_lpf_y.0).as_mut_ptr().offset(bx4 as isize),
-                &mut *(t.l.tx_lpf_y.0).as_mut_ptr().offset(by4 as isize),
+                &mut (*t.a).tx_lpf_y.0[bx4 as usize..],
+                &mut t.l.tx_lpf_y.0[by4 as usize..],
                 if has_chroma {
                     &mut *((*t.a).tx_lpf_uv.0).as_mut_ptr().offset(cbx4 as isize)
                 } else {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4904,7 +4904,7 @@ unsafe fn decode_b(
                 t.by,
                 f.w4,
                 f.h4,
-                b.skip as libc::c_int,
+                b.skip != 0,
                 bs,
                 ytx,
                 &tx_split,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -178,8 +178,7 @@ unsafe fn mask_edges_inter(
     a: &mut [u8],
     l: &mut [u8],
 ) {
-    let t_dim: *const TxfmInfo =
-        &*dav1d_txfm_dimensions.as_ptr().offset(max_tx as isize) as *const TxfmInfo;
+    let t_dim = &dav1d_txfm_dimensions[max_tx as usize];
     let mut y = 0;
     let mut x = 0;
     let mut txa: Align16<[[[[u8; 32]; 32]; 2]; 2]> = Align16([[[[0; 32]; 32]; 2]; 2]);
@@ -201,10 +200,10 @@ unsafe fn mask_edges_inter(
                 x_off,
                 tx_masks,
             );
-            x_0 += (*t_dim).w as libc::c_int;
+            x_0 += t_dim.w as libc::c_int;
             x_off += 1;
         }
-        y_0 += (*t_dim).h as libc::c_int;
+        y_0 += t_dim.h as libc::c_int;
         y_off += 1;
     }
     let mut mask: libc::c_uint = (1 as libc::c_uint) << by4;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -175,8 +175,8 @@ unsafe fn mask_edges_inter(
     skip: libc::c_int,
     max_tx: RectTxfmSize,
     tx_masks: &[u16; 2],
-    a: *mut u8,
-    l: *mut u8,
+    a: &mut [u8],
+    l: &mut [u8],
 ) {
     let t_dim: *const TxfmInfo =
         &*dav1d_txfm_dimensions.as_ptr().offset(max_tx as isize) as *const TxfmInfo;
@@ -214,7 +214,7 @@ unsafe fn mask_edges_inter(
         let smask: libc::c_uint = mask >> (sidx << 4);
         let ref mut fresh0 = masks[0][bx4 as usize][imin(
             txa[0][0][y as usize][0] as libc::c_int,
-            *l.offset(y as isize) as libc::c_int,
+            l[y as usize] as libc::c_int,
         ) as usize][sidx as usize];
         *fresh0 = (*fresh0 as libc::c_uint | smask) as u16;
         y += 1;
@@ -227,7 +227,7 @@ unsafe fn mask_edges_inter(
         let smask_0: libc::c_uint = mask >> (sidx_0 << 4);
         let ref mut fresh1 = masks[1][by4 as usize][imin(
             txa[1][0][0][x as usize] as libc::c_int,
-            *a.offset(x as isize) as libc::c_int,
+            a[x as usize] as libc::c_int,
         ) as usize][sidx_0 as usize];
         *fresh1 = (*fresh1 as libc::c_uint | smask_0) as u16;
         x += 1;
@@ -277,11 +277,11 @@ unsafe fn mask_edges_inter(
     }
     y = 0 as libc::c_int;
     while y < h4 {
-        *l.offset(y as isize) = txa[0][0][y as usize][(w4 - 1) as usize];
+        l[y as usize] = txa[0][0][y as usize][(w4 - 1) as usize];
         y += 1;
     }
     memcpy(
-        a as *mut libc::c_void,
+        a.as_mut_ptr() as *mut libc::c_void,
         (txa[1][0][(h4 - 1) as usize]).as_mut_ptr() as *const libc::c_void,
         w4 as libc::c_ulong,
     );
@@ -700,8 +700,8 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     tx_masks: &[u16; 2],
     uvtx: RectTxfmSize,
     layout: Dav1dPixelLayout,
-    ay: *mut u8,
-    ly: *mut u8,
+    ay: &mut [u8],
+    ly: &mut [u8],
     auv: *mut u8,
     luv: *mut u8,
 ) {

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -21,7 +21,6 @@ use crate::src::tables::dav1d_txfm_dimensions;
 use crate::src::tables::TxfmInfo;
 
 extern "C" {
-    fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong) -> *mut libc::c_void;
 }
 
@@ -244,11 +243,7 @@ unsafe fn mask_edges_inter(
     for y in 0..h4 {
         l[y] = txa[0][0][y][w4 - 1];
     }
-    memcpy(
-        a.as_mut_ptr() as *mut libc::c_void,
-        (txa[1][0][h4 - 1]).as_mut_ptr() as *const libc::c_void,
-        w4 as libc::c_ulong,
-    );
+    a[..w4].copy_from_slice(&mut txa[1][0][h4 - 1][..w4]);
 }
 
 #[inline]

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -167,7 +167,7 @@ unsafe fn decomp_tx(
 
 #[inline]
 unsafe fn mask_edges_inter(
-    masks: *mut [[[u16; 2]; 3]; 32],
+    masks: &mut [[[[u16; 2]; 3]; 32]; 2],
     by4: libc::c_int,
     bx4: libc::c_int,
     w4: libc::c_int,
@@ -212,7 +212,7 @@ unsafe fn mask_edges_inter(
     while y < h4 {
         let sidx = (mask >= 0x10000 as libc::c_int as libc::c_uint) as libc::c_int;
         let smask: libc::c_uint = mask >> (sidx << 4);
-        let ref mut fresh0 = (*masks.offset(0))[bx4 as usize][imin(
+        let ref mut fresh0 = masks[0][bx4 as usize][imin(
             txa[0][0][y as usize][0] as libc::c_int,
             *l.offset(y as isize) as libc::c_int,
         ) as usize][sidx as usize];
@@ -225,7 +225,7 @@ unsafe fn mask_edges_inter(
     while x < w4 {
         let sidx_0 = (mask >= 0x10000 as libc::c_int as libc::c_uint) as libc::c_int;
         let smask_0: libc::c_uint = mask >> (sidx_0 << 4);
-        let ref mut fresh1 = (*masks.offset(1))[by4 as usize][imin(
+        let ref mut fresh1 = masks[1][by4 as usize][imin(
             txa[1][0][0][x as usize] as libc::c_int,
             *a.offset(x as isize) as libc::c_int,
         ) as usize][sidx_0 as usize];
@@ -244,8 +244,8 @@ unsafe fn mask_edges_inter(
             x = step;
             while x < w4 {
                 let rtx = txa[0][0][y as usize][x as usize] as libc::c_int;
-                let ref mut fresh2 = (*masks.offset(0))[(bx4 + x) as usize]
-                    [imin(rtx, ltx) as usize][sidx_1 as usize];
+                let ref mut fresh2 =
+                    masks[0][(bx4 + x) as usize][imin(rtx, ltx) as usize][sidx_1 as usize];
                 *fresh2 = (*fresh2 as libc::c_uint | smask_1) as u16;
                 ltx = rtx;
                 step = txa[0][1][y as usize][x as usize] as libc::c_int;
@@ -264,8 +264,8 @@ unsafe fn mask_edges_inter(
             y = step_0;
             while y < h4 {
                 let btx = txa[1][0][y as usize][x as usize] as libc::c_int;
-                let ref mut fresh3 = (*masks.offset(1))[(by4 + y) as usize]
-                    [imin(ttx, btx) as usize][sidx_2 as usize];
+                let ref mut fresh3 =
+                    masks[1][(by4 + y) as usize][imin(ttx, btx) as usize][sidx_2 as usize];
                 *fresh3 = (*fresh3 as libc::c_uint | smask_2) as u16;
                 ttx = btx;
                 step_0 = txa[1][1][y as usize][x as usize] as libc::c_int;
@@ -726,7 +726,7 @@ pub unsafe fn dav1d_create_lf_mask_inter(
             y += 1;
         }
         mask_edges_inter(
-            ((*lflvl).filter_y).as_mut_ptr(),
+            &mut (*lflvl).filter_y,
             by4,
             bx4,
             bw4,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -179,31 +179,30 @@ unsafe fn mask_edges_inter(
     l: &mut [u8],
 ) {
     let t_dim = &dav1d_txfm_dimensions[max_tx as usize];
-    let mut y = 0;
     let mut x = 0;
     let mut txa = Align16([[[[0; 32]; 32]; 2]; 2]);
     let mut y_off = 0;
-    let mut y_0 = 0;
-    while y_0 < h4 {
+    let mut y = 0;
+    while y < h4 {
         let mut x_off = 0;
-        let mut x_0 = 0;
-        while x_0 < w4 {
+        let mut x = 0;
+        while x < w4 {
             decomp_tx(
                 &mut *(*(*(*txa.0.as_mut_ptr().offset(0)).as_mut_ptr().offset(0))
                     .as_mut_ptr()
-                    .offset(y_0 as isize))
+                    .offset(y as isize))
                 .as_mut_ptr()
-                .offset(x_0 as isize) as *mut u8 as *mut [[[u8; 32]; 32]; 2],
+                .offset(x as isize) as *mut u8 as *mut [[[u8; 32]; 32]; 2],
                 max_tx,
                 0,
                 y_off,
                 x_off,
                 tx_masks,
             );
-            x_0 += t_dim.w as libc::c_int;
+            x += t_dim.w as libc::c_int;
             x_off += 1;
         }
-        y_0 += t_dim.h as libc::c_int;
+        y += t_dim.h as libc::c_int;
         y_off += 1;
     }
     let mut mask = 1 << by4;
@@ -222,13 +221,13 @@ unsafe fn mask_edges_inter(
     x = 0;
     mask = 1 << bx4;
     while x < w4 {
-        let sidx_0 = (mask >= 0x10000) as libc::c_int;
-        let smask_0 = mask >> (sidx_0 << 4);
+        let sidx = (mask >= 0x10000) as libc::c_int;
+        let smask = mask >> (sidx << 4);
         let ref mut fresh1 = masks[1][by4 as usize][imin(
             txa[1][0][0][x as usize] as libc::c_int,
             a[x as usize] as libc::c_int,
-        ) as usize][sidx_0 as usize];
-        *fresh1 = (*fresh1 as libc::c_uint | smask_0) as u16;
+        ) as usize][sidx as usize];
+        *fresh1 = (*fresh1 as libc::c_uint | smask) as u16;
         x += 1;
         mask <<= 1;
     }
@@ -236,16 +235,16 @@ unsafe fn mask_edges_inter(
         y = 0;
         mask = 1 << by4;
         while y < h4 {
-            let sidx_1 = (mask >= 0x10000) as libc::c_int;
-            let smask_1 = mask >> (sidx_1 << 4);
+            let sidx = (mask >= 0x10000) as libc::c_int;
+            let smask = mask >> (sidx << 4);
             let mut ltx = txa[0][0][y as usize][0] as libc::c_int;
             let mut step = txa[0][1][y as usize][0] as libc::c_int;
             x = step;
             while x < w4 {
                 let rtx = txa[0][0][y as usize][x as usize] as libc::c_int;
                 let ref mut fresh2 =
-                    masks[0][(bx4 + x) as usize][imin(rtx, ltx) as usize][sidx_1 as usize];
-                *fresh2 = (*fresh2 as libc::c_uint | smask_1) as u16;
+                    masks[0][(bx4 + x) as usize][imin(rtx, ltx) as usize][sidx as usize];
+                *fresh2 = (*fresh2 as libc::c_uint | smask) as u16;
                 ltx = rtx;
                 step = txa[0][1][y as usize][x as usize] as libc::c_int;
                 x += step;
@@ -256,19 +255,19 @@ unsafe fn mask_edges_inter(
         x = 0;
         mask = 1 << bx4;
         while x < w4 {
-            let sidx_2 = (mask >= 0x10000) as libc::c_int;
-            let smask_2 = mask >> (sidx_2 << 4);
+            let sidx = (mask >= 0x10000) as libc::c_int;
+            let smask = mask >> (sidx << 4);
             let mut ttx = txa[1][0][0][x as usize] as libc::c_int;
-            let mut step_0 = txa[1][1][0][x as usize] as libc::c_int;
-            y = step_0;
+            let mut step = txa[1][1][0][x as usize] as libc::c_int;
+            y = step;
             while y < h4 {
                 let btx = txa[1][0][y as usize][x as usize] as libc::c_int;
                 let ref mut fresh3 =
-                    masks[1][(by4 + y) as usize][imin(ttx, btx) as usize][sidx_2 as usize];
-                *fresh3 = (*fresh3 as libc::c_uint | smask_2) as u16;
+                    masks[1][(by4 + y) as usize][imin(ttx, btx) as usize][sidx as usize];
+                *fresh3 = (*fresh3 as libc::c_uint | smask) as u16;
                 ttx = btx;
-                step_0 = txa[1][1][y as usize][x as usize] as libc::c_int;
-                y += step_0;
+                step = txa[1][1][y as usize][x as usize] as libc::c_int;
+                y += step;
             }
             x += 1;
             mask <<= 1;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -171,7 +171,7 @@ unsafe fn mask_edges_inter(
     bx4: libc::c_int,
     w4: libc::c_int,
     h4: libc::c_int,
-    skip: libc::c_int,
+    skip: bool,
     max_tx: RectTxfmSize,
     tx_masks: &[u16; 2],
     a: &mut [u8],
@@ -208,7 +208,7 @@ unsafe fn mask_edges_inter(
         let smask = mask >> (sidx << 4);
         masks[1][by4][std::cmp::min(txa[1][0][0][x], a[x]) as usize][sidx] |= smask as u16;
     }
-    if skip == 0 {
+    if !skip {
         for y in 0..h4 {
             let mask = 1u32 << (by4 + y);
             let sidx = (mask >= 0x10000) as usize;
@@ -397,7 +397,7 @@ unsafe fn mask_edges_chroma(
     cbx4: libc::c_int,
     cw4: libc::c_int,
     ch4: libc::c_int,
-    skip_inter: libc::c_int,
+    skip_inter: bool,
     tx: RectTxfmSize,
     a: *mut u8,
     l: *mut u8,
@@ -440,7 +440,7 @@ unsafe fn mask_edges_chroma(
         x += 1;
         mask <<= 1;
     }
-    if skip_inter == 0 {
+    if !skip_inter {
         let hstep = (*t_dim).w as libc::c_int;
         let mut t: libc::c_uint = (1 as libc::c_uint) << cby4;
         let mut inner: libc::c_uint = ((t as u64) << ch4).wrapping_sub(t as u64) as libc::c_uint;
@@ -635,7 +635,7 @@ pub unsafe fn dav1d_create_lf_mask_intra(
         cbx4,
         cbw4,
         cbh4,
-        0 as libc::c_int,
+        false,
         uvtx,
         auv,
         luv,
@@ -653,7 +653,7 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     by: libc::c_int,
     iw: libc::c_int,
     ih: libc::c_int,
-    skip: libc::c_int,
+    skip: bool,
     bs: BlockSize,
     max_ytx: RectTxfmSize,
     tx_masks: &[u16; 2],

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -205,14 +205,13 @@ unsafe fn mask_edges_inter(
         y += t_dim.h as libc::c_int;
         y_off += 1;
     }
-    let mut mask = 1 << by4;
+    let mut mask = 1u32 << by4;
     y = 0;
     while y < h4 {
         let sidx = (mask >= 0x10000) as libc::c_int;
         let smask = mask >> (sidx << 4);
-        let ref mut fresh0 = masks[0][bx4 as usize]
-            [std::cmp::min(txa[0][0][y as usize][0], l[y as usize]) as usize][sidx as usize];
-        *fresh0 = (*fresh0 as libc::c_uint | smask) as u16;
+        masks[0][bx4 as usize][std::cmp::min(txa[0][0][y as usize][0], l[y as usize]) as usize]
+            [sidx as usize] |= smask as u16;
         y += 1;
         mask <<= 1;
     }
@@ -221,9 +220,8 @@ unsafe fn mask_edges_inter(
     while x < w4 {
         let sidx = (mask >= 0x10000) as libc::c_int;
         let smask = mask >> (sidx << 4);
-        let ref mut fresh1 = masks[1][by4 as usize]
-            [std::cmp::min(txa[1][0][0][x as usize], a[x as usize]) as usize][sidx as usize];
-        *fresh1 = (*fresh1 as libc::c_uint | smask) as u16;
+        masks[1][by4 as usize][std::cmp::min(txa[1][0][0][x as usize], a[x as usize]) as usize]
+            [sidx as usize] |= smask as u16;
         x += 1;
         mask <<= 1;
     }
@@ -238,9 +236,8 @@ unsafe fn mask_edges_inter(
             x = step;
             while x < w4 {
                 let rtx = txa[0][0][y as usize][x as usize];
-                let ref mut fresh2 =
-                    masks[0][(bx4 + x) as usize][std::cmp::min(rtx, ltx) as usize][sidx as usize];
-                *fresh2 = (*fresh2 as libc::c_uint | smask) as u16;
+                masks[0][(bx4 + x) as usize][std::cmp::min(rtx, ltx) as usize][sidx as usize] |=
+                    smask as u16;
                 ltx = rtx;
                 step = txa[0][1][y as usize][x as usize] as libc::c_int;
                 x += step;
@@ -258,9 +255,8 @@ unsafe fn mask_edges_inter(
             y = step;
             while y < h4 {
                 let btx = txa[1][0][y as usize][x as usize];
-                let ref mut fresh3 =
-                    masks[1][(by4 + y) as usize][std::cmp::min(ttx, btx) as usize][sidx as usize];
-                *fresh3 = (*fresh3 as libc::c_uint | smask) as u16;
+                masks[1][(by4 + y) as usize][std::cmp::min(ttx, btx) as usize][sidx as usize] |=
+                    smask as u16;
                 ttx = btx;
                 step = txa[1][1][y as usize][x as usize] as libc::c_int;
                 y += step;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -214,13 +214,13 @@ unsafe fn mask_edges_inter(
             let sidx = (mask >= 0x10000) as usize;
             let smask = mask >> (sidx << 4);
             let mut ltx = txa[0][0][y][0];
-            let mut step = txa[0][1][y][0] as usize;
+            let step = txa[0][1][y][0] as usize;
             let mut x = step;
             while x < w4 {
                 let rtx = txa[0][0][y][x];
                 masks[0][bx4 + x][std::cmp::min(rtx, ltx) as usize][sidx] |= smask as u16;
                 ltx = rtx;
-                step = txa[0][1][y][x] as usize;
+                let step = txa[0][1][y][x] as usize;
                 x += step;
             }
         }
@@ -229,13 +229,13 @@ unsafe fn mask_edges_inter(
             let sidx = (mask >= 0x10000) as usize;
             let smask = mask >> (sidx << 4);
             let mut ttx = txa[1][0][0][x];
-            let mut step = txa[1][1][0][x] as usize;
+            let step = txa[1][1][0][x] as usize;
             let mut y = step;
             while y < h4 {
                 let btx = txa[1][0][y][x];
                 masks[1][by4 + y][std::cmp::min(ttx, btx) as usize][sidx] |= smask as u16;
                 ttx = btx;
-                step = txa[1][1][y][x] as usize;
+                let step = txa[1][1][y][x] as usize;
                 y += step;
             }
         }

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -210,10 +210,8 @@ unsafe fn mask_edges_inter(
     while y < h4 {
         let sidx = (mask >= 0x10000) as libc::c_int;
         let smask = mask >> (sidx << 4);
-        let ref mut fresh0 = masks[0][bx4 as usize][imin(
-            txa[0][0][y as usize][0] as libc::c_int,
-            l[y as usize] as libc::c_int,
-        ) as usize][sidx as usize];
+        let ref mut fresh0 = masks[0][bx4 as usize]
+            [std::cmp::min(txa[0][0][y as usize][0], l[y as usize]) as usize][sidx as usize];
         *fresh0 = (*fresh0 as libc::c_uint | smask) as u16;
         y += 1;
         mask <<= 1;
@@ -223,10 +221,8 @@ unsafe fn mask_edges_inter(
     while x < w4 {
         let sidx = (mask >= 0x10000) as libc::c_int;
         let smask = mask >> (sidx << 4);
-        let ref mut fresh1 = masks[1][by4 as usize][imin(
-            txa[1][0][0][x as usize] as libc::c_int,
-            a[x as usize] as libc::c_int,
-        ) as usize][sidx as usize];
+        let ref mut fresh1 = masks[1][by4 as usize]
+            [std::cmp::min(txa[1][0][0][x as usize], a[x as usize]) as usize][sidx as usize];
         *fresh1 = (*fresh1 as libc::c_uint | smask) as u16;
         x += 1;
         mask <<= 1;
@@ -237,13 +233,13 @@ unsafe fn mask_edges_inter(
         while y < h4 {
             let sidx = (mask >= 0x10000) as libc::c_int;
             let smask = mask >> (sidx << 4);
-            let mut ltx = txa[0][0][y as usize][0] as libc::c_int;
+            let mut ltx = txa[0][0][y as usize][0];
             let mut step = txa[0][1][y as usize][0] as libc::c_int;
             x = step;
             while x < w4 {
-                let rtx = txa[0][0][y as usize][x as usize] as libc::c_int;
+                let rtx = txa[0][0][y as usize][x as usize];
                 let ref mut fresh2 =
-                    masks[0][(bx4 + x) as usize][imin(rtx, ltx) as usize][sidx as usize];
+                    masks[0][(bx4 + x) as usize][std::cmp::min(rtx, ltx) as usize][sidx as usize];
                 *fresh2 = (*fresh2 as libc::c_uint | smask) as u16;
                 ltx = rtx;
                 step = txa[0][1][y as usize][x as usize] as libc::c_int;
@@ -257,13 +253,13 @@ unsafe fn mask_edges_inter(
         while x < w4 {
             let sidx = (mask >= 0x10000) as libc::c_int;
             let smask = mask >> (sidx << 4);
-            let mut ttx = txa[1][0][0][x as usize] as libc::c_int;
+            let mut ttx = txa[1][0][0][x as usize];
             let mut step = txa[1][1][0][x as usize] as libc::c_int;
             y = step;
             while y < h4 {
-                let btx = txa[1][0][y as usize][x as usize] as libc::c_int;
+                let btx = txa[1][0][y as usize][x as usize];
                 let ref mut fresh3 =
-                    masks[1][(by4 + y) as usize][imin(ttx, btx) as usize][sidx as usize];
+                    masks[1][(by4 + y) as usize][std::cmp::min(ttx, btx) as usize][sidx as usize];
                 *fresh3 = (*fresh3 as libc::c_uint | smask) as u16;
                 ttx = btx;
                 step = txa[1][1][y as usize][x as usize] as libc::c_int;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -178,6 +178,7 @@ unsafe fn mask_edges_inter(
     a: &mut [u8],
     l: &mut [u8],
 ) {
+    let [by4, bx4, w4, h4] = [by4, bx4, w4, h4].map(|it| it as usize);
     let t_dim = &dav1d_txfm_dimensions[max_tx as usize];
     let mut txa = Align16([[[[0; 32]; 32]; 2]; 2]);
     for (y_off, y) in (0..h4).step_by(t_dim.h as usize).enumerate() {
@@ -200,30 +201,27 @@ unsafe fn mask_edges_inter(
         let mask = 1u32 << (by4 + y);
         let sidx = (mask >= 0x10000) as usize;
         let smask = mask >> (sidx << 4);
-        masks[0][bx4 as usize][std::cmp::min(txa[0][0][y as usize][0], l[y as usize]) as usize]
-            [sidx] |= smask as u16;
+        masks[0][bx4][std::cmp::min(txa[0][0][y][0], l[y]) as usize][sidx] |= smask as u16;
     }
     for x in 0..w4 {
         let mask = 1u32 << (bx4 + x);
         let sidx = (mask >= 0x10000) as usize;
         let smask = mask >> (sidx << 4);
-        masks[1][by4 as usize][std::cmp::min(txa[1][0][0][x as usize], a[x as usize]) as usize]
-            [sidx] |= smask as u16;
+        masks[1][by4][std::cmp::min(txa[1][0][0][x], a[x]) as usize][sidx] |= smask as u16;
     }
     if skip == 0 {
         for y in 0..h4 {
             let mask = 1u32 << (by4 + y);
             let sidx = (mask >= 0x10000) as usize;
             let smask = mask >> (sidx << 4);
-            let mut ltx = txa[0][0][y as usize][0];
-            let mut step = txa[0][1][y as usize][0] as libc::c_int;
+            let mut ltx = txa[0][0][y][0];
+            let mut step = txa[0][1][y][0] as usize;
             let mut x = step;
             while x < w4 {
-                let rtx = txa[0][0][y as usize][x as usize];
-                masks[0][(bx4 + x) as usize][std::cmp::min(rtx, ltx) as usize][sidx] |=
-                    smask as u16;
+                let rtx = txa[0][0][y][x];
+                masks[0][bx4 + x][std::cmp::min(rtx, ltx) as usize][sidx] |= smask as u16;
                 ltx = rtx;
-                step = txa[0][1][y as usize][x as usize] as libc::c_int;
+                step = txa[0][1][y][x] as usize;
                 x += step;
             }
         }
@@ -231,25 +229,24 @@ unsafe fn mask_edges_inter(
             let mask = 1u32 << (bx4 + x);
             let sidx = (mask >= 0x10000) as usize;
             let smask = mask >> (sidx << 4);
-            let mut ttx = txa[1][0][0][x as usize];
-            let mut step = txa[1][1][0][x as usize] as libc::c_int;
+            let mut ttx = txa[1][0][0][x];
+            let mut step = txa[1][1][0][x] as usize;
             let mut y = step;
             while y < h4 {
-                let btx = txa[1][0][y as usize][x as usize];
-                masks[1][(by4 + y) as usize][std::cmp::min(ttx, btx) as usize][sidx] |=
-                    smask as u16;
+                let btx = txa[1][0][y][x];
+                masks[1][by4 + y][std::cmp::min(ttx, btx) as usize][sidx] |= smask as u16;
                 ttx = btx;
-                step = txa[1][1][y as usize][x as usize] as libc::c_int;
+                step = txa[1][1][y][x] as usize;
                 y += step;
             }
         }
     }
     for y in 0..h4 {
-        l[y as usize] = txa[0][0][y as usize][(w4 - 1) as usize];
+        l[y] = txa[0][0][y][w4 - 1];
     }
     memcpy(
         a.as_mut_ptr() as *mut libc::c_void,
-        (txa[1][0][(h4 - 1) as usize]).as_mut_ptr() as *const libc::c_void,
+        (txa[1][0][h4 - 1]).as_mut_ptr() as *const libc::c_void,
         w4 as libc::c_ulong,
     );
 }

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -181,7 +181,7 @@ unsafe fn mask_edges_inter(
     let t_dim = &dav1d_txfm_dimensions[max_tx as usize];
     let mut y = 0;
     let mut x = 0;
-    let mut txa: Align16<[[[[u8; 32]; 32]; 2]; 2]> = Align16([[[[0; 32]; 32]; 2]; 2]);
+    let mut txa = Align16([[[[0; 32]; 32]; 2]; 2]);
     let mut y_off = 0;
     let mut y_0 = 0;
     while y_0 < h4 {
@@ -206,11 +206,11 @@ unsafe fn mask_edges_inter(
         y_0 += t_dim.h as libc::c_int;
         y_off += 1;
     }
-    let mut mask: libc::c_uint = (1 as libc::c_uint) << by4;
-    y = 0 as libc::c_int;
+    let mut mask = 1 << by4;
+    y = 0;
     while y < h4 {
-        let sidx = (mask >= 0x10000 as libc::c_int as libc::c_uint) as libc::c_int;
-        let smask: libc::c_uint = mask >> (sidx << 4);
+        let sidx = (mask >= 0x10000) as libc::c_int;
+        let smask = mask >> (sidx << 4);
         let ref mut fresh0 = masks[0][bx4 as usize][imin(
             txa[0][0][y as usize][0] as libc::c_int,
             l[y as usize] as libc::c_int,
@@ -219,11 +219,11 @@ unsafe fn mask_edges_inter(
         y += 1;
         mask <<= 1;
     }
-    x = 0 as libc::c_int;
-    mask = (1 as libc::c_uint) << bx4;
+    x = 0;
+    mask = 1 << bx4;
     while x < w4 {
-        let sidx_0 = (mask >= 0x10000 as libc::c_int as libc::c_uint) as libc::c_int;
-        let smask_0: libc::c_uint = mask >> (sidx_0 << 4);
+        let sidx_0 = (mask >= 0x10000) as libc::c_int;
+        let smask_0 = mask >> (sidx_0 << 4);
         let ref mut fresh1 = masks[1][by4 as usize][imin(
             txa[1][0][0][x as usize] as libc::c_int,
             a[x as usize] as libc::c_int,
@@ -233,11 +233,11 @@ unsafe fn mask_edges_inter(
         mask <<= 1;
     }
     if skip == 0 {
-        y = 0 as libc::c_int;
-        mask = (1 as libc::c_uint) << by4;
+        y = 0;
+        mask = 1 << by4;
         while y < h4 {
-            let sidx_1 = (mask >= 0x10000 as libc::c_uint) as libc::c_int;
-            let smask_1: libc::c_uint = mask >> (sidx_1 << 4);
+            let sidx_1 = (mask >= 0x10000) as libc::c_int;
+            let smask_1 = mask >> (sidx_1 << 4);
             let mut ltx = txa[0][0][y as usize][0] as libc::c_int;
             let mut step = txa[0][1][y as usize][0] as libc::c_int;
             x = step;
@@ -253,11 +253,11 @@ unsafe fn mask_edges_inter(
             y += 1;
             mask <<= 1;
         }
-        x = 0 as libc::c_int;
-        mask = (1 as libc::c_uint) << bx4;
+        x = 0;
+        mask = 1 << bx4;
         while x < w4 {
-            let sidx_2 = (mask >= 0x10000 as libc::c_uint) as libc::c_int;
-            let smask_2: libc::c_uint = mask >> (sidx_2 << 4);
+            let sidx_2 = (mask >= 0x10000) as libc::c_int;
+            let smask_2 = mask >> (sidx_2 << 4);
             let mut ttx = txa[1][0][0][x as usize] as libc::c_int;
             let mut step_0 = txa[1][1][0][x as usize] as libc::c_int;
             y = step_0;
@@ -274,7 +274,7 @@ unsafe fn mask_edges_inter(
             mask <<= 1;
         }
     }
-    y = 0 as libc::c_int;
+    y = 0;
     while y < h4 {
         l[y as usize] = txa[0][0][y as usize][(w4 - 1) as usize];
         y += 1;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -208,20 +208,20 @@ unsafe fn mask_edges_inter(
     let mut mask = 1u32 << by4;
     y = 0;
     while y < h4 {
-        let sidx = (mask >= 0x10000) as libc::c_int;
+        let sidx = (mask >= 0x10000) as usize;
         let smask = mask >> (sidx << 4);
         masks[0][bx4 as usize][std::cmp::min(txa[0][0][y as usize][0], l[y as usize]) as usize]
-            [sidx as usize] |= smask as u16;
+            [sidx] |= smask as u16;
         y += 1;
         mask <<= 1;
     }
     x = 0;
     mask = 1 << bx4;
     while x < w4 {
-        let sidx = (mask >= 0x10000) as libc::c_int;
+        let sidx = (mask >= 0x10000) as usize;
         let smask = mask >> (sidx << 4);
         masks[1][by4 as usize][std::cmp::min(txa[1][0][0][x as usize], a[x as usize]) as usize]
-            [sidx as usize] |= smask as u16;
+            [sidx] |= smask as u16;
         x += 1;
         mask <<= 1;
     }
@@ -229,14 +229,14 @@ unsafe fn mask_edges_inter(
         y = 0;
         mask = 1 << by4;
         while y < h4 {
-            let sidx = (mask >= 0x10000) as libc::c_int;
+            let sidx = (mask >= 0x10000) as usize;
             let smask = mask >> (sidx << 4);
             let mut ltx = txa[0][0][y as usize][0];
             let mut step = txa[0][1][y as usize][0] as libc::c_int;
             x = step;
             while x < w4 {
                 let rtx = txa[0][0][y as usize][x as usize];
-                masks[0][(bx4 + x) as usize][std::cmp::min(rtx, ltx) as usize][sidx as usize] |=
+                masks[0][(bx4 + x) as usize][std::cmp::min(rtx, ltx) as usize][sidx] |=
                     smask as u16;
                 ltx = rtx;
                 step = txa[0][1][y as usize][x as usize] as libc::c_int;
@@ -248,14 +248,14 @@ unsafe fn mask_edges_inter(
         x = 0;
         mask = 1 << bx4;
         while x < w4 {
-            let sidx = (mask >= 0x10000) as libc::c_int;
+            let sidx = (mask >= 0x10000) as usize;
             let smask = mask >> (sidx << 4);
             let mut ttx = txa[1][0][0][x as usize];
             let mut step = txa[1][1][0][x as usize] as libc::c_int;
             y = step;
             while y < h4 {
                 let btx = txa[1][0][y as usize][x as usize];
-                masks[1][(by4 + y) as usize][std::cmp::min(ttx, btx) as usize][sidx as usize] |=
+                masks[1][(by4 + y) as usize][std::cmp::min(ttx, btx) as usize][sidx] |=
                     smask as u16;
                 ttx = btx;
                 step = txa[1][1][y as usize][x as usize] as libc::c_int;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -240,8 +240,8 @@ unsafe fn mask_edges_inter(
             }
         }
     }
-    for y in 0..h4 {
-        l[y] = txa[0][0][y][w4 - 1];
+    for (l, txa) in l[..h4].iter_mut().zip(&txa[0][0][..h4]) {
+        *l = txa[w4 - 1];
     }
     a[..w4].copy_from_slice(&mut txa[1][0][h4 - 1][..w4]);
 }

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -178,8 +178,20 @@ unsafe fn mask_edges_inter(
     l: &mut [u8],
 ) {
     let [by4, bx4, w4, h4] = [by4, bx4, w4, h4].map(|it| it as usize);
+
     let t_dim = &dav1d_txfm_dimensions[max_tx as usize];
+
+    // In `txa`, the array lengths represent from inner to outer:
+    // * `32`: `x`
+    // * `32`: `y`
+    // * `2`: `txsz`, `step`
+    // * `2`: `edge`
+    //
+    // (Note: This is added here in the docs vs. inline `/* */` comments
+    // at the array lengths because `rustfmt` deletes them
+    // (tracked in [rust-lang/rustfmt#5297](https://github.com/rust-lang/rustfmt/issues/5297))).
     let mut txa = Align16([[[[0; 32]; 32]; 2]; 2]);
+
     for (y_off, y) in (0..h4).step_by(t_dim.h as usize).enumerate() {
         for (x_off, x) in (0..w4).step_by(t_dim.w as usize).enumerate() {
             decomp_tx(
@@ -196,12 +208,16 @@ unsafe fn mask_edges_inter(
             );
         }
     }
+
+    // left block edge
     for y in 0..h4 {
         let mask = 1u32 << (by4 + y);
         let sidx = (mask >= 0x10000) as usize;
         let smask = mask >> (sidx << 4);
         masks[0][bx4][std::cmp::min(txa[0][0][y][0], l[y]) as usize][sidx] |= smask as u16;
     }
+
+    // top block edge
     for x in 0..w4 {
         let mask = 1u32 << (bx4 + x);
         let sidx = (mask >= 0x10000) as usize;
@@ -209,6 +225,7 @@ unsafe fn mask_edges_inter(
         masks[1][by4][std::cmp::min(txa[1][0][0][x], a[x]) as usize][sidx] |= smask as u16;
     }
     if !skip {
+        // inner (tx) left|right edges
         for y in 0..h4 {
             let mask = 1u32 << (by4 + y);
             let sidx = (mask >= 0x10000) as usize;
@@ -224,6 +241,10 @@ unsafe fn mask_edges_inter(
                 x += step;
             }
         }
+
+        //            top
+        // inner (tx) --- edges
+        //           bottom
         for x in 0..w4 {
             let mask = 1u32 << (bx4 + x);
             let sidx = (mask >= 0x10000) as usize;
@@ -240,6 +261,7 @@ unsafe fn mask_edges_inter(
             }
         }
     }
+
     for (l, txa) in l[..h4].iter_mut().zip(&txa[0][0][..h4]) {
         *l = txa[w4 - 1];
     }


### PR DESCRIPTION
The only unsafe part left is the `txa` stuff, which I'll fix in a separate PR as mentioned in https://github.com/memorysafety/rav1d/pull/261#issuecomment-1555200944.