### PR TITLE
`const {u,i}N::{MIN,MAX}`: Deduplicate

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -553,7 +553,7 @@ pub unsafe extern "C" fn fill(
     while y < h {
         let mut x = 0;
         while x < w {
-            *tmp.offset(x as isize) = (-(32767 as libc::c_int) - 1) as int16_t;
+            *tmp.offset(x as isize) = i16::MIN;
             x += 1;
         }
         tmp = tmp.offset(stride as isize);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5827,7 +5827,11 @@ pub unsafe extern "C" fn dav1d_decode_frame_exit(f: *mut Dav1dFrameContext, retv
         if !f.out_cdf.progress.is_null() {
             ::core::intrinsics::atomic_store_seqcst(
                 f.out_cdf.progress,
-                if retval == 0 { 1 } else { 2147483647 - 1 },
+                if retval == 0 {
+                    1
+                } else {
+                    i32::MAX as libc::c_uint - 1
+                },
             );
         }
         dav1d_cdf_thread_unref(&mut f.out_cdf);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5922,7 +5922,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
             ::core::intrinsics::atomic_cxchg_seqcst_seqcst(
                 &mut c.task_thread.reset_task_cur,
                 first,
-                2147483647 * 2 + 1,
+                u32::MAX,
             );
             if c.task_thread.cur != 0 && c.task_thread.cur < c.n_fc {
                 c.task_thread.cur -= 1;
@@ -5939,7 +5939,7 @@ pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int
                 &mut *(out_delayed.progress).offset(1) as *mut atomic_uint,
             );
             if (out_delayed.visible != 0 || c.output_invisible_frames != 0)
-                && progress != 2147483647 * 2 + 1 - 1
+                && progress != u32::MAX - 1
             {
                 dav1d_thread_picture_ref(&mut c.out, out_delayed);
                 c.event_flags |= dav1d_picture_get_event_flags(out_delayed);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4831,7 +4831,7 @@ pub unsafe extern "C" fn dav1d_decode_tile_sbrow(t: *mut Dav1dTaskContext) -> li
         while n < 7 {
             let mut m = 0;
             while m < 2 {
-                (*lowest_px.offset(n as isize))[m as usize] = -(2147483647 as libc::c_int) - 1;
+                (*lowest_px.offset(n as isize))[m as usize] = i32::MIN;
                 m += 1;
             }
             n += 1;

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -66,8 +66,8 @@ pub unsafe extern "C" fn inv_txfm_add_rust<BD: BitDepth>(
     let row_clip_min;
     let col_clip_min;
     if BD::BITDEPTH == 8 {
-        row_clip_min = std::i16::MIN as i32;
-        col_clip_min = std::i16::MIN as i32;
+        row_clip_min = i16::MIN as i32;
+        col_clip_min = i16::MIN as i32;
     } else {
         row_clip_min = ((!bitdepth_max) << 7) as libc::c_int;
         col_clip_min = ((!bitdepth_max) << 5) as libc::c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1071,10 +1071,7 @@ pub unsafe extern "C" fn dav1d_open(
                                     current_block = 16409883578687858768;
                                 } else {
                                     (*c).task_thread.cur = (*c).n_fc;
-                                    *&mut (*c).task_thread.reset_task_cur =
-                                        (2147483647 as libc::c_int as libc::c_uint)
-                                            .wrapping_mul(2 as libc::c_uint)
-                                            .wrapping_add(1 as libc::c_uint);
+                                    *&mut (*c).task_thread.reset_task_cur = u32::MAX;
                                     *&mut (*c).task_thread.cond_signaled = 0 as libc::c_int;
                                     (*c).task_thread.inited = 1 as libc::c_int;
                                     current_block = 1868291631715963762;
@@ -1496,9 +1493,7 @@ unsafe extern "C" fn drain_picture(c: *mut Dav1dContext, out: *mut Dav1dPicture)
             let fresh0 = ::core::intrinsics::atomic_cxchg_seqcst_seqcst(
                 &mut (*c).task_thread.reset_task_cur,
                 *&mut first,
-                (2147483647 as libc::c_int as libc::c_uint)
-                    .wrapping_mul(2 as libc::c_uint)
-                    .wrapping_add(1 as libc::c_uint),
+                u32::MAX,
             );
             *&mut first = fresh0.0;
             fresh0.1;
@@ -1527,11 +1522,7 @@ unsafe extern "C" fn drain_picture(c: *mut Dav1dContext, out: *mut Dav1dPicture)
                 &mut *((*out_delayed).progress).offset(1) as *mut atomic_uint,
             );
             if ((*out_delayed).visible != 0 || (*c).output_invisible_frames != 0)
-                && progress
-                    != (2147483647 as libc::c_int as libc::c_uint)
-                        .wrapping_mul(2 as libc::c_uint)
-                        .wrapping_add(1 as libc::c_uint)
-                        .wrapping_sub(1 as libc::c_int as libc::c_uint)
+                && progress != u32::MAX - 1
             {
                 dav1d_thread_picture_ref(&mut (*c).out, out_delayed);
                 (*c).event_flags = ::core::mem::transmute::<libc::c_uint, Dav1dEventFlags>(
@@ -1820,12 +1811,7 @@ pub unsafe extern "C" fn dav1d_flush(c: *mut Dav1dContext) {
         }
         *&mut (*c).task_thread.first = 0 as libc::c_int as libc::c_uint;
         (*c).task_thread.cur = (*c).n_fc;
-        ::core::intrinsics::atomic_store_seqcst(
-            &mut (*c).task_thread.reset_task_cur,
-            (2147483647 as libc::c_int as libc::c_uint)
-                .wrapping_mul(2 as libc::c_uint)
-                .wrapping_add(1 as libc::c_uint),
-        );
+        ::core::intrinsics::atomic_store_seqcst(&mut (*c).task_thread.reset_task_cur, u32::MAX);
         ::core::intrinsics::atomic_store_seqcst(
             &mut (*c).task_thread.cond_signaled,
             0 as libc::c_int,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1233,7 +1233,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
             if latest_frame_offset != -(1 as libc::c_int) {
                 used_frame[(*hdr).refidx[6] as usize] = 1 as libc::c_int;
             }
-            let mut earliest_frame_offset = 2147483647;
+            let mut earliest_frame_offset = i32::MAX;
             let mut i_4 = 0;
             while i_4 < 8 {
                 let hint_0: libc::c_int = shifted_frame_offset[i_4 as usize];
@@ -1246,10 +1246,10 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 }
                 i_4 += 1;
             }
-            if earliest_frame_offset != 2147483647 as libc::c_int {
+            if earliest_frame_offset != i32::MAX {
                 used_frame[(*hdr).refidx[4] as usize] = 1 as libc::c_int;
             }
-            earliest_frame_offset = 2147483647 as libc::c_int;
+            earliest_frame_offset = i32::MAX;
             let mut i_5 = 0;
             while i_5 < 8 {
                 let hint_1: libc::c_int = shifted_frame_offset[i_5 as usize];
@@ -1262,7 +1262,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 }
                 i_5 += 1;
             }
-            if earliest_frame_offset != 2147483647 as libc::c_int {
+            if earliest_frame_offset != i32::MAX {
                 used_frame[(*hdr).refidx[5] as usize] = 1 as libc::c_int;
             }
             let mut i_6 = 1;
@@ -1287,7 +1287,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Dav1dContext, gb: *mut GetBits) -> 
                 }
                 i_6 += 1;
             }
-            earliest_frame_offset = 2147483647 as libc::c_int;
+            earliest_frame_offset = i32::MAX;
             let mut ref_0: libc::c_int = -(1 as libc::c_int);
             let mut i_7 = 0;
             while i_7 < 8 {
@@ -2577,7 +2577,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                 }
                 if (*c).n_tile_data_alloc < (*c).n_tile_data + 1 {
                     if (*c).n_tile_data + 1
-                        > 2147483647
+                        > i32::MAX
                             / ::core::mem::size_of::<Dav1dTileGroup>() as libc::c_ulong
                                 as libc::c_int
                     {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2747,9 +2747,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                     let fresh2 = ::core::intrinsics::atomic_cxchg_seqcst_seqcst(
                         &mut (*c).task_thread.reset_task_cur,
                         *&mut first,
-                        (2147483647 as libc::c_int as libc::c_uint)
-                            .wrapping_mul(2 as libc::c_uint)
-                            .wrapping_add(1 as libc::c_uint),
+                        u32::MAX,
                     );
                     *&mut first = fresh2.0;
                     fresh2.1;
@@ -2768,11 +2766,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                         &mut *((*out_delayed).progress).offset(1) as *mut atomic_uint,
                     );
                     if ((*out_delayed).visible != 0 || (*c).output_invisible_frames != 0)
-                        && progress
-                            != (2147483647 as libc::c_int as libc::c_uint)
-                                .wrapping_mul(2 as libc::c_uint)
-                                .wrapping_add(1 as libc::c_uint)
-                                .wrapping_sub(1 as libc::c_int as libc::c_uint)
+                        && progress != u32::MAX - 1
                     {
                         dav1d_thread_picture_ref(&mut (*c).out, out_delayed);
                         (*c).event_flags = ::core::mem::transmute::<libc::c_uint, Dav1dEventFlags>(

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1245,7 +1245,7 @@ pub unsafe extern "C" fn load_tmvs_c(
     let mut n = 0;
     while n < (*rf).n_mfmvs {
         let ref2cur = (*rf).mfmv_ref2cur[n as usize];
-        if !(ref2cur == -(2147483647 as libc::c_int) - 1) {
+        if !(ref2cur == i32::MIN) {
             let r#ref = (*rf).mfmv_ref[n as usize] as libc::c_int;
             let ref_sign = r#ref - 4;
             let mut r: *const refmvs_temporal_block = &mut *(*((*rf).rp_ref).offset(r#ref as isize))
@@ -1539,7 +1539,7 @@ pub unsafe fn dav1d_refmvs_init_frame(
                 (*frm_hdr).frame_offset,
             );
             if diff1.abs() > 31 {
-                (*rf).mfmv_ref2cur[n as usize] = -(2147483647 as libc::c_int) - 1;
+                (*rf).mfmv_ref2cur[n as usize] = i32::MIN;
             } else {
                 (*rf).mfmv_ref2cur[n as usize] = if ((*rf).mfmv_ref[n as usize] as libc::c_int) < 4
                 {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1128,7 +1128,7 @@ unsafe extern "C" fn check_tile(
     if p1 < (*t).sby {
         return 1 as libc::c_int;
     }
-    let mut error = (p1 == 2147483647 - 1) as libc::c_int;
+    let mut error = (p1 == i32::MAX - 1) as libc::c_int;
     error |= ::core::intrinsics::atomic_or_seqcst(&mut (*f).task_thread.error, error);
     if error == 0 && frame_mt != 0 && tp == 0 {
         let p2 = ::core::intrinsics::atomic_load_seqcst(
@@ -1137,7 +1137,7 @@ unsafe extern "C" fn check_tile(
         if p2 <= (*t).sby {
             return 1 as libc::c_int;
         }
-        error = (p2 == 2147483647 - 1) as libc::c_int;
+        error = (p2 == i32::MAX - 1) as libc::c_int;
         error |= ::core::intrinsics::atomic_or_seqcst(&mut (*f).task_thread.error, error);
     }
     if error == 0
@@ -1506,7 +1506,7 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut libc::c_void) -> *mut libc
                                     if p1 != 0 {
                                         ::core::intrinsics::atomic_or_seqcst(
                                             &mut (*f).task_thread.error,
-                                            (p1 == 2147483647 - 1) as libc::c_int,
+                                            (p1 == i32::MAX - 1) as libc::c_int,
                                         );
                                         current_block = 7012560550443761033;
                                         break;
@@ -1587,7 +1587,7 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut libc::c_void) -> *mut libc
                                                 } else {
                                                     ::core::intrinsics::atomic_or_seqcst(
                                                         &mut (*f).task_thread.error,
-                                                        (p1_0 == 2147483647 - 1) as libc::c_int,
+                                                        (p1_0 == i32::MAX - 1) as libc::c_int,
                                                     );
                                                     current_block = 14832935472441733737;
                                                 }
@@ -1620,7 +1620,7 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut libc::c_void) -> *mut libc
                                                         }
                                                         ::core::intrinsics::atomic_or_seqcst(
                                                             &mut (*f).task_thread.error,
-                                                            (p2 == 2147483647 - 1) as libc::c_int,
+                                                            (p2 == i32::MAX - 1) as libc::c_int,
                                                         );
                                                         tc_0 += 1;
                                                     }
@@ -1688,7 +1688,7 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut libc::c_void) -> *mut libc
                                             if p1_2 >= (*t).deblock_progress {
                                                 ::core::intrinsics::atomic_or_seqcst(
                                                     &mut (*f).task_thread.error,
-                                                    (p1_2 == 2147483647 - 1) as libc::c_int,
+                                                    (p1_2 == i32::MAX - 1) as libc::c_int,
                                                 );
                                                 current_block = 7012560550443761033;
                                                 continue 's_107;
@@ -1763,7 +1763,7 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut libc::c_void) -> *mut libc
                                         1 as libc::c_int as libc::c_uint
                                     })
                                         as libc::c_int;
-                                    if res != 0 || p1_3 == 2147483647 - 1 {
+                                    if res != 0 || p1_3 == i32::MAX - 1 {
                                         pthread_mutex_lock(&mut (*ttd).lock);
                                         abort_frame(
                                             f,
@@ -1798,7 +1798,7 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut libc::c_void) -> *mut libc
                                         ::core::intrinsics::atomic_store_seqcst(
                                             (*f).out_cdf.progress,
                                             (if res_0 < 0 {
-                                                2147483647 - 1
+                                                i32::MAX - 1
                                             } else {
                                                 1 as libc::c_int
                                             })
@@ -1908,11 +1908,8 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut libc::c_void) -> *mut libc
                                     if error_0 == 0 {
                                         error_0 = dav1d_decode_tile_sbrow(tc);
                                     }
-                                    let progress = if error_0 != 0 {
-                                        2147483647 - 1
-                                    } else {
-                                        1 + sby
-                                    };
+                                    let progress =
+                                        if error_0 != 0 { i32::MAX - 1 } else { 1 + sby };
                                     ::core::intrinsics::atomic_or_seqcst(
                                         &mut (*f).task_thread.error,
                                         error_0,
@@ -1980,7 +1977,7 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut libc::c_void) -> *mut libc
                                                 ::core::intrinsics::atomic_store_seqcst(
                                                     (*f).out_cdf.progress,
                                                     (if error_0 != 0 {
-                                                        2147483647 - 1
+                                                        i32::MAX - 1
                                                     } else {
                                                         1 as libc::c_int
                                                     })
@@ -2107,11 +2104,7 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut libc::c_void) -> *mut libc
                                     );
                                     ::core::intrinsics::atomic_store_seqcst(
                                         &mut (*f).frame_thread.deblock_progress,
-                                        if error_0 != 0 {
-                                            2147483647 - 1
-                                        } else {
-                                            sby + 1
-                                        },
+                                        if error_0 != 0 { i32::MAX - 1 } else { sby + 1 },
                                     );
                                     reset_task_cur_async(ttd, (*t).frame_idx, (*c).n_fc);
                                     if ::core::intrinsics::atomic_or_seqcst(
@@ -2238,11 +2231,7 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut libc::c_void) -> *mut libc
                             }
                             ::core::intrinsics::atomic_store_seqcst(
                                 &mut (*f).frame_thread.entropy_progress,
-                                if error_0 != 0 {
-                                    2147483647 - 1
-                                } else {
-                                    sby + 1
-                                },
+                                if error_0 != 0 { i32::MAX - 1 } else { sby + 1 },
                             );
                             if sby + 1 == sbh {
                                 ::core::intrinsics::atomic_store_seqcst(

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1161,18 +1161,18 @@ unsafe extern "C" fn check_tile(
                 lowest = p_b;
                 current_block_14 = 2370887241019905314;
             } else {
-                let y = if (*lowest_px.offset(n as isize))[0] == -(2147483647 as libc::c_int) - 1 {
-                    -(2147483647 as libc::c_int) - 1
+                let y = if (*lowest_px.offset(n as isize))[0] == i32::MIN {
+                    i32::MIN
                 } else {
                     (*lowest_px.offset(n as isize))[0] + 8
                 };
-                let uv = if (*lowest_px.offset(n as isize))[1] == -(2147483647 as libc::c_int) - 1 {
-                    -(2147483647 as libc::c_int) - 1
+                let uv = if (*lowest_px.offset(n as isize))[1] == i32::MIN {
+                    i32::MIN
                 } else {
                     (*lowest_px.offset(n as isize))[1] * ((1 as libc::c_int) << ss_ver) + 8
                 };
                 let max = imax(y, uv);
-                if max == -(2147483647 as libc::c_int) - 1 {
+                if max == i32::MIN {
                     current_block_14 = 7651349459974463963;
                 } else {
                     lowest =


### PR DESCRIPTION
Some of these are themselves part of other constants like `{FRAME,TILE}_ERROR`, but it's easier to fix all of these first.