### PR TITLE
`#![allow(*)]`: Remove unneeded

### DIFF
--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -154,6 +154,7 @@ pub trait BitDepth: Clone + Copy {
 
 #[derive(Clone, Copy)]
 pub struct BitDepth8 {
+    #[allow(dead_code)] // For parity with [`BitDepth16`], where it is used.
     bitdepth_max: <Self as BitDepth>::BitDepthMax,
 }
 

--- a/include/common/dump.rs
+++ b/include/common/dump.rs
@@ -59,7 +59,7 @@ pub unsafe fn coef_dump<Coef: Display>(
 }
 
 #[inline]
-pub fn ac_dump(mut buf: &[i16; 32 * 32], w: usize, h: usize, what: &str) {
+pub fn ac_dump(buf: &[i16; 32 * 32], w: usize, h: usize, what: &str) {
     println!("{}", what);
     for buf in buf.chunks_exact(w).take(h) {
         for x in buf {

--- a/lib.rs
+++ b/lib.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 #![allow(mutable_transmutes)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/lib.rs
+++ b/lib.rs
@@ -1,4 +1,3 @@
-#![allow(mutable_transmutes)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]

--- a/lib.rs
+++ b/lib.rs
@@ -146,8 +146,6 @@ cfg_if::cfg_if! {
         }
     } else if #[cfg(target_os = "macos")] {
         extern "C" {
-            #[link_name = "__stdoutp"]
-            static mut stdout: *mut libc::FILE;
             #[link_name = "__stderrp"]
             static mut stderr: *mut libc::FILE;
         }

--- a/lib.rs
+++ b/lib.rs
@@ -3,7 +3,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-#![allow(unused_assignments)]
 #![feature(c_variadic)]
 #![feature(core_intrinsics)]
 #![feature(extern_types)]

--- a/lib.rs
+++ b/lib.rs
@@ -4,7 +4,6 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(unused_assignments)]
-#![allow(unused_mut)]
 #![feature(c_variadic)]
 #![feature(core_intrinsics)]
 #![feature(extern_types)]

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -128,6 +128,56 @@ extern "C" {
         edges: CdefEdgeFlags,
         bitdepth_max: libc::c_int,
     );
+    pub(crate) fn dav1d_cdef_filter_4x8_8bpc_sse2(
+        dst: *mut DynPixel,
+        stride: ptrdiff_t,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
+        pri_strength: libc::c_int,
+        sec_strength: libc::c_int,
+        dir: libc::c_int,
+        damping: libc::c_int,
+        edges: CdefEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_cdef_dir_8bpc_ssse3(
+        dst: *const DynPixel,
+        dst_stride: ptrdiff_t,
+        var: *mut libc::c_uint,
+        bitdepth_max: libc::c_int,
+    ) -> libc::c_int;
+    pub(crate) fn dav1d_cdef_filter_4x4_8bpc_sse2(
+        dst: *mut DynPixel,
+        stride: ptrdiff_t,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
+        pri_strength: libc::c_int,
+        sec_strength: libc::c_int,
+        dir: libc::c_int,
+        damping: libc::c_int,
+        edges: CdefEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_cdef_filter_8x8_8bpc_sse2(
+        dst: *mut DynPixel,
+        stride: ptrdiff_t,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
+        pri_strength: libc::c_int,
+        sec_strength: libc::c_int,
+        dir: libc::c_int,
+        damping: libc::c_int,
+        edges: CdefEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+}
+
+// TODO(legare): Temporarily pub until init fns are deduplicated.
+#[cfg(all(feature = "asm", feature = "bitdepth_8", target_arch = "x86_64",))]
+extern "C" {
     pub(crate) fn dav1d_cdef_dir_8bpc_avx2(
         dst: *const DynPixel,
         dst_stride: ptrdiff_t,
@@ -212,51 +262,6 @@ extern "C" {
         edges: CdefEdgeFlags,
         bitdepth_max: libc::c_int,
     );
-    pub(crate) fn dav1d_cdef_filter_4x8_8bpc_sse2(
-        dst: *mut DynPixel,
-        stride: ptrdiff_t,
-        left: *const LeftPixelRow2px<DynPixel>,
-        top: *const DynPixel,
-        bottom: *const DynPixel,
-        pri_strength: libc::c_int,
-        sec_strength: libc::c_int,
-        dir: libc::c_int,
-        damping: libc::c_int,
-        edges: CdefEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_cdef_dir_8bpc_ssse3(
-        dst: *const DynPixel,
-        dst_stride: ptrdiff_t,
-        var: *mut libc::c_uint,
-        bitdepth_max: libc::c_int,
-    ) -> libc::c_int;
-    pub(crate) fn dav1d_cdef_filter_4x4_8bpc_sse2(
-        dst: *mut DynPixel,
-        stride: ptrdiff_t,
-        left: *const LeftPixelRow2px<DynPixel>,
-        top: *const DynPixel,
-        bottom: *const DynPixel,
-        pri_strength: libc::c_int,
-        sec_strength: libc::c_int,
-        dir: libc::c_int,
-        damping: libc::c_int,
-        edges: CdefEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_cdef_filter_8x8_8bpc_sse2(
-        dst: *mut DynPixel,
-        stride: ptrdiff_t,
-        left: *const LeftPixelRow2px<DynPixel>,
-        top: *const DynPixel,
-        bottom: *const DynPixel,
-        pri_strength: libc::c_int,
-        sec_strength: libc::c_int,
-        dir: libc::c_int,
-        damping: libc::c_int,
-        edges: CdefEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
 }
 
 // TODO(legare): Temporarily pub until init fns are deduplicated.
@@ -322,6 +327,62 @@ extern "C" {
     feature = "bitdepth_16",
     any(target_arch = "x86", target_arch = "x86_64"),
 ))]
+extern "C" {
+    pub(crate) fn dav1d_cdef_dir_16bpc_sse4(
+        dst: *const DynPixel,
+        dst_stride: ptrdiff_t,
+        var: *mut libc::c_uint,
+        bitdepth_max: libc::c_int,
+    ) -> libc::c_int;
+    pub(crate) fn dav1d_cdef_filter_4x4_16bpc_ssse3(
+        dst: *mut DynPixel,
+        stride: ptrdiff_t,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
+        pri_strength: libc::c_int,
+        sec_strength: libc::c_int,
+        dir: libc::c_int,
+        damping: libc::c_int,
+        edges: CdefEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_cdef_filter_4x8_16bpc_ssse3(
+        dst: *mut DynPixel,
+        stride: ptrdiff_t,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
+        pri_strength: libc::c_int,
+        sec_strength: libc::c_int,
+        dir: libc::c_int,
+        damping: libc::c_int,
+        edges: CdefEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_cdef_filter_8x8_16bpc_ssse3(
+        dst: *mut DynPixel,
+        stride: ptrdiff_t,
+        left: *const LeftPixelRow2px<DynPixel>,
+        top: *const DynPixel,
+        bottom: *const DynPixel,
+        pri_strength: libc::c_int,
+        sec_strength: libc::c_int,
+        dir: libc::c_int,
+        damping: libc::c_int,
+        edges: CdefEdgeFlags,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_cdef_dir_16bpc_ssse3(
+        dst: *const DynPixel,
+        dst_stride: ptrdiff_t,
+        var: *mut libc::c_uint,
+        bitdepth_max: libc::c_int,
+    ) -> libc::c_int;
+}
+
+// TODO(legare): Temporarily pub until init fns are deduplicated.
+#[cfg(all(feature = "asm", feature = "bitdepth_16", target_arch = "x86_64",))]
 extern "C" {
     pub(crate) fn dav1d_cdef_filter_4x4_16bpc_avx512icl(
         dst: *mut DynPixel,
@@ -402,57 +463,6 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_cdef_dir_16bpc_avx2(
-        dst: *const DynPixel,
-        dst_stride: ptrdiff_t,
-        var: *mut libc::c_uint,
-        bitdepth_max: libc::c_int,
-    ) -> libc::c_int;
-    pub(crate) fn dav1d_cdef_dir_16bpc_sse4(
-        dst: *const DynPixel,
-        dst_stride: ptrdiff_t,
-        var: *mut libc::c_uint,
-        bitdepth_max: libc::c_int,
-    ) -> libc::c_int;
-    pub(crate) fn dav1d_cdef_filter_4x4_16bpc_ssse3(
-        dst: *mut DynPixel,
-        stride: ptrdiff_t,
-        left: *const LeftPixelRow2px<DynPixel>,
-        top: *const DynPixel,
-        bottom: *const DynPixel,
-        pri_strength: libc::c_int,
-        sec_strength: libc::c_int,
-        dir: libc::c_int,
-        damping: libc::c_int,
-        edges: CdefEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_cdef_filter_4x8_16bpc_ssse3(
-        dst: *mut DynPixel,
-        stride: ptrdiff_t,
-        left: *const LeftPixelRow2px<DynPixel>,
-        top: *const DynPixel,
-        bottom: *const DynPixel,
-        pri_strength: libc::c_int,
-        sec_strength: libc::c_int,
-        dir: libc::c_int,
-        damping: libc::c_int,
-        edges: CdefEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_cdef_filter_8x8_16bpc_ssse3(
-        dst: *mut DynPixel,
-        stride: ptrdiff_t,
-        left: *const LeftPixelRow2px<DynPixel>,
-        top: *const DynPixel,
-        bottom: *const DynPixel,
-        pri_strength: libc::c_int,
-        sec_strength: libc::c_int,
-        dir: libc::c_int,
-        damping: libc::c_int,
-        edges: CdefEdgeFlags,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_cdef_dir_16bpc_ssse3(
         dst: *const DynPixel,
         dst_stride: ptrdiff_t,
         var: *mut libc::c_uint,

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -559,9 +559,9 @@ unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     return x >> 1;
 }
 unsafe extern "C" fn backup2lines(
-    mut dst: *const *mut pixel,
-    mut src: *const *mut pixel,
-    mut stride: *const ptrdiff_t,
+    dst: *const *mut pixel,
+    src: *const *mut pixel,
+    stride: *const ptrdiff_t,
     layout: Dav1dPixelLayout,
 ) {
     let y_stride: ptrdiff_t = PXSTRIDE(*stride.offset(0));
@@ -625,9 +625,9 @@ unsafe extern "C" fn backup2lines(
     }
 }
 unsafe extern "C" fn backup2x8(
-    mut dst: *mut [[pixel; 2]; 8],
-    mut src: *const *mut pixel,
-    mut src_stride: *const ptrdiff_t,
+    dst: *mut [[pixel; 2]; 8],
+    src: *const *mut pixel,
+    src_stride: *const ptrdiff_t,
     mut x_off: libc::c_int,
     layout: Dav1dPixelLayout,
     flag: Backup2x8Flags,
@@ -689,7 +689,7 @@ unsafe extern "C" fn adjust_strength(strength: libc::c_int, var: libc::c_uint) -
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
     tc: *mut Dav1dTaskContext,
-    mut p: *const *mut pixel,
+    p: *const *mut pixel,
     lflvl: *const Av1Filter,
     by_start: libc::c_int,
     by_end: libc::c_int,
@@ -742,7 +742,7 @@ pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
             6 as libc::c_int as uint8_t,
         ],
     ];
-    let mut uv_dir: *const uint8_t = (uv_dirs[(layout as libc::c_uint
+    let uv_dir: *const uint8_t = (uv_dirs[(layout as libc::c_uint
         == DAV1D_PIXEL_LAYOUT_I422 as libc::c_int as libc::c_uint)
         as libc::c_int as usize])
         .as_ptr();
@@ -838,7 +838,7 @@ pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
                     let mut top: *const pixel = 0 as *const pixel;
                     let mut bot: *const pixel = 0 as *const pixel;
                     let mut offset: ptrdiff_t = 0;
-                    let mut current_block_84: u64;
+                    let current_block_84: u64;
                     if bx + 2 >= (*f).bw {
                         edges = ::core::mem::transmute::<libc::c_uint, CdefEdgeFlags>(
                             edges as libc::c_uint
@@ -996,7 +996,7 @@ pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
                             };
                             let mut pl = 1;
                             while pl <= 2 {
-                                let mut current_block_77: u64;
+                                let current_block_77: u64;
                                 if have_tt == 0 {
                                     current_block_77 = 5687667889785024198;
                                 } else if sbrow_start != 0 && by == by_start {

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -791,16 +791,16 @@ pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
         let mut sbx = 0;
         let mut last_skip = 1;
         while sbx < sb64w {
-            let mut noskip_row: *const [uint16_t; 2] = 0 as *const [uint16_t; 2];
-            let mut noskip_mask: libc::c_uint = 0;
-            let mut y_lvl = 0;
-            let mut uv_lvl = 0;
-            let mut flag: Backup2x8Flags = 0 as Backup2x8Flags;
-            let mut y_pri_lvl = 0;
-            let mut y_sec_lvl = 0;
-            let mut uv_pri_lvl = 0;
-            let mut uv_sec_lvl = 0;
-            let mut bptrs: [*mut pixel; 3] = [0 as *mut pixel; 3];
+            let noskip_row: *const [uint16_t; 2];
+            let noskip_mask: libc::c_uint;
+            let y_lvl;
+            let uv_lvl;
+            let flag: Backup2x8Flags;
+            let y_pri_lvl;
+            let mut y_sec_lvl;
+            let uv_pri_lvl;
+            let mut uv_sec_lvl;
+            let mut bptrs: [*mut pixel; 3];
             let sb128x = sbx >> 1;
             let sb64_idx = ((by & sbsz) >> 3) + (sbx & 1);
             let cdef_idx =
@@ -831,13 +831,13 @@ pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
                 bptrs = [iptrs[0], iptrs[1], iptrs[2]];
                 let mut bx = sbx * sbsz;
                 while bx < imin((sbx + 1) * sbsz, (*f).bw) {
-                    let mut uvdir = 0;
-                    let mut do_left = 0;
-                    let mut dir = 0;
-                    let mut variance: libc::c_uint = 0;
-                    let mut top: *const pixel = 0 as *const pixel;
-                    let mut bot: *const pixel = 0 as *const pixel;
-                    let mut offset: ptrdiff_t = 0;
+                    let uvdir;
+                    let do_left;
+                    let mut dir;
+                    let mut variance: libc::c_uint;
+                    let mut top: *const pixel;
+                    let mut bot: *const pixel;
+                    let mut offset: ptrdiff_t;
                     let current_block_84: u64;
                     if bx + 2 >= (*f).bw {
                         edges = ::core::mem::transmute::<libc::c_uint, CdefEdgeFlags>(
@@ -893,7 +893,6 @@ pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
                         }
                         top = 0 as *const pixel;
                         bot = 0 as *const pixel;
-                        offset = 0;
                         if have_tt == 0 {
                             current_block_84 = 17728966195399430138;
                         } else if sbrow_start != 0 && by == by_start {

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -537,9 +537,9 @@ pub const BACKUP_2X8_Y: Backup2x8Flags = 1;
 use crate::include::common::intops::imin;
 use crate::include::common::intops::ulog2;
 unsafe extern "C" fn backup2lines(
-    mut dst: *const *mut pixel,
-    mut src: *const *mut pixel,
-    mut stride: *const ptrdiff_t,
+    dst: *const *mut pixel,
+    src: *const *mut pixel,
+    stride: *const ptrdiff_t,
     layout: Dav1dPixelLayout,
 ) {
     let y_stride: ptrdiff_t = *stride.offset(0);
@@ -602,9 +602,9 @@ unsafe extern "C" fn backup2lines(
     }
 }
 unsafe extern "C" fn backup2x8(
-    mut dst: *mut [[pixel; 2]; 8],
-    mut src: *const *mut pixel,
-    mut src_stride: *const ptrdiff_t,
+    dst: *mut [[pixel; 2]; 8],
+    src: *const *mut pixel,
+    src_stride: *const ptrdiff_t,
     mut x_off: libc::c_int,
     layout: Dav1dPixelLayout,
     flag: Backup2x8Flags,
@@ -666,7 +666,7 @@ unsafe extern "C" fn adjust_strength(strength: libc::c_int, var: libc::c_uint) -
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
     tc: *mut Dav1dTaskContext,
-    mut p: *const *mut pixel,
+    p: *const *mut pixel,
     lflvl: *const Av1Filter,
     by_start: libc::c_int,
     by_end: libc::c_int,
@@ -719,7 +719,7 @@ pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
             6 as libc::c_int as uint8_t,
         ],
     ];
-    let mut uv_dir: *const uint8_t = (uv_dirs[(layout as libc::c_uint
+    let uv_dir: *const uint8_t = (uv_dirs[(layout as libc::c_uint
         == DAV1D_PIXEL_LAYOUT_I422 as libc::c_int as libc::c_uint)
         as libc::c_int as usize])
         .as_ptr();
@@ -815,7 +815,7 @@ pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
                     let mut top: *const pixel = 0 as *const pixel;
                     let mut bot: *const pixel = 0 as *const pixel;
                     let mut offset: ptrdiff_t = 0;
-                    let mut current_block_84: u64;
+                    let current_block_84: u64;
                     if bx + 2 >= (*f).bw {
                         edges = ::core::mem::transmute::<libc::c_uint, CdefEdgeFlags>(
                             edges as libc::c_uint
@@ -973,7 +973,7 @@ pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
                             };
                             let mut pl = 1;
                             while pl <= 2 {
-                                let mut current_block_77: u64;
+                                let current_block_77: u64;
                                 if have_tt == 0 {
                                     current_block_77 = 5687667889785024198;
                                 } else if sbrow_start != 0 && by == by_start {

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -768,16 +768,16 @@ pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
         let mut sbx = 0;
         let mut last_skip = 1;
         while sbx < sb64w {
-            let mut noskip_row: *const [uint16_t; 2] = 0 as *const [uint16_t; 2];
-            let mut noskip_mask: libc::c_uint = 0;
-            let mut y_lvl = 0;
-            let mut uv_lvl = 0;
-            let mut flag: Backup2x8Flags = 0 as Backup2x8Flags;
-            let mut y_pri_lvl = 0;
-            let mut y_sec_lvl = 0;
-            let mut uv_pri_lvl = 0;
-            let mut uv_sec_lvl = 0;
-            let mut bptrs: [*mut pixel; 3] = [0 as *mut pixel; 3];
+            let noskip_row: *const [uint16_t; 2];
+            let noskip_mask: libc::c_uint;
+            let y_lvl;
+            let uv_lvl;
+            let flag: Backup2x8Flags;
+            let y_pri_lvl;
+            let mut y_sec_lvl;
+            let uv_pri_lvl;
+            let mut uv_sec_lvl;
+            let mut bptrs: [*mut pixel; 3];
             let sb128x = sbx >> 1;
             let sb64_idx = ((by & sbsz) >> 3) + (sbx & 1);
             let cdef_idx =
@@ -808,13 +808,13 @@ pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
                 bptrs = [iptrs[0], iptrs[1], iptrs[2]];
                 let mut bx = sbx * sbsz;
                 while bx < imin((sbx + 1) * sbsz, (*f).bw) {
-                    let mut uvdir = 0;
-                    let mut do_left = 0;
-                    let mut dir = 0;
-                    let mut variance: libc::c_uint = 0;
-                    let mut top: *const pixel = 0 as *const pixel;
-                    let mut bot: *const pixel = 0 as *const pixel;
-                    let mut offset: ptrdiff_t = 0;
+                    let uvdir;
+                    let do_left;
+                    let mut dir;
+                    let mut variance: libc::c_uint;
+                    let mut top: *const pixel;
+                    let mut bot: *const pixel;
+                    let mut offset: ptrdiff_t;
                     let current_block_84: u64;
                     if bx + 2 >= (*f).bw {
                         edges = ::core::mem::transmute::<libc::c_uint, CdefEdgeFlags>(
@@ -870,7 +870,6 @@ pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
                         }
                         top = 0 as *const pixel;
                         bot = 0 as *const pixel;
-                        offset = 0;
                         if have_tt == 0 {
                             current_block_84 = 17728966195399430138;
                         } else if sbrow_start != 0 && by == by_start {

--- a/src/cdef_tmpl_16.rs
+++ b/src/cdef_tmpl_16.rs
@@ -36,7 +36,7 @@ unsafe extern "C" fn padding(
     tmp_stride: ptrdiff_t,
     mut src: *const pixel,
     src_stride: ptrdiff_t,
-    mut left: *const [pixel; 2],
+    left: *const [pixel; 2],
     mut top: *const pixel,
     mut bottom: *const pixel,
     w: libc::c_int,
@@ -134,7 +134,7 @@ unsafe extern "C" fn padding(
 unsafe extern "C" fn cdef_filter_block_c(
     mut dst: *mut pixel,
     dst_stride: ptrdiff_t,
-    mut left: *const [pixel; 2],
+    left: *const [pixel; 2],
     top: *const pixel,
     bottom: *const pixel,
     pri_strength: libc::c_int,
@@ -380,7 +380,7 @@ unsafe extern "C" fn cdef_filter_block_8x8_c_erased(
     );
 }
 unsafe extern "C" fn cdef_find_dir_c_erased(
-    mut img: *const DynPixel,
+    img: *const DynPixel,
     stride: ptrdiff_t,
     var: *mut libc::c_uint,
     bitdepth_max: libc::c_int,
@@ -592,7 +592,7 @@ unsafe extern "C" fn cdef_filter_8x8_neon_erased(
     use crate::src::cdef::*;
 
     let mut tmp_buf = [0; 200];
-    let mut tmp = tmp_buf.as_mut_ptr().offset(2 * 16).offset(8);
+    let tmp = tmp_buf.as_mut_ptr().offset(2 * 16).offset(8);
     dav1d_cdef_padding8_16bpc_neon(tmp, dst, stride, left, top, bottom, 8, edges);
     dav1d_cdef_filter8_16bpc_neon(
         dst,
@@ -611,9 +611,9 @@ unsafe extern "C" fn cdef_filter_8x8_neon_erased(
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 unsafe extern "C" fn cdef_filter_4x8_neon_erased(
-    mut dst: *mut DynPixel,
+    dst: *mut DynPixel,
     stride: ptrdiff_t,
-    mut left: *const LeftPixelRow2px<DynPixel>,
+    left: *const LeftPixelRow2px<DynPixel>,
     top: *const DynPixel,
     bottom: *const DynPixel,
     pri_strength: libc::c_int,
@@ -627,7 +627,7 @@ unsafe extern "C" fn cdef_filter_4x8_neon_erased(
     use crate::src::cdef::*;
 
     let mut tmp_buf: [uint16_t; 104] = [0; 104];
-    let mut tmp = tmp_buf.as_mut_ptr().offset(2 * 8).offset(8);
+    let tmp = tmp_buf.as_mut_ptr().offset(2 * 8).offset(8);
     dav1d_cdef_padding4_16bpc_neon(tmp, dst, stride, left, top, bottom, 8, edges);
     dav1d_cdef_filter4_16bpc_neon(
         dst,
@@ -646,9 +646,9 @@ unsafe extern "C" fn cdef_filter_4x8_neon_erased(
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 unsafe extern "C" fn cdef_filter_4x4_neon_erased(
-    mut dst: *mut DynPixel,
+    dst: *mut DynPixel,
     stride: ptrdiff_t,
-    mut left: *const LeftPixelRow2px<DynPixel>,
+    left: *const LeftPixelRow2px<DynPixel>,
     top: *const DynPixel,
     bottom: *const DynPixel,
     pri_strength: libc::c_int,
@@ -662,7 +662,7 @@ unsafe extern "C" fn cdef_filter_4x4_neon_erased(
     use crate::src::cdef::*;
 
     let mut tmp_buf = [0; 104];
-    let mut tmp = tmp_buf.as_mut_ptr().offset(2 * 8).offset(8);
+    let tmp = tmp_buf.as_mut_ptr().offset(2 * 8).offset(8);
     dav1d_cdef_padding4_16bpc_neon(tmp, dst, stride, left, top, bottom, 4, edges);
     dav1d_cdef_filter4_16bpc_neon(
         dst,

--- a/src/cdef_tmpl_8.rs
+++ b/src/cdef_tmpl_8.rs
@@ -29,7 +29,7 @@ unsafe extern "C" fn padding(
     tmp_stride: ptrdiff_t,
     mut src: *const pixel,
     src_stride: ptrdiff_t,
-    mut left: *const [pixel; 2],
+    left: *const [pixel; 2],
     mut top: *const pixel,
     mut bottom: *const pixel,
     w: libc::c_int,
@@ -128,7 +128,7 @@ unsafe extern "C" fn padding(
 unsafe extern "C" fn cdef_filter_block_c(
     mut dst: *mut pixel,
     dst_stride: ptrdiff_t,
-    mut left: *const [pixel; 2],
+    left: *const [pixel; 2],
     top: *const pixel,
     bottom: *const pixel,
     pri_strength: libc::c_int,
@@ -288,7 +288,7 @@ unsafe extern "C" fn cdef_filter_block_c(
 unsafe extern "C" fn cdef_filter_block_4x4_c_erased(
     dst: *mut DynPixel,
     stride: ptrdiff_t,
-    mut left: *const LeftPixelRow2px<DynPixel>,
+    left: *const LeftPixelRow2px<DynPixel>,
     top: *const DynPixel,
     bottom: *const DynPixel,
     pri_strength: libc::c_int,
@@ -370,7 +370,7 @@ unsafe extern "C" fn cdef_filter_block_8x8_c_erased(
     );
 }
 unsafe extern "C" fn cdef_find_dir_c_erased(
-    mut img: *const DynPixel,
+    img: *const DynPixel,
     stride: ptrdiff_t,
     var: *mut libc::c_uint,
     _bitdepth_max: libc::c_int,
@@ -595,7 +595,7 @@ unsafe extern "C" fn cdef_filter_4x4_neon_erased(
     use crate::src::cdef::*;
 
     let mut tmp_buf = Align16([0; 104]);
-    let mut tmp = tmp_buf.0.as_mut_ptr().offset(2 * 8).offset(8);
+    let tmp = tmp_buf.0.as_mut_ptr().offset(2 * 8).offset(8);
     dav1d_cdef_padding4_8bpc_neon(tmp, dst, stride, left, top, bottom, 4, edges);
     dav1d_cdef_filter4_8bpc_neon(
         dst,
@@ -629,7 +629,7 @@ unsafe extern "C" fn cdef_filter_4x8_neon_erased(
     use crate::src::cdef::*;
 
     let mut tmp_buf = Align16([0; 104]);
-    let mut tmp = tmp_buf.0.as_mut_ptr().offset(2 * 8).offset(8);
+    let tmp = tmp_buf.0.as_mut_ptr().offset(2 * 8).offset(8);
     dav1d_cdef_padding4_8bpc_neon(tmp, dst, stride, left, top, bottom, 8, edges);
     dav1d_cdef_filter4_8bpc_neon(
         dst,
@@ -663,7 +663,7 @@ unsafe extern "C" fn cdef_filter_8x8_neon_erased(
     use crate::src::cdef::*;
 
     let mut tmp_buf = Align16([0; 200]);
-    let mut tmp = tmp_buf.0.as_mut_ptr().offset(2 * 16).offset(8);
+    let tmp = tmp_buf.0.as_mut_ptr().offset(2 * 16).offset(8);
     dav1d_cdef_padding8_8bpc_neon(tmp, dst, stride, left, top, bottom, 8, edges);
     dav1d_cdef_filter8_8bpc_neon(
         dst,

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -41,6 +41,9 @@ pub fn dav1d_get_cpu_flags() -> libc::c_uint {
         if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
             use crate::src::x86::cpu::DAV1D_X86_CPU_FLAG_SSE2;
             flags |= DAV1D_X86_CPU_FLAG_SSE2;
+        } else {
+            // For `unused_mut`.
+            flags |= 0;
         }
     }
     flags

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -3,12 +3,6 @@ use cfg_if::cfg_if;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
 
-#[cfg(target_arch = "x86_64")]
-use crate::src::x86::cpu::dav1d_get_cpu_flags_x86;
-
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-use crate::src::arm::cpu::dav1d_get_cpu_flags_arm;
-
 extern "C" {
     pub type Dav1dContext;
 }
@@ -21,6 +15,7 @@ extern "C" {
 ///
 /// It is written once by [`dav1d_init_cpu`] in initialization code,
 /// and then subsequently read in [`dav1d_get_cpu_flags`] by other initialization code.
+#[cfg(feature = "asm")]
 static dav1d_cpu_flags: AtomicU32 = AtomicU32::new(0);
 
 /// This is atomic, which has interior mutability,
@@ -54,8 +49,12 @@ pub unsafe fn dav1d_init_cpu() {
     #[cfg(feature = "asm")]
     cfg_if! {
         if #[cfg(target_arch = "x86_64")] {
+            use crate::src::x86::cpu::dav1d_get_cpu_flags_x86;
+
             dav1d_cpu_flags.store(dav1d_get_cpu_flags_x86(), Ordering::SeqCst);
         } else if #[cfg(any(target_arch = "arm", target_arch = "aarch64"))] {
+            use crate::src::arm::cpu::dav1d_get_cpu_flags_arm;
+
             dav1d_cpu_flags.store(dav1d_get_cpu_flags_arm(), Ordering::SeqCst);
         }
     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -888,7 +888,7 @@ fn init_quant_tables(
     seq_hdr: &Dav1dSequenceHeader,
     frame_hdr: &Dav1dFrameHeader,
     qidx: libc::c_int,
-    mut dq: &mut [[[uint16_t; 2]; 3]],
+    dq: &mut [[[uint16_t; 2]; 3]],
 ) {
     let tbl = &dav1d_dq_tbl;
 
@@ -925,8 +925,8 @@ unsafe fn read_mv_component_diff(
     let sign = dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut mv_comp.sign.0);
     let cl = dav1d_msac_decode_symbol_adapt16(&mut ts.msac, &mut mv_comp.classes.0, 10);
     let mut up;
-    let mut fp;
-    let mut hp;
+    let fp;
+    let hp;
 
     if cl == 0 {
         up = dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut mv_comp.class0.0) as libc::c_uint;
@@ -1015,7 +1015,7 @@ unsafe fn read_tx_tree(
     let t_dim = &dav1d_txfm_dimensions[from as usize];
     let txw = t_dim.lw as i8;
     let txh = t_dim.lh as i8;
-    let mut is_split;
+    let is_split;
 
     if depth < 2 && from > TX_4X4 {
         let cat = 2 * (TX_64X64 as libc::c_int - t_dim.max as libc::c_int) - depth;
@@ -1067,9 +1067,9 @@ unsafe fn read_tx_tree(
 }
 
 fn neg_deinterleave(
-    mut diff: libc::c_int,
-    mut r#ref: libc::c_int,
-    mut max: libc::c_int,
+    diff: libc::c_int,
+    r#ref: libc::c_int,
+    max: libc::c_int,
 ) -> libc::c_int {
     if r#ref == 0 {
         diff
@@ -1564,7 +1564,7 @@ unsafe fn read_pal_uv(
 }
 
 fn order_palette(
-    mut pal_idx: &[u8],
+    pal_idx: &[u8],
     stride: usize,
     i: usize,
     first: usize,
@@ -2157,7 +2157,7 @@ unsafe fn decode_b(
                     block.0.r#ref.r#ref[0] = 0;
                     block.0.bs = bs as u8;
                 }
-                let mut rr = &t.rt.r[((t.by & 31) + 5) as usize..];
+                let rr = &t.rt.r[((t.by & 31) + 5) as usize..];
                 for y in 0..bh4 - 1 {
                     let block = &mut *rr[y as usize].offset((t.bx + bw4 - 1) as isize);
                     block.0.r#ref.r#ref[0] = 0;
@@ -2234,7 +2234,7 @@ unsafe fn decode_b(
                     r.0.mv.mv[0] = b.mv()[0];
                     r.0.bs = bs as u8;
                 }
-                let mut rr = &t.rt.r[((t.by & 31) + 5) as usize..];
+                let rr = &t.rt.r[((t.by & 31) + 5) as usize..];
                 for y in 0..bh4 as usize - 1 {
                     let r = &mut *rr[y].offset((t.bx + bw4 - 1) as isize);
                     r.0.r#ref.r#ref[0] = b.r#ref()[0] + 1;
@@ -2272,7 +2272,7 @@ unsafe fn decode_b(
     if frame_hdr.segmentation.enabled != 0 {
         if frame_hdr.segmentation.update_map == 0 {
             if !(f.prev_segmap).is_null() {
-                let mut seg_id =
+                let seg_id =
                     get_prev_frame_segid(f, t.by, t.bx, w4, h4, f.prev_segmap, f.b4_stride);
                 if seg_id >= DAV1D_MAX_SEGMENTS.into() {
                     return -1;
@@ -2293,7 +2293,7 @@ unsafe fn decode_b(
             } {
                 // temporal predicted seg_id
                 if !(f.prev_segmap).is_null() {
-                    let mut seg_id =
+                    let seg_id =
                         get_prev_frame_segid(f, t.by, t.bx, w4, h4, f.prev_segmap, f.b4_stride);
                     if seg_id >= DAV1D_MAX_SEGMENTS.into() {
                         return -1;
@@ -2379,7 +2379,7 @@ unsafe fn decode_b(
         } {
             // temporal predicted seg_id
             if !(f.prev_segmap).is_null() {
-                let mut seg_id =
+                let seg_id =
                     get_prev_frame_segid(f, t.by, t.bx, w4, h4, f.prev_segmap, f.b4_stride);
                 if seg_id >= DAV1D_MAX_SEGMENTS.into() {
                     return -1;
@@ -2727,7 +2727,7 @@ unsafe fn decode_b(
         }
 
         if b.pal_sz()[0] != 0 {
-            let mut pal_idx;
+            let pal_idx;
             if t.frame_thread.pass != 0 {
                 let p = t.frame_thread.pass & 1;
                 let frame_thread = &mut ts.frame_thread[p as usize];
@@ -2755,7 +2755,7 @@ unsafe fn decode_b(
         }
 
         if has_chroma && b.pal_sz()[1] != 0 {
-            let mut pal_idx;
+            let pal_idx;
             if t.frame_thread.pass != 0 {
                 let p = t.frame_thread.pass & 1;
                 let frame_thread = &mut ts.frame_thread[p as usize];
@@ -2793,7 +2793,7 @@ unsafe fn decode_b(
             if frame_hdr.txfm_mode == DAV1D_TX_SWITCHABLE && t_dim.max > TX_4X4 as u8 {
                 let tctx = get_tx_ctx(&*t.a, &t.l, &*t_dim, by4, bx4);
                 let tx_cdf = &mut ts.cdf.m.txsz[(t_dim.max - 1) as usize][tctx as usize];
-                let mut depth = dav1d_msac_decode_symbol_adapt4(
+                let depth = dav1d_msac_decode_symbol_adapt4(
                     &mut ts.msac,
                     tx_cdf,
                     std::cmp::min(t_dim.max, 2) as size_t,
@@ -4134,7 +4134,7 @@ unsafe fn decode_sb(
         return decode_sb(t, bl + 1, (*(node as *const EdgeBranch)).split[0]);
     }
 
-    let mut bp;
+    let bp;
     let mut ctx = 0;
     let mut bx8 = 0;
     let mut by8 = 0;
@@ -4382,7 +4382,7 @@ unsafe fn decode_sb(
             _ => unreachable!(),
         }
     } else if have_h_split {
-        let mut is_split;
+        let is_split;
         if let Some(pc) = pc {
             is_split = dav1d_msac_decode_bool(&mut ts.msac, gather_top_partition_prob(pc, bl));
             if DEBUG_BLOCK_INFO(f, t) {
@@ -4433,7 +4433,7 @@ unsafe fn decode_sb(
         }
     } else {
         assert!(have_v_split);
-        let mut is_split;
+        let is_split;
         if let Some(pc) = pc {
             is_split = dav1d_msac_decode_bool(&mut ts.msac, gather_left_partition_prob(pc, bl));
             if f.cur.p.layout == DAV1D_PIXEL_LAYOUT_I422 && !is_split {
@@ -5163,14 +5163,14 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                 let mut tile_idx = 0;
                                 let mut tile_row_0 = 0;
                                 while tile_row_0 < (*(*f).frame_hdr).tiling.rows {
-                                    let mut row_off = (*(*f).frame_hdr).tiling.row_start_sb
+                                    let row_off = (*(*f).frame_hdr).tiling.row_start_sb
                                         [tile_row_0 as usize]
                                         as libc::c_int
                                         * (*f).sb_step
                                         * 4
                                         * (*f).sb128w
                                         * 128;
-                                    let mut b_diff = ((*(*f).frame_hdr).tiling.row_start_sb
+                                    let b_diff = ((*(*f).frame_hdr).tiling.row_start_sb
                                         [(tile_row_0 + 1) as usize]
                                         as libc::c_int
                                         - (*(*f).frame_hdr).tiling.row_start_sb[tile_row_0 as usize]
@@ -5863,7 +5863,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                                                                 64 as libc::c_int
                                                                                     as size_t,
                                                                             );
-                                                                        let mut ptr_1: *mut uint8_t = (*f)
+                                                                        let ptr_1: *mut uint8_t = (*f)
                                                                             .ipred_edge[0] as *mut uint8_t;
                                                                         if ptr_1.is_null() {
                                                                             (*f).ipred_edge_sz =
@@ -6135,7 +6135,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
 }
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) -> libc::c_int {
-    let mut current_block: u64;
+    let current_block: u64;
     let c: *const Dav1dContext = (*f).c;
     let mut retval = -(22 as libc::c_int);
     if (*(*f).frame_hdr).refresh_context != 0 {
@@ -6234,7 +6234,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
 }
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_decode_frame_main(f: *mut Dav1dFrameContext) -> libc::c_int {
-    let mut current_block: u64;
+    let current_block: u64;
     let c: *const Dav1dContext = (*f).c;
     let mut retval = -(22 as libc::c_int);
     if !((*(*f).c).n_tc == 1 as libc::c_uint) {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1066,11 +1066,7 @@ unsafe fn read_tx_tree(
     };
 }
 
-fn neg_deinterleave(
-    diff: libc::c_int,
-    r#ref: libc::c_int,
-    max: libc::c_int,
-) -> libc::c_int {
+fn neg_deinterleave(diff: libc::c_int, r#ref: libc::c_int, max: libc::c_int) -> libc::c_int {
     if r#ref == 0 {
         diff
     } else if r#ref >= max - 1 {
@@ -3067,7 +3063,7 @@ unsafe fn decode_b(
         }
     } else {
         // inter-specific mode/mv coding
-        let mut has_subpel_filter = false;
+        let mut has_subpel_filter;
 
         let is_comp = if b.skip_mode != 0 {
             true
@@ -5037,22 +5033,22 @@ pub unsafe extern "C" fn dav1d_decode_tile_sbrow(t: *mut Dav1dTaskContext) -> li
 }
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> libc::c_int {
-    let mut sby = 0;
-    let mut n_ts = 0;
-    let mut a_sz = 0;
-    let mut num_sb128 = 0;
-    let mut size_mul: *const uint8_t = 0 as *const uint8_t;
-    let mut hbd = 0;
-    let mut y_stride: ptrdiff_t = 0;
-    let mut uv_stride: ptrdiff_t = 0;
-    let mut has_resize = 0;
-    let mut need_cdef_lpf_copy = 0;
-    let mut sb128 = 0;
-    let mut num_lines = 0;
-    let mut lr_mask_sz = 0;
-    let mut ipred_edge_sz = 0;
-    let mut re_sz = 0;
-    let mut has_chroma = 0;
+    let mut sby;
+    let n_ts;
+    let a_sz;
+    let num_sb128;
+    let size_mul: *const uint8_t;
+    let hbd;
+    let mut y_stride: ptrdiff_t;
+    let mut uv_stride: ptrdiff_t;
+    let has_resize;
+    let need_cdef_lpf_copy;
+    let sb128;
+    let num_lines;
+    let lr_mask_sz;
+    let ipred_edge_sz;
+    let re_sz;
+    let has_chroma;
     let mut current_block: u64;
     let c: *const Dav1dContext = (*f).c;
     let mut retval = -(12 as libc::c_int);
@@ -5863,8 +5859,9 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                                                                 64 as libc::c_int
                                                                                     as size_t,
                                                                             );
-                                                                        let ptr_1: *mut uint8_t = (*f)
-                                                                            .ipred_edge[0] as *mut uint8_t;
+                                                                        let ptr_1: *mut uint8_t =
+                                                                            (*f).ipred_edge[0]
+                                                                                as *mut uint8_t;
                                                                         if ptr_1.is_null() {
                                                                             (*f).ipred_edge_sz =
                                                                                 0 as libc::c_int;
@@ -6026,7 +6023,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                                                                                                             [12 as libc::c_int as uint8_t, 4 as libc::c_int as uint8_t],
                                                                                                             [13 as libc::c_int as uint8_t, 3 as libc::c_int as uint8_t],
                                                                                                         ];
-                                                                                                        let mut k = 0;
+                                                                                                        let mut k;
                                                                                                         k = 0 as libc::c_int;
                                                                                                         while k < 3 {
                                                                                                             let c0 = quant_dist_weight[k
@@ -6154,7 +6151,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
         let mut size: size_t = (*((*f).tile).offset(i as isize)).data.sz;
         let mut j = (*((*f).tile).offset(i as isize)).start;
         while j <= (*((*f).tile).offset(i as isize)).end {
-            let mut tile_sz: size_t = 0;
+            let mut tile_sz: size_t;
             if j == (*((*f).tile).offset(i as isize)).end {
                 tile_sz = size;
             } else {
@@ -6417,13 +6414,13 @@ fn get_upscale_x0(in_w: libc::c_int, out_w: libc::c_int, step: libc::c_int) -> l
 
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int {
-    let mut ref_coded_width: [libc::c_int; 7] = [0; 7];
-    let mut uses_2pass = 0;
-    let mut cols = 0;
-    let mut rows = 0;
-    let mut refresh_frame_flags: libc::c_uint = 0;
+    let mut ref_coded_width: [libc::c_int; 7];
+    let uses_2pass;
+    let cols;
+    let rows;
+    let refresh_frame_flags: libc::c_uint;
     let mut current_block: u64;
-    let mut f: *mut Dav1dFrameContext = 0 as *mut Dav1dFrameContext;
+    let f: *mut Dav1dFrameContext;
     let mut res = -(1 as libc::c_int);
     let mut out_delayed: *mut Dav1dThreadPicture = 0 as *mut Dav1dThreadPicture;
     if (*c).n_fc > 1 as libc::c_uint {

--- a/src/env.rs
+++ b/src/env.rs
@@ -375,8 +375,8 @@ pub fn av1_get_ref_ctx(
     l: &BlockContext,
     yb4: libc::c_int,
     xb4: libc::c_int,
-    mut have_top: bool,
-    mut have_left: bool,
+    have_top: bool,
+    have_left: bool,
 ) -> u8 {
     let mut cnt = [0; 2];
 

--- a/src/fg_apply_tmpl_16.rs
+++ b/src/fg_apply_tmpl_16.rs
@@ -78,9 +78,9 @@ unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
 }
 unsafe extern "C" fn generate_scaling(
     bitdepth: libc::c_int,
-    mut points: *const [uint8_t; 2],
+    points: *const [uint8_t; 2],
     num: libc::c_int,
-    mut scaling: *mut uint8_t,
+    scaling: *mut uint8_t,
 ) {
     if !(bitdepth > 8) {
         unreachable!();
@@ -157,8 +157,8 @@ pub unsafe extern "C" fn dav1d_prep_grain_16bpc(
     dsp: *const Dav1dFilmGrainDSPContext,
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,
-    mut scaling: *mut [uint8_t; 4096],
-    mut grain_lut: *mut [[entry; 82]; 74],
+    scaling: *mut [uint8_t; 4096],
+    grain_lut: *mut [[entry; 82]; 74],
 ) {
     let data: *const Dav1dFilmGrainData = &mut (*(*out).frame_hdr).film_grain.data;
     let bitdepth_max = ((1 as libc::c_int) << (*out).p.bpc) - 1;
@@ -284,8 +284,8 @@ pub unsafe extern "C" fn dav1d_apply_grain_row_16bpc(
     dsp: *const Dav1dFilmGrainDSPContext,
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,
-    mut scaling: *const [uint8_t; 4096],
-    mut grain_lut: *const [[entry; 82]; 74],
+    scaling: *const [uint8_t; 4096],
+    grain_lut: *const [[entry; 82]; 74],
     row: libc::c_int,
 ) {
     let data: *const Dav1dFilmGrainData = &mut (*(*out).frame_hdr).film_grain.data;

--- a/src/fg_apply_tmpl_8.rs
+++ b/src/fg_apply_tmpl_8.rs
@@ -70,9 +70,9 @@ pub struct Dav1dFilmGrainDSPContext {
 use crate::include::common::intops::imin;
 unsafe extern "C" fn generate_scaling(
     _bitdepth: libc::c_int,
-    mut points: *const [uint8_t; 2],
+    points: *const [uint8_t; 2],
     num: libc::c_int,
-    mut scaling: *mut uint8_t,
+    scaling: *mut uint8_t,
 ) {
     let shift_x = 0;
     let scaling_size = 256;
@@ -122,8 +122,8 @@ pub unsafe extern "C" fn dav1d_prep_grain_8bpc(
     dsp: *const Dav1dFilmGrainDSPContext,
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,
-    mut scaling: *mut [uint8_t; 256],
-    mut grain_lut: *mut [[entry; 82]; 74],
+    scaling: *mut [uint8_t; 256],
+    grain_lut: *mut [[entry; 82]; 74],
 ) {
     let data: *const Dav1dFilmGrainData = &mut (*(*out).frame_hdr).film_grain.data;
     ((*dsp).generate_grain_y).expect("non-null function pointer")(
@@ -245,8 +245,8 @@ pub unsafe extern "C" fn dav1d_apply_grain_row_8bpc(
     dsp: *const Dav1dFilmGrainDSPContext,
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,
-    mut scaling: *const [uint8_t; 256],
-    mut grain_lut: *const [[entry; 82]; 74],
+    scaling: *const [uint8_t; 256],
+    grain_lut: *const [[entry; 82]; 74],
     row: libc::c_int,
 ) {
     let data: *const Dav1dFilmGrainData = &mut (*(*out).frame_hdr).film_grain.data;

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -6,7 +6,7 @@ pub unsafe extern "C" fn get_random_number(
     state: *mut libc::c_uint,
 ) -> libc::c_int {
     let r = *state as libc::c_int;
-    let mut bit: libc::c_uint = ((r >> 0 ^ r >> 1 ^ r >> 3 ^ r >> 12) & 1) as libc::c_uint;
+    let bit: libc::c_uint = ((r >> 0 ^ r >> 1 ^ r >> 3 ^ r >> 12) & 1) as libc::c_uint;
     *state = (r >> 1) as libc::c_uint | bit << 15;
     return (*state >> 16 - bits & (((1 as libc::c_int) << bits) - 1) as libc::c_uint)
         as libc::c_int;

--- a/src/filmgrain_tmpl_16.rs
+++ b/src/filmgrain_tmpl_16.rs
@@ -404,7 +404,7 @@ unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
 use crate::src::filmgrain::get_random_number;
 use crate::src::filmgrain::round2;
 unsafe extern "C" fn generate_grain_y_c(
-    mut buf: *mut [entry; 82],
+    buf: *mut [entry; 82],
     data: *const Dav1dFilmGrainData,
     bitdepth_max: libc::c_int,
 ) {
@@ -460,8 +460,8 @@ unsafe extern "C" fn generate_grain_y_c(
 }
 #[inline(never)]
 unsafe extern "C" fn generate_grain_uv_c(
-    mut buf: *mut [entry; 82],
-    mut buf_y: *const [entry; 82],
+    buf: *mut [entry; 82],
+    buf_y: *const [entry; 82],
     data: *const Dav1dFilmGrainData,
     uv: intptr_t,
     subx: libc::c_int,
@@ -554,8 +554,8 @@ unsafe extern "C" fn generate_grain_uv_c(
     }
 }
 unsafe extern "C" fn generate_grain_uv_420_c(
-    mut buf: *mut [entry; 82],
-    mut buf_y: *const [entry; 82],
+    buf: *mut [entry; 82],
+    buf_y: *const [entry; 82],
     data: *const Dav1dFilmGrainData,
     uv: intptr_t,
     bitdepth_max: libc::c_int,
@@ -571,8 +571,8 @@ unsafe extern "C" fn generate_grain_uv_420_c(
     );
 }
 unsafe extern "C" fn generate_grain_uv_422_c(
-    mut buf: *mut [entry; 82],
-    mut buf_y: *const [entry; 82],
+    buf: *mut [entry; 82],
+    buf_y: *const [entry; 82],
     data: *const Dav1dFilmGrainData,
     uv: intptr_t,
     bitdepth_max: libc::c_int,
@@ -588,8 +588,8 @@ unsafe extern "C" fn generate_grain_uv_422_c(
     );
 }
 unsafe extern "C" fn generate_grain_uv_444_c(
-    mut buf: *mut [entry; 82],
-    mut buf_y: *const [entry; 82],
+    buf: *mut [entry; 82],
+    buf_y: *const [entry; 82],
     data: *const Dav1dFilmGrainData,
     uv: intptr_t,
     bitdepth_max: libc::c_int,
@@ -606,8 +606,8 @@ unsafe extern "C" fn generate_grain_uv_444_c(
 }
 #[inline]
 unsafe extern "C" fn sample_lut(
-    mut grain_lut: *const [entry; 82],
-    mut offsets: *const [libc::c_int; 2],
+    grain_lut: *const [entry; 82],
+    offsets: *const [libc::c_int; 2],
     subx: libc::c_int,
     suby: libc::c_int,
     bx: libc::c_int,
@@ -627,8 +627,8 @@ unsafe extern "C" fn fgy_32x32xn_c(
     stride: ptrdiff_t,
     data: *const Dav1dFilmGrainData,
     pw: size_t,
-    mut scaling: *const uint8_t,
-    mut grain_lut: *const [entry; 82],
+    scaling: *const uint8_t,
+    grain_lut: *const [entry; 82],
     bh: libc::c_int,
     row_num: libc::c_int,
     bitdepth_max: libc::c_int,
@@ -702,7 +702,7 @@ unsafe extern "C" fn fgy_32x32xn_c(
         while y < bh {
             let mut x = xstart;
             while x < bw {
-                let mut grain = sample_lut(
+                let grain = sample_lut(
                     grain_lut,
                     offsets.as_mut_ptr() as *const [libc::c_int; 2],
                     0 as libc::c_int,
@@ -739,7 +739,7 @@ unsafe extern "C" fn fgy_32x32xn_c(
                     x_0,
                     y,
                 ) as libc::c_int;
-                let mut old = sample_lut(
+                let old = sample_lut(
                     grain_lut,
                     offsets.as_mut_ptr() as *const [libc::c_int; 2],
                     0 as libc::c_int,
@@ -785,7 +785,7 @@ unsafe extern "C" fn fgy_32x32xn_c(
                     x_1,
                     y_0,
                 ) as libc::c_int;
-                let mut old_0 = sample_lut(
+                let old_0 = sample_lut(
                     grain_lut,
                     offsets.as_mut_ptr() as *const [libc::c_int; 2],
                     0 as libc::c_int,
@@ -899,8 +899,8 @@ unsafe extern "C" fn fguv_32x32xn_c(
     stride: ptrdiff_t,
     data: *const Dav1dFilmGrainData,
     pw: size_t,
-    mut scaling: *const uint8_t,
-    mut grain_lut: *const [entry; 82],
+    scaling: *const uint8_t,
+    grain_lut: *const [entry; 82],
     bh: libc::c_int,
     row_num: libc::c_int,
     luma_row: *const pixel,
@@ -984,7 +984,7 @@ unsafe extern "C" fn fguv_32x32xn_c(
         while y < bh {
             let mut x = xstart;
             while x < bw {
-                let mut grain = sample_lut(
+                let grain = sample_lut(
                     grain_lut,
                     offsets.as_mut_ptr() as *const [libc::c_int; 2],
                     sx,
@@ -1040,7 +1040,7 @@ unsafe extern "C" fn fguv_32x32xn_c(
                     x_0,
                     y,
                 ) as libc::c_int;
-                let mut old = sample_lut(
+                let old = sample_lut(
                     grain_lut,
                     offsets.as_mut_ptr() as *const [libc::c_int; 2],
                     sx,
@@ -1107,7 +1107,7 @@ unsafe extern "C" fn fguv_32x32xn_c(
                     x_1,
                     y_0,
                 ) as libc::c_int;
-                let mut old_0 = sample_lut(
+                let old_0 = sample_lut(
                     grain_lut,
                     offsets.as_mut_ptr() as *const [libc::c_int; 2],
                     sx,
@@ -1258,19 +1258,19 @@ unsafe extern "C" fn fguv_32x32xn_c(
     }
 }
 unsafe extern "C" fn fguv_32x32xn_420_c(
-    mut dst_row: *mut pixel,
-    mut src_row: *const pixel,
-    mut stride: ptrdiff_t,
-    mut data: *const Dav1dFilmGrainData,
-    mut pw: size_t,
-    mut scaling: *const uint8_t,
-    mut grain_lut: *const [entry; 82],
-    mut bh: libc::c_int,
-    mut row_num: libc::c_int,
-    mut luma_row: *const pixel,
-    mut luma_stride: ptrdiff_t,
-    mut uv_pl: libc::c_int,
-    mut is_id: libc::c_int,
+    dst_row: *mut pixel,
+    src_row: *const pixel,
+    stride: ptrdiff_t,
+    data: *const Dav1dFilmGrainData,
+    pw: size_t,
+    scaling: *const uint8_t,
+    grain_lut: *const [entry; 82],
+    bh: libc::c_int,
+    row_num: libc::c_int,
+    luma_row: *const pixel,
+    luma_stride: ptrdiff_t,
+    uv_pl: libc::c_int,
+    is_id: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
     fguv_32x32xn_c(
@@ -1293,19 +1293,19 @@ unsafe extern "C" fn fguv_32x32xn_420_c(
     );
 }
 unsafe extern "C" fn fguv_32x32xn_422_c(
-    mut dst_row: *mut pixel,
-    mut src_row: *const pixel,
-    mut stride: ptrdiff_t,
-    mut data: *const Dav1dFilmGrainData,
-    mut pw: size_t,
-    mut scaling: *const uint8_t,
-    mut grain_lut: *const [entry; 82],
-    mut bh: libc::c_int,
-    mut row_num: libc::c_int,
-    mut luma_row: *const pixel,
-    mut luma_stride: ptrdiff_t,
-    mut uv_pl: libc::c_int,
-    mut is_id: libc::c_int,
+    dst_row: *mut pixel,
+    src_row: *const pixel,
+    stride: ptrdiff_t,
+    data: *const Dav1dFilmGrainData,
+    pw: size_t,
+    scaling: *const uint8_t,
+    grain_lut: *const [entry; 82],
+    bh: libc::c_int,
+    row_num: libc::c_int,
+    luma_row: *const pixel,
+    luma_stride: ptrdiff_t,
+    uv_pl: libc::c_int,
+    is_id: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
     fguv_32x32xn_c(
@@ -1328,19 +1328,19 @@ unsafe extern "C" fn fguv_32x32xn_422_c(
     );
 }
 unsafe extern "C" fn fguv_32x32xn_444_c(
-    mut dst_row: *mut pixel,
-    mut src_row: *const pixel,
-    mut stride: ptrdiff_t,
-    mut data: *const Dav1dFilmGrainData,
-    mut pw: size_t,
-    mut scaling: *const uint8_t,
-    mut grain_lut: *const [entry; 82],
-    mut bh: libc::c_int,
-    mut row_num: libc::c_int,
-    mut luma_row: *const pixel,
-    mut luma_stride: ptrdiff_t,
-    mut uv_pl: libc::c_int,
-    mut is_id: libc::c_int,
+    dst_row: *mut pixel,
+    src_row: *const pixel,
+    stride: ptrdiff_t,
+    data: *const Dav1dFilmGrainData,
+    pw: size_t,
+    scaling: *const uint8_t,
+    grain_lut: *const [entry; 82],
+    bh: libc::c_int,
+    row_num: libc::c_int,
+    luma_row: *const pixel,
+    luma_stride: ptrdiff_t,
+    uv_pl: libc::c_int,
+    is_id: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
     fguv_32x32xn_c(
@@ -1463,8 +1463,8 @@ unsafe extern "C" fn fgy_32x32xn_neon(
     stride: ptrdiff_t,
     data: *const Dav1dFilmGrainData,
     pw: size_t,
-    mut scaling: *const uint8_t,
-    mut grain_lut: *const [entry; 82],
+    scaling: *const uint8_t,
+    grain_lut: *const [entry; 82],
     bh: libc::c_int,
     row_num: libc::c_int,
     bitdepth_max: libc::c_int,
@@ -1527,8 +1527,8 @@ unsafe extern "C" fn fguv_32x32xn_420_neon(
     stride: ptrdiff_t,
     data: *const Dav1dFilmGrainData,
     pw: size_t,
-    mut scaling: *const uint8_t,
-    mut grain_lut: *const [entry; 82],
+    scaling: *const uint8_t,
+    grain_lut: *const [entry; 82],
     bh: libc::c_int,
     row_num: libc::c_int,
     luma_row: *const pixel,
@@ -1601,8 +1601,8 @@ unsafe extern "C" fn fguv_32x32xn_422_neon(
     stride: ptrdiff_t,
     data: *const Dav1dFilmGrainData,
     pw: size_t,
-    mut scaling: *const uint8_t,
-    mut grain_lut: *const [entry; 82],
+    scaling: *const uint8_t,
+    grain_lut: *const [entry; 82],
     bh: libc::c_int,
     row_num: libc::c_int,
     luma_row: *const pixel,
@@ -1675,8 +1675,8 @@ unsafe extern "C" fn fguv_32x32xn_444_neon(
     stride: ptrdiff_t,
     data: *const Dav1dFilmGrainData,
     pw: size_t,
-    mut scaling: *const uint8_t,
-    mut grain_lut: *const [entry; 82],
+    scaling: *const uint8_t,
+    grain_lut: *const [entry; 82],
     bh: libc::c_int,
     row_num: libc::c_int,
     luma_row: *const pixel,

--- a/src/filmgrain_tmpl_16.rs
+++ b/src/filmgrain_tmpl_16.rs
@@ -6,22 +6,6 @@ use cfg_if::cfg_if;
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 extern "C" {
-    fn dav1d_fguv_32x32xn_i422_16bpc_avx512icl(
-        dst_row: *mut pixel,
-        src_row: *const pixel,
-        stride: ptrdiff_t,
-        data: *const Dav1dFilmGrainData,
-        pw: size_t,
-        scaling: *const uint8_t,
-        grain_lut: *const [entry; 82],
-        bh: libc::c_int,
-        row_num: libc::c_int,
-        luma_row: *const pixel,
-        luma_stride: ptrdiff_t,
-        uv_pl: libc::c_int,
-        is_id: libc::c_int,
-        bitdepth_max: libc::c_int,
-    );
     fn dav1d_fguv_32x32xn_i422_16bpc_ssse3(
         dst_row: *mut pixel,
         src_row: *const pixel,
@@ -90,6 +74,42 @@ extern "C" {
     fn dav1d_generate_grain_y_16bpc_ssse3(
         buf: *mut [entry; 82],
         data: *const Dav1dFilmGrainData,
+        bitdepth_max: libc::c_int,
+    );
+    fn dav1d_fguv_32x32xn_i444_16bpc_ssse3(
+        dst_row: *mut pixel,
+        src_row: *const pixel,
+        stride: ptrdiff_t,
+        data: *const Dav1dFilmGrainData,
+        pw: size_t,
+        scaling: *const uint8_t,
+        grain_lut: *const [entry; 82],
+        bh: libc::c_int,
+        row_num: libc::c_int,
+        luma_row: *const pixel,
+        luma_stride: ptrdiff_t,
+        uv_pl: libc::c_int,
+        is_id: libc::c_int,
+        bitdepth_max: libc::c_int,
+    );
+}
+
+#[cfg(all(feature = "asm", target_arch = "x86_64"))]
+extern "C" {
+    fn dav1d_fguv_32x32xn_i422_16bpc_avx512icl(
+        dst_row: *mut pixel,
+        src_row: *const pixel,
+        stride: ptrdiff_t,
+        data: *const Dav1dFilmGrainData,
+        pw: size_t,
+        scaling: *const uint8_t,
+        grain_lut: *const [entry; 82],
+        bh: libc::c_int,
+        row_num: libc::c_int,
+        luma_row: *const pixel,
+        luma_stride: ptrdiff_t,
+        uv_pl: libc::c_int,
+        is_id: libc::c_int,
         bitdepth_max: libc::c_int,
     );
     fn dav1d_generate_grain_uv_444_16bpc_avx2(
@@ -172,22 +192,6 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     fn dav1d_fguv_32x32xn_i420_16bpc_avx512icl(
-        dst_row: *mut pixel,
-        src_row: *const pixel,
-        stride: ptrdiff_t,
-        data: *const Dav1dFilmGrainData,
-        pw: size_t,
-        scaling: *const uint8_t,
-        grain_lut: *const [entry; 82],
-        bh: libc::c_int,
-        row_num: libc::c_int,
-        luma_row: *const pixel,
-        luma_stride: ptrdiff_t,
-        uv_pl: libc::c_int,
-        is_id: libc::c_int,
-        bitdepth_max: libc::c_int,
-    );
-    fn dav1d_fguv_32x32xn_i444_16bpc_ssse3(
         dst_row: *mut pixel,
         src_row: *const pixel,
         stride: ptrdiff_t,

--- a/src/filmgrain_tmpl_16.rs
+++ b/src/filmgrain_tmpl_16.rs
@@ -638,8 +638,8 @@ unsafe extern "C" fn fgy_32x32xn_c(
     let grain_ctr = (128 as libc::c_int) << bitdepth_min_8;
     let grain_min = -grain_ctr;
     let grain_max = grain_ctr - 1;
-    let mut min_value = 0;
-    let mut max_value = 0;
+    let min_value;
+    let max_value;
     if (*data).clip_to_restricted_range != 0 {
         min_value = (16 as libc::c_int) << bitdepth_min_8;
         max_value = (235 as libc::c_int) << bitdepth_min_8;
@@ -916,8 +916,8 @@ unsafe extern "C" fn fguv_32x32xn_c(
     let grain_ctr = (128 as libc::c_int) << bitdepth_min_8;
     let grain_min = -grain_ctr;
     let grain_max = grain_ctr - 1;
-    let mut min_value = 0;
-    let mut max_value = 0;
+    let min_value;
+    let max_value;
     if (*data).clip_to_restricted_range != 0 {
         min_value = (16 as libc::c_int) << bitdepth_min_8;
         max_value = (if is_id != 0 {

--- a/src/filmgrain_tmpl_8.rs
+++ b/src/filmgrain_tmpl_8.rs
@@ -361,7 +361,7 @@ use crate::include::common::intops::imin;
 use crate::src::filmgrain::get_random_number;
 use crate::src::filmgrain::round2;
 unsafe extern "C" fn generate_grain_y_c(
-    mut buf: *mut [entry; 82],
+    buf: *mut [entry; 82],
     data: *const Dav1dFilmGrainData,
 ) {
     let bitdepth_min_8 = 8 - 8;
@@ -416,8 +416,8 @@ unsafe extern "C" fn generate_grain_y_c(
 }
 #[inline(never)]
 unsafe extern "C" fn generate_grain_uv_c(
-    mut buf: *mut [entry; 82],
-    mut buf_y: *const [entry; 82],
+    buf: *mut [entry; 82],
+    buf_y: *const [entry; 82],
     data: *const Dav1dFilmGrainData,
     uv: intptr_t,
     subx: libc::c_int,
@@ -509,24 +509,24 @@ unsafe extern "C" fn generate_grain_uv_c(
     }
 }
 unsafe extern "C" fn generate_grain_uv_420_c(
-    mut buf: *mut [entry; 82],
-    mut buf_y: *const [entry; 82],
+    buf: *mut [entry; 82],
+    buf_y: *const [entry; 82],
     data: *const Dav1dFilmGrainData,
     uv: intptr_t,
 ) {
     generate_grain_uv_c(buf, buf_y, data, uv, 1 as libc::c_int, 1 as libc::c_int);
 }
 unsafe extern "C" fn generate_grain_uv_422_c(
-    mut buf: *mut [entry; 82],
-    mut buf_y: *const [entry; 82],
+    buf: *mut [entry; 82],
+    buf_y: *const [entry; 82],
     data: *const Dav1dFilmGrainData,
     uv: intptr_t,
 ) {
     generate_grain_uv_c(buf, buf_y, data, uv, 1 as libc::c_int, 0 as libc::c_int);
 }
 unsafe extern "C" fn generate_grain_uv_444_c(
-    mut buf: *mut [entry; 82],
-    mut buf_y: *const [entry; 82],
+    buf: *mut [entry; 82],
+    buf_y: *const [entry; 82],
     data: *const Dav1dFilmGrainData,
     uv: intptr_t,
 ) {
@@ -534,8 +534,8 @@ unsafe extern "C" fn generate_grain_uv_444_c(
 }
 #[inline]
 unsafe extern "C" fn sample_lut(
-    mut grain_lut: *const [entry; 82],
-    mut offsets: *const [libc::c_int; 2],
+    grain_lut: *const [entry; 82],
+    offsets: *const [libc::c_int; 2],
     subx: libc::c_int,
     suby: libc::c_int,
     bx: libc::c_int,
@@ -555,8 +555,8 @@ unsafe extern "C" fn fgy_32x32xn_c(
     stride: ptrdiff_t,
     data: *const Dav1dFilmGrainData,
     pw: size_t,
-    mut scaling: *const uint8_t,
-    mut grain_lut: *const [entry; 82],
+    scaling: *const uint8_t,
+    grain_lut: *const [entry; 82],
     bh: libc::c_int,
     row_num: libc::c_int,
 ) {
@@ -629,7 +629,7 @@ unsafe extern "C" fn fgy_32x32xn_c(
         while y < bh {
             let mut x = xstart;
             while x < bw {
-                let mut grain = sample_lut(
+                let grain = sample_lut(
                     grain_lut,
                     offsets.as_mut_ptr() as *const [libc::c_int; 2],
                     0 as libc::c_int,
@@ -666,7 +666,7 @@ unsafe extern "C" fn fgy_32x32xn_c(
                     x_0,
                     y,
                 ) as libc::c_int;
-                let mut old = sample_lut(
+                let old = sample_lut(
                     grain_lut,
                     offsets.as_mut_ptr() as *const [libc::c_int; 2],
                     0 as libc::c_int,
@@ -712,7 +712,7 @@ unsafe extern "C" fn fgy_32x32xn_c(
                     x_1,
                     y_0,
                 ) as libc::c_int;
-                let mut old_0 = sample_lut(
+                let old_0 = sample_lut(
                     grain_lut,
                     offsets.as_mut_ptr() as *const [libc::c_int; 2],
                     0 as libc::c_int,
@@ -826,8 +826,8 @@ unsafe extern "C" fn fguv_32x32xn_c(
     stride: ptrdiff_t,
     data: *const Dav1dFilmGrainData,
     pw: size_t,
-    mut scaling: *const uint8_t,
-    mut grain_lut: *const [entry; 82],
+    scaling: *const uint8_t,
+    grain_lut: *const [entry; 82],
     bh: libc::c_int,
     row_num: libc::c_int,
     luma_row: *const pixel,
@@ -910,7 +910,7 @@ unsafe extern "C" fn fguv_32x32xn_c(
         while y < bh {
             let mut x = xstart;
             while x < bw {
-                let mut grain = sample_lut(
+                let grain = sample_lut(
                     grain_lut,
                     offsets.as_mut_ptr() as *const [libc::c_int; 2],
                     sx,
@@ -964,7 +964,7 @@ unsafe extern "C" fn fguv_32x32xn_c(
                     x_0,
                     y,
                 ) as libc::c_int;
-                let mut old = sample_lut(
+                let old = sample_lut(
                     grain_lut,
                     offsets.as_mut_ptr() as *const [libc::c_int; 2],
                     sx,
@@ -1029,7 +1029,7 @@ unsafe extern "C" fn fguv_32x32xn_c(
                     x_1,
                     y_0,
                 ) as libc::c_int;
-                let mut old_0 = sample_lut(
+                let old_0 = sample_lut(
                     grain_lut,
                     offsets.as_mut_ptr() as *const [libc::c_int; 2],
                     sx,
@@ -1176,19 +1176,19 @@ unsafe extern "C" fn fguv_32x32xn_c(
     }
 }
 unsafe extern "C" fn fguv_32x32xn_420_c(
-    mut dst_row: *mut pixel,
-    mut src_row: *const pixel,
-    mut stride: ptrdiff_t,
-    mut data: *const Dav1dFilmGrainData,
-    mut pw: size_t,
-    mut scaling: *const uint8_t,
-    mut grain_lut: *const [entry; 82],
-    mut bh: libc::c_int,
-    mut row_num: libc::c_int,
-    mut luma_row: *const pixel,
-    mut luma_stride: ptrdiff_t,
-    mut uv_pl: libc::c_int,
-    mut is_id: libc::c_int,
+    dst_row: *mut pixel,
+    src_row: *const pixel,
+    stride: ptrdiff_t,
+    data: *const Dav1dFilmGrainData,
+    pw: size_t,
+    scaling: *const uint8_t,
+    grain_lut: *const [entry; 82],
+    bh: libc::c_int,
+    row_num: libc::c_int,
+    luma_row: *const pixel,
+    luma_stride: ptrdiff_t,
+    uv_pl: libc::c_int,
+    is_id: libc::c_int,
 ) {
     fguv_32x32xn_c(
         dst_row,
@@ -1209,19 +1209,19 @@ unsafe extern "C" fn fguv_32x32xn_420_c(
     );
 }
 unsafe extern "C" fn fguv_32x32xn_422_c(
-    mut dst_row: *mut pixel,
-    mut src_row: *const pixel,
-    mut stride: ptrdiff_t,
-    mut data: *const Dav1dFilmGrainData,
-    mut pw: size_t,
-    mut scaling: *const uint8_t,
-    mut grain_lut: *const [entry; 82],
-    mut bh: libc::c_int,
-    mut row_num: libc::c_int,
-    mut luma_row: *const pixel,
-    mut luma_stride: ptrdiff_t,
-    mut uv_pl: libc::c_int,
-    mut is_id: libc::c_int,
+    dst_row: *mut pixel,
+    src_row: *const pixel,
+    stride: ptrdiff_t,
+    data: *const Dav1dFilmGrainData,
+    pw: size_t,
+    scaling: *const uint8_t,
+    grain_lut: *const [entry; 82],
+    bh: libc::c_int,
+    row_num: libc::c_int,
+    luma_row: *const pixel,
+    luma_stride: ptrdiff_t,
+    uv_pl: libc::c_int,
+    is_id: libc::c_int,
 ) {
     fguv_32x32xn_c(
         dst_row,
@@ -1242,19 +1242,19 @@ unsafe extern "C" fn fguv_32x32xn_422_c(
     );
 }
 unsafe extern "C" fn fguv_32x32xn_444_c(
-    mut dst_row: *mut pixel,
-    mut src_row: *const pixel,
-    mut stride: ptrdiff_t,
-    mut data: *const Dav1dFilmGrainData,
-    mut pw: size_t,
-    mut scaling: *const uint8_t,
-    mut grain_lut: *const [entry; 82],
-    mut bh: libc::c_int,
-    mut row_num: libc::c_int,
-    mut luma_row: *const pixel,
-    mut luma_stride: ptrdiff_t,
-    mut uv_pl: libc::c_int,
-    mut is_id: libc::c_int,
+    dst_row: *mut pixel,
+    src_row: *const pixel,
+    stride: ptrdiff_t,
+    data: *const Dav1dFilmGrainData,
+    pw: size_t,
+    scaling: *const uint8_t,
+    grain_lut: *const [entry; 82],
+    bh: libc::c_int,
+    row_num: libc::c_int,
+    luma_row: *const pixel,
+    luma_stride: ptrdiff_t,
+    uv_pl: libc::c_int,
+    is_id: libc::c_int,
 ) {
     fguv_32x32xn_c(
         dst_row,
@@ -1372,8 +1372,8 @@ unsafe extern "C" fn fgy_32x32xn_neon(
     stride: ptrdiff_t,
     data: *const Dav1dFilmGrainData,
     pw: size_t,
-    mut scaling: *const uint8_t,
-    mut grain_lut: *const [entry; 82],
+    scaling: *const uint8_t,
+    grain_lut: *const [entry; 82],
     bh: libc::c_int,
     row_num: libc::c_int,
 ) {
@@ -1434,8 +1434,8 @@ unsafe extern "C" fn fguv_32x32xn_420_neon(
     stride: ptrdiff_t,
     data: *const Dav1dFilmGrainData,
     pw: size_t,
-    mut scaling: *const uint8_t,
-    mut grain_lut: *const [entry; 82],
+    scaling: *const uint8_t,
+    grain_lut: *const [entry; 82],
     bh: libc::c_int,
     row_num: libc::c_int,
     luma_row: *const pixel,
@@ -1506,8 +1506,8 @@ unsafe extern "C" fn fguv_32x32xn_422_neon(
     stride: ptrdiff_t,
     data: *const Dav1dFilmGrainData,
     pw: size_t,
-    mut scaling: *const uint8_t,
-    mut grain_lut: *const [entry; 82],
+    scaling: *const uint8_t,
+    grain_lut: *const [entry; 82],
     bh: libc::c_int,
     row_num: libc::c_int,
     luma_row: *const pixel,
@@ -1578,8 +1578,8 @@ unsafe extern "C" fn fguv_32x32xn_444_neon(
     stride: ptrdiff_t,
     data: *const Dav1dFilmGrainData,
     pw: size_t,
-    mut scaling: *const uint8_t,
-    mut grain_lut: *const [entry; 82],
+    scaling: *const uint8_t,
+    grain_lut: *const [entry; 82],
     bh: libc::c_int,
     row_num: libc::c_int,
     luma_row: *const pixel,

--- a/src/filmgrain_tmpl_8.rs
+++ b/src/filmgrain_tmpl_8.rs
@@ -360,10 +360,7 @@ use crate::include::common::intops::iclip_u8;
 use crate::include::common::intops::imin;
 use crate::src::filmgrain::get_random_number;
 use crate::src::filmgrain::round2;
-unsafe extern "C" fn generate_grain_y_c(
-    buf: *mut [entry; 82],
-    data: *const Dav1dFilmGrainData,
-) {
+unsafe extern "C" fn generate_grain_y_c(buf: *mut [entry; 82], data: *const Dav1dFilmGrainData) {
     let bitdepth_min_8 = 8 - 8;
     let mut seed: libc::c_uint = (*data).seed;
     let shift = 4 - bitdepth_min_8 + (*data).grain_scale_shift;
@@ -565,8 +562,8 @@ unsafe extern "C" fn fgy_32x32xn_c(
     let grain_ctr = (128 as libc::c_int) << bitdepth_min_8;
     let grain_min = -grain_ctr;
     let grain_max = grain_ctr - 1;
-    let mut min_value = 0;
-    let mut max_value = 0;
+    let min_value;
+    let max_value;
     if (*data).clip_to_restricted_range != 0 {
         min_value = (16 as libc::c_int) << bitdepth_min_8;
         max_value = (235 as libc::c_int) << bitdepth_min_8;
@@ -842,8 +839,8 @@ unsafe extern "C" fn fguv_32x32xn_c(
     let grain_ctr = (128 as libc::c_int) << bitdepth_min_8;
     let grain_min = -grain_ctr;
     let grain_max = grain_ctr - 1;
-    let mut min_value = 0;
-    let mut max_value = 0;
+    let min_value;
+    let max_value;
     if (*data).clip_to_restricted_range != 0 {
         min_value = (16 as libc::c_int) << bitdepth_min_8;
         max_value = (if is_id != 0 {

--- a/src/filmgrain_tmpl_8.rs
+++ b/src/filmgrain_tmpl_8.rs
@@ -2,38 +2,8 @@ use ::libc;
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
 
-#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
+#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 extern "C" {
-    fn dav1d_fguv_32x32xn_i422_8bpc_avx512icl(
-        dst_row: *mut pixel,
-        src_row: *const pixel,
-        stride: ptrdiff_t,
-        data: *const Dav1dFilmGrainData,
-        pw: size_t,
-        scaling: *const uint8_t,
-        grain_lut: *const [entry; 82],
-        bh: libc::c_int,
-        row_num: libc::c_int,
-        luma_row: *const pixel,
-        luma_stride: ptrdiff_t,
-        uv_pl: libc::c_int,
-        is_id: libc::c_int,
-    );
-    fn dav1d_fguv_32x32xn_i444_8bpc_avx512icl(
-        dst_row: *mut pixel,
-        src_row: *const pixel,
-        stride: ptrdiff_t,
-        data: *const Dav1dFilmGrainData,
-        pw: size_t,
-        scaling: *const uint8_t,
-        grain_lut: *const [entry; 82],
-        bh: libc::c_int,
-        row_num: libc::c_int,
-        luma_row: *const pixel,
-        luma_stride: ptrdiff_t,
-        uv_pl: libc::c_int,
-        is_id: libc::c_int,
-    );
     fn dav1d_generate_grain_y_8bpc_ssse3(buf: *mut [entry; 82], data: *const Dav1dFilmGrainData);
     fn dav1d_generate_grain_uv_420_8bpc_ssse3(
         buf: *mut [entry; 82],
@@ -80,6 +50,55 @@ extern "C" {
         uv: intptr_t,
     );
     fn dav1d_fguv_32x32xn_i444_8bpc_ssse3(
+        dst_row: *mut pixel,
+        src_row: *const pixel,
+        stride: ptrdiff_t,
+        data: *const Dav1dFilmGrainData,
+        pw: size_t,
+        scaling: *const uint8_t,
+        grain_lut: *const [entry; 82],
+        bh: libc::c_int,
+        row_num: libc::c_int,
+        luma_row: *const pixel,
+        luma_stride: ptrdiff_t,
+        uv_pl: libc::c_int,
+        is_id: libc::c_int,
+    );
+    fn dav1d_fguv_32x32xn_i422_8bpc_ssse3(
+        dst_row: *mut pixel,
+        src_row: *const pixel,
+        stride: ptrdiff_t,
+        data: *const Dav1dFilmGrainData,
+        pw: size_t,
+        scaling: *const uint8_t,
+        grain_lut: *const [entry; 82],
+        bh: libc::c_int,
+        row_num: libc::c_int,
+        luma_row: *const pixel,
+        luma_stride: ptrdiff_t,
+        uv_pl: libc::c_int,
+        is_id: libc::c_int,
+    );
+}
+
+#[cfg(all(feature = "asm", target_arch = "x86_64"))]
+extern "C" {
+    fn dav1d_fguv_32x32xn_i422_8bpc_avx512icl(
+        dst_row: *mut pixel,
+        src_row: *const pixel,
+        stride: ptrdiff_t,
+        data: *const Dav1dFilmGrainData,
+        pw: size_t,
+        scaling: *const uint8_t,
+        grain_lut: *const [entry; 82],
+        bh: libc::c_int,
+        row_num: libc::c_int,
+        luma_row: *const pixel,
+        luma_stride: ptrdiff_t,
+        uv_pl: libc::c_int,
+        is_id: libc::c_int,
+    );
+    fn dav1d_fguv_32x32xn_i444_8bpc_avx512icl(
         dst_row: *mut pixel,
         src_row: *const pixel,
         stride: ptrdiff_t,
@@ -170,21 +189,6 @@ extern "C" {
         is_id: libc::c_int,
     );
     fn dav1d_fguv_32x32xn_i420_8bpc_avx512icl(
-        dst_row: *mut pixel,
-        src_row: *const pixel,
-        stride: ptrdiff_t,
-        data: *const Dav1dFilmGrainData,
-        pw: size_t,
-        scaling: *const uint8_t,
-        grain_lut: *const [entry; 82],
-        bh: libc::c_int,
-        row_num: libc::c_int,
-        luma_row: *const pixel,
-        luma_stride: ptrdiff_t,
-        uv_pl: libc::c_int,
-        is_id: libc::c_int,
-    );
-    fn dav1d_fguv_32x32xn_i422_8bpc_ssse3(
         dst_row: *mut pixel,
         src_row: *const pixel,
         stride: ptrdiff_t,

--- a/src/getbits.rs
+++ b/src/getbits.rs
@@ -97,7 +97,7 @@ pub unsafe fn dav1d_get_sbits(c: *mut GetBits, n: libc::c_int) -> libc::c_int {
 pub unsafe fn dav1d_get_uleb128(c: *mut GetBits) -> libc::c_uint {
     let mut val: uint64_t = 0 as libc::c_int as uint64_t;
     let mut i: libc::c_uint = 0 as libc::c_int as libc::c_uint;
-    let mut more: libc::c_uint = 0;
+    let mut more: libc::c_uint;
     loop {
         let v = dav1d_get_bits(c, 8 as libc::c_int) as libc::c_int;
         more = (v & 0x80 as libc::c_int) as libc::c_uint;

--- a/src/getbits.rs
+++ b/src/getbits.rs
@@ -193,7 +193,7 @@ pub unsafe fn dav1d_get_bits_subexp(
         - ((1 as libc::c_int) << n);
 }
 
-pub unsafe fn dav1d_bytealign_get_bits(mut c: *mut GetBits) {
+pub unsafe fn dav1d_bytealign_get_bits(c: *mut GetBits) {
     if !((*c).bits_left <= 7) {
         unreachable!();
     }

--- a/src/ipred_prepare_tmpl_16.rs
+++ b/src/ipred_prepare_tmpl_16.rs
@@ -107,7 +107,7 @@ pub unsafe extern "C" fn dav1d_prepare_intra_edges_16bpc(
     edge_flags: EdgeFlags,
     dst: *const pixel,
     stride: ptrdiff_t,
-    mut prefilter_toplevel_sb_edge: *const pixel,
+    prefilter_toplevel_sb_edge: *const pixel,
     mut mode: IntraPredMode,
     angle: *mut libc::c_int,
     tw: libc::c_int,

--- a/src/ipred_prepare_tmpl_8.rs
+++ b/src/ipred_prepare_tmpl_8.rs
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn dav1d_prepare_intra_edges_8bpc(
     edge_flags: EdgeFlags,
     dst: *const pixel,
     stride: ptrdiff_t,
-    mut prefilter_toplevel_sb_edge: *const pixel,
+    prefilter_toplevel_sb_edge: *const pixel,
     mut mode: IntraPredMode,
     angle: *mut libc::c_int,
     tw: libc::c_int,

--- a/src/ipred_tmpl_16.rs
+++ b/src/ipred_tmpl_16.rs
@@ -993,7 +993,7 @@ unsafe extern "C" fn dc_gen_top(topleft: *const pixel, width: libc::c_int) -> li
     return dc >> ctz(width as libc::c_uint);
 }
 unsafe extern "C" fn ipred_dc_top_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     topleft: *const pixel,
     width: libc::c_int,
@@ -1013,12 +1013,12 @@ unsafe extern "C" fn ipred_dc_top_c(
     );
 }
 unsafe extern "C" fn ipred_cfl_top_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    mut ac: *const int16_t,
+    ac: *const int16_t,
     alpha: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
@@ -1043,7 +1043,7 @@ unsafe extern "C" fn dc_gen_left(topleft: *const pixel, height: libc::c_int) -> 
     return dc >> ctz(height as libc::c_uint);
 }
 unsafe extern "C" fn ipred_dc_left_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     topleft: *const pixel,
     width: libc::c_int,
@@ -1063,12 +1063,12 @@ unsafe extern "C" fn ipred_dc_left_c(
     );
 }
 unsafe extern "C" fn ipred_cfl_left_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    mut ac: *const int16_t,
+    ac: *const int16_t,
     alpha: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
@@ -1114,7 +1114,7 @@ unsafe extern "C" fn dc_gen(
     return dc;
 }
 unsafe extern "C" fn ipred_dc_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     topleft: *const pixel,
     width: libc::c_int,
@@ -1134,16 +1134,16 @@ unsafe extern "C" fn ipred_dc_c(
     );
 }
 unsafe extern "C" fn ipred_cfl_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    mut ac: *const int16_t,
+    ac: *const int16_t,
     alpha: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
-    let mut dc: libc::c_uint = dc_gen(topleft, width, height);
+    let dc: libc::c_uint = dc_gen(topleft, width, height);
     cfl_pred(
         dst,
         stride,
@@ -1156,7 +1156,7 @@ unsafe extern "C" fn ipred_cfl_c(
     );
 }
 unsafe extern "C" fn ipred_dc_128_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     _topleft: *const pixel,
     width: libc::c_int,
@@ -1170,12 +1170,12 @@ unsafe extern "C" fn ipred_dc_128_c(
     splat_dc(dst, stride, width, height, dc, bitdepth_max);
 }
 unsafe extern "C" fn ipred_cfl_128_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     _topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    mut ac: *const int16_t,
+    ac: *const int16_t,
     alpha: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
@@ -1727,7 +1727,7 @@ unsafe extern "C" fn ipred_z2_c(
     }
 }
 unsafe extern "C" fn ipred_z3_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     topleft_in: *const pixel,
     width: libc::c_int,
@@ -2184,7 +2184,7 @@ unsafe extern "C" fn intra_pred_dsp_init_arm(c: *mut Dav1dIntraPredDSPContext) {
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 unsafe extern "C" fn ipred_z3_neon(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     topleft_in: *const pixel,
     width: libc::c_int,
@@ -2256,7 +2256,7 @@ unsafe extern "C" fn ipred_z3_neon(
         }
     }
     let base_inc = 1 + upsample_left;
-    let mut pad_pixels = imax(64 - max_base_y - 1, height + 15);
+    let pad_pixels = imax(64 - max_base_y - 1, height + 15);
     dav1d_ipred_pixel_set_16bpc_neon(
         &mut *left_out.as_mut_ptr().offset((max_base_y + 1) as isize) as *mut pixel,
         left_out[max_base_y as usize],
@@ -2287,7 +2287,7 @@ unsafe extern "C" fn ipred_z3_neon(
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 unsafe extern "C" fn ipred_z2_neon(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     topleft_in: *const pixel,
     width: libc::c_int,
@@ -2312,9 +2312,9 @@ unsafe extern "C" fn ipred_z2_neon(
 
     // The asm can underread below the start of top[] and left[]; to avoid
     // surprising behaviour, make sure this is within the allocated stack space.
-    let mut left_offset: isize = 2 * (64 + 1);
-    let mut top_offset: isize = 1 * (64 + 1);
-    let mut flipped_offset: isize = 0 * (64 + 1);
+    let left_offset: isize = 2 * (64 + 1);
+    let top_offset: isize = 1 * (64 + 1);
+    let flipped_offset: isize = 0 * (64 + 1);
 
     let upsample_left = if enable_intra_edge_filter != 0 {
         get_upsample(width + height, 180 - angle, is_sm)
@@ -2468,7 +2468,7 @@ unsafe extern "C" fn ipred_z2_neon(
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 unsafe extern "C" fn ipred_z1_neon(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     topleft_in: *const pixel,
     width: libc::c_int,
@@ -2526,7 +2526,7 @@ unsafe extern "C" fn ipred_z1_neon(
         }
     }
     let base_inc = 1 + upsample_above;
-    let mut pad_pixels = width + 15;
+    let pad_pixels = width + 15;
     dav1d_ipred_pixel_set_16bpc_neon(
         &mut *top_out.as_mut_ptr().offset((max_base_x + 1) as isize) as *mut pixel,
         top_out[max_base_x as usize],

--- a/src/ipred_tmpl_16.rs
+++ b/src/ipred_tmpl_16.rs
@@ -5,7 +5,6 @@ use cfg_if::cfg_if;
 use libc;
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
-    fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong) -> *mut libc::c_void;
 }
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]

--- a/src/ipred_tmpl_16.rs
+++ b/src/ipred_tmpl_16.rs
@@ -7,20 +7,9 @@ extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
 }
 
-#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
+#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 extern "C" {
     fn dav1d_ipred_dc_16bpc_ssse3(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-        bitdepth_max: libc::c_int,
-    );
-    fn dav1d_ipred_smooth_h_16bpc_avx512icl(
         dst: *mut pixel,
         stride: ptrdiff_t,
         topleft: *const pixel,
@@ -248,6 +237,21 @@ extern "C" {
         idx: *const uint8_t,
         w: libc::c_int,
         h: libc::c_int,
+    );
+}
+
+#[cfg(all(feature = "asm", target_arch = "x86_64"))]
+extern "C" {
+    fn dav1d_ipred_smooth_h_16bpc_avx512icl(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
+        bitdepth_max: libc::c_int,
     );
     fn dav1d_ipred_dc_16bpc_avx2(
         dst: *mut pixel,
@@ -532,7 +536,7 @@ extern "C" {
     );
 }
 
-#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
+#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 extern "C" {
     fn dav1d_ipred_filter_16bpc_neon(
         dst: *mut pixel,
@@ -722,6 +726,18 @@ extern "C" {
         cw: libc::c_int,
         ch: libc::c_int,
     );
+    fn dav1d_pal_pred_16bpc_neon(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        pal: *const uint16_t,
+        idx: *const uint8_t,
+        w: libc::c_int,
+        h: libc::c_int,
+    );
+}
+
+#[cfg(all(feature = "asm", target_arch = "aarch64"))]
+extern "C" {
     fn dav1d_ipred_z1_fill2_16bpc_neon(
         dst: *mut pixel,
         stride: ptrdiff_t,
@@ -808,14 +824,6 @@ extern "C" {
         height: libc::c_int,
         dy: libc::c_int,
         max_base_y: libc::c_int,
-    );
-    fn dav1d_pal_pred_16bpc_neon(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        pal: *const uint16_t,
-        idx: *const uint8_t,
-        w: libc::c_int,
-        h: libc::c_int,
     );
     fn dav1d_ipred_pixel_set_16bpc_neon(out: *mut pixel, px: pixel, n: libc::c_int);
 }
@@ -2181,7 +2189,7 @@ unsafe extern "C" fn intra_pred_dsp_init_arm(c: *mut Dav1dIntraPredDSPContext) {
     (*c).pal_pred = Some(dav1d_pal_pred_16bpc_neon);
 }
 
-#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
+#[cfg(all(feature = "asm", target_arch = "aarch64"))]
 unsafe extern "C" fn ipred_z3_neon(
     dst: *mut pixel,
     stride: ptrdiff_t,
@@ -2284,7 +2292,7 @@ unsafe extern "C" fn ipred_z3_neon(
     };
 }
 
-#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
+#[cfg(all(feature = "asm", target_arch = "aarch64"))]
 unsafe extern "C" fn ipred_z2_neon(
     dst: *mut pixel,
     stride: ptrdiff_t,
@@ -2465,7 +2473,7 @@ unsafe extern "C" fn ipred_z2_neon(
     };
 }
 
-#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
+#[cfg(all(feature = "asm", target_arch = "aarch64"))]
 unsafe extern "C" fn ipred_z1_neon(
     dst: *mut pixel,
     stride: ptrdiff_t,

--- a/src/ipred_tmpl_16.rs
+++ b/src/ipred_tmpl_16.rs
@@ -1484,7 +1484,7 @@ unsafe extern "C" fn upsample_edge(
         9 as libc::c_int as int8_t,
         -(1 as libc::c_int) as int8_t,
     ];
-    let mut i = 0;
+    let mut i;
     i = 0 as libc::c_int;
     while i < hsz - 1 {
         *out.offset((i * 2) as isize) = *in_0.offset(iclip(i, from, to - 1) as isize);
@@ -1520,8 +1520,8 @@ unsafe extern "C" fn ipred_z1_c(
     }
     let mut dx = dav1d_dr_intra_derivative[(angle >> 1) as usize] as libc::c_int;
     let mut top_out: [pixel; 128] = [0; 128];
-    let mut top: *const pixel = 0 as *const pixel;
-    let mut max_base_x = 0;
+    let top: *const pixel;
+    let max_base_x;
     let upsample_above = if enable_intra_edge_filter != 0 {
         get_upsample(width + height, 90 - angle, is_sm)
     } else {
@@ -1703,7 +1703,7 @@ unsafe extern "C" fn ipred_z2_c(
         let mut x = 0;
         let mut ypos = (y << 6 + upsample_left) - dy;
         while x < width {
-            let mut v = 0;
+            let v;
             if base_x >= 0 {
                 v = *topleft.offset(base_x as isize) as libc::c_int * (64 - frac_x)
                     + *topleft.offset((base_x + 1) as isize) as libc::c_int * frac_x;
@@ -1745,8 +1745,8 @@ unsafe extern "C" fn ipred_z3_c(
     }
     let mut dy = dav1d_dr_intra_derivative[(270 - angle >> 1) as usize] as libc::c_int;
     let mut left_out: [pixel; 128] = [0; 128];
-    let mut left: *const pixel = 0 as *const pixel;
-    let mut max_base_y = 0;
+    let left: *const pixel;
+    let max_base_y;
     let upsample_left = if enable_intra_edge_filter != 0 {
         get_upsample(width + height, angle - 180, is_sm)
     } else {
@@ -1896,8 +1896,8 @@ unsafe extern "C" fn cfl_ac_c(
     ss_hor: libc::c_int,
     ss_ver: libc::c_int,
 ) {
-    let mut y = 0;
-    let mut x = 0;
+    let mut y;
+    let mut x: i32;
     let ac_orig: *mut int16_t = ac;
     if !(w_pad >= 0 && (w_pad * 4) < width) {
         unreachable!();
@@ -2203,7 +2203,7 @@ unsafe extern "C" fn ipred_z3_neon(
     let mut dy = dav1d_dr_intra_derivative[(270 - angle >> 1) as usize] as libc::c_int;
     let mut flipped: [pixel; 144] = [0; 144];
     let mut left_out: [pixel; 286] = [0; 286];
-    let mut max_base_y = 0;
+    let max_base_y;
     let upsample_left = if enable_intra_edge_filter != 0 {
         get_upsample(width + height, angle - 180, is_sm)
     } else {
@@ -2484,7 +2484,7 @@ unsafe extern "C" fn ipred_z1_neon(
     let mut dx = dav1d_dr_intra_derivative[(angle >> 1) as usize] as libc::c_int;
     const top_out_size: usize = 64 + 64 * (64 + 15) * 2 + 16;
     let mut top_out: [pixel; top_out_size] = [0; top_out_size];
-    let mut max_base_x = 0;
+    let max_base_x;
     let upsample_above = if enable_intra_edge_filter != 0 {
         get_upsample(width + height, 90 - angle, is_sm)
     } else {

--- a/src/ipred_tmpl_8.rs
+++ b/src/ipred_tmpl_8.rs
@@ -1444,7 +1444,7 @@ unsafe extern "C" fn upsample_edge(
         9 as libc::c_int as int8_t,
         -(1 as libc::c_int) as int8_t,
     ];
-    let mut i = 0;
+    let mut i;
     i = 0 as libc::c_int;
     while i < hsz - 1 {
         *out.offset((i * 2) as isize) = *in_0.offset(iclip(i, from, to - 1) as isize);
@@ -1478,8 +1478,8 @@ unsafe extern "C" fn ipred_z1_c(
     }
     let mut dx = dav1d_dr_intra_derivative[(angle >> 1) as usize] as libc::c_int;
     let mut top_out: [pixel; 128] = [0; 128];
-    let mut top: *const pixel = 0 as *const pixel;
-    let mut max_base_x = 0;
+    let top: *const pixel;
+    let max_base_x;
     let upsample_above = if enable_intra_edge_filter != 0 {
         get_upsample(width + height, 90 - angle, is_sm)
     } else {
@@ -1651,7 +1651,7 @@ unsafe extern "C" fn ipred_z2_c(
         let mut x = 0;
         let mut ypos = (y << 6 + upsample_left) - dy;
         while x < width {
-            let mut v = 0;
+            let v;
             if base_x >= 0 {
                 v = *topleft.offset(base_x as isize) as libc::c_int * (64 - frac_x)
                     + *topleft.offset((base_x + 1) as isize) as libc::c_int * frac_x;
@@ -1692,8 +1692,8 @@ unsafe extern "C" fn ipred_z3_c(
     }
     let mut dy = dav1d_dr_intra_derivative[(270 - angle >> 1) as usize] as libc::c_int;
     let mut left_out: [pixel; 128] = [0; 128];
-    let mut left: *const pixel = 0 as *const pixel;
-    let mut max_base_y = 0;
+    let left: *const pixel;
+    let max_base_y;
     let upsample_left = if enable_intra_edge_filter != 0 {
         get_upsample(width + height, angle - 180, is_sm)
     } else {
@@ -1835,8 +1835,8 @@ unsafe extern "C" fn cfl_ac_c(
     ss_hor: libc::c_int,
     ss_ver: libc::c_int,
 ) {
-    let mut y = 0;
-    let mut x = 0;
+    let mut y;
+    let mut x;
     let ac_orig: *mut int16_t = ac;
     if !(w_pad >= 0 && (w_pad * 4) < width) {
         unreachable!();
@@ -2146,7 +2146,7 @@ unsafe extern "C" fn ipred_z3_neon(
     let mut dy = dav1d_dr_intra_derivative[(270 - angle >> 1) as usize] as libc::c_int;
     let mut flipped: [pixel; 144] = [0; 144];
     let mut left_out: [pixel; 286] = [0; 286];
-    let mut max_base_y = 0;
+    let max_base_y;
     let upsample_left = if enable_intra_edge_filter != 0 {
         get_upsample(width + height, angle - 180, is_sm)
     } else {
@@ -2421,7 +2421,7 @@ unsafe extern "C" fn ipred_z1_neon(
     let mut dx = dav1d_dr_intra_derivative[(angle >> 1) as usize] as libc::c_int;
     const top_out_size: usize = 64 + 64 * (64 + 15) * 2 + 16;
     let mut top_out: [pixel; top_out_size] = [0; top_out_size];
-    let mut max_base_x = 0;
+    let max_base_x;
     let upsample_above = if enable_intra_edge_filter != 0 {
         get_upsample(width + height, 90 - angle, is_sm)
     } else {

--- a/src/ipred_tmpl_8.rs
+++ b/src/ipred_tmpl_8.rs
@@ -9,39 +9,9 @@ extern "C" {
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong) -> *mut libc::c_void;
 }
 
-#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
+#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 extern "C" {
-    fn dav1d_ipred_dc_8bpc_avx2(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-    );
     fn dav1d_ipred_dc_8bpc_ssse3(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-    );
-    fn dav1d_ipred_dc_8bpc_avx512icl(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-    );
-    fn dav1d_ipred_dc_128_8bpc_avx2(
         dst: *mut pixel,
         stride: ptrdiff_t,
         topleft: *const pixel,
@@ -61,47 +31,7 @@ extern "C" {
         max_width: libc::c_int,
         max_height: libc::c_int,
     );
-    fn dav1d_ipred_dc_128_8bpc_avx512icl(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-    );
     fn dav1d_ipred_dc_top_8bpc_ssse3(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-    );
-    fn dav1d_ipred_dc_top_8bpc_avx512icl(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-    );
-    fn dav1d_ipred_dc_top_8bpc_avx2(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-    );
-    fn dav1d_ipred_dc_left_8bpc_avx2(
         dst: *mut pixel,
         stride: ptrdiff_t,
         topleft: *const pixel,
@@ -121,47 +51,7 @@ extern "C" {
         max_width: libc::c_int,
         max_height: libc::c_int,
     );
-    fn dav1d_ipred_dc_left_8bpc_avx512icl(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-    );
     fn dav1d_ipred_h_8bpc_ssse3(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-    );
-    fn dav1d_ipred_h_8bpc_avx2(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-    );
-    fn dav1d_ipred_h_8bpc_avx512icl(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-    );
-    fn dav1d_ipred_v_8bpc_avx2(
         dst: *mut pixel,
         stride: ptrdiff_t,
         topleft: *const pixel,
@@ -181,37 +71,7 @@ extern "C" {
         max_width: libc::c_int,
         max_height: libc::c_int,
     );
-    fn dav1d_ipred_v_8bpc_avx512icl(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-    );
-    fn dav1d_ipred_paeth_8bpc_avx2(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-    );
     fn dav1d_ipred_paeth_8bpc_ssse3(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-    );
-    fn dav1d_ipred_paeth_8bpc_avx512icl(
         dst: *mut pixel,
         stride: ptrdiff_t,
         topleft: *const pixel,
@@ -231,67 +91,7 @@ extern "C" {
         max_width: libc::c_int,
         max_height: libc::c_int,
     );
-    fn dav1d_ipred_smooth_8bpc_avx2(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-    );
-    fn dav1d_ipred_smooth_8bpc_avx512icl(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-    );
     fn dav1d_ipred_smooth_h_8bpc_ssse3(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-    );
-    fn dav1d_ipred_smooth_h_8bpc_avx2(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-    );
-    fn dav1d_ipred_smooth_h_8bpc_avx512icl(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-    );
-    fn dav1d_ipred_smooth_v_8bpc_avx512icl(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        topleft: *const pixel,
-        width: libc::c_int,
-        height: libc::c_int,
-        angle: libc::c_int,
-        max_width: libc::c_int,
-        max_height: libc::c_int,
-    );
-    fn dav1d_ipred_filter_8bpc_avx512icl(
         dst: *mut pixel,
         stride: ptrdiff_t,
         topleft: *const pixel,
@@ -421,6 +221,210 @@ extern "C" {
         idx: *const uint8_t,
         w: libc::c_int,
         h: libc::c_int,
+    );
+}
+
+#[cfg(all(feature = "asm", target_arch = "x86_64"))]
+extern "C" {
+    fn dav1d_ipred_dc_8bpc_avx2(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
+    );
+    fn dav1d_ipred_dc_8bpc_avx512icl(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
+    );
+    fn dav1d_ipred_dc_128_8bpc_avx2(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
+    );
+    fn dav1d_ipred_dc_128_8bpc_avx512icl(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
+    );
+    fn dav1d_ipred_dc_top_8bpc_avx512icl(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
+    );
+    fn dav1d_ipred_dc_top_8bpc_avx2(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
+    );
+    fn dav1d_ipred_dc_left_8bpc_avx2(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
+    );
+    fn dav1d_ipred_dc_left_8bpc_avx512icl(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
+    );
+    fn dav1d_ipred_h_8bpc_avx2(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
+    );
+    fn dav1d_ipred_h_8bpc_avx512icl(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
+    );
+    fn dav1d_ipred_v_8bpc_avx2(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
+    );
+    fn dav1d_ipred_v_8bpc_avx512icl(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
+    );
+    fn dav1d_ipred_paeth_8bpc_avx2(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
+    );
+    fn dav1d_ipred_paeth_8bpc_avx512icl(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
+    );
+    fn dav1d_ipred_smooth_8bpc_avx2(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
+    );
+    fn dav1d_ipred_smooth_8bpc_avx512icl(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
+    );
+    fn dav1d_ipred_smooth_h_8bpc_avx2(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
+    );
+    fn dav1d_ipred_smooth_h_8bpc_avx512icl(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
+    );
+    fn dav1d_ipred_smooth_v_8bpc_avx512icl(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
+    );
+    fn dav1d_ipred_filter_8bpc_avx512icl(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        topleft: *const pixel,
+        width: libc::c_int,
+        height: libc::c_int,
+        angle: libc::c_int,
+        max_width: libc::c_int,
+        max_height: libc::c_int,
     );
     fn dav1d_ipred_smooth_v_8bpc_avx2(
         dst: *mut pixel,
@@ -553,7 +557,7 @@ extern "C" {
     );
 }
 
-#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
+#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 extern "C" {
     fn dav1d_ipred_dc_8bpc_neon(
         dst: *mut pixel,
@@ -728,6 +732,18 @@ extern "C" {
         cw: libc::c_int,
         ch: libc::c_int,
     );
+    fn dav1d_pal_pred_8bpc_neon(
+        dst: *mut pixel,
+        stride: ptrdiff_t,
+        pal: *const uint16_t,
+        idx: *const uint8_t,
+        w: libc::c_int,
+        h: libc::c_int,
+    );
+}
+
+#[cfg(all(feature = "asm", target_arch = "aarch64"))]
+extern "C" {
     fn dav1d_ipred_z1_fill2_8bpc_neon(
         dst: *mut pixel,
         stride: ptrdiff_t,
@@ -812,14 +828,6 @@ extern "C" {
         height: libc::c_int,
         dy: libc::c_int,
         max_base_y: libc::c_int,
-    );
-    fn dav1d_pal_pred_8bpc_neon(
-        dst: *mut pixel,
-        stride: ptrdiff_t,
-        pal: *const uint16_t,
-        idx: *const uint8_t,
-        w: libc::c_int,
-        h: libc::c_int,
     );
     fn dav1d_ipred_pixel_set_8bpc_neon(out: *mut pixel, px: pixel, n: libc::c_int);
 }
@@ -2126,7 +2134,7 @@ unsafe extern "C" fn intra_pred_dsp_init_arm(c: *mut Dav1dIntraPredDSPContext) {
     (*c).pal_pred = Some(dav1d_pal_pred_8bpc_neon);
 }
 
-#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
+#[cfg(all(feature = "asm", target_arch = "aarch64"))]
 unsafe extern "C" fn ipred_z3_neon(
     dst: *mut pixel,
     stride: ptrdiff_t,
@@ -2227,7 +2235,7 @@ unsafe extern "C" fn ipred_z3_neon(
     };
 }
 
-#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
+#[cfg(all(feature = "asm", target_arch = "aarch64"))]
 unsafe extern "C" fn ipred_z2_neon(
     dst: *mut pixel,
     stride: ptrdiff_t,
@@ -2404,7 +2412,7 @@ unsafe extern "C" fn ipred_z2_neon(
     };
 }
 
-#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
+#[cfg(all(feature = "asm", target_arch = "aarch64"))]
 unsafe extern "C" fn ipred_z1_neon(
     dst: *mut pixel,
     stride: ptrdiff_t,

--- a/src/ipred_tmpl_8.rs
+++ b/src/ipred_tmpl_8.rs
@@ -990,7 +990,7 @@ unsafe extern "C" fn dc_gen_top(topleft: *const pixel, width: libc::c_int) -> li
     return dc >> ctz(width as libc::c_uint);
 }
 unsafe extern "C" fn ipred_dc_top_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     topleft: *const pixel,
     width: libc::c_int,
@@ -1008,12 +1008,12 @@ unsafe extern "C" fn ipred_dc_top_c(
     );
 }
 unsafe extern "C" fn ipred_cfl_top_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    mut ac: *const int16_t,
+    ac: *const int16_t,
     alpha: libc::c_int,
 ) {
     cfl_pred(
@@ -1036,7 +1036,7 @@ unsafe extern "C" fn dc_gen_left(topleft: *const pixel, height: libc::c_int) -> 
     return dc >> ctz(height as libc::c_uint);
 }
 unsafe extern "C" fn ipred_dc_left_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     topleft: *const pixel,
     width: libc::c_int,
@@ -1054,12 +1054,12 @@ unsafe extern "C" fn ipred_dc_left_c(
     );
 }
 unsafe extern "C" fn ipred_cfl_left_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    mut ac: *const int16_t,
+    ac: *const int16_t,
     alpha: libc::c_int,
 ) {
     let dc: libc::c_uint = dc_gen_left(topleft, height);
@@ -1095,7 +1095,7 @@ unsafe extern "C" fn dc_gen(
     return dc;
 }
 unsafe extern "C" fn ipred_dc_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     topleft: *const pixel,
     width: libc::c_int,
@@ -1113,19 +1113,19 @@ unsafe extern "C" fn ipred_dc_c(
     );
 }
 unsafe extern "C" fn ipred_cfl_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    mut ac: *const int16_t,
+    ac: *const int16_t,
     alpha: libc::c_int,
 ) {
-    let mut dc: libc::c_uint = dc_gen(topleft, width, height);
+    let dc: libc::c_uint = dc_gen(topleft, width, height);
     cfl_pred(dst, stride, width, height, dc as libc::c_int, ac, alpha);
 }
 unsafe extern "C" fn ipred_dc_128_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     _topleft: *const pixel,
     width: libc::c_int,
@@ -1138,12 +1138,12 @@ unsafe extern "C" fn ipred_dc_128_c(
     splat_dc(dst, stride, width, height, dc);
 }
 unsafe extern "C" fn ipred_cfl_128_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     _topleft: *const pixel,
     width: libc::c_int,
     height: libc::c_int,
-    mut ac: *const int16_t,
+    ac: *const int16_t,
     alpha: libc::c_int,
 ) {
     let dc = 128;
@@ -1675,7 +1675,7 @@ unsafe extern "C" fn ipred_z2_c(
     }
 }
 unsafe extern "C" fn ipred_z3_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     topleft_in: *const pixel,
     width: libc::c_int,
@@ -2128,7 +2128,7 @@ unsafe extern "C" fn intra_pred_dsp_init_arm(c: *mut Dav1dIntraPredDSPContext) {
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 unsafe extern "C" fn ipred_z3_neon(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     topleft_in: *const pixel,
     width: libc::c_int,
@@ -2198,7 +2198,7 @@ unsafe extern "C" fn ipred_z3_neon(
         }
     }
     let base_inc = 1 + upsample_left;
-    let mut pad_pixels = imax(64 - max_base_y - 1, height + 15);
+    let pad_pixels = imax(64 - max_base_y - 1, height + 15);
     dav1d_ipred_pixel_set_8bpc_neon(
         &mut *left_out.as_mut_ptr().offset((max_base_y + 1) as isize) as *mut pixel,
         left_out[max_base_y as usize],
@@ -2229,7 +2229,7 @@ unsafe extern "C" fn ipred_z3_neon(
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 unsafe extern "C" fn ipred_z2_neon(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     topleft_in: *const pixel,
     width: libc::c_int,
@@ -2252,9 +2252,9 @@ unsafe extern "C" fn ipred_z2_neon(
     let mut buf: [pixel; 3 * (64 + 1)] = [0; 3 * (64 + 1)]; // NOTE: C code doesn't initialize
                                                             // The asm can underread below the start of top[] and left[]; to avoid
                                                             // surprising behaviour, make sure this is within the allocated stack space.
-    let mut left_offset: isize = 2 * (64 + 1);
-    let mut top_offset: isize = 1 * (64 + 1);
-    let mut flipped_offset: isize = 0 * (64 + 1);
+    let left_offset: isize = 2 * (64 + 1);
+    let top_offset: isize = 1 * (64 + 1);
+    let flipped_offset: isize = 0 * (64 + 1);
 
     let upsample_left = if enable_intra_edge_filter != 0 {
         get_upsample(width + height, 180 - angle, is_sm)
@@ -2406,7 +2406,7 @@ unsafe extern "C" fn ipred_z2_neon(
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 unsafe extern "C" fn ipred_z1_neon(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     stride: ptrdiff_t,
     topleft_in: *const pixel,
     width: libc::c_int,
@@ -2462,7 +2462,7 @@ unsafe extern "C" fn ipred_z1_neon(
         }
     }
     let base_inc = 1 + upsample_above;
-    let mut pad_pixels = width + 15;
+    let pad_pixels = width + 15;
     dav1d_ipred_pixel_set_8bpc_neon(
         &mut *top_out.as_mut_ptr().offset((max_base_x + 1) as isize) as *mut pixel,
         top_out[max_base_x as usize],

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -329,7 +329,7 @@ macro_rules! inv_txfm_fn {
         paste::paste! {
             // TODO(legare): Temporarily pub until init fns are deduplicated.
             pub(crate) unsafe extern "C" fn [<inv_txfm_add_ $type1 _ $type2 _ $w x $h _c_erased>] <BD: BitDepth> (
-                mut dst: *mut DynPixel,
+                dst: *mut DynPixel,
                 stride: ptrdiff_t,
                 coeff: *mut DynCoef,
                 eob: libc::c_int,

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -152,6 +152,7 @@ pub struct Dav1dInvTxfmDSPContext {
 macro_rules! decl_itx_fn {
     ($name:ident) => {
         // TODO(legare): Temporarily pub until init fns are deduplicated.
+        #[allow(dead_code)] // TODO(kkysen) Way more asm fns than exist are declared.
         pub(crate) fn $name(
             dst: *mut DynPixel,
             dst_stride: ptrdiff_t,

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -310,14 +310,18 @@ macro_rules! decl_itx_fns {
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 extern "C" {
+    decl_itx_fns!(_sse4);
+    decl_itx_fns!(_ssse3);
+    decl_itx_fn!(dav1d_inv_txfm_add_wht_wht_4x4, _sse2);
+}
+
+#[cfg(all(feature = "asm", target_arch = "x86_64"))]
+extern "C" {
     decl_itx_fns!(_avx512icl);
     decl_itx_fns!(_10bpc, _avx512icl);
     decl_itx_fns!(_avx2);
     decl_itx_fns!(_10bpc, _avx2);
     decl_itx_fns!(_12bpc, _avx2);
-    decl_itx_fns!(_sse4);
-    decl_itx_fns!(_ssse3);
-    decl_itx_fn!(dav1d_inv_txfm_add_wht_wht_4x4, _sse2);
 }
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]

--- a/src/itx_1d.rs
+++ b/src/itx_1d.rs
@@ -111,7 +111,7 @@ unsafe extern "C" fn inv_dct16_1d_internal_c(
     stride: ptrdiff_t,
     min: libc::c_int,
     max: libc::c_int,
-    mut tx64: libc::c_int,
+    tx64: libc::c_int,
 ) {
     if !(stride > 0) {
         unreachable!();
@@ -152,14 +152,14 @@ unsafe extern "C" fn inv_dct16_1d_internal_c(
         t14a = in9 * 1299 + in7 * 1583 + 1024 >> 11;
         t15a = (in1 * (4076 - 4096) + in15 * 401 + 2048 >> 12) + in1;
     }
-    let mut t8 = iclip(t8a + t9a, min, max);
+    let t8 = iclip(t8a + t9a, min, max);
     let mut t9 = iclip(t8a - t9a, min, max);
     let mut t10 = iclip(t11a - t10a, min, max);
     let mut t11 = iclip(t11a + t10a, min, max);
     let mut t12 = iclip(t12a + t13a, min, max);
     let mut t13 = iclip(t12a - t13a, min, max);
     let mut t14 = iclip(t15a - t14a, min, max);
-    let mut t15 = iclip(t15a + t14a, min, max);
+    let t15 = iclip(t15a + t14a, min, max);
     t9a = (t14 * 1567 - t9 * (3784 - 4096) + 2048 >> 12) - t9;
     t14a = (t14 * (3784 - 4096) + t9 * 1567 + 2048 >> 12) + t14;
     t10a = (-(t13 * (3784 - 4096) + t10 * 1567) + 2048 >> 12) - t13;
@@ -897,8 +897,8 @@ unsafe extern "C" fn inv_adst16_1d_internal_c(
     let mut t13 = (in3 * (3857 - 4096) - in12 * 1380 + 2048 >> 12) + in3;
     let mut t14 = (in1 * 601 + in14 * (4052 - 4096) + 2048 >> 12) + in14;
     let mut t15 = (in1 * (4052 - 4096) - in14 * 601 + 2048 >> 12) + in1;
-    let mut t0a = iclip(t0 + t8, min, max);
-    let mut t1a = iclip(t1 + t9, min, max);
+    let t0a = iclip(t0 + t8, min, max);
+    let t1a = iclip(t1 + t9, min, max);
     let mut t2a = iclip(t2 + t10, min, max);
     let mut t3a = iclip(t3 + t11, min, max);
     let mut t4a = iclip(t4 + t12, min, max);

--- a/src/itx_1d.rs
+++ b/src/itx_1d.rs
@@ -15,10 +15,10 @@ unsafe extern "C" fn inv_dct4_1d_internal_c(
     }
     let in0 = *c.offset((0 * stride) as isize);
     let in1 = *c.offset((1 * stride) as isize);
-    let mut t0 = 0;
-    let mut t1 = 0;
-    let mut t2 = 0;
-    let mut t3 = 0;
+    let t0;
+    let t1;
+    let t2;
+    let t3;
     if tx64 != 0 {
         t1 = in0 * 181 + 128 >> 8;
         t0 = t1;
@@ -60,10 +60,10 @@ unsafe extern "C" fn inv_dct8_1d_internal_c(
     inv_dct4_1d_internal_c(c, stride << 1, min, max, tx64);
     let in1 = *c.offset((1 * stride) as isize);
     let in3 = *c.offset((3 * stride) as isize);
-    let mut t4a = 0;
-    let mut t5a = 0;
-    let mut t6a = 0;
-    let mut t7a = 0;
+    let t4a;
+    let mut t5a;
+    let mut t6a;
+    let t7a;
     if tx64 != 0 {
         t4a = in1 * 799 + 2048 >> 12;
         t5a = in3 * -(2276 as libc::c_int) + 2048 >> 12;
@@ -121,14 +121,14 @@ unsafe extern "C" fn inv_dct16_1d_internal_c(
     let in3 = *c.offset((3 * stride) as isize);
     let in5 = *c.offset((5 * stride) as isize);
     let in7 = *c.offset((7 * stride) as isize);
-    let mut t8a = 0;
-    let mut t9a = 0;
-    let mut t10a = 0;
-    let mut t11a = 0;
-    let mut t12a = 0;
-    let mut t13a = 0;
-    let mut t14a = 0;
-    let mut t15a = 0;
+    let mut t8a;
+    let mut t9a;
+    let mut t10a;
+    let mut t11a;
+    let mut t12a;
+    let mut t13a;
+    let mut t14a;
+    let mut t15a;
     if tx64 != 0 {
         t8a = in1 * 401 + 2048 >> 12;
         t9a = in7 * -(2598 as libc::c_int) + 2048 >> 12;
@@ -230,22 +230,22 @@ unsafe extern "C" fn inv_dct32_1d_internal_c(
     let in11 = *c.offset((11 * stride) as isize);
     let in13 = *c.offset((13 * stride) as isize);
     let in15 = *c.offset((15 * stride) as isize);
-    let mut t16a = 0;
-    let mut t17a = 0;
-    let mut t18a = 0;
-    let mut t19a = 0;
-    let mut t20a = 0;
-    let mut t21a = 0;
-    let mut t22a = 0;
-    let mut t23a = 0;
-    let mut t24a = 0;
-    let mut t25a = 0;
-    let mut t26a = 0;
-    let mut t27a = 0;
-    let mut t28a = 0;
-    let mut t29a = 0;
-    let mut t30a = 0;
-    let mut t31a = 0;
+    let mut t16a;
+    let mut t17a;
+    let mut t18a;
+    let mut t19a;
+    let mut t20a;
+    let mut t21a;
+    let mut t22a;
+    let mut t23a;
+    let mut t24a;
+    let mut t25a;
+    let mut t26a;
+    let mut t27a;
+    let mut t28a;
+    let mut t29a;
+    let mut t30a;
+    let mut t31a;
     if tx64 != 0 {
         t16a = in1 * 201 + 2048 >> 12;
         t17a = in15 * -(2751 as libc::c_int) + 2048 >> 12;

--- a/src/itx_tmpl_16.rs
+++ b/src/itx_tmpl_16.rs
@@ -716,7 +716,7 @@ use crate::src::cpu::dav1d_get_cpu_flags;
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]
-unsafe extern "C" fn itx_dsp_init_arm(c: *mut Dav1dInvTxfmDSPContext, mut bpc: libc::c_int) {
+unsafe extern "C" fn itx_dsp_init_arm(c: *mut Dav1dInvTxfmDSPContext, bpc: libc::c_int) {
     use crate::src::arm::cpu::DAV1D_ARM_CPU_FLAG_NEON;
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::itx::*;

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -1049,8 +1049,8 @@ pub unsafe extern "C" fn dav1d_loopfilter_sbrow_cols_16bpc(
     sby: libc::c_int,
     start_of_tile_row: libc::c_int,
 ) {
-    let mut x = 0;
-    let mut have_left = 0;
+    let mut x;
+    let mut have_left;
     let is_sb64 = ((*(*f).seq_hdr).sb128 == 0) as libc::c_int;
     let starty4 = (sby & is_sb64) << 4;
     let sbsz = 32 >> is_sb64;
@@ -1139,7 +1139,7 @@ pub unsafe extern "C" fn dav1d_loopfilter_sbrow_cols_16bpc(
         tile_col += 1;
     }
     if start_of_tile_row != 0 {
-        let mut a: *const BlockContext = 0 as *const BlockContext;
+        let mut a: *const BlockContext;
         x = 0 as libc::c_int;
         a = &mut *((*f).a).offset(((*f).sb128w * (start_of_tile_row - 1)) as isize)
             as *mut BlockContext;
@@ -1200,7 +1200,7 @@ pub unsafe extern "C" fn dav1d_loopfilter_sbrow_cols_16bpc(
             a = a.offset(1);
         }
     }
-    let mut ptr: *mut pixel = 0 as *mut pixel;
+    let mut ptr: *mut pixel;
     let mut level_ptr: *mut [uint8_t; 4] =
         ((*f).lf.level).offset((*f).b4_stride * sby as isize * sbsz as isize);
     ptr = *p.offset(0);
@@ -1227,7 +1227,7 @@ pub unsafe extern "C" fn dav1d_loopfilter_sbrow_cols_16bpc(
     if (*(*f).frame_hdr).loopfilter.level_u == 0 && (*(*f).frame_hdr).loopfilter.level_v == 0 {
         return;
     }
-    let mut uv_off: ptrdiff_t = 0;
+    let mut uv_off: ptrdiff_t;
     level_ptr = ((*f).lf.level).offset((*f).b4_stride * (sby * sbsz >> ss_ver) as isize);
     uv_off = 0 as libc::c_int as ptrdiff_t;
     have_left = 0 as libc::c_int;
@@ -1260,7 +1260,7 @@ pub unsafe extern "C" fn dav1d_loopfilter_sbrow_rows_16bpc(
     lflvl: *mut Av1Filter,
     sby: libc::c_int,
 ) {
-    let mut x = 0;
+    let mut x;
     let have_top = (sby > 0) as libc::c_int;
     let is_sb64 = ((*(*f).seq_hdr).sb128 == 0) as libc::c_int;
     let starty4 = (sby & is_sb64) << 4;
@@ -1271,7 +1271,7 @@ pub unsafe extern "C" fn dav1d_loopfilter_sbrow_rows_16bpc(
         != DAV1D_PIXEL_LAYOUT_I444 as libc::c_int as libc::c_uint) as libc::c_int;
     let endy4: libc::c_uint = (starty4 + imin((*f).h4 - sby * sbsz, sbsz)) as libc::c_uint;
     let uv_endy4: libc::c_uint = endy4.wrapping_add(ss_ver as libc::c_uint) >> ss_ver;
-    let mut ptr: *mut pixel = 0 as *mut pixel;
+    let mut ptr: *mut pixel;
     let mut level_ptr: *mut [uint8_t; 4] =
         ((*f).lf.level).offset((*f).b4_stride * sby as isize * sbsz as isize);
     ptr = *p.offset(0);
@@ -1296,7 +1296,7 @@ pub unsafe extern "C" fn dav1d_loopfilter_sbrow_rows_16bpc(
     if (*(*f).frame_hdr).loopfilter.level_u == 0 && (*(*f).frame_hdr).loopfilter.level_v == 0 {
         return;
     }
-    let mut uv_off: ptrdiff_t = 0;
+    let mut uv_off: ptrdiff_t;
     level_ptr = ((*f).lf.level).offset((*f).b4_stride * (sby * sbsz >> ss_ver) as isize);
     uv_off = 0 as libc::c_int as ptrdiff_t;
     x = 0 as libc::c_int;

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -682,7 +682,7 @@ unsafe extern "C" fn backup_lpf(
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_copy_lpf_16bpc(
     f: *mut Dav1dFrameContext,
-    mut src: *const *mut pixel,
+    src: *const *mut pixel,
     sby: libc::c_int,
 ) {
     let have_tt = ((*(*f).c).n_tc > 1 as libc::c_uint) as libc::c_int;
@@ -842,10 +842,10 @@ pub unsafe extern "C" fn dav1d_copy_lpf_16bpc(
 unsafe extern "C" fn filter_plane_cols_y(
     f: *const Dav1dFrameContext,
     have_left: libc::c_int,
-    mut lvl: *const [uint8_t; 4],
+    lvl: *const [uint8_t; 4],
     b4_stride: ptrdiff_t,
     mask: *const [[uint16_t; 2]; 3],
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     ls: ptrdiff_t,
     w: libc::c_int,
     starty4: libc::c_int,
@@ -932,7 +932,7 @@ unsafe extern "C" fn filter_plane_rows_y(
 unsafe extern "C" fn filter_plane_cols_uv(
     f: *const Dav1dFrameContext,
     have_left: libc::c_int,
-    mut lvl: *const [uint8_t; 4],
+    lvl: *const [uint8_t; 4],
     b4_stride: ptrdiff_t,
     mask: *const [[uint16_t; 2]; 2],
     u: *mut pixel,
@@ -1044,9 +1044,9 @@ unsafe extern "C" fn filter_plane_rows_uv(
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_loopfilter_sbrow_cols_16bpc(
     f: *const Dav1dFrameContext,
-    mut p: *const *mut pixel,
+    p: *const *mut pixel,
     lflvl: *mut Av1Filter,
-    mut sby: libc::c_int,
+    sby: libc::c_int,
     start_of_tile_row: libc::c_int,
 ) {
     let mut x = 0;
@@ -1256,9 +1256,9 @@ pub unsafe extern "C" fn dav1d_loopfilter_sbrow_cols_16bpc(
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_loopfilter_sbrow_rows_16bpc(
     f: *const Dav1dFrameContext,
-    mut p: *const *mut pixel,
+    p: *const *mut pixel,
     lflvl: *mut Av1Filter,
-    mut sby: libc::c_int,
+    sby: libc::c_int,
 ) {
     let mut x = 0;
     let have_top = (sby > 0) as libc::c_int;

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -1000,8 +1000,8 @@ pub unsafe extern "C" fn dav1d_loopfilter_sbrow_cols_8bpc(
     sby: libc::c_int,
     start_of_tile_row: libc::c_int,
 ) {
-    let mut x = 0;
-    let mut have_left = 0;
+    let mut x;
+    let mut have_left;
     let is_sb64 = ((*(*f).seq_hdr).sb128 == 0) as libc::c_int;
     let starty4 = (sby & is_sb64) << 4;
     let sbsz = 32 >> is_sb64;
@@ -1090,7 +1090,7 @@ pub unsafe extern "C" fn dav1d_loopfilter_sbrow_cols_8bpc(
         tile_col += 1;
     }
     if start_of_tile_row != 0 {
-        let mut a: *const BlockContext = 0 as *const BlockContext;
+        let mut a: *const BlockContext;
         x = 0 as libc::c_int;
         a = &mut *((*f).a).offset(((*f).sb128w * (start_of_tile_row - 1)) as isize)
             as *mut BlockContext;
@@ -1151,7 +1151,7 @@ pub unsafe extern "C" fn dav1d_loopfilter_sbrow_cols_8bpc(
             a = a.offset(1);
         }
     }
-    let mut ptr: *mut pixel = 0 as *mut pixel;
+    let mut ptr: *mut pixel;
     let mut level_ptr: *mut [uint8_t; 4] =
         ((*f).lf.level).offset(((*f).b4_stride * sby as isize * sbsz as isize) as isize);
     ptr = *p.offset(0);
@@ -1178,7 +1178,7 @@ pub unsafe extern "C" fn dav1d_loopfilter_sbrow_cols_8bpc(
     if (*(*f).frame_hdr).loopfilter.level_u == 0 && (*(*f).frame_hdr).loopfilter.level_v == 0 {
         return;
     }
-    let mut uv_off: ptrdiff_t = 0;
+    let mut uv_off: ptrdiff_t;
     level_ptr = ((*f).lf.level).offset(((*f).b4_stride * (sby * sbsz >> ss_ver) as isize) as isize);
     uv_off = 0 as libc::c_int as ptrdiff_t;
     have_left = 0 as libc::c_int;
@@ -1211,7 +1211,7 @@ pub unsafe extern "C" fn dav1d_loopfilter_sbrow_rows_8bpc(
     lflvl: *mut Av1Filter,
     sby: libc::c_int,
 ) {
-    let mut x = 0;
+    let mut x;
     let have_top = (sby > 0) as libc::c_int;
     let is_sb64 = ((*(*f).seq_hdr).sb128 == 0) as libc::c_int;
     let starty4 = (sby & is_sb64) << 4;
@@ -1222,7 +1222,7 @@ pub unsafe extern "C" fn dav1d_loopfilter_sbrow_rows_8bpc(
         != DAV1D_PIXEL_LAYOUT_I444 as libc::c_int as libc::c_uint) as libc::c_int;
     let endy4: libc::c_uint = (starty4 + imin((*f).h4 - sby * sbsz, sbsz)) as libc::c_uint;
     let uv_endy4: libc::c_uint = endy4.wrapping_add(ss_ver as libc::c_uint) >> ss_ver;
-    let mut ptr: *mut pixel = 0 as *mut pixel;
+    let mut ptr: *mut pixel;
     let mut level_ptr: *mut [uint8_t; 4] =
         ((*f).lf.level).offset(((*f).b4_stride * sby as isize * sbsz as isize) as isize);
     ptr = *p.offset(0);
@@ -1247,7 +1247,7 @@ pub unsafe extern "C" fn dav1d_loopfilter_sbrow_rows_8bpc(
     if (*(*f).frame_hdr).loopfilter.level_u == 0 && (*(*f).frame_hdr).loopfilter.level_v == 0 {
         return;
     }
-    let mut uv_off: ptrdiff_t = 0;
+    let mut uv_off: ptrdiff_t;
     level_ptr = ((*f).lf.level).offset(((*f).b4_stride * (sby * sbsz >> ss_ver) as isize) as isize);
     uv_off = 0 as libc::c_int as ptrdiff_t;
     x = 0 as libc::c_int;

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -635,7 +635,7 @@ unsafe extern "C" fn backup_lpf(
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_copy_lpf_8bpc(
     f: *mut Dav1dFrameContext,
-    mut src: *const *mut pixel,
+    src: *const *mut pixel,
     sby: libc::c_int,
 ) {
     let have_tt = ((*(*f).c).n_tc > 1 as libc::c_uint) as libc::c_int;
@@ -793,10 +793,10 @@ pub unsafe extern "C" fn dav1d_copy_lpf_8bpc(
 unsafe extern "C" fn filter_plane_cols_y(
     f: *const Dav1dFrameContext,
     have_left: libc::c_int,
-    mut lvl: *const [uint8_t; 4],
+    lvl: *const [uint8_t; 4],
     b4_stride: ptrdiff_t,
     mask: *const [[uint16_t; 2]; 3],
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     ls: ptrdiff_t,
     w: libc::c_int,
     starty4: libc::c_int,
@@ -883,7 +883,7 @@ unsafe extern "C" fn filter_plane_rows_y(
 unsafe extern "C" fn filter_plane_cols_uv(
     f: *const Dav1dFrameContext,
     have_left: libc::c_int,
-    mut lvl: *const [uint8_t; 4],
+    lvl: *const [uint8_t; 4],
     b4_stride: ptrdiff_t,
     mask: *const [[uint16_t; 2]; 2],
     u: *mut pixel,
@@ -995,9 +995,9 @@ unsafe extern "C" fn filter_plane_rows_uv(
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_loopfilter_sbrow_cols_8bpc(
     f: *const Dav1dFrameContext,
-    mut p: *const *mut pixel,
+    p: *const *mut pixel,
     lflvl: *mut Av1Filter,
-    mut sby: libc::c_int,
+    sby: libc::c_int,
     start_of_tile_row: libc::c_int,
 ) {
     let mut x = 0;
@@ -1207,9 +1207,9 @@ pub unsafe extern "C" fn dav1d_loopfilter_sbrow_cols_8bpc(
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_loopfilter_sbrow_rows_8bpc(
     f: *const Dav1dFrameContext,
-    mut p: *const *mut pixel,
+    p: *const *mut pixel,
     lflvl: *mut Av1Filter,
-    mut sby: libc::c_int,
+    sby: libc::c_int,
 ) {
     let mut x = 0;
     let have_top = (sby > 0) as libc::c_int;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -624,7 +624,7 @@ fn calc_lf_value_chroma(
 pub fn dav1d_calc_lf_values(
     lflvl_values: &mut [[[[u8; 2]; 8]; 4]; 8],
     hdr: &Dav1dFrameHeader,
-    mut lf_delta: &[i8; 4],
+    lf_delta: &[i8; 4],
 ) {
     let n_seg = if hdr.segmentation.enabled != 0 { 8 } else { 1 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,6 @@ extern "C" {
     fn dlsym(__handle: *mut libc::c_void, __name: *const libc::c_char) -> *mut libc::c_void;
     fn calloc(_: size_t, _: size_t) -> *mut libc::c_void;
     fn free(_: *mut libc::c_void);
-    fn posix_memalign(
-        __memptr: *mut *mut libc::c_void,
-        __alignment: size_t,
-        __size: size_t,
-    ) -> libc::c_int;
     fn abort() -> !;
     fn fprintf(_: *mut libc::FILE, _: *const libc::c_char, _: ...) -> libc::c_int;
     fn dav1d_num_logical_processors(c: *mut Dav1dContext) -> libc::c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use cfg_if::cfg_if;
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: size_t) -> *mut libc::c_void;
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: size_t) -> *mut libc::c_void;
+    #[cfg(target_os = "linux")]
     fn dlsym(__handle: *mut libc::c_void, __name: *const libc::c_char) -> *mut libc::c_void;
     fn calloc(_: size_t, _: size_t) -> *mut libc::c_void;
     fn free(_: *mut libc::c_void);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -728,8 +728,8 @@ unsafe extern "C" fn get_stack_size_internal(_thread_attr: *const pthread_attr_t
 unsafe extern "C" fn get_num_threads(
     c: *mut Dav1dContext,
     s: *const Dav1dSettings,
-    mut n_tc: *mut libc::c_uint,
-    mut n_fc: *mut libc::c_uint,
+    n_tc: *mut libc::c_uint,
+    n_fc: *mut libc::c_uint,
 ) {
     static mut fc_lut: [uint8_t; 49] = [
         1 as libc::c_int as uint8_t,
@@ -939,7 +939,7 @@ pub unsafe extern "C" fn dav1d_open(
     if pthread_attr_init(&mut thread_attr) != 0 {
         return -(12 as libc::c_int);
     }
-    let mut stack_size: size_t = 1024 * 1024 * get_stack_size_internal(&mut thread_attr);
+    let stack_size: size_t = 1024 * 1024 * get_stack_size_internal(&mut thread_attr);
     pthread_attr_setstacksize(&mut thread_attr, stack_size);
     *c_out = dav1d_alloc_aligned(::core::mem::size_of::<Dav1dContext>(), 64) as *mut Dav1dContext;
     let c: *mut Dav1dContext = *c_out;
@@ -1293,7 +1293,7 @@ pub unsafe extern "C" fn dav1d_parse_sequence_header(
 ) -> libc::c_int {
     let mut current_block: u64;
     let mut buf: Dav1dData = {
-        let mut init = Dav1dData {
+        let init = Dav1dData {
             data: 0 as *const uint8_t,
             sz: 0,
             r#ref: 0 as *mut Dav1dRef,
@@ -1408,7 +1408,7 @@ pub unsafe extern "C" fn dav1d_parse_sequence_header(
     return res;
 }
 unsafe extern "C" fn has_grain(pic: *const Dav1dPicture) -> libc::c_int {
-    let mut fgdata: *const Dav1dFilmGrainData = &mut (*(*pic).frame_hdr).film_grain.data;
+    let fgdata: *const Dav1dFilmGrainData = &mut (*(*pic).frame_hdr).film_grain.data;
     return ((*fgdata).num_y_points != 0
         || (*fgdata).num_uv_points[0] != 0
         || (*fgdata).num_uv_points[1] != 0
@@ -1630,7 +1630,7 @@ pub unsafe extern "C" fn dav1d_send_data(
         return -(11 as libc::c_int);
     }
     dav1d_data_ref(&mut (*c).in_0, in_0);
-    let mut res = gen_picture(c);
+    let res = gen_picture(c);
     if res == 0 {
         dav1d_data_unref_internal(in_0);
     }
@@ -1663,7 +1663,7 @@ pub unsafe extern "C" fn dav1d_get_picture(
     }
     let drain = (*c).drain;
     (*c).drain = 1 as libc::c_int;
-    let mut res = gen_picture(c);
+    let res = gen_picture(c);
     if res < 0 {
         return res;
     }
@@ -1720,7 +1720,7 @@ pub unsafe extern "C" fn dav1d_apply_grain(
         dav1d_picture_ref(out, in_0);
         return 0 as libc::c_int;
     }
-    let mut res = dav1d_picture_alloc_copy(c, out, (*in_0).p.w, in_0);
+    let res = dav1d_picture_alloc_copy(c, out, (*in_0).p.w, in_0);
     if res < 0 {
         dav1d_picture_unref_internal(out);
         return res;
@@ -1848,7 +1848,7 @@ pub unsafe extern "C" fn dav1d_flush(c: *mut Dav1dContext) {
             dav1d_decode_frame_exit(f, -(1 as libc::c_int));
             (*f).n_tile_data = 0 as libc::c_int;
             (*f).task_thread.retval = 0 as libc::c_int;
-            let mut out_delayed: *mut Dav1dThreadPicture = &mut *((*c).frame_thread.out_delayed)
+            let out_delayed: *mut Dav1dThreadPicture = &mut *((*c).frame_thread.out_delayed)
                 .offset(next as isize)
                 as *mut Dav1dThreadPicture;
             if !((*out_delayed).p.frame_hdr).is_null() {
@@ -1876,7 +1876,7 @@ pub unsafe extern "C" fn dav1d_close(c_out: *mut *mut Dav1dContext) {
     close_internal(c_out, 1 as libc::c_int);
 }
 #[cold]
-unsafe extern "C" fn close_internal(c_out: *mut *mut Dav1dContext, mut flush: libc::c_int) {
+unsafe extern "C" fn close_internal(c_out: *mut *mut Dav1dContext, flush: libc::c_int) {
     let c: *mut Dav1dContext = *c_out;
     if c.is_null() {
         return;
@@ -1885,7 +1885,7 @@ unsafe extern "C" fn close_internal(c_out: *mut *mut Dav1dContext, mut flush: li
         dav1d_flush(c);
     }
     if !((*c).tc).is_null() {
-        let mut ttd: *mut TaskThreadData = &mut (*c).task_thread;
+        let ttd: *mut TaskThreadData = &mut (*c).task_thread;
         if (*ttd).inited != 0 {
             pthread_mutex_lock(&mut (*ttd).lock);
             let mut n: libc::c_uint = 0 as libc::c_int as libc::c_uint;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1310,7 +1310,7 @@ pub unsafe extern "C" fn dav1d_parse_sequence_header(
         };
         init
     };
-    let mut res = 0;
+    let mut res;
     if out.is_null() {
         fprintf(
             stderr,
@@ -1559,7 +1559,7 @@ unsafe extern "C" fn drain_picture(c: *mut Dav1dContext, out: *mut Dav1dPicture)
     return -(11 as libc::c_int);
 }
 unsafe extern "C" fn gen_picture(c: *mut Dav1dContext) -> libc::c_int {
-    let mut res = 0;
+    let mut res;
     let in_0: *mut Dav1dData = &mut (*c).in_0;
     if output_picture_ready(c, 0 as libc::c_int) != 0 {
         return 0 as libc::c_int;

--- a/src/log.rs
+++ b/src/log.rs
@@ -537,7 +537,7 @@ pub unsafe extern "C" fn dav1d_log_default_callback(
 pub unsafe extern "C" fn dav1d_log(
     c: *mut Dav1dContext,
     format: *const libc::c_char,
-    mut args: ...
+    args: ...
 ) {
     if c.is_null() {
         fprintf(

--- a/src/log.rs
+++ b/src/log.rs
@@ -534,11 +534,7 @@ pub unsafe extern "C" fn dav1d_log_default_callback(
 }
 #[no_mangle]
 #[cold]
-pub unsafe extern "C" fn dav1d_log(
-    c: *mut Dav1dContext,
-    format: *const libc::c_char,
-    args: ...
-) {
+pub unsafe extern "C" fn dav1d_log(c: *mut Dav1dContext, format: *const libc::c_char, args: ...) {
     if c.is_null() {
         fprintf(
             stderr,

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -27,6 +27,51 @@ pub struct Dav1dLoopFilterDSPContext {
     any(target_arch = "x86", target_arch = "x86_64"),
 ))]
 extern "C" {
+    pub(crate) fn dav1d_lpf_v_sb_uv_8bpc_ssse3(
+        dst: *mut DynPixel,
+        stride: ptrdiff_t,
+        mask: *const uint32_t,
+        lvl: *const [uint8_t; 4],
+        lvl_stride: ptrdiff_t,
+        lut: *const Av1FilterLUT,
+        w: libc::c_int,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_lpf_h_sb_uv_8bpc_ssse3(
+        dst: *mut DynPixel,
+        stride: ptrdiff_t,
+        mask: *const uint32_t,
+        lvl: *const [uint8_t; 4],
+        lvl_stride: ptrdiff_t,
+        lut: *const Av1FilterLUT,
+        w: libc::c_int,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_lpf_v_sb_y_8bpc_ssse3(
+        dst: *mut DynPixel,
+        stride: ptrdiff_t,
+        mask: *const uint32_t,
+        lvl: *const [uint8_t; 4],
+        lvl_stride: ptrdiff_t,
+        lut: *const Av1FilterLUT,
+        w: libc::c_int,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_lpf_h_sb_y_8bpc_ssse3(
+        dst: *mut DynPixel,
+        stride: ptrdiff_t,
+        mask: *const uint32_t,
+        lvl: *const [uint8_t; 4],
+        lvl_stride: ptrdiff_t,
+        lut: *const Av1FilterLUT,
+        w: libc::c_int,
+        bitdepth_max: libc::c_int,
+    );
+}
+
+// TODO(legare): Temporarily pub until init fns have been deduplicated.
+#[cfg(all(feature = "asm", feature = "bitdepth_8", target_arch = "x86_64",))]
+extern "C" {
     pub(crate) fn dav1d_lpf_v_sb_uv_8bpc_avx512icl(
         dst: *mut DynPixel,
         stride: ptrdiff_t,
@@ -107,46 +152,6 @@ extern "C" {
         w: libc::c_int,
         bitdepth_max: libc::c_int,
     );
-    pub(crate) fn dav1d_lpf_v_sb_uv_8bpc_ssse3(
-        dst: *mut DynPixel,
-        stride: ptrdiff_t,
-        mask: *const uint32_t,
-        lvl: *const [uint8_t; 4],
-        lvl_stride: ptrdiff_t,
-        lut: *const Av1FilterLUT,
-        w: libc::c_int,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_lpf_h_sb_uv_8bpc_ssse3(
-        dst: *mut DynPixel,
-        stride: ptrdiff_t,
-        mask: *const uint32_t,
-        lvl: *const [uint8_t; 4],
-        lvl_stride: ptrdiff_t,
-        lut: *const Av1FilterLUT,
-        w: libc::c_int,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_lpf_v_sb_y_8bpc_ssse3(
-        dst: *mut DynPixel,
-        stride: ptrdiff_t,
-        mask: *const uint32_t,
-        lvl: *const [uint8_t; 4],
-        lvl_stride: ptrdiff_t,
-        lut: *const Av1FilterLUT,
-        w: libc::c_int,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_lpf_h_sb_y_8bpc_ssse3(
-        dst: *mut DynPixel,
-        stride: ptrdiff_t,
-        mask: *const uint32_t,
-        lvl: *const [uint8_t; 4],
-        lvl_stride: ptrdiff_t,
-        lut: *const Av1FilterLUT,
-        w: libc::c_int,
-        bitdepth_max: libc::c_int,
-    );
 }
 
 // TODO(legare): Temporarily pub until init fns have been deduplicated.
@@ -204,6 +209,51 @@ extern "C" {
     feature = "bitdepth_16",
     any(target_arch = "x86", target_arch = "x86_64"),
 ))]
+extern "C" {
+    pub(crate) fn dav1d_lpf_v_sb_uv_16bpc_ssse3(
+        dst: *mut DynPixel,
+        stride: ptrdiff_t,
+        mask: *const uint32_t,
+        lvl: *const [uint8_t; 4],
+        lvl_stride: ptrdiff_t,
+        lut: *const Av1FilterLUT,
+        w: libc::c_int,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_lpf_h_sb_uv_16bpc_ssse3(
+        dst: *mut DynPixel,
+        stride: ptrdiff_t,
+        mask: *const uint32_t,
+        lvl: *const [uint8_t; 4],
+        lvl_stride: ptrdiff_t,
+        lut: *const Av1FilterLUT,
+        w: libc::c_int,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_lpf_v_sb_y_16bpc_ssse3(
+        dst: *mut DynPixel,
+        stride: ptrdiff_t,
+        mask: *const uint32_t,
+        lvl: *const [uint8_t; 4],
+        lvl_stride: ptrdiff_t,
+        lut: *const Av1FilterLUT,
+        w: libc::c_int,
+        bitdepth_max: libc::c_int,
+    );
+    pub(crate) fn dav1d_lpf_h_sb_y_16bpc_ssse3(
+        dst: *mut DynPixel,
+        stride: ptrdiff_t,
+        mask: *const uint32_t,
+        lvl: *const [uint8_t; 4],
+        lvl_stride: ptrdiff_t,
+        lut: *const Av1FilterLUT,
+        w: libc::c_int,
+        bitdepth_max: libc::c_int,
+    );
+}
+
+// TODO(legare): Temporarily pub until init fns are deduplicated.
+#[cfg(all(feature = "asm", feature = "bitdepth_16", target_arch = "x86_64",))]
 extern "C" {
     pub(crate) fn dav1d_lpf_v_sb_uv_16bpc_avx512icl(
         dst: *mut DynPixel,
@@ -276,46 +326,6 @@ extern "C" {
         bitdepth_max: libc::c_int,
     );
     pub(crate) fn dav1d_lpf_h_sb_y_16bpc_avx2(
-        dst: *mut DynPixel,
-        stride: ptrdiff_t,
-        mask: *const uint32_t,
-        lvl: *const [uint8_t; 4],
-        lvl_stride: ptrdiff_t,
-        lut: *const Av1FilterLUT,
-        w: libc::c_int,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_lpf_v_sb_uv_16bpc_ssse3(
-        dst: *mut DynPixel,
-        stride: ptrdiff_t,
-        mask: *const uint32_t,
-        lvl: *const [uint8_t; 4],
-        lvl_stride: ptrdiff_t,
-        lut: *const Av1FilterLUT,
-        w: libc::c_int,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_lpf_h_sb_uv_16bpc_ssse3(
-        dst: *mut DynPixel,
-        stride: ptrdiff_t,
-        mask: *const uint32_t,
-        lvl: *const [uint8_t; 4],
-        lvl_stride: ptrdiff_t,
-        lut: *const Av1FilterLUT,
-        w: libc::c_int,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_lpf_v_sb_y_16bpc_ssse3(
-        dst: *mut DynPixel,
-        stride: ptrdiff_t,
-        mask: *const uint32_t,
-        lvl: *const [uint8_t; 4],
-        lvl_stride: ptrdiff_t,
-        lut: *const Av1FilterLUT,
-        w: libc::c_int,
-        bitdepth_max: libc::c_int,
-    );
-    pub(crate) fn dav1d_lpf_h_sb_y_16bpc_ssse3(
         dst: *mut DynPixel,
         stride: ptrdiff_t,
         mask: *const uint32_t,

--- a/src/loopfilter_tmpl_16.rs
+++ b/src/loopfilter_tmpl_16.rs
@@ -50,7 +50,7 @@ unsafe extern "C" fn loop_filter(
         let mut q4 = 0;
         let mut q5 = 0;
         let mut q6 = 0;
-        let mut fm = 0;
+        let mut fm;
         let mut flat8out = 0;
         let mut flat8in = 0;
         fm = ((p1 - p0).abs() <= I
@@ -157,8 +157,8 @@ unsafe extern "C" fn loop_filter(
                         -(128 as libc::c_int) * ((1 as libc::c_int) << bitdepth_min_8),
                         128 * ((1 as libc::c_int) << bitdepth_min_8) - 1,
                     );
-                    let mut f1 = 0;
-                    let mut f2 = 0;
+                    let f1;
+                    let f2;
                     f = iclip(
                         3 * (q0 - p0) + f,
                         -(128 as libc::c_int) * ((1 as libc::c_int) << bitdepth_min_8),
@@ -176,8 +176,8 @@ unsafe extern "C" fn loop_filter(
                         -(128 as libc::c_int) * ((1 as libc::c_int) << bitdepth_min_8),
                         128 * ((1 as libc::c_int) << bitdepth_min_8) - 1,
                     );
-                    let mut f1_0 = 0;
-                    let mut f2_0 = 0;
+                    let f1_0;
+                    let f2_0;
                     f1_0 = imin(f_0 + 4, ((128 as libc::c_int) << bitdepth_min_8) - 1) >> 3;
                     f2_0 = imin(f_0 + 3, ((128 as libc::c_int) << bitdepth_min_8) - 1) >> 3;
                     *dst.offset(strideb * -(1 as libc::c_int) as isize) =

--- a/src/loopfilter_tmpl_16.rs
+++ b/src/loopfilter_tmpl_16.rs
@@ -41,10 +41,10 @@ unsafe extern "C" fn loop_filter(
         let mut p4 = 0;
         let mut p3 = 0;
         let mut p2 = 0;
-        let mut p1 = *dst.offset(strideb * -(2 as libc::c_int) as isize) as libc::c_int;
-        let mut p0 = *dst.offset(strideb * -(1 as libc::c_int) as isize) as libc::c_int;
-        let mut q0 = *dst.offset((strideb * 0) as isize) as libc::c_int;
-        let mut q1 = *dst.offset((strideb * 1) as isize) as libc::c_int;
+        let p1 = *dst.offset(strideb * -(2 as libc::c_int) as isize) as libc::c_int;
+        let p0 = *dst.offset(strideb * -(1 as libc::c_int) as isize) as libc::c_int;
+        let q0 = *dst.offset((strideb * 0) as isize) as libc::c_int;
+        let q1 = *dst.offset((strideb * 1) as isize) as libc::c_int;
         let mut q2 = 0;
         let mut q3 = 0;
         let mut q4 = 0;
@@ -222,8 +222,8 @@ unsafe extern "C" fn loop_filter_h_sb128y_rust(
     stride: ptrdiff_t,
     vmask: *const uint32_t,
     mut l: *const [uint8_t; 4],
-    mut b4_stride: ptrdiff_t,
-    mut lut: *const Av1FilterLUT,
+    b4_stride: ptrdiff_t,
+    lut: *const Av1FilterLUT,
     _h: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
@@ -288,8 +288,8 @@ unsafe extern "C" fn loop_filter_v_sb128y_rust(
     stride: ptrdiff_t,
     vmask: *const uint32_t,
     mut l: *const [uint8_t; 4],
-    mut b4_stride: ptrdiff_t,
-    mut lut: *const Av1FilterLUT,
+    b4_stride: ptrdiff_t,
+    lut: *const Av1FilterLUT,
     _w: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
@@ -354,8 +354,8 @@ unsafe extern "C" fn loop_filter_h_sb128uv_rust(
     stride: ptrdiff_t,
     vmask: *const uint32_t,
     mut l: *const [uint8_t; 4],
-    mut b4_stride: ptrdiff_t,
-    mut lut: *const Av1FilterLUT,
+    b4_stride: ptrdiff_t,
+    lut: *const Av1FilterLUT,
     _h: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
@@ -416,8 +416,8 @@ unsafe extern "C" fn loop_filter_v_sb128uv_rust(
     stride: ptrdiff_t,
     vmask: *const uint32_t,
     mut l: *const [uint8_t; 4],
-    mut b4_stride: ptrdiff_t,
-    mut lut: *const Av1FilterLUT,
+    b4_stride: ptrdiff_t,
+    lut: *const Av1FilterLUT,
     _w: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {

--- a/src/loopfilter_tmpl_8.rs
+++ b/src/loopfilter_tmpl_8.rs
@@ -33,10 +33,10 @@ unsafe extern "C" fn loop_filter(
         let mut p4 = 0;
         let mut p3 = 0;
         let mut p2 = 0;
-        let mut p1 = *dst.offset((strideb * -(2 as libc::c_int) as isize) as isize) as libc::c_int;
-        let mut p0 = *dst.offset((strideb * -(1 as libc::c_int) as isize) as isize) as libc::c_int;
-        let mut q0 = *dst.offset((strideb * 0) as isize) as libc::c_int;
-        let mut q1 = *dst.offset((strideb * 1) as isize) as libc::c_int;
+        let p1 = *dst.offset((strideb * -(2 as libc::c_int) as isize) as isize) as libc::c_int;
+        let p0 = *dst.offset((strideb * -(1 as libc::c_int) as isize) as isize) as libc::c_int;
+        let q0 = *dst.offset((strideb * 0) as isize) as libc::c_int;
+        let q1 = *dst.offset((strideb * 1) as isize) as libc::c_int;
         let mut q2 = 0;
         let mut q3 = 0;
         let mut q4 = 0;
@@ -204,8 +204,8 @@ unsafe fn loop_filter_h_sb128y_rust(
     stride: ptrdiff_t,
     vmask: *const uint32_t,
     mut l: *const [uint8_t; 4],
-    mut b4_stride: ptrdiff_t,
-    mut lut: *const Av1FilterLUT,
+    b4_stride: ptrdiff_t,
+    lut: *const Av1FilterLUT,
     _h: libc::c_int,
 ) {
     let vm: libc::c_uint = *vmask.offset(0) | *vmask.offset(1) | *vmask.offset(2);
@@ -261,8 +261,8 @@ unsafe fn loop_filter_v_sb128y_rust(
     stride: ptrdiff_t,
     vmask: *const uint32_t,
     mut l: *const [uint8_t; 4],
-    mut b4_stride: ptrdiff_t,
-    mut lut: *const Av1FilterLUT,
+    b4_stride: ptrdiff_t,
+    lut: *const Av1FilterLUT,
     _w: libc::c_int,
 ) {
     let vm: libc::c_uint = *vmask.offset(0) | *vmask.offset(1) | *vmask.offset(2);
@@ -318,8 +318,8 @@ unsafe fn loop_filter_h_sb128uv_rust(
     stride: ptrdiff_t,
     vmask: *const uint32_t,
     mut l: *const [uint8_t; 4],
-    mut b4_stride: ptrdiff_t,
-    mut lut: *const Av1FilterLUT,
+    b4_stride: ptrdiff_t,
+    lut: *const Av1FilterLUT,
     _h: libc::c_int,
 ) {
     let vm: libc::c_uint = *vmask.offset(0) | *vmask.offset(1);
@@ -371,8 +371,8 @@ unsafe extern "C" fn loop_filter_v_sb128uv_rust(
     stride: ptrdiff_t,
     vmask: *const uint32_t,
     mut l: *const [uint8_t; 4],
-    mut b4_stride: ptrdiff_t,
-    mut lut: *const Av1FilterLUT,
+    b4_stride: ptrdiff_t,
+    lut: *const Av1FilterLUT,
     _w: libc::c_int,
 ) {
     let vm: libc::c_uint = *vmask.offset(0) | *vmask.offset(1);

--- a/src/loopfilter_tmpl_8.rs
+++ b/src/loopfilter_tmpl_8.rs
@@ -42,7 +42,7 @@ unsafe extern "C" fn loop_filter(
         let mut q4 = 0;
         let mut q5 = 0;
         let mut q6 = 0;
-        let mut fm = 0;
+        let mut fm;
         let mut flat8out = 0;
         let mut flat8in = 0;
         fm = ((p1 - p0).abs() <= I
@@ -149,8 +149,8 @@ unsafe extern "C" fn loop_filter(
                         -(128 as libc::c_int) * ((1 as libc::c_int) << bitdepth_min_8),
                         128 * ((1 as libc::c_int) << bitdepth_min_8) - 1,
                     );
-                    let mut f1 = 0;
-                    let mut f2 = 0;
+                    let f1;
+                    let f2: i32;
                     f = iclip(
                         3 * (q0 - p0) + f,
                         -(128 as libc::c_int) * ((1 as libc::c_int) << bitdepth_min_8),
@@ -167,8 +167,8 @@ unsafe extern "C" fn loop_filter(
                         -(128 as libc::c_int) * ((1 as libc::c_int) << bitdepth_min_8),
                         128 * ((1 as libc::c_int) << bitdepth_min_8) - 1,
                     );
-                    let mut f1_0 = 0;
-                    let mut f2_0 = 0;
+                    let f1_0;
+                    let f2_0;
                     f1_0 = imin(f_0 + 4, ((128 as libc::c_int) << bitdepth_min_8) - 1) >> 3;
                     f2_0 = imin(f_0 + 3, ((128 as libc::c_int) << bitdepth_min_8) - 1) >> 3;
                     *dst.offset((strideb * -(1 as libc::c_int) as isize) as isize) =

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -236,8 +236,8 @@ unsafe fn padding<BD: BitDepth>(
     if !have_right {
         // Pad 3x(STRIPE_H+6) with last column
         for j in 0..stripe_h + 6 {
-            let mut row_last = dst_l[(unit_w - 1) + j * REST_UNIT_STRIDE];
-            let mut pad = &mut dst_l[unit_w + j * REST_UNIT_STRIDE..];
+            let row_last = dst_l[(unit_w - 1) + j * REST_UNIT_STRIDE];
+            let pad = &mut dst_l[unit_w + j * REST_UNIT_STRIDE..];
             BD::pixel_set(pad, row_last, 3);
         }
     }
@@ -389,14 +389,14 @@ unsafe fn wiener_rust<BD: BitDepth>(
 /// * c: Pixel summed not stored
 /// * x: Pixel not summed not stored
 fn boxsum3<BD: BitDepth>(
-    mut sumsq: &mut [int32_t; 68 /*(64 + 2 + 2)*/ * REST_UNIT_STRIDE],
-    mut sum: &mut [BD::Coef; 68 /*(64 + 2 + 2)*/ * REST_UNIT_STRIDE],
-    mut src: &[BD::Pixel; 70 /*(64 + 3 + 3)*/ * REST_UNIT_STRIDE],
+    sumsq: &mut [int32_t; 68 /*(64 + 2 + 2)*/ * REST_UNIT_STRIDE],
+    sum: &mut [BD::Coef; 68 /*(64 + 2 + 2)*/ * REST_UNIT_STRIDE],
+    src: &[BD::Pixel; 70 /*(64 + 3 + 3)*/ * REST_UNIT_STRIDE],
     w: libc::c_int,
     h: libc::c_int,
 ) {
     // We skip the first row, as it is never used
-    let mut src = &src[REST_UNIT_STRIDE..];
+    let src = &src[REST_UNIT_STRIDE..];
 
     // We skip the first and last columns, as they are never used
     for x in 1..w - 1 {
@@ -479,8 +479,8 @@ fn boxsum3<BD: BitDepth>(
 /// * c: Pixel summed not stored
 /// * x: Pixel not summed not stored
 fn boxsum5<BD: BitDepth>(
-    mut sumsq: &mut [int32_t; 68 /*(64 + 2 + 2)*/ * REST_UNIT_STRIDE],
-    mut sum: &mut [BD::Coef; 68 /*(64 + 2 + 2)*/ * REST_UNIT_STRIDE],
+    sumsq: &mut [int32_t; 68 /*(64 + 2 + 2)*/ * REST_UNIT_STRIDE],
+    sum: &mut [BD::Coef; 68 /*(64 + 2 + 2)*/ * REST_UNIT_STRIDE],
     src: &[BD::Pixel; 70 /*(64 + 3 + 3)*/ * REST_UNIT_STRIDE],
     w: libc::c_int,
     h: libc::c_int,
@@ -488,7 +488,7 @@ fn boxsum5<BD: BitDepth>(
     for x in 0..w as usize {
         let mut sum_v = &mut sum[x..];
         let mut sumsq_v = &mut sumsq[x..];
-        let mut s = &src[x..];
+        let s = &src[x..];
         let mut a: libc::c_int = (s[0]).as_();
         let mut a2 = a * a;
         let mut b: libc::c_int = (s[1 * REST_UNIT_STRIDE]).as_();
@@ -555,8 +555,8 @@ fn boxsum5<BD: BitDepth>(
 
 #[inline(never)]
 fn selfguided_filter<BD: BitDepth>(
-    mut dst: &mut [BD::Coef; 24576],
-    mut src: &[BD::Pixel; 27300],
+    dst: &mut [BD::Coef; 24576],
+    src: &[BD::Pixel; 27300],
     _src_stride: ptrdiff_t,
     w: libc::c_int,
     h: libc::c_int,
@@ -1038,7 +1038,7 @@ unsafe fn wiener_filter_neon<BD: BitDepth>(
 ) {
     let filter: *const [int16_t; 8] = (*params).filter.0.as_ptr();
     let mut mid: Align16<[int16_t; 68 * 384]> = Align16([0; 68 * 384]);
-    let mut mid_stride: libc::c_int = w + 7 & !7;
+    let mid_stride: libc::c_int = w + 7 & !7;
     dav1d_wiener_filter_h_neon(
         &mut mid.0[2 * mid_stride as usize..],
         left,
@@ -1703,7 +1703,7 @@ use crate::src::cpu::dav1d_get_cpu_flags;
 #[inline(always)]
 fn loop_restoration_dsp_init_arm<BD: BitDepth>(
     c: &mut Dav1dLoopRestorationDSPContext,
-    mut bpc: libc::c_int,
+    bpc: libc::c_int,
 ) {
     use crate::src::arm::cpu::DAV1D_ARM_CPU_FLAG_NEON;
 

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -568,7 +568,7 @@ unsafe extern "C" fn lr_stripe(
     f: *const Dav1dFrameContext,
     mut p: *mut pixel,
     mut left: *const [pixel; 4],
-    mut x: libc::c_int,
+    x: libc::c_int,
     mut y: libc::c_int,
     plane: libc::c_int,
     unit_w: libc::c_int,
@@ -596,7 +596,7 @@ unsafe extern "C" fn lr_stripe(
         )
         .offset(x as isize);
     let mut stripe_h = imin(64 - 8 * (y == 0) as libc::c_int >> ss_ver, row_h - y);
-    let mut lr_fn: looprestorationfilter_fn;
+    let lr_fn: looprestorationfilter_fn;
     let mut params: LooprestorationParams = LooprestorationParams {
         filter: [[0; 8]; 2].into(),
     };
@@ -810,7 +810,7 @@ unsafe extern "C" fn lr_sbrow(
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_lr_sbrow_16bpc(
     f: *mut Dav1dFrameContext,
-    mut dst: *const *mut pixel,
+    dst: *const *mut pixel,
     sby: libc::c_int,
 ) {
     let offset_y = 8 * (sby != 0) as libc::c_int;

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -546,7 +546,7 @@ unsafe extern "C" fn lr_stripe(
     f: *const Dav1dFrameContext,
     mut p: *mut pixel,
     mut left: *const [pixel; 4],
-    mut x: libc::c_int,
+    x: libc::c_int,
     mut y: libc::c_int,
     plane: libc::c_int,
     unit_w: libc::c_int,
@@ -574,7 +574,7 @@ unsafe extern "C" fn lr_stripe(
         )
         .offset(x as isize);
     let mut stripe_h = imin(64 - 8 * (y == 0) as libc::c_int >> ss_ver, row_h - y);
-    let mut lr_fn: looprestorationfilter_fn;
+    let lr_fn: looprestorationfilter_fn;
     let mut params: LooprestorationParams = LooprestorationParams {
         filter: [[0; 8]; 2].into(),
     };
@@ -786,7 +786,7 @@ unsafe extern "C" fn lr_sbrow(
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_lr_sbrow_8bpc(
     f: *mut Dav1dFrameContext,
-    mut dst: *const *mut pixel,
+    dst: *const *mut pixel,
     sby: libc::c_int,
 ) {
     let offset_y = 8 * (sby != 0) as libc::c_int;

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -38,8 +38,7 @@ pub unsafe fn prep_rust<BD: BitDepth>(
     bd: BD,
 ) {
     let tmp = std::slice::from_raw_parts_mut(tmp, w * h);
-    let src =
-        std::slice::from_raw_parts(src, if h == 0 { 0 } else { src_stride * (h - 1) + w });
+    let src = std::slice::from_raw_parts(src, if h == 0 { 0 } else { src_stride * (h - 1) + w });
     let intermediate_bits = bd.get_intermediate_bits();
     for (tmp, src) in iter::zip(tmp.chunks_exact_mut(w), src.chunks(src_stride)).take(h) {
         for (tmp, src) in iter::zip(tmp, &src[..w]) {

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -20,8 +20,8 @@ pub unsafe fn put_rust<BD: BitDepth>(
 ) {
     let [dst_len, src_len] =
         [dst_stride, src_stride].map(|stride| if h == 0 { 0 } else { stride * (h - 1) + w });
-    let mut dst = std::slice::from_raw_parts_mut(dst, dst_len);
-    let mut src = std::slice::from_raw_parts(src, src_len);
+    let dst = std::slice::from_raw_parts_mut(dst, dst_len);
+    let src = std::slice::from_raw_parts(src, src_len);
     for (dst, src) in iter::zip(dst.chunks_mut(dst_stride), src.chunks(src_stride)) {
         BD::pixel_copy(dst, src, w);
     }
@@ -30,15 +30,15 @@ pub unsafe fn put_rust<BD: BitDepth>(
 // TODO(kkysen) temporarily `pub` until `mc` callers are deduplicated
 #[inline(never)]
 pub unsafe fn prep_rust<BD: BitDepth>(
-    mut tmp: *mut i16,
-    mut src: *const BD::Pixel,
+    tmp: *mut i16,
+    src: *const BD::Pixel,
     src_stride: usize,
     w: usize,
     h: usize,
     bd: BD,
 ) {
-    let mut tmp = std::slice::from_raw_parts_mut(tmp, w * h);
-    let mut src =
+    let tmp = std::slice::from_raw_parts_mut(tmp, w * h);
+    let src =
         std::slice::from_raw_parts(src, if h == 0 { 0 } else { src_stride * (h - 1) + w });
     let intermediate_bits = bd.get_intermediate_bits();
     for (tmp, src) in iter::zip(tmp.chunks_exact_mut(w), src.chunks(src_stride)).take(h) {
@@ -220,12 +220,12 @@ pub unsafe fn put_8tap_rust<BD: BitDepth>(
 // TODO(kkysen) temporarily `pub` until `mc` callers are deduplicated
 #[inline(never)]
 pub unsafe fn put_8tap_scaled_rust<BD: BitDepth>(
-    mut dst: *mut BD::Pixel,
+    dst: *mut BD::Pixel,
     dst_stride: usize,
     mut src: *const BD::Pixel,
     src_stride: usize,
     w: usize,
-    mut h: usize,
+    h: usize,
     mx: usize,
     mut my: usize,
     dx: usize,
@@ -365,7 +365,7 @@ pub unsafe fn prep_8tap_scaled_rust<BD: BitDepth>(
     src_stride: usize,
     w: usize,
     h: usize,
-    mut mx: usize,
+    mx: usize,
     mut my: usize,
     dx: usize,
     dy: usize,
@@ -508,12 +508,12 @@ pub unsafe fn put_bilin_rust<BD: BitDepth>(
 // TODO(kkysen) temporarily `pub` until `mc` callers are deduplicated
 pub unsafe fn put_bilin_scaled_rust<BD: BitDepth>(
     mut dst: *mut BD::Pixel,
-    mut dst_stride: usize,
+    dst_stride: usize,
     mut src: *const BD::Pixel,
-    mut src_stride: usize,
+    src_stride: usize,
     w: usize,
     h: usize,
-    mut mx: usize,
+    mx: usize,
     mut my: usize,
     dx: usize,
     dy: usize,
@@ -626,7 +626,7 @@ pub unsafe fn prep_bilin_scaled_rust<BD: BitDepth>(
     src_stride: usize,
     w: usize,
     h: usize,
-    mut mx: usize,
+    mx: usize,
     mut my: usize,
     dx: usize,
     dy: usize,
@@ -634,7 +634,7 @@ pub unsafe fn prep_bilin_scaled_rust<BD: BitDepth>(
 ) {
     let intermediate_bits = bd.get_intermediate_bits();
     let src_stride = BD::pxstride(src_stride);
-    let mut tmp_h = ((h - 1) * dy + my >> 10) + 2;
+    let tmp_h = ((h - 1) * dy + my >> 10) + 2;
     let mut mid = [0i16; 128 * (256 + 1)];
     let mut mid_ptr = &mut mid[..];
 

--- a/src/mc_tmpl_16.rs
+++ b/src/mc_tmpl_16.rs
@@ -2951,12 +2951,12 @@ unsafe extern "C" fn prep_8tap_sharp_smooth_scaled_c(
 }
 use crate::src::mc::put_bilin_rust;
 unsafe extern "C" fn put_bilin_c(
-    mut dst: *mut pixel,
-    mut dst_stride: ptrdiff_t,
-    mut src: *const pixel,
-    mut src_stride: ptrdiff_t,
+    dst: *mut pixel,
+    dst_stride: ptrdiff_t,
+    src: *const pixel,
+    src_stride: ptrdiff_t,
     w: libc::c_int,
-    mut h: libc::c_int,
+    h: libc::c_int,
     mx: libc::c_int,
     my: libc::c_int,
     bitdepth_max: libc::c_int,
@@ -2975,14 +2975,14 @@ unsafe extern "C" fn put_bilin_c(
 }
 use crate::src::mc::put_bilin_scaled_rust;
 unsafe extern "C" fn put_bilin_scaled_c(
-    mut dst: *mut pixel,
-    mut dst_stride: ptrdiff_t,
-    mut src: *const pixel,
-    mut src_stride: ptrdiff_t,
+    dst: *mut pixel,
+    dst_stride: ptrdiff_t,
+    src: *const pixel,
+    src_stride: ptrdiff_t,
     w: libc::c_int,
-    mut h: libc::c_int,
+    h: libc::c_int,
     mx: libc::c_int,
-    mut my: libc::c_int,
+    my: libc::c_int,
     dx: libc::c_int,
     dy: libc::c_int,
     bitdepth_max: libc::c_int,
@@ -3003,11 +3003,11 @@ unsafe extern "C" fn put_bilin_scaled_c(
 }
 use crate::src::mc::prep_bilin_rust;
 unsafe extern "C" fn prep_bilin_c(
-    mut tmp: *mut int16_t,
-    mut src: *const pixel,
-    mut src_stride: ptrdiff_t,
+    tmp: *mut int16_t,
+    src: *const pixel,
+    src_stride: ptrdiff_t,
     w: libc::c_int,
-    mut h: libc::c_int,
+    h: libc::c_int,
     mx: libc::c_int,
     my: libc::c_int,
     bitdepth_max: libc::c_int,
@@ -3025,13 +3025,13 @@ unsafe extern "C" fn prep_bilin_c(
 }
 use crate::src::mc::prep_bilin_scaled_rust;
 unsafe extern "C" fn prep_bilin_scaled_c(
-    mut tmp: *mut int16_t,
-    mut src: *const pixel,
-    mut src_stride: ptrdiff_t,
+    tmp: *mut int16_t,
+    src: *const pixel,
+    src_stride: ptrdiff_t,
     w: libc::c_int,
-    mut h: libc::c_int,
+    h: libc::c_int,
     mx: libc::c_int,
-    mut my: libc::c_int,
+    my: libc::c_int,
     dx: libc::c_int,
     dy: libc::c_int,
     bitdepth_max: libc::c_int,
@@ -3051,12 +3051,12 @@ unsafe extern "C" fn prep_bilin_scaled_c(
 }
 use crate::src::mc::avg_rust;
 unsafe extern "C" fn avg_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     dst_stride: ptrdiff_t,
-    mut tmp1: *const int16_t,
-    mut tmp2: *const int16_t,
+    tmp1: *const int16_t,
+    tmp2: *const int16_t,
     w: libc::c_int,
-    mut h: libc::c_int,
+    h: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
     avg_rust(
@@ -3180,7 +3180,7 @@ unsafe extern "C" fn w_mask_444_c(
     tmp2: *const int16_t,
     w: libc::c_int,
     h: libc::c_int,
-    mut mask: *mut uint8_t,
+    mask: *mut uint8_t,
     sign: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
@@ -3205,7 +3205,7 @@ unsafe extern "C" fn w_mask_422_c(
     tmp2: *const int16_t,
     w: libc::c_int,
     h: libc::c_int,
-    mut mask: *mut uint8_t,
+    mask: *mut uint8_t,
     sign: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
@@ -3230,7 +3230,7 @@ unsafe extern "C" fn w_mask_420_c(
     tmp2: *const int16_t,
     w: libc::c_int,
     h: libc::c_int,
-    mut mask: *mut uint8_t,
+    mask: *mut uint8_t,
     sign: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {

--- a/src/mc_tmpl_16.rs
+++ b/src/mc_tmpl_16.rs
@@ -5,9 +5,6 @@ use crate::include::stdint::*;
 use ::libc;
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
-extern "C" {
-    fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
-}
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 extern "C" {

--- a/src/mc_tmpl_16.rs
+++ b/src/mc_tmpl_16.rs
@@ -6,6 +6,7 @@ use ::libc;
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
 
+#[cfg_attr(target_arch = "x86", allow(dead_code))] // TODO(kkysen) Will be easier to fix after #416.
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 extern "C" {
     fn dav1d_put_8tap_regular_16bpc_ssse3(

--- a/src/mc_tmpl_8.rs
+++ b/src/mc_tmpl_8.rs
@@ -2875,12 +2875,12 @@ unsafe extern "C" fn put_8tap_sharp_smooth_scaled_c(
 }
 use crate::src::mc::put_bilin_rust;
 unsafe extern "C" fn put_bilin_c(
-    mut dst: *mut pixel,
-    mut dst_stride: ptrdiff_t,
-    mut src: *const pixel,
-    mut src_stride: ptrdiff_t,
+    dst: *mut pixel,
+    dst_stride: ptrdiff_t,
+    src: *const pixel,
+    src_stride: ptrdiff_t,
     w: libc::c_int,
-    mut h: libc::c_int,
+    h: libc::c_int,
     mx: libc::c_int,
     my: libc::c_int,
 ) {
@@ -2898,14 +2898,14 @@ unsafe extern "C" fn put_bilin_c(
 }
 use crate::src::mc::put_bilin_scaled_rust;
 unsafe extern "C" fn put_bilin_scaled_c(
-    mut dst: *mut pixel,
-    mut dst_stride: ptrdiff_t,
-    mut src: *const pixel,
-    mut src_stride: ptrdiff_t,
+    dst: *mut pixel,
+    dst_stride: ptrdiff_t,
+    src: *const pixel,
+    src_stride: ptrdiff_t,
     w: libc::c_int,
-    mut h: libc::c_int,
+    h: libc::c_int,
     mx: libc::c_int,
-    mut my: libc::c_int,
+    my: libc::c_int,
     dx: libc::c_int,
     dy: libc::c_int,
 ) {
@@ -2925,11 +2925,11 @@ unsafe extern "C" fn put_bilin_scaled_c(
 }
 use crate::src::mc::prep_bilin_rust;
 unsafe extern "C" fn prep_bilin_c(
-    mut tmp: *mut int16_t,
-    mut src: *const pixel,
-    mut src_stride: ptrdiff_t,
+    tmp: *mut int16_t,
+    src: *const pixel,
+    src_stride: ptrdiff_t,
     w: libc::c_int,
-    mut h: libc::c_int,
+    h: libc::c_int,
     mx: libc::c_int,
     my: libc::c_int,
 ) {
@@ -2946,13 +2946,13 @@ unsafe extern "C" fn prep_bilin_c(
 }
 use crate::src::mc::prep_bilin_scaled_rust;
 unsafe extern "C" fn prep_bilin_scaled_c(
-    mut tmp: *mut int16_t,
-    mut src: *const pixel,
-    mut src_stride: ptrdiff_t,
+    tmp: *mut int16_t,
+    src: *const pixel,
+    src_stride: ptrdiff_t,
     w: libc::c_int,
-    mut h: libc::c_int,
+    h: libc::c_int,
     mx: libc::c_int,
-    mut my: libc::c_int,
+    my: libc::c_int,
     dx: libc::c_int,
     dy: libc::c_int,
 ) {
@@ -2971,12 +2971,12 @@ unsafe extern "C" fn prep_bilin_scaled_c(
 }
 use crate::src::mc::avg_rust;
 unsafe extern "C" fn avg_c(
-    mut dst: *mut pixel,
+    dst: *mut pixel,
     dst_stride: ptrdiff_t,
-    mut tmp1: *const int16_t,
-    mut tmp2: *const int16_t,
+    tmp1: *const int16_t,
+    tmp2: *const int16_t,
     w: libc::c_int,
-    mut h: libc::c_int,
+    h: libc::c_int,
 ) {
     avg_rust(
         dst,
@@ -3096,7 +3096,7 @@ unsafe extern "C" fn w_mask_444_c(
     tmp2: *const int16_t,
     w: libc::c_int,
     h: libc::c_int,
-    mut mask: *mut uint8_t,
+    mask: *mut uint8_t,
     sign: libc::c_int,
 ) {
     w_mask_c(dst, dst_stride, tmp1, tmp2, w, h, mask, sign, false, false)
@@ -3108,7 +3108,7 @@ unsafe extern "C" fn w_mask_422_c(
     tmp2: *const int16_t,
     w: libc::c_int,
     h: libc::c_int,
-    mut mask: *mut uint8_t,
+    mask: *mut uint8_t,
     sign: libc::c_int,
 ) {
     w_mask_c(dst, dst_stride, tmp1, tmp2, w, h, mask, sign, true, false)
@@ -3120,7 +3120,7 @@ unsafe extern "C" fn w_mask_420_c(
     tmp2: *const int16_t,
     w: libc::c_int,
     h: libc::c_int,
-    mut mask: *mut uint8_t,
+    mask: *mut uint8_t,
     sign: libc::c_int,
 ) {
     w_mask_c(dst, dst_stride, tmp1, tmp2, w, h, mask, sign, true, true)

--- a/src/mc_tmpl_8.rs
+++ b/src/mc_tmpl_8.rs
@@ -5,10 +5,6 @@ use crate::include::stdint::*;
 use ::libc;
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
-extern "C" {
-    fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
-    fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong) -> *mut libc::c_void;
-}
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 extern "C" {

--- a/src/mc_tmpl_8.rs
+++ b/src/mc_tmpl_8.rs
@@ -6,6 +6,7 @@ use ::libc;
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
 
+#[cfg_attr(target_arch = "x86", allow(dead_code))] // TODO(kkysen) Will be easier to fix after #416.
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 extern "C" {
     fn dav1d_put_8tap_regular_8bpc_ssse3(

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -33,8 +33,8 @@ use libc::pthread_mutexattr_t;
 
 #[inline]
 pub unsafe extern "C" fn dav1d_alloc_aligned(
-    mut sz: size_t,
-    mut align: size_t,
+    sz: size_t,
+    align: size_t,
 ) -> *mut libc::c_void {
     if align & align.wrapping_sub(1) != 0 {
         unreachable!();
@@ -47,13 +47,13 @@ pub unsafe extern "C" fn dav1d_alloc_aligned(
 }
 
 #[inline]
-pub unsafe extern "C" fn dav1d_free_aligned(mut ptr: *mut libc::c_void) {
+pub unsafe extern "C" fn dav1d_free_aligned(ptr: *mut libc::c_void) {
     free(ptr);
 }
 
 #[inline]
-pub unsafe extern "C" fn dav1d_freep_aligned(mut ptr: *mut libc::c_void) {
-    let mut mem: *mut *mut libc::c_void = ptr as *mut *mut libc::c_void;
+pub unsafe extern "C" fn dav1d_freep_aligned(ptr: *mut libc::c_void) {
+    let mem: *mut *mut libc::c_void = ptr as *mut *mut libc::c_void;
     if !(*mem).is_null() {
         dav1d_free_aligned(*mem);
         *mem = 0 as *mut libc::c_void;
@@ -61,8 +61,8 @@ pub unsafe extern "C" fn dav1d_freep_aligned(mut ptr: *mut libc::c_void) {
 }
 
 #[inline]
-pub unsafe extern "C" fn freep(mut ptr: *mut libc::c_void) {
-    let mut mem: *mut *mut libc::c_void = ptr as *mut *mut libc::c_void;
+pub unsafe extern "C" fn freep(ptr: *mut libc::c_void) {
+    let mem: *mut *mut libc::c_void = ptr as *mut *mut libc::c_void;
     if !(*mem).is_null() {
         free(*mem);
         *mem = 0 as *mut libc::c_void;
@@ -103,7 +103,7 @@ pub unsafe fn dav1d_mem_pool_pop(pool: *mut Dav1dMemPool, size: size_t) -> *mut 
     let mut buf: *mut Dav1dMemPoolBuffer = (*pool).buf;
     (*pool).ref_cnt += 1;
     let mut data: *mut uint8_t = 0 as *mut uint8_t;
-    let mut current_block_20: u64;
+    let current_block_20: u64;
     if !buf.is_null() {
         (*pool).buf = (*buf).next;
         pthread_mutex_unlock(&mut (*pool).lock);

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -32,10 +32,7 @@ pub struct Dav1dMemPoolBuffer {
 use libc::pthread_mutexattr_t;
 
 #[inline]
-pub unsafe extern "C" fn dav1d_alloc_aligned(
-    sz: size_t,
-    align: size_t,
-) -> *mut libc::c_void {
+pub unsafe extern "C" fn dav1d_alloc_aligned(sz: size_t, align: size_t) -> *mut libc::c_void {
     if align & align.wrapping_sub(1) != 0 {
         unreachable!();
     }
@@ -102,7 +99,7 @@ pub unsafe fn dav1d_mem_pool_pop(pool: *mut Dav1dMemPool, size: size_t) -> *mut 
     pthread_mutex_lock(&mut (*pool).lock);
     let mut buf: *mut Dav1dMemPoolBuffer = (*pool).buf;
     (*pool).ref_cnt += 1;
-    let mut data: *mut uint8_t = 0 as *mut uint8_t;
+    let mut data: *mut uint8_t;
     let current_block_20: u64;
     if !buf.is_null() {
         (*pool).buf = (*buf).next;

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -175,6 +175,10 @@ fn ctx_norm(s: &mut MsacContext, dif: ec_win, rng: libc::c_uint) {
     }
 }
 
+#[cfg_attr(
+    all(feature = "asm", any(target_arch = "x86_64", target_arch = "aarch64")),
+    allow(dead_code)
+)]
 fn dav1d_msac_decode_bool_equi_rust(s: &mut MsacContext) -> bool {
     let r = s.rng;
     let mut dif = s.dif;
@@ -188,6 +192,10 @@ fn dav1d_msac_decode_bool_equi_rust(s: &mut MsacContext) -> bool {
     !ret
 }
 
+#[cfg_attr(
+    all(feature = "asm", any(target_arch = "x86_64", target_arch = "aarch64")),
+    allow(dead_code)
+)]
 fn dav1d_msac_decode_bool_rust(s: &mut MsacContext, f: libc::c_uint) -> bool {
     let r = s.rng;
     let mut dif = s.dif;
@@ -266,6 +274,7 @@ fn dav1d_msac_decode_symbol_adapt_rust(
     val
 }
 
+#[cfg_attr(not(all(feature = "asm", target_arch = "x86_64")), allow(dead_code))]
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn dav1d_msac_decode_symbol_adapt_c(
     s: &mut MsacContext,
@@ -282,6 +291,10 @@ unsafe extern "C" fn dav1d_msac_decode_symbol_adapt_c(
     dav1d_msac_decode_symbol_adapt_rust(s, cdf, n_symbols)
 }
 
+#[cfg_attr(
+    all(feature = "asm", any(target_arch = "x86_64", target_arch = "aarch64")),
+    allow(dead_code)
+)]
 fn dav1d_msac_decode_bool_adapt_rust(s: &mut MsacContext, cdf: &mut [u16; 2]) -> bool {
     let bit = dav1d_msac_decode_bool(s, cdf[0] as libc::c_uint);
     if s.allow_update_cdf() {
@@ -297,6 +310,10 @@ fn dav1d_msac_decode_bool_adapt_rust(s: &mut MsacContext, cdf: &mut [u16; 2]) ->
     bit
 }
 
+#[cfg_attr(
+    all(feature = "asm", any(target_arch = "x86_64", target_arch = "aarch64")),
+    allow(dead_code)
+)]
 fn dav1d_msac_decode_hi_tok_rust(s: &mut MsacContext, cdf: &mut [u16; 4]) -> libc::c_uint {
     let mut tok_br = dav1d_msac_decode_symbol_adapt4(s, cdf, 3);
     let mut tok = 3 + tok_br;

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -230,7 +230,7 @@ fn dav1d_msac_decode_symbol_adapt_rust(
 ) -> libc::c_uint {
     let c = (s.dif >> (EC_WIN_SIZE - 16)) as libc::c_uint;
     let r = s.rng >> 8;
-    let mut u = 0;
+    let mut u;
     let mut v = s.rng;
     let mut val = 0;
     assert!(n_symbols <= 15);

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -637,8 +637,8 @@ unsafe extern "C" fn parse_seq_hdr(
     gb: *mut GetBits,
     hdr: *mut Dav1dSequenceHeader,
 ) -> libc::c_int {
-    let mut op_idx = 0;
-    let mut spatial_mask: libc::c_uint = 0;
+    let op_idx;
+    let spatial_mask: libc::c_uint;
     let mut current_block: u64;
     memset(
         hdr as *mut libc::c_void,
@@ -1058,7 +1058,7 @@ unsafe extern "C" fn read_frame_size(
 }
 #[inline]
 unsafe extern "C" fn tile_log2(sz: libc::c_int, tgt: libc::c_int) -> libc::c_int {
-    let mut k = 0;
+    let mut k;
     k = 0 as libc::c_int;
     while sz << k < tgt {
         k += 1;
@@ -1082,14 +1082,14 @@ static mut default_mode_ref_deltas: Dav1dLoopfilterModeRefDeltas = {
     init
 };
 unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> libc::c_int {
-    let mut sbsz_min1 = 0;
-    let mut sbsz_log2 = 0;
-    let mut sbw = 0;
-    let mut sbh = 0;
-    let mut max_tile_width_sb = 0;
-    let mut max_tile_area_sb = 0;
-    let mut min_log2_tiles = 0;
-    let mut delta_lossless = 0;
+    let sbsz_min1;
+    let sbsz_log2;
+    let sbw;
+    let sbh;
+    let max_tile_width_sb;
+    let max_tile_area_sb;
+    let min_log2_tiles;
+    let delta_lossless;
     let mut current_block: u64;
     let seqhdr: *const Dav1dSequenceHeader = (*c).seq_hdr;
     let hdr: *mut Dav1dFrameHeader = (*c).frame_hdr;
@@ -2207,8 +2207,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                                             == DAV1D_WM_TYPE_IDENTITY as libc::c_int
                                                                 as libc::c_uint)
                                                         {
-                                                            let mut ref_gmv: *const Dav1dWarpedMotionParams = 0
-                                                                as *const Dav1dWarpedMotionParams;
+                                                            let  ref_gmv: *const Dav1dWarpedMotionParams ;
                                                             if (*hdr).primary_ref_frame == 7 {
                                                                 ref_gmv = &dav1d_default_wm_params;
                                                             } else {
@@ -2241,8 +2240,8 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                                                     .as_mut_ptr();
                                                             let ref_mat: *const int32_t =
                                                                 ((*ref_gmv).matrix).as_ptr();
-                                                            let mut bits = 0;
-                                                            let mut shift = 0;
+                                                            let bits;
+                                                            let shift;
                                                             if (*hdr).gmv[i_19 as usize].type_0
                                                                 as libc::c_uint
                                                                 >= DAV1D_WM_TYPE_ROT_ZOOM
@@ -2362,7 +2361,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                                                                     3 as libc::c_int,
                                                                 )
                                                                     as libc::c_int;
-                                                                let mut i_20 = 0;
+                                                                let mut i_20;
                                                                 i_20 = 0 as libc::c_int;
                                                                 while i_20 < 7 {
                                                                     if (*hdr).refidx[i_20 as usize]
@@ -2695,8 +2694,8 @@ pub unsafe extern "C" fn dav1d_parse_obus(
     in_0: *mut Dav1dData,
     global: libc::c_int,
 ) -> libc::c_int {
-    let mut init_bit_pos: libc::c_uint = 0;
-    let mut init_byte_pos: libc::c_uint = 0;
+    let init_bit_pos: libc::c_uint;
+    let init_byte_pos: libc::c_uint;
     let mut current_block: u64;
     let mut gb: GetBits = GetBits {
         state: 0,
@@ -2706,7 +2705,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
         ptr_start: 0 as *const uint8_t,
         ptr_end: 0 as *const uint8_t,
     };
-    let mut res = 0;
+    let mut res;
     dav1d_init_get_bits(&mut gb, (*in_0).data, (*in_0).sz);
     dav1d_get_bit(&mut gb);
     let type_0: Dav1dObuType = dav1d_get_bits(&mut gb, 4 as libc::c_int) as Dav1dObuType;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -627,7 +627,7 @@ use crate::src::getbits::GetBits;
 use crate::src::env::get_poc_diff;
 use crate::src::r#ref::dav1d_ref_inc;
 #[inline]
-unsafe extern "C" fn dav1d_get_bits_pos(mut c: *const GetBits) -> libc::c_uint {
+unsafe extern "C" fn dav1d_get_bits_pos(c: *const GetBits) -> libc::c_uint {
     return (((*c).ptr).offset_from((*c).ptr_start) as libc::c_long as libc::c_uint)
         .wrapping_mul(8 as libc::c_int as libc::c_uint)
         .wrapping_sub((*c).bits_left as libc::c_uint);
@@ -1066,7 +1066,7 @@ unsafe extern "C" fn tile_log2(sz: libc::c_int, tgt: libc::c_int) -> libc::c_int
     return k;
 }
 static mut default_mode_ref_deltas: Dav1dLoopfilterModeRefDeltas = {
-    let mut init = Dav1dLoopfilterModeRefDeltas {
+    let init = Dav1dLoopfilterModeRefDeltas {
         mode_delta: [0 as libc::c_int, 0 as libc::c_int],
         ref_delta: [
             1 as libc::c_int,
@@ -1201,8 +1201,8 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                         &mut *((*hdr).operating_points).as_mut_ptr().offset(i as isize)
                             as *mut Dav1dFrameHeaderOperatingPoint;
                     if (*seqop).decoder_model_param_present != 0 {
-                        let mut in_temporal_layer = (*seqop).idc >> (*hdr).temporal_id & 1;
-                        let mut in_spatial_layer = (*seqop).idc >> (*hdr).spatial_id + 8 & 1;
+                        let in_temporal_layer = (*seqop).idc >> (*hdr).temporal_id & 1;
+                        let in_spatial_layer = (*seqop).idc >> (*hdr).spatial_id + 8 & 1;
                         if (*seqop).idc == 0 || in_temporal_layer != 0 && in_spatial_layer != 0 {
                             (*op).buffer_removal_time =
                                 dav1d_get_bits(gb, (*seqhdr).buffer_removal_delay_length)
@@ -2759,7 +2759,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                     if r#ref.is_null() {
                         return -(12 as libc::c_int);
                     }
-                    let mut seq_hdr: *mut Dav1dSequenceHeader =
+                    let seq_hdr: *mut Dav1dSequenceHeader =
                         (*r#ref).data as *mut Dav1dSequenceHeader;
                     res = parse_seq_hdr(c, &mut gb, seq_hdr);
                     if res < 0 {
@@ -2943,7 +2943,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                             as *const libc::c_char,
                                     );
                                 } else {
-                                    let mut ref_3: *mut Dav1dRef = dav1d_ref_create(
+                                    let ref_3: *mut Dav1dRef = dav1d_ref_create(
                                         (::core::mem::size_of::<Dav1dITUTT35>()).wrapping_add(
                                             (payload_size as size_t)
                                                 .wrapping_mul(::core::mem::size_of::<uint8_t>()),
@@ -3120,7 +3120,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                                             {
                                                 current_block = 2084488458830559219;
                                             } else {
-                                                let mut tile: *mut Dav1dTileGroup = realloc(
+                                                let tile: *mut Dav1dTileGroup = realloc(
                                                     (*c).tile as *mut libc::c_void,
                                                     (((*c).n_tile_data + 1) as size_t)
                                                         .wrapping_mul(::core::mem::size_of::<

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -627,7 +627,7 @@ pub unsafe extern "C" fn dav1d_default_picture_release(
     );
 }
 unsafe extern "C" fn free_buffer(_data: *const uint8_t, user_data: *mut libc::c_void) {
-    let mut pic_ctx: *mut pic_ctx_context = user_data as *mut pic_ctx_context;
+    let pic_ctx: *mut pic_ctx_context = user_data as *mut pic_ctx_context;
     ((*pic_ctx).allocator.release_picture_callback).expect("non-null function pointer")(
         &mut (*pic_ctx).pic,
         (*pic_ctx).allocator.cookie,
@@ -665,7 +665,7 @@ unsafe extern "C" fn picture_alloc_with_edges(
     if !(bpc > 0 && bpc <= 16) {
         unreachable!();
     }
-    let mut pic_ctx: *mut pic_ctx_context =
+    let pic_ctx: *mut pic_ctx_context =
         malloc(extra.wrapping_add(::core::mem::size_of::<pic_ctx_context>()))
             as *mut pic_ctx_context;
     if pic_ctx.is_null() {

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -200,8 +200,8 @@ pub fn get_skip_ctx(
 // `TxfmSize` and `RectTxfmSize` should be part of the same `enum`.
 #[inline]
 pub fn get_dc_sign_ctx(tx: RectTxfmSize, a: &[u8], l: &[u8]) -> libc::c_uint {
-    let mut mask = 0xc0c0c0c0c0c0c0c0 as u64;
-    let mut mul = 0x101010101010101 as u64;
+    let mask = 0xc0c0c0c0c0c0c0c0 as u64;
+    let mul = 0x101010101010101 as u64;
 
     let s = match tx {
         TX_4X4 => {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -689,9 +689,9 @@ unsafe fn decode_coefs(
     txtp: *mut TxfmType,
     res_ctx: *mut uint8_t,
 ) -> libc::c_int {
-    let mut dc_sign_ctx = 0;
-    let mut dc_sign = 0;
-    let mut dc_dq = 0;
+    let dc_sign_ctx;
+    let dc_sign;
+    let mut dc_dq;
     let current_block: u64;
     let ts: *mut Dav1dTileState = (*t).ts;
     let chroma = (plane != 0) as libc::c_int;
@@ -741,7 +741,7 @@ unsafe fn decode_coefs(
     } else if (*(*f).frame_hdr).segmentation.qidx[(*b).seg_id as usize] == 0 {
         *txtp = DCT_DCT;
     } else {
-        let mut idx: libc::c_uint = 0;
+        let idx: libc::c_uint;
         if intra != 0 {
             let y_mode_nofilt: IntraPredMode = (if (*b).c2rust_unnamed.c2rust_unnamed.y_mode
                 as libc::c_int
@@ -888,7 +888,7 @@ unsafe fn decode_coefs(
             (*ts).msac.rng,
         );
     }
-    let mut eob = 0;
+    let eob;
     if eob_bin > 1 {
         let eob_hi_bit_cdf = &mut (*ts).cdf.coef.eob_hi_bit[(*t_dim).ctx as usize][chroma as usize]
             [eob_bin as usize];
@@ -969,8 +969,8 @@ unsafe fn decode_coefs(
                     0 as libc::c_int,
                     (stride * (4 * sw as isize + 2)) as size_t,
                 );
-                let mut x: libc::c_uint = 0;
-                let mut y: libc::c_uint = 0;
+                let mut x: libc::c_uint;
+                let mut y: libc::c_uint;
                 if TX_CLASS_2D as libc::c_int == TX_CLASS_2D as libc::c_int {
                     rc = *scan.offset(eob as isize) as libc::c_uint;
                     x = rc >> shift;
@@ -1031,7 +1031,7 @@ unsafe fn decode_coefs(
                 levels[(x as isize * stride + y as isize) as usize] = level_tok as uint8_t;
                 let mut i = eob - 1;
                 while i > 0 {
-                    let mut rc_i: libc::c_uint = 0;
+                    let rc_i: libc::c_uint;
                     if TX_CLASS_2D as libc::c_int == TX_CLASS_2D as libc::c_int {
                         rc_i = *scan.offset(i as isize) as libc::c_uint;
                         x = rc_i >> shift;
@@ -1196,8 +1196,8 @@ unsafe fn decode_coefs(
                     0 as libc::c_int,
                     (stride_0 * (4 * sh + 2) as isize) as usize,
                 );
-                let mut x_0: libc::c_uint = 0;
-                let mut y_0: libc::c_uint = 0;
+                let mut x_0: libc::c_uint;
+                let mut y_0: libc::c_uint;
                 if TX_CLASS_H as libc::c_int == TX_CLASS_2D as libc::c_int {
                     rc = *scan.offset(eob as isize) as libc::c_uint;
                     x_0 = rc >> shift_0;
@@ -1258,7 +1258,7 @@ unsafe fn decode_coefs(
                 levels[(x_0 as isize * stride_0 + y_0 as isize) as usize] = level_tok as uint8_t;
                 let mut i_0 = eob - 1;
                 while i_0 > 0 {
-                    let mut rc_i_0: libc::c_uint = 0;
+                    let rc_i_0: libc::c_uint;
                     if TX_CLASS_H as libc::c_int == TX_CLASS_2D as libc::c_int {
                         rc_i_0 = *scan.offset(i_0 as isize) as libc::c_uint;
                         x_0 = rc_i_0 >> shift_0;
@@ -1424,8 +1424,8 @@ unsafe fn decode_coefs(
                     0 as libc::c_int,
                     (stride_1 * (4 * sw + 2) as isize) as size_t,
                 );
-                let mut x_1: libc::c_uint = 0;
-                let mut y_1: libc::c_uint = 0;
+                let mut x_1: libc::c_uint;
+                let mut y_1: libc::c_uint;
                 if TX_CLASS_V as libc::c_int == TX_CLASS_2D as libc::c_int {
                     rc = *scan.offset(eob as isize) as libc::c_uint;
                     x_1 = rc >> shift_1;
@@ -1486,7 +1486,7 @@ unsafe fn decode_coefs(
                 levels[(x_1 as isize * stride_1 + y_1 as isize) as usize] = level_tok as uint8_t;
                 let mut i_1 = eob - 1;
                 while i_1 > 0 {
-                    let mut rc_i_1: libc::c_uint = 0;
+                    let rc_i_1: libc::c_uint;
                     if TX_CLASS_V as libc::c_int == TX_CLASS_2D as libc::c_int {
                         rc_i_1 = *scan.offset(i_1 as isize) as libc::c_uint;
                         x_1 = rc_i_1 >> shift_1;
@@ -1691,8 +1691,8 @@ unsafe fn decode_coefs(
         } else {
             (*f).cur.p.bpc
         })) as libc::c_int;
-    let mut cul_level: libc::c_uint = 0;
-    let mut dc_sign_level: libc::c_uint = 0;
+    let mut cul_level: libc::c_uint;
+    let dc_sign_level: libc::c_uint;
     if dc_tok == 0 {
         cul_level = 0 as libc::c_int as libc::c_uint;
         dc_sign_level = ((1 as libc::c_int) << 6) as libc::c_uint;
@@ -1795,12 +1795,12 @@ unsafe fn decode_coefs(
                     );
                 }
                 let rc_tok: libc::c_uint = *cf.offset(rc as isize) as libc::c_uint;
-                let mut tok_0: libc::c_uint = 0;
+                let mut tok_0: libc::c_uint;
                 let mut dq: libc::c_uint = ac_dq
                     .wrapping_mul(*qm_tbl.offset(rc as isize) as libc::c_uint)
                     .wrapping_add(16 as libc::c_int as libc::c_uint)
                     >> 5;
-                let mut dq_sat = 0;
+                let dq_sat;
                 if rc_tok >= ((15 as libc::c_int) << 11) as libc::c_uint {
                     tok_0 = (read_golomb(&mut (*ts).msac))
                         .wrapping_add(15 as libc::c_int as libc::c_uint);
@@ -1846,8 +1846,8 @@ unsafe fn decode_coefs(
                     );
                 }
                 let rc_tok_0: libc::c_uint = *cf.offset(rc as isize) as libc::c_uint;
-                let mut tok_1: libc::c_uint = 0;
-                let mut dq_0 = 0;
+                let mut tok_1: libc::c_uint;
+                let mut dq_0;
                 if rc_tok_0 >= ((15 as libc::c_int) << 11) as libc::c_uint {
                     tok_1 = (read_golomb(&mut (*ts).msac))
                         .wrapping_add(15 as libc::c_int as libc::c_uint);
@@ -1986,8 +1986,8 @@ unsafe extern "C" fn read_coef_tree(
         let by4 = (*t).by & 31;
         let mut txtp: TxfmType = DCT_DCT;
         let mut cf_ctx: uint8_t = 0;
-        let mut eob = 0;
-        let mut cf: *mut coef = 0 as *mut coef;
+        let eob;
+        let cf: *mut coef;
         let mut cbi: *mut CodedBlockInfo = 0 as *mut CodedBlockInfo;
         if (*t).frame_thread.pass != 0 {
             let p = (*t).frame_thread.pass & 1;
@@ -2168,8 +2168,8 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
         while init_x < w4 {
             let sub_w4 = imin(w4, init_x + 16);
             let mut y_off = (init_y != 0) as libc::c_int;
-            let mut y = 0;
-            let mut x = 0;
+            let mut y;
+            let mut x;
             y = init_y;
             (*t).by += init_y;
             while y < sub_h4 {
@@ -2371,12 +2371,12 @@ unsafe extern "C" fn mc(
     let mx = mvx & 15 >> (ss_hor == 0) as libc::c_int;
     let my = mvy & 15 >> (ss_ver == 0) as libc::c_int;
     let mut ref_stride: ptrdiff_t = (*refp).p.stride[(pl != 0) as libc::c_int as usize];
-    let mut r#ref: *const pixel = 0 as *const pixel;
+    let r#ref: *const pixel;
     if (*refp).p.p.w == (*f).cur.p.w && (*refp).p.p.h == (*f).cur.p.h {
         let dx = bx * h_mul + (mvx >> 3 + ss_hor);
         let dy = by * v_mul + (mvy >> 3 + ss_ver);
-        let mut w = 0;
-        let mut h = 0;
+        let w;
+        let h;
         if (*refp).p.data[0] != (*f).cur.data[0] {
             w = (*f).cur.p.w + ss_hor >> ss_hor;
             h = (*f).cur.p.h + ss_ver >> ss_ver;
@@ -2448,8 +2448,8 @@ unsafe extern "C" fn mc(
             (by * v_mul << 4) + mvy * ((1 as libc::c_int) << (ss_ver == 0) as libc::c_int);
         let orig_pos_x =
             (bx * h_mul << 4) + mvx * ((1 as libc::c_int) << (ss_hor == 0) as libc::c_int);
-        let mut pos_y = 0;
-        let mut pos_x = 0;
+        let pos_y;
+        let pos_x;
         let tmp: int64_t = orig_pos_x as int64_t * (*f).svc[refidx as usize][0].scale as int64_t
             + (((*f).svc[refidx as usize][0].scale - 0x4000 as libc::c_int) * 8) as int64_t;
         pos_x = apply_sign64(
@@ -2572,7 +2572,7 @@ unsafe extern "C" fn obmc(
         as libc::c_int;
     let h_mul = 4 >> ss_hor;
     let v_mul = 4 >> ss_ver;
-    let mut res = 0;
+    let mut res;
     if (*t).by > (*(*t).ts).tiling.row_start
         && (pl == 0
             || *b_dim.offset(0) as libc::c_int * h_mul + *b_dim.offset(1) as libc::c_int * v_mul
@@ -2746,7 +2746,7 @@ unsafe extern "C" fn warp_affine(
                 - (*wmp).gamma() as libc::c_int * 4
                 - (*wmp).delta() as libc::c_int * 4
                 & !(0x3f as libc::c_int);
-            let mut ref_ptr: *const pixel = 0 as *const pixel;
+            let ref_ptr: *const pixel;
             let mut ref_stride: ptrdiff_t = (*refp).p.stride[(pl != 0) as libc::c_int as usize];
             if dx < 3 || dx + 8 + 4 > width || dy < 3 || dy + 8 + 4 > height {
                 let emu_edge_buf: *mut pixel =
@@ -2865,7 +2865,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                     (4 * ((*t).by as isize * PXSTRIDE((*f).cur.stride[0]) + (*t).bx as isize))
                         as isize,
                 );
-                let mut pal_idx: *const uint8_t = 0 as *const uint8_t;
+                let pal_idx: *const uint8_t;
                 if (*t).frame_thread.pass != 0 {
                     let p = (*t).frame_thread.pass & 1;
                     if ((*ts).frame_thread[p as usize].pal_idx).is_null() {
@@ -2923,8 +2923,8 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                 intra_edge_flags as libc::c_uint
                     & EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int as libc::c_uint
             }) as libc::c_int;
-            let mut y = 0;
-            let mut x = 0;
+            let mut y;
+            let mut x;
             let sub_w4 = imin(w4, init_x + 16);
             y = init_y;
             (*t).by += init_y;
@@ -2937,10 +2937,10 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                 x = init_x;
                 (*t).bx += init_x;
                 while x < sub_w4 {
-                    let mut angle = 0;
-                    let mut edge_flags: EdgeFlags = 0 as EdgeFlags;
-                    let mut top_sb_edge: *const pixel = 0 as *const pixel;
-                    let mut m: IntraPredMode = DC_PRED;
+                    let mut angle;
+                    let edge_flags: EdgeFlags;
+                    let mut top_sb_edge: *const pixel;
+                    let m: IntraPredMode;
                     if !((*b).c2rust_unnamed.c2rust_unnamed.pal_sz[0] != 0) {
                         angle = (*b).c2rust_unnamed.c2rust_unnamed.y_angle as libc::c_int;
                         edge_flags = ((if (y > init_y || sb_has_tr == 0)
@@ -3019,8 +3019,8 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                         }
                     }
                     if (*b).skip == 0 {
-                        let mut cf: *mut coef = 0 as *mut coef;
-                        let mut eob = 0;
+                        let cf: *mut coef;
+                        let eob;
                         let mut txtp: TxfmType = DCT_DCT;
                         if (*t).frame_thread.pass != 0 {
                             let p_0 = (*t).frame_thread.pass & 1;
@@ -3231,8 +3231,8 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                     let uv_dstoff: ptrdiff_t = 4
                         * (((*t).bx >> ss_hor) as isize
                             + ((*t).by >> ss_ver) as isize * PXSTRIDE((*f).cur.stride[1]));
-                    let mut pal_0: *const [uint16_t; 8] = 0 as *const [uint16_t; 8];
-                    let mut pal_idx_0: *const uint8_t = 0 as *const uint8_t;
+                    let pal_0: *const [uint16_t; 8];
+                    let pal_idx_0: *const uint8_t;
                     if (*t).frame_thread.pass != 0 {
                         let p_1 = (*t).frame_thread.pass & 1;
                         if ((*ts).frame_thread[p_1 as usize].pal_idx).is_null() {
@@ -3327,15 +3327,15 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                         x = init_x >> ss_hor;
                         (*t).bx += init_x;
                         while x < sub_cw4 {
-                            let mut angle_1 = 0;
-                            let mut edge_flags_0: EdgeFlags = 0 as EdgeFlags;
-                            let mut top_sb_edge_1: *const pixel = 0 as *const pixel;
-                            let mut uv_mode: IntraPredMode = DC_PRED;
-                            let mut xpos_0 = 0;
-                            let mut ypos_0 = 0;
-                            let mut xstart_0 = 0;
-                            let mut ystart_0 = 0;
-                            let mut m_1: IntraPredMode = DC_PRED;
+                            let mut angle_1;
+                            let edge_flags_0: EdgeFlags;
+                            let mut top_sb_edge_1: *const pixel;
+                            let uv_mode: IntraPredMode;
+                            let xpos_0;
+                            let ypos_0;
+                            let xstart_0;
+                            let ystart_0;
+                            let m_1: IntraPredMode;
                             if !((*b).c2rust_unnamed.c2rust_unnamed.uv_mode as libc::c_int
                                 == CFL_PRED as libc::c_int
                                 && (*b).c2rust_unnamed.c2rust_unnamed.cfl_alpha[pl_0 as usize]
@@ -3442,8 +3442,8 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                             }
                             if (*b).skip == 0 {
                                 let mut txtp_0: TxfmType = DCT_DCT;
-                                let mut eob_0 = 0;
-                                let mut cf_0: *mut coef = 0 as *mut coef;
+                                let eob_0;
+                                let cf_0: *mut coef;
                                 if (*t).frame_thread.pass != 0 {
                                     let p_2 = (*t).frame_thread.pass & 1;
                                     cf_0 = (*ts).frame_thread[p_2 as usize].cf as *mut coef;
@@ -3600,7 +3600,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
         (DAV1D_PIXEL_LAYOUT_I444 as libc::c_int as libc::c_uint)
             .wrapping_sub((*f).cur.p.layout as libc::c_uint)
     }) as libc::c_int;
-    let mut res = 0;
+    let mut res;
     let cbh4 = bh4 + ss_ver >> ss_ver;
     let cbw4 = bw4 + ss_hor >> ss_hor;
     let mut dst: *mut pixel = ((*f).cur.data[0] as *mut pixel).offset(
@@ -3666,8 +3666,8 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
     } else if (*b).c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_int
         == COMP_INTER_NONE as libc::c_int
     {
-        let mut is_sub8x8 = 0;
-        let mut r: *const *mut refmvs_block = 0 as *const *mut refmvs_block;
+        let mut is_sub8x8;
+        let mut r: *const *mut refmvs_block;
         let refp: *const Dav1dThreadPicture = &*((*f).refp).as_ptr().offset(
             *((*b).c2rust_unnamed.c2rust_unnamed_0.r#ref)
                 .as_ptr()
@@ -4657,12 +4657,12 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
         let mut init_x = 0;
         while init_x < bw4 {
             let mut y_off = (init_y != 0) as libc::c_int;
-            let mut y = 0;
+            let mut y;
             dst = dst.offset((PXSTRIDE((*f).cur.stride[0]) * 4 * init_y as isize) as isize);
             y = init_y;
             (*t).by += init_y;
             while y < imin(h4, init_y + 16) {
-                let mut x = 0;
+                let mut x;
                 let mut x_off = (init_x != 0) as libc::c_int;
                 x = init_x;
                 (*t).bx += init_x;
@@ -4702,13 +4702,13 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                     y = init_y >> ss_ver;
                     (*t).by += init_y;
                     while y < imin(ch4, init_y + 16 >> ss_ver) {
-                        let mut x_0 = 0;
+                        let mut x_0;
                         x_0 = init_x >> ss_hor;
                         (*t).bx += init_x;
                         while x_0 < imin(cw4, init_x + 16 >> ss_hor) {
-                            let mut cf: *mut coef = 0 as *mut coef;
-                            let mut eob = 0;
-                            let mut txtp: TxfmType = DCT_DCT;
+                            let cf: *mut coef;
+                            let eob;
+                            let mut txtp: TxfmType;
                             if (*t).frame_thread.pass != 0 {
                                 let p = (*t).frame_thread.pass & 1;
                                 cf = (*ts).frame_thread[p as usize].cf as *mut coef;
@@ -4971,8 +4971,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_resize_16bpc(
         let dst: *mut pixel =
             (sr_p[pl as usize]).offset(-((h_start as isize * PXSTRIDE(dst_stride)) as isize));
         let src_stride: ptrdiff_t = (*f).cur.stride[(pl != 0) as libc::c_int as usize];
-        let src: *const pixel =
-            (p[pl as usize]).offset(-(h_start as isize * PXSTRIDE(src_stride)));
+        let src: *const pixel = (p[pl as usize]).offset(-(h_start as isize * PXSTRIDE(src_stride)));
         let h_end =
             4 as libc::c_int * (sbsz - 2 * ((sby + 1) < (*f).sbh) as libc::c_int) >> ss_ver_0;
         let ss_hor = (pl != 0

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -7,7 +7,6 @@ use ::libc;
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::size_t) -> *mut libc::c_void;
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::size_t) -> *mut libc::c_void;
-    fn fprintf(_: *mut libc::FILE, _: *const libc::c_char, _: ...) -> libc::c_int;
     fn printf(_: *const libc::c_char, _: ...) -> libc::c_int;
     fn dav1d_cdef_brow_16bpc(
         tc: *mut Dav1dTaskContext,

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -685,14 +685,14 @@ unsafe fn decode_coefs(
     b: *const Av1Block,
     intra: libc::c_int,
     plane: libc::c_int,
-    mut cf: *mut coef,
+    cf: *mut coef,
     txtp: *mut TxfmType,
-    mut res_ctx: *mut uint8_t,
+    res_ctx: *mut uint8_t,
 ) -> libc::c_int {
     let mut dc_sign_ctx = 0;
     let mut dc_sign = 0;
     let mut dc_dq = 0;
-    let mut current_block: u64;
+    let current_block: u64;
     let ts: *mut Dav1dTileState = (*t).ts;
     let chroma = (plane != 0) as libc::c_int;
     let f: *const Dav1dFrameContext = (*t).f;
@@ -937,7 +937,7 @@ unsafe fn decode_coefs(
             + (eob > sw * sh * 2) as libc::c_int
             + (eob > sw * sh * 4) as libc::c_int)
             as libc::c_uint;
-        let mut eob_tok = dav1d_msac_decode_symbol_adapt4(
+        let eob_tok = dav1d_msac_decode_symbol_adapt4(
             &mut (*ts).msac,
             &mut *eob_cdf.offset(ctx as isize),
             2 as libc::c_int as size_t,
@@ -1647,7 +1647,7 @@ unsafe fn decode_coefs(
             }
         }
     } else {
-        let mut tok_br = dav1d_msac_decode_symbol_adapt4(
+        let tok_br = dav1d_msac_decode_symbol_adapt4(
             &mut (*ts).msac,
             &mut *eob_cdf.offset(0),
             2 as libc::c_int as size_t,
@@ -2042,7 +2042,7 @@ unsafe extern "C" fn read_coef_tree(
                     case.set(&mut dir.lcoef.0, cf_ctx);
                 },
             );
-            let mut txtp_map = &mut (*t).txtp_map[(by4 * 32 + bx4) as usize..];
+            let txtp_map = &mut (*t).txtp_map[(by4 * 32 + bx4) as usize..];
             CaseSet::<16, false>::one((), txw as usize, 0, |case, ()| {
                 for txtp_map in txtp_map.chunks_mut(32).take(txh as usize) {
                     case.set(txtp_map, txtp);
@@ -2557,7 +2557,7 @@ unsafe extern "C" fn obmc(
         unreachable!();
     }
     let f: *const Dav1dFrameContext = (*t).f;
-    let mut r: *mut *mut refmvs_block = &mut *((*t).rt.r)
+    let r: *mut *mut refmvs_block = &mut *((*t).rt.r)
         .as_mut_ptr()
         .offset((((*t).by & 31) + 5) as isize)
         as *mut *mut refmvs_block;
@@ -2861,7 +2861,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
         let mut init_x = 0;
         while init_x < w4 {
             if (*b).c2rust_unnamed.c2rust_unnamed.pal_sz[0] != 0 {
-                let mut dst: *mut pixel = ((*f).cur.data[0] as *mut pixel).offset(
+                let dst: *mut pixel = ((*f).cur.data[0] as *mut pixel).offset(
                     (4 * ((*t).by as isize * PXSTRIDE((*f).cur.stride[0]) + (*t).bx as isize))
                         as isize,
                 );
@@ -3132,7 +3132,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                         unreachable!();
                     }
                     let ac = &mut (*t).scratch.c2rust_unnamed_0.ac;
-                    let mut y_src: *mut pixel = ((*f).cur.data[0] as *mut pixel)
+                    let y_src: *mut pixel = ((*f).cur.data[0] as *mut pixel)
                         .offset((4 * ((*t).bx & !ss_hor)) as isize)
                         .offset(
                             ((4 * ((*t).by & !ss_ver)) as isize * PXSTRIDE((*f).cur.stride[0]))
@@ -4285,7 +4285,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
         (*t).tl_4x4_filter = filter_2d;
     } else {
         let filter_2d_0: Filter2d = (*b).c2rust_unnamed.c2rust_unnamed_0.filter2d as Filter2d;
-        let mut tmp_1: *mut [int16_t; 16384] = ((*t)
+        let tmp_1: *mut [int16_t; 16384] = ((*t)
             .scratch
             .c2rust_unnamed
             .c2rust_unnamed
@@ -4840,7 +4840,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_cols_16bpc(
         ((*f).lf.p[2] as *mut pixel)
             .offset((y as isize * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize),
     ];
-    let mut mask: *mut Av1Filter = ((*f).lf.mask)
+    let mask: *mut Av1Filter = ((*f).lf.mask)
         .offset(((sby >> ((*(*f).seq_hdr).sb128 == 0) as libc::c_int) * (*f).sb128w) as isize);
     dav1d_loopfilter_sbrow_cols_16bpc(
         f,
@@ -4865,7 +4865,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_rows_16bpc(
         ((*f).lf.p[2] as *mut pixel)
             .offset((y as isize * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize),
     ];
-    let mut mask: *mut Av1Filter = ((*f).lf.mask)
+    let mask: *mut Av1Filter = ((*f).lf.mask)
         .offset(((sby >> ((*(*f).seq_hdr).sb128 == 0) as libc::c_int) * (*f).sb128w) as isize);
     if (*(*f).c).inloop_filters as libc::c_uint
         & DAV1D_INLOOPFILTER_DEBLOCK as libc::c_int as libc::c_uint
@@ -4902,9 +4902,9 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_16bpc(
         ((*f).lf.p[2] as *mut pixel)
             .offset((y as isize * PXSTRIDE((*f).cur.stride[1]) >> ss_ver) as isize),
     ];
-    let mut prev_mask: *mut Av1Filter = ((*f).lf.mask)
+    let prev_mask: *mut Av1Filter = ((*f).lf.mask)
         .offset(((sby - 1 >> ((*(*f).seq_hdr).sb128 == 0) as libc::c_int) * (*f).sb128w) as isize);
-    let mut mask: *mut Av1Filter = ((*f).lf.mask)
+    let mask: *mut Av1Filter = ((*f).lf.mask)
         .offset(((sby >> ((*(*f).seq_hdr).sb128 == 0) as libc::c_int) * (*f).sb128w) as isize);
     let start = sby * sbsz;
     if sby != 0 {
@@ -4968,10 +4968,10 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_resize_16bpc(
             as libc::c_int;
         let h_start = 8 * (sby != 0) as libc::c_int >> ss_ver_0;
         let dst_stride: ptrdiff_t = (*f).sr_cur.p.stride[(pl != 0) as libc::c_int as usize];
-        let mut dst: *mut pixel =
+        let dst: *mut pixel =
             (sr_p[pl as usize]).offset(-((h_start as isize * PXSTRIDE(dst_stride)) as isize));
         let src_stride: ptrdiff_t = (*f).cur.stride[(pl != 0) as libc::c_int as usize];
-        let mut src: *const pixel =
+        let src: *const pixel =
             (p[pl as usize]).offset(-(h_start as isize * PXSTRIDE(src_stride)));
         let h_end =
             4 as libc::c_int * (sbsz - 2 * ((sby + 1) < (*f).sbh) as libc::c_int) >> ss_ver_0;

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -7,7 +7,6 @@ use ::libc;
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::size_t) -> *mut libc::c_void;
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::size_t) -> *mut libc::c_void;
-    fn fprintf(_: *mut libc::FILE, _: *const libc::c_char, _: ...) -> libc::c_int;
     fn printf(_: *const libc::c_char, _: ...) -> libc::c_int;
     fn dav1d_cdef_brow_8bpc(
         tc: *mut Dav1dTaskContext,

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -665,9 +665,9 @@ unsafe fn decode_coefs(
     txtp: *mut TxfmType,
     res_ctx: *mut uint8_t,
 ) -> libc::c_int {
-    let mut dc_sign_ctx = 0;
-    let mut dc_sign = 0;
-    let mut dc_dq = 0;
+    let dc_sign_ctx;
+    let dc_sign;
+    let mut dc_dq;
     let current_block: u64;
     let ts: *mut Dav1dTileState = (*t).ts;
     let chroma = (plane != 0) as libc::c_int;
@@ -717,7 +717,7 @@ unsafe fn decode_coefs(
     } else if (*(*f).frame_hdr).segmentation.qidx[(*b).seg_id as usize] == 0 {
         *txtp = DCT_DCT;
     } else {
-        let mut idx: libc::c_uint = 0;
+        let idx: libc::c_uint;
         if intra != 0 {
             let y_mode_nofilt: IntraPredMode = (if (*b).c2rust_unnamed.c2rust_unnamed.y_mode
                 as libc::c_int
@@ -864,7 +864,7 @@ unsafe fn decode_coefs(
             (*ts).msac.rng,
         );
     }
-    let mut eob = 0;
+    let eob;
     if eob_bin > 1 {
         let eob_hi_bit_cdf = &mut (*ts).cdf.coef.eob_hi_bit[(*t_dim).ctx as usize][chroma as usize]
             [eob_bin as usize];
@@ -945,8 +945,8 @@ unsafe fn decode_coefs(
                     0 as libc::c_int,
                     (stride * (4 * sw + 2) as isize) as size_t,
                 );
-                let mut x: libc::c_uint = 0;
-                let mut y: libc::c_uint = 0;
+                let mut x: libc::c_uint;
+                let mut y: libc::c_uint;
                 if TX_CLASS_2D as libc::c_int == TX_CLASS_2D as libc::c_int {
                     rc = *scan.offset(eob as isize) as libc::c_uint;
                     x = rc >> shift;
@@ -1007,7 +1007,7 @@ unsafe fn decode_coefs(
                 levels[(x as isize * stride + y as isize) as usize] = level_tok as uint8_t;
                 let mut i = eob - 1;
                 while i > 0 {
-                    let mut rc_i: libc::c_uint = 0;
+                    let rc_i: libc::c_uint;
                     if TX_CLASS_2D as libc::c_int == TX_CLASS_2D as libc::c_int {
                         rc_i = *scan.offset(i as isize) as libc::c_uint;
                         x = rc_i >> shift;
@@ -1172,8 +1172,8 @@ unsafe fn decode_coefs(
                     0 as libc::c_int,
                     (stride_0 * (4 * sh + 2) as isize) as usize,
                 );
-                let mut x_0: libc::c_uint = 0;
-                let mut y_0: libc::c_uint = 0;
+                let mut x_0: libc::c_uint;
+                let mut y_0: libc::c_uint;
                 if TX_CLASS_H as libc::c_int == TX_CLASS_2D as libc::c_int {
                     rc = *scan.offset(eob as isize) as libc::c_uint;
                     x_0 = rc >> shift_0;
@@ -1234,7 +1234,7 @@ unsafe fn decode_coefs(
                 levels[(x_0 as isize * stride_0 + y_0 as isize) as usize] = level_tok as uint8_t;
                 let mut i_0 = eob - 1;
                 while i_0 > 0 {
-                    let mut rc_i_0: libc::c_uint = 0;
+                    let rc_i_0: libc::c_uint;
                     if TX_CLASS_H as libc::c_int == TX_CLASS_2D as libc::c_int {
                         rc_i_0 = *scan.offset(i_0 as isize) as libc::c_uint;
                         x_0 = rc_i_0 >> shift_0;
@@ -1399,8 +1399,8 @@ unsafe fn decode_coefs(
                     0 as libc::c_int,
                     (stride_1 * (4 * sw + 2) as isize) as size_t,
                 );
-                let mut x_1: libc::c_uint = 0;
-                let mut y_1: libc::c_uint = 0;
+                let mut x_1: libc::c_uint;
+                let mut y_1: libc::c_uint;
                 if TX_CLASS_V as libc::c_int == TX_CLASS_2D as libc::c_int {
                     rc = *scan.offset(eob as isize) as libc::c_uint;
                     x_1 = rc >> shift_1;
@@ -1461,7 +1461,7 @@ unsafe fn decode_coefs(
                 levels[(x_1 as isize * stride_1 + y_1 as isize) as usize] = level_tok as uint8_t;
                 let mut i_1 = eob - 1;
                 while i_1 > 0 {
-                    let mut rc_i_1: libc::c_uint = 0;
+                    let rc_i_1: libc::c_uint;
                     if TX_CLASS_V as libc::c_int == TX_CLASS_2D as libc::c_int {
                         rc_i_1 = *scan.offset(i_1 as isize) as libc::c_uint;
                         x_1 = rc_i_1 >> shift_1;
@@ -1666,8 +1666,8 @@ unsafe fn decode_coefs(
         } else {
             (*f).cur.p.bpc
         })) as libc::c_int;
-    let mut cul_level: libc::c_uint = 0;
-    let mut dc_sign_level: libc::c_uint = 0;
+    let mut cul_level: libc::c_uint;
+    let dc_sign_level: libc::c_uint;
     if dc_tok == 0 {
         cul_level = 0 as libc::c_int as libc::c_uint;
         dc_sign_level = ((1 as libc::c_int) << 6) as libc::c_uint;
@@ -1770,12 +1770,12 @@ unsafe fn decode_coefs(
                     );
                 }
                 let rc_tok: libc::c_uint = *cf.offset(rc as isize) as libc::c_uint;
-                let mut tok_0: libc::c_uint = 0;
+                let mut tok_0: libc::c_uint;
                 let mut dq: libc::c_uint = ac_dq
                     .wrapping_mul(*qm_tbl.offset(rc as isize) as libc::c_uint)
                     .wrapping_add(16 as libc::c_int as libc::c_uint)
                     >> 5;
-                let mut dq_sat = 0;
+                let dq_sat;
                 if rc_tok >= ((15 as libc::c_int) << 11) as libc::c_uint {
                     tok_0 = (read_golomb(&mut (*ts).msac))
                         .wrapping_add(15 as libc::c_int as libc::c_uint);
@@ -1821,8 +1821,8 @@ unsafe fn decode_coefs(
                     );
                 }
                 let rc_tok_0: libc::c_uint = *cf.offset(rc as isize) as libc::c_uint;
-                let mut tok_1: libc::c_uint = 0;
-                let mut dq_0 = 0;
+                let mut tok_1: libc::c_uint;
+                let mut dq_0;
                 if rc_tok_0 >= ((15 as libc::c_int) << 11) as libc::c_uint {
                     tok_1 = (read_golomb(&mut (*ts).msac))
                         .wrapping_add(15 as libc::c_int as libc::c_uint);
@@ -1961,8 +1961,8 @@ unsafe extern "C" fn read_coef_tree(
         let by4 = (*t).by & 31;
         let mut txtp: TxfmType = DCT_DCT;
         let mut cf_ctx: uint8_t = 0;
-        let mut eob = 0;
-        let mut cf: *mut coef = 0 as *mut coef;
+        let eob;
+        let cf: *mut coef;
         let mut cbi: *mut CodedBlockInfo = 0 as *mut CodedBlockInfo;
         if (*t).frame_thread.pass != 0 {
             let p = (*t).frame_thread.pass & 1;
@@ -2143,8 +2143,8 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
         while init_x < w4 {
             let sub_w4 = imin(w4, init_x + 16);
             let mut y_off = (init_y != 0) as libc::c_int;
-            let mut y = 0;
-            let mut x = 0;
+            let mut y;
+            let mut x;
             y = init_y;
             (*t).by += init_y;
             while y < sub_h4 {
@@ -2346,12 +2346,12 @@ unsafe extern "C" fn mc(
     let mx = mvx & 15 >> (ss_hor == 0) as libc::c_int;
     let my = mvy & 15 >> (ss_ver == 0) as libc::c_int;
     let mut ref_stride: ptrdiff_t = (*refp).p.stride[(pl != 0) as libc::c_int as usize];
-    let mut r#ref: *const pixel = 0 as *const pixel;
+    let r#ref: *const pixel;
     if (*refp).p.p.w == (*f).cur.p.w && (*refp).p.p.h == (*f).cur.p.h {
         let dx = bx * h_mul + (mvx >> 3 + ss_hor);
         let dy = by * v_mul + (mvy >> 3 + ss_ver);
-        let mut w = 0;
-        let mut h = 0;
+        let w;
+        let h;
         if (*refp).p.data[0] != (*f).cur.data[0] {
             w = (*f).cur.p.w + ss_hor >> ss_hor;
             h = (*f).cur.p.h + ss_ver >> ss_ver;
@@ -2421,8 +2421,8 @@ unsafe extern "C" fn mc(
             (by * v_mul << 4) + mvy * ((1 as libc::c_int) << (ss_ver == 0) as libc::c_int);
         let orig_pos_x =
             (bx * h_mul << 4) + mvx * ((1 as libc::c_int) << (ss_hor == 0) as libc::c_int);
-        let mut pos_y = 0;
-        let mut pos_x = 0;
+        let pos_y;
+        let pos_x;
         let tmp: int64_t = orig_pos_x as int64_t * (*f).svc[refidx as usize][0].scale as int64_t
             + (((*f).svc[refidx as usize][0].scale - 0x4000 as libc::c_int) * 8) as int64_t;
         pos_x = apply_sign64(
@@ -2543,7 +2543,7 @@ unsafe extern "C" fn obmc(
         as libc::c_int;
     let h_mul = 4 >> ss_hor;
     let v_mul = 4 >> ss_ver;
-    let mut res = 0;
+    let mut res;
     if (*t).by > (*(*t).ts).tiling.row_start
         && (pl == 0
             || *b_dim.offset(0) as libc::c_int * h_mul + *b_dim.offset(1) as libc::c_int * v_mul
@@ -2712,7 +2712,7 @@ unsafe extern "C" fn warp_affine(
                 - (*wmp).gamma() as libc::c_int * 4
                 - (*wmp).delta() as libc::c_int * 4
                 & !(0x3f as libc::c_int);
-            let mut ref_ptr: *const pixel = 0 as *const pixel;
+            let ref_ptr: *const pixel;
             let mut ref_stride: ptrdiff_t = (*refp).p.stride[(pl != 0) as libc::c_int as usize];
             if dx < 3 || dx + 8 + 4 > width || dy < 3 || dy + 8 + 4 > height {
                 let emu_edge_buf: *mut pixel =
@@ -2828,7 +2828,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                 let dst: *mut pixel = ((*f).cur.data[0] as *mut pixel).offset(
                     (4 * ((*t).by as isize * (*f).cur.stride[0] + (*t).bx as isize)) as isize,
                 );
-                let mut pal_idx: *const uint8_t = 0 as *const uint8_t;
+                let pal_idx: *const uint8_t;
                 if (*t).frame_thread.pass != 0 {
                     let p = (*t).frame_thread.pass & 1;
                     if ((*ts).frame_thread[p as usize].pal_idx).is_null() {
@@ -2886,8 +2886,8 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                 intra_edge_flags as libc::c_uint
                     & EDGE_I444_LEFT_HAS_BOTTOM as libc::c_int as libc::c_uint
             }) as libc::c_int;
-            let mut y = 0;
-            let mut x = 0;
+            let mut y;
+            let mut x;
             let sub_w4 = imin(w4, init_x + 16);
             y = init_y;
             (*t).by += init_y;
@@ -2900,10 +2900,10 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                 x = init_x;
                 (*t).bx += init_x;
                 while x < sub_w4 {
-                    let mut angle = 0;
-                    let mut edge_flags: EdgeFlags = 0 as EdgeFlags;
-                    let mut top_sb_edge: *const pixel = 0 as *const pixel;
-                    let mut m: IntraPredMode = DC_PRED;
+                    let mut angle;
+                    let edge_flags: EdgeFlags;
+                    let mut top_sb_edge: *const pixel;
+                    let m: IntraPredMode;
                     if !((*b).c2rust_unnamed.c2rust_unnamed.pal_sz[0] != 0) {
                         angle = (*b).c2rust_unnamed.c2rust_unnamed.y_angle as libc::c_int;
                         edge_flags = ((if (y > init_y || sb_has_tr == 0)
@@ -2980,8 +2980,8 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                         }
                     }
                     if (*b).skip == 0 {
-                        let mut cf: *mut coef = 0 as *mut coef;
-                        let mut eob = 0;
+                        let cf: *mut coef;
+                        let eob;
                         let mut txtp: TxfmType = DCT_DCT;
                         if (*t).frame_thread.pass != 0 {
                             let p_0 = (*t).frame_thread.pass & 1;
@@ -3186,8 +3186,8 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                     let uv_dstoff: ptrdiff_t = 4
                         * (((*t).bx >> ss_hor) as isize
                             + ((*t).by >> ss_ver) as isize * (*f).cur.stride[1]);
-                    let mut pal_0: *const [uint16_t; 8] = 0 as *const [uint16_t; 8];
-                    let mut pal_idx_0: *const uint8_t = 0 as *const uint8_t;
+                    let pal_0: *const [uint16_t; 8];
+                    let pal_idx_0: *const uint8_t;
                     if (*t).frame_thread.pass != 0 {
                         let p_1 = (*t).frame_thread.pass & 1;
                         if ((*ts).frame_thread[p_1 as usize].pal_idx).is_null() {
@@ -3282,15 +3282,15 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                         x = init_x >> ss_hor;
                         (*t).bx += init_x;
                         while x < sub_cw4 {
-                            let mut angle_1 = 0;
-                            let mut edge_flags_0: EdgeFlags = 0 as EdgeFlags;
-                            let mut top_sb_edge_1: *const pixel = 0 as *const pixel;
-                            let mut uv_mode: IntraPredMode = DC_PRED;
-                            let mut xpos_0 = 0;
-                            let mut ypos_0 = 0;
-                            let mut xstart_0 = 0;
-                            let mut ystart_0 = 0;
-                            let mut m_1: IntraPredMode = DC_PRED;
+                            let mut angle_1;
+                            let edge_flags_0: EdgeFlags;
+                            let mut top_sb_edge_1: *const pixel;
+                            let uv_mode: IntraPredMode;
+                            let xpos_0;
+                            let ypos_0;
+                            let xstart_0;
+                            let ystart_0;
+                            let m_1: IntraPredMode;
                             if !((*b).c2rust_unnamed.c2rust_unnamed.uv_mode as libc::c_int
                                 == CFL_PRED as libc::c_int
                                 && (*b).c2rust_unnamed.c2rust_unnamed.cfl_alpha[pl_0 as usize]
@@ -3395,8 +3395,8 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                             }
                             if (*b).skip == 0 {
                                 let mut txtp_0: TxfmType = DCT_DCT;
-                                let mut eob_0 = 0;
-                                let mut cf_0: *mut coef = 0 as *mut coef;
+                                let eob_0;
+                                let cf_0: *mut coef;
                                 if (*t).frame_thread.pass != 0 {
                                     let p_2 = (*t).frame_thread.pass & 1;
                                     cf_0 = (*ts).frame_thread[p_2 as usize].cf as *mut coef;
@@ -3553,7 +3553,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
         (DAV1D_PIXEL_LAYOUT_I444 as libc::c_int as libc::c_uint)
             .wrapping_sub((*f).cur.p.layout as libc::c_uint)
     }) as libc::c_int;
-    let mut res = 0;
+    let mut res;
     let cbh4 = bh4 + ss_ver >> ss_ver;
     let cbw4 = bw4 + ss_hor >> ss_hor;
     let mut dst: *mut pixel = ((*f).cur.data[0] as *mut pixel)
@@ -3617,8 +3617,8 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
     } else if (*b).c2rust_unnamed.c2rust_unnamed_0.comp_type as libc::c_int
         == COMP_INTER_NONE as libc::c_int
     {
-        let mut is_sub8x8 = 0;
-        let mut r: *const *mut refmvs_block = 0 as *const *mut refmvs_block;
+        let mut is_sub8x8;
+        let mut r: *const *mut refmvs_block;
         let refp: *const Dav1dThreadPicture = &*((*f).refp).as_ptr().offset(
             *((*b).c2rust_unnamed.c2rust_unnamed_0.r#ref)
                 .as_ptr()
@@ -4597,12 +4597,12 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
         let mut init_x = 0;
         while init_x < bw4 {
             let mut y_off = (init_y != 0) as libc::c_int;
-            let mut y = 0;
+            let mut y;
             dst = dst.offset(((*f).cur.stride[0] * 4 * init_y as isize) as isize);
             y = init_y;
             (*t).by += init_y;
             while y < imin(h4, init_y + 16) {
-                let mut x = 0;
+                let mut x;
                 let mut x_off = (init_x != 0) as libc::c_int;
                 x = init_x;
                 (*t).bx += init_x;
@@ -4640,13 +4640,13 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                     y = init_y >> ss_ver;
                     (*t).by += init_y;
                     while y < imin(ch4, init_y + 16 >> ss_ver) {
-                        let mut x_0 = 0;
+                        let mut x_0;
                         x_0 = init_x >> ss_hor;
                         (*t).bx += init_x;
                         while x_0 < imin(cw4, init_x + 16 >> ss_hor) {
-                            let mut cf: *mut coef = 0 as *mut coef;
-                            let mut eob = 0;
-                            let mut txtp: TxfmType = DCT_DCT;
+                            let cf: *mut coef;
+                            let eob;
+                            let mut txtp: TxfmType;
                             if (*t).frame_thread.pass != 0 {
                                 let p = (*t).frame_thread.pass & 1;
                                 cf = (*ts).frame_thread[p as usize].cf as *mut coef;

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -661,14 +661,14 @@ unsafe fn decode_coefs(
     b: *const Av1Block,
     intra: libc::c_int,
     plane: libc::c_int,
-    mut cf: *mut coef,
+    cf: *mut coef,
     txtp: *mut TxfmType,
-    mut res_ctx: *mut uint8_t,
+    res_ctx: *mut uint8_t,
 ) -> libc::c_int {
     let mut dc_sign_ctx = 0;
     let mut dc_sign = 0;
     let mut dc_dq = 0;
-    let mut current_block: u64;
+    let current_block: u64;
     let ts: *mut Dav1dTileState = (*t).ts;
     let chroma = (plane != 0) as libc::c_int;
     let f: *const Dav1dFrameContext = (*t).f;
@@ -913,7 +913,7 @@ unsafe fn decode_coefs(
             + (eob > sw * sh * 2) as libc::c_int
             + (eob > sw * sh * 4) as libc::c_int)
             as libc::c_uint;
-        let mut eob_tok = dav1d_msac_decode_symbol_adapt4(
+        let eob_tok = dav1d_msac_decode_symbol_adapt4(
             &mut (*ts).msac,
             &mut *eob_cdf.offset(ctx as isize),
             2 as libc::c_int as size_t,
@@ -1622,7 +1622,7 @@ unsafe fn decode_coefs(
             }
         }
     } else {
-        let mut tok_br = dav1d_msac_decode_symbol_adapt4(
+        let tok_br = dav1d_msac_decode_symbol_adapt4(
             &mut (*ts).msac,
             &mut *eob_cdf.offset(0),
             2 as libc::c_int as size_t,
@@ -2017,7 +2017,7 @@ unsafe extern "C" fn read_coef_tree(
                     case.set(&mut dir.lcoef.0, cf_ctx);
                 },
             );
-            let mut txtp_map = &mut (*t).txtp_map[(by4 * 32 + bx4) as usize..];
+            let txtp_map = &mut (*t).txtp_map[(by4 * 32 + bx4) as usize..];
             CaseSet::<16, false>::one((), txw as usize, 0, |case, ()| {
                 for txtp_map in txtp_map.chunks_mut(32).take(txh as usize) {
                     case.set(txtp_map, txtp);
@@ -2528,7 +2528,7 @@ unsafe extern "C" fn obmc(
         unreachable!();
     }
     let f: *const Dav1dFrameContext = (*t).f;
-    let mut r: *mut *mut refmvs_block = &mut *((*t).rt.r)
+    let r: *mut *mut refmvs_block = &mut *((*t).rt.r)
         .as_mut_ptr()
         .offset((((*t).by & 31) + 5) as isize)
         as *mut *mut refmvs_block;
@@ -2825,7 +2825,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
         let mut init_x = 0;
         while init_x < w4 {
             if (*b).c2rust_unnamed.c2rust_unnamed.pal_sz[0] != 0 {
-                let mut dst: *mut pixel = ((*f).cur.data[0] as *mut pixel).offset(
+                let dst: *mut pixel = ((*f).cur.data[0] as *mut pixel).offset(
                     (4 * ((*t).by as isize * (*f).cur.stride[0] + (*t).bx as isize)) as isize,
                 );
                 let mut pal_idx: *const uint8_t = 0 as *const uint8_t;
@@ -3093,7 +3093,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                         unreachable!();
                     }
                     let ac = &mut (*t).scratch.c2rust_unnamed_0.ac;
-                    let mut y_src: *mut pixel = ((*f).cur.data[0] as *mut pixel)
+                    let y_src: *mut pixel = ((*f).cur.data[0] as *mut pixel)
                         .offset((4 * ((*t).bx & !ss_hor)) as isize)
                         .offset(((4 * ((*t).by & !ss_ver)) as isize * (*f).cur.stride[0]) as isize);
                     let uv_off: ptrdiff_t =
@@ -4232,7 +4232,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
         (*t).tl_4x4_filter = filter_2d;
     } else {
         let filter_2d_0: Filter2d = (*b).c2rust_unnamed.c2rust_unnamed_0.filter2d as Filter2d;
-        let mut tmp_1: *mut [int16_t; 16384] = ((*t)
+        let tmp_1: *mut [int16_t; 16384] = ((*t)
             .scratch
             .c2rust_unnamed
             .c2rust_unnamed
@@ -4775,7 +4775,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_cols_8bpc(
         ((*f).lf.p[1] as *mut pixel).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
         ((*f).lf.p[2] as *mut pixel).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
     ];
-    let mut mask: *mut Av1Filter = ((*f).lf.mask)
+    let mask: *mut Av1Filter = ((*f).lf.mask)
         .offset(((sby >> ((*(*f).seq_hdr).sb128 == 0) as libc::c_int) * (*f).sb128w) as isize);
     dav1d_loopfilter_sbrow_cols_8bpc(
         f,
@@ -4798,7 +4798,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_rows_8bpc(
         ((*f).lf.p[1] as *mut pixel).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
         ((*f).lf.p[2] as *mut pixel).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
     ];
-    let mut mask: *mut Av1Filter = ((*f).lf.mask)
+    let mask: *mut Av1Filter = ((*f).lf.mask)
         .offset(((sby >> ((*(*f).seq_hdr).sb128 == 0) as libc::c_int) * (*f).sb128w) as isize);
     if (*(*f).c).inloop_filters as libc::c_uint
         & DAV1D_INLOOPFILTER_DEBLOCK as libc::c_int as libc::c_uint
@@ -4830,9 +4830,9 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_8bpc(tc: *mut Dav1dTaskContext,
         ((*f).lf.p[1] as *mut pixel).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
         ((*f).lf.p[2] as *mut pixel).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
     ];
-    let mut prev_mask: *mut Av1Filter = ((*f).lf.mask)
+    let prev_mask: *mut Av1Filter = ((*f).lf.mask)
         .offset(((sby - 1 >> ((*(*f).seq_hdr).sb128 == 0) as libc::c_int) * (*f).sb128w) as isize);
-    let mut mask: *mut Av1Filter = ((*f).lf.mask)
+    let mask: *mut Av1Filter = ((*f).lf.mask)
         .offset(((sby >> ((*(*f).seq_hdr).sb128 == 0) as libc::c_int) * (*f).sb128w) as isize);
     let start = sby * sbsz;
     if sby != 0 {
@@ -4893,10 +4893,10 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_resize_8bpc(
             as libc::c_int;
         let h_start = 8 * (sby != 0) as libc::c_int >> ss_ver_0;
         let dst_stride: ptrdiff_t = (*f).sr_cur.p.stride[(pl != 0) as libc::c_int as usize];
-        let mut dst: *mut pixel =
+        let dst: *mut pixel =
             (sr_p[pl as usize]).offset(-((h_start as isize * dst_stride) as isize));
         let src_stride: ptrdiff_t = (*f).cur.stride[(pl != 0) as libc::c_int as usize];
-        let mut src: *const pixel =
+        let src: *const pixel =
             (p[pl as usize]).offset(-((h_start as isize * src_stride) as isize));
         let h_end =
             4 as libc::c_int * (sbsz - 2 * ((sby + 1) < (*f).sbh) as libc::c_int) >> ss_ver_0;

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -97,10 +97,10 @@ pub unsafe fn dav1d_ref_create_using_pool(
 
 pub unsafe fn dav1d_ref_wrap(
     ptr: *const uint8_t,
-    mut free_callback: Option<unsafe extern "C" fn(*const uint8_t, *mut libc::c_void) -> ()>,
+    free_callback: Option<unsafe extern "C" fn(*const uint8_t, *mut libc::c_void) -> ()>,
     user_data: *mut libc::c_void,
 ) -> *mut Dav1dRef {
-    let mut res: *mut Dav1dRef =
+    let res: *mut Dav1dRef =
         malloc(::core::mem::size_of::<Dav1dRef>() as libc::c_ulong) as *mut Dav1dRef;
     if res.is_null() {
         return 0 as *mut Dav1dRef;

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -4,12 +4,8 @@ use ::libc;
 extern "C" {
     fn malloc(_: libc::c_ulong) -> *mut libc::c_void;
     fn free(_: *mut libc::c_void);
-    fn posix_memalign(
-        __memptr: *mut *mut libc::c_void,
-        __alignment: size_t,
-        __size: size_t,
-    ) -> libc::c_int;
 }
+
 #[repr(C)]
 pub struct Dav1dRef {
     pub data: *mut libc::c_void,

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1025,7 +1025,7 @@ pub unsafe fn dav1d_refmvs_find(
                         continue;
                     }
                 }
-                for mut cand in &mut same[m..2] {
+                for cand in &mut same[m..2] {
                     cand.mv.mv[n] = tgmv[n];
                 }
             }
@@ -1094,7 +1094,7 @@ pub unsafe fn dav1d_refmvs_find(
     assert!(*cnt <= 8);
 
     // clamping
-    let mut n_refmvs = *cnt;
+    let n_refmvs = *cnt;
     if n_refmvs != 0 {
         let left = -(bx4 + bw4 + 4) * 4 * 8;
         let right = (rf.iw4 - bx4 + 4) * 4 * 8;
@@ -1138,7 +1138,7 @@ pub unsafe fn dav1d_refmvs_save_tmvs(
     col_end8 = imin(col_end8, (*rf).iw8);
     let stride: ptrdiff_t = (*rf).rp_stride;
     let ref_sign: *const uint8_t = ((*rf).mfmv_sign).as_ptr();
-    let mut rp: *mut refmvs_temporal_block = (*rf).rp.offset(row_start8 as isize * stride);
+    let rp: *mut refmvs_temporal_block = (*rf).rp.offset(row_start8 as isize * stride);
 
     (*dsp).save_tmvs.expect("non-null function pointer")(
         rp,
@@ -1355,7 +1355,7 @@ pub unsafe extern "C" fn save_tmvs_c(
                 let mut n = 0;
                 while n < bw8 {
                     *rp.offset(x as isize) = {
-                        let mut init = refmvs_temporal_block {
+                        let init = refmvs_temporal_block {
                             mv: (*cand_b).0.mv.mv[1],
                             r#ref: (*cand_b).0.r#ref.r#ref[1],
                         };
@@ -1373,7 +1373,7 @@ pub unsafe extern "C" fn save_tmvs_c(
                 let mut n_0 = 0;
                 while n_0 < bw8 {
                     *rp.offset(x as isize) = {
-                        let mut init = refmvs_temporal_block {
+                        let init = refmvs_temporal_block {
                             mv: (*cand_b).0.mv.mv[0],
                             r#ref: (*cand_b).0.r#ref.r#ref[0],
                         };
@@ -1403,10 +1403,10 @@ pub unsafe fn dav1d_refmvs_init_frame(
     rf: *mut refmvs_frame,
     seq_hdr: *const Dav1dSequenceHeader,
     frm_hdr: *const Dav1dFrameHeader,
-    mut ref_poc: *const libc::c_uint,
+    ref_poc: *const libc::c_uint,
     rp: *mut refmvs_temporal_block,
-    mut ref_ref_poc: *const [libc::c_uint; 7],
-    mut rp_ref: *const *mut refmvs_temporal_block,
+    ref_ref_poc: *const [libc::c_uint; 7],
+    rp_ref: *const *mut refmvs_temporal_block,
     n_tile_threads: libc::c_int,
     n_frame_threads: libc::c_int,
 ) -> libc::c_int {

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -3,22 +3,8 @@ use crate::include::stdint::*;
 use cfg_if::cfg_if;
 use libc;
 
-#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
+#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 extern "C" {
-    fn dav1d_splat_mv_avx512icl(
-        rr: *mut *mut refmvs_block,
-        rmv: *const refmvs_block,
-        bx4: libc::c_int,
-        bw4: libc::c_int,
-        bh4: libc::c_int,
-    );
-    fn dav1d_splat_mv_avx2(
-        rr: *mut *mut refmvs_block,
-        rmv: *const refmvs_block,
-        bx4: libc::c_int,
-        bw4: libc::c_int,
-        bh4: libc::c_int,
-    );
     fn dav1d_splat_mv_sse2(
         rr: *mut *mut refmvs_block,
         rmv: *const refmvs_block,
@@ -35,6 +21,24 @@ extern "C" {
         row_end8: libc::c_int,
         col_start8: libc::c_int,
         row_start8: libc::c_int,
+    );
+}
+
+#[cfg(all(feature = "asm", target_arch = "x86_64"))]
+extern "C" {
+    fn dav1d_splat_mv_avx512icl(
+        rr: *mut *mut refmvs_block,
+        rmv: *const refmvs_block,
+        bx4: libc::c_int,
+        bw4: libc::c_int,
+        bh4: libc::c_int,
+    );
+    fn dav1d_splat_mv_avx2(
+        rr: *mut *mut refmvs_block,
+        rmv: *const refmvs_block,
+        bx4: libc::c_int,
+        bw4: libc::c_int,
+        bh4: libc::c_int,
     );
     fn dav1d_save_tmvs_avx2(
         rp: *mut refmvs_temporal_block,
@@ -1614,10 +1618,10 @@ mod ffi {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     wrap_splat_mv!(dav1d_splat_mv_sse2);
 
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     wrap_splat_mv!(dav1d_splat_mv_avx2);
 
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     wrap_splat_mv!(dav1d_splat_mv_avx512icl);
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -2,14 +2,6 @@ use crate::include::stddef::*;
 use crate::include::stdint::*;
 use cfg_if::cfg_if;
 use libc;
-extern "C" {
-    fn free(_: *mut libc::c_void);
-    fn posix_memalign(
-        __memptr: *mut *mut libc::c_void,
-        __alignment: size_t,
-        __size: size_t,
-    ) -> libc::c_int;
-}
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
 extern "C" {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -616,8 +616,8 @@ unsafe extern "C" fn reset_task_cur(
     ttd: *mut TaskThreadData,
     mut frame_idx: libc::c_uint,
 ) -> libc::c_int {
-    let mut min_frame_idx: libc::c_uint = 0;
-    let mut cur_frame_idx: libc::c_uint = 0;
+    let min_frame_idx: libc::c_uint;
+    let cur_frame_idx: libc::c_uint;
     let current_block: u64;
     let first: libc::c_uint = ::core::intrinsics::atomic_load_seqcst(&mut (*ttd).first);
     let mut reset_frame_idx: libc::c_uint = ::core::intrinsics::atomic_xchg_seqcst(
@@ -783,7 +783,7 @@ unsafe extern "C" fn insert_tasks(
     last: *mut Dav1dTask,
     cond_signal: libc::c_int,
 ) {
-    let mut t_ptr: *mut Dav1dTask = 0 as *mut Dav1dTask;
+    let mut t_ptr: *mut Dav1dTask;
     let mut prev_t: *mut Dav1dTask = 0 as *mut Dav1dTask;
     let mut current_block_34: u64;
     t_ptr = (*f).task_thread.task_head;
@@ -1252,7 +1252,7 @@ unsafe extern "C" fn get_frame_progress(
         return (*f).sbh - 1;
     }
     let mut idx = (frame_prog >> (*f).sb_shift + 7) as libc::c_int;
-    let mut prog = 0;
+    let mut prog;
     loop {
         let state: *mut atomic_uint =
             &mut *((*f).frame_thread.frame_progress).offset(idx as isize) as *mut atomic_uint;
@@ -1318,9 +1318,9 @@ unsafe extern "C" fn delayed_fg_task(c: *const Dav1dContext, ttd: *mut TaskThrea
     if (*out).p.bpc != 8 as libc::c_int {
         off = ((*out).p.bpc >> 1) - 4;
     }
-    let mut row = 0;
-    let mut progmax = 0;
-    let mut done = 0;
+    let mut row;
+    let mut progmax;
+    let mut done;
     match (*ttd).delayed_fg.type_0 as libc::c_uint {
         11 => {
             (*ttd).delayed_fg.exec = 0 as libc::c_int;
@@ -1460,10 +1460,14 @@ unsafe extern "C" fn delayed_fg_task(c: *const Dav1dContext, ttd: *mut TaskThrea
             &mut *((*ttd).delayed_fg.progress).as_mut_ptr().offset(0) as *mut atomic_int,
             1 as libc::c_int,
         );
-        done = ::core::intrinsics::atomic_xadd_seqcst(
-            &mut *((*ttd).delayed_fg.progress).as_mut_ptr().offset(1) as *mut atomic_int,
-            1 as libc::c_int,
-        ) + 1;
+        #[allow(unused_assignments)]
+        // TODO(kkysen) non-trivial due to the atomics, so leaving for later
+        {
+            done = ::core::intrinsics::atomic_xadd_seqcst(
+                &mut *((*ttd).delayed_fg.progress).as_mut_ptr().offset(1) as *mut atomic_int,
+                1 as libc::c_int,
+            ) + 1;
+        }
         if row < progmax {
             continue;
         }
@@ -1484,12 +1488,12 @@ unsafe extern "C" fn delayed_fg_task(c: *const Dav1dContext, ttd: *mut TaskThrea
 }
 
 pub unsafe extern "C" fn dav1d_worker_task(data: *mut libc::c_void) -> *mut libc::c_void {
-    let mut flush = 0;
-    let mut error_0 = 0;
-    let mut sby = 0;
-    let mut f: *mut Dav1dFrameContext = 0 as *mut Dav1dFrameContext;
-    let mut t: *mut Dav1dTask = 0 as *mut Dav1dTask;
-    let mut prev_t: *mut Dav1dTask = 0 as *mut Dav1dTask;
+    let mut flush;
+    let mut error_0;
+    let mut sby;
+    let mut f: *mut Dav1dFrameContext;
+    let mut t: *mut Dav1dTask;
+    let mut prev_t: *mut Dav1dTask;
     let mut current_block: u64;
     let tc: *mut Dav1dTaskContext = data as *mut Dav1dTaskContext;
     let c: *const Dav1dContext = (*tc).c;
@@ -1663,9 +1667,9 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut libc::c_void) -> *mut libc
                                                         5395695591151878490 => {}
                                                         _ => {
                                                             if ((*t).sby + 1) < (*f).sbh {
-                                                                let next_t: *mut Dav1dTask =
-                                                                    &mut *t.offset(1)
-                                                                        as *mut Dav1dTask;
+                                                                let next_t: *mut Dav1dTask = &mut *t
+                                                                    .offset(1)
+                                                                    as *mut Dav1dTask;
                                                                 *next_t = (*t).clone();
                                                                 (*next_t).sby += 1;
                                                                 let ntr =

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -618,7 +618,7 @@ unsafe extern "C" fn reset_task_cur(
 ) -> libc::c_int {
     let mut min_frame_idx: libc::c_uint = 0;
     let mut cur_frame_idx: libc::c_uint = 0;
-    let mut current_block: u64;
+    let current_block: u64;
     let first: libc::c_uint = ::core::intrinsics::atomic_load_seqcst(&mut (*ttd).first);
     let mut reset_frame_idx: libc::c_uint = ::core::intrinsics::atomic_xchg_seqcst(
         &mut (*ttd).reset_task_cur,
@@ -714,7 +714,7 @@ unsafe extern "C" fn reset_task_cur(
 unsafe extern "C" fn reset_task_cur_async(
     ttd: *mut TaskThreadData,
     mut frame_idx: libc::c_uint,
-    mut n_frames: libc::c_uint,
+    n_frames: libc::c_uint,
 ) {
     let first: libc::c_uint = ::core::intrinsics::atomic_load_seqcst(&mut (*ttd).first);
     if frame_idx < first {
@@ -924,7 +924,7 @@ unsafe extern "C" fn merge_pending(c: *const Dav1dContext) -> libc::c_int {
 unsafe extern "C" fn create_filter_sbrow(
     f: *mut Dav1dFrameContext,
     pass: libc::c_int,
-    mut res_t: *mut *mut Dav1dTask,
+    res_t: *mut *mut Dav1dTask,
 ) -> libc::c_int {
     let has_deblock = ((*(*f).frame_hdr).loopfilter.level_y[0] != 0
         || (*(*f).frame_hdr).loopfilter.level_y[1] != 0) as libc::c_int;
@@ -933,7 +933,7 @@ unsafe extern "C" fn create_filter_sbrow(
     let has_lr = (*f).lf.restore_planes;
     let mut tasks: *mut Dav1dTask = (*f).task_thread.tasks;
     let uses_2pass = ((*(*f).c).n_fc > 1 as libc::c_uint) as libc::c_int;
-    let mut num_tasks = (*f).sbh * (1 + uses_2pass);
+    let num_tasks = (*f).sbh * (1 + uses_2pass);
     if num_tasks > (*f).task_thread.num_tasks {
         let size: size_t = (::core::mem::size_of::<Dav1dTask>()).wrapping_mul(num_tasks as size_t);
         tasks = realloc((*f).task_thread.tasks as *mut libc::c_void, size) as *mut Dav1dTask;
@@ -977,7 +977,7 @@ unsafe extern "C" fn create_filter_sbrow(
         );
     }
     (*f).frame_thread.next_tile_row[(pass & 1) as usize] = 0 as libc::c_int;
-    let mut t: *mut Dav1dTask = &mut *tasks.offset(0) as *mut Dav1dTask;
+    let t: *mut Dav1dTask = &mut *tasks.offset(0) as *mut Dav1dTask;
     (*t).sby = 0 as libc::c_int;
     (*t).recon_progress = 1 as libc::c_int;
     (*t).deblock_progress = 0 as libc::c_int;
@@ -1006,7 +1006,7 @@ pub unsafe extern "C" fn dav1d_task_create_tile_sbrow(
     let uses_2pass = ((*(*f).c).n_fc > 1 as libc::c_uint) as libc::c_int;
     let num_tasks = (*(*f).frame_hdr).tiling.cols * (*(*f).frame_hdr).tiling.rows;
     if pass < 2 {
-        let mut alloc_num_tasks = num_tasks * (1 + uses_2pass);
+        let alloc_num_tasks = num_tasks * (1 + uses_2pass);
         if alloc_num_tasks > (*f).task_thread.num_tile_tasks {
             let size: size_t =
                 (::core::mem::size_of::<Dav1dTask>()).wrapping_mul(alloc_num_tasks as size_t);
@@ -1031,7 +1031,7 @@ pub unsafe extern "C" fn dav1d_task_create_tile_sbrow(
     while tile_idx < num_tasks {
         let ts: *mut Dav1dTileState =
             &mut *((*f).ts).offset(tile_idx as isize) as *mut Dav1dTileState;
-        let mut t: *mut Dav1dTask = &mut *tasks.offset(tile_idx as isize) as *mut Dav1dTask;
+        let t: *mut Dav1dTask = &mut *tasks.offset(tile_idx as isize) as *mut Dav1dTask;
         (*t).sby = (*ts).tiling.row_start >> (*f).sb_shift;
         if !pf_t.is_null() && (*t).sby != 0 {
             (*prev_t).next = pf_t;
@@ -1123,7 +1123,7 @@ unsafe extern "C" fn ensure_progress(
     state: *mut atomic_int,
     target: *mut libc::c_int,
 ) -> libc::c_int {
-    let mut p1 = ::core::intrinsics::atomic_load_seqcst(state);
+    let p1 = ::core::intrinsics::atomic_load_seqcst(state);
     if p1 < (*t).sby {
         (*t).type_0 = type_0;
         (*t).deblock_progress = 0 as libc::c_int;
@@ -1168,7 +1168,7 @@ unsafe extern "C" fn check_tile(
         && frame_mt != 0
         && (*(*f).frame_hdr).frame_type as libc::c_uint & 1 as libc::c_uint != 0
     {
-        let mut p: *const Dav1dThreadPicture = &mut (*f).sr_cur;
+        let p: *const Dav1dThreadPicture = &mut (*f).sr_cur;
         let ss_ver = ((*p).p.p.layout as libc::c_uint
             == DAV1D_PIXEL_LAYOUT_I420 as libc::c_int as libc::c_uint)
             as libc::c_int;
@@ -1236,7 +1236,7 @@ unsafe extern "C" fn get_frame_progress(
     c: *const Dav1dContext,
     f: *const Dav1dFrameContext,
 ) -> libc::c_int {
-    let mut frame_prog: libc::c_uint = if (*c).n_fc > 1 as libc::c_uint {
+    let frame_prog: libc::c_uint = if (*c).n_fc > 1 as libc::c_uint {
         ::core::intrinsics::atomic_load_seqcst(
             &mut *((*f).sr_cur.progress).offset(1) as *mut atomic_uint
         )
@@ -1254,7 +1254,7 @@ unsafe extern "C" fn get_frame_progress(
     let mut idx = (frame_prog >> (*f).sb_shift + 7) as libc::c_int;
     let mut prog = 0;
     loop {
-        let mut state: *mut atomic_uint =
+        let state: *mut atomic_uint =
             &mut *((*f).frame_thread.frame_progress).offset(idx as isize) as *mut atomic_uint;
         let val: libc::c_uint = !::core::intrinsics::atomic_load_seqcst(state);
         prog = if val != 0 {
@@ -1483,7 +1483,7 @@ unsafe extern "C" fn delayed_fg_task(c: *const Dav1dContext, ttd: *mut TaskThrea
     }
 }
 
-pub unsafe extern "C" fn dav1d_worker_task(mut data: *mut libc::c_void) -> *mut libc::c_void {
+pub unsafe extern "C" fn dav1d_worker_task(data: *mut libc::c_void) -> *mut libc::c_void {
     let mut flush = 0;
     let mut error_0 = 0;
     let mut sby = 0;
@@ -1597,7 +1597,7 @@ pub unsafe extern "C" fn dav1d_worker_task(mut data: *mut libc::c_void) -> *mut 
                                                 == DAV1D_TASK_TYPE_ENTROPY_PROGRESS as libc::c_int
                                                     as libc::c_uint)
                                                 as libc::c_int;
-                                            let mut error = ::core::intrinsics::atomic_load_seqcst(
+                                            let error = ::core::intrinsics::atomic_load_seqcst(
                                                 &mut (*f).task_thread.error,
                                             );
                                             if !(::core::intrinsics::atomic_load_seqcst(
@@ -1663,7 +1663,7 @@ pub unsafe extern "C" fn dav1d_worker_task(mut data: *mut libc::c_void) -> *mut 
                                                         5395695591151878490 => {}
                                                         _ => {
                                                             if ((*t).sby + 1) < (*f).sbh {
-                                                                let mut next_t: *mut Dav1dTask =
+                                                                let next_t: *mut Dav1dTask =
                                                                     &mut *t.offset(1)
                                                                         as *mut Dav1dTask;
                                                                 *next_t = (*t).clone();
@@ -1699,7 +1699,7 @@ pub unsafe extern "C" fn dav1d_worker_task(mut data: *mut libc::c_void) -> *mut 
                                         } else if (*t).type_0 as libc::c_uint
                                             == DAV1D_TASK_TYPE_CDEF as libc::c_int as libc::c_uint
                                         {
-                                            let mut prog_0: *mut atomic_uint =
+                                            let prog_0: *mut atomic_uint =
                                                 (*f).frame_thread.copy_lpf_progress;
                                             let p1_1 = ::core::intrinsics::atomic_load_seqcst(
                                                 &mut *prog_0.offset(((*t).sby - 1 >> 5) as isize)
@@ -1798,8 +1798,8 @@ pub unsafe extern "C" fn dav1d_worker_task(mut data: *mut libc::c_void) -> *mut 
                                     if !((*c).n_fc > 1 as libc::c_uint) {
                                         unreachable!();
                                     }
-                                    let mut res = dav1d_decode_frame_init(f);
-                                    let mut p1_3 = (if !((*f).in_cdf.progress).is_null() {
+                                    let res = dav1d_decode_frame_init(f);
+                                    let p1_3 = (if !((*f).in_cdf.progress).is_null() {
                                         ::core::intrinsics::atomic_load_seqcst((*f).in_cdf.progress)
                                     } else {
                                         1 as libc::c_int as libc::c_uint
@@ -2176,7 +2176,7 @@ pub unsafe extern "C" fn dav1d_worker_task(mut data: *mut libc::c_void) -> *mut 
                                         (1 as libc::c_uint) << (sby & 31),
                                     );
                                     if sby != 0 {
-                                        let mut prog_1 = ::core::intrinsics::atomic_load_seqcst(
+                                        let prog_1 = ::core::intrinsics::atomic_load_seqcst(
                                             &mut *((*f).frame_thread.copy_lpf_progress)
                                                 .offset((sby - 1 >> 5) as isize)
                                                 as *mut atomic_uint,

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -57,7 +57,7 @@ pub fn dav1d_get_shear_params(wm: &mut Dav1dWarpedMotionParams) -> bool {
     let alpha = iclip_wmp(mat[2] - 0x10000) as i16;
     let beta = iclip_wmp(mat[3]) as i16;
 
-    let (mut shift, y) = resolve_divisor_32((mat[2]).abs() as u32);
+    let (shift, y) = resolve_divisor_32((mat[2]).abs() as u32);
     let y = apply_sign(y, mat[2]);
     let v1 = mat[4] as i64 * 0x10000 * y as i64;
     let rnd = 1 << shift >> 1;

--- a/src/wedge.rs
+++ b/src/wedge.rs
@@ -49,7 +49,7 @@ use crate::include::common::intops::imax;
 use crate::include::common::intops::imin;
 static mut wedge_codebook_16_hgtw: [wedge_code_type; 16] = [
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE27 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -57,7 +57,7 @@ static mut wedge_codebook_16_hgtw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE63 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -65,7 +65,7 @@ static mut wedge_codebook_16_hgtw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE117 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -73,7 +73,7 @@ static mut wedge_codebook_16_hgtw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE153 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -81,7 +81,7 @@ static mut wedge_codebook_16_hgtw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_HORIZONTAL as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 2 as libc::c_int as uint8_t,
@@ -89,7 +89,7 @@ static mut wedge_codebook_16_hgtw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_HORIZONTAL as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -97,7 +97,7 @@ static mut wedge_codebook_16_hgtw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_HORIZONTAL as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 6 as libc::c_int as uint8_t,
@@ -105,7 +105,7 @@ static mut wedge_codebook_16_hgtw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_VERTICAL as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -113,7 +113,7 @@ static mut wedge_codebook_16_hgtw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE27 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 2 as libc::c_int as uint8_t,
@@ -121,7 +121,7 @@ static mut wedge_codebook_16_hgtw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE27 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 6 as libc::c_int as uint8_t,
@@ -129,7 +129,7 @@ static mut wedge_codebook_16_hgtw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE153 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 2 as libc::c_int as uint8_t,
@@ -137,7 +137,7 @@ static mut wedge_codebook_16_hgtw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE153 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 6 as libc::c_int as uint8_t,
@@ -145,7 +145,7 @@ static mut wedge_codebook_16_hgtw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE63 as libc::c_int as uint8_t,
             x_offset: 2 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -153,7 +153,7 @@ static mut wedge_codebook_16_hgtw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE63 as libc::c_int as uint8_t,
             x_offset: 6 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -161,7 +161,7 @@ static mut wedge_codebook_16_hgtw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE117 as libc::c_int as uint8_t,
             x_offset: 2 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -169,7 +169,7 @@ static mut wedge_codebook_16_hgtw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE117 as libc::c_int as uint8_t,
             x_offset: 6 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -179,7 +179,7 @@ static mut wedge_codebook_16_hgtw: [wedge_code_type; 16] = [
 ];
 static mut wedge_codebook_16_hltw: [wedge_code_type; 16] = [
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE27 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -187,7 +187,7 @@ static mut wedge_codebook_16_hltw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE63 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -195,7 +195,7 @@ static mut wedge_codebook_16_hltw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE117 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -203,7 +203,7 @@ static mut wedge_codebook_16_hltw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE153 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -211,7 +211,7 @@ static mut wedge_codebook_16_hltw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_VERTICAL as libc::c_int as uint8_t,
             x_offset: 2 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -219,7 +219,7 @@ static mut wedge_codebook_16_hltw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_VERTICAL as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -227,7 +227,7 @@ static mut wedge_codebook_16_hltw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_VERTICAL as libc::c_int as uint8_t,
             x_offset: 6 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -235,7 +235,7 @@ static mut wedge_codebook_16_hltw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_HORIZONTAL as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -243,7 +243,7 @@ static mut wedge_codebook_16_hltw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE27 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 2 as libc::c_int as uint8_t,
@@ -251,7 +251,7 @@ static mut wedge_codebook_16_hltw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE27 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 6 as libc::c_int as uint8_t,
@@ -259,7 +259,7 @@ static mut wedge_codebook_16_hltw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE153 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 2 as libc::c_int as uint8_t,
@@ -267,7 +267,7 @@ static mut wedge_codebook_16_hltw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE153 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 6 as libc::c_int as uint8_t,
@@ -275,7 +275,7 @@ static mut wedge_codebook_16_hltw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE63 as libc::c_int as uint8_t,
             x_offset: 2 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -283,7 +283,7 @@ static mut wedge_codebook_16_hltw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE63 as libc::c_int as uint8_t,
             x_offset: 6 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -291,7 +291,7 @@ static mut wedge_codebook_16_hltw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE117 as libc::c_int as uint8_t,
             x_offset: 2 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -299,7 +299,7 @@ static mut wedge_codebook_16_hltw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE117 as libc::c_int as uint8_t,
             x_offset: 6 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -309,7 +309,7 @@ static mut wedge_codebook_16_hltw: [wedge_code_type; 16] = [
 ];
 static mut wedge_codebook_16_heqw: [wedge_code_type; 16] = [
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE27 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -317,7 +317,7 @@ static mut wedge_codebook_16_heqw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE63 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -325,7 +325,7 @@ static mut wedge_codebook_16_heqw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE117 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -333,7 +333,7 @@ static mut wedge_codebook_16_heqw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE153 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -341,7 +341,7 @@ static mut wedge_codebook_16_heqw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_HORIZONTAL as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 2 as libc::c_int as uint8_t,
@@ -349,7 +349,7 @@ static mut wedge_codebook_16_heqw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_HORIZONTAL as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 6 as libc::c_int as uint8_t,
@@ -357,7 +357,7 @@ static mut wedge_codebook_16_heqw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_VERTICAL as libc::c_int as uint8_t,
             x_offset: 2 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -365,7 +365,7 @@ static mut wedge_codebook_16_heqw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_VERTICAL as libc::c_int as uint8_t,
             x_offset: 6 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -373,7 +373,7 @@ static mut wedge_codebook_16_heqw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE27 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 2 as libc::c_int as uint8_t,
@@ -381,7 +381,7 @@ static mut wedge_codebook_16_heqw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE27 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 6 as libc::c_int as uint8_t,
@@ -389,7 +389,7 @@ static mut wedge_codebook_16_heqw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE153 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 2 as libc::c_int as uint8_t,
@@ -397,7 +397,7 @@ static mut wedge_codebook_16_heqw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE153 as libc::c_int as uint8_t,
             x_offset: 4 as libc::c_int as uint8_t,
             y_offset: 6 as libc::c_int as uint8_t,
@@ -405,7 +405,7 @@ static mut wedge_codebook_16_heqw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE63 as libc::c_int as uint8_t,
             x_offset: 2 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -413,7 +413,7 @@ static mut wedge_codebook_16_heqw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE63 as libc::c_int as uint8_t,
             x_offset: 6 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -421,7 +421,7 @@ static mut wedge_codebook_16_heqw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE117 as libc::c_int as uint8_t,
             x_offset: 2 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -429,7 +429,7 @@ static mut wedge_codebook_16_heqw: [wedge_code_type; 16] = [
         init
     },
     {
-        let mut init = wedge_code_type {
+        let init = wedge_code_type {
             direction: WEDGE_OBLIQUE117 as libc::c_int as uint8_t,
             x_offset: 6 as libc::c_int as uint8_t,
             y_offset: 4 as libc::c_int as uint8_t,
@@ -588,7 +588,7 @@ unsafe extern "C" fn init_chroma(
 }
 #[cold]
 unsafe extern "C" fn fill2d_16x2(
-    mut dst: *mut uint8_t,
+    dst: *mut uint8_t,
     w: libc::c_int,
     h: libc::c_int,
     bs: BlockSize,

--- a/src/x86/cpu.rs
+++ b/src/x86/cpu.rs
@@ -3,6 +3,7 @@ use ::libc;
 extern "C" {
     fn memcmp(_: *const libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> libc::c_int;
     fn dav1d_cpu_cpuid(regs: *mut CpuidRegisters, leaf: libc::c_uint, subleaf: libc::c_uint);
+    #[cfg(target_arch = "x86_64")]
     fn dav1d_cpu_xgetbv(xcr: libc::c_uint) -> uint64_t;
 }
 

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -1,5 +1,4 @@
 #![allow(
-    dead_code,
     mutable_transmutes,
     non_camel_case_types,
     non_snake_case,

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -1,9 +1,6 @@
-#![allow(
-    mutable_transmutes,
-    non_camel_case_types,
-    non_snake_case,
-    non_upper_case_globals,
-)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
 #![feature(extern_types)]
 #![feature(c_variadic)]
 extern crate rav1d;

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -1,5 +1,4 @@
 #![allow(non_camel_case_types)]
-#![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![feature(extern_types)]
 #![feature(c_variadic)]

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -5,7 +5,6 @@
     non_snake_case,
     non_upper_case_globals,
     unused_assignments,
-    unused_mut
 )]
 #![feature(extern_types)]
 #![feature(c_variadic)]
@@ -140,7 +139,7 @@ unsafe extern "C" fn get_seed() -> libc::c_uint {
         .wrapping_add(ts.tv_nsec as libc::c_ulonglong) as libc::c_uint;
 }
 static mut xs_state: [uint32_t; 4] = [0; 4];
-unsafe fn xor128_srand(mut seed: libc::c_uint) {
+unsafe fn xor128_srand(seed: libc::c_uint) {
     xs_state[0] = seed;
     xs_state[1] = seed & 0xffff0000 | !seed & 0xffff;
     xs_state[2] = !seed & 0xffff0000 | seed & 0xffff;
@@ -395,7 +394,7 @@ unsafe extern "C" fn seek(
 unsafe fn main_0(argc: libc::c_int, argv: *const *mut libc::c_char) -> libc::c_int {
     let mut shift: libc::c_uint = 0;
     let mut current_block: u64;
-    let mut version: *const libc::c_char = dav1d_version();
+    let version: *const libc::c_char = dav1d_version();
     if libc::strcmp(version, b"966d63c1\0" as *const u8 as *const libc::c_char) != 0 {
         libc::fprintf(
             stderr,

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -4,7 +4,6 @@
     non_camel_case_types,
     non_snake_case,
     non_upper_case_globals,
-    unused_assignments,
 )]
 #![feature(extern_types)]
 #![feature(c_variadic)]
@@ -162,7 +161,7 @@ unsafe extern "C" fn decode_frame(
     c: *mut Dav1dContext,
     data: *mut Dav1dData,
 ) -> libc::c_int {
-    let mut res: libc::c_int = 0;
+    let mut res: libc::c_int;
     libc::memset(
         p as *mut libc::c_void,
         0,
@@ -255,7 +254,7 @@ unsafe extern "C" fn decode_all(
     c: *mut Dav1dContext,
     data: *mut Dav1dData,
 ) -> libc::c_int {
-    let mut res: libc::c_int = 0 as libc::c_int;
+    let mut res: libc::c_int;
     let mut p: Dav1dPicture = Dav1dPicture {
         seq_hdr: 0 as *mut Dav1dSequenceHeader,
         frame_hdr: 0 as *mut Dav1dFrameHeader,
@@ -307,7 +306,7 @@ unsafe extern "C" fn seek(
     pts: uint64_t,
     data: *mut Dav1dData,
 ) -> libc::c_int {
-    let mut res: libc::c_int = 0;
+    let mut res: libc::c_int;
     res = input_seek(in_0, pts);
     if res != 0 {
         return res;
@@ -392,7 +391,7 @@ unsafe extern "C" fn seek(
     return res;
 }
 unsafe fn main_0(argc: libc::c_int, argv: *const *mut libc::c_char) -> libc::c_int {
-    let mut shift: libc::c_uint = 0;
+    let mut shift: libc::c_uint;
     let mut current_block: u64;
     let version: *const libc::c_char = dav1d_version();
     if libc::strcmp(version, b"966d63c1\0" as *const u8 as *const libc::c_char) != 0 {
@@ -462,10 +461,10 @@ unsafe fn main_0(argc: libc::c_int, argv: *const *mut libc::c_char) -> libc::c_i
     let mut total: libc::c_uint = 0;
     let mut i_fps: [libc::c_uint; 2] = [0; 2];
     let mut i_timebase: [libc::c_uint; 2] = [0; 2];
-    let mut timebase: libc::c_double = 0.;
-    let mut spf: libc::c_double = 0.;
-    let mut fps: libc::c_double = 0.;
-    let mut pts: uint64_t = 0;
+    let timebase: libc::c_double;
+    let spf: libc::c_double;
+    let fps: libc::c_double;
+    let mut pts: uint64_t;
     xor128_srand(get_seed());
     parse(argc, argv, &mut cli_settings, &mut lib_settings);
     if input_open(

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -1,5 +1,4 @@
 #![allow(
-    dead_code,
     mutable_transmutes,
     non_camel_case_types,
     non_snake_case,

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -1,5 +1,4 @@
 #![allow(non_camel_case_types)]
-#![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![feature(extern_types)]
 #![feature(c_variadic)]

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -1,9 +1,6 @@
-#![allow(
-    mutable_transmutes,
-    non_camel_case_types,
-    non_snake_case,
-    non_upper_case_globals,
-)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
 #![feature(extern_types)]
 #![feature(c_variadic)]
 use crate::include::stddef::*;

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -5,7 +5,6 @@
     non_snake_case,
     non_upper_case_globals,
     unused_assignments,
-    unused_mut
 )]
 #![feature(extern_types)]
 #![feature(c_variadic)]
@@ -191,10 +190,10 @@ unsafe extern "C" fn get_time_nanos() -> uint64_t {
         .wrapping_mul(ts.tv_sec as libc::c_ulonglong)
         .wrapping_add(ts.tv_nsec as libc::c_ulonglong) as uint64_t;
 }
-unsafe extern "C" fn sleep_nanos(mut d: uint64_t) {
+unsafe extern "C" fn sleep_nanos(d: uint64_t) {
     // TODO: C version has Windows specific code path
     let ts: libc::timespec = {
-        let mut init = libc::timespec {
+        let init = libc::timespec {
             tv_sec: d as libc::time_t / 1000000000,
             tv_nsec: d as libc::time_t % 1000000000,
         };
@@ -455,7 +454,7 @@ unsafe fn main_0(argc: libc::c_int, argv: *const *mut libc::c_char) -> libc::c_i
     let mut elapsed: uint64_t = 0;
     let mut i_fps: libc::c_double = 0.;
     let mut frametimes: *mut libc::FILE = 0 as *mut libc::FILE;
-    let mut version: *const libc::c_char = dav1d_version();
+    let version: *const libc::c_char = dav1d_version();
     if strcmp(version, b"966d63c1\0" as *const u8 as *const libc::c_char) != 0 {
         fprintf(
             stderr,

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -4,7 +4,6 @@
     non_camel_case_types,
     non_snake_case,
     non_upper_case_globals,
-    unused_assignments,
 )]
 #![feature(extern_types)]
 #![feature(c_variadic)]
@@ -355,7 +354,7 @@ unsafe extern "C" fn picture_release(p: *mut Dav1dPicture, _: *mut libc::c_void)
 }
 unsafe fn main_0(argc: libc::c_int, argv: *const *mut libc::c_char) -> libc::c_int {
     let istty = isatty(fileno(stderr));
-    let mut res = 0;
+    let mut res;
     let mut cli_settings: CLISettings = CLISettings {
         outputfile: 0 as *const libc::c_char,
         inputfile: 0 as *const libc::c_char,
@@ -449,10 +448,10 @@ unsafe fn main_0(argc: libc::c_int, argv: *const *mut libc::c_char) -> libc::c_i
     let mut total: libc::c_uint = 0;
     let mut fps: [libc::c_uint; 2] = [0; 2];
     let mut timebase: [libc::c_uint; 2] = [0; 2];
-    let mut nspf: uint64_t = 0;
-    let mut tfirst: uint64_t = 0;
+    let nspf: uint64_t;
+    let tfirst: uint64_t;
     let mut elapsed: uint64_t = 0;
-    let mut i_fps: libc::c_double = 0.;
+    let i_fps: libc::c_double;
     let mut frametimes: *mut libc::FILE = 0 as *mut libc::FILE;
     let version: *const libc::c_char = dav1d_version();
     if strcmp(version, b"966d63c1\0" as *const u8 as *const libc::c_char) != 0 {

--- a/tools/dav1d_cli_parse.rs
+++ b/tools/dav1d_cli_parse.rs
@@ -370,7 +370,7 @@ unsafe extern "C" fn error(
     shouldbe: *const libc::c_char,
 ) {
     let mut optname: [libc::c_char; 256] = [0; 256];
-    let mut n = 0;
+    let mut n;
     n = 0 as libc::c_int;
     while !(long_opts[n as usize].name).is_null() {
         if long_opts[n as usize].val == option {
@@ -620,7 +620,7 @@ unsafe extern "C" fn parse_enum(
         n += 1;
     }
     let mut end: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut res: libc::c_uint = 0;
+    let res: libc::c_uint;
     if strncmp(
         optarg_0,
         b"0x\0" as *const u8 as *const libc::c_char,
@@ -648,7 +648,7 @@ pub unsafe extern "C" fn parse(
     cli_settings: *mut CLISettings,
     lib_settings: *mut Dav1dSettings,
 ) {
-    let mut o = 0;
+    let mut o;
     memset(
         cli_settings as *mut libc::c_void,
         0 as libc::c_int,

--- a/tools/dav1d_cli_parse.rs
+++ b/tools/dav1d_cli_parse.rs
@@ -3,7 +3,6 @@ use ::libc;
 use rav1d::include::stdint::uint64_t;
 use rav1d::include::stdint::uint8_t;
 extern "C" {
-    pub type Dav1dRef;
     static mut optarg: *mut libc::c_char;
     static mut optind: libc::c_int;
     fn getopt_long(
@@ -82,9 +81,6 @@ pub struct CLISettings {
     pub neg_stride: libc::c_int,
 }
 pub type CLISettings_realtime = libc::c_uint;
-pub const REALTIME_CUSTOM: CLISettings_realtime = 2;
-pub const REALTIME_INPUT: CLISettings_realtime = 1;
-pub const REALTIME_DISABLE: CLISettings_realtime = 0;
 pub const ARG_DECODE_FRAME_TYPE: arg = 273;
 #[repr(C)]
 pub struct EnumParseTable {

--- a/tools/dav1d_cli_parse.rs
+++ b/tools/dav1d_cli_parse.rs
@@ -119,7 +119,7 @@ static mut short_opts: [libc::c_char; 11] =
     unsafe { *::core::mem::transmute::<&[u8; 11], &[libc::c_char; 11]>(b"i:o:vql:s:\0") };
 static mut long_opts: [option; 25] = [
     {
-        let mut init = option {
+        let init = option {
             name: b"input\0" as *const u8 as *const libc::c_char,
             has_arg: 1 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -128,7 +128,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"output\0" as *const u8 as *const libc::c_char,
             has_arg: 1 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -137,7 +137,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"quiet\0" as *const u8 as *const libc::c_char,
             has_arg: 0 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -146,7 +146,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"demuxer\0" as *const u8 as *const libc::c_char,
             has_arg: 1 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -155,7 +155,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"muxer\0" as *const u8 as *const libc::c_char,
             has_arg: 1 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -164,7 +164,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"version\0" as *const u8 as *const libc::c_char,
             has_arg: 0 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -173,7 +173,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"frametimes\0" as *const u8 as *const libc::c_char,
             has_arg: 1 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -182,7 +182,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"limit\0" as *const u8 as *const libc::c_char,
             has_arg: 1 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -191,7 +191,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"skip\0" as *const u8 as *const libc::c_char,
             has_arg: 1 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -200,7 +200,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"realtime\0" as *const u8 as *const libc::c_char,
             has_arg: 2 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -209,7 +209,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"realtimecache\0" as *const u8 as *const libc::c_char,
             has_arg: 1 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -218,7 +218,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"threads\0" as *const u8 as *const libc::c_char,
             has_arg: 1 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -227,7 +227,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"framedelay\0" as *const u8 as *const libc::c_char,
             has_arg: 1 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -236,7 +236,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"verify\0" as *const u8 as *const libc::c_char,
             has_arg: 1 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -245,7 +245,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"filmgrain\0" as *const u8 as *const libc::c_char,
             has_arg: 1 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -254,7 +254,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"oppoint\0" as *const u8 as *const libc::c_char,
             has_arg: 1 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -263,7 +263,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"alllayers\0" as *const u8 as *const libc::c_char,
             has_arg: 1 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -272,7 +272,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"sizelimit\0" as *const u8 as *const libc::c_char,
             has_arg: 1 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -281,7 +281,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"strict\0" as *const u8 as *const libc::c_char,
             has_arg: 1 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -290,7 +290,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"cpumask\0" as *const u8 as *const libc::c_char,
             has_arg: 1 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -299,7 +299,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"negstride\0" as *const u8 as *const libc::c_char,
             has_arg: 0 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -308,7 +308,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"outputinvisible\0" as *const u8 as *const libc::c_char,
             has_arg: 1 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -317,7 +317,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"inloopfilters\0" as *const u8 as *const libc::c_char,
             has_arg: 1 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -326,7 +326,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: b"decodeframetype\0" as *const u8 as *const libc::c_char,
             has_arg: 1 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -335,7 +335,7 @@ static mut long_opts: [option; 25] = [
         init
     },
     {
-        let mut init = option {
+        let init = option {
             name: 0 as *const libc::c_char,
             has_arg: 0 as libc::c_int,
             flag: 0 as *const libc::c_int as *mut libc::c_int,
@@ -344,7 +344,7 @@ static mut long_opts: [option; 25] = [
         init
     },
 ];
-unsafe extern "C" fn usage(app: *const libc::c_char, reason: *const libc::c_char, mut args: ...) {
+unsafe extern "C" fn usage(app: *const libc::c_char, reason: *const libc::c_char, args: ...) {
     if !reason.is_null() {
         let mut args_0: ::core::ffi::VaListImpl;
         args_0 = args.clone();
@@ -425,7 +425,7 @@ unsafe extern "C" fn parse_optional_fraction(
     optarg_0: *const libc::c_char,
     option: libc::c_int,
     app: *const libc::c_char,
-    mut value: *mut libc::c_double,
+    value: *mut libc::c_double,
 ) -> libc::c_int {
     if optarg_0.is_null() {
         return 0 as libc::c_int;
@@ -433,7 +433,7 @@ unsafe extern "C" fn parse_optional_fraction(
     let mut end: *mut libc::c_char = 0 as *mut libc::c_char;
     *value = strtod(optarg_0, &mut end);
     if *end as libc::c_int == '/' as i32 && end != optarg_0 as *mut libc::c_char {
-        let mut optarg2: *const libc::c_char = end.offset(1);
+        let optarg2: *const libc::c_char = end.offset(1);
         *value /= strtod(optarg2, &mut end);
         if *end as libc::c_int != 0 || end == optarg2 as *mut libc::c_char {
             error(
@@ -455,42 +455,42 @@ unsafe extern "C" fn parse_optional_fraction(
 }
 static mut cpu_mask_tbl: [EnumParseTable; 6] = [
     {
-        let mut init = EnumParseTable {
+        let init = EnumParseTable {
             str_0: b"sse2\0" as *const u8 as *const libc::c_char,
             val: X86_CPU_MASK_SSE2 as libc::c_int,
         };
         init
     },
     {
-        let mut init = EnumParseTable {
+        let init = EnumParseTable {
             str_0: b"ssse3\0" as *const u8 as *const libc::c_char,
             val: X86_CPU_MASK_SSSE3 as libc::c_int,
         };
         init
     },
     {
-        let mut init = EnumParseTable {
+        let init = EnumParseTable {
             str_0: b"sse41\0" as *const u8 as *const libc::c_char,
             val: X86_CPU_MASK_SSE41 as libc::c_int,
         };
         init
     },
     {
-        let mut init = EnumParseTable {
+        let init = EnumParseTable {
             str_0: b"avx2\0" as *const u8 as *const libc::c_char,
             val: X86_CPU_MASK_AVX2 as libc::c_int,
         };
         init
     },
     {
-        let mut init = EnumParseTable {
+        let init = EnumParseTable {
             str_0: b"avx512icl\0" as *const u8 as *const libc::c_char,
             val: X86_CPU_MASK_AVX512ICL as libc::c_int,
         };
         init
     },
     {
-        let mut init = EnumParseTable {
+        let init = EnumParseTable {
             str_0: b"none\0" as *const u8 as *const libc::c_char,
             val: 0 as libc::c_int,
         };
@@ -499,49 +499,49 @@ static mut cpu_mask_tbl: [EnumParseTable; 6] = [
 ];
 static mut inloop_filters_tbl: [EnumParseTable; 8] = [
     {
-        let mut init = EnumParseTable {
+        let init = EnumParseTable {
             str_0: b"none\0" as *const u8 as *const libc::c_char,
             val: DAV1D_INLOOPFILTER_NONE as libc::c_int,
         };
         init
     },
     {
-        let mut init = EnumParseTable {
+        let init = EnumParseTable {
             str_0: b"deblock\0" as *const u8 as *const libc::c_char,
             val: DAV1D_INLOOPFILTER_DEBLOCK as libc::c_int,
         };
         init
     },
     {
-        let mut init = EnumParseTable {
+        let init = EnumParseTable {
             str_0: b"nodeblock\0" as *const u8 as *const libc::c_char,
             val: DAV1D_INLOOPFILTER_ALL as libc::c_int - DAV1D_INLOOPFILTER_DEBLOCK as libc::c_int,
         };
         init
     },
     {
-        let mut init = EnumParseTable {
+        let init = EnumParseTable {
             str_0: b"cdef\0" as *const u8 as *const libc::c_char,
             val: DAV1D_INLOOPFILTER_CDEF as libc::c_int,
         };
         init
     },
     {
-        let mut init = EnumParseTable {
+        let init = EnumParseTable {
             str_0: b"nocdef\0" as *const u8 as *const libc::c_char,
             val: DAV1D_INLOOPFILTER_ALL as libc::c_int - DAV1D_INLOOPFILTER_CDEF as libc::c_int,
         };
         init
     },
     {
-        let mut init = EnumParseTable {
+        let init = EnumParseTable {
             str_0: b"restoration\0" as *const u8 as *const libc::c_char,
             val: DAV1D_INLOOPFILTER_RESTORATION as libc::c_int,
         };
         init
     },
     {
-        let mut init = EnumParseTable {
+        let init = EnumParseTable {
             str_0: b"norestoration\0" as *const u8 as *const libc::c_char,
             val: DAV1D_INLOOPFILTER_ALL as libc::c_int
                 - DAV1D_INLOOPFILTER_RESTORATION as libc::c_int,
@@ -549,7 +549,7 @@ static mut inloop_filters_tbl: [EnumParseTable; 8] = [
         init
     },
     {
-        let mut init = EnumParseTable {
+        let init = EnumParseTable {
             str_0: b"all\0" as *const u8 as *const libc::c_char,
             val: DAV1D_INLOOPFILTER_ALL as libc::c_int,
         };
@@ -558,28 +558,28 @@ static mut inloop_filters_tbl: [EnumParseTable; 8] = [
 ];
 static mut decode_frame_type_tbl: [EnumParseTable; 4] = [
     {
-        let mut init = EnumParseTable {
+        let init = EnumParseTable {
             str_0: b"all\0" as *const u8 as *const libc::c_char,
             val: DAV1D_DECODEFRAMETYPE_ALL as libc::c_int,
         };
         init
     },
     {
-        let mut init = EnumParseTable {
+        let init = EnumParseTable {
             str_0: b"reference\0" as *const u8 as *const libc::c_char,
             val: DAV1D_DECODEFRAMETYPE_REFERENCE as libc::c_int,
         };
         init
     },
     {
-        let mut init = EnumParseTable {
+        let init = EnumParseTable {
             str_0: b"intra\0" as *const u8 as *const libc::c_char,
             val: DAV1D_DECODEFRAMETYPE_INTRA as libc::c_int,
         };
         init
     },
     {
-        let mut init = EnumParseTable {
+        let init = EnumParseTable {
             str_0: b"key\0" as *const u8 as *const libc::c_char,
             val: DAV1D_DECODEFRAMETYPE_KEY as libc::c_int,
         };
@@ -587,11 +587,11 @@ static mut decode_frame_type_tbl: [EnumParseTable; 4] = [
     },
 ];
 unsafe extern "C" fn parse_enum(
-    mut optarg_0: *mut libc::c_char,
+    optarg_0: *mut libc::c_char,
     tbl: *const EnumParseTable,
     tbl_sz: libc::c_int,
     option: libc::c_int,
-    mut app: *const libc::c_char,
+    app: *const libc::c_char,
 ) -> libc::c_uint {
     let mut str: [libc::c_char; 1024] = [0; 1024];
     strcpy(

--- a/tools/input/annexb.rs
+++ b/tools/input/annexb.rs
@@ -7,7 +7,6 @@ use rav1d::include::stddef::size_t;
 use rav1d::include::stdint::uint64_t;
 use rav1d::include::stdint::uint8_t;
 extern "C" {
-    pub type Dav1dRef;
     fn fclose(__stream: *mut libc::FILE) -> libc::c_int;
     fn fopen(_: *const libc::c_char, _: *const libc::c_char) -> *mut libc::FILE;
     fn fprintf(_: *mut libc::FILE, _: *const libc::c_char, _: ...) -> libc::c_int;

--- a/tools/input/annexb.rs
+++ b/tools/input/annexb.rs
@@ -50,7 +50,7 @@ use rav1d::include::common::intops::imin;
 unsafe extern "C" fn leb128(f: *mut libc::FILE, len: *mut size_t) -> libc::c_int {
     let mut val: uint64_t = 0 as libc::c_int as uint64_t;
     let mut i: libc::c_uint = 0 as libc::c_int as libc::c_uint;
-    let mut more: libc::c_uint = 0;
+    let mut more: libc::c_uint;
     loop {
         let mut v: uint8_t = 0;
         if fread(&mut v as *mut uint8_t as *mut libc::c_void, 1, 1, f) < 1 {
@@ -77,7 +77,7 @@ unsafe extern "C" fn leb(
 ) -> libc::c_int {
     let mut val: uint64_t = 0 as libc::c_int as uint64_t;
     let mut i: libc::c_uint = 0 as libc::c_int as libc::c_uint;
-    let mut more: libc::c_uint = 0;
+    let mut more: libc::c_uint;
     loop {
         let fresh0 = sz;
         sz = sz - 1;
@@ -109,9 +109,9 @@ unsafe extern "C" fn parse_obu_header(
     type_0: *mut Dav1dObuType,
     allow_implicit_size: libc::c_int,
 ) -> libc::c_int {
-    let mut ret = 0;
-    let mut extension_flag = 0;
-    let mut has_size_flag = 0;
+    let ret;
+    let extension_flag;
+    let has_size_flag;
     if buf_size == 0 {
         return -(1 as libc::c_int);
     }
@@ -142,7 +142,7 @@ unsafe extern "C" fn parse_obu_header(
     return buf_size + 1 + extension_flag;
 }
 unsafe extern "C" fn annexb_probe(data: *const uint8_t) -> libc::c_int {
-    let mut ret = 0;
+    let mut ret;
     let mut cnt = 0;
     let mut temporal_unit_size: size_t = 0;
     ret = leb(
@@ -232,7 +232,7 @@ unsafe extern "C" fn annexb_open(
     num_frames: *mut libc::c_uint,
     timebase: *mut libc::c_uint,
 ) -> libc::c_int {
-    let mut res = 0;
+    let mut res;
     let mut len: size_t = 0;
     (*c).f = fopen(file, b"rb\0" as *const u8 as *const libc::c_char);
     if ((*c).f).is_null() {
@@ -262,7 +262,7 @@ unsafe extern "C" fn annexb_open(
 }
 unsafe extern "C" fn annexb_read(c: *mut AnnexbInputContext, data: *mut Dav1dData) -> libc::c_int {
     let mut len: size_t = 0;
-    let mut res = 0;
+    let mut res;
     if (*c).temporal_unit_size == 0 {
         res = leb128((*c).f, &mut (*c).temporal_unit_size);
         if res < 0 {

--- a/tools/input/annexb.rs
+++ b/tools/input/annexb.rs
@@ -141,7 +141,7 @@ unsafe extern "C" fn parse_obu_header(
     *obu_size = buf_size as size_t;
     return buf_size + 1 + extension_flag;
 }
-unsafe extern "C" fn annexb_probe(mut data: *const uint8_t) -> libc::c_int {
+unsafe extern "C" fn annexb_probe(data: *const uint8_t) -> libc::c_int {
     let mut ret = 0;
     let mut cnt = 0;
     let mut temporal_unit_size: size_t = 0;
@@ -228,9 +228,9 @@ unsafe extern "C" fn annexb_probe(mut data: *const uint8_t) -> libc::c_int {
 unsafe extern "C" fn annexb_open(
     c: *mut AnnexbInputContext,
     file: *const libc::c_char,
-    mut fps: *mut libc::c_uint,
+    fps: *mut libc::c_uint,
     num_frames: *mut libc::c_uint,
-    mut timebase: *mut libc::c_uint,
+    timebase: *mut libc::c_uint,
 ) -> libc::c_int {
     let mut res = 0;
     let mut len: size_t = 0;
@@ -282,7 +282,7 @@ unsafe extern "C" fn annexb_read(c: *mut AnnexbInputContext, data: *mut Dav1dDat
     if res < 0 || len.wrapping_add(res as size_t) > (*c).frame_unit_size {
         return -(1 as libc::c_int);
     }
-    let mut ptr: *mut uint8_t = dav1d_data_create(data, len);
+    let ptr: *mut uint8_t = dav1d_data_create(data, len);
     if ptr.is_null() {
         return -(1 as libc::c_int);
     }
@@ -306,7 +306,7 @@ unsafe extern "C" fn annexb_close(c: *mut AnnexbInputContext) {
 }
 #[no_mangle]
 pub static mut annexb_demuxer: Demuxer = {
-    let mut init = Demuxer {
+    let init = Demuxer {
         priv_data_size: ::core::mem::size_of::<AnnexbInputContext>() as libc::c_ulong
             as libc::c_int,
         name: b"annexb\0" as *const u8 as *const libc::c_char,

--- a/tools/input/input.rs
+++ b/tools/input/input.rs
@@ -64,9 +64,9 @@ pub unsafe extern "C" fn input_open(
     c_out: *mut *mut DemuxerContext,
     name: *const libc::c_char,
     filename: *const libc::c_char,
-    mut fps: *mut libc::c_uint,
+    fps: *mut libc::c_uint,
     num_frames: *mut libc::c_uint,
-    mut timebase: *mut libc::c_uint,
+    timebase: *mut libc::c_uint,
 ) -> libc::c_int {
     let mut impl_0: *const Demuxer = 0 as *const Demuxer;
     let mut c: *mut DemuxerContext = 0 as *mut DemuxerContext;
@@ -105,7 +105,7 @@ pub unsafe extern "C" fn input_open(
             );
             return -(12 as libc::c_int);
         }
-        let mut f: *mut libc::FILE = fopen(filename, b"rb\0" as *const u8 as *const libc::c_char);
+        let f: *mut libc::FILE = fopen(filename, b"rb\0" as *const u8 as *const libc::c_char);
         if f.is_null() {
             fprintf(
                 stderr,

--- a/tools/input/input.rs
+++ b/tools/input/input.rs
@@ -69,9 +69,9 @@ pub unsafe extern "C" fn input_open(
     timebase: *mut libc::c_uint,
 ) -> libc::c_int {
     let mut impl_0: *const Demuxer = 0 as *const Demuxer;
-    let mut c: *mut DemuxerContext = 0 as *mut DemuxerContext;
-    let mut res = 0;
-    let mut i = 0;
+    let c: *mut DemuxerContext;
+    let mut res;
+    let mut i;
     if !name.is_null() {
         i = 0 as libc::c_int;
         while !(demuxers[i as usize]).is_null() {

--- a/tools/input/input.rs
+++ b/tools/input/input.rs
@@ -4,7 +4,6 @@ use ::libc;
 use rav1d::include::stdint::uint64_t;
 use rav1d::include::stdint::uint8_t;
 extern "C" {
-    pub type Dav1dRef;
     pub type DemuxerPriv;
     fn fclose(__stream: *mut libc::FILE) -> libc::c_int;
     fn fopen(_: *const libc::c_char, _: *const libc::c_char) -> *mut libc::FILE;

--- a/tools/input/ivf.rs
+++ b/tools/input/ivf.rs
@@ -84,9 +84,9 @@ unsafe extern "C" fn rl64(p: *const uint8_t) -> int64_t {
 unsafe extern "C" fn ivf_open(
     c: *mut IvfInputContext,
     file: *const libc::c_char,
-    mut fps: *mut libc::c_uint,
+    fps: *mut libc::c_uint,
     num_frames: *mut libc::c_uint,
-    mut timebase: *mut libc::c_uint,
+    timebase: *mut libc::c_uint,
 ) -> libc::c_int {
     let mut hdr: [uint8_t; 32] = [0; 32];
     (*c).f = fopen(file, b"rb\0" as *const u8 as *const libc::c_char);
@@ -162,7 +162,7 @@ unsafe extern "C" fn ivf_open(
     while !(fread(data.as_mut_ptr() as *mut libc::c_void, 4, 1, (*c).f)
         != 1 as libc::c_int as libc::c_ulong)
     {
-        let mut sz: size_t = rl32(data.as_mut_ptr()) as size_t;
+        let sz: size_t = rl32(data.as_mut_ptr()) as size_t;
         if fread(data.as_mut_ptr() as *mut libc::c_void, 8, 1, (*c).f)
             != 1 as libc::c_int as libc::c_ulong
         {
@@ -334,7 +334,7 @@ unsafe extern "C" fn ivf_close(c: *mut IvfInputContext) {
 }
 #[no_mangle]
 pub static mut ivf_demuxer: Demuxer = {
-    let mut init = Demuxer {
+    let init = Demuxer {
         priv_data_size: ::core::mem::size_of::<IvfInputContext>() as libc::c_ulong as libc::c_int,
         name: b"ivf\0" as *const u8 as *const libc::c_char,
         probe_sz: ::core::mem::size_of::<[uint8_t; 12]>() as libc::c_ulong as libc::c_int,

--- a/tools/input/ivf.rs
+++ b/tools/input/ivf.rs
@@ -183,7 +183,7 @@ unsafe extern "C" fn ivf_open(
     if fps_num != 0 && fps_den != 0 {
         let mut gcd: uint64_t = fps_num;
         let mut a: uint64_t = fps_den;
-        let mut b: uint64_t = 0;
+        let mut b: uint64_t;
         loop {
             b = a.wrapping_rem(gcd);
             if !(b != 0) {
@@ -251,7 +251,7 @@ unsafe extern "C" fn ivf_read_header(
     return 0 as libc::c_int;
 }
 unsafe extern "C" fn ivf_read(c: *mut IvfInputContext, buf: *mut Dav1dData) -> libc::c_int {
-    let mut ptr: *mut uint8_t = 0 as *mut uint8_t;
+    let ptr: *mut uint8_t;
     let mut sz: ptrdiff_t = 0;
     let mut off: libc::off_t = 0;
     let mut ts: uint64_t = 0;

--- a/tools/input/ivf.rs
+++ b/tools/input/ivf.rs
@@ -8,7 +8,6 @@ use rav1d::include::stdint::uint32_t;
 use rav1d::include::stdint::uint64_t;
 use rav1d::include::stdint::uint8_t;
 extern "C" {
-    pub type Dav1dRef;
     fn llround(_: libc::c_double) -> libc::c_longlong;
     fn fclose(__stream: *mut libc::FILE) -> libc::c_int;
     fn fopen(_: *const libc::c_char, _: *const libc::c_char) -> *mut libc::FILE;

--- a/tools/input/section5.rs
+++ b/tools/input/section5.rs
@@ -5,7 +5,6 @@ use rav1d::include::stddef::size_t;
 use rav1d::include::stdint::uint64_t;
 use rav1d::include::stdint::uint8_t;
 extern "C" {
-    pub type Dav1dRef;
     fn fclose(__stream: *mut libc::FILE) -> libc::c_int;
     fn fopen(_: *const libc::c_char, _: *const libc::c_char) -> *mut libc::FILE;
     fn fprintf(_: *mut libc::FILE, _: *const libc::c_char, _: ...) -> libc::c_int;

--- a/tools/input/section5.rs
+++ b/tools/input/section5.rs
@@ -138,7 +138,7 @@ unsafe extern "C" fn leb128(f: *mut libc::FILE, len: *mut size_t) -> libc::c_int
     *len = val as usize;
     return i as libc::c_int;
 }
-unsafe extern "C" fn section5_probe(mut data: *const uint8_t) -> libc::c_int {
+unsafe extern "C" fn section5_probe(data: *const uint8_t) -> libc::c_int {
     let mut ret = 0;
     let mut cnt = 0;
     let mut obu_size: size_t = 0;
@@ -184,9 +184,9 @@ unsafe extern "C" fn section5_probe(mut data: *const uint8_t) -> libc::c_int {
 unsafe extern "C" fn section5_open(
     c: *mut Section5InputContext,
     file: *const libc::c_char,
-    mut fps: *mut libc::c_uint,
+    fps: *mut libc::c_uint,
     num_frames: *mut libc::c_uint,
-    mut timebase: *mut libc::c_uint,
+    timebase: *mut libc::c_uint,
 ) -> libc::c_int {
     (*c).f = fopen(file, b"rb\0" as *const u8 as *const libc::c_char);
     if ((*c).f).is_null() {
@@ -301,7 +301,7 @@ unsafe extern "C" fn section5_read(
         }
     }
     fseeko((*c).f, -(total_bytes as libc::off_t), 1 as libc::c_int);
-    let mut ptr: *mut uint8_t = dav1d_data_create(data, total_bytes);
+    let ptr: *mut uint8_t = dav1d_data_create(data, total_bytes);
     if ptr.is_null() {
         return -(1 as libc::c_int);
     }
@@ -321,7 +321,7 @@ unsafe extern "C" fn section5_close(c: *mut Section5InputContext) {
 }
 #[no_mangle]
 pub static mut section5_demuxer: Demuxer = {
-    let mut init = Demuxer {
+    let init = Demuxer {
         priv_data_size: ::core::mem::size_of::<Section5InputContext>() as libc::c_ulong
             as libc::c_int,
         name: b"section5\0" as *const u8 as *const libc::c_char,

--- a/tools/input/section5.rs
+++ b/tools/input/section5.rs
@@ -51,7 +51,7 @@ unsafe extern "C" fn leb(
 ) -> libc::c_int {
     let mut val: uint64_t = 0 as libc::c_int as uint64_t;
     let mut i: libc::c_uint = 0 as libc::c_int as libc::c_uint;
-    let mut more: libc::c_uint = 0;
+    let mut more: libc::c_uint;
     loop {
         let fresh0 = sz;
         sz = sz - 1;
@@ -83,9 +83,9 @@ unsafe extern "C" fn parse_obu_header(
     type_0: *mut Dav1dObuType,
     allow_implicit_size: libc::c_int,
 ) -> libc::c_int {
-    let mut ret = 0;
-    let mut extension_flag = 0;
-    let mut has_size_flag = 0;
+    let ret;
+    let extension_flag;
+    let has_size_flag;
     if buf_size == 0 {
         return -(1 as libc::c_int);
     }
@@ -118,7 +118,7 @@ unsafe extern "C" fn parse_obu_header(
 unsafe extern "C" fn leb128(f: *mut libc::FILE, len: *mut size_t) -> libc::c_int {
     let mut val: uint64_t = 0 as libc::c_int as uint64_t;
     let mut i: libc::c_uint = 0 as libc::c_int as libc::c_uint;
-    let mut more: libc::c_uint = 0;
+    let mut more: libc::c_uint;
     loop {
         let mut v: uint8_t = 0;
         if fread(&mut v as *mut uint8_t as *mut libc::c_void, 1, 1, f) < 1 {
@@ -139,7 +139,7 @@ unsafe extern "C" fn leb128(f: *mut libc::FILE, len: *mut size_t) -> libc::c_int
     return i as libc::c_int;
 }
 unsafe extern "C" fn section5_probe(data: *const uint8_t) -> libc::c_int {
-    let mut ret = 0;
+    let mut ret;
     let mut cnt = 0;
     let mut obu_size: size_t = 0;
     let mut type_0: Dav1dObuType = 0 as Dav1dObuType;

--- a/tools/output/md5.rs
+++ b/tools/output/md5.rs
@@ -706,7 +706,7 @@ unsafe extern "C" fn md5_verify(
 }
 #[no_mangle]
 pub static mut md5_muxer: Muxer = {
-    let mut init = Muxer {
+    let init = Muxer {
         priv_data_size: ::core::mem::size_of::<MD5Context>() as libc::c_ulong as libc::c_int,
         name: b"md5\0" as *const u8 as *const libc::c_char,
         extension: b"md5\0" as *const u8 as *const libc::c_char,

--- a/tools/output/md5.rs
+++ b/tools/output/md5.rs
@@ -5,7 +5,6 @@ use rav1d::include::stdint::uint32_t;
 use rav1d::include::stdint::uint64_t;
 use rav1d::include::stdint::uint8_t;
 extern "C" {
-    pub type Dav1dRef;
     fn fclose(__stream: *mut libc::FILE) -> libc::c_int;
     fn fopen(_: *const libc::c_char, _: *const libc::c_char) -> *mut libc::FILE;
     fn fprintf(_: *mut libc::FILE, _: *const libc::c_char, _: ...) -> libc::c_int;

--- a/tools/output/null.rs
+++ b/tools/output/null.rs
@@ -32,7 +32,7 @@ unsafe extern "C" fn null_write(_c: *mut NullOutputContext, p: *mut Dav1dPicture
 }
 #[no_mangle]
 pub static mut null_muxer: Muxer = {
-    let mut init = Muxer {
+    let init = Muxer {
         priv_data_size: 0 as libc::c_int,
         name: b"null\0" as *const u8 as *const libc::c_char,
         extension: b"null\0" as *const u8 as *const libc::c_char,

--- a/tools/output/null.rs
+++ b/tools/output/null.rs
@@ -1,6 +1,5 @@
 use ::libc;
 extern "C" {
-    pub type Dav1dRef;
     pub type MuxerPriv;
     fn dav1d_picture_unref(p: *mut Dav1dPicture);
 }

--- a/tools/output/output.rs
+++ b/tools/output/output.rs
@@ -3,7 +3,6 @@ use ::libc;
 use libc::size_t;
 use rav1d::include::stdint::uint64_t;
 extern "C" {
-    pub type Dav1dRef;
     pub type MuxerPriv;
     fn fprintf(_: *mut libc::FILE, _: *const libc::c_char, _: ...) -> libc::c_int;
     fn snprintf(_: *mut libc::c_char, _: size_t, _: *const libc::c_char, _: ...) -> libc::c_int;

--- a/tools/output/output.rs
+++ b/tools/output/output.rs
@@ -88,7 +88,7 @@ pub unsafe extern "C" fn output_open(
     name: *const libc::c_char,
     filename: *const libc::c_char,
     p: *const Dav1dPictureParameters,
-    mut fps: *const libc::c_uint,
+    fps: *const libc::c_uint,
 ) -> libc::c_int {
     let mut impl_0: *const Muxer = 0 as *const Muxer;
     let mut c: *mut MuxerContext = 0 as *mut MuxerContext;

--- a/tools/output/output.rs
+++ b/tools/output/output.rs
@@ -91,8 +91,8 @@ pub unsafe extern "C" fn output_open(
     fps: *const libc::c_uint,
 ) -> libc::c_int {
     let mut impl_0: *const Muxer = 0 as *const Muxer;
-    let mut c: *mut MuxerContext = 0 as *mut MuxerContext;
-    let mut i: libc::c_uint = 0;
+    let c: *mut MuxerContext;
+    let mut i: libc::c_uint;
     let mut res = 0;
     let mut name_offset = 0;
     if !name.is_null() {
@@ -280,7 +280,7 @@ unsafe extern "C" fn assemble_filename(
         unreachable!();
     }
     let mut ptr: *const libc::c_char = (*ctx).filename;
-    let mut iptr: *const libc::c_char = 0 as *const libc::c_char;
+    let mut iptr: *const libc::c_char;
     loop {
         iptr = strchr(ptr, '%' as i32);
         if iptr.is_null() {
@@ -342,7 +342,7 @@ unsafe extern "C" fn assemble_filename(
 }
 #[no_mangle]
 pub unsafe extern "C" fn output_write(ctx: *mut MuxerContext, p: *mut Dav1dPicture) -> libc::c_int {
-    let mut res = 0;
+    let mut res;
     if (*ctx).one_file_per_frame != 0 && ((*(*ctx).impl_0).write_header).is_some() {
         let mut filename: [libc::c_char; 1024] = [0; 1024];
         assemble_filename(

--- a/tools/output/y4m2.rs
+++ b/tools/output/y4m2.rs
@@ -129,7 +129,7 @@ unsafe extern "C" fn write_header(
         (fw as uint64_t).wrapping_mul((*(*p).frame_hdr).render_height as uint64_t);
     let mut gcd: uint64_t = ah;
     let mut a: uint64_t = aw;
-    let mut b: uint64_t = 0;
+    let mut b: uint64_t;
     loop {
         b = a.wrapping_rem(gcd);
         if !(b != 0) {
@@ -163,7 +163,7 @@ unsafe extern "C" fn y4m2_write(c: *mut Y4m2OutputContext, p: *mut Dav1dPicture)
         }
     }
     fprintf((*c).f, b"FRAME\n\0" as *const u8 as *const libc::c_char);
-    let mut ptr: *mut uint8_t = 0 as *mut uint8_t;
+    let mut ptr: *mut uint8_t;
     let hbd = ((*p).p.bpc > 8) as libc::c_int;
     ptr = (*p).data[0] as *mut uint8_t;
     let mut y = 0;

--- a/tools/output/y4m2.rs
+++ b/tools/output/y4m2.rs
@@ -57,7 +57,7 @@ unsafe extern "C" fn y4m2_open(
     c: *mut Y4m2OutputContext,
     file: *const libc::c_char,
     mut _p: *const Dav1dPictureParameters,
-    mut fps: *const libc::c_uint,
+    fps: *const libc::c_uint,
 ) -> libc::c_int {
     if strcmp(file, b"-\0" as *const u8 as *const libc::c_char) == 0 {
         (*c).f = stdout;
@@ -250,7 +250,7 @@ unsafe extern "C" fn y4m2_close(c: *mut Y4m2OutputContext) {
 }
 #[no_mangle]
 pub static mut y4m2_muxer: Muxer = {
-    let mut init = Muxer {
+    let init = Muxer {
         priv_data_size: ::core::mem::size_of::<Y4m2OutputContext>() as libc::c_ulong as libc::c_int,
         name: b"yuv4mpeg2\0" as *const u8 as *const libc::c_char,
         extension: b"y4m\0" as *const u8 as *const libc::c_char,

--- a/tools/output/y4m2.rs
+++ b/tools/output/y4m2.rs
@@ -4,7 +4,6 @@ use ::libc;
 use rav1d::include::stdint::uint64_t;
 use rav1d::include::stdint::uint8_t;
 extern "C" {
-    pub type Dav1dRef;
     fn fclose(__stream: *mut libc::FILE) -> libc::c_int;
     fn fopen(_: *const libc::c_char, _: *const libc::c_char) -> *mut libc::FILE;
     fn fprintf(_: *mut libc::FILE, _: *const libc::c_char, _: ...) -> libc::c_int;

--- a/tools/output/yuv.rs
+++ b/tools/output/yuv.rs
@@ -72,7 +72,7 @@ unsafe extern "C" fn yuv_open(
 }
 unsafe extern "C" fn yuv_write(c: *mut YuvOutputContext, p: *mut Dav1dPicture) -> libc::c_int {
     let mut current_block: u64;
-    let mut ptr: *mut uint8_t = 0 as *mut uint8_t;
+    let mut ptr: *mut uint8_t;
     let hbd = ((*p).p.bpc > 8) as libc::c_int;
     ptr = (*p).data[0] as *mut uint8_t;
     let mut y = 0;

--- a/tools/output/yuv.rs
+++ b/tools/output/yuv.rs
@@ -159,7 +159,7 @@ unsafe extern "C" fn yuv_close(c: *mut YuvOutputContext) {
 }
 #[no_mangle]
 pub static mut yuv_muxer: Muxer = {
-    let mut init = Muxer {
+    let init = Muxer {
         priv_data_size: ::core::mem::size_of::<YuvOutputContext>() as libc::c_ulong as libc::c_int,
         name: b"yuv\0" as *const u8 as *const libc::c_char,
         extension: b"yuv\0" as *const u8 as *const libc::c_char,

--- a/tools/output/yuv.rs
+++ b/tools/output/yuv.rs
@@ -3,7 +3,6 @@ use crate::{stderr, stdout};
 use ::libc;
 use rav1d::include::stdint::uint8_t;
 extern "C" {
-    pub type Dav1dRef;
     fn fclose(__stream: *mut libc::FILE) -> libc::c_int;
     fn fopen(_: *const libc::c_char, _: *const libc::c_char) -> *mut libc::FILE;
     fn fprintf(_: *mut libc::FILE, _: *const libc::c_char, _: ...) -> libc::c_int;


### PR DESCRIPTION
This removes all the `#![allow(*)]`s that aren't needed or unused.

Warning on `unused_mut` and `unused_assignments` helps catch a lot of little mistakes so it's nice to have, and fixing this cleans up a lot of code we'd otherwise have to manually clean up when going function-by-function.

Warning on `dead_code` helps catch a bunch of little mistakes as well as a lot of over-declaring asm `fn`s that don't exist.  I've fixed most of them (they're mostly `avx{2,512icl}` on `x86`), except for in `mc_*.rs` since #416 is in the middle of that so I don't want to overly touch it, and `itx.rs`, where way more asm `fn`s than actually exist are declared.

`mutable_transmutes` and `non_snake_case` (for the `dav1d` and `seek_stress` binaries) are just wholly unused, so we can remove those.