### PR TITLE
`MsacContext::symbol_adapt16`: Devirtualize

### DIFF
--- a/src/msac.rs
+++ b/src/msac.rs
@@ -134,7 +134,7 @@ pub fn dav1d_msac_decode_uniform(s: &mut MsacContext, n: libc::c_uint) -> libc::
 
 #[cfg(all(feature = "asm", target_arch = "x86_64"))]
 #[inline(always)]
-unsafe fn msac_init_x86(s: &mut MsacContext) {
+fn msac_init_x86(s: &mut MsacContext) {
     use crate::src::cpu::dav1d_get_cpu_flags;
     use crate::src::x86::cpu::DAV1D_X86_CPU_FLAG_AVX2;
     use crate::src::x86::cpu::DAV1D_X86_CPU_FLAG_SSE2;

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -61,6 +61,14 @@ extern "C" {
 pub type ec_win = size_t;
 
 #[derive(Copy, Clone)]
+#[repr(u8)]
+pub enum FnSymbolAdapt16 {
+    Rust,
+    Sse2,
+    Avx2,
+}
+
+#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct MsacContext {
     buf_pos: *const uint8_t,
@@ -70,8 +78,7 @@ pub struct MsacContext {
     pub cnt: libc::c_int,
     allow_update_cdf: libc::c_int,
     #[cfg(all(feature = "asm", target_arch = "x86_64"))]
-    pub symbol_adapt16:
-        Option<unsafe extern "C" fn(*mut MsacContext, *mut uint16_t, size_t) -> libc::c_uint>,
+    pub symbol_adapt16: FnSymbolAdapt16,
 }
 
 impl MsacContext {
@@ -134,10 +141,10 @@ unsafe fn msac_init_x86(s: &mut MsacContext) {
 
     let flags = dav1d_get_cpu_flags();
     if flags & DAV1D_X86_CPU_FLAG_SSE2 != 0 {
-        s.symbol_adapt16 = Some(dav1d_msac_decode_symbol_adapt16_sse2);
+        s.symbol_adapt16 = FnSymbolAdapt16::Sse2;
     }
     if flags & DAV1D_X86_CPU_FLAG_AVX2 != 0 {
-        s.symbol_adapt16 = Some(dav1d_msac_decode_symbol_adapt16_avx2);
+        s.symbol_adapt16 = FnSymbolAdapt16::Avx2;
     }
 }
 
@@ -338,7 +345,7 @@ pub unsafe fn dav1d_msac_init(
 
     #[cfg(all(feature = "asm", target_arch = "x86_64"))]
     {
-        s.symbol_adapt16 = Some(dav1d_msac_decode_symbol_adapt_c);
+        s.symbol_adapt16 = FnSymbolAdapt16::Rust;
         msac_init_x86(s);
     }
 }
@@ -394,10 +401,12 @@ pub fn dav1d_msac_decode_symbol_adapt16(
 ) -> libc::c_uint {
     cfg_if! {
         if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
-            assert!(n_symbols < cdf.len());
-            // Safety: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_symbol_adapt_rust`].
-            unsafe {
-                (s.symbol_adapt16).expect("non-null function pointer")(s, cdf.as_mut_ptr(), n_symbols)
+            match s.symbol_adapt16 {
+                FnSymbolAdapt16::Rust => dav1d_msac_decode_symbol_adapt_rust(s, cdf, n_symbols),
+                // Safety: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_symbol_adapt_rust`].
+                FnSymbolAdapt16::Sse2 => unsafe { dav1d_msac_decode_symbol_adapt16_sse2(s, cdf.as_mut_ptr(), n_symbols) },
+                // Safety: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_symbol_adapt_rust`].
+                FnSymbolAdapt16::Avx2 => unsafe { dav1d_msac_decode_symbol_adapt16_avx2(s, cdf.as_mut_ptr(), n_symbols) } ,
             }
         } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
             // Safety: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_symbol_adapt_rust`].

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -272,28 +272,6 @@ fn dav1d_msac_decode_symbol_adapt_rust(
     val
 }
 
-#[deny(unsafe_op_in_unsafe_fn)]
-unsafe extern "C" fn dav1d_msac_decode_symbol_adapt_c(
-    s: *mut MsacContext,
-    cdf: *mut u16,
-    n_symbols: size_t,
-) -> libc::c_uint {
-    // # Safety
-    //
-    // This is only called from [`dav1d_msac_decode_symbol_adapt16`],
-    // where it comes from a valid `&mut`.
-    let s = unsafe { &mut *s };
-
-    // # Safety
-    //
-    // This is only called from [`dav1d_msac_decode_symbol_adapt16`],
-    // where there is an `assert!(n_symbols < cdf.len());`.
-    // Thus, `n_symbols + 1` is a valid length for the slice `cdf` came from.
-    let cdf = unsafe { std::slice::from_raw_parts_mut(cdf, n_symbols + 1) };
-
-    dav1d_msac_decode_symbol_adapt_rust(s, cdf, n_symbols)
-}
-
 fn dav1d_msac_decode_bool_adapt_rust(s: &mut MsacContext, cdf: &mut [u16; 2]) -> bool {
     let bit = dav1d_msac_decode_bool(s, cdf[0] as libc::c_uint);
     if s.allow_update_cdf() {


### PR DESCRIPTION
This is a small, simple example of devirtualizing a `fn` ptr into an `enum` in code I've already cleaned up.  Since it still works and there are no segfaults, I assume assembly is not calling the `fn` ptr directly (though there is untested assembly).