### PR TITLE
Remove error/cleanup-like `goto`s in C

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -2945,7 +2945,7 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
         f->lf.start_of_tile_row = malloc(f->sbh * sizeof(uint8_t));
         if (!f->lf.start_of_tile_row) {
             f->lf.start_of_tile_row_sz = 0;
-            goto error;
+            return retval;
         }
         f->lf.start_of_tile_row_sz = f->sbh;
     }
@@ -2964,12 +2964,12 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
                 malloc(sizeof(*f->frame_thread.tile_start_off) * n_ts);
             if (!f->frame_thread.tile_start_off) {
                 f->n_ts = 0;
-                goto error;
+                return retval;
             }
         }
         dav1d_free_aligned(f->ts);
         f->ts = dav1d_alloc_aligned(sizeof(*f->ts) * n_ts, 32);
-        if (!f->ts) goto error;
+        if (!f->ts) return retval;
         f->n_ts = n_ts;
     }
 
@@ -2979,7 +2979,7 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
         f->a = malloc(sizeof(*f->a) * a_sz);
         if (!f->a) {
             f->a_sz = 0;
-            goto error;
+            return retval;
         }
         f->a_sz = a_sz;
     }
@@ -3007,7 +3007,7 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
                 malloc(lowest_pixel_mem_sz * sizeof(*f->tile_thread.lowest_pixel_mem));
             if (!f->tile_thread.lowest_pixel_mem) {
                 f->tile_thread.lowest_pixel_mem_sz = 0;
-                goto error;
+                return retval;
             }
             f->tile_thread.lowest_pixel_mem_sz = lowest_pixel_mem_sz;
         }
@@ -3030,7 +3030,7 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
                 dav1d_alloc_aligned((size_t)cf_sz * 128 * 128 / 2, 64);
             if (!f->frame_thread.cf) {
                 f->frame_thread.cf_sz = 0;
-                goto error;
+                return retval;
             }
             memset(f->frame_thread.cf, 0, (size_t)cf_sz * 128 * 128 / 2);
             f->frame_thread.cf_sz = cf_sz;
@@ -3044,7 +3044,7 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
                                         num_sb128 * 16 * 16, 64);
                 if (!f->frame_thread.pal) {
                     f->frame_thread.pal_sz = 0;
-                    goto error;
+                    return retval;
                 }
                 f->frame_thread.pal_sz = num_sb128;
             }
@@ -3057,7 +3057,7 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
                                         pal_idx_sz * 128 * 128 / 4, 64);
                 if (!f->frame_thread.pal_idx) {
                     f->frame_thread.pal_idx_sz = 0;
-                    goto error;
+                    return retval;
                 }
                 f->frame_thread.pal_idx_sz = pal_idx_sz;
             }
@@ -3084,7 +3084,7 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
         uint8_t *ptr = f->lf.cdef_line_buf = dav1d_alloc_aligned(alloc_sz, 32);
         if (!ptr) {
             f->lf.cdef_buf_plane_sz[0] = f->lf.cdef_buf_plane_sz[1] = 0;
-            goto error;
+            return retval;
         }
 
         ptr += 32;
@@ -3144,7 +3144,7 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
         uint8_t *ptr = f->lf.lr_line_buf = dav1d_alloc_aligned(alloc_sz, 64);
         if (!ptr) {
             f->lf.lr_buf_plane_sz[0] = f->lf.lr_buf_plane_sz[1] = 0;
-            goto error;
+            return retval;
         }
 
         ptr += 64;
@@ -3175,7 +3175,7 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
         f->lf.level = malloc(sizeof(*f->lf.level) * num_sb128 * 32 * 32 + 3);
         if (!f->lf.mask || !f->lf.level) {
             f->lf.mask_sz = 0;
-            goto error;
+            return retval;
         }
         if (c->n_fc > 1) {
             freep(&f->frame_thread.b);
@@ -3186,7 +3186,7 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
                                          num_sb128 * 32 * 32);
             if (!f->frame_thread.b || !f->frame_thread.cbi) {
                 f->lf.mask_sz = 0;
-                goto error;
+                return retval;
             }
         }
         f->lf.mask_sz = num_sb128;
@@ -3199,7 +3199,7 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
         f->lf.lr_mask = malloc(sizeof(*f->lf.lr_mask) * lr_mask_sz);
         if (!f->lf.lr_mask) {
             f->lf.lr_mask_sz = 0;
-            goto error;
+            return retval;
         }
         f->lf.lr_mask_sz = lr_mask_sz;
     }
@@ -3221,7 +3221,7 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
             dav1d_alloc_aligned(ipred_edge_sz * 128 * 3, 64);
         if (!ptr) {
             f->ipred_edge_sz = 0;
-            goto error;
+            return retval;
         }
         f->ipred_edge[1] = ptr + ipred_edge_sz * 128 * 1;
         f->ipred_edge[2] = ptr + ipred_edge_sz * 128 * 2;
