### PR TITLE
WIP: Backport per-plane reference counts from dav1d 1.2.0

### DIFF
--- a/src/fg_apply_tmpl.c
+++ b/src/fg_apply_tmpl.c
@@ -37,6 +37,7 @@
 #include "common/bitdepth.h"
 
 #include "src/fg_apply.h"
+#include "src/ref.h"
 
 static void generate_scaling(const int bitdepth,
                              const uint8_t points[][2], const int num,
@@ -125,36 +126,32 @@ void bitfn(dav1d_prep_grain)(const Dav1dFilmGrainDSPContext *const dsp,
     if (data->num_uv_points[1])
         generate_scaling(in->p.bpc, data->uv_points[1], data->num_uv_points[1], scaling[2]);
 
-    // Copy over the non-modified planes
-    // TODO: eliminate in favor of per-plane refs
+    // Create new references for the non-modified planes
     assert(out->stride[0] == in->stride[0]);
     if (!data->num_y_points) {
-        const ptrdiff_t stride = out->stride[0];
-        const ptrdiff_t sz = out->p.h * stride;
-        if (sz < 0)
-            memcpy((uint8_t*) out->data[0] + sz - stride,
-                   (uint8_t*) in->data[0] + sz - stride, -sz);
-        else
-            memcpy(out->data[0], in->data[0], sz);
+        struct Dav1dRef **out_plane_ref = out->ref->user_data;
+        struct Dav1dRef **in_plane_ref = in->ref->user_data;
+        dav1d_ref_dec(&out_plane_ref[0]);
+        out_plane_ref[0] = in_plane_ref[0];
+        dav1d_ref_inc(out_plane_ref[0]);
+        out->data[0] = in->data[0];
     }
 
     if (in->p.layout != DAV1D_PIXEL_LAYOUT_I400 && !data->chroma_scaling_from_luma) {
         assert(out->stride[1] == in->stride[1]);
-        const int ss_ver = in->p.layout == DAV1D_PIXEL_LAYOUT_I420;
-        const ptrdiff_t stride = out->stride[1];
-        const ptrdiff_t sz = ((out->p.h + ss_ver) >> ss_ver) * stride;
-        if (sz < 0) {
-            if (!data->num_uv_points[0])
-                memcpy((uint8_t*) out->data[1] + sz - stride,
-                       (uint8_t*) in->data[1] + sz - stride, -sz);
-            if (!data->num_uv_points[1])
-                memcpy((uint8_t*) out->data[2] + sz - stride,
-                       (uint8_t*) in->data[2] + sz - stride, -sz);
-        } else {
-            if (!data->num_uv_points[0])
-                memcpy(out->data[1], in->data[1], sz);
-            if (!data->num_uv_points[1])
-                memcpy(out->data[2], in->data[2], sz);
+        struct Dav1dRef **out_plane_ref = out->ref->user_data;
+        struct Dav1dRef **in_plane_ref = in->ref->user_data;
+        if (!data->num_uv_points[0]) {
+            dav1d_ref_dec(&out_plane_ref[1]);
+            out_plane_ref[1] = in_plane_ref[1];
+            dav1d_ref_inc(out_plane_ref[1]);
+            out->data[1] = in->data[1];
+        }
+        if (!data->num_uv_points[1]) {
+            dav1d_ref_dec(&out_plane_ref[2]);
+            out_plane_ref[2] = in_plane_ref[2];
+            dav1d_ref_inc(out_plane_ref[2]);
+            out->data[2] = in->data[2];
         }
     }
 }

--- a/src/fg_apply_tmpl_8.rs
+++ b/src/fg_apply_tmpl_8.rs
@@ -1,10 +1,10 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 use crate::src::align::Align16;
+use crate::src::r#ref::{dav1d_ref_dec, dav1d_ref_inc, Dav1dRef};
 use ::libc;
 use cfg_if::cfg_if;
 extern "C" {
-    pub type Dav1dRef;
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong) -> *mut libc::c_void;
 }
@@ -181,21 +181,13 @@ pub unsafe extern "C" fn dav1d_prep_grain_8bpc(
         unreachable!();
     }
     if (*data).num_y_points == 0 {
-        let stride: ptrdiff_t = (*out).stride[0];
-        let sz: ptrdiff_t = (*out).p.h as isize * stride;
-        if sz < 0 {
-            memcpy(
-                ((*out).data[0] as *mut uint8_t)
-                    .offset(sz as isize)
-                    .offset(-(stride as isize)) as *mut libc::c_void,
-                ((*in_0).data[0] as *mut uint8_t)
-                    .offset(sz as isize)
-                    .offset(-(stride as isize)) as *const libc::c_void,
-                -sz as libc::c_ulong,
-            );
-        } else {
-            memcpy((*out).data[0], (*in_0).data[0], sz as libc::c_ulong);
-        }
+        let out_plane_ref: *mut *mut Dav1dRef = (*(*out).r#ref).user_data as *mut *mut Dav1dRef;
+        let in_plane_ref: *const *const Dav1dRef =
+            (*(*in_0).r#ref).user_data as *const *const Dav1dRef;
+        dav1d_ref_dec(&mut *out_plane_ref as *mut *mut Dav1dRef);
+        *out_plane_ref = *in_plane_ref as *mut Dav1dRef;
+        dav1d_ref_inc(*out_plane_ref as *mut Dav1dRef);
+        (*out).data[0] = (*in_0).data[0];
     }
     if (*in_0).p.layout as libc::c_uint != DAV1D_PIXEL_LAYOUT_I400 as libc::c_int as libc::c_uint
         && (*data).chroma_scaling_from_luma == 0
@@ -203,41 +195,20 @@ pub unsafe extern "C" fn dav1d_prep_grain_8bpc(
         if !((*out).stride[1] == (*in_0).stride[1]) {
             unreachable!();
         }
-        let ss_ver = ((*in_0).p.layout as libc::c_uint
-            == DAV1D_PIXEL_LAYOUT_I420 as libc::c_int as libc::c_uint)
-            as libc::c_int;
-        let stride_0: ptrdiff_t = (*out).stride[1];
-        let sz_0: ptrdiff_t = ((*out).p.h + ss_ver >> ss_ver) as isize * stride_0;
-        if sz_0 < 0 {
-            if (*data).num_uv_points[0] == 0 {
-                memcpy(
-                    ((*out).data[1] as *mut uint8_t)
-                        .offset(sz_0 as isize)
-                        .offset(-(stride_0 as isize)) as *mut libc::c_void,
-                    ((*in_0).data[1] as *mut uint8_t)
-                        .offset(sz_0 as isize)
-                        .offset(-(stride_0 as isize)) as *const libc::c_void,
-                    -sz_0 as libc::c_ulong,
-                );
-            }
-            if (*data).num_uv_points[1] == 0 {
-                memcpy(
-                    ((*out).data[2] as *mut uint8_t)
-                        .offset(sz_0 as isize)
-                        .offset(-(stride_0 as isize)) as *mut libc::c_void,
-                    ((*in_0).data[2] as *mut uint8_t)
-                        .offset(sz_0 as isize)
-                        .offset(-(stride_0 as isize)) as *const libc::c_void,
-                    -sz_0 as libc::c_ulong,
-                );
-            }
-        } else {
-            if (*data).num_uv_points[0] == 0 {
-                memcpy((*out).data[1], (*in_0).data[1], sz_0 as libc::c_ulong);
-            }
-            if (*data).num_uv_points[1] == 0 {
-                memcpy((*out).data[2], (*in_0).data[2], sz_0 as libc::c_ulong);
-            }
+        let out_plane_ref: *mut *mut Dav1dRef = (*(*out).r#ref).user_data as *mut *mut Dav1dRef;
+        let in_plane_ref: *const *const Dav1dRef =
+            (*(*in_0).r#ref).user_data as *const *const Dav1dRef;
+        if (*data).num_uv_points[0] == 0 {
+            dav1d_ref_dec(&mut *out_plane_ref.offset(1) as *mut *mut Dav1dRef);
+            *out_plane_ref.offset(1) = *in_plane_ref.offset(1) as *mut Dav1dRef;
+            dav1d_ref_inc(*out_plane_ref.offset(1) as *mut Dav1dRef);
+            (*out).data[1] = (*in_0).data[1];
+        }
+        if (*data).num_uv_points[1] == 0 {
+            dav1d_ref_dec(&mut *out_plane_ref.offset(2) as *mut *mut Dav1dRef);
+            *out_plane_ref.offset(2) = *in_plane_ref.offset(2) as *mut Dav1dRef;
+            dav1d_ref_inc(*out_plane_ref.offset(2) as *mut Dav1dRef);
+            (*out).data[2] = (*in_0).data[2];
         }
     }
 }

--- a/src/picture.c
+++ b/src/picture.c
@@ -87,17 +87,31 @@ void dav1d_default_picture_release(Dav1dPicture *const p, void *const cookie) {
 }
 
 struct pic_ctx_context {
+    struct Dav1dRef *plane_ref[3]; /* MUST BE FIRST */
+    enum Dav1dPixelLayout layout;
+    void *extra_ptr; /* MUST BE AT THE END */
+};
+
+struct plane_ctx_context {
     Dav1dPicAllocator allocator;
     Dav1dPicture pic;
-    void *extra_ptr; /* MUST BE AT THE END */
 };
 
 static void free_buffer(const uint8_t *const data, void *const user_data) {
     struct pic_ctx_context *pic_ctx = user_data;
+    const int planes = pic_ctx->layout != DAV1D_PIXEL_LAYOUT_I400 ? 3 : 1;
 
-    pic_ctx->allocator.release_picture_callback(&pic_ctx->pic,
-                                                pic_ctx->allocator.cookie);
+    for (int i = 0; i < planes; i++)
+        dav1d_ref_dec(&pic_ctx->plane_ref[i]);
     free(pic_ctx);
+}
+
+static void free_plane_buffer(const uint8_t *const data, void *const user_data) {
+    struct plane_ctx_context *plane_ctx = user_data;
+
+    plane_ctx->allocator.release_picture_callback(&plane_ctx->pic,
+                                                  plane_ctx->allocator.cookie);
+    free(plane_ctx);
 }
 
 static int picture_alloc_with_edges(Dav1dContext *const c,
@@ -122,6 +136,7 @@ static int picture_alloc_with_edges(Dav1dContext *const c,
     struct pic_ctx_context *pic_ctx = malloc(extra + sizeof(struct pic_ctx_context));
     if (pic_ctx == NULL)
         return DAV1D_ERR(ENOMEM);
+    memset(pic_ctx, 0, sizeof(struct pic_ctx_context));
 
     p->p.w = w;
     p->p.h = h;
@@ -139,14 +154,38 @@ static int picture_alloc_with_edges(Dav1dContext *const c,
         return res;
     }
 
-    pic_ctx->allocator = *p_allocator;
-    pic_ctx->pic = *p;
+    pic_ctx->layout = p->p.layout;
 
     if (!(p->ref = dav1d_ref_wrap(p->data[0], free_buffer, pic_ctx))) {
         p_allocator->release_picture_callback(p, p_allocator->cookie);
         free(pic_ctx);
         dav1d_log(c, "Failed to wrap picture: %s\n", strerror(errno));
         return DAV1D_ERR(ENOMEM);
+    }
+
+    struct plane_ctx_context *plane_ctx = malloc(sizeof(struct plane_ctx_context));
+    if (plane_ctx == NULL){
+        dav1d_ref_dec(&p->ref);
+        p_allocator->release_picture_callback(p, p_allocator->cookie);
+        return DAV1D_ERR(ENOMEM);
+    }
+
+    plane_ctx->allocator = *p_allocator;
+    plane_ctx->pic = *p;
+
+    pic_ctx->plane_ref[0] = dav1d_ref_wrap(p->data[0], free_plane_buffer, plane_ctx);
+    if (!pic_ctx->plane_ref[0]) {
+        dav1d_ref_dec(&p->ref);
+        p_allocator->release_picture_callback(p, p_allocator->cookie);
+        free(plane_ctx);
+        dav1d_log(c, "Failed to wrap picture plane: %s\n", strerror(errno));
+        return DAV1D_ERR(ENOMEM);
+    }
+
+    const int planes = p->p.layout != DAV1D_PIXEL_LAYOUT_I400 ? 3 : 1;
+    for (int i = 1; i < planes; i++) {
+        pic_ctx->plane_ref[i] = pic_ctx->plane_ref[0];
+        dav1d_ref_inc(pic_ctx->plane_ref[i]);
     }
 
     p->seq_hdr_ref = seq_hdr_ref;
@@ -214,13 +253,14 @@ int dav1d_picture_alloc_copy(Dav1dContext *const c, Dav1dPicture *const dst, con
                              const Dav1dPicture *const src)
 {
     struct pic_ctx_context *const pic_ctx = src->ref->user_data;
+    struct plane_ctx_context *const plane_ctx = pic_ctx->plane_ref[0]->user_data;
     const int res = picture_alloc_with_edges(c, dst, w, src->p.h,
                                              src->seq_hdr, src->seq_hdr_ref,
                                              src->frame_hdr, src->frame_hdr_ref,
                                              src->content_light, src->content_light_ref,
                                              src->mastering_display, src->mastering_display_ref,
                                              src->itut_t35, src->itut_t35_ref,
-                                             src->p.bpc, &src->m, &pic_ctx->allocator,
+                                             src->p.bpc, &src->m, &plane_ctx->allocator,
                                              0, NULL);
     return res;
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -54,6 +54,7 @@ if is_asm_enabled
             'checkasm_bitdepth_@0@'.format(bitdepth),
             checkasm_tmpl_sources,
             include_directories: dav1d_inc_dirs,
+            dependencies : [stdatomic_dependencies],
             c_args: ['-DBITDEPTH=@0@'.format(bitdepth)],
             install: false,
             build_by_default: false,


### PR DESCRIPTION
Use per-plane reference counts to avoid copying pixel data. Partially addresses #225.