### PR TITLE
`fn get_lo_ctx`: Cleanup and make safe

### DIFF
--- a/src/recon.rs
+++ b/src/recon.rs
@@ -617,19 +617,18 @@ pub unsafe fn get_lo_ctx(
 ) -> libc::c_uint {
     let mut mag = levels[(0 * stride + 1) as usize] as libc::c_uint
         + levels[(1 * stride + 0) as usize] as libc::c_uint;
-    let mut offset = 0;
-    if tx_class == TX_CLASS_2D {
+    let offset = if tx_class == TX_CLASS_2D {
         mag += levels[(1 * stride + 1) as usize] as libc::c_uint;
         *hi_mag = mag;
         mag += levels[(0 * stride + 2) as usize] as libc::c_uint
             + levels[(2 * stride + 0) as usize] as libc::c_uint;
-        offset = ctx_offsets.unwrap()[umin(y, 4) as usize][umin(x, 4) as usize] as libc::c_uint;
+        ctx_offsets.unwrap()[umin(y, 4) as usize][umin(x, 4) as usize] as libc::c_uint
     } else {
         mag += levels[(0 * stride + 2) as usize] as libc::c_uint;
         *hi_mag = mag;
         mag += levels[(0 * stride + 3) as usize] as libc::c_uint
             + levels[(0 * stride + 4) as usize] as libc::c_uint;
-        offset = 26 + if y > 1 { 10 } else { y * 5 };
-    }
+        26 + if y > 1 { 10 } else { y * 5 }
+    };
     offset + if mag > 512 { 4 } else { (mag + 64) >> 7 }
 }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -614,16 +614,18 @@ pub unsafe fn get_lo_ctx(
     y: usize,
     stride: usize,
 ) -> usize {
-    let mut mag = levels[0 * stride + 1] as libc::c_uint + levels[1 * stride + 0] as libc::c_uint;
+    let level = |y, x| levels[y * stride + x] as libc::c_uint;
+
+    let mut mag = level(0, 1) + level(1, 0);
     let offset = if tx_class == TX_CLASS_2D {
-        mag += levels[1 * stride + 1] as libc::c_uint;
+        mag += level(1, 1);
         *hi_mag = mag;
-        mag += levels[0 * stride + 2] as libc::c_uint + levels[2 * stride + 0] as libc::c_uint;
+        mag += level(0, 2) + level(2, 0);
         ctx_offsets.unwrap()[std::cmp::min(y, 4)][std::cmp::min(x, 4)] as usize
     } else {
-        mag += levels[0 * stride + 2] as libc::c_uint;
+        mag += level(0, 2);
         *hi_mag = mag;
-        mag += levels[0 * stride + 3] as libc::c_uint + levels[0 * stride + 4] as libc::c_uint;
+        mag += level(0, 3) + level(0, 4);
         26 + if y > 1 { 10 } else { y * 5 }
     };
     offset

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -605,7 +605,7 @@ pub unsafe fn get_dc_sign_ctx(tx: libc::c_int, a: &[u8], l: &[u8]) -> libc::c_ui
 }
 
 #[inline]
