### PR TITLE
`fn dav1d_decode_frame_init_cdf`: Cleanup and make mostly safe

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5676,10 +5676,10 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
                 for k in 0..(*f.frame_hdr).tiling.n_bytes {
                     let fresh37 = data;
                     data = data.offset(1);
-                    tile_sz |= ((*fresh37 as libc::c_uint) << k.wrapping_mul(8)) as size_t;
+                    tile_sz |= ((*fresh37 as libc::c_uint) << (k * 8)) as size_t;
                 }
-                tile_sz = tile_sz.wrapping_add(1);
-                size = size.wrapping_sub((*f.frame_hdr).tiling.n_bytes as usize);
+                tile_sz += 1;
+                size -= (*f.frame_hdr).tiling.n_bytes as usize;
                 if tile_sz > size {
                     return -22;
                 }
@@ -5709,7 +5709,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
                 f.task_thread.update_set = true;
             }
             data = data.offset(tile_sz as isize);
-            size = size.wrapping_sub(tile_sz);
+            size -= tile_sz;
         }
     }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5660,13 +5660,13 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
     let mut tile_row = 0;
     let mut tile_col = 0;
     f.task_thread.update_set = false;
-    for i in 0..f.n_tile_data {
-        let mut data: *const uint8_t = (*(f.tile).offset(i as isize)).data.data;
-        let mut size: size_t = (*(f.tile).offset(i as isize)).data.sz;
+    for tile in slice::from_raw_parts(f.tile, f.n_tile_data.try_into().unwrap()) {
+        let mut data: *const uint8_t = tile.data.data;
+        let mut size: size_t = tile.data.sz;
 
-        for j in (*(f.tile).offset(i as isize)).start..=(*(f.tile).offset(i as isize)).end {
+        for j in tile.start..=tile.end {
             let mut tile_sz: size_t;
-            if j == (*(f.tile).offset(i as isize)).end {
+            if j == tile.end {
                 tile_sz = size;
             } else {
                 if (*f.frame_hdr).tiling.n_bytes as size_t > size {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5674,9 +5674,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
                 }
                 tile_sz = 0;
                 for k in 0..(*f.frame_hdr).tiling.n_bytes {
-                    let fresh37 = data;
+                    tile_sz |= (*data as usize) << (k * 8);
                     data = data.offset(1);
-                    tile_sz |= ((*fresh37 as libc::c_uint) << (k * 8)) as size_t;
                 }
                 tile_sz += 1;
                 size -= (*f.frame_hdr).tiling.n_bytes as usize;
@@ -5684,8 +5683,6 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
                     return -22;
                 }
             }
-            let fresh38 = tile_col;
-            tile_col = tile_col + 1;
 
             setup_tile(
                 &mut *(f.ts).offset(j as isize),
@@ -5693,13 +5690,14 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
                 data,
                 tile_sz,
                 tile_row as usize,
-                fresh38 as usize,
+                tile_col as usize,
                 if c.n_fc > 1 {
                     *(f.frame_thread.tile_start_off).offset(j as isize) as usize
                 } else {
                     0
                 },
             );
+            tile_col += 1;
 
             if tile_col == (*f.frame_hdr).tiling.cols {
                 tile_col = 0;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5656,6 +5656,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
         dav1d_cdf_thread_copy(f.out_cdf.data.cdf, &mut f.in_cdf);
     }
 
+    let uses_2pass = c.n_fc > 1;
+
     let tiling = &(*f.frame_hdr).tiling;
 
     let n_tile_data = f.n_tile_data.try_into().unwrap();
@@ -5676,7 +5678,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
             slice::from_raw_parts_mut(f.ts, (tile.end + 1).try_into().unwrap()),
             slice::from_raw_parts(
                 f.frame_thread.tile_start_off,
-                if c.n_fc > 1 {
+                if uses_2pass {
                     (tile.end + 1).try_into().unwrap()
                 } else {
                     0
@@ -5725,7 +5727,6 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
     }
 
     if c.n_tc > 1 {
-        let uses_2pass = c.n_fc > 1;
         for (n, ctx) in slice::from_raw_parts_mut(f.a, sb128w * rows * (1 + uses_2pass as usize))
             .iter_mut()
             .enumerate()

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5649,13 +5649,13 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) -> libc::c_int {
     let c: *const Dav1dContext = (*f).c;
-    let mut retval: libc::c_int = -(22 as libc::c_int);
+    let mut retval: libc::c_int = -22;
     if (*(*f).frame_hdr).refresh_context != 0 {
         dav1d_cdf_thread_copy((*f).out_cdf.data.cdf, &mut (*f).in_cdf);
     }
     let mut tile_row = 0;
     let mut tile_col = 0;
-    (*f).task_thread.update_set = 0 as libc::c_int;
+    (*f).task_thread.update_set = 0;
     let mut i = 0;
     while i < (*f).n_tile_data {
         let mut data: *const uint8_t = (*((*f).tile).offset(i as isize)).data.data;
@@ -5669,8 +5669,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
                 if (*(*f).frame_hdr).tiling.n_bytes as size_t > size {
                     return retval;
                 }
-                tile_sz = 0 as libc::c_int as size_t;
-                let mut k: libc::c_uint = 0 as libc::c_int as libc::c_uint;
+                tile_sz = 0;
+                let mut k: libc::c_uint = 0;
                 while k < (*(*f).frame_hdr).tiling.n_bytes {
                     let fresh37 = data;
                     data = data.offset(1);
@@ -5678,9 +5678,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
                     k = k.wrapping_add(1);
                 }
                 tile_sz = tile_sz.wrapping_add(1);
-                size = (size as libc::c_ulong)
-                    .wrapping_sub((*(*f).frame_hdr).tiling.n_bytes as libc::c_ulong)
-                    as size_t as size_t;
+                size = size.wrapping_sub((*(*f).frame_hdr).tiling.n_bytes as usize);
                 if tile_sz > size {
                     return retval;
                 }
@@ -5694,43 +5692,42 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
                 tile_sz,
                 tile_row as usize,
                 fresh38 as usize,
-                if (*c).n_fc > 1 as libc::c_uint {
+                if (*c).n_fc > 1 {
                     *((*f).frame_thread.tile_start_off).offset(j as isize) as usize
                 } else {
                     0
                 },
             );
             if tile_col == (*(*f).frame_hdr).tiling.cols {
-                tile_col = 0 as libc::c_int;
+                tile_col = 0;
                 tile_row += 1;
             }
             if j == (*(*f).frame_hdr).tiling.update && (*(*f).frame_hdr).refresh_context != 0 {
-                (*f).task_thread.update_set = 1 as libc::c_int;
+                (*f).task_thread.update_set = 1;
             }
             data = data.offset(tile_sz as isize);
-            size = (size as size_t).wrapping_sub(tile_sz) as size_t as size_t;
+            size = size.wrapping_sub(tile_sz);
             j += 1;
         }
         i += 1;
     }
-    if (*c).n_tc > 1 as libc::c_uint {
-        let uses_2pass: libc::c_int = ((*c).n_fc > 1 as libc::c_uint) as libc::c_int;
+    if (*c).n_tc > 1 {
+        let uses_2pass: libc::c_int = ((*c).n_fc > 1) as libc::c_int;
         let mut n = 0;
         while n < (*f).sb128w * (*(*f).frame_hdr).tiling.rows * (1 + uses_2pass) {
             reset_context(
                 &mut *((*f).a).offset(n as isize),
                 (*(*f).frame_hdr).frame_type & 1 == 0,
                 if uses_2pass != 0 {
-                    1 as libc::c_int
-                        + (n >= (*f).sb128w * (*(*f).frame_hdr).tiling.rows) as libc::c_int
+                    1 + (n >= (*f).sb128w * (*(*f).frame_hdr).tiling.rows) as libc::c_int
                 } else {
-                    0 as libc::c_int
+                    0
                 },
             );
             n += 1;
         }
     }
-    retval = 0 as libc::c_int;
+    retval = 0;
     return retval;
 }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5650,7 +5650,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
 pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) -> libc::c_int {
     let f = &mut *f; // TODO(kkysen) propagate to arg once we deduplicate the fn decl
 
-    let c: *const Dav1dContext = f.c;
+    let c = &*f.c;
     let mut retval: libc::c_int = -22;
     if (*f.frame_hdr).refresh_context != 0 {
         dav1d_cdf_thread_copy(f.out_cdf.data.cdf, &mut f.in_cdf);
@@ -5694,7 +5694,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
                 tile_sz,
                 tile_row as usize,
                 fresh38 as usize,
-                if (*c).n_fc > 1 {
+                if c.n_fc > 1 {
                     *(f.frame_thread.tile_start_off).offset(j as isize) as usize
                 } else {
                     0
@@ -5713,8 +5713,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
         }
         i += 1;
     }
-    if (*c).n_tc > 1 {
-        let uses_2pass: libc::c_int = ((*c).n_fc > 1) as libc::c_int;
+    if c.n_tc > 1 {
+        let uses_2pass: libc::c_int = (c.n_fc > 1) as libc::c_int;
         let mut n = 0;
         while n < f.sb128w * (*f.frame_hdr).tiling.rows * (1 + uses_2pass) {
             reset_context(

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5651,7 +5651,6 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
     let f = &mut *f; // TODO(kkysen) propagate to arg once we deduplicate the fn decl
 
     let c = &*f.c;
-    let mut retval: libc::c_int = -22;
 
     if (*f.frame_hdr).refresh_context != 0 {
         dav1d_cdf_thread_copy(f.out_cdf.data.cdf, &mut f.in_cdf);
@@ -5673,7 +5672,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
                 tile_sz = size;
             } else {
                 if (*f.frame_hdr).tiling.n_bytes as size_t > size {
-                    return retval;
+                    return -22;
                 }
                 tile_sz = 0;
                 let mut k: libc::c_uint = 0;
@@ -5686,7 +5685,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
                 tile_sz = tile_sz.wrapping_add(1);
                 size = size.wrapping_sub((*f.frame_hdr).tiling.n_bytes as usize);
                 if tile_sz > size {
-                    return retval;
+                    return -22;
                 }
             }
             let fresh38 = tile_col;
@@ -5737,8 +5736,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
         }
     }
 
-    retval = 0;
-    return retval;
+    0
 }
 
 unsafe fn dav1d_decode_frame_main(f: &mut Dav1dFrameContext) -> libc::c_int {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5674,7 +5674,6 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
         let end: usize = tile.end.try_into().unwrap();
 
         let mut data = slice::from_raw_parts(tile.data.data, tile.data.sz);
-        let mut size = data.len();
 
         for (j, (ts, tile_start_off)) in iter::zip(
             slice::from_raw_parts_mut(f.ts, end + 1),
@@ -5690,9 +5689,9 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
         .skip(start)
         {
             let tile_sz = if j == end {
-                size
+                data.len()
             } else {
-                if n_bytes > size {
+                if n_bytes > data.len() {
                     return -22;
                 }
                 let (cur_data, rest_data) = data.split_at(n_bytes);
@@ -5703,8 +5702,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
                     .fold(0, |tile_sz, data_k| tile_sz | data_k)
                     + 1;
                 data = rest_data;
-                size -= n_bytes;
-                if tile_sz > size {
+                if tile_sz > data.len() {
                     return -22;
                 }
                 tile_sz
@@ -5722,7 +5720,6 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
                 f.task_thread.update_set = true;
             }
             data = rest_data;
-            size -= tile_sz;
         }
     }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5659,7 +5659,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
     // parse individual tiles per tile group
     let mut tile_row = 0;
     let mut tile_col = 0;
-    f.task_thread.update_set = 0;
+    f.task_thread.update_set = false;
     let mut i = 0;
     while i < f.n_tile_data {
         let mut data: *const uint8_t = (*(f.tile).offset(i as isize)).data.data;
@@ -5710,7 +5710,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
                 tile_row += 1;
             }
             if j == (*f.frame_hdr).tiling.update && (*f.frame_hdr).refresh_context != 0 {
-                f.task_thread.update_set = 1;
+                f.task_thread.update_set = true;
             }
             data = data.offset(tile_sz as isize);
             size = size.wrapping_sub(tile_sz);
@@ -5880,7 +5880,7 @@ pub unsafe fn dav1d_decode_frame(f: &mut Dav1dFrameContext) -> libc::c_int {
             res = f.task_thread.retval;
         } else {
             res = dav1d_decode_frame_main(f);
-            if res == 0 && (*f.frame_hdr).refresh_context != 0 && f.task_thread.update_set != 0 {
+            if res == 0 && (*f.frame_hdr).refresh_context != 0 && f.task_thread.update_set {
                 dav1d_cdf_thread_update(
                     f.frame_hdr,
                     f.out_cdf.data.cdf,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5717,12 +5717,20 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
 
     if c.n_tc > 1 {
         let uses_2pass = c.n_fc > 1;
-        for n in 0..f.sb128w * tiling.rows * (1 + uses_2pass as libc::c_int) {
+        for (n, ctx) in slice::from_raw_parts_mut(
+            f.a,
+            (f.sb128w * tiling.rows * (1 + uses_2pass as libc::c_int))
+                .try_into()
+                .unwrap(),
+        )
+        .iter_mut()
+        .enumerate()
+        {
             reset_context(
-                &mut *(f.a).offset(n as isize),
+                ctx,
                 is_key_or_intra(&*f.frame_hdr),
                 if uses_2pass {
-                    1 + (n >= f.sb128w * tiling.rows) as libc::c_int
+                    1 + (n >= (f.sb128w * tiling.rows) as usize) as libc::c_int
                 } else {
                     0
                 },

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5657,6 +5657,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
     }
 
     let tiling = &(*f.frame_hdr).tiling;
+    let n_bytes = tiling.n_bytes.try_into().unwrap();
 
     // parse individual tiles per tile group
     let mut tile_row = 0;
@@ -5670,17 +5671,17 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
             let tile_sz = if j == tile.end {
                 size
             } else {
-                if tiling.n_bytes as size_t > size {
+                if n_bytes > size {
                     return -22;
                 }
-                let tile_sz = slice::from_raw_parts(data, tiling.n_bytes.try_into().unwrap())
+                let tile_sz = slice::from_raw_parts(data, n_bytes)
                     .iter()
                     .enumerate()
                     .map(|(k, &data)| (data as usize) << (k * 8))
                     .fold(0, |tile_sz, data_k| tile_sz | data_k)
                     + 1;
-                data = data.offset(tiling.n_bytes as isize);
-                size -= tiling.n_bytes as usize;
+                data = data.offset(n_bytes as isize);
+                size -= n_bytes;
                 if tile_sz > size {
                     return -22;
                 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5691,8 +5691,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
                 f,
                 data,
                 tile_sz,
-                tile_row as usize,
-                tile_col as usize,
+                tile_row,
+                tile_col,
                 if c.n_fc > 1 {
                     *(f.frame_thread.tile_start_off).offset(j as isize) as usize
                 } else {
@@ -5701,7 +5701,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
             );
             tile_col += 1;
 
-            if tile_col == (*f.frame_hdr).tiling.cols {
+            if tile_col == (*f.frame_hdr).tiling.cols as usize {
                 tile_col = 0;
                 tile_row += 1;
             }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5657,13 +5657,15 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
     }
 
     let tiling = &(*f.frame_hdr).tiling;
+
+    let n_tile_data = f.n_tile_data.try_into().unwrap();
     let n_bytes = tiling.n_bytes.try_into().unwrap();
 
     // parse individual tiles per tile group
     let mut tile_row = 0;
     let mut tile_col = 0;
     f.task_thread.update_set = false;
-    for tile in slice::from_raw_parts(f.tile, f.n_tile_data.try_into().unwrap()) {
+    for tile in slice::from_raw_parts(f.tile, n_tile_data) {
         let mut data: *const uint8_t = tile.data.data;
         let mut size: size_t = tile.data.sz;
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5714,13 +5714,13 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
         i += 1;
     }
     if c.n_tc > 1 {
-        let uses_2pass: libc::c_int = (c.n_fc > 1) as libc::c_int;
+        let uses_2pass = c.n_fc > 1;
         let mut n = 0;
-        while n < f.sb128w * (*f.frame_hdr).tiling.rows * (1 + uses_2pass) {
+        while n < f.sb128w * (*f.frame_hdr).tiling.rows * (1 + uses_2pass as libc::c_int) {
             reset_context(
                 &mut *(f.a).offset(n as isize),
                 (*f.frame_hdr).frame_type & 1 == 0,
-                if uses_2pass != 0 {
+                if uses_2pass {
                     1 + (n >= f.sb128w * (*f.frame_hdr).tiling.rows) as libc::c_int
                 } else {
                     0

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5665,14 +5665,13 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
         let mut size: size_t = tile.data.sz;
 
         for j in tile.start..=tile.end {
-            let tile_sz: size_t;
-            if j == tile.end {
-                tile_sz = size;
+            let tile_sz = if j == tile.end {
+                size
             } else {
                 if (*f.frame_hdr).tiling.n_bytes as size_t > size {
                     return -22;
                 }
-                tile_sz =
+                let tile_sz =
                     slice::from_raw_parts(data, (*f.frame_hdr).tiling.n_bytes.try_into().unwrap())
                         .iter()
                         .enumerate()
@@ -5684,7 +5683,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
                 if tile_sz > size {
                     return -22;
                 }
-            }
+                tile_sz
+            };
 
             setup_tile(
                 &mut *(f.ts).offset(j as isize),

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5671,27 +5671,26 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
     let mut tile_col = 0;
     f.task_thread.update_set = false;
     for tile in slice::from_raw_parts(f.tile, n_tile_data) {
+        let start = tile.start.try_into().unwrap();
+        let end: usize = tile.end.try_into().unwrap();
+
         let mut data: *const uint8_t = tile.data.data;
         let mut size: size_t = tile.data.sz;
 
         for (j, (ts, tile_start_off)) in iter::zip(
-            slice::from_raw_parts_mut(f.ts, (tile.end + 1).try_into().unwrap()),
+            slice::from_raw_parts_mut(f.ts, end + 1),
             slice::from_raw_parts(
                 f.frame_thread.tile_start_off,
-                if uses_2pass {
-                    (tile.end + 1).try_into().unwrap()
-                } else {
-                    0
-                },
+                if uses_2pass { end + 1 } else { 0 },
             )
             .into_iter()
             .map(|&it| it as usize)
             .chain(iter::repeat(0)),
         )
         .enumerate()
-        .skip(tile.start as usize)
+        .skip(start)
         {
-            let tile_sz = if j == tile.end as usize {
+            let tile_sz = if j == end {
                 size
             } else {
                 if n_bytes > size {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5660,13 +5660,11 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
     let mut tile_row = 0;
     let mut tile_col = 0;
     f.task_thread.update_set = false;
-    let mut i = 0;
-    while i < f.n_tile_data {
+    for i in 0..f.n_tile_data {
         let mut data: *const uint8_t = (*(f.tile).offset(i as isize)).data.data;
         let mut size: size_t = (*(f.tile).offset(i as isize)).data.sz;
 
-        let mut j: libc::c_int = (*(f.tile).offset(i as isize)).start;
-        while j <= (*(f.tile).offset(i as isize)).end {
+        for j in (*(f.tile).offset(i as isize)).start..=(*(f.tile).offset(i as isize)).end {
             let mut tile_sz: size_t;
             if j == (*(f.tile).offset(i as isize)).end {
                 tile_sz = size;
@@ -5675,12 +5673,10 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
                     return -22;
                 }
                 tile_sz = 0;
-                let mut k: libc::c_uint = 0;
-                while k < (*f.frame_hdr).tiling.n_bytes {
+                for k in 0..(*f.frame_hdr).tiling.n_bytes {
                     let fresh37 = data;
                     data = data.offset(1);
                     tile_sz |= ((*fresh37 as libc::c_uint) << k.wrapping_mul(8)) as size_t;
-                    k = k.wrapping_add(1);
                 }
                 tile_sz = tile_sz.wrapping_add(1);
                 size = size.wrapping_sub((*f.frame_hdr).tiling.n_bytes as usize);
@@ -5714,15 +5710,12 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
             }
             data = data.offset(tile_sz as isize);
             size = size.wrapping_sub(tile_sz);
-            j += 1;
         }
-        i += 1;
     }
 
     if c.n_tc > 1 {
         let uses_2pass = c.n_fc > 1;
-        let mut n = 0;
-        while n < f.sb128w * (*f.frame_hdr).tiling.rows * (1 + uses_2pass as libc::c_int) {
+        for n in 0..f.sb128w * (*f.frame_hdr).tiling.rows * (1 + uses_2pass as libc::c_int) {
             reset_context(
                 &mut *(f.a).offset(n as isize),
                 is_key_or_intra(&*f.frame_hdr),
@@ -5732,7 +5725,6 @@ pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) 
                     0
                 },
             );
-            n += 1;
         }
     }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -207,7 +207,7 @@ pub struct Dav1dFrameContext_task_thread {
     pub init_done: atomic_int,
     pub done: [atomic_int; 2],
     pub retval: libc::c_int,
-    pub update_set: libc::c_int,
+    pub update_set: bool,
     pub error: atomic_int,
     pub task_counter: atomic_int,
     pub task_head: *mut Dav1dTask,

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1797,7 +1797,7 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut libc::c_void) -> *mut libc
                                         res_0 = dav1d_decode_frame_init_cdf(f);
                                     }
                                     if (*(*f).frame_hdr).refresh_context != 0
-                                        && (*f).task_thread.update_set == 0
+                                        && !(*f).task_thread.update_set
                                     {
                                         ::core::intrinsics::atomic_store_seqcst(
                                             (*f).out_cdf.progress,
@@ -1963,7 +1963,7 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut libc::c_void) -> *mut libc
                                         );
                                         if (*(*f).frame_hdr).refresh_context != 0
                                             && (*tc).frame_thread.pass <= 1
-                                            && (*f).task_thread.update_set != 0
+                                            && (*f).task_thread.update_set
                                             && (*(*f).frame_hdr).tiling.update == tile_idx
                                         {
                                             if error_0 == 0 {


### PR DESCRIPTION
This involved some heavy iterator code to avoid bounds checks as much as possible.  One especially, 08f1a37caaa6da368108f931ab6b974198528f60, I want to benchmark.  @fbossen, how have you been doing that?