### PR TITLE
`fn put_8tap_c`: Deduplicate w/ generics and cleanup/re-translate, including macros used

### DIFF
--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -71,7 +71,7 @@ impl_FromPrimitive!(isize => {, ...});
 impl_FromPrimitive!(f32 => {, ...});
 impl_FromPrimitive!(f64 => {, ...});
 
-pub trait BitDepth {
+pub trait BitDepth: Clone + Copy {
     const BITDEPTH: u8;
 
     type Pixel: Copy
@@ -123,6 +123,7 @@ pub trait BitDepth {
     const PREP_BIAS: i16;
 }
 
+#[derive(Clone, Copy)]
 pub struct BitDepth8 {
     bitdepth_max: <Self as BitDepth>::BitDepthMax,
 }
@@ -165,6 +166,8 @@ impl BitDepth for BitDepth8 {
     /// Output in interval `[-5132, 9212]`; fits in [`i16`] as is.
     const PREP_BIAS: i16 = 0;
 }
+
+#[derive(Clone, Copy)]
 pub struct BitDepth16 {
     bitdepth_max: <Self as BitDepth>::BitDepthMax,
 }

--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -77,6 +77,8 @@ pub trait BitDepth: Clone + Copy {
     type Pixel: Copy
         + Ord
         + From<u8>
+        + Into<i32>
+        + TryFrom<i32>
         + FromPrimitive<c_int>
         + FromPrimitive<c_uint>
         + ToPrimitive<c_int>

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -132,8 +132,9 @@ fn get_filters(
     )
 }
 
+// TODO(kkysen) temporarily `pub` until `mc` callers are deduplicated
 #[inline(never)]
-unsafe fn put_8tap_c<BD: BitDepth>(
+pub unsafe fn put_8tap_c<BD: BitDepth>(
     dst: *mut BD::Pixel,
     dst_stride: usize,
     mut src: *const BD::Pixel,

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -118,3 +118,16 @@ fn get_v_filter(my: usize, h: usize, filter_type: Dav1dFilterMode) -> Option<&'s
     };
     Some(&dav1d_mc_subpel_filters[i as usize][mx])
 }
+
+fn get_filters(
+    mx: usize,
+    my: usize,
+    w: usize,
+    h: usize,
+    filter_type: Dav1dFilterMode,
+) -> (Option<&'static [i8; 8]>, Option<&'static [i8; 8]>) {
+    (
+        get_h_filter(mx, w, filter_type),
+        get_v_filter(my, h, filter_type),
+    )
+}

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -52,3 +52,13 @@ unsafe fn filter_8tap<T: Into<i32>>(src: *const T, x: usize, f: &[i8; 8], stride
         })
         .sum()
 }
+
+unsafe fn dav1d_filter_8tap_rnd<T: Into<i32>>(
+    src: *const T,
+    x: usize,
+    f: &[i8; 8],
+    stride: usize,
+    sh: u8,
+) -> i32 {
+    (filter_8tap(src, x, f, stride) + ((1 << sh) >> 1)) >> sh
+}

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -73,3 +73,14 @@ unsafe fn dav1d_filter_8tap_rnd2<T: Into<i32>>(
 ) -> i32 {
     (filter_8tap(src, x, f, stride) + (rnd as i32)) >> sh
 }
+
+unsafe fn dav1d_filter_8tap_clip<BD: BitDepth, T: Into<i32>>(
+    bd: BD,
+    src: *const T,
+    x: usize,
+    f: &[i8; 8],
+    stride: usize,
+    sh: u8,
+) -> BD::Pixel {
+    bd.iclip_pixel(dav1d_filter_8tap_rnd(src, x, f, stride, sh))
+}

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -41,3 +41,14 @@ pub unsafe fn prep_c<BD: BitDepth>(
         }
     }
 }
