### PR TITLE
Centralize type-erased types

### DIFF
--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -270,8 +270,11 @@ impl Display for DisplayPixel16 {
     }
 }
 
-pub type DynPixel = c_void;
-pub type DynCoef = c_void;
+#[repr(transparent)]
+pub struct DynPixel(c_void);
+
+#[repr(transparent)]
+pub struct DynCoef(c_void);
 
 pub type LeftPixelRow<Pixel> = [Pixel; 4];
 pub type LeftPixelRow2px<Pixel> = [Pixel; 2];

--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_int, c_uint};
+use std::ffi::{c_int, c_uint, c_void};
 use std::fmt::{self, Display, Formatter};
 use std::ops::{Add, Mul, Shr};
 
@@ -269,3 +269,6 @@ impl Display for DisplayPixel16 {
         write!(f, "{:03x}", self.0)
     }
 }
+
+pub type DynPixel = c_void;
+pub type DynCoef = c_void;

--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -272,3 +272,6 @@ impl Display for DisplayPixel16 {
 
 pub type DynPixel = c_void;
 pub type DynCoef = c_void;
+
+pub type LeftPixelRow<Pixel> = [Pixel; 4];
+pub type LeftPixelRow2px<Pixel> = [Pixel; 2];

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -1,3 +1,5 @@
+use crate::include::common::bitdepth::DynPixel;
+use crate::include::common::bitdepth::LeftPixelRow2px;
 use crate::include::common::intops::apply_sign;
 use crate::include::common::intops::imax;
 use crate::include::common::intops::imin;
@@ -14,14 +16,12 @@ pub const CDEF_HAVE_TOP: CdefEdgeFlags = 4;
 pub const CDEF_HAVE_RIGHT: CdefEdgeFlags = 2;
 pub const CDEF_HAVE_LEFT: CdefEdgeFlags = 1;
 
-pub type pixel = libc::c_void;
-pub type const_left_pixel_row_2px = *const libc::c_void; // const_left_pixel_row_2px
 pub type cdef_fn = unsafe extern "C" fn(
-    *mut pixel,
+    *mut DynPixel,
     ptrdiff_t,
-    const_left_pixel_row_2px,
-    *const pixel,
-    *const pixel,
+    *const LeftPixelRow2px<DynPixel>,
+    *const DynPixel,
+    *const DynPixel,
     libc::c_int,
     libc::c_int,
     libc::c_int,
@@ -30,7 +30,7 @@ pub type cdef_fn = unsafe extern "C" fn(
     libc::c_int,
 ) -> ();
 pub type cdef_dir_fn =
-    unsafe extern "C" fn(*const pixel, ptrdiff_t, *mut libc::c_uint, libc::c_int) -> libc::c_int;
+    unsafe extern "C" fn(*const DynPixel, ptrdiff_t, *mut libc::c_uint, libc::c_int) -> libc::c_int;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dCdefDSPContext {
@@ -46,11 +46,11 @@ pub struct Dav1dCdefDSPContext {
 ))]
 extern "C" {
     pub(crate) fn dav1d_cdef_filter_8x8_8bpc_ssse3(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -59,11 +59,11 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_filter_4x8_8bpc_ssse3(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -72,11 +72,11 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_filter_4x4_8bpc_ssse3(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -85,17 +85,17 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_dir_8bpc_sse4(
-        dst: *const pixel,
+        dst: *const DynPixel,
         dst_stride: ptrdiff_t,
         var: *mut libc::c_uint,
         bitdepth_max: libc::c_int,
     ) -> libc::c_int;
     pub(crate) fn dav1d_cdef_filter_8x8_8bpc_sse4(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -104,11 +104,11 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_filter_4x8_8bpc_sse4(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -117,11 +117,11 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_filter_4x4_8bpc_sse4(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -130,17 +130,17 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_dir_8bpc_avx2(
-        dst: *const pixel,
+        dst: *const DynPixel,
         dst_stride: ptrdiff_t,
         var: *mut libc::c_uint,
         bitdepth_max: libc::c_int,
     ) -> libc::c_int;
     pub(crate) fn dav1d_cdef_filter_8x8_8bpc_avx2(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -149,11 +149,11 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_filter_4x8_8bpc_avx2(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -162,11 +162,11 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_filter_4x4_8bpc_avx2(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -175,11 +175,11 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_filter_8x8_8bpc_avx512icl(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -188,11 +188,11 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_filter_4x8_8bpc_avx512icl(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -201,11 +201,11 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_filter_4x4_8bpc_avx512icl(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -214,11 +214,11 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_filter_4x8_8bpc_sse2(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -227,17 +227,17 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_dir_8bpc_ssse3(
-        dst: *const pixel,
+        dst: *const DynPixel,
         dst_stride: ptrdiff_t,
         var: *mut libc::c_uint,
         bitdepth_max: libc::c_int,
     ) -> libc::c_int;
     pub(crate) fn dav1d_cdef_filter_4x4_8bpc_sse2(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -246,11 +246,11 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_filter_8x8_8bpc_sse2(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -268,33 +268,33 @@ extern "C" {
 ))]
 extern "C" {
     pub(crate) fn dav1d_cdef_find_dir_8bpc_neon(
-        dst: *const pixel,
+        dst: *const DynPixel,
         dst_stride: ptrdiff_t,
         var: *mut libc::c_uint,
         bitdepth_max: libc::c_int,
     ) -> libc::c_int;
     pub(crate) fn dav1d_cdef_padding4_8bpc_neon(
         tmp: *mut uint16_t,
-        src: *const pixel,
+        src: *const DynPixel,
         src_stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         h: libc::c_int,
         edges: CdefEdgeFlags,
     );
     pub(crate) fn dav1d_cdef_padding8_8bpc_neon(
         tmp: *mut uint16_t,
-        src: *const pixel,
+        src: *const DynPixel,
         src_stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         h: libc::c_int,
         edges: CdefEdgeFlags,
     );
     pub(crate) fn dav1d_cdef_filter4_8bpc_neon(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         dst_stride: ptrdiff_t,
         tmp: *const uint16_t,
         pri_strength: libc::c_int,
@@ -305,7 +305,7 @@ extern "C" {
         edges: size_t,
     );
     pub(crate) fn dav1d_cdef_filter8_8bpc_neon(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         dst_stride: ptrdiff_t,
         tmp: *const uint16_t,
         pri_strength: libc::c_int,
@@ -325,11 +325,11 @@ extern "C" {
 ))]
 extern "C" {
     pub(crate) fn dav1d_cdef_filter_4x4_16bpc_avx512icl(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -338,11 +338,11 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_filter_4x8_16bpc_avx512icl(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -351,11 +351,11 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_filter_8x8_16bpc_avx512icl(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -364,11 +364,11 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_filter_4x4_16bpc_avx2(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -377,11 +377,11 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_filter_4x8_16bpc_avx2(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -390,11 +390,11 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_filter_8x8_16bpc_avx2(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -403,23 +403,23 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_dir_16bpc_avx2(
-        dst: *const pixel,
+        dst: *const DynPixel,
         dst_stride: ptrdiff_t,
         var: *mut libc::c_uint,
         bitdepth_max: libc::c_int,
     ) -> libc::c_int;
     pub(crate) fn dav1d_cdef_dir_16bpc_sse4(
-        dst: *const pixel,
+        dst: *const DynPixel,
         dst_stride: ptrdiff_t,
         var: *mut libc::c_uint,
         bitdepth_max: libc::c_int,
     ) -> libc::c_int;
     pub(crate) fn dav1d_cdef_filter_4x4_16bpc_ssse3(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -428,11 +428,11 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_filter_4x8_16bpc_ssse3(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -441,11 +441,11 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_filter_8x8_16bpc_ssse3(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         pri_strength: libc::c_int,
         sec_strength: libc::c_int,
         dir: libc::c_int,
@@ -454,7 +454,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_dir_16bpc_ssse3(
-        dst: *const pixel,
+        dst: *const DynPixel,
         dst_stride: ptrdiff_t,
         var: *mut libc::c_uint,
         bitdepth_max: libc::c_int,
@@ -469,33 +469,33 @@ extern "C" {
 ))]
 extern "C" {
     pub(crate) fn dav1d_cdef_find_dir_16bpc_neon(
-        dst: *const pixel,
+        dst: *const DynPixel,
         dst_stride: ptrdiff_t,
         var: *mut libc::c_uint,
         bitdepth_max: libc::c_int,
     ) -> libc::c_int;
     pub(crate) fn dav1d_cdef_padding4_16bpc_neon(
         tmp: *mut uint16_t,
-        src: *const pixel,
+        src: *const DynPixel,
         src_stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         h: libc::c_int,
         edges: CdefEdgeFlags,
     );
     pub(crate) fn dav1d_cdef_padding8_16bpc_neon(
         tmp: *mut uint16_t,
-        src: *const pixel,
+        src: *const DynPixel,
         src_stride: ptrdiff_t,
-        left: const_left_pixel_row_2px,
-        top: *const pixel,
-        bottom: *const pixel,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
         h: libc::c_int,
         edges: CdefEdgeFlags,
     );
     pub(crate) fn dav1d_cdef_filter4_16bpc_neon(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         dst_stride: ptrdiff_t,
         tmp: *const uint16_t,
         pri_strength: libc::c_int,
@@ -507,7 +507,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_filter8_16bpc_neon(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         dst_stride: ptrdiff_t,
         tmp: *const uint16_t,
         pri_strength: libc::c_int,

--- a/src/cdef_tmpl_16.rs
+++ b/src/cdef_tmpl_16.rs
@@ -1,3 +1,5 @@
+use crate::include::common::bitdepth::DynPixel;
+use crate::include::common::bitdepth::LeftPixelRow2px;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 use ::libc;
@@ -291,11 +293,11 @@ unsafe extern "C" fn cdef_filter_block_c(
     };
 }
 unsafe extern "C" fn cdef_filter_block_4x4_c_erased(
-    dst: *mut libc::c_void,
+    dst: *mut DynPixel,
     stride: ptrdiff_t,
-    left: *const libc::c_void,
-    top: *const libc::c_void,
-    bottom: *const libc::c_void,
+    left: *const LeftPixelRow2px<DynPixel>,
+    top: *const DynPixel,
+    bottom: *const DynPixel,
     pri_strength: libc::c_int,
     sec_strength: libc::c_int,
     dir: libc::c_int,
@@ -320,11 +322,11 @@ unsafe extern "C" fn cdef_filter_block_4x4_c_erased(
     );
 }
 unsafe extern "C" fn cdef_filter_block_4x8_c_erased(
-    dst: *mut libc::c_void,
+    dst: *mut DynPixel,
     stride: ptrdiff_t,
-    left: *const libc::c_void,
-    top: *const libc::c_void,
-    bottom: *const libc::c_void,
+    left: *const LeftPixelRow2px<DynPixel>,
+    top: *const DynPixel,
+    bottom: *const DynPixel,
     pri_strength: libc::c_int,
     sec_strength: libc::c_int,
     dir: libc::c_int,
@@ -349,11 +351,11 @@ unsafe extern "C" fn cdef_filter_block_4x8_c_erased(
     );
 }
 unsafe extern "C" fn cdef_filter_block_8x8_c_erased(
-    dst: *mut libc::c_void,
+    dst: *mut DynPixel,
     stride: ptrdiff_t,
-    left: *const libc::c_void,
-    top: *const libc::c_void,
-    bottom: *const libc::c_void,
+    left: *const LeftPixelRow2px<DynPixel>,
+    top: *const DynPixel,
+    bottom: *const DynPixel,
     pri_strength: libc::c_int,
     sec_strength: libc::c_int,
     dir: libc::c_int,
@@ -576,9 +578,9 @@ unsafe extern "C" fn cdef_dsp_init_arm(c: *mut Dav1dCdefDSPContext) {
 unsafe extern "C" fn cdef_filter_8x8_neon_erased(
     dst: *mut libc::c_void,
     stride: ptrdiff_t,
-    left: *const libc::c_void,
-    top: *const libc::c_void,
-    bottom: *const libc::c_void,
+    left: *const LeftPixelRow2px<DynPixel>,
+    top: *const DynPixel,
+    bottom: *const DynPixel,
     pri_strength: libc::c_int,
     sec_strength: libc::c_int,
     dir: libc::c_int,
@@ -611,9 +613,9 @@ unsafe extern "C" fn cdef_filter_8x8_neon_erased(
 unsafe extern "C" fn cdef_filter_4x8_neon_erased(
     mut dst: *mut libc::c_void,
     stride: ptrdiff_t,
-    mut left: *const libc::c_void,
-    top: *const libc::c_void,
-    bottom: *const libc::c_void,
+    mut left: *const LeftPixelRow2px<DynPixel>,
+    top: *const DynPixel,
+    bottom: *const DynPixel,
     pri_strength: libc::c_int,
     sec_strength: libc::c_int,
     dir: libc::c_int,
@@ -646,9 +648,9 @@ unsafe extern "C" fn cdef_filter_4x8_neon_erased(
 unsafe extern "C" fn cdef_filter_4x4_neon_erased(
     mut dst: *mut libc::c_void,
     stride: ptrdiff_t,
-    mut left: *const libc::c_void,
-    top: *const libc::c_void,
-    bottom: *const libc::c_void,
+    mut left: *const LeftPixelRow2px<DynPixel>,
+    top: *const DynPixel,
+    bottom: *const DynPixel,
     pri_strength: libc::c_int,
     sec_strength: libc::c_int,
     dir: libc::c_int,

--- a/src/cdef_tmpl_16.rs
+++ b/src/cdef_tmpl_16.rs
@@ -380,7 +380,7 @@ unsafe extern "C" fn cdef_filter_block_8x8_c_erased(
     );
 }
 unsafe extern "C" fn cdef_find_dir_c_erased(
-    mut img: *const libc::c_void,
+    mut img: *const DynPixel,
     stride: ptrdiff_t,
     var: *mut libc::c_uint,
     bitdepth_max: libc::c_int,
@@ -576,7 +576,7 @@ unsafe extern "C" fn cdef_dsp_init_arm(c: *mut Dav1dCdefDSPContext) {
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 unsafe extern "C" fn cdef_filter_8x8_neon_erased(
-    dst: *mut libc::c_void,
+    dst: *mut DynPixel,
     stride: ptrdiff_t,
     left: *const LeftPixelRow2px<DynPixel>,
     top: *const DynPixel,
@@ -611,7 +611,7 @@ unsafe extern "C" fn cdef_filter_8x8_neon_erased(
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 unsafe extern "C" fn cdef_filter_4x8_neon_erased(
-    mut dst: *mut libc::c_void,
+    mut dst: *mut DynPixel,
     stride: ptrdiff_t,
     mut left: *const LeftPixelRow2px<DynPixel>,
     top: *const DynPixel,
@@ -646,7 +646,7 @@ unsafe extern "C" fn cdef_filter_4x8_neon_erased(
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 unsafe extern "C" fn cdef_filter_4x4_neon_erased(
-    mut dst: *mut libc::c_void,
+    mut dst: *mut DynPixel,
     stride: ptrdiff_t,
     mut left: *const LeftPixelRow2px<DynPixel>,
     top: *const DynPixel,

--- a/src/cdef_tmpl_8.rs
+++ b/src/cdef_tmpl_8.rs
@@ -370,7 +370,7 @@ unsafe extern "C" fn cdef_filter_block_8x8_c_erased(
     );
 }
 unsafe extern "C" fn cdef_find_dir_c_erased(
-    mut img: *const libc::c_void,
+    mut img: *const DynPixel,
     stride: ptrdiff_t,
     var: *mut libc::c_uint,
     _bitdepth_max: libc::c_int,

--- a/src/cdef_tmpl_8.rs
+++ b/src/cdef_tmpl_8.rs
@@ -1,3 +1,5 @@
+use crate::include::common::bitdepth::DynPixel;
+use crate::include::common::bitdepth::LeftPixelRow2px;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
@@ -284,11 +286,11 @@ unsafe extern "C" fn cdef_filter_block_c(
     };
 }
 unsafe extern "C" fn cdef_filter_block_4x4_c_erased(
-    dst: *mut libc::c_void,
+    dst: *mut DynPixel,
     stride: ptrdiff_t,
-    mut left: *const libc::c_void,
-    top: *const libc::c_void,
-    bottom: *const libc::c_void,
+    mut left: *const LeftPixelRow2px<DynPixel>,
+    top: *const DynPixel,
+    bottom: *const DynPixel,
     pri_strength: libc::c_int,
     sec_strength: libc::c_int,
     dir: libc::c_int,
@@ -312,11 +314,11 @@ unsafe extern "C" fn cdef_filter_block_4x4_c_erased(
     );
 }
 unsafe extern "C" fn cdef_filter_block_4x8_c_erased(
-    dst: *mut libc::c_void,
+    dst: *mut DynPixel,
     stride: ptrdiff_t,
-    left: *const libc::c_void,
-    top: *const libc::c_void,
-    bottom: *const libc::c_void,
+    left: *const LeftPixelRow2px<DynPixel>,
+    top: *const DynPixel,
+    bottom: *const DynPixel,
     pri_strength: libc::c_int,
     sec_strength: libc::c_int,
     dir: libc::c_int,
@@ -340,11 +342,11 @@ unsafe extern "C" fn cdef_filter_block_4x8_c_erased(
     );
 }
 unsafe extern "C" fn cdef_filter_block_8x8_c_erased(
-    dst: *mut libc::c_void,
+    dst: *mut DynPixel,
     stride: ptrdiff_t,
-    left: *const libc::c_void,
-    top: *const libc::c_void,
-    bottom: *const libc::c_void,
+    left: *const LeftPixelRow2px<DynPixel>,
+    top: *const DynPixel,
+    bottom: *const DynPixel,
     pri_strength: libc::c_int,
     sec_strength: libc::c_int,
     dir: libc::c_int,
@@ -577,11 +579,11 @@ unsafe extern "C" fn cdef_dsp_init_arm(c: *mut Dav1dCdefDSPContext) {
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 unsafe extern "C" fn cdef_filter_4x4_neon_erased(
-    dst: *mut libc::c_void,
+    dst: *mut DynPixel,
     stride: ptrdiff_t,
-    left: *const libc::c_void,
-    top: *const libc::c_void,
-    bottom: *const libc::c_void,
+    left: *const LeftPixelRow2px<DynPixel>,
+    top: *const DynPixel,
+    bottom: *const DynPixel,
     pri_strength: libc::c_int,
     sec_strength: libc::c_int,
     dir: libc::c_int,
@@ -611,11 +613,11 @@ unsafe extern "C" fn cdef_filter_4x4_neon_erased(
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 unsafe extern "C" fn cdef_filter_4x8_neon_erased(
-    dst: *mut libc::c_void,
+    dst: *mut DynPixel,
     stride: ptrdiff_t,
-    left: *const libc::c_void,
-    top: *const libc::c_void,
-    bottom: *const libc::c_void,
+    left: *const LeftPixelRow2px<DynPixel>,
+    top: *const DynPixel,
+    bottom: *const DynPixel,
     pri_strength: libc::c_int,
     sec_strength: libc::c_int,
     dir: libc::c_int,
@@ -645,11 +647,11 @@ unsafe extern "C" fn cdef_filter_4x8_neon_erased(
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 unsafe extern "C" fn cdef_filter_8x8_neon_erased(
-    dst: *mut libc::c_void,
+    dst: *mut DynPixel,
     stride: ptrdiff_t,
-    left: *const libc::c_void,
-    top: *const libc::c_void,
-    bottom: *const libc::c_void,
+    left: *const LeftPixelRow2px<DynPixel>,
+    top: *const DynPixel,
+    bottom: *const DynPixel,
     pri_strength: libc::c_int,
     sec_strength: libc::c_int,
     dir: libc::c_int,

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -1,12 +1,11 @@
+use crate::include::common::bitdepth::DynPixel;
 use crate::include::stddef::ptrdiff_t;
 use crate::include::stdint::uint32_t;
 use crate::include::stdint::uint8_t;
 use crate::src::lf_mask::Av1FilterLUT;
 
-pub type pixel = libc::c_void;
-
 pub type loopfilter_sb_fn = unsafe extern "C" fn(
-    *mut pixel,
+    *mut DynPixel,
     ptrdiff_t,
     *const uint32_t,
     *const [uint8_t; 4],
@@ -30,7 +29,7 @@ pub struct Dav1dLoopFilterDSPContext {
 ))]
 extern "C" {
     pub(crate) fn dav1d_lpf_v_sb_uv_8bpc_avx512icl(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -40,7 +39,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_h_sb_uv_8bpc_avx512icl(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -50,7 +49,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_v_sb_y_8bpc_avx512icl(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -60,7 +59,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_h_sb_y_8bpc_avx512icl(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -70,7 +69,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_v_sb_uv_8bpc_avx2(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -80,7 +79,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_h_sb_uv_8bpc_avx2(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -90,7 +89,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_v_sb_y_8bpc_avx2(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -100,7 +99,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_h_sb_y_8bpc_avx2(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -110,7 +109,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_v_sb_uv_8bpc_ssse3(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -120,7 +119,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_h_sb_uv_8bpc_ssse3(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -130,7 +129,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_v_sb_y_8bpc_ssse3(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -140,7 +139,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_h_sb_y_8bpc_ssse3(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -159,7 +158,7 @@ extern "C" {
 ))]
 extern "C" {
     pub(crate) fn dav1d_lpf_h_sb_uv_8bpc_neon(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -169,7 +168,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_v_sb_y_8bpc_neon(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -179,7 +178,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_h_sb_y_8bpc_neon(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -189,7 +188,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_v_sb_uv_8bpc_neon(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -208,7 +207,7 @@ extern "C" {
 ))]
 extern "C" {
     pub(crate) fn dav1d_lpf_v_sb_uv_16bpc_avx512icl(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -218,7 +217,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_h_sb_uv_16bpc_avx512icl(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -228,7 +227,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_v_sb_y_16bpc_avx512icl(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -238,7 +237,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_h_sb_y_16bpc_avx512icl(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -248,7 +247,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_v_sb_uv_16bpc_avx2(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -258,7 +257,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_h_sb_uv_16bpc_avx2(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -268,7 +267,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_v_sb_y_16bpc_avx2(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -278,7 +277,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_h_sb_y_16bpc_avx2(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -288,7 +287,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_v_sb_uv_16bpc_ssse3(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -298,7 +297,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_h_sb_uv_16bpc_ssse3(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -308,7 +307,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_v_sb_y_16bpc_ssse3(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -318,7 +317,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_h_sb_y_16bpc_ssse3(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -337,7 +336,7 @@ extern "C" {
 ))]
 extern "C" {
     pub(crate) fn dav1d_lpf_v_sb_uv_16bpc_neon(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -347,7 +346,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_h_sb_uv_16bpc_neon(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -357,7 +356,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_v_sb_y_16bpc_neon(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],
@@ -367,7 +366,7 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_h_sb_y_16bpc_neon(
-        dst: *mut pixel,
+        dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,
         lvl: *const [uint8_t; 4],

--- a/src/loopfilter_tmpl_16.rs
+++ b/src/loopfilter_tmpl_16.rs
@@ -1,3 +1,4 @@
+use crate::include::common::bitdepth::DynPixel;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 use ::libc;
@@ -196,7 +197,7 @@ unsafe extern "C" fn loop_filter(
     }
 }
 unsafe extern "C" fn loop_filter_h_sb128y_c_erased(
-    dst: *mut libc::c_void,
+    dst: *mut DynPixel,
     stride: ptrdiff_t,
     vmask: *const uint32_t,
     l: *const [uint8_t; 4],
@@ -262,7 +263,7 @@ unsafe extern "C" fn loop_filter_h_sb128y_rust(
     }
 }
 unsafe extern "C" fn loop_filter_v_sb128y_c_erased(
-    dst: *mut libc::c_void,
+    dst: *mut DynPixel,
     stride: ptrdiff_t,
     vmask: *const uint32_t,
     l: *const [uint8_t; 4],
@@ -328,7 +329,7 @@ unsafe extern "C" fn loop_filter_v_sb128y_rust(
     }
 }
 unsafe extern "C" fn loop_filter_h_sb128uv_c_erased(
-    dst: *mut libc::c_void,
+    dst: *mut DynPixel,
     stride: ptrdiff_t,
     vmask: *const uint32_t,
     l: *const [uint8_t; 4],
@@ -390,7 +391,7 @@ unsafe extern "C" fn loop_filter_h_sb128uv_rust(
     }
 }
 unsafe extern "C" fn loop_filter_v_sb128uv_c_erased(
-    dst: *mut libc::c_void,
+    dst: *mut DynPixel,
     stride: ptrdiff_t,
     vmask: *const uint32_t,
     l: *const [uint8_t; 4],

--- a/src/loopfilter_tmpl_8.rs
+++ b/src/loopfilter_tmpl_8.rs
@@ -1,3 +1,4 @@
+use crate::include::common::bitdepth::DynPixel;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 use ::libc;
@@ -186,7 +187,7 @@ unsafe extern "C" fn loop_filter(
 }
 
 unsafe extern "C" fn loop_filter_h_sb128y_c_erased(
-    dst: *mut libc::c_void,
+    dst: *mut DynPixel,
     stride: ptrdiff_t,
     vmask: *const uint32_t,
     l: *const [uint8_t; 4],
@@ -243,7 +244,7 @@ unsafe fn loop_filter_h_sb128y_rust(
 }
 
 unsafe extern "C" fn loop_filter_v_sb128y_c_erased(
-    dst: *mut libc::c_void,
+    dst: *mut DynPixel,
     stride: ptrdiff_t,
     vmask: *const uint32_t,
     l: *const [uint8_t; 4],
@@ -300,7 +301,7 @@ unsafe fn loop_filter_v_sb128y_rust(
 }
 
 unsafe extern "C" fn loop_filter_h_sb128uv_c_erased(
-    dst: *mut libc::c_void,
+    dst: *mut DynPixel,
     stride: ptrdiff_t,
     vmask: *const uint32_t,
     l: *const [uint8_t; 4],
@@ -353,7 +354,7 @@ unsafe fn loop_filter_h_sb128uv_rust(
 }
 
 unsafe extern "C" fn loop_filter_v_sb128uv_c_erased(
-    dst: *mut libc::c_void,
+    dst: *mut DynPixel,
     stride: ptrdiff_t,
     vmask: *const uint32_t,
     l: *const [uint8_t; 4],

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -257,7 +257,7 @@ unsafe fn padding<BD: BitDepth>(
 }
 
 unsafe extern "C" fn wiener_c_erased<BD: BitDepth>(
-    p: *mut libc::c_void,
+    p: *mut DynPixel,
     stride: ptrdiff_t,
     left: *const LeftPixelRow<DynPixel>,
     lpf: *const DynPixel,
@@ -739,7 +739,7 @@ unsafe extern "C" fn selfguided_filter<BD: BitDepth>(
 }
 
 unsafe extern "C" fn sgr_5x5_c_erased<BD: BitDepth>(
-    p: *mut libc::c_void,
+    p: *mut DynPixel,
     stride: ptrdiff_t,
     left: *const LeftPixelRow<DynPixel>,
     lpf: *const DynPixel,
@@ -814,7 +814,7 @@ unsafe fn sgr_5x5_rust<BD: BitDepth>(
 }
 
 unsafe extern "C" fn sgr_3x3_c_erased<BD: BitDepth>(
-    p: *mut libc::c_void,
+    p: *mut DynPixel,
     stride: ptrdiff_t,
     left: *const LeftPixelRow<DynPixel>,
     lpf: *const DynPixel,
@@ -884,7 +884,7 @@ unsafe fn sgr_3x3_rust<BD: BitDepth>(
 }
 
 unsafe extern "C" fn sgr_mix_c_erased<BD: BitDepth>(
-    p: *mut libc::c_void,
+    p: *mut DynPixel,
     stride: ptrdiff_t,
     left: *const LeftPixelRow<DynPixel>,
     lpf: *const DynPixel,
@@ -1060,7 +1060,7 @@ unsafe fn dav1d_wiener_filter_v_neon<BD: BitDepth>(
 
 #[cfg(all(feature = "asm", target_arch = "arm"))]
 unsafe extern "C" fn wiener_filter_neon_erased<BD: BitDepth>(
-    p: *mut libc::c_void,
+    p: *mut DynPixel,
     stride: ptrdiff_t,
     left: *const LeftPixelRow<DynPixel>,
     lpf: *const DynPixel,
@@ -1406,9 +1406,9 @@ unsafe fn dav1d_sgr_weighted1_neon<BD: BitDepth>(
         ($name:ident) => {{
             extern "C" {
                 fn $name(
-                    dst: *mut libc::c_void,
+                    dst: *mut DynPixel,
                     dst_stride: ptrdiff_t,
-                    src: *const libc::c_void,
+                    src: *const DynPixel,
                     src_stride: ptrdiff_t,
                     t1: *const int16_t,
                     w: libc::c_int,
@@ -1487,7 +1487,7 @@ unsafe fn dav1d_sgr_weighted2_neon<BD: BitDepth>(
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 unsafe extern "C" fn sgr_filter_5x5_neon_erased<BD: BitDepth>(
-    p: *mut libc::c_void,
+    p: *mut DynPixel,
     stride: ptrdiff_t,
     left: *const LeftPixelRow<DynPixel>,
     lpf: *const DynPixel,
@@ -1550,7 +1550,7 @@ unsafe fn sgr_filter_5x5_neon<BD: BitDepth>(
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 unsafe extern "C" fn sgr_filter_3x3_neon_erased<BD: BitDepth>(
-    p: *mut libc::c_void,
+    p: *mut DynPixel,
     stride: ptrdiff_t,
     left: *const LeftPixelRow<DynPixel>,
     lpf: *const DynPixel,
@@ -1613,7 +1613,7 @@ unsafe fn sgr_filter_3x3_neon<BD: BitDepth>(
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 unsafe extern "C" fn sgr_filter_mix_neon_erased<BD: BitDepth>(
-    p: *mut libc::c_void,
+    p: *mut DynPixel,
     stride: ptrdiff_t,
     left: *const LeftPixelRow<DynPixel>,
     lpf: *const DynPixel,

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -1,5 +1,7 @@
 use crate::include::common::bitdepth::AsPrimitive;
 use crate::include::common::bitdepth::BitDepth;
+use crate::include::common::bitdepth::DynPixel;
+use crate::include::common::bitdepth::LeftPixelRow;
 #[cfg(feature = "asm")]
 use crate::include::common::bitdepth::BPC;
 use crate::include::common::intops::iclip;
@@ -37,14 +39,11 @@ pub union LooprestorationParams {
     pub sgr: LooprestorationParams_sgr,
 }
 
-type pixel = libc::c_void;
-pub type const_left_pixel_row = *const libc::c_void; // *const [pixel; 4]
-
 pub type looprestorationfilter_fn = unsafe extern "C" fn(
-    *mut pixel,
+    *mut DynPixel,
     ptrdiff_t,
-    const_left_pixel_row,
-    *const pixel,
+    *const LeftPixelRow<DynPixel>,
+    *const DynPixel,
     libc::c_int,
     libc::c_int,
     *const LooprestorationParams,
@@ -67,10 +66,10 @@ macro_rules! decl_looprestorationfilter_fn {
     (fn $name:ident) => {{
         extern "C" {
             fn $name(
-                dst: *mut pixel,
+                dst: *mut DynPixel,
                 dst_stride: ptrdiff_t,
-                left: const_left_pixel_row,
-                lpf: *const pixel,
+                left: *const LeftPixelRow<DynPixel>,
+                lpf: *const DynPixel,
                 w: libc::c_int,
                 h: libc::c_int,
                 params: *const LooprestorationParams,
@@ -260,8 +259,8 @@ unsafe fn padding<BD: BitDepth>(
 unsafe extern "C" fn wiener_c_erased<BD: BitDepth>(
     p: *mut libc::c_void,
     stride: ptrdiff_t,
-    left: *const libc::c_void,
-    lpf: *const libc::c_void,
+    left: *const LeftPixelRow<DynPixel>,
+    lpf: *const DynPixel,
     w: libc::c_int,
     h: libc::c_int,
     params: *const LooprestorationParams,
@@ -742,8 +741,8 @@ unsafe extern "C" fn selfguided_filter<BD: BitDepth>(
 unsafe extern "C" fn sgr_5x5_c_erased<BD: BitDepth>(
     p: *mut libc::c_void,
     stride: ptrdiff_t,
-    left: *const libc::c_void,
-    lpf: *const libc::c_void,
+    left: *const LeftPixelRow<DynPixel>,
+    lpf: *const DynPixel,
     w: libc::c_int,
     h: libc::c_int,
     params: *const LooprestorationParams,
@@ -817,8 +816,8 @@ unsafe fn sgr_5x5_rust<BD: BitDepth>(
 unsafe extern "C" fn sgr_3x3_c_erased<BD: BitDepth>(
     p: *mut libc::c_void,
     stride: ptrdiff_t,
-    left: *const libc::c_void,
-    lpf: *const libc::c_void,
+    left: *const LeftPixelRow<DynPixel>,
+    lpf: *const DynPixel,
     w: libc::c_int,
     h: libc::c_int,
     params: *const LooprestorationParams,
@@ -887,8 +886,8 @@ unsafe fn sgr_3x3_rust<BD: BitDepth>(
 unsafe extern "C" fn sgr_mix_c_erased<BD: BitDepth>(
     p: *mut libc::c_void,
     stride: ptrdiff_t,
-    left: *const libc::c_void,
-    lpf: *const libc::c_void,
+    left: *const LeftPixelRow<DynPixel>,
+    lpf: *const DynPixel,
     w: libc::c_int,
     h: libc::c_int,
     params: *const LooprestorationParams,
@@ -1063,8 +1062,8 @@ unsafe fn dav1d_wiener_filter_v_neon<BD: BitDepth>(
 unsafe extern "C" fn wiener_filter_neon_erased<BD: BitDepth>(
     p: *mut libc::c_void,
     stride: ptrdiff_t,
-    left: *const libc::c_void,
-    lpf: *const libc::c_void,
+    left: *const LeftPixelRow<DynPixel>,
+    lpf: *const DynPixel,
     w: libc::c_int,
     h: libc::c_int,
     params: *const LooprestorationParams,
@@ -1490,8 +1489,8 @@ unsafe fn dav1d_sgr_weighted2_neon<BD: BitDepth>(
 unsafe extern "C" fn sgr_filter_5x5_neon_erased<BD: BitDepth>(
     p: *mut libc::c_void,
     stride: ptrdiff_t,
-    left: *const libc::c_void,
-    lpf: *const libc::c_void,
+    left: *const LeftPixelRow<DynPixel>,
+    lpf: *const DynPixel,
     w: libc::c_int,
     h: libc::c_int,
     params: *const LooprestorationParams,
@@ -1553,8 +1552,8 @@ unsafe fn sgr_filter_5x5_neon<BD: BitDepth>(
 unsafe extern "C" fn sgr_filter_3x3_neon_erased<BD: BitDepth>(
     p: *mut libc::c_void,
     stride: ptrdiff_t,
-    left: *const libc::c_void,
-    lpf: *const libc::c_void,
+    left: *const LeftPixelRow<DynPixel>,
+    lpf: *const DynPixel,
     w: libc::c_int,
     h: libc::c_int,
     params: *const LooprestorationParams,
@@ -1616,8 +1615,8 @@ unsafe fn sgr_filter_3x3_neon<BD: BitDepth>(
 unsafe extern "C" fn sgr_filter_mix_neon_erased<BD: BitDepth>(
     p: *mut libc::c_void,
     stride: ptrdiff_t,
-    left: *const libc::c_void,
-    lpf: *const libc::c_void,
+    left: *const LeftPixelRow<DynPixel>,
+    lpf: *const DynPixel,
     w: libc::c_int,
     h: libc::c_int,
     params: *const LooprestorationParams,


### PR DESCRIPTION
This centralizes all of the type-erased type aliases (for already type-erased modules; for the rest we can do this as we type-erase them).  These are named `Dyn{Pixel,Coef}` so there can't be any confusion with existing bitdepth-specific `pixel` and `coef`.  I also made them `#[repr(transparent)]` newtypes instead of just type aliases so we can't accidentally just use `libc::c_void` instead, so this makes all the signatures a lot easier to understand now instead of having a ton of `libc::c_void`s that could be multiple things.

There are also type aliases for `LeftRowPixel{,2px}`, which can be used with `BD::Pixel` or `DynPixel`.  `LeftRowPixel<DynPixel>` aka `[c_void; 4]` is different from the previous alias of just `libc::c_void`, but they're both behind `*const` ptrs and so passing them over FFI should be totally fine.