### PR TITLE
`fn {{,w_}avg,mask,blend{,_v,_h}_{c => rust}`: Deduplicate w/ generics and cleanup/re-translate

### DIFF
--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -1,6 +1,6 @@
 use std::ffi::{c_int, c_uint};
 use std::fmt::{self, Display, Formatter};
-use std::ops::Add;
+use std::ops::{Add, Mul, Shr};
 
 use crate::include::common::intops::clip;
 
@@ -77,6 +77,9 @@ pub trait BitDepth: Clone + Copy {
 
     type Pixel: Copy
         + Ord
+        + Add<Output = Self::Pixel>
+        + Mul<Output = Self::Pixel>
+        + Shr<u8, Output = Self::Pixel>
         + From<u8>
         + Into<i32>
         + TryFrom<i32>

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -758,7 +758,8 @@ fn blend_px<BD: BitDepth>(a: BD::Pixel, b: BD::Pixel, m: u8) -> BD::Pixel {
     ((a.as_::<u32>() * (64 - m) + b.as_::<u32>() * m + 32) >> 6).as_::<BD::Pixel>()
 }
 
-unsafe fn blend_rust<BD: BitDepth>(
+// TODO(kkysen) temporarily `pub` until `mc` callers are deduplicated
+pub unsafe fn blend_rust<BD: BitDepth>(
     mut dst: *mut BD::Pixel,
     dst_stride: usize,
     mut tmp: *const BD::Pixel,

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -689,3 +689,33 @@ pub unsafe fn avg_rust<BD: BitDepth>(
         dst = dst.offset(dst_stride as isize);
     }
 }
+
+unsafe fn w_avg_rust<BD: BitDepth>(
+    bd: BD,
+    mut dst: *mut BD::Pixel,
+    dst_stride: usize,
+    mut tmp1: *const i16,
+    mut tmp2: *const i16,
+    w: usize,
+    h: usize,
+    weight: i32,
+) {
+    let intermediate_bits = bd.get_intermediate_bits();
+    let sh = intermediate_bits + 4;
+    let rnd = (8 << intermediate_bits) + i32::from(BD::PREP_BIAS) * 16;
+    let dst_stride = BD::pxstride(dst_stride);
+    for _ in 0..h {
+        for x in 0..w {
+            *dst.offset(x as isize) = bd.iclip_pixel(
+                (*tmp1.offset(x as isize) as i32 * weight
+                    + *tmp2.offset(x as isize) as i32 * (16 - weight)
+                    + rnd)
+                    >> sh,
+            );
+        }
+
+        tmp1 = tmp1.offset(w as isize);
+        tmp2 = tmp2.offset(w as isize);
+        dst = dst.offset(dst_stride as isize);
+    }
+}

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -662,14 +662,15 @@ pub unsafe fn prep_bilin_scaled_rust<BD: BitDepth>(
     }
 }
 
-unsafe fn avg_rust<BD: BitDepth>(
-    bd: BD,
+// TODO(kkysen) temporarily `pub` until `mc` callers are deduplicated
+pub unsafe fn avg_rust<BD: BitDepth>(
     mut dst: *mut BD::Pixel,
     dst_stride: usize,
     mut tmp1: *const i16,
     mut tmp2: *const i16,
     w: usize,
     h: usize,
+    bd: BD,
 ) {
     let intermediate_bits = bd.get_intermediate_bits();
     let sh = intermediate_bits + 1;

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -721,8 +721,8 @@ pub unsafe fn w_avg_rust<BD: BitDepth>(
     }
 }
 
-unsafe fn mask_rust<BD: BitDepth>(
-    bd: BD,
+// TODO(kkysen) temporarily `pub` until `mc` callers are deduplicated
+pub unsafe fn mask_rust<BD: BitDepth>(
     mut dst: *mut BD::Pixel,
     dst_stride: usize,
     mut tmp1: *const i16,
@@ -730,6 +730,7 @@ unsafe fn mask_rust<BD: BitDepth>(
     w: usize,
     h: usize,
     mut mask: *const u8,
+    bd: BD,
 ) {
     let intermediate_bits = bd.get_intermediate_bits();
     let sh = intermediate_bits + 6;

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -784,7 +784,8 @@ pub unsafe fn blend_rust<BD: BitDepth>(
     }
 }
 
-unsafe fn blend_v_rust<BD: BitDepth>(
+// TODO(kkysen) temporarily `pub` until `mc` callers are deduplicated
+pub unsafe fn blend_v_rust<BD: BitDepth>(
     mut dst: *mut BD::Pixel,
     dst_stride: usize,
     mut tmp: *const BD::Pixel,

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -804,3 +804,24 @@ pub unsafe fn blend_v_rust<BD: BitDepth>(
         tmp = tmp.offset(w as isize);
     }
 }
+
+unsafe fn blend_h_rust<BD: BitDepth>(
+    mut dst: *mut BD::Pixel,
+    dst_stride: usize,
+    mut tmp: *const BD::Pixel,
+    w: usize,
+    h: usize,
+) {
+    let mask = &dav1d_obmc_masks.0[h..];
+    let h = h * 3 >> 2;
+    let dst_stride = BD::pxstride(dst_stride);
+    for y in 0..h {
+        for x in 0..w {
+            *dst.offset(x as isize) =
+                blend_px::<BD>(*dst.offset(x as isize), *tmp.offset(x as isize), mask[y]);
+        }
+
+        dst = dst.offset(dst_stride as isize);
+        tmp = tmp.offset(w as isize);
+    }
+}

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -690,8 +690,8 @@ pub unsafe fn avg_rust<BD: BitDepth>(
     }
 }
 
-unsafe fn w_avg_rust<BD: BitDepth>(
-    bd: BD,
+// TODO(kkysen) temporarily `pub` until `mc` callers are deduplicated
+pub unsafe fn w_avg_rust<BD: BitDepth>(
     mut dst: *mut BD::Pixel,
     dst_stride: usize,
     mut tmp1: *const i16,
@@ -699,6 +699,7 @@ unsafe fn w_avg_rust<BD: BitDepth>(
     w: usize,
     h: usize,
     weight: i32,
+    bd: BD,
 ) {
     let intermediate_bits = bd.get_intermediate_bits();
     let sh = intermediate_bits + 4;

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -752,3 +752,32 @@ pub unsafe fn mask_rust<BD: BitDepth>(
         dst = dst.offset(dst_stride as isize);
     }
 }
+
+fn blend_px<BD: BitDepth>(a: BD::Pixel, b: BD::Pixel, m: u8) -> BD::Pixel {
+    let m = m as u32;
+    ((a.as_::<u32>() * (64 - m) + b.as_::<u32>() * m + 32) >> 6).as_::<BD::Pixel>()
+}
+
+unsafe fn blend_rust<BD: BitDepth>(
+    mut dst: *mut BD::Pixel,
+    dst_stride: usize,
+    mut tmp: *const BD::Pixel,
+    w: usize,
+    h: usize,
+    mut mask: *const u8,
+) {
+    let dst_stride = BD::pxstride(dst_stride);
+    for _ in 0..h {
+        for x in 0..w {
+            *dst.offset(x as isize) = blend_px::<BD>(
+                *dst.offset(x as isize),
+                *tmp.offset(x as isize),
+                *mask.offset(x as isize),
+            )
+        }
+
+        dst = dst.offset(dst_stride as isize);
+        tmp = tmp.offset(w as isize);
+        mask = mask.offset(w as isize);
+    }
+}

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -805,7 +805,8 @@ pub unsafe fn blend_v_rust<BD: BitDepth>(
     }
 }
 
-unsafe fn blend_h_rust<BD: BitDepth>(
+// TODO(kkysen) temporarily `pub` until `mc` callers are deduplicated
+pub unsafe fn blend_h_rust<BD: BitDepth>(
     mut dst: *mut BD::Pixel,
     dst_stride: usize,
     mut tmp: *const BD::Pixel,

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -720,3 +720,34 @@ pub unsafe fn w_avg_rust<BD: BitDepth>(
         dst = dst.offset(dst_stride as isize);
     }
 }
+
+unsafe fn mask_rust<BD: BitDepth>(
+    bd: BD,
+    mut dst: *mut BD::Pixel,
+    dst_stride: usize,
+    mut tmp1: *const i16,
+    mut tmp2: *const i16,
+    w: usize,
+    h: usize,
+    mut mask: *const u8,
+) {
+    let intermediate_bits = bd.get_intermediate_bits();
+    let sh = intermediate_bits + 6;
+    let rnd = (32 << intermediate_bits) + i32::from(BD::PREP_BIAS) * 64;
+    let dst_stride = BD::pxstride(dst_stride);
+    for _ in 0..h {
+        for x in 0..w {
+            *dst.offset(x as isize) = bd.iclip_pixel(
+                (*tmp1.offset(x as isize) as i32 * *mask.offset(x as isize) as i32
+                    + *tmp2.offset(x as isize) as i32 * (64 - *mask.offset(x as isize) as i32)
+                    + rnd)
+                    >> sh,
+            );
+        }
+
+        tmp1 = tmp1.offset(w as isize);
+        tmp2 = tmp2.offset(w as isize);
+        mask = mask.offset(w as isize);
+        dst = dst.offset(dst_stride as isize);
+    }
+}

--- a/src/mc_tmpl_16.rs
+++ b/src/mc_tmpl_16.rs
@@ -3136,32 +3136,16 @@ unsafe extern "C" fn mask_c(
         BitDepth16::new(bitdepth_max as u16),
     )
 }
+use crate::src::mc::blend_rust;
 unsafe extern "C" fn blend_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     dst_stride: ptrdiff_t,
-    mut tmp: *const pixel,
+    tmp: *const pixel,
     w: libc::c_int,
-    mut h: libc::c_int,
-    mut mask: *const uint8_t,
+    h: libc::c_int,
+    mask: *const uint8_t,
 ) {
-    loop {
-        let mut x = 0;
-        while x < w {
-            *dst.offset(x as isize) = (*dst.offset(x as isize) as libc::c_int
-                * (64 - *mask.offset(x as isize) as libc::c_int)
-                + *tmp.offset(x as isize) as libc::c_int * *mask.offset(x as isize) as libc::c_int
-                + 32
-                >> 6) as pixel;
-            x += 1;
-        }
-        dst = dst.offset(PXSTRIDE(dst_stride) as isize);
-        tmp = tmp.offset(w as isize);
-        mask = mask.offset(w as isize);
-        h -= 1;
-        if !(h != 0) {
-            break;
-        }
-    }
+    blend_rust::<BitDepth16>(dst, dst_stride as usize, tmp, w as usize, h as usize, mask)
 }
 unsafe extern "C" fn blend_v_c(
     mut dst: *mut pixel,

--- a/src/mc_tmpl_16.rs
+++ b/src/mc_tmpl_16.rs
@@ -3147,31 +3147,15 @@ unsafe extern "C" fn blend_c(
 ) {
     blend_rust::<BitDepth16>(dst, dst_stride as usize, tmp, w as usize, h as usize, mask)
 }
+use crate::src::mc::blend_v_rust;
 unsafe extern "C" fn blend_v_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     dst_stride: ptrdiff_t,
-    mut tmp: *const pixel,
+    tmp: *const pixel,
     w: libc::c_int,
-    mut h: libc::c_int,
+    h: libc::c_int,
 ) {
-    let mask: *const uint8_t = &*dav1d_obmc_masks.0.as_ptr().offset(w as isize) as *const uint8_t;
-    loop {
-        let mut x = 0;
-        while x < w * 3 >> 2 {
-            *dst.offset(x as isize) = (*dst.offset(x as isize) as libc::c_int
-                * (64 - *mask.offset(x as isize) as libc::c_int)
-                + *tmp.offset(x as isize) as libc::c_int * *mask.offset(x as isize) as libc::c_int
-                + 32
-                >> 6) as pixel;
-            x += 1;
-        }
-        dst = dst.offset(PXSTRIDE(dst_stride) as isize);
-        tmp = tmp.offset(w as isize);
-        h -= 1;
-        if !(h != 0) {
-            break;
-        }
-    }
+    blend_v_rust::<BitDepth16>(dst, dst_stride as usize, tmp, w as usize, h as usize)
 }
 unsafe extern "C" fn blend_h_c(
     mut dst: *mut pixel,

--- a/src/mc_tmpl_16.rs
+++ b/src/mc_tmpl_16.rs
@@ -3114,42 +3114,27 @@ unsafe extern "C" fn w_avg_c(
         BitDepth16::new(bitdepth_max as u16),
     )
 }
+use crate::src::mc::mask_rust;
 unsafe extern "C" fn mask_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     dst_stride: ptrdiff_t,
-    mut tmp1: *const int16_t,
-    mut tmp2: *const int16_t,
+    tmp1: *const int16_t,
+    tmp2: *const int16_t,
     w: libc::c_int,
-    mut h: libc::c_int,
-    mut mask: *const uint8_t,
+    h: libc::c_int,
+    mask: *const uint8_t,
     bitdepth_max: libc::c_int,
 ) {
-    let intermediate_bits = 14 as libc::c_int - (32 - clz(bitdepth_max as libc::c_uint));
-    let sh = intermediate_bits + 6;
-    let rnd = ((32 as libc::c_int) << intermediate_bits) + 8192 * 64;
-    loop {
-        let mut x = 0;
-        while x < w {
-            *dst.offset(x as isize) = iclip(
-                *tmp1.offset(x as isize) as libc::c_int * *mask.offset(x as isize) as libc::c_int
-                    + *tmp2.offset(x as isize) as libc::c_int
-                        * (64 - *mask.offset(x as isize) as libc::c_int)
-                    + rnd
-                    >> sh,
-                0 as libc::c_int,
-                bitdepth_max,
-            ) as pixel;
-            x += 1;
-        }
-        tmp1 = tmp1.offset(w as isize);
-        tmp2 = tmp2.offset(w as isize);
-        mask = mask.offset(w as isize);
-        dst = dst.offset(PXSTRIDE(dst_stride) as isize);
-        h -= 1;
-        if !(h != 0) {
-            break;
-        }
-    }
+    mask_rust(
+        dst,
+        dst_stride as usize,
+        tmp1,
+        tmp2,
+        w as usize,
+        h as usize,
+        mask,
+        BitDepth16::new(bitdepth_max as u16),
+    )
 }
 unsafe extern "C" fn blend_c(
     mut dst: *mut pixel,

--- a/src/mc_tmpl_16.rs
+++ b/src/mc_tmpl_16.rs
@@ -1846,7 +1846,6 @@ extern "C" {
 }
 
 use crate::src::tables::dav1d_mc_warp_filter;
-use crate::src::tables::dav1d_obmc_masks;
 use crate::src::tables::dav1d_resize_filter;
 
 pub type pixel = uint16_t;
@@ -3157,35 +3156,15 @@ unsafe extern "C" fn blend_v_c(
 ) {
     blend_v_rust::<BitDepth16>(dst, dst_stride as usize, tmp, w as usize, h as usize)
 }
+use crate::src::mc::blend_h_rust;
 unsafe extern "C" fn blend_h_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     dst_stride: ptrdiff_t,
-    mut tmp: *const pixel,
+    tmp: *const pixel,
     w: libc::c_int,
-    mut h: libc::c_int,
+    h: libc::c_int,
 ) {
-    let mut mask: *const uint8_t =
-        &*dav1d_obmc_masks.0.as_ptr().offset(h as isize) as *const uint8_t;
-    h = h * 3 >> 2;
-    loop {
-        let fresh0 = mask;
-        mask = mask.offset(1);
-        let m = *fresh0 as libc::c_int;
-        let mut x = 0;
-        while x < w {
-            *dst.offset(x as isize) = (*dst.offset(x as isize) as libc::c_int * (64 - m)
-                + *tmp.offset(x as isize) as libc::c_int * m
-                + 32
-                >> 6) as pixel;
-            x += 1;
-        }
-        dst = dst.offset(PXSTRIDE(dst_stride) as isize);
-        tmp = tmp.offset(w as isize);
-        h -= 1;
-        if !(h != 0) {
-            break;
-        }
-    }
+    blend_h_rust::<BitDepth16>(dst, dst_stride as usize, tmp, w as usize, h as usize)
 }
 unsafe extern "C" fn w_mask_c(
     mut dst: *mut pixel,

--- a/src/mc_tmpl_8.rs
+++ b/src/mc_tmpl_8.rs
@@ -3049,31 +3049,15 @@ unsafe extern "C" fn blend_c(
 ) {
     blend_rust::<BitDepth8>(dst, dst_stride as usize, tmp, w as usize, h as usize, mask)
 }
+use crate::src::mc::blend_v_rust;
 unsafe extern "C" fn blend_v_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     dst_stride: ptrdiff_t,
-    mut tmp: *const pixel,
+    tmp: *const pixel,
     w: libc::c_int,
-    mut h: libc::c_int,
+    h: libc::c_int,
 ) {
-    let mask: *const uint8_t = &*dav1d_obmc_masks.0.as_ptr().offset(w as isize) as *const uint8_t;
-    loop {
-        let mut x = 0;
-        while x < w * 3 >> 2 {
-            *dst.offset(x as isize) = (*dst.offset(x as isize) as libc::c_int
-                * (64 - *mask.offset(x as isize) as libc::c_int)
-                + *tmp.offset(x as isize) as libc::c_int * *mask.offset(x as isize) as libc::c_int
-                + 32
-                >> 6) as pixel;
-            x += 1;
-        }
-        dst = dst.offset(dst_stride as isize);
-        tmp = tmp.offset(w as isize);
-        h -= 1;
-        if !(h != 0) {
-            break;
-        }
-    }
+    blend_v_rust::<BitDepth8>(dst, dst_stride as usize, tmp, w as usize, h as usize)
 }
 unsafe extern "C" fn blend_h_c(
     mut dst: *mut pixel,

--- a/src/mc_tmpl_8.rs
+++ b/src/mc_tmpl_8.rs
@@ -3017,39 +3017,26 @@ unsafe extern "C" fn w_avg_c(
         BitDepth8::new(()),
     )
 }
+use crate::src::mc::mask_rust;
 unsafe extern "C" fn mask_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     dst_stride: ptrdiff_t,
-    mut tmp1: *const int16_t,
-    mut tmp2: *const int16_t,
+    tmp1: *const int16_t,
+    tmp2: *const int16_t,
     w: libc::c_int,
-    mut h: libc::c_int,
-    mut mask: *const uint8_t,
+    h: libc::c_int,
+    mask: *const uint8_t,
 ) {
-    let intermediate_bits = 4;
-    let sh = intermediate_bits + 6;
-    let rnd = ((32 as libc::c_int) << intermediate_bits) + 0 * 64;
-    loop {
-        let mut x = 0;
-        while x < w {
-            *dst.offset(x as isize) = iclip_u8(
-                *tmp1.offset(x as isize) as libc::c_int * *mask.offset(x as isize) as libc::c_int
-                    + *tmp2.offset(x as isize) as libc::c_int
-                        * (64 - *mask.offset(x as isize) as libc::c_int)
-                    + rnd
-                    >> sh,
-            ) as pixel;
-            x += 1;
-        }
-        tmp1 = tmp1.offset(w as isize);
-        tmp2 = tmp2.offset(w as isize);
-        mask = mask.offset(w as isize);
-        dst = dst.offset(dst_stride as isize);
-        h -= 1;
-        if !(h != 0) {
-            break;
-        }
-    }
+    mask_rust(
+        dst,
+        dst_stride as usize,
+        tmp1,
+        tmp2,
+        w as usize,
+        h as usize,
+        mask,
+        BitDepth8::new(()),
+    )
 }
 unsafe extern "C" fn blend_c(
     mut dst: *mut pixel,

--- a/src/mc_tmpl_8.rs
+++ b/src/mc_tmpl_8.rs
@@ -3038,32 +3038,16 @@ unsafe extern "C" fn mask_c(
         BitDepth8::new(()),
     )
 }
+use crate::src::mc::blend_rust;
 unsafe extern "C" fn blend_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     dst_stride: ptrdiff_t,
-    mut tmp: *const pixel,
+    tmp: *const pixel,
     w: libc::c_int,
-    mut h: libc::c_int,
-    mut mask: *const uint8_t,
+    h: libc::c_int,
+    mask: *const uint8_t,
 ) {
-    loop {
-        let mut x = 0;
-        while x < w {
-            *dst.offset(x as isize) = (*dst.offset(x as isize) as libc::c_int
-                * (64 - *mask.offset(x as isize) as libc::c_int)
-                + *tmp.offset(x as isize) as libc::c_int * *mask.offset(x as isize) as libc::c_int
-                + 32
-                >> 6) as pixel;
-            x += 1;
-        }
-        dst = dst.offset(dst_stride as isize);
-        tmp = tmp.offset(w as isize);
-        mask = mask.offset(w as isize);
-        h -= 1;
-        if !(h != 0) {
-            break;
-        }
-    }
+    blend_rust::<BitDepth8>(dst, dst_stride as usize, tmp, w as usize, h as usize, mask)
 }
 unsafe extern "C" fn blend_v_c(
     mut dst: *mut pixel,

--- a/src/mc_tmpl_8.rs
+++ b/src/mc_tmpl_8.rs
@@ -2996,37 +2996,26 @@ unsafe extern "C" fn avg_c(
         BitDepth8::new(()),
     )
 }
+use crate::src::mc::w_avg_rust;
 unsafe extern "C" fn w_avg_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     dst_stride: ptrdiff_t,
-    mut tmp1: *const int16_t,
-    mut tmp2: *const int16_t,
+    tmp1: *const int16_t,
+    tmp2: *const int16_t,
     w: libc::c_int,
-    mut h: libc::c_int,
+    h: libc::c_int,
     weight: libc::c_int,
 ) {
-    let intermediate_bits = 4;
-    let sh = intermediate_bits + 4;
-    let rnd = ((8 as libc::c_int) << intermediate_bits) + 0 * 16;
-    loop {
-        let mut x = 0;
-        while x < w {
-            *dst.offset(x as isize) = iclip_u8(
-                *tmp1.offset(x as isize) as libc::c_int * weight
-                    + *tmp2.offset(x as isize) as libc::c_int * (16 - weight)
-                    + rnd
-                    >> sh,
-            ) as pixel;
-            x += 1;
-        }
-        tmp1 = tmp1.offset(w as isize);
-        tmp2 = tmp2.offset(w as isize);
-        dst = dst.offset(dst_stride as isize);
-        h -= 1;
-        if !(h != 0) {
-            break;
-        }
-    }
+    w_avg_rust(
+        dst,
+        dst_stride as usize,
+        tmp1,
+        tmp2,
+        w as usize,
+        h as usize,
+        weight,
+        BitDepth8::new(()),
+    )
 }
 unsafe extern "C" fn mask_c(
     mut dst: *mut pixel,

--- a/src/mc_tmpl_8.rs
+++ b/src/mc_tmpl_8.rs
@@ -2977,6 +2977,7 @@ unsafe extern "C" fn prep_bilin_scaled_c(
         BitDepth8::new(()),
     )
 }