@@ -3234,7 +3234,7 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
         f->lf.tx_lpf_right_edge[0] = malloc(re_sz * 32 * 2);
         if (!f->lf.tx_lpf_right_edge[0]) {
             f->lf.re_sz = 0;
-            goto error;
+            return retval;
         }
         f->lf.tx_lpf_right_edge[1] = f->lf.tx_lpf_right_edge[0] + re_sz * 32;
         f->lf.re_sz = re_sz;
@@ -3246,7 +3246,7 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
             dav1d_refmvs_init_frame(&f->rf, f->seq_hdr, f->frame_hdr,
                                     f->refpoc, f->mvs, f->refrefpoc, f->ref_mvs,
                                     f->c->n_tc, f->c->n_fc);
-        if (ret < 0) goto error;
+        if (ret < 0) return retval;
     }
 
     // setup dequant tables
@@ -3312,7 +3312,6 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
     f->lf.sr_p[2] = f->sr_cur.p.data[has_chroma ? 2 : 0];
 
     retval = 0;
-error:
     return retval;
 }
 

--- a/src/decode.c
+++ b/src/decode.c
@@ -3397,7 +3397,7 @@ int dav1d_decode_frame_main(Dav1dFrameContext *const f) {
             }
             for (int tile_col = 0; tile_col < f->frame_hdr->tiling.cols; tile_col++) {
                 t->ts = &f->ts[tile_row * f->frame_hdr->tiling.cols + tile_col];
-                if (dav1d_decode_tile_sbrow(t)) goto error;
+                if (dav1d_decode_tile_sbrow(t)) return retval;
             }
             if (IS_INTER_OR_SWITCH(f->frame_hdr)) {
                 dav1d_refmvs_save_tmvs(&f->c->refmvs_dsp, &t->rt,
@@ -3410,7 +3410,6 @@ int dav1d_decode_frame_main(Dav1dFrameContext *const f) {
     }
 
     retval = 0;
-error:
     return retval;
 }
 

--- a/src/decode.c
+++ b/src/decode.c
@@ -3334,13 +3334,13 @@ int dav1d_decode_frame_init_cdf(Dav1dFrameContext *const f) {
             if (j == f->tile[i].end) {
                 tile_sz = size;
             } else {
-                if (f->frame_hdr->tiling.n_bytes > size) goto error;
+                if (f->frame_hdr->tiling.n_bytes > size) return retval;
                 tile_sz = 0;
                 for (unsigned k = 0; k < f->frame_hdr->tiling.n_bytes; k++)
                     tile_sz |= (unsigned)*data++ << (k * 8);
                 tile_sz++;
                 size -= f->frame_hdr->tiling.n_bytes;
-                if (tile_sz > size) goto error;
+                if (tile_sz > size) return retval;
             }
 
             setup_tile(&f->ts[j], f, data, tile_sz, tile_row, tile_col++,
@@ -3365,7 +3365,6 @@ int dav1d_decode_frame_init_cdf(Dav1dFrameContext *const f) {
     }
 
     retval = 0;
-error:
     return retval;
 }
 

--- a/src/lib.c
+++ b/src/lib.c
@@ -366,12 +366,11 @@ static int output_image(Dav1dContext *const c, Dav1dPicture *const out)
     if (!c->apply_grain || !has_grain(&in->p)) {
         dav1d_picture_move_ref(out, &in->p);
         dav1d_thread_picture_unref(in);
-        goto end;
+    } else {
+        res = dav1d_apply_grain(c, out, &in->p);
+        dav1d_thread_picture_unref(in);
     }
 
-    res = dav1d_apply_grain(c, out, &in->p);
-    dav1d_thread_picture_unref(in);
-end:
     if (!c->all_layers && c->max_spatial_id && c->out.p.data[0]) {
         dav1d_thread_picture_move_ref(in, &c->out);
     }

--- a/src/lib.c
+++ b/src/lib.c
@@ -543,7 +543,10 @@ int dav1d_apply_grain(Dav1dContext *const c, Dav1dPicture *const out,
     }
 
     int res = dav1d_picture_alloc_copy(c, out, in->p.w, in);
-    if (res < 0) goto error;
+    if (res < 0) {
+        dav1d_picture_unref_internal(out);
+        return res;
+    }
 
     if (c->n_tc > 1) {
         dav1d_task_delayed_fg(c, out, in);
@@ -565,10 +568,6 @@ int dav1d_apply_grain(Dav1dContext *const c, Dav1dPicture *const out,
     }
 
     return 0;
-
-error:
-    dav1d_picture_unref_internal(out);
-    return res;
 }
 
 void dav1d_flush(Dav1dContext *const c) {

--- a/src/lib.c
+++ b/src/lib.c
@@ -129,6 +129,12 @@ COLD int dav1d_get_frame_delay(const Dav1dSettings *const s) {
     return n_fc;
 }
 
+static int dav1d_open_error(Dav1dContext *const c, Dav1dContext **const c_out, pthread_attr_t *const thread_attr) {
+    if (c) close_internal(c_out, 0);
+    pthread_attr_destroy(thread_attr);
+    return DAV1D_ERR(ENOMEM);
+}
+
 COLD int dav1d_open(Dav1dContext **const c_out, const Dav1dSettings *const s) {
     static pthread_once_t initted = PTHREAD_ONCE_INIT;
     pthread_once(&initted, init_internal);
@@ -155,7 +161,7 @@ COLD int dav1d_open(Dav1dContext **const c_out, const Dav1dSettings *const s) {
     pthread_attr_setstacksize(&thread_attr, stack_size);
 
     Dav1dContext *const c = *c_out = dav1d_alloc_aligned(sizeof(*c), 64);
-    if (!c) goto error;
+    if (!c) return dav1d_open_error(c, c_out, &thread_attr);
     memset(c, 0, sizeof(*c));
 
     c->allocator = s->allocator;
@@ -177,19 +183,19 @@ COLD int dav1d_open(Dav1dContext **const c_out, const Dav1dSettings *const s) {
         dav1d_mem_pool_init(&c->refmvs_pool) ||
         dav1d_mem_pool_init(&c->cdf_pool))
     {
-        goto error;
+        return dav1d_open_error(c, c_out, &thread_attr);
     }
 
     if (c->allocator.alloc_picture_callback   == dav1d_default_picture_alloc &&
         c->allocator.release_picture_callback == dav1d_default_picture_release)
     {
-        if (c->allocator.cookie) goto error;
-        if (dav1d_mem_pool_init(&c->picture_pool)) goto error;
+        if (c->allocator.cookie) return dav1d_open_error(c, c_out, &thread_attr);
+        if (dav1d_mem_pool_init(&c->picture_pool)) return dav1d_open_error(c, c_out, &thread_attr);
         c->allocator.cookie = c->picture_pool;
     } else if (c->allocator.alloc_picture_callback   == dav1d_default_picture_alloc ||
                c->allocator.release_picture_callback == dav1d_default_picture_release)
     {
-        goto error;
+        return dav1d_open_error(c, c_out, &thread_attr);
     }
 
     /* On 32-bit systems extremely large frame sizes can cause overflows in
@@ -209,22 +215,22 @@ COLD int dav1d_open(Dav1dContext **const c_out, const Dav1dSettings *const s) {
     get_num_threads(c, s, &c->n_tc, &c->n_fc);
 
     c->fc = dav1d_alloc_aligned(sizeof(*c->fc) * c->n_fc, 32);
-    if (!c->fc) goto error;
+    if (!c->fc) return dav1d_open_error(c, c_out, &thread_attr);
     memset(c->fc, 0, sizeof(*c->fc) * c->n_fc);
 
     c->tc = dav1d_alloc_aligned(sizeof(*c->tc) * c->n_tc, 64);
-    if (!c->tc) goto error;
+    if (!c->tc) return dav1d_open_error(c, c_out, &thread_attr);
     memset(c->tc, 0, sizeof(*c->tc) * c->n_tc);
     if (c->n_tc > 1) {
-        if (pthread_mutex_init(&c->task_thread.lock, NULL)) goto error;
+        if (pthread_mutex_init(&c->task_thread.lock, NULL)) return dav1d_open_error(c, c_out, &thread_attr);
         if (pthread_cond_init(&c->task_thread.cond, NULL)) {
             pthread_mutex_destroy(&c->task_thread.lock);
-            goto error;
+            return dav1d_open_error(c, c_out, &thread_attr);
         }
         if (pthread_cond_init(&c->task_thread.delayed_fg.cond, NULL)) {
             pthread_cond_destroy(&c->task_thread.cond);
             pthread_mutex_destroy(&c->task_thread.lock);
-            goto error;
+            return dav1d_open_error(c, c_out, &thread_attr);
         }
         c->task_thread.cur = c->n_fc;
         atomic_init(&c->task_thread.reset_task_cur, UINT_MAX);
@@ -235,20 +241,20 @@ COLD int dav1d_open(Dav1dContext **const c_out, const Dav1dSettings *const s) {
     if (c->n_fc > 1) {
         c->frame_thread.out_delayed =
             calloc(c->n_fc, sizeof(*c->frame_thread.out_delayed));
-        if (!c->frame_thread.out_delayed) goto error;
+        if (!c->frame_thread.out_delayed) return dav1d_open_error(c, c_out, &thread_attr);
     }
     for (unsigned n = 0; n < c->n_fc; n++) {
         Dav1dFrameContext *const f = &c->fc[n];
         if (c->n_tc > 1) {
-            if (pthread_mutex_init(&f->task_thread.lock, NULL)) goto error;
+            if (pthread_mutex_init(&f->task_thread.lock, NULL)) return dav1d_open_error(c, c_out, &thread_attr);
             if (pthread_cond_init(&f->task_thread.cond, NULL)) {
                 pthread_mutex_destroy(&f->task_thread.lock);
-                goto error;
+                return dav1d_open_error(c, c_out, &thread_attr);
             }
             if (pthread_mutex_init(&f->task_thread.pending_tasks.lock, NULL)) {
                 pthread_cond_destroy(&f->task_thread.cond);
                 pthread_mutex_destroy(&f->task_thread.lock);
-                goto error;
+                return dav1d_open_error(c, c_out, &thread_attr);
             }
         }
         f->c = c;
@@ -264,15 +270,15 @@ COLD int dav1d_open(Dav1dContext **const c_out, const Dav1dSettings *const s) {
         t->c = c;
         memset(t->cf_16bpc, 0, sizeof(t->cf_16bpc));
         if (c->n_tc > 1) {
-            if (pthread_mutex_init(&t->task_thread.td.lock, NULL)) goto error;
+            if (pthread_mutex_init(&t->task_thread.td.lock, NULL)) return dav1d_open_error(c, c_out, &thread_attr);
             if (pthread_cond_init(&t->task_thread.td.cond, NULL)) {
                 pthread_mutex_destroy(&t->task_thread.td.lock);
-                goto error;
+                return dav1d_open_error(c, c_out, &thread_attr);
             }
             if (pthread_create(&t->task_thread.td.thread, &thread_attr, dav1d_worker_task, t)) {
                 pthread_cond_destroy(&t->task_thread.td.cond);
                 pthread_mutex_destroy(&t->task_thread.td.lock);
-                goto error;
+                return dav1d_open_error(c, c_out, &thread_attr);
             }
             t->task_thread.td.inited = 1;
         }
@@ -288,11 +294,6 @@ COLD int dav1d_open(Dav1dContext **const c_out, const Dav1dSettings *const s) {
     pthread_attr_destroy(&thread_attr);
 
     return 0;
-
-error:
-    if (c) close_internal(c_out, 0);
-    pthread_attr_destroy(&thread_attr);
-    return DAV1D_ERR(ENOMEM);
 }
 
 static void dummy_free(const uint8_t *const data, void *const user_data) {

--- a/tests/libfuzzer/dav1d_fuzzer.c
+++ b/tests/libfuzzer/dav1d_fuzzer.c
@@ -101,7 +101,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     dav1d_version();
 
-    if (size < 32) goto end;
+    if (size < 32) return 0;
 #ifdef DAV1D_ALLOC_FAIL
     unsigned h = djb_xor(ptr, 32);
     unsigned seed = h;
@@ -129,7 +129,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 #endif
 
     err = dav1d_open(&ctx, &settings);
-    if (err < 0) goto end;
+    if (err < 0) return 0;
 
     while (ptr <= data + size - 12) {
         Dav1dData buf;
@@ -194,6 +194,5 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
 cleanup:
     dav1d_close(&ctx);
-end:
     return 0;
 }

--- a/tests/libfuzzer/dav1d_fuzzer.c
+++ b/tests/libfuzzer/dav1d_fuzzer.c
@@ -156,7 +156,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
         // copy frame data to a new buffer to catch reads past the end of input
         p = dav1d_data_create(&buf, frame_size);
-        if (!p) goto cleanup;
+        if (!p) {
+            dav1d_close(&ctx);
+            return 0;
+        }
         memcpy(p, ptr, frame_size);
         ptr += frame_size;
 
@@ -192,7 +195,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         return 0;
     }
 
-cleanup:
     dav1d_close(&ctx);
     return 0;
 }


### PR DESCRIPTION
The relooper algorithm `c2rust transpile` uses to translate `goto`s makes a mess of the control flow to the point where it takes a long time to untangle the state machines into normal control flow.  Most of these `goto`s use fairly simple control flow, being mostly used for error cleanup.  So they can be removed by either inlining (if the `goto` is very short), outlining and then calling the outline function at each `goto`, or in a few cases, just reorganize the structured control flow a little bit.

I intend to re-transpile and merge back these `goto`-less functions, as I'm pretty sure that'll be easier than untangling the relooper state machines (I usually end up just re-translating by hand, but some of these functions are quite long).  I'll probably add this to this same PR, but I want to put up these changes to the C first for some initial review.  In particular the ones where I re-organized control flow, as the inlining and outlining are much more straightforward.