### PR TITLE
Move Dav1dTaskContext and friends into internal.rs

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,13 +1,30 @@
+use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
+use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
+use crate::include::dav1d::dav1d::Dav1dEventFlags;
+use crate::include::dav1d::dav1d::Dav1dInloopFilterType;
+use crate::include::dav1d::dav1d::Dav1dLogger;
+use crate::include::dav1d::headers::Dav1dContentLightLevel;
+use crate::include::dav1d::headers::Dav1dFilmGrainData;
+use crate::include::dav1d::headers::Dav1dFrameHeader;
+use crate::include::dav1d::headers::Dav1dITUTT35;
+use crate::include::dav1d::headers::Dav1dMasteringDisplay;
+use crate::include::dav1d::headers::Dav1dSequenceHeader;
+use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
+use crate::include::dav1d::picture::Dav1dPicAllocator;
 use crate::include::dav1d::picture::Dav1dPicture;
 use crate::include::pthread::pthread_cond_t;
 use crate::include::pthread::pthread_mutex_t;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
+use crate::include::stddef::ptrdiff_t;
+use crate::include::stddef::size_t;
 use crate::include::stdint::int16_t;
 use crate::include::stdint::int32_t;
 use crate::include::stdint::int8_t;
+use crate::include::stdint::intptr_t;
 use crate::include::stdint::uint16_t;
+use crate::include::stdint::uint32_t;
 use crate::include::stdint::uint8_t;
 use crate::src::align::*;
 use crate::src::cdf::CdfContext;
@@ -23,6 +40,21 @@ use crate::src::msac::MsacContext;
 use crate::src::picture::Dav1dThreadPicture;
 use crate::src::r#ref::Dav1dRef;
 use crate::src::thread_data::thread_data;
+
+use super::cdef::CdefEdgeFlags;
+use super::cdf::CdfThreadContext;
+use super::env::BlockContext;
+use super::intra_edge::EdgeFlags;
+use super::levels::BlockSize;
+use super::levels::Filter2d;
+use super::looprestoration::LooprestorationParams;
+use super::looprestoration::LrEdgeFlags;
+use super::mem::Dav1dMemPool;
+use super::picture::PictureFlags;
+use super::refmvs::Dav1dRefmvsDSPContext;
+use super::refmvs::refmvs_frame;
+use super::refmvs::refmvs_temporal_block;
+use super::refmvs::refmvs_tile;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -46,6 +78,314 @@ pub const DAV1D_TASK_TYPE_ENTROPY_PROGRESS: TaskType = 3;
 pub const DAV1D_TASK_TYPE_TILE_ENTROPY: TaskType = 2;
 pub const DAV1D_TASK_TYPE_INIT_CDF: TaskType = 1;
 pub const DAV1D_TASK_TYPE_INIT: TaskType = 0;
