### PR TITLE
`fn dav1d_msac_init`: Make safe

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4647,8 +4647,7 @@ unsafe fn setup_tile(
     ts.last_delta_lf.fill(0);
     dav1d_msac_init(
         &mut ts.msac,
-        data,
-        sz,
+        std::slice::from_raw_parts(data, sz),
         (*f.frame_hdr).disable_cdf_update != 0,
     );
     ts.tiling.row = tile_row as libc::c_int;

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -257,7 +257,7 @@ pub struct Dav1dTileState_frame_thread {
 #[repr(C)]
 pub struct Dav1dTileState {
     pub cdf: CdfContext,
-    pub msac: MsacContext,
+    pub msac: MsacContext<'static>,
     pub tiling: Dav1dTileState_tiling,
     pub progress: [atomic_int; 2],
     pub frame_thread: [Dav1dTileState_frame_thread; 2],

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -317,15 +317,13 @@ fn dav1d_msac_decode_hi_tok_rust(s: &mut MsacContext, cdf: &mut [u16; 4]) -> lib
 
 /// # Safety
 ///
-/// `data` and `sz` must form a valid slice,
-/// and must live longer than all of the other functions called on [`MsacContext`].
+/// `data` must live longer than all of the other functions called on [`MsacContext`].
 pub unsafe fn dav1d_msac_init(
     s: &mut MsacContext,
-    data: *const uint8_t,
-    sz: size_t,
+    data: &[u8],
     disable_cdf_update_flag: bool,
 ) {
-    s.set_buf(std::slice::from_raw_parts(data, sz));
+    s.set_buf(data);
     s.dif = (1 << (EC_WIN_SIZE - 1)) - 1;
     s.rng = 0x8000;
     s.cnt = -15;


### PR DESCRIPTION
I'm not sure if this works correctly, but I tried to make this safe by adding a phantom lifetime to `MsacContext` for the `buf`'s lifetime, which originally was a slice, but is made into pointers to be `#[repr(C)]` and stay layout-compatible with asm.  I'm particularly not sure about the `'static` I stuck in the `MsacContext` in its containing `struct`.  Is that any less safe/checked than before?