+use crate::src::mc::avg_rust;
 unsafe extern "C" fn avg_c(
     mut dst: *mut pixel,
     dst_stride: ptrdiff_t,
@@ -2985,28 +2986,15 @@ unsafe extern "C" fn avg_c(
     w: libc::c_int,
     mut h: libc::c_int,
 ) {
-    let intermediate_bits = 4;
-    let sh = intermediate_bits + 1;
-    let rnd = ((1 as libc::c_int) << intermediate_bits) + 0 * 2;
-    loop {
-        let mut x = 0;
-        while x < w {
-            *dst.offset(x as isize) = iclip_u8(
-                *tmp1.offset(x as isize) as libc::c_int
-                    + *tmp2.offset(x as isize) as libc::c_int
-                    + rnd
-                    >> sh,
-            ) as pixel;
-            x += 1;
-        }
-        tmp1 = tmp1.offset(w as isize);
-        tmp2 = tmp2.offset(w as isize);
-        dst = dst.offset(dst_stride as isize);
-        h -= 1;
-        if !(h != 0) {
-            break;
-        }
-    }
+    avg_rust(
+        dst,
+        dst_stride as usize,
+        tmp1,
+        tmp2,
+        w as usize,
+        h as usize,
+        BitDepth8::new(()),
+    )
 }
 unsafe extern "C" fn w_avg_c(
     mut dst: *mut pixel,


### PR DESCRIPTION
I had these from when I was working off of #322.  They're now rebased on `main` and I want to get them merged before I forget too much about them.  After deduplicating `mc.rs`'s `fn`s with `BitDepth` generics, I'll deduplicate its `fn` ptrs with type erasure.