### PR TITLE
Normalize and deduplicate many of the bitdepth-dependent types

### DIFF
--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -49,7 +49,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut pixel; 3],
+    pub ipred_edge: [*mut libc::c_void; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -10,7 +10,6 @@ extern "C" {
 pub type pixel = uint16_t;
 pub type coef = int32_t;
 use crate::include::stdatomic::atomic_int;
-use crate::include::stdatomic::atomic_uint;
 
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
@@ -95,60 +94,13 @@ use crate::include::dav1d::headers::Dav1dSequenceHeader;
 
 use crate::src::align::Align16;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_lf {
-    pub level: *mut [uint8_t; 4],
-    pub mask: *mut Av1Filter,
-    pub lr_mask: *mut Av1Restoration,
-    pub mask_sz: libc::c_int,
-    pub lr_mask_sz: libc::c_int,
-    pub cdef_buf_plane_sz: [libc::c_int; 2],
-    pub cdef_buf_sbh: libc::c_int,
-    pub lr_buf_plane_sz: [libc::c_int; 2],
-    pub re_sz: libc::c_int,
-    pub lim_lut: Align16<Av1FilterLUT>,
-    pub last_sharpness: libc::c_int,
-    pub lvl: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub tx_lpf_right_edge: [*mut uint8_t; 2],
-    pub cdef_line_buf: *mut uint8_t,
-    pub lr_line_buf: *mut uint8_t,
-    pub cdef_line: [[*mut pixel; 3]; 2],
-    pub cdef_lpf_line: [*mut pixel; 3],
-    pub lr_lpf_line: [*mut pixel; 3],
-    pub start_of_tile_row: *mut uint8_t,
-    pub start_of_tile_row_sz: libc::c_int,
-    pub need_cdef_lpf_copy: libc::c_int,
-    pub p: [*mut pixel; 3],
-    pub sr_p: [*mut pixel; 3],
-    pub mask_ptr: *mut Av1Filter,
-    pub prev_mask_ptr: *mut Av1Filter,
-    pub restore_planes: libc::c_int,
-}
+use crate::src::internal::Dav1dFrameContext_frame_thread;
+use crate::src::internal::Dav1dFrameContext_lf;
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
-use crate::src::lf_mask::Av1Restoration;
+
 use crate::src::lf_mask::Av1RestorationUnit;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_frame_thread {
-    pub next_tile_row: [libc::c_int; 2],
-    pub entropy_progress: atomic_int,
-    pub deblock_progress: atomic_int,
-    pub frame_progress: *mut atomic_uint,
-    pub copy_lpf_progress: *mut atomic_uint,
-    pub b: *mut Av1Block,
-    pub cbi: *mut CodedBlockInfo,
-    pub pal: *mut [[uint16_t; 8]; 3],
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut coef,
-    pub prog_sz: libc::c_int,
-    pub pal_sz: libc::c_int,
-    pub pal_idx_sz: libc::c_int,
-    pub cf_sz: libc::c_int,
-    pub tile_start_off: *mut libc::c_int,
-}
-use crate::src::internal::CodedBlockInfo;
+
 use crate::src::levels::Av1Block;
 use crate::src::refmvs::refmvs_frame;
 
@@ -910,11 +862,11 @@ pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
             && edges as libc::c_uint & CDEF_HAVE_BOTTOM as libc::c_int as libc::c_uint != 0
         {
             let cdef_top_bak: [*mut pixel; 3] = [
-                ((*f).lf.cdef_line[(tf == 0) as libc::c_int as usize][0])
+                ((*f).lf.cdef_line[(tf == 0) as libc::c_int as usize][0] as *mut pixel)
                     .offset(((have_tt * sby * 4) as isize * y_stride) as isize),
-                ((*f).lf.cdef_line[(tf == 0) as libc::c_int as usize][1])
+                ((*f).lf.cdef_line[(tf == 0) as libc::c_int as usize][1] as *mut pixel)
                     .offset(((have_tt * sby * 8) as isize * uv_stride) as isize),
-                ((*f).lf.cdef_line[(tf == 0) as libc::c_int as usize][2])
+                ((*f).lf.cdef_line[(tf == 0) as libc::c_int as usize][2] as *mut pixel)
                     .offset(((have_tt * sby * 8) as isize * uv_stride) as isize),
             ];
             backup2lines(
@@ -1044,36 +996,37 @@ pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
                         } else if sbrow_start != 0 && by == by_start {
                             if resize != 0 {
                                 offset = ((sby - 1) * 4) as isize * y_stride + (bx * 4) as isize;
-                                top = &mut *(*((*f).lf.cdef_lpf_line).as_mut_ptr().offset(0))
-                                    .offset(offset as isize)
-                                    as *mut pixel;
+                                top = &mut *((*((*f).lf.cdef_lpf_line).as_mut_ptr().offset(0))
+                                    as *mut pixel)
+                                    .offset(offset as isize);
                             } else {
                                 offset = (sby * ((4 as libc::c_int) << sb128) - 4) as isize
                                     * y_stride
                                     + (bx * 4) as isize;
-                                top = &mut *(*((*f).lf.lr_lpf_line).as_mut_ptr().offset(0))
-                                    .offset(offset as isize)
-                                    as *mut pixel;
+                                top = &mut *((*((*f).lf.lr_lpf_line).as_mut_ptr().offset(0))
+                                    as *mut pixel)
+                                    .offset(offset as isize);
                             }
                             bot = (bptrs[0]).offset((8 * y_stride) as isize);
                             current_block_84 = 17075014677070940716;
                         } else if sbrow_start == 0 && by + 2 >= by_end {
-                            top = &mut *(*(*((*f).lf.cdef_line).as_mut_ptr().offset(tf as isize))
+                            top = &mut *((*(*((*f).lf.cdef_line).as_mut_ptr().offset(tf as isize))
                                 .as_mut_ptr()
-                                .offset(0))
-                            .offset(((sby * 4) as isize * y_stride + (bx * 4) as isize) as isize)
-                                as *mut pixel;
+                                .offset(0)) as *mut pixel)
+                                .offset(
+                                    ((sby * 4) as isize * y_stride + (bx * 4) as isize) as isize,
+                                );
                             if resize != 0 {
                                 offset = (sby * 4 + 2) as isize * y_stride + (bx * 4) as isize;
-                                bot = &mut *(*((*f).lf.cdef_lpf_line).as_mut_ptr().offset(0))
-                                    .offset(offset as isize)
-                                    as *mut pixel;
+                                bot = &mut *((*((*f).lf.cdef_lpf_line).as_mut_ptr().offset(0))
+                                    as *mut pixel)
+                                    .offset(offset as isize);
                             } else {
                                 let line = sby * ((4 as libc::c_int) << sb128) + 4 * sb128 + 2;
                                 offset = line as isize * y_stride + (bx * 4) as isize;
-                                bot = &mut *(*((*f).lf.lr_lpf_line).as_mut_ptr().offset(0))
-                                    .offset(offset as isize)
-                                    as *mut pixel;
+                                bot = &mut *((*((*f).lf.lr_lpf_line).as_mut_ptr().offset(0))
+                                    as *mut pixel)
+                                    .offset(offset as isize);
                             }
                             current_block_84 = 17075014677070940716;
                         } else {
@@ -1082,13 +1035,15 @@ pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
                         match current_block_84 {
                             17728966195399430138 => {
                                 offset = (sby * 4) as isize * y_stride;
-                                top = &mut *(*(*((*f).lf.cdef_line)
+                                top = &mut *((*(*((*f).lf.cdef_line)
                                     .as_mut_ptr()
                                     .offset(tf as isize))
                                 .as_mut_ptr()
                                 .offset(0))
-                                .offset((have_tt as isize * offset + (bx * 4) as isize) as isize)
-                                    as *mut pixel;
+                                    as *mut pixel)
+                                    .offset(
+                                        (have_tt as isize * offset + (bx * 4) as isize) as isize,
+                                    );
                                 bot = (bptrs[0]).offset((8 * y_stride) as isize);
                             }
                             _ => {}
@@ -1146,20 +1101,20 @@ pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
                                     if resize != 0 {
                                         offset = ((sby - 1) * 4) as isize * uv_stride
                                             + (bx * 4 >> ss_hor) as isize;
-                                        top = &mut *(*((*f).lf.cdef_lpf_line)
+                                        top = &mut *((*((*f).lf.cdef_lpf_line)
                                             .as_mut_ptr()
                                             .offset(pl as isize))
-                                        .offset(offset as isize)
-                                            as *mut pixel;
+                                            as *mut pixel)
+                                            .offset(offset as isize);
                                     } else {
                                         let line_0 = sby * ((4 as libc::c_int) << sb128) - 4;
                                         offset = line_0 as isize * uv_stride
                                             + (bx * 4 >> ss_hor) as isize;
-                                        top = &mut *(*((*f).lf.lr_lpf_line)
+                                        top = &mut *((*((*f).lf.lr_lpf_line)
                                             .as_mut_ptr()
                                             .offset(pl as isize))
-                                        .offset(offset as isize)
-                                            as *mut pixel;
+                                            as *mut pixel)
+                                            .offset(offset as isize);
                                     }
                                     bot = (bptrs[pl as usize])
                                         .offset(((8 >> ss_ver) as isize * uv_stride) as isize);
@@ -1167,31 +1122,31 @@ pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
                                 } else if sbrow_start == 0 && by + 2 >= by_end {
                                     let top_offset: ptrdiff_t = (sby * 8) as isize * uv_stride
                                         + (bx * 4 >> ss_hor) as isize;
-                                    top = &mut *(*(*((*f).lf.cdef_line)
+                                    top = &mut *((*(*((*f).lf.cdef_line)
                                         .as_mut_ptr()
                                         .offset(tf as isize))
                                     .as_mut_ptr()
                                     .offset(pl as isize))
-                                    .offset(top_offset as isize)
-                                        as *mut pixel;
+                                        as *mut pixel)
+                                        .offset(top_offset as isize);
                                     if resize != 0 {
                                         offset = (sby * 4 + 2) as isize * uv_stride
                                             + (bx * 4 >> ss_hor) as isize;
-                                        bot = &mut *(*((*f).lf.cdef_lpf_line)
+                                        bot = &mut *((*((*f).lf.cdef_lpf_line)
                                             .as_mut_ptr()
                                             .offset(pl as isize))
-                                        .offset(offset as isize)
-                                            as *mut pixel;
+                                            as *mut pixel)
+                                            .offset(offset as isize);
                                     } else {
                                         let line_1 =
                                             sby * ((4 as libc::c_int) << sb128) + 4 * sb128 + 2;
                                         offset = line_1 as isize * uv_stride
                                             + (bx * 4 >> ss_hor) as isize;
-                                        bot = &mut *(*((*f).lf.lr_lpf_line)
+                                        bot = &mut *((*((*f).lf.lr_lpf_line)
                                             .as_mut_ptr()
                                             .offset(pl as isize))
-                                        .offset(offset as isize)
-                                            as *mut pixel;
+                                            as *mut pixel)
+                                            .offset(offset as isize);
                                     }
                                     current_block_77 = 6540614962658479183;
                                 } else {
@@ -1200,17 +1155,17 @@ pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
                                 match current_block_77 {
                                     5687667889785024198 => {
                                         let offset_0: ptrdiff_t = (sby * 8) as isize * uv_stride;
-                                        top = &mut *(*(*((*f).lf.cdef_line)
+                                        top = &mut *((*(*((*f).lf.cdef_line)
                                             .as_mut_ptr()
                                             .offset(tf as isize))
                                         .as_mut_ptr()
                                         .offset(pl as isize))
-                                        .offset(
-                                            (have_tt as isize * offset_0
-                                                + (bx * 4 >> ss_hor) as isize)
-                                                as isize,
-                                        )
-                                            as *mut pixel;
+                                            as *mut pixel)
+                                            .offset(
+                                                (have_tt as isize * offset_0
+                                                    + (bx * 4 >> ss_hor) as isize)
+                                                    as isize,
+                                            );
                                         bot = (bptrs[pl as usize])
                                             .offset(((8 >> ss_ver) as isize * uv_stride) as isize);
                                     }

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -221,12 +221,7 @@ pub struct Dav1dTileState {
     pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
     pub lr_ref: [*mut Av1RestorationUnit; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState_frame_thread {
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut coef,
-}
+use crate::src::internal::Dav1dTileState_frame_thread;
 use crate::src::internal::Dav1dTileState_tiling;
 
 #[derive(Copy, Clone)]

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -1,7 +1,6 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use crate::src::cdf::CdfContext;
-use crate::src::msac::MsacContext;
+
 use ::libc;
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: size_t) -> *mut libc::c_void;
@@ -99,8 +98,6 @@ use crate::src::internal::Dav1dFrameContext_lf;
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
 
-use crate::src::lf_mask::Av1RestorationUnit;
-
 use crate::src::levels::Av1Block;
 use crate::src::refmvs::refmvs_frame;
 
@@ -156,25 +153,7 @@ use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::internal::Dav1dTaskContext_scratch;
 use crate::src::refmvs::refmvs_tile;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState {
-    pub cdf: CdfContext,
-    pub msac: MsacContext,
-    pub tiling: Dav1dTileState_tiling,
-    pub progress: [atomic_int; 2],
-    pub frame_thread: [Dav1dTileState_frame_thread; 2],
-    pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
-    pub dqmem: [[[uint16_t; 2]; 3]; 8],
-    pub dq: *const [[uint16_t; 2]; 3],
-    pub last_qidx: libc::c_int,
-    pub last_delta_lf: [int8_t; 4],
-    pub lflvlmem: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
-    pub lr_ref: [*mut Av1RestorationUnit; 3],
-}
-use crate::src::internal::Dav1dTileState_frame_thread;
-use crate::src::internal::Dav1dTileState_tiling;
+use crate::src::internal::Dav1dTileState;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -49,7 +49,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut pixel; 3],
+    pub ipred_edge: [*mut libc::c_void; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -1,7 +1,6 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use crate::src::cdf::CdfContext;
-use crate::src::msac::MsacContext;
+
 use ::libc;
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: size_t) -> *mut libc::c_void;
@@ -100,8 +99,6 @@ use crate::src::internal::Dav1dFrameContext_lf;
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
 
-use crate::src::lf_mask::Av1RestorationUnit;
-
 use crate::src::levels::Av1Block;
 use crate::src::refmvs::refmvs_frame;
 
@@ -157,25 +154,7 @@ use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::internal::Dav1dTaskContext_scratch;
 use crate::src::refmvs::refmvs_tile;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState {
-    pub cdf: CdfContext,
-    pub msac: MsacContext,
-    pub tiling: Dav1dTileState_tiling,
-    pub progress: [atomic_int; 2],
-    pub frame_thread: [Dav1dTileState_frame_thread; 2],
-    pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
-    pub dqmem: [[[uint16_t; 2]; 3]; 8],
-    pub dq: *const [[uint16_t; 2]; 3],
-    pub last_qidx: libc::c_int,
-    pub last_delta_lf: [int8_t; 4],
-    pub lflvlmem: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
-    pub lr_ref: [*mut Av1RestorationUnit; 3],
-}
-use crate::src::internal::Dav1dTileState_frame_thread;
-use crate::src::internal::Dav1dTileState_tiling;
+use crate::src::internal::Dav1dTileState;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -222,12 +222,7 @@ pub struct Dav1dTileState {
     pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
     pub lr_ref: [*mut Av1RestorationUnit; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState_frame_thread {
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut coef,
-}
+use crate::src::internal::Dav1dTileState_frame_thread;
 use crate::src::internal::Dav1dTileState_tiling;
 
 #[derive(Copy, Clone)]

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -10,7 +10,6 @@ extern "C" {
 pub type pixel = uint8_t;
 pub type coef = int16_t;
 use crate::include::stdatomic::atomic_int;
-use crate::include::stdatomic::atomic_uint;
 
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
@@ -96,60 +95,13 @@ use crate::include::dav1d::headers::Dav1dSequenceHeader;
 
 use crate::src::align::Align16;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_lf {
-    pub level: *mut [uint8_t; 4],
-    pub mask: *mut Av1Filter,
-    pub lr_mask: *mut Av1Restoration,
-    pub mask_sz: libc::c_int,
-    pub lr_mask_sz: libc::c_int,
-    pub cdef_buf_plane_sz: [libc::c_int; 2],
-    pub cdef_buf_sbh: libc::c_int,
-    pub lr_buf_plane_sz: [libc::c_int; 2],
-    pub re_sz: libc::c_int,
-    pub lim_lut: Align16<Av1FilterLUT>,
-    pub last_sharpness: libc::c_int,
-    pub lvl: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub tx_lpf_right_edge: [*mut uint8_t; 2],
-    pub cdef_line_buf: *mut uint8_t,
-    pub lr_line_buf: *mut uint8_t,
-    pub cdef_line: [[*mut pixel; 3]; 2],
-    pub cdef_lpf_line: [*mut pixel; 3],
-    pub lr_lpf_line: [*mut pixel; 3],
-    pub start_of_tile_row: *mut uint8_t,
-    pub start_of_tile_row_sz: libc::c_int,
-    pub need_cdef_lpf_copy: libc::c_int,
-    pub p: [*mut pixel; 3],
-    pub sr_p: [*mut pixel; 3],
-    pub mask_ptr: *mut Av1Filter,
-    pub prev_mask_ptr: *mut Av1Filter,
-    pub restore_planes: libc::c_int,
-}
+use crate::src::internal::Dav1dFrameContext_frame_thread;
+use crate::src::internal::Dav1dFrameContext_lf;
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
-use crate::src::lf_mask::Av1Restoration;
+
 use crate::src::lf_mask::Av1RestorationUnit;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_frame_thread {
-    pub next_tile_row: [libc::c_int; 2],
-    pub entropy_progress: atomic_int,
-    pub deblock_progress: atomic_int,
-    pub frame_progress: *mut atomic_uint,
-    pub copy_lpf_progress: *mut atomic_uint,
-    pub b: *mut Av1Block,
-    pub cbi: *mut CodedBlockInfo,
-    pub pal: *mut [[uint16_t; 8]; 3],
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut coef,
-    pub prog_sz: libc::c_int,
-    pub pal_sz: libc::c_int,
-    pub pal_idx_sz: libc::c_int,
-    pub cf_sz: libc::c_int,
-    pub tile_start_off: *mut libc::c_int,
-}
-use crate::src::internal::CodedBlockInfo;
+
 use crate::src::levels::Av1Block;
 use crate::src::refmvs::refmvs_frame;
 
@@ -883,11 +835,11 @@ pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
             && edges as libc::c_uint & CDEF_HAVE_BOTTOM as libc::c_int as libc::c_uint != 0
         {
             let cdef_top_bak: [*mut pixel; 3] = [
-                ((*f).lf.cdef_line[(tf == 0) as libc::c_int as usize][0])
+                ((*f).lf.cdef_line[(tf == 0) as libc::c_int as usize][0] as *mut pixel)
                     .offset(((have_tt * sby * 4) as isize * y_stride) as isize),
-                ((*f).lf.cdef_line[(tf == 0) as libc::c_int as usize][1])
+                ((*f).lf.cdef_line[(tf == 0) as libc::c_int as usize][1] as *mut pixel)
                     .offset(((have_tt * sby * 8) as isize * uv_stride) as isize),
-                ((*f).lf.cdef_line[(tf == 0) as libc::c_int as usize][2])
+                ((*f).lf.cdef_line[(tf == 0) as libc::c_int as usize][2] as *mut pixel)
                     .offset(((have_tt * sby * 8) as isize * uv_stride) as isize),
             ];
             backup2lines(
@@ -1016,36 +968,37 @@ pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
                         } else if sbrow_start != 0 && by == by_start {
                             if resize != 0 {
                                 offset = ((sby - 1) * 4) as isize * y_stride + (bx * 4) as isize;
-                                top = &mut *(*((*f).lf.cdef_lpf_line).as_mut_ptr().offset(0))
-                                    .offset(offset as isize)
-                                    as *mut pixel;
+                                top = &mut *((*((*f).lf.cdef_lpf_line).as_mut_ptr().offset(0))
+                                    as *mut pixel)
+                                    .offset(offset as isize);
                             } else {
                                 offset = (sby * ((4 as libc::c_int) << sb128) - 4) as isize
                                     * y_stride
                                     + (bx * 4) as isize;
-                                top = &mut *(*((*f).lf.lr_lpf_line).as_mut_ptr().offset(0))
-                                    .offset(offset as isize)
-                                    as *mut pixel;
+                                top = &mut *((*((*f).lf.lr_lpf_line).as_mut_ptr().offset(0))
+                                    as *mut pixel)
+                                    .offset(offset as isize);
                             }
                             bot = (bptrs[0]).offset((8 * y_stride) as isize);
                             current_block_84 = 17075014677070940716;
                         } else if sbrow_start == 0 && by + 2 >= by_end {
-                            top = &mut *(*(*((*f).lf.cdef_line).as_mut_ptr().offset(tf as isize))
+                            top = &mut *((*(*((*f).lf.cdef_line).as_mut_ptr().offset(tf as isize))
                                 .as_mut_ptr()
-                                .offset(0))
-                            .offset(((sby * 4) as isize * y_stride + (bx * 4) as isize) as isize)
-                                as *mut pixel;
+                                .offset(0)) as *mut pixel)
+                                .offset(
+                                    ((sby * 4) as isize * y_stride + (bx * 4) as isize) as isize,
+                                );
                             if resize != 0 {
                                 offset = (sby * 4 + 2) as isize * y_stride + (bx * 4) as isize;
-                                bot = &mut *(*((*f).lf.cdef_lpf_line).as_mut_ptr().offset(0))
-                                    .offset(offset as isize)
-                                    as *mut pixel;
+                                bot = &mut *((*((*f).lf.cdef_lpf_line).as_mut_ptr().offset(0))
+                                    as *mut pixel)
+                                    .offset(offset as isize);
                             } else {
                                 let line = sby * ((4 as libc::c_int) << sb128) + 4 * sb128 + 2;
                                 offset = line as isize * y_stride + (bx * 4) as isize;
-                                bot = &mut *(*((*f).lf.lr_lpf_line).as_mut_ptr().offset(0))
-                                    .offset(offset as isize)
-                                    as *mut pixel;
+                                bot = &mut *((*((*f).lf.lr_lpf_line).as_mut_ptr().offset(0))
+                                    as *mut pixel)
+                                    .offset(offset as isize);
                             }
                             current_block_84 = 17075014677070940716;
                         } else {
@@ -1054,13 +1007,15 @@ pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
                         match current_block_84 {
                             17728966195399430138 => {
                                 offset = (sby * 4) as isize * y_stride;
-                                top = &mut *(*(*((*f).lf.cdef_line)
+                                top = &mut *((*(*((*f).lf.cdef_line)
                                     .as_mut_ptr()
                                     .offset(tf as isize))
                                 .as_mut_ptr()
                                 .offset(0))
-                                .offset((have_tt as isize * offset + (bx * 4) as isize) as isize)
-                                    as *mut pixel;
+                                    as *mut pixel)
+                                    .offset(
+                                        (have_tt as isize * offset + (bx * 4) as isize) as isize,
+                                    );
                                 bot = (bptrs[0]).offset((8 * y_stride) as isize);
                             }
                             _ => {}
@@ -1116,20 +1071,20 @@ pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
                                     if resize != 0 {
                                         offset = ((sby - 1) * 4) as isize * uv_stride
                                             + (bx * 4 >> ss_hor) as isize;
-                                        top = &mut *(*((*f).lf.cdef_lpf_line)
+                                        top = &mut *((*((*f).lf.cdef_lpf_line)
                                             .as_mut_ptr()
                                             .offset(pl as isize))
-                                        .offset(offset as isize)
-                                            as *mut pixel;
+                                            as *mut pixel)
+                                            .offset(offset as isize);
                                     } else {
                                         let line_0 = sby * ((4 as libc::c_int) << sb128) - 4;
                                         offset = line_0 as isize * uv_stride
                                             + (bx * 4 >> ss_hor) as isize;
-                                        top = &mut *(*((*f).lf.lr_lpf_line)
+                                        top = &mut *((*((*f).lf.lr_lpf_line)
                                             .as_mut_ptr()
                                             .offset(pl as isize))
-                                        .offset(offset as isize)
-                                            as *mut pixel;
+                                            as *mut pixel)
+                                            .offset(offset as isize);
                                     }
                                     bot = (bptrs[pl as usize])
                                         .offset(((8 >> ss_ver) as isize * uv_stride) as isize);
@@ -1137,31 +1092,31 @@ pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
                                 } else if sbrow_start == 0 && by + 2 >= by_end {
                                     let top_offset: ptrdiff_t = (sby * 8) as isize * uv_stride
                                         + (bx * 4 >> ss_hor) as isize;
-                                    top = &mut *(*(*((*f).lf.cdef_line)
+                                    top = &mut *((*(*((*f).lf.cdef_line)
                                         .as_mut_ptr()
                                         .offset(tf as isize))
                                     .as_mut_ptr()
                                     .offset(pl as isize))
-                                    .offset(top_offset as isize)
-                                        as *mut pixel;
+                                        as *mut pixel)
+                                        .offset(top_offset as isize);
                                     if resize != 0 {
                                         offset = (sby * 4 + 2) as isize * uv_stride
                                             + (bx * 4 >> ss_hor) as isize;
-                                        bot = &mut *(*((*f).lf.cdef_lpf_line)
+                                        bot = &mut *((*((*f).lf.cdef_lpf_line)
                                             .as_mut_ptr()
                                             .offset(pl as isize))
-                                        .offset(offset as isize)
-                                            as *mut pixel;
+                                            as *mut pixel)
+                                            .offset(offset as isize);
                                     } else {
                                         let line_1 =
                                             sby * ((4 as libc::c_int) << sb128) + 4 * sb128 + 2;
                                         offset = line_1 as isize * uv_stride
                                             + (bx * 4 >> ss_hor) as isize;
-                                        bot = &mut *(*((*f).lf.lr_lpf_line)
+                                        bot = &mut *((*((*f).lf.lr_lpf_line)
                                             .as_mut_ptr()
                                             .offset(pl as isize))
-                                        .offset(offset as isize)
-                                            as *mut pixel;
+                                            as *mut pixel)
+                                            .offset(offset as isize);
                                     }
                                     current_block_77 = 6540614962658479183;
                                 } else {
@@ -1170,17 +1125,17 @@ pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
                                 match current_block_77 {
                                     5687667889785024198 => {
                                         let offset_0: ptrdiff_t = (sby * 8) as isize * uv_stride;
-                                        top = &mut *(*(*((*f).lf.cdef_line)
+                                        top = &mut *((*(*((*f).lf.cdef_line)
                                             .as_mut_ptr()
                                             .offset(tf as isize))
                                         .as_mut_ptr()
                                         .offset(pl as isize))
-                                        .offset(
-                                            (have_tt as isize * offset_0
-                                                + (bx * 4 >> ss_hor) as isize)
-                                                as isize,
-                                        )
-                                            as *mut pixel;
+                                            as *mut pixel)
+                                            .offset(
+                                                (have_tt as isize * offset_0
+                                                    + (bx * 4 >> ss_hor) as isize)
+                                                    as isize,
+                                            );
                                         bot = (bptrs[pl as usize])
                                             .offset(((8 >> ss_ver) as isize * uv_stride) as isize);
                                     }

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -222,12 +222,7 @@ pub struct Dav1dTileState {
     pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
     pub lr_ref: [*mut Av1RestorationUnit; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState_frame_thread {
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut libc::c_void,
-}
+use crate::src::internal::Dav1dTileState_frame_thread;
 use crate::src::internal::Dav1dTileState_tiling;
 
 #[derive(Copy, Clone)]

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -94,62 +94,15 @@ use crate::include::dav1d::headers::Dav1dSequenceHeader;
 
 use crate::src::align::Align16;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_lf {
-    pub level: *mut [uint8_t; 4],
-    pub mask: *mut Av1Filter,
-    pub lr_mask: *mut Av1Restoration,
-    pub mask_sz: libc::c_int,
-    pub lr_mask_sz: libc::c_int,
-    pub cdef_buf_plane_sz: [libc::c_int; 2],
-    pub cdef_buf_sbh: libc::c_int,
-    pub lr_buf_plane_sz: [libc::c_int; 2],
-    pub re_sz: libc::c_int,
-    pub lim_lut: Align16<Av1FilterLUT>,
-    pub last_sharpness: libc::c_int,
-    pub lvl: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub tx_lpf_right_edge: [*mut uint8_t; 2],
-    pub cdef_line_buf: *mut uint8_t,
-    pub lr_line_buf: *mut uint8_t,
-    pub cdef_line: [[*mut libc::c_void; 3]; 2],
-    pub cdef_lpf_line: [*mut libc::c_void; 3],
-    pub lr_lpf_line: [*mut libc::c_void; 3],
-    pub start_of_tile_row: *mut uint8_t,
-    pub start_of_tile_row_sz: libc::c_int,
-    pub need_cdef_lpf_copy: libc::c_int,
-    pub p: [*mut libc::c_void; 3],
-    pub sr_p: [*mut libc::c_void; 3],
-    pub mask_ptr: *mut Av1Filter,
-    pub prev_mask_ptr: *mut Av1Filter,
-    pub restore_planes: libc::c_int,
-}
+use crate::src::internal::Dav1dFrameContext_lf;
 use crate::src::lf_mask::Av1Filter;
 pub type pixel = ();
 use crate::src::lf_mask::Av1FilterLUT;
-use crate::src::lf_mask::Av1Restoration;
+
+use crate::src::internal::Dav1dFrameContext_frame_thread;
 use crate::src::lf_mask::Av1RestorationUnit;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_frame_thread {
-    pub next_tile_row: [libc::c_int; 2],
-    pub entropy_progress: atomic_int,
-    pub deblock_progress: atomic_int,
-    pub frame_progress: *mut atomic_uint,
-    pub copy_lpf_progress: *mut atomic_uint,
-    pub b: *mut Av1Block,
-    pub cbi: *mut CodedBlockInfo,
-    pub pal: *mut [[uint16_t; 8]; 3],
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut libc::c_void,
-    pub prog_sz: libc::c_int,
-    pub pal_sz: libc::c_int,
-    pub pal_idx_sz: libc::c_int,
-    pub cf_sz: libc::c_int,
-    pub tile_start_off: *mut libc::c_int,
-}
 pub type coef = ();
-use crate::src::internal::CodedBlockInfo;
+
 use crate::src::levels::Av1Block;
 use crate::src::refmvs::refmvs_frame;
 

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -1,7 +1,7 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 use crate::src::align::*;
-use crate::src::msac::MsacContext;
+
 use ::libc;
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
@@ -100,7 +100,7 @@ pub type pixel = ();
 use crate::src::lf_mask::Av1FilterLUT;
 
 use crate::src::internal::Dav1dFrameContext_frame_thread;
-use crate::src::lf_mask::Av1RestorationUnit;
+
 pub type coef = ();
 
 use crate::src::levels::Av1Block;
@@ -158,25 +158,7 @@ use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::internal::Dav1dTaskContext_scratch;
 use crate::src::refmvs::refmvs_tile;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState {
-    pub cdf: CdfContext,
-    pub msac: MsacContext,
-    pub tiling: Dav1dTileState_tiling,
-    pub progress: [atomic_int; 2],
-    pub frame_thread: [Dav1dTileState_frame_thread; 2],
-    pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
-    pub dqmem: [[[uint16_t; 2]; 3]; 8],
-    pub dq: *const [[uint16_t; 2]; 3],
-    pub last_qidx: libc::c_int,
-    pub last_delta_lf: [int8_t; 4],
-    pub lflvlmem: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
-    pub lr_ref: [*mut Av1RestorationUnit; 3],
-}
-use crate::src::internal::Dav1dTileState_frame_thread;
-use crate::src::internal::Dav1dTileState_tiling;
+use crate::src::internal::Dav1dTileState;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -328,60 +328,13 @@ use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
 
 use crate::include::pthread::pthread_cond_t;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_lf {
-    pub level: *mut [uint8_t; 4],
-    pub mask: *mut Av1Filter,
-    pub lr_mask: *mut Av1Restoration,
-    pub mask_sz: libc::c_int,
-    pub lr_mask_sz: libc::c_int,
-    pub cdef_buf_plane_sz: [libc::c_int; 2],
-    pub cdef_buf_sbh: libc::c_int,
-    pub lr_buf_plane_sz: [libc::c_int; 2],
-    pub re_sz: libc::c_int,
-    pub lim_lut: Align16<Av1FilterLUT>,
-    pub last_sharpness: libc::c_int,
-    pub lvl: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub tx_lpf_right_edge: [*mut uint8_t; 2],
-    pub cdef_line_buf: *mut uint8_t,
-    pub lr_line_buf: *mut uint8_t,
-    pub cdef_line: [[*mut libc::c_void; 3]; 2],
-    pub cdef_lpf_line: [*mut libc::c_void; 3],
-    pub lr_lpf_line: [*mut libc::c_void; 3],
-    pub start_of_tile_row: *mut uint8_t,
-    pub start_of_tile_row_sz: libc::c_int,
-    pub need_cdef_lpf_copy: libc::c_int,
-    pub p: [*mut libc::c_void; 3],
-    pub sr_p: [*mut libc::c_void; 3],
-    pub mask_ptr: *mut Av1Filter,
-    pub prev_mask_ptr: *mut Av1Filter,
-    pub restore_planes: libc::c_int,
-}
+use crate::src::internal::Dav1dFrameContext_lf;
 use crate::src::lf_mask::Av1Filter;
 pub type pixel = ();
+use crate::src::internal::Dav1dFrameContext_frame_thread;
 use crate::src::lf_mask::Av1FilterLUT;
 use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_frame_thread {
-    pub next_tile_row: [libc::c_int; 2],
-    pub entropy_progress: atomic_int,
-    pub deblock_progress: atomic_int,
-    pub frame_progress: *mut atomic_uint,
-    pub copy_lpf_progress: *mut atomic_uint,
-    pub b: *mut Av1Block,
-    pub cbi: *mut CodedBlockInfo,
-    pub pal: *mut [[uint16_t; 8]; 3],
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut libc::c_void,
-    pub prog_sz: libc::c_int,
-    pub pal_sz: libc::c_int,
-    pub pal_idx_sz: libc::c_int,
-    pub cf_sz: libc::c_int,
-    pub tile_start_off: *mut libc::c_int,
-}
 pub type coef = ();
 use crate::src::internal::CodedBlockInfo;
 use crate::src::levels::Av1Block;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5,7 +5,7 @@ use crate::include::stdint::*;
 use crate::src::align::Align16;
 use crate::src::cdf::{CdfContext, CdfMvComponent, CdfMvContext};
 use crate::src::ctx::{case_set, case_set_upto16, SetCtxFn};
-use crate::src::msac::MsacContext;
+
 use libc;
 
 extern "C" {
@@ -434,25 +434,7 @@ use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::internal::Dav1dTaskContext_scratch;
 use crate::src::refmvs::refmvs_tile;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState {
-    pub cdf: CdfContext,
-    pub msac: MsacContext,
-    pub tiling: Dav1dTileState_tiling,
-    pub progress: [atomic_int; 2],
-    pub frame_thread: [Dav1dTileState_frame_thread; 2],
-    pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
-    pub dqmem: [[[uint16_t; 2]; 3]; 8],
-    pub dq: *const [[uint16_t; 2]; 3],
-    pub last_qidx: libc::c_int,
-    pub last_delta_lf: [int8_t; 4],
-    pub lflvlmem: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
-    pub lr_ref: [*mut Av1RestorationUnit; 3],
-}
-use crate::src::internal::Dav1dTileState_frame_thread;
-use crate::src::internal::Dav1dTileState_tiling;
+use crate::src::internal::Dav1dTileState;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -498,12 +498,7 @@ pub struct Dav1dTileState {
     pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
     pub lr_ref: [*mut Av1RestorationUnit; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState_frame_thread {
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut libc::c_void,
-}
+use crate::src::internal::Dav1dTileState_frame_thread;
 use crate::src::internal::Dav1dTileState_tiling;
 
 #[derive(Copy, Clone)]

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -13,6 +13,10 @@ use crate::src::align::*;
 use crate::src::intra_edge::EdgeBranch;
 use crate::src::intra_edge::EdgeNode;
 use crate::src::intra_edge::EdgeTip;
+use crate::src::levels::Av1Block;
+use crate::src::lf_mask::Av1Filter;
+use crate::src::lf_mask::Av1FilterLUT;
+use crate::src::lf_mask::Av1Restoration;
 use crate::src::picture::Dav1dThreadPicture;
 use crate::src::r#ref::Dav1dRef;
 use crate::src::thread_data::thread_data;
@@ -136,6 +140,57 @@ pub struct ScalableMotionParams {
 pub struct CodedBlockInfo {
     pub eob: [int16_t; 3],
     pub txtp: [uint8_t; 3],
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Dav1dFrameContext_frame_thread {
+    pub next_tile_row: [libc::c_int; 2],
+    pub entropy_progress: atomic_int,
+    pub deblock_progress: atomic_int,
+    pub frame_progress: *mut atomic_uint,
+    pub copy_lpf_progress: *mut atomic_uint,
+    pub b: *mut Av1Block,
+    pub cbi: *mut CodedBlockInfo,
+    pub pal: *mut [[uint16_t; 8]; 3],
+    pub pal_idx: *mut uint8_t,
+    pub cf: *mut libc::c_void,
+    pub prog_sz: libc::c_int,
+    pub pal_sz: libc::c_int,
+    pub pal_idx_sz: libc::c_int,
+    pub cf_sz: libc::c_int,
+    pub tile_start_off: *mut libc::c_int,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Dav1dFrameContext_lf {
+    pub level: *mut [uint8_t; 4],
+    pub mask: *mut Av1Filter,
+    pub lr_mask: *mut Av1Restoration,
+    pub mask_sz: libc::c_int,
+    pub lr_mask_sz: libc::c_int,
+    pub cdef_buf_plane_sz: [libc::c_int; 2],
+    pub cdef_buf_sbh: libc::c_int,
+    pub lr_buf_plane_sz: [libc::c_int; 2],
+    pub re_sz: libc::c_int,
+    pub lim_lut: Align16<Av1FilterLUT>,
+    pub last_sharpness: libc::c_int,
+    pub lvl: [[[[uint8_t; 2]; 8]; 4]; 8],
+    pub tx_lpf_right_edge: [*mut uint8_t; 2],
+    pub cdef_line_buf: *mut uint8_t,
+    pub lr_line_buf: *mut uint8_t,
+    pub cdef_line: [[*mut libc::c_void; 3]; 2],
+    pub cdef_lpf_line: [*mut libc::c_void; 3],
+    pub lr_lpf_line: [*mut libc::c_void; 3],
+    pub start_of_tile_row: *mut uint8_t,
+    pub start_of_tile_row_sz: libc::c_int,
+    pub need_cdef_lpf_copy: libc::c_int,
+    pub p: [*mut libc::c_void; 3],
+    pub sr_p: [*mut libc::c_void; 3],
+    pub mask_ptr: *mut Av1Filter,
+    pub prev_mask_ptr: *mut Av1Filter,
+    pub restore_planes: libc::c_int,
 }
 
 #[derive(Copy, Clone)]

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -10,6 +10,7 @@ use crate::include::stdint::int8_t;
 use crate::include::stdint::uint16_t;
 use crate::include::stdint::uint8_t;
 use crate::src::align::*;
+use crate::src::cdf::CdfContext;
 use crate::src::intra_edge::EdgeBranch;
 use crate::src::intra_edge::EdgeNode;
 use crate::src::intra_edge::EdgeTip;
@@ -17,6 +18,8 @@ use crate::src::levels::Av1Block;
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
 use crate::src::lf_mask::Av1Restoration;
+use crate::src::lf_mask::Av1RestorationUnit;
+use crate::src::msac::MsacContext;
 use crate::src::picture::Dav1dThreadPicture;
 use crate::src::r#ref::Dav1dRef;
 use crate::src::thread_data::thread_data;
@@ -248,6 +251,24 @@ pub struct Dav1dTileState_tiling {
 pub struct Dav1dTileState_frame_thread {
     pub pal_idx: *mut uint8_t,
     pub cf: *mut libc::c_void,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Dav1dTileState {
+    pub cdf: CdfContext,
+    pub msac: MsacContext,
+    pub tiling: Dav1dTileState_tiling,
+    pub progress: [atomic_int; 2],
+    pub frame_thread: [Dav1dTileState_frame_thread; 2],
+    pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
+    pub dqmem: [[[uint16_t; 2]; 3]; 8],
+    pub dq: *const [[uint16_t; 2]; 3],
+    pub last_qidx: libc::c_int,
+    pub last_delta_lf: [int8_t; 4],
+    pub lflvlmem: [[[[uint8_t; 2]; 8]; 4]; 8],
+    pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
+    pub lr_ref: [*mut Av1RestorationUnit; 3],
 }
 
 #[derive(Copy, Clone)]

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -189,6 +189,13 @@ pub struct Dav1dTileState_tiling {
 }
 
 #[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Dav1dTileState_frame_thread {
+    pub pal_idx: *mut uint8_t,
+    pub cf: *mut libc::c_void,
+}
+
+#[derive(Copy, Clone)]
 #[repr(C, align(64))]
 pub union Dav1dTaskContext_cf {
     pub cf_8bpc: [int16_t; 1024],

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -49,7 +49,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut pixel; 3],
+    pub ipred_edge: [*mut libc::c_void; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -1,7 +1,6 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use crate::src::cdf::CdfContext;
-use crate::src::msac::MsacContext;
+
 use ::libc;
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: size_t) -> *mut libc::c_void;
@@ -95,7 +94,6 @@ use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
 
 use crate::src::internal::Dav1dFrameContext_frame_thread;
-use crate::src::lf_mask::Av1RestorationUnit;
 
 use crate::src::levels::Av1Block;
 use crate::src::refmvs::refmvs_frame;
@@ -152,25 +150,7 @@ use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::internal::Dav1dTaskContext_scratch;
 use crate::src::refmvs::refmvs_tile;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState {
-    pub cdf: CdfContext,
-    pub msac: MsacContext,
-    pub tiling: Dav1dTileState_tiling,
-    pub progress: [atomic_int; 2],
-    pub frame_thread: [Dav1dTileState_frame_thread; 2],
-    pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
-    pub dqmem: [[[uint16_t; 2]; 3]; 8],
-    pub dq: *const [[uint16_t; 2]; 3],
-    pub last_qidx: libc::c_int,
-    pub last_delta_lf: [int8_t; 4],
-    pub lflvlmem: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
-    pub lr_ref: [*mut Av1RestorationUnit; 3],
-}
-use crate::src::internal::Dav1dTileState_frame_thread;
-use crate::src::internal::Dav1dTileState_tiling;
+use crate::src::internal::Dav1dTileState;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -219,12 +219,7 @@ pub struct Dav1dTileState {
     pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
     pub lr_ref: [*mut Av1RestorationUnit; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState_frame_thread {
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut coef,
-}
+use crate::src::internal::Dav1dTileState_frame_thread;
 use crate::src::internal::Dav1dTileState_tiling;
 
 #[derive(Copy, Clone)]

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -49,7 +49,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut pixel; 3],
+    pub ipred_edge: [*mut libc::c_void; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -1,7 +1,6 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use crate::src::cdf::CdfContext;
-use crate::src::msac::MsacContext;
+
 use ::libc;
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: size_t) -> *mut libc::c_void;
@@ -96,7 +95,6 @@ use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
 
 use crate::src::internal::Dav1dFrameContext_frame_thread;
-use crate::src::lf_mask::Av1RestorationUnit;
 
 use crate::src::levels::Av1Block;
 use crate::src::refmvs::refmvs_frame;
@@ -153,25 +151,7 @@ use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::internal::Dav1dTaskContext_scratch;
 use crate::src::refmvs::refmvs_tile;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState {
-    pub cdf: CdfContext,
-    pub msac: MsacContext,
-    pub tiling: Dav1dTileState_tiling,
-    pub progress: [atomic_int; 2],
-    pub frame_thread: [Dav1dTileState_frame_thread; 2],
-    pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
-    pub dqmem: [[[uint16_t; 2]; 3]; 8],
-    pub dq: *const [[uint16_t; 2]; 3],
-    pub last_qidx: libc::c_int,
-    pub last_delta_lf: [int8_t; 4],
-    pub lflvlmem: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
-    pub lr_ref: [*mut Av1RestorationUnit; 3],
-}
-use crate::src::internal::Dav1dTileState_frame_thread;
-use crate::src::internal::Dav1dTileState_tiling;
+use crate::src::internal::Dav1dTileState;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -10,7 +10,6 @@ extern "C" {
 pub type pixel = uint8_t;
 pub type coef = int16_t;
 use crate::include::stdatomic::atomic_int;
-use crate::include::stdatomic::atomic_uint;
 
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
@@ -92,62 +91,13 @@ use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
 
-use crate::src::align::Align16;
-
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_lf {
-    pub level: *mut [uint8_t; 4],
-    pub mask: *mut Av1Filter,
-    pub lr_mask: *mut Av1Restoration,
-    pub mask_sz: libc::c_int,
-    pub lr_mask_sz: libc::c_int,
-    pub cdef_buf_plane_sz: [libc::c_int; 2],
-    pub cdef_buf_sbh: libc::c_int,
-    pub lr_buf_plane_sz: [libc::c_int; 2],
-    pub re_sz: libc::c_int,
-    pub lim_lut: Align16<Av1FilterLUT>,
-    pub last_sharpness: libc::c_int,
-    pub lvl: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub tx_lpf_right_edge: [*mut uint8_t; 2],
-    pub cdef_line_buf: *mut uint8_t,
-    pub lr_line_buf: *mut uint8_t,
-    pub cdef_line: [[*mut pixel; 3]; 2],
-    pub cdef_lpf_line: [*mut pixel; 3],
-    pub lr_lpf_line: [*mut pixel; 3],
-    pub start_of_tile_row: *mut uint8_t,
-    pub start_of_tile_row_sz: libc::c_int,
-    pub need_cdef_lpf_copy: libc::c_int,
-    pub p: [*mut pixel; 3],
-    pub sr_p: [*mut pixel; 3],
-    pub mask_ptr: *mut Av1Filter,
-    pub prev_mask_ptr: *mut Av1Filter,
-    pub restore_planes: libc::c_int,
-}
+use crate::src::internal::Dav1dFrameContext_lf;
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
-use crate::src::lf_mask::Av1Restoration;
+
+use crate::src::internal::Dav1dFrameContext_frame_thread;
 use crate::src::lf_mask::Av1RestorationUnit;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_frame_thread {
-    pub next_tile_row: [libc::c_int; 2],
-    pub entropy_progress: atomic_int,
-    pub deblock_progress: atomic_int,
-    pub frame_progress: *mut atomic_uint,
-    pub copy_lpf_progress: *mut atomic_uint,
-    pub b: *mut Av1Block,
-    pub cbi: *mut CodedBlockInfo,
-    pub pal: *mut [[uint16_t; 8]; 3],
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut coef,
-    pub prog_sz: libc::c_int,
-    pub pal_sz: libc::c_int,
-    pub pal_idx_sz: libc::c_int,
-    pub cf_sz: libc::c_int,
-    pub tile_start_off: *mut libc::c_int,
-}
-use crate::src::internal::CodedBlockInfo;
+
 use crate::src::levels::Av1Block;
 use crate::src::refmvs::refmvs_frame;
 
@@ -789,9 +739,12 @@ pub unsafe extern "C" fn dav1d_copy_lpf_8bpc(
     let lr_stride: *const ptrdiff_t = ((*f).sr_cur.p.stride).as_mut_ptr();
     let tt_off = have_tt * sby * ((4 as libc::c_int) << (*(*f).seq_hdr).sb128);
     let dst: [*mut pixel; 3] = [
-        ((*f).lf.lr_lpf_line[0]).offset((tt_off as isize * *lr_stride.offset(0)) as isize),
-        ((*f).lf.lr_lpf_line[1]).offset((tt_off as isize * *lr_stride.offset(1)) as isize),
-        ((*f).lf.lr_lpf_line[2]).offset((tt_off as isize * *lr_stride.offset(1)) as isize),
+        ((*f).lf.lr_lpf_line[0] as *mut pixel)
+            .offset((tt_off as isize * *lr_stride.offset(0)) as isize),
+        ((*f).lf.lr_lpf_line[1] as *mut pixel)
+            .offset((tt_off as isize * *lr_stride.offset(1)) as isize),
+        ((*f).lf.lr_lpf_line[2] as *mut pixel)
+            .offset((tt_off as isize * *lr_stride.offset(1)) as isize),
     ];
     let restore_planes = (*f).lf.restore_planes;
     if (*(*f).seq_hdr).cdef != 0 || restore_planes & LR_RESTORE_Y as libc::c_int != 0 {
@@ -820,7 +773,7 @@ pub unsafe extern "C" fn dav1d_copy_lpf_8bpc(
             let cdef_off_y: ptrdiff_t = (sby * 4) as isize * *src_stride.offset(0);
             backup_lpf(
                 f,
-                ((*f).lf.cdef_lpf_line[0]).offset(cdef_off_y as isize),
+                ((*f).lf.cdef_lpf_line[0] as *mut pixel).offset(cdef_off_y as isize),
                 *src_stride.offset(0),
                 (*src.offset(0)).offset(-((offset as isize * *src_stride.offset(0)) as isize)),
                 *src_stride.offset(0),
@@ -874,7 +827,7 @@ pub unsafe extern "C" fn dav1d_copy_lpf_8bpc(
             if have_tt != 0 && resize != 0 {
                 backup_lpf(
                     f,
-                    ((*f).lf.cdef_lpf_line[1]).offset(cdef_off_uv as isize),
+                    ((*f).lf.cdef_lpf_line[1] as *mut pixel).offset(cdef_off_uv as isize),
                     *src_stride.offset(1),
                     (*src.offset(1))
                         .offset(-((offset_uv as isize * *src_stride.offset(1)) as isize)),
@@ -912,7 +865,7 @@ pub unsafe extern "C" fn dav1d_copy_lpf_8bpc(
             if have_tt != 0 && resize != 0 {
                 backup_lpf(
                     f,
-                    ((*f).lf.cdef_lpf_line[2]).offset(cdef_off_uv as isize),
+                    ((*f).lf.cdef_lpf_line[2] as *mut pixel).offset(cdef_off_uv as isize),
                     *src_stride.offset(1),
                     (*src.offset(2))
                         .offset(-((offset_uv as isize * *src_stride.offset(1)) as isize)),

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -220,12 +220,7 @@ pub struct Dav1dTileState {
     pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
     pub lr_ref: [*mut Av1RestorationUnit; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState_frame_thread {
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut coef,
-}
+use crate::src::internal::Dav1dTileState_frame_thread;
 use crate::src::internal::Dav1dTileState_tiling;
 
 #[derive(Copy, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use crate::src::cdf::CdfContext;
-use crate::src::msac::MsacContext;
+
 use crate::stderr;
 use ::libc;
 extern "C" {
@@ -633,28 +632,9 @@ use crate::src::lf_mask::Av1Filter;
 use crate::src::refmvs::refmvs_tile;
 
 use crate::src::env::BlockContext;
+use crate::src::internal::Dav1dTileState;
 use crate::src::refmvs::refmvs_frame;
 use crate::src::refmvs::refmvs_temporal_block;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState {
-    pub cdf: CdfContext,
-    pub msac: MsacContext,
-    pub tiling: Dav1dTileState_tiling,
-    pub progress: [atomic_int; 2],
-    pub frame_thread: [Dav1dTileState_frame_thread; 2],
-    pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
-    pub dqmem: [[[uint16_t; 2]; 3]; 8],
-    pub dq: *const [[uint16_t; 2]; 3],
-    pub last_qidx: libc::c_int,
-    pub last_delta_lf: [int8_t; 4],
-    pub lflvlmem: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
-    pub lr_ref: [*mut Av1RestorationUnit; 3],
-}
-use crate::src::internal::Dav1dTileState_frame_thread;
-use crate::src::internal::Dav1dTileState_tiling;
-use crate::src::lf_mask::Av1RestorationUnit;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -719,59 +719,10 @@ use crate::src::internal::Dav1dFrameContext_task_thread;
 
 use crate::src::internal::Dav1dTask;
 
-use crate::src::align::Align16;
+use crate::src::internal::Dav1dFrameContext_lf;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_lf {
-    pub level: *mut [uint8_t; 4],
-    pub mask: *mut Av1Filter,
-    pub lr_mask: *mut Av1Restoration,
-    pub mask_sz: libc::c_int,
-    pub lr_mask_sz: libc::c_int,
-    pub cdef_buf_plane_sz: [libc::c_int; 2],
-    pub cdef_buf_sbh: libc::c_int,
-    pub lr_buf_plane_sz: [libc::c_int; 2],
-    pub re_sz: libc::c_int,
-    pub lim_lut: Align16<Av1FilterLUT>,
-    pub last_sharpness: libc::c_int,
-    pub lvl: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub tx_lpf_right_edge: [*mut uint8_t; 2],
-    pub cdef_line_buf: *mut uint8_t,
-    pub lr_line_buf: *mut uint8_t,
-    pub cdef_line: [[*mut libc::c_void; 3]; 2],
-    pub cdef_lpf_line: [*mut libc::c_void; 3],
-    pub lr_lpf_line: [*mut libc::c_void; 3],
-    pub start_of_tile_row: *mut uint8_t,
-    pub start_of_tile_row_sz: libc::c_int,
-    pub need_cdef_lpf_copy: libc::c_int,
-    pub p: [*mut libc::c_void; 3],
-    pub sr_p: [*mut libc::c_void; 3],
-    pub mask_ptr: *mut Av1Filter,
-    pub prev_mask_ptr: *mut Av1Filter,
-    pub restore_planes: libc::c_int,
-}
-use crate::src::lf_mask::Av1Restoration;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_frame_thread {
-    pub next_tile_row: [libc::c_int; 2],
-    pub entropy_progress: atomic_int,
-    pub deblock_progress: atomic_int,
-    pub frame_progress: *mut atomic_uint,
-    pub copy_lpf_progress: *mut atomic_uint,
-    pub b: *mut Av1Block,
-    pub cbi: *mut CodedBlockInfo,
-    pub pal: *mut [[uint16_t; 8]; 3],
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut libc::c_void,
-    pub prog_sz: libc::c_int,
-    pub pal_sz: libc::c_int,
-    pub pal_idx_sz: libc::c_int,
-    pub cf_sz: libc::c_int,
-    pub tile_start_off: *mut libc::c_int,
-}
 use crate::src::internal::CodedBlockInfo;
+use crate::src::internal::Dav1dFrameContext_frame_thread;
 use crate::src::levels::Av1Block;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -652,14 +652,9 @@ pub struct Dav1dTileState {
     pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
     pub lr_ref: [*mut Av1RestorationUnit; 3],
 }
-use crate::src::lf_mask::Av1RestorationUnit;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState_frame_thread {
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut libc::c_void,
-}
+use crate::src::internal::Dav1dTileState_frame_thread;
 use crate::src::internal::Dav1dTileState_tiling;
+use crate::src::lf_mask::Av1RestorationUnit;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/log.rs
+++ b/src/log.rs
@@ -461,7 +461,7 @@ pub type generate_grain_uv_fn = Option<
 >;
 pub type generate_grain_y_fn =
     Option<unsafe extern "C" fn(*mut [entry; 82], *const Dav1dFilmGrainData) -> ()>;
-use crate::include::stdatomic::atomic_uint;
+
 use crate::src::cdf::CdfThreadContext;
 
 use crate::src::internal::Dav1dContext_frame_thread;
@@ -588,59 +588,10 @@ pub struct Dav1dFrameContext {
 }
 use crate::src::internal::Dav1dFrameContext_task_thread;
 
-use crate::src::align::Align16;
+use crate::src::internal::Dav1dFrameContext_lf;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_lf {
-    pub level: *mut [uint8_t; 4],
-    pub mask: *mut Av1Filter,
-    pub lr_mask: *mut Av1Restoration,
-    pub mask_sz: libc::c_int,
-    pub lr_mask_sz: libc::c_int,
-    pub cdef_buf_plane_sz: [libc::c_int; 2],
-    pub cdef_buf_sbh: libc::c_int,
-    pub lr_buf_plane_sz: [libc::c_int; 2],
-    pub re_sz: libc::c_int,
-    pub lim_lut: Align16<Av1FilterLUT>,
-    pub last_sharpness: libc::c_int,
-    pub lvl: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub tx_lpf_right_edge: [*mut uint8_t; 2],
-    pub cdef_line_buf: *mut uint8_t,
-    pub lr_line_buf: *mut uint8_t,
-    pub cdef_line: [[*mut libc::c_void; 3]; 2],
-    pub cdef_lpf_line: [*mut libc::c_void; 3],
-    pub lr_lpf_line: [*mut libc::c_void; 3],
-    pub start_of_tile_row: *mut uint8_t,
-    pub start_of_tile_row_sz: libc::c_int,
-    pub need_cdef_lpf_copy: libc::c_int,
-    pub p: [*mut libc::c_void; 3],
-    pub sr_p: [*mut libc::c_void; 3],
-    pub mask_ptr: *mut Av1Filter,
-    pub prev_mask_ptr: *mut Av1Filter,
-    pub restore_planes: libc::c_int,
-}
-use crate::src::lf_mask::Av1Restoration;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_frame_thread {
-    pub next_tile_row: [libc::c_int; 2],
-    pub entropy_progress: atomic_int,
-    pub deblock_progress: atomic_int,
-    pub frame_progress: *mut atomic_uint,
-    pub copy_lpf_progress: *mut atomic_uint,
-    pub b: *mut Av1Block,
-    pub cbi: *mut CodedBlockInfo,
-    pub pal: *mut [[uint16_t; 8]; 3],
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut libc::c_void,
-    pub prog_sz: libc::c_int,
-    pub pal_sz: libc::c_int,
-    pub pal_idx_sz: libc::c_int,
-    pub cf_sz: libc::c_int,
-    pub tile_start_off: *mut libc::c_int,
-}
-use crate::src::internal::CodedBlockInfo;
+use crate::src::internal::Dav1dFrameContext_frame_thread;
+
 use crate::src::levels::Av1Block;
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,7 +1,6 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use crate::src::cdf::CdfContext;
-use crate::src::msac::MsacContext;
+
 use crate::stderr;
 use ::libc;
 extern "C" {
@@ -504,28 +503,9 @@ use crate::src::lf_mask::Av1Filter;
 use crate::src::refmvs::refmvs_tile;
 
 use crate::src::env::BlockContext;
+use crate::src::internal::Dav1dTileState;
 use crate::src::refmvs::refmvs_frame;
 use crate::src::refmvs::refmvs_temporal_block;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState {
-    pub cdf: CdfContext,
-    pub msac: MsacContext,
-    pub tiling: Dav1dTileState_tiling,
-    pub progress: [atomic_int; 2],
-    pub frame_thread: [Dav1dTileState_frame_thread; 2],
-    pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
-    pub dqmem: [[[uint16_t; 2]; 3]; 8],
-    pub dq: *const [[uint16_t; 2]; 3],
-    pub last_qidx: libc::c_int,
-    pub last_delta_lf: [int8_t; 4],
-    pub lflvlmem: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
-    pub lr_ref: [*mut Av1RestorationUnit; 3],
-}
-use crate::src::internal::Dav1dTileState_frame_thread;
-use crate::src::internal::Dav1dTileState_tiling;
-use crate::src::lf_mask::Av1RestorationUnit;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/log.rs
+++ b/src/log.rs
@@ -523,14 +523,9 @@ pub struct Dav1dTileState {
     pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
     pub lr_ref: [*mut Av1RestorationUnit; 3],
 }
-use crate::src::lf_mask::Av1RestorationUnit;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState_frame_thread {
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut libc::c_void,
-}
+use crate::src::internal::Dav1dTileState_frame_thread;
 use crate::src::internal::Dav1dTileState_tiling;
+use crate::src::lf_mask::Av1RestorationUnit;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -51,7 +51,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut pixel; 3],
+    pub ipred_edge: [*mut libc::c_void; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -12,7 +12,6 @@ use crate::src::tables::dav1d_sgr_params;
 pub type pixel = uint16_t;
 pub type coef = int32_t;
 use crate::include::stdatomic::atomic_int;
-use crate::include::stdatomic::atomic_uint;
 
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
@@ -99,60 +98,13 @@ use crate::include::dav1d::headers::Dav1dSequenceHeader;
 
 use crate::src::align::Align16;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_lf {
-    pub level: *mut [uint8_t; 4],
-    pub mask: *mut Av1Filter,
-    pub lr_mask: *mut Av1Restoration,
-    pub mask_sz: libc::c_int,
-    pub lr_mask_sz: libc::c_int,
-    pub cdef_buf_plane_sz: [libc::c_int; 2],
-    pub cdef_buf_sbh: libc::c_int,
-    pub lr_buf_plane_sz: [libc::c_int; 2],
-    pub re_sz: libc::c_int,
-    pub lim_lut: Align16<Av1FilterLUT>,
-    pub last_sharpness: libc::c_int,
-    pub lvl: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub tx_lpf_right_edge: [*mut uint8_t; 2],
-    pub cdef_line_buf: *mut uint8_t,
-    pub lr_line_buf: *mut uint8_t,
-    pub cdef_line: [[*mut pixel; 3]; 2],
-    pub cdef_lpf_line: [*mut pixel; 3],
-    pub lr_lpf_line: [*mut pixel; 3],
-    pub start_of_tile_row: *mut uint8_t,
-    pub start_of_tile_row_sz: libc::c_int,
-    pub need_cdef_lpf_copy: libc::c_int,
-    pub p: [*mut pixel; 3],
-    pub sr_p: [*mut pixel; 3],
-    pub mask_ptr: *mut Av1Filter,
-    pub prev_mask_ptr: *mut Av1Filter,
-    pub restore_planes: libc::c_int,
-}
+use crate::src::internal::Dav1dFrameContext_lf;
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
-use crate::src::lf_mask::Av1Restoration;
+
+use crate::src::internal::Dav1dFrameContext_frame_thread;
 use crate::src::lf_mask::Av1RestorationUnit;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_frame_thread {
-    pub next_tile_row: [libc::c_int; 2],
-    pub entropy_progress: atomic_int,
-    pub deblock_progress: atomic_int,
-    pub frame_progress: *mut atomic_uint,
-    pub copy_lpf_progress: *mut atomic_uint,
-    pub b: *mut Av1Block,
-    pub cbi: *mut CodedBlockInfo,
-    pub pal: *mut [[uint16_t; 8]; 3],
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut coef,
-    pub prog_sz: libc::c_int,
-    pub pal_sz: libc::c_int,
-    pub pal_idx_sz: libc::c_int,
-    pub cf_sz: libc::c_int,
-    pub tile_start_off: *mut libc::c_int,
-}
-use crate::src::internal::CodedBlockInfo;
+
 use crate::src::levels::Av1Block;
 use crate::src::refmvs::refmvs_frame;
 
@@ -731,7 +683,7 @@ unsafe extern "C" fn lr_stripe(
             0 as libc::c_int
         }) >> 6 - ss_ver + (*(*f).seq_hdr).sb128;
     let have_tt = ((*(*f).c).n_tc > 1 as libc::c_uint) as libc::c_int;
-    let mut lpf: *const pixel = ((*f).lf.lr_lpf_line[plane as usize])
+    let mut lpf: *const pixel = ((*f).lf.lr_lpf_line[plane as usize] as *mut pixel)
         .offset(
             ((have_tt * (sby * ((4 as libc::c_int) << (*(*f).seq_hdr).sb128) - 4)) as isize
                 * PXSTRIDE(stride)) as isize,

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -1,7 +1,6 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use crate::src::cdf::CdfContext;
-use crate::src::msac::MsacContext;
+
 use ::libc;
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
@@ -160,25 +159,7 @@ use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::internal::Dav1dTaskContext_scratch;
 use crate::src::refmvs::refmvs_tile;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState {
-    pub cdf: CdfContext,
-    pub msac: MsacContext,
-    pub tiling: Dav1dTileState_tiling,
-    pub progress: [atomic_int; 2],
-    pub frame_thread: [Dav1dTileState_frame_thread; 2],
-    pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
-    pub dqmem: [[[uint16_t; 2]; 3]; 8],
-    pub dq: *const [[uint16_t; 2]; 3],
-    pub last_qidx: libc::c_int,
-    pub last_delta_lf: [int8_t; 4],
-    pub lflvlmem: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
-    pub lr_ref: [*mut Av1RestorationUnit; 3],
-}
-use crate::src::internal::Dav1dTileState_frame_thread;
-use crate::src::internal::Dav1dTileState_tiling;
+use crate::src::internal::Dav1dTileState;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -225,12 +225,7 @@ pub struct Dav1dTileState {
     pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
     pub lr_ref: [*mut Av1RestorationUnit; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState_frame_thread {
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut coef,
-}
+use crate::src::internal::Dav1dTileState_frame_thread;
 use crate::src::internal::Dav1dTileState_tiling;
 
 #[derive(Copy, Clone)]

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -51,7 +51,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut pixel; 3],
+    pub ipred_edge: [*mut libc::c_void; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -1,7 +1,6 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use crate::src::cdf::CdfContext;
-use crate::src::msac::MsacContext;
+
 use ::libc;
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
@@ -161,25 +160,7 @@ use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::internal::Dav1dTaskContext_scratch;
 use crate::src::refmvs::refmvs_tile;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState {
-    pub cdf: CdfContext,
-    pub msac: MsacContext,
-    pub tiling: Dav1dTileState_tiling,
-    pub progress: [atomic_int; 2],
-    pub frame_thread: [Dav1dTileState_frame_thread; 2],
-    pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
-    pub dqmem: [[[uint16_t; 2]; 3]; 8],
-    pub dq: *const [[uint16_t; 2]; 3],
-    pub last_qidx: libc::c_int,
-    pub last_delta_lf: [int8_t; 4],
-    pub lflvlmem: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
-    pub lr_ref: [*mut Av1RestorationUnit; 3],
-}
-use crate::src::internal::Dav1dTileState_frame_thread;
-use crate::src::internal::Dav1dTileState_tiling;
+use crate::src::internal::Dav1dTileState;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -226,12 +226,7 @@ pub struct Dav1dTileState {
     pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
     pub lr_ref: [*mut Av1RestorationUnit; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState_frame_thread {
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut coef,
-}
+use crate::src::internal::Dav1dTileState_frame_thread;
 use crate::src::internal::Dav1dTileState_tiling;
 
 #[derive(Copy, Clone)]

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -12,7 +12,6 @@ use crate::src::tables::dav1d_sgr_params;
 pub type pixel = uint8_t;
 pub type coef = int16_t;
 use crate::include::stdatomic::atomic_int;
-use crate::include::stdatomic::atomic_uint;
 
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
@@ -100,60 +99,13 @@ use crate::include::dav1d::headers::Dav1dSequenceHeader;
 
 use crate::src::align::Align16;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_lf {
-    pub level: *mut [uint8_t; 4],
-    pub mask: *mut Av1Filter,
-    pub lr_mask: *mut Av1Restoration,
-    pub mask_sz: libc::c_int,
-    pub lr_mask_sz: libc::c_int,
-    pub cdef_buf_plane_sz: [libc::c_int; 2],
-    pub cdef_buf_sbh: libc::c_int,
-    pub lr_buf_plane_sz: [libc::c_int; 2],
-    pub re_sz: libc::c_int,
-    pub lim_lut: Align16<Av1FilterLUT>,
-    pub last_sharpness: libc::c_int,
-    pub lvl: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub tx_lpf_right_edge: [*mut uint8_t; 2],
-    pub cdef_line_buf: *mut uint8_t,
-    pub lr_line_buf: *mut uint8_t,
-    pub cdef_line: [[*mut pixel; 3]; 2],
-    pub cdef_lpf_line: [*mut pixel; 3],
-    pub lr_lpf_line: [*mut pixel; 3],
-    pub start_of_tile_row: *mut uint8_t,
-    pub start_of_tile_row_sz: libc::c_int,
-    pub need_cdef_lpf_copy: libc::c_int,
-    pub p: [*mut pixel; 3],
-    pub sr_p: [*mut pixel; 3],
-    pub mask_ptr: *mut Av1Filter,
-    pub prev_mask_ptr: *mut Av1Filter,
-    pub restore_planes: libc::c_int,
-}
+use crate::src::internal::Dav1dFrameContext_lf;
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
-use crate::src::lf_mask::Av1Restoration;
+
+use crate::src::internal::Dav1dFrameContext_frame_thread;
 use crate::src::lf_mask::Av1RestorationUnit;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_frame_thread {
-    pub next_tile_row: [libc::c_int; 2],
-    pub entropy_progress: atomic_int,
-    pub deblock_progress: atomic_int,
-    pub frame_progress: *mut atomic_uint,
-    pub copy_lpf_progress: *mut atomic_uint,
-    pub b: *mut Av1Block,
-    pub cbi: *mut CodedBlockInfo,
-    pub pal: *mut [[uint16_t; 8]; 3],
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut coef,
-    pub prog_sz: libc::c_int,
-    pub pal_sz: libc::c_int,
-    pub pal_idx_sz: libc::c_int,
-    pub cf_sz: libc::c_int,
-    pub tile_start_off: *mut libc::c_int,
-}
-use crate::src::internal::CodedBlockInfo;
+
 use crate::src::levels::Av1Block;
 use crate::src::refmvs::refmvs_frame;
 
@@ -705,7 +657,7 @@ unsafe extern "C" fn lr_stripe(
             0 as libc::c_int
         }) >> 6 - ss_ver + (*(*f).seq_hdr).sb128;
     let have_tt = ((*(*f).c).n_tc > 1 as libc::c_uint) as libc::c_int;
-    let mut lpf: *const pixel = ((*f).lf.lr_lpf_line[plane as usize])
+    let mut lpf: *const pixel = ((*f).lf.lr_lpf_line[plane as usize] as *mut pixel)
         .offset(
             ((have_tt * (sby * ((4 as libc::c_int) << (*(*f).seq_hdr).sb128) - 4)) as isize
                 * stride) as isize,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -299,12 +299,7 @@ pub struct Dav1dTileState {
     pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
     pub lr_ref: [*mut Av1RestorationUnit; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState_frame_thread {
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut libc::c_void,
-}
+use crate::src::internal::Dav1dTileState_frame_thread;
 use crate::src::internal::Dav1dTileState_tiling;
 
 #[derive(Copy, Clone)]

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1,7 +1,6 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use crate::src::cdf::CdfContext;
-use crate::src::msac::MsacContext;
+
 use ::libc;
 extern "C" {
     fn realloc(_: *mut libc::c_void, _: size_t) -> *mut libc::c_void;
@@ -175,7 +174,7 @@ pub type pixel = ();
 use crate::src::lf_mask::Av1FilterLUT;
 
 use crate::src::internal::Dav1dFrameContext_frame_thread;
-use crate::src::lf_mask::Av1RestorationUnit;
+
 pub type coef = ();
 
 use crate::src::levels::Av1Block;
@@ -233,25 +232,7 @@ use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::internal::Dav1dTaskContext_scratch;
 use crate::src::refmvs::refmvs_tile;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState {
-    pub cdf: CdfContext,
-    pub msac: MsacContext,
-    pub tiling: Dav1dTileState_tiling,
-    pub progress: [atomic_int; 2],
-    pub frame_thread: [Dav1dTileState_frame_thread; 2],
-    pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
-    pub dqmem: [[[uint16_t; 2]; 3]; 8],
-    pub dq: *const [[uint16_t; 2]; 3],
-    pub last_qidx: libc::c_int,
-    pub last_delta_lf: [int8_t; 4],
-    pub lflvlmem: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
-    pub lr_ref: [*mut Av1RestorationUnit; 3],
-}
-use crate::src::internal::Dav1dTileState_frame_thread;
-use crate::src::internal::Dav1dTileState_tiling;
+use crate::src::internal::Dav1dTileState;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -169,64 +169,15 @@ use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
 use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
 use crate::include::pthread::pthread_cond_t;
 
-use crate::src::align::Align16;
-
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_lf {
-    pub level: *mut [uint8_t; 4],
-    pub mask: *mut Av1Filter,
-    pub lr_mask: *mut Av1Restoration,
-    pub mask_sz: libc::c_int,
-    pub lr_mask_sz: libc::c_int,
-    pub cdef_buf_plane_sz: [libc::c_int; 2],
-    pub cdef_buf_sbh: libc::c_int,
-    pub lr_buf_plane_sz: [libc::c_int; 2],
-    pub re_sz: libc::c_int,
-    pub lim_lut: Align16<Av1FilterLUT>,
-    pub last_sharpness: libc::c_int,
-    pub lvl: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub tx_lpf_right_edge: [*mut uint8_t; 2],
-    pub cdef_line_buf: *mut uint8_t,
-    pub lr_line_buf: *mut uint8_t,
-    pub cdef_line: [[*mut libc::c_void; 3]; 2],
-    pub cdef_lpf_line: [*mut libc::c_void; 3],
-    pub lr_lpf_line: [*mut libc::c_void; 3],
-    pub start_of_tile_row: *mut uint8_t,
-    pub start_of_tile_row_sz: libc::c_int,
-    pub need_cdef_lpf_copy: libc::c_int,
-    pub p: [*mut libc::c_void; 3],
-    pub sr_p: [*mut libc::c_void; 3],
-    pub mask_ptr: *mut Av1Filter,
-    pub prev_mask_ptr: *mut Av1Filter,
-    pub restore_planes: libc::c_int,
-}
+use crate::src::internal::Dav1dFrameContext_lf;
 use crate::src::lf_mask::Av1Filter;
 pub type pixel = ();
 use crate::src::lf_mask::Av1FilterLUT;
-use crate::src::lf_mask::Av1Restoration;
+
+use crate::src::internal::Dav1dFrameContext_frame_thread;
 use crate::src::lf_mask::Av1RestorationUnit;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_frame_thread {
-    pub next_tile_row: [libc::c_int; 2],
-    pub entropy_progress: atomic_int,
-    pub deblock_progress: atomic_int,
-    pub frame_progress: *mut atomic_uint,
-    pub copy_lpf_progress: *mut atomic_uint,
-    pub b: *mut Av1Block,
-    pub cbi: *mut CodedBlockInfo,
-    pub pal: *mut [[uint16_t; 8]; 3],
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut libc::c_void,
-    pub prog_sz: libc::c_int,
-    pub pal_sz: libc::c_int,
-    pub pal_idx_sz: libc::c_int,
-    pub cf_sz: libc::c_int,
-    pub tile_start_off: *mut libc::c_int,
-}
 pub type coef = ();
-use crate::src::internal::CodedBlockInfo;
+
 use crate::src::levels::Av1Block;
 use crate::src::refmvs::refmvs_frame;
 

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -103,64 +103,15 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
 
-use crate::src::align::Align16;
-
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_lf {
-    pub level: *mut [uint8_t; 4],
-    pub mask: *mut Av1Filter,
-    pub lr_mask: *mut Av1Restoration,
-    pub mask_sz: libc::c_int,
-    pub lr_mask_sz: libc::c_int,
-    pub cdef_buf_plane_sz: [libc::c_int; 2],
-    pub cdef_buf_sbh: libc::c_int,
-    pub lr_buf_plane_sz: [libc::c_int; 2],
-    pub re_sz: libc::c_int,
-    pub lim_lut: Align16<Av1FilterLUT>,
-    pub last_sharpness: libc::c_int,
-    pub lvl: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub tx_lpf_right_edge: [*mut uint8_t; 2],
-    pub cdef_line_buf: *mut uint8_t,
-    pub lr_line_buf: *mut uint8_t,
-    pub cdef_line: [[*mut libc::c_void; 3]; 2],
-    pub cdef_lpf_line: [*mut libc::c_void; 3],
-    pub lr_lpf_line: [*mut libc::c_void; 3],
-    pub start_of_tile_row: *mut uint8_t,
-    pub start_of_tile_row_sz: libc::c_int,
-    pub need_cdef_lpf_copy: libc::c_int,
-    pub p: [*mut libc::c_void; 3],
-    pub sr_p: [*mut libc::c_void; 3],
-    pub mask_ptr: *mut Av1Filter,
-    pub prev_mask_ptr: *mut Av1Filter,
-    pub restore_planes: libc::c_int,
-}
+use crate::src::internal::Dav1dFrameContext_lf;
 use crate::src::lf_mask::Av1Filter;
 pub type pixel = ();
 use crate::src::lf_mask::Av1FilterLUT;
-use crate::src::lf_mask::Av1Restoration;
+
+use crate::src::internal::Dav1dFrameContext_frame_thread;
 use crate::src::lf_mask::Av1RestorationUnit;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_frame_thread {
-    pub next_tile_row: [libc::c_int; 2],
-    pub entropy_progress: atomic_int,
-    pub deblock_progress: atomic_int,
-    pub frame_progress: *mut atomic_uint,
-    pub copy_lpf_progress: *mut atomic_uint,
-    pub b: *mut Av1Block,
-    pub cbi: *mut CodedBlockInfo,
-    pub pal: *mut [[uint16_t; 8]; 3],
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut libc::c_void,
-    pub prog_sz: libc::c_int,
-    pub pal_sz: libc::c_int,
-    pub pal_idx_sz: libc::c_int,
-    pub cf_sz: libc::c_int,
-    pub tile_start_off: *mut libc::c_int,
-}
 pub type coef = ();
-use crate::src::internal::CodedBlockInfo;
+
 use crate::src::levels::Av1Block;
 use crate::src::refmvs::refmvs_frame;
 

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -234,12 +234,7 @@ pub struct Dav1dTileState {
     pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
     pub lr_ref: [*mut Av1RestorationUnit; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState_frame_thread {
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut libc::c_void,
-}
+use crate::src::internal::Dav1dTileState_frame_thread;
 use crate::src::internal::Dav1dTileState_tiling;
 
 #[derive(Copy, Clone)]

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -1,7 +1,6 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use crate::src::cdf::CdfContext;
-use crate::src::msac::MsacContext;
+
 use crate::{errno_location, stderr};
 use ::libc;
 use ::libc::malloc;
@@ -109,7 +108,7 @@ pub type pixel = ();
 use crate::src::lf_mask::Av1FilterLUT;
 
 use crate::src::internal::Dav1dFrameContext_frame_thread;
-use crate::src::lf_mask::Av1RestorationUnit;
+
 pub type coef = ();
 
 use crate::src::levels::Av1Block;
@@ -168,25 +167,7 @@ use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::internal::Dav1dTaskContext_scratch;
 use crate::src::refmvs::refmvs_tile;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState {
-    pub cdf: CdfContext,
-    pub msac: MsacContext,
-    pub tiling: Dav1dTileState_tiling,
-    pub progress: [atomic_int; 2],
-    pub frame_thread: [Dav1dTileState_frame_thread; 2],
-    pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
-    pub dqmem: [[[uint16_t; 2]; 3]; 8],
-    pub dq: *const [[uint16_t; 2]; 3],
-    pub last_qidx: libc::c_int,
-    pub last_delta_lf: [int8_t; 4],
-    pub lflvlmem: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
-    pub lr_ref: [*mut Av1RestorationUnit; 3],
-}
-use crate::src::internal::Dav1dTileState_frame_thread;
-use crate::src::internal::Dav1dTileState_tiling;
+use crate::src::internal::Dav1dTileState;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -2,8 +2,6 @@ use crate::include::stddef::*;
 use crate::include::stdint::*;
 use ::libc;
 
-use crate::src::cdf::CdfContext;
-use crate::src::msac::MsacContext;
 use crate::stdout;
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::size_t) -> *mut libc::c_void;
@@ -170,8 +168,6 @@ use crate::src::levels::Av1Block;
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
 
-use crate::src::lf_mask::Av1RestorationUnit;
-
 use crate::src::env::BlockContext;
 use crate::src::refmvs::refmvs_block;
 use crate::src::refmvs::refmvs_frame;
@@ -228,25 +224,7 @@ use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::internal::Dav1dTaskContext_scratch;
 use crate::src::refmvs::refmvs_tile;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState {
-    pub cdf: CdfContext,
-    pub msac: MsacContext,
-    pub tiling: Dav1dTileState_tiling,
-    pub progress: [atomic_int; 2],
-    pub frame_thread: [Dav1dTileState_frame_thread; 2],
-    pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
-    pub dqmem: [[[uint16_t; 2]; 3]; 8],
-    pub dq: *const [[uint16_t; 2]; 3],
-    pub last_qidx: libc::c_int,
-    pub last_delta_lf: [int8_t; 4],
-    pub lflvlmem: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
-    pub lr_ref: [*mut Av1RestorationUnit; 3],
-}
-use crate::src::internal::Dav1dTileState_frame_thread;
-use crate::src::internal::Dav1dTileState_tiling;
+use crate::src::internal::Dav1dTileState;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -116,7 +116,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut pixel; 3],
+    pub ipred_edge: [*mut libc::c_void; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,
@@ -4217,7 +4217,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                         })) as EdgeFlags;
                         top_sb_edge = 0 as *const pixel;
                         if (*t).by & (*f).sb_step - 1 == 0 {
-                            top_sb_edge = (*f).ipred_edge[0];
+                            top_sb_edge = (*f).ipred_edge[0] as *mut pixel;
                             let sby = (*t).by >> (*f).sb_shift;
                             top_sb_edge =
                                 top_sb_edge.offset(((*f).sb128w * 128 * (sby - 1)) as isize);
@@ -4646,7 +4646,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                             let mut angle_0 = 0;
                             let mut top_sb_edge_0: *const pixel = 0 as *const pixel;
                             if (*t).by & !ss_ver & (*f).sb_step - 1 == 0 {
-                                top_sb_edge_0 = (*f).ipred_edge[(pl + 1) as usize];
+                                top_sb_edge_0 = (*f).ipred_edge[(pl + 1) as usize] as *mut pixel;
                                 let sby_0 = (*t).by >> (*f).sb_shift;
                                 top_sb_edge_0 = top_sb_edge_0
                                     .offset(((*f).sb128w * 128 * (sby_0 - 1)) as isize);
@@ -4845,7 +4845,8 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                 })) as EdgeFlags;
                                 top_sb_edge_1 = 0 as *const pixel;
                                 if (*t).by & !ss_ver & (*f).sb_step - 1 == 0 {
-                                    top_sb_edge_1 = (*f).ipred_edge[(1 + pl_0) as usize];
+                                    top_sb_edge_1 =
+                                        (*f).ipred_edge[(1 + pl_0) as usize] as *mut pixel;
                                     let sby_1 = (*t).by >> (*f).sb_shift;
                                     top_sb_edge_1 = top_sb_edge_1
                                         .offset(((*f).sb128w * 128 * (sby_1 - 1)) as isize);
@@ -5568,7 +5569,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
             let mut angle = 0;
             let mut top_sb_edge: *const pixel = 0 as *const pixel;
             if (*t).by & (*f).sb_step - 1 == 0 {
-                top_sb_edge = (*f).ipred_edge[0];
+                top_sb_edge = (*f).ipred_edge[0] as *mut pixel;
                 let sby = (*t).by >> (*f).sb_shift;
                 top_sb_edge = top_sb_edge.offset(((*f).sb128w * 128 * (sby - 1)) as isize);
             }
@@ -6015,7 +6016,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                             .offset(uvdstoff as isize);
                         let mut top_sb_edge_0: *const pixel = 0 as *const pixel;
                         if (*t).by & (*f).sb_step - 1 == 0 {
-                            top_sb_edge_0 = (*f).ipred_edge[(pl_6 + 1) as usize];
+                            top_sb_edge_0 = (*f).ipred_edge[(pl_6 + 1) as usize] as *mut pixel;
                             let sby_0 = (*t).by >> (*f).sb_shift;
                             top_sb_edge_0 =
                                 top_sb_edge_0.offset(((*f).sb128w * 128 * (sby_0 - 1)) as isize);
@@ -7355,8 +7356,8 @@ pub unsafe extern "C" fn dav1d_backup_ipred_edge_16bpc(t: *mut Dav1dTaskContext)
             ((((*t).by + (*f).sb_step) * 4 - 1) as isize * PXSTRIDE((*f).cur.stride[0])) as isize,
         );
     memcpy(
-        &mut *(*((*f).ipred_edge).as_ptr().offset(0)).offset((sby_off + x_off * 4) as isize)
-            as *mut pixel as *mut libc::c_void,
+        &mut *(*((*f).ipred_edge).as_ptr().offset(0) as *mut pixel)
+            .offset((sby_off + x_off * 4) as isize) as *mut pixel as *mut libc::c_void,
         y as *const libc::c_void,
         (4 * ((*ts).tiling.col_end - x_off) << 1) as size_t,
     );
@@ -7373,7 +7374,7 @@ pub unsafe extern "C" fn dav1d_backup_ipred_edge_16bpc(t: *mut Dav1dTaskContext)
         let mut pl = 1;
         while pl <= 2 {
             memcpy(
-                &mut *(*((*f).ipred_edge).as_ptr().offset(pl as isize))
+                &mut *(*((*f).ipred_edge).as_ptr().offset(pl as isize) as *mut pixel)
                     .offset((sby_off + (x_off * 4 >> ss_hor)) as isize)
                     as *mut pixel as *mut libc::c_void,
                 &*(*((*f).cur.data).as_ptr().offset(pl as isize) as *const pixel)

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -295,12 +295,7 @@ pub struct Dav1dTileState {
     pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
     pub lr_ref: [*mut Av1RestorationUnit; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState_frame_thread {
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut coef,
-}
+use crate::src::internal::Dav1dTileState_frame_thread;
 use crate::src::internal::Dav1dTileState_tiling;
 
 #[derive(Copy, Clone)]
@@ -2559,12 +2554,13 @@ unsafe extern "C" fn read_coef_tree(
             if ((*ts).frame_thread[p as usize].cf).is_null() {
                 unreachable!();
             }
-            cf = (*ts).frame_thread[p as usize].cf;
-            (*ts).frame_thread[p as usize].cf = ((*ts).frame_thread[p as usize].cf).offset(
-                (imin((*t_dim).w as libc::c_int, 8 as libc::c_int)
-                    * imin((*t_dim).h as libc::c_int, 8 as libc::c_int)
-                    * 16) as isize,
-            );
+            cf = (*ts).frame_thread[p as usize].cf as *mut coef;
+            (*ts).frame_thread[p as usize].cf = ((*ts).frame_thread[p as usize].cf as *mut coef)
+                .offset(
+                    (imin((*t_dim).w as libc::c_int, 8 as libc::c_int)
+                        * imin((*t_dim).h as libc::c_int, 8 as libc::c_int)
+                        * 16) as isize,
+                ) as *mut libc::c_void;
             cbi = &mut *((*f).frame_thread.cbi)
                 .offset(((*t).by as isize * (*f).b4_stride + (*t).bx as isize) as isize)
                 as *mut CodedBlockInfo;
@@ -3267,7 +3263,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                             b,
                             1 as libc::c_int,
                             0 as libc::c_int,
-                            (*ts).frame_thread[1].cf,
+                            (*ts).frame_thread[1].cf as *mut coef,
                             &mut txtp,
                             &mut cf_ctx,
                         ) as int16_t;
@@ -3283,11 +3279,11 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                             );
                         }
                         (*cbi.offset((*t).bx as isize)).txtp[0] = txtp as uint8_t;
-                        (*ts).frame_thread[1].cf = ((*ts).frame_thread[1].cf).offset(
+                        (*ts).frame_thread[1].cf = ((*ts).frame_thread[1].cf as *mut coef).offset(
                             (imin((*t_dim).w as libc::c_int, 8 as libc::c_int)
                                 * imin((*t_dim).h as libc::c_int, 8 as libc::c_int)
                                 * 16) as isize,
-                        );
+                        ) as *mut libc::c_void;
                         match imin((*t_dim).h as libc::c_int, (*f).bh - (*t).by) {
                             1 => {
                                 (*(&mut *((*t).l.lcoef.0).as_mut_ptr().offset((by4 + y) as isize)
@@ -3453,7 +3449,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                 b,
                                 (*b).intra as libc::c_int,
                                 1 + pl,
-                                (*ts).frame_thread[1].cf,
+                                (*ts).frame_thread[1].cf as *mut coef,
                                 &mut txtp_0,
                                 &mut cf_ctx_0,
                             ) as int16_t;
@@ -3472,10 +3468,12 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                             }
                             (*cbi_0.offset((*t).bx as isize)).txtp[(1 + pl) as usize] =
                                 txtp_0 as uint8_t;
-                            (*ts).frame_thread[1].cf = ((*ts).frame_thread[1].cf).offset(
-                                ((*uv_t_dim).w as libc::c_int * (*uv_t_dim).h as libc::c_int * 16)
-                                    as isize,
-                            );
+                            (*ts).frame_thread[1].cf =
+                                ((*ts).frame_thread[1].cf as *mut coef).offset(
+                                    ((*uv_t_dim).w as libc::c_int
+                                        * (*uv_t_dim).h as libc::c_int
+                                        * 16) as isize,
+                                ) as *mut libc::c_void;
                             match imin(
                                 (*uv_t_dim).h as libc::c_int,
                                 (*f).bh - (*t).by + ss_ver >> ss_ver,
@@ -4341,13 +4339,13 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                         let mut txtp: TxfmType = DCT_DCT;
                         if (*t).frame_thread.pass != 0 {
                             let p_0 = (*t).frame_thread.pass & 1;
-                            cf = (*ts).frame_thread[p_0 as usize].cf;
+                            cf = (*ts).frame_thread[p_0 as usize].cf as *mut coef;
                             (*ts).frame_thread[p_0 as usize].cf =
-                                ((*ts).frame_thread[p_0 as usize].cf).offset(
+                                ((*ts).frame_thread[p_0 as usize].cf as *mut coef).offset(
                                     (imin((*t_dim).w as libc::c_int, 8 as libc::c_int)
                                         * imin((*t_dim).h as libc::c_int, 8 as libc::c_int)
                                         * 16) as isize,
-                                );
+                                ) as *mut libc::c_void;
                             let cbi: *const CodedBlockInfo = &mut *((*f).frame_thread.cbi).offset(
                                 ((*t).by as isize * (*f).b4_stride + (*t).bx as isize) as isize,
                             )
@@ -4987,14 +4985,15 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                 let mut cf_0: *mut coef = 0 as *mut coef;
                                 if (*t).frame_thread.pass != 0 {
                                     let p_2 = (*t).frame_thread.pass & 1;
-                                    cf_0 = (*ts).frame_thread[p_2 as usize].cf;
+                                    cf_0 = (*ts).frame_thread[p_2 as usize].cf as *mut coef;
                                     (*ts).frame_thread[p_2 as usize].cf =
-                                        ((*ts).frame_thread[p_2 as usize].cf).offset(
+                                        ((*ts).frame_thread[p_2 as usize].cf as *mut coef).offset(
                                             ((*uv_t_dim).w as libc::c_int
                                                 * (*uv_t_dim).h as libc::c_int
                                                 * 16)
                                                 as isize,
-                                        );
+                                        )
+                                            as *mut libc::c_void;
                                     let cbi_0: *const CodedBlockInfo = &mut *((*f).frame_thread.cbi)
                                         .offset(
                                             ((*t).by as isize * (*f).b4_stride + (*t).bx as isize)
@@ -6910,12 +6909,12 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                             let mut txtp: TxfmType = DCT_DCT;
                             if (*t).frame_thread.pass != 0 {
                                 let p = (*t).frame_thread.pass & 1;
-                                cf = (*ts).frame_thread[p as usize].cf;
+                                cf = (*ts).frame_thread[p as usize].cf as *mut coef;
                                 (*ts).frame_thread[p as usize].cf =
-                                    ((*ts).frame_thread[p as usize].cf).offset(
+                                    ((*ts).frame_thread[p as usize].cf as *mut coef).offset(
                                         ((*uvtx).w as libc::c_int * (*uvtx).h as libc::c_int * 16)
                                             as isize,
-                                    );
+                                    ) as *mut libc::c_void;
                                 let cbi: *const CodedBlockInfo =
                                     &mut *((*f).frame_thread.cbi).offset(
                                         ((*t).by as isize * (*f).b4_stride + (*t).bx as isize)

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -77,7 +77,6 @@ use crate::src::tables::dav1d_txtp_from_uvmode;
 pub type pixel = uint16_t;
 pub type coef = int32_t;
 use crate::include::stdatomic::atomic_int;
-use crate::include::stdatomic::atomic_uint;
 
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
@@ -163,64 +162,15 @@ use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
 
-use crate::src::align::Align16;
-
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_lf {
-    pub level: *mut [uint8_t; 4],
-    pub mask: *mut Av1Filter,
-    pub lr_mask: *mut Av1Restoration,
-    pub mask_sz: libc::c_int,
-    pub lr_mask_sz: libc::c_int,
-    pub cdef_buf_plane_sz: [libc::c_int; 2],
-    pub cdef_buf_sbh: libc::c_int,
-    pub lr_buf_plane_sz: [libc::c_int; 2],
-    pub re_sz: libc::c_int,
-    pub lim_lut: Align16<Av1FilterLUT>,
-    pub last_sharpness: libc::c_int,
-    pub lvl: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub tx_lpf_right_edge: [*mut uint8_t; 2],
-    pub cdef_line_buf: *mut uint8_t,
-    pub lr_line_buf: *mut uint8_t,
-    pub cdef_line: [[*mut pixel; 3]; 2],
-    pub cdef_lpf_line: [*mut pixel; 3],
-    pub lr_lpf_line: [*mut pixel; 3],
-    pub start_of_tile_row: *mut uint8_t,
-    pub start_of_tile_row_sz: libc::c_int,
-    pub need_cdef_lpf_copy: libc::c_int,
-    pub p: [*mut pixel; 3],
-    pub sr_p: [*mut pixel; 3],
-    pub mask_ptr: *mut Av1Filter,
-    pub prev_mask_ptr: *mut Av1Filter,
-    pub restore_planes: libc::c_int,
-}
-use crate::src::lf_mask::Av1Filter;
-use crate::src::lf_mask::Av1FilterLUT;
-use crate::src::lf_mask::Av1Restoration;
-use crate::src::lf_mask::Av1RestorationUnit;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_frame_thread {
-    pub next_tile_row: [libc::c_int; 2],
-    pub entropy_progress: atomic_int,
-    pub deblock_progress: atomic_int,
-    pub frame_progress: *mut atomic_uint,
-    pub copy_lpf_progress: *mut atomic_uint,
-    pub b: *mut Av1Block,
-    pub cbi: *mut CodedBlockInfo,
-    pub pal: *mut [[uint16_t; 8]; 3],
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut coef,
-    pub prog_sz: libc::c_int,
-    pub pal_sz: libc::c_int,
-    pub pal_idx_sz: libc::c_int,
-    pub cf_sz: libc::c_int,
-    pub tile_start_off: *mut libc::c_int,
-}
 use crate::src::internal::CodedBlockInfo;
+use crate::src::internal::Dav1dFrameContext_frame_thread;
+use crate::src::internal::Dav1dFrameContext_lf;
 use crate::src::levels::mv;
 use crate::src::levels::Av1Block;
+use crate::src::lf_mask::Av1Filter;
+use crate::src::lf_mask::Av1FilterLUT;
+
+use crate::src::lf_mask::Av1RestorationUnit;
 
 use crate::src::env::BlockContext;
 use crate::src::refmvs::refmvs_block;
@@ -7195,9 +7145,11 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_cols_16bpc(
     let ss_ver = ((*f).cur.p.layout as libc::c_uint
         == DAV1D_PIXEL_LAYOUT_I420 as libc::c_int as libc::c_uint) as libc::c_int;
     let p: [*mut pixel; 3] = [
-        ((*f).lf.p[0]).offset((y as isize * PXSTRIDE((*f).cur.stride[0])) as isize),
-        ((*f).lf.p[1]).offset((y as isize * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize),
-        ((*f).lf.p[2]).offset((y as isize * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize),
+        ((*f).lf.p[0] as *mut pixel).offset((y as isize * PXSTRIDE((*f).cur.stride[0])) as isize),
+        ((*f).lf.p[1] as *mut pixel)
+            .offset((y as isize * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize),
+        ((*f).lf.p[2] as *mut pixel)
+            .offset((y as isize * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize),
     ];
     let mut mask: *mut Av1Filter = ((*f).lf.mask)
         .offset(((sby >> ((*(*f).seq_hdr).sb128 == 0) as libc::c_int) * (*f).sb128w) as isize);
@@ -7218,9 +7170,11 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_rows_16bpc(
     let ss_ver = ((*f).cur.p.layout as libc::c_uint
         == DAV1D_PIXEL_LAYOUT_I420 as libc::c_int as libc::c_uint) as libc::c_int;
     let p: [*mut pixel; 3] = [
-        ((*f).lf.p[0]).offset((y as isize * PXSTRIDE((*f).cur.stride[0])) as isize),
-        ((*f).lf.p[1]).offset((y as isize * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize),
-        ((*f).lf.p[2]).offset((y as isize * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize),
+        ((*f).lf.p[0] as *mut pixel).offset((y as isize * PXSTRIDE((*f).cur.stride[0])) as isize),
+        ((*f).lf.p[1] as *mut pixel)
+            .offset((y as isize * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize),
+        ((*f).lf.p[2] as *mut pixel)
+            .offset((y as isize * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize),
     ];
     let mut mask: *mut Av1Filter = ((*f).lf.mask)
         .offset(((sby >> ((*(*f).seq_hdr).sb128 == 0) as libc::c_int) * (*f).sb128w) as isize);
@@ -7253,9 +7207,11 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_16bpc(
     let ss_ver = ((*f).cur.p.layout as libc::c_uint
         == DAV1D_PIXEL_LAYOUT_I420 as libc::c_int as libc::c_uint) as libc::c_int;
     let p: [*mut pixel; 3] = [
-        ((*f).lf.p[0]).offset((y as isize * PXSTRIDE((*f).cur.stride[0])) as isize),
-        ((*f).lf.p[1]).offset((y as isize * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize),
-        ((*f).lf.p[2]).offset((y as isize * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize),
+        ((*f).lf.p[0] as *mut pixel).offset((y as isize * PXSTRIDE((*f).cur.stride[0])) as isize),
+        ((*f).lf.p[1] as *mut pixel)
+            .offset((y as isize * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize),
+        ((*f).lf.p[2] as *mut pixel)
+            .offset((y as isize * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize),
     ];
     let mut prev_mask: *mut Av1Filter = ((*f).lf.mask)
         .offset(((sby - 1 >> ((*(*f).seq_hdr).sb128 == 0) as libc::c_int) * (*f).sb128w) as isize);
@@ -7295,17 +7251,21 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_resize_16bpc(
     let ss_ver = ((*f).cur.p.layout as libc::c_uint
         == DAV1D_PIXEL_LAYOUT_I420 as libc::c_int as libc::c_uint) as libc::c_int;
     let p: [*const pixel; 3] = [
-        ((*f).lf.p[0]).offset((y as isize * PXSTRIDE((*f).cur.stride[0])) as isize) as *const pixel,
-        ((*f).lf.p[1]).offset((y as isize * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize)
+        ((*f).lf.p[0] as *mut pixel).offset((y as isize * PXSTRIDE((*f).cur.stride[0])) as isize)
             as *const pixel,
-        ((*f).lf.p[2]).offset((y as isize * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize)
+        ((*f).lf.p[1] as *mut pixel)
+            .offset((y as isize * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize)
+            as *const pixel,
+        ((*f).lf.p[2] as *mut pixel)
+            .offset((y as isize * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize)
             as *const pixel,
     ];
     let sr_p: [*mut pixel; 3] = [
-        ((*f).lf.sr_p[0]).offset((y as isize * PXSTRIDE((*f).sr_cur.p.stride[0])) as isize),
-        ((*f).lf.sr_p[1])
+        ((*f).lf.sr_p[0] as *mut pixel)
+            .offset((y as isize * PXSTRIDE((*f).sr_cur.p.stride[0])) as isize),
+        ((*f).lf.sr_p[1] as *mut pixel)
             .offset((y as isize * PXSTRIDE((*f).sr_cur.p.stride[1]) >> ss_ver) as isize),
-        ((*f).lf.sr_p[2])
+        ((*f).lf.sr_p[2] as *mut pixel)
             .offset((y as isize * PXSTRIDE((*f).sr_cur.p.stride[1]) >> ss_ver) as isize),
     ];
     let has_chroma = ((*f).cur.p.layout as libc::c_uint
@@ -7360,9 +7320,11 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_lr_16bpc(f: *mut Dav1dFrameContext, 
     let ss_ver = ((*f).cur.p.layout as libc::c_uint
         == DAV1D_PIXEL_LAYOUT_I420 as libc::c_int as libc::c_uint) as libc::c_int;
     let sr_p: [*mut pixel; 3] = [
-        ((*f).lf.sr_p[0]).offset(y as isize * PXSTRIDE((*f).sr_cur.p.stride[0])),
-        ((*f).lf.sr_p[1]).offset(y as isize * PXSTRIDE((*f).sr_cur.p.stride[1]) >> ss_ver),
-        ((*f).lf.sr_p[2]).offset(y as isize * PXSTRIDE((*f).sr_cur.p.stride[1]) >> ss_ver),
+        ((*f).lf.sr_p[0] as *mut pixel).offset(y as isize * PXSTRIDE((*f).sr_cur.p.stride[0])),
+        ((*f).lf.sr_p[1] as *mut pixel)
+            .offset(y as isize * PXSTRIDE((*f).sr_cur.p.stride[1]) >> ss_ver),
+        ((*f).lf.sr_p[2] as *mut pixel)
+            .offset(y as isize * PXSTRIDE((*f).sr_cur.p.stride[1]) >> ss_ver),
     ];
     dav1d_lr_sbrow_16bpc(f, sr_p.as_ptr(), sby);
 }

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -76,7 +76,6 @@ use crate::src::tables::dav1d_txtp_from_uvmode;
 pub type pixel = uint8_t;
 pub type coef = int16_t;
 use crate::include::stdatomic::atomic_int;
-use crate::include::stdatomic::atomic_uint;
 
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
@@ -161,64 +160,15 @@ use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
 
-use crate::src::align::Align16;
-
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_lf {
-    pub level: *mut [uint8_t; 4],
-    pub mask: *mut Av1Filter,
-    pub lr_mask: *mut Av1Restoration,
-    pub mask_sz: libc::c_int,
-    pub lr_mask_sz: libc::c_int,
-    pub cdef_buf_plane_sz: [libc::c_int; 2],
-    pub cdef_buf_sbh: libc::c_int,
-    pub lr_buf_plane_sz: [libc::c_int; 2],
-    pub re_sz: libc::c_int,
-    pub lim_lut: Align16<Av1FilterLUT>,
-    pub last_sharpness: libc::c_int,
-    pub lvl: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub tx_lpf_right_edge: [*mut uint8_t; 2],
-    pub cdef_line_buf: *mut uint8_t,
-    pub lr_line_buf: *mut uint8_t,
-    pub cdef_line: [[*mut pixel; 3]; 2],
-    pub cdef_lpf_line: [*mut pixel; 3],
-    pub lr_lpf_line: [*mut pixel; 3],
-    pub start_of_tile_row: *mut uint8_t,
-    pub start_of_tile_row_sz: libc::c_int,
-    pub need_cdef_lpf_copy: libc::c_int,
-    pub p: [*mut pixel; 3],
-    pub sr_p: [*mut pixel; 3],
-    pub mask_ptr: *mut Av1Filter,
-    pub prev_mask_ptr: *mut Av1Filter,
-    pub restore_planes: libc::c_int,
-}
+use crate::src::internal::Dav1dFrameContext_lf;
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
-use crate::src::lf_mask::Av1Restoration;
-use crate::src::lf_mask::Av1RestorationUnit;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_frame_thread {
-    pub next_tile_row: [libc::c_int; 2],
-    pub entropy_progress: atomic_int,
-    pub deblock_progress: atomic_int,
-    pub frame_progress: *mut atomic_uint,
-    pub copy_lpf_progress: *mut atomic_uint,
-    pub b: *mut Av1Block,
-    pub cbi: *mut CodedBlockInfo,
-    pub pal: *mut [[uint16_t; 8]; 3],
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut coef,
-    pub prog_sz: libc::c_int,
-    pub pal_sz: libc::c_int,
-    pub pal_idx_sz: libc::c_int,
-    pub cf_sz: libc::c_int,
-    pub tile_start_off: *mut libc::c_int,
-}
+
 use crate::src::internal::CodedBlockInfo;
+use crate::src::internal::Dav1dFrameContext_frame_thread;
 use crate::src::levels::mv;
 use crate::src::levels::Av1Block;
+use crate::src::lf_mask::Av1RestorationUnit;
 
 use crate::src::env::BlockContext;
 use crate::src::refmvs::refmvs_block;
@@ -7362,9 +7312,9 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_cols_8bpc(
     let ss_ver = ((*f).cur.p.layout as libc::c_uint
         == DAV1D_PIXEL_LAYOUT_I420 as libc::c_int as libc::c_uint) as libc::c_int;
     let p: [*mut pixel; 3] = [
-        ((*f).lf.p[0]).offset((y as isize * (*f).cur.stride[0]) as isize),
-        ((*f).lf.p[1]).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
-        ((*f).lf.p[2]).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
+        ((*f).lf.p[0] as *mut pixel).offset((y as isize * (*f).cur.stride[0]) as isize),
+        ((*f).lf.p[1] as *mut pixel).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
+        ((*f).lf.p[2] as *mut pixel).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
     ];
     let mut mask: *mut Av1Filter = ((*f).lf.mask)
         .offset(((sby >> ((*(*f).seq_hdr).sb128 == 0) as libc::c_int) * (*f).sb128w) as isize);
@@ -7385,9 +7335,9 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_rows_8bpc(
     let ss_ver = ((*f).cur.p.layout as libc::c_uint
         == DAV1D_PIXEL_LAYOUT_I420 as libc::c_int as libc::c_uint) as libc::c_int;
     let p: [*mut pixel; 3] = [
-        ((*f).lf.p[0]).offset((y as isize * (*f).cur.stride[0]) as isize),
-        ((*f).lf.p[1]).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
-        ((*f).lf.p[2]).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
+        ((*f).lf.p[0] as *mut pixel).offset((y as isize * (*f).cur.stride[0]) as isize),
+        ((*f).lf.p[1] as *mut pixel).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
+        ((*f).lf.p[2] as *mut pixel).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
     ];
     let mut mask: *mut Av1Filter = ((*f).lf.mask)
         .offset(((sby >> ((*(*f).seq_hdr).sb128 == 0) as libc::c_int) * (*f).sb128w) as isize);
@@ -7417,9 +7367,9 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_8bpc(tc: *mut Dav1dTaskContext,
     let ss_ver = ((*f).cur.p.layout as libc::c_uint
         == DAV1D_PIXEL_LAYOUT_I420 as libc::c_int as libc::c_uint) as libc::c_int;
     let p: [*mut pixel; 3] = [
-        ((*f).lf.p[0]).offset((y as isize * (*f).cur.stride[0]) as isize),
-        ((*f).lf.p[1]).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
-        ((*f).lf.p[2]).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
+        ((*f).lf.p[0] as *mut pixel).offset((y as isize * (*f).cur.stride[0]) as isize),
+        ((*f).lf.p[1] as *mut pixel).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
+        ((*f).lf.p[2] as *mut pixel).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
     ];
     let mut prev_mask: *mut Av1Filter = ((*f).lf.mask)
         .offset(((sby - 1 >> ((*(*f).seq_hdr).sb128 == 0) as libc::c_int) * (*f).sb128w) as isize);
@@ -7459,14 +7409,19 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_resize_8bpc(
     let ss_ver = ((*f).cur.p.layout as libc::c_uint
         == DAV1D_PIXEL_LAYOUT_I420 as libc::c_int as libc::c_uint) as libc::c_int;
     let p: [*const pixel; 3] = [
-        ((*f).lf.p[0]).offset((y as isize * (*f).cur.stride[0]) as isize) as *const pixel,
-        ((*f).lf.p[1]).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize) as *const pixel,
-        ((*f).lf.p[2]).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize) as *const pixel,
+        ((*f).lf.p[0] as *mut pixel).offset((y as isize * (*f).cur.stride[0]) as isize)
+            as *const pixel,
+        ((*f).lf.p[1] as *mut pixel).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize)
+            as *const pixel,
+        ((*f).lf.p[2] as *mut pixel).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize)
+            as *const pixel,
     ];
     let sr_p: [*mut pixel; 3] = [
-        ((*f).lf.sr_p[0]).offset((y as isize * (*f).sr_cur.p.stride[0]) as isize),
-        ((*f).lf.sr_p[1]).offset((y as isize * (*f).sr_cur.p.stride[1] >> ss_ver) as isize),
-        ((*f).lf.sr_p[2]).offset((y as isize * (*f).sr_cur.p.stride[1] >> ss_ver) as isize),
+        ((*f).lf.sr_p[0] as *mut pixel).offset((y as isize * (*f).sr_cur.p.stride[0]) as isize),
+        ((*f).lf.sr_p[1] as *mut pixel)
+            .offset((y as isize * (*f).sr_cur.p.stride[1] >> ss_ver) as isize),
+        ((*f).lf.sr_p[2] as *mut pixel)
+            .offset((y as isize * (*f).sr_cur.p.stride[1] >> ss_ver) as isize),
     ];
     let has_chroma = ((*f).cur.p.layout as libc::c_uint
         != DAV1D_PIXEL_LAYOUT_I400 as libc::c_int as libc::c_uint)
@@ -7519,9 +7474,11 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_lr_8bpc(f: *mut Dav1dFrameContext, s
     let ss_ver = ((*f).cur.p.layout as libc::c_uint
         == DAV1D_PIXEL_LAYOUT_I420 as libc::c_int as libc::c_uint) as libc::c_int;
     let sr_p: [*mut pixel; 3] = [
-        ((*f).lf.sr_p[0]).offset((y as isize * (*f).sr_cur.p.stride[0]) as isize),
-        ((*f).lf.sr_p[1]).offset((y as isize * (*f).sr_cur.p.stride[1] >> ss_ver) as isize),
-        ((*f).lf.sr_p[2]).offset((y as isize * (*f).sr_cur.p.stride[1] >> ss_ver) as isize),
+        ((*f).lf.sr_p[0] as *mut pixel).offset((y as isize * (*f).sr_cur.p.stride[0]) as isize),
+        ((*f).lf.sr_p[1] as *mut pixel)
+            .offset((y as isize * (*f).sr_cur.p.stride[1] >> ss_ver) as isize),
+        ((*f).lf.sr_p[2] as *mut pixel)
+            .offset((y as isize * (*f).sr_cur.p.stride[1] >> ss_ver) as isize),
     ];
     dav1d_lr_sbrow_8bpc(f, sr_p.as_ptr(), sby);
 }

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -2,8 +2,6 @@ use crate::include::stddef::*;
 use crate::include::stdint::*;
 use ::libc;
 
-use crate::src::cdf::CdfContext;
-use crate::src::msac::MsacContext;
 use crate::stdout;
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::size_t) -> *mut libc::c_void;
@@ -168,7 +166,6 @@ use crate::src::internal::CodedBlockInfo;
 use crate::src::internal::Dav1dFrameContext_frame_thread;
 use crate::src::levels::mv;
 use crate::src::levels::Av1Block;
-use crate::src::lf_mask::Av1RestorationUnit;
 
 use crate::src::env::BlockContext;
 use crate::src::refmvs::refmvs_block;
@@ -226,25 +223,7 @@ use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::internal::Dav1dTaskContext_scratch;
 use crate::src::refmvs::refmvs_tile;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState {
-    pub cdf: CdfContext,
-    pub msac: MsacContext,
-    pub tiling: Dav1dTileState_tiling,
-    pub progress: [atomic_int; 2],
-    pub frame_thread: [Dav1dTileState_frame_thread; 2],
-    pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
-    pub dqmem: [[[uint16_t; 2]; 3]; 8],
-    pub dq: *const [[uint16_t; 2]; 3],
-    pub last_qidx: libc::c_int,
-    pub last_delta_lf: [int8_t; 4],
-    pub lflvlmem: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
-    pub lr_ref: [*mut Av1RestorationUnit; 3],
-}
-use crate::src::internal::Dav1dTileState_frame_thread;
-use crate::src::internal::Dav1dTileState_tiling;
+use crate::src::internal::Dav1dTileState;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -115,7 +115,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut pixel; 3],
+    pub ipred_edge: [*mut libc::c_void; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,
@@ -4416,7 +4416,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                         })) as EdgeFlags;
                         top_sb_edge = 0 as *const pixel;
                         if (*t).by & (*f).sb_step - 1 == 0 {
-                            top_sb_edge = (*f).ipred_edge[0];
+                            top_sb_edge = (*f).ipred_edge[0] as *mut pixel;
                             let sby = (*t).by >> (*f).sb_shift;
                             top_sb_edge =
                                 top_sb_edge.offset(((*f).sb128w * 128 * (sby - 1)) as isize);
@@ -4838,7 +4838,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                             let mut angle_0 = 0;
                             let mut top_sb_edge_0: *const pixel = 0 as *const pixel;
                             if (*t).by & !ss_ver & (*f).sb_step - 1 == 0 {
-                                top_sb_edge_0 = (*f).ipred_edge[(pl + 1) as usize];
+                                top_sb_edge_0 = (*f).ipred_edge[(pl + 1) as usize] as *mut pixel;
                                 let sby_0 = (*t).by >> (*f).sb_shift;
                                 top_sb_edge_0 = top_sb_edge_0
                                     .offset(((*f).sb128w * 128 * (sby_0 - 1)) as isize);
@@ -5035,7 +5035,8 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                 })) as EdgeFlags;
                                 top_sb_edge_1 = 0 as *const pixel;
                                 if (*t).by & !ss_ver & (*f).sb_step - 1 == 0 {
-                                    top_sb_edge_1 = (*f).ipred_edge[(1 + pl_0) as usize];
+                                    top_sb_edge_1 =
+                                        (*f).ipred_edge[(1 + pl_0) as usize] as *mut pixel;
                                     let sby_1 = (*t).by >> (*f).sb_shift;
                                     top_sb_edge_1 = top_sb_edge_1
                                         .offset(((*f).sb128w * 128 * (sby_1 - 1)) as isize);
@@ -5750,7 +5751,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
             let mut angle = 0;
             let mut top_sb_edge: *const pixel = 0 as *const pixel;
             if (*t).by & (*f).sb_step - 1 == 0 {
-                top_sb_edge = (*f).ipred_edge[0];
+                top_sb_edge = (*f).ipred_edge[0] as *mut pixel;
                 let sby = (*t).by >> (*f).sb_shift;
                 top_sb_edge = top_sb_edge.offset(((*f).sb128w * 128 * (sby - 1)) as isize);
             }
@@ -6195,7 +6196,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                             .offset(uvdstoff as isize);
                         let mut top_sb_edge_0: *const pixel = 0 as *const pixel;
                         if (*t).by & (*f).sb_step - 1 == 0 {
-                            top_sb_edge_0 = (*f).ipred_edge[(pl_6 + 1) as usize];
+                            top_sb_edge_0 = (*f).ipred_edge[(pl_6 + 1) as usize] as *mut pixel;
                             let sby_0 = (*t).by >> (*f).sb_shift;
                             top_sb_edge_0 =
                                 top_sb_edge_0.offset(((*f).sb128w * 128 * (sby_0 - 1)) as isize);
@@ -7507,8 +7508,8 @@ pub unsafe extern "C" fn dav1d_backup_ipred_edge_8bpc(t: *mut Dav1dTaskContext) 
         .offset((x_off * 4) as isize)
         .offset(((((*t).by + (*f).sb_step) * 4 - 1) as isize * (*f).cur.stride[0]) as isize);
     memcpy(
-        &mut *(*((*f).ipred_edge).as_ptr().offset(0)).offset((sby_off + x_off * 4) as isize)
-            as *mut pixel as *mut libc::c_void,
+        &mut *(*((*f).ipred_edge).as_ptr().offset(0) as *mut pixel)
+            .offset((sby_off + x_off * 4) as isize) as *mut pixel as *mut libc::c_void,
         y as *const libc::c_void,
         (4 * ((*ts).tiling.col_end - x_off)) as size_t,
     );
@@ -7524,7 +7525,7 @@ pub unsafe extern "C" fn dav1d_backup_ipred_edge_8bpc(t: *mut Dav1dTaskContext) 
         let mut pl = 1;
         while pl <= 2 {
             memcpy(
-                &mut *(*((*f).ipred_edge).as_ptr().offset(pl as isize))
+                &mut *(*((*f).ipred_edge).as_ptr().offset(pl as isize) as *mut pixel)
                     .offset((sby_off + (x_off * 4 >> ss_hor)) as isize)
                     as *mut pixel as *mut libc::c_void,
                 &*(*((*f).cur.data).as_ptr().offset(pl as isize) as *const pixel)

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1,7 +1,7 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 use crate::src::cdf::CdfContext;
-use crate::src::msac::MsacContext;
+
 use ::libc;
 extern "C" {
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: size_t) -> *mut libc::c_void;
@@ -163,7 +163,7 @@ pub type pixel = ();
 use crate::src::lf_mask::Av1FilterLUT;
 
 use crate::src::internal::Dav1dFrameContext_frame_thread;
-use crate::src::lf_mask::Av1RestorationUnit;
+
 pub type coef = ();
 
 use crate::src::levels::Av1Block;
@@ -221,25 +221,7 @@ use crate::src::internal::Dav1dTaskContext_cf;
 use crate::src::internal::Dav1dTaskContext_scratch;
 use crate::src::refmvs::refmvs_tile;
 
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState {
-    pub cdf: CdfContext,
-    pub msac: MsacContext,
-    pub tiling: Dav1dTileState_tiling,
-    pub progress: [atomic_int; 2],
-    pub frame_thread: [Dav1dTileState_frame_thread; 2],
-    pub lowest_pixel: *mut [[libc::c_int; 2]; 7],
-    pub dqmem: [[[uint16_t; 2]; 3]; 8],
-    pub dq: *const [[uint16_t; 2]; 3],
-    pub last_qidx: libc::c_int,
-    pub last_delta_lf: [int8_t; 4],
-    pub lflvlmem: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
-    pub lr_ref: [*mut Av1RestorationUnit; 3],
-}
-use crate::src::internal::Dav1dTileState_frame_thread;
-use crate::src::internal::Dav1dTileState_tiling;
+use crate::src::internal::Dav1dTileState;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -157,64 +157,15 @@ use crate::include::dav1d::headers::Dav1dSequenceHeader;
 
 use crate::include::pthread::pthread_cond_t;
 
-use crate::src::align::Align16;
-
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_lf {
-    pub level: *mut [uint8_t; 4],
-    pub mask: *mut Av1Filter,
-    pub lr_mask: *mut Av1Restoration,
-    pub mask_sz: libc::c_int,
-    pub lr_mask_sz: libc::c_int,
-    pub cdef_buf_plane_sz: [libc::c_int; 2],
-    pub cdef_buf_sbh: libc::c_int,
-    pub lr_buf_plane_sz: [libc::c_int; 2],
-    pub re_sz: libc::c_int,
-    pub lim_lut: Align16<Av1FilterLUT>,
-    pub last_sharpness: libc::c_int,
-    pub lvl: [[[[uint8_t; 2]; 8]; 4]; 8],
-    pub tx_lpf_right_edge: [*mut uint8_t; 2],
-    pub cdef_line_buf: *mut uint8_t,
-    pub lr_line_buf: *mut uint8_t,
-    pub cdef_line: [[*mut libc::c_void; 3]; 2],
-    pub cdef_lpf_line: [*mut libc::c_void; 3],
-    pub lr_lpf_line: [*mut libc::c_void; 3],
-    pub start_of_tile_row: *mut uint8_t,
-    pub start_of_tile_row_sz: libc::c_int,
-    pub need_cdef_lpf_copy: libc::c_int,
-    pub p: [*mut libc::c_void; 3],
-    pub sr_p: [*mut libc::c_void; 3],
-    pub mask_ptr: *mut Av1Filter,
-    pub prev_mask_ptr: *mut Av1Filter,
-    pub restore_planes: libc::c_int,
-}
+use crate::src::internal::Dav1dFrameContext_lf;
 use crate::src::lf_mask::Av1Filter;
 pub type pixel = ();
 use crate::src::lf_mask::Av1FilterLUT;
-use crate::src::lf_mask::Av1Restoration;
+
+use crate::src::internal::Dav1dFrameContext_frame_thread;
 use crate::src::lf_mask::Av1RestorationUnit;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dFrameContext_frame_thread {
-    pub next_tile_row: [libc::c_int; 2],
-    pub entropy_progress: atomic_int,
-    pub deblock_progress: atomic_int,
-    pub frame_progress: *mut atomic_uint,
-    pub copy_lpf_progress: *mut atomic_uint,
-    pub b: *mut Av1Block,
-    pub cbi: *mut CodedBlockInfo,
-    pub pal: *mut [[uint16_t; 8]; 3],
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut libc::c_void,
-    pub prog_sz: libc::c_int,
-    pub pal_sz: libc::c_int,
-    pub pal_idx_sz: libc::c_int,
-    pub cf_sz: libc::c_int,
-    pub tile_start_off: *mut libc::c_int,
-}
 pub type coef = ();
-use crate::src::internal::CodedBlockInfo;
+
 use crate::src::levels::Av1Block;
 use crate::src::refmvs::refmvs_frame;
 

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -287,12 +287,7 @@ pub struct Dav1dTileState {
     pub lflvl: *const [[[uint8_t; 2]; 8]; 4],
     pub lr_ref: [*mut Av1RestorationUnit; 3],
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dTileState_frame_thread {
-    pub pal_idx: *mut uint8_t,
-    pub cf: *mut libc::c_void,
-}
+use crate::src::internal::Dav1dTileState_frame_thread;
 use crate::src::internal::Dav1dTileState_tiling;
 
 #[derive(Copy, Clone)]


### PR DESCRIPTION
The reason why there are still a lot of duplicate types left is because they contain bitdepth-dependent types, mainly `pixel` and `coef`.  Luckily, these are all behind pointers, and so we can normalize them to `*mut libc::c_void` and then cast them to the appropriate bitdepth-dependent type when they're used.  Once normalized, they can then be deduplicated.

I initially was going to use a `union` for this, given that there are only two bitdepth variants in the code, 8 and 16, but there are some cases where `coef` and `pixel` pointers are cast to other types as well, such as `*mut uint8_t` and `*mut libc::c_void`, so I've just left them as `*mut libc::c_void` for now.  They can always be changed to a `union` later.

Note also that many of these pointers are slices, so before `.offset`ting them and doing pointer arithmetic on them, we need to make sure to cast them to the right concrete type, not `*mut libc::c_void` or a `*mut` to a `union`, as then the type sizes are different and `.offset` calculates things differently.

Almost all of the cases of `pixel`s and `coef`s in shared types have been normalized now, except for those in function pointers that ultimately are in `struct Dav1dDSPContext`.  `Dav1dDSPContext` is in multiple other types, and many of the remaining types are in each other, meaning there are unfortunately still a lot of duplicate types remaining just due to `Dav1dDSPContext`.

Bitdepth-dependent `fn` pointer args (e.x. `*mut pixel`) are trickier than `struct` fields since we can't just insert the casts at use sites, as many of these `fn` pointers are coming from assembly.  What we can probably do it add generated wrapper `fn`s around the bitdepth-dependent `fn` pointers that convert from the type-erased args, or to use a `union` with two `fn` pointers for each bitdepth.  Either way, it's quite a bit more involved, so I'm leaving it for later.