### PR TITLE
`fn init_edges`: Cleanup

### DIFF
--- a/src/intra_edge.rs
+++ b/src/intra_edge.rs
@@ -90,9 +90,9 @@ unsafe fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags: EdgeFlags)
 
         nwc.h4[0] = edge_flags
             | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
-        nwc.h4[2] =
+        nwc.h4[1] =
             EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM;
-        nwc.h4[1] = nwc.h4[2];
+        nwc.h4[2] = nwc.h4[1];
         nwc.h4[3] = edge_flags
             & (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
         if bl == BL_16X16 {
@@ -101,8 +101,8 @@ unsafe fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags: EdgeFlags)
 
         nwc.v4[0] = edge_flags
             | (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
-        nwc.v4[2] = EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT;
-        nwc.v4[1] = nwc.v4[2];
+        nwc.v4[1] = EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT;
+        nwc.v4[2] = nwc.v4[1];
         nwc.v4[3] = edge_flags
             & (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
         if bl == BL_16X16 {

--- a/src/intra_edge.rs
+++ b/src/intra_edge.rs
@@ -49,7 +49,7 @@ use crate::src::levels::BL_8X8;
 unsafe fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags: EdgeFlags) {
     (*node).o = edge_flags;
     if bl == BL_8X8 {
-        let nt: *mut EdgeTip = node as *mut EdgeTip;
+        let nt = &mut *(node as *mut EdgeTip);
         (*node).h[0] = edge_flags
             | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
         (*node).h[1] = edge_flags
@@ -61,15 +61,13 @@ unsafe fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags: EdgeFlags)
             & ((EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT)
                 | EDGE_I420_LEFT_HAS_BOTTOM
                 | EDGE_I422_LEFT_HAS_BOTTOM);
-        (*nt).split[0] = (EDGE_I444_TOP_HAS_RIGHT
-            | EDGE_I422_TOP_HAS_RIGHT
-            | EDGE_I420_TOP_HAS_RIGHT)
+        nt.split[0] = (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT)
             | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
-        (*nt).split[1] = (edge_flags
+        nt.split[1] = (edge_flags
             & (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT))
             | EDGE_I422_LEFT_HAS_BOTTOM;
-        (*nt).split[2] = edge_flags | EDGE_I444_TOP_HAS_RIGHT;
-        (*nt).split[3] = edge_flags
+        nt.split[2] = edge_flags | EDGE_I444_TOP_HAS_RIGHT;
+        nt.split[3] = edge_flags
             & (EDGE_I420_TOP_HAS_RIGHT | EDGE_I420_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM);
     } else {
         let nwc: *mut EdgeBranch = node as *mut EdgeBranch;

--- a/src/intra_edge.rs
+++ b/src/intra_edge.rs
@@ -50,14 +50,15 @@ unsafe fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags: EdgeFlags)
     (*node).o = edge_flags;
     if bl == BL_8X8 {
         let nt = &mut *(node as *mut EdgeTip);
-        (*node).h[0] = edge_flags
+        let node = &mut nt.node;
+        node.h[0] = edge_flags
             | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
-        (*node).h[1] = edge_flags
+        node.h[1] = edge_flags
             & ((EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM)
                 | EDGE_I420_TOP_HAS_RIGHT);
-        (*node).v[0] = edge_flags
+        node.v[0] = edge_flags
             | (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
-        (*node).v[1] = edge_flags
+        node.v[1] = edge_flags
             & ((EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT)
                 | EDGE_I420_LEFT_HAS_BOTTOM
                 | EDGE_I422_LEFT_HAS_BOTTOM);
@@ -71,13 +72,14 @@ unsafe fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags: EdgeFlags)
             & (EDGE_I420_TOP_HAS_RIGHT | EDGE_I420_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM);
     } else {
         let nwc = &mut *(node as *mut EdgeBranch);
-        (*node).h[0] = edge_flags
+        let node = &mut nwc.node;
+        node.h[0] = edge_flags
             | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
-        (*node).h[1] = edge_flags
+        node.h[1] = edge_flags
             & (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
-        (*node).v[0] = edge_flags
+        node.v[0] = edge_flags
             | (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
-        (*node).v[1] = edge_flags
+        node.v[1] = edge_flags
             & (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
         nwc.h4[0] = edge_flags
             | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);

--- a/src/intra_edge.rs
+++ b/src/intra_edge.rs
@@ -48,20 +48,24 @@ use crate::src::levels::BL_8X8;
 
 unsafe fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags: EdgeFlags) {
     (*node).o = edge_flags;
+
     if bl == BL_8X8 {
         let nt = &mut *(node as *mut EdgeTip);
         let node = &mut nt.node;
+
         node.h[0] = edge_flags
             | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
         node.h[1] = edge_flags
             & ((EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM)
                 | EDGE_I420_TOP_HAS_RIGHT);
+
         node.v[0] = edge_flags
             | (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
         node.v[1] = edge_flags
             & ((EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT)
                 | EDGE_I420_LEFT_HAS_BOTTOM
                 | EDGE_I422_LEFT_HAS_BOTTOM);
+
         nt.split[0] = (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT)
             | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
         nt.split[1] = (edge_flags
@@ -73,14 +77,17 @@ unsafe fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags: EdgeFlags)
     } else {
         let nwc = &mut *(node as *mut EdgeBranch);
         let node = &mut nwc.node;
+
         node.h[0] = edge_flags
             | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
         node.h[1] = edge_flags
             & (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
+
         node.v[0] = edge_flags
             | (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
         node.v[1] = edge_flags
             & (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
+
         nwc.h4[0] = edge_flags
             | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
         nwc.h4[2] =
@@ -91,6 +98,7 @@ unsafe fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags: EdgeFlags)
         if bl == BL_16X16 {
             nwc.h4[1] |= edge_flags & EDGE_I420_TOP_HAS_RIGHT;
         }
+
         nwc.v4[0] = edge_flags
             | (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
         nwc.v4[2] = EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT;
@@ -100,23 +108,27 @@ unsafe fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags: EdgeFlags)
         if bl == BL_16X16 {
             nwc.v4[1] |= edge_flags & (EDGE_I420_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM);
         }
+
         nwc.tls[0] = (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT)
             | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
         nwc.tls[1] = edge_flags
             & (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
         nwc.tls[2] = edge_flags
             & (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
+
         nwc.trs[0] = edge_flags
             | (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
         nwc.trs[1] = edge_flags
             | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
         nwc.trs[2] = 0 as EdgeFlags;
+
         nwc.tts[0] = (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT)
             | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
         nwc.tts[1] = edge_flags
             & (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
         nwc.tts[2] = edge_flags
             & (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
+
         nwc.tbs[0] = edge_flags
             | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
         nwc.tbs[1] = edge_flags

--- a/src/intra_edge.rs
+++ b/src/intra_edge.rs
@@ -45,7 +45,8 @@ use crate::src::levels::BL_64X64;
 use crate::src::levels::BL_128X128;
 use crate::src::levels::BL_16X16;
 use crate::src::levels::BL_8X8;
-unsafe extern "C" fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags: EdgeFlags) {
+
+unsafe fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags: EdgeFlags) {
     (*node).o = edge_flags;
     if bl as libc::c_uint == BL_8X8 as libc::c_int as libc::c_uint {
         let nt: *mut EdgeTip = node as *mut EdgeTip;

--- a/src/intra_edge.rs
+++ b/src/intra_edge.rs
@@ -70,7 +70,7 @@ unsafe fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags: EdgeFlags)
         nt.split[3] = edge_flags
             & (EDGE_I420_TOP_HAS_RIGHT | EDGE_I420_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM);
     } else {
-        let nwc: *mut EdgeBranch = node as *mut EdgeBranch;
+        let nwc = &mut *(node as *mut EdgeBranch);
         (*node).h[0] = edge_flags
             | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
         (*node).h[1] = edge_flags
@@ -79,51 +79,47 @@ unsafe fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags: EdgeFlags)
             | (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
         (*node).v[1] = edge_flags
             & (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
-        (*nwc).h4[0] = edge_flags
+        nwc.h4[0] = edge_flags
             | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
-        (*nwc).h4[2] =
+        nwc.h4[2] =
             EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM;
-        (*nwc).h4[1] = (*nwc).h4[2];
-        (*nwc).h4[3] = edge_flags
+        nwc.h4[1] = nwc.h4[2];
+        nwc.h4[3] = edge_flags
             & (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
         if bl == BL_16X16 {
-            (*nwc).h4[1] |= edge_flags & EDGE_I420_TOP_HAS_RIGHT;
+            nwc.h4[1] |= edge_flags & EDGE_I420_TOP_HAS_RIGHT;
         }
-        (*nwc).v4[0] = edge_flags
+        nwc.v4[0] = edge_flags
             | (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
-        (*nwc).v4[2] = EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT;
-        (*nwc).v4[1] = (*nwc).v4[2];
-        (*nwc).v4[3] = edge_flags
+        nwc.v4[2] = EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT;
+        nwc.v4[1] = nwc.v4[2];
+        nwc.v4[3] = edge_flags
             & (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
         if bl == BL_16X16 {
-            (*nwc).v4[1] |= edge_flags & (EDGE_I420_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM);
+            nwc.v4[1] |= edge_flags & (EDGE_I420_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM);
         }
-        (*nwc).tls[0] = (EDGE_I444_TOP_HAS_RIGHT
-            | EDGE_I422_TOP_HAS_RIGHT
-            | EDGE_I420_TOP_HAS_RIGHT)
+        nwc.tls[0] = (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT)
             | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
-        (*nwc).tls[1] = edge_flags
+        nwc.tls[1] = edge_flags
             & (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
-        (*nwc).tls[2] = edge_flags
+        nwc.tls[2] = edge_flags
             & (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
-        (*nwc).trs[0] = edge_flags
+        nwc.trs[0] = edge_flags
             | (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
-        (*nwc).trs[1] = edge_flags
+        nwc.trs[1] = edge_flags
             | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
-        (*nwc).trs[2] = 0 as EdgeFlags;
-        (*nwc).tts[0] = (EDGE_I444_TOP_HAS_RIGHT
-            | EDGE_I422_TOP_HAS_RIGHT
-            | EDGE_I420_TOP_HAS_RIGHT)
+        nwc.trs[2] = 0 as EdgeFlags;
+        nwc.tts[0] = (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT)
             | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
-        (*nwc).tts[1] = edge_flags
+        nwc.tts[1] = edge_flags
             & (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
-        (*nwc).tts[2] = edge_flags
+        nwc.tts[2] = edge_flags
             & (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
-        (*nwc).tbs[0] = edge_flags
+        nwc.tbs[0] = edge_flags
             | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
-        (*nwc).tbs[1] = edge_flags
+        nwc.tbs[1] = edge_flags
             | (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
-        (*nwc).tbs[2] = 0 as EdgeFlags;
+        nwc.tbs[2] = 0 as EdgeFlags;
     };
 }
 unsafe extern "C" fn init_mode_node(

--- a/src/intra_edge.rs
+++ b/src/intra_edge.rs
@@ -89,7 +89,7 @@ unsafe fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags: EdgeFlags)
         (*nwc).h4[3] = edge_flags
             & (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
         if bl == BL_16X16 {
-            (*nwc).h4[1] = (*nwc).h4[1] | edge_flags & EDGE_I420_TOP_HAS_RIGHT;
+            (*nwc).h4[1] |= edge_flags & EDGE_I420_TOP_HAS_RIGHT;
         }
         (*nwc).v4[0] = edge_flags
             | (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
@@ -98,8 +98,7 @@ unsafe fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags: EdgeFlags)
         (*nwc).v4[3] = edge_flags
             & (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
         if bl == BL_16X16 {
-            (*nwc).v4[1] =
-                (*nwc).v4[1] | edge_flags & (EDGE_I420_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM);
+            (*nwc).v4[1] |= edge_flags & (EDGE_I420_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM);
         }
         (*nwc).tls[0] = (EDGE_I444_TOP_HAS_RIGHT
             | EDGE_I422_TOP_HAS_RIGHT

--- a/src/intra_edge.rs
+++ b/src/intra_edge.rs
@@ -48,161 +48,84 @@ use crate::src::levels::BL_8X8;
 
 unsafe fn init_edges(node: *mut EdgeNode, bl: BlockLevel, edge_flags: EdgeFlags) {
     (*node).o = edge_flags;
-    if bl as libc::c_uint == BL_8X8 as libc::c_int as libc::c_uint {
+    if bl == BL_8X8 {
         let nt: *mut EdgeTip = node as *mut EdgeTip;
-        (*node).h[0] = (edge_flags as libc::c_uint
-            | (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
-        (*node).h[1] = (edge_flags as libc::c_uint
-            & (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
-        (*node).v[0] = (edge_flags as libc::c_uint
-            | (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
-        (*node).v[1] = (edge_flags as libc::c_uint
-            & (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I420_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
-        (*nt).split[0] = (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
-            | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
-            | EDGE_I420_TOP_HAS_RIGHT as libc::c_int
-            | (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int)) as EdgeFlags;
-        (*nt).split[1] = (edge_flags as libc::c_uint
-            & (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint
-            | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int as libc::c_uint)
-            as EdgeFlags;
-        (*nt).split[2] = (edge_flags as libc::c_uint
-            | EDGE_I444_TOP_HAS_RIGHT as libc::c_int as libc::c_uint)
-            as EdgeFlags;
-        (*nt).split[3] = (edge_flags as libc::c_uint
-            & (EDGE_I420_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
+        (*node).h[0] = edge_flags
+            | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
+        (*node).h[1] = edge_flags
+            & ((EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM)
+                | EDGE_I420_TOP_HAS_RIGHT);
+        (*node).v[0] = edge_flags
+            | (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
+        (*node).v[1] = edge_flags
+            & ((EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT)
+                | EDGE_I420_LEFT_HAS_BOTTOM
+                | EDGE_I422_LEFT_HAS_BOTTOM);
+        (*nt).split[0] = (EDGE_I444_TOP_HAS_RIGHT
+            | EDGE_I422_TOP_HAS_RIGHT
+            | EDGE_I420_TOP_HAS_RIGHT)
+            | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
+        (*nt).split[1] = (edge_flags
+            & (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT))
+            | EDGE_I422_LEFT_HAS_BOTTOM;
+        (*nt).split[2] = edge_flags | EDGE_I444_TOP_HAS_RIGHT;
+        (*nt).split[3] = edge_flags
+            & (EDGE_I420_TOP_HAS_RIGHT | EDGE_I420_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM);
     } else {
         let nwc: *mut EdgeBranch = node as *mut EdgeBranch;
-        (*node).h[0] = (edge_flags as libc::c_uint
-            | (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
-        (*node).h[1] = (edge_flags as libc::c_uint
-            & (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
-        (*node).v[0] = (edge_flags as libc::c_uint
-            | (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
-        (*node).v[1] = (edge_flags as libc::c_uint
-            & (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
-        (*nwc).h4[0] = (edge_flags as libc::c_uint
-            | (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
-        (*nwc).h4[2] = (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
-            | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
-            | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as EdgeFlags;
+        (*node).h[0] = edge_flags
+            | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
+        (*node).h[1] = edge_flags
+            & (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
+        (*node).v[0] = edge_flags
+            | (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
+        (*node).v[1] = edge_flags
+            & (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
+        (*nwc).h4[0] = edge_flags
+            | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
+        (*nwc).h4[2] =
+            EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM;
         (*nwc).h4[1] = (*nwc).h4[2];
-        (*nwc).h4[3] = (edge_flags as libc::c_uint
-            & (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
-        if bl as libc::c_uint == BL_16X16 as libc::c_int as libc::c_uint {
+        (*nwc).h4[3] = edge_flags
+            & (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
+        if bl == BL_16X16 {
             (*nwc).h4[1] = (*nwc).h4[1] | edge_flags & EDGE_I420_TOP_HAS_RIGHT;
         }
-        (*nwc).v4[0] = (edge_flags as libc::c_uint
-            | (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
-        (*nwc).v4[2] = (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
-            | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
-            | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as EdgeFlags;
+        (*nwc).v4[0] = edge_flags
+            | (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
+        (*nwc).v4[2] = EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT;
         (*nwc).v4[1] = (*nwc).v4[2];
-        (*nwc).v4[3] = (edge_flags as libc::c_uint
-            & (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
-        if bl as libc::c_uint == BL_16X16 as libc::c_int as libc::c_uint {
+        (*nwc).v4[3] = edge_flags
+            & (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
+        if bl == BL_16X16 {
             (*nwc).v4[1] =
                 (*nwc).v4[1] | edge_flags & (EDGE_I420_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM);
         }
-        (*nwc).tls[0] = (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
-            | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
-            | EDGE_I420_TOP_HAS_RIGHT as libc::c_int
-            | (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int)) as EdgeFlags;
-        (*nwc).tls[1] = (edge_flags as libc::c_uint
-            & (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
-        (*nwc).tls[2] = (edge_flags as libc::c_uint
-            & (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
-        (*nwc).trs[0] = (edge_flags as libc::c_uint
-            | (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
-        (*nwc).trs[1] = (edge_flags as libc::c_uint
-            | (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
+        (*nwc).tls[0] = (EDGE_I444_TOP_HAS_RIGHT
+            | EDGE_I422_TOP_HAS_RIGHT
+            | EDGE_I420_TOP_HAS_RIGHT)
+            | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
+        (*nwc).tls[1] = edge_flags
+            & (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
+        (*nwc).tls[2] = edge_flags
+            & (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
+        (*nwc).trs[0] = edge_flags
+            | (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
+        (*nwc).trs[1] = edge_flags
+            | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
         (*nwc).trs[2] = 0 as EdgeFlags;
-        (*nwc).tts[0] = (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
-            | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
-            | EDGE_I420_TOP_HAS_RIGHT as libc::c_int
-            | (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int)) as EdgeFlags;
-        (*nwc).tts[1] = (edge_flags as libc::c_uint
-            & (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
-        (*nwc).tts[2] = (edge_flags as libc::c_uint
-            & (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
-        (*nwc).tbs[0] = (edge_flags as libc::c_uint
-            | (EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I422_LEFT_HAS_BOTTOM as libc::c_int
-                | EDGE_I420_LEFT_HAS_BOTTOM as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
-        (*nwc).tbs[1] = (edge_flags as libc::c_uint
-            | (EDGE_I444_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I422_TOP_HAS_RIGHT as libc::c_int
-                | EDGE_I420_TOP_HAS_RIGHT as libc::c_int) as libc::c_uint)
-            as EdgeFlags;
+        (*nwc).tts[0] = (EDGE_I444_TOP_HAS_RIGHT
+            | EDGE_I422_TOP_HAS_RIGHT
+            | EDGE_I420_TOP_HAS_RIGHT)
+            | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
+        (*nwc).tts[1] = edge_flags
+            & (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
+        (*nwc).tts[2] = edge_flags
+            & (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
+        (*nwc).tbs[0] = edge_flags
+            | (EDGE_I444_LEFT_HAS_BOTTOM | EDGE_I422_LEFT_HAS_BOTTOM | EDGE_I420_LEFT_HAS_BOTTOM);
+        (*nwc).tbs[1] = edge_flags
+            | (EDGE_I444_TOP_HAS_RIGHT | EDGE_I422_TOP_HAS_RIGHT | EDGE_I420_TOP_HAS_RIGHT);
         (*nwc).tbs[2] = 0 as EdgeFlags;
     };
 }


### PR DESCRIPTION
I'll work on the safety of the `Edge*` types once I do initial cleanup for their functions.