-pub unsafe fn get_lo_ctx(
+pub fn get_lo_ctx(
     levels: &[u8],
     tx_class: TxClass,
     hi_mag: &mut libc::c_uint,

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -631,5 +631,5 @@ pub unsafe fn get_lo_ctx(
             + levels[(0 * stride + 4) as usize] as libc::c_uint;
         offset = 26 + if y > 1 { 10 } else { y * 5 };
     }
-    return offset + if mag > 512 { 4 } else { (mag + 64) >> 7 };
+    offset + if mag > 512 { 4 } else { (mag + 64) >> 7 }
 }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -613,18 +613,23 @@ pub unsafe fn get_lo_ctx(
     x: usize,
     y: usize,
     stride: usize,
-) -> libc::c_uint {
+) -> usize {
     let mut mag = levels[0 * stride + 1] as libc::c_uint + levels[1 * stride + 0] as libc::c_uint;
     let offset = if tx_class == TX_CLASS_2D {
         mag += levels[1 * stride + 1] as libc::c_uint;
         *hi_mag = mag;
         mag += levels[0 * stride + 2] as libc::c_uint + levels[2 * stride + 0] as libc::c_uint;
-        ctx_offsets.unwrap()[std::cmp::min(y, 4)][std::cmp::min(x, 4)] as libc::c_uint
+        ctx_offsets.unwrap()[std::cmp::min(y, 4)][std::cmp::min(x, 4)] as usize
     } else {
         mag += levels[0 * stride + 2] as libc::c_uint;
         *hi_mag = mag;
         mag += levels[0 * stride + 3] as libc::c_uint + levels[0 * stride + 4] as libc::c_uint;
-        26 + if y > 1 { 10 } else { y as libc::c_uint * 5 }
+        26 + if y > 1 { 10 } else { y * 5 }
     };
-    offset + if mag > 512 { 4 } else { (mag + 64) >> 7 }
+    offset
+        + if mag > 512 {
+            4
+        } else {
+            (mag as usize + 64) >> 7
+        }
 }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -610,8 +610,8 @@ pub unsafe fn get_lo_ctx(
     tx_class: TxClass,
     hi_mag: &mut libc::c_uint,
     ctx_offsets: Option<&[[u8; 5]; 5]>,
-    x: libc::c_uint,
-    y: libc::c_uint,
+    x: usize,
+    y: usize,
     stride: usize,
 ) -> libc::c_uint {
     let mut mag = levels[0 * stride + 1] as libc::c_uint + levels[1 * stride + 0] as libc::c_uint;
@@ -619,13 +619,12 @@ pub unsafe fn get_lo_ctx(
         mag += levels[1 * stride + 1] as libc::c_uint;
         *hi_mag = mag;
         mag += levels[0 * stride + 2] as libc::c_uint + levels[2 * stride + 0] as libc::c_uint;
-        ctx_offsets.unwrap()[std::cmp::min(y, 4) as usize][std::cmp::min(x, 4) as usize]
-            as libc::c_uint
+        ctx_offsets.unwrap()[std::cmp::min(y, 4)][std::cmp::min(x, 4)] as libc::c_uint
     } else {
         mag += levels[0 * stride + 2] as libc::c_uint;
         *hi_mag = mag;
         mag += levels[0 * stride + 3] as libc::c_uint + levels[0 * stride + 4] as libc::c_uint;
-        26 + if y > 1 { 10 } else { y * 5 }
+        26 + if y > 1 { 10 } else { y as libc::c_uint * 5 }
     };
     offset + if mag > 512 { 4 } else { (mag + 64) >> 7 }
 }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2,7 +2,6 @@ use crate::include::common::intops::umin;
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::stddef::ptrdiff_t;
 use crate::include::stdint::uint16_t;
 use crate::include::stdint::uint32_t;
 use crate::include::stdint::uint64_t;
@@ -613,21 +612,18 @@ pub unsafe fn get_lo_ctx(
     ctx_offsets: Option<&[[u8; 5]; 5]>,
     x: libc::c_uint,
     y: libc::c_uint,
-    stride: ptrdiff_t,
+    stride: usize,
 ) -> libc::c_uint {
-    let mut mag = levels[(0 * stride + 1) as usize] as libc::c_uint
-        + levels[(1 * stride + 0) as usize] as libc::c_uint;
+    let mut mag = levels[0 * stride + 1] as libc::c_uint + levels[1 * stride + 0] as libc::c_uint;
     let offset = if tx_class == TX_CLASS_2D {
-        mag += levels[(1 * stride + 1) as usize] as libc::c_uint;
+        mag += levels[1 * stride + 1] as libc::c_uint;
         *hi_mag = mag;
-        mag += levels[(0 * stride + 2) as usize] as libc::c_uint
-            + levels[(2 * stride + 0) as usize] as libc::c_uint;
+        mag += levels[0 * stride + 2] as libc::c_uint + levels[2 * stride + 0] as libc::c_uint;
         ctx_offsets.unwrap()[umin(y, 4) as usize][umin(x, 4) as usize] as libc::c_uint
     } else {
-        mag += levels[(0 * stride + 2) as usize] as libc::c_uint;
+        mag += levels[0 * stride + 2] as libc::c_uint;
         *hi_mag = mag;
-        mag += levels[(0 * stride + 3) as usize] as libc::c_uint
-            + levels[(0 * stride + 4) as usize] as libc::c_uint;
+        mag += levels[0 * stride + 3] as libc::c_uint + levels[0 * stride + 4] as libc::c_uint;
         26 + if y > 1 { 10 } else { y * 5 }
     };
     offset + if mag > 512 { 4 } else { (mag + 64) >> 7 }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -619,7 +619,8 @@ pub unsafe fn get_lo_ctx(
         mag += levels[1 * stride + 1] as libc::c_uint;
         *hi_mag = mag;
         mag += levels[0 * stride + 2] as libc::c_uint + levels[2 * stride + 0] as libc::c_uint;
-        ctx_offsets.unwrap()[umin(y, 4) as usize][umin(x, 4) as usize] as libc::c_uint
+        ctx_offsets.unwrap()[std::cmp::min(y, 4) as usize][std::cmp::min(x, 4) as usize]
+            as libc::c_uint
     } else {
         mag += levels[0 * stride + 2] as libc::c_uint;
         *hi_mag = mag;

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -614,24 +614,19 @@ pub unsafe fn get_lo_ctx(
     y: usize,
     stride: usize,
 ) -> usize {
-    let level = |y, x| levels[y * stride + x] as libc::c_uint;
+    let level = |y, x| levels[y * stride + x] as usize;
 
     let mut mag = level(0, 1) + level(1, 0);
     let offset = if tx_class == TX_CLASS_2D {
         mag += level(1, 1);
-        *hi_mag = mag;
+        *hi_mag = mag as libc::c_uint;
         mag += level(0, 2) + level(2, 0);
         ctx_offsets.unwrap()[std::cmp::min(y, 4)][std::cmp::min(x, 4)] as usize
     } else {
         mag += level(0, 2);
-        *hi_mag = mag;
+        *hi_mag = mag as libc::c_uint;
         mag += level(0, 3) + level(0, 4);
         26 + if y > 1 { 10 } else { y * 5 }
     };
-    offset
-        + if mag > 512 {
-            4
-        } else {
-            (mag as usize + 64) >> 7
-        }
+    offset + if mag > 512 { 4 } else { (mag + 64) >> 7 }
 }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -615,35 +615,29 @@ pub unsafe fn get_lo_ctx(
     y: libc::c_uint,
     stride: ptrdiff_t,
 ) -> libc::c_uint {
-    let mut mag: libc::c_uint = (levels[(0 * stride + 1) as usize] as libc::c_int
-        + levels[(1 * stride + 0) as usize] as libc::c_int)
-        as libc::c_uint;
-    let mut offset: libc::c_uint = 0;
-    if tx_class as libc::c_uint == TX_CLASS_2D as libc::c_int as libc::c_uint {
+    let mut mag = levels[(0 * stride + 1) as usize] as libc::c_uint
+        + levels[(1 * stride + 0) as usize] as libc::c_uint;
+    let mut offset = 0;
+    if tx_class == TX_CLASS_2D {
         mag = mag.wrapping_add(levels[(1 * stride + 1) as usize] as libc::c_uint);
         *hi_mag = mag;
         mag = mag.wrapping_add(
-            (levels[(0 * stride + 2) as usize] as libc::c_int
-                + levels[(2 * stride + 0) as usize] as libc::c_int) as libc::c_uint,
+            levels[(0 * stride + 2) as usize] as libc::c_uint
+                + levels[(2 * stride + 0) as usize] as libc::c_uint,
         );
-        offset = ctx_offsets.unwrap()[umin(y, 4 as libc::c_int as libc::c_uint) as usize]
-            [umin(x, 4 as libc::c_int as libc::c_uint) as usize] as libc::c_uint;
+        offset = ctx_offsets.unwrap()[umin(y, 4) as usize][umin(x, 4) as usize] as libc::c_uint;
     } else {
         mag = mag.wrapping_add(levels[(0 * stride + 2) as usize] as libc::c_uint);
         *hi_mag = mag;
         mag = mag.wrapping_add(
-            (levels[(0 * stride + 3) as usize] as libc::c_int
-                + levels[(0 * stride + 4) as usize] as libc::c_int) as libc::c_uint,
+            levels[(0 * stride + 3) as usize] as libc::c_uint
+                + levels[(0 * stride + 4) as usize] as libc::c_uint,
         );
-        offset = (26 as libc::c_int as libc::c_uint).wrapping_add(if y > 1 as libc::c_uint {
-            10 as libc::c_int as libc::c_uint
-        } else {
-            y.wrapping_mul(5 as libc::c_int as libc::c_uint)
-        });
+        offset = (26 as libc::c_uint).wrapping_add(if y > 1 { 10 } else { y.wrapping_mul(5) });
     }
-    return offset.wrapping_add(if mag > 512 as libc::c_uint {
-        4 as libc::c_int as libc::c_uint
+    return offset.wrapping_add(if mag > 512 {
+        4
     } else {
-        mag.wrapping_add(64 as libc::c_int as libc::c_uint) >> 7
+        mag.wrapping_add(64) >> 7
     });
 }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -619,25 +619,17 @@ pub unsafe fn get_lo_ctx(
         + levels[(1 * stride + 0) as usize] as libc::c_uint;
     let mut offset = 0;
     if tx_class == TX_CLASS_2D {
-        mag = mag.wrapping_add(levels[(1 * stride + 1) as usize] as libc::c_uint);
+        mag += levels[(1 * stride + 1) as usize] as libc::c_uint;
         *hi_mag = mag;
-        mag = mag.wrapping_add(
-            levels[(0 * stride + 2) as usize] as libc::c_uint
-                + levels[(2 * stride + 0) as usize] as libc::c_uint,
-        );
+        mag += levels[(0 * stride + 2) as usize] as libc::c_uint
+            + levels[(2 * stride + 0) as usize] as libc::c_uint;
         offset = ctx_offsets.unwrap()[umin(y, 4) as usize][umin(x, 4) as usize] as libc::c_uint;
     } else {
-        mag = mag.wrapping_add(levels[(0 * stride + 2) as usize] as libc::c_uint);
+        mag += levels[(0 * stride + 2) as usize] as libc::c_uint;
         *hi_mag = mag;
-        mag = mag.wrapping_add(
-            levels[(0 * stride + 3) as usize] as libc::c_uint
-                + levels[(0 * stride + 4) as usize] as libc::c_uint,
-        );
-        offset = (26 as libc::c_uint).wrapping_add(if y > 1 { 10 } else { y.wrapping_mul(5) });
+        mag += levels[(0 * stride + 3) as usize] as libc::c_uint
+            + levels[(0 * stride + 4) as usize] as libc::c_uint;
+        offset = 26 + if y > 1 { 10 } else { y * 5 };
     }
-    return offset.wrapping_add(if mag > 512 {
-        4
-    } else {
-        mag.wrapping_add(64) >> 7
-    });
+    return offset + if mag > 512 { 4 } else { (mag + 64) >> 7 };
 }

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1205,7 +1205,7 @@ unsafe fn decode_coefs(
                         x as usize,
                         y as usize,
                         stride as usize,
-                    );
+                    ) as libc::c_uint;
                     if TX_CLASS_2D as libc::c_int == TX_CLASS_2D as libc::c_int {
                         y |= x;
                     }
@@ -1286,7 +1286,7 @@ unsafe fn decode_coefs(
                         0,
                         0,
                         stride as usize,
-                    )
+                    ) as libc::c_uint
                 };
                 dc_tok = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
@@ -1433,7 +1433,7 @@ unsafe fn decode_coefs(
                         x_0 as usize,
                         y_0 as usize,
                         stride_0 as usize,
-                    );
+                    ) as libc::c_uint;
                     if TX_CLASS_H as libc::c_int == TX_CLASS_2D as libc::c_int {
                         y_0 |= x_0;
                     }
@@ -1514,7 +1514,7 @@ unsafe fn decode_coefs(
                         0,
                         0,
                         stride_0 as usize,
-                    )
+                    ) as libc::c_uint
                 };
                 dc_tok = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
