### PR TITLE
`struct Dav1dIntraPredDSPContext`: Remove (most) `Option`s

### DIFF
--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -13,55 +13,49 @@ pub unsafe extern "C" fn get_upsample(
     return (angle < 40 && wh <= 16 >> is_sm) as libc::c_int;
 }
 
-pub type angular_ipred_fn = Option<
-    unsafe extern "C" fn(
-        *mut DynPixel,
-        ptrdiff_t,
-        *const DynPixel,
-        libc::c_int,
-        libc::c_int,
-        libc::c_int,
-        libc::c_int,
-        libc::c_int,
-        libc::c_int,
-    ) -> (),
->;
-pub type cfl_ac_fn = Option<
-    unsafe extern "C" fn(
-        *mut int16_t,
-        *const DynPixel,
-        ptrdiff_t,
-        libc::c_int,
-        libc::c_int,
-        libc::c_int,
-        libc::c_int,
-    ) -> (),
->;
-pub type cfl_pred_fn = Option<
-    unsafe extern "C" fn(
-        *mut DynPixel,
-        ptrdiff_t,
-        *const DynPixel,
-        libc::c_int,
-        libc::c_int,
-        *const int16_t,
-        libc::c_int,
-        libc::c_int,
-    ) -> (),
->;
-pub type pal_pred_fn = Option<
-    unsafe extern "C" fn(
-        *mut DynPixel,
-        ptrdiff_t,
-        *const uint16_t,
-        *const uint8_t,
-        libc::c_int,
-        libc::c_int,
-    ) -> (),
->;
+pub type angular_ipred_fn = unsafe extern "C" fn(
+    *mut DynPixel,
+    ptrdiff_t,
+    *const DynPixel,
+    libc::c_int,
+    libc::c_int,
+    libc::c_int,
+    libc::c_int,
+    libc::c_int,
+    libc::c_int,
+) -> ();
+pub type cfl_ac_fn = unsafe extern "C" fn(
+    *mut int16_t,
+    *const DynPixel,
+    ptrdiff_t,
+    libc::c_int,
+    libc::c_int,
+    libc::c_int,
+    libc::c_int,
+) -> ();
+pub type cfl_pred_fn = unsafe extern "C" fn(
+    *mut DynPixel,
+    ptrdiff_t,
+    *const DynPixel,
+    libc::c_int,
+    libc::c_int,
+    *const int16_t,
+    libc::c_int,
+    libc::c_int,
+) -> ();
+pub type pal_pred_fn = unsafe extern "C" fn(
+    *mut DynPixel,
+    ptrdiff_t,
+    *const uint16_t,
+    *const uint8_t,
+    libc::c_int,
+    libc::c_int,
+) -> ();
 #[repr(C)]
 pub struct Dav1dIntraPredDSPContext {
-    pub intra_pred: [angular_ipred_fn; 14],
+    // TODO(legare): Remove `Option` once `dav1d_submit_frame` is no longer checking
+    // this field with `is_none`.
+    pub intra_pred: [Option<angular_ipred_fn>; 14],
     pub cfl_ac: [cfl_ac_fn; 3],
     pub cfl_pred: [cfl_pred_fn; 6],
     pub pal_pred: pal_pred_fn,

--- a/src/ipred_tmpl_16.rs
+++ b/src/ipred_tmpl_16.rs
@@ -1558,16 +1558,16 @@ unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Dav1dIntraPredDSPContext) {
     (*c).intra_pred[Z3_PRED as usize] = Some(dav1d_ipred_z3_16bpc_ssse3);
     (*c).intra_pred[FILTER_PRED as usize] = Some(dav1d_ipred_filter_16bpc_ssse3);
 
-    (*c).cfl_pred[DC_PRED as usize] = Some(dav1d_ipred_cfl_16bpc_ssse3);
-    (*c).cfl_pred[DC_128_PRED as usize] = Some(dav1d_ipred_cfl_128_16bpc_ssse3);
-    (*c).cfl_pred[TOP_DC_PRED as usize] = Some(dav1d_ipred_cfl_top_16bpc_ssse3);
-    (*c).cfl_pred[LEFT_DC_PRED as usize] = Some(dav1d_ipred_cfl_left_16bpc_ssse3);
+    (*c).cfl_pred[DC_PRED as usize] = dav1d_ipred_cfl_16bpc_ssse3;
+    (*c).cfl_pred[DC_128_PRED as usize] = dav1d_ipred_cfl_128_16bpc_ssse3;
+    (*c).cfl_pred[TOP_DC_PRED as usize] = dav1d_ipred_cfl_top_16bpc_ssse3;
+    (*c).cfl_pred[LEFT_DC_PRED as usize] = dav1d_ipred_cfl_left_16bpc_ssse3;
 
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(dav1d_ipred_cfl_ac_420_16bpc_ssse3);
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(dav1d_ipred_cfl_ac_422_16bpc_ssse3);
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(dav1d_ipred_cfl_ac_444_16bpc_ssse3);
+    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = dav1d_ipred_cfl_ac_420_16bpc_ssse3;
+    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = dav1d_ipred_cfl_ac_422_16bpc_ssse3;
+    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = dav1d_ipred_cfl_ac_444_16bpc_ssse3;
 
-    (*c).pal_pred = Some(dav1d_pal_pred_16bpc_ssse3);
+    (*c).pal_pred = dav1d_pal_pred_16bpc_ssse3;
 
     #[cfg(target_arch = "x86_64")]
     {
@@ -1590,19 +1590,16 @@ unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Dav1dIntraPredDSPContext) {
         (*c).intra_pred[Z3_PRED as usize] = Some(dav1d_ipred_z3_16bpc_avx2);
         (*c).intra_pred[FILTER_PRED as usize] = Some(dav1d_ipred_filter_16bpc_avx2);
 
-        (*c).cfl_pred[DC_PRED as usize] = Some(dav1d_ipred_cfl_16bpc_avx2);
-        (*c).cfl_pred[DC_128_PRED as usize] = Some(dav1d_ipred_cfl_128_16bpc_avx2);
-        (*c).cfl_pred[TOP_DC_PRED as usize] = Some(dav1d_ipred_cfl_top_16bpc_avx2);
-        (*c).cfl_pred[LEFT_DC_PRED as usize] = Some(dav1d_ipred_cfl_left_16bpc_avx2);
+        (*c).cfl_pred[DC_PRED as usize] = dav1d_ipred_cfl_16bpc_avx2;
+        (*c).cfl_pred[DC_128_PRED as usize] = dav1d_ipred_cfl_128_16bpc_avx2;
+        (*c).cfl_pred[TOP_DC_PRED as usize] = dav1d_ipred_cfl_top_16bpc_avx2;
+        (*c).cfl_pred[LEFT_DC_PRED as usize] = dav1d_ipred_cfl_left_16bpc_avx2;
 
-        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
-            Some(dav1d_ipred_cfl_ac_420_16bpc_avx2);
-        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
-            Some(dav1d_ipred_cfl_ac_422_16bpc_avx2);
-        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
-            Some(dav1d_ipred_cfl_ac_444_16bpc_avx2);
+        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = dav1d_ipred_cfl_ac_420_16bpc_avx2;
+        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = dav1d_ipred_cfl_ac_422_16bpc_avx2;
+        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = dav1d_ipred_cfl_ac_444_16bpc_avx2;
 
-        (*c).pal_pred = Some(dav1d_pal_pred_16bpc_avx2);
+        (*c).pal_pred = dav1d_pal_pred_16bpc_avx2;
 
         if flags & DAV1D_X86_CPU_FLAG_AVX512ICL == 0 {
             return;
@@ -1614,7 +1611,7 @@ unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Dav1dIntraPredDSPContext) {
         (*c).intra_pred[SMOOTH_V_PRED as usize] = Some(dav1d_ipred_smooth_v_16bpc_avx512icl);
         (*c).intra_pred[FILTER_PRED as usize] = Some(dav1d_ipred_filter_16bpc_avx512icl);
 
-        (*c).pal_pred = Some(dav1d_pal_pred_16bpc_avx512icl);
+        (*c).pal_pred = dav1d_pal_pred_16bpc_avx512icl;
     }
 }
 
@@ -1651,16 +1648,16 @@ unsafe extern "C" fn intra_pred_dsp_init_arm(c: *mut Dav1dIntraPredDSPContext) {
     }
     (*c).intra_pred[FILTER_PRED as usize] = Some(dav1d_ipred_filter_16bpc_neon);
 
-    (*c).cfl_pred[DC_PRED as usize] = Some(dav1d_ipred_cfl_16bpc_neon);
-    (*c).cfl_pred[DC_128_PRED as usize] = Some(dav1d_ipred_cfl_128_16bpc_neon);
-    (*c).cfl_pred[TOP_DC_PRED as usize] = Some(dav1d_ipred_cfl_top_16bpc_neon);
-    (*c).cfl_pred[LEFT_DC_PRED as usize] = Some(dav1d_ipred_cfl_left_16bpc_neon);
+    (*c).cfl_pred[DC_PRED as usize] = dav1d_ipred_cfl_16bpc_neon;
+    (*c).cfl_pred[DC_128_PRED as usize] = dav1d_ipred_cfl_128_16bpc_neon;
+    (*c).cfl_pred[TOP_DC_PRED as usize] = dav1d_ipred_cfl_top_16bpc_neon;
+    (*c).cfl_pred[LEFT_DC_PRED as usize] = dav1d_ipred_cfl_left_16bpc_neon;
 
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(dav1d_ipred_cfl_ac_420_16bpc_neon);
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(dav1d_ipred_cfl_ac_422_16bpc_neon);
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(dav1d_ipred_cfl_ac_444_16bpc_neon);
+    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = dav1d_ipred_cfl_ac_420_16bpc_neon;
+    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = dav1d_ipred_cfl_ac_422_16bpc_neon;
+    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = dav1d_ipred_cfl_ac_444_16bpc_neon;
 
-    (*c).pal_pred = Some(dav1d_pal_pred_16bpc_neon);
+    (*c).pal_pred = dav1d_pal_pred_16bpc_neon;
 }
 
 #[cfg(all(feature = "asm", target_arch = "aarch64"))]
