### PR TITLE
`fn w_mask*c`: Make `ss_{hor,ver}` args `bool`s

### DIFF
--- a/src/mc_tmpl_16.rs
+++ b/src/mc_tmpl_16.rs
@@ -3175,8 +3175,8 @@ unsafe extern "C" fn w_mask_c(
     h: libc::c_int,
     mask: *mut uint8_t,
     sign: libc::c_int,
-    ss_hor: libc::c_int,
-    ss_ver: libc::c_int,
+    ss_hor: bool,
+    ss_ver: bool,
     bitdepth_max: libc::c_int,
 ) {
     debug_assert!(sign == 0 || sign == 1);
@@ -3189,8 +3189,8 @@ unsafe extern "C" fn w_mask_c(
         h as usize,
         mask,
         sign != 0,
-        ss_hor != 0,
-        ss_ver != 0,
+        ss_hor,
+        ss_ver,
         BitDepth16::new(bitdepth_max as u16),
     )
 }
@@ -3214,10 +3214,10 @@ unsafe extern "C" fn w_mask_444_c(
         h,
         mask,
         sign,
-        0 as libc::c_int,
-        0 as libc::c_int,
+        false,
+        false,
         bitdepth_max,
-    );
+    )
 }
 unsafe extern "C" fn w_mask_422_c(
     dst: *mut pixel,
@@ -3239,10 +3239,10 @@ unsafe extern "C" fn w_mask_422_c(
         h,
         mask,
         sign,
-        1 as libc::c_int,
-        0 as libc::c_int,
+        true,
+        false,
         bitdepth_max,
-    );
+    )
 }
 unsafe extern "C" fn w_mask_420_c(
     dst: *mut pixel,
@@ -3264,10 +3264,10 @@ unsafe extern "C" fn w_mask_420_c(
         h,
         mask,
         sign,
-        1 as libc::c_int,
-        1 as libc::c_int,
+        true,
+        true,
         bitdepth_max,
-    );
+    )
 }
 unsafe extern "C" fn warp_affine_8x8_c(
     mut dst: *mut pixel,

--- a/src/mc_tmpl_8.rs
+++ b/src/mc_tmpl_8.rs
@@ -3077,8 +3077,8 @@ unsafe extern "C" fn w_mask_c(
     h: libc::c_int,
     mask: *mut uint8_t,
     sign: libc::c_int,
-    ss_hor: libc::c_int,
-    ss_ver: libc::c_int,
+    ss_hor: bool,
+    ss_ver: bool,
 ) {
     debug_assert!(sign == 0 || sign == 1);
     w_mask_rust(
@@ -3090,8 +3090,8 @@ unsafe extern "C" fn w_mask_c(
         h as usize,
         mask,
         sign != 0,
-        ss_hor != 0,
-        ss_ver != 0,
+        ss_hor,
+        ss_ver,
         BitDepth8::new(()),
     )
 }
@@ -3105,20 +3105,8 @@ unsafe extern "C" fn w_mask_444_c(
     mut mask: *mut uint8_t,
     sign: libc::c_int,
 ) {
-    w_mask_c(
-        dst,
-        dst_stride,
-        tmp1,
-        tmp2,
-        w,
-        h,
-        mask,
-        sign,
-        0 as libc::c_int,
-        0 as libc::c_int,
-    );
+    w_mask_c(dst, dst_stride, tmp1, tmp2, w, h, mask, sign, false, false)
 }
-
 unsafe extern "C" fn w_mask_422_c(
     dst: *mut pixel,
     dst_stride: ptrdiff_t,
@@ -3129,18 +3117,7 @@ unsafe extern "C" fn w_mask_422_c(
     mut mask: *mut uint8_t,
     sign: libc::c_int,
 ) {
-    w_mask_c(
-        dst,
-        dst_stride,
-        tmp1,
-        tmp2,
-        w,
-        h,
-        mask,
-        sign,
-        1 as libc::c_int,
-        0 as libc::c_int,
-    );
+    w_mask_c(dst, dst_stride, tmp1, tmp2, w, h, mask, sign, true, false)
 }
 unsafe extern "C" fn w_mask_420_c(
     dst: *mut pixel,
@@ -3152,18 +3129,7 @@ unsafe extern "C" fn w_mask_420_c(
     mut mask: *mut uint8_t,
     sign: libc::c_int,
 ) {
-    w_mask_c(
-        dst,
-        dst_stride,
-        tmp1,
-        tmp2,
-        w,
-        h,
-        mask,
-        sign,
-        1 as libc::c_int,
-        1 as libc::c_int,
-    );
+    w_mask_c(dst, dst_stride, tmp1, tmp2, w, h, mask, sign, true, true)
 }
 unsafe extern "C" fn warp_affine_8x8_c(
     mut dst: *mut pixel,


### PR DESCRIPTION
I didn't deduplicate these ones since they're so trivial and because I'll make `ss_{hor,ver}` `const` generics once I type erase them so that I can just do `w_mask_c_erased::<true, true>`, etc.