### PR TITLE
`fn decode_sb`: Cleanup majority of `fn`

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4190,9 +4190,7 @@ unsafe fn decode_sb(
     let have_h_split = f.bw > t.bx + hsz;
     let have_v_split = f.bh > t.by + hsz;
     if !have_h_split && !have_v_split {
-        if !((bl as libc::c_uint) < BL_8X8 as libc::c_int as libc::c_uint) {
-            unreachable!();
-        }
+        assert!((bl as libc::c_uint) < BL_8X8 as libc::c_int as libc::c_uint);
         return decode_sb(
             t,
             (bl as libc::c_uint).wrapping_add(1 as libc::c_int as libc::c_uint) as BlockLevel,
@@ -4324,9 +4322,7 @@ unsafe fn decode_sb(
             3 => {
                 if bl as libc::c_uint == BL_8X8 as libc::c_int as libc::c_uint {
                     let tip: *const EdgeTip = node as *const EdgeTip;
-                    if !(hsz == 1) {
-                        unreachable!();
-                    }
+                    assert!(hsz == 1);
                     if decode_b(t, bl, BS_4x4, PARTITION_SPLIT, (*tip).split[0]) != 0 {
                         return -(1 as libc::c_int);
                     }
@@ -4647,11 +4643,7 @@ unsafe fn decode_sb(
                 }
                 t.bx -= hsz * 3 >> 1;
             }
-            _ => {
-                if 0 == 0 {
-                    unreachable!();
-                }
-            }
+            _ => unreachable!(),
         }
     } else if have_h_split {
         let mut is_split: libc::c_uint = 0;
@@ -4682,9 +4674,7 @@ unsafe fn decode_sb(
                 );
             }
         }
-        if !((bl as libc::c_uint) < BL_8X8 as libc::c_int as libc::c_uint) {
-            unreachable!();
-        }
+        assert!((bl as libc::c_uint) < BL_8X8 as libc::c_int as libc::c_uint);
         if is_split != 0 {
             let branch_6: *const EdgeBranch = node as *const EdgeBranch;
             bp = PARTITION_SPLIT;
@@ -4720,9 +4710,7 @@ unsafe fn decode_sb(
             }
         }
     } else {
-        if !have_v_split {
-            unreachable!();
-        }
+        assert!(have_v_split);
         let mut is_split_0: libc::c_uint = 0;
         if t.frame_thread.pass == 2 {
             let b_2: *const Av1Block = &mut *(f.frame_thread.b)
@@ -4757,9 +4745,7 @@ unsafe fn decode_sb(
                 );
             }
         }
-        if !((bl as libc::c_uint) < BL_8X8 as libc::c_int as libc::c_uint) {
-            unreachable!();
-        }
+        assert!((bl as libc::c_uint) < BL_8X8 as libc::c_int as libc::c_uint);
         if is_split_0 != 0 {
             let branch_7: *const EdgeBranch = node as *const EdgeBranch;
             bp = PARTITION_SPLIT;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4251,29 +4251,29 @@ unsafe fn decode_sb(
                 );
             }
         }
-        let b: *const uint8_t = (dav1d_block_sizes[bl as usize][bp as usize]).as_ptr();
+        let b = &dav1d_block_sizes[bl as usize][bp as usize];
         match bp as libc::c_uint {
             0 => {
-                if decode_b(t, bl, *b.offset(0) as BlockSize, PARTITION_NONE, (*node).o) != 0 {
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_NONE, (*node).o) != 0 {
                     return -1;
                 }
             }
             1 => {
-                if decode_b(t, bl, *b.offset(0) as BlockSize, PARTITION_H, (*node).h[0]) != 0 {
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_H, (*node).h[0]) != 0 {
                     return -1;
                 }
                 t.by += hsz;
-                if decode_b(t, bl, *b.offset(0) as BlockSize, PARTITION_H, (*node).h[1]) != 0 {
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_H, (*node).h[1]) != 0 {
                     return -1;
                 }
                 t.by -= hsz;
             }
             2 => {
-                if decode_b(t, bl, *b.offset(0) as BlockSize, PARTITION_V, (*node).v[0]) != 0 {
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_V, (*node).v[0]) != 0 {
                     return -1;
                 }
                 t.bx += hsz;
-                if decode_b(t, bl, *b.offset(0) as BlockSize, PARTITION_V, (*node).v[1]) != 0 {
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_V, (*node).v[1]) != 0 {
                     return -1;
                 }
                 t.bx -= hsz;
@@ -4337,7 +4337,7 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b.offset(0) as BlockSize,
+                    b[0] as BlockSize,
                     PARTITION_T_TOP_SPLIT,
                     (*branch).tts[0],
                 ) != 0
@@ -4348,7 +4348,7 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b.offset(0) as BlockSize,
+                    b[0] as BlockSize,
                     PARTITION_T_TOP_SPLIT,
                     (*branch).tts[1],
                 ) != 0
@@ -4360,7 +4360,7 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b.offset(1) as BlockSize,
+                    b[1] as BlockSize,
                     PARTITION_T_TOP_SPLIT,
                     (*branch).tts[2],
                 ) != 0
@@ -4374,7 +4374,7 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b.offset(0) as BlockSize,
+                    b[0] as BlockSize,
                     PARTITION_T_BOTTOM_SPLIT,
                     (*branch).tbs[0],
                 ) != 0
@@ -4385,7 +4385,7 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b.offset(1) as BlockSize,
+                    b[1] as BlockSize,
                     PARTITION_T_BOTTOM_SPLIT,
                     (*branch).tbs[1],
                 ) != 0
@@ -4396,7 +4396,7 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b.offset(1) as BlockSize,
+                    b[1] as BlockSize,
                     PARTITION_T_BOTTOM_SPLIT,
                     (*branch).tbs[2],
                 ) != 0
@@ -4411,7 +4411,7 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b.offset(0) as BlockSize,
+                    b[0] as BlockSize,
                     PARTITION_T_LEFT_SPLIT,
                     (*branch).tls[0],
                 ) != 0
@@ -4422,7 +4422,7 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b.offset(0) as BlockSize,
+                    b[0] as BlockSize,
                     PARTITION_T_LEFT_SPLIT,
                     (*branch).tls[1],
                 ) != 0
@@ -4434,7 +4434,7 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b.offset(1) as BlockSize,
+                    b[1] as BlockSize,
                     PARTITION_T_LEFT_SPLIT,
                     (*branch).tls[2],
                 ) != 0
@@ -4448,7 +4448,7 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b.offset(0) as BlockSize,
+                    b[0] as BlockSize,
                     PARTITION_T_RIGHT_SPLIT,
                     (*branch).trs[0],
                 ) != 0
@@ -4459,7 +4459,7 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b.offset(1) as BlockSize,
+                    b[1] as BlockSize,
                     PARTITION_T_RIGHT_SPLIT,
                     (*branch).trs[1],
                 ) != 0
@@ -4470,7 +4470,7 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b.offset(1) as BlockSize,
+                    b[1] as BlockSize,
                     PARTITION_T_RIGHT_SPLIT,
                     (*branch).trs[2],
                 ) != 0
