### PR TITLE
`fn dav1d_decode_frame`: Cleanup and make mostly safe

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -6383,10 +6383,13 @@ pub unsafe extern "C" fn dav1d_decode_frame_exit(f: *mut Dav1dFrameContext, retv
 
 pub unsafe fn dav1d_decode_frame(f: &mut Dav1dFrameContext) -> libc::c_int {
     assert!((*f.c).n_fc == 1);
+    // if n_tc > 1 (but n_fc == 1), we could run init/exit in the task
+    // threads also. Not sure it makes a measurable difference.
     let mut res = dav1d_decode_frame_init(f);
     if res == 0 {
         res = dav1d_decode_frame_init_cdf(f);
     }
+    // wait until all threads have completed
     if res == 0 {
         if (*f.c).n_tc > 1 {
             res = dav1d_task_create_tile_sbrow(f, 0, 1);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -6382,7 +6382,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_exit(f: *mut Dav1dFrameContext, retv
 }
 
 pub unsafe fn dav1d_decode_frame(f: &mut Dav1dFrameContext) -> libc::c_int {
-    if !((*f.c).n_fc == 1 as libc::c_uint) {
+    if !((*f.c).n_fc == 1) {
         unreachable!();
     }
     let mut res = dav1d_decode_frame_init(f);
@@ -6390,8 +6390,8 @@ pub unsafe fn dav1d_decode_frame(f: &mut Dav1dFrameContext) -> libc::c_int {
         res = dav1d_decode_frame_init_cdf(f);
     }
     if res == 0 {
-        if (*f.c).n_tc > 1 as libc::c_uint {
-            res = dav1d_task_create_tile_sbrow(f, 0 as libc::c_int, 1 as libc::c_int);
+        if (*f.c).n_tc > 1 {
+            res = dav1d_task_create_tile_sbrow(f, 0, 1);
             pthread_mutex_lock(&mut (*f.task_thread.ttd).lock);
             pthread_cond_signal(&mut (*f.task_thread.ttd).cond);
             if res == 0 {
@@ -6411,13 +6411,13 @@ pub unsafe fn dav1d_decode_frame(f: &mut Dav1dFrameContext) -> libc::c_int {
                 dav1d_cdf_thread_update(
                     f.frame_hdr,
                     f.out_cdf.data.cdf,
-                    &mut (*(f.ts).offset((*f.frame_hdr).tiling.update as isize)).cdf,
+                    &mut (*f.ts.offset((*f.frame_hdr).tiling.update as isize)).cdf,
                 );
             }
         }
     }
     dav1d_decode_frame_exit(f, res);
-    f.n_tile_data = 0 as libc::c_int;
+    f.n_tile_data = 0;
     return res;
 }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -6380,8 +6380,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_exit(f: *mut Dav1dFrameContext, retv
     }
     (*f).task_thread.retval = retval;
 }
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_decode_frame(f: *mut Dav1dFrameContext) -> libc::c_int {
+
+pub unsafe fn dav1d_decode_frame(f: *mut Dav1dFrameContext) -> libc::c_int {
     if !((*(*f).c).n_fc == 1 as libc::c_uint) {
         unreachable!();
     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -19,19 +19,12 @@ use libc;
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: size_t) -> *mut libc::c_void;
-    fn memcmp(_: *const libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> libc::c_int;
-    fn printf(_: *const libc::c_char, _: ...) -> libc::c_int;
     #[cfg(feature = "bitdepth_8")]
     fn dav1d_cdef_dsp_init_8bpc(c: *mut Dav1dCdefDSPContext);
     #[cfg(feature = "bitdepth_16")]
     fn dav1d_cdef_dsp_init_16bpc(c: *mut Dav1dCdefDSPContext);
     fn malloc(_: libc::c_ulong) -> *mut libc::c_void;
     fn free(_: *mut libc::c_void);
-    fn posix_memalign(
-        __memptr: *mut *mut libc::c_void,
-        __alignment: size_t,
-        __size: size_t,
-    ) -> libc::c_int;
     fn dav1d_cdf_thread_alloc(
         c: *mut Dav1dContext,
         cdf: *mut CdfThreadContext,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -6416,7 +6416,7 @@ pub unsafe fn dav1d_decode_frame(f: &mut Dav1dFrameContext) -> libc::c_int {
     }
     dav1d_decode_frame_exit(f, res);
     f.n_tile_data = 0;
-    return res;
+    res
 }
 
 fn get_upscale_x0(in_w: libc::c_int, out_w: libc::c_int, step: libc::c_int) -> libc::c_int {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -6382,9 +6382,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_exit(f: *mut Dav1dFrameContext, retv
 }
 
 pub unsafe fn dav1d_decode_frame(f: &mut Dav1dFrameContext) -> libc::c_int {
-    if !((*f.c).n_fc == 1) {
-        unreachable!();
-    }
+    assert!((*f.c).n_fc == 1);
     let mut res = dav1d_decode_frame_init(f);
     if res == 0 {
         res = dav1d_decode_frame_init_cdf(f);


### PR DESCRIPTION
I had to do the unsafe cast to `AtomicI32` in 708315c8b688c812969e59fca748e79427a29a66 since making the field itself `AtomicI32` requires us to remove the `#[derive(Copy)]`, which has to be done recursively, so I'd like to do that in its own PR.