### PR TITLE
Cleanup trivial redundant casts after removing most `goto`s

### DIFF
--- a/src/cdef_tmpl_16.rs
+++ b/src/cdef_tmpl_16.rs
@@ -159,8 +159,8 @@ unsafe extern "C" fn cdef_filter_block_c(
         tmp, tmp_stride, dst, dst_stride, left, top, bottom, w, h, edges,
     );
     if pri_strength != 0 {
-        let bitdepth_min_8 = 32 as libc::c_int - clz(bitdepth_max as libc::c_uint) - 8;
-        let pri_tap = 4 as libc::c_int - (pri_strength >> bitdepth_min_8 & 1);
+        let bitdepth_min_8 = 32 - clz(bitdepth_max as libc::c_uint) - 8;
+        let pri_tap = 4 - (pri_strength >> bitdepth_min_8 & 1);
         let pri_shift = imax(
             0 as libc::c_int,
             damping - ulog2(pri_strength as libc::c_uint),
@@ -393,7 +393,7 @@ unsafe fn cdef_find_dir_rust(
     var: *mut libc::c_uint,
     bitdepth_max: libc::c_int,
 ) -> libc::c_int {
-    let bitdepth_min_8 = 32 as libc::c_int - clz(bitdepth_max as libc::c_uint) - 8;
+    let bitdepth_min_8 = 32 - clz(bitdepth_max as libc::c_uint) - 8;
     let mut partial_sum_hv: [[libc::c_int; 8]; 2] =
         [[0 as libc::c_int, 0, 0, 0, 0, 0, 0, 0], [0; 8]];
     let mut partial_sum_diag: [[libc::c_int; 15]; 2] = [

--- a/src/cdef_tmpl_8.rs
+++ b/src/cdef_tmpl_8.rs
@@ -153,7 +153,7 @@ unsafe extern "C" fn cdef_filter_block_c(
     );
     if pri_strength != 0 {
         let bitdepth_min_8 = 8 - 8;
-        let pri_tap = 4 as libc::c_int - (pri_strength >> bitdepth_min_8 & 1);
+        let pri_tap = 4 - (pri_strength >> bitdepth_min_8 & 1);
         let pri_shift = imax(
             0 as libc::c_int,
             damping - ulog2(pri_strength as libc::c_uint),

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -6021,7 +6021,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
     (*c).frame_hdr_ref = 0 as *mut Dav1dRef;
     (*f).dsp =
         &mut *((*c).dsp).as_mut_ptr().offset((*(*f).seq_hdr).hbd as isize) as *mut Dav1dDSPContext;
-    let bpc: libc::c_int = 8 + 2 * (*(*f).seq_hdr).hbd;
+    let bpc = 8 + 2 * (*(*f).seq_hdr).hbd;
     if ((*(*f).dsp).ipred.intra_pred[DC_PRED as libc::c_int as usize]).is_none() {
         let dsp: *mut Dav1dDSPContext =
             &mut *((*c).dsp).as_mut_ptr().offset((*(*f).seq_hdr).hbd as isize)

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5249,17 +5249,16 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             (*f).frame_thread.pal_sz = (*f).frame_thread.pal_idx_sz;
         }
     }
-    let mut y_stride: ptrdiff_t = (*f).cur.stride[0 as libc::c_int as usize];
-    let mut uv_stride: ptrdiff_t = (*f).cur.stride[1 as libc::c_int as usize];
-    let has_resize: libc::c_int = ((*(*f).frame_hdr).width[0 as libc::c_int as usize]
-        != (*(*f).frame_hdr).width[1 as libc::c_int as usize])
-        as libc::c_int;
+    let mut y_stride: ptrdiff_t = (*f).cur.stride[0];
+    let mut uv_stride: ptrdiff_t = (*f).cur.stride[1];
+    let has_resize: libc::c_int =
+        ((*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1]) as libc::c_int;
     let need_cdef_lpf_copy: libc::c_int =
         ((*c).n_tc > 1 as libc::c_int as libc::c_uint && has_resize != 0) as libc::c_int;
     if y_stride * (*f).sbh as isize * 4 as libc::c_int as isize
-        != (*f).lf.cdef_buf_plane_sz[0 as libc::c_int as usize] as isize
+        != (*f).lf.cdef_buf_plane_sz[0] as isize
         || uv_stride * (*f).sbh as isize * 8 as libc::c_int as isize
-            != (*f).lf.cdef_buf_plane_sz[1 as libc::c_int as usize] as isize
+            != (*f).lf.cdef_buf_plane_sz[1] as isize
         || need_cdef_lpf_copy != (*f).lf.need_cdef_lpf_copy
         || (*f).sbh != (*f).lf.cdef_buf_sbh
     {
@@ -5281,26 +5280,21 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             dav1d_alloc_aligned(alloc_sz, 32 as libc::c_int as size_t) as *mut uint8_t;
         let mut ptr: *mut uint8_t = (*f).lf.cdef_line_buf;
         if ptr.is_null() {
-            (*f).lf.cdef_buf_plane_sz[1 as libc::c_int as usize] = 0 as libc::c_int;
-            (*f).lf.cdef_buf_plane_sz[0 as libc::c_int as usize] =
-                (*f).lf.cdef_buf_plane_sz[1 as libc::c_int as usize];
+            (*f).lf.cdef_buf_plane_sz[1] = 0 as libc::c_int;
+            (*f).lf.cdef_buf_plane_sz[0] = (*f).lf.cdef_buf_plane_sz[1];
             return retval;
         }
         ptr = ptr.offset(32 as libc::c_int as isize);
         if y_stride < 0 {
-            (*f).lf.cdef_line[0 as libc::c_int as usize][0 as libc::c_int as usize] = ptr.offset(
+            (*f).lf.cdef_line[0][0] = ptr.offset(
                 -((y_stride * ((*f).sbh * 4 as libc::c_int - 1 as libc::c_int) as isize) as isize),
-            )
-                as *mut libc::c_void;
-            (*f).lf.cdef_line[1 as libc::c_int as usize][0 as libc::c_int as usize] = ptr.offset(
+            ) as *mut libc::c_void;
+            (*f).lf.cdef_line[1][0] = ptr.offset(
                 -((y_stride * ((*f).sbh * 4 as libc::c_int - 3 as libc::c_int) as isize) as isize),
-            )
-                as *mut libc::c_void;
+            ) as *mut libc::c_void;
         } else {
-            (*f).lf.cdef_line[0 as libc::c_int as usize][0 as libc::c_int as usize] =
-                ptr.offset((y_stride * 0) as isize) as *mut libc::c_void;
-            (*f).lf.cdef_line[1 as libc::c_int as usize][0 as libc::c_int as usize] =
-                ptr.offset((y_stride * 2) as isize) as *mut libc::c_void;
+            (*f).lf.cdef_line[0][0] = ptr.offset((y_stride * 0) as isize) as *mut libc::c_void;
+            (*f).lf.cdef_line[1][0] = ptr.offset((y_stride * 2) as isize) as *mut libc::c_void;
         }
         ptr = ptr.offset(
             ((y_stride as libc::c_longlong).abs()
@@ -5308,31 +5302,23 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 * 4 as libc::c_int as libc::c_longlong) as isize,
         );
         if uv_stride < 0 {
-            (*f).lf.cdef_line[0 as libc::c_int as usize][1 as libc::c_int as usize] = ptr.offset(
+            (*f).lf.cdef_line[0][1] = ptr.offset(
                 -((uv_stride * ((*f).sbh * 8 as libc::c_int - 1 as libc::c_int) as isize) as isize),
-            )
-                as *mut libc::c_void;
-            (*f).lf.cdef_line[0 as libc::c_int as usize][2 as libc::c_int as usize] = ptr.offset(
+            ) as *mut libc::c_void;
+            (*f).lf.cdef_line[0][2] = ptr.offset(
                 -((uv_stride * ((*f).sbh * 8 as libc::c_int - 3 as libc::c_int) as isize) as isize),
-            )
-                as *mut libc::c_void;
-            (*f).lf.cdef_line[1 as libc::c_int as usize][1 as libc::c_int as usize] = ptr.offset(
+            ) as *mut libc::c_void;
+            (*f).lf.cdef_line[1][1] = ptr.offset(
                 -((uv_stride * ((*f).sbh * 8 as libc::c_int - 5 as libc::c_int) as isize) as isize),
-            )
-                as *mut libc::c_void;
-            (*f).lf.cdef_line[1 as libc::c_int as usize][2 as libc::c_int as usize] = ptr.offset(
+            ) as *mut libc::c_void;
+            (*f).lf.cdef_line[1][2] = ptr.offset(
                 -((uv_stride * ((*f).sbh * 8 as libc::c_int - 7 as libc::c_int) as isize) as isize),
-            )
-                as *mut libc::c_void;
+            ) as *mut libc::c_void;
         } else {
-            (*f).lf.cdef_line[0 as libc::c_int as usize][1 as libc::c_int as usize] =
-                ptr.offset((uv_stride * 0) as isize) as *mut libc::c_void;
-            (*f).lf.cdef_line[0 as libc::c_int as usize][2 as libc::c_int as usize] =
-                ptr.offset((uv_stride * 2) as isize) as *mut libc::c_void;
-            (*f).lf.cdef_line[1 as libc::c_int as usize][1 as libc::c_int as usize] =
-                ptr.offset((uv_stride * 4) as isize) as *mut libc::c_void;
-            (*f).lf.cdef_line[1 as libc::c_int as usize][2 as libc::c_int as usize] =
-                ptr.offset((uv_stride * 6) as isize) as *mut libc::c_void;
+            (*f).lf.cdef_line[0][1] = ptr.offset((uv_stride * 0) as isize) as *mut libc::c_void;
+            (*f).lf.cdef_line[0][2] = ptr.offset((uv_stride * 2) as isize) as *mut libc::c_void;
+            (*f).lf.cdef_line[1][1] = ptr.offset((uv_stride * 4) as isize) as *mut libc::c_void;
+            (*f).lf.cdef_line[1][2] = ptr.offset((uv_stride * 6) as isize) as *mut libc::c_void;
         }
         if need_cdef_lpf_copy != 0 {
             ptr = ptr.offset(
@@ -5341,13 +5327,12 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     * 8 as libc::c_int as libc::c_longlong) as isize,
             );
             if y_stride < 0 {
-                (*f).lf.cdef_lpf_line[0 as libc::c_int as usize] = ptr.offset(
+                (*f).lf.cdef_lpf_line[0] = ptr.offset(
                     -((y_stride * ((*f).sbh * 4 as libc::c_int - 1 as libc::c_int) as isize)
                         as isize),
-                )
-                    as *mut libc::c_void;
+                ) as *mut libc::c_void;
             } else {
-                (*f).lf.cdef_lpf_line[0 as libc::c_int as usize] = ptr as *mut libc::c_void;
+                (*f).lf.cdef_lpf_line[0] = ptr as *mut libc::c_void;
             }
             ptr = ptr.offset(
                 ((y_stride as libc::c_longlong).abs()
@@ -5355,26 +5340,22 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     * 4 as libc::c_int as libc::c_longlong) as isize,
             );
             if uv_stride < 0 {
-                (*f).lf.cdef_lpf_line[1 as libc::c_int as usize] = ptr.offset(
+                (*f).lf.cdef_lpf_line[1] = ptr.offset(
                     -((uv_stride * ((*f).sbh * 4 as libc::c_int - 1 as libc::c_int) as isize)
                         as isize),
-                )
-                    as *mut libc::c_void;
-                (*f).lf.cdef_lpf_line[2 as libc::c_int as usize] = ptr.offset(
+                ) as *mut libc::c_void;
+                (*f).lf.cdef_lpf_line[2] = ptr.offset(
                     -((uv_stride * ((*f).sbh * 8 as libc::c_int - 1 as libc::c_int) as isize)
                         as isize),
-                )
-                    as *mut libc::c_void;
+                ) as *mut libc::c_void;
             } else {
-                (*f).lf.cdef_lpf_line[1 as libc::c_int as usize] = ptr as *mut libc::c_void;
-                (*f).lf.cdef_lpf_line[2 as libc::c_int as usize] =
+                (*f).lf.cdef_lpf_line[1] = ptr as *mut libc::c_void;
+                (*f).lf.cdef_lpf_line[2] =
                     ptr.offset((uv_stride * (*f).sbh as isize * 4) as isize) as *mut libc::c_void;
             }
         }
-        (*f).lf.cdef_buf_plane_sz[0 as libc::c_int as usize] =
-            y_stride as libc::c_int * (*f).sbh * 4 as libc::c_int;
-        (*f).lf.cdef_buf_plane_sz[1 as libc::c_int as usize] =
-            uv_stride as libc::c_int * (*f).sbh * 8 as libc::c_int;
+        (*f).lf.cdef_buf_plane_sz[0] = y_stride as libc::c_int * (*f).sbh * 4 as libc::c_int;
+        (*f).lf.cdef_buf_plane_sz[1] = uv_stride as libc::c_int * (*f).sbh * 8 as libc::c_int;
         (*f).lf.need_cdef_lpf_copy = need_cdef_lpf_copy;
         (*f).lf.cdef_buf_sbh = (*f).sbh;
     }
@@ -5384,11 +5365,10 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     } else {
         12 as libc::c_int
     };
-    y_stride = (*f).sr_cur.p.stride[0 as libc::c_int as usize];
-    uv_stride = (*f).sr_cur.p.stride[1 as libc::c_int as usize];
-    if y_stride * num_lines as isize != (*f).lf.lr_buf_plane_sz[0 as libc::c_int as usize] as isize
-        || uv_stride * num_lines as isize * 2
-            != (*f).lf.lr_buf_plane_sz[1 as libc::c_int as usize] as isize
+    y_stride = (*f).sr_cur.p.stride[0];
+    uv_stride = (*f).sr_cur.p.stride[1];
+    if y_stride * num_lines as isize != (*f).lf.lr_buf_plane_sz[0] as isize
+        || uv_stride * num_lines as isize * 2 != (*f).lf.lr_buf_plane_sz[1] as isize
     {
         dav1d_free_aligned((*f).lf.lr_line_buf as *mut libc::c_void);
         let mut alloc_sz_0: size_t = 128 as libc::c_int as size_t;
@@ -5404,39 +5384,37 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             dav1d_alloc_aligned(alloc_sz_0, 64 as libc::c_int as size_t) as *mut uint8_t;
         let mut ptr_0: *mut uint8_t = (*f).lf.lr_line_buf;
         if ptr_0.is_null() {
-            (*f).lf.lr_buf_plane_sz[1 as libc::c_int as usize] = 0 as libc::c_int;
-            (*f).lf.lr_buf_plane_sz[0 as libc::c_int as usize] =
-                (*f).lf.lr_buf_plane_sz[1 as libc::c_int as usize];
+            (*f).lf.lr_buf_plane_sz[1] = 0 as libc::c_int;
+            (*f).lf.lr_buf_plane_sz[0] = (*f).lf.lr_buf_plane_sz[1];
             return retval;
         }
         ptr_0 = ptr_0.offset(64 as libc::c_int as isize);
         if y_stride < 0 {
-            (*f).lf.lr_lpf_line[0 as libc::c_int as usize] = ptr_0
+            (*f).lf.lr_lpf_line[0] = ptr_0
                 .offset(-((y_stride * (num_lines - 1 as libc::c_int) as isize) as isize))
                 as *mut libc::c_void;
         } else {
-            (*f).lf.lr_lpf_line[0 as libc::c_int as usize] = ptr_0 as *mut libc::c_void;
+            (*f).lf.lr_lpf_line[0] = ptr_0 as *mut libc::c_void;
         }
         ptr_0 = ptr_0.offset(
             ((y_stride as libc::c_longlong).abs() * num_lines as libc::c_longlong) as isize,
         );
         if uv_stride < 0 {
-            (*f).lf.lr_lpf_line[1 as libc::c_int as usize] = ptr_0.offset(
+            (*f).lf.lr_lpf_line[1] = ptr_0.offset(
                 -((uv_stride * (num_lines * 1 as libc::c_int - 1 as libc::c_int) as isize)
                     as isize),
             ) as *mut libc::c_void;
-            (*f).lf.lr_lpf_line[2 as libc::c_int as usize] = ptr_0.offset(
+            (*f).lf.lr_lpf_line[2] = ptr_0.offset(
                 -((uv_stride * (num_lines * 2 as libc::c_int - 1 as libc::c_int) as isize)
                     as isize),
             ) as *mut libc::c_void;
         } else {
-            (*f).lf.lr_lpf_line[1 as libc::c_int as usize] = ptr_0 as *mut libc::c_void;
-            (*f).lf.lr_lpf_line[2 as libc::c_int as usize] =
+            (*f).lf.lr_lpf_line[1] = ptr_0 as *mut libc::c_void;
+            (*f).lf.lr_lpf_line[2] =
                 ptr_0.offset((uv_stride * num_lines as isize) as isize) as *mut libc::c_void;
         }
-        (*f).lf.lr_buf_plane_sz[0 as libc::c_int as usize] = y_stride as libc::c_int * num_lines;
-        (*f).lf.lr_buf_plane_sz[1 as libc::c_int as usize] =
-            uv_stride as libc::c_int * num_lines * 2 as libc::c_int;
+        (*f).lf.lr_buf_plane_sz[0] = y_stride as libc::c_int * num_lines;
+        (*f).lf.lr_buf_plane_sz[1] = uv_stride as libc::c_int * num_lines * 2 as libc::c_int;
     }
     if num_sb128 != (*f).lf.mask_sz {
         freep(&mut (*f).lf.mask as *mut *mut Av1Filter as *mut libc::c_void);
@@ -5492,15 +5470,14 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         }
         (*f).lf.lr_mask_sz = lr_mask_sz;
     }
-    (*f).lf.restore_planes = ((((*(*f).frame_hdr).restoration.type_0[0 as libc::c_int as usize]
-        as libc::c_uint
+    (*f).lf.restore_planes = ((((*(*f).frame_hdr).restoration.type_0[0] as libc::c_uint
         != DAV1D_RESTORATION_NONE as libc::c_int as libc::c_uint)
         as libc::c_int)
         << 0 as libc::c_int)
-        + ((((*(*f).frame_hdr).restoration.type_0[1 as libc::c_int as usize] as libc::c_uint
+        + ((((*(*f).frame_hdr).restoration.type_0[1] as libc::c_uint
             != DAV1D_RESTORATION_NONE as libc::c_int as libc::c_uint) as libc::c_int)
             << 1 as libc::c_int)
-        + ((((*(*f).frame_hdr).restoration.type_0[2 as libc::c_int as usize] as libc::c_uint
+        + ((((*(*f).frame_hdr).restoration.type_0[2] as libc::c_uint
             != DAV1D_RESTORATION_NONE as libc::c_int as libc::c_uint) as libc::c_int)
             << 2 as libc::c_int);
     if (*(*f).frame_hdr).loopfilter.sharpness != (*f).lf.last_sharpness {
@@ -5524,19 +5501,19 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 .offset(0 as libc::c_int as isize) as *mut *mut libc::c_void
                 as *mut libc::c_void,
         );
-        (*f).ipred_edge[0 as libc::c_int as usize] = dav1d_alloc_aligned(
+        (*f).ipred_edge[0] = dav1d_alloc_aligned(
             (ipred_edge_sz * 128 as libc::c_int * 3 as libc::c_int) as size_t,
             64 as libc::c_int as size_t,
         );
-        let ptr_1: *mut uint8_t = (*f).ipred_edge[0 as libc::c_int as usize] as *mut uint8_t;
+        let ptr_1: *mut uint8_t = (*f).ipred_edge[0] as *mut uint8_t;
         if ptr_1.is_null() {
             (*f).ipred_edge_sz = 0 as libc::c_int;
             return retval;
         }
-        (*f).ipred_edge[1 as libc::c_int as usize] = ptr_1
+        (*f).ipred_edge[1] = ptr_1
             .offset((ipred_edge_sz * 128 as libc::c_int * 1 as libc::c_int) as isize)
             as *mut libc::c_void;
-        (*f).ipred_edge[2 as libc::c_int as usize] = ptr_1
+        (*f).ipred_edge[2] = ptr_1
             .offset((ipred_edge_sz * 128 as libc::c_int * 2 as libc::c_int) as isize)
             as *mut libc::c_void;
         (*f).ipred_edge_sz = ipred_edge_sz;
@@ -5549,15 +5526,14 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 .offset(0 as libc::c_int as isize) as *mut *mut uint8_t
                 as *mut libc::c_void,
         );
-        (*f).lf.tx_lpf_right_edge[0 as libc::c_int as usize] =
+        (*f).lf.tx_lpf_right_edge[0] =
             malloc((re_sz * 32 as libc::c_int * 2 as libc::c_int) as libc::c_ulong) as *mut uint8_t;
-        if ((*f).lf.tx_lpf_right_edge[0 as libc::c_int as usize]).is_null() {
+        if ((*f).lf.tx_lpf_right_edge[0]).is_null() {
             (*f).lf.re_sz = 0 as libc::c_int;
             return retval;
         }
-        (*f).lf.tx_lpf_right_edge[1 as libc::c_int as usize] = ((*f).lf.tx_lpf_right_edge
-            [0 as libc::c_int as usize])
-            .offset((re_sz * 32 as libc::c_int) as isize);
+        (*f).lf.tx_lpf_right_edge[1] =
+            ((*f).lf.tx_lpf_right_edge[0]).offset((re_sz * 32 as libc::c_int) as isize);
         (*f).lf.re_sz = re_sz;
     }
     if (*(*f).frame_hdr).frame_type as libc::c_uint & 1 as libc::c_int as libc::c_uint != 0
@@ -5665,24 +5641,24 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         != DAV1D_PIXEL_LAYOUT_I400 as libc::c_int as libc::c_uint)
         as libc::c_int;
     (*f).lf.mask_ptr = (*f).lf.mask;
-    (*f).lf.p[0 as libc::c_int as usize] = (*f).cur.data[0 as libc::c_int as usize];
-    (*f).lf.p[1 as libc::c_int as usize] = (*f).cur.data[(if has_chroma != 0 {
+    (*f).lf.p[0] = (*f).cur.data[0];
+    (*f).lf.p[1] = (*f).cur.data[(if has_chroma != 0 {
         1 as libc::c_int
     } else {
         0 as libc::c_int
     }) as usize];
-    (*f).lf.p[2 as libc::c_int as usize] = (*f).cur.data[(if has_chroma != 0 {
+    (*f).lf.p[2] = (*f).cur.data[(if has_chroma != 0 {
         2 as libc::c_int
     } else {
         0 as libc::c_int
     }) as usize];
-    (*f).lf.sr_p[0 as libc::c_int as usize] = (*f).sr_cur.p.data[0 as libc::c_int as usize];
-    (*f).lf.sr_p[1 as libc::c_int as usize] = (*f).sr_cur.p.data[(if has_chroma != 0 {
+    (*f).lf.sr_p[0] = (*f).sr_cur.p.data[0];
+    (*f).lf.sr_p[1] = (*f).sr_cur.p.data[(if has_chroma != 0 {
         1 as libc::c_int
     } else {
         0 as libc::c_int
     }) as usize];
-    (*f).lf.sr_p[2 as libc::c_int as usize] = (*f).sr_cur.p.data[(if has_chroma != 0 {
+    (*f).lf.sr_p[2] = (*f).sr_cur.p.data[(if has_chroma != 0 {
         2 as libc::c_int
     } else {
         0 as libc::c_int
@@ -6005,7 +5981,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
         }
         out_delayed =
             &mut *((*c).frame_thread.out_delayed).offset(next as isize) as *mut Dav1dThreadPicture;
-        if !((*out_delayed).p.data[0 as libc::c_int as usize]).is_null()
+        if !((*out_delayed).p.data[0]).is_null()
             || ::core::intrinsics::atomic_load_seqcst(
                 &mut (*f).task_thread.error as *mut atomic_int,
             ) != 0
@@ -6042,7 +6018,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
             (*c).cached_error = error;
             dav1d_data_props_copy(&mut (*c).cached_error_props, &mut (*out_delayed).p.m);
             dav1d_thread_picture_unref(out_delayed);
-        } else if !((*out_delayed).p.data[0 as libc::c_int as usize]).is_null() {
+        } else if !((*out_delayed).p.data[0]).is_null() {
             let progress: libc::c_uint = ::core::intrinsics::atomic_load_relaxed(
                 &mut *((*out_delayed).progress).offset(1 as libc::c_int as isize)
                     as *mut atomic_uint,
@@ -6230,7 +6206,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
         if (*(*f).frame_hdr).primary_ref_frame != 7 as libc::c_int {
             let pri_ref: libc::c_int =
                 (*(*f).frame_hdr).refidx[(*(*f).frame_hdr).primary_ref_frame as usize];
-            if ((*c).refs[pri_ref as usize].p.p.data[0 as libc::c_int as usize]).is_null() {
+            if ((*c).refs[pri_ref as usize].p.p.data[0]).is_null() {
                 res = -(22 as libc::c_int);
                 return dav1d_submit_frame_error(res, f, c, out_delayed);
             }
@@ -6238,12 +6214,12 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
         let mut i: libc::c_int = 0 as libc::c_int;
         while i < 7 as libc::c_int {
             let refidx: libc::c_int = (*(*f).frame_hdr).refidx[i as usize];
-            if ((*c).refs[refidx as usize].p.p.data[0 as libc::c_int as usize]).is_null()
-                || ((*(*f).frame_hdr).width[0 as libc::c_int as usize] * 2 as libc::c_int)
+            if ((*c).refs[refidx as usize].p.p.data[0]).is_null()
+                || ((*(*f).frame_hdr).width[0] * 2 as libc::c_int)
                     < (*c).refs[refidx as usize].p.p.p.w
                 || ((*(*f).frame_hdr).height * 2 as libc::c_int)
                     < (*c).refs[refidx as usize].p.p.p.h
-                || (*(*f).frame_hdr).width[0 as libc::c_int as usize]
+                || (*(*f).frame_hdr).width[0]
                     > (*c).refs[refidx as usize].p.p.p.w * 16 as libc::c_int
                 || (*(*f).frame_hdr).height > (*c).refs[refidx as usize].p.p.p.h * 16 as libc::c_int
                 || (*(*f).seq_hdr).layout as libc::c_uint
@@ -6262,30 +6238,25 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                 &mut *((*f).refp).as_mut_ptr().offset(i as isize),
                 &mut (*((*c).refs).as_mut_ptr().offset(refidx as isize)).p,
             );
-            ref_coded_width[i as usize] =
-                (*(*c).refs[refidx as usize].p.p.frame_hdr).width[0 as libc::c_int as usize];
-            if (*(*f).frame_hdr).width[0 as libc::c_int as usize]
-                != (*c).refs[refidx as usize].p.p.p.w
+            ref_coded_width[i as usize] = (*(*c).refs[refidx as usize].p.p.frame_hdr).width[0];
+            if (*(*f).frame_hdr).width[0] != (*c).refs[refidx as usize].p.p.p.w
                 || (*(*f).frame_hdr).height != (*c).refs[refidx as usize].p.p.p.h
             {
-                (*f).svc[i as usize][0 as libc::c_int as usize].scale =
-                    (((*c).refs[refidx as usize].p.p.p.w << 14 as libc::c_int)
-                        + ((*(*f).frame_hdr).width[0 as libc::c_int as usize] >> 1 as libc::c_int))
-                        / (*(*f).frame_hdr).width[0 as libc::c_int as usize];
-                (*f).svc[i as usize][1 as libc::c_int as usize].scale =
-                    (((*c).refs[refidx as usize].p.p.p.h << 14 as libc::c_int)
-                        + ((*(*f).frame_hdr).height >> 1 as libc::c_int))
-                        / (*(*f).frame_hdr).height;
-                (*f).svc[i as usize][0 as libc::c_int as usize].step =
-                    (*f).svc[i as usize][0 as libc::c_int as usize].scale + 8 as libc::c_int
-                        >> 4 as libc::c_int;
-                (*f).svc[i as usize][1 as libc::c_int as usize].step =
-                    (*f).svc[i as usize][1 as libc::c_int as usize].scale + 8 as libc::c_int
-                        >> 4 as libc::c_int;
+                (*f).svc[i as usize][0].scale = (((*c).refs[refidx as usize].p.p.p.w
+                    << 14 as libc::c_int)
+                    + ((*(*f).frame_hdr).width[0] >> 1 as libc::c_int))
+                    / (*(*f).frame_hdr).width[0];
+                (*f).svc[i as usize][1].scale = (((*c).refs[refidx as usize].p.p.p.h
+                    << 14 as libc::c_int)
+                    + ((*(*f).frame_hdr).height >> 1 as libc::c_int))
+                    / (*(*f).frame_hdr).height;
+                (*f).svc[i as usize][0].step =
+                    (*f).svc[i as usize][0].scale + 8 as libc::c_int >> 4 as libc::c_int;
+                (*f).svc[i as usize][1].step =
+                    (*f).svc[i as usize][1].scale + 8 as libc::c_int >> 4 as libc::c_int;
             } else {
-                (*f).svc[i as usize][1 as libc::c_int as usize].scale = 0 as libc::c_int;
-                (*f).svc[i as usize][0 as libc::c_int as usize].scale =
-                    (*f).svc[i as usize][1 as libc::c_int as usize].scale;
+                (*f).svc[i as usize][1].scale = 0 as libc::c_int;
+                (*f).svc[i as usize][0].scale = (*f).svc[i as usize][1].scale;
             }
             (*f).gmv_warp_allowed[i as usize] = ((*(*f).frame_hdr).gmv[i as usize].type_0
                 as libc::c_uint
@@ -6294,7 +6265,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                 && !dav1d_get_shear_params(
                     &mut *((*(*f).frame_hdr).gmv).as_mut_ptr().offset(i as isize),
                 )
-                && (*f).svc[i as usize][0 as libc::c_int as usize].scale == 0)
+                && (*f).svc[i as usize][0].scale == 0)
                 as libc::c_int as uint8_t;
             i += 1;
         }
@@ -6356,13 +6327,11 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
     if res < 0 as libc::c_int {
         return dav1d_submit_frame_error(res, f, c, out_delayed);
     }
-    if (*(*f).frame_hdr).width[0 as libc::c_int as usize]
-        != (*(*f).frame_hdr).width[1 as libc::c_int as usize]
-    {
+    if (*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1] {
         res = dav1d_picture_alloc_copy(
             c,
             &mut (*f).cur,
-            (*(*f).frame_hdr).width[0 as libc::c_int as usize],
+            (*(*f).frame_hdr).width[0],
             &mut (*f).sr_cur.p,
         );
         if res < 0 as libc::c_int {
@@ -6371,10 +6340,8 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
     } else {
         dav1d_picture_ref(&mut (*f).cur, &mut (*f).sr_cur.p);
     }
-    if (*(*f).frame_hdr).width[0 as libc::c_int as usize]
-        != (*(*f).frame_hdr).width[1 as libc::c_int as usize]
-    {
-        (*f).resize_step[0 as libc::c_int as usize] = (((*f).cur.p.w << 14 as libc::c_int)
+    if (*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1] {
+        (*f).resize_step[0] = (((*f).cur.p.w << 14 as libc::c_int)
             + ((*f).sr_cur.p.p.w >> 1 as libc::c_int))
             / (*f).sr_cur.p.p.w;
         let ss_hor: libc::c_int = ((*f).cur.p.layout as libc::c_uint
@@ -6382,15 +6349,10 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
             as libc::c_int;
         let in_cw: libc::c_int = (*f).cur.p.w + ss_hor >> ss_hor;
         let out_cw: libc::c_int = (*f).sr_cur.p.p.w + ss_hor >> ss_hor;
-        (*f).resize_step[1 as libc::c_int as usize] =
+        (*f).resize_step[1] =
             ((in_cw << 14 as libc::c_int) + (out_cw >> 1 as libc::c_int)) / out_cw;
-        (*f).resize_start[0 as libc::c_int as usize] = get_upscale_x0(
-            (*f).cur.p.w,
-            (*f).sr_cur.p.p.w,
-            (*f).resize_step[0 as libc::c_int as usize],
-        );
-        (*f).resize_start[1 as libc::c_int as usize] =
-            get_upscale_x0(in_cw, out_cw, (*f).resize_step[1 as libc::c_int as usize]);
+        (*f).resize_start[0] = get_upscale_x0((*f).cur.p.w, (*f).sr_cur.p.p.w, (*f).resize_step[0]);
+        (*f).resize_start[1] = get_upscale_x0(in_cw, out_cw, (*f).resize_step[1]);
     }
     if (*c).n_fc == 1 as libc::c_int as libc::c_uint {
         if (*(*f).frame_hdr).show_frame != 0 || (*c).output_invisible_frames != 0 {
@@ -6403,12 +6365,10 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
     } else {
         dav1d_thread_picture_ref(out_delayed, &mut (*f).sr_cur);
     }
-    (*f).w4 =
-        (*(*f).frame_hdr).width[0 as libc::c_int as usize] + 3 as libc::c_int >> 2 as libc::c_int;
+    (*f).w4 = (*(*f).frame_hdr).width[0] + 3 as libc::c_int >> 2 as libc::c_int;
     (*f).h4 = (*(*f).frame_hdr).height + 3 as libc::c_int >> 2 as libc::c_int;
-    (*f).bw = ((*(*f).frame_hdr).width[0 as libc::c_int as usize] + 7 as libc::c_int
-        >> 3 as libc::c_int)
-        << 1 as libc::c_int;
+    (*f).bw =
+        ((*(*f).frame_hdr).width[0] + 7 as libc::c_int >> 3 as libc::c_int) << 1 as libc::c_int;
     (*f).bh = ((*(*f).frame_hdr).height + 7 as libc::c_int >> 3 as libc::c_int) << 1 as libc::c_int;
     (*f).sb128w = (*f).bw + 31 as libc::c_int >> 5 as libc::c_int;
     (*f).sb128h = (*f).bh + 31 as libc::c_int >> 5 as libc::c_int;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5051,8 +5051,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         }
         (*f).lf.start_of_tile_row_sz = (*f).sbh;
     }
-    let mut sby: libc::c_int = 0 as libc::c_int;
-    let mut tile_row: libc::c_int = 0 as libc::c_int;
+    let mut sby = 0;
+    let mut tile_row = 0;
     while tile_row < (*(*f).frame_hdr).tiling.rows {
         let fresh33 = sby;
         sby = sby + 1;
@@ -5113,8 +5113,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     let size_mul: *const uint8_t = (ss_size_mul[(*f).cur.p.layout as usize]).as_ptr();
     let hbd: libc::c_int = ((*(*f).seq_hdr).hbd != 0) as libc::c_int;
     if (*c).n_fc > 1 as libc::c_int as libc::c_uint {
-        let mut tile_idx: libc::c_int = 0 as libc::c_int;
-        let mut tile_row_0: libc::c_int = 0 as libc::c_int;
+        let mut tile_idx = 0;
+        let mut tile_row_0 = 0;
         while tile_row_0 < (*(*f).frame_hdr).tiling.rows {
             let row_off: libc::c_int = (*(*f).frame_hdr).tiling.row_start_sb[tile_row_0 as usize]
                 as libc::c_int
@@ -5128,7 +5128,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 - (*(*f).frame_hdr).tiling.row_start_sb[tile_row_0 as usize] as libc::c_int)
                 * (*f).sb_step
                 * 4 as libc::c_int;
-            let mut tile_col: libc::c_int = 0 as libc::c_int;
+            let mut tile_col = 0;
             while tile_col < (*(*f).frame_hdr).tiling.cols {
                 let fresh35 = tile_idx;
                 tile_idx = tile_idx + 1;
@@ -5155,14 +5155,14 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             (*f).tile_thread.lowest_pixel_mem_sz = lowest_pixel_mem_sz;
         }
         let mut lowest_pixel_ptr: *mut [[libc::c_int; 2]; 7] = (*f).tile_thread.lowest_pixel_mem;
-        let mut tile_row_1: libc::c_int = 0 as libc::c_int;
-        let mut tile_row_base: libc::c_int = 0 as libc::c_int;
+        let mut tile_row_1 = 0;
+        let mut tile_row_base = 0;
         while tile_row_1 < (*(*f).frame_hdr).tiling.rows {
             let tile_row_sb_h: libc::c_int = (*(*f).frame_hdr).tiling.row_start_sb
                 [(tile_row_1 + 1 as libc::c_int) as usize]
                 as libc::c_int
                 - (*(*f).frame_hdr).tiling.row_start_sb[tile_row_1 as usize] as libc::c_int;
-            let mut tile_col_0: libc::c_int = 0 as libc::c_int;
+            let mut tile_col_0 = 0;
             while tile_col_0 < (*(*f).frame_hdr).tiling.cols {
                 let ref mut fresh36 =
                     (*((*f).ts).offset((tile_row_base + tile_col_0) as isize)).lowest_pixel;
@@ -5571,7 +5571,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         );
     }
     if (*(*f).frame_hdr).switchable_comp_refs != 0 {
-        let mut i_0: libc::c_int = 0 as libc::c_int;
+        let mut i_0 = 0;
         while i_0 < 7 as libc::c_int {
             let ref0poc: libc::c_uint =
                 (*(*f).refp[i_0 as usize].p.frame_hdr).frame_offset as libc::c_uint;
@@ -5668,10 +5668,10 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
     if (*(*f).frame_hdr).refresh_context != 0 {
         dav1d_cdf_thread_copy((*f).out_cdf.data.cdf, &mut (*f).in_cdf);
     }
-    let mut tile_row: libc::c_int = 0 as libc::c_int;
-    let mut tile_col: libc::c_int = 0 as libc::c_int;
+    let mut tile_row = 0;
+    let mut tile_col = 0;
     (*f).task_thread.update_set = 0 as libc::c_int;
-    let mut i: libc::c_int = 0 as libc::c_int;
+    let mut i = 0;
     while i < (*f).n_tile_data {
         let mut data: *const uint8_t = (*((*f).tile).offset(i as isize)).data.data;
         let mut size: size_t = (*((*f).tile).offset(i as isize)).data.sz;
@@ -5730,7 +5730,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
     }
     if (*c).n_tc > 1 as libc::c_int as libc::c_uint {
         let uses_2pass: libc::c_int = ((*c).n_fc > 1 as libc::c_int as libc::c_uint) as libc::c_int;
-        let mut n: libc::c_int = 0 as libc::c_int;
+        let mut n = 0;
         while n < (*f).sb128w * (*(*f).frame_hdr).tiling.rows * (1 as libc::c_int + uses_2pass) {
             reset_context(
                 &mut *((*f).a).offset(n as isize),
@@ -5761,7 +5761,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_main(f: *mut Dav1dFrameContext) -> l
         as *mut Dav1dTaskContext;
     (*t).f = f;
     (*t).frame_thread.pass = 0 as libc::c_int;
-    let mut n: libc::c_int = 0 as libc::c_int;
+    let mut n = 0;
     while n < (*f).sb128w * (*(*f).frame_hdr).tiling.rows {
         reset_context(
             &mut *((*f).a).offset(n as isize),
@@ -5770,7 +5770,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_main(f: *mut Dav1dFrameContext) -> l
         );
         n += 1;
     }
-    let mut tile_row: libc::c_int = 0 as libc::c_int;
+    let mut tile_row = 0;
     while tile_row < (*(*f).frame_hdr).tiling.rows {
         let sbh_end: libc::c_int = imin(
             (*(*f).frame_hdr).tiling.row_start_sb[(tile_row + 1 as libc::c_int) as usize]
@@ -5792,7 +5792,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_main(f: *mut Dav1dFrameContext) -> l
                     by_end,
                 );
             }
-            let mut tile_col: libc::c_int = 0 as libc::c_int;
+            let mut tile_col = 0;
             while tile_col < (*(*f).frame_hdr).tiling.cols {
                 (*t).ts = &mut *((*f).ts)
                     .offset((tile_row * (*(*f).frame_hdr).tiling.cols + tile_col) as isize)
@@ -5925,7 +5925,7 @@ unsafe extern "C" fn dav1d_submit_frame_error(
     if (*(*f).frame_hdr).refresh_context != 0 {
         dav1d_cdf_thread_unref(&mut (*f).out_cdf);
     }
-    let mut i: libc::c_int = 0 as libc::c_int;
+    let mut i = 0;
     while i < 7 as libc::c_int {
         if !((*f).refp[i as usize].p.frame_hdr).is_null() {
             dav1d_thread_picture_unref(&mut *((*f).refp).as_mut_ptr().offset(i as isize));
@@ -5944,7 +5944,7 @@ unsafe extern "C" fn dav1d_submit_frame_error(
     dav1d_ref_dec(&mut (*f).seq_hdr_ref);
     dav1d_ref_dec(&mut (*f).frame_hdr_ref);
     dav1d_data_props_copy(&mut (*c).cached_error_props, &mut (*c).in_0.m);
-    let mut i_0: libc::c_int = 0 as libc::c_int;
+    let mut i_0 = 0;
     while i_0 < (*f).n_tile_data {
         dav1d_data_unref_internal(&mut (*((*f).tile).offset(i_0 as isize)).data);
         i_0 += 1;
@@ -6204,7 +6204,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                 return dav1d_submit_frame_error(res, f, c, out_delayed);
             }
         }
-        let mut i: libc::c_int = 0 as libc::c_int;
+        let mut i = 0;
         while i < 7 as libc::c_int {
             let refidx: libc::c_int = (*(*f).frame_hdr).refidx[i as usize];
             if ((*c).refs[refidx as usize].p.p.data[0]).is_null()
@@ -6219,7 +6219,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                     != (*c).refs[refidx as usize].p.p.p.layout as libc::c_uint
                 || bpc != (*c).refs[refidx as usize].p.p.p.bpc
             {
-                let mut j: libc::c_int = 0 as libc::c_int;
+                let mut j = 0;
                 while j < i {
                     dav1d_thread_picture_unref(&mut *((*f).refp).as_mut_ptr().offset(j as isize));
                     j += 1;
@@ -6394,7 +6394,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
         }
         (*f).mvs = (*(*f).mvs_ref).data as *mut refmvs_temporal_block;
         if (*(*f).frame_hdr).allow_intrabc == 0 {
-            let mut i_0: libc::c_int = 0 as libc::c_int;
+            let mut i_0 = 0;
             while i_0 < 7 as libc::c_int {
                 (*f).refpoc[i_0 as usize] =
                     (*(*f).refp[i_0 as usize].p.frame_hdr).frame_offset as libc::c_uint;
@@ -6408,7 +6408,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
             );
         }
         if (*(*f).frame_hdr).use_ref_frame_mvs != 0 {
-            let mut i_1: libc::c_int = 0 as libc::c_int;
+            let mut i_1 = 0;
             while i_1 < 7 as libc::c_int {
                 let refidx_0: libc::c_int = (*(*f).frame_hdr).refidx[i_1 as usize];
                 let ref_w: libc::c_int = (ref_coded_width[i_1 as usize] + 7 as libc::c_int
@@ -6517,7 +6517,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
         (*f).prev_segmap_ref = 0 as *mut Dav1dRef;
     }
     let refresh_frame_flags: libc::c_uint = (*(*f).frame_hdr).refresh_frame_flags as libc::c_uint;
-    let mut i_2: libc::c_int = 0 as libc::c_int;
+    let mut i_2 = 0;
     while i_2 < 8 as libc::c_int {
         if refresh_frame_flags & ((1 as libc::c_int) << i_2) as libc::c_uint != 0 {
             if !((*c).refs[i_2 as usize].p.p.frame_hdr).is_null() {
@@ -6563,7 +6563,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
         res = dav1d_decode_frame(&mut *f);
         if res < 0 as libc::c_int {
             dav1d_thread_picture_unref(&mut (*c).out);
-            let mut i_3: libc::c_int = 0 as libc::c_int;
+            let mut i_3 = 0;
             while i_3 < 8 as libc::c_int {
                 if refresh_frame_flags & ((1 as libc::c_int) << i_3) as libc::c_uint != 0 {
                     if !((*c).refs[i_3 as usize].p.p.frame_hdr).is_null() {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5057,10 +5057,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         let fresh33 = sby;
         sby = sby + 1;
         *((*f).lf.start_of_tile_row).offset(fresh33 as isize) = tile_row as uint8_t;
-        while sby
-            < (*(*f).frame_hdr).tiling.row_start_sb[(tile_row + 1 as libc::c_int) as usize]
-                as libc::c_int
-        {
+        while sby < (*(*f).frame_hdr).tiling.row_start_sb[(tile_row + 1) as usize] as libc::c_int {
             let fresh34 = sby;
             sby = sby + 1;
             *((*f).lf.start_of_tile_row).offset(fresh34 as isize) = 0 as libc::c_int as uint8_t;
@@ -5069,7 +5066,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     }
     let n_ts: libc::c_int = (*(*f).frame_hdr).tiling.cols * (*(*f).frame_hdr).tiling.rows;
     if n_ts != (*f).n_ts {
-        if (*c).n_fc > 1 as libc::c_int as libc::c_uint {
+        if (*c).n_fc > 1 as libc::c_uint {
             freep(
                 &mut (*f).frame_thread.tile_start_off as *mut *mut libc::c_int as *mut libc::c_void,
             );
@@ -5095,8 +5092,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     let a_sz: libc::c_int = (*f).sb128w
         * (*(*f).frame_hdr).tiling.rows
         * (1 as libc::c_int
-            + ((*c).n_fc > 1 as libc::c_int as libc::c_uint
-                && (*c).n_tc > 1 as libc::c_int as libc::c_uint) as libc::c_int);
+            + ((*c).n_fc > 1 as libc::c_uint && (*c).n_tc > 1 as libc::c_uint) as libc::c_int);
     if a_sz != (*f).a_sz {
         freep(&mut (*f).a as *mut *mut BlockContext as *mut libc::c_void);
         (*f).a = malloc(
@@ -5112,22 +5108,21 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     let num_sb128: libc::c_int = (*f).sb128w * (*f).sb128h;
     let size_mul: *const uint8_t = (ss_size_mul[(*f).cur.p.layout as usize]).as_ptr();
     let hbd: libc::c_int = ((*(*f).seq_hdr).hbd != 0) as libc::c_int;
-    if (*c).n_fc > 1 as libc::c_int as libc::c_uint {
+    if (*c).n_fc > 1 as libc::c_uint {
         let mut tile_idx = 0;
         let mut tile_row_0 = 0;
         while tile_row_0 < (*(*f).frame_hdr).tiling.rows {
             let row_off: libc::c_int = (*(*f).frame_hdr).tiling.row_start_sb[tile_row_0 as usize]
                 as libc::c_int
                 * (*f).sb_step
-                * 4 as libc::c_int
+                * 4
                 * (*f).sb128w
-                * 128 as libc::c_int;
+                * 128;
             let b_diff: libc::c_int = ((*(*f).frame_hdr).tiling.row_start_sb
-                [(tile_row_0 + 1 as libc::c_int) as usize]
-                as libc::c_int
+                [(tile_row_0 + 1) as usize] as libc::c_int
                 - (*(*f).frame_hdr).tiling.row_start_sb[tile_row_0 as usize] as libc::c_int)
                 * (*f).sb_step
-                * 4 as libc::c_int;
+                * 4;
             let mut tile_col = 0;
             while tile_col < (*(*f).frame_hdr).tiling.cols {
                 let fresh35 = tile_idx;
@@ -5136,7 +5131,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     + b_diff
                         * (*(*f).frame_hdr).tiling.col_start_sb[tile_col as usize] as libc::c_int
                         * (*f).sb_step
-                        * 4 as libc::c_int;
+                        * 4;
                 tile_col += 1;
             }
             tile_row_0 += 1;
@@ -5158,10 +5153,9 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         let mut tile_row_1 = 0;
         let mut tile_row_base = 0;
         while tile_row_1 < (*(*f).frame_hdr).tiling.rows {
-            let tile_row_sb_h: libc::c_int = (*(*f).frame_hdr).tiling.row_start_sb
-                [(tile_row_1 + 1 as libc::c_int) as usize]
-                as libc::c_int
-                - (*(*f).frame_hdr).tiling.row_start_sb[tile_row_1 as usize] as libc::c_int;
+            let tile_row_sb_h: libc::c_int =
+                (*(*f).frame_hdr).tiling.row_start_sb[(tile_row_1 + 1) as usize] as libc::c_int
+                    - (*(*f).frame_hdr).tiling.row_start_sb[tile_row_1 as usize] as libc::c_int;
             let mut tile_col_0 = 0;
             while tile_col_0 < (*(*f).frame_hdr).tiling.cols {
                 let ref mut fresh36 =
@@ -5252,11 +5246,9 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     let has_resize: libc::c_int =
         ((*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1]) as libc::c_int;
     let need_cdef_lpf_copy: libc::c_int =
-        ((*c).n_tc > 1 as libc::c_int as libc::c_uint && has_resize != 0) as libc::c_int;
-    if y_stride * (*f).sbh as isize * 4 as libc::c_int as isize
-        != (*f).lf.cdef_buf_plane_sz[0] as isize
-        || uv_stride * (*f).sbh as isize * 8 as libc::c_int as isize
-            != (*f).lf.cdef_buf_plane_sz[1] as isize
+        ((*c).n_tc > 1 as libc::c_uint && has_resize != 0) as libc::c_int;
+    if y_stride * (*f).sbh as isize * 4 as isize != (*f).lf.cdef_buf_plane_sz[0] as isize
+        || uv_stride * (*f).sbh as isize * 8 as isize != (*f).lf.cdef_buf_plane_sz[1] as isize
         || need_cdef_lpf_copy != (*f).lf.need_cdef_lpf_copy
         || (*f).sbh != (*f).lf.cdef_buf_sbh
     {
@@ -5284,12 +5276,12 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         }
         ptr = ptr.offset(32);
         if y_stride < 0 {
-            (*f).lf.cdef_line[0][0] = ptr.offset(
-                -((y_stride * ((*f).sbh * 4 as libc::c_int - 1 as libc::c_int) as isize) as isize),
-            ) as *mut libc::c_void;
-            (*f).lf.cdef_line[1][0] = ptr.offset(
-                -((y_stride * ((*f).sbh * 4 as libc::c_int - 3 as libc::c_int) as isize) as isize),
-            ) as *mut libc::c_void;
+            (*f).lf.cdef_line[0][0] = ptr
+                .offset(-((y_stride * ((*f).sbh * 4 - 1) as isize) as isize))
+                as *mut libc::c_void;
+            (*f).lf.cdef_line[1][0] = ptr
+                .offset(-((y_stride * ((*f).sbh * 4 - 3) as isize) as isize))
+                as *mut libc::c_void;
         } else {
             (*f).lf.cdef_line[0][0] = ptr.offset((y_stride * 0) as isize) as *mut libc::c_void;
             (*f).lf.cdef_line[1][0] = ptr.offset((y_stride * 2) as isize) as *mut libc::c_void;
@@ -5297,21 +5289,21 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         ptr = ptr.offset(
             ((y_stride as libc::c_longlong).abs()
                 * (*f).sbh as libc::c_longlong
-                * 4 as libc::c_int as libc::c_longlong) as isize,
+                * 4 as libc::c_longlong) as isize,
         );
         if uv_stride < 0 {
-            (*f).lf.cdef_line[0][1] = ptr.offset(
-                -((uv_stride * ((*f).sbh * 8 as libc::c_int - 1 as libc::c_int) as isize) as isize),
-            ) as *mut libc::c_void;
-            (*f).lf.cdef_line[0][2] = ptr.offset(
-                -((uv_stride * ((*f).sbh * 8 as libc::c_int - 3 as libc::c_int) as isize) as isize),
-            ) as *mut libc::c_void;
-            (*f).lf.cdef_line[1][1] = ptr.offset(
-                -((uv_stride * ((*f).sbh * 8 as libc::c_int - 5 as libc::c_int) as isize) as isize),
-            ) as *mut libc::c_void;
-            (*f).lf.cdef_line[1][2] = ptr.offset(
-                -((uv_stride * ((*f).sbh * 8 as libc::c_int - 7 as libc::c_int) as isize) as isize),
-            ) as *mut libc::c_void;
+            (*f).lf.cdef_line[0][1] = ptr
+                .offset(-((uv_stride * ((*f).sbh * 8 - 1) as isize) as isize))
+                as *mut libc::c_void;
+            (*f).lf.cdef_line[0][2] = ptr
+                .offset(-((uv_stride * ((*f).sbh * 8 - 3) as isize) as isize))
+                as *mut libc::c_void;
+            (*f).lf.cdef_line[1][1] = ptr
+                .offset(-((uv_stride * ((*f).sbh * 8 - 5) as isize) as isize))
+                as *mut libc::c_void;
+            (*f).lf.cdef_line[1][2] = ptr
+                .offset(-((uv_stride * ((*f).sbh * 8 - 7) as isize) as isize))
+                as *mut libc::c_void;
         } else {
             (*f).lf.cdef_line[0][1] = ptr.offset((uv_stride * 0) as isize) as *mut libc::c_void;
             (*f).lf.cdef_line[0][2] = ptr.offset((uv_stride * 2) as isize) as *mut libc::c_void;
@@ -5322,44 +5314,41 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             ptr = ptr.offset(
                 ((uv_stride as libc::c_longlong).abs()
                     * (*f).sbh as libc::c_longlong
-                    * 8 as libc::c_int as libc::c_longlong) as isize,
+                    * 8 as libc::c_longlong) as isize,
             );
             if y_stride < 0 {
-                (*f).lf.cdef_lpf_line[0] = ptr.offset(
-                    -((y_stride * ((*f).sbh * 4 as libc::c_int - 1 as libc::c_int) as isize)
-                        as isize),
-                ) as *mut libc::c_void;
+                (*f).lf.cdef_lpf_line[0] = ptr
+                    .offset(-((y_stride * ((*f).sbh * 4 - 1) as isize) as isize))
+                    as *mut libc::c_void;
             } else {
                 (*f).lf.cdef_lpf_line[0] = ptr as *mut libc::c_void;
             }
             ptr = ptr.offset(
                 ((y_stride as libc::c_longlong).abs()
                     * (*f).sbh as libc::c_longlong
-                    * 4 as libc::c_int as libc::c_longlong) as isize,
+                    * 4 as libc::c_longlong) as isize,
             );
             if uv_stride < 0 {
-                (*f).lf.cdef_lpf_line[1] = ptr.offset(
-                    -((uv_stride * ((*f).sbh * 4 as libc::c_int - 1 as libc::c_int) as isize)
-                        as isize),
-                ) as *mut libc::c_void;
-                (*f).lf.cdef_lpf_line[2] = ptr.offset(
-                    -((uv_stride * ((*f).sbh * 8 as libc::c_int - 1 as libc::c_int) as isize)
-                        as isize),
-                ) as *mut libc::c_void;
+                (*f).lf.cdef_lpf_line[1] = ptr
+                    .offset(-((uv_stride * ((*f).sbh * 4 - 1) as isize) as isize))
+                    as *mut libc::c_void;
+                (*f).lf.cdef_lpf_line[2] = ptr
+                    .offset(-((uv_stride * ((*f).sbh * 8 - 1) as isize) as isize))
+                    as *mut libc::c_void;
             } else {
                 (*f).lf.cdef_lpf_line[1] = ptr as *mut libc::c_void;
                 (*f).lf.cdef_lpf_line[2] =
                     ptr.offset((uv_stride * (*f).sbh as isize * 4) as isize) as *mut libc::c_void;
             }
         }
-        (*f).lf.cdef_buf_plane_sz[0] = y_stride as libc::c_int * (*f).sbh * 4 as libc::c_int;
-        (*f).lf.cdef_buf_plane_sz[1] = uv_stride as libc::c_int * (*f).sbh * 8 as libc::c_int;
+        (*f).lf.cdef_buf_plane_sz[0] = y_stride as libc::c_int * (*f).sbh * 4;
+        (*f).lf.cdef_buf_plane_sz[1] = uv_stride as libc::c_int * (*f).sbh * 8;
         (*f).lf.need_cdef_lpf_copy = need_cdef_lpf_copy;
         (*f).lf.cdef_buf_sbh = (*f).sbh;
     }
     let sb128: libc::c_int = (*(*f).seq_hdr).sb128;
-    let num_lines: libc::c_int = if (*c).n_tc > 1 as libc::c_int as libc::c_uint {
-        ((*f).sbh * 4 as libc::c_int) << sb128
+    let num_lines: libc::c_int = if (*c).n_tc > 1 as libc::c_uint {
+        ((*f).sbh * 4) << sb128
     } else {
         12 as libc::c_int
     };
@@ -5388,8 +5377,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         }
         ptr_0 = ptr_0.offset(64);
         if y_stride < 0 {
-            (*f).lf.lr_lpf_line[0] = ptr_0
-                .offset(-((y_stride * (num_lines - 1 as libc::c_int) as isize) as isize))
+            (*f).lf.lr_lpf_line[0] = ptr_0.offset(-((y_stride * (num_lines - 1) as isize) as isize))
                 as *mut libc::c_void;
         } else {
             (*f).lf.lr_lpf_line[0] = ptr_0 as *mut libc::c_void;
@@ -5398,21 +5386,19 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             ((y_stride as libc::c_longlong).abs() * num_lines as libc::c_longlong) as isize,
         );
         if uv_stride < 0 {
-            (*f).lf.lr_lpf_line[1] = ptr_0.offset(
-                -((uv_stride * (num_lines * 1 as libc::c_int - 1 as libc::c_int) as isize)
-                    as isize),
-            ) as *mut libc::c_void;
-            (*f).lf.lr_lpf_line[2] = ptr_0.offset(
-                -((uv_stride * (num_lines * 2 as libc::c_int - 1 as libc::c_int) as isize)
-                    as isize),
-            ) as *mut libc::c_void;
+            (*f).lf.lr_lpf_line[1] = ptr_0
+                .offset(-((uv_stride * (num_lines * 1 - 1) as isize) as isize))
+                as *mut libc::c_void;
+            (*f).lf.lr_lpf_line[2] = ptr_0
+                .offset(-((uv_stride * (num_lines * 2 - 1) as isize) as isize))
+                as *mut libc::c_void;
         } else {
             (*f).lf.lr_lpf_line[1] = ptr_0 as *mut libc::c_void;
             (*f).lf.lr_lpf_line[2] =
                 ptr_0.offset((uv_stride * num_lines as isize) as isize) as *mut libc::c_void;
         }
         (*f).lf.lr_buf_plane_sz[0] = y_stride as libc::c_int * num_lines;
-        (*f).lf.lr_buf_plane_sz[1] = uv_stride as libc::c_int * num_lines * 2 as libc::c_int;
+        (*f).lf.lr_buf_plane_sz[1] = uv_stride as libc::c_int * num_lines * 2;
     }
     if num_sb128 != (*f).lf.mask_sz {
         freep(&mut (*f).lf.mask as *mut *mut Av1Filter as *mut libc::c_void);
@@ -5432,7 +5418,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             (*f).lf.mask_sz = 0 as libc::c_int;
             return retval;
         }
-        if (*c).n_fc > 1 as libc::c_int as libc::c_uint {
+        if (*c).n_fc > 1 as libc::c_uint {
             freep(&mut (*f).frame_thread.b as *mut *mut Av1Block as *mut libc::c_void);
             freep(&mut (*f).frame_thread.cbi as *mut *mut CodedBlockInfo as *mut libc::c_void);
             (*f).frame_thread.b = malloc(
@@ -5454,7 +5440,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         }
         (*f).lf.mask_sz = num_sb128;
     }
-    (*f).sr_sb128w = (*f).sr_cur.p.p.w + 127 as libc::c_int >> 7 as libc::c_int;
+    (*f).sr_sb128w = (*f).sr_cur.p.p.w + 127 >> 7;
     let lr_mask_sz: libc::c_int = (*f).sr_sb128w * (*f).sb128h;
     if lr_mask_sz != (*f).lf.lr_mask_sz {
         freep(&mut (*f).lf.lr_mask as *mut *mut Av1Restoration as *mut libc::c_void);
@@ -5471,13 +5457,13 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     (*f).lf.restore_planes = ((((*(*f).frame_hdr).restoration.type_0[0] as libc::c_uint
         != DAV1D_RESTORATION_NONE as libc::c_int as libc::c_uint)
         as libc::c_int)
-        << 0 as libc::c_int)
+        << 0)
         + ((((*(*f).frame_hdr).restoration.type_0[1] as libc::c_uint
             != DAV1D_RESTORATION_NONE as libc::c_int as libc::c_uint) as libc::c_int)
-            << 1 as libc::c_int)
+            << 1)
         + ((((*(*f).frame_hdr).restoration.type_0[2] as libc::c_uint
             != DAV1D_RESTORATION_NONE as libc::c_int as libc::c_uint) as libc::c_int)
-            << 2 as libc::c_int);
+            << 2);
     if (*(*f).frame_hdr).loopfilter.sharpness != (*f).lf.last_sharpness {
         dav1d_calc_eih(
             &mut (*f).lf.lim_lut.0,
@@ -5498,7 +5484,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 as *mut libc::c_void,
         );
         (*f).ipred_edge[0] = dav1d_alloc_aligned(
-            (ipred_edge_sz * 128 as libc::c_int * 3 as libc::c_int) as size_t,
+            (ipred_edge_sz * 128 * 3) as size_t,
             64 as libc::c_int as size_t,
         );
         let ptr_1: *mut uint8_t = (*f).ipred_edge[0] as *mut uint8_t;
@@ -5506,12 +5492,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             (*f).ipred_edge_sz = 0 as libc::c_int;
             return retval;
         }
-        (*f).ipred_edge[1] = ptr_1
-            .offset((ipred_edge_sz * 128 as libc::c_int * 1 as libc::c_int) as isize)
-            as *mut libc::c_void;
-        (*f).ipred_edge[2] = ptr_1
-            .offset((ipred_edge_sz * 128 as libc::c_int * 2 as libc::c_int) as isize)
-            as *mut libc::c_void;
+        (*f).ipred_edge[1] = ptr_1.offset((ipred_edge_sz * 128 * 1) as isize) as *mut libc::c_void;
+        (*f).ipred_edge[2] = ptr_1.offset((ipred_edge_sz * 128 * 2) as isize) as *mut libc::c_void;
         (*f).ipred_edge_sz = ipred_edge_sz;
     }
     let re_sz: libc::c_int = (*f).sb128h * (*(*f).frame_hdr).tiling.cols;
@@ -5520,17 +5502,15 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             &mut *((*f).lf.tx_lpf_right_edge).as_mut_ptr().offset(0) as *mut *mut uint8_t
                 as *mut libc::c_void,
         );
-        (*f).lf.tx_lpf_right_edge[0] =
-            malloc((re_sz * 32 as libc::c_int * 2 as libc::c_int) as libc::c_ulong) as *mut uint8_t;
+        (*f).lf.tx_lpf_right_edge[0] = malloc((re_sz * 32 * 2) as libc::c_ulong) as *mut uint8_t;
         if ((*f).lf.tx_lpf_right_edge[0]).is_null() {
             (*f).lf.re_sz = 0 as libc::c_int;
             return retval;
         }
-        (*f).lf.tx_lpf_right_edge[1] =
-            ((*f).lf.tx_lpf_right_edge[0]).offset((re_sz * 32 as libc::c_int) as isize);
+        (*f).lf.tx_lpf_right_edge[1] = ((*f).lf.tx_lpf_right_edge[0]).offset((re_sz * 32) as isize);
         (*f).lf.re_sz = re_sz;
     }
-    if (*(*f).frame_hdr).frame_type as libc::c_uint & 1 as libc::c_int as libc::c_uint != 0
+    if (*(*f).frame_hdr).frame_type as libc::c_uint & 1 as libc::c_uint != 0
         || (*(*f).frame_hdr).allow_intrabc != 0
     {
         let ret: libc::c_int = dav1d_refmvs_init_frame(
@@ -5544,7 +5524,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             (*(*f).c).n_tc as libc::c_int,
             (*(*f).c).n_fc as libc::c_int,
         );
-        if ret < 0 as libc::c_int {
+        if ret < 0 {
             return retval;
         }
     }
@@ -5572,11 +5552,11 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     }
     if (*(*f).frame_hdr).switchable_comp_refs != 0 {
         let mut i_0 = 0;
-        while i_0 < 7 as libc::c_int {
+        while i_0 < 7 {
             let ref0poc: libc::c_uint =
                 (*(*f).refp[i_0 as usize].p.frame_hdr).frame_offset as libc::c_uint;
-            let mut j: libc::c_int = i_0 + 1 as libc::c_int;
-            while j < 7 as libc::c_int {
+            let mut j: libc::c_int = i_0 + 1;
+            while j < 7 {
                 let ref1poc: libc::c_uint =
                     (*(*f).refp[j as usize].p.frame_hdr).frame_offset as libc::c_uint;
                 let d1: libc::c_uint = imin(
@@ -5611,7 +5591,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 ];
                 let mut k: libc::c_int;
                 k = 0 as libc::c_int;
-                while k < 3 as libc::c_int {
+                while k < 3 {
                     let c0: libc::c_int =
                         quant_dist_weight[k as usize][order as usize] as libc::c_int;
                     let c1: libc::c_int = quant_dist_weight[k as usize]
@@ -5709,7 +5689,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
                 tile_sz,
                 tile_row as usize,
                 fresh38 as usize,
-                if (*c).n_fc > 1 as libc::c_int as libc::c_uint {
+                if (*c).n_fc > 1 as libc::c_uint {
                     *((*f).frame_thread.tile_start_off).offset(j as isize) as usize
                 } else {
                     0
@@ -5728,8 +5708,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
         }
         i += 1;
     }
-    if (*c).n_tc > 1 as libc::c_int as libc::c_uint {
-        let uses_2pass: libc::c_int = ((*c).n_fc > 1 as libc::c_int as libc::c_uint) as libc::c_int;
+    if (*c).n_tc > 1 as libc::c_uint {
+        let uses_2pass: libc::c_int = ((*c).n_fc > 1 as libc::c_uint) as libc::c_int;
         let mut n = 0;
         while n < (*f).sb128w * (*(*f).frame_hdr).tiling.rows * (1 as libc::c_int + uses_2pass) {
             reset_context(
@@ -5753,7 +5733,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
 pub unsafe extern "C" fn dav1d_decode_frame_main(f: *mut Dav1dFrameContext) -> libc::c_int {
     let c: *const Dav1dContext = (*f).c;
     let mut retval: libc::c_int = -(22 as libc::c_int);
-    if !((*(*f).c).n_tc == 1 as libc::c_int as libc::c_uint) {
+    if !((*(*f).c).n_tc == 1 as libc::c_uint) {
         unreachable!();
     }
     let t: *mut Dav1dTaskContext = &mut *((*c).tc)
@@ -5773,22 +5753,21 @@ pub unsafe extern "C" fn dav1d_decode_frame_main(f: *mut Dav1dFrameContext) -> l
     let mut tile_row = 0;
     while tile_row < (*(*f).frame_hdr).tiling.rows {
         let sbh_end: libc::c_int = imin(
-            (*(*f).frame_hdr).tiling.row_start_sb[(tile_row + 1 as libc::c_int) as usize]
-                as libc::c_int,
+            (*(*f).frame_hdr).tiling.row_start_sb[(tile_row + 1) as usize] as libc::c_int,
             (*f).sbh,
         );
         let mut sby: libc::c_int =
             (*(*f).frame_hdr).tiling.row_start_sb[tile_row as usize] as libc::c_int;
         while sby < sbh_end {
-            (*t).by = sby << 4 as libc::c_int + (*(*f).seq_hdr).sb128;
-            let by_end: libc::c_int = (*t).by + (*f).sb_step >> 1 as libc::c_int;
+            (*t).by = sby << 4 + (*(*f).seq_hdr).sb128;
+            let by_end: libc::c_int = (*t).by + (*f).sb_step >> 1;
             if (*(*f).frame_hdr).use_ref_frame_mvs != 0 {
                 ((*(*f).c).refmvs_dsp.load_tmvs).expect("non-null function pointer")(
                     &mut (*f).rf,
                     tile_row,
                     0 as libc::c_int,
-                    (*f).bw >> 1 as libc::c_int,
-                    (*t).by >> 1 as libc::c_int,
+                    (*f).bw >> 1,
+                    (*t).by >> 1,
                     by_end,
                 );
             }
@@ -5802,14 +5781,13 @@ pub unsafe extern "C" fn dav1d_decode_frame_main(f: *mut Dav1dFrameContext) -> l
                 }
                 tile_col += 1;
             }
-            if (*(*f).frame_hdr).frame_type as libc::c_uint & 1 as libc::c_int as libc::c_uint != 0
-            {
+            if (*(*f).frame_hdr).frame_type as libc::c_uint & 1 as libc::c_uint != 0 {
                 dav1d_refmvs_save_tmvs(
                     &(*(*f).c).refmvs_dsp,
                     &mut (*t).rt,
                     0 as libc::c_int,
-                    (*f).bw >> 1 as libc::c_int,
-                    (*t).by >> 1 as libc::c_int,
+                    (*f).bw >> 1,
+                    (*t).by >> 1,
                     by_end,
                 );
             }
@@ -5926,14 +5904,14 @@ unsafe extern "C" fn dav1d_submit_frame_error(
         dav1d_cdf_thread_unref(&mut (*f).out_cdf);
     }
     let mut i = 0;
-    while i < 7 as libc::c_int {
+    while i < 7 {
         if !((*f).refp[i as usize].p.frame_hdr).is_null() {
             dav1d_thread_picture_unref(&mut *((*f).refp).as_mut_ptr().offset(i as isize));
         }
         dav1d_ref_dec(&mut *((*f).ref_mvs_ref).as_mut_ptr().offset(i as isize));
         i += 1;
     }
-    if (*c).n_fc == 1 as libc::c_int as libc::c_uint {
+    if (*c).n_fc == 1 as libc::c_uint {
         dav1d_thread_picture_unref(&mut (*c).out);
     } else {
         dav1d_thread_picture_unref(out_delayed);
@@ -5950,7 +5928,7 @@ unsafe extern "C" fn dav1d_submit_frame_error(
         i_0 += 1;
     }
     (*f).n_tile_data = 0 as libc::c_int;
-    if (*c).n_fc > 1 as libc::c_int as libc::c_uint {
+    if (*c).n_fc > 1 as libc::c_uint {
         pthread_mutex_unlock(&mut (*c).task_thread.lock);
     }
     return res;
@@ -5961,7 +5939,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
     let f: *mut Dav1dFrameContext;
     let mut res: libc::c_int;
     let mut out_delayed: *mut Dav1dThreadPicture = 0 as *mut Dav1dThreadPicture;
-    if (*c).n_fc > 1 as libc::c_int as libc::c_uint {
+    if (*c).n_fc > 1 as libc::c_uint {
         pthread_mutex_lock(&mut (*c).task_thread.lock);
         let fresh39 = (*c).frame_thread.next;
         (*c).frame_thread.next = ((*c).frame_thread.next).wrapping_add(1);
@@ -5970,7 +5948,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
             (*c).frame_thread.next = 0 as libc::c_int as libc::c_uint;
         }
         f = &mut *((*c).fc).offset(next as isize) as *mut Dav1dFrameContext;
-        while (*f).n_tile_data > 0 as libc::c_int {
+        while (*f).n_tile_data > 0 {
             pthread_cond_wait(&mut (*f).task_thread.cond, &mut (*c).task_thread.lock);
         }
         out_delayed =
@@ -6043,7 +6021,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
     (*c).frame_hdr_ref = 0 as *mut Dav1dRef;
     (*f).dsp =
         &mut *((*c).dsp).as_mut_ptr().offset((*(*f).seq_hdr).hbd as isize) as *mut Dav1dDSPContext;
-    let bpc: libc::c_int = 8 as libc::c_int + 2 as libc::c_int * (*(*f).seq_hdr).hbd;
+    let bpc: libc::c_int = 8 as libc::c_int + 2 * (*(*f).seq_hdr).hbd;
     if ((*(*f).dsp).ipred.intra_pred[DC_PRED as libc::c_int as usize]).is_none() {
         let dsp: *mut Dav1dDSPContext =
             &mut *((*c).dsp).as_mut_ptr().offset((*(*f).seq_hdr).hbd as isize)
@@ -6074,7 +6052,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                     c,
                     b"Compiled without support for %d-bit decoding\n\0" as *const u8
                         as *const libc::c_char,
-                    8 as libc::c_int + 2 as libc::c_int * (*(*f).seq_hdr).hbd,
+                    8 as libc::c_int + 2 * (*(*f).seq_hdr).hbd,
                 );
                 res = -(92 as libc::c_int);
                 return dav1d_submit_frame_error(res, f, c, out_delayed);
@@ -6195,7 +6173,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
         }
     }
     let mut ref_coded_width: [libc::c_int; 7] = [0; 7];
-    if (*(*f).frame_hdr).frame_type as libc::c_uint & 1 as libc::c_int as libc::c_uint != 0 {
+    if (*(*f).frame_hdr).frame_type as libc::c_uint & 1 as libc::c_uint != 0 {
         if (*(*f).frame_hdr).primary_ref_frame != 7 as libc::c_int {
             let pri_ref: libc::c_int =
                 (*(*f).frame_hdr).refidx[(*(*f).frame_hdr).primary_ref_frame as usize];
@@ -6205,16 +6183,13 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
             }
         }
         let mut i = 0;
-        while i < 7 as libc::c_int {
+        while i < 7 {
             let refidx: libc::c_int = (*(*f).frame_hdr).refidx[i as usize];
             if ((*c).refs[refidx as usize].p.p.data[0]).is_null()
-                || ((*(*f).frame_hdr).width[0] * 2 as libc::c_int)
-                    < (*c).refs[refidx as usize].p.p.p.w
-                || ((*(*f).frame_hdr).height * 2 as libc::c_int)
-                    < (*c).refs[refidx as usize].p.p.p.h
-                || (*(*f).frame_hdr).width[0]
-                    > (*c).refs[refidx as usize].p.p.p.w * 16 as libc::c_int
-                || (*(*f).frame_hdr).height > (*c).refs[refidx as usize].p.p.p.h * 16 as libc::c_int
+                || ((*(*f).frame_hdr).width[0] * 2) < (*c).refs[refidx as usize].p.p.p.w
+                || ((*(*f).frame_hdr).height * 2) < (*c).refs[refidx as usize].p.p.p.h
+                || (*(*f).frame_hdr).width[0] > (*c).refs[refidx as usize].p.p.p.w * 16
+                || (*(*f).frame_hdr).height > (*c).refs[refidx as usize].p.p.p.h * 16
                 || (*(*f).seq_hdr).layout as libc::c_uint
                     != (*c).refs[refidx as usize].p.p.p.layout as libc::c_uint
                 || bpc != (*c).refs[refidx as usize].p.p.p.bpc
@@ -6235,18 +6210,14 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
             if (*(*f).frame_hdr).width[0] != (*c).refs[refidx as usize].p.p.p.w
                 || (*(*f).frame_hdr).height != (*c).refs[refidx as usize].p.p.p.h
             {
-                (*f).svc[i as usize][0].scale = (((*c).refs[refidx as usize].p.p.p.w
-                    << 14 as libc::c_int)
-                    + ((*(*f).frame_hdr).width[0] >> 1 as libc::c_int))
+                (*f).svc[i as usize][0].scale = (((*c).refs[refidx as usize].p.p.p.w << 14)
+                    + ((*(*f).frame_hdr).width[0] >> 1))
                     / (*(*f).frame_hdr).width[0];
-                (*f).svc[i as usize][1].scale = (((*c).refs[refidx as usize].p.p.p.h
-                    << 14 as libc::c_int)
-                    + ((*(*f).frame_hdr).height >> 1 as libc::c_int))
+                (*f).svc[i as usize][1].scale = (((*c).refs[refidx as usize].p.p.p.h << 14)
+                    + ((*(*f).frame_hdr).height >> 1))
                     / (*(*f).frame_hdr).height;
-                (*f).svc[i as usize][0].step =
-                    (*f).svc[i as usize][0].scale + 8 as libc::c_int >> 4 as libc::c_int;
-                (*f).svc[i as usize][1].step =
-                    (*f).svc[i as usize][1].scale + 8 as libc::c_int >> 4 as libc::c_int;
+                (*f).svc[i as usize][0].step = (*f).svc[i as usize][0].scale + 8 >> 4;
+                (*f).svc[i as usize][1].step = (*f).svc[i as usize][1].scale + 8 >> 4;
             } else {
                 (*f).svc[i as usize][1].scale = 0 as libc::c_int;
                 (*f).svc[i as usize][0].scale = (*f).svc[i as usize][1].scale;
@@ -6263,7 +6234,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
             i += 1;
         }
     }
-    if (*(*f).frame_hdr).primary_ref_frame == 7 as libc::c_int {
+    if (*(*f).frame_hdr).primary_ref_frame == 7 {
         dav1d_cdf_thread_init_static(&mut (*f).in_cdf, (*(*f).frame_hdr).quant.yac);
     } else {
         let pri_ref_0: libc::c_int =
@@ -6277,17 +6248,16 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
         res = dav1d_cdf_thread_alloc(
             c,
             &mut (*f).out_cdf,
-            ((*c).n_fc > 1 as libc::c_int as libc::c_uint) as libc::c_int,
+            ((*c).n_fc > 1 as libc::c_uint) as libc::c_int,
         );
-        if res < 0 as libc::c_int {
+        if res < 0 {
             return dav1d_submit_frame_error(res, f, c, out_delayed);
         }
     }
     if (*f).n_tile_data_alloc < (*c).n_tile_data {
         freep(&mut (*f).tile as *mut *mut Dav1dTileGroup as *mut libc::c_void);
         if !((*c).n_tile_data
-            < 2147483647 as libc::c_int
-                / ::core::mem::size_of::<Dav1dTileGroup>() as libc::c_ulong as libc::c_int)
+            < 2147483647 / ::core::mem::size_of::<Dav1dTileGroup>() as libc::c_ulong as libc::c_int)
         {
             unreachable!();
         }
@@ -6317,7 +6287,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
     (*f).n_tile_data = (*c).n_tile_data;
     (*c).n_tile_data = 0 as libc::c_int;
     res = dav1d_thread_picture_alloc(c, f, bpc);
-    if res < 0 as libc::c_int {
+    if res < 0 {
         return dav1d_submit_frame_error(res, f, c, out_delayed);
     }
     if (*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1] {
@@ -6327,27 +6297,24 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
             (*(*f).frame_hdr).width[0],
             &mut (*f).sr_cur.p,
         );
-        if res < 0 as libc::c_int {
+        if res < 0 {
             return dav1d_submit_frame_error(res, f, c, out_delayed);
         }
     } else {
         dav1d_picture_ref(&mut (*f).cur, &mut (*f).sr_cur.p);
     }
     if (*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1] {
-        (*f).resize_step[0] = (((*f).cur.p.w << 14 as libc::c_int)
-            + ((*f).sr_cur.p.p.w >> 1 as libc::c_int))
-            / (*f).sr_cur.p.p.w;
+        (*f).resize_step[0] = (((*f).cur.p.w << 14) + ((*f).sr_cur.p.p.w >> 1)) / (*f).sr_cur.p.p.w;
         let ss_hor: libc::c_int = ((*f).cur.p.layout as libc::c_uint
             != DAV1D_PIXEL_LAYOUT_I444 as libc::c_int as libc::c_uint)
             as libc::c_int;
         let in_cw: libc::c_int = (*f).cur.p.w + ss_hor >> ss_hor;
         let out_cw: libc::c_int = (*f).sr_cur.p.p.w + ss_hor >> ss_hor;
-        (*f).resize_step[1] =
-            ((in_cw << 14 as libc::c_int) + (out_cw >> 1 as libc::c_int)) / out_cw;
+        (*f).resize_step[1] = ((in_cw << 14) + (out_cw >> 1)) / out_cw;
         (*f).resize_start[0] = get_upscale_x0((*f).cur.p.w, (*f).sr_cur.p.p.w, (*f).resize_step[0]);
         (*f).resize_start[1] = get_upscale_x0(in_cw, out_cw, (*f).resize_step[1]);
     }
-    if (*c).n_fc == 1 as libc::c_int as libc::c_uint {
+    if (*c).n_fc == 1 as libc::c_uint {
         if (*(*f).frame_hdr).show_frame != 0 || (*c).output_invisible_frames != 0 {
             dav1d_thread_picture_ref(&mut (*c).out, &mut (*f).sr_cur);
             (*c).event_flags = ::core::mem::transmute::<libc::c_uint, Dav1dEventFlags>(
@@ -6358,27 +6325,26 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
     } else {
         dav1d_thread_picture_ref(out_delayed, &mut (*f).sr_cur);
     }
-    (*f).w4 = (*(*f).frame_hdr).width[0] + 3 as libc::c_int >> 2 as libc::c_int;
-    (*f).h4 = (*(*f).frame_hdr).height + 3 as libc::c_int >> 2 as libc::c_int;
-    (*f).bw =
-        ((*(*f).frame_hdr).width[0] + 7 as libc::c_int >> 3 as libc::c_int) << 1 as libc::c_int;
-    (*f).bh = ((*(*f).frame_hdr).height + 7 as libc::c_int >> 3 as libc::c_int) << 1 as libc::c_int;
-    (*f).sb128w = (*f).bw + 31 as libc::c_int >> 5 as libc::c_int;
-    (*f).sb128h = (*f).bh + 31 as libc::c_int >> 5 as libc::c_int;
+    (*f).w4 = (*(*f).frame_hdr).width[0] + 3 >> 2;
+    (*f).h4 = (*(*f).frame_hdr).height + 3 >> 2;
+    (*f).bw = ((*(*f).frame_hdr).width[0] + 7 >> 3) << 1;
+    (*f).bh = ((*(*f).frame_hdr).height + 7 >> 3) << 1;
+    (*f).sb128w = (*f).bw + 31 >> 5;
+    (*f).sb128h = (*f).bh + 31 >> 5;
     (*f).sb_shift = 4 as libc::c_int + (*(*f).seq_hdr).sb128;
     (*f).sb_step = (16 as libc::c_int) << (*(*f).seq_hdr).sb128;
-    (*f).sbh = (*f).bh + (*f).sb_step - 1 as libc::c_int >> (*f).sb_shift;
-    (*f).b4_stride = ((*f).bw + 31 as libc::c_int & !(31 as libc::c_int)) as ptrdiff_t;
-    (*f).bitdepth_max = ((1 as libc::c_int) << (*f).cur.p.bpc) - 1 as libc::c_int;
+    (*f).sbh = (*f).bh + (*f).sb_step - 1 >> (*f).sb_shift;
+    (*f).b4_stride = ((*f).bw + 31 & !(31 as libc::c_int)) as ptrdiff_t;
+    (*f).bitdepth_max = ((1 as libc::c_int) << (*f).cur.p.bpc) - 1;
     *&mut (*f).task_thread.error = 0 as libc::c_int;
-    let uses_2pass: libc::c_int = ((*c).n_fc > 1 as libc::c_int as libc::c_uint) as libc::c_int;
+    let uses_2pass: libc::c_int = ((*c).n_fc > 1 as libc::c_uint) as libc::c_int;
     let cols: libc::c_int = (*(*f).frame_hdr).tiling.cols;
     let rows: libc::c_int = (*(*f).frame_hdr).tiling.rows;
     ::core::intrinsics::atomic_store_seqcst(
         &mut (*f).task_thread.task_counter,
         cols * rows + (*f).sbh << uses_2pass,
     );
-    if (*(*f).frame_hdr).frame_type as libc::c_uint & 1 as libc::c_int as libc::c_uint != 0
+    if (*(*f).frame_hdr).frame_type as libc::c_uint & 1 as libc::c_uint != 0
         || (*(*f).frame_hdr).allow_intrabc != 0
     {
         (*f).mvs_ref = dav1d_ref_create_using_pool(
@@ -6386,7 +6352,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
             (::core::mem::size_of::<refmvs_temporal_block>())
                 .wrapping_mul((*f).sb128h as size_t)
                 .wrapping_mul(16)
-                .wrapping_mul(((*f).b4_stride >> 1 as libc::c_int) as size_t),
+                .wrapping_mul(((*f).b4_stride >> 1) as size_t),
         );
         if ((*f).mvs_ref).is_null() {
             res = -(12 as libc::c_int);
@@ -6395,7 +6361,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
         (*f).mvs = (*(*f).mvs_ref).data as *mut refmvs_temporal_block;
         if (*(*f).frame_hdr).allow_intrabc == 0 {
             let mut i_0 = 0;
-            while i_0 < 7 as libc::c_int {
+            while i_0 < 7 {
                 (*f).refpoc[i_0 as usize] =
                     (*(*f).refp[i_0 as usize].p.frame_hdr).frame_offset as libc::c_uint;
                 i_0 += 1;
@@ -6409,14 +6375,10 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
         }
         if (*(*f).frame_hdr).use_ref_frame_mvs != 0 {
             let mut i_1 = 0;
-            while i_1 < 7 as libc::c_int {
+            while i_1 < 7 {
                 let refidx_0: libc::c_int = (*(*f).frame_hdr).refidx[i_1 as usize];
-                let ref_w: libc::c_int = (ref_coded_width[i_1 as usize] + 7 as libc::c_int
-                    >> 3 as libc::c_int)
-                    << 1 as libc::c_int;
-                let ref_h: libc::c_int = ((*f).refp[i_1 as usize].p.p.h + 7 as libc::c_int
-                    >> 3 as libc::c_int)
-                    << 1 as libc::c_int;
+                let ref_w: libc::c_int = (ref_coded_width[i_1 as usize] + 7 >> 3) << 1;
+                let ref_h: libc::c_int = ((*f).refp[i_1 as usize].p.p.h + 7 >> 3) << 1;
                 if !((*c).refs[refidx_0 as usize].refmvs).is_null()
                     && ref_w == (*f).bw
                     && ref_h == (*f).bh
@@ -6461,12 +6423,8 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
             if !(pri_ref_1 != 7 as libc::c_int) {
                 unreachable!();
             }
-            let ref_w_0: libc::c_int = (ref_coded_width[pri_ref_1 as usize] + 7 as libc::c_int
-                >> 3 as libc::c_int)
-                << 1 as libc::c_int;
-            let ref_h_0: libc::c_int = ((*f).refp[pri_ref_1 as usize].p.p.h + 7 as libc::c_int
-                >> 3 as libc::c_int)
-                << 1 as libc::c_int;
+            let ref_w_0: libc::c_int = (ref_coded_width[pri_ref_1 as usize] + 7 >> 3) << 1;
+            let ref_h_0: libc::c_int = ((*f).refp[pri_ref_1 as usize].p.p.h + 7 >> 3) << 1;
             if ref_w_0 == (*f).bw && ref_h_0 == (*f).bh {
                 (*f).prev_segmap_ref =
                     (*c).refs[(*(*f).frame_hdr).refidx[pri_ref_1 as usize] as usize].segmap;
@@ -6518,7 +6476,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
     }
     let refresh_frame_flags: libc::c_uint = (*(*f).frame_hdr).refresh_frame_flags as libc::c_uint;
     let mut i_2 = 0;
-    while i_2 < 8 as libc::c_int {
+    while i_2 < 8 {
         if refresh_frame_flags & ((1 as libc::c_int) << i_2) as libc::c_uint != 0 {
             if !((*c).refs[i_2 as usize].p.p.frame_hdr).is_null() {
                 dav1d_thread_picture_unref(&mut (*((*c).refs).as_mut_ptr().offset(i_2 as isize)).p);
@@ -6559,12 +6517,12 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
         }
         i_2 += 1;
     }
-    if (*c).n_fc == 1 as libc::c_int as libc::c_uint {
+    if (*c).n_fc == 1 as libc::c_uint {
         res = dav1d_decode_frame(&mut *f);
-        if res < 0 as libc::c_int {
+        if res < 0 {
             dav1d_thread_picture_unref(&mut (*c).out);
             let mut i_3 = 0;
-            while i_3 < 8 as libc::c_int {
+            while i_3 < 8 {
                 if refresh_frame_flags & ((1 as libc::c_int) << i_3) as libc::c_uint != 0 {
                     if !((*c).refs[i_3 as usize].p.p.frame_hdr).is_null() {
                         dav1d_thread_picture_unref(

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5173,8 +5173,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             tile_row_1 += 1;
             tile_row_base += (*(*f).frame_hdr).tiling.cols;
         }
-        let cf_sz: libc::c_int =
-            (num_sb128 * *size_mul.offset(0 as libc::c_int as isize) as libc::c_int) << hbd;
+        let cf_sz: libc::c_int = (num_sb128 * *size_mul.offset(0) as libc::c_int) << hbd;
         if cf_sz != (*f).frame_thread.cf_sz {
             dav1d_freep_aligned(
                 &mut (*f).frame_thread.cf as *mut *mut libc::c_void as *mut libc::c_void,
@@ -5218,8 +5217,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 }
                 (*f).frame_thread.pal_sz = num_sb128;
             }
-            let pal_idx_sz: libc::c_int =
-                num_sb128 * *size_mul.offset(1 as libc::c_int as isize) as libc::c_int;
+            let pal_idx_sz: libc::c_int = num_sb128 * *size_mul.offset(1) as libc::c_int;
             if pal_idx_sz != (*f).frame_thread.pal_idx_sz {
                 dav1d_freep_aligned(
                     &mut (*f).frame_thread.pal_idx as *mut *mut uint8_t as *mut libc::c_void,
@@ -5284,7 +5282,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             (*f).lf.cdef_buf_plane_sz[0] = (*f).lf.cdef_buf_plane_sz[1];
             return retval;
         }
-        ptr = ptr.offset(32 as libc::c_int as isize);
+        ptr = ptr.offset(32);
         if y_stride < 0 {
             (*f).lf.cdef_line[0][0] = ptr.offset(
                 -((y_stride * ((*f).sbh * 4 as libc::c_int - 1 as libc::c_int) as isize) as isize),
@@ -5388,7 +5386,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             (*f).lf.lr_buf_plane_sz[0] = (*f).lf.lr_buf_plane_sz[1];
             return retval;
         }
-        ptr_0 = ptr_0.offset(64 as libc::c_int as isize);
+        ptr_0 = ptr_0.offset(64);
         if y_stride < 0 {
             (*f).lf.lr_lpf_line[0] = ptr_0
                 .offset(-((y_stride * (num_lines - 1 as libc::c_int) as isize) as isize))
@@ -5496,9 +5494,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     let ipred_edge_sz: libc::c_int = (*f).sbh * (*f).sb128w << hbd;
     if ipred_edge_sz != (*f).ipred_edge_sz {
         dav1d_freep_aligned(
-            &mut *((*f).ipred_edge)
-                .as_mut_ptr()
-                .offset(0 as libc::c_int as isize) as *mut *mut libc::c_void
+            &mut *((*f).ipred_edge).as_mut_ptr().offset(0) as *mut *mut libc::c_void
                 as *mut libc::c_void,
         );
         (*f).ipred_edge[0] = dav1d_alloc_aligned(
@@ -5521,9 +5517,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     let re_sz: libc::c_int = (*f).sb128h * (*(*f).frame_hdr).tiling.cols;
     if re_sz != (*f).lf.re_sz {
         freep(
-            &mut *((*f).lf.tx_lpf_right_edge)
-                .as_mut_ptr()
-                .offset(0 as libc::c_int as isize) as *mut *mut uint8_t
+            &mut *((*f).lf.tx_lpf_right_edge).as_mut_ptr().offset(0) as *mut *mut uint8_t
                 as *mut libc::c_void,
         );
         (*f).lf.tx_lpf_right_edge[0] =
@@ -6020,8 +6014,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
             dav1d_thread_picture_unref(out_delayed);
         } else if !((*out_delayed).p.data[0]).is_null() {
             let progress: libc::c_uint = ::core::intrinsics::atomic_load_relaxed(
-                &mut *((*out_delayed).progress).offset(1 as libc::c_int as isize)
-                    as *mut atomic_uint,
+                &mut *((*out_delayed).progress).offset(1) as *mut atomic_uint,
             );
             if ((*out_delayed).visible != 0 || (*c).output_invisible_frames != 0)
                 && progress

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5711,7 +5711,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
     if (*c).n_tc > 1 as libc::c_uint {
         let uses_2pass: libc::c_int = ((*c).n_fc > 1 as libc::c_uint) as libc::c_int;
         let mut n = 0;
-        while n < (*f).sb128w * (*(*f).frame_hdr).tiling.rows * (1 as libc::c_int + uses_2pass) {
+        while n < (*f).sb128w * (*(*f).frame_hdr).tiling.rows * (1 + uses_2pass) {
             reset_context(
                 &mut *((*f).a).offset(n as isize),
                 (*(*f).frame_hdr).frame_type & 1 == 0,
@@ -6021,7 +6021,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
     (*c).frame_hdr_ref = 0 as *mut Dav1dRef;
     (*f).dsp =
         &mut *((*c).dsp).as_mut_ptr().offset((*(*f).seq_hdr).hbd as isize) as *mut Dav1dDSPContext;
-    let bpc: libc::c_int = 8 as libc::c_int + 2 * (*(*f).seq_hdr).hbd;
+    let bpc: libc::c_int = 8 + 2 * (*(*f).seq_hdr).hbd;
     if ((*(*f).dsp).ipred.intra_pred[DC_PRED as libc::c_int as usize]).is_none() {
         let dsp: *mut Dav1dDSPContext =
             &mut *((*c).dsp).as_mut_ptr().offset((*(*f).seq_hdr).hbd as isize)
@@ -6052,7 +6052,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                     c,
                     b"Compiled without support for %d-bit decoding\n\0" as *const u8
                         as *const libc::c_char,
-                    8 as libc::c_int + 2 * (*(*f).seq_hdr).hbd,
+                    8 + 2 * (*(*f).seq_hdr).hbd,
                 );
                 res = -(92 as libc::c_int);
                 return dav1d_submit_frame_error(res, f, c, out_delayed);
@@ -6331,7 +6331,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
     (*f).bh = ((*(*f).frame_hdr).height + 7 >> 3) << 1;
     (*f).sb128w = (*f).bw + 31 >> 5;
     (*f).sb128h = (*f).bh + 31 >> 5;
-    (*f).sb_shift = 4 as libc::c_int + (*(*f).seq_hdr).sb128;
+    (*f).sb_shift = 4 + (*(*f).seq_hdr).sb128;
     (*f).sb_step = (16 as libc::c_int) << (*(*f).seq_hdr).sb128;
     (*f).sbh = (*f).bh + (*f).sb_step - 1 >> (*f).sb_shift;
     (*f).b4_stride = ((*f).bw + 31 & !(31 as libc::c_int)) as ptrdiff_t;

--- a/src/filmgrain_tmpl_16.rs
+++ b/src/filmgrain_tmpl_16.rs
@@ -412,7 +412,7 @@ unsafe extern "C" fn generate_grain_y_c(
     data: *const Dav1dFilmGrainData,
     bitdepth_max: libc::c_int,
 ) {
-    let bitdepth_min_8 = 32 as libc::c_int - clz(bitdepth_max as libc::c_uint) - 8;
+    let bitdepth_min_8 = 32 - clz(bitdepth_max as libc::c_uint) - 8;
     let mut seed: libc::c_uint = (*data).seed;
     let shift = 4 - bitdepth_min_8 + (*data).grain_scale_shift;
     let grain_ctr = (128 as libc::c_int) << bitdepth_min_8;
@@ -472,7 +472,7 @@ unsafe extern "C" fn generate_grain_uv_c(
     suby: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
-    let bitdepth_min_8 = 32 as libc::c_int - clz(bitdepth_max as libc::c_uint) - 8;
+    let bitdepth_min_8 = 32 - clz(bitdepth_max as libc::c_uint) - 8;
     let mut seed: libc::c_uint = (*data).seed
         ^ (if uv != 0 {
             0x49d8 as libc::c_int
@@ -620,8 +620,8 @@ unsafe extern "C" fn sample_lut(
     y: libc::c_int,
 ) -> entry {
     let randval = (*offsets.offset(bx as isize))[by as usize];
-    let offx = 3 as libc::c_int + (2 >> subx) * (3 + (randval >> 4));
-    let offy = 3 as libc::c_int + (2 >> suby) * (3 + (randval & 0xf as libc::c_int));
+    let offx = 3 + (2 >> subx) * (3 + (randval >> 4));
+    let offy = 3 + (2 >> suby) * (3 + (randval & 0xf as libc::c_int));
     return (*grain_lut.offset((offy + y + (32 >> suby) * by) as isize))
         [(offx + x + (32 >> subx) * bx) as usize];
 }
@@ -637,8 +637,8 @@ unsafe extern "C" fn fgy_32x32xn_c(
     row_num: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
-    let rows = 1 as libc::c_int + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
-    let bitdepth_min_8 = 32 as libc::c_int - clz(bitdepth_max as libc::c_uint) - 8;
+    let rows = 1 + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
+    let bitdepth_min_8 = 32 - clz(bitdepth_max as libc::c_uint) - 8;
     let grain_ctr = (128 as libc::c_int) << bitdepth_min_8;
     let grain_min = -grain_ctr;
     let grain_max = grain_ctr - 1;
@@ -915,8 +915,8 @@ unsafe extern "C" fn fguv_32x32xn_c(
     sy: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
-    let rows = 1 as libc::c_int + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
-    let bitdepth_min_8 = 32 as libc::c_int - clz(bitdepth_max as libc::c_uint) - 8;
+    let rows = 1 + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
+    let bitdepth_min_8 = 32 - clz(bitdepth_max as libc::c_uint) - 8;
     let grain_ctr = (128 as libc::c_int) << bitdepth_min_8;
     let grain_min = -grain_ctr;
     let grain_max = grain_ctr - 1;
@@ -1473,7 +1473,7 @@ unsafe extern "C" fn fgy_32x32xn_neon(
     row_num: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
-    let rows = 1 as libc::c_int + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
+    let rows = 1 + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
     let mut seed: [libc::c_uint; 2] = [0; 2];
     let mut i = 0;
     while i < rows {
@@ -1541,7 +1541,7 @@ unsafe extern "C" fn fguv_32x32xn_420_neon(
     is_id: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
-    let rows = 1 as libc::c_int + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
+    let rows = 1 + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
     let mut seed: [libc::c_uint; 2] = [0; 2];
     let mut i = 0;
     while i < rows {
@@ -1615,7 +1615,7 @@ unsafe extern "C" fn fguv_32x32xn_422_neon(
     is_id: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
-    let rows = 1 as libc::c_int + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
+    let rows = 1 + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
     let mut seed: [libc::c_uint; 2] = [0; 2];
     let mut i = 0;
     while i < rows {
@@ -1689,7 +1689,7 @@ unsafe extern "C" fn fguv_32x32xn_444_neon(
     is_id: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
-    let rows = 1 as libc::c_int + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
+    let rows = 1 + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
     let mut seed: [libc::c_uint; 2] = [0; 2];
     let mut i = 0;
     while i < rows {

--- a/src/filmgrain_tmpl_8.rs
+++ b/src/filmgrain_tmpl_8.rs
@@ -545,8 +545,8 @@ unsafe extern "C" fn sample_lut(
     y: libc::c_int,
 ) -> entry {
     let randval = (*offsets.offset(bx as isize))[by as usize];
-    let offx = 3 as libc::c_int + (2 >> subx) * (3 + (randval >> 4));
-    let offy = 3 as libc::c_int + (2 >> suby) * (3 + (randval & 0xf as libc::c_int));
+    let offx = 3 + (2 >> subx) * (3 + (randval >> 4));
+    let offy = 3 + (2 >> suby) * (3 + (randval & 0xf as libc::c_int));
     return (*grain_lut.offset((offy + y + (32 >> suby) * by) as isize))
         [(offx + x + (32 >> subx) * bx) as usize];
 }
@@ -561,7 +561,7 @@ unsafe extern "C" fn fgy_32x32xn_c(
     bh: libc::c_int,
     row_num: libc::c_int,
 ) {
-    let rows = 1 as libc::c_int + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
+    let rows = 1 + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
     let bitdepth_min_8 = 8 - 8;
     let grain_ctr = (128 as libc::c_int) << bitdepth_min_8;
     let grain_min = -grain_ctr;
@@ -838,7 +838,7 @@ unsafe extern "C" fn fguv_32x32xn_c(
     sx: libc::c_int,
     sy: libc::c_int,
 ) {
-    let rows = 1 as libc::c_int + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
+    let rows = 1 + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
     let bitdepth_min_8 = 8 - 8;
     let grain_ctr = (128 as libc::c_int) << bitdepth_min_8;
     let grain_min = -grain_ctr;
@@ -1378,7 +1378,7 @@ unsafe extern "C" fn fgy_32x32xn_neon(
     bh: libc::c_int,
     row_num: libc::c_int,
 ) {
-    let rows = 1 as libc::c_int + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
+    let rows = 1 + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
     let mut seed: [libc::c_uint; 2] = [0; 2];
     let mut i = 0;
     while i < rows {
@@ -1444,7 +1444,7 @@ unsafe extern "C" fn fguv_32x32xn_420_neon(
     uv: libc::c_int,
     is_id: libc::c_int,
 ) {
-    let rows = 1 as libc::c_int + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
+    let rows = 1 + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
     let mut seed: [libc::c_uint; 2] = [0; 2];
     let mut i = 0;
     while i < rows {
@@ -1516,7 +1516,7 @@ unsafe extern "C" fn fguv_32x32xn_422_neon(
     uv: libc::c_int,
     is_id: libc::c_int,
 ) {
-    let rows = 1 as libc::c_int + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
+    let rows = 1 + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
     let mut seed: [libc::c_uint; 2] = [0; 2];
     let mut i = 0;
     while i < rows {
@@ -1588,7 +1588,7 @@ unsafe extern "C" fn fguv_32x32xn_444_neon(
     uv: libc::c_int,
     is_id: libc::c_int,
 ) {
-    let rows = 1 as libc::c_int + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
+    let rows = 1 + ((*data).overlap_flag != 0 && row_num > 0) as libc::c_int;
     let mut seed: [libc::c_uint; 2] = [0; 2];
     let mut i = 0;
     while i < rows {

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -624,7 +624,7 @@ unsafe extern "C" fn backup_lpf(
     }
     if lr_backup != 0 && (*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1] {
         while row + stripe_h <= row_h {
-            let n_lines = 4 as libc::c_int - (row + stripe_h + 1 == h) as libc::c_int;
+            let n_lines = 4 - (row + stripe_h + 1 == h) as libc::c_int;
             ((*(*f).dsp).mc.resize).expect("non-null function pointer")(
                 dst,
                 dst_stride,
@@ -654,7 +654,7 @@ unsafe extern "C" fn backup_lpf(
         }
     } else {
         while row + stripe_h <= row_h {
-            let n_lines_0 = 4 as libc::c_int - (row + stripe_h + 1 == h) as libc::c_int;
+            let n_lines_0 = 4 - (row + stripe_h + 1 == h) as libc::c_int;
             let mut i = 0;
             while i < 4 {
                 memcpy(

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -583,7 +583,7 @@ unsafe extern "C" fn backup_lpf(
     }
     if lr_backup != 0 && (*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1] {
         while row + stripe_h <= row_h {
-            let n_lines = 4 as libc::c_int - (row + stripe_h + 1 == h) as libc::c_int;
+            let n_lines = 4 - (row + stripe_h + 1 == h) as libc::c_int;
             ((*(*f).dsp).mc.resize).expect("non-null function pointer")(
                 dst,
                 dst_stride,
@@ -610,7 +610,7 @@ unsafe extern "C" fn backup_lpf(
         }
     } else {
         while row + stripe_h <= row_h {
-            let n_lines_0 = 4 as libc::c_int - (row + stripe_h + 1 == h) as libc::c_int;
+            let n_lines_0 = 4 - (row + stripe_h + 1 == h) as libc::c_int;
             let mut i = 0;
             while i < 4 {
                 memcpy(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1009,7 +1009,7 @@ pub unsafe extern "C" fn dav1d_open(
                         && ((*s).frame_size_limit).wrapping_sub(1 as libc::c_int as libc::c_uint)
                             >= (8192 * 8192) as libc::c_uint
                     {
-                        (*c).frame_size_limit = (8192 as libc::c_int * 8192) as libc::c_uint;
+                        (*c).frame_size_limit = (8192 * 8192) as libc::c_uint;
                         if (*s).frame_size_limit != 0 {
                             dav1d_log(
                                 c,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1475,7 +1475,7 @@ unsafe extern "C" fn drain_picture(c: *mut Dav1dContext, out: *mut Dav1dPicture)
         }
         let out_delayed: *mut Dav1dThreadPicture =
             &mut *((*c).frame_thread.out_delayed).offset(next as isize) as *mut Dav1dThreadPicture;
-        if !((*out_delayed).p.data[0 as libc::c_int as usize]).is_null()
+        if !((*out_delayed).p.data[0]).is_null()
             || ::core::intrinsics::atomic_load_seqcst(
                 &mut (*f).task_thread.error as *mut atomic_int,
             ) != 0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1461,7 +1461,7 @@ unsafe extern "C" fn output_picture_ready(c: *mut Dav1dContext, drain: libc::c_i
 }
 unsafe extern "C" fn drain_picture(c: *mut Dav1dContext, out: *mut Dav1dPicture) -> libc::c_int {
     let mut drain_count: libc::c_uint = 0 as libc::c_int as libc::c_uint;
-    let mut drained: libc::c_int = 0 as libc::c_int;
+    let mut drained = 0;
     loop {
         let next: libc::c_uint = (*c).frame_thread.next;
         let f: *mut Dav1dFrameContext =

--- a/src/loopfilter_tmpl_16.rs
+++ b/src/loopfilter_tmpl_16.rs
@@ -29,7 +29,7 @@ unsafe extern "C" fn loop_filter(
     wd: libc::c_int,
     bitdepth_max: libc::c_int,
 ) {
-    let bitdepth_min_8 = 32 as libc::c_int - clz(bitdepth_max as libc::c_uint) - 8;
+    let bitdepth_min_8 = 32 - clz(bitdepth_max as libc::c_uint) - 8;
     let F = (1 as libc::c_int) << bitdepth_min_8;
     E <<= bitdepth_min_8;
     I <<= bitdepth_min_8;

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -924,7 +924,7 @@ pub unsafe fn warp_affine_8x8_rust<BD: BitDepth>(
         let mut tmx = mx;
         while x < 8 {
             let filter: *const i8 =
-                (dav1d_mc_warp_filter[(64 as libc::c_int + (tmx + 512 >> 10)) as usize]).as_ptr();
+                (dav1d_mc_warp_filter[(64 + (tmx + 512 >> 10)) as usize]).as_ptr();
             *mid_ptr.offset(x as isize) = (*filter.offset(0) as libc::c_int
                 * (*src.offset((x - 3 * 1) as isize)).as_::<libc::c_int>()
                 + *filter.offset(1) as libc::c_int
@@ -958,7 +958,7 @@ pub unsafe fn warp_affine_8x8_rust<BD: BitDepth>(
         let mut tmy = my;
         while x_0 < 8 {
             let filter_0: *const i8 =
-                (dav1d_mc_warp_filter[(64 as libc::c_int + (tmy + 512 >> 10)) as usize]).as_ptr();
+                (dav1d_mc_warp_filter[(64 + (tmy + 512 >> 10)) as usize]).as_ptr();
             *dst.offset(x_0 as isize) = bd.iclip_pixel(
                 *filter_0.offset(0) as libc::c_int
                     * *mid_ptr.offset((x_0 - 3 * 8) as isize) as libc::c_int
@@ -1010,7 +1010,7 @@ pub unsafe fn warp_affine_8x8t_rust<BD: BitDepth>(
         let mut tmx = mx;
         while x < 8 {
             let filter: *const i8 =
-                (dav1d_mc_warp_filter[(64 as libc::c_int + (tmx + 512 >> 10)) as usize]).as_ptr();
+                (dav1d_mc_warp_filter[(64 + (tmx + 512 >> 10)) as usize]).as_ptr();
             *mid_ptr.offset(x as isize) = (*filter.offset(0) as libc::c_int
                 * (*src.offset((x - 3 * 1) as isize)).as_::<libc::c_int>()
                 + *filter.offset(1) as libc::c_int
@@ -1044,7 +1044,7 @@ pub unsafe fn warp_affine_8x8t_rust<BD: BitDepth>(
         let mut tmy = my;
         while x_0 < 8 {
             let filter_0: *const i8 =
-                (dav1d_mc_warp_filter[(64 as libc::c_int + (tmy + 512 >> 10)) as usize]).as_ptr();
+                (dav1d_mc_warp_filter[(64 + (tmy + 512 >> 10)) as usize]).as_ptr();
             *tmp.offset(x_0 as isize) = ((*filter_0.offset(0) as libc::c_int
                 * *mid_ptr.offset((x_0 - 3 * 8) as isize) as libc::c_int
                 + *filter_0.offset(1) as libc::c_int

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1200,7 +1200,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             (*hdr).refidx[4] = (*hdr).refidx[5];
             let mut shifted_frame_offset: [libc::c_int; 8] = [0; 8];
             let current_frame_offset: libc::c_int =
-                (1 as libc::c_int) << (*seqhdr).order_hint_n_bits - 1 as libc::c_int;
+                (1 as libc::c_int) << (*seqhdr).order_hint_n_bits - 1;
             let mut i_2 = 0;
             while i_2 < 8 {
                 if ((*c).refs[i_2 as usize].p.p.frame_hdr).is_null() {
@@ -1219,7 +1219,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             used_frame[(*hdr).refidx[3] as usize] = 1 as libc::c_int;
             let mut latest_frame_offset: libc::c_int = -(1 as libc::c_int);
             let mut i_3 = 0;
-            while i_3 < 8 as libc::c_int {
+            while i_3 < 8 {
                 let hint: libc::c_int = shifted_frame_offset[i_3 as usize];
                 if used_frame[i_3 as usize] == 0
                     && hint >= current_frame_offset
@@ -1235,7 +1235,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             }
             let mut earliest_frame_offset = 2147483647;
             let mut i_4 = 0;
-            while i_4 < 8 as libc::c_int {
+            while i_4 < 8 {
                 let hint_0: libc::c_int = shifted_frame_offset[i_4 as usize];
                 if used_frame[i_4 as usize] == 0
                     && hint_0 >= current_frame_offset
@@ -1251,7 +1251,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             }
             earliest_frame_offset = 2147483647 as libc::c_int;
             let mut i_5 = 0;
-            while i_5 < 8 as libc::c_int {
+            while i_5 < 8 {
                 let hint_1: libc::c_int = shifted_frame_offset[i_5 as usize];
                 if used_frame[i_5 as usize] == 0
                     && hint_1 >= current_frame_offset
@@ -1266,11 +1266,11 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 used_frame[(*hdr).refidx[5] as usize] = 1 as libc::c_int;
             }
             let mut i_6 = 1;
-            while i_6 < 7 as libc::c_int {
-                if (*hdr).refidx[i_6 as usize] < 0 as libc::c_int {
+            while i_6 < 7 {
+                if (*hdr).refidx[i_6 as usize] < 0 {
                     latest_frame_offset = -(1 as libc::c_int);
                     let mut j = 0;
-                    while j < 8 as libc::c_int {
+                    while j < 8 {
                         let hint_2: libc::c_int = shifted_frame_offset[j as usize];
                         if used_frame[j as usize] == 0
                             && hint_2 < current_frame_offset
@@ -1290,7 +1290,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             earliest_frame_offset = 2147483647 as libc::c_int;
             let mut ref_0: libc::c_int = -(1 as libc::c_int);
             let mut i_7 = 0;
-            while i_7 < 8 as libc::c_int {
+            while i_7 < 8 {
                 let hint_3: libc::c_int = shifted_frame_offset[i_7 as usize];
                 if hint_3 < earliest_frame_offset {
                     ref_0 = i_7;
@@ -1299,15 +1299,15 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 i_7 += 1;
             }
             let mut i_8 = 0;
-            while i_8 < 7 as libc::c_int {
-                if (*hdr).refidx[i_8 as usize] < 0 as libc::c_int {
+            while i_8 < 7 {
+                if (*hdr).refidx[i_8 as usize] < 0 {
                     (*hdr).refidx[i_8 as usize] = ref_0;
                 }
                 i_8 += 1;
             }
         }
         let mut i_9 = 0;
-        while i_9 < 7 as libc::c_int {
+        while i_9 < 7 {
             if (*hdr).frame_ref_short_signaling == 0 {
                 (*hdr).refidx[i_9 as usize] = dav1d_get_bits(gb, 3 as libc::c_int) as libc::c_int;
             }
@@ -1317,8 +1317,8 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 let ref_frame_id: libc::c_int = (*hdr).frame_id
                     + ((1 as libc::c_int) << (*seqhdr).frame_id_n_bits)
                     - delta_ref_frame_id_minus_1
-                    - 1 as libc::c_int
-                    & ((1 as libc::c_int) << (*seqhdr).frame_id_n_bits) - 1 as libc::c_int;
+                    - 1
+                    & ((1 as libc::c_int) << (*seqhdr).frame_id_n_bits) - 1;
                 let ref_frame_hdr_0: *mut Dav1dFrameHeader = (*c).refs
                     [(*hdr).refidx[i_9 as usize] as usize]
                     .p
@@ -1332,7 +1332,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         }
         let use_ref: libc::c_int =
             ((*hdr).error_resilient_mode == 0 && (*hdr).frame_size_override != 0) as libc::c_int;
-        if read_frame_size(c, gb, use_ref) < 0 as libc::c_int {
+        if read_frame_size(c, gb, use_ref) < 0 {
             return parse_frame_hdr_error(c);
         }
         (*hdr).hp = ((*hdr).force_integer_mv == 0 && dav1d_get_bit(gb) != 0) as libc::c_int;
@@ -1345,20 +1345,19 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         (*hdr).use_ref_frame_mvs = ((*hdr).error_resilient_mode == 0
             && (*seqhdr).ref_frame_mvs != 0
             && (*seqhdr).order_hint != 0
-            && (*hdr).frame_type as libc::c_uint & 1 as libc::c_int as libc::c_uint != 0
+            && (*hdr).frame_type as libc::c_uint & 1 as libc::c_uint != 0
             && dav1d_get_bit(gb) != 0) as libc::c_int;
     }
     (*hdr).refresh_context = ((*seqhdr).reduced_still_picture_header == 0
         && (*hdr).disable_cdf_update == 0
         && dav1d_get_bit(gb) == 0) as libc::c_int;
     (*hdr).tiling.uniform = dav1d_get_bit(gb) as libc::c_int;
-    let sbsz_min1: libc::c_int = ((64 as libc::c_int) << (*seqhdr).sb128) - 1 as libc::c_int;
+    let sbsz_min1: libc::c_int = ((64 as libc::c_int) << (*seqhdr).sb128) - 1;
     let sbsz_log2: libc::c_int = 6 as libc::c_int + (*seqhdr).sb128;
     let sbw: libc::c_int = (*hdr).width[0] + sbsz_min1 >> sbsz_log2;
     let sbh: libc::c_int = (*hdr).height + sbsz_min1 >> sbsz_log2;
     let max_tile_width_sb: libc::c_int = 4096 as libc::c_int >> sbsz_log2;
-    let max_tile_area_sb: libc::c_int =
-        4096 as libc::c_int * 2304 as libc::c_int >> 2 as libc::c_int * sbsz_log2;
+    let max_tile_area_sb: libc::c_int = 4096 as libc::c_int * 2304 >> 2 * sbsz_log2;
     (*hdr).tiling.min_log2_cols = tile_log2(max_tile_width_sb, sbw);
     (*hdr).tiling.max_log2_cols = tile_log2(1 as libc::c_int, imin(sbw, 64 as libc::c_int));
     (*hdr).tiling.max_log2_rows = tile_log2(1 as libc::c_int, imin(sbh, 64 as libc::c_int));
@@ -1371,8 +1370,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         while (*hdr).tiling.log2_cols < (*hdr).tiling.max_log2_cols && dav1d_get_bit(gb) != 0 {
             (*hdr).tiling.log2_cols += 1;
         }
-        let tile_w: libc::c_int =
-            1 as libc::c_int + (sbw - 1 as libc::c_int >> (*hdr).tiling.log2_cols);
+        let tile_w: libc::c_int = 1 as libc::c_int + (sbw - 1 >> (*hdr).tiling.log2_cols);
         (*hdr).tiling.cols = 0 as libc::c_int;
         let mut sbx = 0;
         while sbx < sbw {
@@ -1386,8 +1384,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         while (*hdr).tiling.log2_rows < (*hdr).tiling.max_log2_rows && dav1d_get_bit(gb) != 0 {
             (*hdr).tiling.log2_rows += 1;
         }
-        let tile_h: libc::c_int =
-            1 as libc::c_int + (sbh - 1 as libc::c_int >> (*hdr).tiling.log2_rows);
+        let tile_h: libc::c_int = 1 as libc::c_int + (sbh - 1 >> (*hdr).tiling.log2_rows);
         (*hdr).tiling.rows = 0 as libc::c_int;
         let mut sby = 0;
         while sby < sbh {
@@ -1400,9 +1397,9 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         let mut widest_tile = 0;
         let mut max_tile_area_sb_0: libc::c_int = sbw * sbh;
         let mut sbx_0 = 0;
-        while sbx_0 < sbw && (*hdr).tiling.cols < 64 as libc::c_int {
+        while sbx_0 < sbw && (*hdr).tiling.cols < 64 {
             let tile_width_sb: libc::c_int = imin(sbw - sbx_0, max_tile_width_sb);
-            let tile_w_0: libc::c_int = (if tile_width_sb > 1 as libc::c_int {
+            let tile_w_0: libc::c_int = (if tile_width_sb > 1 {
                 (1 as libc::c_int as libc::c_uint)
                     .wrapping_add(dav1d_get_uniform(gb, tile_width_sb as libc::c_uint))
             } else {
@@ -1415,15 +1412,15 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         }
         (*hdr).tiling.log2_cols = tile_log2(1 as libc::c_int, (*hdr).tiling.cols);
         if min_log2_tiles != 0 {
-            max_tile_area_sb_0 >>= min_log2_tiles + 1 as libc::c_int;
+            max_tile_area_sb_0 >>= min_log2_tiles + 1;
         }
         let max_tile_height_sb: libc::c_int =
             imax(max_tile_area_sb_0 / widest_tile, 1 as libc::c_int);
         (*hdr).tiling.rows = 0 as libc::c_int;
         let mut sby_0 = 0;
-        while sby_0 < sbh && (*hdr).tiling.rows < 64 as libc::c_int {
+        while sby_0 < sbh && (*hdr).tiling.rows < 64 {
             let tile_height_sb: libc::c_int = imin(sbh - sby_0, max_tile_height_sb);
-            let tile_h_0: libc::c_int = (if tile_height_sb > 1 as libc::c_int {
+            let tile_h_0: libc::c_int = (if tile_height_sb > 1 {
                 (1 as libc::c_int as libc::c_uint)
                     .wrapping_add(dav1d_get_uniform(gb, tile_height_sb as libc::c_uint))
             } else {
@@ -1499,7 +1496,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
     }
     (*hdr).segmentation.enabled = dav1d_get_bit(gb) as libc::c_int;
     if (*hdr).segmentation.enabled != 0 {
-        if (*hdr).primary_ref_frame == 7 as libc::c_int {
+        if (*hdr).primary_ref_frame == 7 {
             (*hdr).segmentation.update_map = 1 as libc::c_int;
             (*hdr).segmentation.temporal = 0 as libc::c_int;
             (*hdr).segmentation.update_data = 1 as libc::c_int;
@@ -1516,7 +1513,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             (*hdr).segmentation.seg_data.preskip = 0 as libc::c_int;
             (*hdr).segmentation.seg_data.last_active_segid = -(1 as libc::c_int);
             let mut i_10 = 0;
-            while i_10 < 8 as libc::c_int {
+            while i_10 < 8 {
                 let seg: *mut Dav1dSegmentationData = &mut *((*hdr).segmentation.seg_data.d)
                     .as_mut_ptr()
                     .offset(i_10 as isize)
@@ -1590,7 +1587,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             ::core::mem::size_of::<Dav1dSegmentationDataSet>(),
         );
         let mut i_11 = 0;
-        while i_11 < 8 as libc::c_int {
+        while i_11 < 8 {
             (*hdr).segmentation.seg_data.d[i_11 as usize].r#ref = -(1 as libc::c_int);
             i_11 += 1;
         }
@@ -1625,7 +1622,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         && (*hdr).quant.vac_delta == 0) as libc::c_int;
     (*hdr).all_lossless = 1 as libc::c_int;
     let mut i_12 = 0;
-    while i_12 < 8 as libc::c_int {
+    while i_12 < 8 {
         (*hdr).segmentation.qidx[i_12 as usize] = if (*hdr).segmentation.enabled != 0 {
             iclip_u8((*hdr).quant.yac + (*hdr).segmentation.seg_data.d[i_12 as usize].delta_q)
         } else {
@@ -1655,7 +1652,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             (*hdr).loopfilter.level_v = dav1d_get_bits(gb, 6 as libc::c_int) as libc::c_int;
         }
         (*hdr).loopfilter.sharpness = dav1d_get_bits(gb, 3 as libc::c_int) as libc::c_int;
-        if (*hdr).primary_ref_frame == 7 as libc::c_int {
+        if (*hdr).primary_ref_frame == 7 {
             (*hdr).loopfilter.mode_ref_deltas = default_mode_ref_deltas.clone();
         } else {
             let ref_1: libc::c_int = (*hdr).refidx[(*hdr).primary_ref_frame as usize];
@@ -1672,7 +1669,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             (*hdr).loopfilter.mode_ref_delta_update = dav1d_get_bit(gb) as libc::c_int;
             if (*hdr).loopfilter.mode_ref_delta_update != 0 {
                 let mut i_13 = 0;
-                while i_13 < 8 as libc::c_int {
+                while i_13 < 8 {
                     if dav1d_get_bit(gb) != 0 {
                         (*hdr).loopfilter.mode_ref_deltas.ref_delta[i_13 as usize] =
                             dav1d_get_sbits(gb, 7 as libc::c_int);
@@ -1680,7 +1677,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                     i_13 += 1;
                 }
                 let mut i_14 = 0;
-                while i_14 < 2 as libc::c_int {
+                while i_14 < 2 {
                     if dav1d_get_bit(gb) != 0 {
                         (*hdr).loopfilter.mode_ref_deltas.mode_delta[i_14 as usize] =
                             dav1d_get_sbits(gb, 7 as libc::c_int);
@@ -1741,8 +1738,8 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             (*hdr).restoration.unit_size[1] = (*hdr).restoration.unit_size[0];
             if ((*hdr).restoration.type_0[1] as libc::c_uint != 0
                 || (*hdr).restoration.type_0[2] as libc::c_uint != 0)
-                && (*seqhdr).ss_hor == 1 as libc::c_int
-                && (*seqhdr).ss_ver == 1 as libc::c_int
+                && (*seqhdr).ss_hor == 1
+                && (*seqhdr).ss_ver == 1
             {
                 (*hdr).restoration.unit_size[1] = ((*hdr).restoration.unit_size[1] as libc::c_uint)
                     .wrapping_sub(dav1d_get_bit(gb))
@@ -1763,15 +1760,14 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
     } else {
         DAV1D_TX_LARGEST as libc::c_int
     }) as Dav1dTxfmMode;
-    (*hdr).switchable_comp_refs =
-        (if (*hdr).frame_type as libc::c_uint & 1 as libc::c_int as libc::c_uint != 0 {
-            dav1d_get_bit(gb)
-        } else {
-            0 as libc::c_int as libc::c_uint
-        }) as libc::c_int;
+    (*hdr).switchable_comp_refs = (if (*hdr).frame_type as libc::c_uint & 1 as libc::c_uint != 0 {
+        dav1d_get_bit(gb)
+    } else {
+        0 as libc::c_int as libc::c_uint
+    }) as libc::c_int;
     (*hdr).skip_mode_allowed = 0 as libc::c_int;
     if (*hdr).switchable_comp_refs != 0
-        && (*hdr).frame_type as libc::c_uint & 1 as libc::c_int as libc::c_uint != 0
+        && (*hdr).frame_type as libc::c_uint & 1 as libc::c_uint != 0
         && (*seqhdr).order_hint != 0
     {
         let poc: libc::c_uint = (*hdr).frame_offset as libc::c_uint;
@@ -1780,7 +1776,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         let mut off_before_idx: libc::c_int = 0;
         let mut off_after_idx: libc::c_int = 0;
         let mut i_16 = 0;
-        while i_16 < 7 as libc::c_int {
+        while i_16 < 7 {
             if ((*c).refs[(*hdr).refidx[i_16 as usize] as usize]
                 .p
                 .p
@@ -1799,24 +1795,24 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 refpoc as libc::c_int,
                 poc as libc::c_int,
             );
-            if diff > 0 as libc::c_int {
+            if diff > 0 {
                 if off_after == -(1 as libc::c_int)
                     || get_poc_diff(
                         (*seqhdr).order_hint_n_bits,
                         off_after,
                         refpoc as libc::c_int,
-                    ) > 0 as libc::c_int
+                    ) > 0
                 {
                     off_after = refpoc as libc::c_int;
                     off_after_idx = i_16;
                 }
-            } else if diff < 0 as libc::c_int
+            } else if diff < 0
                 && (off_before == 0xffffffff as libc::c_uint
                     || get_poc_diff(
                         (*seqhdr).order_hint_n_bits,
                         refpoc as libc::c_int,
                         off_before as libc::c_int,
-                    ) > 0 as libc::c_int)
+                    ) > 0)
             {
                 off_before = refpoc;
                 off_before_idx = i_16;
@@ -1831,7 +1827,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             let mut off_before2: libc::c_uint = 0xffffffff as libc::c_uint;
             let mut off_before2_idx: libc::c_int = 0;
             let mut i_17 = 0;
-            while i_17 < 7 as libc::c_int {
+            while i_17 < 7 {
                 if ((*c).refs[(*hdr).refidx[i_17 as usize] as usize]
                     .p
                     .p
@@ -1849,14 +1845,14 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                     (*seqhdr).order_hint_n_bits,
                     refpoc_0 as libc::c_int,
                     off_before as libc::c_int,
-                ) < 0 as libc::c_int
+                ) < 0
                 {
                     if off_before2 == 0xffffffff as libc::c_uint
                         || get_poc_diff(
                             (*seqhdr).order_hint_n_bits,
                             refpoc_0 as libc::c_int,
                             off_before2 as libc::c_int,
-                        ) > 0 as libc::c_int
+                        ) > 0
                     {
                         off_before2 = refpoc_0;
                         off_before2_idx = i_17;
@@ -1877,18 +1873,18 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         0 as libc::c_int as libc::c_uint
     }) as libc::c_int;
     (*hdr).warp_motion = ((*hdr).error_resilient_mode == 0
-        && (*hdr).frame_type as libc::c_uint & 1 as libc::c_int as libc::c_uint != 0
+        && (*hdr).frame_type as libc::c_uint & 1 as libc::c_uint != 0
         && (*seqhdr).warped_motion != 0
         && dav1d_get_bit(gb) != 0) as libc::c_int;
     (*hdr).reduced_txtp_set = dav1d_get_bit(gb) as libc::c_int;
     let mut i_18 = 0;
-    while i_18 < 7 as libc::c_int {
+    while i_18 < 7 {
         (*hdr).gmv[i_18 as usize] = dav1d_default_wm_params.clone();
         i_18 += 1;
     }
-    if (*hdr).frame_type as libc::c_uint & 1 as libc::c_int as libc::c_uint != 0 {
+    if (*hdr).frame_type as libc::c_uint & 1 as libc::c_uint != 0 {
         let mut i_19 = 0;
-        while i_19 < 7 as libc::c_int {
+        while i_19 < 7 {
             (*hdr).gmv[i_19 as usize].type_0 = (if dav1d_get_bit(gb) == 0 {
                 DAV1D_WM_TYPE_IDENTITY as libc::c_int
             } else if dav1d_get_bit(gb) != 0 {
@@ -1902,7 +1898,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 == DAV1D_WM_TYPE_IDENTITY as libc::c_int as libc::c_uint)
             {
                 let ref_gmv: *const Dav1dWarpedMotionParams;
-                if (*hdr).primary_ref_frame == 7 as libc::c_int {
+                if (*hdr).primary_ref_frame == 7 {
                     ref_gmv = &dav1d_default_wm_params;
                 } else {
                     let pri_ref_0: libc::c_int = (*hdr).refidx[(*hdr).primary_ref_frame as usize];
@@ -1925,18 +1921,16 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 if (*hdr).gmv[i_19 as usize].type_0 as libc::c_uint
                     >= DAV1D_WM_TYPE_ROT_ZOOM as libc::c_int as libc::c_uint
                 {
-                    *mat.offset(2) = ((1 as libc::c_int) << 16 as libc::c_int)
-                        + 2 as libc::c_int
-                            * dav1d_get_bits_subexp(
-                                gb,
-                                *ref_mat.offset(2) - ((1 as libc::c_int) << 16 as libc::c_int)
-                                    >> 1 as libc::c_int,
-                                12 as libc::c_int as libc::c_uint,
-                            );
+                    *mat.offset(2) = ((1 as libc::c_int) << 16)
+                        + 2 * dav1d_get_bits_subexp(
+                            gb,
+                            *ref_mat.offset(2) - ((1 as libc::c_int) << 16) >> 1,
+                            12 as libc::c_int as libc::c_uint,
+                        );
                     *mat.offset(3) = 2 as libc::c_int
                         * dav1d_get_bits_subexp(
                             gb,
-                            *ref_mat.offset(3) >> 1 as libc::c_int,
+                            *ref_mat.offset(3) >> 1,
                             12 as libc::c_int as libc::c_uint,
                         );
                     bits = 12 as libc::c_int;
@@ -1951,17 +1945,15 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                     *mat.offset(4) = 2 as libc::c_int
                         * dav1d_get_bits_subexp(
                             gb,
-                            *ref_mat.offset(4) >> 1 as libc::c_int,
+                            *ref_mat.offset(4) >> 1,
                             12 as libc::c_int as libc::c_uint,
                         );
-                    *mat.offset(5) = ((1 as libc::c_int) << 16 as libc::c_int)
-                        + 2 as libc::c_int
-                            * dav1d_get_bits_subexp(
-                                gb,
-                                *ref_mat.offset(5) - ((1 as libc::c_int) << 16 as libc::c_int)
-                                    >> 1 as libc::c_int,
-                                12 as libc::c_int as libc::c_uint,
-                            );
+                    *mat.offset(5) = ((1 as libc::c_int) << 16)
+                        + 2 * dav1d_get_bits_subexp(
+                            gb,
+                            *ref_mat.offset(5) - ((1 as libc::c_int) << 16) >> 1,
+                            12 as libc::c_int as libc::c_uint,
+                        );
                 } else {
                     *mat.offset(4) = -*mat.offset(3);
                     *mat.offset(5) = *mat.offset(2);
@@ -1988,13 +1980,13 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             let refidx: libc::c_int = dav1d_get_bits(gb, 3 as libc::c_int) as libc::c_int;
             let mut i_20: libc::c_int;
             i_20 = 0 as libc::c_int;
-            while i_20 < 7 as libc::c_int {
+            while i_20 < 7 {
                 if (*hdr).refidx[i_20 as usize] == refidx {
                     break;
                 }
                 i_20 += 1;
             }
-            if i_20 == 7 as libc::c_int || ((*c).refs[refidx as usize].p.p.frame_hdr).is_null() {
+            if i_20 == 7 || ((*c).refs[refidx as usize].p.p.frame_hdr).is_null() {
                 return parse_frame_hdr_error(c);
             }
             (*hdr).film_grain.data = (*(*c).refs[refidx as usize].p.p.frame_hdr)
@@ -2006,14 +1998,14 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             let fgd: *mut Dav1dFilmGrainData = &mut (*hdr).film_grain.data;
             (*fgd).seed = seed;
             (*fgd).num_y_points = dav1d_get_bits(gb, 4 as libc::c_int) as libc::c_int;
-            if (*fgd).num_y_points > 14 as libc::c_int {
+            if (*fgd).num_y_points > 14 {
                 return parse_frame_hdr_error(c);
             }
             let mut i_21 = 0;
             while i_21 < (*fgd).num_y_points {
                 (*fgd).y_points[i_21 as usize][0] = dav1d_get_bits(gb, 8 as libc::c_int) as uint8_t;
                 if i_21 != 0
-                    && (*fgd).y_points[(i_21 - 1 as libc::c_int) as usize][0] as libc::c_int
+                    && (*fgd).y_points[(i_21 - 1) as usize][0] as libc::c_int
                         >= (*fgd).y_points[i_21 as usize][0] as libc::c_int
                 {
                     return parse_frame_hdr_error(c);
@@ -2025,18 +2017,16 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 ((*seqhdr).monochrome == 0 && dav1d_get_bit(gb) != 0) as libc::c_int;
             if (*seqhdr).monochrome != 0
                 || (*fgd).chroma_scaling_from_luma != 0
-                || (*seqhdr).ss_ver == 1 as libc::c_int
-                    && (*seqhdr).ss_hor == 1 as libc::c_int
-                    && (*fgd).num_y_points == 0
+                || (*seqhdr).ss_ver == 1 && (*seqhdr).ss_hor == 1 && (*fgd).num_y_points == 0
             {
                 (*fgd).num_uv_points[1] = 0 as libc::c_int;
                 (*fgd).num_uv_points[0] = (*fgd).num_uv_points[1];
             } else {
                 let mut pl = 0;
-                while pl < 2 as libc::c_int {
+                while pl < 2 {
                     (*fgd).num_uv_points[pl as usize] =
                         dav1d_get_bits(gb, 4 as libc::c_int) as libc::c_int;
-                    if (*fgd).num_uv_points[pl as usize] > 10 as libc::c_int {
+                    if (*fgd).num_uv_points[pl as usize] > 10 {
                         return parse_frame_hdr_error(c);
                     }
                     let mut i_22 = 0;
@@ -2044,8 +2034,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                         (*fgd).uv_points[pl as usize][i_22 as usize][0] =
                             dav1d_get_bits(gb, 8 as libc::c_int) as uint8_t;
                         if i_22 != 0
-                            && (*fgd).uv_points[pl as usize][(i_22 - 1 as libc::c_int) as usize][0]
-                                as libc::c_int
+                            && (*fgd).uv_points[pl as usize][(i_22 - 1) as usize][0] as libc::c_int
                                 >= (*fgd).uv_points[pl as usize][i_22 as usize][0] as libc::c_int
                         {
                             return parse_frame_hdr_error(c);
@@ -2057,8 +2046,8 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                     pl += 1;
                 }
             }
-            if (*seqhdr).ss_hor == 1 as libc::c_int
-                && (*seqhdr).ss_ver == 1 as libc::c_int
+            if (*seqhdr).ss_hor == 1
+                && (*seqhdr).ss_ver == 1
                 && ((*fgd).num_uv_points[0] != 0) as libc::c_int
                     != ((*fgd).num_uv_points[1] != 0) as libc::c_int
             {
@@ -2069,7 +2058,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 as libc::c_int;
             (*fgd).ar_coeff_lag = dav1d_get_bits(gb, 2 as libc::c_int) as libc::c_int;
             let num_y_pos: libc::c_int =
-                2 as libc::c_int * (*fgd).ar_coeff_lag * ((*fgd).ar_coeff_lag + 1 as libc::c_int);
+                2 as libc::c_int * (*fgd).ar_coeff_lag * ((*fgd).ar_coeff_lag + 1);
             if (*fgd).num_y_points != 0 {
                 let mut i_23 = 0;
                 while i_23 < num_y_pos {
@@ -2080,7 +2069,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 }
             }
             let mut pl_0 = 0;
-            while pl_0 < 2 as libc::c_int {
+            while pl_0 < 2 {
                 if (*fgd).num_uv_points[pl_0 as usize] != 0 || (*fgd).chroma_scaling_from_luma != 0
                 {
                     let num_uv_pos: libc::c_int =
@@ -2105,7 +2094,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 as uint64_t;
             (*fgd).grain_scale_shift = dav1d_get_bits(gb, 2 as libc::c_int) as libc::c_int;
             let mut pl_1 = 0;
-            while pl_1 < 2 as libc::c_int {
+            while pl_1 < 2 {
                 if (*fgd).num_uv_points[pl_1 as usize] != 0 {
                     (*fgd).uv_mult[pl_1 as usize] = (dav1d_get_bits(gb, 8 as libc::c_int))
                         .wrapping_sub(128 as libc::c_int as libc::c_uint)
@@ -2195,7 +2184,7 @@ unsafe extern "C" fn dav1d_parse_obus_skip(
     init_byte_pos: libc::c_uint,
 ) -> libc::c_int {
     let mut i = 0;
-    while i < 8 as libc::c_int {
+    while i < 8 {
         if (*(*c).frame_hdr).refresh_frame_flags & (1 as libc::c_int) << i != 0 {
             dav1d_thread_picture_unref(&mut (*((*c).refs).as_mut_ptr().offset(i as isize)).p);
             (*c).refs[i as usize].p.p.frame_hdr = (*c).frame_hdr;
@@ -2252,8 +2241,8 @@ pub unsafe extern "C" fn dav1d_parse_obus(
         return dav1d_parse_obus_error(c, in_0);
     }
     let init_bit_pos: libc::c_uint = dav1d_get_bits_pos(&mut gb);
-    let init_byte_pos: libc::c_uint = init_bit_pos >> 3 as libc::c_int;
-    if !(init_bit_pos & 7 as libc::c_int as libc::c_uint == 0 as libc::c_int as libc::c_uint) {
+    let init_byte_pos: libc::c_uint = init_bit_pos >> 3;
+    if !(init_bit_pos & 7 as libc::c_uint == 0 as libc::c_uint) {
         unreachable!();
     }
     if !((*in_0).sz >= init_byte_pos as size_t) {
@@ -2267,12 +2256,10 @@ pub unsafe extern "C" fn dav1d_parse_obus(
         && has_extension != 0
         && (*c).operating_point_idc != 0 as libc::c_int as libc::c_uint
     {
-        let in_temporal_layer: libc::c_int = ((*c).operating_point_idc >> temporal_id
-            & 1 as libc::c_int as libc::c_uint)
-            as libc::c_int;
+        let in_temporal_layer: libc::c_int =
+            ((*c).operating_point_idc >> temporal_id & 1 as libc::c_uint) as libc::c_int;
         let in_spatial_layer: libc::c_int =
-            ((*c).operating_point_idc >> spatial_id + 8 as libc::c_int
-                & 1 as libc::c_int as libc::c_uint) as libc::c_int;
+            ((*c).operating_point_idc >> spatial_id + 8 & 1 as libc::c_uint) as libc::c_int;
         if in_temporal_layer == 0 || in_spatial_layer == 0 {
             return len.wrapping_add(init_byte_pos) as libc::c_int;
         }
@@ -2289,7 +2276,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
             }
             let seq_hdr: *mut Dav1dSequenceHeader = (*ref_0).data as *mut Dav1dSequenceHeader;
             res = parse_seq_hdr(c, &mut gb, seq_hdr);
-            if res < 0 as libc::c_int {
+            if res < 0 {
                 dav1d_ref_dec(&mut ref_0);
                 return dav1d_parse_obus_error(c, in_0);
             }
@@ -2315,7 +2302,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                 dav1d_ref_dec(&mut (*c).mastering_display_ref);
                 dav1d_ref_dec(&mut (*c).content_light_ref);
                 let mut i = 0;
-                while i < 8 as libc::c_int {
+                while i < 8 {
                     if !((*c).refs[i as usize].p.p.frame_hdr).is_null() {
                         dav1d_thread_picture_unref(
                             &mut (*((*c).refs).as_mut_ptr().offset(i as isize)).p,
@@ -2361,9 +2348,8 @@ pub unsafe extern "C" fn dav1d_parse_obus(
         }
         5 => {
             let meta_type: ObuMetaType = dav1d_get_uleb128(&mut gb) as ObuMetaType;
-            let meta_type_len: libc::c_int = ((dav1d_get_bits_pos(&mut gb))
-                .wrapping_sub(init_bit_pos)
-                >> 3 as libc::c_int) as libc::c_int;
+            let meta_type_len: libc::c_int =
+                ((dav1d_get_bits_pos(&mut gb)).wrapping_sub(init_bit_pos) >> 3) as libc::c_int;
             if gb.error != 0 {
                 return dav1d_parse_obus_error(c, in_0);
             }
@@ -2399,7 +2385,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                     let mastering_display: *mut Dav1dMasteringDisplay =
                         (*ref_2).data as *mut Dav1dMasteringDisplay;
                     let mut i_1 = 0;
-                    while i_1 < 3 as libc::c_int {
+                    while i_1 < 3 {
                         (*mastering_display).primaries[i_1 as usize][0] =
                             dav1d_get_bits(&mut gb, 16 as libc::c_int) as uint16_t;
                         (*mastering_display).primaries[i_1 as usize][1] =
@@ -2424,7 +2410,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                 }
                 4 => {
                     let mut payload_size: libc::c_int = len as libc::c_int;
-                    while payload_size > 0 as libc::c_int
+                    while payload_size > 0
                         && *((*in_0).data).offset(
                             init_byte_pos
                                 .wrapping_add(payload_size as libc::c_uint)
@@ -2445,7 +2431,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                             dav1d_get_bits(&mut gb, 8 as libc::c_int) as libc::c_int;
                         payload_size -= 1;
                     }
-                    if payload_size <= 0 as libc::c_int {
+                    if payload_size <= 0 {
                         dav1d_log(
                             c,
                             b"Malformed ITU-T T.35 metadata message format\n\0" as *const u8
@@ -2537,7 +2523,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                 (*(*c).frame_hdr).temporal_id = temporal_id;
                 (*(*c).frame_hdr).spatial_id = spatial_id;
                 res = parse_frame_hdr(c, &mut gb);
-                if res < 0 as libc::c_int {
+                if res < 0 {
                     (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
                     return dav1d_parse_obus_error(c, in_0);
                 }
@@ -2590,9 +2576,9 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                 if ((*c).frame_hdr).is_null() {
                     return dav1d_parse_obus_error(c, in_0);
                 }
-                if (*c).n_tile_data_alloc < (*c).n_tile_data + 1 as libc::c_int {
-                    if (*c).n_tile_data + 1 as libc::c_int
-                        > 2147483647 as libc::c_int
+                if (*c).n_tile_data_alloc < (*c).n_tile_data + 1 {
+                    if (*c).n_tile_data + 1
+                        > 2147483647
                             / ::core::mem::size_of::<Dav1dTileGroup>() as libc::c_ulong
                                 as libc::c_int
                     {
@@ -2612,7 +2598,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                         0 as libc::c_int,
                         ::core::mem::size_of::<Dav1dTileGroup>(),
                     );
-                    (*c).n_tile_data_alloc = (*c).n_tile_data + 1 as libc::c_int;
+                    (*c).n_tile_data_alloc = (*c).n_tile_data + 1;
                 }
                 parse_tile_hdr(c, &mut gb);
                 dav1d_bytealign_get_bits(&mut gb);
@@ -2621,11 +2607,10 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                 }
                 let pkt_bytelen: libc::c_uint = init_byte_pos.wrapping_add(len);
                 let bit_pos: libc::c_uint = dav1d_get_bits_pos(&mut gb);
-                if !(bit_pos & 7 as libc::c_int as libc::c_uint == 0 as libc::c_int as libc::c_uint)
-                {
+                if !(bit_pos & 7 as libc::c_uint == 0 as libc::c_uint) {
                     unreachable!();
                 }
-                if !(pkt_bytelen >= bit_pos >> 3 as libc::c_int) {
+                if !(pkt_bytelen >= bit_pos >> 3) {
                     unreachable!();
                 }
                 dav1d_data_ref(
@@ -2633,9 +2618,9 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                     in_0,
                 );
                 let ref mut fresh0 = (*((*c).tile).offset((*c).n_tile_data as isize)).data.data;
-                *fresh0 = (*fresh0).offset((bit_pos >> 3 as libc::c_int) as isize);
+                *fresh0 = (*fresh0).offset((bit_pos >> 3) as isize);
                 (*((*c).tile).offset((*c).n_tile_data as isize)).data.sz =
-                    pkt_bytelen.wrapping_sub(bit_pos >> 3 as libc::c_int) as size_t;
+                    pkt_bytelen.wrapping_sub(bit_pos >> 3) as size_t;
                 if (*((*c).tile).offset((*c).n_tile_data as isize)).start
                     > (*((*c).tile).offset((*c).n_tile_data as isize)).end
                     || (*((*c).tile).offset((*c).n_tile_data as isize)).start != (*c).n_tiles
@@ -2705,7 +2690,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
             {
                 return dav1d_parse_obus_error(c, in_0);
             }
-            if (*c).n_fc == 1 as libc::c_int as libc::c_uint {
+            if (*c).n_fc == 1 as libc::c_uint {
                 dav1d_thread_picture_ref(
                     &mut (*c).out,
                     &mut (*((*c).refs)
@@ -2733,7 +2718,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                 }
                 let f: *mut Dav1dFrameContext =
                     &mut *((*c).fc).offset(next as isize) as *mut Dav1dFrameContext;
-                while (*f).n_tile_data > 0 as libc::c_int {
+                while (*f).n_tile_data > 0 {
                     pthread_cond_wait(
                         &mut (*f).task_thread.cond,
                         &mut (*(*f).task_thread.ttd).lock,
@@ -2819,7 +2804,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                 let r: libc::c_int = (*(*c).frame_hdr).existing_frame_idx;
                 (*c).refs[r as usize].p.showable = 0 as libc::c_int;
                 let mut i_3 = 0;
-                while i_3 < 8 as libc::c_int {
+                while i_3 < 8 {
                     if !(i_3 == r) {
                         if !((*c).refs[i_3 as usize].p.p.frame_hdr).is_null() {
                             dav1d_thread_picture_unref(
@@ -2874,7 +2859,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                 return dav1d_parse_obus_error(c, in_0);
             }
             res = dav1d_submit_frame(c);
-            if res < 0 as libc::c_int {
+            if res < 0 {
                 return res;
             }
             if (*c).n_tile_data != 0 {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1218,7 +1218,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             used_frame[(*hdr).refidx[0] as usize] = 1 as libc::c_int;
             used_frame[(*hdr).refidx[3] as usize] = 1 as libc::c_int;
             let mut latest_frame_offset: libc::c_int = -(1 as libc::c_int);
-            let mut i_3: libc::c_int = 0 as libc::c_int;
+            let mut i_3 = 0;
             while i_3 < 8 as libc::c_int {
                 let hint: libc::c_int = shifted_frame_offset[i_3 as usize];
                 if used_frame[i_3 as usize] == 0
@@ -1233,8 +1233,8 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             if latest_frame_offset != -(1 as libc::c_int) {
                 used_frame[(*hdr).refidx[6] as usize] = 1 as libc::c_int;
             }
-            let mut earliest_frame_offset: libc::c_int = 2147483647 as libc::c_int;
-            let mut i_4: libc::c_int = 0 as libc::c_int;
+            let mut earliest_frame_offset = 2147483647;
+            let mut i_4 = 0;
             while i_4 < 8 as libc::c_int {
                 let hint_0: libc::c_int = shifted_frame_offset[i_4 as usize];
                 if used_frame[i_4 as usize] == 0
@@ -1250,7 +1250,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 used_frame[(*hdr).refidx[4] as usize] = 1 as libc::c_int;
             }
             earliest_frame_offset = 2147483647 as libc::c_int;
-            let mut i_5: libc::c_int = 0 as libc::c_int;
+            let mut i_5 = 0;
             while i_5 < 8 as libc::c_int {
                 let hint_1: libc::c_int = shifted_frame_offset[i_5 as usize];
                 if used_frame[i_5 as usize] == 0
@@ -1265,11 +1265,11 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             if earliest_frame_offset != 2147483647 as libc::c_int {
                 used_frame[(*hdr).refidx[5] as usize] = 1 as libc::c_int;
             }
-            let mut i_6: libc::c_int = 1 as libc::c_int;
+            let mut i_6 = 1;
             while i_6 < 7 as libc::c_int {
                 if (*hdr).refidx[i_6 as usize] < 0 as libc::c_int {
                     latest_frame_offset = -(1 as libc::c_int);
-                    let mut j: libc::c_int = 0 as libc::c_int;
+                    let mut j = 0;
                     while j < 8 as libc::c_int {
                         let hint_2: libc::c_int = shifted_frame_offset[j as usize];
                         if used_frame[j as usize] == 0
@@ -1289,7 +1289,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             }
             earliest_frame_offset = 2147483647 as libc::c_int;
             let mut ref_0: libc::c_int = -(1 as libc::c_int);
-            let mut i_7: libc::c_int = 0 as libc::c_int;
+            let mut i_7 = 0;
             while i_7 < 8 as libc::c_int {
                 let hint_3: libc::c_int = shifted_frame_offset[i_7 as usize];
                 if hint_3 < earliest_frame_offset {
@@ -1298,7 +1298,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 }
                 i_7 += 1;
             }
-            let mut i_8: libc::c_int = 0 as libc::c_int;
+            let mut i_8 = 0;
             while i_8 < 7 as libc::c_int {
                 if (*hdr).refidx[i_8 as usize] < 0 as libc::c_int {
                     (*hdr).refidx[i_8 as usize] = ref_0;
@@ -1306,7 +1306,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 i_8 += 1;
             }
         }
-        let mut i_9: libc::c_int = 0 as libc::c_int;
+        let mut i_9 = 0;
         while i_9 < 7 as libc::c_int {
             if (*hdr).frame_ref_short_signaling == 0 {
                 (*hdr).refidx[i_9 as usize] = dav1d_get_bits(gb, 3 as libc::c_int) as libc::c_int;
@@ -1374,7 +1374,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         let tile_w: libc::c_int =
             1 as libc::c_int + (sbw - 1 as libc::c_int >> (*hdr).tiling.log2_cols);
         (*hdr).tiling.cols = 0 as libc::c_int;
-        let mut sbx: libc::c_int = 0 as libc::c_int;
+        let mut sbx = 0;
         while sbx < sbw {
             (*hdr).tiling.col_start_sb[(*hdr).tiling.cols as usize] = sbx as uint16_t;
             sbx += tile_w;
@@ -1389,7 +1389,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         let tile_h: libc::c_int =
             1 as libc::c_int + (sbh - 1 as libc::c_int >> (*hdr).tiling.log2_rows);
         (*hdr).tiling.rows = 0 as libc::c_int;
-        let mut sby: libc::c_int = 0 as libc::c_int;
+        let mut sby = 0;
         while sby < sbh {
             (*hdr).tiling.row_start_sb[(*hdr).tiling.rows as usize] = sby as uint16_t;
             sby += tile_h;
@@ -1397,9 +1397,9 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         }
     } else {
         (*hdr).tiling.cols = 0 as libc::c_int;
-        let mut widest_tile: libc::c_int = 0 as libc::c_int;
+        let mut widest_tile = 0;
         let mut max_tile_area_sb_0: libc::c_int = sbw * sbh;
-        let mut sbx_0: libc::c_int = 0 as libc::c_int;
+        let mut sbx_0 = 0;
         while sbx_0 < sbw && (*hdr).tiling.cols < 64 as libc::c_int {
             let tile_width_sb: libc::c_int = imin(sbw - sbx_0, max_tile_width_sb);
             let tile_w_0: libc::c_int = (if tile_width_sb > 1 as libc::c_int {
@@ -1420,7 +1420,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         let max_tile_height_sb: libc::c_int =
             imax(max_tile_area_sb_0 / widest_tile, 1 as libc::c_int);
         (*hdr).tiling.rows = 0 as libc::c_int;
-        let mut sby_0: libc::c_int = 0 as libc::c_int;
+        let mut sby_0 = 0;
         while sby_0 < sbh && (*hdr).tiling.rows < 64 as libc::c_int {
             let tile_height_sb: libc::c_int = imin(sbh - sby_0, max_tile_height_sb);
             let tile_h_0: libc::c_int = (if tile_height_sb > 1 as libc::c_int {
@@ -1515,7 +1515,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         if (*hdr).segmentation.update_data != 0 {
             (*hdr).segmentation.seg_data.preskip = 0 as libc::c_int;
             (*hdr).segmentation.seg_data.last_active_segid = -(1 as libc::c_int);
-            let mut i_10: libc::c_int = 0 as libc::c_int;
+            let mut i_10 = 0;
             while i_10 < 8 as libc::c_int {
                 let seg: *mut Dav1dSegmentationData = &mut *((*hdr).segmentation.seg_data.d)
                     .as_mut_ptr()
@@ -1589,7 +1589,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             0 as libc::c_int,
             ::core::mem::size_of::<Dav1dSegmentationDataSet>(),
         );
-        let mut i_11: libc::c_int = 0 as libc::c_int;
+        let mut i_11 = 0;
         while i_11 < 8 as libc::c_int {
             (*hdr).segmentation.seg_data.d[i_11 as usize].r#ref = -(1 as libc::c_int);
             i_11 += 1;
@@ -1624,7 +1624,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         && (*hdr).quant.vdc_delta == 0
         && (*hdr).quant.vac_delta == 0) as libc::c_int;
     (*hdr).all_lossless = 1 as libc::c_int;
-    let mut i_12: libc::c_int = 0 as libc::c_int;
+    let mut i_12 = 0;
     while i_12 < 8 as libc::c_int {
         (*hdr).segmentation.qidx[i_12 as usize] = if (*hdr).segmentation.enabled != 0 {
             iclip_u8((*hdr).quant.yac + (*hdr).segmentation.seg_data.d[i_12 as usize].delta_q)
@@ -1671,7 +1671,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         if (*hdr).loopfilter.mode_ref_delta_enabled != 0 {
             (*hdr).loopfilter.mode_ref_delta_update = dav1d_get_bit(gb) as libc::c_int;
             if (*hdr).loopfilter.mode_ref_delta_update != 0 {
-                let mut i_13: libc::c_int = 0 as libc::c_int;
+                let mut i_13 = 0;
                 while i_13 < 8 as libc::c_int {
                     if dav1d_get_bit(gb) != 0 {
                         (*hdr).loopfilter.mode_ref_deltas.ref_delta[i_13 as usize] =
@@ -1679,7 +1679,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                     }
                     i_13 += 1;
                 }
-                let mut i_14: libc::c_int = 0 as libc::c_int;
+                let mut i_14 = 0;
                 while i_14 < 2 as libc::c_int {
                     if dav1d_get_bit(gb) != 0 {
                         (*hdr).loopfilter.mode_ref_deltas.mode_delta[i_14 as usize] =
@@ -1695,7 +1695,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             .wrapping_add(3 as libc::c_int as libc::c_uint)
             as libc::c_int;
         (*hdr).cdef.n_bits = dav1d_get_bits(gb, 2 as libc::c_int) as libc::c_int;
-        let mut i_15: libc::c_int = 0 as libc::c_int;
+        let mut i_15 = 0;
         while i_15 < (1 as libc::c_int) << (*hdr).cdef.n_bits {
             (*hdr).cdef.y_strength[i_15 as usize] =
                 dav1d_get_bits(gb, 6 as libc::c_int) as libc::c_int;
@@ -1779,7 +1779,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         let mut off_after: libc::c_int = -(1 as libc::c_int);
         let mut off_before_idx: libc::c_int = 0;
         let mut off_after_idx: libc::c_int = 0;
-        let mut i_16: libc::c_int = 0 as libc::c_int;
+        let mut i_16 = 0;
         while i_16 < 7 as libc::c_int {
             if ((*c).refs[(*hdr).refidx[i_16 as usize] as usize]
                 .p
@@ -1830,7 +1830,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         } else if off_before != 0xffffffff as libc::c_uint {
             let mut off_before2: libc::c_uint = 0xffffffff as libc::c_uint;
             let mut off_before2_idx: libc::c_int = 0;
-            let mut i_17: libc::c_int = 0 as libc::c_int;
+            let mut i_17 = 0;
             while i_17 < 7 as libc::c_int {
                 if ((*c).refs[(*hdr).refidx[i_17 as usize] as usize]
                     .p
@@ -1881,13 +1881,13 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         && (*seqhdr).warped_motion != 0
         && dav1d_get_bit(gb) != 0) as libc::c_int;
     (*hdr).reduced_txtp_set = dav1d_get_bit(gb) as libc::c_int;
-    let mut i_18: libc::c_int = 0 as libc::c_int;
+    let mut i_18 = 0;
     while i_18 < 7 as libc::c_int {
         (*hdr).gmv[i_18 as usize] = dav1d_default_wm_params.clone();
         i_18 += 1;
     }
     if (*hdr).frame_type as libc::c_uint & 1 as libc::c_int as libc::c_uint != 0 {
-        let mut i_19: libc::c_int = 0 as libc::c_int;
+        let mut i_19 = 0;
         while i_19 < 7 as libc::c_int {
             (*hdr).gmv[i_19 as usize].type_0 = (if dav1d_get_bit(gb) == 0 {
                 DAV1D_WM_TYPE_IDENTITY as libc::c_int
@@ -2009,7 +2009,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             if (*fgd).num_y_points > 14 as libc::c_int {
                 return parse_frame_hdr_error(c);
             }
-            let mut i_21: libc::c_int = 0 as libc::c_int;
+            let mut i_21 = 0;
             while i_21 < (*fgd).num_y_points {
                 (*fgd).y_points[i_21 as usize][0] = dav1d_get_bits(gb, 8 as libc::c_int) as uint8_t;
                 if i_21 != 0
@@ -2032,14 +2032,14 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 (*fgd).num_uv_points[1] = 0 as libc::c_int;
                 (*fgd).num_uv_points[0] = (*fgd).num_uv_points[1];
             } else {
-                let mut pl: libc::c_int = 0 as libc::c_int;
+                let mut pl = 0;
                 while pl < 2 as libc::c_int {
                     (*fgd).num_uv_points[pl as usize] =
                         dav1d_get_bits(gb, 4 as libc::c_int) as libc::c_int;
                     if (*fgd).num_uv_points[pl as usize] > 10 as libc::c_int {
                         return parse_frame_hdr_error(c);
                     }
-                    let mut i_22: libc::c_int = 0 as libc::c_int;
+                    let mut i_22 = 0;
                     while i_22 < (*fgd).num_uv_points[pl as usize] {
                         (*fgd).uv_points[pl as usize][i_22 as usize][0] =
                             dav1d_get_bits(gb, 8 as libc::c_int) as uint8_t;
@@ -2071,7 +2071,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             let num_y_pos: libc::c_int =
                 2 as libc::c_int * (*fgd).ar_coeff_lag * ((*fgd).ar_coeff_lag + 1 as libc::c_int);
             if (*fgd).num_y_points != 0 {
-                let mut i_23: libc::c_int = 0 as libc::c_int;
+                let mut i_23 = 0;
                 while i_23 < num_y_pos {
                     (*fgd).ar_coeffs_y[i_23 as usize] = (dav1d_get_bits(gb, 8 as libc::c_int))
                         .wrapping_sub(128 as libc::c_int as libc::c_uint)
@@ -2079,13 +2079,13 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                     i_23 += 1;
                 }
             }
-            let mut pl_0: libc::c_int = 0 as libc::c_int;
+            let mut pl_0 = 0;
             while pl_0 < 2 as libc::c_int {
                 if (*fgd).num_uv_points[pl_0 as usize] != 0 || (*fgd).chroma_scaling_from_luma != 0
                 {
                     let num_uv_pos: libc::c_int =
                         num_y_pos + ((*fgd).num_y_points != 0) as libc::c_int;
-                    let mut i_24: libc::c_int = 0 as libc::c_int;
+                    let mut i_24 = 0;
                     while i_24 < num_uv_pos {
                         (*fgd).ar_coeffs_uv[pl_0 as usize][i_24 as usize] =
                             (dav1d_get_bits(gb, 8 as libc::c_int))
@@ -2104,7 +2104,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 .wrapping_add(6 as libc::c_int as libc::c_uint)
                 as uint64_t;
             (*fgd).grain_scale_shift = dav1d_get_bits(gb, 2 as libc::c_int) as libc::c_int;
-            let mut pl_1: libc::c_int = 0 as libc::c_int;
+            let mut pl_1 = 0;
             while pl_1 < 2 as libc::c_int {
                 if (*fgd).num_uv_points[pl_1 as usize] != 0 {
                     (*fgd).uv_mult[pl_1 as usize] = (dav1d_get_bits(gb, 8 as libc::c_int))
@@ -2194,7 +2194,7 @@ unsafe extern "C" fn dav1d_parse_obus_skip(
     len: libc::c_uint,
     init_byte_pos: libc::c_uint,
 ) -> libc::c_int {
-    let mut i: libc::c_int = 0 as libc::c_int;
+    let mut i = 0;
     while i < 8 as libc::c_int {
         if (*(*c).frame_hdr).refresh_frame_flags & (1 as libc::c_int) << i != 0 {
             dav1d_thread_picture_unref(&mut (*((*c).refs).as_mut_ptr().offset(i as isize)).p);
@@ -2234,8 +2234,8 @@ pub unsafe extern "C" fn dav1d_parse_obus(
     let has_extension: libc::c_int = dav1d_get_bit(&mut gb) as libc::c_int;
     let has_length_field: libc::c_int = dav1d_get_bit(&mut gb) as libc::c_int;
     dav1d_get_bit(&mut gb);
-    let mut temporal_id: libc::c_int = 0 as libc::c_int;
-    let mut spatial_id: libc::c_int = 0 as libc::c_int;
+    let mut temporal_id = 0;
+    let mut spatial_id = 0;
     if has_extension != 0 {
         temporal_id = dav1d_get_bits(&mut gb, 3 as libc::c_int) as libc::c_int;
         spatial_id = dav1d_get_bits(&mut gb, 2 as libc::c_int) as libc::c_int;
@@ -2314,7 +2314,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                 (*c).content_light = 0 as *mut Dav1dContentLightLevel;
                 dav1d_ref_dec(&mut (*c).mastering_display_ref);
                 dav1d_ref_dec(&mut (*c).content_light_ref);
-                let mut i: libc::c_int = 0 as libc::c_int;
+                let mut i = 0;
                 while i < 8 as libc::c_int {
                     if !((*c).refs[i as usize].p.p.frame_hdr).is_null() {
                         dav1d_thread_picture_unref(
@@ -2398,7 +2398,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                     }
                     let mastering_display: *mut Dav1dMasteringDisplay =
                         (*ref_2).data as *mut Dav1dMasteringDisplay;
-                    let mut i_1: libc::c_int = 0 as libc::c_int;
+                    let mut i_1 = 0;
                     while i_1 < 3 as libc::c_int {
                         (*mastering_display).primaries[i_1 as usize][0] =
                             dav1d_get_bits(&mut gb, 16 as libc::c_int) as uint16_t;
@@ -2436,7 +2436,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                     }
                     payload_size -= 1;
                     payload_size -= meta_type_len;
-                    let mut country_code_extension_byte: libc::c_int = 0 as libc::c_int;
+                    let mut country_code_extension_byte = 0;
                     let country_code: libc::c_int =
                         dav1d_get_bits(&mut gb, 8 as libc::c_int) as libc::c_int;
                     payload_size -= 1;
@@ -2468,7 +2468,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                         (*itut_t35_metadata).country_code = country_code as uint8_t;
                         (*itut_t35_metadata).country_code_extension_byte =
                             country_code_extension_byte as uint8_t;
-                        let mut i_2: libc::c_int = 0 as libc::c_int;
+                        let mut i_2 = 0;
                         while i_2 < payload_size {
                             *((*itut_t35_metadata).payload).offset(i_2 as isize) =
                                 dav1d_get_bits(&mut gb, 8 as libc::c_int) as uint8_t;
@@ -2541,7 +2541,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                     (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
                     return dav1d_parse_obus_error(c, in_0);
                 }
-                let mut n: libc::c_int = 0 as libc::c_int;
+                let mut n = 0;
                 while n < (*c).n_tile_data {
                     dav1d_data_unref_internal(&mut (*((*c).tile).offset(n as isize)).data);
                     n += 1;
@@ -2640,7 +2640,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                     > (*((*c).tile).offset((*c).n_tile_data as isize)).end
                     || (*((*c).tile).offset((*c).n_tile_data as isize)).start != (*c).n_tiles
                 {
-                    let mut i_0: libc::c_int = 0 as libc::c_int;
+                    let mut i_0 = 0;
                     while i_0 <= (*c).n_tile_data {
                         dav1d_data_unref_internal(&mut (*((*c).tile).offset(i_0 as isize)).data);
                         i_0 += 1;
@@ -2818,7 +2818,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
             {
                 let r: libc::c_int = (*(*c).frame_hdr).existing_frame_idx;
                 (*c).refs[r as usize].p.showable = 0 as libc::c_int;
-                let mut i_3: libc::c_int = 0 as libc::c_int;
+                let mut i_3 = 0;
                 while i_3 < 8 as libc::c_int {
                     if !(i_3 == r) {
                         if !((*c).refs[i_3 as usize].p.p.frame_hdr).is_null() {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1353,11 +1353,11 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         && dav1d_get_bit(gb) == 0) as libc::c_int;
     (*hdr).tiling.uniform = dav1d_get_bit(gb) as libc::c_int;
     let sbsz_min1: libc::c_int = ((64 as libc::c_int) << (*seqhdr).sb128) - 1;
-    let sbsz_log2: libc::c_int = 6 + (*seqhdr).sb128;
+    let sbsz_log2 = 6 + (*seqhdr).sb128;
     let sbw: libc::c_int = (*hdr).width[0] + sbsz_min1 >> sbsz_log2;
     let sbh: libc::c_int = (*hdr).height + sbsz_min1 >> sbsz_log2;
-    let max_tile_width_sb: libc::c_int = 4096 >> sbsz_log2;
-    let max_tile_area_sb: libc::c_int = 4096 * 2304 >> 2 * sbsz_log2;
+    let max_tile_width_sb = 4096 >> sbsz_log2;
+    let max_tile_area_sb = 4096 * 2304 >> 2 * sbsz_log2;
     (*hdr).tiling.min_log2_cols = tile_log2(max_tile_width_sb, sbw);
     (*hdr).tiling.max_log2_cols = tile_log2(1 as libc::c_int, imin(sbw, 64 as libc::c_int));
     (*hdr).tiling.max_log2_rows = tile_log2(1 as libc::c_int, imin(sbh, 64 as libc::c_int));
@@ -1370,7 +1370,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         while (*hdr).tiling.log2_cols < (*hdr).tiling.max_log2_cols && dav1d_get_bit(gb) != 0 {
             (*hdr).tiling.log2_cols += 1;
         }
-        let tile_w: libc::c_int = 1 + (sbw - 1 >> (*hdr).tiling.log2_cols);
+        let tile_w = 1 + (sbw - 1 >> (*hdr).tiling.log2_cols);
         (*hdr).tiling.cols = 0 as libc::c_int;
         let mut sbx = 0;
         while sbx < sbw {
@@ -1384,7 +1384,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         while (*hdr).tiling.log2_rows < (*hdr).tiling.max_log2_rows && dav1d_get_bit(gb) != 0 {
             (*hdr).tiling.log2_rows += 1;
         }
-        let tile_h: libc::c_int = 1 + (sbh - 1 >> (*hdr).tiling.log2_rows);
+        let tile_h = 1 + (sbh - 1 >> (*hdr).tiling.log2_rows);
         (*hdr).tiling.rows = 0 as libc::c_int;
         let mut sby = 0;
         while sby < sbh {
@@ -1773,8 +1773,8 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         let poc: libc::c_uint = (*hdr).frame_offset as libc::c_uint;
         let mut off_before: libc::c_uint = 0xffffffff as libc::c_uint;
         let mut off_after: libc::c_int = -(1 as libc::c_int);
-        let mut off_before_idx: libc::c_int = 0;
-        let mut off_after_idx: libc::c_int = 0;
+        let mut off_before_idx = 0;
+        let mut off_after_idx = 0;
         let mut i_16 = 0;
         while i_16 < 7 {
             if ((*c).refs[(*hdr).refidx[i_16 as usize] as usize]
@@ -1825,7 +1825,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             (*hdr).skip_mode_allowed = 1 as libc::c_int;
         } else if off_before != 0xffffffff as libc::c_uint {
             let mut off_before2: libc::c_uint = 0xffffffff as libc::c_uint;
-            let mut off_before2_idx: libc::c_int = 0;
+            let mut off_before2_idx = 0;
             let mut i_17 = 0;
             while i_17 < 7 {
                 if ((*c).refs[(*hdr).refidx[i_17 as usize] as usize]
@@ -2057,7 +2057,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 .wrapping_add(8 as libc::c_int as libc::c_uint)
                 as libc::c_int;
             (*fgd).ar_coeff_lag = dav1d_get_bits(gb, 2 as libc::c_int) as libc::c_int;
-            let num_y_pos: libc::c_int = 2 * (*fgd).ar_coeff_lag * ((*fgd).ar_coeff_lag + 1);
+            let num_y_pos = 2 * (*fgd).ar_coeff_lag * ((*fgd).ar_coeff_lag + 1);
             if (*fgd).num_y_points != 0 {
                 let mut i_23 = 0;
                 while i_23 < num_y_pos {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1925,20 +1925,18 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 if (*hdr).gmv[i_19 as usize].type_0 as libc::c_uint
                     >= DAV1D_WM_TYPE_ROT_ZOOM as libc::c_int as libc::c_uint
                 {
-                    *mat.offset(2 as libc::c_int as isize) = ((1 as libc::c_int)
-                        << 16 as libc::c_int)
+                    *mat.offset(2) = ((1 as libc::c_int) << 16 as libc::c_int)
                         + 2 as libc::c_int
                             * dav1d_get_bits_subexp(
                                 gb,
-                                *ref_mat.offset(2 as libc::c_int as isize)
-                                    - ((1 as libc::c_int) << 16 as libc::c_int)
+                                *ref_mat.offset(2) - ((1 as libc::c_int) << 16 as libc::c_int)
                                     >> 1 as libc::c_int,
                                 12 as libc::c_int as libc::c_uint,
                             );
-                    *mat.offset(3 as libc::c_int as isize) = 2 as libc::c_int
+                    *mat.offset(3) = 2 as libc::c_int
                         * dav1d_get_bits_subexp(
                             gb,
-                            *ref_mat.offset(3 as libc::c_int as isize) >> 1 as libc::c_int,
+                            *ref_mat.offset(3) >> 1 as libc::c_int,
                             12 as libc::c_int as libc::c_uint,
                         );
                     bits = 12 as libc::c_int;
@@ -1950,37 +1948,30 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 if (*hdr).gmv[i_19 as usize].type_0 as libc::c_uint
                     == DAV1D_WM_TYPE_AFFINE as libc::c_int as libc::c_uint
                 {
-                    *mat.offset(4 as libc::c_int as isize) = 2 as libc::c_int
+                    *mat.offset(4) = 2 as libc::c_int
                         * dav1d_get_bits_subexp(
                             gb,
-                            *ref_mat.offset(4 as libc::c_int as isize) >> 1 as libc::c_int,
+                            *ref_mat.offset(4) >> 1 as libc::c_int,
                             12 as libc::c_int as libc::c_uint,
                         );
-                    *mat.offset(5 as libc::c_int as isize) = ((1 as libc::c_int)
-                        << 16 as libc::c_int)
+                    *mat.offset(5) = ((1 as libc::c_int) << 16 as libc::c_int)
                         + 2 as libc::c_int
                             * dav1d_get_bits_subexp(
                                 gb,
-                                *ref_mat.offset(5 as libc::c_int as isize)
-                                    - ((1 as libc::c_int) << 16 as libc::c_int)
+                                *ref_mat.offset(5) - ((1 as libc::c_int) << 16 as libc::c_int)
                                     >> 1 as libc::c_int,
                                 12 as libc::c_int as libc::c_uint,
                             );
                 } else {
-                    *mat.offset(4 as libc::c_int as isize) =
-                        -*mat.offset(3 as libc::c_int as isize);
-                    *mat.offset(5 as libc::c_int as isize) = *mat.offset(2 as libc::c_int as isize);
+                    *mat.offset(4) = -*mat.offset(3);
+                    *mat.offset(5) = *mat.offset(2);
                 }
-                *mat.offset(0 as libc::c_int as isize) = dav1d_get_bits_subexp(
-                    gb,
-                    *ref_mat.offset(0 as libc::c_int as isize) >> shift,
-                    bits as libc::c_uint,
-                ) * ((1 as libc::c_int) << shift);
-                *mat.offset(1 as libc::c_int as isize) = dav1d_get_bits_subexp(
-                    gb,
-                    *ref_mat.offset(1 as libc::c_int as isize) >> shift,
-                    bits as libc::c_uint,
-                ) * ((1 as libc::c_int) << shift);
+                *mat.offset(0) =
+                    dav1d_get_bits_subexp(gb, *ref_mat.offset(0) >> shift, bits as libc::c_uint)
+                        * ((1 as libc::c_int) << shift);
+                *mat.offset(1) =
+                    dav1d_get_bits_subexp(gb, *ref_mat.offset(1) >> shift, bits as libc::c_uint)
+                        * ((1 as libc::c_int) << shift);
             }
             i_19 += 1;
         }
@@ -2473,8 +2464,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                         let itut_t35_metadata: *mut Dav1dITUTT35 =
                             (*ref_3).data as *mut Dav1dITUTT35;
                         (*itut_t35_metadata).payload =
-                            &mut *itut_t35_metadata.offset(1 as libc::c_int as isize)
-                                as *mut Dav1dITUTT35 as *mut uint8_t;
+                            &mut *itut_t35_metadata.offset(1) as *mut Dav1dITUTT35 as *mut uint8_t;
                         (*itut_t35_metadata).country_code = country_code as uint8_t;
                         (*itut_t35_metadata).country_code_extension_byte =
                             country_code_extension_byte as uint8_t;
@@ -2791,8 +2781,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                     dav1d_thread_picture_unref(out_delayed);
                 } else if !((*out_delayed).p.data[0]).is_null() {
                     let progress: libc::c_uint = ::core::intrinsics::atomic_load_relaxed(
-                        &mut *((*out_delayed).progress).offset(1 as libc::c_int as isize)
-                            as *mut atomic_uint,
+                        &mut *((*out_delayed).progress).offset(1) as *mut atomic_uint,
                     );
                     if ((*out_delayed).visible != 0 || (*c).output_invisible_frames != 0)
                         && progress

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -854,7 +854,7 @@ unsafe extern "C" fn parse_seq_hdr(
     {
         (*hdr).layout = DAV1D_PIXEL_LAYOUT_I444;
         (*hdr).color_range = 1 as libc::c_int;
-        if (*hdr).profile != 1 as libc::c_int && !((*hdr).profile == 2 && (*hdr).hbd == 2) {
+        if (*hdr).profile != 1 && !((*hdr).profile == 2 && (*hdr).hbd == 2) {
             return parse_seq_hdr_error(c);
         }
     } else {
@@ -1353,11 +1353,11 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         && dav1d_get_bit(gb) == 0) as libc::c_int;
     (*hdr).tiling.uniform = dav1d_get_bit(gb) as libc::c_int;
     let sbsz_min1: libc::c_int = ((64 as libc::c_int) << (*seqhdr).sb128) - 1;
-    let sbsz_log2: libc::c_int = 6 as libc::c_int + (*seqhdr).sb128;
+    let sbsz_log2: libc::c_int = 6 + (*seqhdr).sb128;
     let sbw: libc::c_int = (*hdr).width[0] + sbsz_min1 >> sbsz_log2;
     let sbh: libc::c_int = (*hdr).height + sbsz_min1 >> sbsz_log2;
-    let max_tile_width_sb: libc::c_int = 4096 as libc::c_int >> sbsz_log2;
-    let max_tile_area_sb: libc::c_int = 4096 as libc::c_int * 2304 >> 2 * sbsz_log2;
+    let max_tile_width_sb: libc::c_int = 4096 >> sbsz_log2;
+    let max_tile_area_sb: libc::c_int = 4096 * 2304 >> 2 * sbsz_log2;
     (*hdr).tiling.min_log2_cols = tile_log2(max_tile_width_sb, sbw);
     (*hdr).tiling.max_log2_cols = tile_log2(1 as libc::c_int, imin(sbw, 64 as libc::c_int));
     (*hdr).tiling.max_log2_rows = tile_log2(1 as libc::c_int, imin(sbh, 64 as libc::c_int));
@@ -1370,7 +1370,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         while (*hdr).tiling.log2_cols < (*hdr).tiling.max_log2_cols && dav1d_get_bit(gb) != 0 {
             (*hdr).tiling.log2_cols += 1;
         }
-        let tile_w: libc::c_int = 1 as libc::c_int + (sbw - 1 >> (*hdr).tiling.log2_cols);
+        let tile_w: libc::c_int = 1 + (sbw - 1 >> (*hdr).tiling.log2_cols);
         (*hdr).tiling.cols = 0 as libc::c_int;
         let mut sbx = 0;
         while sbx < sbw {
@@ -1384,7 +1384,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         while (*hdr).tiling.log2_rows < (*hdr).tiling.max_log2_rows && dav1d_get_bit(gb) != 0 {
             (*hdr).tiling.log2_rows += 1;
         }
-        let tile_h: libc::c_int = 1 as libc::c_int + (sbh - 1 >> (*hdr).tiling.log2_rows);
+        let tile_h: libc::c_int = 1 + (sbh - 1 >> (*hdr).tiling.log2_rows);
         (*hdr).tiling.rows = 0 as libc::c_int;
         let mut sby = 0;
         while sby < sbh {
@@ -1725,7 +1725,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             || (*hdr).restoration.type_0[1] as libc::c_uint != 0
             || (*hdr).restoration.type_0[2] as libc::c_uint != 0
         {
-            (*hdr).restoration.unit_size[0] = 6 as libc::c_int + (*seqhdr).sb128;
+            (*hdr).restoration.unit_size[0] = 6 + (*seqhdr).sb128;
             if dav1d_get_bit(gb) != 0 {
                 (*hdr).restoration.unit_size[0] += 1;
                 if (*seqhdr).sb128 == 0 {
@@ -1936,8 +1936,8 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                     bits = 12 as libc::c_int;
                     shift = 10 as libc::c_int;
                 } else {
-                    bits = 9 as libc::c_int - ((*hdr).hp == 0) as libc::c_int;
-                    shift = 13 as libc::c_int + ((*hdr).hp == 0) as libc::c_int;
+                    bits = 9 - ((*hdr).hp == 0) as libc::c_int;
+                    shift = 13 + ((*hdr).hp == 0) as libc::c_int;
                 }
                 if (*hdr).gmv[i_19 as usize].type_0 as libc::c_uint
                     == DAV1D_WM_TYPE_AFFINE as libc::c_int as libc::c_uint
@@ -2057,8 +2057,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 .wrapping_add(8 as libc::c_int as libc::c_uint)
                 as libc::c_int;
             (*fgd).ar_coeff_lag = dav1d_get_bits(gb, 2 as libc::c_int) as libc::c_int;
-            let num_y_pos: libc::c_int =
-                2 as libc::c_int * (*fgd).ar_coeff_lag * ((*fgd).ar_coeff_lag + 1);
+            let num_y_pos: libc::c_int = 2 * (*fgd).ar_coeff_lag * ((*fgd).ar_coeff_lag + 1);
             if (*fgd).num_y_points != 0 {
                 let mut i_23 = 0;
                 while i_23 < num_y_pos {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1215,8 +1215,8 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 i_2 += 1;
             }
             let mut used_frame: [libc::c_int; 8] = [0 as libc::c_int, 0, 0, 0, 0, 0, 0, 0];
-            used_frame[(*hdr).refidx[0 as libc::c_int as usize] as usize] = 1 as libc::c_int;
-            used_frame[(*hdr).refidx[3 as libc::c_int as usize] as usize] = 1 as libc::c_int;
+            used_frame[(*hdr).refidx[0] as usize] = 1 as libc::c_int;
+            used_frame[(*hdr).refidx[3] as usize] = 1 as libc::c_int;
             let mut latest_frame_offset: libc::c_int = -(1 as libc::c_int);
             let mut i_3: libc::c_int = 0 as libc::c_int;
             while i_3 < 8 as libc::c_int {
@@ -1225,13 +1225,13 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                     && hint >= current_frame_offset
                     && hint >= latest_frame_offset
                 {
-                    (*hdr).refidx[6 as libc::c_int as usize] = i_3;
+                    (*hdr).refidx[6] = i_3;
                     latest_frame_offset = hint;
                 }
                 i_3 += 1;
             }
             if latest_frame_offset != -(1 as libc::c_int) {
-                used_frame[(*hdr).refidx[6 as libc::c_int as usize] as usize] = 1 as libc::c_int;
+                used_frame[(*hdr).refidx[6] as usize] = 1 as libc::c_int;
             }
             let mut earliest_frame_offset: libc::c_int = 2147483647 as libc::c_int;
             let mut i_4: libc::c_int = 0 as libc::c_int;
@@ -1241,13 +1241,13 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                     && hint_0 >= current_frame_offset
                     && hint_0 < earliest_frame_offset
                 {
-                    (*hdr).refidx[4 as libc::c_int as usize] = i_4;
+                    (*hdr).refidx[4] = i_4;
                     earliest_frame_offset = hint_0;
                 }
                 i_4 += 1;
             }
             if earliest_frame_offset != 2147483647 as libc::c_int {
-                used_frame[(*hdr).refidx[4 as libc::c_int as usize] as usize] = 1 as libc::c_int;
+                used_frame[(*hdr).refidx[4] as usize] = 1 as libc::c_int;
             }
             earliest_frame_offset = 2147483647 as libc::c_int;
             let mut i_5: libc::c_int = 0 as libc::c_int;
@@ -1257,13 +1257,13 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                     && hint_1 >= current_frame_offset
                     && hint_1 < earliest_frame_offset
                 {
-                    (*hdr).refidx[5 as libc::c_int as usize] = i_5;
+                    (*hdr).refidx[5] = i_5;
                     earliest_frame_offset = hint_1;
                 }
                 i_5 += 1;
             }
             if earliest_frame_offset != 2147483647 as libc::c_int {
-                used_frame[(*hdr).refidx[5 as libc::c_int as usize] as usize] = 1 as libc::c_int;
+                used_frame[(*hdr).refidx[5] as usize] = 1 as libc::c_int;
             }
             let mut i_6: libc::c_int = 1 as libc::c_int;
             while i_6 < 7 as libc::c_int {
@@ -1354,7 +1354,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
     (*hdr).tiling.uniform = dav1d_get_bit(gb) as libc::c_int;
     let sbsz_min1: libc::c_int = ((64 as libc::c_int) << (*seqhdr).sb128) - 1 as libc::c_int;
     let sbsz_log2: libc::c_int = 6 as libc::c_int + (*seqhdr).sb128;
-    let sbw: libc::c_int = (*hdr).width[0 as libc::c_int as usize] + sbsz_min1 >> sbsz_log2;
+    let sbw: libc::c_int = (*hdr).width[0] + sbsz_min1 >> sbsz_log2;
     let sbh: libc::c_int = (*hdr).height + sbsz_min1 >> sbsz_log2;
     let max_tile_width_sb: libc::c_int = 4096 as libc::c_int >> sbsz_log2;
     let max_tile_area_sb: libc::c_int =
@@ -1637,9 +1637,8 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         i_12 += 1;
     }
     if (*hdr).all_lossless != 0 || (*hdr).allow_intrabc != 0 {
-        (*hdr).loopfilter.level_y[1 as libc::c_int as usize] = 0 as libc::c_int;
-        (*hdr).loopfilter.level_y[0 as libc::c_int as usize] =
-            (*hdr).loopfilter.level_y[1 as libc::c_int as usize];
+        (*hdr).loopfilter.level_y[1] = 0 as libc::c_int;
+        (*hdr).loopfilter.level_y[0] = (*hdr).loopfilter.level_y[1];
         (*hdr).loopfilter.level_v = 0 as libc::c_int;
         (*hdr).loopfilter.level_u = (*hdr).loopfilter.level_v;
         (*hdr).loopfilter.sharpness = 0 as libc::c_int;
@@ -1647,13 +1646,10 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         (*hdr).loopfilter.mode_ref_delta_update = 1 as libc::c_int;
         (*hdr).loopfilter.mode_ref_deltas = default_mode_ref_deltas.clone();
     } else {
-        (*hdr).loopfilter.level_y[0 as libc::c_int as usize] =
-            dav1d_get_bits(gb, 6 as libc::c_int) as libc::c_int;
-        (*hdr).loopfilter.level_y[1 as libc::c_int as usize] =
-            dav1d_get_bits(gb, 6 as libc::c_int) as libc::c_int;
+        (*hdr).loopfilter.level_y[0] = dav1d_get_bits(gb, 6 as libc::c_int) as libc::c_int;
+        (*hdr).loopfilter.level_y[1] = dav1d_get_bits(gb, 6 as libc::c_int) as libc::c_int;
         if (*seqhdr).monochrome == 0
-            && ((*hdr).loopfilter.level_y[0 as libc::c_int as usize] != 0
-                || (*hdr).loopfilter.level_y[1 as libc::c_int as usize] != 0)
+            && ((*hdr).loopfilter.level_y[0] != 0 || (*hdr).loopfilter.level_y[1] != 0)
         {
             (*hdr).loopfilter.level_u = dav1d_get_bits(gb, 6 as libc::c_int) as libc::c_int;
             (*hdr).loopfilter.level_v = dav1d_get_bits(gb, 6 as libc::c_int) as libc::c_int;
@@ -1711,59 +1707,54 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
         }
     } else {
         (*hdr).cdef.n_bits = 0 as libc::c_int;
-        (*hdr).cdef.y_strength[0 as libc::c_int as usize] = 0 as libc::c_int;
-        (*hdr).cdef.uv_strength[0 as libc::c_int as usize] = 0 as libc::c_int;
+        (*hdr).cdef.y_strength[0] = 0 as libc::c_int;
+        (*hdr).cdef.uv_strength[0] = 0 as libc::c_int;
     }
     if ((*hdr).all_lossless == 0 || (*hdr).super_res.enabled != 0)
         && (*seqhdr).restoration != 0
         && (*hdr).allow_intrabc == 0
     {
-        (*hdr).restoration.type_0[0 as libc::c_int as usize] =
-            dav1d_get_bits(gb, 2 as libc::c_int) as Dav1dRestorationType;
+        (*hdr).restoration.type_0[0] = dav1d_get_bits(gb, 2 as libc::c_int) as Dav1dRestorationType;
         if (*seqhdr).monochrome == 0 {
-            (*hdr).restoration.type_0[1 as libc::c_int as usize] =
+            (*hdr).restoration.type_0[1] =
                 dav1d_get_bits(gb, 2 as libc::c_int) as Dav1dRestorationType;
-            (*hdr).restoration.type_0[2 as libc::c_int as usize] =
+            (*hdr).restoration.type_0[2] =
                 dav1d_get_bits(gb, 2 as libc::c_int) as Dav1dRestorationType;
         } else {
-            (*hdr).restoration.type_0[2 as libc::c_int as usize] = DAV1D_RESTORATION_NONE;
-            (*hdr).restoration.type_0[1 as libc::c_int as usize] =
-                (*hdr).restoration.type_0[2 as libc::c_int as usize];
+            (*hdr).restoration.type_0[2] = DAV1D_RESTORATION_NONE;
+            (*hdr).restoration.type_0[1] = (*hdr).restoration.type_0[2];
         }
-        if (*hdr).restoration.type_0[0 as libc::c_int as usize] as libc::c_uint != 0
-            || (*hdr).restoration.type_0[1 as libc::c_int as usize] as libc::c_uint != 0
-            || (*hdr).restoration.type_0[2 as libc::c_int as usize] as libc::c_uint != 0
+        if (*hdr).restoration.type_0[0] as libc::c_uint != 0
+            || (*hdr).restoration.type_0[1] as libc::c_uint != 0
+            || (*hdr).restoration.type_0[2] as libc::c_uint != 0
         {
-            (*hdr).restoration.unit_size[0 as libc::c_int as usize] =
-                6 as libc::c_int + (*seqhdr).sb128;
+            (*hdr).restoration.unit_size[0] = 6 as libc::c_int + (*seqhdr).sb128;
             if dav1d_get_bit(gb) != 0 {
-                (*hdr).restoration.unit_size[0 as libc::c_int as usize] += 1;
+                (*hdr).restoration.unit_size[0] += 1;
                 if (*seqhdr).sb128 == 0 {
-                    (*hdr).restoration.unit_size[0 as libc::c_int as usize] =
-                        ((*hdr).restoration.unit_size[0 as libc::c_int as usize] as libc::c_uint)
+                    (*hdr).restoration.unit_size[0] =
+                        ((*hdr).restoration.unit_size[0] as libc::c_uint)
                             .wrapping_add(dav1d_get_bit(gb)) as libc::c_int
                             as libc::c_int;
                 }
             }
-            (*hdr).restoration.unit_size[1 as libc::c_int as usize] =
-                (*hdr).restoration.unit_size[0 as libc::c_int as usize];
-            if ((*hdr).restoration.type_0[1 as libc::c_int as usize] as libc::c_uint != 0
-                || (*hdr).restoration.type_0[2 as libc::c_int as usize] as libc::c_uint != 0)
+            (*hdr).restoration.unit_size[1] = (*hdr).restoration.unit_size[0];
+            if ((*hdr).restoration.type_0[1] as libc::c_uint != 0
+                || (*hdr).restoration.type_0[2] as libc::c_uint != 0)
                 && (*seqhdr).ss_hor == 1 as libc::c_int
                 && (*seqhdr).ss_ver == 1 as libc::c_int
             {
-                (*hdr).restoration.unit_size[1 as libc::c_int as usize] =
-                    ((*hdr).restoration.unit_size[1 as libc::c_int as usize] as libc::c_uint)
-                        .wrapping_sub(dav1d_get_bit(gb)) as libc::c_int
-                        as libc::c_int;
+                (*hdr).restoration.unit_size[1] = ((*hdr).restoration.unit_size[1] as libc::c_uint)
+                    .wrapping_sub(dav1d_get_bit(gb))
+                    as libc::c_int as libc::c_int;
             }
         } else {
-            (*hdr).restoration.unit_size[0 as libc::c_int as usize] = 8 as libc::c_int;
+            (*hdr).restoration.unit_size[0] = 8 as libc::c_int;
         }
     } else {
-        (*hdr).restoration.type_0[0 as libc::c_int as usize] = DAV1D_RESTORATION_NONE;
-        (*hdr).restoration.type_0[1 as libc::c_int as usize] = DAV1D_RESTORATION_NONE;
-        (*hdr).restoration.type_0[2 as libc::c_int as usize] = DAV1D_RESTORATION_NONE;
+        (*hdr).restoration.type_0[0] = DAV1D_RESTORATION_NONE;
+        (*hdr).restoration.type_0[1] = DAV1D_RESTORATION_NONE;
+        (*hdr).restoration.type_0[2] = DAV1D_RESTORATION_NONE;
     }
     (*hdr).txfm_mode = (if (*hdr).all_lossless != 0 {
         DAV1D_TX_4X4_ONLY as libc::c_int
@@ -1833,8 +1824,8 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             i_16 += 1;
         }
         if off_before != 0xffffffff as libc::c_uint && off_after != -(1 as libc::c_int) {
-            (*hdr).skip_mode_refs[0 as libc::c_int as usize] = imin(off_before_idx, off_after_idx);
-            (*hdr).skip_mode_refs[1 as libc::c_int as usize] = imax(off_before_idx, off_after_idx);
+            (*hdr).skip_mode_refs[0] = imin(off_before_idx, off_after_idx);
+            (*hdr).skip_mode_refs[1] = imax(off_before_idx, off_after_idx);
             (*hdr).skip_mode_allowed = 1 as libc::c_int;
         } else if off_before != 0xffffffff as libc::c_uint {
             let mut off_before2: libc::c_uint = 0xffffffff as libc::c_uint;
@@ -1874,10 +1865,8 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 i_17 += 1;
             }
             if off_before2 != 0xffffffff as libc::c_uint {
-                (*hdr).skip_mode_refs[0 as libc::c_int as usize] =
-                    imin(off_before_idx, off_before2_idx);
-                (*hdr).skip_mode_refs[1 as libc::c_int as usize] =
-                    imax(off_before_idx, off_before2_idx);
+                (*hdr).skip_mode_refs[0] = imin(off_before_idx, off_before2_idx);
+                (*hdr).skip_mode_refs[1] = imax(off_before_idx, off_before2_idx);
                 (*hdr).skip_mode_allowed = 1 as libc::c_int;
             }
         }
@@ -2031,17 +2020,14 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             }
             let mut i_21: libc::c_int = 0 as libc::c_int;
             while i_21 < (*fgd).num_y_points {
-                (*fgd).y_points[i_21 as usize][0 as libc::c_int as usize] =
-                    dav1d_get_bits(gb, 8 as libc::c_int) as uint8_t;
+                (*fgd).y_points[i_21 as usize][0] = dav1d_get_bits(gb, 8 as libc::c_int) as uint8_t;
                 if i_21 != 0
-                    && (*fgd).y_points[(i_21 - 1 as libc::c_int) as usize]
-                        [0 as libc::c_int as usize] as libc::c_int
-                        >= (*fgd).y_points[i_21 as usize][0 as libc::c_int as usize] as libc::c_int
+                    && (*fgd).y_points[(i_21 - 1 as libc::c_int) as usize][0] as libc::c_int
+                        >= (*fgd).y_points[i_21 as usize][0] as libc::c_int
                 {
                     return parse_frame_hdr_error(c);
                 }
-                (*fgd).y_points[i_21 as usize][1 as libc::c_int as usize] =
-                    dav1d_get_bits(gb, 8 as libc::c_int) as uint8_t;
+                (*fgd).y_points[i_21 as usize][1] = dav1d_get_bits(gb, 8 as libc::c_int) as uint8_t;
                 i_21 += 1;
             }
             (*fgd).chroma_scaling_from_luma =
@@ -2052,9 +2038,8 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                     && (*seqhdr).ss_hor == 1 as libc::c_int
                     && (*fgd).num_y_points == 0
             {
-                (*fgd).num_uv_points[1 as libc::c_int as usize] = 0 as libc::c_int;
-                (*fgd).num_uv_points[0 as libc::c_int as usize] =
-                    (*fgd).num_uv_points[1 as libc::c_int as usize];
+                (*fgd).num_uv_points[1] = 0 as libc::c_int;
+                (*fgd).num_uv_points[0] = (*fgd).num_uv_points[1];
             } else {
                 let mut pl: libc::c_int = 0 as libc::c_int;
                 while pl < 2 as libc::c_int {
@@ -2065,19 +2050,16 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                     }
                     let mut i_22: libc::c_int = 0 as libc::c_int;
                     while i_22 < (*fgd).num_uv_points[pl as usize] {
-                        (*fgd).uv_points[pl as usize][i_22 as usize][0 as libc::c_int as usize] =
+                        (*fgd).uv_points[pl as usize][i_22 as usize][0] =
                             dav1d_get_bits(gb, 8 as libc::c_int) as uint8_t;
                         if i_22 != 0
-                            && (*fgd).uv_points[pl as usize][(i_22 - 1 as libc::c_int) as usize]
-                                [0 as libc::c_int as usize]
+                            && (*fgd).uv_points[pl as usize][(i_22 - 1 as libc::c_int) as usize][0]
                                 as libc::c_int
-                                >= (*fgd).uv_points[pl as usize][i_22 as usize]
-                                    [0 as libc::c_int as usize]
-                                    as libc::c_int
+                                >= (*fgd).uv_points[pl as usize][i_22 as usize][0] as libc::c_int
                         {
                             return parse_frame_hdr_error(c);
                         }
-                        (*fgd).uv_points[pl as usize][i_22 as usize][1 as libc::c_int as usize] =
+                        (*fgd).uv_points[pl as usize][i_22 as usize][1] =
                             dav1d_get_bits(gb, 8 as libc::c_int) as uint8_t;
                         i_22 += 1;
                     }
@@ -2086,8 +2068,8 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             }
             if (*seqhdr).ss_hor == 1 as libc::c_int
                 && (*seqhdr).ss_ver == 1 as libc::c_int
-                && ((*fgd).num_uv_points[0 as libc::c_int as usize] != 0) as libc::c_int
-                    != ((*fgd).num_uv_points[1 as libc::c_int as usize] != 0) as libc::c_int
+                && ((*fgd).num_uv_points[0] != 0) as libc::c_int
+                    != ((*fgd).num_uv_points[1] != 0) as libc::c_int
             {
                 return parse_frame_hdr_error(c);
             }
@@ -2427,15 +2409,15 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                         (*ref_2).data as *mut Dav1dMasteringDisplay;
                     let mut i_1: libc::c_int = 0 as libc::c_int;
                     while i_1 < 3 as libc::c_int {
-                        (*mastering_display).primaries[i_1 as usize][0 as libc::c_int as usize] =
+                        (*mastering_display).primaries[i_1 as usize][0] =
                             dav1d_get_bits(&mut gb, 16 as libc::c_int) as uint16_t;
-                        (*mastering_display).primaries[i_1 as usize][1 as libc::c_int as usize] =
+                        (*mastering_display).primaries[i_1 as usize][1] =
                             dav1d_get_bits(&mut gb, 16 as libc::c_int) as uint16_t;
                         i_1 += 1;
                     }
-                    (*mastering_display).white_point[0 as libc::c_int as usize] =
+                    (*mastering_display).white_point[0] =
                         dav1d_get_bits(&mut gb, 16 as libc::c_int) as uint16_t;
-                    (*mastering_display).white_point[1 as libc::c_int as usize] =
+                    (*mastering_display).white_point[1] =
                         dav1d_get_bits(&mut gb, 16 as libc::c_int) as uint16_t;
                     (*mastering_display).max_luminance = dav1d_get_bits(&mut gb, 32 as libc::c_int);
                     (*mastering_display).min_luminance = dav1d_get_bits(&mut gb, 32 as libc::c_int);
@@ -2584,15 +2566,14 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                     }
                 }
                 if (*c).frame_size_limit != 0
-                    && (*(*c).frame_hdr).width[1 as libc::c_int as usize] as int64_t
-                        * (*(*c).frame_hdr).height as int64_t
+                    && (*(*c).frame_hdr).width[1] as int64_t * (*(*c).frame_hdr).height as int64_t
                         > (*c).frame_size_limit as int64_t
                 {
                     dav1d_log(
                         c,
                         b"Frame size %dx%d exceeds limit %u\n\0" as *const u8
                             as *const libc::c_char,
-                        (*(*c).frame_hdr).width[1 as libc::c_int as usize],
+                        (*(*c).frame_hdr).width[1],
                         (*(*c).frame_hdr).height,
                         (*c).frame_size_limit,
                     );
@@ -2721,7 +2702,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
             if ((*c).refs[(*(*c).frame_hdr).existing_frame_idx as usize]
                 .p
                 .p
-                .data[0 as libc::c_int as usize])
+                .data[0])
                 .is_null()
             {
                 return dav1d_parse_obus_error(c, in_0);
@@ -2771,7 +2752,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                 let out_delayed: *mut Dav1dThreadPicture = &mut *((*c).frame_thread.out_delayed)
                     .offset(next as isize)
                     as *mut Dav1dThreadPicture;
-                if !((*out_delayed).p.data[0 as libc::c_int as usize]).is_null()
+                if !((*out_delayed).p.data[0]).is_null()
                     || ::core::intrinsics::atomic_load_seqcst(
                         &mut (*f).task_thread.error as *mut atomic_int,
                     ) != 0
@@ -2808,7 +2789,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                     (*f).task_thread.retval = 0 as libc::c_int;
                     dav1d_data_props_copy(&mut (*c).cached_error_props, &mut (*out_delayed).p.m);
                     dav1d_thread_picture_unref(out_delayed);
-                } else if !((*out_delayed).p.data[0 as libc::c_int as usize]).is_null() {
+                } else if !((*out_delayed).p.data[0]).is_null() {
                     let progress: libc::c_uint = ::core::intrinsics::atomic_load_relaxed(
                         &mut *((*out_delayed).progress).offset(1 as libc::c_int as isize)
                             as *mut atomic_uint,

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -4971,8 +4971,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_resize_16bpc(
             (sr_p[pl as usize]).offset(-((h_start as isize * PXSTRIDE(dst_stride)) as isize));
         let src_stride: ptrdiff_t = (*f).cur.stride[(pl != 0) as libc::c_int as usize];
         let src: *const pixel = (p[pl as usize]).offset(-(h_start as isize * PXSTRIDE(src_stride)));
-        let h_end =
-            4 as libc::c_int * (sbsz - 2 * ((sby + 1) < (*f).sbh) as libc::c_int) >> ss_ver_0;
+        let h_end = 4 * (sbsz - 2 * ((sby + 1) < (*f).sbh) as libc::c_int) >> ss_ver_0;
         let ss_hor = (pl != 0
             && (*f).cur.p.layout as libc::c_uint
                 != DAV1D_PIXEL_LAYOUT_I444 as libc::c_int as libc::c_uint)

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -4897,8 +4897,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_resize_8bpc(
         let src_stride: ptrdiff_t = (*f).cur.stride[(pl != 0) as libc::c_int as usize];
         let src: *const pixel =
             (p[pl as usize]).offset(-((h_start as isize * src_stride) as isize));
-        let h_end =
-            4 as libc::c_int * (sbsz - 2 * ((sby + 1) < (*f).sbh) as libc::c_int) >> ss_ver_0;
+        let h_end = 4 * (sbsz - 2 * ((sby + 1) < (*f).sbh) as libc::c_int) >> ss_ver_0;
         let ss_hor = (pl != 0
             && (*f).cur.p.layout as libc::c_uint
                 != DAV1D_PIXEL_LAYOUT_I444 as libc::c_int as libc::c_uint)

--- a/src/wedge.rs
+++ b/src/wedge.rs
@@ -529,7 +529,7 @@ unsafe extern "C" fn invert(
         let mut x = 0;
         while x < w {
             *dst.offset((y_off + x) as isize) =
-                (64 as libc::c_int - *src.offset((y_off + x) as isize) as libc::c_int) as uint8_t;
+                (64 - *src.offset((y_off + x) as isize) as libc::c_int) as uint8_t;
             x += 1;
         }
         y += 1;
@@ -607,8 +607,8 @@ unsafe extern "C" fn fill2d_16x2(
             (*master.offset((*cb.offset(n as isize)).direction as isize)).as_ptr(),
             w,
             h,
-            32 as libc::c_int - (w * (*cb.offset(n as isize)).x_offset as libc::c_int >> 3),
-            32 as libc::c_int - (h * (*cb.offset(n as isize)).y_offset as libc::c_int >> 3),
+            32 - (w * (*cb.offset(n as isize)).x_offset as libc::c_int >> 3),
+            32 - (h * (*cb.offset(n as isize)).y_offset as libc::c_int >> 3),
         );
         ptr = ptr.offset((w * h) as isize);
         n += 1;

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -194,7 +194,7 @@ unsafe extern "C" fn decode_rand(
     data: *mut Dav1dData,
     fps: libc::c_double,
 ) -> libc::c_int {
-    let mut res: libc::c_int = 0;
+    let mut res = 0;
     let mut p: Dav1dPicture = Dav1dPicture {
         seq_hdr: 0 as *mut Dav1dSequenceHeader,
         frame_hdr: 0 as *mut Dav1dFrameHeader,
@@ -483,7 +483,7 @@ unsafe fn main_0(argc: libc::c_int, argv: *const *mut libc::c_char) -> libc::c_i
     spf = i_fps[1] as libc::c_double / i_fps[0] as libc::c_double;
     fps = i_fps[0] as libc::c_double / i_fps[1] as libc::c_double;
     if !(fps < 1 as libc::c_double) {
-        let mut i: libc::c_int = 0;
+        let mut i = 0;
         loop {
             if !(i < 3) {
                 current_block = 5948590327928692120;
@@ -593,7 +593,7 @@ unsafe fn main_0(argc: libc::c_int, argv: *const *mut libc::c_char) -> libc::c_i
                             }
                         }
                         // simulate seeking after the end of the file
-                        let mut i_1: libc::c_int = 0;
+                        let mut i_1 = 0;
                         while i_1 < 2 {
                             if seek(
                                 in_0,
@@ -611,7 +611,7 @@ unsafe fn main_0(argc: libc::c_int, argv: *const *mut libc::c_char) -> libc::c_i
                             if decode_all(in_0, c, &mut data) != 0 {
                                 break;
                             }
-                            let mut num_flush: libc::c_int = 1 + 64 + xor128_rand() % 64;
+                            let mut num_flush = 1 + 64 + xor128_rand() % 64;
                             loop {
                                 num_flush -= 1;
                                 if num_flush == 0 {

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -231,7 +231,7 @@ unsafe extern "C" fn decode_rand(
     };
     let num_frames: libc::c_int =
         xor128_rand() % (fps * 5 as libc::c_int as libc::c_double) as libc::c_int;
-    let mut i: libc::c_int = 0 as libc::c_int;
+    let mut i = 0;
     while i < num_frames {
         res = decode_frame(&mut p, c, data);
         if res != 0 {
@@ -508,8 +508,8 @@ unsafe fn main_0(argc: libc::c_int, argv: *const *mut libc::c_char) -> libc::c_i
             _ => {
                 pts = llround(data.m.timestamp as libc::c_double * timebase * 1000000000.0f64)
                     as uint64_t;
-                let mut i_0: libc::c_int = 0 as libc::c_int;
-                let mut tries: libc::c_int = 0 as libc::c_int;
+                let mut i_0 = 0;
+                let mut tries = 0;
                 loop {
                     if !(i_0 - tries < 4 as libc::c_int
                         && tries < 4 as libc::c_int / 2 as libc::c_int)

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -229,8 +229,7 @@ unsafe extern "C" fn decode_rand(
         r#ref: 0 as *mut Dav1dRef,
         allocator_data: 0 as *mut libc::c_void,
     };
-    let num_frames: libc::c_int =
-        xor128_rand() % (fps * 5 as libc::c_int as libc::c_double) as libc::c_int;
+    let num_frames: libc::c_int = xor128_rand() % (fps * 5 as libc::c_double) as libc::c_int;
     let mut i = 0;
     while i < num_frames {
         res = decode_frame(&mut p, c, data);
@@ -469,7 +468,7 @@ unsafe fn main_0(argc: libc::c_int, argv: *const *mut libc::c_char) -> libc::c_i
         i_fps.as_mut_ptr(),
         &mut total,
         i_timebase.as_mut_ptr(),
-    ) < 0 as libc::c_int
+    ) < 0
         || i_timebase[0] == 0
         || i_timebase[1] == 0
         || i_fps[0] == 0
@@ -486,7 +485,7 @@ unsafe fn main_0(argc: libc::c_int, argv: *const *mut libc::c_char) -> libc::c_i
     if !(fps < 1 as libc::c_double) {
         let mut i: libc::c_int = 0;
         loop {
-            if !(i < 3 as libc::c_int) {
+            if !(i < 3) {
                 current_block = 5948590327928692120;
                 break;
             }
@@ -511,13 +510,11 @@ unsafe fn main_0(argc: libc::c_int, argv: *const *mut libc::c_char) -> libc::c_i
                 let mut i_0 = 0;
                 let mut tries = 0;
                 loop {
-                    if !(i_0 - tries < 4 as libc::c_int
-                        && tries < 4 as libc::c_int / 2 as libc::c_int)
-                    {
+                    if !(i_0 - tries < 4 && tries < 4 / 2) {
                         current_block = 8693738493027456495;
                         break;
                     }
-                    let sign: libc::c_int = if xor128_rand() & 1 as libc::c_int != 0 {
+                    let sign: libc::c_int = if xor128_rand() & 1 != 0 {
                         -(1 as libc::c_int)
                     } else {
                         1 as libc::c_int
@@ -597,7 +594,7 @@ unsafe fn main_0(argc: libc::c_int, argv: *const *mut libc::c_char) -> libc::c_i
                         }
                         // simulate seeking after the end of the file
                         let mut i_1: libc::c_int = 0;
-                        while i_1 < 2 as libc::c_int {
+                        while i_1 < 2 {
                             if seek(
                                 in_0,
                                 c,


### PR DESCRIPTION
This is a repeat of #166 after #425, since #425 heavily reduced indentation, making a lot of the regexes from #166 now work.