@@ -1660,7 +1660,7 @@ unsafe fn decode_coefs(
                         x_1 as usize,
                         y_1 as usize,
                         stride_1 as usize,
-                    );
+                    ) as libc::c_uint;
                     if TX_CLASS_V as libc::c_int == TX_CLASS_2D as libc::c_int {
                         y_1 |= x_1;
                     }
@@ -1741,7 +1741,7 @@ unsafe fn decode_coefs(
                         0,
                         0,
                         stride_1 as usize,
-                    )
+                    ) as libc::c_uint
                 };
                 dc_tok = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1197,7 +1197,15 @@ unsafe fn decode_coefs(
                         unreachable!();
                     }
                     let level = &mut levels[(x as isize * stride + y as isize) as usize..];
-                    ctx = get_lo_ctx(level, TX_CLASS_2D, &mut mag, lo_ctx_offsets, x, y, stride as usize);
+                    ctx = get_lo_ctx(
+                        level,
+                        TX_CLASS_2D,
+                        &mut mag,
+                        lo_ctx_offsets,
+                        x as usize,
+                        y as usize,
+                        stride as usize,
+                    );
                     if TX_CLASS_2D as libc::c_int == TX_CLASS_2D as libc::c_int {
                         y |= x;
                     }
@@ -1275,8 +1283,8 @@ unsafe fn decode_coefs(
                         TX_CLASS_2D,
                         &mut mag,
                         lo_ctx_offsets,
-                        0 as libc::c_int as libc::c_uint,
-                        0 as libc::c_int as libc::c_uint,
+                        0,
+                        0,
                         stride as usize,
                     )
                 };
