### PR TITLE
`fn padding`: Further cleanup

### DIFF
--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -155,7 +155,7 @@ const REST_UNIT_STRIDE: usize = 390;
 pub(crate) unsafe fn padding<BD: BitDepth>(
     dst: &mut [BD::Pixel; 70 /*(64 + 3 + 3)*/ * REST_UNIT_STRIDE],
     mut p: *const BD::Pixel,
-    stride: ptrdiff_t,
+    stride: usize,
     mut left: *const [BD::Pixel; 4],
     mut lpf: *const BD::Pixel,
     mut unit_w: usize,
@@ -322,7 +322,14 @@ unsafe fn wiener_rust<BD: BitDepth>(
     let mut tmp_ptr: *mut BD::Pixel = tmp.as_mut_ptr();
 
     padding::<BD>(
-        &mut tmp, p, stride, left, lpf, w as usize, h as usize, edges,
+        &mut tmp,
+        p,
+        stride as usize,
+        left,
+        lpf,
+        w as usize,
+        h as usize,
+        edges,
     );
 
     let mut hor: [uint16_t; 27300] = [0; 27300];
@@ -745,7 +752,14 @@ unsafe fn sgr_5x5_rust<BD: BitDepth>(
     let mut tmp: [BD::Pixel; 27300] = [0.as_(); 27300];
     let mut dst: [BD::Coef; 24576] = [0.as_(); 24576];
     padding::<BD>(
-        &mut tmp, p, stride, left, lpf, w as usize, h as usize, edges,
+        &mut tmp,
+        p,
+        stride as usize,
+        left,
+        lpf,
+        w as usize,
+        h as usize,
+        edges,
     );
     selfguided_filter(
         dst.as_mut_ptr(),
@@ -813,7 +827,14 @@ unsafe fn sgr_3x3_rust<BD: BitDepth>(
     let mut tmp: [BD::Pixel; 27300] = [0.as_(); 27300];
     let mut dst: [BD::Coef; 24576] = [0.as_(); 24576];
     padding::<BD>(
-        &mut tmp, p, stride, left, lpf, w as usize, h as usize, edges,
+        &mut tmp,
+        p,
+        stride as usize,
+        left,
+        lpf,
+        w as usize,
+        h as usize,
+        edges,
     );
     selfguided_filter(
         dst.as_mut_ptr(),
@@ -882,7 +903,14 @@ unsafe fn sgr_mix_rust<BD: BitDepth>(
     let mut dst0: [BD::Coef; 24576] = [0.as_(); 24576];
     let mut dst1: [BD::Coef; 24576] = [0.as_(); 24576];
     padding::<BD>(
-        &mut tmp, p, stride, left, lpf, w as usize, h as usize, edges,
+        &mut tmp,
+        p,
+        stride as usize,
+        left,
+        lpf,
+        w as usize,
+        h as usize,
+        edges,
     );
     selfguided_filter(
         dst0.as_mut_ptr(),

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -285,12 +285,15 @@ pub(crate) unsafe fn padding<BD: BitDepth>(
         // Pad 3x(STRIPE_H+6) with first column
         for j in 0..stripe_h as usize + 6 {
             let offset = j * REST_UNIT_STRIDE;
+            // This would be `dst_l[offset]` in C,
+            // but that results in multiple mutable borrows of `dst`,
+            // so we recalculate `dst_l` here.
+            // `3 * (have_left == 0) as libc::c_int` simplifies to `3 * 1` and then `3`.
             let val = dst[3 + offset];
             BD::pixel_set(&mut dst[offset..], val, 3);
         }
     } else {
         let dst = &mut dst[3 * REST_UNIT_STRIDE..];
-
         for j in 0..stripe_h as usize {
             BD::pixel_copy(
                 &mut dst[j * REST_UNIT_STRIDE..],

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -154,10 +154,10 @@ const REST_UNIT_STRIDE: usize = 390;
 #[inline(never)]
 pub(crate) unsafe fn padding<BD: BitDepth>(
     dst: &mut [BD::Pixel; 70 /*(64 + 3 + 3)*/ * REST_UNIT_STRIDE],
-    mut p: *const BD::Pixel,
+    p: *const BD::Pixel,
     stride: usize,
     mut left: *const [BD::Pixel; 4],
-    mut lpf: *const BD::Pixel,
+    lpf: *const BD::Pixel,
     unit_w: usize,
     stripe_h: usize,
     edges: LrEdgeFlags,
@@ -172,8 +172,8 @@ pub(crate) unsafe fn padding<BD: BitDepth>(
     // Copy more pixels if we don't have to pad them
     let unit_w = unit_w + have_left_3 + have_right_3;
     let dst_l = &mut dst[3 - have_left_3..];
-    p = p.offset(-(have_left_3 as isize));
-    lpf = lpf.offset(-(have_left_3 as isize));
+    let p = p.offset(-(have_left_3 as isize));
+    let lpf = lpf.offset(-(have_left_3 as isize));
 
     if have_top {
         // Copy previous loop filtered rows

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -177,18 +177,15 @@ pub(crate) unsafe fn padding<BD: BitDepth>(
         // Copy previous loop filtered rows
         let above_1 = std::slice::from_raw_parts(lpf, stride + unit_w as usize);
         let above_2 = &above_1[stride..];
-
         BD::pixel_copy(dst_l, above_1, unit_w as usize);
         BD::pixel_copy(&mut dst_l[REST_UNIT_STRIDE..], above_1, unit_w as usize);
         BD::pixel_copy(&mut dst_l[2 * REST_UNIT_STRIDE..], above_2, unit_w as usize);
     } else {
         // Pad with first row
         let p = std::slice::from_raw_parts(p, unit_w as usize);
-
         BD::pixel_copy(dst_l, p, unit_w as usize);
         BD::pixel_copy(&mut dst_l[REST_UNIT_STRIDE..], p, unit_w as usize);
         BD::pixel_copy(&mut dst_l[2 * REST_UNIT_STRIDE..], p, unit_w as usize);
-
         if have_left != 0 {
             let left = &(*left.offset(0))[1..];
             BD::pixel_copy(dst_l, left, 3);
@@ -202,7 +199,6 @@ pub(crate) unsafe fn padding<BD: BitDepth>(
         // Copy next loop filtered rows
         let below_1 = std::slice::from_raw_parts(lpf.offset(6 * stride as isize), unit_w as usize);
         let below_2 = std::slice::from_raw_parts(lpf.offset(7 * stride as isize), unit_w as usize);
-
         BD::pixel_copy(
             &mut dst_tl[stripe_h as usize * REST_UNIT_STRIDE..],
             below_1,
@@ -224,7 +220,6 @@ pub(crate) unsafe fn padding<BD: BitDepth>(
             p.offset(((stripe_h - 1) as isize * stride as isize) as isize),
             unit_w as usize,
         );
-
         BD::pixel_copy(
             &mut dst_tl[stripe_h as usize * REST_UNIT_STRIDE..],
             src,
@@ -240,10 +235,8 @@ pub(crate) unsafe fn padding<BD: BitDepth>(
             src,
             unit_w as usize,
         );
-
         if have_left != 0 {
             let left = &(*left.offset((stripe_h - 1) as isize))[1..];
-
             BD::pixel_copy(&mut dst_tl[stripe_h as usize * REST_UNIT_STRIDE..], left, 3);
             BD::pixel_copy(
                 &mut dst_tl[(stripe_h + 1) as usize * REST_UNIT_STRIDE..],

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -153,7 +153,7 @@ const REST_UNIT_STRIDE: usize = 390;
 // been deduplicated.
 #[inline(never)]
 pub(crate) unsafe fn padding<BD: BitDepth>(
-    mut dst: &mut [BD::Pixel; 70 /*(64 + 3 + 3)*/ * REST_UNIT_STRIDE],
+    dst: &mut [BD::Pixel; 70 /*(64 + 3 + 3)*/ * REST_UNIT_STRIDE],
     mut p: *const BD::Pixel,
     stride: ptrdiff_t,
     mut left: *const [BD::Pixel; 4],
@@ -169,7 +169,7 @@ pub(crate) unsafe fn padding<BD: BitDepth>(
 
     // Copy more pixels if we don't have to pad them
     unit_w += 3 * have_left + 3 * have_right;
-    let mut dst_l = &mut dst[(3 * (have_left == 0) as libc::c_int) as usize..];
+    let dst_l = &mut dst[(3 * (have_left == 0) as libc::c_int) as usize..];
     p = p.offset(-((3 * have_left) as isize));
     lpf = lpf.offset(-((3 * have_left) as isize));
 

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -156,7 +156,7 @@ pub(crate) unsafe fn padding<BD: BitDepth>(
     dst: &mut [BD::Pixel; 70 /*(64 + 3 + 3)*/ * REST_UNIT_STRIDE],
     p: *const BD::Pixel,
     stride: usize,
-    mut left: *const [BD::Pixel; 4],
+    left: *const [BD::Pixel; 4],
     lpf: *const BD::Pixel,
     unit_w: usize,
     stripe_h: usize,
@@ -196,7 +196,7 @@ pub(crate) unsafe fn padding<BD: BitDepth>(
         }
     }
 
-    let mut dst_tl = &mut dst_l[3 * REST_UNIT_STRIDE..];
+    let dst_tl = &mut dst_l[3 * REST_UNIT_STRIDE..];
     if have_bottom {
         // Copy next loop filtered rows
         let lpf = std::slice::from_raw_parts(lpf, 7 * stride + unit_w);

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -171,7 +171,7 @@ pub(crate) unsafe fn padding<BD: BitDepth>(
 
     // Copy more pixels if we don't have to pad them
     let unit_w = unit_w + have_left_3 + have_right_3;
-    let dst_l = &mut dst[3 * !have_left as usize..];
+    let dst_l = &mut dst[3 - have_left_3..];
     p = p.offset(-(have_left_3 as isize));
     lpf = lpf.offset(-(have_left_3 as isize));
 

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -158,7 +158,7 @@ pub(crate) unsafe fn padding<BD: BitDepth>(
     stride: usize,
     mut left: *const [BD::Pixel; 4],
     mut lpf: *const BD::Pixel,
-    mut unit_w: usize,
+    unit_w: usize,
     stripe_h: usize,
     edges: LrEdgeFlags,
 ) {
@@ -168,7 +168,7 @@ pub(crate) unsafe fn padding<BD: BitDepth>(
     let have_right = (edges & LR_HAVE_RIGHT != 0) as usize;
 
     // Copy more pixels if we don't have to pad them
-    unit_w += 3 * have_left + 3 * have_right;
+    let unit_w = unit_w + 3 * have_left + 3 * have_right;
     let dst_l = &mut dst[(3 * (have_left == 0) as libc::c_int) as usize..];
     p = p.offset(-((3 * have_left) as isize));
     lpf = lpf.offset(-((3 * have_left) as isize));


### PR DESCRIPTION
These are mostly from my comments on #330 further cleaning up `fn padding`, plus a few other things.

I also think there are other cleanups we can do that would get rid of most of the bounds checking that was added to `fn padding`.  I'll wait until #334 merges first, though.