### PR TITLE
`looprestoration`: Dedup init fns w/ generics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "libc",
  "nasm-rs",
  "num_cpus",
+ "paste",
 ]
 
 [[package]]
@@ -76,6 +77,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ c2rust-bitfields= "0.3"
 cfg-if = "1.0.0"
 libc= "0.2"
 num_cpus = "1.0"
+paste = "1.0.14"
 
 [build-dependencies]
 cc = "1.0.79"

--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -72,6 +72,7 @@ impl_FromPrimitive!(isize => {, ...});
 impl_FromPrimitive!(f32 => {, ...});
 impl_FromPrimitive!(f64 => {, ...});
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BPC {
     BPC8,
     BPC16,

--- a/lib.rs
+++ b/lib.rs
@@ -95,10 +95,6 @@ pub mod src {
     #[cfg(feature = "bitdepth_8")]
     pub mod loopfilter_tmpl_8;
     pub mod looprestoration;
-    #[cfg(feature = "bitdepth_16")]
-    pub mod looprestoration_tmpl_16;
-    #[cfg(feature = "bitdepth_8")]
-    pub mod looprestoration_tmpl_8;
     pub mod lr_apply;
     #[cfg(feature = "bitdepth_16")]
     pub mod lr_apply_tmpl_16;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "bitdepth_16")]
+use crate::include::common::bitdepth::BitDepth16;
+#[cfg(feature = "bitdepth_8")]
+use crate::include::common::bitdepth::BitDepth8;
 use crate::include::common::frame::{is_inter_or_switch, is_key_or_intra};
 use crate::include::dav1d::headers::{Dav1dTxfmMode, DAV1D_MAX_SEGMENTS};
 use crate::include::stddef::*;
@@ -5,6 +9,7 @@ use crate::include::stdint::*;
 use crate::src::align::Align16;
 use crate::src::cdf::{CdfContext, CdfMvComponent, CdfMvContext};
 use crate::src::ctx::CaseSet;
+use crate::src::looprestoration::dav1d_loop_restoration_dsp_init;
 
 use libc;
 
@@ -93,16 +98,6 @@ extern "C" {
     fn dav1d_loop_filter_dsp_init_8bpc(c: *mut Dav1dLoopFilterDSPContext);
     #[cfg(feature = "bitdepth_16")]
     fn dav1d_loop_filter_dsp_init_16bpc(c: *mut Dav1dLoopFilterDSPContext);
-    #[cfg(feature = "bitdepth_8")]
-    fn dav1d_loop_restoration_dsp_init_8bpc(
-        c: *mut Dav1dLoopRestorationDSPContext,
-        bpc: libc::c_int,
-    );
-    #[cfg(feature = "bitdepth_16")]
-    fn dav1d_loop_restoration_dsp_init_16bpc(
-        c: *mut Dav1dLoopRestorationDSPContext,
-        bpc: libc::c_int,
-    );
     #[cfg(feature = "bitdepth_8")]
     fn dav1d_mc_dsp_init_8bpc(c: *mut Dav1dMCDSPContext);
     #[cfg(feature = "bitdepth_16")]
@@ -6994,7 +6989,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                 dav1d_intra_pred_dsp_init_8bpc(&mut (*dsp).ipred);
                 dav1d_itx_dsp_init_8bpc(&mut (*dsp).itx, bpc);
                 dav1d_loop_filter_dsp_init_8bpc(&mut (*dsp).lf);
-                dav1d_loop_restoration_dsp_init_8bpc(&mut (*dsp).lr, bpc);
+                dav1d_loop_restoration_dsp_init::<BitDepth8>(&mut (*dsp).lr, bpc);
                 dav1d_mc_dsp_init_8bpc(&mut (*dsp).mc);
                 dav1d_film_grain_dsp_init_8bpc(&mut (*dsp).fg);
                 current_block = 313581471991351815;
@@ -7005,7 +7000,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                 dav1d_intra_pred_dsp_init_16bpc(&mut (*dsp).ipred);
                 dav1d_itx_dsp_init_16bpc(&mut (*dsp).itx, bpc);
                 dav1d_loop_filter_dsp_init_16bpc(&mut (*dsp).lf);
-                dav1d_loop_restoration_dsp_init_16bpc(&mut (*dsp).lr, bpc);
+                dav1d_loop_restoration_dsp_init::<BitDepth16>(&mut (*dsp).lr, bpc);
                 dav1d_mc_dsp_init_16bpc(&mut (*dsp).mc);
                 dav1d_film_grain_dsp_init_16bpc(&mut (*dsp).fg);
                 current_block = 313581471991351815;


### PR DESCRIPTION
Deduplicate the init functions using the `BPC` enum matching approach introduced in #355. I used a macro to generate the wrapper functions to cut down on boilerplate. There a couple of asm functions that don't have both 8bpc and 16bpc versions, so those are handled differently.