### PR TITLE
`fn get_dc_sign_ctx`: Cleanup and make safe

### DIFF
--- a/src/recon.rs
+++ b/src/recon.rs
@@ -574,7 +574,8 @@ pub fn get_dc_sign_ctx(tx: RectTxfmSize, a: &[u8], l: &[u8]) -> libc::c_uint {
         }
         _ => unreachable!(),
     };
-    return (s != 0) as libc::c_uint + (s > 0) as libc::c_uint;
+
+    (s != 0) as libc::c_uint + (s > 0) as libc::c_uint
 }
 
 #[inline]

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -411,31 +411,29 @@ pub unsafe fn get_dc_sign_ctx(tx: libc::c_int, a: &[u8], l: &[u8]) -> libc::c_ui
     let mut mask = 0xc0c0c0c0c0c0c0c0 as uint64_t;
     let mut mul = 0x101010101010101 as uint64_t;
     let mut s = 0;
-    let mut current_block_66: u64;
     match tx {
         0 => {
-            current_block_66 = 6873731126896040597;
+            let mut t = *a as libc::c_int >> 6;
+            t += *l as libc::c_int >> 6;
+            s = t - 1 - 1;
         }
         1 => {
             let mut t_0 = *(a as *const uint16_t) as uint32_t & mask as uint32_t;
             t_0 = t_0.wrapping_add(*(l as *const uint16_t) as uint32_t & mask as uint32_t);
             t_0 = t_0.wrapping_mul(0x4040404);
             s = (t_0 >> 24) as libc::c_int - 2 - 2;
-            current_block_66 = 2606304779496145856;
         }
         2 => {
             let mut t_1 = (*(a as *const uint32_t) & mask as uint32_t) >> 6;
             t_1 = t_1.wrapping_add((*(l as *const uint32_t) & mask as uint32_t) >> 6);
             t_1 = t_1.wrapping_mul(mul as uint32_t);
             s = (t_1 >> 24) as libc::c_int - 4 - 4;
-            current_block_66 = 2606304779496145856;
         }
         3 => {
             let mut t_2 = (*(a as *const uint64_t) & mask) >> 6;
             t_2 = t_2.wrapping_add((*(l as *const uint64_t) & mask) >> 6);
             t_2 = t_2.wrapping_mul(mul);
             s = (t_2 >> 56) as libc::c_int - 8 - 8;
-            current_block_66 = 2606304779496145856;
         }
         4 => {
             let mut t_3 = (*(&*a.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6;
@@ -447,49 +445,42 @@ pub unsafe fn get_dc_sign_ctx(tx: libc::c_int, a: &[u8], l: &[u8]) -> libc::c_ui
                 .wrapping_add((*(&*l.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6);
             t_3 = t_3.wrapping_mul(mul);
             s = (t_3 >> 56) as libc::c_int - 16 - 16;
-            current_block_66 = 2606304779496145856;
         }
         5 => {
             let mut t_4 = *a as uint32_t & mask as uint32_t;
             t_4 = t_4.wrapping_add(*(l as *const uint16_t) as uint32_t & mask as uint32_t);
             t_4 = t_4.wrapping_mul(0x4040404);
             s = (t_4 >> 24) as libc::c_int - 1 - 2;
-            current_block_66 = 2606304779496145856;
         }
         6 => {
             let mut t_5 = *(a as *const uint16_t) as uint32_t & mask as uint32_t;
             t_5 = t_5.wrapping_add(*l as uint32_t & mask as uint32_t);
             t_5 = t_5.wrapping_mul(0x4040404);
             s = (t_5 >> 24) as libc::c_int - 2 - 1;
-            current_block_66 = 2606304779496145856;
         }
         7 => {
             let mut t_6 = *(a as *const uint16_t) as uint32_t & mask as uint32_t;
             t_6 = t_6.wrapping_add(*(l as *const uint32_t) & mask as uint32_t);
             t_6 = (t_6 >> 6).wrapping_mul(mul as uint32_t);
             s = (t_6 >> 24) as libc::c_int - 2 - 4;
-            current_block_66 = 2606304779496145856;
         }
         8 => {
             let mut t_7 = *(a as *const uint32_t) & mask as uint32_t;
             t_7 = t_7.wrapping_add(*(l as *const uint16_t) as libc::c_uint & mask as uint32_t);
             t_7 = (t_7 >> 6).wrapping_mul(mul as uint32_t);
             s = (t_7 >> 24) as libc::c_int - 4 - 2;
-            current_block_66 = 2606304779496145856;
         }
         9 => {
             let mut t_8 = (*(a as *const uint32_t) & mask as uint32_t) as uint64_t;
             t_8 = t_8.wrapping_add(*(l as *const uint64_t) & mask);
             t_8 = (t_8 >> 6).wrapping_mul(mul);
             s = (t_8 >> 56) as libc::c_int - 4 - 8;
-            current_block_66 = 2606304779496145856;
         }
         10 => {
             let mut t_9 = *(a as *const uint64_t) & mask;
             t_9 = t_9 + (*(l as *const uint32_t) & mask as uint32_t) as uint64_t;
             t_9 = (t_9 >> 6).wrapping_mul(mul);
             s = (t_9 >> 56) as libc::c_int - 8 - 4;
-            current_block_66 = 2606304779496145856;
         }
         11 => {
             let mut t_10 = (*(&*a.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6;
@@ -499,7 +490,6 @@ pub unsafe fn get_dc_sign_ctx(tx: libc::c_int, a: &[u8], l: &[u8]) -> libc::c_ui
                 .wrapping_add((*(&*l.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6);
             t_10 = t_10.wrapping_mul(mul);
             s = (t_10 >> 56) as libc::c_int - 8 - 16;
-            current_block_66 = 2606304779496145856;
         }
         12 => {
             let mut t_11 = (*(&*a.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6;
@@ -509,28 +499,24 @@ pub unsafe fn get_dc_sign_ctx(tx: libc::c_int, a: &[u8], l: &[u8]) -> libc::c_ui
                 .wrapping_add((*(&*l.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6);
             t_11 = t_11.wrapping_mul(mul);
             s = (t_11 >> 56) as libc::c_int - 16 - 8;
-            current_block_66 = 2606304779496145856;
         }
         13 => {
             let mut t_12 = *a as uint32_t & mask as uint32_t;
             t_12 = t_12.wrapping_add(*(l as *const uint32_t) & mask as uint32_t);
             t_12 = (t_12 >> 6).wrapping_mul(mul as uint32_t);
             s = (t_12 >> 24) as libc::c_int - 1 - 4;
-            current_block_66 = 2606304779496145856;
         }
         14 => {
             let mut t_13 = *(a as *const uint32_t) & mask as uint32_t;
             t_13 = t_13.wrapping_add(*l as libc::c_uint & mask as uint32_t);
             t_13 = (t_13 >> 6).wrapping_mul(mul as uint32_t);
             s = (t_13 >> 24) as libc::c_int - 4 - 1;
-            current_block_66 = 2606304779496145856;
         }
         15 => {
             let mut t_14 = (*(a as *const uint16_t) as libc::c_uint & mask as uint32_t) as uint64_t;
             t_14 = t_14.wrapping_add(*(l as *const uint64_t) & mask);
             t_14 = (t_14 >> 6).wrapping_mul(mul);
             s = (t_14 >> 56) as libc::c_int - 2 - 8;
-            current_block_66 = 2606304779496145856;
         }
         16 => {
             let mut t_15 = *(a as *const uint64_t) & mask;
@@ -538,7 +524,6 @@ pub unsafe fn get_dc_sign_ctx(tx: libc::c_int, a: &[u8], l: &[u8]) -> libc::c_ui
                 .wrapping_add((*(l as *const uint16_t) as uint32_t & mask as uint32_t) as uint64_t);
             t_15 = (t_15 >> 6).wrapping_mul(mul);
             s = (t_15 >> 56) as libc::c_int - 8 - 2;
-            current_block_66 = 2606304779496145856;
         }
         17 => {
             let mut t_16 = (*(a as *const uint32_t) & mask as uint32_t) as uint64_t;
@@ -547,7 +532,6 @@ pub unsafe fn get_dc_sign_ctx(tx: libc::c_int, a: &[u8], l: &[u8]) -> libc::c_ui
                 .wrapping_add((*(&*l.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6);
             t_16 = t_16.wrapping_mul(mul);
             s = (t_16 >> 56) as libc::c_int - 4 - 16;
-            current_block_66 = 2606304779496145856;
         }
         18 => {
             let mut t_17 = *(&*a.offset(0) as *const uint8_t as *const uint64_t) & mask;
@@ -556,22 +540,8 @@ pub unsafe fn get_dc_sign_ctx(tx: libc::c_int, a: &[u8], l: &[u8]) -> libc::c_ui
                 .wrapping_add((*(&*a.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6);
             t_17 = t_17.wrapping_mul(mul);
             s = (t_17 >> 56) as libc::c_int - 16 - 4;
-            current_block_66 = 2606304779496145856;
         }
-        _ => {
-            if 0 == 0 {
-                unreachable!();
-            }
-            current_block_66 = 6873731126896040597;
-        }
-    }
-    match current_block_66 {
-        6873731126896040597 => {
-            let mut t = *a as libc::c_int >> 6;
-            t += *l as libc::c_int >> 6;
-            s = t - 1 - 1;
-        }
-        _ => {}
+        _ => unreachable!(),
     }
     return (s != 0) as libc::c_uint + (s > 0) as libc::c_uint;
 }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -75,6 +75,12 @@ pub fn read_golomb(msac: &mut MsacContext) -> libc::c_uint {
 }
 
 trait ReadInt {
+    /// (Try to or panic) read [`Self`] from the front of `bytes` in native endianness.
+    /// These are similar to the [`u32::from_ne_bytes`] type methods,
+    /// but generalized into a `trait` to be generic,
+    /// and operating on a slice that is sliced and converted into an array first.
+    ///
+    /// This replaces the previous code that used `unsafe` transmutes through casting.
     fn read_ne(bytes: &[u8]) -> Self;
 }
 

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -418,128 +418,121 @@ pub unsafe fn get_dc_sign_ctx(tx: libc::c_int, a: &[u8], l: &[u8]) -> libc::c_ui
             s = t - 1 - 1;
         }
         1 => {
-            let mut t_0 = *(a as *const uint16_t) as uint32_t & mask as uint32_t;
-            t_0 = t_0.wrapping_add(*(l as *const uint16_t) as uint32_t & mask as uint32_t);
-            t_0 = t_0.wrapping_mul(0x4040404);
-            s = (t_0 >> 24) as libc::c_int - 2 - 2;
+            let mut t = *(a as *const uint16_t) as uint32_t & mask as uint32_t;
+            t = t.wrapping_add(*(l as *const uint16_t) as uint32_t & mask as uint32_t);
+            t = t.wrapping_mul(0x4040404);
+            s = (t >> 24) as libc::c_int - 2 - 2;
         }
         2 => {
-            let mut t_1 = (*(a as *const uint32_t) & mask as uint32_t) >> 6;
-            t_1 = t_1.wrapping_add((*(l as *const uint32_t) & mask as uint32_t) >> 6);
-            t_1 = t_1.wrapping_mul(mul as uint32_t);
-            s = (t_1 >> 24) as libc::c_int - 4 - 4;
+            let mut t = (*(a as *const uint32_t) & mask as uint32_t) >> 6;
+            t = t.wrapping_add((*(l as *const uint32_t) & mask as uint32_t) >> 6);
+            t = t.wrapping_mul(mul as uint32_t);
+            s = (t >> 24) as libc::c_int - 4 - 4;
         }
         3 => {
-            let mut t_2 = (*(a as *const uint64_t) & mask) >> 6;
-            t_2 = t_2.wrapping_add((*(l as *const uint64_t) & mask) >> 6);
-            t_2 = t_2.wrapping_mul(mul);
-            s = (t_2 >> 56) as libc::c_int - 8 - 8;
+            let mut t = (*(a as *const uint64_t) & mask) >> 6;
+            t = t.wrapping_add((*(l as *const uint64_t) & mask) >> 6);
+            t = t.wrapping_mul(mul);
+            s = (t >> 56) as libc::c_int - 8 - 8;
         }
         4 => {
-            let mut t_3 = (*(&*a.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6;
-            t_3 = t_3
-                .wrapping_add((*(&*a.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6);
-            t_3 = t_3
-                .wrapping_add((*(&*l.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6);
-            t_3 = t_3
-                .wrapping_add((*(&*l.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6);
-            t_3 = t_3.wrapping_mul(mul);
-            s = (t_3 >> 56) as libc::c_int - 16 - 16;
+            let mut t = (*(&*a.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6;
+            t = t.wrapping_add((*(&*a.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6);
+            t = t.wrapping_add((*(&*l.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6);
+            t = t.wrapping_add((*(&*l.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6);
+            t = t.wrapping_mul(mul);
+            s = (t >> 56) as libc::c_int - 16 - 16;
         }
         5 => {
-            let mut t_4 = *a as uint32_t & mask as uint32_t;
-            t_4 = t_4.wrapping_add(*(l as *const uint16_t) as uint32_t & mask as uint32_t);
-            t_4 = t_4.wrapping_mul(0x4040404);
-            s = (t_4 >> 24) as libc::c_int - 1 - 2;
+            let mut t = *a as uint32_t & mask as uint32_t;
+            t = t.wrapping_add(*(l as *const uint16_t) as uint32_t & mask as uint32_t);
+            t = t.wrapping_mul(0x4040404);
+            s = (t >> 24) as libc::c_int - 1 - 2;
         }
         6 => {
-            let mut t_5 = *(a as *const uint16_t) as uint32_t & mask as uint32_t;
-            t_5 = t_5.wrapping_add(*l as uint32_t & mask as uint32_t);
-            t_5 = t_5.wrapping_mul(0x4040404);
-            s = (t_5 >> 24) as libc::c_int - 2 - 1;
+            let mut t = *(a as *const uint16_t) as uint32_t & mask as uint32_t;
+            t = t.wrapping_add(*l as uint32_t & mask as uint32_t);
+            t = t.wrapping_mul(0x4040404);
+            s = (t >> 24) as libc::c_int - 2 - 1;
         }
         7 => {
-            let mut t_6 = *(a as *const uint16_t) as uint32_t & mask as uint32_t;
-            t_6 = t_6.wrapping_add(*(l as *const uint32_t) & mask as uint32_t);
-            t_6 = (t_6 >> 6).wrapping_mul(mul as uint32_t);
-            s = (t_6 >> 24) as libc::c_int - 2 - 4;
+            let mut t = *(a as *const uint16_t) as uint32_t & mask as uint32_t;
+            t = t.wrapping_add(*(l as *const uint32_t) & mask as uint32_t);
+            t = (t >> 6).wrapping_mul(mul as uint32_t);
+            s = (t >> 24) as libc::c_int - 2 - 4;
         }
         8 => {
-            let mut t_7 = *(a as *const uint32_t) & mask as uint32_t;
-            t_7 = t_7.wrapping_add(*(l as *const uint16_t) as libc::c_uint & mask as uint32_t);
-            t_7 = (t_7 >> 6).wrapping_mul(mul as uint32_t);
-            s = (t_7 >> 24) as libc::c_int - 4 - 2;
+            let mut t = *(a as *const uint32_t) & mask as uint32_t;
+            t = t.wrapping_add(*(l as *const uint16_t) as libc::c_uint & mask as uint32_t);
+            t = (t >> 6).wrapping_mul(mul as uint32_t);
+            s = (t >> 24) as libc::c_int - 4 - 2;
         }
         9 => {
-            let mut t_8 = (*(a as *const uint32_t) & mask as uint32_t) as uint64_t;
-            t_8 = t_8.wrapping_add(*(l as *const uint64_t) & mask);
-            t_8 = (t_8 >> 6).wrapping_mul(mul);
-            s = (t_8 >> 56) as libc::c_int - 4 - 8;
+            let mut t = (*(a as *const uint32_t) & mask as uint32_t) as uint64_t;
+            t = t.wrapping_add(*(l as *const uint64_t) & mask);
+            t = (t >> 6).wrapping_mul(mul);
+            s = (t >> 56) as libc::c_int - 4 - 8;
         }
         10 => {
-            let mut t_9 = *(a as *const uint64_t) & mask;
-            t_9 = t_9 + (*(l as *const uint32_t) & mask as uint32_t) as uint64_t;
-            t_9 = (t_9 >> 6).wrapping_mul(mul);
-            s = (t_9 >> 56) as libc::c_int - 8 - 4;
+            let mut t = *(a as *const uint64_t) & mask;
+            t = t + (*(l as *const uint32_t) & mask as uint32_t) as uint64_t;
+            t = (t >> 6).wrapping_mul(mul);
+            s = (t >> 56) as libc::c_int - 8 - 4;
         }
         11 => {
-            let mut t_10 = (*(&*a.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6;
-            t_10 = t_10
-                .wrapping_add((*(&*l.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6);
-            t_10 = t_10
-                .wrapping_add((*(&*l.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6);
-            t_10 = t_10.wrapping_mul(mul);
-            s = (t_10 >> 56) as libc::c_int - 8 - 16;
+            let mut t = (*(&*a.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6;
+            t = t.wrapping_add((*(&*l.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6);
+            t = t.wrapping_add((*(&*l.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6);
+            t = t.wrapping_mul(mul);
+            s = (t >> 56) as libc::c_int - 8 - 16;
         }
         12 => {
-            let mut t_11 = (*(&*a.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6;
-            t_11 = t_11
-                .wrapping_add((*(&*a.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6);
-            t_11 = t_11
-                .wrapping_add((*(&*l.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6);
-            t_11 = t_11.wrapping_mul(mul);
-            s = (t_11 >> 56) as libc::c_int - 16 - 8;
+            let mut t = (*(&*a.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6;
+            t = t.wrapping_add((*(&*a.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6);
+            t = t.wrapping_add((*(&*l.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6);
+            t = t.wrapping_mul(mul);
+            s = (t >> 56) as libc::c_int - 16 - 8;
         }
         13 => {
-            let mut t_12 = *a as uint32_t & mask as uint32_t;
-            t_12 = t_12.wrapping_add(*(l as *const uint32_t) & mask as uint32_t);
-            t_12 = (t_12 >> 6).wrapping_mul(mul as uint32_t);
-            s = (t_12 >> 24) as libc::c_int - 1 - 4;
+            let mut t = *a as uint32_t & mask as uint32_t;
+            t = t.wrapping_add(*(l as *const uint32_t) & mask as uint32_t);
+            t = (t >> 6).wrapping_mul(mul as uint32_t);
+            s = (t >> 24) as libc::c_int - 1 - 4;
         }
         14 => {
-            let mut t_13 = *(a as *const uint32_t) & mask as uint32_t;
-            t_13 = t_13.wrapping_add(*l as libc::c_uint & mask as uint32_t);
-            t_13 = (t_13 >> 6).wrapping_mul(mul as uint32_t);
-            s = (t_13 >> 24) as libc::c_int - 4 - 1;
+            let mut t = *(a as *const uint32_t) & mask as uint32_t;
+            t = t.wrapping_add(*l as libc::c_uint & mask as uint32_t);
+            t = (t >> 6).wrapping_mul(mul as uint32_t);
+            s = (t >> 24) as libc::c_int - 4 - 1;
         }
         15 => {
-            let mut t_14 = (*(a as *const uint16_t) as libc::c_uint & mask as uint32_t) as uint64_t;
-            t_14 = t_14.wrapping_add(*(l as *const uint64_t) & mask);
-            t_14 = (t_14 >> 6).wrapping_mul(mul);
-            s = (t_14 >> 56) as libc::c_int - 2 - 8;
+            let mut t = (*(a as *const uint16_t) as libc::c_uint & mask as uint32_t) as uint64_t;
+            t = t.wrapping_add(*(l as *const uint64_t) & mask);
+            t = (t >> 6).wrapping_mul(mul);
+            s = (t >> 56) as libc::c_int - 2 - 8;
         }
         16 => {
-            let mut t_15 = *(a as *const uint64_t) & mask;
-            t_15 = t_15
+            let mut t = *(a as *const uint64_t) & mask;
+            t = t
                 .wrapping_add((*(l as *const uint16_t) as uint32_t & mask as uint32_t) as uint64_t);
-            t_15 = (t_15 >> 6).wrapping_mul(mul);
-            s = (t_15 >> 56) as libc::c_int - 8 - 2;
+            t = (t >> 6).wrapping_mul(mul);
+            s = (t >> 56) as libc::c_int - 8 - 2;
         }
         17 => {
-            let mut t_16 = (*(a as *const uint32_t) & mask as uint32_t) as uint64_t;
-            t_16 = t_16.wrapping_add(*(&*l.offset(0) as *const uint8_t as *const uint64_t) & mask);
-            t_16 = (t_16 >> 6)
+            let mut t = (*(a as *const uint32_t) & mask as uint32_t) as uint64_t;
+            t = t.wrapping_add(*(&*l.offset(0) as *const uint8_t as *const uint64_t) & mask);
+            t = (t >> 6)
                 .wrapping_add((*(&*l.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6);
-            t_16 = t_16.wrapping_mul(mul);
-            s = (t_16 >> 56) as libc::c_int - 4 - 16;
+            t = t.wrapping_mul(mul);
+            s = (t >> 56) as libc::c_int - 4 - 16;
         }
         18 => {
-            let mut t_17 = *(&*a.offset(0) as *const uint8_t as *const uint64_t) & mask;
-            t_17 = t_17 + (*(l as *const uint32_t) & mask as uint32_t) as uint64_t;
-            t_17 = (t_17 >> 6)
+            let mut t = *(&*a.offset(0) as *const uint8_t as *const uint64_t) & mask;
+            t = t + (*(l as *const uint32_t) & mask as uint32_t) as uint64_t;
+            t = (t >> 6)
                 .wrapping_add((*(&*a.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6);
-            t_17 = t_17.wrapping_mul(mul);
-            s = (t_17 >> 56) as libc::c_int - 16 - 4;
+            t = t.wrapping_mul(mul);
+            s = (t >> 56) as libc::c_int - 16 - 4;
         }
         _ => unreachable!(),
     }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -460,115 +460,115 @@ pub fn get_dc_sign_ctx(tx: RectTxfmSize, a: &[u8], l: &[u8]) -> libc::c_uint {
         }
         TX_8X8 => {
             let mut t = u16::read_ne(a) as u32 & mask as u32;
-            t = t.wrapping_add(u16::read_ne(l) as u32 & mask as u32);
+            t += u16::read_ne(l) as u32 & mask as u32;
             t = t.wrapping_mul(0x4040404);
             (t >> 24) as i32 - 2 - 2
         }
         TX_16X16 => {
             let mut t = (u32::read_ne(a) & mask as u32) >> 6;
-            t = t.wrapping_add((u32::read_ne(l) & mask as u32) >> 6);
+            t += (u32::read_ne(l) & mask as u32) >> 6;
             t = t.wrapping_mul(mul as u32);
             (t >> 24) as i32 - 4 - 4
         }
         TX_32X32 => {
             let mut t = (u64::read_ne(a) & mask) >> 6;
-            t = t.wrapping_add((u64::read_ne(l) & mask) >> 6);
+            t += (u64::read_ne(l) & mask) >> 6;
             t = t.wrapping_mul(mul);
             (t >> 56) as i32 - 8 - 8
         }
         TX_64X64 => {
             let mut t = (u64::read_ne(&a[0..]) & mask) >> 6;
-            t = t.wrapping_add((u64::read_ne(&a[8..]) & mask) >> 6);
-            t = t.wrapping_add((u64::read_ne(&l[0..]) & mask) >> 6);
-            t = t.wrapping_add((u64::read_ne(&l[8..]) & mask) >> 6);
+            t += (u64::read_ne(&a[8..]) & mask) >> 6;
+            t += (u64::read_ne(&l[0..]) & mask) >> 6;
+            t += (u64::read_ne(&l[8..]) & mask) >> 6;
             t = t.wrapping_mul(mul);
             (t >> 56) as i32 - 16 - 16
         }
         RTX_4X8 => {
             let mut t = u8::read_ne(a) as u32 & mask as u32;
-            t = t.wrapping_add(u16::read_ne(l) as u32 & mask as u32);
+            t += u16::read_ne(l) as u32 & mask as u32;
             t = t.wrapping_mul(0x4040404);
             (t >> 24) as i32 - 1 - 2
         }
         RTX_8X4 => {
             let mut t = u16::read_ne(a) as u32 & mask as u32;
-            t = t.wrapping_add(u8::read_ne(l) as u32 & mask as u32);
+            t += u8::read_ne(l) as u32 & mask as u32;
             t = t.wrapping_mul(0x4040404);
             (t >> 24) as i32 - 2 - 1
         }
         RTX_8X16 => {
             let mut t = u16::read_ne(a) as u32 & mask as u32;
-            t = t.wrapping_add(u32::read_ne(l) & mask as u32);
+            t += u32::read_ne(l) & mask as u32;
             t = (t >> 6).wrapping_mul(mul as u32);
             (t >> 24) as i32 - 2 - 4
         }
         RTX_16X8 => {
             let mut t = u32::read_ne(a) & mask as u32;
-            t = t.wrapping_add(u16::read_ne(l) as libc::c_uint & mask as u32);
+            t += u16::read_ne(l) as libc::c_uint & mask as u32;
             t = (t >> 6).wrapping_mul(mul as u32);
             (t >> 24) as i32 - 4 - 2
         }
         RTX_16X32 => {
             let mut t = (u32::read_ne(a) & mask as u32) as u64;
-            t = t.wrapping_add(u64::read_ne(l) & mask);
+            t += u64::read_ne(l) & mask;
             t = (t >> 6).wrapping_mul(mul);
             (t >> 56) as i32 - 4 - 8
         }
         RTX_32X16 => {
             let mut t = u64::read_ne(a) & mask;
-            t = t + (u32::read_ne(l) & mask as u32) as u64;
+            t += (u32::read_ne(l) & mask as u32) as u64;
             t = (t >> 6).wrapping_mul(mul);
             (t >> 56) as i32 - 8 - 4
         }
         RTX_32X64 => {
             let mut t = (u64::read_ne(&a[0..]) & mask) >> 6;
-            t = t.wrapping_add((u64::read_ne(&l[0..]) & mask) >> 6);
-            t = t.wrapping_add((u64::read_ne(&l[8..]) & mask) >> 6);
+            t += (u64::read_ne(&l[0..]) & mask) >> 6;
+            t += (u64::read_ne(&l[8..]) & mask) >> 6;
             t = t.wrapping_mul(mul);
             (t >> 56) as i32 - 8 - 16
         }
         RTX_64X32 => {
             let mut t = (u64::read_ne(&a[0..]) & mask) >> 6;
-            t = t.wrapping_add((u64::read_ne(&a[8..]) & mask) >> 6);
-            t = t.wrapping_add((u64::read_ne(&l[0..]) & mask) >> 6);
+            t += (u64::read_ne(&a[8..]) & mask) >> 6;
+            t += (u64::read_ne(&l[0..]) & mask) >> 6;
             t = t.wrapping_mul(mul);
             (t >> 56) as i32 - 16 - 8
         }
         RTX_4X16 => {
             let mut t = u8::read_ne(a) as u32 & mask as u32;
-            t = t.wrapping_add(u32::read_ne(l) & mask as u32);
+            t += u32::read_ne(l) & mask as u32;
             t = (t >> 6).wrapping_mul(mul as u32);
             (t >> 24) as i32 - 1 - 4
         }
         RTX_16X4 => {
             let mut t = u32::read_ne(a) & mask as u32;
-            t = t.wrapping_add(u8::read_ne(l) as u32 & mask as u32);
+            t += u8::read_ne(l) as u32 & mask as u32;
             t = (t >> 6).wrapping_mul(mul as u32);
             (t >> 24) as i32 - 4 - 1
         }
         RTX_8X32 => {
             let mut t = (u16::read_ne(a) as u32 & mask as u32) as u64;
-            t = t.wrapping_add(u64::read_ne(l) & mask);
+            t += u64::read_ne(l) & mask;
             t = (t >> 6).wrapping_mul(mul);
             (t >> 56) as i32 - 2 - 8
         }
         RTX_32X8 => {
             let mut t = u64::read_ne(a) & mask;
-            t = t.wrapping_add((u16::read_ne(l) as u32 & mask as u32) as u64);
+            t += (u16::read_ne(l) as u32 & mask as u32) as u64;
             t = (t >> 6).wrapping_mul(mul);
             (t >> 56) as i32 - 8 - 2
         }
         RTX_16X64 => {
             let mut t = (u32::read_ne(a) & mask as u32) as u64;
-            t = t.wrapping_add(u64::read_ne(&l[0..]) & mask);
-            t = (t >> 6).wrapping_add((u64::read_ne(&l[8..]) & mask) >> 6);
+            t += u64::read_ne(&l[0..]) & mask;
+            t = (t >> 6) + ((u64::read_ne(&l[8..]) & mask) >> 6);
             t = t.wrapping_mul(mul);
             (t >> 56) as i32 - 4 - 16
         }
         RTX_64X16 => {
             let mut t = u64::read_ne(&a[0..]) & mask;
-            t = t + (u32::read_ne(l) & mask as u32) as u64;
-            t = (t >> 6).wrapping_add((u64::read_ne(&a[8..]) & mask) >> 6);
+            t += (u32::read_ne(l) & mask as u32) as u64;
+            t = (t >> 6) + ((u64::read_ne(&a[8..]) & mask) >> 6);
             t = t.wrapping_mul(mul);
             (t >> 56) as i32 - 16 - 4
         }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -408,8 +408,8 @@ pub unsafe fn get_dc_sign_ctx(tx: libc::c_int, a: &[u8], l: &[u8]) -> libc::c_ui
     let a = a.as_ptr();
     let l = l.as_ptr();
 
-    let mut mask: uint64_t = 0xc0c0c0c0c0c0c0c0 as libc::c_ulonglong as uint64_t;
-    let mut mul: uint64_t = 0x101010101010101 as libc::c_ulonglong as uint64_t;
+    let mut mask = 0xc0c0c0c0c0c0c0c0 as uint64_t;
+    let mut mul = 0x101010101010101 as uint64_t;
     let mut s = 0;
     let mut current_block_66: u64;
     match tx {
@@ -417,172 +417,144 @@ pub unsafe fn get_dc_sign_ctx(tx: libc::c_int, a: &[u8], l: &[u8]) -> libc::c_ui
             current_block_66 = 6873731126896040597;
         }
         1 => {
-            let mut t_0: uint32_t = *(a as *const uint16_t) as libc::c_uint & mask as uint32_t;
-            t_0 = (t_0 as libc::c_uint)
-                .wrapping_add(*(l as *const uint16_t) as libc::c_uint & mask as uint32_t)
-                as uint32_t as uint32_t;
-            t_0 = (t_0 as libc::c_uint).wrapping_mul(0x4040404 as libc::c_uint) as uint32_t
-                as uint32_t;
+            let mut t_0 = *(a as *const uint16_t) as uint32_t & mask as uint32_t;
+            t_0 = t_0.wrapping_add(*(l as *const uint16_t) as uint32_t & mask as uint32_t);
+            t_0 = t_0.wrapping_mul(0x4040404);
             s = (t_0 >> 24) as libc::c_int - 2 - 2;
             current_block_66 = 2606304779496145856;
         }
         2 => {
-            let mut t_1: uint32_t = (*(a as *const uint32_t) & mask as uint32_t) >> 6;
-            t_1 = (t_1 as libc::c_uint)
-                .wrapping_add((*(l as *const uint32_t) & mask as uint32_t) >> 6)
-                as uint32_t as uint32_t;
-            t_1 = (t_1 as libc::c_uint).wrapping_mul(mul as uint32_t) as uint32_t as uint32_t;
+            let mut t_1 = (*(a as *const uint32_t) & mask as uint32_t) >> 6;
+            t_1 = t_1.wrapping_add((*(l as *const uint32_t) & mask as uint32_t) >> 6);
+            t_1 = t_1.wrapping_mul(mul as uint32_t);
             s = (t_1 >> 24) as libc::c_int - 4 - 4;
             current_block_66 = 2606304779496145856;
         }
         3 => {
-            let mut t_2: uint64_t = (*(a as *const uint64_t) & mask) >> 6;
-            t_2 = t_2.wrapping_add((*(l as *const uint64_t) & mask) >> 6) as uint64_t as uint64_t;
-            t_2 = t_2.wrapping_mul(mul) as uint64_t as uint64_t;
+            let mut t_2 = (*(a as *const uint64_t) & mask) >> 6;
+            t_2 = t_2.wrapping_add((*(l as *const uint64_t) & mask) >> 6);
+            t_2 = t_2.wrapping_mul(mul);
             s = (t_2 >> 56) as libc::c_int - 8 - 8;
             current_block_66 = 2606304779496145856;
         }
         4 => {
-            let mut t_3: uint64_t =
-                (*(&*a.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6;
+            let mut t_3 = (*(&*a.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6;
             t_3 = t_3
-                .wrapping_add((*(&*a.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6)
-                as uint64_t as uint64_t;
+                .wrapping_add((*(&*a.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6);
             t_3 = t_3
-                .wrapping_add((*(&*l.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6)
-                as uint64_t as uint64_t;
+                .wrapping_add((*(&*l.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6);
             t_3 = t_3
-                .wrapping_add((*(&*l.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6)
-                as uint64_t as uint64_t;
-            t_3 = t_3.wrapping_mul(mul) as uint64_t as uint64_t;
+                .wrapping_add((*(&*l.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6);
+            t_3 = t_3.wrapping_mul(mul);
             s = (t_3 >> 56) as libc::c_int - 16 - 16;
             current_block_66 = 2606304779496145856;
         }
         5 => {
-            let mut t_4: uint32_t = *a as libc::c_uint & mask as uint32_t;
-            t_4 = (t_4 as libc::c_uint)
-                .wrapping_add(*(l as *const uint16_t) as libc::c_uint & mask as uint32_t)
-                as uint32_t as uint32_t;
-            t_4 = (t_4 as libc::c_uint).wrapping_mul(0x4040404 as libc::c_uint) as uint32_t
-                as uint32_t;
+            let mut t_4 = *a as uint32_t & mask as uint32_t;
+            t_4 = t_4.wrapping_add(*(l as *const uint16_t) as uint32_t & mask as uint32_t);
+            t_4 = t_4.wrapping_mul(0x4040404);
             s = (t_4 >> 24) as libc::c_int - 1 - 2;
             current_block_66 = 2606304779496145856;
         }
         6 => {
-            let mut t_5: uint32_t = *(a as *const uint16_t) as libc::c_uint & mask as uint32_t;
-            t_5 = (t_5 as libc::c_uint).wrapping_add(*l as libc::c_uint & mask as uint32_t)
-                as uint32_t as uint32_t;
-            t_5 = (t_5 as libc::c_uint).wrapping_mul(0x4040404 as libc::c_uint) as uint32_t
-                as uint32_t;
+            let mut t_5 = *(a as *const uint16_t) as uint32_t & mask as uint32_t;
+            t_5 = t_5.wrapping_add(*l as uint32_t & mask as uint32_t);
+            t_5 = t_5.wrapping_mul(0x4040404);
             s = (t_5 >> 24) as libc::c_int - 2 - 1;
             current_block_66 = 2606304779496145856;
         }
         7 => {
-            let mut t_6: uint32_t = *(a as *const uint16_t) as libc::c_uint & mask as uint32_t;
-            t_6 = (t_6 as libc::c_uint).wrapping_add(*(l as *const uint32_t) & mask as uint32_t)
-                as uint32_t as uint32_t;
+            let mut t_6 = *(a as *const uint16_t) as uint32_t & mask as uint32_t;
+            t_6 = t_6.wrapping_add(*(l as *const uint32_t) & mask as uint32_t);
             t_6 = (t_6 >> 6).wrapping_mul(mul as uint32_t);
             s = (t_6 >> 24) as libc::c_int - 2 - 4;
             current_block_66 = 2606304779496145856;
         }
         8 => {
-            let mut t_7: uint32_t = *(a as *const uint32_t) & mask as uint32_t;
-            t_7 = (t_7 as libc::c_uint)
-                .wrapping_add(*(l as *const uint16_t) as libc::c_uint & mask as uint32_t)
-                as uint32_t as uint32_t;
+            let mut t_7 = *(a as *const uint32_t) & mask as uint32_t;
+            t_7 = t_7.wrapping_add(*(l as *const uint16_t) as libc::c_uint & mask as uint32_t);
             t_7 = (t_7 >> 6).wrapping_mul(mul as uint32_t);
             s = (t_7 >> 24) as libc::c_int - 4 - 2;
             current_block_66 = 2606304779496145856;
         }
         9 => {
-            let mut t_8: uint64_t = (*(a as *const uint32_t) & mask as uint32_t) as uint64_t;
-            t_8 = t_8.wrapping_add(*(l as *const uint64_t) & mask) as uint64_t as uint64_t;
+            let mut t_8 = (*(a as *const uint32_t) & mask as uint32_t) as uint64_t;
+            t_8 = t_8.wrapping_add(*(l as *const uint64_t) & mask);
             t_8 = (t_8 >> 6).wrapping_mul(mul);
             s = (t_8 >> 56) as libc::c_int - 4 - 8;
             current_block_66 = 2606304779496145856;
         }
         10 => {
-            let mut t_9: uint64_t = *(a as *const uint64_t) & mask;
+            let mut t_9 = *(a as *const uint64_t) & mask;
             t_9 = t_9 + (*(l as *const uint32_t) & mask as uint32_t) as uint64_t;
             t_9 = (t_9 >> 6).wrapping_mul(mul);
             s = (t_9 >> 56) as libc::c_int - 8 - 4;
             current_block_66 = 2606304779496145856;
         }
         11 => {
-            let mut t_10: uint64_t =
-                (*(&*a.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6;
+            let mut t_10 = (*(&*a.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6;
             t_10 = t_10
-                .wrapping_add((*(&*l.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6)
-                as uint64_t as uint64_t;
+                .wrapping_add((*(&*l.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6);
             t_10 = t_10
-                .wrapping_add((*(&*l.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6)
-                as uint64_t as uint64_t;
-            t_10 = t_10.wrapping_mul(mul) as uint64_t as uint64_t;
+                .wrapping_add((*(&*l.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6);
+            t_10 = t_10.wrapping_mul(mul);
             s = (t_10 >> 56) as libc::c_int - 8 - 16;
             current_block_66 = 2606304779496145856;
         }
         12 => {
-            let mut t_11: uint64_t =
-                (*(&*a.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6;
+            let mut t_11 = (*(&*a.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6;
             t_11 = t_11
-                .wrapping_add((*(&*a.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6)
-                as uint64_t as uint64_t;
+                .wrapping_add((*(&*a.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6);
             t_11 = t_11
-                .wrapping_add((*(&*l.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6)
-                as uint64_t as uint64_t;
-            t_11 = t_11.wrapping_mul(mul) as uint64_t as uint64_t;
+                .wrapping_add((*(&*l.offset(0) as *const uint8_t as *const uint64_t) & mask) >> 6);
+            t_11 = t_11.wrapping_mul(mul);
             s = (t_11 >> 56) as libc::c_int - 16 - 8;
             current_block_66 = 2606304779496145856;
         }
         13 => {
-            let mut t_12: uint32_t = *a as libc::c_uint & mask as uint32_t;
-            t_12 = (t_12 as libc::c_uint).wrapping_add(*(l as *const uint32_t) & mask as uint32_t)
-                as uint32_t as uint32_t;
+            let mut t_12 = *a as uint32_t & mask as uint32_t;
+            t_12 = t_12.wrapping_add(*(l as *const uint32_t) & mask as uint32_t);
             t_12 = (t_12 >> 6).wrapping_mul(mul as uint32_t);
             s = (t_12 >> 24) as libc::c_int - 1 - 4;
             current_block_66 = 2606304779496145856;
         }
         14 => {
-            let mut t_13: uint32_t = *(a as *const uint32_t) & mask as uint32_t;
-            t_13 = (t_13 as libc::c_uint).wrapping_add(*l as libc::c_uint & mask as uint32_t)
-                as uint32_t as uint32_t;
+            let mut t_13 = *(a as *const uint32_t) & mask as uint32_t;
+            t_13 = t_13.wrapping_add(*l as libc::c_uint & mask as uint32_t);
             t_13 = (t_13 >> 6).wrapping_mul(mul as uint32_t);
             s = (t_13 >> 24) as libc::c_int - 4 - 1;
             current_block_66 = 2606304779496145856;
         }
         15 => {
-            let mut t_14: uint64_t =
-                (*(a as *const uint16_t) as libc::c_uint & mask as uint32_t) as uint64_t;
-            t_14 = t_14.wrapping_add(*(l as *const uint64_t) & mask) as uint64_t as uint64_t;
+            let mut t_14 = (*(a as *const uint16_t) as libc::c_uint & mask as uint32_t) as uint64_t;
+            t_14 = t_14.wrapping_add(*(l as *const uint64_t) & mask);
             t_14 = (t_14 >> 6).wrapping_mul(mul);
             s = (t_14 >> 56) as libc::c_int - 2 - 8;
             current_block_66 = 2606304779496145856;
         }
         16 => {
-            let mut t_15: uint64_t = *(a as *const uint64_t) & mask;
-            t_15 = t_15.wrapping_add(
-                (*(l as *const uint16_t) as libc::c_uint & mask as uint32_t) as uint64_t,
-            ) as uint64_t as uint64_t;
+            let mut t_15 = *(a as *const uint64_t) & mask;
+            t_15 = t_15
+                .wrapping_add((*(l as *const uint16_t) as uint32_t & mask as uint32_t) as uint64_t);
             t_15 = (t_15 >> 6).wrapping_mul(mul);
             s = (t_15 >> 56) as libc::c_int - 8 - 2;
             current_block_66 = 2606304779496145856;
         }
         17 => {
-            let mut t_16: uint64_t = (*(a as *const uint32_t) & mask as uint32_t) as uint64_t;
-            t_16 = t_16.wrapping_add(*(&*l.offset(0) as *const uint8_t as *const uint64_t) & mask)
-                as uint64_t as uint64_t;
+            let mut t_16 = (*(a as *const uint32_t) & mask as uint32_t) as uint64_t;
+            t_16 = t_16.wrapping_add(*(&*l.offset(0) as *const uint8_t as *const uint64_t) & mask);
             t_16 = (t_16 >> 6)
                 .wrapping_add((*(&*l.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6);
-            t_16 = t_16.wrapping_mul(mul) as uint64_t as uint64_t;
+            t_16 = t_16.wrapping_mul(mul);
             s = (t_16 >> 56) as libc::c_int - 4 - 16;
             current_block_66 = 2606304779496145856;
         }
         18 => {
-            let mut t_17: uint64_t = *(&*a.offset(0) as *const uint8_t as *const uint64_t) & mask;
+            let mut t_17 = *(&*a.offset(0) as *const uint8_t as *const uint64_t) & mask;
             t_17 = t_17 + (*(l as *const uint32_t) & mask as uint32_t) as uint64_t;
             t_17 = (t_17 >> 6)
                 .wrapping_add((*(&*a.offset(8) as *const uint8_t as *const uint64_t) & mask) >> 6);
-            t_17 = t_17.wrapping_mul(mul) as uint64_t as uint64_t;
+            t_17 = t_17.wrapping_mul(mul);
             s = (t_17 >> 56) as libc::c_int - 16 - 4;
             current_block_66 = 2606304779496145856;
         }
@@ -601,7 +573,7 @@ pub unsafe fn get_dc_sign_ctx(tx: libc::c_int, a: &[u8], l: &[u8]) -> libc::c_ui
         }
         _ => {}
     }
-    return ((s != 0 as libc::c_int) as libc::c_int + (s > 0) as libc::c_int) as libc::c_uint;
+    return (s != 0) as libc::c_uint + (s > 0) as libc::c_uint;
 }
 
 #[inline]

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -448,7 +448,7 @@ pub unsafe fn get_skip_ctx(
 // `tx: RectTxfmSize` arg is also `TxfmSize`.
 // `TxfmSize` and `RectTxfmSize` should be part of the same `enum`.
 #[inline]
-pub unsafe fn get_dc_sign_ctx(tx: RectTxfmSize, a: &[u8], l: &[u8]) -> libc::c_uint {
+pub fn get_dc_sign_ctx(tx: RectTxfmSize, a: &[u8], l: &[u8]) -> libc::c_uint {
     let mut mask = 0xc0c0c0c0c0c0c0c0 as uint64_t;
     let mut mul = 0x101010101010101 as uint64_t;
     let mut s = 0;

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -451,31 +451,30 @@ pub unsafe fn get_skip_ctx(
 pub fn get_dc_sign_ctx(tx: RectTxfmSize, a: &[u8], l: &[u8]) -> libc::c_uint {
     let mut mask = 0xc0c0c0c0c0c0c0c0 as uint64_t;
     let mut mul = 0x101010101010101 as uint64_t;
-    let mut s = 0;
 
-    match tx {
+    let s = match tx {
         TX_4X4 => {
             let mut t = u8::read_ne(a) as libc::c_int >> 6;
             t += u8::read_ne(l) as libc::c_int >> 6;
-            s = t - 1 - 1;
+            t - 1 - 1
         }
         TX_8X8 => {
             let mut t = u16::read_ne(a) as uint32_t & mask as uint32_t;
             t = t.wrapping_add(u16::read_ne(l) as uint32_t & mask as uint32_t);
             t = t.wrapping_mul(0x4040404);
-            s = (t >> 24) as libc::c_int - 2 - 2;
+            (t >> 24) as libc::c_int - 2 - 2
         }
         TX_16X16 => {
             let mut t = (u32::read_ne(a) & mask as uint32_t) >> 6;
             t = t.wrapping_add((u32::read_ne(l) & mask as uint32_t) >> 6);
             t = t.wrapping_mul(mul as uint32_t);
-            s = (t >> 24) as libc::c_int - 4 - 4;
+            (t >> 24) as libc::c_int - 4 - 4
         }
         TX_32X32 => {
             let mut t = (u64::read_ne(a) & mask) >> 6;
             t = t.wrapping_add((u64::read_ne(l) & mask) >> 6);
             t = t.wrapping_mul(mul);
-            s = (t >> 56) as libc::c_int - 8 - 8;
+            (t >> 56) as libc::c_int - 8 - 8
         }
         TX_64X64 => {
             let mut t = (u64::read_ne(&a[0..]) & mask) >> 6;
@@ -483,98 +482,98 @@ pub fn get_dc_sign_ctx(tx: RectTxfmSize, a: &[u8], l: &[u8]) -> libc::c_uint {
             t = t.wrapping_add((u64::read_ne(&l[0..]) & mask) >> 6);
             t = t.wrapping_add((u64::read_ne(&l[8..]) & mask) >> 6);
             t = t.wrapping_mul(mul);
-            s = (t >> 56) as libc::c_int - 16 - 16;
+            (t >> 56) as libc::c_int - 16 - 16
         }
         RTX_4X8 => {
             let mut t = u8::read_ne(a) as uint32_t & mask as uint32_t;
             t = t.wrapping_add(u16::read_ne(l) as uint32_t & mask as uint32_t);
             t = t.wrapping_mul(0x4040404);
-            s = (t >> 24) as libc::c_int - 1 - 2;
+            (t >> 24) as libc::c_int - 1 - 2
         }
         RTX_8X4 => {
             let mut t = u16::read_ne(a) as uint32_t & mask as uint32_t;
             t = t.wrapping_add(u8::read_ne(l) as uint32_t & mask as uint32_t);
             t = t.wrapping_mul(0x4040404);
-            s = (t >> 24) as libc::c_int - 2 - 1;
+            (t >> 24) as libc::c_int - 2 - 1
         }
         RTX_8X16 => {
             let mut t = u16::read_ne(a) as uint32_t & mask as uint32_t;
             t = t.wrapping_add(u32::read_ne(l) & mask as uint32_t);
             t = (t >> 6).wrapping_mul(mul as uint32_t);
-            s = (t >> 24) as libc::c_int - 2 - 4;
+            (t >> 24) as libc::c_int - 2 - 4
         }
         RTX_16X8 => {
             let mut t = u32::read_ne(a) & mask as uint32_t;
             t = t.wrapping_add(u16::read_ne(l) as libc::c_uint & mask as uint32_t);
             t = (t >> 6).wrapping_mul(mul as uint32_t);
-            s = (t >> 24) as libc::c_int - 4 - 2;
+            (t >> 24) as libc::c_int - 4 - 2
         }
         RTX_16X32 => {
             let mut t = (u32::read_ne(a) & mask as uint32_t) as uint64_t;
             t = t.wrapping_add(u64::read_ne(l) & mask);
             t = (t >> 6).wrapping_mul(mul);
-            s = (t >> 56) as libc::c_int - 4 - 8;
+            (t >> 56) as libc::c_int - 4 - 8
         }
         RTX_32X16 => {
             let mut t = u64::read_ne(a) & mask;
             t = t + (u32::read_ne(l) & mask as uint32_t) as uint64_t;
             t = (t >> 6).wrapping_mul(mul);
-            s = (t >> 56) as libc::c_int - 8 - 4;
+            (t >> 56) as libc::c_int - 8 - 4
         }
         RTX_32X64 => {
             let mut t = (u64::read_ne(&a[0..]) & mask) >> 6;
             t = t.wrapping_add((u64::read_ne(&l[0..]) & mask) >> 6);
             t = t.wrapping_add((u64::read_ne(&l[8..]) & mask) >> 6);
             t = t.wrapping_mul(mul);
-            s = (t >> 56) as libc::c_int - 8 - 16;
+            (t >> 56) as libc::c_int - 8 - 16
         }
         RTX_64X32 => {
             let mut t = (u64::read_ne(&a[0..]) & mask) >> 6;
             t = t.wrapping_add((u64::read_ne(&a[8..]) & mask) >> 6);
             t = t.wrapping_add((u64::read_ne(&l[0..]) & mask) >> 6);
             t = t.wrapping_mul(mul);
-            s = (t >> 56) as libc::c_int - 16 - 8;
+            (t >> 56) as libc::c_int - 16 - 8
         }
         RTX_4X16 => {
             let mut t = u8::read_ne(a) as uint32_t & mask as uint32_t;
             t = t.wrapping_add(u32::read_ne(l) & mask as uint32_t);
             t = (t >> 6).wrapping_mul(mul as uint32_t);
-            s = (t >> 24) as libc::c_int - 1 - 4;
+            (t >> 24) as libc::c_int - 1 - 4
         }
         RTX_16X4 => {
             let mut t = u32::read_ne(a) & mask as uint32_t;
             t = t.wrapping_add(u8::read_ne(l) as libc::c_uint & mask as uint32_t);
             t = (t >> 6).wrapping_mul(mul as uint32_t);
-            s = (t >> 24) as libc::c_int - 4 - 1;
+            (t >> 24) as libc::c_int - 4 - 1
         }
         RTX_8X32 => {
             let mut t = (u16::read_ne(a) as libc::c_uint & mask as uint32_t) as uint64_t;
             t = t.wrapping_add(u64::read_ne(l) & mask);
             t = (t >> 6).wrapping_mul(mul);
-            s = (t >> 56) as libc::c_int - 2 - 8;
+            (t >> 56) as libc::c_int - 2 - 8
         }
         RTX_32X8 => {
             let mut t = u64::read_ne(a) & mask;
             t = t.wrapping_add((u16::read_ne(l) as uint32_t & mask as uint32_t) as uint64_t);
             t = (t >> 6).wrapping_mul(mul);
-            s = (t >> 56) as libc::c_int - 8 - 2;
+            (t >> 56) as libc::c_int - 8 - 2
         }
         RTX_16X64 => {
             let mut t = (u32::read_ne(a) & mask as uint32_t) as uint64_t;
             t = t.wrapping_add(u64::read_ne(&l[0..]) & mask);
             t = (t >> 6).wrapping_add((u64::read_ne(&l[8..]) & mask) >> 6);
             t = t.wrapping_mul(mul);
-            s = (t >> 56) as libc::c_int - 4 - 16;
+            (t >> 56) as libc::c_int - 4 - 16
         }
         RTX_64X16 => {
             let mut t = u64::read_ne(&a[0..]) & mask;
             t = t + (u32::read_ne(l) & mask as uint32_t) as uint64_t;
             t = (t >> 6).wrapping_add((u64::read_ne(&a[8..]) & mask) >> 6);
             t = t.wrapping_mul(mul);
-            s = (t >> 56) as libc::c_int - 16 - 4;
+            (t >> 56) as libc::c_int - 16 - 4
         }
         _ => unreachable!(),
-    }
+    };
     return (s != 0) as libc::c_uint + (s > 0) as libc::c_uint;
 }
 

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -449,32 +449,32 @@ pub unsafe fn get_skip_ctx(
 // `TxfmSize` and `RectTxfmSize` should be part of the same `enum`.
 #[inline]
 pub fn get_dc_sign_ctx(tx: RectTxfmSize, a: &[u8], l: &[u8]) -> libc::c_uint {
-    let mut mask = 0xc0c0c0c0c0c0c0c0 as uint64_t;
-    let mut mul = 0x101010101010101 as uint64_t;
+    let mut mask = 0xc0c0c0c0c0c0c0c0 as u64;
+    let mut mul = 0x101010101010101 as u64;
 
     let s = match tx {
         TX_4X4 => {
-            let mut t = u8::read_ne(a) as libc::c_int >> 6;
-            t += u8::read_ne(l) as libc::c_int >> 6;
+            let mut t = u8::read_ne(a) as i32 >> 6;
+            t += u8::read_ne(l) as i32 >> 6;
             t - 1 - 1
         }
         TX_8X8 => {
-            let mut t = u16::read_ne(a) as uint32_t & mask as uint32_t;
-            t = t.wrapping_add(u16::read_ne(l) as uint32_t & mask as uint32_t);
+            let mut t = u16::read_ne(a) as u32 & mask as u32;
+            t = t.wrapping_add(u16::read_ne(l) as u32 & mask as u32);
             t = t.wrapping_mul(0x4040404);
-            (t >> 24) as libc::c_int - 2 - 2
+            (t >> 24) as i32 - 2 - 2
         }
         TX_16X16 => {
-            let mut t = (u32::read_ne(a) & mask as uint32_t) >> 6;
-            t = t.wrapping_add((u32::read_ne(l) & mask as uint32_t) >> 6);
-            t = t.wrapping_mul(mul as uint32_t);
-            (t >> 24) as libc::c_int - 4 - 4
+            let mut t = (u32::read_ne(a) & mask as u32) >> 6;
+            t = t.wrapping_add((u32::read_ne(l) & mask as u32) >> 6);
+            t = t.wrapping_mul(mul as u32);
+            (t >> 24) as i32 - 4 - 4
         }
         TX_32X32 => {
             let mut t = (u64::read_ne(a) & mask) >> 6;
             t = t.wrapping_add((u64::read_ne(l) & mask) >> 6);
             t = t.wrapping_mul(mul);
-            (t >> 56) as libc::c_int - 8 - 8
+            (t >> 56) as i32 - 8 - 8
         }
         TX_64X64 => {
             let mut t = (u64::read_ne(&a[0..]) & mask) >> 6;
@@ -482,95 +482,95 @@ pub fn get_dc_sign_ctx(tx: RectTxfmSize, a: &[u8], l: &[u8]) -> libc::c_uint {
             t = t.wrapping_add((u64::read_ne(&l[0..]) & mask) >> 6);
             t = t.wrapping_add((u64::read_ne(&l[8..]) & mask) >> 6);
             t = t.wrapping_mul(mul);
-            (t >> 56) as libc::c_int - 16 - 16
+            (t >> 56) as i32 - 16 - 16
         }
         RTX_4X8 => {
-            let mut t = u8::read_ne(a) as uint32_t & mask as uint32_t;
-            t = t.wrapping_add(u16::read_ne(l) as uint32_t & mask as uint32_t);
+            let mut t = u8::read_ne(a) as u32 & mask as u32;
+            t = t.wrapping_add(u16::read_ne(l) as u32 & mask as u32);
             t = t.wrapping_mul(0x4040404);
-            (t >> 24) as libc::c_int - 1 - 2
+            (t >> 24) as i32 - 1 - 2
         }
         RTX_8X4 => {
-            let mut t = u16::read_ne(a) as uint32_t & mask as uint32_t;
-            t = t.wrapping_add(u8::read_ne(l) as uint32_t & mask as uint32_t);
+            let mut t = u16::read_ne(a) as u32 & mask as u32;
+            t = t.wrapping_add(u8::read_ne(l) as u32 & mask as u32);
             t = t.wrapping_mul(0x4040404);
-            (t >> 24) as libc::c_int - 2 - 1
+            (t >> 24) as i32 - 2 - 1
         }
         RTX_8X16 => {
-            let mut t = u16::read_ne(a) as uint32_t & mask as uint32_t;
-            t = t.wrapping_add(u32::read_ne(l) & mask as uint32_t);
-            t = (t >> 6).wrapping_mul(mul as uint32_t);
-            (t >> 24) as libc::c_int - 2 - 4
+            let mut t = u16::read_ne(a) as u32 & mask as u32;
+            t = t.wrapping_add(u32::read_ne(l) & mask as u32);
+            t = (t >> 6).wrapping_mul(mul as u32);
+            (t >> 24) as i32 - 2 - 4
         }
         RTX_16X8 => {
-            let mut t = u32::read_ne(a) & mask as uint32_t;
-            t = t.wrapping_add(u16::read_ne(l) as libc::c_uint & mask as uint32_t);
-            t = (t >> 6).wrapping_mul(mul as uint32_t);
-            (t >> 24) as libc::c_int - 4 - 2
+            let mut t = u32::read_ne(a) & mask as u32;
+            t = t.wrapping_add(u16::read_ne(l) as libc::c_uint & mask as u32);
+            t = (t >> 6).wrapping_mul(mul as u32);
+            (t >> 24) as i32 - 4 - 2
         }
         RTX_16X32 => {
-            let mut t = (u32::read_ne(a) & mask as uint32_t) as uint64_t;
+            let mut t = (u32::read_ne(a) & mask as u32) as u64;
             t = t.wrapping_add(u64::read_ne(l) & mask);
             t = (t >> 6).wrapping_mul(mul);
-            (t >> 56) as libc::c_int - 4 - 8
+            (t >> 56) as i32 - 4 - 8
         }
         RTX_32X16 => {
             let mut t = u64::read_ne(a) & mask;
-            t = t + (u32::read_ne(l) & mask as uint32_t) as uint64_t;
+            t = t + (u32::read_ne(l) & mask as u32) as u64;
             t = (t >> 6).wrapping_mul(mul);
-            (t >> 56) as libc::c_int - 8 - 4
+            (t >> 56) as i32 - 8 - 4
         }
         RTX_32X64 => {
             let mut t = (u64::read_ne(&a[0..]) & mask) >> 6;
             t = t.wrapping_add((u64::read_ne(&l[0..]) & mask) >> 6);
             t = t.wrapping_add((u64::read_ne(&l[8..]) & mask) >> 6);
             t = t.wrapping_mul(mul);
-            (t >> 56) as libc::c_int - 8 - 16
+            (t >> 56) as i32 - 8 - 16
         }
         RTX_64X32 => {
             let mut t = (u64::read_ne(&a[0..]) & mask) >> 6;
             t = t.wrapping_add((u64::read_ne(&a[8..]) & mask) >> 6);
             t = t.wrapping_add((u64::read_ne(&l[0..]) & mask) >> 6);
             t = t.wrapping_mul(mul);
-            (t >> 56) as libc::c_int - 16 - 8
+            (t >> 56) as i32 - 16 - 8
         }
         RTX_4X16 => {
-            let mut t = u8::read_ne(a) as uint32_t & mask as uint32_t;
-            t = t.wrapping_add(u32::read_ne(l) & mask as uint32_t);
-            t = (t >> 6).wrapping_mul(mul as uint32_t);
-            (t >> 24) as libc::c_int - 1 - 4
+            let mut t = u8::read_ne(a) as u32 & mask as u32;
+            t = t.wrapping_add(u32::read_ne(l) & mask as u32);
+            t = (t >> 6).wrapping_mul(mul as u32);
+            (t >> 24) as i32 - 1 - 4
         }
         RTX_16X4 => {
-            let mut t = u32::read_ne(a) & mask as uint32_t;
-            t = t.wrapping_add(u8::read_ne(l) as libc::c_uint & mask as uint32_t);
-            t = (t >> 6).wrapping_mul(mul as uint32_t);
-            (t >> 24) as libc::c_int - 4 - 1
+            let mut t = u32::read_ne(a) & mask as u32;
+            t = t.wrapping_add(u8::read_ne(l) as u32 & mask as u32);
+            t = (t >> 6).wrapping_mul(mul as u32);
+            (t >> 24) as i32 - 4 - 1
         }
         RTX_8X32 => {
-            let mut t = (u16::read_ne(a) as libc::c_uint & mask as uint32_t) as uint64_t;
+            let mut t = (u16::read_ne(a) as u32 & mask as u32) as u64;
             t = t.wrapping_add(u64::read_ne(l) & mask);
             t = (t >> 6).wrapping_mul(mul);
-            (t >> 56) as libc::c_int - 2 - 8
+            (t >> 56) as i32 - 2 - 8
         }
         RTX_32X8 => {
             let mut t = u64::read_ne(a) & mask;
-            t = t.wrapping_add((u16::read_ne(l) as uint32_t & mask as uint32_t) as uint64_t);
+            t = t.wrapping_add((u16::read_ne(l) as u32 & mask as u32) as u64);
             t = (t >> 6).wrapping_mul(mul);
-            (t >> 56) as libc::c_int - 8 - 2
+            (t >> 56) as i32 - 8 - 2
         }
         RTX_16X64 => {
-            let mut t = (u32::read_ne(a) & mask as uint32_t) as uint64_t;
+            let mut t = (u32::read_ne(a) & mask as u32) as u64;
             t = t.wrapping_add(u64::read_ne(&l[0..]) & mask);
             t = (t >> 6).wrapping_add((u64::read_ne(&l[8..]) & mask) >> 6);
             t = t.wrapping_mul(mul);
-            (t >> 56) as libc::c_int - 4 - 16
+            (t >> 56) as i32 - 4 - 16
         }
         RTX_64X16 => {
             let mut t = u64::read_ne(&a[0..]) & mask;
-            t = t + (u32::read_ne(l) & mask as uint32_t) as uint64_t;
+            t = t + (u32::read_ne(l) & mask as u32) as u64;
             t = (t >> 6).wrapping_add((u64::read_ne(&a[8..]) & mask) >> 6);
             t = t.wrapping_mul(mul);
-            (t >> 56) as libc::c_int - 16 - 4
+            (t >> 56) as i32 - 16 - 4
         }
         _ => unreachable!(),
     };

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1850,7 +1850,7 @@ unsafe fn decode_coefs(
             current_block = 2404388531445638768;
         }
     } else {
-        dc_sign_ctx = get_dc_sign_ctx(tx as libc::c_int, a, l) as libc::c_int;
+        dc_sign_ctx = get_dc_sign_ctx(tx, a, l) as libc::c_int;
         let dc_sign_cdf = &mut (*ts).cdf.coef.dc_sign[chroma as usize][dc_sign_ctx as usize];
         dc_sign = dav1d_msac_decode_bool_adapt(&mut (*ts).msac, dc_sign_cdf) as libc::c_int;
         if dbg != 0 {

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1821,7 +1821,7 @@ unsafe fn decode_coefs(
             current_block = 16948539754621368774;
         }
     } else {
-        dc_sign_ctx = get_dc_sign_ctx(tx as libc::c_int, a, l) as libc::c_int;
+        dc_sign_ctx = get_dc_sign_ctx(tx, a, l) as libc::c_int;
         let dc_sign_cdf = &mut (*ts).cdf.coef.dc_sign[chroma as usize][dc_sign_ctx as usize];
         dc_sign = dav1d_msac_decode_bool_adapt(&mut (*ts).msac, dc_sign_cdf) as libc::c_int;
         if dbg != 0 {


### PR DESCRIPTION
There's more cleanup we could do here I think to make this function way more concise using some generics, but this is the way the C does it, so I'll leave it at that for now, and it's safe now.