### PR TITLE
`#[derive(Copy, Clone)]`: Remove except where needed

### DIFF
--- a/include/dav1d/common.rs
+++ b/include/dav1d/common.rs
@@ -3,13 +3,14 @@ use crate::include::stdint::int64_t;
 use crate::include::stdint::uint8_t;
 use crate::src::r#ref::Dav1dRef;
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dUserData {
     pub data: *const uint8_t,
     pub r#ref: *mut Dav1dRef,
 }
-#[derive(Copy, Clone)]
+
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dDataProps {
     pub timestamp: int64_t,

--- a/include/dav1d/data.rs
+++ b/include/dav1d/data.rs
@@ -3,7 +3,7 @@ use crate::include::stddef::size_t;
 use crate::include::stdint::uint8_t;
 use crate::src::r#ref::Dav1dRef;
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dData {
     pub data: *const uint8_t,

--- a/include/dav1d/dav1d.rs
+++ b/include/dav1d/dav1d.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dLogger {
     pub cookie: *mut libc::c_void,

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -42,7 +42,7 @@ pub const DAV1D_WM_TYPE_ROT_ZOOM: Dav1dWarpedMotionType = 2;
 pub const DAV1D_WM_TYPE_TRANSLATION: Dav1dWarpedMotionType = 1;
 pub const DAV1D_WM_TYPE_IDENTITY: Dav1dWarpedMotionType = 0;
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
     pub type_0: Dav1dWarpedMotionType,
@@ -135,13 +135,11 @@ pub const DAV1D_CHR_UNKNOWN: Dav1dChromaSamplePosition = 0;
 // Constants from Section 3. "Symbols and abbreviated terms"
 pub const DAV1D_MAX_SEGMENTS: u8 = 8;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContentLightLevel {
     pub max_content_light_level: libc::c_int,
     pub max_frame_average_light_level: libc::c_int,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dMasteringDisplay {
     pub primaries: [[uint16_t; 2]; 3],
@@ -149,7 +147,6 @@ pub struct Dav1dMasteringDisplay {
     pub max_luminance: uint32_t,
     pub min_luminance: uint32_t,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dITUTT35 {
     pub country_code: uint8_t,
@@ -157,7 +154,8 @@ pub struct Dav1dITUTT35 {
     pub payload_size: size_t,
     pub payload: *mut uint8_t,
 }
-#[derive(Copy, Clone)]
+
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct Dav1dSequenceHeaderOperatingPoint {
     pub major_level: libc::c_int,
@@ -168,14 +166,15 @@ pub struct Dav1dSequenceHeaderOperatingPoint {
     pub decoder_model_param_present: libc::c_int,
     pub display_model_param_present: libc::c_int,
 }
-#[derive(Copy, Clone)]
+
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct Dav1dSequenceHeaderOperatingParameterInfo {
     pub decoder_buffer_delay: libc::c_int,
     pub encoder_buffer_delay: libc::c_int,
     pub low_delay_mode: libc::c_int,
 }
-#[derive(Copy, Clone)]
+
 #[repr(C)]
 pub struct Dav1dSequenceHeader {
     pub profile: libc::c_int,
@@ -232,7 +231,8 @@ pub struct Dav1dSequenceHeader {
     pub film_grain_present: libc::c_int,
     pub operating_parameter_info: [Dav1dSequenceHeaderOperatingParameterInfo; 32],
 }
-#[derive(Copy, Clone)]
+
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dSegmentationData {
     pub delta_q: libc::c_int,
@@ -244,20 +244,23 @@ pub struct Dav1dSegmentationData {
     pub skip: libc::c_int,
     pub globalmv: libc::c_int,
 }
-#[derive(Copy, Clone)]
+
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dSegmentationDataSet {
     pub d: [Dav1dSegmentationData; 8],
     pub preskip: libc::c_int,
     pub last_active_segid: libc::c_int,
 }
-#[derive(Copy, Clone)]
+
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dLoopfilterModeRefDeltas {
     pub mode_delta: [libc::c_int; 2],
     pub ref_delta: [libc::c_int; 8],
 }
-#[derive(Copy, Clone)]
+
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFilmGrainData {
     pub seed: libc::c_uint,
@@ -278,25 +281,21 @@ pub struct Dav1dFilmGrainData {
     pub overlap_flag: libc::c_int,
     pub clip_to_restricted_range: libc::c_int,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeaderOperatingPoint {
     pub buffer_removal_time: libc::c_int,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
@@ -313,7 +312,6 @@ pub struct Dav1dFrameHeader_tiling {
     pub row_start_sb: [uint16_t; 65],
     pub update: libc::c_int,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
@@ -327,7 +325,6 @@ pub struct Dav1dFrameHeader_quant {
     pub qm_u: libc::c_int,
     pub qm_v: libc::c_int,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
@@ -338,26 +335,22 @@ pub struct Dav1dFrameHeader_segmentation {
     pub lossless: [libc::c_int; 8],
     pub qidx: [libc::c_int; 8],
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_delta {
     pub q: Dav1dFrameHeader_delta_q,
     pub lf: Dav1dFrameHeader_delta_lf,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
@@ -368,7 +361,6 @@ pub struct Dav1dFrameHeader_loopfilter {
     pub mode_ref_deltas: Dav1dLoopfilterModeRefDeltas,
     pub sharpness: libc::c_int,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
@@ -376,13 +368,11 @@ pub struct Dav1dFrameHeader_cdef {
     pub y_strength: [libc::c_int; 8],
     pub uv_strength: [libc::c_int; 8],
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
     pub film_grain: Dav1dFrameHeader_film_grain,

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -9,7 +9,7 @@ use crate::include::stddef::ptrdiff_t;
 use crate::include::stdint::uintptr_t;
 use crate::src::r#ref::Dav1dRef;
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dPictureParameters {
     pub w: libc::c_int,
@@ -18,7 +18,7 @@ pub struct Dav1dPictureParameters {
     pub bpc: libc::c_int,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dPicture {
     pub seq_hdr: *mut Dav1dSequenceHeader,
@@ -41,7 +41,7 @@ pub struct Dav1dPicture {
     pub allocator_data: *mut libc::c_void,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dPicAllocator {
     pub cookie: *mut libc::c_void,

--- a/include/pthread.rs
+++ b/include/pthread.rs
@@ -7,7 +7,6 @@ cfg_if::cfg_if! {
             0
         }
     } else if #[cfg(target_os = "macos")] {
-        #[derive(Copy, Clone)]
         #[repr(C)]
         pub struct _opaque_pthread_once_t {
             pub __sig: libc::c_long,

--- a/include/sched.rs
+++ b/include/sched.rs
@@ -1,6 +1,5 @@
 pub type __cpu_mask = libc::c_ulong;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct cpu_set_t {
     pub __bits: [__cpu_mask; 16],

--- a/include/stdio.rs
+++ b/include/stdio.rs
@@ -8,7 +8,6 @@ extern "C" {
     pub type _IO_marker;
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct _IO_FILE {
     pub _flags: libc::c_int,

--- a/src/align.rs
+++ b/src/align.rs
@@ -10,7 +10,7 @@ use std::ops::{Index, IndexMut};
 
 macro_rules! def_align {
     ($align:literal, $name:ident) => {
-        #[derive(Copy, Clone)]
+        #[derive(Clone, Copy)]
         #[repr(C, align($align))]
         pub struct $name<T>(pub T);
 

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -31,7 +31,6 @@ pub type cdef_fn = unsafe extern "C" fn(
 ) -> ();
 pub type cdef_dir_fn =
     unsafe extern "C" fn(*const DynPixel, ptrdiff_t, *mut libc::c_uint, libc::c_int) -> libc::c_int;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dCdefDSPContext {
     pub dir: cdef_dir_fn,

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -13,7 +13,6 @@ use crate::include::stdatomic::atomic_int;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
 use crate::src::r#ref::Dav1dRef;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext {
     pub seq_hdr_ref: *mut Dav1dRef,
@@ -102,7 +101,6 @@ use crate::src::refmvs::refmvs_frame;
 
 use crate::src::env::BlockContext;
 use crate::src::refmvs::refmvs_temporal_block;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
@@ -120,7 +118,6 @@ pub type read_coef_blocks_fn =
     Option<unsafe extern "C" fn(*mut Dav1dTaskContext, BlockSize, *const Av1Block) -> ()>;
 use crate::src::levels::BlockSize;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTaskContext {
     pub c: *const Dav1dContext,
@@ -154,7 +151,6 @@ use crate::src::refmvs::refmvs_tile;
 
 use crate::src::internal::Dav1dTileState;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {
     pub fc: *mut Dav1dFrameContext,
@@ -226,7 +222,6 @@ use crate::src::internal::Dav1dContext_intra_edge;
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::refmvs::Dav1dRefmvsDSPContext;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dDSPContext {
     pub fg: Dav1dFilmGrainDSPContext,
@@ -247,7 +242,6 @@ use crate::src::cdef::CDEF_HAVE_RIGHT;
 use crate::src::cdef::CDEF_HAVE_TOP;
 use crate::src::itx::Dav1dInvTxfmDSPContext;
 use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dMCDSPContext {
     pub mc: [mc_fn; 10],
@@ -433,7 +427,6 @@ pub type mc_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dIntraPredDSPContext {
     pub intra_pred: [angular_ipred_fn; 14],
@@ -487,7 +480,6 @@ pub type angular_ipred_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -13,7 +13,6 @@ use crate::include::stdatomic::atomic_int;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
 use crate::src::r#ref::Dav1dRef;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext {
     pub seq_hdr_ref: *mut Dav1dRef,
@@ -103,7 +102,6 @@ use crate::src::refmvs::refmvs_frame;
 
 use crate::src::env::BlockContext;
 use crate::src::refmvs::refmvs_temporal_block;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
@@ -121,7 +119,6 @@ pub type read_coef_blocks_fn =
     Option<unsafe extern "C" fn(*mut Dav1dTaskContext, BlockSize, *const Av1Block) -> ()>;
 use crate::src::levels::BlockSize;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTaskContext {
     pub c: *const Dav1dContext,
@@ -155,7 +152,6 @@ use crate::src::refmvs::refmvs_tile;
 
 use crate::src::internal::Dav1dTileState;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {
     pub fc: *mut Dav1dFrameContext,
@@ -227,7 +223,6 @@ use crate::src::internal::Dav1dContext_intra_edge;
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::refmvs::Dav1dRefmvsDSPContext;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dDSPContext {
     pub fg: Dav1dFilmGrainDSPContext,
@@ -248,7 +243,6 @@ use crate::src::cdef::CDEF_HAVE_RIGHT;
 use crate::src::cdef::CDEF_HAVE_TOP;
 use crate::src::itx::Dav1dInvTxfmDSPContext;
 use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dMCDSPContext {
     pub mc: [mc_fn; 10],
@@ -423,7 +417,6 @@ pub type mc_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dIntraPredDSPContext {
     pub intra_pred: [angular_ipred_fn; 14],
@@ -475,7 +468,6 @@ pub type angular_ipred_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -18,7 +18,6 @@ use crate::include::dav1d::data::Dav1dData;
 use crate::src::r#ref::dav1d_ref_create_using_pool;
 use crate::src::r#ref::dav1d_ref_dec;
 use crate::src::r#ref::Dav1dRef;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext {
     pub seq_hdr_ref: *mut Dav1dRef,
@@ -107,7 +106,6 @@ use crate::src::refmvs::refmvs_frame;
 
 use crate::src::env::BlockContext;
 use crate::src::refmvs::refmvs_temporal_block;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
@@ -125,7 +123,6 @@ pub type read_coef_blocks_fn =
     Option<unsafe extern "C" fn(*mut Dav1dTaskContext, BlockSize, *const Av1Block) -> ()>;
 use crate::src::levels::BlockSize;
 use crate::src::levels::N_BS_SIZES;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTaskContext {
     pub c: *const Dav1dContext,
@@ -159,7 +156,6 @@ use crate::src::refmvs::refmvs_tile;
 
 use crate::src::internal::Dav1dTileState;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct CdfContext {
     pub m: CdfModeContext,
@@ -168,13 +164,13 @@ pub struct CdfContext {
     pub mv: CdfMvContext,
     pub dmv: CdfMvContext,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct CdfMvContext {
     pub comp: [CdfMvComponent; 2],
     pub joint: Align8<[uint16_t; 4]>,
 }
-#[derive(Copy, Clone)]
+
+#[derive(Clone)]
 #[repr(C)]
 pub struct CdfMvComponent {
     pub classes: Align32<[uint16_t; 16]>,
@@ -186,7 +182,8 @@ pub struct CdfMvComponent {
     pub classN: Align4<[[uint16_t; 2]; 10]>,
     pub sign: Align4<[uint16_t; 2]>,
 }
-#[derive(Copy, Clone)]
+
+#[derive(Clone)]
 #[repr(C)]
 pub struct CdfCoefContext {
     pub eob_bin_16: Align16<[[[uint16_t; 8]; 2]; 2]>,
@@ -203,7 +200,8 @@ pub struct CdfCoefContext {
     pub skip: Align4<[[[uint16_t; 2]; 13]; 5]>,
     pub dc_sign: Align4<[[[uint16_t; 2]; 3]; 2]>,
 }
-#[derive(Copy, Clone)]
+
+#[derive(Clone)]
 #[repr(C)]
 pub struct CdfModeContext {
     pub y_mode: Align32<[[uint16_t; 16]; 4]>,
@@ -258,7 +256,6 @@ pub struct CdfModeContext {
     pub pal_uv: Align4<[[uint16_t; 2]; 2]>,
     pub intrabc: Align4<[uint16_t; 2]>,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {
     pub fc: *mut Dav1dFrameContext,
@@ -330,7 +327,6 @@ use crate::src::internal::Dav1dContext_intra_edge;
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::refmvs::Dav1dRefmvsDSPContext;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dDSPContext {
     pub fg: Dav1dFilmGrainDSPContext,
@@ -345,7 +341,6 @@ use crate::src::cdef::Dav1dCdefDSPContext;
 use crate::src::itx::Dav1dInvTxfmDSPContext;
 use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
 use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dMCDSPContext {
     pub mc: [mc_fn; 10],
@@ -526,7 +521,6 @@ pub type mc_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dIntraPredDSPContext {
     pub intra_pred: [angular_ipred_fn; 14],
@@ -578,7 +572,6 @@ pub type angular_ipred_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,
@@ -627,19 +620,22 @@ pub type generate_grain_uv_fn = Option<
 >;
 pub type generate_grain_y_fn =
     Option<unsafe extern "C" fn(*mut [entry; 82], *const Dav1dFilmGrainData) -> ()>;
-#[derive(Copy, Clone)]
+
+#[derive(Clone)]
 #[repr(C)]
 pub struct CdfThreadContext {
     pub r#ref: *mut Dav1dRef,
     pub data: CdfThreadContext_data,
     pub progress: *mut atomic_uint,
 }
-#[derive(Copy, Clone)]
+
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub union CdfThreadContext_data {
     pub cdf: *mut CdfContext,
     pub qcat: libc::c_uint,
 }
+
 use crate::src::internal::Dav1dContext_frame_thread;
 use crate::src::internal::Dav1dContext_refs;
 use crate::src::internal::Dav1dTileGroup;
@@ -6157,13 +6153,13 @@ pub unsafe fn dav1d_cdf_thread_copy(dst: *mut CdfContext, src: *const CdfThreadC
             ::core::mem::size_of::<CdfContext>() as libc::c_ulong,
         );
     } else {
-        (*dst).m = av1_default_cdf;
+        (*dst).m = av1_default_cdf.clone();
         memcpy(
             ((*dst).kfym.0).as_mut_ptr() as *mut libc::c_void,
             default_kf_y_mode_cdf.0.as_ptr() as *const libc::c_void,
             ::core::mem::size_of::<[[[uint16_t; 16]; 5]; 5]>() as libc::c_ulong,
         );
-        (*dst).coef = av1_default_coef_cdf[(*src).data.qcat as usize];
+        (*dst).coef = av1_default_coef_cdf[(*src).data.qcat as usize].clone();
         memcpy(
             ((*dst).mv.joint.0).as_mut_ptr() as *mut libc::c_void,
             default_mv_joint_cdf.0.as_ptr() as *const libc::c_void,
@@ -6174,10 +6170,10 @@ pub unsafe fn dav1d_cdf_thread_copy(dst: *mut CdfContext, src: *const CdfThreadC
             default_mv_joint_cdf.0.as_ptr() as *const libc::c_void,
             ::core::mem::size_of::<[uint16_t; 4]>() as libc::c_ulong,
         );
-        (*dst).dmv.comp[1] = default_mv_component_cdf;
-        (*dst).dmv.comp[0] = (*dst).dmv.comp[1];
-        (*dst).mv.comp[1] = (*dst).dmv.comp[0];
-        (*dst).mv.comp[0] = (*dst).mv.comp[1];
+        (*dst).dmv.comp[1] = default_mv_component_cdf.clone();
+        (*dst).dmv.comp[0] = (*dst).dmv.comp[1].clone();
+        (*dst).mv.comp[1] = (*dst).dmv.comp[0].clone();
+        (*dst).mv.comp[0] = (*dst).mv.comp[1].clone();
     };
 }
 
@@ -6203,7 +6199,7 @@ pub unsafe extern "C" fn dav1d_cdf_thread_alloc(
 }
 
 pub unsafe fn dav1d_cdf_thread_ref(dst: *mut CdfThreadContext, src: *mut CdfThreadContext) {
-    *dst = *src;
+    *dst = (*src).clone();
     if !((*src).r#ref).is_null() {
         dav1d_ref_inc((*src).r#ref);
     }

--- a/src/data.rs
+++ b/src/data.rs
@@ -183,7 +183,7 @@ pub unsafe fn dav1d_data_ref(dst: *mut Dav1dData, src: *const Dav1dData) {
     if !((*src).m.user_data.r#ref).is_null() {
         dav1d_ref_inc((*src).m.user_data.r#ref);
     }
-    *dst = *src;
+    *dst = (*src).clone();
 }
 
 pub unsafe fn dav1d_data_props_copy(dst: *mut Dav1dDataProps, src: *const Dav1dDataProps) {
@@ -194,7 +194,7 @@ pub unsafe fn dav1d_data_props_copy(dst: *mut Dav1dDataProps, src: *const Dav1dD
         unreachable!();
     }
     dav1d_ref_dec(&mut (*dst).user_data.r#ref);
-    *dst = *src;
+    *dst = (*src).clone();
     if !((*dst).user_data.r#ref).is_null() {
         dav1d_ref_inc((*dst).user_data.r#ref);
     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -171,7 +171,6 @@ use crate::include::stdatomic::atomic_uint;
 use crate::src::data::dav1d_data_props_copy;
 use crate::src::data::dav1d_data_unref_internal;
 use crate::src::r#ref::Dav1dRef;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext {
     pub seq_hdr_ref: *mut Dav1dRef,
@@ -288,7 +287,6 @@ use crate::src::refmvs::refmvs_frame;
 use crate::src::refmvs::refmvs_mvpair;
 use crate::src::refmvs::refmvs_refpair;
 use crate::src::refmvs::refmvs_temporal_block;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
@@ -340,7 +338,6 @@ use crate::src::levels::BlockSize;
 use crate::src::levels::BS_128x128;
 use crate::src::levels::BS_4x4;
 use crate::src::levels::BS_64x64;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTaskContext {
     pub c: *const Dav1dContext,
@@ -376,7 +373,6 @@ use crate::src::refmvs::refmvs_tile;
 
 use crate::src::internal::Dav1dTileState;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {
     pub fc: *mut Dav1dFrameContext,
@@ -452,7 +448,6 @@ use crate::src::intra_edge::EdgeNode;
 use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
 use crate::src::refmvs::Dav1dRefmvsDSPContext;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dDSPContext {
     pub fg: Dav1dFilmGrainDSPContext,
@@ -467,7 +462,6 @@ use crate::src::cdef::Dav1dCdefDSPContext;
 use crate::src::itx::Dav1dInvTxfmDSPContext;
 use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
 use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dMCDSPContext {
     pub mc: [mc_fn; 10],
@@ -648,7 +642,6 @@ pub type mc_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dIntraPredDSPContext {
     pub intra_pred: [angular_ipred_fn; 14],
@@ -700,7 +693,6 @@ pub type angular_ipred_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,

--- a/src/env.rs
+++ b/src/env.rs
@@ -35,7 +35,6 @@ use crate::src::levels::V_FLIPADST;
 use crate::src::refmvs::refmvs_candidate;
 use crate::src::tables::TxfmInfo;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct BlockContext {
     pub mode: Align8<[uint8_t; 32]>,

--- a/src/fg_apply_tmpl_16.rs
+++ b/src/fg_apply_tmpl_16.rs
@@ -61,7 +61,6 @@ pub type fguv_32x32xn_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,

--- a/src/fg_apply_tmpl_8.rs
+++ b/src/fg_apply_tmpl_8.rs
@@ -60,7 +60,6 @@ pub type fguv_32x32xn_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,

--- a/src/filmgrain_tmpl_16.rs
+++ b/src/filmgrain_tmpl_16.rs
@@ -384,7 +384,6 @@ pub type fguv_32x32xn_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,

--- a/src/filmgrain_tmpl_8.rs
+++ b/src/filmgrain_tmpl_8.rs
@@ -348,7 +348,6 @@ pub type fguv_32x32xn_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,

--- a/src/getbits.rs
+++ b/src/getbits.rs
@@ -2,7 +2,6 @@ use crate::include::stddef::*;
 use crate::include::stdint::*;
 use ::libc;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct GetBits {
     pub state: uint64_t,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -24,7 +24,6 @@ use crate::src::thread_data::thread_data;
 use libc::pthread_cond_t;
 use libc::pthread_mutex_t;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTileGroup {
     pub data: Dav1dData,
@@ -47,35 +46,32 @@ pub const DAV1D_TASK_TYPE_TILE_ENTROPY: TaskType = 2;
 pub const DAV1D_TASK_TYPE_INIT_CDF: TaskType = 1;
 pub const DAV1D_TASK_TYPE_INIT: TaskType = 0;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext_frame_thread {
     pub out_delayed: *mut Dav1dThreadPicture,
     pub next: libc::c_uint,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct TaskThreadData_grain_lut_scaling_8 {
     pub grain_lut_8bpc: Align16<[[[int8_t; 82]; 74]; 3]>,
     pub scaling_8bpc: Align64<[[uint8_t; 256]; 3]>,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct TaskThreadData_grain_lut_scaling_16 {
     pub grain_lut_16bpc: Align16<[[[int16_t; 82]; 74]; 3]>,
     pub scaling_16bpc: Align64<[[uint8_t; 4096]; 3]>,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub union TaskThreadData_grain_lut_scaling {
     pub c2rust_unnamed: TaskThreadData_grain_lut_scaling_8,
     pub c2rust_unnamed_0: TaskThreadData_grain_lut_scaling_16,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct TaskThreadData_delayed_fg {
     pub exec: libc::c_int,
@@ -87,7 +83,6 @@ pub struct TaskThreadData_delayed_fg {
     pub c2rust_unnamed: TaskThreadData_grain_lut_scaling,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct TaskThreadData {
     pub lock: pthread_mutex_t,
@@ -100,7 +95,6 @@ pub struct TaskThreadData {
     pub inited: libc::c_int,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext_refs {
     pub p: Dav1dThreadPicture,
@@ -109,7 +103,6 @@ pub struct Dav1dContext_refs {
     pub refpoc: [libc::c_uint; 7],
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext_intra_edge {
     pub root: [*mut EdgeNode; 2],
@@ -119,7 +112,7 @@ pub struct Dav1dContext_intra_edge {
     pub tip_sb64: [EdgeTip; 64],
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dTask {
     pub frame_idx: libc::c_uint,
@@ -131,21 +124,18 @@ pub struct Dav1dTask {
     pub next: *mut Dav1dTask,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct ScalableMotionParams {
     pub scale: libc::c_int,
     pub step: libc::c_int,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct CodedBlockInfo {
     pub eob: [int16_t; 3],
     pub txtp: [uint8_t; 3],
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext_frame_thread {
     pub next_tile_row: [libc::c_int; 2],
@@ -165,7 +155,6 @@ pub struct Dav1dFrameContext_frame_thread {
     pub tile_start_off: *mut libc::c_int,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext_lf {
     pub level: *mut [uint8_t; 4],
@@ -196,7 +185,6 @@ pub struct Dav1dFrameContext_lf {
     pub restore_planes: libc::c_int,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext_task_thread_pending_tasks {
     pub merge: atomic_int,
@@ -205,7 +193,6 @@ pub struct Dav1dFrameContext_task_thread_pending_tasks {
     pub tail: *mut Dav1dTask,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext_task_thread {
     pub lock: pthread_mutex_t,
@@ -228,14 +215,12 @@ pub struct Dav1dFrameContext_task_thread {
     pub pending_tasks: Dav1dFrameContext_task_thread_pending_tasks,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct FrameTileThreadData {
     pub lowest_pixel_mem: *mut [[libc::c_int; 2]; 7],
     pub lowest_pixel_mem_sz: libc::c_int,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTileState_tiling {
     pub col_start: libc::c_int,
@@ -246,14 +231,12 @@ pub struct Dav1dTileState_tiling {
     pub row: libc::c_int,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTileState_frame_thread {
     pub pal_idx: *mut uint8_t,
     pub cf: *mut libc::c_void,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTileState {
     pub cdf: CdfContext,
@@ -271,21 +254,20 @@ pub struct Dav1dTileState {
     pub lr_ref: [*mut Av1RestorationUnit; 3],
 }
 
-#[derive(Copy, Clone)]
 #[repr(C, align(64))]
 pub union Dav1dTaskContext_cf {
     pub cf_8bpc: [int16_t; 1024],
     pub cf_16bpc: [int32_t; 1024],
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct Dav1dTaskContext_scratch_compinter_seg_mask {
     pub compinter: [[int16_t; 16384]; 2],
     pub seg_mask: [uint8_t; 16384],
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub union Dav1dTaskContext_scratch_lap {
     pub lap_8bpc: [uint8_t; 4096],
@@ -293,56 +275,56 @@ pub union Dav1dTaskContext_scratch_lap {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub union Dav1dTaskContext_scratch_emu_edge {
     pub emu_edge_8bpc: [uint8_t; 84160],
     pub emu_edge_16bpc: [uint16_t; 84160],
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct Dav1dTaskContext_scratch_lap_emu_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct Dav1dTaskContext_scratch_pal {
     pub pal_order: [[uint8_t; 8]; 64],
     pub pal_ctx: [uint8_t; 64],
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub union Dav1dTaskContext_scratch_levels_pal {
     pub levels: [uint8_t; 1088],
     pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [uint8_t; 4096],
     pub edge_8bpc: [uint8_t; 257],
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [uint16_t; 4096],
     pub edge_16bpc: [uint16_t; 257],
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 #[repr(C, align(64))]
 pub union Dav1dTaskContext_scratch_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_levels_pal,
@@ -352,20 +334,17 @@ pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C, align(64))]
 pub union Dav1dTaskContext_scratch {
     pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
     pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTaskContext_frame_thread {
     pub pass: libc::c_int,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTaskContext_task_thread {
     pub td: thread_data,

--- a/src/intra_edge.rs
+++ b/src/intra_edge.rs
@@ -17,7 +17,6 @@ pub const EDGE_I420_TOP_HAS_RIGHT: EdgeFlags = 4;
 pub const EDGE_I422_TOP_HAS_RIGHT: EdgeFlags = 2;
 pub const EDGE_I444_TOP_HAS_RIGHT: EdgeFlags = 1;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct EdgeNode {
     pub o: EdgeFlags,
@@ -25,14 +24,12 @@ pub struct EdgeNode {
     pub v: [EdgeFlags; 2],
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct EdgeTip {
     pub node: EdgeNode,
     pub split: [EdgeFlags; 4],
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct EdgeBranch {
     pub node: EdgeNode,

--- a/src/ipred_tmpl_16.rs
+++ b/src/ipred_tmpl_16.rs
@@ -891,7 +891,6 @@ pub type pal_pred_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dIntraPredDSPContext {
     pub intra_pred: [angular_ipred_fn; 14],

--- a/src/ipred_tmpl_8.rs
+++ b/src/ipred_tmpl_8.rs
@@ -900,7 +900,6 @@ pub type pal_pred_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dIntraPredDSPContext {
     pub intra_pred: [angular_ipred_fn; 14],

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -143,7 +143,6 @@ pub unsafe extern "C" fn inv_txfm_add_rust<BD: BitDepth>(
 pub type itxfm_fn = Option<
     unsafe extern "C" fn(*mut DynPixel, ptrdiff_t, *mut DynCoef, libc::c_int, libc::c_int) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dInvTxfmDSPContext {
     pub itxfm_add: [[itxfm_fn; 17]; 19],

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -242,7 +242,7 @@ pub struct Av1Block_intra {
     pub cfl_alpha: [int8_t; 2],
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct Av1Block_inter_1d {
     pub mv: [mv; 2],
@@ -251,21 +251,21 @@ pub struct Av1Block_inter_1d {
     pub interintra_mode: uint8_t,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct Av1Block_inter_2d {
     pub mv2d: mv,
     pub matrix: [int16_t; 4],
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub union Av1Block_inter_nd {
     pub c2rust_unnamed: Av1Block_inter_1d,
     pub c2rust_unnamed_0: Av1Block_inter_2d,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct Av1Block_inter {
     pub c2rust_unnamed: Av1Block_inter_nd,
@@ -281,7 +281,6 @@ pub struct Av1Block_inter {
     pub tx_split1: uint16_t,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub union Av1Block_intra_inter {
     pub c2rust_unnamed: Av1Block_intra,
@@ -296,7 +295,7 @@ impl Default for Av1Block_intra_inter {
     }
 }
 
-#[derive(Copy, Clone, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct Av1Block {
     pub bl: uint8_t,

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -13,7 +13,6 @@ use crate::include::stdatomic::atomic_int;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
 use crate::src::r#ref::Dav1dRef;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext {
     pub seq_hdr_ref: *mut Dav1dRef,
@@ -99,7 +98,6 @@ use crate::src::refmvs::refmvs_frame;
 
 use crate::src::env::BlockContext;
 use crate::src::refmvs::refmvs_temporal_block;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
@@ -117,7 +115,6 @@ pub type read_coef_blocks_fn =
     Option<unsafe extern "C" fn(*mut Dav1dTaskContext, BlockSize, *const Av1Block) -> ()>;
 use crate::src::levels::BlockSize;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTaskContext {
     pub c: *const Dav1dContext,
@@ -151,7 +148,6 @@ use crate::src::refmvs::refmvs_tile;
 
 use crate::src::internal::Dav1dTileState;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {
     pub fc: *mut Dav1dFrameContext,
@@ -223,7 +219,6 @@ use crate::src::internal::Dav1dContext_intra_edge;
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::refmvs::Dav1dRefmvsDSPContext;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dDSPContext {
     pub fg: Dav1dFilmGrainDSPContext,
@@ -238,7 +233,6 @@ use crate::src::cdef::Dav1dCdefDSPContext;
 use crate::src::itx::Dav1dInvTxfmDSPContext;
 use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
 use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dMCDSPContext {
     pub mc: [mc_fn; 10],
@@ -424,7 +418,6 @@ pub type mc_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dIntraPredDSPContext {
     pub intra_pred: [angular_ipred_fn; 14],
@@ -478,7 +471,6 @@ pub type angular_ipred_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -13,7 +13,6 @@ use crate::include::stdatomic::atomic_int;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
 use crate::src::r#ref::Dav1dRef;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext {
     pub seq_hdr_ref: *mut Dav1dRef,
@@ -100,7 +99,6 @@ use crate::src::refmvs::refmvs_frame;
 
 use crate::src::env::BlockContext;
 use crate::src::refmvs::refmvs_temporal_block;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
@@ -118,7 +116,6 @@ pub type read_coef_blocks_fn =
     Option<unsafe extern "C" fn(*mut Dav1dTaskContext, BlockSize, *const Av1Block) -> ()>;
 use crate::src::levels::BlockSize;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTaskContext {
     pub c: *const Dav1dContext,
@@ -152,7 +149,6 @@ use crate::src::refmvs::refmvs_tile;
 
 use crate::src::internal::Dav1dTileState;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {
     pub fc: *mut Dav1dFrameContext,
@@ -224,7 +220,6 @@ use crate::src::internal::Dav1dContext_intra_edge;
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::refmvs::Dav1dRefmvsDSPContext;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dDSPContext {
     pub fg: Dav1dFilmGrainDSPContext,
@@ -239,7 +234,6 @@ use crate::src::cdef::Dav1dCdefDSPContext;
 use crate::src::itx::Dav1dInvTxfmDSPContext;
 use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
 use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dMCDSPContext {
     pub mc: [mc_fn; 10],
@@ -414,7 +408,6 @@ pub type mc_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dIntraPredDSPContext {
     pub intra_pred: [angular_ipred_fn; 14],
@@ -466,7 +459,6 @@ pub type angular_ipred_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -14,7 +14,6 @@ use crate::src::levels::TX_4X4;
 use crate::src::tables::dav1d_block_dimensions;
 use crate::src::tables::dav1d_txfm_dimensions;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Av1FilterLUT {
     pub e: [u8; 64],
@@ -22,7 +21,6 @@ pub struct Av1FilterLUT {
     pub sharp: [u64; 2],
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Av1RestorationUnit {
     pub r#type: Dav1dRestorationType,
@@ -32,7 +30,6 @@ pub struct Av1RestorationUnit {
     pub sgr_weights: [i8; 2],
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Av1Filter {
     pub filter_y: [[[[u16; 2]; 3]; 32]; 2],
@@ -41,7 +38,6 @@ pub struct Av1Filter {
     pub noskip_mask: [[u16; 2]; 16],
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Av1Restoration {
     pub lr: [[Av1RestorationUnit; 4]; 3],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,6 @@ use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::data::Dav1dData;
 use crate::include::dav1d::picture::Dav1dPicAllocator;
 use crate::include::dav1d::picture::Dav1dPicture;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {
     pub fc: *mut Dav1dFrameContext,
@@ -182,7 +181,6 @@ use crate::src::intra_edge::EdgeFlags;
 use crate::src::refmvs::dav1d_refmvs_clear;
 use crate::src::refmvs::dav1d_refmvs_init;
 use crate::src::refmvs::Dav1dRefmvsDSPContext;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dDSPContext {
     pub fg: Dav1dFilmGrainDSPContext,
@@ -198,7 +196,6 @@ use crate::src::itx::Dav1dInvTxfmDSPContext;
 use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
 use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 pub type coef = ();
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dMCDSPContext {
     pub mc: [mc_fn; 10],
@@ -379,7 +376,6 @@ pub type mc_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dIntraPredDSPContext {
     pub intra_pred: [angular_ipred_fn; 14],
@@ -431,7 +427,6 @@ pub type angular_ipred_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,
@@ -498,7 +493,6 @@ use crate::src::picture::dav1d_thread_picture_move_ref;
 use crate::src::picture::dav1d_thread_picture_ref;
 use crate::src::picture::dav1d_thread_picture_unref;
 use crate::src::picture::Dav1dThreadPicture;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTaskContext {
     pub c: *const Dav1dContext,
@@ -539,7 +533,6 @@ use crate::src::internal::Dav1dTileState;
 use crate::src::refmvs::refmvs_frame;
 use crate::src::refmvs::refmvs_temporal_block;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext {
     pub seq_hdr_ref: *mut Dav1dRef,
@@ -607,7 +600,6 @@ use crate::src::internal::Dav1dFrameContext_lf;
 use crate::src::internal::CodedBlockInfo;
 use crate::src::internal::Dav1dFrameContext_frame_thread;
 use crate::src::levels::Av1Block;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
@@ -633,7 +625,6 @@ pub type recon_b_intra_fn = Option<
     unsafe extern "C" fn(*mut Dav1dTaskContext, BlockSize, EdgeFlags, *const Av1Block) -> (),
 >;
 use crate::src::internal::ScalableMotionParams;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dSettings {
     pub n_threads: libc::c_int,
@@ -958,8 +949,8 @@ pub unsafe extern "C" fn dav1d_open(
             0,
             ::core::mem::size_of::<Dav1dContext>(),
         );
-        (*c).allocator = (*s).allocator;
-        (*c).logger = (*s).logger;
+        (*c).allocator = (*s).allocator.clone();
+        (*c).logger = (*s).logger.clone();
         (*c).apply_grain = (*s).apply_grain;
         (*c).operating_point = (*s).operating_point;
         (*c).all_layers = (*s).all_layers;
@@ -2076,7 +2067,7 @@ pub unsafe extern "C" fn dav1d_get_decode_error_data_props(
         return -(22 as libc::c_int);
     }
     dav1d_data_props_unref_internal(out);
-    *out = (*c).cached_error_props;
+    *out = (*c).cached_error_props.clone();
     dav1d_data_props_set_defaults(&mut (*c).cached_error_props);
     return 0 as libc::c_int;
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -24,7 +24,6 @@ use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::data::Dav1dData;
 use crate::include::dav1d::picture::Dav1dPicAllocator;
 use crate::include::dav1d::picture::Dav1dPicture;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {
     pub fc: *mut Dav1dFrameContext,
@@ -94,7 +93,6 @@ use crate::src::internal::Dav1dContext_intra_edge;
 
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::refmvs::Dav1dRefmvsDSPContext;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dDSPContext {
     pub fg: Dav1dFilmGrainDSPContext,
@@ -110,7 +108,6 @@ use crate::src::itx::Dav1dInvTxfmDSPContext;
 use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
 use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
 pub type coef = ();
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dMCDSPContext {
     pub mc: [mc_fn; 10],
@@ -291,7 +288,6 @@ pub type mc_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dIntraPredDSPContext {
     pub intra_pred: [angular_ipred_fn; 14],
@@ -343,7 +339,6 @@ pub type angular_ipred_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,
@@ -400,7 +395,6 @@ use crate::src::internal::Dav1dContext_refs;
 use crate::src::internal::Dav1dTileGroup;
 use crate::src::internal::TaskThreadData;
 use crate::src::picture::Dav1dThreadPicture;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTaskContext {
     pub c: *const Dav1dContext,
@@ -439,7 +433,6 @@ use crate::src::internal::Dav1dTileState;
 use crate::src::refmvs::refmvs_frame;
 use crate::src::refmvs::refmvs_temporal_block;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext {
     pub seq_hdr_ref: *mut Dav1dRef,
@@ -505,7 +498,6 @@ use crate::src::internal::Dav1dFrameContext_lf;
 use crate::src::internal::Dav1dFrameContext_frame_thread;
 
 use crate::src::levels::Av1Block;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -15,7 +15,6 @@ pub type loopfilter_sb_fn = unsafe extern "C" fn(
     libc::c_int,
 ) -> ();
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dLoopFilterDSPContext {
     pub loop_filter_sb: [[loopfilter_sb_fn; 2]; 2],

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -31,7 +31,7 @@ pub const LR_HAVE_TOP: LrEdgeFlags = 4;
 pub const LR_HAVE_RIGHT: LrEdgeFlags = 2;
 pub const LR_HAVE_LEFT: LrEdgeFlags = 1;
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct LooprestorationParams_sgr {
     pub s0: uint32_t,
@@ -40,7 +40,6 @@ pub struct LooprestorationParams_sgr {
     pub w1: int16_t,
 }
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub union LooprestorationParams {
     pub filter: Align16<[[int16_t; 8]; 2]>,
@@ -59,7 +58,6 @@ pub type looprestorationfilter_fn = unsafe extern "C" fn(
     libc::c_int,
 ) -> ();
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dLoopRestorationDSPContext {
     pub wiener: [looprestorationfilter_fn; 2],

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -15,7 +15,6 @@ use crate::include::stdatomic::atomic_int;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
 use crate::src::r#ref::Dav1dRef;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext {
     pub seq_hdr_ref: *mut Dav1dRef,
@@ -108,7 +107,6 @@ use crate::src::refmvs::refmvs_frame;
 
 use crate::src::env::BlockContext;
 use crate::src::refmvs::refmvs_temporal_block;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
@@ -126,7 +124,6 @@ pub type read_coef_blocks_fn =
     Option<unsafe extern "C" fn(*mut Dav1dTaskContext, BlockSize, *const Av1Block) -> ()>;
 use crate::src::levels::BlockSize;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTaskContext {
     pub c: *const Dav1dContext,
@@ -160,7 +157,6 @@ use crate::src::refmvs::refmvs_tile;
 
 use crate::src::internal::Dav1dTileState;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {
     pub fc: *mut Dav1dFrameContext,
@@ -232,7 +228,6 @@ use crate::src::internal::Dav1dContext_intra_edge;
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::refmvs::Dav1dRefmvsDSPContext;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dDSPContext {
     pub fg: Dav1dFilmGrainDSPContext,
@@ -254,7 +249,6 @@ use crate::src::looprestoration::LR_HAVE_BOTTOM;
 use crate::src::looprestoration::LR_HAVE_LEFT;
 use crate::src::looprestoration::LR_HAVE_RIGHT;
 use crate::src::looprestoration::LR_HAVE_TOP;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dMCDSPContext {
     pub mc: [mc_fn; 10],
@@ -440,7 +434,6 @@ pub type mc_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dIntraPredDSPContext {
     pub intra_pred: [angular_ipred_fn; 14],
@@ -494,7 +487,6 @@ pub type angular_ipred_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -15,7 +15,6 @@ use crate::include::stdatomic::atomic_int;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
 use crate::src::r#ref::Dav1dRef;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext {
     pub seq_hdr_ref: *mut Dav1dRef,
@@ -109,7 +108,6 @@ use crate::src::refmvs::refmvs_frame;
 
 use crate::src::env::BlockContext;
 use crate::src::refmvs::refmvs_temporal_block;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
@@ -127,7 +125,6 @@ pub type read_coef_blocks_fn =
     Option<unsafe extern "C" fn(*mut Dav1dTaskContext, BlockSize, *const Av1Block) -> ()>;
 use crate::src::levels::BlockSize;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTaskContext {
     pub c: *const Dav1dContext,
@@ -161,7 +158,6 @@ use crate::src::refmvs::refmvs_tile;
 
 use crate::src::internal::Dav1dTileState;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {
     pub fc: *mut Dav1dFrameContext,
@@ -233,7 +229,6 @@ use crate::src::internal::Dav1dContext_intra_edge;
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::refmvs::Dav1dRefmvsDSPContext;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dDSPContext {
     pub fg: Dav1dFilmGrainDSPContext,
@@ -255,7 +250,6 @@ use crate::src::looprestoration::LR_HAVE_BOTTOM;
 use crate::src::looprestoration::LR_HAVE_LEFT;
 use crate::src::looprestoration::LR_HAVE_RIGHT;
 use crate::src::looprestoration::LR_HAVE_TOP;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dMCDSPContext {
     pub mc: [mc_fn; 10],
@@ -430,7 +424,6 @@ pub type mc_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dIntraPredDSPContext {
     pub intra_pred: [angular_ipred_fn; 14],
@@ -482,7 +475,6 @@ pub type angular_ipred_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,

--- a/src/mc_tmpl_16.rs
+++ b/src/mc_tmpl_16.rs
@@ -2027,7 +2027,6 @@ pub type resize_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dMCDSPContext {
     pub mc: [mc_fn; 10],

--- a/src/mc_tmpl_8.rs
+++ b/src/mc_tmpl_8.rs
@@ -1987,7 +1987,6 @@ pub type resize_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dMCDSPContext {
     pub mc: [mc_fn; 10],

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -17,7 +17,6 @@ use libc::pthread_mutex_lock;
 use libc::pthread_mutex_t;
 use libc::pthread_mutex_unlock;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dMemPool {
     pub lock: pthread_mutex_t,
@@ -25,7 +24,6 @@ pub struct Dav1dMemPool {
     pub ref_cnt: libc::c_int,
     pub end: libc::c_int,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dMemPoolBuffer {
     pub data: *mut libc::c_void,

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -62,7 +62,6 @@ extern "C" {
 
 pub type ec_win = size_t;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct MsacContext {
     buf_pos: *const uint8_t,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -24,7 +24,6 @@ use crate::src::r#ref::dav1d_ref_dec;
 use crate::src::r#ref::Dav1dRef;
 
 use crate::include::stdatomic::atomic_uint;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext {
     pub seq_hdr_ref: *mut Dav1dRef,
@@ -164,7 +163,6 @@ use crate::src::refmvs::refmvs_frame;
 
 use crate::src::env::BlockContext;
 use crate::src::refmvs::refmvs_temporal_block;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
@@ -182,7 +180,6 @@ pub type read_coef_blocks_fn =
     Option<unsafe extern "C" fn(*mut Dav1dTaskContext, BlockSize, *const Av1Block) -> ()>;
 use crate::src::levels::BlockSize;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTaskContext {
     pub c: *const Dav1dContext,
@@ -216,7 +213,6 @@ use crate::src::refmvs::refmvs_tile;
 
 use crate::src::internal::Dav1dTileState;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {
     pub fc: *mut Dav1dFrameContext,
@@ -294,7 +290,6 @@ use crate::src::internal::Dav1dContext_intra_edge;
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::refmvs::Dav1dRefmvsDSPContext;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dDSPContext {
     pub fg: Dav1dFilmGrainDSPContext,
@@ -309,7 +304,6 @@ use crate::src::cdef::Dav1dCdefDSPContext;
 use crate::src::itx::Dav1dInvTxfmDSPContext;
 use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
 use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dMCDSPContext {
     pub mc: [mc_fn; 10],
@@ -490,7 +484,6 @@ pub type mc_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dIntraPredDSPContext {
     pub intra_pred: [angular_ipred_fn; 14],
@@ -542,7 +535,6 @@ pub type angular_ipred_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,
@@ -1722,7 +1714,8 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                     (*hdr).segmentation.seg_data =
                                         (*(*c).refs[pri_ref as usize].p.p.frame_hdr)
                                             .segmentation
-                                            .seg_data;
+                                            .seg_data
+                                            .clone();
                                     current_block = 8075351136037156718;
                                 }
                             }
@@ -1807,7 +1800,8 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                     (*hdr).loopfilter.sharpness = 0 as libc::c_int;
                                     (*hdr).loopfilter.mode_ref_delta_enabled = 1 as libc::c_int;
                                     (*hdr).loopfilter.mode_ref_delta_update = 1 as libc::c_int;
-                                    (*hdr).loopfilter.mode_ref_deltas = default_mode_ref_deltas;
+                                    (*hdr).loopfilter.mode_ref_deltas =
+                                        default_mode_ref_deltas.clone();
                                     current_block = 1424623445371442388;
                                 } else {
                                     (*hdr).loopfilter.level_y[0] =
@@ -1826,7 +1820,8 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                     (*hdr).loopfilter.sharpness =
                                         dav1d_get_bits(gb, 3 as libc::c_int) as libc::c_int;
                                     if (*hdr).primary_ref_frame == 7 {
-                                        (*hdr).loopfilter.mode_ref_deltas = default_mode_ref_deltas;
+                                        (*hdr).loopfilter.mode_ref_deltas =
+                                            default_mode_ref_deltas.clone();
                                         current_block = 13291976673896753943;
                                     } else {
                                         let ref_1 =
@@ -1837,7 +1832,8 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                             (*hdr).loopfilter.mode_ref_deltas =
                                                 (*(*c).refs[ref_1 as usize].p.p.frame_hdr)
                                                     .loopfilter
-                                                    .mode_ref_deltas;
+                                                    .mode_ref_deltas
+                                                    .clone();
                                             current_block = 13291976673896753943;
                                         }
                                     }
@@ -2179,7 +2175,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                                 let mut i_18 = 0;
                                                 while i_18 < 7 {
                                                     (*hdr).gmv[i_18 as usize] =
-                                                        dav1d_default_wm_params;
+                                                        dav1d_default_wm_params.clone();
                                                     i_18 += 1;
                                                 }
                                                 if (*hdr).frame_type as libc::c_uint
@@ -2393,7 +2389,8 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                                                             .p
                                                                             .frame_hdr)
                                                                             .film_grain
-                                                                            .data;
+                                                                            .data
+                                                                            .clone();
                                                                     (*hdr).film_grain.data.seed =
                                                                         seed;
                                                                     current_block =

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -20,7 +20,6 @@ use crate::src::data::dav1d_data_props_set_defaults;
 use crate::src::r#ref::dav1d_ref_dec;
 use crate::src::r#ref::dav1d_ref_wrap;
 use crate::src::r#ref::Dav1dRef;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext {
     pub seq_hdr_ref: *mut Dav1dRef,
@@ -109,7 +108,6 @@ use crate::src::refmvs::refmvs_frame;
 
 use crate::src::env::BlockContext;
 use crate::src::refmvs::refmvs_temporal_block;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
@@ -127,7 +125,6 @@ pub type read_coef_blocks_fn =
     Option<unsafe extern "C" fn(*mut Dav1dTaskContext, BlockSize, *const Av1Block) -> ()>;
 use crate::src::levels::BlockSize;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTaskContext {
     pub c: *const Dav1dContext,
@@ -162,7 +159,6 @@ use crate::src::refmvs::refmvs_tile;
 
 use crate::src::internal::Dav1dTileState;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {
     pub fc: *mut Dav1dFrameContext,
@@ -240,7 +236,6 @@ use crate::src::internal::Dav1dContext_intra_edge;
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::refmvs::Dav1dRefmvsDSPContext;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dDSPContext {
     pub fg: Dav1dFilmGrainDSPContext,
@@ -255,7 +250,6 @@ use crate::src::cdef::Dav1dCdefDSPContext;
 use crate::src::itx::Dav1dInvTxfmDSPContext;
 use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
 use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dMCDSPContext {
     pub mc: [mc_fn; 10],
@@ -436,7 +430,6 @@ pub type mc_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dIntraPredDSPContext {
     pub intra_pred: [angular_ipred_fn; 14],
@@ -488,7 +481,6 @@ pub type angular_ipred_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,
@@ -540,7 +532,6 @@ pub type generate_grain_y_fn =
 use crate::src::cdf::CdfThreadContext;
 
 use crate::src::internal::Dav1dContext_refs;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dThreadPicture {
     pub p: Dav1dPicture,
@@ -559,7 +550,6 @@ pub type recon_b_intra_fn = Option<
     unsafe extern "C" fn(*mut Dav1dTaskContext, BlockSize, EdgeFlags, *const Av1Block) -> (),
 >;
 use crate::src::internal::ScalableMotionParams;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct pic_ctx_context {
     pub allocator: Dav1dPicAllocator,
@@ -699,8 +689,8 @@ unsafe extern "C" fn picture_alloc_with_edges(
         free(pic_ctx as *mut libc::c_void);
         return res;
     }
-    (*pic_ctx).allocator = *p_allocator;
-    (*pic_ctx).pic = *p;
+    (*pic_ctx).allocator = (*p_allocator).clone();
+    (*pic_ctx).pic = (*p).clone();
     (*p).r#ref = dav1d_ref_wrap(
         (*p).data[0] as *const uint8_t,
         Some(free_buffer as unsafe extern "C" fn(*const uint8_t, *mut libc::c_void) -> ()),
@@ -895,7 +885,7 @@ pub unsafe fn dav1d_picture_ref(dst: *mut Dav1dPicture, src: *const Dav1dPicture
     if !((*src).itut_t35_ref).is_null() {
         dav1d_ref_inc((*src).itut_t35_ref);
     }
-    *dst = *src;
+    *dst = (*src).clone();
 }
 
 pub unsafe fn dav1d_picture_move_ref(dst: *mut Dav1dPicture, src: *mut Dav1dPicture) {
@@ -950,7 +940,7 @@ pub unsafe fn dav1d_picture_move_ref(dst: *mut Dav1dPicture, src: *mut Dav1dPict
             return;
         }
     }
-    *dst = *src;
+    *dst = (*src).clone();
     memset(
         src as *mut libc::c_void,
         0 as libc::c_int,

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -79,7 +79,6 @@ use crate::include::stdatomic::atomic_int;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
 use crate::src::r#ref::Dav1dRef;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext {
     pub seq_hdr_ref: *mut Dav1dRef,
@@ -170,7 +169,6 @@ use crate::src::env::BlockContext;
 use crate::src::refmvs::refmvs_block;
 use crate::src::refmvs::refmvs_frame;
 use crate::src::refmvs::refmvs_temporal_block;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
@@ -188,7 +186,6 @@ pub type read_coef_blocks_fn =
     Option<unsafe extern "C" fn(*mut Dav1dTaskContext, BlockSize, *const Av1Block) -> ()>;
 use crate::src::levels::BlockSize;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTaskContext {
     pub c: *const Dav1dContext,
@@ -224,7 +221,6 @@ use crate::src::refmvs::refmvs_tile;
 
 use crate::src::internal::Dav1dTileState;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {
     pub fc: *mut Dav1dFrameContext,
@@ -306,7 +302,6 @@ use crate::src::intra_edge::EDGE_I444_LEFT_HAS_BOTTOM;
 use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
 use crate::src::refmvs::Dav1dRefmvsDSPContext;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dDSPContext {
     pub fg: Dav1dFilmGrainDSPContext,
@@ -321,7 +316,6 @@ use crate::src::cdef::Dav1dCdefDSPContext;
 use crate::src::itx::Dav1dInvTxfmDSPContext;
 use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
 use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dMCDSPContext {
     pub mc: [mc_fn; 10],
@@ -507,7 +501,6 @@ pub type mc_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dIntraPredDSPContext {
     pub intra_pred: [angular_ipred_fn; 14],
@@ -561,7 +554,6 @@ pub type angular_ipred_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -78,7 +78,6 @@ use crate::include::stdatomic::atomic_int;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
 use crate::src::r#ref::Dav1dRef;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext {
     pub seq_hdr_ref: *mut Dav1dRef,
@@ -169,7 +168,6 @@ use crate::src::env::BlockContext;
 use crate::src::refmvs::refmvs_block;
 use crate::src::refmvs::refmvs_frame;
 use crate::src::refmvs::refmvs_temporal_block;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
@@ -187,7 +185,6 @@ pub type read_coef_blocks_fn =
     Option<unsafe extern "C" fn(*mut Dav1dTaskContext, BlockSize, *const Av1Block) -> ()>;
 use crate::src::levels::BlockSize;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTaskContext {
     pub c: *const Dav1dContext,
@@ -223,7 +220,6 @@ use crate::src::refmvs::refmvs_tile;
 
 use crate::src::internal::Dav1dTileState;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {
     pub fc: *mut Dav1dFrameContext,
@@ -305,7 +301,6 @@ use crate::src::intra_edge::EDGE_I444_LEFT_HAS_BOTTOM;
 use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
 use crate::src::refmvs::Dav1dRefmvsDSPContext;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dDSPContext {
     pub fg: Dav1dFilmGrainDSPContext,
@@ -320,7 +315,6 @@ use crate::src::cdef::Dav1dCdefDSPContext;
 use crate::src::itx::Dav1dInvTxfmDSPContext;
 use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
 use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dMCDSPContext {
     pub mc: [mc_fn; 10],
@@ -495,7 +489,6 @@ pub type mc_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dIntraPredDSPContext {
     pub intra_pred: [angular_ipred_fn; 14],
@@ -547,7 +540,6 @@ pub type angular_ipred_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -10,7 +10,6 @@ extern "C" {
         __size: size_t,
     ) -> libc::c_int;
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dRef {
     pub data: *mut libc::c_void,

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -90,7 +90,6 @@ use crate::src::levels::mv;
 
 use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
 
-#[derive(Copy, Clone)]
 #[repr(C, packed)]
 pub struct refmvs_temporal_block {
     pub mv: mv,
@@ -116,7 +115,7 @@ pub struct refmvs_mvpair {
 }
 
 /// For why this unaligned, see the aligned [`refmvs_block`] below.
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 #[repr(C, packed)]
 pub struct refmvs_block_unaligned {
     pub mv: refmvs_mvpair,
@@ -133,11 +132,10 @@ pub struct refmvs_block_unaligned {
 /// into an inner packed [`refmvs_block_unaligned`]
 /// and an outer aligned [`refmvs_block`]
 /// that is just a wrapper over the real [`refmvs_block_unaligned`].
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 #[repr(C, align(4))]
 pub struct refmvs_block(pub refmvs_block_unaligned);
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct refmvs_frame {
     pub frm_hdr: *const Dav1dFrameHeader,
@@ -164,13 +162,11 @@ pub struct refmvs_frame {
     pub n_tile_threads: libc::c_int,
     pub n_frame_threads: libc::c_int,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct refmvs_tile_range {
     pub start: libc::c_int,
     pub end: libc::c_int,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct refmvs_tile {
     pub rf: *const refmvs_frame,
@@ -212,7 +208,6 @@ pub type splat_mv_fn = Option<
     unsafe extern "C" fn(*mut *mut refmvs_block, usize, &refmvs_block, usize, usize, usize) -> (),
 >;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dRefmvsDSPContext {
     pub load_tmvs: load_tmvs_fn,
@@ -1649,7 +1644,7 @@ unsafe extern "C" fn splat_mv_rust(
     let rr = unsafe { std::slice::from_raw_parts_mut(rr, rr_len) };
 
     for r in &mut rr[..bh4] {
-        std::slice::from_raw_parts_mut(*r, bx4 + bw4)[bx4..].fill(*rmv);
+        std::slice::from_raw_parts_mut(*r, bx4 + bw4)[bx4..].fill_with(|| rmv.clone())
     }
 }
 

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -91,7 +91,6 @@ use crate::src::levels::V_ADST;
 use crate::src::levels::V_DCT;
 use crate::src::levels::V_FLIPADST;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct TxfmInfo {
     pub w: u8,

--- a/src/thread_data.rs
+++ b/src/thread_data.rs
@@ -2,7 +2,6 @@ use libc::pthread_cond_t;
 use libc::pthread_mutex_t;
 use libc::pthread_t;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct thread_data {
     pub thread: pthread_t,

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -58,7 +58,6 @@ use crate::include::stdatomic::atomic_uint;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
 use crate::src::r#ref::Dav1dRef;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext {
     pub seq_hdr_ref: *mut Dav1dRef,
@@ -166,7 +165,6 @@ use crate::src::refmvs::refmvs_frame;
 
 use crate::src::env::BlockContext;
 use crate::src::refmvs::refmvs_temporal_block;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
@@ -184,7 +182,6 @@ pub type read_coef_blocks_fn =
     Option<unsafe extern "C" fn(*mut Dav1dTaskContext, BlockSize, *const Av1Block) -> ()>;
 use crate::src::levels::BlockSize;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dTaskContext {
     pub c: *const Dav1dContext,
@@ -218,7 +215,6 @@ use crate::src::refmvs::refmvs_tile;
 
 use crate::src::internal::Dav1dTileState;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dContext {
     pub fc: *mut Dav1dFrameContext,
@@ -290,7 +286,6 @@ use crate::src::internal::Dav1dContext_intra_edge;
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::refmvs::Dav1dRefmvsDSPContext;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dDSPContext {
     pub fg: Dav1dFilmGrainDSPContext,
@@ -305,7 +300,6 @@ use crate::src::cdef::Dav1dCdefDSPContext;
 use crate::src::itx::Dav1dInvTxfmDSPContext;
 use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
 use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dMCDSPContext {
     pub mc: [mc_fn; 10],
@@ -486,7 +480,6 @@ pub type mc_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dIntraPredDSPContext {
     pub intra_pred: [angular_ipred_fn; 14],
@@ -538,7 +531,6 @@ pub type angular_ipred_fn = Option<
         libc::c_int,
     ) -> (),
 >;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,
@@ -1674,7 +1666,7 @@ pub unsafe extern "C" fn dav1d_worker_task(mut data: *mut libc::c_void) -> *mut 
                                                                 let mut next_t: *mut Dav1dTask =
                                                                     &mut *t.offset(1)
                                                                         as *mut Dav1dTask;
-                                                                *next_t = *t;
+                                                                *next_t = (*t).clone();
                                                                 (*next_t).sby += 1;
                                                                 let ntr =
                                                                     (*f).frame_thread.next_tile_row

--- a/src/wedge.rs
+++ b/src/wedge.rs
@@ -26,7 +26,6 @@ use crate::src::levels::BS_32x16;
 use crate::src::levels::BS_32x32;
 use crate::src::levels::BS_32x8;
 
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct wedge_code_type {
     pub direction: uint8_t,

--- a/src/x86/cpu.rs
+++ b/src/x86/cpu.rs
@@ -14,7 +14,7 @@ pub const DAV1D_X86_CPU_FLAG_SSE41: CpuFlags = 4;
 pub const DAV1D_X86_CPU_FLAG_SSSE3: CpuFlags = 2;
 pub const DAV1D_X86_CPU_FLAG_SSE2: CpuFlags = 1;
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct CpuidRegisters {
     pub eax: uint32_t,
@@ -22,13 +22,12 @@ pub struct CpuidRegisters {
     pub edx: uint32_t,
     pub ecx: uint32_t,
 }
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct C2RustUnnamed {
     pub max_leaf: uint32_t,
     pub vendor: [libc::c_char; 12],
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed_0 {
     pub r: CpuidRegisters,

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -109,7 +109,6 @@ cfg_if::cfg_if! {
         }
     }
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct CLISettings {
     pub outputfile: *const libc::c_char,

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -145,7 +145,6 @@ use crate::include::dav1d::picture::Dav1dPicture;
 use crate::include::dav1d::picture::Dav1dPictureParameters;
 
 use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dSettings {
     pub n_threads: libc::c_int,
@@ -162,7 +161,6 @@ pub struct Dav1dSettings {
     pub decode_frame_type: Dav1dDecodeFrameType,
     pub reserved: [uint8_t; 16],
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct CLISettings {
     pub outputfile: *const libc::c_char,

--- a/tools/dav1d_cli_parse.rs
+++ b/tools/dav1d_cli_parse.rs
@@ -27,7 +27,6 @@ extern "C" {
     fn dav1d_version() -> *const libc::c_char;
     fn dav1d_default_settings(s: *mut Dav1dSettings);
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct option {
     pub name: *const libc::c_char,
@@ -50,7 +49,6 @@ use rav1d::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
 use rav1d::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
 use rav1d::include::dav1d::picture::Dav1dPicAllocator;
 use rav1d::src::cpu::dav1d_set_cpu_flags_mask;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Dav1dSettings {
     pub n_threads: libc::c_int,
@@ -67,7 +65,6 @@ pub struct Dav1dSettings {
     pub decode_frame_type: Dav1dDecodeFrameType,
     pub reserved: [uint8_t; 16],
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct CLISettings {
     pub outputfile: *const libc::c_char,
@@ -89,7 +86,6 @@ pub const REALTIME_CUSTOM: CLISettings_realtime = 2;
 pub const REALTIME_INPUT: CLISettings_realtime = 1;
 pub const REALTIME_DISABLE: CLISettings_realtime = 0;
 pub const ARG_DECODE_FRAME_TYPE: arg = 273;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct EnumParseTable {
     pub str_0: *const libc::c_char,

--- a/tools/input/annexb.rs
+++ b/tools/input/annexb.rs
@@ -20,14 +20,12 @@ use rav1d::include::dav1d::headers::Dav1dObuType;
 use rav1d::include::dav1d::headers::DAV1D_OBU_TD;
 
 use rav1d::include::dav1d::data::Dav1dData;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct DemuxerPriv {
     pub f: *mut libc::FILE,
     pub temporal_unit_size: size_t,
     pub frame_unit_size: size_t,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Demuxer {
     pub priv_data_size: libc::c_int,

--- a/tools/input/input.rs
+++ b/tools/input/input.rs
@@ -25,14 +25,12 @@ extern "C" {
     static section5_demuxer: Demuxer;
 }
 use rav1d::include::dav1d::data::Dav1dData;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct DemuxerContext {
     pub data: *mut DemuxerPriv,
     pub impl_0: *const Demuxer,
     pub priv_data: [uint64_t; 0],
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Demuxer {
     pub priv_data_size: libc::c_int,

--- a/tools/input/ivf.rs
+++ b/tools/input/ivf.rs
@@ -23,7 +23,6 @@ extern "C" {
 }
 
 use rav1d::include::dav1d::data::Dav1dData;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct DemuxerPriv {
     pub f: *mut libc::FILE,
@@ -32,7 +31,6 @@ pub struct DemuxerPriv {
     pub last_ts: uint64_t,
     pub step: uint64_t,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Demuxer {
     pub priv_data_size: libc::c_int,

--- a/tools/input/section5.rs
+++ b/tools/input/section5.rs
@@ -20,12 +20,10 @@ use rav1d::include::dav1d::headers::Dav1dObuType;
 use rav1d::include::dav1d::headers::DAV1D_OBU_TD;
 
 use rav1d::include::dav1d::data::Dav1dData;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct DemuxerPriv {
     pub f: *mut libc::FILE,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Demuxer {
     pub priv_data_size: libc::c_int,

--- a/tools/output/md5.rs
+++ b/tools/output/md5.rs
@@ -25,7 +25,6 @@ use rav1d::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 
 use rav1d::include::dav1d::picture::Dav1dPicture;
 use rav1d::include::dav1d::picture::Dav1dPictureParameters;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct MuxerPriv {
     pub abcd: [uint32_t; 4],
@@ -33,13 +32,11 @@ pub struct MuxerPriv {
     pub len: uint64_t,
     pub f: *mut libc::FILE,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub union C2RustUnnamed {
     pub data: [uint8_t; 64],
     pub data32: [uint32_t; 16],
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Muxer {
     pub priv_data_size: libc::c_int,

--- a/tools/output/null.rs
+++ b/tools/output/null.rs
@@ -7,7 +7,6 @@ extern "C" {
 
 use rav1d::include::dav1d::picture::Dav1dPicture;
 use rav1d::include::dav1d::picture::Dav1dPictureParameters;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Muxer {
     pub priv_data_size: libc::c_int,

--- a/tools/output/output.rs
+++ b/tools/output/output.rs
@@ -21,7 +21,6 @@ extern "C" {
 }
 use rav1d::include::dav1d::picture::Dav1dPicture;
 use rav1d::include::dav1d::picture::Dav1dPictureParameters;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct MuxerContext {
     pub data: *mut MuxerPriv,
@@ -32,7 +31,6 @@ pub struct MuxerContext {
     pub framenum: libc::c_int,
     pub priv_data: [uint64_t; 0],
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Muxer {
     pub priv_data_size: libc::c_int,

--- a/tools/output/y4m2.rs
+++ b/tools/output/y4m2.rs
@@ -28,14 +28,12 @@ use rav1d::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
 
 use rav1d::include::dav1d::picture::Dav1dPicture;
 use rav1d::include::dav1d::picture::Dav1dPictureParameters;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct MuxerPriv {
     pub f: *mut libc::FILE,
     pub first: libc::c_int,
     pub fps: [libc::c_uint; 2],
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Muxer {
     pub priv_data_size: libc::c_int,

--- a/tools/output/yuv.rs
+++ b/tools/output/yuv.rs
@@ -25,12 +25,10 @@ use rav1d::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 
 use rav1d::include::dav1d::picture::Dav1dPicture;
 use rav1d::include::dav1d::picture::Dav1dPictureParameters;
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct MuxerPriv {
     pub f: *mut libc::FILE,
 }
-#[derive(Copy, Clone)]
 #[repr(C)]
 pub struct Muxer {
     pub priv_data_size: libc::c_int,


### PR DESCRIPTION
`Copy` is needed for `union` fields and array repeat initializers.

`Clone` is needed for copying assignments, which are now `.clone()`d for explicitness.

This is needed to replace fields with non-`Copy` and non-`Clone` types, such as `AtomicI32`, `Vec`, etc.