### PR TITLE
`src/looprestoration.rs`: Switch associated `const` `fn` ptrs to compile-time `BPC` `match`es for greater flexibility

### DIFF
--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -117,6 +117,11 @@ pub trait BitDepth: Clone + Copy {
     /// that `bitdepth_max: c_int` arg back to a [`BitDepth`].
     fn from_c(bitdepth_max: c_int) -> Self;
 
+    /// The opposite of [`BitDepth::from_c`].
+    fn into_c(self) -> c_int {
+        self.bitdepth_max().into()
+    }
+
     fn pixel_copy(dest: &mut [Self::Pixel], src: &[Self::Pixel], n: usize) {
         dest[..n].copy_from_slice(&src[..n]);
     }

--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -72,7 +72,13 @@ impl_FromPrimitive!(isize => {, ...});
 impl_FromPrimitive!(f32 => {, ...});
 impl_FromPrimitive!(f64 => {, ...});
 
+pub enum BPC {
+    BPC8,
+    BPC16,
+}
+
 pub trait BitDepth: Clone + Copy {
+    const BPC: BPC;
     const BITDEPTH: u8;
 
     type Pixel: Copy
@@ -146,6 +152,7 @@ pub struct BitDepth8 {
 }
 
 impl BitDepth for BitDepth8 {
+    const BPC: BPC = BPC::BPC8;
     const BITDEPTH: u8 = 8;
 
     type Pixel = u8;
@@ -194,6 +201,7 @@ pub struct BitDepth16 {
 }
 
 impl BitDepth for BitDepth16 {
+    const BPC: BPC = BPC::BPC16;
     const BITDEPTH: u8 = 16;
 
     type Pixel = u16;

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -424,7 +424,7 @@ unsafe fn wiener_rust<BD: BitDepth>(
                 iclip(
                     sum_0 + rounding_off_v >> round_bits_v,
                     0 as libc::c_int,
-                    bd.bitdepth_max().into(),
+                    bd.into_c(),
                 )
                 .as_();
             i_0 += 1;
@@ -1033,7 +1033,7 @@ unsafe fn dav1d_wiener_filter_h_neon<BD: BitDepth>(
         w,
         h,
         edges,
-        bd.bitdepth_max().into(),
+        bd.into_c(),
     )
 }
 
@@ -1079,7 +1079,7 @@ unsafe fn dav1d_wiener_filter_v_neon<BD: BitDepth>(
         fv,
         edges,
         mid_stride,
-        bd.bitdepth_max().into(),
+        bd.into_c(),
     )
 }
 
@@ -1298,7 +1298,7 @@ pub(crate) unsafe fn dav1d_sgr_filter1_neon<BD: BitDepth>(
         );
     }
     dav1d_sgr_box3_v_neon(sumsq, sum, w, h, edges);
-    dav1d_sgr_calc_ab1_neon(a, b, w, h, strength, bd.bitdepth_max().into());
+    dav1d_sgr_calc_ab1_neon(a, b, w, h, strength, bd.into_c());
     dav1d_sgr_finish_filter1_neon::<BD>(tmp, src, stride, a, b, w, h);
 }
 
@@ -1420,7 +1420,7 @@ pub(crate) unsafe fn dav1d_sgr_filter2_neon<BD: BitDepth>(
         );
     }
     dav1d_sgr_box5_v_neon(sumsq, sum, w, h, edges);
-    dav1d_sgr_calc_ab2_neon(a, b, w, h, strength, bd.bitdepth_max().into());
+    dav1d_sgr_calc_ab2_neon(a, b, w, h, strength, bd.into_c());
     dav1d_sgr_finish_filter2_neon::<BD>(tmp, src, stride, a, b, w, h);
 }
 
@@ -1466,7 +1466,7 @@ unsafe fn dav1d_sgr_weighted1_neon<BD: BitDepth>(
         w,
         h,
         wt,
-        bd.bitdepth_max().into(),
+        bd.into_c(),
     )
 }
 
@@ -1515,7 +1515,7 @@ unsafe fn dav1d_sgr_weighted2_neon<BD: BitDepth>(
         w,
         h,
         wt,
-        bd.bitdepth_max().into(),
+        bd.into_c(),
     )
 }
 


### PR DESCRIPTION
As discussed with @randomPoison in #341, this way of `match`ing on `enum BPC` is a bit cleaner, since it co-locates the bitdepth versions for each `fn`, similarly to the C declarations with `BF`, and it doesn't have to leave a `pub trait`.  Importantly, though, it lets us move conversions from safe to unsafe constructs to inside these wrapper dispatching functions, like is done in 281a8dea3ee8ab84406bbdd49c9eaa70a6233cef.  This way we don't need these conversions to raw pointers at all call sites, just once.  As we continue to clean up these functions further, that will get even more useful.  For now I just cleaned up the trivial ones, like where an array in the caller is passed `.as(_mut)_ptr()`.

Also, we know this is also zero-cost since it successfully links with only one bitdepth enabled; if the `match` were not at compile time only, this wouldn't work.