### PR TITLE
`fn dav1d_sgr_filter1_neon`: Deduplicate w/ generics

### DIFF
--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -956,44 +956,37 @@ unsafe fn sgr_mix_rust<BD: BitDepth>(
     }
 }
 
+type fn_dav1d_sgr_box3_h_neon<BD> = unsafe extern "C" fn(
+    sumsq: *mut int32_t,
+    sum: *mut int16_t,
+    left: *const [<BD as BitDepth>::Pixel; 4],
+    src: *const <BD as BitDepth>::Pixel,
+    stride: ptrdiff_t,
+    w: libc::c_int,
+    h: libc::c_int,
+    edges: LrEdgeFlags,
+);
+
+type fn_dav1d_sgr_finish_filter1_neon<BD> = unsafe extern "C" fn(
+    tmp: *mut int16_t,
+    src: *const <BD as BitDepth>::Pixel,
+    stride: ptrdiff_t,
+    a: *const int32_t,
+    b: *const int16_t,
+    w: libc::c_int,
+    h: libc::c_int,
+);
+
 // TODO(randomPoison): Temporarily pub until all usages can be made private.
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 pub(crate) trait BitDepthLooprestorationArm: BitDepth {
-    fn dav1d_sgr_box3_h_neon(
-        sumsq: *mut int32_t,
-        sum: *mut int16_t,
-        left: *const [Self::Pixel; 4],
-        src: *const Self::Pixel,
-        stride: ptrdiff_t,
-        w: libc::c_int,
-        h: libc::c_int,
-        edges: LrEdgeFlags,
-    );
-
-    fn dav1d_sgr_finish_filter1_neon(
-        tmp: *mut int16_t,
-        src: *const Self::Pixel,
-        stride: ptrdiff_t,
-        a: *const int32_t,
-        b: *const int16_t,
-        w: libc::c_int,
-        h: libc::c_int,
-    );
+    const dav1d_sgr_box3_h_neon: fn_dav1d_sgr_box3_h_neon<Self>;
+    const dav1d_sgr_finish_filter1_neon: fn_dav1d_sgr_finish_filter1_neon<Self>;
 }
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 impl BitDepthLooprestorationArm for BitDepth8 {
-    #[inline(always)]
-    fn dav1d_sgr_box3_h_neon(
-        sumsq: *mut int32_t,
-        sum: *mut int16_t,
-        left: *const [Self::Pixel; 4],
-        src: *const Self::Pixel,
-        stride: ptrdiff_t,
-        w: libc::c_int,
-        h: libc::c_int,
-        edges: LrEdgeFlags,
-    ) {
+    const dav1d_sgr_box3_h_neon: fn_dav1d_sgr_box3_h_neon<Self> = {
         extern "C" {
             fn dav1d_sgr_box3_h_8bpc_neon(
                 sumsq: *mut int32_t,
@@ -1007,19 +1000,10 @@ impl BitDepthLooprestorationArm for BitDepth8 {
             );
         }
 
-        unsafe { dav1d_sgr_box3_h_8bpc_neon(sumsq, sum, left, src, stride, w, h, edges) }
-    }
+        dav1d_sgr_box3_h_8bpc_neon
+    };
 
-    #[inline(always)]
-    fn dav1d_sgr_finish_filter1_neon(
-        tmp: *mut int16_t,
-        src: *const Self::Pixel,
-        stride: ptrdiff_t,
-        a: *const int32_t,
-        b: *const int16_t,
-        w: libc::c_int,
-        h: libc::c_int,
-    ) {
+    const dav1d_sgr_finish_filter1_neon: fn_dav1d_sgr_finish_filter1_neon<Self> = {
         extern "C" {
             fn dav1d_sgr_finish_filter1_8bpc_neon(
                 tmp: *mut int16_t,
@@ -1032,23 +1016,13 @@ impl BitDepthLooprestorationArm for BitDepth8 {
             );
         }
 
-        unsafe { dav1d_sgr_finish_filter1_8bpc_neon(tmp, src, stride, a, b, w, h) }
-    }
+        dav1d_sgr_finish_filter1_8bpc_neon
+    };
 }
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 impl BitDepthLooprestorationArm for BitDepth16 {
-    #[inline(always)]
-    fn dav1d_sgr_box3_h_neon(
-        sumsq: *mut int32_t,
-        sum: *mut int16_t,
-        left: *const [Self::Pixel; 4],
-        src: *const Self::Pixel,
-        stride: ptrdiff_t,
-        w: libc::c_int,
-        h: libc::c_int,
-        edges: LrEdgeFlags,
-    ) {
+    const dav1d_sgr_box3_h_neon: fn_dav1d_sgr_box3_h_neon<Self> = {
         extern "C" {
             fn dav1d_sgr_box3_h_16bpc_neon(
                 sumsq: *mut int32_t,
@@ -1062,19 +1036,10 @@ impl BitDepthLooprestorationArm for BitDepth16 {
             );
         }
 
-        unsafe { dav1d_sgr_box3_h_16bpc_neon(sumsq, sum, left, src, stride, w, h, edges) }
-    }
+        dav1d_sgr_box3_h_16bpc_neon
+    };
 
-    #[inline(always)]
-    fn dav1d_sgr_finish_filter1_neon(
-        tmp: *mut int16_t,
-        src: *const Self::Pixel,
-        stride: ptrdiff_t,
-        a: *const int32_t,
-        b: *const int16_t,
-        w: libc::c_int,
-        h: libc::c_int,
-    ) {
+    const dav1d_sgr_finish_filter1_neon: fn_dav1d_sgr_finish_filter1_neon<Self> = {
         extern "C" {
             fn dav1d_sgr_finish_filter1_16bpc_neon(
                 tmp: *mut int16_t,
@@ -1087,8 +1052,8 @@ impl BitDepthLooprestorationArm for BitDepth16 {
             );
         }
 
-        unsafe { dav1d_sgr_finish_filter1_16bpc_neon(tmp, src, stride, a, b, w, h) }
-    }
+        dav1d_sgr_finish_filter1_16bpc_neon
+    };
 }
 
 // TODO(randomPoison): Temporarily pub until callers are deduplicated.

--- a/src/looprestoration_tmpl_8.rs
+++ b/src/looprestoration_tmpl_8.rs
@@ -42,30 +42,6 @@ extern "C" {
         w: libc::c_int,
         h: libc::c_int,
     );
-    fn dav1d_sgr_box3_v_neon(
-        sumsq: *mut int32_t,
-        sum: *mut int16_t,
-        w: libc::c_int,
-        h: libc::c_int,
-        edges: LrEdgeFlags,
-    );
-    fn dav1d_sgr_calc_ab1_neon(
-        a: *mut int32_t,
-        b: *mut int16_t,
-        w: libc::c_int,
-        h: libc::c_int,
-        strength: libc::c_int,
-        bitdepth_max: libc::c_int,
-    );
-    fn dav1d_sgr_finish_filter1_8bpc_neon(
-        tmp: *mut int16_t,
-        src: *const pixel,
-        stride: ptrdiff_t,
-        a: *const int32_t,
-        b: *const int16_t,
-        w: libc::c_int,
-        h: libc::c_int,
-    );
     fn dav1d_sgr_weighted1_8bpc_neon(
         dst: *mut pixel,
         dst_stride: ptrdiff_t,
@@ -86,16 +62,6 @@ extern "C" {
         w: libc::c_int,
         h: libc::c_int,
         wt: *const int16_t,
-    );
-    fn dav1d_sgr_box3_h_8bpc_neon(
-        sumsq: *mut int32_t,
-        sum: *mut int16_t,
-        left: *const [pixel; 4],
-        src: *const pixel,
-        stride: ptrdiff_t,
-        w: libc::c_int,
-        h: libc::c_int,
-        edges: LrEdgeFlags,
     );
 }
 
@@ -323,63 +289,6 @@ unsafe extern "C" fn loop_restoration_dsp_init_arm(
 }
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
-unsafe extern "C" fn dav1d_sgr_filter1_neon(
-    mut tmp: *mut int16_t,
-    mut src: *const pixel,
-    stride: ptrdiff_t,
-    mut left: *const [pixel; 4],
-    mut lpf: *const pixel,
-    w: libc::c_int,
-    h: libc::c_int,
-    strength: libc::c_int,
-    edges: LrEdgeFlags,
-) {
-    use crate::src::looprestoration::LR_HAVE_BOTTOM;
-    use crate::src::looprestoration::LR_HAVE_TOP;
-
-    let mut sumsq_mem: Align16<[int32_t; 27208]> = Align16([0; 27208]);
-    let sumsq: *mut int32_t = &mut *sumsq_mem
-        .0
-        .as_mut_ptr()
-        .offset(((384 + 16) * 2 + 8) as isize) as *mut int32_t;
-    let a: *mut int32_t = sumsq;
-    let mut sum_mem: Align16<[int16_t; 27216]> = Align16([0; 27216]);
-    let sum: *mut int16_t = &mut *sum_mem
-        .0
-        .as_mut_ptr()
-        .offset(((384 + 16) * 2 + 16) as isize) as *mut int16_t;
-    let b: *mut int16_t = sum;
-    dav1d_sgr_box3_h_8bpc_neon(sumsq, sum, left, src, stride, w, h, edges);
-    if edges as libc::c_uint & LR_HAVE_TOP as libc::c_int as libc::c_uint != 0 {
-        dav1d_sgr_box3_h_8bpc_neon(
-            &mut *sumsq.offset((-(2 as libc::c_int) * (384 + 16)) as isize),
-            &mut *sum.offset((-(2 as libc::c_int) * (384 + 16)) as isize),
-            0 as *const [pixel; 4],
-            lpf,
-            stride,
-            w,
-            2 as libc::c_int,
-            edges,
-        );
-    }
-    if edges as libc::c_uint & LR_HAVE_BOTTOM as libc::c_int as libc::c_uint != 0 {
-        dav1d_sgr_box3_h_8bpc_neon(
-            &mut *sumsq.offset((h * (384 + 16)) as isize),
-            &mut *sum.offset((h * (384 + 16)) as isize),
-            0 as *const [pixel; 4],
-            lpf.offset((6 * stride) as isize),
-            stride,
-            w,
-            2 as libc::c_int,
-            edges,
-        );
-    }
-    dav1d_sgr_box3_v_neon(sumsq, sum, w, h, edges);
-    dav1d_sgr_calc_ab1_neon(a, b, w, h, strength, 0xff as libc::c_int);
-    dav1d_sgr_finish_filter1_8bpc_neon(tmp, src, stride, a, b, w, h);
-}
-
-#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 unsafe extern "C" fn dav1d_sgr_filter2_neon(
     mut tmp: *mut int16_t,
     mut src: *const pixel,
@@ -530,6 +439,9 @@ unsafe extern "C" fn sgr_filter_3x3_neon(
     params: *const LooprestorationParams,
     edges: LrEdgeFlags,
 ) {
+    use crate::include::common::bitdepth::BitDepth;
+    use crate::src::looprestoration::dav1d_sgr_filter1_neon;
+
     let mut tmp: Align16<[int16_t; 24576]> = Align16([0; 24576]);
     dav1d_sgr_filter1_neon(
         tmp.0.as_mut_ptr(),
@@ -541,6 +453,7 @@ unsafe extern "C" fn sgr_filter_3x3_neon(
         h,
         (*params).sgr.s1 as libc::c_int,
         edges,
+        BitDepth8::new(()),
     );
     dav1d_sgr_weighted1_8bpc_neon(
         dst,
@@ -589,6 +502,9 @@ unsafe extern "C" fn sgr_filter_mix_neon(
     params: *const LooprestorationParams,
     edges: LrEdgeFlags,
 ) {
+    use crate::include::common::bitdepth::BitDepth;
+    use crate::src::looprestoration::dav1d_sgr_filter1_neon;
+
     let mut tmp1: Align16<[int16_t; 24576]> = Align16([0; 24576]);
     let mut tmp2: Align16<[int16_t; 24576]> = Align16([0; 24576]);
     dav1d_sgr_filter2_neon(
@@ -612,6 +528,7 @@ unsafe extern "C" fn sgr_filter_mix_neon(
         h,
         (*params).sgr.s1 as libc::c_int,
         edges,
+        BitDepth8::new(()),
     );
     let wt: [int16_t; 2] = [(*params).sgr.w0, (*params).sgr.w1];
     dav1d_sgr_weighted2_8bpc_neon(


### PR DESCRIPTION
This is the first bit of bitdepth deduplication that I've touched that needs to call into bitdepth-specific asm. ~~I used an extension trait to handle this. It's more boilerplate than I'd like, but that can probably be addressed with a macro later if needed. @kkysen let me know if you have a better suggestion.~~ An extension `trait` with associated `const`s in now used.  See https://github.com/memorysafety/rav1d/pull/341#pullrequestreview-1559981624 for an incoming follow-up.