### PR TITLE
`fn pthread_*`: Deduplicate declarations into `use` imports

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -32,7 +32,6 @@ extern "C" {
         __alignment: size_t,
         __size: size_t,
     ) -> libc::c_int;
-    fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn dav1d_cdf_thread_alloc(
         c: *mut Dav1dContext,
         cdf: *mut CdfThreadContext,
@@ -242,7 +241,7 @@ use crate::src::internal::FrameTileThreadData;
 use libc::pthread_cond_signal;
 use libc::pthread_cond_wait;
 use libc::pthread_mutex_lock;
-use libc::pthread_mutex_t;
+use libc::pthread_mutex_unlock;
 
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dITUTT35;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -32,7 +32,6 @@ extern "C" {
         __alignment: size_t,
         __size: size_t,
     ) -> libc::c_int;
-    fn pthread_mutex_lock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn dav1d_cdf_thread_alloc(
         c: *mut Dav1dContext,
@@ -242,6 +241,7 @@ use crate::src::internal::Dav1dFrameContext_task_thread;
 use crate::src::internal::FrameTileThreadData;
 use libc::pthread_cond_signal;
 use libc::pthread_cond_wait;
+use libc::pthread_mutex_lock;
 use libc::pthread_mutex_t;
 
 use crate::include::dav1d::headers::Dav1dContentLightLevel;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -34,8 +34,6 @@ extern "C" {
     ) -> libc::c_int;
     fn pthread_mutex_lock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
-    fn pthread_cond_wait(__cond: *mut pthread_cond_t, __mutex: *mut pthread_mutex_t)
-        -> libc::c_int;
     fn dav1d_cdf_thread_alloc(
         c: *mut Dav1dContext,
         cdf: *mut CdfThreadContext,
@@ -243,6 +241,7 @@ pub struct Dav1dFrameContext {
 use crate::src::internal::Dav1dFrameContext_task_thread;
 use crate::src::internal::FrameTileThreadData;
 use libc::pthread_cond_signal;
+use libc::pthread_cond_wait;
 use libc::pthread_mutex_t;
 
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
@@ -275,8 +274,6 @@ use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-
-use libc::pthread_cond_t;
 
 use crate::src::internal::Dav1dFrameContext_lf;
 use crate::src::lf_mask::Av1Filter;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -34,7 +34,6 @@ extern "C" {
     ) -> libc::c_int;
     fn pthread_mutex_lock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
-    fn pthread_cond_signal(__cond: *mut pthread_cond_t) -> libc::c_int;
     fn pthread_cond_wait(__cond: *mut pthread_cond_t, __mutex: *mut pthread_mutex_t)
         -> libc::c_int;
     fn dav1d_cdf_thread_alloc(
@@ -243,6 +242,7 @@ pub struct Dav1dFrameContext {
 }
 use crate::src::internal::Dav1dFrameContext_task_thread;
 use crate::src::internal::FrameTileThreadData;
+use libc::pthread_cond_signal;
 use libc::pthread_mutex_t;
 
 use crate::include::dav1d::headers::Dav1dContentLightLevel;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,6 @@ extern "C" {
     ) -> libc::c_int;
     fn pthread_cond_wait(__cond: *mut pthread_cond_t, __mutex: *mut pthread_mutex_t)
         -> libc::c_int;
-    fn pthread_cond_broadcast(__cond: *mut pthread_cond_t) -> libc::c_int;
     fn pthread_cond_destroy(__cond: *mut pthread_cond_t) -> libc::c_int;
     fn dav1d_log(c: *mut Dav1dContext, format: *const libc::c_char, _: ...);
     fn dav1d_parse_obus(
@@ -171,6 +170,7 @@ use crate::src::mem::Dav1dMemPool;
 use libc::pthread_attr_destroy;
 use libc::pthread_attr_init;
 use libc::pthread_attr_setstacksize;
+use libc::pthread_cond_broadcast;
 use libc::pthread_mutex_t;
 
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,6 @@ extern "C" {
     fn pthread_mutex_lock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn pthread_mutex_destroy(__mutex: *mut pthread_mutex_t) -> libc::c_int;
-    fn pthread_cond_wait(__cond: *mut pthread_cond_t, __mutex: *mut pthread_mutex_t)
-        -> libc::c_int;
     fn dav1d_log(c: *mut Dav1dContext, format: *const libc::c_char, _: ...);
     fn dav1d_parse_obus(
         c: *mut Dav1dContext,
@@ -168,6 +166,7 @@ use libc::pthread_attr_setstacksize;
 use libc::pthread_cond_broadcast;
 use libc::pthread_cond_destroy;
 use libc::pthread_cond_init;
+use libc::pthread_cond_wait;
 use libc::pthread_mutex_t;
 
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
@@ -510,7 +509,6 @@ use crate::src::picture::dav1d_thread_picture_move_ref;
 use crate::src::picture::dav1d_thread_picture_ref;
 use crate::src::picture::dav1d_thread_picture_unref;
 use crate::src::picture::Dav1dThreadPicture;
-use libc::pthread_cond_t;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTaskContext {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,6 @@ extern "C" {
         __once_control: *mut pthread_once_t,
         __init_routine: Option<unsafe extern "C" fn() -> ()>,
     ) -> libc::c_int;
-    fn pthread_attr_setstacksize(__attr: *mut pthread_attr_t, __stacksize: size_t) -> libc::c_int;
     fn pthread_mutex_init(
         __mutex: *mut pthread_mutex_t,
         __mutexattr: *const pthread_mutexattr_t,
@@ -171,6 +170,7 @@ use crate::src::mem::Dav1dMemPool;
 
 use libc::pthread_attr_destroy;
 use libc::pthread_attr_init;
+use libc::pthread_attr_setstacksize;
 use libc::pthread_mutex_t;
 
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,10 +48,6 @@ extern "C" {
         __once_control: *mut pthread_once_t,
         __init_routine: Option<unsafe extern "C" fn() -> ()>,
     ) -> libc::c_int;
-    fn pthread_mutex_init(
-        __mutex: *mut pthread_mutex_t,
-        __mutexattr: *const pthread_mutexattr_t,
-    ) -> libc::c_int;
     fn pthread_mutex_lock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn dav1d_log(c: *mut Dav1dContext, format: *const libc::c_char, _: ...);
@@ -167,6 +163,7 @@ use libc::pthread_cond_init;
 use libc::pthread_cond_wait;
 use libc::pthread_join;
 use libc::pthread_mutex_destroy;
+use libc::pthread_mutex_init;
 use libc::pthread_mutex_t;
 
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,6 @@ extern "C" {
         __arg: *mut libc::c_void,
     ) -> libc::c_int;
     fn dav1d_refmvs_dsp_init(dsp: *mut Dav1dRefmvsDSPContext);
-    fn pthread_join(__th: pthread_t, __thread_return: *mut *mut libc::c_void) -> libc::c_int;
     fn pthread_once(
         __once_control: *mut pthread_once_t,
         __init_routine: Option<unsafe extern "C" fn() -> ()>,
@@ -167,6 +166,7 @@ use libc::pthread_cond_broadcast;
 use libc::pthread_cond_destroy;
 use libc::pthread_cond_init;
 use libc::pthread_cond_wait;
+use libc::pthread_join;
 use libc::pthread_mutex_t;
 
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,6 @@ extern "C" {
         w: libc::c_int,
         src: *const Dav1dPicture,
     ) -> libc::c_int;
-    fn pthread_attr_init(__attr: *mut pthread_attr_t) -> libc::c_int;
     fn __sysconf(__name: libc::c_int) -> libc::c_long;
     fn pthread_create(
         __newthread: *mut pthread_t,
@@ -171,6 +170,7 @@ pub struct Dav1dContext {
 use crate::src::mem::Dav1dMemPool;
 
 use libc::pthread_attr_destroy;
+use libc::pthread_attr_init;
 use libc::pthread_mutex_t;
 
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,6 @@ extern "C" {
         __once_control: *mut pthread_once_t,
         __init_routine: Option<unsafe extern "C" fn() -> ()>,
     ) -> libc::c_int;
-    fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn dav1d_log(c: *mut Dav1dContext, format: *const libc::c_char, _: ...);
     fn dav1d_parse_obus(
         c: *mut Dav1dContext,
@@ -164,7 +163,7 @@ use libc::pthread_join;
 use libc::pthread_mutex_destroy;
 use libc::pthread_mutex_init;
 use libc::pthread_mutex_lock;
-use libc::pthread_mutex_t;
+use libc::pthread_mutex_unlock;
 
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
 use crate::include::dav1d::dav1d::Dav1dEventFlags;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,6 @@ extern "C" {
     ) -> libc::c_int;
     fn pthread_mutex_lock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
-    fn pthread_mutex_destroy(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn dav1d_log(c: *mut Dav1dContext, format: *const libc::c_char, _: ...);
     fn dav1d_parse_obus(
         c: *mut Dav1dContext,
@@ -167,6 +166,7 @@ use libc::pthread_cond_destroy;
 use libc::pthread_cond_init;
 use libc::pthread_cond_wait;
 use libc::pthread_join;
+use libc::pthread_mutex_destroy;
 use libc::pthread_mutex_t;
 
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,6 @@ extern "C" {
     ) -> libc::c_int;
     fn pthread_cond_wait(__cond: *mut pthread_cond_t, __mutex: *mut pthread_mutex_t)
         -> libc::c_int;
-    fn pthread_cond_destroy(__cond: *mut pthread_cond_t) -> libc::c_int;
     fn dav1d_log(c: *mut Dav1dContext, format: *const libc::c_char, _: ...);
     fn dav1d_parse_obus(
         c: *mut Dav1dContext,
@@ -171,6 +170,7 @@ use libc::pthread_attr_destroy;
 use libc::pthread_attr_init;
 use libc::pthread_attr_setstacksize;
 use libc::pthread_cond_broadcast;
+use libc::pthread_cond_destroy;
 use libc::pthread_mutex_t;
 
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,6 @@ extern "C" {
     ) -> libc::c_int;
     fn dav1d_refmvs_dsp_init(dsp: *mut Dav1dRefmvsDSPContext);
     fn pthread_join(__th: pthread_t, __thread_return: *mut *mut libc::c_void) -> libc::c_int;
-    fn pthread_attr_destroy(__attr: *mut pthread_attr_t) -> libc::c_int;
     fn pthread_once(
         __once_control: *mut pthread_once_t,
         __init_routine: Option<unsafe extern "C" fn() -> ()>,
@@ -171,6 +170,7 @@ pub struct Dav1dContext {
 }
 use crate::src::mem::Dav1dMemPool;
 
+use libc::pthread_attr_destroy;
 use libc::pthread_mutex_t;
 
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,10 +56,6 @@ extern "C" {
     fn pthread_mutex_lock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn pthread_mutex_destroy(__mutex: *mut pthread_mutex_t) -> libc::c_int;
-    fn pthread_cond_init(
-        __cond: *mut pthread_cond_t,
-        __cond_attr: *const pthread_condattr_t,
-    ) -> libc::c_int;
     fn pthread_cond_wait(__cond: *mut pthread_cond_t, __mutex: *mut pthread_mutex_t)
         -> libc::c_int;
     fn dav1d_log(c: *mut Dav1dContext, format: *const libc::c_char, _: ...);
@@ -171,6 +167,7 @@ use libc::pthread_attr_init;
 use libc::pthread_attr_setstacksize;
 use libc::pthread_cond_broadcast;
 use libc::pthread_cond_destroy;
+use libc::pthread_cond_init;
 use libc::pthread_mutex_t;
 
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,6 @@ extern "C" {
         __once_control: *mut pthread_once_t,
         __init_routine: Option<unsafe extern "C" fn() -> ()>,
     ) -> libc::c_int;
-    fn pthread_mutex_lock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn dav1d_log(c: *mut Dav1dContext, format: *const libc::c_char, _: ...);
     fn dav1d_parse_obus(
@@ -164,6 +163,7 @@ use libc::pthread_cond_wait;
 use libc::pthread_join;
 use libc::pthread_mutex_destroy;
 use libc::pthread_mutex_init;
+use libc::pthread_mutex_lock;
 use libc::pthread_mutex_t;
 
 use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -2,10 +2,6 @@ use crate::include::stddef::*;
 use crate::include::stdint::*;
 use ::libc;
 extern "C" {
-    fn pthread_mutex_init(
-        __mutex: *mut pthread_mutex_t,
-        __mutexattr: *const pthread_mutexattr_t,
-    ) -> libc::c_int;
     fn pthread_mutex_lock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn malloc(_: libc::c_ulong) -> *mut libc::c_void;
@@ -18,6 +14,7 @@ extern "C" {
 }
 
 use libc::pthread_mutex_destroy;
+use libc::pthread_mutex_init;
 use libc::pthread_mutex_t;
 
 #[derive(Copy, Clone)]

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -6,7 +6,6 @@ extern "C" {
         __mutex: *mut pthread_mutex_t,
         __mutexattr: *const pthread_mutexattr_t,
     ) -> libc::c_int;
-    fn pthread_mutex_destroy(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn pthread_mutex_lock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn malloc(_: libc::c_ulong) -> *mut libc::c_void;
@@ -18,6 +17,7 @@ extern "C" {
     ) -> libc::c_int;
 }
 
+use libc::pthread_mutex_destroy;
 use libc::pthread_mutex_t;
 
 #[derive(Copy, Clone)]

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -2,7 +2,6 @@ use crate::include::stddef::*;
 use crate::include::stdint::*;
 use ::libc;
 extern "C" {
-    fn pthread_mutex_lock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn malloc(_: libc::c_ulong) -> *mut libc::c_void;
     fn free(_: *mut libc::c_void);
@@ -15,6 +14,7 @@ extern "C" {
 
 use libc::pthread_mutex_destroy;
 use libc::pthread_mutex_init;
+use libc::pthread_mutex_lock;
 use libc::pthread_mutex_t;
 
 #[derive(Copy, Clone)]

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -2,7 +2,6 @@ use crate::include::stddef::*;
 use crate::include::stdint::*;
 use ::libc;
 extern "C" {
-    fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn malloc(_: libc::c_ulong) -> *mut libc::c_void;
     fn free(_: *mut libc::c_void);
     fn posix_memalign(
@@ -16,6 +15,7 @@ use libc::pthread_mutex_destroy;
 use libc::pthread_mutex_init;
 use libc::pthread_mutex_lock;
 use libc::pthread_mutex_t;
+use libc::pthread_mutex_unlock;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -7,7 +7,6 @@ extern "C" {
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: size_t) -> *mut libc::c_void;
     fn memcmp(_: *const libc::c_void, _: *const libc::c_void, _: size_t) -> libc::c_int;
     fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int;
-    fn pthread_mutex_lock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn dav1d_log(c: *mut Dav1dContext, format: *const libc::c_char, _: ...);
 }
@@ -88,6 +87,7 @@ pub struct Dav1dFrameContext {
 use crate::src::internal::Dav1dFrameContext_task_thread;
 use crate::src::internal::FrameTileThreadData;
 use libc::pthread_cond_wait;
+use libc::pthread_mutex_lock;
 use libc::pthread_mutex_t;
 
 use crate::include::dav1d::headers::Dav1dContentLightLevel;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -9,8 +9,6 @@ extern "C" {
     fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int;
     fn pthread_mutex_lock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
-    fn pthread_cond_wait(__cond: *mut pthread_cond_t, __mutex: *mut pthread_mutex_t)
-        -> libc::c_int;
     fn dav1d_log(c: *mut Dav1dContext, format: *const libc::c_char, _: ...);
 }
 
@@ -89,6 +87,7 @@ pub struct Dav1dFrameContext {
 }
 use crate::src::internal::Dav1dFrameContext_task_thread;
 use crate::src::internal::FrameTileThreadData;
+use libc::pthread_cond_wait;
 use libc::pthread_mutex_t;
 
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
@@ -152,7 +151,6 @@ use crate::include::dav1d::headers::Dav1dColorPrimaries;
 
 use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
 use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use libc::pthread_cond_t;
 
 use crate::src::internal::Dav1dFrameContext_lf;
 use crate::src::lf_mask::Av1Filter;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -7,7 +7,6 @@ extern "C" {
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: size_t) -> *mut libc::c_void;
     fn memcmp(_: *const libc::c_void, _: *const libc::c_void, _: size_t) -> libc::c_int;
     fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int;
-    fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn dav1d_log(c: *mut Dav1dContext, format: *const libc::c_char, _: ...);
 }
 
@@ -88,7 +87,7 @@ use crate::src::internal::Dav1dFrameContext_task_thread;
 use crate::src::internal::FrameTileThreadData;
 use libc::pthread_cond_wait;
 use libc::pthread_mutex_lock;
-use libc::pthread_mutex_t;
+use libc::pthread_mutex_unlock;
 
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dITUTT35;

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -6,7 +6,6 @@ extern "C" {
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: size_t) -> *mut libc::c_void;
     fn realloc(_: *mut libc::c_void, _: size_t) -> *mut libc::c_void;
     fn abort() -> !;
-    fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     cfg_if! {
         if #[cfg(target_os = "linux")] {
             fn prctl(__option: libc::c_int, _: ...) -> libc::c_int;
@@ -139,7 +138,7 @@ use crate::src::internal::DAV1D_TASK_TYPE_TILE_RECONSTRUCTION;
 use libc::pthread_cond_signal;
 use libc::pthread_cond_wait;
 use libc::pthread_mutex_lock;
-use libc::pthread_mutex_t;
+use libc::pthread_mutex_unlock;
 
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dITUTT35;

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -8,7 +8,6 @@ extern "C" {
     fn abort() -> !;
     fn pthread_mutex_lock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
-    fn pthread_cond_signal(__cond: *mut pthread_cond_t) -> libc::c_int;
     fn pthread_cond_wait(__cond: *mut pthread_cond_t, __mutex: *mut pthread_mutex_t)
         -> libc::c_int;
     cfg_if! {
@@ -140,6 +139,7 @@ use crate::src::internal::DAV1D_TASK_TYPE_INIT_CDF;
 use crate::src::internal::DAV1D_TASK_TYPE_SUPER_RESOLUTION;
 use crate::src::internal::DAV1D_TASK_TYPE_TILE_ENTROPY;
 use crate::src::internal::DAV1D_TASK_TYPE_TILE_RECONSTRUCTION;
+use libc::pthread_cond_signal;
 use libc::pthread_mutex_t;
 
 use crate::include::dav1d::headers::Dav1dContentLightLevel;

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -8,8 +8,6 @@ extern "C" {
     fn abort() -> !;
     fn pthread_mutex_lock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
-    fn pthread_cond_wait(__cond: *mut pthread_cond_t, __mutex: *mut pthread_mutex_t)
-        -> libc::c_int;
     cfg_if! {
         if #[cfg(target_os = "linux")] {
             fn prctl(__option: libc::c_int, _: ...) -> libc::c_int;
@@ -140,6 +138,7 @@ use crate::src::internal::DAV1D_TASK_TYPE_SUPER_RESOLUTION;
 use crate::src::internal::DAV1D_TASK_TYPE_TILE_ENTROPY;
 use crate::src::internal::DAV1D_TASK_TYPE_TILE_RECONSTRUCTION;
 use libc::pthread_cond_signal;
+use libc::pthread_cond_wait;
 use libc::pthread_mutex_t;
 
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
@@ -154,8 +153,6 @@ use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
 
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-
-use libc::pthread_cond_t;
 
 use crate::src::internal::Dav1dFrameContext_lf;
 use crate::src::lf_mask::Av1Filter;

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -6,7 +6,6 @@ extern "C" {
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: size_t) -> *mut libc::c_void;
     fn realloc(_: *mut libc::c_void, _: size_t) -> *mut libc::c_void;
     fn abort() -> !;
-    fn pthread_mutex_lock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     fn pthread_mutex_unlock(__mutex: *mut pthread_mutex_t) -> libc::c_int;
     cfg_if! {
         if #[cfg(target_os = "linux")] {
@@ -139,6 +138,7 @@ use crate::src::internal::DAV1D_TASK_TYPE_TILE_ENTROPY;
 use crate::src::internal::DAV1D_TASK_TYPE_TILE_RECONSTRUCTION;
 use libc::pthread_cond_signal;
 use libc::pthread_cond_wait;
+use libc::pthread_mutex_lock;
 use libc::pthread_mutex_t;
 
 use crate::include::dav1d::headers::Dav1dContentLightLevel;


### PR DESCRIPTION
A few are left, the arch-specific ones/ones not in `libc` as well as `pthread_create` since I need to make the `fn` ptr safe first.