### PR TITLE
`splat_mv_fn`: Make safer

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1979,8 +1979,8 @@ unsafe fn splat_oneref_mv(
     t: &mut Dav1dTaskContext,
     bs: BlockSize,
     b: &Av1Block,
-    bw4: libc::c_int,
-    bh4: libc::c_int,
+    bw4: usize,
+    bh4: usize,
 ) {
     let mode = b.inter_mode() as InterPredMode;
     let tmpl = Align16(refmvs_block(refmvs_block_unaligned {
@@ -1999,7 +1999,7 @@ unsafe fn splat_oneref_mv(
     c.refmvs_dsp.splat_mv(
         &mut t.rt.r[((t.by & 31) + 5) as usize..],
         &tmpl.0,
-        t.bx,
+        t.bx as usize,
         bw4,
         bh4,
     );
@@ -2011,8 +2011,8 @@ unsafe fn splat_intrabc_mv(
     t: &mut Dav1dTaskContext,
     bs: BlockSize,
     b: &Av1Block,
-    bw4: libc::c_int,
-    bh4: libc::c_int,
+    bw4: usize,
+    bh4: usize,
 ) {
     let tmpl = Align16(refmvs_block(refmvs_block_unaligned {
         mv: refmvs_mvpair {
@@ -2025,7 +2025,7 @@ unsafe fn splat_intrabc_mv(
     c.refmvs_dsp.splat_mv(
         &mut t.rt.r[((t.by & 31) + 5) as usize..],
         &tmpl.0,
-        t.bx,
+        t.bx as usize,
         bw4,
         bh4,
     );
@@ -2037,8 +2037,8 @@ unsafe fn splat_tworef_mv(
     t: &mut Dav1dTaskContext,
     bs: BlockSize,
     b: &Av1Block,
-    bw4: libc::c_int,
-    bh4: libc::c_int,
+    bw4: usize,
+    bh4: usize,
 ) {
     assert!(bw4 >= 2 && bh4 >= 2);
     let mode = b.inter_mode() as CompInterPredMode;
@@ -2053,7 +2053,7 @@ unsafe fn splat_tworef_mv(
     c.refmvs_dsp.splat_mv(
         &mut t.rt.r[((t.by & 31) + 5) as usize..],
         &tmpl.0,
-        t.bx,
+        t.bx as usize,
         bw4,
         bh4,
     );
@@ -2064,8 +2064,8 @@ unsafe fn splat_intraref(
     c: &Dav1dContext,
     t: &mut Dav1dTaskContext,
     bs: BlockSize,
-    bw4: libc::c_int,
-    bh4: libc::c_int,
+    bw4: usize,
+    bh4: usize,
 ) {
     let tmpl = Align16(refmvs_block(refmvs_block_unaligned {
         mv: refmvs_mvpair {
@@ -2078,7 +2078,7 @@ unsafe fn splat_intraref(
     c.refmvs_dsp.splat_mv(
         &mut t.rt.r[((t.by & 31) + 5) as usize..],
         &tmpl.0,
-        t.bx,
+        t.bx as usize,
         bw4,
         bh4,
     );
@@ -3165,7 +3165,7 @@ unsafe fn decode_b(
         }
 
         if is_inter_or_switch(frame_hdr) || frame_hdr.allow_intrabc != 0 {
-            splat_intraref(&*f.c, t, bs, bw4, bh4);
+            splat_intraref(&*f.c, t, bs, bw4 as usize, bh4 as usize);
         }
     } else if is_key_or_intra(frame_hdr) {
         // intra block copy
@@ -3287,7 +3287,7 @@ unsafe fn decode_b(
             return -1;
         }
 
-        splat_intrabc_mv(&*f.c, t, bs, b, bw4, bh4);
+        splat_intrabc_mv(&*f.c, t, bs, b, bw4 as usize, bh4 as usize);
 
         let mut set_ctx = |dir: &mut BlockContext, diridx: usize, off, mul, rep_macro: SetCtxFn| {
             rep_macro(
@@ -4084,9 +4084,9 @@ unsafe fn decode_b(
             );
         }
         if is_comp {
-            splat_tworef_mv(&*f.c, t, bs, b, bw4, bh4);
+            splat_tworef_mv(&*f.c, t, bs, b, bw4 as usize, bh4 as usize);
         } else {
-            splat_oneref_mv(&*f.c, t, bs, b, bw4, bh4);
+            splat_oneref_mv(&*f.c, t, bs, b, bw4 as usize, bh4 as usize);
         }
 
         let mut set_ctx = |dir: &mut BlockContext, diridx: usize, off, mul, rep_macro: SetCtxFn| {

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1599,25 +1599,16 @@ pub unsafe extern "C" fn dav1d_refmvs_clear(rf: *mut refmvs_frame) {
 }
 
 unsafe extern "C" fn splat_mv_rust(
-    mut rr: *mut *mut refmvs_block,
+    rr: *mut *mut refmvs_block,
     rmv: *const refmvs_block,
     bx4: libc::c_int,
     bw4: libc::c_int,
-    mut bh4: libc::c_int,
+    bh4: libc::c_int,
 ) {
-    loop {
-        let fresh17 = rr;
-        rr = rr.offset(1);
-        let r: *mut refmvs_block = (*fresh17).offset(bx4 as isize);
-        let mut x = 0;
-        while x < bw4 {
-            *r.offset(x as isize) = *rmv;
-            x += 1;
-        }
-        bh4 -= 1;
-        if !(bh4 != 0) {
-            break;
-        }
+    let [bx4, bw4, bh4] = [bx4, bw4, bh4].map(|it| it as usize);
+    let rmv = &*rmv;
+    for r in std::slice::from_raw_parts_mut(rr, bh4) {
+        std::slice::from_raw_parts_mut(*r, bx4 + bw4)[bx4..].fill(*rmv);
     }
 }
 

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1597,7 +1597,8 @@ pub unsafe extern "C" fn dav1d_refmvs_clear(rf: *mut refmvs_frame) {
         );
     }
 }
-unsafe extern "C" fn splat_mv_c(
+
+unsafe extern "C" fn splat_mv_rust(
     mut rr: *mut *mut refmvs_block,
     rmv: *const refmvs_block,
     bx4: libc::c_int,
@@ -1675,16 +1676,7 @@ unsafe extern "C" fn refmvs_dsp_init_arm(c: *mut Dav1dRefmvsDSPContext) {
 pub unsafe extern "C" fn dav1d_refmvs_dsp_init(c: *mut Dav1dRefmvsDSPContext) {
     (*c).load_tmvs = Some(load_tmvs_c);
     (*c).save_tmvs = Some(save_tmvs_c);
-    (*c).splat_mv = Some(
-        splat_mv_c
-            as unsafe extern "C" fn(
-                *mut *mut refmvs_block,
-                *const refmvs_block,
-                libc::c_int,
-                libc::c_int,
-                libc::c_int,
-            ) -> (),
-    );
+    (*c).splat_mv = Some(splat_mv_rust);
     cfg_if! {
         if #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "asm"))] {
             refmvs_dsp_init_x86(c);

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -207,15 +207,17 @@ pub type save_tmvs_fn = Option<
         libc::c_int,
     ) -> (),
 >;
+
 pub type splat_mv_fn = Option<
     unsafe extern "C" fn(
         *mut *mut refmvs_block,
-        *const refmvs_block,
+        &refmvs_block,
         libc::c_int,
         libc::c_int,
         libc::c_int,
     ) -> (),
 >;
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dRefmvsDSPContext {
@@ -1606,7 +1608,7 @@ mod ffi {
         ($fn_name:ident) => {
             pub(super) unsafe extern "C" fn $fn_name(
                 rr: *mut *mut refmvs_block,
-                rmv: *const refmvs_block,
+                rmv: &refmvs_block,
                 bx4: libc::c_int,
                 bw4: libc::c_int,
                 bh4: libc::c_int,
@@ -1631,13 +1633,12 @@ mod ffi {
 
 unsafe extern "C" fn splat_mv_rust(
     rr: *mut *mut refmvs_block,
-    rmv: *const refmvs_block,
+    rmv: &refmvs_block,
     bx4: libc::c_int,
     bw4: libc::c_int,
     bh4: libc::c_int,
 ) {
     let [bx4, bw4, bh4] = [bx4, bw4, bh4].map(|it| it as usize);
-    let rmv = &*rmv;
     for r in std::slice::from_raw_parts_mut(rr, bh4) {
         std::slice::from_raw_parts_mut(*r, bx4 + bw4)[bx4..].fill(*rmv);
     }


### PR DESCRIPTION
This adds wrapper `fn`s around the FFI/asm `fn`s so things can be made safer without changing any asm signatures.

Once fewer things have to be `#[repr(C)]`, then the `fn` ptr can be made non-`extern "C"` and the args even safer (e.x. slices will work, but aren't safe currently over C's ABI).

Once the inner `*mut refmvs_block` raw ptr is made safe (a slice or an obviously correct separate length), then these functions can be made fully safe (with `unsafe` blocks, but checked ones).