@@ -4482,48 +4482,20 @@ unsafe fn decode_sb(
             }
             8 => {
                 let branch: *const EdgeBranch = node as *const EdgeBranch;
-                if decode_b(
-                    t,
-                    bl,
-                    *b.offset(0) as BlockSize,
-                    PARTITION_H4,
-                    (*branch).h4[0],
-                ) != 0
-                {
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_H4, (*branch).h4[0]) != 0 {
                     return -1;
                 }
                 t.by += hsz >> 1;
-                if decode_b(
-                    t,
-                    bl,
-                    *b.offset(0) as BlockSize,
-                    PARTITION_H4,
-                    (*branch).h4[1],
-                ) != 0
-                {
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_H4, (*branch).h4[1]) != 0 {
                     return -1;
                 }
                 t.by += hsz >> 1;
-                if decode_b(
-                    t,
-                    bl,
-                    *b.offset(0) as BlockSize,
-                    PARTITION_H4,
-                    (*branch).h4[2],
-                ) != 0
-                {
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_H4, (*branch).h4[2]) != 0 {
                     return -1;
                 }
                 t.by += hsz >> 1;
                 if t.by < f.bh {
-                    if decode_b(
-                        t,
-                        bl,
-                        *b.offset(0) as BlockSize,
-                        PARTITION_H4,
-                        (*branch).h4[3],
-                    ) != 0
-                    {
+                    if decode_b(t, bl, b[0] as BlockSize, PARTITION_H4, (*branch).h4[3]) != 0 {
                         return -1;
                     }
                 }
@@ -4531,48 +4503,20 @@ unsafe fn decode_sb(
             }
             9 => {
                 let branch: *const EdgeBranch = node as *const EdgeBranch;
-                if decode_b(
-                    t,
-                    bl,
-                    *b.offset(0) as BlockSize,
-                    PARTITION_V4,
-                    (*branch).v4[0],
-                ) != 0
-                {
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_V4, (*branch).v4[0]) != 0 {
                     return -1;
                 }
                 t.bx += hsz >> 1;
-                if decode_b(
-                    t,
-                    bl,
-                    *b.offset(0) as BlockSize,
-                    PARTITION_V4,
-                    (*branch).v4[1],
-                ) != 0
-                {
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_V4, (*branch).v4[1]) != 0 {
                     return -1;
                 }
                 t.bx += hsz >> 1;
-                if decode_b(
-                    t,
-                    bl,
-                    *b.offset(0) as BlockSize,
-                    PARTITION_V4,
-                    (*branch).v4[2],
-                ) != 0
-                {
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_V4, (*branch).v4[2]) != 0 {
                     return -1;
                 }
                 t.bx += hsz >> 1;
                 if t.bx < f.bw {
-                    if decode_b(
-                        t,
-                        bl,
-                        *b.offset(0) as BlockSize,
-                        PARTITION_V4,
-                        (*branch).v4[3],
-                    ) != 0
-                    {
+                    if decode_b(t, bl, b[0] as BlockSize, PARTITION_V4, (*branch).v4[3]) != 0 {
                         return -1;
                     }
                 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4644,7 +4644,7 @@ unsafe fn decode_sb(
             },
         );
     }
-    return 0;
+    0
 }
 
 unsafe extern "C" fn reset_context(

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4200,12 +4200,12 @@ unsafe fn decode_sb(
     let mut by8 = 0;
     if t.frame_thread.pass != 2 {
         if bl == BL_64X64 {
-            printf(
-                b"poc=%d,y=%d,x=%d,bl=%d,r=%d\n\0" as *const u8 as *const libc::c_char,
+            println!(
+                "poc={},y={},x={},bl={},r={}",
                 (*f.frame_hdr).frame_offset,
                 t.by,
                 t.bx,
-                bl as libc::c_uint,
+                bl,
                 ts.msac.rng,
             );
         }
@@ -4239,15 +4239,14 @@ unsafe fn decode_sb(
                 return 1;
             }
             if DEBUG_BLOCK_INFO(f, t) {
-                printf(
-                    b"poc=%d,y=%d,x=%d,bl=%d,ctx=%d,bp=%d: r=%d\n\0" as *const u8
-                        as *const libc::c_char,
+                println!(
+                    "poc={},y={},x={},bl={},ctx={},bp={}: r={}",
                     (*f.frame_hdr).frame_offset,
                     t.by,
                     t.bx,
-                    bl as libc::c_uint,
-                    ctx as libc::c_int,
-                    bp as libc::c_uint,
+                    bl,
+                    ctx,
+                    bp,
                     ts.msac.rng,
                 );
             }
@@ -4592,18 +4591,17 @@ unsafe fn decode_sb(
             is_split = dav1d_msac_decode_bool(&mut ts.msac, gather_top_partition_prob(pc, bl))
                 as libc::c_uint;
             if DEBUG_BLOCK_INFO(f, t) {
-                printf(
-                    b"poc=%d,y=%d,x=%d,bl=%d,ctx=%d,bp=%d: r=%d\n\0" as *const u8
-                        as *const libc::c_char,
+                println!(
+                    "poc={},y={},x={},bl={},ctx={},bp={}: r={}",
                     (*f.frame_hdr).frame_offset,
                     t.by,
                     t.bx,
-                    bl as libc::c_uint,
-                    ctx as libc::c_int,
+                    bl,
+                    ctx,
                     if is_split != 0 {
-                        PARTITION_SPLIT as libc::c_int
+                        PARTITION_SPLIT
                     } else {
-                        PARTITION_H as libc::c_int
+                        PARTITION_H
                     },
                     ts.msac.rng,
                 );
@@ -4649,18 +4647,17 @@ unsafe fn decode_sb(
                 return 1;
             }
             if DEBUG_BLOCK_INFO(f, t) {
-                printf(
-                    b"poc=%d,y=%d,x=%d,bl=%d,ctx=%d,bp=%d: r=%d\n\0" as *const u8
-                        as *const libc::c_char,
+                println!(
+                    "poc={},y={},x={},bl={},ctx={},bp={}: r={}",
                     (*f.frame_hdr).frame_offset,
                     t.by,
                     t.bx,
-                    bl as libc::c_uint,
-                    ctx as libc::c_int,
+                    bl,
+                    ctx,
                     if is_split != 0 {
-                        PARTITION_SPLIT as libc::c_int
+                        PARTITION_SPLIT
                     } else {
-                        PARTITION_V as libc::c_int
+                        PARTITION_V
                     },
                     ts.msac.rng,
                 );

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4286,7 +4286,7 @@ unsafe fn decode_sb(
                     if decode_b(t, bl, BS_4x4, PARTITION_SPLIT, tip.split[0]) != 0 {
                         return -1;
                     }
-                    let tl_filter: Filter2d = t.tl_4x4_filter;
+                    let tl_filter = t.tl_4x4_filter;
                     t.bx += 1;
                     if decode_b(t, bl, BS_4x4, PARTITION_SPLIT, tip.split[1]) != 0 {
                         return -1;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4581,15 +4581,14 @@ unsafe fn decode_sb(
             _ => unreachable!(),
         }
     } else if have_h_split {
-        let mut is_split: libc::c_uint = 0;
+        let mut is_split;
         if t.frame_thread.pass == 2 {
             let b: *const Av1Block = &mut *(f.frame_thread.b)
                 .offset((t.by as isize * f.b4_stride + t.bx as isize) as isize)
                 as *mut Av1Block;
-            is_split = ((*b).bl as BlockLevel != bl) as libc::c_uint;
+            is_split = (*b).bl as BlockLevel != bl;
         } else {
-            is_split = dav1d_msac_decode_bool(&mut ts.msac, gather_top_partition_prob(pc, bl))
-                as libc::c_uint;
+            is_split = dav1d_msac_decode_bool(&mut ts.msac, gather_top_partition_prob(pc, bl));
             if DEBUG_BLOCK_INFO(f, t) {
                 println!(
                     "poc={},y={},x={},bl={},ctx={},bp={}: r={}",
@@ -4598,7 +4597,7 @@ unsafe fn decode_sb(
                     t.bx,
                     bl,
                     ctx,
-                    if is_split != 0 {
+                    if is_split {
                         PARTITION_SPLIT
                     } else {
                         PARTITION_H
@@ -4608,7 +4607,7 @@ unsafe fn decode_sb(
             }
         }
         assert!(bl < BL_8X8);
-        if is_split != 0 {
+        if is_split {
             let branch: *const EdgeBranch = node as *const EdgeBranch;
             bp = PARTITION_SPLIT;
             if decode_sb(t, bl + 1, (*branch).split[0]) != 0 {
@@ -4634,16 +4633,15 @@ unsafe fn decode_sb(
         }
     } else {
         assert!(have_v_split);
-        let mut is_split: libc::c_uint = 0;
+        let mut is_split;
         if t.frame_thread.pass == 2 {
             let b: *const Av1Block = &mut *(f.frame_thread.b)
                 .offset((t.by as isize * f.b4_stride + t.bx as isize) as isize)
                 as *mut Av1Block;
-            is_split = ((*b).bl as BlockLevel != bl) as libc::c_uint;
+            is_split = (*b).bl as BlockLevel != bl;
         } else {
-            is_split = dav1d_msac_decode_bool(&mut ts.msac, gather_left_partition_prob(pc, bl))
-                as libc::c_uint;
-            if f.cur.p.layout == DAV1D_PIXEL_LAYOUT_I422 && is_split == 0 {
+            is_split = dav1d_msac_decode_bool(&mut ts.msac, gather_left_partition_prob(pc, bl));
+            if f.cur.p.layout == DAV1D_PIXEL_LAYOUT_I422 && !is_split {
                 return 1;
             }
             if DEBUG_BLOCK_INFO(f, t) {
@@ -4654,7 +4652,7 @@ unsafe fn decode_sb(
                     t.bx,
                     bl,
                     ctx,
-                    if is_split != 0 {
+                    if is_split {
                         PARTITION_SPLIT
                     } else {
                         PARTITION_V
@@ -4664,7 +4662,7 @@ unsafe fn decode_sb(
             }
         }
         assert!(bl < BL_8X8);
-        if is_split != 0 {
+        if is_split {
             let branch: *const EdgeBranch = node as *const EdgeBranch;
             bp = PARTITION_SPLIT;
             if decode_sb(t, bl + 1, (*branch).split[0]) != 0 {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4179,7 +4179,7 @@ unsafe fn decode_b(
     0
 }
 
-unsafe extern "C" fn decode_sb(
+unsafe fn decode_sb(
     t: *mut Dav1dTaskContext,
     bl: BlockLevel,
     node: *const EdgeNode,
@@ -4811,6 +4811,7 @@ unsafe extern "C" fn decode_sb(
     }
     return 0 as libc::c_int;
 }
+
 unsafe extern "C" fn reset_context(
     ctx: *mut BlockContext,
     keyframe: libc::c_int,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4304,12 +4304,10 @@ unsafe fn decode_sb(
                     t.bx -= 1;
                     t.by -= 1;
                     if t.frame_thread.pass != 0 {
-                        let p = t.frame_thread.pass & 1;
-                        ts.frame_thread[p as usize].cf = ((ts.frame_thread[p as usize].cf
-                            as uintptr_t)
-                            .wrapping_add(63)
-                            & !(63))
-                            as *mut libc::c_void;
+                        let p = (t.frame_thread.pass & 1) as usize;
+                        ts.frame_thread[p].cf =
+                            ((ts.frame_thread[p].cf as uintptr_t).wrapping_add(63) & !(63))
+                                as *mut libc::c_void;
                     }
                 } else {
                     let branch = &*(node as *const EdgeBranch);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4216,11 +4216,9 @@ unsafe fn decode_sb(
     }
     if have_h_split && have_v_split {
         if t.frame_thread.pass == 2 {
-            let b: *const Av1Block = &mut *(f.frame_thread.b)
-                .offset((t.by as isize * f.b4_stride + t.bx as isize) as isize)
-                as *mut Av1Block;
-            bp = if (*b).bl as BlockLevel == bl {
-                (*b).bp as BlockPartition
+            let b = &mut *(f.frame_thread.b).offset(t.by as isize * f.b4_stride + t.bx as isize);
+            bp = if b.bl as BlockLevel == bl {
+                b.bp as BlockPartition
             } else {
                 PARTITION_SPLIT
             };
@@ -4527,10 +4525,8 @@ unsafe fn decode_sb(
     } else if have_h_split {
         let mut is_split;
         if t.frame_thread.pass == 2 {
-            let b: *const Av1Block = &mut *(f.frame_thread.b)
-                .offset((t.by as isize * f.b4_stride + t.bx as isize) as isize)
-                as *mut Av1Block;
-            is_split = (*b).bl as BlockLevel != bl;
+            let b = &mut *(f.frame_thread.b).offset(t.by as isize * f.b4_stride + t.bx as isize);
+            is_split = b.bl as BlockLevel != bl;
         } else {
             is_split = dav1d_msac_decode_bool(&mut ts.msac, gather_top_partition_prob(pc, bl));
             if DEBUG_BLOCK_INFO(f, t) {
@@ -4579,10 +4575,8 @@ unsafe fn decode_sb(
         assert!(have_v_split);
         let mut is_split;
         if t.frame_thread.pass == 2 {
-            let b: *const Av1Block = &mut *(f.frame_thread.b)
-                .offset((t.by as isize * f.b4_stride + t.bx as isize) as isize)
-                as *mut Av1Block;
-            is_split = (*b).bl as BlockLevel != bl;
+            let b = &mut *(f.frame_thread.b).offset(t.by as isize * f.b4_stride + t.bx as isize);
+            is_split = b.bl as BlockLevel != bl;
         } else {
             is_split = dav1d_msac_decode_bool(&mut ts.msac, gather_left_partition_prob(pc, bl));
             if f.cur.p.layout == DAV1D_PIXEL_LAYOUT_I422 && !is_split {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4184,11 +4184,11 @@ unsafe fn decode_sb(
     bl: BlockLevel,
     node: *const EdgeNode,
 ) -> libc::c_int {
-    let f: *const Dav1dFrameContext = t.f;
+    let f = &*t.f;
     let ts: *mut Dav1dTileState = t.ts;
     let hsz = 16 >> bl as libc::c_uint;
-    let have_h_split = ((*f).bw > t.bx + hsz) as libc::c_int;
-    let have_v_split = ((*f).bh > t.by + hsz) as libc::c_int;
+    let have_h_split = (f.bw > t.bx + hsz) as libc::c_int;
+    let have_v_split = (f.bh > t.by + hsz) as libc::c_int;
     if have_h_split == 0 && have_v_split == 0 {
         if !((bl as libc::c_uint) < BL_8X8 as libc::c_int as libc::c_uint) {
             unreachable!();
@@ -4208,7 +4208,7 @@ unsafe fn decode_sb(
         if 0 as libc::c_int != 0 && bl as libc::c_uint == BL_64X64 as libc::c_int as libc::c_uint {
             printf(
                 b"poc=%d,y=%d,x=%d,bl=%d,r=%d\n\0" as *const u8 as *const libc::c_char,
-                (*(*f).frame_hdr).frame_offset,
+                (*f.frame_hdr).frame_offset,
                 t.by,
                 t.bx,
                 bl as libc::c_uint,
@@ -4222,8 +4222,8 @@ unsafe fn decode_sb(
     }
     if have_h_split != 0 && have_v_split != 0 {
         if t.frame_thread.pass == 2 {
-            let b: *const Av1Block = &mut *((*f).frame_thread.b)
-                .offset((t.by as isize * (*f).b4_stride + t.bx as isize) as isize)
+            let b: *const Av1Block = &mut *(f.frame_thread.b)
+                .offset((t.by as isize * f.b4_stride + t.bx as isize) as isize)
                 as *mut Av1Block;
             bp = (if (*b).bl as libc::c_uint == bl as libc::c_uint {
                 (*b).bp as libc::c_int
@@ -4236,7 +4236,7 @@ unsafe fn decode_sb(
                 pc,
                 dav1d_partition_type_count[bl as usize] as size_t,
             ) as BlockPartition;
-            if (*f).cur.p.layout as libc::c_uint
+            if f.cur.p.layout as libc::c_uint
                 == DAV1D_PIXEL_LAYOUT_I422 as libc::c_int as libc::c_uint
                 && (bp as libc::c_uint == PARTITION_V as libc::c_int as libc::c_uint
                     || bp as libc::c_uint == PARTITION_V4 as libc::c_int as libc::c_uint
@@ -4245,11 +4245,11 @@ unsafe fn decode_sb(
             {
                 return 1 as libc::c_int;
             }
-            if DEBUG_BLOCK_INFO(&*f, t) {
+            if DEBUG_BLOCK_INFO(f, t) {
                 printf(
                     b"poc=%d,y=%d,x=%d,bl=%d,ctx=%d,bp=%d: r=%d\n\0" as *const u8
                         as *const libc::c_char,
-                    (*(*f).frame_hdr).frame_offset,
+                    (*f.frame_hdr).frame_offset,
                     t.by,
                     t.bx,
                     bl as libc::c_uint,
@@ -4582,7 +4582,7 @@ unsafe fn decode_sb(
                     return -(1 as libc::c_int);
                 }
                 t.by += hsz >> 1;
-                if t.by < (*f).bh {
+                if t.by < f.bh {
                     if decode_b(
                         t,
                         bl,
@@ -4631,7 +4631,7 @@ unsafe fn decode_sb(
                     return -(1 as libc::c_int);
                 }
                 t.bx += hsz >> 1;
-                if t.bx < (*f).bw {
+                if t.bx < f.bw {
                     if decode_b(
                         t,
                         bl,
@@ -4654,19 +4654,19 @@ unsafe fn decode_sb(
     } else if have_h_split != 0 {
         let mut is_split: libc::c_uint = 0;
         if t.frame_thread.pass == 2 {
-            let b_1: *const Av1Block = &mut *((*f).frame_thread.b)
-                .offset((t.by as isize * (*f).b4_stride + t.bx as isize) as isize)
+            let b_1: *const Av1Block = &mut *(f.frame_thread.b)
+                .offset((t.by as isize * f.b4_stride + t.bx as isize) as isize)
                 as *mut Av1Block;
             is_split =
                 ((*b_1).bl as libc::c_uint != bl as libc::c_uint) as libc::c_int as libc::c_uint;
         } else {
             is_split = dav1d_msac_decode_bool(&mut (*ts).msac, gather_top_partition_prob(pc, bl))
                 as libc::c_uint;
-            if DEBUG_BLOCK_INFO(&*f, t) {
+            if DEBUG_BLOCK_INFO(f, t) {
                 printf(
                     b"poc=%d,y=%d,x=%d,bl=%d,ctx=%d,bp=%d: r=%d\n\0" as *const u8
                         as *const libc::c_char,
-                    (*(*f).frame_hdr).frame_offset,
+                    (*f.frame_hdr).frame_offset,
                     t.by,
                     t.bx,
                     bl as libc::c_uint,
@@ -4723,25 +4723,25 @@ unsafe fn decode_sb(
         }
         let mut is_split_0: libc::c_uint = 0;
         if t.frame_thread.pass == 2 {
-            let b_2: *const Av1Block = &mut *((*f).frame_thread.b)
-                .offset((t.by as isize * (*f).b4_stride + t.bx as isize) as isize)
+            let b_2: *const Av1Block = &mut *(f.frame_thread.b)
+                .offset((t.by as isize * f.b4_stride + t.bx as isize) as isize)
                 as *mut Av1Block;
             is_split_0 =
                 ((*b_2).bl as libc::c_uint != bl as libc::c_uint) as libc::c_int as libc::c_uint;
         } else {
             is_split_0 = dav1d_msac_decode_bool(&mut (*ts).msac, gather_left_partition_prob(pc, bl))
                 as libc::c_uint;
-            if (*f).cur.p.layout as libc::c_uint
+            if f.cur.p.layout as libc::c_uint
                 == DAV1D_PIXEL_LAYOUT_I422 as libc::c_int as libc::c_uint
                 && is_split_0 == 0
             {
                 return 1 as libc::c_int;
             }
-            if DEBUG_BLOCK_INFO(&*f, t) {
+            if DEBUG_BLOCK_INFO(f, t) {
                 printf(
                     b"poc=%d,y=%d,x=%d,bl=%d,ctx=%d,bp=%d: r=%d\n\0" as *const u8
                         as *const libc::c_char,
-                    (*(*f).frame_hdr).frame_offset,
+                    (*f.frame_hdr).frame_offset,
                     t.by,
                     t.bx,
                     bl as libc::c_uint,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4194,7 +4194,7 @@ unsafe fn decode_sb(
         return decode_sb(t, bl + 1, (*(node as *const EdgeBranch)).split[0]);
     }
     let mut pc = &mut Default::default();
-    let mut bp: BlockPartition = PARTITION_NONE;
+    let mut bp;
     let mut ctx = 0;
     let mut bx8 = 0;
     let mut by8 = 0;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4252,50 +4252,53 @@ unsafe fn decode_sb(
         let b = &dav1d_block_sizes[bl as usize][bp as usize];
         match bp {
             PARTITION_NONE => {
-                if decode_b(t, bl, b[0] as BlockSize, PARTITION_NONE, (*node).o) != 0 {
+                let node = &*node;
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_NONE, node.o) != 0 {
                     return -1;
                 }
             }
             PARTITION_H => {
-                if decode_b(t, bl, b[0] as BlockSize, PARTITION_H, (*node).h[0]) != 0 {
+                let node = &*node;
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_H, node.h[0]) != 0 {
                     return -1;
                 }
                 t.by += hsz;
-                if decode_b(t, bl, b[0] as BlockSize, PARTITION_H, (*node).h[1]) != 0 {
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_H, node.h[1]) != 0 {
                     return -1;
                 }
                 t.by -= hsz;
             }
             PARTITION_V => {
-                if decode_b(t, bl, b[0] as BlockSize, PARTITION_V, (*node).v[0]) != 0 {
+                let node = &*node;
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_V, node.v[0]) != 0 {
                     return -1;
                 }
                 t.bx += hsz;
-                if decode_b(t, bl, b[0] as BlockSize, PARTITION_V, (*node).v[1]) != 0 {
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_V, node.v[1]) != 0 {
                     return -1;
                 }
                 t.bx -= hsz;
             }
             PARTITION_SPLIT => {
                 if bl == BL_8X8 {
-                    let tip: *const EdgeTip = node as *const EdgeTip;
+                    let tip = &*(node as *const EdgeTip);
                     assert!(hsz == 1);
-                    if decode_b(t, bl, BS_4x4, PARTITION_SPLIT, (*tip).split[0]) != 0 {
+                    if decode_b(t, bl, BS_4x4, PARTITION_SPLIT, tip.split[0]) != 0 {
                         return -1;
                     }
                     let tl_filter: Filter2d = t.tl_4x4_filter;
                     t.bx += 1;
-                    if decode_b(t, bl, BS_4x4, PARTITION_SPLIT, (*tip).split[1]) != 0 {
+                    if decode_b(t, bl, BS_4x4, PARTITION_SPLIT, tip.split[1]) != 0 {
                         return -1;
                     }
                     t.bx -= 1;
                     t.by += 1;
-                    if decode_b(t, bl, BS_4x4, PARTITION_SPLIT, (*tip).split[2]) != 0 {
+                    if decode_b(t, bl, BS_4x4, PARTITION_SPLIT, tip.split[2]) != 0 {
                         return -1;
                     }
                     t.bx += 1;
                     t.tl_4x4_filter = tl_filter;
-                    if decode_b(t, bl, BS_4x4, PARTITION_SPLIT, (*tip).split[3]) != 0 {
+                    if decode_b(t, bl, BS_4x4, PARTITION_SPLIT, tip.split[3]) != 0 {
                         return -1;
                     }
                     t.bx -= 1;
@@ -4309,21 +4312,21 @@ unsafe fn decode_sb(
                             as *mut libc::c_void;
                     }
                 } else {
-                    let branch: *const EdgeBranch = node as *const EdgeBranch;
-                    if decode_sb(t, bl + 1, (*branch).split[0]) != 0 {
+                    let branch = &*(node as *const EdgeBranch);
+                    if decode_sb(t, bl + 1, branch.split[0]) != 0 {
                         return 1;
                     }
                     t.bx += hsz;
-                    if decode_sb(t, bl + 1, (*branch).split[1]) != 0 {
+                    if decode_sb(t, bl + 1, branch.split[1]) != 0 {
                         return 1;
                     }
                     t.bx -= hsz;
                     t.by += hsz;
-                    if decode_sb(t, bl + 1, (*branch).split[2]) != 0 {
+                    if decode_sb(t, bl + 1, branch.split[2]) != 0 {
                         return 1;
                     }
                     t.bx += hsz;
-                    if decode_sb(t, bl + 1, (*branch).split[3]) != 0 {
+                    if decode_sb(t, bl + 1, branch.split[3]) != 0 {
                         return 1;
                     }
                     t.bx -= hsz;
@@ -4331,13 +4334,13 @@ unsafe fn decode_sb(
                 }
             }
             PARTITION_T_TOP_SPLIT => {
-                let branch: *const EdgeBranch = node as *const EdgeBranch;
+                let branch = &*(node as *const EdgeBranch);
                 if decode_b(
                     t,
                     bl,
                     b[0] as BlockSize,
                     PARTITION_T_TOP_SPLIT,
-                    (*branch).tts[0],
+                    branch.tts[0],
                 ) != 0
                 {
                     return -1;
@@ -4348,7 +4351,7 @@ unsafe fn decode_sb(
                     bl,
                     b[0] as BlockSize,
                     PARTITION_T_TOP_SPLIT,
-                    (*branch).tts[1],
+                    branch.tts[1],
                 ) != 0
                 {
                     return -1;
@@ -4360,7 +4363,7 @@ unsafe fn decode_sb(
                     bl,
                     b[1] as BlockSize,
                     PARTITION_T_TOP_SPLIT,
-                    (*branch).tts[2],
+                    branch.tts[2],
                 ) != 0
                 {
                     return -1;
@@ -4368,13 +4371,13 @@ unsafe fn decode_sb(
                 t.by -= hsz;
             }
             PARTITION_T_BOTTOM_SPLIT => {
-                let branch: *const EdgeBranch = node as *const EdgeBranch;
+                let branch = &*(node as *const EdgeBranch);
                 if decode_b(
                     t,
                     bl,
                     b[0] as BlockSize,
                     PARTITION_T_BOTTOM_SPLIT,
-                    (*branch).tbs[0],
+                    branch.tbs[0],
                 ) != 0
                 {
                     return -1;
@@ -4385,7 +4388,7 @@ unsafe fn decode_sb(
                     bl,
                     b[1] as BlockSize,
                     PARTITION_T_BOTTOM_SPLIT,
-                    (*branch).tbs[1],
+                    branch.tbs[1],
                 ) != 0
                 {
                     return -1;
@@ -4396,7 +4399,7 @@ unsafe fn decode_sb(
                     bl,
                     b[1] as BlockSize,
                     PARTITION_T_BOTTOM_SPLIT,
-                    (*branch).tbs[2],
+                    branch.tbs[2],
                 ) != 0
                 {
                     return -1;
@@ -4405,13 +4408,13 @@ unsafe fn decode_sb(
                 t.by -= hsz;
             }
             PARTITION_T_LEFT_SPLIT => {
-                let branch: *const EdgeBranch = node as *const EdgeBranch;
+                let branch = &*(node as *const EdgeBranch);
                 if decode_b(
                     t,
                     bl,
                     b[0] as BlockSize,
                     PARTITION_T_LEFT_SPLIT,
-                    (*branch).tls[0],
+                    branch.tls[0],
                 ) != 0
                 {
                     return -1;
@@ -4422,7 +4425,7 @@ unsafe fn decode_sb(
                     bl,
                     b[0] as BlockSize,
                     PARTITION_T_LEFT_SPLIT,
-                    (*branch).tls[1],
+                    branch.tls[1],
                 ) != 0
                 {
                     return -1;
@@ -4434,7 +4437,7 @@ unsafe fn decode_sb(
                     bl,
                     b[1] as BlockSize,
                     PARTITION_T_LEFT_SPLIT,
-                    (*branch).tls[2],
+                    branch.tls[2],
                 ) != 0
                 {
                     return -1;
@@ -4442,13 +4445,13 @@ unsafe fn decode_sb(
                 t.bx -= hsz;
             }
             PARTITION_T_RIGHT_SPLIT => {
-                let branch: *const EdgeBranch = node as *const EdgeBranch;
+                let branch = &*(node as *const EdgeBranch);
                 if decode_b(
                     t,
                     bl,
                     b[0] as BlockSize,
                     PARTITION_T_RIGHT_SPLIT,
-                    (*branch).trs[0],
+                    branch.trs[0],
                 ) != 0
                 {
                     return -1;
@@ -4459,7 +4462,7 @@ unsafe fn decode_sb(
                     bl,
                     b[1] as BlockSize,
                     PARTITION_T_RIGHT_SPLIT,
-                    (*branch).trs[1],
+                    branch.trs[1],
                 ) != 0
                 {
                     return -1;
@@ -4479,42 +4482,42 @@ unsafe fn decode_sb(
                 t.bx -= hsz;
             }
             PARTITION_H4 => {
-                let branch: *const EdgeBranch = node as *const EdgeBranch;
-                if decode_b(t, bl, b[0] as BlockSize, PARTITION_H4, (*branch).h4[0]) != 0 {
+                let branch = &*(node as *const EdgeBranch);
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_H4, branch.h4[0]) != 0 {
                     return -1;
                 }
                 t.by += hsz >> 1;
-                if decode_b(t, bl, b[0] as BlockSize, PARTITION_H4, (*branch).h4[1]) != 0 {
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_H4, branch.h4[1]) != 0 {
                     return -1;
                 }
                 t.by += hsz >> 1;
-                if decode_b(t, bl, b[0] as BlockSize, PARTITION_H4, (*branch).h4[2]) != 0 {
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_H4, branch.h4[2]) != 0 {
                     return -1;
                 }
                 t.by += hsz >> 1;
                 if t.by < f.bh {
-                    if decode_b(t, bl, b[0] as BlockSize, PARTITION_H4, (*branch).h4[3]) != 0 {
+                    if decode_b(t, bl, b[0] as BlockSize, PARTITION_H4, branch.h4[3]) != 0 {
                         return -1;
                     }
                 }
                 t.by -= hsz * 3 >> 1;
             }
             PARTITION_V4 => {
-                let branch: *const EdgeBranch = node as *const EdgeBranch;
-                if decode_b(t, bl, b[0] as BlockSize, PARTITION_V4, (*branch).v4[0]) != 0 {
+                let branch = &*(node as *const EdgeBranch);
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_V4, branch.v4[0]) != 0 {
                     return -1;
                 }
                 t.bx += hsz >> 1;
-                if decode_b(t, bl, b[0] as BlockSize, PARTITION_V4, (*branch).v4[1]) != 0 {
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_V4, branch.v4[1]) != 0 {
                     return -1;
                 }
                 t.bx += hsz >> 1;
-                if decode_b(t, bl, b[0] as BlockSize, PARTITION_V4, (*branch).v4[2]) != 0 {
+                if decode_b(t, bl, b[0] as BlockSize, PARTITION_V4, branch.v4[2]) != 0 {
                     return -1;
                 }
                 t.bx += hsz >> 1;
                 if t.bx < f.bw {
-                    if decode_b(t, bl, b[0] as BlockSize, PARTITION_V4, (*branch).v4[3]) != 0 {
+                    if decode_b(t, bl, b[0] as BlockSize, PARTITION_V4, branch.v4[3]) != 0 {
                         return -1;
                     }
                 }
@@ -4548,13 +4551,13 @@ unsafe fn decode_sb(
         }
         assert!(bl < BL_8X8);
         if is_split {
-            let branch: *const EdgeBranch = node as *const EdgeBranch;
+            let branch = &*(node as *const EdgeBranch);
             bp = PARTITION_SPLIT;
-            if decode_sb(t, bl + 1, (*branch).split[0]) != 0 {
+            if decode_sb(t, bl + 1, branch.split[0]) != 0 {
                 return 1;
             }
             t.bx += hsz;
-            if decode_sb(t, bl + 1, (*branch).split[1]) != 0 {
+            if decode_sb(t, bl + 1, branch.split[1]) != 0 {
                 return 1;
             }
             t.bx -= hsz;
@@ -4601,13 +4604,13 @@ unsafe fn decode_sb(
         }
         assert!(bl < BL_8X8);
         if is_split {
-            let branch: *const EdgeBranch = node as *const EdgeBranch;
+            let branch = &*(node as *const EdgeBranch);
             bp = PARTITION_SPLIT;
-            if decode_sb(t, bl + 1, (*branch).split[0]) != 0 {
+            if decode_sb(t, bl + 1, branch.split[0]) != 0 {
                 return 1;
             }
             t.by += hsz;
-            if decode_sb(t, bl + 1, (*branch).split[2]) != 0 {
+            if decode_sb(t, bl + 1, branch.split[2]) != 0 {
                 return 1;
             }
             t.by -= hsz;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4252,64 +4252,29 @@ unsafe fn decode_sb(
                 );
             }
         }
-        let b_0: *const uint8_t = (dav1d_block_sizes[bl as usize][bp as usize]).as_ptr();
+        let b: *const uint8_t = (dav1d_block_sizes[bl as usize][bp as usize]).as_ptr();
         match bp as libc::c_uint {
             0 => {
-                if decode_b(
-                    t,
-                    bl,
-                    *b_0.offset(0) as BlockSize,
-                    PARTITION_NONE,
-                    (*node).o,
-                ) != 0
-                {
+                if decode_b(t, bl, *b.offset(0) as BlockSize, PARTITION_NONE, (*node).o) != 0 {
                     return -1;
                 }
             }
             1 => {
-                if decode_b(
-                    t,
-                    bl,
-                    *b_0.offset(0) as BlockSize,
-                    PARTITION_H,
-                    (*node).h[0],
-                ) != 0
-                {
+                if decode_b(t, bl, *b.offset(0) as BlockSize, PARTITION_H, (*node).h[0]) != 0 {
                     return -1;
                 }
                 t.by += hsz;
-                if decode_b(
-                    t,
-                    bl,
-                    *b_0.offset(0) as BlockSize,
-                    PARTITION_H,
-                    (*node).h[1],
-                ) != 0
-                {
+                if decode_b(t, bl, *b.offset(0) as BlockSize, PARTITION_H, (*node).h[1]) != 0 {
                     return -1;
                 }
                 t.by -= hsz;
             }
             2 => {
-                if decode_b(
-                    t,
-                    bl,
-                    *b_0.offset(0) as BlockSize,
-                    PARTITION_V,
-                    (*node).v[0],
-                ) != 0
-                {
+                if decode_b(t, bl, *b.offset(0) as BlockSize, PARTITION_V, (*node).v[0]) != 0 {
                     return -1;
                 }
                 t.bx += hsz;
-                if decode_b(
-                    t,
-                    bl,
-                    *b_0.offset(0) as BlockSize,
-                    PARTITION_V,
-                    (*node).v[1],
-                ) != 0
-                {
+                if decode_b(t, bl, *b.offset(0) as BlockSize, PARTITION_V, (*node).v[1]) != 0 {
                     return -1;
                 }
                 t.bx -= hsz;
@@ -4369,13 +4334,13 @@ unsafe fn decode_sb(
                 }
             }
             4 => {
-                let branch_0: *const EdgeBranch = node as *const EdgeBranch;
+                let branch: *const EdgeBranch = node as *const EdgeBranch;
                 if decode_b(
                     t,
                     bl,
-                    *b_0.offset(0) as BlockSize,
+                    *b.offset(0) as BlockSize,
                     PARTITION_T_TOP_SPLIT,
-                    (*branch_0).tts[0],
+                    (*branch).tts[0],
                 ) != 0
                 {
                     return -1;
@@ -4384,9 +4349,9 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b_0.offset(0) as BlockSize,
+                    *b.offset(0) as BlockSize,
                     PARTITION_T_TOP_SPLIT,
-                    (*branch_0).tts[1],
+                    (*branch).tts[1],
                 ) != 0
                 {
                     return -1;
@@ -4396,9 +4361,9 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b_0.offset(1) as BlockSize,
+                    *b.offset(1) as BlockSize,
                     PARTITION_T_TOP_SPLIT,
-                    (*branch_0).tts[2],
+                    (*branch).tts[2],
                 ) != 0
                 {
                     return -1;
@@ -4406,13 +4371,13 @@ unsafe fn decode_sb(
                 t.by -= hsz;
             }
             5 => {
-                let branch_1: *const EdgeBranch = node as *const EdgeBranch;
+                let branch: *const EdgeBranch = node as *const EdgeBranch;
                 if decode_b(
                     t,
                     bl,
-                    *b_0.offset(0) as BlockSize,
+                    *b.offset(0) as BlockSize,
                     PARTITION_T_BOTTOM_SPLIT,
-                    (*branch_1).tbs[0],
+                    (*branch).tbs[0],
                 ) != 0
                 {
                     return -1;
@@ -4421,9 +4386,9 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b_0.offset(1) as BlockSize,
+                    *b.offset(1) as BlockSize,
                     PARTITION_T_BOTTOM_SPLIT,
-                    (*branch_1).tbs[1],
+                    (*branch).tbs[1],
                 ) != 0
                 {
                     return -1;
@@ -4432,9 +4397,9 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b_0.offset(1) as BlockSize,
+                    *b.offset(1) as BlockSize,
                     PARTITION_T_BOTTOM_SPLIT,
-                    (*branch_1).tbs[2],
+                    (*branch).tbs[2],
                 ) != 0
                 {
                     return -1;
@@ -4443,13 +4408,13 @@ unsafe fn decode_sb(
                 t.by -= hsz;
             }
             6 => {
-                let branch_2: *const EdgeBranch = node as *const EdgeBranch;
+                let branch: *const EdgeBranch = node as *const EdgeBranch;
                 if decode_b(
                     t,
                     bl,
-                    *b_0.offset(0) as BlockSize,
+                    *b.offset(0) as BlockSize,
                     PARTITION_T_LEFT_SPLIT,
-                    (*branch_2).tls[0],
+                    (*branch).tls[0],
                 ) != 0
                 {
                     return -1;
@@ -4458,9 +4423,9 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b_0.offset(0) as BlockSize,
+                    *b.offset(0) as BlockSize,
                     PARTITION_T_LEFT_SPLIT,
-                    (*branch_2).tls[1],
+                    (*branch).tls[1],
                 ) != 0
                 {
                     return -1;
@@ -4470,9 +4435,9 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b_0.offset(1) as BlockSize,
+                    *b.offset(1) as BlockSize,
                     PARTITION_T_LEFT_SPLIT,
-                    (*branch_2).tls[2],
+                    (*branch).tls[2],
                 ) != 0
                 {
                     return -1;
@@ -4480,13 +4445,13 @@ unsafe fn decode_sb(
                 t.bx -= hsz;
             }
             7 => {
-                let branch_3: *const EdgeBranch = node as *const EdgeBranch;
+                let branch: *const EdgeBranch = node as *const EdgeBranch;
                 if decode_b(
                     t,
                     bl,
-                    *b_0.offset(0) as BlockSize,
+                    *b.offset(0) as BlockSize,
                     PARTITION_T_RIGHT_SPLIT,
-                    (*branch_3).trs[0],
+                    (*branch).trs[0],
                 ) != 0
                 {
                     return -1;
@@ -4495,9 +4460,9 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b_0.offset(1) as BlockSize,
+                    *b.offset(1) as BlockSize,
                     PARTITION_T_RIGHT_SPLIT,
-                    (*branch_3).trs[1],
+                    (*branch).trs[1],
                 ) != 0
                 {
                     return -1;
@@ -4506,9 +4471,9 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b_0.offset(1) as BlockSize,
+                    *b.offset(1) as BlockSize,
                     PARTITION_T_RIGHT_SPLIT,
-                    (*branch_3).trs[2],
+                    (*branch).trs[2],
                 ) != 0
                 {
                     return -1;
@@ -4517,13 +4482,13 @@ unsafe fn decode_sb(
                 t.bx -= hsz;
             }
             8 => {
-                let branch_4: *const EdgeBranch = node as *const EdgeBranch;
+                let branch: *const EdgeBranch = node as *const EdgeBranch;
                 if decode_b(
                     t,
                     bl,
-                    *b_0.offset(0) as BlockSize,
+                    *b.offset(0) as BlockSize,
                     PARTITION_H4,
-                    (*branch_4).h4[0],
+                    (*branch).h4[0],
                 ) != 0
                 {
                     return -1;
@@ -4532,9 +4497,9 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b_0.offset(0) as BlockSize,
+                    *b.offset(0) as BlockSize,
                     PARTITION_H4,
-                    (*branch_4).h4[1],
+                    (*branch).h4[1],
                 ) != 0
                 {
                     return -1;
@@ -4543,9 +4508,9 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b_0.offset(0) as BlockSize,
+                    *b.offset(0) as BlockSize,
                     PARTITION_H4,
-                    (*branch_4).h4[2],
+                    (*branch).h4[2],
                 ) != 0
                 {
                     return -1;
@@ -4555,9 +4520,9 @@ unsafe fn decode_sb(
                     if decode_b(
                         t,
                         bl,
-                        *b_0.offset(0) as BlockSize,
+                        *b.offset(0) as BlockSize,
                         PARTITION_H4,
-                        (*branch_4).h4[3],
+                        (*branch).h4[3],
                     ) != 0
                     {
                         return -1;
@@ -4566,13 +4531,13 @@ unsafe fn decode_sb(
                 t.by -= hsz * 3 >> 1;
             }
             9 => {
-                let branch_5: *const EdgeBranch = node as *const EdgeBranch;
+                let branch: *const EdgeBranch = node as *const EdgeBranch;
                 if decode_b(
                     t,
                     bl,
-                    *b_0.offset(0) as BlockSize,
+                    *b.offset(0) as BlockSize,
                     PARTITION_V4,
-                    (*branch_5).v4[0],
+                    (*branch).v4[0],
                 ) != 0
                 {
                     return -1;
@@ -4581,9 +4546,9 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b_0.offset(0) as BlockSize,
+                    *b.offset(0) as BlockSize,
                     PARTITION_V4,
-                    (*branch_5).v4[1],
+                    (*branch).v4[1],
                 ) != 0
                 {
                     return -1;
@@ -4592,9 +4557,9 @@ unsafe fn decode_sb(
                 if decode_b(
                     t,
                     bl,
-                    *b_0.offset(0) as BlockSize,
+                    *b.offset(0) as BlockSize,
                     PARTITION_V4,
-                    (*branch_5).v4[2],
+                    (*branch).v4[2],
                 ) != 0
                 {
                     return -1;
@@ -4604,9 +4569,9 @@ unsafe fn decode_sb(
                     if decode_b(
                         t,
                         bl,
-                        *b_0.offset(0) as BlockSize,
+                        *b.offset(0) as BlockSize,
                         PARTITION_V4,
-                        (*branch_5).v4[3],
+                        (*branch).v4[3],
                     ) != 0
                     {
                         return -1;
@@ -4619,10 +4584,10 @@ unsafe fn decode_sb(
     } else if have_h_split {
         let mut is_split: libc::c_uint = 0;
         if t.frame_thread.pass == 2 {
-            let b_1: *const Av1Block = &mut *(f.frame_thread.b)
+            let b: *const Av1Block = &mut *(f.frame_thread.b)
                 .offset((t.by as isize * f.b4_stride + t.bx as isize) as isize)
                 as *mut Av1Block;
-            is_split = ((*b_1).bl as BlockLevel != bl) as libc::c_uint;
+            is_split = ((*b).bl as BlockLevel != bl) as libc::c_uint;
         } else {
             is_split = dav1d_msac_decode_bool(&mut ts.msac, gather_top_partition_prob(pc, bl))
                 as libc::c_uint;
@@ -4646,13 +4611,13 @@ unsafe fn decode_sb(
         }
         assert!(bl < BL_8X8);
         if is_split != 0 {
-            let branch_6: *const EdgeBranch = node as *const EdgeBranch;
+            let branch: *const EdgeBranch = node as *const EdgeBranch;
             bp = PARTITION_SPLIT;
-            if decode_sb(t, bl + 1, (*branch_6).split[0]) != 0 {
+            if decode_sb(t, bl + 1, (*branch).split[0]) != 0 {
                 return 1;
             }
             t.bx += hsz;
-            if decode_sb(t, bl + 1, (*branch_6).split[1]) != 0 {
+            if decode_sb(t, bl + 1, (*branch).split[1]) != 0 {
                 return 1;
             }
             t.bx -= hsz;
@@ -4671,16 +4636,16 @@ unsafe fn decode_sb(
         }
     } else {
         assert!(have_v_split);
-        let mut is_split_0: libc::c_uint = 0;
+        let mut is_split: libc::c_uint = 0;
         if t.frame_thread.pass == 2 {
-            let b_2: *const Av1Block = &mut *(f.frame_thread.b)
+            let b: *const Av1Block = &mut *(f.frame_thread.b)
                 .offset((t.by as isize * f.b4_stride + t.bx as isize) as isize)
                 as *mut Av1Block;
-            is_split_0 = ((*b_2).bl as BlockLevel != bl) as libc::c_uint;
+            is_split = ((*b).bl as BlockLevel != bl) as libc::c_uint;
         } else {
-            is_split_0 = dav1d_msac_decode_bool(&mut ts.msac, gather_left_partition_prob(pc, bl))
+            is_split = dav1d_msac_decode_bool(&mut ts.msac, gather_left_partition_prob(pc, bl))
                 as libc::c_uint;
-            if f.cur.p.layout == DAV1D_PIXEL_LAYOUT_I422 && is_split_0 == 0 {
+            if f.cur.p.layout == DAV1D_PIXEL_LAYOUT_I422 && is_split == 0 {
                 return 1;
             }
             if DEBUG_BLOCK_INFO(f, t) {
@@ -4692,7 +4657,7 @@ unsafe fn decode_sb(
                     t.bx,
                     bl as libc::c_uint,
                     ctx as libc::c_int,
-                    if is_split_0 != 0 {
+                    if is_split != 0 {
                         PARTITION_SPLIT as libc::c_int
                     } else {
                         PARTITION_V as libc::c_int
@@ -4702,14 +4667,14 @@ unsafe fn decode_sb(
             }
         }
         assert!(bl < BL_8X8);
-        if is_split_0 != 0 {
-            let branch_7: *const EdgeBranch = node as *const EdgeBranch;
+        if is_split != 0 {
+            let branch: *const EdgeBranch = node as *const EdgeBranch;
             bp = PARTITION_SPLIT;
-            if decode_sb(t, bl + 1, (*branch_7).split[0]) != 0 {
+            if decode_sb(t, bl + 1, (*branch).split[0]) != 0 {
                 return 1;
             }
             t.by += hsz;
-            if decode_sb(t, bl + 1, (*branch_7).split[2]) != 0 {
+            if decode_sb(t, bl + 1, (*branch).split[2]) != 0 {
                 return 1;
             }
             t.by -= hsz;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4252,13 +4252,13 @@ unsafe fn decode_sb(
             }
         }
         let b = &dav1d_block_sizes[bl as usize][bp as usize];
-        match bp as libc::c_uint {
-            0 => {
+        match bp {
+            PARTITION_NONE => {
                 if decode_b(t, bl, b[0] as BlockSize, PARTITION_NONE, (*node).o) != 0 {
                     return -1;
                 }
             }
-            1 => {
+            PARTITION_H => {
                 if decode_b(t, bl, b[0] as BlockSize, PARTITION_H, (*node).h[0]) != 0 {
                     return -1;
                 }
@@ -4268,7 +4268,7 @@ unsafe fn decode_sb(
                 }
                 t.by -= hsz;
             }
-            2 => {
+            PARTITION_V => {
                 if decode_b(t, bl, b[0] as BlockSize, PARTITION_V, (*node).v[0]) != 0 {
                     return -1;
                 }
@@ -4278,7 +4278,7 @@ unsafe fn decode_sb(
                 }
                 t.bx -= hsz;
             }
-            3 => {
+            PARTITION_SPLIT => {
                 if bl == BL_8X8 {
                     let tip: *const EdgeTip = node as *const EdgeTip;
                     assert!(hsz == 1);
@@ -4332,7 +4332,7 @@ unsafe fn decode_sb(
                     t.by -= hsz;
                 }
             }
-            4 => {
+            PARTITION_T_TOP_SPLIT => {
                 let branch: *const EdgeBranch = node as *const EdgeBranch;
                 if decode_b(
                     t,
@@ -4369,7 +4369,7 @@ unsafe fn decode_sb(
                 }
                 t.by -= hsz;
             }
-            5 => {
+            PARTITION_T_BOTTOM_SPLIT => {
                 let branch: *const EdgeBranch = node as *const EdgeBranch;
                 if decode_b(
                     t,
@@ -4406,7 +4406,7 @@ unsafe fn decode_sb(
                 t.bx -= hsz;
                 t.by -= hsz;
             }
-            6 => {
+            PARTITION_T_LEFT_SPLIT => {
                 let branch: *const EdgeBranch = node as *const EdgeBranch;
                 if decode_b(
                     t,
@@ -4443,7 +4443,7 @@ unsafe fn decode_sb(
                 }
                 t.bx -= hsz;
             }
-            7 => {
+            PARTITION_T_RIGHT_SPLIT => {
                 let branch: *const EdgeBranch = node as *const EdgeBranch;
                 if decode_b(
                     t,
@@ -4480,7 +4480,7 @@ unsafe fn decode_sb(
                 t.by -= hsz;
                 t.bx -= hsz;
             }
-            8 => {
+            PARTITION_H4 => {
                 let branch: *const EdgeBranch = node as *const EdgeBranch;
                 if decode_b(t, bl, b[0] as BlockSize, PARTITION_H4, (*branch).h4[0]) != 0 {
                     return -1;
@@ -4501,7 +4501,7 @@ unsafe fn decode_sb(
                 }
                 t.by -= hsz * 3 >> 1;
             }
-            9 => {
+            PARTITION_V4 => {
                 let branch: *const EdgeBranch = node as *const EdgeBranch;
                 if decode_b(t, bl, b[0] as BlockSize, PARTITION_V4, (*branch).v4[0]) != 0 {
                     return -1;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4226,7 +4226,7 @@ unsafe fn decode_sb(
             bp = dav1d_msac_decode_symbol_adapt16(
                 &mut ts.msac,
                 pc,
-                dav1d_partition_type_count[bl as usize] as size_t,
+                dav1d_partition_type_count[bl as usize].into(),
             ) as BlockPartition;
             if f.cur.p.layout == DAV1D_PIXEL_LAYOUT_I422
                 && (bp == PARTITION_V

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4187,9 +4187,9 @@ unsafe fn decode_sb(
     let f = &*t.f;
     let ts = &mut *t.ts;
     let hsz = 16 >> bl as libc::c_uint;
-    let have_h_split = (f.bw > t.bx + hsz) as libc::c_int;
-    let have_v_split = (f.bh > t.by + hsz) as libc::c_int;
-    if have_h_split == 0 && have_v_split == 0 {
+    let have_h_split = f.bw > t.bx + hsz;
+    let have_v_split = f.bh > t.by + hsz;
+    if !have_h_split && !have_v_split {
         if !((bl as libc::c_uint) < BL_8X8 as libc::c_int as libc::c_uint) {
             unreachable!();
         }
@@ -4220,7 +4220,7 @@ unsafe fn decode_sb(
         ctx = get_partition_ctx(&*t.a, &t.l, bl, by8, bx8);
         pc = &mut ts.cdf.m.partition[bl as usize][ctx as usize];
     }
-    if have_h_split != 0 && have_v_split != 0 {
+    if have_h_split && have_v_split {
         if t.frame_thread.pass == 2 {
             let b: *const Av1Block = &mut *(f.frame_thread.b)
                 .offset((t.by as isize * f.b4_stride + t.bx as isize) as isize)
@@ -4653,7 +4653,7 @@ unsafe fn decode_sb(
                 }
             }
         }
-    } else if have_h_split != 0 {
+    } else if have_h_split {
         let mut is_split: libc::c_uint = 0;
         if t.frame_thread.pass == 2 {
             let b_1: *const Av1Block = &mut *(f.frame_thread.b)
@@ -4720,7 +4720,7 @@ unsafe fn decode_sb(
             }
         }
     } else {
-        if have_v_split == 0 {
+        if !have_v_split {
             unreachable!();
         }
         let mut is_split_0: libc::c_uint = 0;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4303,7 +4303,7 @@ unsafe fn decode_sb(
                     }
                     t.bx -= 1;
                     t.by -= 1;
-                    if t.frame_thread.pass != 0 {
+                    if cfg!(target_arch = "x86_64") && t.frame_thread.pass != 0 {
                         let p = (t.frame_thread.pass & 1) as usize;
                         ts.frame_thread[p].cf = (((ts.frame_thread[p].cf as uintptr_t) + 63) & !63)
                             as *mut libc::c_void;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4305,9 +4305,8 @@ unsafe fn decode_sb(
                     t.by -= 1;
                     if t.frame_thread.pass != 0 {
                         let p = (t.frame_thread.pass & 1) as usize;
-                        ts.frame_thread[p].cf =
-                            ((ts.frame_thread[p].cf as uintptr_t).wrapping_add(63) & !(63))
-                                as *mut libc::c_void;
+                        ts.frame_thread[p].cf = (((ts.frame_thread[p].cf as uintptr_t) + 63) & !63)
+                            as *mut libc::c_void;
                     }
                 } else {
                     let branch = &*(node as *const EdgeBranch);


### PR DESCRIPTION
This cleans up the majority of `fn decode_sb`, all the simple cleanups that comprise most of the changes.  There are still some things I want to change, but those are more involved, so I want to keep them as separate PRs.

For example, I want to change some of the `enum` sizes separately (`enum`s that were translated as type aliases).  And I want to try to turn `EdgeNode` into an `enum` or at least `union`, as it can be an `EdgeTip` or `EdgeBranch`.  And some other small but trickier things.