### PR TITLE
`fn {clip,iclip_pixel}`: Allow them to clip into a smaller type

### DIFF
--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -106,7 +106,8 @@ pub trait BitDepth {
 
     fn iclip_pixel<T>(&self, pixel: T) -> Self::Pixel
     where
-        T: Copy + Ord + From<Self::Pixel> + TryInto<Self::Pixel>,
+        T: Copy + Ord + TryInto<Self::Pixel>,
+        Self::Pixel: Into<T>,
     {
         clip(pixel, 0.into(), self.bitdepth_max())
     }

--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -104,7 +104,10 @@ pub trait BitDepth {
 
     fn display(pixel: Self::Pixel) -> Self::DisplayPixel;
 
-    fn iclip_pixel(&self, pixel: Self::Pixel) -> Self::Pixel {
+    fn iclip_pixel<T>(&self, pixel: T) -> Self::Pixel
+    where
+        T: Copy + Ord + From<Self::Pixel> + TryInto<Self::Pixel>,
+    {
         clip(pixel, 0.into(), self.bitdepth_max())
     }
 

--- a/include/common/intops.rs
+++ b/include/common/intops.rs
@@ -1,5 +1,4 @@
 use std::ffi::{c_int, c_uint, c_ulonglong};
-use std::fmt::Debug;
 
 use crate::include::common::attributes::clz;
 use crate::include::common::attributes::clzll;
@@ -32,23 +31,33 @@ pub fn umin(a: c_uint, b: c_uint) -> c_uint {
 }
 
 #[inline]
-pub fn clip<T: Ord>(v: T, min: T, max: T) -> T {
-    if v < min {
+pub fn clip<T, U>(v: T, min: U, max: U) -> U
+where
+    U: Copy + Ord + Into<T>,
+    T: Copy + Ord + TryInto<U>,
+{
+    assert!(min <= max);
+    if v < min.into() {
         min
-    } else if v > max {
+    } else if v > max.into() {
         max
     } else {
-        v
+        let v = v.try_into();
+        // # Safety
+        // `min <= v <= max`, `min: U`, `max: U`,
+        // so `v` must be in `U`, too.
+        //
+        // Note that `v.try_into().unwrap()` is not always optimized out.
+        unsafe { v.unwrap_unchecked() }
     }
 }
 
 #[inline]
 pub fn clip_u8<T>(v: T) -> u8
 where
-    T: Ord + From<u8> + TryInto<u8>,
-    <T as TryInto<u8>>::Error: Debug,
+    T: Copy + Ord + From<u8> + TryInto<u8>,
 {
-    clip(v, u8::MIN.into(), u8::MAX.into()).try_into().unwrap()
+    clip(v, u8::MIN, u8::MAX)
 }
 
 #[inline]

--- a/include/common/intops.rs
+++ b/include/common/intops.rs
@@ -30,6 +30,10 @@ pub fn umin(a: c_uint, b: c_uint) -> c_uint {
     }
 }
 
+/// # Safety
+///
+/// `U: Into<T>` and `T: TryInto<U>` must be well-formed
+/// such that for all `u: U`, `u.into().try_into() == Ok(u)`.
 #[inline]
 pub fn clip<T, U>(v: T, min: U, max: U) -> U
 where
@@ -45,6 +49,7 @@ where
         let v = v.try_into();
         // # Safety
         // `min <= v <= max`, `min: U`, `max: U`,
+        // and for all `u: U`, `u.into().try_into() == Ok(u)`,
         // so `v` must be in `U`, too.
         //
         // Note that `v.try_into().unwrap()` is not always optimized out.

--- a/include/common/intops.rs
+++ b/include/common/intops.rs
@@ -33,8 +33,8 @@ pub fn umin(a: c_uint, b: c_uint) -> c_uint {
 #[inline]
 pub fn clip<T, U>(v: T, min: U, max: U) -> U
 where
-    U: Copy + Ord + Into<T>,
     T: Copy + Ord + TryInto<U>,
+    U: Copy + Ord + Into<T>,
 {
     assert!(min <= max);
     if v < min.into() {


### PR DESCRIPTION
This reflects actual usage of `iclip_pixel`.

I used an `unsafe` in `fn clip`, as `.try_into().unwrap()` doesn't always get optimized out, and it's way slower when not.  This should be safe as long as the `U: Into<T>` and `T: TryInto<U>` `impl`s are well-formed (they definitely are for all primitives).