### PR TITLE
`fn mask_edges_intra`: Cleanup and make mostly safe

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -147,6 +147,7 @@ pub unsafe fn case_set_upto32_with_default<D, F, G>(
 ) where
     F: FnMut(&mut D, usize, isize, u64, SetCtxFn),
     G: FnMut(&mut D, usize, isize, libc::c_int),
+    D: ?Sized,
 {
     match var {
         1 => set_ctx(dir, diridx, off, 0x01, set_ctx_rep1::<alias8>),

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -135,3 +135,33 @@ pub unsafe fn case_set_upto16<D, F>(
         _ => {}
     }
 }
+
+#[inline]
+pub unsafe fn case_set_upto32_with_default<D, F, G>(
+    var: libc::c_int,
+    dir: &mut D,
+    diridx: usize,
+    off: isize,
+    set_ctx: &mut F,
+    mut default_memset: G,
+) where
+    F: FnMut(&mut D, usize, isize, u64, SetCtxFn),
+    G: FnMut(&mut D, usize, isize, libc::c_int),
+{
+    match var {
+        1 => set_ctx(dir, diridx, off, 0x01, set_ctx_rep1::<alias8>),
+        2 => set_ctx(dir, diridx, off, 0x0101, set_ctx_rep1::<alias16>),
+        4 => set_ctx(dir, diridx, off, 0x01010101, set_ctx_rep1::<alias32>),
+        8 => set_ctx(
+            dir,
+            diridx,
+            off,
+            0x0101010101010101,
+            set_ctx_rep1::<alias64>,
+        ),
+        16 => set_ctx(dir, diridx, off, 0x0101010101010101, set_ctx_rep2),
+        32 => set_ctx(dir, diridx, off, 0x0101010101010101, set_ctx_rep4),
+
+        _ => default_memset(dir, diridx, off, var),
+    }
+}

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3579,8 +3579,8 @@ unsafe fn decode_b(
                 b.tx() as RectTxfmSize,
                 b.uvtx as RectTxfmSize,
                 f.cur.p.layout,
-                &mut (*t.a).tx_lpf_y.0[bx4 as usize],
-                &mut t.l.tx_lpf_y.0[by4 as usize],
+                &mut (*t.a).tx_lpf_y.0[bx4 as usize..],
+                &mut t.l.tx_lpf_y.0[by4 as usize..],
                 if has_chroma {
                     &mut (*t.a).tx_lpf_uv.0[cbx4 as usize]
                 } else {

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -301,7 +301,7 @@ unsafe fn mask_edges_intra(
     }
     let hstep = t_dim.w as usize;
     let mut t = 1u32 << by4;
-    let mut inner = ((t as u64) << h4).wrapping_sub(t as u64) as libc::c_uint;
+    let mut inner = (((t as u64) << h4) - (t as u64)) as libc::c_uint;
     let mut inner1 = inner & 0xffff;
     let mut inner2 = inner >> 16;
     for x in (hstep..w4).step_by(hstep) {
@@ -314,7 +314,7 @@ unsafe fn mask_edges_intra(
     }
     let vstep = t_dim.h as usize;
     t = 1u32 << bx4;
-    inner = ((t as u64) << w4).wrapping_sub(t as u64) as libc::c_uint;
+    inner = (((t as u64) << w4) - (t as u64)) as libc::c_uint;
     inner1 = inner & 0xffff;
     inner2 = inner >> 16;
     for y in (vstep..h4).step_by(vstep) {

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -271,7 +271,7 @@ unsafe fn mask_edges_inter(
 
 #[inline]
 unsafe fn mask_edges_intra(
-    masks: *mut [[[u16; 2]; 3]; 32],
+    masks: &mut [[[[u16; 2]; 3]; 32]; 2],
     by4: libc::c_int,
     bx4: libc::c_int,
     w4: libc::c_int,
@@ -293,7 +293,7 @@ unsafe fn mask_edges_intra(
     while y < h4 {
         let sidx = (mask >= 0x10000 as libc::c_int as libc::c_uint) as libc::c_int;
         let smask: libc::c_uint = mask >> (sidx << 4);
-        let ref mut fresh4 = (*masks.offset(0))[bx4 as usize]
+        let ref mut fresh4 = masks[0][bx4 as usize]
             [imin(twl4c, *l.offset(y as isize) as libc::c_int) as usize][sidx as usize];
         *fresh4 = (*fresh4 as libc::c_uint | smask) as u16;
         y += 1;
@@ -304,7 +304,7 @@ unsafe fn mask_edges_intra(
     while x < w4 {
         let sidx_0 = (mask >= 0x10000 as libc::c_int as libc::c_uint) as libc::c_int;
         let smask_0: libc::c_uint = mask >> (sidx_0 << 4);
-        let ref mut fresh5 = (*masks.offset(1))[by4 as usize]
+        let ref mut fresh5 = masks[1][by4 as usize]
             [imin(thl4c, *a.offset(x as isize) as libc::c_int) as usize][sidx_0 as usize];
         *fresh5 = (*fresh5 as libc::c_uint | smask_0) as u16;
         x += 1;
@@ -318,11 +318,11 @@ unsafe fn mask_edges_intra(
     x = hstep;
     while x < w4 {
         if inner1 != 0 {
-            let ref mut fresh6 = (*masks.offset(0))[(bx4 + x) as usize][twl4c as usize][0];
+            let ref mut fresh6 = masks[0][(bx4 + x) as usize][twl4c as usize][0];
             *fresh6 = (*fresh6 as libc::c_uint | inner1) as u16;
         }
         if inner2 != 0 {
-            let ref mut fresh7 = (*masks.offset(0))[(bx4 + x) as usize][twl4c as usize][1];
+            let ref mut fresh7 = masks[0][(bx4 + x) as usize][twl4c as usize][1];
             *fresh7 = (*fresh7 as libc::c_uint | inner2) as u16;
         }
         x += hstep;
@@ -335,11 +335,11 @@ unsafe fn mask_edges_intra(
     y = vstep;
     while y < h4 {
         if inner1 != 0 {
-            let ref mut fresh8 = (*masks.offset(1))[(by4 + y) as usize][thl4c as usize][0];
+            let ref mut fresh8 = masks[1][(by4 + y) as usize][thl4c as usize][0];
             *fresh8 = (*fresh8 as libc::c_uint | inner1) as u16;
         }
         if inner2 != 0 {
-            let ref mut fresh9 = (*masks.offset(1))[(by4 + y) as usize][thl4c as usize][1];
+            let ref mut fresh9 = masks[1][(by4 + y) as usize][thl4c as usize][1];
             *fresh9 = (*fresh9 as libc::c_uint | inner2) as u16;
         }
         y += vstep;
@@ -569,7 +569,7 @@ pub unsafe fn dav1d_create_lf_mask_intra(
             y += 1;
         }
         mask_edges_intra(
-            ((*lflvl).filter_y).as_mut_ptr(),
+            &mut (*lflvl).filter_y,
             by4,
             bx4,
             bw4,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -287,18 +287,24 @@ unsafe fn mask_edges_intra(
     let thl4 = t_dim.lh;
     let twl4c = std::cmp::min(2, twl4);
     let thl4c = std::cmp::min(2, thl4);
+
+    // left block edge
     for y in 0..h4 {
         let mask = 1u32 << (by4 + y);
         let sidx = (mask >= 0x10000) as usize;
         let smask = mask >> (sidx << 4);
         masks[0][bx4][std::cmp::min(twl4c, l[y]) as usize][sidx] |= smask as u16;
     }
+
+    // top block edge
     for x in 0..w4 {
         let mask = 1u32 << (bx4 + x);
         let sidx = (mask >= 0x10000) as usize;
         let smask = mask >> (sidx << 4);
         masks[1][by4][std::cmp::min(thl4c, a[x]) as usize][sidx] |= smask as u16;
     }
+
+    // inner (tx) left|right edges
     let hstep = t_dim.w as usize;
     let t = 1u32 << by4;
     let inner = (((t as u64) << h4) - (t as u64)) as u32;
@@ -311,6 +317,10 @@ unsafe fn mask_edges_intra(
             masks[0][bx4 + x][twl4c as usize][1] |= inner[1];
         }
     }
+
+    //            top
+    // inner (tx) --- edges
+    //           bottom
     let vstep = t_dim.h as usize;
     let t = 1u32 << bx4;
     let inner = (((t as u64) << w4) - (t as u64)) as u32;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -301,28 +301,26 @@ unsafe fn mask_edges_intra(
     }
     let hstep = t_dim.w as usize;
     let t = 1u32 << by4;
-    let inner = (((t as u64) << h4) - (t as u64)) as libc::c_uint;
-    let inner1 = inner & 0xffff;
-    let inner2 = inner >> 16;
+    let inner = (((t as u64) << h4) - (t as u64)) as u32;
+    let inner = [inner as u16, (inner >> 16) as u16];
     for x in (hstep..w4).step_by(hstep) {
-        if inner1 != 0 {
-            masks[0][bx4 + x][twl4c as usize][0] |= inner1 as u16;
+        if inner[0] != 0 {
+            masks[0][bx4 + x][twl4c as usize][0] |= inner[0];
         }
-        if inner2 != 0 {
-            masks[0][bx4 + x][twl4c as usize][1] |= inner2 as u16;
+        if inner[1] != 0 {
+            masks[0][bx4 + x][twl4c as usize][1] |= inner[1];
         }
     }
     let vstep = t_dim.h as usize;
     let t = 1u32 << bx4;
-    let inner = (((t as u64) << w4) - (t as u64)) as libc::c_uint;
-    let inner1 = inner & 0xffff;
-    let inner2 = inner >> 16;
+    let inner = (((t as u64) << w4) - (t as u64)) as u32;
+    let inner = [inner as u16, (inner >> 16) as u16];
     for y in (vstep..h4).step_by(vstep) {
-        if inner1 != 0 {
-            masks[1][by4 + y][thl4c as usize][0] |= inner1 as u16;
+        if inner[0] != 0 {
+            masks[1][by4 + y][thl4c as usize][0] |= inner[0];
         }
-        if inner2 != 0 {
-            masks[1][by4 + y][thl4c as usize][1] |= inner2 as u16;
+        if inner[1] != 0 {
+            masks[1][by4 + y][thl4c as usize][1] |= inner[1];
         }
     }
 

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -280,10 +280,9 @@ unsafe fn mask_edges_intra(
     a: &mut [u8],
     l: &mut [u8],
 ) {
-    let t_dim: *const TxfmInfo =
-        &*dav1d_txfm_dimensions.as_ptr().offset(tx as isize) as *const TxfmInfo;
-    let twl4 = (*t_dim).lw as libc::c_int;
-    let thl4 = (*t_dim).lh as libc::c_int;
+    let t_dim = &dav1d_txfm_dimensions[tx as usize];
+    let twl4 = t_dim.lw as libc::c_int;
+    let thl4 = t_dim.lh as libc::c_int;
     let twl4c = imin(2 as libc::c_int, twl4);
     let thl4c = imin(2 as libc::c_int, thl4);
     let mut y = 0;
@@ -310,7 +309,7 @@ unsafe fn mask_edges_intra(
         x += 1;
         mask <<= 1;
     }
-    let hstep = (*t_dim).w as libc::c_int;
+    let hstep = t_dim.w as libc::c_int;
     let mut t: libc::c_uint = (1 as libc::c_uint) << by4;
     let mut inner: libc::c_uint = ((t as u64) << h4).wrapping_sub(t as u64) as libc::c_uint;
     let mut inner1: libc::c_uint = inner & 0xffff as libc::c_int as libc::c_uint;
@@ -327,7 +326,7 @@ unsafe fn mask_edges_intra(
         }
         x += hstep;
     }
-    let vstep = (*t_dim).h as libc::c_int;
+    let vstep = t_dim.h as libc::c_int;
     t = (1 as libc::c_uint) << bx4;
     inner = ((t as u64) << w4).wrapping_sub(t as u64) as libc::c_uint;
     inner1 = inner & 0xffff as libc::c_int as libc::c_uint;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -283,26 +283,26 @@ unsafe fn mask_edges_intra(
     let t_dim = &dav1d_txfm_dimensions[tx as usize];
     let twl4 = t_dim.lw as libc::c_int;
     let thl4 = t_dim.lh as libc::c_int;
-    let twl4c = imin(2 as libc::c_int, twl4);
-    let thl4c = imin(2 as libc::c_int, thl4);
+    let twl4c = imin(2, twl4);
+    let thl4c = imin(2, thl4);
     let mut y = 0;
     let mut x = 0;
-    let mut mask: libc::c_uint = (1 as libc::c_uint) << by4;
-    y = 0 as libc::c_int;
+    let mut mask = 1 << by4;
+    y = 0;
     while y < h4 {
-        let sidx = (mask >= 0x10000 as libc::c_int as libc::c_uint) as libc::c_int;
-        let smask: libc::c_uint = mask >> (sidx << 4);
+        let sidx = (mask >= 0x10000) as libc::c_int;
+        let smask = mask >> (sidx << 4);
         let ref mut fresh4 = masks[0][bx4 as usize]
             [imin(twl4c, l[y as usize] as libc::c_int) as usize][sidx as usize];
         *fresh4 = (*fresh4 as libc::c_uint | smask) as u16;
         y += 1;
         mask <<= 1;
     }
-    x = 0 as libc::c_int;
-    mask = (1 as libc::c_uint) << bx4;
+    x = 0;
+    mask = 1 << bx4;
     while x < w4 {
-        let sidx_0 = (mask >= 0x10000 as libc::c_int as libc::c_uint) as libc::c_int;
-        let smask_0: libc::c_uint = mask >> (sidx_0 << 4);
+        let sidx_0 = (mask >= 0x10000) as libc::c_int;
+        let smask_0 = mask >> (sidx_0 << 4);
         let ref mut fresh5 = masks[1][by4 as usize]
             [imin(thl4c, a[x as usize] as libc::c_int) as usize][sidx_0 as usize];
         *fresh5 = (*fresh5 as libc::c_uint | smask_0) as u16;
@@ -310,10 +310,10 @@ unsafe fn mask_edges_intra(
         mask <<= 1;
     }
     let hstep = t_dim.w as libc::c_int;
-    let mut t: libc::c_uint = (1 as libc::c_uint) << by4;
-    let mut inner: libc::c_uint = ((t as u64) << h4).wrapping_sub(t as u64) as libc::c_uint;
-    let mut inner1: libc::c_uint = inner & 0xffff as libc::c_int as libc::c_uint;
-    let mut inner2: libc::c_uint = inner >> 16;
+    let mut t = 1 << by4;
+    let mut inner = ((t as u64) << h4).wrapping_sub(t as u64) as libc::c_uint;
+    let mut inner1 = inner & 0xffff;
+    let mut inner2 = inner >> 16;
     x = hstep;
     while x < w4 {
         if inner1 != 0 {
@@ -327,9 +327,9 @@ unsafe fn mask_edges_intra(
         x += hstep;
     }
     let vstep = t_dim.h as libc::c_int;
-    t = (1 as libc::c_uint) << bx4;
+    t = 1 << bx4;
     inner = ((t as u64) << w4).wrapping_sub(t as u64) as libc::c_uint;
-    inner1 = inner & 0xffff as libc::c_int as libc::c_uint;
+    inner1 = inner & 0xffff;
     inner2 = inner >> 16;
     y = vstep;
     while y < h4 {

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -283,8 +283,8 @@ unsafe fn mask_edges_intra(
     let t_dim = &dav1d_txfm_dimensions[tx as usize];
     let twl4 = t_dim.lw as libc::c_int;
     let thl4 = t_dim.lh as libc::c_int;
-    let twl4c = imin(2, twl4);
-    let thl4c = imin(2, thl4);
+    let twl4c = std::cmp::min(2, twl4);
+    let thl4c = std::cmp::min(2, thl4);
     let mut y = 0;
     let mut x = 0;
     let mut mask = 1u32 << by4;
@@ -292,8 +292,8 @@ unsafe fn mask_edges_intra(
     while y < h4 {
         let sidx = (mask >= 0x10000) as usize;
         let smask = mask >> (sidx << 4);
-        masks[0][bx4 as usize][imin(twl4c, l[y as usize] as libc::c_int) as usize][sidx] |=
-            smask as u16;
+        masks[0][bx4 as usize][std::cmp::min(twl4c, l[y as usize] as libc::c_int) as usize]
+            [sidx] |= smask as u16;
         y += 1;
         mask <<= 1;
     }
@@ -302,8 +302,8 @@ unsafe fn mask_edges_intra(
     while x < w4 {
         let sidx = (mask >= 0x10000) as usize;
         let smask = mask >> (sidx << 4);
-        masks[1][by4 as usize][imin(thl4c, a[x as usize] as libc::c_int) as usize][sidx] |=
-            smask as u16;
+        masks[1][by4 as usize][std::cmp::min(thl4c, a[x as usize] as libc::c_int) as usize]
+            [sidx] |= smask as u16;
         x += 1;
         mask <<= 1;
     }

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -287,59 +287,53 @@ unsafe fn mask_edges_intra(
     let thl4c = imin(2, thl4);
     let mut y = 0;
     let mut x = 0;
-    let mut mask = 1 << by4;
+    let mut mask = 1u32 << by4;
     y = 0;
     while y < h4 {
         let sidx = (mask >= 0x10000) as usize;
         let smask = mask >> (sidx << 4);
-        let ref mut fresh4 =
-            masks[0][bx4 as usize][imin(twl4c, l[y as usize] as libc::c_int) as usize][sidx];
-        *fresh4 = (*fresh4 as libc::c_uint | smask) as u16;
+        masks[0][bx4 as usize][imin(twl4c, l[y as usize] as libc::c_int) as usize][sidx] |=
+            smask as u16;
         y += 1;
         mask <<= 1;
     }
     x = 0;
-    mask = 1 << bx4;
+    mask = 1u32 << bx4;
     while x < w4 {
         let sidx = (mask >= 0x10000) as usize;
         let smask = mask >> (sidx << 4);
-        let ref mut fresh5 =
-            masks[1][by4 as usize][imin(thl4c, a[x as usize] as libc::c_int) as usize][sidx];
-        *fresh5 = (*fresh5 as libc::c_uint | smask) as u16;
+        masks[1][by4 as usize][imin(thl4c, a[x as usize] as libc::c_int) as usize][sidx] |=
+            smask as u16;
         x += 1;
         mask <<= 1;
     }
     let hstep = t_dim.w as libc::c_int;
-    let mut t = 1 << by4;
+    let mut t = 1u32 << by4;
     let mut inner = ((t as u64) << h4).wrapping_sub(t as u64) as libc::c_uint;
     let mut inner1 = inner & 0xffff;
     let mut inner2 = inner >> 16;
     x = hstep;
     while x < w4 {
         if inner1 != 0 {
-            let ref mut fresh6 = masks[0][(bx4 + x) as usize][twl4c as usize][0];
-            *fresh6 = (*fresh6 as libc::c_uint | inner1) as u16;
+            masks[0][(bx4 + x) as usize][twl4c as usize][0] |= inner1 as u16;
         }
         if inner2 != 0 {
-            let ref mut fresh7 = masks[0][(bx4 + x) as usize][twl4c as usize][1];
-            *fresh7 = (*fresh7 as libc::c_uint | inner2) as u16;
+            masks[0][(bx4 + x) as usize][twl4c as usize][1] |= inner2 as u16;
         }
         x += hstep;
     }
     let vstep = t_dim.h as libc::c_int;
-    t = 1 << bx4;
+    t = 1u32 << bx4;
     inner = ((t as u64) << w4).wrapping_sub(t as u64) as libc::c_uint;
     inner1 = inner & 0xffff;
     inner2 = inner >> 16;
     y = vstep;
     while y < h4 {
         if inner1 != 0 {
-            let ref mut fresh8 = masks[1][(by4 + y) as usize][thl4c as usize][0];
-            *fresh8 = (*fresh8 as libc::c_uint | inner1) as u16;
+            masks[1][(by4 + y) as usize][thl4c as usize][0] |= inner1 as u16;
         }
         if inner2 != 0 {
-            let ref mut fresh9 = masks[1][(by4 + y) as usize][thl4c as usize][1];
-            *fresh9 = (*fresh9 as libc::c_uint | inner2) as u16;
+            masks[1][(by4 + y) as usize][thl4c as usize][1] |= inner2 as u16;
         }
         y += vstep;
     }

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -300,10 +300,10 @@ unsafe fn mask_edges_intra(
         masks[1][by4][std::cmp::min(thl4c, a[x]) as usize][sidx] |= smask as u16;
     }
     let hstep = t_dim.w as usize;
-    let mut t = 1u32 << by4;
-    let mut inner = (((t as u64) << h4) - (t as u64)) as libc::c_uint;
-    let mut inner1 = inner & 0xffff;
-    let mut inner2 = inner >> 16;
+    let t = 1u32 << by4;
+    let inner = (((t as u64) << h4) - (t as u64)) as libc::c_uint;
+    let inner1 = inner & 0xffff;
+    let inner2 = inner >> 16;
     for x in (hstep..w4).step_by(hstep) {
         if inner1 != 0 {
             masks[0][bx4 + x][twl4c as usize][0] |= inner1 as u16;
@@ -313,10 +313,10 @@ unsafe fn mask_edges_intra(
         }
     }
     let vstep = t_dim.h as usize;
-    t = 1u32 << bx4;
-    inner = (((t as u64) << w4) - (t as u64)) as libc::c_uint;
-    inner1 = inner & 0xffff;
-    inner2 = inner >> 16;
+    let t = 1u32 << bx4;
+    let inner = (((t as u64) << w4) - (t as u64)) as libc::c_uint;
+    let inner1 = inner & 0xffff;
+    let inner2 = inner >> 16;
     for y in (vstep..h4).step_by(vstep) {
         if inner1 != 0 {
             masks[1][by4 + y][thl4c as usize][0] |= inner1 as u16;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -12,6 +12,7 @@ use crate::src::ctx::alias32;
 use crate::src::ctx::alias64;
 use crate::src::ctx::alias8;
 use crate::src::ctx::case_set_upto16;
+use crate::src::ctx::case_set_upto32_with_default;
 use crate::src::ctx::SetCtxFn;
 use crate::src::levels::BlockSize;
 use crate::src::levels::RectTxfmSize;
@@ -343,74 +344,35 @@ unsafe fn mask_edges_intra(
         }
         y += vstep;
     }
-    match w4 {
-        1 => {
-            (*(&mut *a.offset(0) as *mut u8 as *mut alias8)).u8_0 = (0x1 * thl4c) as u8;
-        }
-        2 => {
-            (*(&mut *a.offset(0) as *mut u8 as *mut alias16)).u16_0 = (0x101 * thl4c) as u16;
-        }
-        4 => {
-            (*(&mut *a.offset(0) as *mut u8 as *mut alias32)).u32_0 =
-                (0x1010101 as libc::c_uint).wrapping_mul(thl4c as libc::c_uint);
-        }
-        8 => {
-            (*(&mut *a.offset(0) as *mut u8 as *mut alias64)).u64_0 =
-                (0x101010101010101 as libc::c_ulonglong).wrapping_mul(thl4c as libc::c_ulonglong)
-                    as u64;
-        }
-        16 => {
-            let const_val: u64 = (0x101010101010101 as libc::c_ulonglong)
-                .wrapping_mul(thl4c as libc::c_ulonglong) as u64;
-            (*(&mut *a.offset((0 + 0) as isize) as *mut u8 as *mut alias64)).u64_0 = const_val;
-            (*(&mut *a.offset((0 + 8) as isize) as *mut u8 as *mut alias64)).u64_0 = const_val;
-        }
-        32 => {
-            let const_val_0: u64 = (0x101010101010101 as libc::c_ulonglong)
-                .wrapping_mul(thl4c as libc::c_ulonglong) as u64;
-            (*(&mut *a.offset((0 + 0) as isize) as *mut u8 as *mut alias64)).u64_0 = const_val_0;
-            (*(&mut *a.offset((0 + 8) as isize) as *mut u8 as *mut alias64)).u64_0 = const_val_0;
-            (*(&mut *a.offset((0 + 16) as isize) as *mut u8 as *mut alias64)).u64_0 = const_val_0;
-            (*(&mut *a.offset((0 + 24) as isize) as *mut u8 as *mut alias64)).u64_0 = const_val_0;
-        }
-        _ => {
-            memset(a as *mut libc::c_void, thl4c, w4 as libc::c_ulong);
-        }
-    }
-    match h4 {
-        1 => {
-            (*(&mut *l.offset(0) as *mut u8 as *mut alias8)).u8_0 = (0x1 * twl4c) as u8;
-        }
-        2 => {
-            (*(&mut *l.offset(0) as *mut u8 as *mut alias16)).u16_0 = (0x101 * twl4c) as u16;
-        }
-        4 => {
-            (*(&mut *l.offset(0) as *mut u8 as *mut alias32)).u32_0 =
-                (0x1010101 as libc::c_uint).wrapping_mul(twl4c as libc::c_uint);
-        }
-        8 => {
-            (*(&mut *l.offset(0) as *mut u8 as *mut alias64)).u64_0 =
-                (0x101010101010101 as libc::c_ulonglong).wrapping_mul(twl4c as libc::c_ulonglong)
-                    as u64;
-        }
-        16 => {
-            let const_val_1: u64 = (0x101010101010101 as libc::c_ulonglong)
-                .wrapping_mul(twl4c as libc::c_ulonglong) as u64;
-            (*(&mut *l.offset((0 + 0) as isize) as *mut u8 as *mut alias64)).u64_0 = const_val_1;
-            (*(&mut *l.offset((0 + 8) as isize) as *mut u8 as *mut alias64)).u64_0 = const_val_1;
-        }
-        32 => {
-            let const_val_2: u64 = (0x101010101010101 as libc::c_ulonglong)
-                .wrapping_mul(twl4c as libc::c_ulonglong) as u64;
-            (*(&mut *l.offset((0 + 0) as isize) as *mut u8 as *mut alias64)).u64_0 = const_val_2;
-            (*(&mut *l.offset((0 + 8) as isize) as *mut u8 as *mut alias64)).u64_0 = const_val_2;
-            (*(&mut *l.offset((0 + 16) as isize) as *mut u8 as *mut alias64)).u64_0 = const_val_2;
-            (*(&mut *l.offset((0 + 24) as isize) as *mut u8 as *mut alias64)).u64_0 = const_val_2;
-        }
-        _ => {
-            memset(l as *mut libc::c_void, twl4c, h4 as libc::c_ulong);
-        }
+
+    let mut set_ctx = |_dir: &mut (), _diridx, off, mul, rep_macro: SetCtxFn| {
+        rep_macro(a, off, mul * thl4c as u64);
     };
+    let default_memset = |_dir: &mut (), _diridx, _off, var| {
+        memset(a as *mut libc::c_void, thl4c, var as libc::c_ulong);
+    };
+    case_set_upto32_with_default(
+        w4 as libc::c_int,
+        &mut (),            // Was nothing in C.
+        Default::default(), // Was nothing in C.
+        0,
+        &mut set_ctx,
+        default_memset,
+    );
+    let mut set_ctx = |_dir: &mut (), _diridx, off, mul, rep_macro: SetCtxFn| {
+        rep_macro(l, off, mul * twl4c as u64);
+    };
+    let default_memset = |_dir: &mut (), _diridx, _off, var| {
+        memset(l as *mut libc::c_void, twl4c, var as libc::c_ulong);
+    };
+    case_set_upto32_with_default(
+        h4 as libc::c_int,
+        &mut (),            // Was nothing in C.
+        Default::default(), // Was nothing in C.
+        0,
+        &mut set_ctx,
+        default_memset,
+    );
 }
 
 unsafe fn mask_edges_chroma(

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -281,8 +281,8 @@ unsafe fn mask_edges_intra(
     l: &mut [u8],
 ) {
     let t_dim = &dav1d_txfm_dimensions[tx as usize];
-    let twl4 = t_dim.lw as libc::c_int;
-    let thl4 = t_dim.lh as libc::c_int;
+    let twl4 = t_dim.lw;
+    let thl4 = t_dim.lh;
     let twl4c = std::cmp::min(2, twl4);
     let thl4c = std::cmp::min(2, thl4);
     let mut y = 0;
@@ -292,8 +292,7 @@ unsafe fn mask_edges_intra(
     while y < h4 {
         let sidx = (mask >= 0x10000) as usize;
         let smask = mask >> (sidx << 4);
-        masks[0][bx4 as usize][std::cmp::min(twl4c, l[y as usize] as libc::c_int) as usize]
-            [sidx] |= smask as u16;
+        masks[0][bx4 as usize][std::cmp::min(twl4c, l[y as usize]) as usize][sidx] |= smask as u16;
         y += 1;
         mask <<= 1;
     }
@@ -302,8 +301,7 @@ unsafe fn mask_edges_intra(
     while x < w4 {
         let sidx = (mask >= 0x10000) as usize;
         let smask = mask >> (sidx << 4);
-        masks[1][by4 as usize][std::cmp::min(thl4c, a[x as usize] as libc::c_int) as usize]
-            [sidx] |= smask as u16;
+        masks[1][by4 as usize][std::cmp::min(thl4c, a[x as usize]) as usize][sidx] |= smask as u16;
         x += 1;
         mask <<= 1;
     }
@@ -342,11 +340,7 @@ unsafe fn mask_edges_intra(
         rep_macro(dir.as_mut_ptr(), off, mul * thl4c as u64);
     };
     let default_memset = |dir: &mut [u8], _diridx, _off, var| {
-        memset(
-            dir.as_mut_ptr() as *mut libc::c_void,
-            thl4c,
-            var as libc::c_ulong,
-        );
+        dir[..var as usize].fill(thl4c);
     };
     case_set_upto32_with_default(
         w4 as libc::c_int,
@@ -360,11 +354,7 @@ unsafe fn mask_edges_intra(
         rep_macro(dir.as_mut_ptr(), off, mul * twl4c as u64);
     };
     let default_memset = |dir: &mut [u8], _diridx, _off, var| {
-        memset(
-            dir.as_mut_ptr() as *mut libc::c_void,
-            twl4c,
-            var as libc::c_ulong,
-        );
+        dir[..var as usize].fill(twl4c);
     };
     case_set_upto32_with_default(
         h4 as libc::c_int,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -285,55 +285,43 @@ unsafe fn mask_edges_intra(
     let thl4 = t_dim.lh;
     let twl4c = std::cmp::min(2, twl4);
     let thl4c = std::cmp::min(2, thl4);
-    let mut y = 0;
-    let mut x = 0;
-    let mut mask = 1u32 << by4;
-    y = 0;
-    while y < h4 {
+    for y in 0..h4 {
+        let mask = 1u32 << (by4 + y);
         let sidx = (mask >= 0x10000) as usize;
         let smask = mask >> (sidx << 4);
         masks[0][bx4 as usize][std::cmp::min(twl4c, l[y as usize]) as usize][sidx] |= smask as u16;
-        y += 1;
-        mask <<= 1;
     }
-    x = 0;
-    mask = 1u32 << bx4;
-    while x < w4 {
+    for x in 0..w4 {
+        let mask = 1u32 << (bx4 + x);
         let sidx = (mask >= 0x10000) as usize;
         let smask = mask >> (sidx << 4);
         masks[1][by4 as usize][std::cmp::min(thl4c, a[x as usize]) as usize][sidx] |= smask as u16;
-        x += 1;
-        mask <<= 1;
     }
     let hstep = t_dim.w as libc::c_int;
     let mut t = 1u32 << by4;
     let mut inner = ((t as u64) << h4).wrapping_sub(t as u64) as libc::c_uint;
     let mut inner1 = inner & 0xffff;
     let mut inner2 = inner >> 16;
-    x = hstep;
-    while x < w4 {
+    for x in (hstep..w4).step_by(hstep as usize) {
         if inner1 != 0 {
             masks[0][(bx4 + x) as usize][twl4c as usize][0] |= inner1 as u16;
         }
         if inner2 != 0 {
             masks[0][(bx4 + x) as usize][twl4c as usize][1] |= inner2 as u16;
         }
-        x += hstep;
     }
     let vstep = t_dim.h as libc::c_int;
     t = 1u32 << bx4;
     inner = ((t as u64) << w4).wrapping_sub(t as u64) as libc::c_uint;
     inner1 = inner & 0xffff;
     inner2 = inner >> 16;
-    y = vstep;
-    while y < h4 {
+    for y in (vstep..h4).step_by(vstep as usize) {
         if inner1 != 0 {
             masks[1][(by4 + y) as usize][thl4c as usize][0] |= inner1 as u16;
         }
         if inner2 != 0 {
             masks[1][(by4 + y) as usize][thl4c as usize][1] |= inner2 as u16;
         }
-        y += vstep;
     }
 
     let mut set_ctx = |dir: &mut [u8], _diridx, off, mul, rep_macro: SetCtxFn| {

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -301,11 +301,11 @@ unsafe fn mask_edges_intra(
     x = 0;
     mask = 1 << bx4;
     while x < w4 {
-        let sidx_0 = (mask >= 0x10000) as libc::c_int;
-        let smask_0 = mask >> (sidx_0 << 4);
+        let sidx = (mask >= 0x10000) as libc::c_int;
+        let smask = mask >> (sidx << 4);
         let ref mut fresh5 = masks[1][by4 as usize]
-            [imin(thl4c, a[x as usize] as libc::c_int) as usize][sidx_0 as usize];
-        *fresh5 = (*fresh5 as libc::c_uint | smask_0) as u16;
+            [imin(thl4c, a[x as usize] as libc::c_int) as usize][sidx as usize];
+        *fresh5 = (*fresh5 as libc::c_uint | smask) as u16;
         x += 1;
         mask <<= 1;
     }

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -277,8 +277,8 @@ unsafe fn mask_edges_intra(
     w4: libc::c_int,
     h4: libc::c_int,
     tx: RectTxfmSize,
-    a: *mut u8,
-    l: *mut u8,
+    a: &mut [u8],
+    l: &mut [u8],
 ) {
     let t_dim: *const TxfmInfo =
         &*dav1d_txfm_dimensions.as_ptr().offset(tx as isize) as *const TxfmInfo;
@@ -294,7 +294,7 @@ unsafe fn mask_edges_intra(
         let sidx = (mask >= 0x10000 as libc::c_int as libc::c_uint) as libc::c_int;
         let smask: libc::c_uint = mask >> (sidx << 4);
         let ref mut fresh4 = masks[0][bx4 as usize]
-            [imin(twl4c, *l.offset(y as isize) as libc::c_int) as usize][sidx as usize];
+            [imin(twl4c, l[y as usize] as libc::c_int) as usize][sidx as usize];
         *fresh4 = (*fresh4 as libc::c_uint | smask) as u16;
         y += 1;
         mask <<= 1;
@@ -305,7 +305,7 @@ unsafe fn mask_edges_intra(
         let sidx_0 = (mask >= 0x10000 as libc::c_int as libc::c_uint) as libc::c_int;
         let smask_0: libc::c_uint = mask >> (sidx_0 << 4);
         let ref mut fresh5 = masks[1][by4 as usize]
-            [imin(thl4c, *a.offset(x as isize) as libc::c_int) as usize][sidx_0 as usize];
+            [imin(thl4c, a[x as usize] as libc::c_int) as usize][sidx_0 as usize];
         *fresh5 = (*fresh5 as libc::c_uint | smask_0) as u16;
         x += 1;
         mask <<= 1;
@@ -345,29 +345,37 @@ unsafe fn mask_edges_intra(
         y += vstep;
     }
 
-    let mut set_ctx = |_dir: &mut (), _diridx, off, mul, rep_macro: SetCtxFn| {
-        rep_macro(a, off, mul * thl4c as u64);
+    let mut set_ctx = |dir: &mut [u8], _diridx, off, mul, rep_macro: SetCtxFn| {
+        rep_macro(dir.as_mut_ptr(), off, mul * thl4c as u64);
     };
-    let default_memset = |_dir: &mut (), _diridx, _off, var| {
-        memset(a as *mut libc::c_void, thl4c, var as libc::c_ulong);
+    let default_memset = |dir: &mut [u8], _diridx, _off, var| {
+        memset(
+            dir.as_mut_ptr() as *mut libc::c_void,
+            thl4c,
+            var as libc::c_ulong,
+        );
     };
     case_set_upto32_with_default(
         w4 as libc::c_int,
-        &mut (),            // Was nothing in C.
+        a,                  // Was nothing in C; changed to `l` for borrowck.
         Default::default(), // Was nothing in C.
         0,
         &mut set_ctx,
         default_memset,
     );
-    let mut set_ctx = |_dir: &mut (), _diridx, off, mul, rep_macro: SetCtxFn| {
-        rep_macro(l, off, mul * twl4c as u64);
+    let mut set_ctx = |dir: &mut [u8], _diridx, off, mul, rep_macro: SetCtxFn| {
+        rep_macro(dir.as_mut_ptr(), off, mul * twl4c as u64);
     };
-    let default_memset = |_dir: &mut (), _diridx, _off, var| {
-        memset(l as *mut libc::c_void, twl4c, var as libc::c_ulong);
+    let default_memset = |dir: &mut [u8], _diridx, _off, var| {
+        memset(
+            dir.as_mut_ptr() as *mut libc::c_void,
+            twl4c,
+            var as libc::c_ulong,
+        );
     };
     case_set_upto32_with_default(
         h4 as libc::c_int,
-        &mut (),            // Was nothing in C.
+        l,                  // Was nothing in C; changed to `l` for borrowck.
         Default::default(), // Was nothing in C.
         0,
         &mut set_ctx,
@@ -543,8 +551,8 @@ pub unsafe fn dav1d_create_lf_mask_intra(
     ytx: RectTxfmSize,
     uvtx: RectTxfmSize,
     layout: Dav1dPixelLayout,
-    ay: *mut u8,
-    ly: *mut u8,
+    ay: &mut [u8],
+    ly: &mut [u8],
     auv: *mut u8,
     luv: *mut u8,
 ) {
@@ -568,16 +576,7 @@ pub unsafe fn dav1d_create_lf_mask_intra(
             level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
             y += 1;
         }
-        mask_edges_intra(
-            &mut (*lflvl).filter_y,
-            by4,
-            bx4,
-            bw4,
-            bh4,
-            ytx,
-            ay,
-            ly,
-        );
+        mask_edges_intra(&mut (*lflvl).filter_y, by4, bx4, bw4, bh4, ytx, ay, ly);
     }
     if auv.is_null() {
         return;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -290,10 +290,10 @@ unsafe fn mask_edges_intra(
     let mut mask = 1 << by4;
     y = 0;
     while y < h4 {
-        let sidx = (mask >= 0x10000) as libc::c_int;
+        let sidx = (mask >= 0x10000) as usize;
         let smask = mask >> (sidx << 4);
-        let ref mut fresh4 = masks[0][bx4 as usize]
-            [imin(twl4c, l[y as usize] as libc::c_int) as usize][sidx as usize];
+        let ref mut fresh4 =
+            masks[0][bx4 as usize][imin(twl4c, l[y as usize] as libc::c_int) as usize][sidx];
         *fresh4 = (*fresh4 as libc::c_uint | smask) as u16;
         y += 1;
         mask <<= 1;
@@ -301,10 +301,10 @@ unsafe fn mask_edges_intra(
     x = 0;
     mask = 1 << bx4;
     while x < w4 {
-        let sidx = (mask >= 0x10000) as libc::c_int;
+        let sidx = (mask >= 0x10000) as usize;
         let smask = mask >> (sidx << 4);
-        let ref mut fresh5 = masks[1][by4 as usize]
-            [imin(thl4c, a[x as usize] as libc::c_int) as usize][sidx as usize];
+        let ref mut fresh5 =
+            masks[1][by4 as usize][imin(thl4c, a[x as usize] as libc::c_int) as usize][sidx];
         *fresh5 = (*fresh5 as libc::c_uint | smask) as u16;
         x += 1;
         mask <<= 1;


### PR DESCRIPTION
The only thing still `unsafe` here is the `case_set*` functions.  I can start looking into how to make that safe soon, though it may end up being a more different implementation (like #127).