### PR TITLE
`fn decode_sb`: Add back condition accidentally removed in #382

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4141,7 +4141,7 @@ unsafe fn decode_sb(
     let pc = if t.frame_thread.pass == 2 {
         None
     } else {
-        if bl == BL_64X64 {
+        if false && bl == BL_64X64 {
             println!(
                 "poc={},y={},x={},bl={},r={}",
                 (*f.frame_hdr).frame_offset,


### PR DESCRIPTION
Addresses performance issue by disabling println! statements.