### PR TITLE
Fix macOS build on x86 hosts

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -49,6 +49,8 @@ fn build_nasm_files(x86_64: bool) {
         config_file.write(b"%define STACK_ALIGNMENT 4\n").unwrap();
     }
     config_file.write(b"%define PIC 1\n").unwrap();
+    #[cfg(target_os = "macos")]
+    config_file.write(b"%define PREFIX 1\n").unwrap();
     config_file
         .write(b"%define FORCE_VEX_ENCODING 0\n")
         .unwrap();


### PR DESCRIPTION
We need to set PREFIX to one in config.asm such that the assembly routine names get mangled correctly, otherwise linking will fail.