### PR TITLE
CI: Test on x86_64-apple-darwin

### DIFF
--- a/.github/workflows/build-and-test-x86.yml
+++ b/.github/workflows/build-and-test-x86.yml
@@ -60,3 +60,47 @@ jobs:
           name: meson-test-logs
           path: |
              ${{ github.workspace }}/build/meson-logs/testlog-*.txt
+  test-on-macos-latest:
+    runs-on: macos-latest
+    steps:
+      - name: install prerequisites
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+        run: brew install meson nasm
+      - name: git checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: cache rust toolchain
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.rustup/toolchains
+            ~/.rustup/update-hashes
+            ~/.rustup/settings.toml
+          key: ${{ runner.os }}-rust-toolchain-${{ hashFiles('rust-toolchain', 'rust-toolchain.toml') }}
+      - name: cache rust crates
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: cargo build for x86_64-apple-darwin
+        run: |
+          cargo build --release
+      - name: meson test for x86_64-apple-darwin
+        run: |
+          .github/workflows/test.sh -r ../target/release/dav1d
+          cp ${{ github.workspace }}/build/meson-logs/testlog.txt \
+              ${{ github.workspace }}/build/meson-logs/testlog-x86_64-apple-darwin.txt
+      - name: upload build artifacts
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: meson-test-logs
+          path: |
+              ${{ github.workspace }}/build/meson-logs/testlog-*.txt


### PR DESCRIPTION
Since performance testing happens on macOS (for aarch64), it would be nice to automatically test breakage on macOS although GitHub actions do not offer any arch64-apple-darwin test runners at the moment.