### PR TITLE
`fn dav1d_create_lf_mask_{intra,inter}`: Cleanup and make mostly safe

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4871,18 +4871,6 @@ unsafe fn decode_b(
                 } else {
                     GLOBALMV as libc::c_int
                 })) as libc::c_int;
-            let lf_lvls: *const [[uint8_t; 2]; 8] =
-                &*(*(*(*(ts.lflvl).offset(b.seg_id as isize)).as_ptr().offset(0))
-                    .as_ptr()
-                    .offset(
-                        (*(b.c2rust_unnamed.c2rust_unnamed_0.r#ref)
-                            .as_mut_ptr()
-                            .offset(0) as libc::c_int
-                            + 1) as isize,
-                    ))
-                .as_ptr()
-                .offset((is_globalmv == 0) as libc::c_int as isize)
-                    as *const uint8_t as *const [[uint8_t; 2]; 8];
             let tx_split: [uint16_t; 2] = [
                 b.c2rust_unnamed.c2rust_unnamed_0.tx_split0 as uint16_t,
                 b.c2rust_unnamed.c2rust_unnamed_0.tx_split1,
@@ -4897,7 +4885,14 @@ unsafe fn decode_b(
                 &mut *t.lf_mask,
                 f.lf.level,
                 f.b4_stride,
-                lf_lvls,
+                // In C, the inner dimensions (`ref`, `is_gmv`) are offset,
+                // but then cast back to a pointer to the full array,
+                // even though the whole array is not passed.
+                // Dereferencing this in Rust is UB, so instead
+                // we pass the indices as args, which are then applied at the use sites.
+                &*ts.lflvl.offset(b.seg_id as isize),
+                (b.r#ref()[0] + 1) as usize,
+                is_globalmv == 0,
                 t.bx,
                 t.by,
                 f.w4,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3570,7 +3570,7 @@ unsafe fn decode_b(
                 &mut *t.lf_mask,
                 f.lf.level,
                 f.b4_stride,
-                &(*ts.lflvl.offset(b.seg_id as isize))[0],
+                &*ts.lflvl.offset(b.seg_id as isize),
                 t.bx,
                 t.by,
                 f.w4,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3567,7 +3567,7 @@ unsafe fn decode_b(
 
         if frame_hdr.loopfilter.level_y[0] != 0 || frame_hdr.loopfilter.level_y[1] != 0 {
             dav1d_create_lf_mask_intra(
-                t.lf_mask,
+                &mut *t.lf_mask,
                 f.lf.level,
                 f.b4_stride,
                 &(*ts.lflvl.offset(b.seg_id as isize))[0],
@@ -4894,7 +4894,7 @@ unsafe fn decode_b(
                 uvtx = TX_4X4 as libc::c_int as RectTxfmSize;
             }
             dav1d_create_lf_mask_inter(
-                t.lf_mask,
+                &mut *t.lf_mask,
                 f.lf.level,
                 f.b4_stride,
                 lf_lvls,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -1,5 +1,4 @@
 use crate::include::common::intops::iclip;
-use crate::include::common::intops::imin;
 use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Dav1dPixelLayout;
@@ -435,8 +434,8 @@ pub unsafe fn dav1d_create_lf_mask_intra(
     aluv: Option<(&mut [u8], &mut [u8])>,
 ) {
     let b_dim = &dav1d_block_dimensions[bs as usize];
-    let bw4 = imin(iw - bx, b_dim[0] as libc::c_int);
-    let bh4 = imin(ih - by, b_dim[1] as libc::c_int);
+    let bw4 = std::cmp::min(iw - bx, b_dim[0] as libc::c_int);
+    let bh4 = std::cmp::min(ih - by, b_dim[1] as libc::c_int);
     let bx4 = bx & 31;
     let by4 = by & 31;
     if bw4 != 0 && bh4 != 0 {
@@ -458,11 +457,11 @@ pub unsafe fn dav1d_create_lf_mask_intra(
     };
     let ss_ver = (layout == DAV1D_PIXEL_LAYOUT_I420) as libc::c_int;
     let ss_hor = (layout != DAV1D_PIXEL_LAYOUT_I444) as libc::c_int;
-    let cbw4 = imin(
+    let cbw4 = std::cmp::min(
         (iw + ss_hor >> ss_hor) - (bx >> ss_hor),
         b_dim[0] as libc::c_int + ss_hor >> ss_hor,
     );
-    let cbh4 = imin(
+    let cbh4 = std::cmp::min(
         (ih + ss_ver >> ss_ver) - (by >> ss_ver),
         b_dim[1] as libc::c_int + ss_ver >> ss_ver,
     );
@@ -516,8 +515,8 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     aluv: Option<(&mut [u8], &mut [u8])>,
 ) {
     let b_dim = &dav1d_block_dimensions[bs as usize];
-    let bw4 = imin(iw - bx, b_dim[0] as libc::c_int);
-    let bh4 = imin(ih - by, b_dim[1] as libc::c_int);
+    let bw4 = std::cmp::min(iw - bx, b_dim[0] as libc::c_int);
+    let bh4 = std::cmp::min(ih - by, b_dim[1] as libc::c_int);
     let bx4 = bx & 31;
     let by4 = by & 31;
     if bw4 != 0 && bh4 != 0 {
@@ -550,11 +549,11 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     };
     let ss_ver = (layout == DAV1D_PIXEL_LAYOUT_I420) as libc::c_int;
     let ss_hor = (layout != DAV1D_PIXEL_LAYOUT_I444) as libc::c_int;
-    let cbw4 = imin(
+    let cbw4 = std::cmp::min(
         (iw + ss_hor >> ss_hor) - (bx >> ss_hor),
         b_dim[0] as libc::c_int + ss_hor >> ss_hor,
     );
-    let cbh4 = imin(
+    let cbh4 = std::cmp::min(
         (ih + ss_ver >> ss_ver) - (by >> ss_ver),
         b_dim[1] as libc::c_int + ss_ver >> ss_ver,
     );

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -440,7 +440,7 @@ pub unsafe fn dav1d_create_lf_mask_intra(
     let bx4 = bx & 31;
     let by4 = by & 31;
     if bw4 != 0 && bh4 != 0 {
-        let mut level_cache_ptr: *mut [u8; 4] = level_cache
+        let mut level_cache_ptr = level_cache
             .offset(by as isize * b4_stride)
             .offset(bx as isize);
         for _ in 0..bh4 {
@@ -456,10 +456,8 @@ pub unsafe fn dav1d_create_lf_mask_intra(
         None => return,
         Some(aluv) => aluv,
     };
-    let ss_ver = (layout as libc::c_uint == DAV1D_PIXEL_LAYOUT_I420 as libc::c_int as libc::c_uint)
-        as libc::c_int;
-    let ss_hor = (layout as libc::c_uint != DAV1D_PIXEL_LAYOUT_I444 as libc::c_int as libc::c_uint)
-        as libc::c_int;
+    let ss_ver = (layout == DAV1D_PIXEL_LAYOUT_I420) as libc::c_int;
+    let ss_hor = (layout != DAV1D_PIXEL_LAYOUT_I444) as libc::c_int;
     let cbw4 = imin(
         (iw + ss_hor >> ss_hor) - (bx >> ss_hor),
         b_dim[0] as libc::c_int + ss_hor >> ss_hor,
@@ -473,7 +471,7 @@ pub unsafe fn dav1d_create_lf_mask_intra(
     }
     let cbx4 = bx4 >> ss_hor;
     let cby4 = by4 >> ss_ver;
-    let mut level_cache_ptr: *mut [u8; 4] = level_cache
+    let mut level_cache_ptr = level_cache
         .offset(((by >> ss_ver) as isize * b4_stride) as isize)
         .offset((bx >> ss_hor) as isize);
     for _ in 0..cbh4 {
@@ -523,7 +521,7 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     let bx4 = bx & 31;
     let by4 = by & 31;
     if bw4 != 0 && bh4 != 0 {
-        let mut level_cache_ptr: *mut [u8; 4] = level_cache
+        let mut level_cache_ptr = level_cache
             .offset(by as isize * b4_stride)
             .offset(bx as isize);
         for _ in 0..bh4 {
@@ -550,10 +548,8 @@ pub unsafe fn dav1d_create_lf_mask_inter(
         None => return,
         Some(aluv) => aluv,
     };
-    let ss_ver = (layout as libc::c_uint == DAV1D_PIXEL_LAYOUT_I420 as libc::c_int as libc::c_uint)
-        as libc::c_int;
-    let ss_hor = (layout as libc::c_uint != DAV1D_PIXEL_LAYOUT_I444 as libc::c_int as libc::c_uint)
-        as libc::c_int;
+    let ss_ver = (layout == DAV1D_PIXEL_LAYOUT_I420) as libc::c_int;
+    let ss_hor = (layout != DAV1D_PIXEL_LAYOUT_I444) as libc::c_int;
     let cbw4 = imin(
         (iw + ss_hor >> ss_hor) - (bx >> ss_hor),
         b_dim[0] as libc::c_int + ss_hor >> ss_hor,
@@ -567,7 +563,7 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     }
     let cbx4 = bx4 >> ss_hor;
     let cby4 = by4 >> ss_ver;
-    let mut level_cache_ptr: *mut [u8; 4] = level_cache
+    let mut level_cache_ptr = level_cache
         .offset(((by >> ss_ver) as isize * b4_stride) as isize)
         .offset((bx >> ss_hor) as isize);
     for _ in 0..cbh4 {

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -502,7 +502,9 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     lflvl: &mut Av1Filter,
     level_cache: *mut [u8; 4],
     b4_stride: ptrdiff_t,
-    mut filter_level: *const [[u8; 2]; 8],
+    filter_level: &[[[u8; 2]; 8]; 4],
+    r#ref: usize,
+    is_gmv: bool,
     bx: libc::c_int,
     by: libc::c_int,
     iw: libc::c_int,
@@ -518,6 +520,7 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     aluv: Option<(&mut [u8], &mut [u8])>,
 ) {
     let b4_stride = b4_stride as usize;
+    let is_gmv = is_gmv as usize;
     let [bx, by, iw, ih] = [bx, by, iw, ih].map(|it| it as usize);
 
     let b_dim = &dav1d_block_dimensions[bs as usize];
@@ -531,8 +534,8 @@ pub unsafe fn dav1d_create_lf_mask_inter(
         let mut level_cache_ptr = level_cache.offset((by * b4_stride + bx) as isize);
         for _ in 0..bh4 {
             for x in 0..bw4 {
-                (*level_cache_ptr.offset(x as isize))[0] = (*filter_level.offset(0))[0][0];
-                (*level_cache_ptr.offset(x as isize))[1] = (*filter_level.offset(1))[0][0];
+                (*level_cache_ptr.offset(x as isize))[0] = filter_level[0][r#ref][is_gmv];
+                (*level_cache_ptr.offset(x as isize))[1] = filter_level[1][r#ref][is_gmv];
             }
             level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
         }
@@ -578,8 +581,8 @@ pub unsafe fn dav1d_create_lf_mask_inter(
         level_cache.offset(((by >> ss_ver) * b4_stride + (bx >> ss_hor)) as isize);
     for _ in 0..cbh4 {
         for x in 0..cbw4 {
-            (*level_cache_ptr.offset(x as isize))[2] = (*filter_level.offset(2))[0][0];
-            (*level_cache_ptr.offset(x as isize))[3] = (*filter_level.offset(3))[0][0];
+            (*level_cache_ptr.offset(x as isize))[2] = filter_level[2][r#ref][is_gmv];
+            (*level_cache_ptr.offset(x as isize))[3] = filter_level[3][r#ref][is_gmv];
         }
         level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
     }

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -443,16 +443,12 @@ pub unsafe fn dav1d_create_lf_mask_intra(
         let mut level_cache_ptr: *mut [u8; 4] = level_cache
             .offset(by as isize * b4_stride)
             .offset(bx as isize);
-        let mut y = 0;
-        while y < bh4 {
-            let mut x = 0;
-            while x < bw4 {
+        for _ in 0..bh4 {
+            for x in 0..bw4 {
                 (*level_cache_ptr.offset(x as isize))[0] = (*filter_level.offset(0))[0][0];
                 (*level_cache_ptr.offset(x as isize))[1] = (*filter_level.offset(1))[0][0];
-                x += 1;
             }
             level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
-            y += 1;
         }
         mask_edges_intra(&mut lflvl.filter_y, by4, bx4, bw4, bh4, ytx, ay, ly);
     }
@@ -480,16 +476,12 @@ pub unsafe fn dav1d_create_lf_mask_intra(
     let mut level_cache_ptr: *mut [u8; 4] = level_cache
         .offset(((by >> ss_ver) as isize * b4_stride) as isize)
         .offset((bx >> ss_hor) as isize);
-    let mut y = 0;
-    while y < cbh4 {
-        let mut x = 0;
-        while x < cbw4 {
+    for _ in 0..cbh4 {
+        for x in 0..cbw4 {
             (*level_cache_ptr.offset(x as isize))[2] = (*filter_level.offset(2))[0][0];
             (*level_cache_ptr.offset(x as isize))[3] = (*filter_level.offset(3))[0][0];
-            x += 1;
         }
         level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
-        y += 1;
     }
     mask_edges_chroma(
         &mut lflvl.filter_uv,
@@ -534,16 +526,12 @@ pub unsafe fn dav1d_create_lf_mask_inter(
         let mut level_cache_ptr: *mut [u8; 4] = level_cache
             .offset(by as isize * b4_stride)
             .offset(bx as isize);
-        let mut y = 0;
-        while y < bh4 {
-            let mut x = 0;
-            while x < bw4 {
+        for _ in 0..bh4 {
+            for x in 0..bw4 {
                 (*level_cache_ptr.offset(x as isize))[0] = (*filter_level.offset(0))[0][0];
                 (*level_cache_ptr.offset(x as isize))[1] = (*filter_level.offset(1))[0][0];
-                x += 1;
             }
             level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
-            y += 1;
         }
         mask_edges_inter(
             &mut lflvl.filter_y,
@@ -582,16 +570,12 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     let mut level_cache_ptr: *mut [u8; 4] = level_cache
         .offset(((by >> ss_ver) as isize * b4_stride) as isize)
         .offset((bx >> ss_hor) as isize);
-    let mut y = 0;
-    while y < cbh4 {
-        let mut x = 0;
-        while x < cbw4 {
+    for _ in 0..cbh4 {
+        for x in 0..cbw4 {
             (*level_cache_ptr.offset(x as isize))[2] = (*filter_level.offset(2))[0][0];
             (*level_cache_ptr.offset(x as isize))[3] = (*filter_level.offset(3))[0][0];
-            x += 1;
         }
         level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
-        y += 1;
     }
     mask_edges_chroma(
         &mut lflvl.filter_uv,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -427,6 +427,7 @@ pub unsafe fn dav1d_create_lf_mask_intra(
     ly: &mut [u8],
     aluv: Option<(&mut [u8], &mut [u8])>,
 ) {
+    let b4_stride = b4_stride as usize;
     let [bx, by, iw, ih] = [bx, by, iw, ih].map(|it| it as usize);
     let b_dim = &dav1d_block_dimensions[bs as usize];
     let b_dim = b_dim.map(|it| it as usize);
@@ -435,9 +436,7 @@ pub unsafe fn dav1d_create_lf_mask_intra(
     let bx4 = bx & 31;
     let by4 = by & 31;
     if bw4 != 0 && bh4 != 0 {
-        let mut level_cache_ptr = level_cache
-            .offset(by as isize * b4_stride)
-            .offset(bx as isize);
+        let mut level_cache_ptr = level_cache.offset((by * b4_stride + bx) as isize);
         for _ in 0..bh4 {
             for x in 0..bw4 {
                 (*level_cache_ptr.offset(x as isize))[0] = (*filter_level.offset(0))[0][0];
@@ -466,9 +465,8 @@ pub unsafe fn dav1d_create_lf_mask_intra(
     }
     let cbx4 = bx4 >> ss_hor;
     let cby4 = by4 >> ss_ver;
-    let mut level_cache_ptr = level_cache
-        .offset(((by >> ss_ver) as isize * b4_stride) as isize)
-        .offset((bx >> ss_hor) as isize);
+    let mut level_cache_ptr =
+        level_cache.offset(((by >> ss_ver) * b4_stride + (bx >> ss_hor)) as isize);
     for _ in 0..cbh4 {
         for x in 0..cbw4 {
             (*level_cache_ptr.offset(x as isize))[2] = (*filter_level.offset(2))[0][0];
@@ -510,6 +508,7 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     ly: &mut [u8],
     aluv: Option<(&mut [u8], &mut [u8])>,
 ) {
+    let b4_stride = b4_stride as usize;
     let [bx, by, iw, ih] = [bx, by, iw, ih].map(|it| it as usize);
     let b_dim = &dav1d_block_dimensions[bs as usize];
     let b_dim = b_dim.map(|it| it as usize);
@@ -518,9 +517,7 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     let bx4 = bx & 31;
     let by4 = by & 31;
     if bw4 != 0 && bh4 != 0 {
-        let mut level_cache_ptr = level_cache
-            .offset(by as isize * b4_stride)
-            .offset(bx as isize);
+        let mut level_cache_ptr = level_cache.offset((by * b4_stride + bx) as isize);
         for _ in 0..bh4 {
             for x in 0..bw4 {
                 (*level_cache_ptr.offset(x as isize))[0] = (*filter_level.offset(0))[0][0];
@@ -560,9 +557,8 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     }
     let cbx4 = bx4 >> ss_hor;
     let cby4 = by4 >> ss_ver;
-    let mut level_cache_ptr = level_cache
-        .offset(((by >> ss_ver) as isize * b4_stride) as isize)
-        .offset((bx >> ss_hor) as isize);
+    let mut level_cache_ptr =
+        level_cache.offset(((by >> ss_ver) * b4_stride + (bx >> ss_hor)) as isize);
     for _ in 0..cbh4 {
         for x in 0..cbw4 {
             (*level_cache_ptr.offset(x as isize))[2] = (*filter_level.offset(2))[0][0];

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -445,9 +445,9 @@ pub unsafe fn dav1d_create_lf_mask_intra(
         let offset = by * b4_stride + bx;
         for y in 0..bh4 {
             let offset = offset + y * b4_stride;
-            for x in 0..bw4 {
-                level_cache[offset + x][0] = filter_level[0][0][0];
-                level_cache[offset + x][1] = filter_level[1][0][0];
+            for level_cache in &mut level_cache[offset..][..bw4] {
+                level_cache[0] = filter_level[0][0][0];
+                level_cache[1] = filter_level[1][0][0];
             }
         }
 
@@ -485,9 +485,9 @@ pub unsafe fn dav1d_create_lf_mask_intra(
     let offset = (by >> ss_ver) * b4_stride + (bx >> ss_hor);
     for y in 0..cbh4 {
         let offset = offset + y * b4_stride;
-        for x in 0..cbw4 {
-            level_cache[offset + x][2] = filter_level[2][0][0];
-            level_cache[offset + x][3] = filter_level[3][0][0];
+        for level_cache in &mut level_cache[offset..][..cbw4] {
+            level_cache[2] = filter_level[2][0][0];
+            level_cache[3] = filter_level[3][0][0];
         }
     }
 
@@ -546,9 +546,9 @@ pub unsafe fn dav1d_create_lf_mask_inter(
         let offset = by * b4_stride + bx;
         for y in 0..bh4 {
             let offset = offset + y * b4_stride;
-            for x in 0..bw4 {
-                level_cache[offset + x][0] = filter_level[0][r#ref][is_gmv];
-                level_cache[offset + x][1] = filter_level[1][r#ref][is_gmv];
+            for level_cache in &mut level_cache[offset..][..bw4] {
+                level_cache[0] = filter_level[0][r#ref][is_gmv];
+                level_cache[1] = filter_level[1][r#ref][is_gmv];
             }
         }
 
@@ -597,9 +597,9 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     let offset = (by >> ss_ver) * b4_stride + (bx >> ss_hor);
     for y in 0..cbh4 {
         let offset = offset + y * b4_stride;
-        for x in 0..cbw4 {
-            level_cache[offset + x][2] = filter_level[2][r#ref][is_gmv];
-            level_cache[offset + x][3] = filter_level[3][r#ref][is_gmv];
+        for level_cache in &mut level_cache[offset..][..cbw4] {
+            level_cache[2] = filter_level[2][r#ref][is_gmv];
+            level_cache[3] = filter_level[3][r#ref][is_gmv];
         }
     }
 

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -418,7 +418,7 @@ unsafe fn mask_edges_chroma(
 }
 
 pub unsafe fn dav1d_create_lf_mask_intra(
-    lflvl: *mut Av1Filter,
+    lflvl: &mut Av1Filter,
     level_cache: *mut [u8; 4],
     b4_stride: ptrdiff_t,
     mut filter_level: *const [[u8; 2]; 8],
@@ -454,7 +454,7 @@ pub unsafe fn dav1d_create_lf_mask_intra(
             level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
             y += 1;
         }
-        mask_edges_intra(&mut (*lflvl).filter_y, by4, bx4, bw4, bh4, ytx, ay, ly);
+        mask_edges_intra(&mut lflvl.filter_y, by4, bx4, bw4, bh4, ytx, ay, ly);
     }
     let (auv, luv) = match aluv {
         None => return,
@@ -492,7 +492,7 @@ pub unsafe fn dav1d_create_lf_mask_intra(
         y_0 += 1;
     }
     mask_edges_chroma(
-        &mut (*lflvl).filter_uv,
+        &mut lflvl.filter_uv,
         cby4,
         cbx4,
         cbw4,
@@ -507,7 +507,7 @@ pub unsafe fn dav1d_create_lf_mask_intra(
 }
 
 pub unsafe fn dav1d_create_lf_mask_inter(
-    lflvl: *mut Av1Filter,
+    lflvl: &mut Av1Filter,
     level_cache: *mut [u8; 4],
     b4_stride: ptrdiff_t,
     mut filter_level: *const [[u8; 2]; 8],
@@ -546,7 +546,7 @@ pub unsafe fn dav1d_create_lf_mask_inter(
             y += 1;
         }
         mask_edges_inter(
-            &mut (*lflvl).filter_y,
+            &mut lflvl.filter_y,
             by4,
             bx4,
             bw4,
@@ -594,7 +594,7 @@ pub unsafe fn dav1d_create_lf_mask_inter(
         y_0 += 1;
     }
     mask_edges_chroma(
-        &mut (*lflvl).filter_uv,
+        &mut lflvl.filter_uv,
         cby4,
         cbx4,
         cbw4,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -438,13 +438,17 @@ pub unsafe fn dav1d_create_lf_mask_intra(
     let by4 = by & 31;
 
     if bw4 != 0 && bh4 != 0 {
-        let mut level_cache_ptr = level_cache.offset((by * b4_stride + bx) as isize);
+        // TODO: Remove when `level_cache` is already a slice coming from a `Vec`.
+        // That refactor is complex, though, so for now we make it a slice by how elements are accessed.
+        let level_cache_len = (by * b4_stride + bx) + (bh4 * b4_stride);
+        let level_cache = std::slice::from_raw_parts_mut(level_cache, level_cache_len);
+        let mut level_cache_ptr = &mut level_cache[by * b4_stride + bx..];
         for _ in 0..bh4 {
             for x in 0..bw4 {
-                (*level_cache_ptr.offset(x as isize))[0] = filter_level[0][0][0];
-                (*level_cache_ptr.offset(x as isize))[1] = filter_level[1][0][0];
+                level_cache_ptr[x][0] = filter_level[0][0][0];
+                level_cache_ptr[x][1] = filter_level[1][0][0];
             }
-            level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
+            level_cache_ptr = &mut level_cache_ptr[b4_stride..];
         }
 
         mask_edges_intra(&mut lflvl.filter_y, by4, bx4, bw4, bh4, ytx, ay, ly);
@@ -473,14 +477,17 @@ pub unsafe fn dav1d_create_lf_mask_intra(
     let cbx4 = bx4 >> ss_hor;
     let cby4 = by4 >> ss_ver;
 
-    let mut level_cache_ptr =
-        level_cache.offset(((by >> ss_ver) * b4_stride + (bx >> ss_hor)) as isize);
+    // TODO: Remove when `level_cache` is already a slice coming from a `Vec`.
+    // That refactor is complex, though, so for now we make it a slice by how elements are accessed.
+    let level_cache_len = ((by >> ss_ver) * b4_stride + (bx >> ss_hor)) + (cbh4 * b4_stride);
+    let level_cache = std::slice::from_raw_parts_mut(level_cache, level_cache_len);
+    let mut level_cache_ptr = &mut level_cache[(by >> ss_ver) * b4_stride + (bx >> ss_hor)..];
     for _ in 0..cbh4 {
         for x in 0..cbw4 {
-            (*level_cache_ptr.offset(x as isize))[2] = filter_level[2][0][0];
-            (*level_cache_ptr.offset(x as isize))[3] = filter_level[3][0][0];
+            level_cache_ptr[x][2] = filter_level[2][0][0];
+            level_cache_ptr[x][3] = filter_level[3][0][0];
         }
-        level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
+        level_cache_ptr = &mut level_cache_ptr[b4_stride..];
     }
 
     mask_edges_chroma(
@@ -531,13 +538,17 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     let by4 = by & 31;
 
     if bw4 != 0 && bh4 != 0 {
-        let mut level_cache_ptr = level_cache.offset((by * b4_stride + bx) as isize);
+        // TODO: Remove when `level_cache` is already a slice coming from a `Vec`.
+        // That refactor is complex, though, so for now we make it a slice by how elements are accessed.
+        let level_cache_len = (by * b4_stride + bx) + (bh4 * b4_stride);
+        let level_cache = std::slice::from_raw_parts_mut(level_cache, level_cache_len);
+        let mut level_cache_ptr = &mut level_cache[by * b4_stride + bx..];
         for _ in 0..bh4 {
             for x in 0..bw4 {
-                (*level_cache_ptr.offset(x as isize))[0] = filter_level[0][r#ref][is_gmv];
-                (*level_cache_ptr.offset(x as isize))[1] = filter_level[1][r#ref][is_gmv];
+                level_cache_ptr[x][0] = filter_level[0][r#ref][is_gmv];
+                level_cache_ptr[x][1] = filter_level[1][r#ref][is_gmv];
             }
-            level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
+            level_cache_ptr = &mut level_cache_ptr[b4_stride..];
         }
 
         mask_edges_inter(
@@ -577,14 +588,17 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     let cbx4 = bx4 >> ss_hor;
     let cby4 = by4 >> ss_ver;
 
-    let mut level_cache_ptr =
-        level_cache.offset(((by >> ss_ver) * b4_stride + (bx >> ss_hor)) as isize);
+    // TODO: Remove when `level_cache` is already a slice coming from a `Vec`.
+    // That refactor is complex, though, so for now we make it a slice by how elements are accessed.
+    let level_cache_len = ((by >> ss_ver) * b4_stride + (bx >> ss_hor)) + (cbh4 * b4_stride);
+    let level_cache = std::slice::from_raw_parts_mut(level_cache, level_cache_len);
+    let mut level_cache_ptr = &mut level_cache[(by >> ss_ver) * b4_stride + (bx >> ss_hor)..];
     for _ in 0..cbh4 {
         for x in 0..cbw4 {
-            (*level_cache_ptr.offset(x as isize))[2] = filter_level[2][r#ref][is_gmv];
-            (*level_cache_ptr.offset(x as isize))[3] = filter_level[3][r#ref][is_gmv];
+            level_cache_ptr[x][2] = filter_level[2][r#ref][is_gmv];
+            level_cache_ptr[x][3] = filter_level[3][r#ref][is_gmv];
         }
-        level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
+        level_cache_ptr = &mut level_cache_ptr[b4_stride..];
     }
 
     mask_edges_chroma(

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -440,15 +440,15 @@ pub unsafe fn dav1d_create_lf_mask_intra(
     if bw4 != 0 && bh4 != 0 {
         // TODO: Remove when `level_cache` is already a slice coming from a `Vec`.
         // That refactor is complex, though, so for now we make it a slice by how elements are accessed.
-        let level_cache_len = (by * b4_stride + bx) + (bh4 * b4_stride);
+        let level_cache_len = (by * b4_stride + bx) + ((bh4 - 1) * b4_stride + bw4);
         let level_cache = std::slice::from_raw_parts_mut(level_cache, level_cache_len);
-        let mut level_cache_ptr = &mut level_cache[by * b4_stride + bx..];
-        for _ in 0..bh4 {
+        let offset = by * b4_stride + bx;
+        for y in 0..bh4 {
+            let offset = offset + y * b4_stride;
             for x in 0..bw4 {
-                level_cache_ptr[x][0] = filter_level[0][0][0];
-                level_cache_ptr[x][1] = filter_level[1][0][0];
+                level_cache[offset + x][0] = filter_level[0][0][0];
+                level_cache[offset + x][1] = filter_level[1][0][0];
             }
-            level_cache_ptr = &mut level_cache_ptr[b4_stride..];
         }
 
         mask_edges_intra(&mut lflvl.filter_y, by4, bx4, bw4, bh4, ytx, ay, ly);
@@ -479,15 +479,16 @@ pub unsafe fn dav1d_create_lf_mask_intra(
 
     // TODO: Remove when `level_cache` is already a slice coming from a `Vec`.
     // That refactor is complex, though, so for now we make it a slice by how elements are accessed.
-    let level_cache_len = ((by >> ss_ver) * b4_stride + (bx >> ss_hor)) + (cbh4 * b4_stride);
+    let level_cache_len =
+        ((by >> ss_ver) * b4_stride + (bx >> ss_hor)) + ((cbh4 - 1) * b4_stride + cbw4);
     let level_cache = std::slice::from_raw_parts_mut(level_cache, level_cache_len);
-    let mut level_cache_ptr = &mut level_cache[(by >> ss_ver) * b4_stride + (bx >> ss_hor)..];
-    for _ in 0..cbh4 {
+    let offset = (by >> ss_ver) * b4_stride + (bx >> ss_hor);
+    for y in 0..cbh4 {
+        let offset = offset + y * b4_stride;
         for x in 0..cbw4 {
-            level_cache_ptr[x][2] = filter_level[2][0][0];
-            level_cache_ptr[x][3] = filter_level[3][0][0];
+            level_cache[offset + x][2] = filter_level[2][0][0];
+            level_cache[offset + x][3] = filter_level[3][0][0];
         }
-        level_cache_ptr = &mut level_cache_ptr[b4_stride..];
     }
 
     mask_edges_chroma(
@@ -540,15 +541,15 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     if bw4 != 0 && bh4 != 0 {
         // TODO: Remove when `level_cache` is already a slice coming from a `Vec`.
         // That refactor is complex, though, so for now we make it a slice by how elements are accessed.
-        let level_cache_len = (by * b4_stride + bx) + (bh4 * b4_stride);
+        let level_cache_len = (by * b4_stride + bx) + ((bh4 - 1) * b4_stride + bw4);
         let level_cache = std::slice::from_raw_parts_mut(level_cache, level_cache_len);
-        let mut level_cache_ptr = &mut level_cache[by * b4_stride + bx..];
-        for _ in 0..bh4 {
+        let offset = by * b4_stride + bx;
+        for y in 0..bh4 {
+            let offset = offset + y * b4_stride;
             for x in 0..bw4 {
-                level_cache_ptr[x][0] = filter_level[0][r#ref][is_gmv];
-                level_cache_ptr[x][1] = filter_level[1][r#ref][is_gmv];
+                level_cache[offset + x][0] = filter_level[0][r#ref][is_gmv];
+                level_cache[offset + x][1] = filter_level[1][r#ref][is_gmv];
             }
-            level_cache_ptr = &mut level_cache_ptr[b4_stride..];
         }
 
         mask_edges_inter(
@@ -590,15 +591,16 @@ pub unsafe fn dav1d_create_lf_mask_inter(
 
     // TODO: Remove when `level_cache` is already a slice coming from a `Vec`.
     // That refactor is complex, though, so for now we make it a slice by how elements are accessed.
-    let level_cache_len = ((by >> ss_ver) * b4_stride + (bx >> ss_hor)) + (cbh4 * b4_stride);
+    let level_cache_len =
+        ((by >> ss_ver) * b4_stride + (bx >> ss_hor)) + ((cbh4 - 1) * b4_stride + cbw4);
     let level_cache = std::slice::from_raw_parts_mut(level_cache, level_cache_len);
-    let mut level_cache_ptr = &mut level_cache[(by >> ss_ver) * b4_stride + (bx >> ss_hor)..];
-    for _ in 0..cbh4 {
+    let offset = (by >> ss_ver) * b4_stride + (bx >> ss_hor);
+    for y in 0..cbh4 {
+        let offset = offset + y * b4_stride;
         for x in 0..cbw4 {
-            level_cache_ptr[x][2] = filter_level[2][r#ref][is_gmv];
-            level_cache_ptr[x][3] = filter_level[3][r#ref][is_gmv];
+            level_cache[offset + x][2] = filter_level[2][r#ref][is_gmv];
+            level_cache[offset + x][3] = filter_level[3][r#ref][is_gmv];
         }
-        level_cache_ptr = &mut level_cache_ptr[b4_stride..];
     }
 
     mask_edges_chroma(

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -414,7 +414,7 @@ pub unsafe fn dav1d_create_lf_mask_intra(
     lflvl: &mut Av1Filter,
     level_cache: *mut [u8; 4],
     b4_stride: ptrdiff_t,
-    mut filter_level: *const [[u8; 2]; 8],
+    filter_level: &[[[u8; 2]; 8]; 4],
     bx: libc::c_int,
     by: libc::c_int,
     iw: libc::c_int,
@@ -441,8 +441,8 @@ pub unsafe fn dav1d_create_lf_mask_intra(
         let mut level_cache_ptr = level_cache.offset((by * b4_stride + bx) as isize);
         for _ in 0..bh4 {
             for x in 0..bw4 {
-                (*level_cache_ptr.offset(x as isize))[0] = (*filter_level.offset(0))[0][0];
-                (*level_cache_ptr.offset(x as isize))[1] = (*filter_level.offset(1))[0][0];
+                (*level_cache_ptr.offset(x as isize))[0] = filter_level[0][0][0];
+                (*level_cache_ptr.offset(x as isize))[1] = filter_level[1][0][0];
             }
             level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
         }
@@ -477,8 +477,8 @@ pub unsafe fn dav1d_create_lf_mask_intra(
         level_cache.offset(((by >> ss_ver) * b4_stride + (bx >> ss_hor)) as isize);
     for _ in 0..cbh4 {
         for x in 0..cbw4 {
-            (*level_cache_ptr.offset(x as isize))[2] = (*filter_level.offset(2))[0][0];
-            (*level_cache_ptr.offset(x as isize))[3] = (*filter_level.offset(3))[0][0];
+            (*level_cache_ptr.offset(x as isize))[2] = filter_level[2][0][0];
+            (*level_cache_ptr.offset(x as isize))[3] = filter_level[3][0][0];
         }
         level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
     }

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -429,12 +429,14 @@ pub unsafe fn dav1d_create_lf_mask_intra(
 ) {
     let b4_stride = b4_stride as usize;
     let [bx, by, iw, ih] = [bx, by, iw, ih].map(|it| it as usize);
+
     let b_dim = &dav1d_block_dimensions[bs as usize];
     let b_dim = b_dim.map(|it| it as usize);
     let bw4 = std::cmp::min(iw - bx, b_dim[0]);
     let bh4 = std::cmp::min(ih - by, b_dim[1]);
     let bx4 = bx & 31;
     let by4 = by & 31;
+
     if bw4 != 0 && bh4 != 0 {
         let mut level_cache_ptr = level_cache.offset((by * b4_stride + bx) as isize);
         for _ in 0..bh4 {
@@ -444,12 +446,15 @@ pub unsafe fn dav1d_create_lf_mask_intra(
             }
             level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
         }
+
         mask_edges_intra(&mut lflvl.filter_y, by4, bx4, bw4, bh4, ytx, ay, ly);
     }
+
     let (auv, luv) = match aluv {
         None => return,
         Some(aluv) => aluv,
     };
+
     let ss_ver = (layout == DAV1D_PIXEL_LAYOUT_I420) as usize;
     let ss_hor = (layout != DAV1D_PIXEL_LAYOUT_I444) as usize;
     let cbw4 = std::cmp::min(
@@ -460,11 +465,14 @@ pub unsafe fn dav1d_create_lf_mask_intra(
         (ih + ss_ver >> ss_ver) - (by >> ss_ver),
         (b_dim[1] + ss_ver) >> ss_ver,
     );
+
     if cbw4 == 0 || cbh4 == 0 {
         return;
     }
+
     let cbx4 = bx4 >> ss_hor;
     let cby4 = by4 >> ss_ver;
+
     let mut level_cache_ptr =
         level_cache.offset(((by >> ss_ver) * b4_stride + (bx >> ss_hor)) as isize);
     for _ in 0..cbh4 {
@@ -474,6 +482,7 @@ pub unsafe fn dav1d_create_lf_mask_intra(
         }
         level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
     }
+
     mask_edges_chroma(
         &mut lflvl.filter_uv,
         cby4,
@@ -510,12 +519,14 @@ pub unsafe fn dav1d_create_lf_mask_inter(
 ) {
     let b4_stride = b4_stride as usize;
     let [bx, by, iw, ih] = [bx, by, iw, ih].map(|it| it as usize);
+
     let b_dim = &dav1d_block_dimensions[bs as usize];
     let b_dim = b_dim.map(|it| it as usize);
     let bw4 = std::cmp::min(iw - bx, b_dim[0]);
     let bh4 = std::cmp::min(ih - by, b_dim[1]);
     let bx4 = bx & 31;
     let by4 = by & 31;
+
     if bw4 != 0 && bh4 != 0 {
         let mut level_cache_ptr = level_cache.offset((by * b4_stride + bx) as isize);
         for _ in 0..bh4 {
@@ -525,6 +536,7 @@ pub unsafe fn dav1d_create_lf_mask_inter(
             }
             level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
         }
+
         mask_edges_inter(
             &mut lflvl.filter_y,
             by4,
@@ -538,10 +550,12 @@ pub unsafe fn dav1d_create_lf_mask_inter(
             ly,
         );
     }
+
     let (auv, luv) = match aluv {
         None => return,
         Some(aluv) => aluv,
     };
+
     let ss_ver = (layout == DAV1D_PIXEL_LAYOUT_I420) as usize;
     let ss_hor = (layout != DAV1D_PIXEL_LAYOUT_I444) as usize;
     let cbw4 = std::cmp::min(
@@ -552,11 +566,14 @@ pub unsafe fn dav1d_create_lf_mask_inter(
         (ih + ss_ver >> ss_ver) - (by >> ss_ver),
         (b_dim[1] + ss_ver) >> ss_ver,
     );
+
     if cbw4 == 0 || cbh4 == 0 {
         return;
     }
+
     let cbx4 = bx4 >> ss_hor;
     let cby4 = by4 >> ss_ver;
+
     let mut level_cache_ptr =
         level_cache.offset(((by >> ss_ver) * b4_stride + (bx >> ss_hor)) as isize);
     for _ in 0..cbh4 {
@@ -566,6 +583,7 @@ pub unsafe fn dav1d_create_lf_mask_inter(
         }
         level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
     }
+
     mask_edges_chroma(
         &mut lflvl.filter_uv,
         cby4,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -434,9 +434,9 @@ pub unsafe fn dav1d_create_lf_mask_intra(
     ly: &mut [u8],
     aluv: Option<(&mut [u8], &mut [u8])>,
 ) {
-    let b_dim: *const u8 = (dav1d_block_dimensions[bs as usize]).as_ptr();
-    let bw4 = imin(iw - bx, *b_dim.offset(0) as libc::c_int);
-    let bh4 = imin(ih - by, *b_dim.offset(1) as libc::c_int);
+    let b_dim = &dav1d_block_dimensions[bs as usize];
+    let bw4 = imin(iw - bx, b_dim[0] as libc::c_int);
+    let bh4 = imin(ih - by, b_dim[1] as libc::c_int);
     let bx4 = bx & 31;
     let by4 = by & 31;
     if bw4 != 0 && bh4 != 0 {
@@ -466,11 +466,11 @@ pub unsafe fn dav1d_create_lf_mask_intra(
         as libc::c_int;
     let cbw4 = imin(
         (iw + ss_hor >> ss_hor) - (bx >> ss_hor),
-        *b_dim.offset(0) as libc::c_int + ss_hor >> ss_hor,
+        b_dim[0] as libc::c_int + ss_hor >> ss_hor,
     );
     let cbh4 = imin(
         (ih + ss_ver >> ss_ver) - (by >> ss_ver),
-        *b_dim.offset(1) as libc::c_int + ss_ver >> ss_ver,
+        b_dim[1] as libc::c_int + ss_ver >> ss_ver,
     );
     if cbw4 == 0 || cbh4 == 0 {
         return;
@@ -525,9 +525,9 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     ly: &mut [u8],
     aluv: Option<(&mut [u8], &mut [u8])>,
 ) {
-    let b_dim: *const u8 = (dav1d_block_dimensions[bs as usize]).as_ptr();
-    let bw4 = imin(iw - bx, *b_dim.offset(0) as libc::c_int);
-    let bh4 = imin(ih - by, *b_dim.offset(1) as libc::c_int);
+    let b_dim = &dav1d_block_dimensions[bs as usize];
+    let bw4 = imin(iw - bx, b_dim[0] as libc::c_int);
+    let bh4 = imin(ih - by, b_dim[1] as libc::c_int);
     let bx4 = bx & 31;
     let by4 = by & 31;
     if bw4 != 0 && bh4 != 0 {
@@ -568,11 +568,11 @@ pub unsafe fn dav1d_create_lf_mask_inter(
         as libc::c_int;
     let cbw4 = imin(
         (iw + ss_hor >> ss_hor) - (bx >> ss_hor),
-        *b_dim.offset(0) as libc::c_int + ss_hor >> ss_hor,
+        b_dim[0] as libc::c_int + ss_hor >> ss_hor,
     );
     let cbh4 = imin(
         (ih + ss_ver >> ss_ver) - (by >> ss_ver),
-        *b_dim.offset(1) as libc::c_int + ss_ver >> ss_ver,
+        b_dim[1] as libc::c_int + ss_ver >> ss_ver,
     );
     if cbw4 == 0 || cbh4 == 0 {
         return;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -477,19 +477,19 @@ pub unsafe fn dav1d_create_lf_mask_intra(
     }
     let cbx4 = bx4 >> ss_hor;
     let cby4 = by4 >> ss_ver;
-    let mut level_cache_ptr_0: *mut [u8; 4] = level_cache
+    let mut level_cache_ptr: *mut [u8; 4] = level_cache
         .offset(((by >> ss_ver) as isize * b4_stride) as isize)
         .offset((bx >> ss_hor) as isize);
-    let mut y_0 = 0;
-    while y_0 < cbh4 {
-        let mut x_0 = 0;
-        while x_0 < cbw4 {
-            (*level_cache_ptr_0.offset(x_0 as isize))[2] = (*filter_level.offset(2))[0][0];
-            (*level_cache_ptr_0.offset(x_0 as isize))[3] = (*filter_level.offset(3))[0][0];
-            x_0 += 1;
+    let mut y = 0;
+    while y < cbh4 {
+        let mut x = 0;
+        while x < cbw4 {
+            (*level_cache_ptr.offset(x as isize))[2] = (*filter_level.offset(2))[0][0];
+            (*level_cache_ptr.offset(x as isize))[3] = (*filter_level.offset(3))[0][0];
+            x += 1;
         }
-        level_cache_ptr_0 = level_cache_ptr_0.offset(b4_stride as isize);
-        y_0 += 1;
+        level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
+        y += 1;
     }
     mask_edges_chroma(
         &mut lflvl.filter_uv,
@@ -579,19 +579,19 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     }
     let cbx4 = bx4 >> ss_hor;
     let cby4 = by4 >> ss_ver;
-    let mut level_cache_ptr_0: *mut [u8; 4] = level_cache
+    let mut level_cache_ptr: *mut [u8; 4] = level_cache
         .offset(((by >> ss_ver) as isize * b4_stride) as isize)
         .offset((bx >> ss_hor) as isize);
-    let mut y_0 = 0;
-    while y_0 < cbh4 {
-        let mut x_0 = 0;
-        while x_0 < cbw4 {
-            (*level_cache_ptr_0.offset(x_0 as isize))[2] = (*filter_level.offset(2))[0][0];
-            (*level_cache_ptr_0.offset(x_0 as isize))[3] = (*filter_level.offset(3))[0][0];
-            x_0 += 1;
+    let mut y = 0;
+    while y < cbh4 {
+        let mut x = 0;
+        while x < cbw4 {
+            (*level_cache_ptr.offset(x as isize))[2] = (*filter_level.offset(2))[0][0];
+            (*level_cache_ptr.offset(x as isize))[3] = (*filter_level.offset(3))[0][0];
+            x += 1;
         }
-        level_cache_ptr_0 = level_cache_ptr_0.offset(b4_stride as isize);
-        y_0 += 1;
+        level_cache_ptr = level_cache_ptr.offset(b4_stride as isize);
+        y += 1;
     }
     mask_edges_chroma(
         &mut lflvl.filter_uv,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -134,18 +134,16 @@ unsafe fn decomp_tx(
 #[inline]
 unsafe fn mask_edges_inter(
     masks: &mut [[[[u16; 2]; 3]; 32]; 2],
-    by4: libc::c_int,
-    bx4: libc::c_int,
-    w4: libc::c_int,
-    h4: libc::c_int,
+    by4: usize,
+    bx4: usize,
+    w4: usize,
+    h4: usize,
     skip: bool,
     max_tx: RectTxfmSize,
     tx_masks: &[u16; 2],
     a: &mut [u8],
     l: &mut [u8],
 ) {
-    let [by4, bx4, w4, h4] = [by4, bx4, w4, h4].map(|it| it as usize);
-
     let t_dim = &dav1d_txfm_dimensions[max_tx as usize];
 
     // See [`decomp_tx`]'s docs for the `txa` arg.
@@ -219,16 +217,14 @@ unsafe fn mask_edges_inter(
 #[inline]
 unsafe fn mask_edges_intra(
     masks: &mut [[[[u16; 2]; 3]; 32]; 2],
-    by4: libc::c_int,
-    bx4: libc::c_int,
-    w4: libc::c_int,
-    h4: libc::c_int,
+    by4: usize,
+    bx4: usize,
+    w4: usize,
+    h4: usize,
     tx: RectTxfmSize,
     a: &mut [u8],
     l: &mut [u8],
 ) {
-    let [by4, bx4, w4, h4] = [by4, bx4, w4, h4].map(|it| it as usize);
-
     let t_dim = &dav1d_txfm_dimensions[tx as usize];
     let twl4 = t_dim.lw;
     let thl4 = t_dim.lh;
@@ -313,19 +309,17 @@ unsafe fn mask_edges_intra(
 
 unsafe fn mask_edges_chroma(
     masks: &mut [[[[u16; 2]; 2]; 32]; 2],
-    cby4: libc::c_int,
-    cbx4: libc::c_int,
-    cw4: libc::c_int,
-    ch4: libc::c_int,
+    cby4: usize,
+    cbx4: usize,
+    cw4: usize,
+    ch4: usize,
     skip_inter: bool,
     tx: RectTxfmSize,
     a: &mut [u8],
     l: &mut [u8],
-    ss_hor: libc::c_int,
-    ss_ver: libc::c_int,
+    ss_hor: usize,
+    ss_ver: usize,
 ) {
-    let [cby4, cbx4, cw4, ch4] = [cby4, cbx4, cw4, ch4].map(|it| it as usize);
-
     let t_dim = &dav1d_txfm_dimensions[tx as usize];
     let twl4 = t_dim.lw;
     let thl4 = t_dim.lh;
@@ -433,9 +427,11 @@ pub unsafe fn dav1d_create_lf_mask_intra(
     ly: &mut [u8],
     aluv: Option<(&mut [u8], &mut [u8])>,
 ) {
+    let [bx, by, iw, ih] = [bx, by, iw, ih].map(|it| it as usize);
     let b_dim = &dav1d_block_dimensions[bs as usize];
-    let bw4 = std::cmp::min(iw - bx, b_dim[0] as libc::c_int);
-    let bh4 = std::cmp::min(ih - by, b_dim[1] as libc::c_int);
+    let b_dim = b_dim.map(|it| it as usize);
+    let bw4 = std::cmp::min(iw - bx, b_dim[0]);
+    let bh4 = std::cmp::min(ih - by, b_dim[1]);
     let bx4 = bx & 31;
     let by4 = by & 31;
     if bw4 != 0 && bh4 != 0 {
@@ -455,15 +451,15 @@ pub unsafe fn dav1d_create_lf_mask_intra(
         None => return,
         Some(aluv) => aluv,
     };
-    let ss_ver = (layout == DAV1D_PIXEL_LAYOUT_I420) as libc::c_int;
-    let ss_hor = (layout != DAV1D_PIXEL_LAYOUT_I444) as libc::c_int;
+    let ss_ver = (layout == DAV1D_PIXEL_LAYOUT_I420) as usize;
+    let ss_hor = (layout != DAV1D_PIXEL_LAYOUT_I444) as usize;
     let cbw4 = std::cmp::min(
         (iw + ss_hor >> ss_hor) - (bx >> ss_hor),
-        b_dim[0] as libc::c_int + ss_hor >> ss_hor,
+        b_dim[0] + ss_hor >> ss_hor,
     );
     let cbh4 = std::cmp::min(
         (ih + ss_ver >> ss_ver) - (by >> ss_ver),
-        b_dim[1] as libc::c_int + ss_ver >> ss_ver,
+        b_dim[1] + ss_ver >> ss_ver,
     );
     if cbw4 == 0 || cbh4 == 0 {
         return;
@@ -514,9 +510,11 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     ly: &mut [u8],
     aluv: Option<(&mut [u8], &mut [u8])>,
 ) {
+    let [bx, by, iw, ih] = [bx, by, iw, ih].map(|it| it as usize);
     let b_dim = &dav1d_block_dimensions[bs as usize];
-    let bw4 = std::cmp::min(iw - bx, b_dim[0] as libc::c_int);
-    let bh4 = std::cmp::min(ih - by, b_dim[1] as libc::c_int);
+    let b_dim = b_dim.map(|it| it as usize);
+    let bw4 = std::cmp::min(iw - bx, b_dim[0]);
+    let bh4 = std::cmp::min(ih - by, b_dim[1]);
     let bx4 = bx & 31;
     let by4 = by & 31;
     if bw4 != 0 && bh4 != 0 {
@@ -547,15 +545,15 @@ pub unsafe fn dav1d_create_lf_mask_inter(
         None => return,
         Some(aluv) => aluv,
     };
-    let ss_ver = (layout == DAV1D_PIXEL_LAYOUT_I420) as libc::c_int;
-    let ss_hor = (layout != DAV1D_PIXEL_LAYOUT_I444) as libc::c_int;
+    let ss_ver = (layout == DAV1D_PIXEL_LAYOUT_I420) as usize;
+    let ss_hor = (layout != DAV1D_PIXEL_LAYOUT_I444) as usize;
     let cbw4 = std::cmp::min(
         (iw + ss_hor >> ss_hor) - (bx >> ss_hor),
-        b_dim[0] as libc::c_int + ss_hor >> ss_hor,
+        b_dim[0] + ss_hor >> ss_hor,
     );
     let cbh4 = std::cmp::min(
         (ih + ss_ver >> ss_ver) - (by >> ss_ver),
-        b_dim[1] as libc::c_int + ss_ver >> ss_ver,
+        b_dim[1] + ss_ver >> ss_ver,
     );
     if cbw4 == 0 || cbh4 == 0 {
         return;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -454,11 +454,11 @@ pub unsafe fn dav1d_create_lf_mask_intra(
     let ss_hor = (layout != DAV1D_PIXEL_LAYOUT_I444) as usize;
     let cbw4 = std::cmp::min(
         (iw + ss_hor >> ss_hor) - (bx >> ss_hor),
-        b_dim[0] + ss_hor >> ss_hor,
+        (b_dim[0] + ss_hor) >> ss_hor,
     );
     let cbh4 = std::cmp::min(
         (ih + ss_ver >> ss_ver) - (by >> ss_ver),
-        b_dim[1] + ss_ver >> ss_ver,
+        (b_dim[1] + ss_ver) >> ss_ver,
     );
     if cbw4 == 0 || cbh4 == 0 {
         return;
@@ -546,11 +546,11 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     let ss_hor = (layout != DAV1D_PIXEL_LAYOUT_I444) as usize;
     let cbw4 = std::cmp::min(
         (iw + ss_hor >> ss_hor) - (bx >> ss_hor),
-        b_dim[0] + ss_hor >> ss_hor,
+        (b_dim[0] + ss_hor) >> ss_hor,
     );
     let cbh4 = std::cmp::min(
         (ih + ss_ver >> ss_ver) - (by >> ss_ver),
-        b_dim[1] + ss_ver >> ss_ver,
+        (b_dim[1] + ss_ver) >> ss_ver,
     );
     if cbw4 == 0 || cbh4 == 0 {
         return;


### PR DESCRIPTION
In 529ed6f159eda299b24f6640abc4895fe74115c3, I had to do something similar to #264 to remove the UB.

The remaining unsafety besides calls to other `unsafe fn`s is from `level_cache` (9bb20b40327b062bc50f7f4aaf6f12795c8505b5).  Passing it as a slice would require making `Dav1dFrameContext_lf::level` a `Vec`, which I can do (and have done), but it's a much more involved refactor, and it results in warnings due to `Vec`s passing over FFI, so we should remove unnecessary FFI calls first.