### PR TITLE
Shrink intra_edge structs

### DIFF
--- a/src/intra_edge.h
+++ b/src/intra_edge.h
@@ -1,6 +1,6 @@
 /*
- * Copyright © 2018, VideoLAN and dav1d authors
- * Copyright © 2018, Two Orioles, LLC
+ * Copyright © 2018-2023, VideoLAN and dav1d authors
+ * Copyright © 2018-2023, Two Orioles, LLC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,8 @@
 #ifndef DAV1D_SRC_INTRA_EDGE_H
 #define DAV1D_SRC_INTRA_EDGE_H
 
+#include <stdint.h>
+
 enum EdgeFlags {
     EDGE_I444_TOP_HAS_RIGHT = 1 << 0,
     EDGE_I422_TOP_HAS_RIGHT = 1 << 1,
@@ -37,17 +39,18 @@ enum EdgeFlags {
     EDGE_I420_LEFT_HAS_BOTTOM = 1 << 5,
 };
 
-typedef struct EdgeNode EdgeNode;
-struct EdgeNode {
-    enum EdgeFlags o, h[2], v[2];
-};
+typedef struct EdgeNode {
+    uint8_t /* enum EdgeFlags */ o, h[2], v[2];
+} EdgeNode;
+
 typedef struct EdgeTip {
     EdgeNode node;
-    enum EdgeFlags split[4];
+    uint8_t /* enum EdgeFlags */ split[4];
 } EdgeTip;
+
 typedef struct EdgeBranch {
     EdgeNode node;
-    enum EdgeFlags tts[3], tbs[3], tls[3], trs[3], h4[4], v4[4];
+    uint8_t /* enum EdgeFlags */ tts[3], tbs[3], tls[3], trs[3], h4[4], v4[4];
     EdgeNode *split[4];
 } EdgeBranch;
 

--- a/src/intra_edge.rs
+++ b/src/intra_edge.rs
@@ -1,5 +1,6 @@
+use crate::include::stdint::uint8_t;
 use ::libc;
-pub type EdgeFlags = libc::c_uint;
+pub type EdgeFlags = uint8_t;
 pub const EDGE_I420_LEFT_HAS_BOTTOM: EdgeFlags = 32;
 pub const EDGE_I422_LEFT_HAS_BOTTOM: EdgeFlags = 16;
 pub const EDGE_I444_LEFT_HAS_BOTTOM: EdgeFlags = 8;
@@ -128,11 +129,7 @@ unsafe extern "C" fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags:
                 | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
             as EdgeFlags;
         if bl as libc::c_uint == BL_16X16 as libc::c_int as libc::c_uint {
-            (*nwc).h4[1] = ::core::mem::transmute::<libc::c_uint, EdgeFlags>(
-                (*nwc).h4[1] as libc::c_uint
-                    | edge_flags as libc::c_uint
-                        & EDGE_I420_TOP_HAS_RIGHT as libc::c_int as libc::c_uint,
-            );
+            (*nwc).h4[1] = (*nwc).h4[1] | edge_flags & EDGE_I420_TOP_HAS_RIGHT;
         }
         (*nwc).v4[0] = (edge_flags as libc::c_uint
             | (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
@@ -149,13 +146,8 @@ unsafe extern "C" fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags:
                 | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)
             as EdgeFlags;
         if bl as libc::c_uint == BL_16X16 as libc::c_int as libc::c_uint {
-            (*nwc).v4[1] = ::core::mem::transmute::<libc::c_uint, EdgeFlags>(
-                (*nwc).v4[1] as libc::c_uint
-                    | edge_flags as libc::c_uint
-                        & (EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int
-                            | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int)
-                            as libc::c_uint,
-            );
+            (*nwc).v4[1] =
+                (*nwc).v4[1] | edge_flags & (EDGE_I420_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM);
         }
         (*nwc).tls[0] = (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
             | EDGE_I422_TOP_HAS_RIGHT as libc::c_int


### PR DESCRIPTION
Backport performance improvement from dav1d 1.2.1. Partially solves #286.

Use 8 bits to represent EdgeFlags instead of 32 bits