@@ -1422,8 +1430,8 @@ unsafe fn decode_coefs(
                         TX_CLASS_H,
                         &mut mag,
                         lo_ctx_offsets_0,
-                        x_0,
-                        y_0,
+                        x_0 as usize,
+                        y_0 as usize,
                         stride_0 as usize,
                     );
                     if TX_CLASS_H as libc::c_int == TX_CLASS_2D as libc::c_int {
@@ -1503,8 +1511,8 @@ unsafe fn decode_coefs(
                         TX_CLASS_H,
                         &mut mag,
                         lo_ctx_offsets_0,
-                        0 as libc::c_int as libc::c_uint,
-                        0 as libc::c_int as libc::c_uint,
+                        0,
+                        0,
                         stride_0 as usize,
                     )
                 };
@@ -1649,8 +1657,8 @@ unsafe fn decode_coefs(
                         TX_CLASS_V,
                         &mut mag,
                         lo_ctx_offsets_1,
-                        x_1,
-                        y_1,
+                        x_1 as usize,
+                        y_1 as usize,
                         stride_1 as usize,
                     );
                     if TX_CLASS_V as libc::c_int == TX_CLASS_2D as libc::c_int {
@@ -1730,8 +1738,8 @@ unsafe fn decode_coefs(
                         TX_CLASS_V,
                         &mut mag,
                         lo_ctx_offsets_1,
-                        0 as libc::c_int as libc::c_uint,
-                        0 as libc::c_int as libc::c_uint,
+                        0,
+                        0,
                         stride_1 as usize,
                     )
                 };

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1197,7 +1197,7 @@ unsafe fn decode_coefs(
                         unreachable!();
                     }
                     let level = &mut levels[(x as isize * stride + y as isize) as usize..];
