### PR TITLE
Replace `.expect(...)`s with `.unwrap_unchecked()`s on fn ptrs to avoid extra unused instructions

### DIFF
--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -960,7 +960,7 @@ pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
                         dir = 0;
                         variance = 0;
                         if y_pri_lvl != 0 || uv_pri_lvl != 0 {
-                            dir = ((*dsp).cdef.dir).expect("non-null function pointer")(
+                            dir = ((*dsp).cdef.dir).unwrap_unchecked()(
                                 bptrs[0],
                                 (*f).cur.stride[0],
                                 &mut variance,
@@ -1030,7 +1030,7 @@ pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
                         if y_pri_lvl != 0 {
                             let adj_y_pri_lvl = adjust_strength(y_pri_lvl, variance);
                             if adj_y_pri_lvl != 0 || y_sec_lvl != 0 {
-                                ((*dsp).cdef.fb[0]).expect("non-null function pointer")(
+                                ((*dsp).cdef.fb[0]).unwrap_unchecked()(
                                     bptrs[0],
                                     (*f).cur.stride[0],
                                     (lr_bak[bit as usize][0]).as_mut_ptr()
@@ -1046,7 +1046,7 @@ pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
                                 );
                             }
                         } else if y_sec_lvl != 0 {
-                            ((*dsp).cdef.fb[0]).expect("non-null function pointer")(
+                            ((*dsp).cdef.fb[0]).unwrap_unchecked()(
                                 bptrs[0],
                                 (*f).cur.stride[0],
                                 (lr_bak[bit as usize][0]).as_mut_ptr() as const_left_pixel_row_2px,
@@ -1150,8 +1150,7 @@ pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
                                     }
                                     _ => {}
                                 }
-                                ((*dsp).cdef.fb[uv_idx as usize])
-                                    .expect("non-null function pointer")(
+                                ((*dsp).cdef.fb[uv_idx as usize]).unwrap_unchecked()(
                                     bptrs[pl as usize],
                                     (*f).cur.stride[1],
                                     (lr_bak[bit as usize][pl as usize]).as_mut_ptr()

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -933,7 +933,7 @@ pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
                         dir = 0;
                         variance = 0;
                         if y_pri_lvl != 0 || uv_pri_lvl != 0 {
-                            dir = ((*dsp).cdef.dir).expect("non-null function pointer")(
+                            dir = ((*dsp).cdef.dir).unwrap_unchecked()(
                                 bptrs[0],
                                 (*f).cur.stride[0],
                                 &mut variance,
@@ -1002,7 +1002,7 @@ pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
                         if y_pri_lvl != 0 {
                             let adj_y_pri_lvl = adjust_strength(y_pri_lvl, variance);
                             if adj_y_pri_lvl != 0 || y_sec_lvl != 0 {
-                                ((*dsp).cdef.fb[0]).expect("non-null function pointer")(
+                                ((*dsp).cdef.fb[0]).unwrap_unchecked()(
                                     bptrs[0],
                                     (*f).cur.stride[0],
                                     (lr_bak[bit as usize][0]).as_mut_ptr()
@@ -1017,7 +1017,7 @@ pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
                                 );
                             }
                         } else if y_sec_lvl != 0 {
-                            ((*dsp).cdef.fb[0]).expect("non-null function pointer")(
+                            ((*dsp).cdef.fb[0]).unwrap_unchecked()(
                                 bptrs[0],
                                 (*f).cur.stride[0],
                                 (lr_bak[bit as usize][0]).as_mut_ptr() as const_left_pixel_row_2px,
@@ -1120,8 +1120,7 @@ pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
                                     }
                                     _ => {}
                                 }
-                                ((*dsp).cdef.fb[uv_idx as usize])
-                                    .expect("non-null function pointer")(
+                                ((*dsp).cdef.fb[uv_idx as usize]).unwrap_unchecked()(
                                     bptrs[pl as usize],
                                     (*f).cur.stride[1],
                                     (lr_bak[bit as usize][pl as usize]).as_mut_ptr()

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -367,7 +367,7 @@ impl Dav1dFrameContext_bd_fn {
         flags: EdgeFlags,
         block: *const Av1Block,
     ) {
-        self.recon_b_intra.expect("non-null function pointer")(context, block_size, flags, block);
+        self.recon_b_intra.unwrap_unchecked()(context, block_size, flags, block);
     }
 
     pub unsafe fn recon_b_inter(
@@ -376,7 +376,7 @@ impl Dav1dFrameContext_bd_fn {
         block_size: BlockSize,
         block: *const Av1Block,
     ) -> libc::c_int {
-        self.recon_b_inter.expect("non-null function pointer")(context, block_size, block)
+        self.recon_b_inter.unwrap_unchecked()(context, block_size, block)
     }
 
     pub unsafe fn read_coef_blocks(
@@ -385,7 +385,7 @@ impl Dav1dFrameContext_bd_fn {
         block_size: BlockSize,
         block: *const Av1Block,
     ) {
-        self.read_coef_blocks.expect("non-null function pointer")(context, block_size, block);
+        self.read_coef_blocks.unwrap_unchecked()(context, block_size, block);
     }
 }
 
@@ -5340,17 +5340,14 @@ pub unsafe extern "C" fn dav1d_decode_tile_sbrow(t: *mut Dav1dTaskContext) -> li
             }
             (*t).bx += sb_step;
         }
-        ((*f).bd_fn.backup_ipred_edge).expect("non-null function pointer")(t);
+        ((*f).bd_fn.backup_ipred_edge).unwrap_unchecked()(t);
         return 0 as libc::c_int;
     }
     if (*ts).msac.cnt < -(15 as libc::c_int) {
         return 1 as libc::c_int;
     }
     if (*(*f).c).n_tc > 1 as libc::c_uint && (*(*f).frame_hdr).use_ref_frame_mvs != 0 {
-        (*(*f).c)
-            .refmvs_dsp
-            .load_tmvs
-            .expect("non-null function pointer")(
+        (*(*f).c).refmvs_dsp.load_tmvs.unwrap_unchecked()(
             &(*f).rf,
             (*ts).tiling.row,
             (*ts).tiling.col_start >> 1,
@@ -5480,7 +5477,7 @@ pub unsafe extern "C" fn dav1d_decode_tile_sbrow(t: *mut Dav1dTaskContext) -> li
         );
     }
     if (*t).frame_thread.pass != 1 as libc::c_int {
-        ((*f).bd_fn.backup_ipred_edge).expect("non-null function pointer")(t);
+        ((*f).bd_fn.backup_ipred_edge).unwrap_unchecked()(t);
     }
     let mut align_h = (*f).bh + 31 & !(31 as libc::c_int);
     memcpy(
@@ -6756,10 +6753,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_main(f: *mut Dav1dFrameContext) -> l
             (*t).by = sby << 4 + (*(*f).seq_hdr).sb128;
             let by_end = (*t).by + (*f).sb_step >> 1;
             if (*(*f).frame_hdr).use_ref_frame_mvs != 0 {
-                (*(*f).c)
-                    .refmvs_dsp
-                    .load_tmvs
-                    .expect("non-null function pointer")(
+                (*(*f).c).refmvs_dsp.load_tmvs.unwrap_unchecked()(
                     &mut (*f).rf,
                     tile_row,
                     0 as libc::c_int,
@@ -6789,7 +6783,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_main(f: *mut Dav1dFrameContext) -> l
                     by_end,
                 );
             }
-            ((*f).bd_fn.filter_sbrow).expect("non-null function pointer")(f, sby);
+            ((*f).bd_fn.filter_sbrow).unwrap_unchecked()(f, sby);
             sby += 1;
         }
         tile_row += 1;

--- a/src/fg_apply_tmpl_16.rs
+++ b/src/fg_apply_tmpl_16.rs
@@ -163,7 +163,7 @@ pub unsafe extern "C" fn dav1d_prep_grain_16bpc(
 ) {
     let data: *const Dav1dFilmGrainData = &mut (*(*out).frame_hdr).film_grain.data;
     let bitdepth_max = ((1 as libc::c_int) << (*out).p.bpc) - 1;
-    ((*dsp).generate_grain_y).expect("non-null function pointer")(
+    ((*dsp).generate_grain_y).unwrap_unchecked()(
         (*grain_lut.offset(0)).as_mut_ptr(),
         data,
         bitdepth_max,
@@ -172,7 +172,7 @@ pub unsafe extern "C" fn dav1d_prep_grain_16bpc(
         ((*dsp).generate_grain_uv[((*in_0).p.layout as libc::c_uint)
             .wrapping_sub(1 as libc::c_int as libc::c_uint)
             as usize])
-            .expect("non-null function pointer")(
+            .unwrap_unchecked()(
             (*grain_lut.offset(1)).as_mut_ptr(),
             (*grain_lut.offset(0)).as_mut_ptr() as *const [entry; 82],
             data,
@@ -184,7 +184,7 @@ pub unsafe extern "C" fn dav1d_prep_grain_16bpc(
         ((*dsp).generate_grain_uv[((*in_0).p.layout as libc::c_uint)
             .wrapping_sub(1 as libc::c_int as libc::c_uint)
             as usize])
-            .expect("non-null function pointer")(
+            .unwrap_unchecked()(
             (*grain_lut.offset(2)).as_mut_ptr(),
             (*grain_lut.offset(0)).as_mut_ptr() as *const [entry; 82],
             data,
@@ -302,7 +302,7 @@ pub unsafe extern "C" fn dav1d_apply_grain_row_16bpc(
     let bitdepth_max = ((1 as libc::c_int) << (*out).p.bpc) - 1;
     if (*data).num_y_points != 0 {
         let bh = imin((*out).p.h - row * 32, 32 as libc::c_int);
-        ((*dsp).fgy_32x32xn).expect("non-null function pointer")(
+        ((*dsp).fgy_32x32xn).unwrap_unchecked()(
             ((*out).data[0] as *mut pixel)
                 .offset(((row * 32) as isize * PXSTRIDE((*out).stride[0])) as isize),
             luma_src,
@@ -339,7 +339,7 @@ pub unsafe extern "C" fn dav1d_apply_grain_row_16bpc(
             ((*dsp).fguv_32x32xn[((*in_0).p.layout as libc::c_uint)
                 .wrapping_sub(1 as libc::c_int as libc::c_uint)
                 as usize])
-                .expect("non-null function pointer")(
+                .unwrap_unchecked()(
                 ((*out).data[(1 + pl) as usize] as *mut pixel).offset(uv_off as isize),
                 ((*in_0).data[(1 + pl) as usize] as *const pixel).offset(uv_off as isize),
                 (*in_0).stride[1],
@@ -364,7 +364,7 @@ pub unsafe extern "C" fn dav1d_apply_grain_row_16bpc(
                 ((*dsp).fguv_32x32xn[((*in_0).p.layout as libc::c_uint)
                     .wrapping_sub(1 as libc::c_int as libc::c_uint)
                     as usize])
-                    .expect("non-null function pointer")(
+                    .unwrap_unchecked()(
                     ((*out).data[(1 + pl_0) as usize] as *mut pixel).offset(uv_off as isize),
                     ((*in_0).data[(1 + pl_0) as usize] as *const pixel).offset(uv_off as isize),
                     (*in_0).stride[1],

--- a/src/fg_apply_tmpl_8.rs
+++ b/src/fg_apply_tmpl_8.rs
@@ -127,15 +127,12 @@ pub unsafe extern "C" fn dav1d_prep_grain_8bpc(
     mut grain_lut: *mut [[entry; 82]; 74],
 ) {
     let data: *const Dav1dFilmGrainData = &mut (*(*out).frame_hdr).film_grain.data;
-    ((*dsp).generate_grain_y).expect("non-null function pointer")(
-        (*grain_lut.offset(0)).as_mut_ptr(),
-        data,
-    );
+    ((*dsp).generate_grain_y).unwrap_unchecked()((*grain_lut.offset(0)).as_mut_ptr(), data);
     if (*data).num_uv_points[0] != 0 || (*data).chroma_scaling_from_luma != 0 {
         ((*dsp).generate_grain_uv[((*in_0).p.layout as libc::c_uint)
             .wrapping_sub(1 as libc::c_int as libc::c_uint)
             as usize])
-            .expect("non-null function pointer")(
+            .unwrap_unchecked()(
             (*grain_lut.offset(1)).as_mut_ptr(),
             (*grain_lut.offset(0)).as_mut_ptr() as *const [entry; 82],
             data,
@@ -146,7 +143,7 @@ pub unsafe extern "C" fn dav1d_prep_grain_8bpc(
         ((*dsp).generate_grain_uv[((*in_0).p.layout as libc::c_uint)
             .wrapping_sub(1 as libc::c_int as libc::c_uint)
             as usize])
-            .expect("non-null function pointer")(
+            .unwrap_unchecked()(
             (*grain_lut.offset(2)).as_mut_ptr(),
             (*grain_lut.offset(0)).as_mut_ptr() as *const [entry; 82],
             data,
@@ -262,7 +259,7 @@ pub unsafe extern "C" fn dav1d_apply_grain_row_8bpc(
         ((*in_0).data[0] as *mut pixel).offset(((row * 32) as isize * (*in_0).stride[0]) as isize);
     if (*data).num_y_points != 0 {
         let bh = imin((*out).p.h - row * 32, 32 as libc::c_int);
-        ((*dsp).fgy_32x32xn).expect("non-null function pointer")(
+        ((*dsp).fgy_32x32xn).unwrap_unchecked()(
             ((*out).data[0] as *mut pixel)
                 .offset(((row * 32) as isize * (*out).stride[0]) as isize),
             luma_src,
@@ -298,7 +295,7 @@ pub unsafe extern "C" fn dav1d_apply_grain_row_8bpc(
             ((*dsp).fguv_32x32xn[((*in_0).p.layout as libc::c_uint)
                 .wrapping_sub(1 as libc::c_int as libc::c_uint)
                 as usize])
-                .expect("non-null function pointer")(
+                .unwrap_unchecked()(
                 ((*out).data[(1 + pl) as usize] as *mut pixel).offset(uv_off as isize),
                 ((*in_0).data[(1 + pl) as usize] as *const pixel).offset(uv_off as isize),
                 (*in_0).stride[1],
@@ -322,7 +319,7 @@ pub unsafe extern "C" fn dav1d_apply_grain_row_8bpc(
                 ((*dsp).fguv_32x32xn[((*in_0).p.layout as libc::c_uint)
                     .wrapping_sub(1 as libc::c_int as libc::c_uint)
                     as usize])
-                    .expect("non-null function pointer")(
+                    .unwrap_unchecked()(
                     ((*out).data[(1 + pl_0) as usize] as *mut pixel).offset(uv_off as isize),
                     ((*in_0).data[(1 + pl_0) as usize] as *const pixel).offset(uv_off as isize),
                     (*in_0).stride[1],

--- a/src/itx_tmpl_16.rs
+++ b/src/itx_tmpl_16.rs
@@ -5034,7 +5034,7 @@ unsafe extern "C" fn inv_txfm_add_c(
                 x_1 += 1;
             }
         }
-        first_1d_fn.expect("non-null function pointer")(
+        first_1d_fn.unwrap_unchecked()(
             c,
             1 as libc::c_int as ptrdiff_t,
             row_clip_min,
@@ -5057,7 +5057,7 @@ unsafe extern "C" fn inv_txfm_add_c(
     }
     let mut x_2 = 0;
     while x_2 < w {
-        second_1d_fn.expect("non-null function pointer")(
+        second_1d_fn.unwrap_unchecked()(
             &mut *tmp.as_mut_ptr().offset(x_2 as isize),
             w as ptrdiff_t,
             col_clip_min,

--- a/src/itx_tmpl_8.rs
+++ b/src/itx_tmpl_8.rs
@@ -3933,7 +3933,7 @@ unsafe extern "C" fn inv_txfm_add_c(
                 x_1 += 1;
             }
         }
-        first_1d_fn.expect("non-null function pointer")(
+        first_1d_fn.unwrap_unchecked()(
             c,
             1 as libc::c_int as ptrdiff_t,
             row_clip_min,
@@ -3956,7 +3956,7 @@ unsafe extern "C" fn inv_txfm_add_c(
     }
     let mut x_2 = 0;
     while x_2 < w {
-        second_1d_fn.expect("non-null function pointer")(
+        second_1d_fn.unwrap_unchecked()(
             &mut *tmp.as_mut_ptr().offset(x_2 as isize),
             w as ptrdiff_t,
             col_clip_min,

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -703,7 +703,7 @@ unsafe extern "C" fn backup_lpf(
     if lr_backup != 0 && (*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1] {
         while row + stripe_h <= row_h {
             let n_lines = 4 as libc::c_int - (row + stripe_h + 1 == h) as libc::c_int;
-            ((*(*f).dsp).mc.resize).expect("non-null function pointer")(
+            ((*(*f).dsp).mc.resize).unwrap_unchecked()(
                 dst,
                 dst_stride,
                 src,
@@ -949,7 +949,7 @@ unsafe extern "C" fn filter_plane_cols_y(
                 hmask[2] = (*mask.offset(x as isize))[2][1] as uint32_t;
             }
             hmask[3] = 0 as libc::c_int as uint32_t;
-            ((*dsp).lf.loop_filter_sb[0][0]).expect("non-null function pointer")(
+            ((*dsp).lf.loop_filter_sb[0][0]).unwrap_unchecked()(
                 &mut *dst.offset((x * 4) as isize),
                 ls,
                 hmask.as_mut_ptr(),
@@ -990,7 +990,7 @@ unsafe extern "C" fn filter_plane_rows_y(
                     | ((*mask.offset(y as isize))[2][1] as libc::c_uint) << 16,
                 0 as libc::c_int as uint32_t,
             ];
-            ((*dsp).lf.loop_filter_sb[0][1]).expect("non-null function pointer")(
+            ((*dsp).lf.loop_filter_sb[0][1]).unwrap_unchecked()(
                 dst,
                 ls,
                 vmask.as_ptr(),
@@ -1040,7 +1040,7 @@ unsafe extern "C" fn filter_plane_cols_uv(
                 hmask[1] = (*mask.offset(x as isize))[1][1] as uint32_t;
             }
             hmask[2] = 0 as libc::c_int as uint32_t;
-            ((*dsp).lf.loop_filter_sb[1][0]).expect("non-null function pointer")(
+            ((*dsp).lf.loop_filter_sb[1][0]).unwrap_unchecked()(
                 &mut *u.offset((x * 4) as isize),
                 ls,
                 hmask.as_mut_ptr(),
@@ -1051,7 +1051,7 @@ unsafe extern "C" fn filter_plane_cols_uv(
                 endy4 - starty4,
                 (*f).bitdepth_max,
             );
-            ((*dsp).lf.loop_filter_sb[1][0]).expect("non-null function pointer")(
+            ((*dsp).lf.loop_filter_sb[1][0]).unwrap_unchecked()(
                 &mut *v.offset((x * 4) as isize),
                 ls,
                 hmask.as_mut_ptr(),
@@ -1093,7 +1093,7 @@ unsafe extern "C" fn filter_plane_rows_uv(
                     | ((*mask.offset(y as isize))[1][1] as libc::c_uint) << (16 >> ss_hor),
                 0 as libc::c_int as uint32_t,
             ];
-            ((*dsp).lf.loop_filter_sb[1][1]).expect("non-null function pointer")(
+            ((*dsp).lf.loop_filter_sb[1][1]).unwrap_unchecked()(
                 &mut *u.offset(off_l as isize),
                 ls,
                 vmask.as_ptr(),
@@ -1103,7 +1103,7 @@ unsafe extern "C" fn filter_plane_rows_uv(
                 w,
                 (*f).bitdepth_max,
             );
-            ((*dsp).lf.loop_filter_sb[1][1]).expect("non-null function pointer")(
+            ((*dsp).lf.loop_filter_sb[1][1]).unwrap_unchecked()(
                 &mut *v.offset(off_l as isize),
                 ls,
                 vmask.as_ptr(),

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -658,7 +658,7 @@ unsafe extern "C" fn backup_lpf(
     if lr_backup != 0 && (*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1] {
         while row + stripe_h <= row_h {
             let n_lines = 4 as libc::c_int - (row + stripe_h + 1 == h) as libc::c_int;
-            ((*(*f).dsp).mc.resize).expect("non-null function pointer")(
+            ((*(*f).dsp).mc.resize).unwrap_unchecked()(
                 dst,
                 dst_stride,
                 src,
@@ -896,7 +896,7 @@ unsafe extern "C" fn filter_plane_cols_y(
                 hmask[2] = (*mask.offset(x as isize))[2][1] as uint32_t;
             }
             hmask[3] = 0 as libc::c_int as uint32_t;
-            ((*dsp).lf.loop_filter_sb[0][0]).expect("non-null function pointer")(
+            ((*dsp).lf.loop_filter_sb[0][0]).unwrap_unchecked()(
                 &mut *dst.offset((x * 4) as isize),
                 ls,
                 hmask.as_mut_ptr(),
@@ -936,7 +936,7 @@ unsafe extern "C" fn filter_plane_rows_y(
                     | ((*mask.offset(y as isize))[2][1] as libc::c_uint) << 16,
                 0 as libc::c_int as uint32_t,
             ];
-            ((*dsp).lf.loop_filter_sb[0][1]).expect("non-null function pointer")(
+            ((*dsp).lf.loop_filter_sb[0][1]).unwrap_unchecked()(
                 dst,
                 ls,
                 vmask.as_ptr(),
@@ -985,7 +985,7 @@ unsafe extern "C" fn filter_plane_cols_uv(
                 hmask[1] = (*mask.offset(x as isize))[1][1] as uint32_t;
             }
             hmask[2] = 0 as libc::c_int as uint32_t;
-            ((*dsp).lf.loop_filter_sb[1][0]).expect("non-null function pointer")(
+            ((*dsp).lf.loop_filter_sb[1][0]).unwrap_unchecked()(
                 &mut *u.offset((x * 4) as isize),
                 ls,
                 hmask.as_mut_ptr(),
@@ -995,7 +995,7 @@ unsafe extern "C" fn filter_plane_cols_uv(
                 &(*f).lf.lim_lut.0,
                 endy4 - starty4,
             );
-            ((*dsp).lf.loop_filter_sb[1][0]).expect("non-null function pointer")(
+            ((*dsp).lf.loop_filter_sb[1][0]).unwrap_unchecked()(
                 &mut *v.offset((x * 4) as isize),
                 ls,
                 hmask.as_mut_ptr(),
@@ -1036,7 +1036,7 @@ unsafe extern "C" fn filter_plane_rows_uv(
                     | ((*mask.offset(y as isize))[1][1] as libc::c_uint) << (16 >> ss_hor),
                 0 as libc::c_int as uint32_t,
             ];
-            ((*dsp).lf.loop_filter_sb[1][1]).expect("non-null function pointer")(
+            ((*dsp).lf.loop_filter_sb[1][1]).unwrap_unchecked()(
                 &mut *u.offset(off_l as isize),
                 ls,
                 vmask.as_ptr(),
@@ -1045,7 +1045,7 @@ unsafe extern "C" fn filter_plane_rows_uv(
                 &(*f).lf.lim_lut.0,
                 w,
             );
-            ((*dsp).lf.loop_filter_sb[1][1]).expect("non-null function pointer")(
+            ((*dsp).lf.loop_filter_sb[1][1]).unwrap_unchecked()(
                 &mut *v.offset(off_l as isize),
                 ls,
                 vmask.as_ptr(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -822,7 +822,7 @@ unsafe extern "C" fn get_stack_size_internal(_thread_attr: *const pthread_attr_t
                         b"__pthread_get_minstack\0" as *const u8 as *const libc::c_char,
                     ));
                 if get_minstack.is_some() {
-                    return (get_minstack.expect("non-null function pointer")(_thread_attr))
+                    return (get_minstack.unwrap_unchecked()(_thread_attr))
                         .wrapping_sub(__sysconf(75) as size_t);
                 }
             }

--- a/src/log.rs
+++ b/src/log.rs
@@ -629,9 +629,5 @@ pub unsafe extern "C" fn dav1d_log(
     }
     let mut ap: ::core::ffi::VaListImpl;
     ap = args.clone();
-    ((*c).logger.callback).expect("non-null function pointer")(
-        (*c).logger.cookie,
-        format,
-        ap.as_va_list(),
-    );
+    ((*c).logger.callback).unwrap_unchecked()((*c).logger.cookie, format, ap.as_va_list());
 }

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -732,7 +732,7 @@ unsafe extern "C" fn lr_stripe(
                     ^ edges as libc::c_uint)
                     & LR_HAVE_BOTTOM as libc::c_int as libc::c_uint,
         );
-        lr_fn.expect("non-null function pointer")(
+        lr_fn.unwrap_unchecked()(
             p,
             stride,
             left,

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -704,16 +704,7 @@ unsafe extern "C" fn lr_stripe(
                     ^ edges as libc::c_uint)
                     & LR_HAVE_BOTTOM as libc::c_int as libc::c_uint,
         );
-        lr_fn.expect("non-null function pointer")(
-            p,
-            stride,
-            left,
-            lpf,
-            unit_w,
-            stripe_h,
-            &mut params,
-            edges,
-        );
+        lr_fn.unwrap_unchecked()(p, stride, left, lpf, unit_w, stripe_h, &mut params, edges);
         left = left.offset(stripe_h as isize);
         y += stripe_h;
         p = p.offset((stripe_h as isize * stride) as isize);

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -709,7 +709,7 @@ pub unsafe extern "C" fn dav1d_default_picture_release(
 }
 unsafe extern "C" fn free_buffer(_data: *const uint8_t, user_data: *mut libc::c_void) {
     let mut pic_ctx: *mut pic_ctx_context = user_data as *mut pic_ctx_context;
-    ((*pic_ctx).allocator.release_picture_callback).expect("non-null function pointer")(
+    ((*pic_ctx).allocator.release_picture_callback).unwrap_unchecked()(
         &mut (*pic_ctx).pic,
         (*pic_ctx).allocator.cookie,
     );
@@ -762,10 +762,7 @@ unsafe extern "C" fn picture_alloc_with_edges(
     (*p).p.layout = (*seq_hdr).layout;
     (*p).p.bpc = bpc;
     dav1d_data_props_set_defaults(&mut (*p).m);
-    let res = ((*p_allocator).alloc_picture_callback).expect("non-null function pointer")(
-        p,
-        (*p_allocator).cookie,
-    );
+    let res = ((*p_allocator).alloc_picture_callback).unwrap_unchecked()(p, (*p_allocator).cookie);
     if res < 0 {
         free(pic_ctx as *mut libc::c_void);
         return res;
@@ -778,10 +775,7 @@ unsafe extern "C" fn picture_alloc_with_edges(
         pic_ctx as *mut libc::c_void,
     );
     if ((*p).r#ref).is_null() {
-        ((*p_allocator).release_picture_callback).expect("non-null function pointer")(
-            p,
-            (*p_allocator).cookie,
-        );
+        ((*p_allocator).release_picture_callback).unwrap_unchecked()(p, (*p_allocator).cookie);
         free(pic_ctx as *mut libc::c_void);
         dav1d_log(
             c,

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -2149,8 +2149,7 @@ unsafe extern "C" fn read_coef_tree(
                         "dq",
                     );
                 }
-                ((*dsp).itx.itxfm_add[ytx as usize][txtp as usize])
-                    .expect("non-null function pointer")(
+                ((*dsp).itx.itxfm_add[ytx as usize][txtp as usize]).unwrap_unchecked()(
                     dst,
                     (*f).cur.stride[0],
                     cf,
@@ -2470,7 +2469,7 @@ unsafe extern "C" fn mc(
         {
             let emu_edge_buf: *mut pixel =
                 ((*t).scratch.c2rust_unnamed.c2rust_unnamed_0.emu_edge_16bpc).as_mut_ptr();
-            ((*(*f).dsp).mc.emu_edge).expect("non-null function pointer")(
+            ((*(*f).dsp).mc.emu_edge).unwrap_unchecked()(
                 (bw4 * h_mul + (mx != 0) as libc::c_int * 7) as intptr_t,
                 (bh4 * v_mul + (my != 0) as libc::c_int * 7) as intptr_t,
                 w as intptr_t,
@@ -2496,7 +2495,7 @@ unsafe extern "C" fn mc(
                 .offset(dx as isize);
         }
         if !dst8.is_null() {
-            ((*(*f).dsp).mc.mc[filter_2d as usize]).expect("non-null function pointer")(
+            ((*(*f).dsp).mc.mc[filter_2d as usize]).unwrap_unchecked()(
                 dst8,
                 dst_stride,
                 r#ref,
@@ -2508,7 +2507,7 @@ unsafe extern "C" fn mc(
                 (*f).bitdepth_max,
             );
         } else {
-            ((*(*f).dsp).mc.mct[filter_2d as usize]).expect("non-null function pointer")(
+            ((*(*f).dsp).mc.mct[filter_2d as usize]).unwrap_unchecked()(
                 dst16,
                 r#ref,
                 ref_stride,
@@ -2564,7 +2563,7 @@ unsafe extern "C" fn mc(
         if left < 3 || top < 3 || right + 4 > w_0 || bottom + 4 > h_0 {
             let emu_edge_buf_0: *mut pixel =
                 ((*t).scratch.c2rust_unnamed.c2rust_unnamed_0.emu_edge_16bpc).as_mut_ptr();
-            ((*(*f).dsp).mc.emu_edge).expect("non-null function pointer")(
+            ((*(*f).dsp).mc.emu_edge).unwrap_unchecked()(
                 (right - left + 7) as intptr_t,
                 (bottom - top + 7) as intptr_t,
                 w_0 as intptr_t,
@@ -2591,7 +2590,7 @@ unsafe extern "C" fn mc(
                 .offset(left as isize);
         }
         if !dst8.is_null() {
-            ((*(*f).dsp).mc.mc_scaled[filter_2d as usize]).expect("non-null function pointer")(
+            ((*(*f).dsp).mc.mc_scaled[filter_2d as usize]).unwrap_unchecked()(
                 dst8,
                 dst_stride,
                 r#ref,
@@ -2605,7 +2604,7 @@ unsafe extern "C" fn mc(
                 (*f).bitdepth_max,
             );
         } else {
-            ((*(*f).dsp).mc.mct_scaled[filter_2d as usize]).expect("non-null function pointer")(
+            ((*(*f).dsp).mc.mct_scaled[filter_2d as usize]).unwrap_unchecked()(
                 dst16,
                 r#ref,
                 ref_stride,
@@ -2696,7 +2695,7 @@ unsafe extern "C" fn obmc(
                 if res != 0 {
                     return res;
                 }
-                ((*(*f).dsp).mc.blend_h).expect("non-null function pointer")(
+                ((*(*f).dsp).mc.blend_h).unwrap_unchecked()(
                     &mut *dst.offset((x * h_mul) as isize),
                     dst_stride,
                     lap,
@@ -2748,7 +2747,7 @@ unsafe extern "C" fn obmc(
                 if res != 0 {
                     return res;
                 }
-                ((*(*f).dsp).mc.blend_v).expect("non-null function pointer")(
+                ((*(*f).dsp).mc.blend_v).unwrap_unchecked()(
                     &mut *dst.offset(
                         ((y * v_mul) as isize
                             * (PXSTRIDE as unsafe extern "C" fn(ptrdiff_t) -> ptrdiff_t)(
@@ -2830,7 +2829,7 @@ unsafe extern "C" fn warp_affine(
             if dx < 3 || dx + 8 + 4 > width || dy < 3 || dy + 8 + 4 > height {
                 let emu_edge_buf: *mut pixel =
                     ((*t).scratch.c2rust_unnamed.c2rust_unnamed_0.emu_edge_16bpc).as_mut_ptr();
-                ((*(*f).dsp).mc.emu_edge).expect("non-null function pointer")(
+                ((*(*f).dsp).mc.emu_edge).unwrap_unchecked()(
                     15 as libc::c_int as intptr_t,
                     15 as libc::c_int as intptr_t,
                     width as intptr_t,
@@ -2854,7 +2853,7 @@ unsafe extern "C" fn warp_affine(
                     .offset(dx as isize);
             }
             if !dst16.is_null() {
-                ((*dsp).mc.warp8x8t).expect("non-null function pointer")(
+                ((*dsp).mc.warp8x8t).unwrap_unchecked()(
                     &mut *dst16.offset(x as isize),
                     dstride,
                     ref_ptr,
@@ -2865,7 +2864,7 @@ unsafe extern "C" fn warp_affine(
                     (*f).bitdepth_max,
                 );
             } else {
-                ((*dsp).mc.warp8x8).expect("non-null function pointer")(
+                ((*dsp).mc.warp8x8).unwrap_unchecked()(
                     &mut *dst8.offset(x as isize),
                     dstride,
                     ref_ptr,
@@ -2966,7 +2965,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                 } else {
                     ((*t).scratch.c2rust_unnamed_0.pal[0]).as_mut_ptr()
                 };
-                ((*(*f).dsp).ipred.pal_pred).expect("non-null function pointer")(
+                ((*(*f).dsp).ipred.pal_pred).unwrap_unchecked()(
                     dst,
                     (*f).cur.stride[0],
                     pal,
@@ -3061,7 +3060,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                             edge,
                             (*f).bitdepth_max,
                         );
-                        ((*dsp).ipred.intra_pred[m as usize]).expect("non-null function pointer")(
+                        ((*dsp).ipred.intra_pred[m as usize]).unwrap_unchecked()(
                             dst_0,
                             (*f).cur.stride[0],
                             edge,
@@ -3166,7 +3165,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                             }
                             ((*dsp).itx.itxfm_add[(*b).c2rust_unnamed.c2rust_unnamed.tx as usize]
                                 [txtp as usize])
-                                .expect("non-null function pointer")(
+                                .unwrap_unchecked()(
                                 dst_0,
                                 (*f).cur.stride[0],
                                 cf,
@@ -3231,7 +3230,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                     ((*dsp).ipred.cfl_ac[((*f).cur.p.layout as libc::c_uint)
                         .wrapping_sub(1 as libc::c_int as libc::c_uint)
                         as usize])
-                        .expect("non-null function pointer")(
+                        .unwrap_unchecked()(
                         ac.as_mut_ptr(),
                         y_src,
                         (*f).cur.stride[0],
@@ -3274,8 +3273,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                 edge,
                                 (*f).bitdepth_max,
                             );
-                            ((*dsp).ipred.cfl_pred[m_0 as usize])
-                                .expect("non-null function pointer")(
+                            ((*dsp).ipred.cfl_pred[m_0 as usize]).unwrap_unchecked()(
                                 uv_dst[pl as usize],
                                 stride,
                                 edge,
@@ -3335,7 +3333,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                             .offset((bw4 * bh4 * 16) as isize)
                             as *mut uint8_t;
                     }
-                    ((*(*f).dsp).ipred.pal_pred).expect("non-null function pointer")(
+                    ((*(*f).dsp).ipred.pal_pred).unwrap_unchecked()(
                         ((*f).cur.data[1] as *mut pixel).offset(uv_dstoff as isize),
                         (*f).cur.stride[1],
                         (*pal_0.offset(1)).as_ptr(),
@@ -3343,7 +3341,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                         cbw4 * 4,
                         cbh4 * 4,
                     );
-                    ((*(*f).dsp).ipred.pal_pred).expect("non-null function pointer")(
+                    ((*(*f).dsp).ipred.pal_pred).unwrap_unchecked()(
                         ((*f).cur.data[2] as *mut pixel).offset(uv_dstoff as isize),
                         (*f).cur.stride[1],
                         (*pal_0.offset(2)).as_ptr(),
@@ -3478,8 +3476,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                     (*f).bitdepth_max,
                                 );
                                 angle_1 |= intra_edge_filter_flag;
-                                ((*dsp).ipred.intra_pred[m_1 as usize])
-                                    .expect("non-null function pointer")(
+                                ((*dsp).ipred.intra_pred[m_1 as usize]).unwrap_unchecked()(
                                     dst_1,
                                     stride,
                                     edge,
@@ -3601,7 +3598,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                         );
                                     }
                                     ((*dsp).itx.itxfm_add[(*b).uvtx as usize][txtp_0 as usize])
-                                        .expect("non-null function pointer")(
+                                        .unwrap_unchecked()(
                                         dst_1,
                                         stride,
                                         cf_0,
@@ -3887,7 +3884,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                 tl_edge,
                 (*f).bitdepth_max,
             );
-            ((*dsp).ipred.intra_pred[m as usize]).expect("non-null function pointer")(
+            ((*dsp).ipred.intra_pred[m as usize]).unwrap_unchecked()(
                 tmp,
                 ((4 * bw4) as libc::c_ulong)
                     .wrapping_mul(::core::mem::size_of::<pixel>() as libc::c_ulong)
@@ -3918,7 +3915,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                     .c2rust_unnamed
                     .wedge_idx as usize]
             };
-            ((*dsp).mc.blend).expect("non-null function pointer")(
+            ((*dsp).mc.blend).unwrap_unchecked()(
                 dst,
                 (*f).cur.stride[0],
                 tmp,
@@ -4335,7 +4332,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                             tl_edge_0,
                             (*f).bitdepth_max,
                         );
-                        ((*dsp).ipred.intra_pred[m_0 as usize]).expect("non-null function pointer")(
+                        ((*dsp).ipred.intra_pred[m_0 as usize]).unwrap_unchecked()(
                             tmp_0,
                             ((cbw4 * 4) as libc::c_ulong)
                                 .wrapping_mul(::core::mem::size_of::<pixel>() as libc::c_ulong)
@@ -4348,7 +4345,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                             0 as libc::c_int,
                             (*f).bitdepth_max,
                         );
-                        ((*dsp).mc.blend).expect("non-null function pointer")(
+                        ((*dsp).mc.blend).unwrap_unchecked()(
                             uvdst,
                             (*f).cur.stride[1],
                             tmp_0,
@@ -4439,7 +4436,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
         }
         match (*b).c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_int {
             2 => {
-                ((*dsp).mc.avg).expect("non-null function pointer")(
+                ((*dsp).mc.avg).unwrap_unchecked()(
                     dst,
                     (*f).cur.stride[0],
                     (*tmp_1.offset(0)).as_mut_ptr(),
@@ -4454,7 +4451,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                     [(*b).c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as usize]
                     [(*b).c2rust_unnamed.c2rust_unnamed_0.r#ref[1] as usize]
                     as libc::c_int;
-                ((*dsp).mc.w_avg).expect("non-null function pointer")(
+                ((*dsp).mc.w_avg).unwrap_unchecked()(
                     dst,
                     (*f).cur.stride[0],
                     (*tmp_1.offset(0)).as_mut_ptr(),
@@ -4466,7 +4463,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                 );
             }
             3 => {
-                ((*dsp).mc.w_mask[chr_layout_idx as usize]).expect("non-null function pointer")(
+                ((*dsp).mc.w_mask[chr_layout_idx as usize]).unwrap_unchecked()(
                     dst,
                     (*f).cur.stride[0],
                     (*tmp_1.offset(
@@ -4507,7 +4504,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                     .c2rust_unnamed
                     .wedge_idx
                     as usize];
-                ((*dsp).mc.mask).expect("non-null function pointer")(
+                ((*dsp).mc.mask).unwrap_unchecked()(
                     dst,
                     (*f).cur.stride[0],
                     (*tmp_1.offset(
@@ -4616,7 +4613,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                     ((*f).cur.data[(1 + pl_7) as usize] as *mut pixel).offset(uvdstoff as isize);
                 match (*b).c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_int {
                     2 => {
-                        ((*dsp).mc.avg).expect("non-null function pointer")(
+                        ((*dsp).mc.avg).unwrap_unchecked()(
                             uvdst_0,
                             (*f).cur.stride[1],
                             (*tmp_1.offset(0)).as_mut_ptr(),
@@ -4627,7 +4624,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                         );
                     }
                     1 => {
-                        ((*dsp).mc.w_avg).expect("non-null function pointer")(
+                        ((*dsp).mc.w_avg).unwrap_unchecked()(
                             uvdst_0,
                             (*f).cur.stride[1],
                             (*tmp_1.offset(0)).as_mut_ptr(),
@@ -4639,7 +4636,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                         );
                     }
                     4 | 3 => {
-                        ((*dsp).mc.mask).expect("non-null function pointer")(
+                        ((*dsp).mc.mask).unwrap_unchecked()(
                             uvdst_0,
                             (*f).cur.stride[1],
                             (*tmp_1.offset(
@@ -4859,7 +4856,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                     );
                                 }
                                 ((*dsp).itx.itxfm_add[(*b).uvtx as usize][txtp as usize])
-                                    .expect("non-null function pointer")(
+                                    .unwrap_unchecked()(
                                     &mut *uvdst_1.offset((4 * x_0) as isize),
                                     (*f).cur.stride[1],
                                     cf,
@@ -5061,7 +5058,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_resize_16bpc(
         let dst_w = (*f).sr_cur.p.p.w + ss_hor >> ss_hor;
         let src_w = 4 * (*f).bw + ss_hor >> ss_hor;
         let img_h = (*f).cur.p.h - sbsz * 4 * sby + ss_ver_0 >> ss_ver_0;
-        ((*(*f).dsp).mc.resize).expect("non-null function pointer")(
+        ((*(*f).dsp).mc.resize).unwrap_unchecked()(
             dst,
             dst_stride,
             src,

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -2120,9 +2120,11 @@ unsafe extern "C" fn read_coef_tree(
                         "dq",
                     );
                 }
-                ((*dsp).itx.itxfm_add[ytx as usize][txtp as usize])
-                    .expect("non-null function pointer")(
-                    dst, (*f).cur.stride[0], cf, eob
+                ((*dsp).itx.itxfm_add[ytx as usize][txtp as usize]).unwrap_unchecked()(
+                    dst,
+                    (*f).cur.stride[0],
+                    cf,
+                    eob,
                 );
                 if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                     hex_dump::<BitDepth8>(
@@ -2437,7 +2439,7 @@ unsafe extern "C" fn mc(
         {
             let emu_edge_buf: *mut pixel =
                 ((*t).scratch.c2rust_unnamed.c2rust_unnamed_0.emu_edge_8bpc).as_mut_ptr();
-            ((*(*f).dsp).mc.emu_edge).expect("non-null function pointer")(
+            ((*(*f).dsp).mc.emu_edge).unwrap_unchecked()(
                 (bw4 * h_mul + (mx != 0) as libc::c_int * 7) as intptr_t,
                 (bh4 * v_mul + (my != 0) as libc::c_int * 7) as intptr_t,
                 w as intptr_t,
@@ -2463,7 +2465,7 @@ unsafe extern "C" fn mc(
                 .offset(dx as isize);
         }
         if !dst8.is_null() {
-            ((*(*f).dsp).mc.mc[filter_2d as usize]).expect("non-null function pointer")(
+            ((*(*f).dsp).mc.mc[filter_2d as usize]).unwrap_unchecked()(
                 dst8,
                 dst_stride,
                 r#ref,
@@ -2474,7 +2476,7 @@ unsafe extern "C" fn mc(
                 my << (ss_ver == 0) as libc::c_int,
             );
         } else {
-            ((*(*f).dsp).mc.mct[filter_2d as usize]).expect("non-null function pointer")(
+            ((*(*f).dsp).mc.mct[filter_2d as usize]).unwrap_unchecked()(
                 dst16,
                 r#ref,
                 ref_stride,
@@ -2529,7 +2531,7 @@ unsafe extern "C" fn mc(
         if left < 3 || top < 3 || right + 4 > w_0 || bottom + 4 > h_0 {
             let emu_edge_buf_0: *mut pixel =
                 ((*t).scratch.c2rust_unnamed.c2rust_unnamed_0.emu_edge_8bpc).as_mut_ptr();
-            ((*(*f).dsp).mc.emu_edge).expect("non-null function pointer")(
+            ((*(*f).dsp).mc.emu_edge).unwrap_unchecked()(
                 (right - left + 7) as intptr_t,
                 (bottom - top + 7) as intptr_t,
                 w_0 as intptr_t,
@@ -2556,7 +2558,7 @@ unsafe extern "C" fn mc(
                 .offset(left as isize);
         }
         if !dst8.is_null() {
-            ((*(*f).dsp).mc.mc_scaled[filter_2d as usize]).expect("non-null function pointer")(
+            ((*(*f).dsp).mc.mc_scaled[filter_2d as usize]).unwrap_unchecked()(
                 dst8,
                 dst_stride,
                 r#ref,
@@ -2569,7 +2571,7 @@ unsafe extern "C" fn mc(
                 (*f).svc[refidx as usize][1].step,
             );
         } else {
-            ((*(*f).dsp).mc.mct_scaled[filter_2d as usize]).expect("non-null function pointer")(
+            ((*(*f).dsp).mc.mct_scaled[filter_2d as usize]).unwrap_unchecked()(
                 dst16,
                 r#ref,
                 ref_stride,
@@ -2659,7 +2661,7 @@ unsafe extern "C" fn obmc(
                 if res != 0 {
                     return res;
                 }
-                ((*(*f).dsp).mc.blend_h).expect("non-null function pointer")(
+                ((*(*f).dsp).mc.blend_h).unwrap_unchecked()(
                     &mut *dst.offset((x * h_mul) as isize),
                     dst_stride,
                     lap,
@@ -2711,7 +2713,7 @@ unsafe extern "C" fn obmc(
                 if res != 0 {
                     return res;
                 }
-                ((*(*f).dsp).mc.blend_v).expect("non-null function pointer")(
+                ((*(*f).dsp).mc.blend_v).unwrap_unchecked()(
                     &mut *dst.offset(((y * v_mul) as isize * dst_stride) as isize),
                     dst_stride,
                     lap,
@@ -2788,7 +2790,7 @@ unsafe extern "C" fn warp_affine(
             if dx < 3 || dx + 8 + 4 > width || dy < 3 || dy + 8 + 4 > height {
                 let emu_edge_buf: *mut pixel =
                     ((*t).scratch.c2rust_unnamed.c2rust_unnamed_0.emu_edge_8bpc).as_mut_ptr();
-                ((*(*f).dsp).mc.emu_edge).expect("non-null function pointer")(
+                ((*(*f).dsp).mc.emu_edge).unwrap_unchecked()(
                     15 as libc::c_int as intptr_t,
                     15 as libc::c_int as intptr_t,
                     width as intptr_t,
@@ -2812,7 +2814,7 @@ unsafe extern "C" fn warp_affine(
                     .offset(dx as isize);
             }
             if !dst16.is_null() {
-                ((*dsp).mc.warp8x8t).expect("non-null function pointer")(
+                ((*dsp).mc.warp8x8t).unwrap_unchecked()(
                     &mut *dst16.offset(x as isize),
                     dstride,
                     ref_ptr,
@@ -2822,7 +2824,7 @@ unsafe extern "C" fn warp_affine(
                     my,
                 );
             } else {
-                ((*dsp).mc.warp8x8).expect("non-null function pointer")(
+                ((*dsp).mc.warp8x8).unwrap_unchecked()(
                     &mut *dst8.offset(x as isize),
                     dstride,
                     ref_ptr,
@@ -2921,7 +2923,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                 } else {
                     ((*t).scratch.c2rust_unnamed_0.pal[0]).as_mut_ptr()
                 };
-                ((*(*f).dsp).ipred.pal_pred).expect("non-null function pointer")(
+                ((*(*f).dsp).ipred.pal_pred).unwrap_unchecked()(
                     dst,
                     (*f).cur.stride[0],
                     pal,
@@ -3015,7 +3017,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                             (*(*f).seq_hdr).intra_edge_filter,
                             edge,
                         );
-                        ((*dsp).ipred.intra_pred[m as usize]).expect("non-null function pointer")(
+                        ((*dsp).ipred.intra_pred[m as usize]).unwrap_unchecked()(
                             dst_0,
                             (*f).cur.stride[0],
                             edge,
@@ -3119,11 +3121,8 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                             }
                             ((*dsp).itx.itxfm_add[(*b).c2rust_unnamed.c2rust_unnamed.tx as usize]
                                 [txtp as usize])
-                                .expect("non-null function pointer")(
-                                dst_0,
-                                (*f).cur.stride[0],
-                                cf,
-                                eob,
+                                .unwrap_unchecked()(
+                                dst_0, (*f).cur.stride[0], cf, eob
                             );
                             if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                                 hex_dump::<BitDepth8>(
@@ -3179,7 +3178,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                     ((*dsp).ipred.cfl_ac[((*f).cur.p.layout as libc::c_uint)
                         .wrapping_sub(1 as libc::c_int as libc::c_uint)
                         as usize])
-                        .expect("non-null function pointer")(
+                        .unwrap_unchecked()(
                         ac.as_mut_ptr(),
                         y_src,
                         (*f).cur.stride[0],
@@ -3221,8 +3220,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                 0 as libc::c_int,
                                 edge,
                             );
-                            ((*dsp).ipred.cfl_pred[m_0 as usize])
-                                .expect("non-null function pointer")(
+                            ((*dsp).ipred.cfl_pred[m_0 as usize]).unwrap_unchecked()(
                                 uv_dst[pl as usize],
                                 stride,
                                 edge,
@@ -3281,7 +3279,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                             .offset((bw4 * bh4 * 16) as isize)
                             as *mut uint8_t;
                     }
-                    ((*(*f).dsp).ipred.pal_pred).expect("non-null function pointer")(
+                    ((*(*f).dsp).ipred.pal_pred).unwrap_unchecked()(
                         ((*f).cur.data[1] as *mut pixel).offset(uv_dstoff as isize),
                         (*f).cur.stride[1],
                         (*pal_0.offset(1)).as_ptr(),
@@ -3289,7 +3287,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                         cbw4 * 4,
                         cbh4 * 4,
                     );
-                    ((*(*f).dsp).ipred.pal_pred).expect("non-null function pointer")(
+                    ((*(*f).dsp).ipred.pal_pred).unwrap_unchecked()(
                         ((*f).cur.data[2] as *mut pixel).offset(uv_dstoff as isize),
                         (*f).cur.stride[1],
                         (*pal_0.offset(2)).as_ptr(),
@@ -3423,8 +3421,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                     edge,
                                 );
                                 angle_1 |= intra_edge_filter_flag;
-                                ((*dsp).ipred.intra_pred[m_1 as usize])
-                                    .expect("non-null function pointer")(
+                                ((*dsp).ipred.intra_pred[m_1 as usize]).unwrap_unchecked()(
                                     dst_1,
                                     stride,
                                     edge,
@@ -3545,8 +3542,8 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                         );
                                     }
                                     ((*dsp).itx.itxfm_add[(*b).uvtx as usize][txtp_0 as usize])
-                                        .expect("non-null function pointer")(
-                                        dst_1, stride, cf_0, eob_0,
+                                        .unwrap_unchecked()(
+                                        dst_1, stride, cf_0, eob_0
                                     );
                                     if DEBUG_BLOCK_INFO(&*f, &*t) && 0 != 0 {
                                         hex_dump::<BitDepth8>(
@@ -3824,7 +3821,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                 0 as libc::c_int,
                 tl_edge,
             );
-            ((*dsp).ipred.intra_pred[m as usize]).expect("non-null function pointer")(
+            ((*dsp).ipred.intra_pred[m as usize]).unwrap_unchecked()(
                 tmp,
                 ((4 * bw4) as libc::c_ulong)
                     .wrapping_mul(::core::mem::size_of::<pixel>() as libc::c_ulong)
@@ -3854,7 +3851,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                     .c2rust_unnamed
                     .wedge_idx as usize]
             };
-            ((*dsp).mc.blend).expect("non-null function pointer")(
+            ((*dsp).mc.blend).unwrap_unchecked()(
                 dst,
                 (*f).cur.stride[0],
                 tmp,
@@ -4270,7 +4267,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                             0 as libc::c_int,
                             tl_edge_0,
                         );
-                        ((*dsp).ipred.intra_pred[m_0 as usize]).expect("non-null function pointer")(
+                        ((*dsp).ipred.intra_pred[m_0 as usize]).unwrap_unchecked()(
                             tmp_0,
                             ((cbw4 * 4) as libc::c_ulong)
                                 .wrapping_mul(::core::mem::size_of::<pixel>() as libc::c_ulong)
@@ -4282,7 +4279,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                             0 as libc::c_int,
                             0 as libc::c_int,
                         );
-                        ((*dsp).mc.blend).expect("non-null function pointer")(
+                        ((*dsp).mc.blend).unwrap_unchecked()(
                             uvdst,
                             (*f).cur.stride[1],
                             tmp_0,
@@ -4373,7 +4370,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
         }
         match (*b).c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_int {
             2 => {
-                ((*dsp).mc.avg).expect("non-null function pointer")(
+                ((*dsp).mc.avg).unwrap_unchecked()(
                     dst,
                     (*f).cur.stride[0],
                     (*tmp_1.offset(0)).as_mut_ptr(),
@@ -4387,7 +4384,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                     [(*b).c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as usize]
                     [(*b).c2rust_unnamed.c2rust_unnamed_0.r#ref[1] as usize]
                     as libc::c_int;
-                ((*dsp).mc.w_avg).expect("non-null function pointer")(
+                ((*dsp).mc.w_avg).unwrap_unchecked()(
                     dst,
                     (*f).cur.stride[0],
                     (*tmp_1.offset(0)).as_mut_ptr(),
@@ -4398,7 +4395,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                 );
             }
             3 => {
-                ((*dsp).mc.w_mask[chr_layout_idx as usize]).expect("non-null function pointer")(
+                ((*dsp).mc.w_mask[chr_layout_idx as usize]).unwrap_unchecked()(
                     dst,
                     (*f).cur.stride[0],
                     (*tmp_1.offset(
@@ -4438,7 +4435,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                     .c2rust_unnamed
                     .wedge_idx
                     as usize];
-                ((*dsp).mc.mask).expect("non-null function pointer")(
+                ((*dsp).mc.mask).unwrap_unchecked()(
                     dst,
                     (*f).cur.stride[0],
                     (*tmp_1.offset(
@@ -4546,7 +4543,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                     ((*f).cur.data[(1 + pl_7) as usize] as *mut pixel).offset(uvdstoff as isize);
                 match (*b).c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_int {
                     2 => {
-                        ((*dsp).mc.avg).expect("non-null function pointer")(
+                        ((*dsp).mc.avg).unwrap_unchecked()(
                             uvdst_0,
                             (*f).cur.stride[1],
                             (*tmp_1.offset(0)).as_mut_ptr(),
@@ -4556,7 +4553,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                         );
                     }
                     1 => {
-                        ((*dsp).mc.w_avg).expect("non-null function pointer")(
+                        ((*dsp).mc.w_avg).unwrap_unchecked()(
                             uvdst_0,
                             (*f).cur.stride[1],
                             (*tmp_1.offset(0)).as_mut_ptr(),
@@ -4567,7 +4564,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                         );
                     }
                     4 | 3 => {
-                        ((*dsp).mc.mask).expect("non-null function pointer")(
+                        ((*dsp).mc.mask).unwrap_unchecked()(
                             uvdst_0,
                             (*f).cur.stride[1],
                             (*tmp_1.offset(
@@ -4784,7 +4781,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                     );
                                 }
                                 ((*dsp).itx.itxfm_add[(*b).uvtx as usize][txtp as usize])
-                                    .expect("non-null function pointer")(
+                                    .unwrap_unchecked()(
                                     &mut *uvdst_1.offset((4 * x_0) as isize),
                                     (*f).cur.stride[1],
                                     cf,
@@ -4972,7 +4969,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_resize_8bpc(
         let dst_w = (*f).sr_cur.p.p.w + ss_hor >> ss_hor;
         let src_w = 4 * (*f).bw + ss_hor >> ss_hor;
         let img_h = (*f).cur.p.h - sbsz * 4 * sby + ss_ver_0 >> ss_ver_0;
-        ((*(*f).dsp).mc.resize).expect("non-null function pointer")(
+        ((*(*f).dsp).mc.resize).unwrap_unchecked()(
             dst,
             dst_stride,
             src,

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -130,7 +130,7 @@ pub unsafe extern "C" fn dav1d_ref_dec(pref: *mut *mut Dav1dRef) {
     ) == 1
     {
         let free_ref = (*r#ref).free_ref;
-        ((*r#ref).free_callback).expect("non-null function pointer")(
+        ((*r#ref).free_callback).unwrap_unchecked()(
             (*r#ref).const_data as *const uint8_t,
             (*r#ref).user_data,
         );

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -229,14 +229,7 @@ impl Dav1dRefmvsDSPContext {
         bw4: usize,
         bh4: usize,
     ) {
-        self.splat_mv.expect("non-null function pointer")(
-            rr.as_mut_ptr(),
-            rr.len(),
-            rmv,
-            bx4,
-            bw4,
-            bh4,
-        );
+        self.splat_mv.unwrap_unchecked()(rr.as_mut_ptr(), rr.len(), rmv, bx4, bw4, bh4);
     }
 }
 
@@ -1146,7 +1139,7 @@ pub unsafe extern "C" fn dav1d_refmvs_save_tmvs(
     let ref_sign: *const uint8_t = ((*rf).mfmv_sign).as_ptr();
     let mut rp: *mut refmvs_temporal_block = (*rf).rp.offset(row_start8 as isize * stride);
 
-    (*dsp).save_tmvs.expect("non-null function pointer")(
+    (*dsp).save_tmvs.unwrap_unchecked()(
         rp,
         stride,
         (*rt).r.as_ptr().offset(6) as *const *const refmvs_block,

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -2177,9 +2177,8 @@ pub unsafe extern "C" fn dav1d_worker_task(mut data: *mut libc::c_void) -> *mut 
                                         &mut (*f).task_thread.error as *mut atomic_int,
                                     ) == 0
                                     {
-                                        ((*f).bd_fn.filter_sbrow_deblock_cols)
-                                            .expect("non-null function pointer")(
-                                            f, sby
+                                        ((*f).bd_fn.filter_sbrow_deblock_cols).unwrap_unchecked()(
+                                            f, sby,
                                         );
                                     }
                                     if ensure_progress(
@@ -2232,9 +2231,8 @@ pub unsafe extern "C" fn dav1d_worker_task(mut data: *mut libc::c_void) -> *mut 
                                     &mut (*f).task_thread.error as *mut atomic_int,
                                 ) == 0
                                 {
-                                    ((*f).bd_fn.filter_sbrow_deblock_rows)
-                                        .expect("non-null function pointer")(
-                                        f, sby
+                                    ((*f).bd_fn.filter_sbrow_deblock_rows).unwrap_unchecked()(
+                                        f, sby,
                                     );
                                 }
                                 if (*(*f).frame_hdr).loopfilter.level_y[0] != 0
@@ -2297,10 +2295,7 @@ pub unsafe extern "C" fn dav1d_worker_task(mut data: *mut libc::c_void) -> *mut 
                                         &mut (*f).task_thread.error as *mut atomic_int,
                                     ) == 0
                                     {
-                                        ((*f).bd_fn.filter_sbrow_cdef)
-                                            .expect("non-null function pointer")(
-                                            tc, sby
-                                        );
+                                        ((*f).bd_fn.filter_sbrow_cdef).unwrap_unchecked()(tc, sby);
                                     }
                                     reset_task_cur_async(ttd, (*t).frame_idx, (*c).n_fc);
                                     if ::core::intrinsics::atomic_or_seqcst(
@@ -2322,10 +2317,7 @@ pub unsafe extern "C" fn dav1d_worker_task(mut data: *mut libc::c_void) -> *mut 
                                         &mut (*f).task_thread.error as *mut atomic_int,
                                     ) == 0
                                     {
-                                        ((*f).bd_fn.filter_sbrow_resize)
-                                            .expect("non-null function pointer")(
-                                            f, sby
-                                        );
+                                        ((*f).bd_fn.filter_sbrow_resize).unwrap_unchecked()(f, sby);
                                     }
                                 }
                                 current_block = 563177965161376451;
@@ -2339,10 +2331,7 @@ pub unsafe extern "C" fn dav1d_worker_task(mut data: *mut libc::c_void) -> *mut 
                                 ) == 0
                                     && (*f).lf.restore_planes != 0
                                 {
-                                    ((*f).bd_fn.filter_sbrow_lr)
-                                        .expect("non-null function pointer")(
-                                        f, sby
-                                    );
+                                    ((*f).bd_fn.filter_sbrow_lr).unwrap_unchecked()(f, sby);
                                 }
                                 current_block = 18238912670629178022;
                             }

--- a/tools/input/input.rs
+++ b/tools/input/input.rs
@@ -141,8 +141,7 @@ pub unsafe extern "C" fn input_open(
         }
         i = 0 as libc::c_int;
         while !(demuxers[i as usize]).is_null() {
-            if ((*demuxers[i as usize]).probe).expect("non-null function pointer")(probe_data) != 0
-            {
+            if ((*demuxers[i as usize]).probe).unwrap_unchecked()(probe_data) != 0 {
                 impl_0 = demuxers[i as usize];
                 break;
             } else {
@@ -172,13 +171,7 @@ pub unsafe extern "C" fn input_open(
     }
     (*c).impl_0 = impl_0;
     (*c).data = ((*c).priv_data).as_mut_ptr() as *mut DemuxerPriv;
-    res = ((*impl_0).open).expect("non-null function pointer")(
-        (*c).data,
-        filename,
-        fps,
-        num_frames,
-        timebase,
-    );
+    res = ((*impl_0).open).unwrap_unchecked()((*c).data, filename, fps, num_frames, timebase);
     if res < 0 {
         free(c as *mut libc::c_void);
         return res;
@@ -188,18 +181,18 @@ pub unsafe extern "C" fn input_open(
 }
 #[no_mangle]
 pub unsafe extern "C" fn input_read(ctx: *mut DemuxerContext, data: *mut Dav1dData) -> libc::c_int {
-    return ((*(*ctx).impl_0).read).expect("non-null function pointer")((*ctx).data, data);
+    return ((*(*ctx).impl_0).read).unwrap_unchecked()((*ctx).data, data);
 }
 #[no_mangle]
 pub unsafe extern "C" fn input_seek(ctx: *mut DemuxerContext, pts: uint64_t) -> libc::c_int {
     return if ((*(*ctx).impl_0).seek).is_some() {
-        ((*(*ctx).impl_0).seek).expect("non-null function pointer")((*ctx).data, pts)
+        ((*(*ctx).impl_0).seek).unwrap_unchecked()((*ctx).data, pts)
     } else {
         -(1 as libc::c_int)
     };
 }
 #[no_mangle]
 pub unsafe extern "C" fn input_close(ctx: *mut DemuxerContext) {
-    ((*(*ctx).impl_0).close).expect("non-null function pointer")((*ctx).data);
+    ((*(*ctx).impl_0).close).unwrap_unchecked()((*ctx).data);
     free(ctx as *mut libc::c_void);
 }

--- a/tools/output/output.rs
+++ b/tools/output/output.rs
@@ -186,12 +186,7 @@ pub unsafe extern "C" fn output_open(
         (*c).filename = filename;
         (*c).framenum = 0 as libc::c_int;
     } else if ((*impl_0).write_header).is_some() && {
-        res = ((*impl_0).write_header).expect("non-null function pointer")(
-            (*c).data,
-            filename,
-            p,
-            fps,
-        );
+        res = ((*impl_0).write_header).unwrap_unchecked()((*c).data, filename, p, fps);
         res < 0
     } {
         free(c as *mut libc::c_void);
@@ -353,7 +348,7 @@ pub unsafe extern "C" fn output_write(ctx: *mut MuxerContext, p: *mut Dav1dPictu
             ::core::mem::size_of::<[libc::c_char; 1024]>() as libc::c_ulong as libc::c_int,
             &mut (*p).p,
         );
-        res = ((*(*ctx).impl_0).write_header).expect("non-null function pointer")(
+        res = ((*(*ctx).impl_0).write_header).unwrap_unchecked()(
             (*ctx).data,
             filename.as_mut_ptr(),
             &mut (*p).p,
@@ -363,19 +358,19 @@ pub unsafe extern "C" fn output_write(ctx: *mut MuxerContext, p: *mut Dav1dPictu
             return res;
         }
     }
-    res = ((*(*ctx).impl_0).write_picture).expect("non-null function pointer")((*ctx).data, p);
+    res = ((*(*ctx).impl_0).write_picture).unwrap_unchecked()((*ctx).data, p);
     if res < 0 {
         return res;
     }
     if (*ctx).one_file_per_frame != 0 && ((*(*ctx).impl_0).write_trailer).is_some() {
-        ((*(*ctx).impl_0).write_trailer).expect("non-null function pointer")((*ctx).data);
+        ((*(*ctx).impl_0).write_trailer).unwrap_unchecked()((*ctx).data);
     }
     return 0 as libc::c_int;
 }
 #[no_mangle]
 pub unsafe extern "C" fn output_close(ctx: *mut MuxerContext) {
     if (*ctx).one_file_per_frame == 0 && ((*(*ctx).impl_0).write_trailer).is_some() {
-        ((*(*ctx).impl_0).write_trailer).expect("non-null function pointer")((*ctx).data);
+        ((*(*ctx).impl_0).write_trailer).unwrap_unchecked()((*ctx).data);
     }
     free(ctx as *mut libc::c_void);
 }
@@ -385,7 +380,7 @@ pub unsafe extern "C" fn output_verify(
     md5_str: *const libc::c_char,
 ) -> libc::c_int {
     let res = if ((*(*ctx).impl_0).verify).is_some() {
-        ((*(*ctx).impl_0).verify).expect("non-null function pointer")((*ctx).data, md5_str)
+        ((*(*ctx).impl_0).verify).unwrap_unchecked()((*ctx).data, md5_str)
     } else {
         0 as libc::c_int
     };


### PR DESCRIPTION
Replace `.expect\("non-null function pointer"\)` with `.unwrap_unchecked()` to avoid extra unused instructions at fn ptr call sites, as we found instruction density is important for perf.

Ideally, we'd properly initialize these to the Rust/C fn ptr in the first place so there is no extra overhead at all, but I want to check if this makes a difference for performance, as when benchmarking the devirtualization PRs, we found that instruction density (i.e. iTLB misses) was important, and this might explain part of the perf difference between non-devirtualized `rav1d` and `dav1d`.