### PR TITLE
`fn ac_dump`: Cleanup and make safe

### DIFF
--- a/include/common/dump.rs
+++ b/include/common/dump.rs
@@ -1,18 +1,11 @@
-use crate::include::stdint::int16_t;
-
 #[inline]
-pub unsafe fn ac_dump(
-    mut buf: *const int16_t,
-    w: libc::c_int,
-    h: libc::c_int,
-    what: &str,
-) {
+pub unsafe fn ac_dump(mut buf: &[i16], w: libc::c_int, h: libc::c_int, what: &str) {
     println!("{}", what);
     for _ in 0..h {
         for x in 0..w {
-            print!(" {:03}", *buf.offset(x as isize));
+            print!(" {:03}", buf[x as usize]);
         }
-        buf = buf.offset(w as isize);
+        buf = &buf[w as usize..];
         println!();
     }
 }

--- a/include/common/dump.rs
+++ b/include/common/dump.rs
@@ -1,5 +1,5 @@
 #[inline]
-pub unsafe fn ac_dump(mut buf: &[i16], w: libc::c_int, h: libc::c_int, what: &str) {
+pub fn ac_dump(mut buf: &[i16], w: libc::c_int, h: libc::c_int, what: &str) {
     println!("{}", what);
     for _ in 0..h {
         for x in 0..w {

--- a/include/common/dump.rs
+++ b/include/common/dump.rs
@@ -1,11 +1,10 @@
 #[inline]
 pub fn ac_dump(mut buf: &[i16], w: libc::c_int, h: libc::c_int, what: &str) {
     println!("{}", what);
-    for _ in 0..h {
-        for x in 0..w {
-            print!(" {:03}", buf[x as usize]);
+    for buf in buf.chunks_exact(w as usize).take(h as usize) {
+        for x in buf {
+            print!(" {:03}", x);
         }
-        buf = &buf[w as usize..];
         println!();
     }
 }

--- a/include/common/dump.rs
+++ b/include/common/dump.rs
@@ -1,7 +1,7 @@
 #[inline]
-pub fn ac_dump(mut buf: &[i16], w: libc::c_int, h: libc::c_int, what: &str) {
+pub fn ac_dump(mut buf: &[i16], w: usize, h: usize, what: &str) {
     println!("{}", what);
-    for buf in buf.chunks_exact(w as usize).take(h as usize) {
+    for buf in buf.chunks_exact(w).take(h) {
         for x in buf {
             print!(" {:03}", x);
         }

--- a/include/common/dump.rs
+++ b/include/common/dump.rs
@@ -3,21 +3,14 @@ use crate::include::stdint::int16_t;
 #[inline]
 pub unsafe fn ac_dump(
     mut buf: *const int16_t,
-    mut w: libc::c_int,
-    mut h: libc::c_int,
+    w: libc::c_int,
+    h: libc::c_int,
     what: &str,
 ) {
     println!("{}", what);
-    loop {
-        let fresh1 = h;
-        h = h - 1;
-        if !(fresh1 != 0) {
-            break;
-        }
-        let mut x = 0;
-        while x < w {
+    for _ in 0..h {
+        for x in 0..w {
             print!(" {:03}", *buf.offset(x as isize));
-            x += 1;
         }
         buf = buf.offset(w as isize);
         println!();

--- a/include/common/dump.rs
+++ b/include/common/dump.rs
@@ -1,17 +1,13 @@
 use crate::include::stdint::int16_t;
 
-extern "C" {
-    fn printf(_: *const libc::c_char, _: ...) -> libc::c_int;
-}
-
 #[inline]
 pub unsafe fn ac_dump(
     mut buf: *const int16_t,
     mut w: libc::c_int,
     mut h: libc::c_int,
-    mut what: *const libc::c_char,
+    what: &str,
 ) {
-    printf(b"%s\n\0" as *const u8 as *const libc::c_char, what);
+    println!("{}", what);
     loop {
         let fresh1 = h;
         h = h - 1;
@@ -20,13 +16,10 @@ pub unsafe fn ac_dump(
         }
         let mut x = 0;
         while x < w {
-            printf(
-                b" %03d\0" as *const u8 as *const libc::c_char,
-                *buf.offset(x as isize) as libc::c_int,
-            );
+            print!(" {:03}", *buf.offset(x as isize));
             x += 1;
         }
         buf = buf.offset(w as isize);
-        printf(b"\n\0" as *const u8 as *const libc::c_char);
+        println!();
     }
 }

--- a/include/common/dump.rs
+++ b/include/common/dump.rs
@@ -5,7 +5,7 @@ extern "C" {
 }
 
 #[inline]
-pub unsafe extern "C" fn ac_dump(
+pub unsafe fn ac_dump(
     mut buf: *const int16_t,
     mut w: libc::c_int,
     mut h: libc::c_int,

--- a/include/common/dump.rs
+++ b/include/common/dump.rs
@@ -1,5 +1,5 @@
 #[inline]
-pub fn ac_dump(mut buf: &[i16], w: usize, h: usize, what: &str) {
+pub fn ac_dump(mut buf: &[i16; 32 * 32], w: usize, h: usize, what: &str) {
     println!("{}", what);
     for buf in buf.chunks_exact(w).take(h) {
         for x in buf {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -3361,12 +3361,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                         pl += 1;
                     }
                     if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
-                        ac_dump(
-                            ac,
-                            4 * cbw4,
-                            4 * cbh4,
-                            b"ac\0" as *const u8 as *const libc::c_char,
-                        );
+                        ac_dump(ac, 4 * cbw4, 4 * cbh4, "ac");
                         hex_dump(
                             uv_dst[0],
                             stride,

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -3281,7 +3281,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                     if !(init_x == 0 && init_y == 0) {
                         unreachable!();
                     }
-                    let ac: *mut int16_t = ((*t).scratch.c2rust_unnamed_0.ac).as_mut_ptr();
+                    let ac = &mut (*t).scratch.c2rust_unnamed_0.ac;
                     let mut y_src: *mut pixel = ((*f).cur.data[0] as *mut pixel)
                         .offset((4 * ((*t).bx & !ss_hor)) as isize)
                         .offset(
@@ -3303,7 +3303,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                         .wrapping_sub(1 as libc::c_int as libc::c_uint)
                         as usize])
                         .expect("non-null function pointer")(
-                        ac,
+                        ac.as_mut_ptr(),
                         y_src,
                         (*f).cur.stride[0],
                         cbw4 - (furthest_r >> ss_hor),
@@ -3352,7 +3352,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                 edge,
                                 (*uv_t_dim).w as libc::c_int * 4,
                                 (*uv_t_dim).h as libc::c_int * 4,
-                                ac,
+                                ac.as_mut_ptr(),
                                 (*b).c2rust_unnamed.c2rust_unnamed.cfl_alpha[pl as usize]
                                     as libc::c_int,
                                 (*f).bitdepth_max,

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -3361,7 +3361,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                         pl += 1;
                     }
                     if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
-                        ac_dump(ac, 4 * cbw4, 4 * cbh4, "ac");
+                        ac_dump(ac, 4 * cbw4 as usize, 4 * cbh4 as usize, "ac");
                         hex_dump(
                             uv_dst[0],
                             stride,

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -3233,7 +3233,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                     if !(init_x == 0 && init_y == 0) {
                         unreachable!();
                     }
-                    let ac: *mut int16_t = ((*t).scratch.c2rust_unnamed_0.ac).as_mut_ptr();
+                    let ac = &mut (*t).scratch.c2rust_unnamed_0.ac;
                     let mut y_src: *mut pixel = ((*f).cur.data[0] as *mut pixel)
                         .offset((4 * ((*t).bx & !ss_hor)) as isize)
                         .offset(((4 * ((*t).by & !ss_ver)) as isize * (*f).cur.stride[0]) as isize);
@@ -3251,7 +3251,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                         .wrapping_sub(1 as libc::c_int as libc::c_uint)
                         as usize])
                         .expect("non-null function pointer")(
-                        ac,
+                        ac.as_mut_ptr(),
                         y_src,
                         (*f).cur.stride[0],
                         cbw4 - (furthest_r >> ss_hor),
@@ -3299,7 +3299,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                 edge,
                                 (*uv_t_dim).w as libc::c_int * 4,
                                 (*uv_t_dim).h as libc::c_int * 4,
-                                ac,
+                                ac.as_mut_ptr(),
                                 (*b).c2rust_unnamed.c2rust_unnamed.cfl_alpha[pl as usize]
                                     as libc::c_int,
                             );

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -3307,12 +3307,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                         pl += 1;
                     }
                     if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
-                        ac_dump(
-                            ac,
-                            4 * cbw4,
-                            4 * cbh4,
-                            b"ac\0" as *const u8 as *const libc::c_char,
-                        );
+                        ac_dump(ac, 4 * cbw4, 4 * cbh4, "ac");
                         hex_dump(
                             uv_dst[0],
                             stride,

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -3307,7 +3307,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                         pl += 1;
                     }
                     if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
-                        ac_dump(ac, 4 * cbw4, 4 * cbh4, "ac");
+                        ac_dump(ac, 4 * cbw4 as usize, 4 * cbh4 as usize, "ac");
                         hex_dump(
                             uv_dst[0],
                             stride,


### PR DESCRIPTION
This `fn` is in `include/`, but is not marked `DAV1D_API`, so I consider it non-exported.