### PR TITLE
Fix a typo bug from 9f923675 causing crashes (out-of-bounds accesses) in the argon tests

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4220,7 +4220,7 @@ unsafe fn decode_b(
                             bh4,
                             (*rr).0.mv.mv[0].y,
                             ss_ver,
-                            &f.svc[(*rr).0.r#ref.r#ref[0] as usize][1],
+                            &f.svc[(*rr).0.r#ref.r#ref[0] as usize - 1][1],
                         );
                     }
                     if bw4 == 1 {
@@ -4232,7 +4232,7 @@ unsafe fn decode_b(
                             bh4,
                             (*rr).0.mv.mv[0].y,
                             ss_ver,
-                            &f.svc[(*rr).0.r#ref.r#ref[0] as usize][1],
+                            &f.svc[(*rr).0.r#ref.r#ref[0] as usize - 1][1],
                         );
                     }
                     if bh4 == ss_ver {
@@ -4243,7 +4243,7 @@ unsafe fn decode_b(
                             bh4,
                             (*rr).0.mv.mv[0].y,
                             ss_ver,
-                            &f.svc[(*rr).0.r#ref.r#ref[0] as usize][1],
+                            &f.svc[(*rr).0.r#ref.r#ref[0] as usize - 1][1],
                         );
                     }
                     mc_lowest_px(


### PR DESCRIPTION
An example crash:

```shell
❯ cargo run -- -i ./tests/argon/profile0_core/streams/test10041.obu --filmgrain 1 --verify 8823d10667e90c4314d12b6e1171afdd --cpumask -1 --threads 0 -q   Compiling c2rust_out v0.0.0 (/home/kkysen/work/rust/rav1d)
    Finished dev [unoptimized + debuginfo] target(s) in 2.12s
     Running `target/debug/dav1d -i /home/kkysen/work/rust/rav1d/tests/argon/profile0_core/streams/test10041.obu --filmgrain 1 --verify 8823d10667e90c4314d12b6e1171afdd --cpumask -1 --threads 0 -q`
Unknown Metadata OBU type 0
thread '<unnamed>' panicked at 'index out of bounds: the len is 7 but the index is 7', src/decode.rs:4244:30
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread '<unnamed>' panicked at 'index out of bounds: the len is 7 but the index is 7', src/decode.rs:4255:30
fatal runtime error: failed to initiate panic, error 5
Aborted (core dumped)
```