### PR TITLE
`pal_idx`: Make a safe slice

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1798,11 +1798,7 @@ unsafe fn order_palette(
 ) {
     let mut have_top = i > first;
 
-    let mut pal_idx = pal_idx
-        .as_ptr()
-        .offset((first + (i - first) * stride) as isize);
-
-    let stride = stride as isize;
+    let mut offset = first + (i - first) * stride;
 
     for ((ctx, order), j) in ctx
         .iter_mut()
@@ -1824,14 +1820,14 @@ unsafe fn order_palette(
 
         if !have_left {
             *ctx = 0;
-            add(*pal_idx.offset(-stride));
+            add(pal_idx[offset - stride]);
         } else if !have_top {
             *ctx = 0;
-            add(*pal_idx.offset(-1));
+            add(pal_idx[offset - 1]);
         } else {
-            let l = *pal_idx.offset(-1);
-            let t = *pal_idx.offset(-stride);
-            let tl = *pal_idx.offset(-(stride + 1));
+            let l = pal_idx[offset - 1];
+            let t = pal_idx[offset - stride];
+            let tl = pal_idx[offset - (stride + 1)];
             let same_t_l = t == l;
             let same_t_tl = t == tl;
             let same_l_tl = l == tl;
@@ -1863,7 +1859,7 @@ unsafe fn order_palette(
         }
         assert!(o_idx == u8::BITS as usize);
         have_top = true;
-        pal_idx = pal_idx.offset(stride - 1);
+        offset += stride - 1;
     }
 }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1906,8 +1906,10 @@ unsafe fn read_pal_indices(
     // fill invisible edges
     if bw4 > w4 {
         for y in 0..4 * h4 {
-            let filler = pal_idx[y * stride + (4 * w4) - 1];
-            pal_idx[y * stride + (4 * w4)..][..4 * (bw4 - w4)].fill(filler);
+            let offset = y * stride + (4 * w4);
+            let len = 4 * (bw4 - w4);
+            let filler = pal_idx[offset - 1];
+            pal_idx[offset..][..len].fill(filler);
         }
     }
     if h4 < bh4 {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1787,7 +1787,7 @@ unsafe fn read_pal_uv(
     }
 }
 
-unsafe fn order_palette(
+fn order_palette(
     mut pal_idx: &[u8],
     stride: usize,
     i: usize,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1913,14 +1913,12 @@ unsafe fn read_pal_indices(
         }
     }
     if h4 < bh4 {
+        let y_start = h4 * 4;
         let len = bw4 * 4;
-        let src = std::slice::from_raw_parts(
-            pal_idx.as_ptr().offset((stride * (4 * h4 - 1)) as isize),
-            len,
-        );
-        for y in h4 * 4..bh4 * 4 {
-            std::slice::from_raw_parts_mut(pal_idx.as_mut_ptr().offset((y * stride) as isize), len)
-                .copy_from_slice(src);
+        let (src, dests) = pal_idx.split_at_mut(stride * y_start);
+        let src = &src[stride * (y_start - 1)..][..len];
+        for y in 0..(bh4 - h4) * 4 {
+            dests[y * stride..][..len].copy_from_slice(src);
         }
     }
 }


### PR DESCRIPTION
This is mainly done by using `std::slice::from_raw_parts_mut` on `frame_thread.pal_idx` and determining the length by the `frame_thread.pal_idx.offset(len)` call afterward.  Making it safe all the way to the allocation root is a lot more complex.