@@ -2129,16 +2126,16 @@ pub unsafe extern "C" fn dav1d_intra_pred_dsp_init_16bpc(c: *mut Dav1dIntraPredD
     (*c).intra_pred[Z3_PRED as usize] = Some(ipred_z3_c_erased);
     (*c).intra_pred[FILTER_PRED as usize] = Some(ipred_filter_c_erased);
 
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(cfl_ac_420_c_erased);
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(cfl_ac_422_c_erased);
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(cfl_ac_444_c_erased);
-    (*c).cfl_pred[DC_PRED as usize] = Some(ipred_cfl_c_erased);
+    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = cfl_ac_420_c_erased;
+    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = cfl_ac_422_c_erased;
+    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = cfl_ac_444_c_erased;
+    (*c).cfl_pred[DC_PRED as usize] = ipred_cfl_c_erased;
 
-    (*c).cfl_pred[DC_128_PRED as usize] = Some(ipred_cfl_128_c_erased);
-    (*c).cfl_pred[TOP_DC_PRED as usize] = Some(ipred_cfl_top_c_erased);
-    (*c).cfl_pred[LEFT_DC_PRED as usize] = Some(ipred_cfl_left_c_erased);
+    (*c).cfl_pred[DC_128_PRED as usize] = ipred_cfl_128_c_erased;
+    (*c).cfl_pred[TOP_DC_PRED as usize] = ipred_cfl_top_c_erased;
+    (*c).cfl_pred[LEFT_DC_PRED as usize] = ipred_cfl_left_c_erased;
 
-    (*c).pal_pred = Some(pal_pred_c_erased);
+    (*c).pal_pred = pal_pred_c_erased;
 
     #[cfg(feature = "asm")]
     cfg_if! {

--- a/src/ipred_tmpl_8.rs
+++ b/src/ipred_tmpl_8.rs
@@ -1499,16 +1499,16 @@ unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Dav1dIntraPredDSPContext) {
     (*c).intra_pred[Z3_PRED as usize] = Some(dav1d_ipred_z3_8bpc_ssse3);
     (*c).intra_pred[FILTER_PRED as usize] = Some(dav1d_ipred_filter_8bpc_ssse3);
 
-    (*c).cfl_pred[DC_PRED as usize] = Some(dav1d_ipred_cfl_8bpc_ssse3);
-    (*c).cfl_pred[DC_128_PRED as usize] = Some(dav1d_ipred_cfl_128_8bpc_ssse3);
-    (*c).cfl_pred[TOP_DC_PRED as usize] = Some(dav1d_ipred_cfl_top_8bpc_ssse3);
-    (*c).cfl_pred[LEFT_DC_PRED as usize] = Some(dav1d_ipred_cfl_left_8bpc_ssse3);
+    (*c).cfl_pred[DC_PRED as usize] = dav1d_ipred_cfl_8bpc_ssse3;
+    (*c).cfl_pred[DC_128_PRED as usize] = dav1d_ipred_cfl_128_8bpc_ssse3;
+    (*c).cfl_pred[TOP_DC_PRED as usize] = dav1d_ipred_cfl_top_8bpc_ssse3;
+    (*c).cfl_pred[LEFT_DC_PRED as usize] = dav1d_ipred_cfl_left_8bpc_ssse3;
 
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(dav1d_ipred_cfl_ac_420_8bpc_ssse3);
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(dav1d_ipred_cfl_ac_422_8bpc_ssse3);
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(dav1d_ipred_cfl_ac_444_8bpc_ssse3);
+    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = dav1d_ipred_cfl_ac_420_8bpc_ssse3;
+    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = dav1d_ipred_cfl_ac_422_8bpc_ssse3;
+    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = dav1d_ipred_cfl_ac_444_8bpc_ssse3;
 
-    (*c).pal_pred = Some(dav1d_pal_pred_8bpc_ssse3);
+    (*c).pal_pred = dav1d_pal_pred_8bpc_ssse3;
 
     #[cfg(target_arch = "x86_64")]
     {
@@ -1531,19 +1531,16 @@ unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Dav1dIntraPredDSPContext) {
         (*c).intra_pred[Z3_PRED as usize] = Some(dav1d_ipred_z3_8bpc_avx2);
         (*c).intra_pred[FILTER_PRED as usize] = Some(dav1d_ipred_filter_8bpc_avx2);
 
-        (*c).cfl_pred[DC_PRED as usize] = Some(dav1d_ipred_cfl_8bpc_avx2);
-        (*c).cfl_pred[DC_128_PRED as usize] = Some(dav1d_ipred_cfl_128_8bpc_avx2);
-        (*c).cfl_pred[TOP_DC_PRED as usize] = Some(dav1d_ipred_cfl_top_8bpc_avx2);
-        (*c).cfl_pred[LEFT_DC_PRED as usize] = Some(dav1d_ipred_cfl_left_8bpc_avx2);
+        (*c).cfl_pred[DC_PRED as usize] = dav1d_ipred_cfl_8bpc_avx2;
+        (*c).cfl_pred[DC_128_PRED as usize] = dav1d_ipred_cfl_128_8bpc_avx2;
+        (*c).cfl_pred[TOP_DC_PRED as usize] = dav1d_ipred_cfl_top_8bpc_avx2;
+        (*c).cfl_pred[LEFT_DC_PRED as usize] = dav1d_ipred_cfl_left_8bpc_avx2;
 
-        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
-            Some(dav1d_ipred_cfl_ac_420_8bpc_avx2);
-        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
-            Some(dav1d_ipred_cfl_ac_422_8bpc_avx2);
-        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
-            Some(dav1d_ipred_cfl_ac_444_8bpc_avx2);
+        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = dav1d_ipred_cfl_ac_420_8bpc_avx2;
+        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = dav1d_ipred_cfl_ac_422_8bpc_avx2;
+        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = dav1d_ipred_cfl_ac_444_8bpc_avx2;
 
-        (*c).pal_pred = Some(dav1d_pal_pred_8bpc_avx2);
+        (*c).pal_pred = dav1d_pal_pred_8bpc_avx2;
 
         if flags & DAV1D_X86_CPU_FLAG_AVX512ICL == 0 {
             return;
@@ -1561,7 +1558,7 @@ unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Dav1dIntraPredDSPContext) {
         (*c).intra_pred[SMOOTH_V_PRED as usize] = Some(dav1d_ipred_smooth_v_8bpc_avx512icl);
         (*c).intra_pred[FILTER_PRED as usize] = Some(dav1d_ipred_filter_8bpc_avx512icl);
 
-        (*c).pal_pred = Some(dav1d_pal_pred_8bpc_avx512icl);
+        (*c).pal_pred = dav1d_pal_pred_8bpc_avx512icl;
     }
 }
 
@@ -1599,16 +1596,16 @@ unsafe extern "C" fn intra_pred_dsp_init_arm(c: *mut Dav1dIntraPredDSPContext) {
     }
     (*c).intra_pred[FILTER_PRED as usize] = Some(dav1d_ipred_filter_8bpc_neon);
 
-    (*c).cfl_pred[DC_PRED as usize] = Some(dav1d_ipred_cfl_8bpc_neon);
-    (*c).cfl_pred[DC_128_PRED as usize] = Some(dav1d_ipred_cfl_128_8bpc_neon);
-    (*c).cfl_pred[TOP_DC_PRED as usize] = Some(dav1d_ipred_cfl_top_8bpc_neon);
-    (*c).cfl_pred[LEFT_DC_PRED as usize] = Some(dav1d_ipred_cfl_left_8bpc_neon);
+    (*c).cfl_pred[DC_PRED as usize] = dav1d_ipred_cfl_8bpc_neon;
+    (*c).cfl_pred[DC_128_PRED as usize] = dav1d_ipred_cfl_128_8bpc_neon;
+    (*c).cfl_pred[TOP_DC_PRED as usize] = dav1d_ipred_cfl_top_8bpc_neon;
+    (*c).cfl_pred[LEFT_DC_PRED as usize] = dav1d_ipred_cfl_left_8bpc_neon;
 
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(dav1d_ipred_cfl_ac_420_8bpc_neon);
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(dav1d_ipred_cfl_ac_422_8bpc_neon);
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(dav1d_ipred_cfl_ac_444_8bpc_neon);
+    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = dav1d_ipred_cfl_ac_420_8bpc_neon;
+    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = dav1d_ipred_cfl_ac_422_8bpc_neon;
+    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = dav1d_ipred_cfl_ac_444_8bpc_neon;
 
-    (*c).pal_pred = Some(dav1d_pal_pred_8bpc_neon);
+    (*c).pal_pred = dav1d_pal_pred_8bpc_neon;
 }
 
 #[cfg(all(feature = "asm", target_arch = "aarch64"))]
@@ -2064,15 +2061,15 @@ pub unsafe extern "C" fn dav1d_intra_pred_dsp_init_8bpc(c: *mut Dav1dIntraPredDS
     (*c).intra_pred[Z3_PRED as usize] = Some(ipred_z3_c_erased);
     (*c).intra_pred[FILTER_PRED as usize] = Some(ipred_filter_c_erased);
 
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(cfl_ac_420_c_erased);
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(cfl_ac_422_c_erased);
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(cfl_ac_444_c_erased);
-    (*c).cfl_pred[DC_PRED as usize] = Some(ipred_cfl_c_erased);
-    (*c).cfl_pred[DC_128_PRED as usize] = Some(ipred_cfl_128_c_erased);
-    (*c).cfl_pred[TOP_DC_PRED as usize] = Some(ipred_cfl_top_c_erased);
-    (*c).cfl_pred[LEFT_DC_PRED as usize] = Some(ipred_cfl_left_c_erased);
+    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = cfl_ac_420_c_erased;
+    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = cfl_ac_422_c_erased;
+    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = cfl_ac_444_c_erased;
+    (*c).cfl_pred[DC_PRED as usize] = ipred_cfl_c_erased;
+    (*c).cfl_pred[DC_128_PRED as usize] = ipred_cfl_128_c_erased;
+    (*c).cfl_pred[TOP_DC_PRED as usize] = ipred_cfl_top_c_erased;
+    (*c).cfl_pred[LEFT_DC_PRED as usize] = ipred_cfl_left_c_erased;
 
-    (*c).pal_pred = Some(pal_pred_c_erased);
+    (*c).pal_pred = pal_pred_c_erased;
 
     #[cfg(feature = "asm")]
     cfg_if! {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -2651,7 +2651,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                 } else {
                     ((*t).scratch.c2rust_unnamed_0.pal[0]).as_mut_ptr()
                 };
-                ((*(*f).dsp).ipred.pal_pred).expect("non-null function pointer")(
+                ((*(*f).dsp).ipred.pal_pred)(
                     dst.cast(),
                     (*f).cur.stride[0],
                     pal,
@@ -2913,10 +2913,9 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                         & !((*t_dim).w as libc::c_int - 1);
                     let furthest_b = (ch4 << ss_ver) + (*t_dim).h as libc::c_int - 1
                         & !((*t_dim).h as libc::c_int - 1);
-                    ((*dsp).ipred.cfl_ac[((*f).cur.p.layout as libc::c_uint)
+                    (*dsp).ipred.cfl_ac[((*f).cur.p.layout as libc::c_uint)
                         .wrapping_sub(1 as libc::c_int as libc::c_uint)
-                        as usize])
-                        .expect("non-null function pointer")(
+                        as usize](
                         ac.as_mut_ptr(),
                         y_src.cast(),
                         (*f).cur.stride[0],
@@ -2959,8 +2958,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                 edge,
                                 (*f).bitdepth_max,
                             );
-                            ((*dsp).ipred.cfl_pred[m_0 as usize])
-                                .expect("non-null function pointer")(
+                            (*dsp).ipred.cfl_pred[m_0 as usize](
                                 uv_dst[pl as usize].cast(),
                                 stride,
                                 edge.cast(),
@@ -3020,7 +3018,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                             .offset((bw4 * bh4 * 16) as isize)
                             as *mut uint8_t;
                     }
-                    ((*(*f).dsp).ipred.pal_pred).expect("non-null function pointer")(
+                    ((*(*f).dsp).ipred.pal_pred)(
                         ((*f).cur.data[1] as *mut pixel)
                             .offset(uv_dstoff as isize)
                             .cast(),
@@ -3030,7 +3028,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                         cbw4 * 4,
                         cbh4 * 4,
                     );
-                    ((*(*f).dsp).ipred.pal_pred).expect("non-null function pointer")(
+                    ((*(*f).dsp).ipred.pal_pred)(
                         ((*f).cur.data[2] as *mut pixel)
                             .offset(uv_dstoff as isize)
                             .cast(),

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -2633,7 +2633,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                 } else {
                     ((*t).scratch.c2rust_unnamed_0.pal[0]).as_mut_ptr()
                 };
-                ((*(*f).dsp).ipred.pal_pred).expect("non-null function pointer")(
+                ((*(*f).dsp).ipred.pal_pred)(
                     dst.cast(),
                     (*f).cur.stride[0],
                     pal,
@@ -2890,10 +2890,9 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                         & !((*t_dim).w as libc::c_int - 1);
                     let furthest_b = (ch4 << ss_ver) + (*t_dim).h as libc::c_int - 1
                         & !((*t_dim).h as libc::c_int - 1);
-                    ((*dsp).ipred.cfl_ac[((*f).cur.p.layout as libc::c_uint)
+                    (*dsp).ipred.cfl_ac[((*f).cur.p.layout as libc::c_uint)
                         .wrapping_sub(1 as libc::c_int as libc::c_uint)
-                        as usize])
-                        .expect("non-null function pointer")(
+                        as usize](
                         ac.as_mut_ptr(),
                         y_src.cast(),
                         (*f).cur.stride[0],
@@ -2935,8 +2934,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                 0 as libc::c_int,
                                 edge,
                             );
-                            ((*dsp).ipred.cfl_pred[m_0 as usize])
-                                .expect("non-null function pointer")(
+                            (*dsp).ipred.cfl_pred[m_0 as usize](
                                 uv_dst[pl as usize].cast(),
                                 stride,
                                 edge.cast(),
@@ -2996,7 +2994,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                             .offset((bw4 * bh4 * 16) as isize)
                             as *mut uint8_t;
                     }
-                    ((*(*f).dsp).ipred.pal_pred).expect("non-null function pointer")(
+                    ((*(*f).dsp).ipred.pal_pred)(
                         ((*f).cur.data[1] as *mut pixel)
                             .offset(uv_dstoff as isize)
                             .cast(),
@@ -3006,7 +3004,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                         cbw4 * 4,
                         cbh4 * 4,
                     );
-                    ((*(*f).dsp).ipred.pal_pred).expect("non-null function pointer")(
+                    ((*(*f).dsp).ipred.pal_pred)(
                         ((*f).cur.data[2] as *mut pixel)
                             .offset(uv_dstoff as isize)
                             .cast(),


### PR DESCRIPTION
I wasn't able to remove one of the `Option`s because there's actually a bit of code that checks if that field is `None` in `dav1d_submit_frame`, and it wasn't clear to me if there was another flag that we can use as an appropriate sentinel. 