### PR TITLE
`struct Dav1dLoopRestorationDSPContext`: Deduplicate via type-erased `fn` pointers

### DIFF
--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -238,29 +238,8 @@ pub struct Dav1dDSPContext {
     pub cdef: Dav1dCdefDSPContext,
     pub lr: Dav1dLoopRestorationDSPContext,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dLoopRestorationDSPContext {
-    pub wiener: [looprestorationfilter_fn; 2],
-    pub sgr: [looprestorationfilter_fn; 3],
-}
-pub type looprestorationfilter_fn = Option<
-    unsafe extern "C" fn(
-        *mut pixel,
-        ptrdiff_t,
-        const_left_pixel_row,
-        *const pixel,
-        libc::c_int,
-        libc::c_int,
-        *const LooprestorationParams,
-        LrEdgeFlags,
-        libc::c_int,
-    ) -> (),
->;
-use crate::src::looprestoration::LooprestorationParams;
-use crate::src::looprestoration::LrEdgeFlags;
+use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 
-pub type const_left_pixel_row = *const [pixel; 4];
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dCdefDSPContext {

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -239,28 +239,8 @@ pub struct Dav1dDSPContext {
     pub cdef: Dav1dCdefDSPContext,
     pub lr: Dav1dLoopRestorationDSPContext,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dLoopRestorationDSPContext {
-    pub wiener: [looprestorationfilter_fn; 2],
-    pub sgr: [looprestorationfilter_fn; 3],
-}
-pub type looprestorationfilter_fn = Option<
-    unsafe extern "C" fn(
-        *mut pixel,
-        ptrdiff_t,
-        const_left_pixel_row,
-        *const pixel,
-        libc::c_int,
-        libc::c_int,
-        *const LooprestorationParams,
-        LrEdgeFlags,
-    ) -> (),
->;
-use crate::src::looprestoration::LooprestorationParams;
-use crate::src::looprestoration::LrEdgeFlags;
+use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 
-pub type const_left_pixel_row = *const [pixel; 4];
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dCdefDSPContext {

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -342,28 +342,8 @@ pub struct Dav1dDSPContext {
     pub cdef: Dav1dCdefDSPContext,
     pub lr: Dav1dLoopRestorationDSPContext,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dLoopRestorationDSPContext {
-    pub wiener: [looprestorationfilter_fn; 2],
-    pub sgr: [looprestorationfilter_fn; 3],
-}
-pub type looprestorationfilter_fn = Option<
-    unsafe extern "C" fn(
-        *mut libc::c_void,
-        ptrdiff_t,
-        const_left_pixel_row,
-        *const libc::c_void,
-        libc::c_int,
-        libc::c_int,
-        *const LooprestorationParams,
-        LrEdgeFlags,
-    ) -> (),
->;
-use crate::src::looprestoration::LooprestorationParams;
-use crate::src::looprestoration::LrEdgeFlags;
+use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 
-pub type const_left_pixel_row = *const libc::c_void;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dCdefDSPContext {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -519,28 +519,8 @@ pub struct Dav1dDSPContext {
     pub cdef: Dav1dCdefDSPContext,
     pub lr: Dav1dLoopRestorationDSPContext,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dLoopRestorationDSPContext {
-    pub wiener: [looprestorationfilter_fn; 2],
-    pub sgr: [looprestorationfilter_fn; 3],
-}
-pub type looprestorationfilter_fn = Option<
-    unsafe extern "C" fn(
-        *mut libc::c_void,
-        ptrdiff_t,
-        const_left_pixel_row,
-        *const libc::c_void,
-        libc::c_int,
-        libc::c_int,
-        *const LooprestorationParams,
-        LrEdgeFlags,
-    ) -> (),
->;
-use crate::src::looprestoration::LooprestorationParams;
-use crate::src::looprestoration::LrEdgeFlags;
+use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 
-pub type const_left_pixel_row = *const libc::c_void;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dCdefDSPContext {

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -235,29 +235,8 @@ pub struct Dav1dDSPContext {
     pub cdef: Dav1dCdefDSPContext,
     pub lr: Dav1dLoopRestorationDSPContext,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dLoopRestorationDSPContext {
-    pub wiener: [looprestorationfilter_fn; 2],
-    pub sgr: [looprestorationfilter_fn; 3],
-}
-pub type looprestorationfilter_fn = Option<
-    unsafe extern "C" fn(
-        *mut pixel,
-        ptrdiff_t,
-        const_left_pixel_row,
-        *const pixel,
-        libc::c_int,
-        libc::c_int,
-        *const LooprestorationParams,
-        LrEdgeFlags,
-        libc::c_int,
-    ) -> (),
->;
-use crate::src::looprestoration::LooprestorationParams;
-use crate::src::looprestoration::LrEdgeFlags;
+use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 
-pub type const_left_pixel_row = *const [pixel; 4];
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dCdefDSPContext {

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -236,28 +236,8 @@ pub struct Dav1dDSPContext {
     pub cdef: Dav1dCdefDSPContext,
     pub lr: Dav1dLoopRestorationDSPContext,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dLoopRestorationDSPContext {
-    pub wiener: [looprestorationfilter_fn; 2],
-    pub sgr: [looprestorationfilter_fn; 3],
-}
-pub type looprestorationfilter_fn = Option<
-    unsafe extern "C" fn(
-        *mut pixel,
-        ptrdiff_t,
-        const_left_pixel_row,
-        *const pixel,
-        libc::c_int,
-        libc::c_int,
-        *const LooprestorationParams,
-        LrEdgeFlags,
-    ) -> (),
->;
-use crate::src::looprestoration::LooprestorationParams;
-use crate::src::looprestoration::LrEdgeFlags;
+use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 
-pub type const_left_pixel_row = *const [pixel; 4];
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dCdefDSPContext {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,29 +232,9 @@ pub struct Dav1dDSPContext {
     pub cdef: Dav1dCdefDSPContext,
     pub lr: Dav1dLoopRestorationDSPContext,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dLoopRestorationDSPContext {
-    pub wiener: [looprestorationfilter_fn; 2],
-    pub sgr: [looprestorationfilter_fn; 3],
-}
-pub type looprestorationfilter_fn = Option<
-    unsafe extern "C" fn(
-        *mut libc::c_void,
-        ptrdiff_t,
-        const_left_pixel_row,
-        *const libc::c_void,
-        libc::c_int,
-        libc::c_int,
-        *const LooprestorationParams,
-        LrEdgeFlags,
-    ) -> (),
->;
-use crate::src::looprestoration::LooprestorationParams;
-use crate::src::looprestoration::LrEdgeFlags;
+use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 
 pub type pixel = ();
-pub type const_left_pixel_row = *const libc::c_void;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dCdefDSPContext {

--- a/src/log.rs
+++ b/src/log.rs
@@ -105,29 +105,9 @@ pub struct Dav1dDSPContext {
     pub cdef: Dav1dCdefDSPContext,
     pub lr: Dav1dLoopRestorationDSPContext,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dLoopRestorationDSPContext {
-    pub wiener: [looprestorationfilter_fn; 2],
-    pub sgr: [looprestorationfilter_fn; 3],
-}
-pub type looprestorationfilter_fn = Option<
-    unsafe extern "C" fn(
-        *mut libc::c_void,
-        ptrdiff_t,
-        const_left_pixel_row,
-        *const libc::c_void,
-        libc::c_int,
-        libc::c_int,
-        *const LooprestorationParams,
-        LrEdgeFlags,
-    ) -> (),
->;
-use crate::src::looprestoration::LooprestorationParams;
-use crate::src::looprestoration::LrEdgeFlags;
+use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 
 pub type pixel = ();
-pub type const_left_pixel_row = *const libc::c_void;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dCdefDSPContext {

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -48,3 +48,360 @@ pub struct Dav1dLoopRestorationDSPContext {
     pub wiener: [looprestorationfilter_fn; 2],
     pub sgr: [looprestorationfilter_fn; 3],
 }
+
+#[cfg(all(
+    feature = "bitdepth_8",
+    feature = "asm",
+    any(target_arch = "x86", target_arch = "x86_64"),
+))]
+extern "C" {
+    pub(crate) fn dav1d_wiener_filter7_8bpc_sse2(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_wiener_filter5_8bpc_sse2(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_wiener_filter7_8bpc_ssse3(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_wiener_filter5_8bpc_ssse3(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_wiener_filter5_8bpc_avx2(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_wiener_filter7_8bpc_avx2(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_wiener_filter7_8bpc_avx512icl(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_sgr_filter_mix_8bpc_avx512icl(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_sgr_filter_3x3_8bpc_avx512icl(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_sgr_filter_5x5_8bpc_avx512icl(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_sgr_filter_mix_8bpc_avx2(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_sgr_filter_3x3_8bpc_avx2(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_sgr_filter_5x5_8bpc_avx2(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_sgr_filter_mix_8bpc_ssse3(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_sgr_filter_3x3_8bpc_ssse3(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_sgr_filter_5x5_8bpc_ssse3(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+}
+
+#[cfg(all(
+    feature = "bitdepth_16",
+    feature = "asm",
+    any(target_arch = "x86", target_arch = "x86_64"),
+))]
+extern "C" {
+    pub(crate) fn dav1d_wiener_filter5_16bpc_ssse3(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_wiener_filter7_16bpc_ssse3(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_wiener_filter5_16bpc_avx2(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_wiener_filter7_16bpc_avx2(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_wiener_filter5_16bpc_avx512icl(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_wiener_filter7_16bpc_avx512icl(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_sgr_filter_mix_16bpc_ssse3(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_sgr_filter_3x3_16bpc_ssse3(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_sgr_filter_5x5_16bpc_ssse3(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_sgr_filter_mix_16bpc_avx2(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_sgr_filter_3x3_16bpc_avx2(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_sgr_filter_5x5_16bpc_avx2(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_sgr_filter_5x5_16bpc_avx512icl(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_sgr_filter_3x3_16bpc_avx512icl(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_sgr_filter_mix_16bpc_avx512icl(
+        dst: *mut pixel,
+        dst_stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+}

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -1,3 +1,4 @@
+use crate::include::stddef::ptrdiff_t;
 use crate::include::stdint::int16_t;
 use crate::include::stdint::uint32_t;
 use crate::src::align::Align16;
@@ -22,4 +23,28 @@ pub struct LooprestorationParams_sgr {
 pub union LooprestorationParams {
     pub filter: Align16<[[int16_t; 8]; 2]>,
     pub sgr: LooprestorationParams_sgr,
+}
+
+type pixel = libc::c_void;
+pub type const_left_pixel_row = *const libc::c_void; // *const [pixel; 4]
+
+pub type looprestorationfilter_fn = Option<
+    unsafe extern "C" fn(
+        *mut pixel,
+        ptrdiff_t,
+        const_left_pixel_row,
+        *const pixel,
+        libc::c_int,
+        libc::c_int,
+        *const LooprestorationParams,
+        LrEdgeFlags,
+        libc::c_int,
+    ) -> (),
+>;
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Dav1dLoopRestorationDSPContext {
+    pub wiener: [looprestorationfilter_fn; 2],
+    pub sgr: [looprestorationfilter_fn; 3],
 }

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -49,6 +49,7 @@ pub struct Dav1dLoopRestorationDSPContext {
     pub sgr: [looprestorationfilter_fn; 3],
 }
 
+// TODO(randomPoison): Temporarily pub until init fns are deduplicated.
 #[cfg(all(
     feature = "bitdepth_8",
     feature = "asm",
@@ -233,6 +234,7 @@ extern "C" {
     );
 }
 
+// TODO(randomPoison): Temporarily pub until init fns are deduplicated.
 #[cfg(all(
     feature = "bitdepth_16",
     feature = "asm",
@@ -406,6 +408,7 @@ extern "C" {
     );
 }
 
+// TODO(randomPoison): Temporarily pub until init fns are deduplicated.
 #[cfg(all(
     feature = "bitdepth_16",
     feature = "asm",
@@ -436,6 +439,7 @@ extern "C" {
     );
 }
 
+// TODO(randomPoison): Temporarily pub until init fns are deduplicated.
 #[cfg(all(
     feature = "bitdepth_8",
     feature = "asm",

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -405,3 +405,63 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
 }
+
+#[cfg(all(
+    feature = "bitdepth_16",
+    feature = "asm",
+    any(target_arch = "arm", target_arch = "aarch64"),
+))]
+extern "C" {
+    pub(crate) fn dav1d_wiener_filter7_16bpc_neon(
+        p: *mut pixel,
+        stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_wiener_filter5_16bpc_neon(
+        p: *mut pixel,
+        stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+}
+
+#[cfg(all(
+    feature = "bitdepth_8",
+    feature = "asm",
+    any(target_arch = "arm", target_arch = "aarch64"),
+))]
+extern "C" {
+    pub(crate) fn dav1d_wiener_filter7_8bpc_neon(
+        p: *mut pixel,
+        stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_wiener_filter5_8bpc_neon(
+        p: *mut pixel,
+        stride: ptrdiff_t,
+        left: const_left_pixel_row,
+        lpf: *const pixel,
+        w: libc::c_int,
+        h: libc::c_int,
+        params: *const LooprestorationParams,
+        edges: LrEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+}

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -49,8 +49,8 @@ pub struct Dav1dLoopRestorationDSPContext {
     pub sgr: [looprestorationfilter_fn; 3],
 }
 
-macro_rules! extern_fn {
-    ( $( $name:ident, )* ) => {
+macro_rules! decl_looprestorationfilter_fn {
+    ( $( fn $name:ident, )* ) => {
         extern "C" {
             $(
                 // TODO(randomPoison): Temporarily pub until init fns are deduplicated.
@@ -75,23 +75,23 @@ macro_rules! extern_fn {
     feature = "asm",
     any(target_arch = "x86", target_arch = "x86_64"),
 ))]
-extern_fn! {
-    dav1d_wiener_filter7_8bpc_sse2,
-    dav1d_wiener_filter5_8bpc_sse2,
-    dav1d_wiener_filter7_8bpc_ssse3,
-    dav1d_wiener_filter5_8bpc_ssse3,
-    dav1d_wiener_filter5_8bpc_avx2,
-    dav1d_wiener_filter7_8bpc_avx2,
-    dav1d_wiener_filter7_8bpc_avx512icl,
-    dav1d_sgr_filter_mix_8bpc_avx512icl,
-    dav1d_sgr_filter_3x3_8bpc_avx512icl,
-    dav1d_sgr_filter_5x5_8bpc_avx512icl,
-    dav1d_sgr_filter_mix_8bpc_avx2,
-    dav1d_sgr_filter_3x3_8bpc_avx2,
-    dav1d_sgr_filter_5x5_8bpc_avx2,
-    dav1d_sgr_filter_mix_8bpc_ssse3,
-    dav1d_sgr_filter_3x3_8bpc_ssse3,
-    dav1d_sgr_filter_5x5_8bpc_ssse3,
+decl_looprestorationfilter_fn! {
+    fn dav1d_wiener_filter7_8bpc_sse2,
+    fn dav1d_wiener_filter5_8bpc_sse2,
+    fn dav1d_wiener_filter7_8bpc_ssse3,
+    fn dav1d_wiener_filter5_8bpc_ssse3,
+    fn dav1d_wiener_filter5_8bpc_avx2,
+    fn dav1d_wiener_filter7_8bpc_avx2,
+    fn dav1d_wiener_filter7_8bpc_avx512icl,
+    fn dav1d_sgr_filter_mix_8bpc_avx512icl,
+    fn dav1d_sgr_filter_3x3_8bpc_avx512icl,
+    fn dav1d_sgr_filter_5x5_8bpc_avx512icl,
+    fn dav1d_sgr_filter_mix_8bpc_avx2,
+    fn dav1d_sgr_filter_3x3_8bpc_avx2,
+    fn dav1d_sgr_filter_5x5_8bpc_avx2,
+    fn dav1d_sgr_filter_mix_8bpc_ssse3,
+    fn dav1d_sgr_filter_3x3_8bpc_ssse3,
+    fn dav1d_sgr_filter_5x5_8bpc_ssse3,
 }
 
 #[cfg(all(
@@ -99,22 +99,22 @@ extern_fn! {
     feature = "asm",
     any(target_arch = "x86", target_arch = "x86_64"),
 ))]
-extern_fn! {
-    dav1d_wiener_filter5_16bpc_ssse3,
-    dav1d_wiener_filter7_16bpc_ssse3,
-    dav1d_wiener_filter5_16bpc_avx2,
-    dav1d_wiener_filter7_16bpc_avx2,
-    dav1d_wiener_filter5_16bpc_avx512icl,
-    dav1d_wiener_filter7_16bpc_avx512icl,
-    dav1d_sgr_filter_mix_16bpc_ssse3,
-    dav1d_sgr_filter_3x3_16bpc_ssse3,
-    dav1d_sgr_filter_5x5_16bpc_ssse3,
-    dav1d_sgr_filter_mix_16bpc_avx2,
-    dav1d_sgr_filter_3x3_16bpc_avx2,
-    dav1d_sgr_filter_5x5_16bpc_avx2,
-    dav1d_sgr_filter_5x5_16bpc_avx512icl,
-    dav1d_sgr_filter_3x3_16bpc_avx512icl,
-    dav1d_sgr_filter_mix_16bpc_avx512icl,
+decl_looprestorationfilter_fn! {
+    fn dav1d_wiener_filter5_16bpc_ssse3,
+    fn dav1d_wiener_filter7_16bpc_ssse3,
+    fn dav1d_wiener_filter5_16bpc_avx2,
+    fn dav1d_wiener_filter7_16bpc_avx2,
+    fn dav1d_wiener_filter5_16bpc_avx512icl,
+    fn dav1d_wiener_filter7_16bpc_avx512icl,
+    fn dav1d_sgr_filter_mix_16bpc_ssse3,
+    fn dav1d_sgr_filter_3x3_16bpc_ssse3,
+    fn dav1d_sgr_filter_5x5_16bpc_ssse3,
+    fn dav1d_sgr_filter_mix_16bpc_avx2,
+    fn dav1d_sgr_filter_3x3_16bpc_avx2,
+    fn dav1d_sgr_filter_5x5_16bpc_avx2,
+    fn dav1d_sgr_filter_5x5_16bpc_avx512icl,
+    fn dav1d_sgr_filter_3x3_16bpc_avx512icl,
+    fn dav1d_sgr_filter_mix_16bpc_avx512icl,
 }
 
 #[cfg(all(
@@ -122,9 +122,9 @@ extern_fn! {
     feature = "asm",
     any(target_arch = "arm", target_arch = "aarch64"),
 ))]
-extern_fn! {
-    dav1d_wiener_filter7_8bpc_neon,
-    dav1d_wiener_filter5_8bpc_neon,
+decl_looprestorationfilter_fn! {
+    fn dav1d_wiener_filter7_8bpc_neon,
+    fn dav1d_wiener_filter5_8bpc_neon,
 }
 
 #[cfg(all(
@@ -132,7 +132,7 @@ extern_fn! {
     feature = "asm",
     any(target_arch = "arm", target_arch = "aarch64"),
 ))]
-extern_fn! {
-    dav1d_wiener_filter7_16bpc_neon,
-    dav1d_wiener_filter5_16bpc_neon,
+decl_looprestorationfilter_fn! {
+    fn dav1d_wiener_filter7_16bpc_neon,
+    fn dav1d_wiener_filter5_16bpc_neon,
 }

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -49,423 +49,90 @@ pub struct Dav1dLoopRestorationDSPContext {
     pub sgr: [looprestorationfilter_fn; 3],
 }
 
-// TODO(randomPoison): Temporarily pub until init fns are deduplicated.
+macro_rules! extern_fn {
+    ( $( $name:ident, )* ) => {
+        extern "C" {
+            $(
+                // TODO(randomPoison): Temporarily pub until init fns are deduplicated.
+                pub(crate) fn $name(
+                    dst: *mut pixel,
+                    dst_stride: ptrdiff_t,
+                    left: const_left_pixel_row,
+                    lpf: *const pixel,
+                    w: libc::c_int,
+                    h: libc::c_int,
+                    params: *const LooprestorationParams,
+                    edges: LrEdgeFlags,
+                    bitdepth_max: libc::c_int,
+                );
+            )*
+        }
+    };
+}
+
 #[cfg(all(
     feature = "bitdepth_8",
     feature = "asm",
     any(target_arch = "x86", target_arch = "x86_64"),
 ))]
-extern "C" {
-    pub(crate) fn dav1d_wiener_filter7_8bpc_sse2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_wiener_filter5_8bpc_sse2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_wiener_filter7_8bpc_ssse3(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_wiener_filter5_8bpc_ssse3(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_wiener_filter5_8bpc_avx2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_wiener_filter7_8bpc_avx2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_wiener_filter7_8bpc_avx512icl(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_sgr_filter_mix_8bpc_avx512icl(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_sgr_filter_3x3_8bpc_avx512icl(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_sgr_filter_5x5_8bpc_avx512icl(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_sgr_filter_mix_8bpc_avx2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_sgr_filter_3x3_8bpc_avx2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_sgr_filter_5x5_8bpc_avx2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_sgr_filter_mix_8bpc_ssse3(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_sgr_filter_3x3_8bpc_ssse3(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_sgr_filter_5x5_8bpc_ssse3(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
+extern_fn! {
+    dav1d_wiener_filter7_8bpc_sse2,
+    dav1d_wiener_filter5_8bpc_sse2,
+    dav1d_wiener_filter7_8bpc_ssse3,
+    dav1d_wiener_filter5_8bpc_ssse3,
+    dav1d_wiener_filter5_8bpc_avx2,
+    dav1d_wiener_filter7_8bpc_avx2,
+    dav1d_wiener_filter7_8bpc_avx512icl,
+    dav1d_sgr_filter_mix_8bpc_avx512icl,
+    dav1d_sgr_filter_3x3_8bpc_avx512icl,
+    dav1d_sgr_filter_5x5_8bpc_avx512icl,
+    dav1d_sgr_filter_mix_8bpc_avx2,
+    dav1d_sgr_filter_3x3_8bpc_avx2,
+    dav1d_sgr_filter_5x5_8bpc_avx2,
+    dav1d_sgr_filter_mix_8bpc_ssse3,
+    dav1d_sgr_filter_3x3_8bpc_ssse3,
+    dav1d_sgr_filter_5x5_8bpc_ssse3,
 }
 
-// TODO(randomPoison): Temporarily pub until init fns are deduplicated.
 #[cfg(all(
     feature = "bitdepth_16",
     feature = "asm",
     any(target_arch = "x86", target_arch = "x86_64"),
 ))]
-extern "C" {
-    pub(crate) fn dav1d_wiener_filter5_16bpc_ssse3(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_wiener_filter7_16bpc_ssse3(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_wiener_filter5_16bpc_avx2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_wiener_filter7_16bpc_avx2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_wiener_filter5_16bpc_avx512icl(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_wiener_filter7_16bpc_avx512icl(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_sgr_filter_mix_16bpc_ssse3(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_sgr_filter_3x3_16bpc_ssse3(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_sgr_filter_5x5_16bpc_ssse3(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_sgr_filter_mix_16bpc_avx2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_sgr_filter_3x3_16bpc_avx2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_sgr_filter_5x5_16bpc_avx2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_sgr_filter_5x5_16bpc_avx512icl(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_sgr_filter_3x3_16bpc_avx512icl(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_sgr_filter_mix_16bpc_avx512icl(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
+extern_fn! {
+    dav1d_wiener_filter5_16bpc_ssse3,
+    dav1d_wiener_filter7_16bpc_ssse3,
+    dav1d_wiener_filter5_16bpc_avx2,
+    dav1d_wiener_filter7_16bpc_avx2,
+    dav1d_wiener_filter5_16bpc_avx512icl,
+    dav1d_wiener_filter7_16bpc_avx512icl,
+    dav1d_sgr_filter_mix_16bpc_ssse3,
+    dav1d_sgr_filter_3x3_16bpc_ssse3,
+    dav1d_sgr_filter_5x5_16bpc_ssse3,
+    dav1d_sgr_filter_mix_16bpc_avx2,
+    dav1d_sgr_filter_3x3_16bpc_avx2,
+    dav1d_sgr_filter_5x5_16bpc_avx2,
+    dav1d_sgr_filter_5x5_16bpc_avx512icl,
+    dav1d_sgr_filter_3x3_16bpc_avx512icl,
+    dav1d_sgr_filter_mix_16bpc_avx512icl,
 }
 
-// TODO(randomPoison): Temporarily pub until init fns are deduplicated.
-#[cfg(all(
-    feature = "bitdepth_16",
-    feature = "asm",
-    any(target_arch = "arm", target_arch = "aarch64"),
-))]
-extern "C" {
-    pub(crate) fn dav1d_wiener_filter7_16bpc_neon(
-        p: *mut pixel,
-        stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_wiener_filter5_16bpc_neon(
-        p: *mut pixel,
-        stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-}
-
-// TODO(randomPoison): Temporarily pub until init fns are deduplicated.
 #[cfg(all(
     feature = "bitdepth_8",
     feature = "asm",
     any(target_arch = "arm", target_arch = "aarch64"),
 ))]
-extern "C" {
-    pub(crate) fn dav1d_wiener_filter7_8bpc_neon(
-        p: *mut pixel,
-        stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_wiener_filter5_8bpc_neon(
-        p: *mut pixel,
-        stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
+extern_fn! {
+    dav1d_wiener_filter7_8bpc_neon,
+    dav1d_wiener_filter5_8bpc_neon,
+}
+
+#[cfg(all(
+    feature = "bitdepth_16",
+    feature = "asm",
+    any(target_arch = "arm", target_arch = "aarch64"),
+))]
+extern_fn! {
+    dav1d_wiener_filter7_16bpc_neon,
+    dav1d_wiener_filter5_16bpc_neon,
 }

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -49,7 +49,7 @@ pub struct Dav1dLoopRestorationDSPContext {
     pub sgr: [looprestorationfilter_fn; 3],
 }
 
-macro_rules! decl_looprestorationfilter_fn {
+macro_rules! decl_looprestorationfilter_fns {
     ( $( fn $name:ident, )* ) => {
         extern "C" {
             $(
@@ -75,7 +75,7 @@ macro_rules! decl_looprestorationfilter_fn {
     feature = "asm",
     any(target_arch = "x86", target_arch = "x86_64"),
 ))]
-decl_looprestorationfilter_fn! {
+decl_looprestorationfilter_fns! {
     fn dav1d_wiener_filter7_8bpc_sse2,
     fn dav1d_wiener_filter5_8bpc_sse2,
     fn dav1d_wiener_filter7_8bpc_ssse3,
@@ -99,7 +99,7 @@ decl_looprestorationfilter_fn! {
     feature = "asm",
     any(target_arch = "x86", target_arch = "x86_64"),
 ))]
-decl_looprestorationfilter_fn! {
+decl_looprestorationfilter_fns! {
     fn dav1d_wiener_filter5_16bpc_ssse3,
     fn dav1d_wiener_filter7_16bpc_ssse3,
     fn dav1d_wiener_filter5_16bpc_avx2,
@@ -122,7 +122,7 @@ decl_looprestorationfilter_fn! {
     feature = "asm",
     any(target_arch = "arm", target_arch = "aarch64"),
 ))]
-decl_looprestorationfilter_fn! {
+decl_looprestorationfilter_fns! {
     fn dav1d_wiener_filter7_8bpc_neon,
     fn dav1d_wiener_filter5_8bpc_neon,
 }
@@ -132,7 +132,7 @@ decl_looprestorationfilter_fn! {
     feature = "asm",
     any(target_arch = "arm", target_arch = "aarch64"),
 ))]
-decl_looprestorationfilter_fn! {
+decl_looprestorationfilter_fns! {
     fn dav1d_wiener_filter7_16bpc_neon,
     fn dav1d_wiener_filter5_16bpc_neon,
 }

--- a/src/looprestoration_tmpl_16.rs
+++ b/src/looprestoration_tmpl_16.rs
@@ -332,25 +332,7 @@ use crate::src::looprestoration::LR_HAVE_TOP;
 pub type const_left_pixel_row = *const [pixel; 4];
 use crate::src::looprestoration::LooprestorationParams;
 
-pub type looprestorationfilter_fn = Option<
-    unsafe extern "C" fn(
-        *mut pixel,
-        ptrdiff_t,
-        const_left_pixel_row,
-        *const pixel,
-        libc::c_int,
-        libc::c_int,
-        *const LooprestorationParams,
-        LrEdgeFlags,
-        libc::c_int,
-    ) -> (),
->;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dLoopRestorationDSPContext {
-    pub wiener: [looprestorationfilter_fn; 2],
-    pub sgr: [looprestorationfilter_fn; 3],
-}
+use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 use crate::include::common::attributes::clz;
 use crate::include::common::intops::iclip;
 use crate::include::common::intops::imax;

--- a/src/looprestoration_tmpl_16.rs
+++ b/src/looprestoration_tmpl_16.rs
@@ -141,11 +141,11 @@ use crate::src::looprestoration::LR_HAVE_TOP;
 pub type const_left_pixel_row = *const [pixel; 4];
 use crate::src::looprestoration::LooprestorationParams;
 
-use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 use crate::include::common::attributes::clz;
 use crate::include::common::intops::iclip;
 use crate::include::common::intops::imax;
 use crate::include::common::intops::umin;
+use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 #[inline]
 unsafe extern "C" fn pixel_set(dst: *mut pixel, val: libc::c_int, num: libc::c_int) {
     let mut n = 0;
@@ -938,8 +938,8 @@ unsafe extern "C" fn loop_restoration_dsp_init_x86(
     c: *mut Dav1dLoopRestorationDSPContext,
     bpc: libc::c_int,
 ) {
-    use crate::src::x86::cpu::*;
     use crate::src::looprestoration::*;
+    use crate::src::x86::cpu::*;
 
     let flags = dav1d_get_cpu_flags();
 
@@ -1120,7 +1120,6 @@ unsafe extern "C" fn loop_restoration_dsp_init_arm(
         (*c).sgr[2] = Some(sgr_filter_mix_neon_erased);
     }
 }
-
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 unsafe extern "C" fn sgr_filter_3x3_neon_erased(

--- a/src/looprestoration_tmpl_16.rs
+++ b/src/looprestoration_tmpl_16.rs
@@ -938,6 +938,7 @@ unsafe extern "C" fn loop_restoration_dsp_init_x86(
     c: *mut Dav1dLoopRestorationDSPContext,
     bpc: libc::c_int,
 ) {
+    // TODO(randomPoison): Import temporarily needed until init fns are deduplicated.
     use crate::src::looprestoration::*;
     use crate::src::x86::cpu::*;
 
@@ -992,10 +993,10 @@ unsafe extern "C" fn loop_restoration_dsp_init_x86(
 
 #[cfg(all(feature = "asm", target_arch = "arm"))]
 unsafe extern "C" fn wiener_filter_neon_erased(
-    mut p: *mut libc::c_void,
+    p: *mut libc::c_void,
     stride: ptrdiff_t,
     left: *const libc::c_void,
-    mut lpf: *const libc::c_void,
+    lpf: *const libc::c_void,
     w: libc::c_int,
     h: libc::c_int,
     params: *const LooprestorationParams,
@@ -1095,6 +1096,7 @@ unsafe extern "C" fn loop_restoration_dsp_init_arm(
     mut bpc: libc::c_int,
 ) {
     use crate::src::arm::cpu::DAV1D_ARM_CPU_FLAG_NEON;
+    // TODO(randomPoison): Import temporarily needed until init fns are deduplicated.
     #[cfg(target_arch = "aarch64")]
     use crate::src::looprestoration::*;
 
@@ -1123,10 +1125,10 @@ unsafe extern "C" fn loop_restoration_dsp_init_arm(
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 unsafe extern "C" fn sgr_filter_3x3_neon_erased(
-    mut p: *mut libc::c_void,
+    p: *mut libc::c_void,
     stride: ptrdiff_t,
     left: *const libc::c_void,
-    mut lpf: *const libc::c_void,
+    lpf: *const libc::c_void,
     w: libc::c_int,
     h: libc::c_int,
     params: *const LooprestorationParams,
@@ -1296,10 +1298,10 @@ unsafe extern "C" fn dav1d_sgr_filter2_neon(
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 unsafe extern "C" fn sgr_filter_5x5_neon_erased(
-    mut p: *mut libc::c_void,
+    p: *mut libc::c_void,
     stride: ptrdiff_t,
     left: *const libc::c_void,
-    mut lpf: *const libc::c_void,
+    lpf: *const libc::c_void,
     w: libc::c_int,
     h: libc::c_int,
     params: *const LooprestorationParams,
@@ -1359,10 +1361,10 @@ unsafe extern "C" fn sgr_filter_5x5_neon(
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 unsafe extern "C" fn sgr_filter_mix_neon_erased(
-    mut p: *mut libc::c_void,
+    p: *mut libc::c_void,
     stride: ptrdiff_t,
     left: *const libc::c_void,
-    mut lpf: *const libc::c_void,
+    lpf: *const libc::c_void,
     w: libc::c_int,
     h: libc::c_int,
     params: *const LooprestorationParams,

--- a/src/looprestoration_tmpl_16.rs
+++ b/src/looprestoration_tmpl_16.rs
@@ -9,175 +9,6 @@ extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
 }
 
-#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
-extern "C" {
-    fn dav1d_wiener_filter5_16bpc_ssse3(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    fn dav1d_wiener_filter7_16bpc_ssse3(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    fn dav1d_wiener_filter5_16bpc_avx2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    fn dav1d_wiener_filter7_16bpc_avx2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    fn dav1d_wiener_filter5_16bpc_avx512icl(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    fn dav1d_wiener_filter7_16bpc_avx512icl(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    fn dav1d_sgr_filter_mix_16bpc_ssse3(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    fn dav1d_sgr_filter_3x3_16bpc_ssse3(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    fn dav1d_sgr_filter_5x5_16bpc_ssse3(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    fn dav1d_sgr_filter_mix_16bpc_avx2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    fn dav1d_sgr_filter_3x3_16bpc_avx2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    fn dav1d_sgr_filter_5x5_16bpc_avx2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    fn dav1d_sgr_filter_5x5_16bpc_avx512icl(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    fn dav1d_sgr_filter_3x3_16bpc_avx512icl(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    fn dav1d_sgr_filter_mix_16bpc_avx512icl(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-}
-
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 extern "C" {
     fn dav1d_wiener_filter7_16bpc_neon(
@@ -525,7 +356,32 @@ unsafe extern "C" fn padding(
         }
     };
 }
+
 unsafe extern "C" fn wiener_c(
+    mut p: *mut libc::c_void,
+    stride: ptrdiff_t,
+    left: *const libc::c_void,
+    mut lpf: *const libc::c_void,
+    w: libc::c_int,
+    h: libc::c_int,
+    params: *const LooprestorationParams,
+    edges: LrEdgeFlags,
+    bitdepth_max: libc::c_int,
+) {
+    wiener_rust(
+        p.cast(),
+        stride,
+        left.cast(),
+        lpf.cast(),
+        w,
+        h,
+        params,
+        edges,
+        bitdepth_max,
+    )
+}
+
+unsafe extern "C" fn wiener_rust(
     mut p: *mut pixel,
     stride: ptrdiff_t,
     left: *const [pixel; 4],
@@ -887,7 +743,32 @@ unsafe extern "C" fn selfguided_filter(
         }
     };
 }
+
 unsafe extern "C" fn sgr_5x5_c(
+    mut p: *mut libc::c_void,
+    stride: ptrdiff_t,
+    left: *const libc::c_void,
+    mut lpf: *const libc::c_void,
+    w: libc::c_int,
+    h: libc::c_int,
+    params: *const LooprestorationParams,
+    edges: LrEdgeFlags,
+    bitdepth_max: libc::c_int,
+) {
+    sgr_5x5_rust(
+        p.cast(),
+        stride,
+        left.cast(),
+        lpf.cast(),
+        w,
+        h,
+        params,
+        edges,
+        bitdepth_max,
+    )
+}
+
+unsafe extern "C" fn sgr_5x5_rust(
     mut p: *mut pixel,
     stride: ptrdiff_t,
     left: *const [pixel; 4],
@@ -928,7 +809,32 @@ unsafe extern "C" fn sgr_5x5_c(
         j += 1;
     }
 }
+
 unsafe extern "C" fn sgr_3x3_c(
+    mut p: *mut libc::c_void,
+    stride: ptrdiff_t,
+    left: *const libc::c_void,
+    mut lpf: *const libc::c_void,
+    w: libc::c_int,
+    h: libc::c_int,
+    params: *const LooprestorationParams,
+    edges: LrEdgeFlags,
+    bitdepth_max: libc::c_int,
+) {
+    sgr_3x3_rust(
+        p.cast(),
+        stride,
+        left.cast(),
+        lpf.cast(),
+        w,
+        h,
+        params,
+        edges,
+        bitdepth_max,
+    )
+}
+
+unsafe extern "C" fn sgr_3x3_rust(
     mut p: *mut pixel,
     stride: ptrdiff_t,
     left: *const [pixel; 4],
@@ -969,7 +875,32 @@ unsafe extern "C" fn sgr_3x3_c(
         j += 1;
     }
 }
+
 unsafe extern "C" fn sgr_mix_c(
+    mut p: *mut libc::c_void,
+    stride: ptrdiff_t,
+    left: *const libc::c_void,
+    mut lpf: *const libc::c_void,
+    w: libc::c_int,
+    h: libc::c_int,
+    params: *const LooprestorationParams,
+    edges: LrEdgeFlags,
+    bitdepth_max: libc::c_int,
+) {
+    sgr_mix_rust(
+        p.cast(),
+        stride,
+        left.cast(),
+        lpf.cast(),
+        w,
+        h,
+        params,
+        edges,
+        bitdepth_max,
+    )
+}
+
+unsafe extern "C" fn sgr_mix_rust(
     mut p: *mut pixel,
     stride: ptrdiff_t,
     left: *const [pixel; 4],
@@ -1030,6 +961,7 @@ unsafe extern "C" fn loop_restoration_dsp_init_x86(
     bpc: libc::c_int,
 ) {
     use crate::src::x86::cpu::*;
+    use crate::src::looprestoration::*;
 
     let flags = dav1d_get_cpu_flags();
 

--- a/src/looprestoration_tmpl_8.rs
+++ b/src/looprestoration_tmpl_8.rs
@@ -909,6 +909,7 @@ unsafe extern "C" fn loop_restoration_dsp_init_x86(
     c: *mut Dav1dLoopRestorationDSPContext,
     _bpc: libc::c_int,
 ) {
+    // TODO(randomPoison): Import temporarily needed until init fns are deduplicated.
     use crate::src::looprestoration::*;
     use crate::src::x86::cpu::*;
 
@@ -960,10 +961,10 @@ unsafe extern "C" fn loop_restoration_dsp_init_x86(
 
 #[cfg(all(feature = "asm", target_arch = "arm"))]
 unsafe extern "C" fn wiener_filter_neon_erased(
-    mut p: *mut libc::c_void,
+    p: *mut libc::c_void,
     stride: ptrdiff_t,
     left: *const libc::c_void,
-    mut lpf: *const libc::c_void,
+    lpf: *const libc::c_void,
     w: libc::c_int,
     h: libc::c_int,
     params: *const LooprestorationParams,
@@ -1056,6 +1057,7 @@ unsafe extern "C" fn loop_restoration_dsp_init_arm(
     mut _bpc: libc::c_int,
 ) {
     use crate::src::arm::cpu::DAV1D_ARM_CPU_FLAG_NEON;
+    // TODO(randomPoison): Import temporarily needed until init fns are deduplicated.
     #[cfg(target_arch = "aarch64")]
     use crate::src::looprestoration::*;
 
@@ -1190,10 +1192,10 @@ unsafe extern "C" fn dav1d_sgr_filter2_neon(
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 unsafe extern "C" fn sgr_filter_5x5_neon_erased(
-    mut p: *mut libc::c_void,
+    p: *mut libc::c_void,
     stride: ptrdiff_t,
     left: *const libc::c_void,
-    mut lpf: *const libc::c_void,
+    lpf: *const libc::c_void,
     w: libc::c_int,
     h: libc::c_int,
     params: *const LooprestorationParams,
@@ -1249,10 +1251,10 @@ unsafe extern "C" fn sgr_filter_5x5_neon(
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 unsafe extern "C" fn sgr_filter_3x3_neon_erased(
-    mut p: *mut libc::c_void,
+    p: *mut libc::c_void,
     stride: ptrdiff_t,
     left: *const libc::c_void,
-    mut lpf: *const libc::c_void,
+    lpf: *const libc::c_void,
     w: libc::c_int,
     h: libc::c_int,
     params: *const LooprestorationParams,
@@ -1308,10 +1310,10 @@ unsafe extern "C" fn sgr_filter_3x3_neon(
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 unsafe extern "C" fn sgr_filter_mix_neon_erased(
-    mut p: *mut libc::c_void,
+    p: *mut libc::c_void,
     stride: ptrdiff_t,
     left: *const libc::c_void,
-    mut lpf: *const libc::c_void,
+    lpf: *const libc::c_void,
     w: libc::c_int,
     h: libc::c_int,
     params: *const LooprestorationParams,

--- a/src/looprestoration_tmpl_8.rs
+++ b/src/looprestoration_tmpl_8.rs
@@ -323,25 +323,8 @@ use crate::src::looprestoration::LR_HAVE_RIGHT;
 use crate::src::looprestoration::LR_HAVE_TOP;
 pub type const_left_pixel_row = *const [pixel; 4];
 use crate::src::looprestoration::LooprestorationParams;
+use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 
-pub type looprestorationfilter_fn = Option<
-    unsafe extern "C" fn(
-        *mut pixel,
-        ptrdiff_t,
-        const_left_pixel_row,
-        *const pixel,
-        libc::c_int,
-        libc::c_int,
-        *const LooprestorationParams,
-        LrEdgeFlags,
-    ) -> (),
->;
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dLoopRestorationDSPContext {
-    pub wiener: [looprestorationfilter_fn; 2],
-    pub sgr: [looprestorationfilter_fn; 3],
-}
 use crate::include::common::intops::iclip;
 use crate::include::common::intops::iclip_u8;
 use crate::include::common::intops::imax;

--- a/src/looprestoration_tmpl_8.rs
+++ b/src/looprestoration_tmpl_8.rs
@@ -11,170 +11,6 @@ extern "C" {
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: size_t) -> *mut libc::c_void;
 }
 
-#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
-extern "C" {
-    fn dav1d_wiener_filter7_8bpc_sse2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-    );
-    fn dav1d_wiener_filter5_8bpc_sse2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-    );
-    fn dav1d_wiener_filter7_8bpc_ssse3(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-    );
-    fn dav1d_wiener_filter5_8bpc_ssse3(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-    );
-    fn dav1d_wiener_filter5_8bpc_avx2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-    );
-    fn dav1d_wiener_filter7_8bpc_avx2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-    );
-    fn dav1d_wiener_filter7_8bpc_avx512icl(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-    );
-    fn dav1d_sgr_filter_mix_8bpc_avx512icl(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-    );
-    fn dav1d_sgr_filter_3x3_8bpc_avx512icl(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-    );
-    fn dav1d_sgr_filter_5x5_8bpc_avx512icl(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-    );
-    fn dav1d_sgr_filter_mix_8bpc_avx2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-    );
-    fn dav1d_sgr_filter_3x3_8bpc_avx2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-    );
-    fn dav1d_sgr_filter_5x5_8bpc_avx2(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-    );
-    fn dav1d_sgr_filter_mix_8bpc_ssse3(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-    );
-    fn dav1d_sgr_filter_3x3_8bpc_ssse3(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-    );
-    fn dav1d_sgr_filter_5x5_8bpc_ssse3(
-        dst: *mut pixel,
-        dst_stride: ptrdiff_t,
-        left: const_left_pixel_row,
-        lpf: *const pixel,
-        w: libc::c_int,
-        h: libc::c_int,
-        params: *const LooprestorationParams,
-        edges: LrEdgeFlags,
-    );
-}
-
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 extern "C" {
     fn dav1d_sgr_box5_h_8bpc_neon(
@@ -322,8 +158,8 @@ use crate::src::looprestoration::LR_HAVE_LEFT;
 use crate::src::looprestoration::LR_HAVE_RIGHT;
 use crate::src::looprestoration::LR_HAVE_TOP;
 pub type const_left_pixel_row = *const [pixel; 4];
-use crate::src::looprestoration::LooprestorationParams;
 use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
+use crate::src::looprestoration::LooprestorationParams;
 
 use crate::include::common::intops::iclip;
 use crate::include::common::intops::iclip_u8;
@@ -502,7 +338,31 @@ unsafe extern "C" fn padding(
         }
     };
 }
+
 unsafe extern "C" fn wiener_c(
+    mut p: *mut libc::c_void,
+    stride: ptrdiff_t,
+    left: *const libc::c_void,
+    mut lpf: *const libc::c_void,
+    w: libc::c_int,
+    h: libc::c_int,
+    params: *const LooprestorationParams,
+    edges: LrEdgeFlags,
+    _bitdepth_max: libc::c_int,
+) {
+    wiener_rust(
+        p.cast(),
+        stride,
+        left.cast(),
+        lpf.cast(),
+        w,
+        h,
+        params,
+        edges,
+    )
+}
+
+unsafe extern "C" fn wiener_rust(
     mut p: *mut pixel,
     stride: ptrdiff_t,
     left: *const [pixel; 4],
@@ -867,7 +727,31 @@ unsafe extern "C" fn selfguided_filter(
         }
     };
 }
+
 unsafe extern "C" fn sgr_5x5_c(
+    mut p: *mut libc::c_void,
+    stride: ptrdiff_t,
+    left: *const libc::c_void,
+    mut lpf: *const libc::c_void,
+    w: libc::c_int,
+    h: libc::c_int,
+    params: *const LooprestorationParams,
+    edges: LrEdgeFlags,
+    _bitdepth_max: libc::c_int,
+) {
+    sgr_5x5_rust(
+        p.cast(),
+        stride,
+        left.cast(),
+        lpf.cast(),
+        w,
+        h,
+        params,
+        edges,
+    )
+}
+
+unsafe extern "C" fn sgr_5x5_rust(
     mut p: *mut pixel,
     stride: ptrdiff_t,
     left: *const [pixel; 4],
@@ -904,7 +788,31 @@ unsafe extern "C" fn sgr_5x5_c(
         j += 1;
     }
 }
+
 unsafe extern "C" fn sgr_3x3_c(
+    mut p: *mut libc::c_void,
+    stride: ptrdiff_t,
+    left: *const libc::c_void,
+    mut lpf: *const libc::c_void,
+    w: libc::c_int,
+    h: libc::c_int,
+    params: *const LooprestorationParams,
+    edges: LrEdgeFlags,
+    _bitdepth_max: libc::c_int,
+) {
+    sgr_3x3_rust(
+        p.cast(),
+        stride,
+        left.cast(),
+        lpf.cast(),
+        w,
+        h,
+        params,
+        edges,
+    )
+}
+
+unsafe extern "C" fn sgr_3x3_rust(
     mut p: *mut pixel,
     stride: ptrdiff_t,
     left: *const [pixel; 4],
@@ -941,7 +849,31 @@ unsafe extern "C" fn sgr_3x3_c(
         j += 1;
     }
 }
+
 unsafe extern "C" fn sgr_mix_c(
+    mut p: *mut libc::c_void,
+    stride: ptrdiff_t,
+    left: *const libc::c_void,
+    mut lpf: *const libc::c_void,
+    w: libc::c_int,
+    h: libc::c_int,
+    params: *const LooprestorationParams,
+    edges: LrEdgeFlags,
+    _bitdepth_max: libc::c_int,
+) {
+    sgr_mix_rust(
+        p.cast(),
+        stride,
+        left.cast(),
+        lpf.cast(),
+        w,
+        h,
+        params,
+        edges,
+    )
+}
+
+unsafe extern "C" fn sgr_mix_rust(
     mut p: *mut pixel,
     stride: ptrdiff_t,
     left: *const [pixel; 4],
@@ -997,6 +929,7 @@ unsafe extern "C" fn loop_restoration_dsp_init_x86(
     c: *mut Dav1dLoopRestorationDSPContext,
     _bpc: libc::c_int,
 ) {
+    use crate::src::looprestoration::*;
     use crate::src::x86::cpu::*;
 
     let flags = dav1d_get_cpu_flags();

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -244,8 +244,8 @@ pub struct Dav1dDSPContext {
     pub cdef: Dav1dCdefDSPContext,
     pub lr: Dav1dLoopRestorationDSPContext,
 }
-use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 use crate::src::looprestoration::looprestorationfilter_fn;
+use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 use crate::src::looprestoration::LooprestorationParams;
 use crate::src::looprestoration::LrEdgeFlags;
 use crate::src::looprestoration::LR_HAVE_BOTTOM;

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -244,25 +244,8 @@ pub struct Dav1dDSPContext {
     pub cdef: Dav1dCdefDSPContext,
     pub lr: Dav1dLoopRestorationDSPContext,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dLoopRestorationDSPContext {
-    pub wiener: [looprestorationfilter_fn; 2],
-    pub sgr: [looprestorationfilter_fn; 3],
-}
-pub type looprestorationfilter_fn = Option<
-    unsafe extern "C" fn(
-        *mut pixel,
-        ptrdiff_t,
-        const_left_pixel_row,
-        *const pixel,
-        libc::c_int,
-        libc::c_int,
-        *const LooprestorationParams,
-        LrEdgeFlags,
-        libc::c_int,
-    ) -> (),
->;
+use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
+use crate::src::looprestoration::looprestorationfilter_fn;
 use crate::src::looprestoration::LooprestorationParams;
 use crate::src::looprestoration::LrEdgeFlags;
 use crate::src::looprestoration::LR_HAVE_BOTTOM;
@@ -270,7 +253,6 @@ use crate::src::looprestoration::LR_HAVE_LEFT;
 use crate::src::looprestoration::LR_HAVE_RIGHT;
 use crate::src::looprestoration::LR_HAVE_TOP;
 
-pub type const_left_pixel_row = *const [pixel; 4];
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dCdefDSPContext {

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -715,10 +715,10 @@ unsafe extern "C" fn lr_stripe(
                     & LR_HAVE_BOTTOM as libc::c_int as libc::c_uint,
         );
         lr_fn.expect("non-null function pointer")(
-            p,
+            p.cast(),
             stride,
-            left,
-            lpf,
+            left.cast(),
+            lpf.cast(),
             unit_w,
             stripe_h,
             &mut params,

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -245,24 +245,8 @@ pub struct Dav1dDSPContext {
     pub cdef: Dav1dCdefDSPContext,
     pub lr: Dav1dLoopRestorationDSPContext,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dLoopRestorationDSPContext {
-    pub wiener: [looprestorationfilter_fn; 2],
-    pub sgr: [looprestorationfilter_fn; 3],
-}
-pub type looprestorationfilter_fn = Option<
-    unsafe extern "C" fn(
-        *mut pixel,
-        ptrdiff_t,
-        const_left_pixel_row,
-        *const pixel,
-        libc::c_int,
-        libc::c_int,
-        *const LooprestorationParams,
-        LrEdgeFlags,
-    ) -> (),
->;
+use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
+use crate::src::looprestoration::looprestorationfilter_fn;
 use crate::src::looprestoration::LooprestorationParams;
 use crate::src::looprestoration::LrEdgeFlags;
 use crate::src::looprestoration::LR_HAVE_BOTTOM;
@@ -270,7 +254,6 @@ use crate::src::looprestoration::LR_HAVE_LEFT;
 use crate::src::looprestoration::LR_HAVE_RIGHT;
 use crate::src::looprestoration::LR_HAVE_TOP;
 
-pub type const_left_pixel_row = *const [pixel; 4];
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dCdefDSPContext {

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -245,8 +245,8 @@ pub struct Dav1dDSPContext {
     pub cdef: Dav1dCdefDSPContext,
     pub lr: Dav1dLoopRestorationDSPContext,
 }
-use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 use crate::src::looprestoration::looprestorationfilter_fn;
+use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 use crate::src::looprestoration::LooprestorationParams;
 use crate::src::looprestoration::LrEdgeFlags;
 use crate::src::looprestoration::LR_HAVE_BOTTOM;

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -688,14 +688,15 @@ unsafe extern "C" fn lr_stripe(
                     & LR_HAVE_BOTTOM as libc::c_int as libc::c_uint,
         );
         lr_fn.expect("non-null function pointer")(
-            p,
+            p.cast(),
             stride,
-            left,
-            lpf,
+            left.cast(),
+            lpf.cast(),
             unit_w,
             stripe_h,
             &mut params,
             edges,
+            8,
         );
         left = left.offset(stripe_h as isize);
         y += stripe_h;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -323,28 +323,7 @@ pub struct Dav1dDSPContext {
     pub cdef: Dav1dCdefDSPContext,
     pub lr: Dav1dLoopRestorationDSPContext,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dLoopRestorationDSPContext {
-    pub wiener: [looprestorationfilter_fn; 2],
-    pub sgr: [looprestorationfilter_fn; 3],
-}
-pub type looprestorationfilter_fn = Option<
-    unsafe extern "C" fn(
-        *mut libc::c_void,
-        ptrdiff_t,
-        const_left_pixel_row,
-        *const libc::c_void,
-        libc::c_int,
-        libc::c_int,
-        *const LooprestorationParams,
-        LrEdgeFlags,
-    ) -> (),
->;
-use crate::src::looprestoration::LooprestorationParams;
-use crate::src::looprestoration::LrEdgeFlags;
-
-pub type const_left_pixel_row = *const libc::c_void;
+use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dCdefDSPContext {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -256,28 +256,8 @@ pub struct Dav1dDSPContext {
     pub cdef: Dav1dCdefDSPContext,
     pub lr: Dav1dLoopRestorationDSPContext,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dLoopRestorationDSPContext {
-    pub wiener: [looprestorationfilter_fn; 2],
-    pub sgr: [looprestorationfilter_fn; 3],
-}
-pub type looprestorationfilter_fn = Option<
-    unsafe extern "C" fn(
-        *mut libc::c_void,
-        ptrdiff_t,
-        const_left_pixel_row,
-        *const libc::c_void,
-        libc::c_int,
-        libc::c_int,
-        *const LooprestorationParams,
-        LrEdgeFlags,
-    ) -> (),
->;
-use crate::src::looprestoration::LooprestorationParams;
-use crate::src::looprestoration::LrEdgeFlags;
+use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 
-pub type const_left_pixel_row = *const libc::c_void;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dCdefDSPContext {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -319,29 +319,8 @@ pub struct Dav1dDSPContext {
     pub cdef: Dav1dCdefDSPContext,
     pub lr: Dav1dLoopRestorationDSPContext,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dLoopRestorationDSPContext {
-    pub wiener: [looprestorationfilter_fn; 2],
-    pub sgr: [looprestorationfilter_fn; 3],
-}
-pub type looprestorationfilter_fn = Option<
-    unsafe extern "C" fn(
-        *mut pixel,
-        ptrdiff_t,
-        const_left_pixel_row,
-        *const pixel,
-        libc::c_int,
-        libc::c_int,
-        *const LooprestorationParams,
-        LrEdgeFlags,
-        libc::c_int,
-    ) -> (),
->;
-use crate::src::looprestoration::LooprestorationParams;
-use crate::src::looprestoration::LrEdgeFlags;
+use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 
-pub type const_left_pixel_row = *const [pixel; 4];
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dCdefDSPContext {

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -318,28 +318,8 @@ pub struct Dav1dDSPContext {
     pub cdef: Dav1dCdefDSPContext,
     pub lr: Dav1dLoopRestorationDSPContext,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dLoopRestorationDSPContext {
-    pub wiener: [looprestorationfilter_fn; 2],
-    pub sgr: [looprestorationfilter_fn; 3],
-}
-pub type looprestorationfilter_fn = Option<
-    unsafe extern "C" fn(
-        *mut pixel,
-        ptrdiff_t,
-        const_left_pixel_row,
-        *const pixel,
-        libc::c_int,
-        libc::c_int,
-        *const LooprestorationParams,
-        LrEdgeFlags,
-    ) -> (),
->;
-use crate::src::looprestoration::LooprestorationParams;
-use crate::src::looprestoration::LrEdgeFlags;
+use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 
-pub type const_left_pixel_row = *const [pixel; 4];
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dCdefDSPContext {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -312,28 +312,8 @@ pub struct Dav1dDSPContext {
     pub cdef: Dav1dCdefDSPContext,
     pub lr: Dav1dLoopRestorationDSPContext,
 }
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct Dav1dLoopRestorationDSPContext {
-    pub wiener: [looprestorationfilter_fn; 2],
-    pub sgr: [looprestorationfilter_fn; 3],
-}
-pub type looprestorationfilter_fn = Option<
-    unsafe extern "C" fn(
-        *mut libc::c_void,
-        ptrdiff_t,
-        const_left_pixel_row,
-        *const libc::c_void,
-        libc::c_int,
-        libc::c_int,
-        *const LooprestorationParams,
-        LrEdgeFlags,
-    ) -> (),
->;
-use crate::src::looprestoration::LooprestorationParams;
-use crate::src::looprestoration::LrEdgeFlags;
+use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 
-pub type const_left_pixel_row = *const libc::c_void;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dCdefDSPContext {


### PR DESCRIPTION
Alternative to #323 that approaches the problem of deduplicating bitdepth-dependent fn pointers by type-erasing the bitdepth-dependent parts. To accomplish this, the relevant `extern "C"` declarations were moved into `looprestoration.rs`, where `pixel` has been defined as `c_void`. For the 8bpc versions, an extra `bitdepth_max: c_int` argument has been added so that the 8bpc and 16bpc fns have the same signature, with the understanding that this extra argument will simply be ignored by the called asm routine. For fn pointers that are defined in Rust code, type-erased wrappers have been added..