### PR TITLE
Set `default-run = "dav1d"` so that `cargo run` still runs `dav1d` like it did before

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 edition = "2021"
 autobins = false
 autotests = false
+default-run = "dav1d"
 
 [lib]
 name = "rav1d"


### PR DESCRIPTION
Set `default-run = "dav1d"` so that `cargo run` still runs `dav1d` like it did before adding the `seek-stress` binary.