+
+unsafe fn filter_8tap<T: Into<i32>>(src: *const T, x: usize, f: &[i8; 8], stride: usize) -> i32 {
+    f.into_iter()
+        .enumerate()
+        .map(|(i, &f)| {
+            let [i, x, stride] = [i, x, stride].map(|it| it as isize);
+            let j = x + (i - 3) * stride;
+            i32::from(f) * src.offset(j).read().into()
+        })
+        .sum()
+}

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -62,3 +62,14 @@ unsafe fn dav1d_filter_8tap_rnd<T: Into<i32>>(
 ) -> i32 {
     (filter_8tap(src, x, f, stride) + ((1 << sh) >> 1)) >> sh
 }
+
+unsafe fn dav1d_filter_8tap_rnd2<T: Into<i32>>(
+    src: *const T,
+    x: usize,
+    f: &[i8; 8],
+    stride: usize,
+    rnd: u8,
+    sh: u8,
+) -> i32 {
+    (filter_8tap(src, x, f, stride) + (rnd as i32)) >> sh
+}

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -84,3 +84,15 @@ unsafe fn dav1d_filter_8tap_clip<BD: BitDepth, T: Into<i32>>(
 ) -> BD::Pixel {
     bd.iclip_pixel(dav1d_filter_8tap_rnd(src, x, f, stride, sh))
 }
+
+unsafe fn dav1d_filter_8tap_clip2<BD: BitDepth, T: Into<i32>>(
+    bd: BD,
+    src: *const T,
+    x: usize,
+    f: &[i8; 8],
+    stride: usize,
+    rnd: u8,
+    sh: u8,
+) -> BD::Pixel {
+    bd.iclip_pixel(dav1d_filter_8tap_rnd2(src, x, f, stride, rnd, sh))
+}

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -1,6 +1,8 @@
 use std::iter;
 
 use crate::include::common::bitdepth::{AsPrimitive, BitDepth};
+use crate::include::dav1d::headers::Dav1dFilterMode;
+use crate::src::tables::dav1d_mc_subpel_filters;
 
 // TODO(kkysen) temporarily `pub` until `mc` callers are deduplicated
 #[inline(never)]
@@ -95,4 +97,14 @@ unsafe fn dav1d_filter_8tap_clip2<BD: BitDepth, T: Into<i32>>(
     sh: u8,
 ) -> BD::Pixel {
     bd.iclip_pixel(dav1d_filter_8tap_rnd2(src, x, f, stride, rnd, sh))
+}
+
+fn get_h_filter(mx: usize, w: usize, filter_type: Dav1dFilterMode) -> Option<&'static [i8; 8]> {
+    let mx = mx.checked_sub(1)?;
+    let i = if w > 4 {
+        filter_type & 3
+    } else {
+        3 + (filter_type & 1)
+    };
+    Some(&dav1d_mc_subpel_filters[i as usize][mx])
 }

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -108,3 +108,13 @@ fn get_h_filter(mx: usize, w: usize, filter_type: Dav1dFilterMode) -> Option<&'s
     };
     Some(&dav1d_mc_subpel_filters[i as usize][mx])
 }
+
+fn get_v_filter(my: usize, h: usize, filter_type: Dav1dFilterMode) -> Option<&'static [i8; 8]> {
+    let mx = my.checked_sub(1)?;
+    let i = if h > 4 {
+        filter_type >> 2
+    } else {
+        3 + ((filter_type >> 2) & 1)
+    };
+    Some(&dav1d_mc_subpel_filters[i as usize][mx])
+}

--- a/src/mc_tmpl_8.rs
+++ b/src/mc_tmpl_8.rs
@@ -2015,198 +2015,8 @@ use crate::include::common::intops::iclip;
 use crate::include::common::intops::iclip_u8;
 use crate::include::common::intops::imin;
 use crate::src::mc::prep_c;
+use crate::src::mc::put_8tap_c;
 use crate::src::mc::put_c;