-                    ctx = get_lo_ctx(level, TX_CLASS_2D, &mut mag, lo_ctx_offsets, x, y, stride);
+                    ctx = get_lo_ctx(level, TX_CLASS_2D, &mut mag, lo_ctx_offsets, x, y, stride as usize);
                     if TX_CLASS_2D as libc::c_int == TX_CLASS_2D as libc::c_int {
                         y |= x;
                     }
@@ -1277,7 +1277,7 @@ unsafe fn decode_coefs(
                         lo_ctx_offsets,
                         0 as libc::c_int as libc::c_uint,
                         0 as libc::c_int as libc::c_uint,
-                        stride,
+                        stride as usize,
                     )
                 };
                 dc_tok = dav1d_msac_decode_symbol_adapt4(
@@ -1424,7 +1424,7 @@ unsafe fn decode_coefs(
                         lo_ctx_offsets_0,
                         x_0,
                         y_0,
-                        stride_0,
+                        stride_0 as usize,
                     );
                     if TX_CLASS_H as libc::c_int == TX_CLASS_2D as libc::c_int {
                         y_0 |= x_0;
@@ -1505,7 +1505,7 @@ unsafe fn decode_coefs(
                         lo_ctx_offsets_0,
                         0 as libc::c_int as libc::c_uint,
                         0 as libc::c_int as libc::c_uint,
-                        stride_0,
+                        stride_0 as usize,
                     )
                 };
                 dc_tok = dav1d_msac_decode_symbol_adapt4(
@@ -1651,7 +1651,7 @@ unsafe fn decode_coefs(
                         lo_ctx_offsets_1,
                         x_1,
                         y_1,
-                        stride_1,
+                        stride_1 as usize,
                     );
                     if TX_CLASS_V as libc::c_int == TX_CLASS_2D as libc::c_int {
                         y_1 |= x_1;
@@ -1732,7 +1732,7 @@ unsafe fn decode_coefs(
                         lo_ctx_offsets_1,
                         0 as libc::c_int as libc::c_uint,
                         0 as libc::c_int as libc::c_uint,
-                        stride_1,
+                        stride_1 as usize,
                     )
                 };
                 dc_tok = dav1d_msac_decode_symbol_adapt4(

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1169,7 +1169,7 @@ unsafe fn decode_coefs(
                         unreachable!();
                     }
                     let level = &mut levels[(x as isize * stride + y as isize) as usize..];
-                    ctx = get_lo_ctx(level, TX_CLASS_2D, &mut mag, lo_ctx_offsets, x, y, stride);
+                    ctx = get_lo_ctx(level, TX_CLASS_2D, &mut mag, lo_ctx_offsets, x, y, stride as usize);
                     if TX_CLASS_2D as libc::c_int == TX_CLASS_2D as libc::c_int {
                         y |= x;
                     }
@@ -1249,7 +1249,7 @@ unsafe fn decode_coefs(
                         lo_ctx_offsets,
                         0 as libc::c_int as libc::c_uint,
                         0 as libc::c_int as libc::c_uint,
-                        stride,
+                        stride as usize,
                     )
                 };
                 dc_tok = dav1d_msac_decode_symbol_adapt4(
@@ -1395,7 +1395,7 @@ unsafe fn decode_coefs(
                         lo_ctx_offsets_0,
                         x_0,
                         y_0,
-                        stride_0,
+                        stride_0 as usize,
                     );
                     if TX_CLASS_H as libc::c_int == TX_CLASS_2D as libc::c_int {
                         y_0 |= x_0;
@@ -1476,7 +1476,7 @@ unsafe fn decode_coefs(
                         lo_ctx_offsets_0,
                         0 as libc::c_int as libc::c_uint,
                         0 as libc::c_int as libc::c_uint,
-                        stride_0,
+                        stride_0 as usize,
                     )
                 };
                 dc_tok = dav1d_msac_decode_symbol_adapt4(
@@ -1622,7 +1622,7 @@ unsafe fn decode_coefs(
                         lo_ctx_offsets_1,
                         x_1,
                         y_1,
-                        stride_1,
+                        stride_1 as usize,
                     );
                     if TX_CLASS_V as libc::c_int == TX_CLASS_2D as libc::c_int {
                         y_1 |= x_1;
@@ -1703,7 +1703,7 @@ unsafe fn decode_coefs(
                         lo_ctx_offsets_1,
                         0 as libc::c_int as libc::c_uint,
                         0 as libc::c_int as libc::c_uint,
-                        stride_1,
+                        stride_1 as usize,
                     )
                 };
                 dc_tok = dav1d_msac_decode_symbol_adapt4(

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1177,7 +1177,7 @@ unsafe fn decode_coefs(
                         x as usize,
                         y as usize,
                         stride as usize,
-                    );
+                    ) as libc::c_uint;
                     if TX_CLASS_2D as libc::c_int == TX_CLASS_2D as libc::c_int {
                         y |= x;
                     }
@@ -1258,7 +1258,7 @@ unsafe fn decode_coefs(
                         0,
                         0,
                         stride as usize,
-                    )
+                    ) as libc::c_uint
                 };
                 dc_tok = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
@@ -1404,7 +1404,7 @@ unsafe fn decode_coefs(
                         x_0 as usize,
                         y_0 as usize,
                         stride_0 as usize,
-                    );
+                    ) as libc::c_uint;
                     if TX_CLASS_H as libc::c_int == TX_CLASS_2D as libc::c_int {
                         y_0 |= x_0;
                     }
@@ -1485,7 +1485,7 @@ unsafe fn decode_coefs(
                         0,
                         0,
                         stride_0 as usize,
-                    )
+                    ) as libc::c_uint
                 };
                 dc_tok = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