+
+pub type backup_ipred_edge_fn = Option<unsafe extern "C" fn(*mut Dav1dTaskContext) -> ()>;
+pub type filter_sbrow_fn = Option<unsafe extern "C" fn(*mut Dav1dFrameContext, libc::c_int) -> ()>;
+pub type recon_b_inter_fn =
+    Option<unsafe extern "C" fn(*mut Dav1dTaskContext, BlockSize, *const Av1Block) -> libc::c_int>;
+pub type recon_b_intra_fn = Option<
+    unsafe extern "C" fn(*mut Dav1dTaskContext, BlockSize, EdgeFlags, *const Av1Block) -> (),
+>;
+pub type read_coef_blocks_fn =
+    Option<unsafe extern "C" fn(*mut Dav1dTaskContext, BlockSize, *const Av1Block) -> ()>;
+
+pub type entry = int8_t;
+pub type fgy_32x32xn_fn = Option<
+    unsafe extern "C" fn(
+        *mut libc::c_void,
+        *const libc::c_void,
+        ptrdiff_t,
+        *const Dav1dFilmGrainData,
+        size_t,
+        *const uint8_t,
+        *const [entry; 82],
+        libc::c_int,
+        libc::c_int,
+    ) -> (),
+>;
+pub type generate_grain_uv_fn = Option<
+    unsafe extern "C" fn(
+        *mut [entry; 82],
+        *const [entry; 82],
+        *const Dav1dFilmGrainData,
+        intptr_t,
+    ) -> (),
+>;
+pub type generate_grain_y_fn =
+    Option<unsafe extern "C" fn(*mut [entry; 82], *const Dav1dFilmGrainData) -> ()>;
+pub type fguv_32x32xn_fn = Option<
+    unsafe extern "C" fn(
+        *mut libc::c_void,
+        *const libc::c_void,
+        ptrdiff_t,
+        *const Dav1dFilmGrainData,
+        size_t,
+        *const uint8_t,
+        *const [entry; 82],
+        libc::c_int,
+        libc::c_int,
+        *const libc::c_void,
+        ptrdiff_t,
+        libc::c_int,
+        libc::c_int,
+    ) -> (),
+>;
+
+pub type pal_pred_fn = Option<
+    unsafe extern "C" fn(
+        *mut libc::c_void,
+        ptrdiff_t,
+        *const uint16_t,
+        *const uint8_t,
+        libc::c_int,
+        libc::c_int,
+    ) -> (),
+>;
+pub type cfl_pred_fn = Option<
+    unsafe extern "C" fn(
+        *mut libc::c_void,
+        ptrdiff_t,
+        *const libc::c_void,
+        libc::c_int,
+        libc::c_int,
+        *const int16_t,
+        libc::c_int,
+    ) -> (),
+>;
+pub type cfl_ac_fn = Option<
+    unsafe extern "C" fn(
+        *mut int16_t,
+        *const libc::c_void,
+        ptrdiff_t,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+    ) -> (),
+>;
+pub type angular_ipred_fn = Option<
+    unsafe extern "C" fn(
+        *mut libc::c_void,
+        ptrdiff_t,
+        *const libc::c_void,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+    ) -> (),
+>;
+
+pub type resize_fn = Option<
+    unsafe extern "C" fn(
+        *mut libc::c_void,
+        ptrdiff_t,
+        *const libc::c_void,
+        ptrdiff_t,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+    ) -> (),
+>;
+pub type emu_edge_fn = Option<
+    unsafe extern "C" fn(
+        intptr_t,
+        intptr_t,
+        intptr_t,
+        intptr_t,
+        intptr_t,
+        intptr_t,
+        *mut libc::c_void,
+        ptrdiff_t,
+        *const libc::c_void,
+        ptrdiff_t,
+    ) -> (),
+>;
+pub type warp8x8t_fn = Option<
+    unsafe extern "C" fn(
+        *mut int16_t,
+        ptrdiff_t,
+        *const libc::c_void,
+        ptrdiff_t,
+        *const int16_t,
+        libc::c_int,
+        libc::c_int,
+    ) -> (),
+>;
+pub type warp8x8_fn = Option<
+    unsafe extern "C" fn(
+        *mut libc::c_void,
+        ptrdiff_t,
+        *const libc::c_void,
+        ptrdiff_t,
+        *const int16_t,
+        libc::c_int,
+        libc::c_int,
+    ) -> (),
+>;
+pub type blend_dir_fn = Option<
+    unsafe extern "C" fn(
+        *mut libc::c_void,
+        ptrdiff_t,
+        *const libc::c_void,
+        libc::c_int,
+        libc::c_int,
+    ) -> (),
+>;
+pub type blend_fn = Option<
+    unsafe extern "C" fn(
+        *mut libc::c_void,
+        ptrdiff_t,
+        *const libc::c_void,
+        libc::c_int,
+        libc::c_int,
+        *const uint8_t,
+    ) -> (),
+>;
+pub type w_mask_fn = Option<
+    unsafe extern "C" fn(
+        *mut libc::c_void,
+        ptrdiff_t,
+        *const int16_t,
+        *const int16_t,
+        libc::c_int,
+        libc::c_int,
+        *mut uint8_t,
+        libc::c_int,
+    ) -> (),
+>;
+pub type mask_fn = Option<
+    unsafe extern "C" fn(
+        *mut libc::c_void,
+        ptrdiff_t,
+        *const int16_t,
+        *const int16_t,
+        libc::c_int,
+        libc::c_int,
+        *const uint8_t,
+    ) -> (),
+>;
+pub type w_avg_fn = Option<
+    unsafe extern "C" fn(
+        *mut libc::c_void,
+        ptrdiff_t,
+        *const int16_t,
+        *const int16_t,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+    ) -> (),
+>;
+pub type avg_fn = Option<
+    unsafe extern "C" fn(
+        *mut libc::c_void,
+        ptrdiff_t,
+        *const int16_t,
+        *const int16_t,
+        libc::c_int,
+        libc::c_int,
+    ) -> (),
+>;
+pub type mct_scaled_fn = Option<
+    unsafe extern "C" fn(
+        *mut int16_t,
+        *const libc::c_void,
+        ptrdiff_t,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+    ) -> (),
+>;
+pub type mct_fn = Option<
+    unsafe extern "C" fn(
+        *mut int16_t,
+        *const libc::c_void,
+        ptrdiff_t,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+    ) -> (),
+>;
+pub type mc_scaled_fn = Option<
+    unsafe extern "C" fn(
+        *mut libc::c_void,
+        ptrdiff_t,
+        *const libc::c_void,
+        ptrdiff_t,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+    ) -> (),
+>;
+pub type mc_fn = Option<
+    unsafe extern "C" fn(
+        *mut libc::c_void,
+        ptrdiff_t,
+        *const libc::c_void,
+        ptrdiff_t,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+    ) -> (),
+>;
+
+pub type itxfm_fn = Option<
+    unsafe extern "C" fn(*mut libc::c_void, ptrdiff_t, *mut libc::c_void, libc::c_int) -> (),
+>;
+
+pub type loopfilter_sb_fn = Option<
+    unsafe extern "C" fn(
+        *mut libc::c_void,
+        ptrdiff_t,
+        *const uint32_t,
+        *const [uint8_t; 4],
+        ptrdiff_t,
+        *const Av1FilterLUT,
+        libc::c_int,
+    ) -> (),
+>;
+
+pub type const_left_pixel_row_2px = *const libc::c_void;
+pub type cdef_fn = Option<
+    unsafe extern "C" fn(
+        *mut libc::c_void,
+        ptrdiff_t,
+        const_left_pixel_row_2px,
+        *const libc::c_void,
+        *const libc::c_void,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+        libc::c_int,
+        CdefEdgeFlags,
+    ) -> (),
+>;
+pub type cdef_dir_fn =
+    Option<unsafe extern "C" fn(*const libc::c_void, ptrdiff_t, *mut libc::c_uint) -> libc::c_int>;
+
+pub type const_left_pixel_row = *const libc::c_void;
+pub type looprestorationfilter_fn = Option<
+    unsafe extern "C" fn(
+        *mut libc::c_void,
+        ptrdiff_t,
+        const_left_pixel_row,
+        *const libc::c_void,
+        libc::c_int,
+        libc::c_int,
+        *const LooprestorationParams,
+        LrEdgeFlags,
+    ) -> (),
+>;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -373,4 +713,268 @@ pub struct Dav1dTaskContext_task_thread {
     pub fttd: *mut FrameTileThreadData,
     pub flushed: libc::c_int,
     pub die: libc::c_int,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Dav1dTaskContext {
+    pub c: *const Dav1dContext,
+    pub f: *const Dav1dFrameContext,
+    pub ts: *mut Dav1dTileState,
+    pub bx: libc::c_int,
+    pub by: libc::c_int,
+    pub l: BlockContext,
+    pub a: *mut BlockContext,
+    pub rt: refmvs_tile,
+    pub c2rust_unnamed: Dav1dTaskContext_cf,
+    pub al_pal: [[[[uint16_t; 8]; 3]; 32]; 2],
+    pub pal_sz_uv: [[uint8_t; 32]; 2],
+    pub txtp_map: [uint8_t; 1024],
+    pub scratch: Dav1dTaskContext_scratch,
+    pub warpmv: Dav1dWarpedMotionParams,
+    pub lf_mask: *mut Av1Filter,
+    pub top_pre_cdef_toggle: libc::c_int,
+    pub cur_sb_cdef_idx_ptr: *mut int8_t,
+    pub tl_4x4_filter: Filter2d,
+    pub frame_thread: Dav1dTaskContext_frame_thread,
+    pub task_thread: Dav1dTaskContext_task_thread,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Dav1dContext {
+    pub fc: *mut Dav1dFrameContext,
+    pub n_fc: libc::c_uint,
+    pub tc: *mut Dav1dTaskContext,
+    pub n_tc: libc::c_uint,
+    pub tile: *mut Dav1dTileGroup,
+    pub n_tile_data_alloc: libc::c_int,
+    pub n_tile_data: libc::c_int,
+    pub n_tiles: libc::c_int,
+    pub seq_hdr_pool: *mut Dav1dMemPool,
+    pub seq_hdr_ref: *mut Dav1dRef,
+    pub seq_hdr: *mut Dav1dSequenceHeader,
+    pub frame_hdr_pool: *mut Dav1dMemPool,
+    pub frame_hdr_ref: *mut Dav1dRef,
+    pub frame_hdr: *mut Dav1dFrameHeader,
+    pub content_light_ref: *mut Dav1dRef,
+    pub content_light: *mut Dav1dContentLightLevel,
+    pub mastering_display_ref: *mut Dav1dRef,
+    pub mastering_display: *mut Dav1dMasteringDisplay,
+    pub itut_t35_ref: *mut Dav1dRef,
+    pub itut_t35: *mut Dav1dITUTT35,
+    pub in_0: Dav1dData,
+    pub out: Dav1dThreadPicture,
+    pub cache: Dav1dThreadPicture,
+    pub flush_mem: atomic_int,
+    pub flush: *mut atomic_int,
+    pub frame_thread: Dav1dContext_frame_thread,
+    pub task_thread: TaskThreadData,
+    pub segmap_pool: *mut Dav1dMemPool,
+    pub refmvs_pool: *mut Dav1dMemPool,
+    pub refs: [Dav1dContext_refs; 8],
+    pub cdf_pool: *mut Dav1dMemPool,
+    pub cdf: [CdfThreadContext; 8],
+    pub dsp: [Dav1dDSPContext; 3],
+    pub refmvs_dsp: Dav1dRefmvsDSPContext,
+    pub intra_edge: Dav1dContext_intra_edge,
+    pub allocator: Dav1dPicAllocator,
+    pub apply_grain: libc::c_int,
+    pub operating_point: libc::c_int,
+    pub operating_point_idc: libc::c_uint,
+    pub all_layers: libc::c_int,
+    pub max_spatial_id: libc::c_int,
+    pub frame_size_limit: libc::c_uint,
+    pub strict_std_compliance: libc::c_int,
+    pub output_invisible_frames: libc::c_int,
+    pub inloop_filters: Dav1dInloopFilterType,
+    pub decode_frame_type: Dav1dDecodeFrameType,
+    pub drain: libc::c_int,
+    pub frame_flags: PictureFlags,
+    pub event_flags: Dav1dEventFlags,
+    pub cached_error_props: Dav1dDataProps,
+    pub cached_error: libc::c_int,
+    pub logger: Dav1dLogger,
+    pub picture_pool: *mut Dav1dMemPool,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Dav1dFrameContext {
+    pub seq_hdr_ref: *mut Dav1dRef,
+    pub seq_hdr: *mut Dav1dSequenceHeader,
+    pub frame_hdr_ref: *mut Dav1dRef,
+    pub frame_hdr: *mut Dav1dFrameHeader,
+    pub refp: [Dav1dThreadPicture; 7],
+    pub cur: Dav1dPicture,
+    pub sr_cur: Dav1dThreadPicture,
+    pub mvs_ref: *mut Dav1dRef,
+    pub mvs: *mut refmvs_temporal_block,
+    pub ref_mvs: [*mut refmvs_temporal_block; 7],
+    pub ref_mvs_ref: [*mut Dav1dRef; 7],
+    pub cur_segmap_ref: *mut Dav1dRef,
+    pub prev_segmap_ref: *mut Dav1dRef,
+    pub cur_segmap: *mut uint8_t,
+    pub prev_segmap: *const uint8_t,
+    pub refpoc: [libc::c_uint; 7],
+    pub refrefpoc: [[libc::c_uint; 7]; 7],
+    pub gmv_warp_allowed: [uint8_t; 7],
+    pub in_cdf: CdfThreadContext,
+    pub out_cdf: CdfThreadContext,
+    pub tile: *mut Dav1dTileGroup,
+    pub n_tile_data_alloc: libc::c_int,
+    pub n_tile_data: libc::c_int,
+    pub svc: [[ScalableMotionParams; 2]; 7],
+    pub resize_step: [libc::c_int; 2],
+    pub resize_start: [libc::c_int; 2],
+    pub c: *const Dav1dContext,
+    pub ts: *mut Dav1dTileState,
+    pub n_ts: libc::c_int,
+    pub dsp: *const Dav1dDSPContext,
+    pub bd_fn: Dav1dFrameContext_bd_fn,
+    pub ipred_edge_sz: libc::c_int,
+    pub ipred_edge: [*mut libc::c_void; 3],
+    pub b4_stride: ptrdiff_t,
+    pub w4: libc::c_int,
+    pub h4: libc::c_int,
+    pub bw: libc::c_int,
+    pub bh: libc::c_int,
+    pub sb128w: libc::c_int,
+    pub sb128h: libc::c_int,
+    pub sbh: libc::c_int,
+    pub sb_shift: libc::c_int,
+    pub sb_step: libc::c_int,
+    pub sr_sb128w: libc::c_int,
+    pub dq: [[[uint16_t; 2]; 3]; 8],
+    pub qm: [[*const uint8_t; 3]; 19],
+    pub a: *mut BlockContext,
+    pub a_sz: libc::c_int,
+    pub rf: refmvs_frame,
+    pub jnt_weights: [[uint8_t; 7]; 7],
+    pub bitdepth_max: libc::c_int,
+    pub frame_thread: Dav1dFrameContext_frame_thread,
+    pub lf: Dav1dFrameContext_lf,
+    pub task_thread: Dav1dFrameContext_task_thread,
+    pub tile_thread: FrameTileThreadData,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Dav1dFrameContext_bd_fn {
+    pub recon_b_intra: recon_b_intra_fn,
+    pub recon_b_inter: recon_b_inter_fn,
+    pub filter_sbrow: filter_sbrow_fn,
+    pub filter_sbrow_deblock_cols: filter_sbrow_fn,
+    pub filter_sbrow_deblock_rows: filter_sbrow_fn,
+    pub filter_sbrow_cdef: Option<unsafe extern "C" fn(*mut Dav1dTaskContext, libc::c_int) -> ()>,
+    pub filter_sbrow_resize: filter_sbrow_fn,
+    pub filter_sbrow_lr: filter_sbrow_fn,
+    pub backup_ipred_edge: backup_ipred_edge_fn,
+    pub read_coef_blocks: read_coef_blocks_fn,
+}
+
+impl Dav1dFrameContext_bd_fn {
+    pub unsafe fn recon_b_intra(
+        &self,
+        context: *mut Dav1dTaskContext,
+        block_size: BlockSize,
+        flags: EdgeFlags,
+        block: *const Av1Block,
+    ) {
+        self.recon_b_intra.expect("non-null function pointer")(context, block_size, flags, block);
+    }
+
+    pub unsafe fn recon_b_inter(
+        &self,
+        context: *mut Dav1dTaskContext,
+        block_size: BlockSize,
+        block: *const Av1Block,
+    ) -> libc::c_int {
+        self.recon_b_inter.expect("non-null function pointer")(context, block_size, block)
+    }
+
+    pub unsafe fn read_coef_blocks(
+        &self,
+        context: *mut Dav1dTaskContext,
+        block_size: BlockSize,
+        block: *const Av1Block,
+    ) {
+        self.read_coef_blocks.expect("non-null function pointer")(context, block_size, block);
+    }
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Dav1dDSPContext {
+    pub fg: Dav1dFilmGrainDSPContext,
+    pub ipred: Dav1dIntraPredDSPContext,
+    pub mc: Dav1dMCDSPContext,
+    pub itx: Dav1dInvTxfmDSPContext,
+    pub lf: Dav1dLoopFilterDSPContext,
+    pub cdef: Dav1dCdefDSPContext,
+    pub lr: Dav1dLoopRestorationDSPContext,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Dav1dFilmGrainDSPContext {
+    pub generate_grain_y: generate_grain_y_fn,
+    pub generate_grain_uv: [generate_grain_uv_fn; 3],
+    pub fgy_32x32xn: fgy_32x32xn_fn,
+    pub fguv_32x32xn: [fguv_32x32xn_fn; 3],
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Dav1dIntraPredDSPContext {
+    pub intra_pred: [angular_ipred_fn; 14],
+    pub cfl_ac: [cfl_ac_fn; 3],
+    pub cfl_pred: [cfl_pred_fn; 6],
+    pub pal_pred: pal_pred_fn,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Dav1dMCDSPContext {
+    pub mc: [mc_fn; 10],
+    pub mc_scaled: [mc_scaled_fn; 10],
+    pub mct: [mct_fn; 10],
+    pub mct_scaled: [mct_scaled_fn; 10],
+    pub avg: avg_fn,
+    pub w_avg: w_avg_fn,
+    pub mask: mask_fn,
+    pub w_mask: [w_mask_fn; 3],
+    pub blend: blend_fn,
+    pub blend_v: blend_dir_fn,
+    pub blend_h: blend_dir_fn,
+    pub warp8x8: warp8x8_fn,
+    pub warp8x8t: warp8x8t_fn,
+    pub emu_edge: emu_edge_fn,
+    pub resize: resize_fn,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Dav1dInvTxfmDSPContext {
+    pub itxfm_add: [[itxfm_fn; 17]; 19],
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Dav1dLoopFilterDSPContext {
+    pub loop_filter_sb: [[loopfilter_sb_fn; 2]; 2],
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Dav1dCdefDSPContext {
+    pub dir: cdef_dir_fn,
+    pub fb: [cdef_fn; 3],
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Dav1dLoopRestorationDSPContext {
+    pub wiener: [looprestorationfilter_fn; 2],
+    pub sgr: [looprestorationfilter_fn; 3],
 }


### PR DESCRIPTION
This PR adds the definitions for `Dav1dTaskContext` and its contained types into `internal.rs`. This actually *increases* duplication because these types are still re-defined in every file where they're used. In order to deduplicate any of these types we need all of their related type declarations. Duplicating the type definitions into `internal.rs` allows us to then incrementally deduplicate the type definitions across mulitple PRs, instead of having to do all of them in a single PR.