### PR TITLE
`static dav1d_qm_tbl`: Store slices instead of raw ptrs

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -6035,9 +6035,9 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                                                                             );
                                                                                             if (*(*f).frame_hdr).quant.qm != 0 {
                                                                                                 for i in 0..N_RECT_TX_SIZES as usize {
-                                                                                                    (*f).qm[i][0] = dav1d_qm_tbl[(*(*f).frame_hdr).quant.qm_y as usize][0][i];
-                                                                                                    (*f).qm[i][1] = dav1d_qm_tbl[(*(*f).frame_hdr).quant.qm_u as usize][1][i];
-                                                                                                    (*f).qm[i][2] = dav1d_qm_tbl[(*(*f).frame_hdr).quant.qm_v as usize][1][i];
+                                                                                                    (*f).qm[i][0] = dav1d_qm_tbl[(*(*f).frame_hdr).quant.qm_y as usize][0][i].map_or(std::ptr::null(), |qm| qm.as_ptr());
+                                                                                                    (*f).qm[i][1] = dav1d_qm_tbl[(*(*f).frame_hdr).quant.qm_u as usize][1][i].map_or(std::ptr::null(), |qm| qm.as_ptr());
+                                                                                                    (*f).qm[i][2] = dav1d_qm_tbl[(*(*f).frame_hdr).quant.qm_v as usize][1][i].map_or(std::ptr::null(), |qm| qm.as_ptr());
                                                                                                 }
                                                                                             } else {
                                                                                                 memset(

--- a/src/qm.rs
+++ b/src/qm.rs
@@ -2972,7 +2972,7 @@ static qm_tbl_32x32_t: [[[u8; 528]; 2]; 15] = [
     ],
 ];
 
-pub static mut dav1d_qm_tbl: [[[*const u8; 19]; 2]; 16] = [[[0 as *const u8; 19]; 2]; 16];
+pub static mut dav1d_qm_tbl: [[[Option<&'static [u8]>; 19]; 2]; 16] = [[[None; 19]; 2]; 16];
 
 static mut qm_tbl_4x4: [[[u8; 16]; 2]; 15] = [[[0; 16]; 2]; 15];
 static mut qm_tbl_4x8: [[[u8; 32]; 2]; 15] = [[[0; 32]; 2]; 15];
@@ -3030,29 +3030,29 @@ pub unsafe fn dav1d_init_qm_tables() {
             // note that the w/h in the assignment is inverted, this is on purpose
             // because we store coefficients transposed
             transpose(&mut qm_tbl_4x8[i][j], &qm_tbl_8x4[i][j], 8, 4);
-            dav1d_qm_tbl[i][j][RTX_4X8 as usize] = qm_tbl_8x4[i][j].as_ptr();
-            dav1d_qm_tbl[i][j][RTX_8X4 as usize] = qm_tbl_4x8[i][j].as_ptr();
+            dav1d_qm_tbl[i][j][RTX_4X8 as usize] = Some(&qm_tbl_8x4[i][j]);
+            dav1d_qm_tbl[i][j][RTX_8X4 as usize] = Some(&qm_tbl_4x8[i][j]);
             transpose(&mut qm_tbl_4x16[i][j], &qm_tbl_16x4[i][j], 16, 4);
-            dav1d_qm_tbl[i][j][RTX_4X16 as usize] = qm_tbl_16x4[i][j].as_ptr();
-            dav1d_qm_tbl[i][j][RTX_16X4 as usize] = qm_tbl_4x16[i][j].as_ptr();
+            dav1d_qm_tbl[i][j][RTX_4X16 as usize] = Some(&qm_tbl_16x4[i][j]);
+            dav1d_qm_tbl[i][j][RTX_16X4 as usize] = Some(&qm_tbl_4x16[i][j]);
             transpose(&mut qm_tbl_8x16[i][j], &qm_tbl_16x8[i][j], 16, 8);
-            dav1d_qm_tbl[i][j][RTX_8X16 as usize] = qm_tbl_16x8[i][j].as_ptr();
-            dav1d_qm_tbl[i][j][RTX_16X8 as usize] = qm_tbl_8x16[i][j].as_ptr();
+            dav1d_qm_tbl[i][j][RTX_8X16 as usize] = Some(&qm_tbl_16x8[i][j]);
+            dav1d_qm_tbl[i][j][RTX_16X8 as usize] = Some(&qm_tbl_8x16[i][j]);
             transpose(&mut qm_tbl_8x32[i][j], &qm_tbl_32x8[i][j], 32, 8);
-            dav1d_qm_tbl[i][j][RTX_8X32 as usize] = qm_tbl_32x8[i][j].as_ptr();
-            dav1d_qm_tbl[i][j][RTX_32X8 as usize] = qm_tbl_8x32[i][j].as_ptr();
+            dav1d_qm_tbl[i][j][RTX_8X32 as usize] = Some(&qm_tbl_32x8[i][j]);
+            dav1d_qm_tbl[i][j][RTX_32X8 as usize] = Some(&qm_tbl_8x32[i][j]);
             transpose(&mut qm_tbl_16x32[i][j], &qm_tbl_32x16[i][j], 32, 16);
-            dav1d_qm_tbl[i][j][RTX_16X32 as usize] = qm_tbl_32x16[i][j].as_ptr();
-            dav1d_qm_tbl[i][j][RTX_32X16 as usize] = qm_tbl_16x32[i][j].as_ptr();
+            dav1d_qm_tbl[i][j][RTX_16X32 as usize] = Some(&qm_tbl_32x16[i][j]);
+            dav1d_qm_tbl[i][j][RTX_32X16 as usize] = Some(&qm_tbl_16x32[i][j]);
 
             untriangle(&mut qm_tbl_4x4[i][j], &qm_tbl_4x4_t[i][j], 4);
-            dav1d_qm_tbl[i][j][TX_4X4 as usize] = qm_tbl_4x4[i][j].as_ptr();
+            dav1d_qm_tbl[i][j][TX_4X4 as usize] = Some(&qm_tbl_4x4[i][j]);
             untriangle(&mut qm_tbl_8x8[i][j], &qm_tbl_8x8_t[i][j], 8);
-            dav1d_qm_tbl[i][j][TX_8X8 as usize] = qm_tbl_8x8[i][j].as_ptr();
+            dav1d_qm_tbl[i][j][TX_8X8 as usize] = Some(&qm_tbl_8x8[i][j]);
             untriangle(&mut qm_tbl_32x32[i][j], &qm_tbl_32x32_t[i][j], 32);
-            dav1d_qm_tbl[i][j][TX_16X16 as usize] = qm_tbl_16x16[i][j].as_ptr();
+            dav1d_qm_tbl[i][j][TX_16X16 as usize] = Some(&qm_tbl_16x16[i][j]);
             subsample(&mut qm_tbl_16x16[i][j], &qm_tbl_32x32[i][j], 16, 2);
-            dav1d_qm_tbl[i][j][TX_32X32 as usize] = qm_tbl_32x32[i][j].as_ptr();
+            dav1d_qm_tbl[i][j][TX_32X32 as usize] = Some(&qm_tbl_32x32[i][j]);
 
             dav1d_qm_tbl[i][j][TX_64X64 as usize] = dav1d_qm_tbl[i][j][TX_32X32 as usize];
             dav1d_qm_tbl[i][j][RTX_64X32 as usize] = dav1d_qm_tbl[i][j][TX_32X32 as usize];


### PR DESCRIPTION
This is half the way to safety.  I still need to make them non-`mut`, which is much more difficult (but should be doable).