@@ -1631,7 +1631,7 @@ unsafe fn decode_coefs(
                         x_1 as usize,
                         y_1 as usize,
                         stride_1 as usize,
-                    );
+                    ) as libc::c_uint;
                     if TX_CLASS_V as libc::c_int == TX_CLASS_2D as libc::c_int {
                         y_1 |= x_1;
                     }
@@ -1712,7 +1712,7 @@ unsafe fn decode_coefs(
                         0,
                         0,
                         stride_1 as usize,
-                    )
+                    ) as libc::c_uint
                 };
                 dc_tok = dav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1169,7 +1169,15 @@ unsafe fn decode_coefs(
                         unreachable!();
                     }
                     let level = &mut levels[(x as isize * stride + y as isize) as usize..];
-                    ctx = get_lo_ctx(level, TX_CLASS_2D, &mut mag, lo_ctx_offsets, x, y, stride as usize);
+                    ctx = get_lo_ctx(
+                        level,
+                        TX_CLASS_2D,
+                        &mut mag,
+                        lo_ctx_offsets,
+                        x as usize,
+                        y as usize,
+                        stride as usize,
+                    );
                     if TX_CLASS_2D as libc::c_int == TX_CLASS_2D as libc::c_int {
                         y |= x;
                     }
@@ -1247,8 +1255,8 @@ unsafe fn decode_coefs(
                         TX_CLASS_2D,
                         &mut mag,
                         lo_ctx_offsets,
-                        0 as libc::c_int as libc::c_uint,
-                        0 as libc::c_int as libc::c_uint,
+                        0,
+                        0,
                         stride as usize,
                     )
                 };