-#[inline(never)]
-unsafe extern "C" fn put_8tap_c(
-    mut dst: *mut pixel,
-    mut dst_stride: ptrdiff_t,
-    mut src: *const pixel,
-    mut src_stride: ptrdiff_t,
-    w: libc::c_int,
-    mut h: libc::c_int,
-    mx: libc::c_int,
-    my: libc::c_int,
-    filter_type: libc::c_int,
-) {
-    let intermediate_bits = 4;
-    let intermediate_rnd = 32 as libc::c_int + ((1 as libc::c_int) << 6 - intermediate_bits >> 1);
-    let fh: *const int8_t = if mx == 0 {
-        0 as *const int8_t
-    } else if w > 4 {
-        (dav1d_mc_subpel_filters[(filter_type & 3) as usize][(mx - 1) as usize]).as_ptr()
-    } else {
-        (dav1d_mc_subpel_filters[(3 + (filter_type & 1)) as usize][(mx - 1) as usize]).as_ptr()
-    };
-    let fv: *const int8_t = if my == 0 {
-        0 as *const int8_t
-    } else if h > 4 {
-        (dav1d_mc_subpel_filters[(filter_type >> 2) as usize][(my - 1) as usize]).as_ptr()
-    } else {
-        (dav1d_mc_subpel_filters[(3 as libc::c_int + (filter_type >> 2 & 1)) as usize]
-            [(my - 1) as usize])
-            .as_ptr()
-    };
-    dst_stride = dst_stride;
-    src_stride = src_stride;
-    if !fh.is_null() {
-        if !fv.is_null() {
-            let mut tmp_h = h + 7;
-            let mut mid: [int16_t; 17280] = [0; 17280];
-            let mut mid_ptr: *mut int16_t = mid.as_mut_ptr();
-            src = src.offset(-((src_stride * 3) as isize));
-            loop {
-                let mut x = 0;
-                while x < w {
-                    *mid_ptr.offset(x as isize) = (*fh.offset(0) as libc::c_int
-                        * *src.offset((x + -(3 as libc::c_int) * 1) as isize) as libc::c_int
-                        + *fh.offset(1) as libc::c_int
-                            * *src.offset((x + -(2 as libc::c_int) * 1) as isize) as libc::c_int
-                        + *fh.offset(2) as libc::c_int
-                            * *src.offset((x + -(1 as libc::c_int) * 1) as isize) as libc::c_int
-                        + *fh.offset(3) as libc::c_int
-                            * *src.offset((x + 0 * 1) as isize) as libc::c_int
-                        + *fh.offset(4) as libc::c_int
-                            * *src.offset((x + 1 * 1) as isize) as libc::c_int
-                        + *fh.offset(5) as libc::c_int
-                            * *src.offset((x + 2 * 1) as isize) as libc::c_int
-                        + *fh.offset(6) as libc::c_int
-                            * *src.offset((x + 3 * 1) as isize) as libc::c_int
-                        + *fh.offset(7) as libc::c_int
-                            * *src.offset((x + 4 * 1) as isize) as libc::c_int
-                        + ((1 as libc::c_int) << 6 - intermediate_bits >> 1)
-                        >> 6 - intermediate_bits)
-                        as int16_t;
-                    x += 1;
-                }
-                mid_ptr = mid_ptr.offset(128);
-                src = src.offset(src_stride as isize);
-                tmp_h -= 1;
-                if !(tmp_h != 0) {
-                    break;
-                }
-            }
-            mid_ptr = mid.as_mut_ptr().offset((128 * 3) as isize);
-            loop {
-                let mut x_0 = 0;
-                while x_0 < w {
-                    *dst.offset(x_0 as isize) = iclip_u8(
-                        *fv.offset(0) as libc::c_int
-                            * *mid_ptr.offset((x_0 + -(3 as libc::c_int) * 128) as isize)
-                                as libc::c_int
-                            + *fv.offset(1) as libc::c_int
-                                * *mid_ptr.offset((x_0 + -(2 as libc::c_int) * 128) as isize)
-                                    as libc::c_int
-                            + *fv.offset(2) as libc::c_int
-                                * *mid_ptr.offset((x_0 + -(1 as libc::c_int) * 128) as isize)
-                                    as libc::c_int
-                            + *fv.offset(3) as libc::c_int
-                                * *mid_ptr.offset((x_0 + 0 * 128) as isize) as libc::c_int
-                            + *fv.offset(4) as libc::c_int
-                                * *mid_ptr.offset((x_0 + 1 * 128) as isize) as libc::c_int
-                            + *fv.offset(5) as libc::c_int
-                                * *mid_ptr.offset((x_0 + 2 * 128) as isize) as libc::c_int
-                            + *fv.offset(6) as libc::c_int
-                                * *mid_ptr.offset((x_0 + 3 * 128) as isize) as libc::c_int
-                            + *fv.offset(7) as libc::c_int
-                                * *mid_ptr.offset((x_0 + 4 * 128) as isize) as libc::c_int
-                            + ((1 as libc::c_int) << 6 + intermediate_bits >> 1)
-                            >> 6 + intermediate_bits,
-                    ) as pixel;
-                    x_0 += 1;
-                }
-                mid_ptr = mid_ptr.offset(128);
-                dst = dst.offset(dst_stride as isize);
-                h -= 1;
-                if !(h != 0) {
-                    break;
-                }
-            }
-        } else {
-            loop {
-                let mut x_1 = 0;
-                while x_1 < w {
-                    *dst.offset(x_1 as isize) = iclip_u8(
-                        *fh.offset(0) as libc::c_int
-                            * *src.offset((x_1 + -(3 as libc::c_int) * 1) as isize) as libc::c_int
-                            + *fh.offset(1) as libc::c_int
-                                * *src.offset((x_1 + -(2 as libc::c_int) * 1) as isize)
-                                    as libc::c_int
-                            + *fh.offset(2) as libc::c_int
-                                * *src.offset((x_1 + -(1 as libc::c_int) * 1) as isize)
-                                    as libc::c_int
-                            + *fh.offset(3) as libc::c_int
-                                * *src.offset((x_1 + 0 * 1) as isize) as libc::c_int
-                            + *fh.offset(4) as libc::c_int
-                                * *src.offset((x_1 + 1 * 1) as isize) as libc::c_int
-                            + *fh.offset(5) as libc::c_int
-                                * *src.offset((x_1 + 2 * 1) as isize) as libc::c_int
-                            + *fh.offset(6) as libc::c_int
-                                * *src.offset((x_1 + 3 * 1) as isize) as libc::c_int
-                            + *fh.offset(7) as libc::c_int
-                                * *src.offset((x_1 + 4 * 1) as isize) as libc::c_int
-                            + intermediate_rnd
-                            >> 6,
-                    ) as pixel;
-                    x_1 += 1;
-                }
-                dst = dst.offset(dst_stride as isize);
-                src = src.offset(src_stride as isize);
-                h -= 1;
-                if !(h != 0) {
-                    break;
-                }
-            }
-        }
-    } else if !fv.is_null() {
-        loop {
-            let mut x_2 = 0;
-            while x_2 < w {
-                *dst.offset(x_2 as isize) = iclip_u8(
-                    *fv.offset(0) as libc::c_int
-                        * *src.offset(
-                            (x_2 as isize + -(3 as libc::c_int) as isize * src_stride) as isize,
-                        ) as libc::c_int
-                        + *fv.offset(1) as libc::c_int
-                            * *src.offset(
-                                (x_2 as isize + -(2 as libc::c_int) as isize * src_stride) as isize,
-                            ) as libc::c_int
-                        + *fv.offset(2) as libc::c_int
-                            * *src.offset(
-                                (x_2 as isize + -(1 as libc::c_int) as isize * src_stride) as isize,
-                            ) as libc::c_int
-                        + *fv.offset(3) as libc::c_int
-                            * *src.offset((x_2 as isize + 0 * src_stride) as isize) as libc::c_int
-                        + *fv.offset(4) as libc::c_int
-                            * *src.offset((x_2 as isize + 1 * src_stride) as isize) as libc::c_int
-                        + *fv.offset(5) as libc::c_int
-                            * *src.offset((x_2 as isize + 2 * src_stride) as isize) as libc::c_int
-                        + *fv.offset(6) as libc::c_int
-                            * *src.offset((x_2 as isize + 3 * src_stride) as isize) as libc::c_int
-                        + *fv.offset(7) as libc::c_int
-                            * *src.offset((x_2 as isize + 4 * src_stride) as isize) as libc::c_int
-                        + ((1 as libc::c_int) << 6 >> 1)
-                        >> 6,
-                ) as pixel;
-                x_2 += 1;
-            }
-            dst = dst.offset(dst_stride as isize);
-            src = src.offset(src_stride as isize);
-            h -= 1;
-            if !(h != 0) {
-                break;
-            }
-        }
-    } else {
-        put_c::<BitDepth8>(
-            dst,
-            dst_stride as usize,
-            src,
-            src_stride as usize,
-            w as usize,
-            h as usize,
-        );
-    };
-}
 #[inline(never)]
 unsafe extern "C" fn put_8tap_scaled_c(
     mut dst: *mut pixel,
@@ -2648,14 +2458,15 @@ unsafe extern "C" fn put_8tap_regular_c(
 ) {
     put_8tap_c(
         dst,
-        dst_stride,
+        dst_stride as usize,
         src,
-        src_stride,
-        w,
-        h,
-        mx,
-        my,
-        DAV1D_FILTER_8TAP_REGULAR as libc::c_int | (DAV1D_FILTER_8TAP_REGULAR as libc::c_int) << 2,
+        src_stride as usize,
+        w as usize,
+        h as usize,
+        mx as usize,
+        my as usize,
+        DAV1D_FILTER_8TAP_REGULAR | (DAV1D_FILTER_8TAP_REGULAR << 2),
+        BitDepth8::new(()),
     );
 }
 unsafe extern "C" fn put_8tap_regular_scaled_c(
@@ -2810,14 +2621,15 @@ unsafe extern "C" fn put_8tap_regular_sharp_c(
 ) {
     put_8tap_c(
         dst,
-        dst_stride,
+        dst_stride as usize,
         src,
-        src_stride,
-        w,
-        h,
-        mx,
-        my,
-        DAV1D_FILTER_8TAP_REGULAR as libc::c_int | (DAV1D_FILTER_8TAP_SHARP as libc::c_int) << 2,
+        src_stride as usize,
+        w as usize,
+        h as usize,
+        mx as usize,
+        my as usize,
+        DAV1D_FILTER_8TAP_REGULAR | (DAV1D_FILTER_8TAP_SHARP << 2),
+        BitDepth8::new(()),
     );
 }
 unsafe extern "C" fn prep_8tap_regular_smooth_scaled_c(
@@ -2902,14 +2714,15 @@ unsafe extern "C" fn put_8tap_regular_smooth_c(
 ) {
     put_8tap_c(
         dst,
-        dst_stride,
+        dst_stride as usize,
         src,
-        src_stride,
-        w,
-        h,
-        mx,
-        my,
-        DAV1D_FILTER_8TAP_REGULAR as libc::c_int | (DAV1D_FILTER_8TAP_SMOOTH as libc::c_int) << 2,
+        src_stride as usize,
+        w as usize,
+        h as usize,
+        mx as usize,
+        my as usize,
+        DAV1D_FILTER_8TAP_REGULAR | (DAV1D_FILTER_8TAP_SMOOTH << 2),
+        BitDepth8::new(()),
     );
 }
 unsafe extern "C" fn put_8tap_smooth_scaled_c(
@@ -2994,14 +2807,15 @@ unsafe extern "C" fn put_8tap_smooth_c(
 ) {
     put_8tap_c(
         dst,
-        dst_stride,
+        dst_stride as usize,
         src,
-        src_stride,
-        w,
-        h,
-        mx,
-        my,
-        DAV1D_FILTER_8TAP_SMOOTH as libc::c_int | (DAV1D_FILTER_8TAP_SMOOTH as libc::c_int) << 2,
+        src_stride as usize,
+        w as usize,
+        h as usize,
+        mx as usize,
+        my as usize,
+        DAV1D_FILTER_8TAP_SMOOTH | (DAV1D_FILTER_8TAP_SMOOTH << 2),
+        BitDepth8::new(()),
     );
 }
 unsafe extern "C" fn prep_8tap_smooth_regular_scaled_c(
@@ -3040,14 +2854,15 @@ unsafe extern "C" fn put_8tap_smooth_regular_c(
 ) {
     put_8tap_c(
         dst,
-        dst_stride,
+        dst_stride as usize,
         src,
-        src_stride,
-        w,
-        h,
-        mx,
-        my,
-        DAV1D_FILTER_8TAP_SMOOTH as libc::c_int | (DAV1D_FILTER_8TAP_REGULAR as libc::c_int) << 2,
+        src_stride as usize,
+        w as usize,
+        h as usize,
+        mx as usize,
+        my as usize,
+        DAV1D_FILTER_8TAP_SMOOTH | (DAV1D_FILTER_8TAP_REGULAR << 2),
+        BitDepth8::new(()),
     );
 }
 unsafe extern "C" fn put_8tap_smooth_regular_scaled_c(
@@ -3132,14 +2947,15 @@ unsafe extern "C" fn put_8tap_smooth_sharp_c(
 ) {
     put_8tap_c(
         dst,
-        dst_stride,
+        dst_stride as usize,
         src,
-        src_stride,
-        w,
-        h,
-        mx,
-        my,
-        DAV1D_FILTER_8TAP_SMOOTH as libc::c_int | (DAV1D_FILTER_8TAP_SHARP as libc::c_int) << 2,
+        src_stride as usize,
+        w as usize,
+        h as usize,
+        mx as usize,
+        my as usize,
+        DAV1D_FILTER_8TAP_SMOOTH | (DAV1D_FILTER_8TAP_SHARP << 2),
+        BitDepth8::new(()),
     );
 }
 unsafe extern "C" fn put_8tap_smooth_sharp_scaled_c(
@@ -3200,14 +3016,15 @@ unsafe extern "C" fn put_8tap_sharp_c(
 ) {
     put_8tap_c(
         dst,
-        dst_stride,
+        dst_stride as usize,
         src,
-        src_stride,
-        w,
-        h,
-        mx,
-        my,
-        DAV1D_FILTER_8TAP_SHARP as libc::c_int | (DAV1D_FILTER_8TAP_SHARP as libc::c_int) << 2,
+        src_stride as usize,
+        w as usize,
+        h as usize,
+        mx as usize,
+        my as usize,
+        DAV1D_FILTER_8TAP_SHARP | (DAV1D_FILTER_8TAP_SHARP << 2),
+        BitDepth8::new(()),
     );
 }
 unsafe extern "C" fn prep_8tap_sharp_c(
@@ -3362,14 +3179,15 @@ unsafe extern "C" fn put_8tap_sharp_regular_c(
 ) {
     put_8tap_c(
         dst,
-        dst_stride,
+        dst_stride as usize,
         src,
-        src_stride,
-        w,
-        h,
-        mx,
-        my,
-        DAV1D_FILTER_8TAP_SHARP as libc::c_int | (DAV1D_FILTER_8TAP_REGULAR as libc::c_int) << 2,
+        src_stride as usize,
+        w as usize,
+        h as usize,
+        mx as usize,
+        my as usize,
+        DAV1D_FILTER_8TAP_SHARP | (DAV1D_FILTER_8TAP_REGULAR << 2),
+        BitDepth8::new(()),
     );
 }
 unsafe extern "C" fn put_8tap_sharp_smooth_c(
@@ -3384,14 +3202,15 @@ unsafe extern "C" fn put_8tap_sharp_smooth_c(
 ) {
     put_8tap_c(
         dst,
-        dst_stride,
+        dst_stride as usize,
         src,
-        src_stride,
-        w,
-        h,
-        mx,
-        my,
-        DAV1D_FILTER_8TAP_SHARP as libc::c_int | (DAV1D_FILTER_8TAP_SMOOTH as libc::c_int) << 2,
+        src_stride as usize,
+        w as usize,
+        h as usize,
+        mx as usize,
+        my as usize,
+        DAV1D_FILTER_8TAP_SHARP | (DAV1D_FILTER_8TAP_SMOOTH << 2),
+        BitDepth8::new(()),
     );
 }
 unsafe extern "C" fn prep_8tap_sharp_smooth_scaled_c(


### PR DESCRIPTION
`src` is left as a raw ptr due to the negative offset.  It's easier to wait to fix it once the pointers become slices top-down than to figure out exactly how to adjust the indices and calculate the length here.