@@ -1393,8 +1401,8 @@ unsafe fn decode_coefs(
                         TX_CLASS_H,
                         &mut mag,
                         lo_ctx_offsets_0,
-                        x_0,
-                        y_0,
+                        x_0 as usize,
+                        y_0 as usize,
                         stride_0 as usize,
                     );
                     if TX_CLASS_H as libc::c_int == TX_CLASS_2D as libc::c_int {
@@ -1474,8 +1482,8 @@ unsafe fn decode_coefs(
                         TX_CLASS_H,
                         &mut mag,
                         lo_ctx_offsets_0,
-                        0 as libc::c_int as libc::c_uint,
-                        0 as libc::c_int as libc::c_uint,
+                        0,
+                        0,
                         stride_0 as usize,
                     )
                 };
@@ -1620,8 +1628,8 @@ unsafe fn decode_coefs(
                         TX_CLASS_V,
                         &mut mag,
                         lo_ctx_offsets_1,
-                        x_1,
-                        y_1,
+                        x_1 as usize,
+                        y_1 as usize,
                         stride_1 as usize,
                     );
                     if TX_CLASS_V as libc::c_int == TX_CLASS_2D as libc::c_int {
@@ -1701,8 +1709,8 @@ unsafe fn decode_coefs(
                         TX_CLASS_V,
                         &mut mag,
                         lo_ctx_offsets_1,
-                        0 as libc::c_int as libc::c_uint,
-                        0 as libc::c_int as libc::c_uint,
+                        0,
+                        0,
                         stride_1 as usize,
                     )
                 };


### PR DESCRIPTION
This leaves a bunch of casts at `get_lo_ctx` call sites in `decode_coefs`, but those should go away once I clean up `decode_coefs`, but since it's still duplicated, I'll do that after deduplication.