### PR TITLE
`fn dav1d_decode_frame_init`: Cleanup part 1

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5412,10 +5412,10 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             &mut f.rf,
             f.seq_hdr,
             f.frame_hdr,
-            f.refpoc.as_mut_ptr() as *const libc::c_uint,
+            f.refpoc.as_ptr(),
             f.mvs,
-            f.refrefpoc.as_mut_ptr() as *const [libc::c_uint; 7],
-            f.ref_mvs.as_mut_ptr() as *const *mut refmvs_temporal_block,
+            f.refrefpoc.as_ptr(),
+            f.ref_mvs.as_ptr(),
             (*f.c).n_tc as libc::c_int,
             (*f.c).n_fc as libc::c_int,
         );

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5467,14 +5467,14 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     .unsigned_abs(),
                     31,
                 );
-                let order = (d0 <= d1) as libc::c_int;
+                let order = d0 <= d1;
                 static mut quant_dist_weight: [[uint8_t; 2]; 3] = [[2, 3], [2, 5], [2, 7]];
                 static mut quant_dist_lookup_table: [[uint8_t; 2]; 4] =
                     [[9, 7], [11, 5], [12, 4], [13, 3]];
                 let mut k = 0;
                 while k < 3 {
                     let c0 = quant_dist_weight[k][order as usize] as libc::c_int;
-                    let c1 = quant_dist_weight[k][(order == 0) as usize] as libc::c_int;
+                    let c1 = quant_dist_weight[k][!order as usize] as libc::c_int;
                     let d0_c0 = (d0 * c0 as libc::c_uint) as libc::c_int;
                     let d1_c1 = (d1 * c1 as libc::c_uint) as libc::c_int;
                     if d0 > d1 && d0_c0 < d1_c1 || d0 <= d1 && d0_c0 > d1_c1 {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5103,7 +5103,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         f.a_sz = a_sz;
     }
     let num_sb128 = f.sb128w * f.sb128h;
-    let size_mul = ss_size_mul[f.cur.p.layout as usize].as_ptr();
+    let size_mul = &ss_size_mul[f.cur.p.layout as usize];
     let hbd = ((*f.seq_hdr).hbd != 0) as libc::c_int;
     if c.n_fc > 1 {
         let mut tile_idx = 0;
@@ -5161,7 +5161,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             tile_row += 1;
             tile_row_base += (*f.frame_hdr).tiling.cols;
         }
-        let cf_sz = (num_sb128 * *size_mul.offset(0) as libc::c_int) << hbd;
+        let cf_sz = (num_sb128 * size_mul[0] as libc::c_int) << hbd;
         if cf_sz != f.frame_thread.cf_sz {
             dav1d_freep_aligned(
                 &mut f.frame_thread.cf as *mut *mut libc::c_void as *mut libc::c_void,
@@ -5193,7 +5193,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 }
                 f.frame_thread.pal_sz = num_sb128;
             }
-            let pal_idx_sz = num_sb128 * *size_mul.offset(1) as libc::c_int;
+            let pal_idx_sz = num_sb128 * size_mul[1] as libc::c_int;
             if pal_idx_sz != f.frame_thread.pal_idx_sz {
                 dav1d_freep_aligned(
                     &mut f.frame_thread.pal_idx as *mut *mut uint8_t as *mut libc::c_void,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5175,7 +5175,11 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 f.frame_thread.cf_sz = 0;
                 return retval;
             }
-            memset(f.frame_thread.cf, 0, cf_sz as size_t * 128 * 128 / 2);
+            slice::from_raw_parts_mut(
+                f.frame_thread.cf.cast::<u8>(),
+                usize::try_from(cf_sz).unwrap() * 128 * 128 / 2,
+            )
+            .fill(0);
             f.frame_thread.cf_sz = cf_sz;
         }
         if (*f.frame_hdr).allow_screen_content_tools != 0 {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5394,11 +5394,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         f.lf.last_sharpness = (*f.frame_hdr).loopfilter.sharpness;
     }
     dav1d_calc_lf_values(&mut f.lf.lvl, &*f.frame_hdr, &[0, 0, 0, 0]);
-    memset(
-        f.lf.mask as *mut libc::c_void,
-        0,
-        ::core::mem::size_of::<Av1Filter>() * num_sb128 as size_t,
-    );
+    slice::from_raw_parts_mut(f.lf.mask, num_sb128.try_into().unwrap()).fill_with(Default::default);
     let ipred_edge_sz = f.sbh * f.sb128w << hbd;
     if ipred_edge_sz != f.ipred_edge_sz {
         dav1d_freep_aligned(

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5051,7 +5051,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             (f.sbh as libc::c_ulong)
                 .wrapping_mul(::core::mem::size_of::<uint8_t>() as libc::c_ulong),
         ) as *mut uint8_t;
-        if (f.lf.start_of_tile_row).is_null() {
+        if f.lf.start_of_tile_row.is_null() {
             f.lf.start_of_tile_row_sz = 0;
             return retval;
         }
@@ -5062,11 +5062,11 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     while tile_row < (*f.frame_hdr).tiling.rows {
         let fresh33 = sby;
         sby = sby + 1;
-        *(f.lf.start_of_tile_row).offset(fresh33 as isize) = tile_row as uint8_t;
+        *f.lf.start_of_tile_row.offset(fresh33 as isize) = tile_row as uint8_t;
         while sby < (*f.frame_hdr).tiling.row_start_sb[(tile_row + 1) as usize] as libc::c_int {
             let fresh34 = sby;
             sby = sby + 1;
-            *(f.lf.start_of_tile_row).offset(fresh34 as isize) = 0;
+            *f.lf.start_of_tile_row.offset(fresh34 as isize) = 0;
         }
         tile_row += 1;
     }
@@ -5078,7 +5078,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 (::core::mem::size_of::<libc::c_int>() as libc::c_ulong)
                     .wrapping_mul(n_ts as libc::c_ulong),
             ) as *mut libc::c_int;
-            if (f.frame_thread.tile_start_off).is_null() {
+            if f.frame_thread.tile_start_off.is_null() {
                 f.n_ts = 0;
                 return retval;
             }
@@ -5088,7 +5088,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             (::core::mem::size_of::<Dav1dTileState>()).wrapping_mul(n_ts as size_t),
             32,
         ) as *mut Dav1dTileState;
-        if (f.ts).is_null() {
+        if f.ts.is_null() {
             return retval;
         }
         f.n_ts = n_ts;
@@ -5101,14 +5101,14 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             (::core::mem::size_of::<BlockContext>() as libc::c_ulong)
                 .wrapping_mul(a_sz as libc::c_ulong),
         ) as *mut BlockContext;
-        if (f.a).is_null() {
+        if f.a.is_null() {
             f.a_sz = 0;
             return retval;
         }
         f.a_sz = a_sz;
     }
     let num_sb128 = f.sb128w * f.sb128h;
-    let size_mul = (ss_size_mul[f.cur.p.layout as usize]).as_ptr();
+    let size_mul = ss_size_mul[f.cur.p.layout as usize].as_ptr();
     let hbd = ((*f.seq_hdr).hbd != 0) as libc::c_int;
     if c.n_fc > 1 {
         let mut tile_idx = 0;
@@ -5128,7 +5128,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             while tile_col < (*f.frame_hdr).tiling.cols {
                 let fresh35 = tile_idx;
                 tile_idx = tile_idx + 1;
-                *(f.frame_thread.tile_start_off).offset(fresh35 as isize) = row_off
+                *f.frame_thread.tile_start_off.offset(fresh35 as isize) = row_off
                     + b_diff
                         * (*f.frame_hdr).tiling.col_start_sb[tile_col as usize] as libc::c_int
                         * f.sb_step
@@ -5144,7 +5144,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 (lowest_pixel_mem_sz as libc::c_ulong)
                     .wrapping_mul(::core::mem::size_of::<[[libc::c_int; 2]; 7]>() as libc::c_ulong),
             ) as *mut [[libc::c_int; 2]; 7];
-            if (f.tile_thread.lowest_pixel_mem).is_null() {
+            if f.tile_thread.lowest_pixel_mem.is_null() {
                 f.tile_thread.lowest_pixel_mem_sz = 0;
                 return retval;
             }
@@ -5180,7 +5180,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     .wrapping_div(2),
                 64,
             );
-            if (f.frame_thread.cf).is_null() {
+            if f.frame_thread.cf.is_null() {
                 f.frame_thread.cf_sz = 0;
                 return retval;
             }
@@ -5206,7 +5206,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                         .wrapping_mul(16),
                     64,
                 ) as *mut [[uint16_t; 8]; 3];
-                if (f.frame_thread.pal).is_null() {
+                if f.frame_thread.pal.is_null() {
                     f.frame_thread.pal_sz = 0;
                     return retval;
                 }
@@ -5225,13 +5225,13 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                         .wrapping_div(4),
                     64,
                 ) as *mut uint8_t;
-                if (f.frame_thread.pal_idx).is_null() {
+                if f.frame_thread.pal_idx.is_null() {
                     f.frame_thread.pal_idx_sz = 0;
                     return retval;
                 }
                 f.frame_thread.pal_idx_sz = pal_idx_sz;
             }
-        } else if !(f.frame_thread.pal).is_null() {
+        } else if !f.frame_thread.pal.is_null() {
             dav1d_freep_aligned(
                 &mut f.frame_thread.pal as *mut *mut [[uint16_t; 8]; 3] as *mut libc::c_void,
             );
@@ -5380,7 +5380,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 .wrapping_mul(32)
                 .wrapping_add(3),
         ) as *mut [uint8_t; 4];
-        if (f.lf.mask).is_null() || (f.lf.level).is_null() {
+        if f.lf.mask.is_null() || f.lf.level.is_null() {
             f.lf.mask_sz = 0;
             return retval;
         }
@@ -5399,7 +5399,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     .wrapping_mul(32)
                     .wrapping_mul(32),
             ) as *mut CodedBlockInfo;
-            if (f.frame_thread.b).is_null() || (f.frame_thread.cbi).is_null() {
+            if f.frame_thread.b.is_null() || f.frame_thread.cbi.is_null() {
                 f.lf.mask_sz = 0;
                 return retval;
             }
@@ -5414,7 +5414,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             (::core::mem::size_of::<Av1Restoration>() as libc::c_ulong)
                 .wrapping_mul(lr_mask_sz as libc::c_ulong),
         ) as *mut Av1Restoration;
-        if (f.lf.lr_mask).is_null() {
+        if f.lf.lr_mask.is_null() {
             f.lf.lr_mask_sz = 0;
             return retval;
         }
@@ -5438,7 +5438,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     let ipred_edge_sz = f.sbh * f.sb128w << hbd;
     if ipred_edge_sz != f.ipred_edge_sz {
         dav1d_freep_aligned(
-            &mut *(f.ipred_edge).as_mut_ptr().offset(0) as *mut *mut libc::c_void
+            &mut *f.ipred_edge.as_mut_ptr().offset(0) as *mut *mut libc::c_void
                 as *mut libc::c_void,
         );
         f.ipred_edge[0] = dav1d_alloc_aligned(ipred_edge_sz as size_t * 128 * 3, 64);
@@ -5454,15 +5454,15 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     let re_sz = f.sb128h * (*f.frame_hdr).tiling.cols;
     if re_sz != f.lf.re_sz {
         freep(
-            &mut *(f.lf.tx_lpf_right_edge).as_mut_ptr().offset(0) as *mut *mut uint8_t
+            &mut *f.lf.tx_lpf_right_edge.as_mut_ptr().offset(0) as *mut *mut uint8_t
                 as *mut libc::c_void,
         );
         f.lf.tx_lpf_right_edge[0] = malloc(re_sz as libc::c_ulong * 32 * 2) as *mut uint8_t;
-        if (f.lf.tx_lpf_right_edge[0]).is_null() {
+        if f.lf.tx_lpf_right_edge[0].is_null() {
             f.lf.re_sz = 0;
             return retval;
         }
-        f.lf.tx_lpf_right_edge[1] = (f.lf.tx_lpf_right_edge[0]).offset((re_sz * 32) as isize);
+        f.lf.tx_lpf_right_edge[1] = f.lf.tx_lpf_right_edge[0].offset((re_sz * 32) as isize);
         f.lf.re_sz = re_sz;
     }
     if (*f.frame_hdr).frame_type & 1 != 0 || (*f.frame_hdr).allow_intrabc != 0 {
@@ -5470,10 +5470,10 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             &mut f.rf,
             f.seq_hdr,
             f.frame_hdr,
-            (f.refpoc).as_mut_ptr() as *const libc::c_uint,
+            f.refpoc.as_mut_ptr() as *const libc::c_uint,
             f.mvs,
-            (f.refrefpoc).as_mut_ptr() as *const [libc::c_uint; 7],
-            (f.ref_mvs).as_mut_ptr() as *const *mut refmvs_temporal_block,
+            f.refrefpoc.as_mut_ptr() as *const [libc::c_uint; 7],
+            f.ref_mvs.as_mut_ptr() as *const *mut refmvs_temporal_block,
             (*f.c).n_tc as libc::c_int,
             (*f.c).n_fc as libc::c_int,
         );
@@ -5498,7 +5498,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         }
     } else {
         memset(
-            (f.qm).as_mut_ptr() as *mut libc::c_void,
+            f.qm.as_mut_ptr() as *mut libc::c_void,
             0,
             ::core::mem::size_of::<[[*const uint8_t; 3]; 19]>(),
         );

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5041,184 +5041,184 @@ pub unsafe extern "C" fn dav1d_decode_tile_sbrow(t: *mut Dav1dTaskContext) -> li
 
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> libc::c_int {
-    let c = (*f).c;
+    let f = &mut *f; // TODO(kkysen) propagate to arg once we deduplicate the fn decl
+
+    let c = f.c;
     let mut retval = -12;
-    if (*f).sbh > (*f).lf.start_of_tile_row_sz {
-        free((*f).lf.start_of_tile_row as *mut libc::c_void);
-        (*f).lf.start_of_tile_row = malloc(
-            ((*f).sbh as libc::c_ulong)
+    if f.sbh > f.lf.start_of_tile_row_sz {
+        free(f.lf.start_of_tile_row as *mut libc::c_void);
+        f.lf.start_of_tile_row = malloc(
+            (f.sbh as libc::c_ulong)
                 .wrapping_mul(::core::mem::size_of::<uint8_t>() as libc::c_ulong),
         ) as *mut uint8_t;
-        if ((*f).lf.start_of_tile_row).is_null() {
-            (*f).lf.start_of_tile_row_sz = 0;
+        if (f.lf.start_of_tile_row).is_null() {
+            f.lf.start_of_tile_row_sz = 0;
             return retval;
         }
-        (*f).lf.start_of_tile_row_sz = (*f).sbh;
+        f.lf.start_of_tile_row_sz = f.sbh;
     }
     let mut sby = 0;
     let mut tile_row = 0;
-    while tile_row < (*(*f).frame_hdr).tiling.rows {
+    while tile_row < (*f.frame_hdr).tiling.rows {
         let fresh33 = sby;
         sby = sby + 1;
-        *((*f).lf.start_of_tile_row).offset(fresh33 as isize) = tile_row as uint8_t;
-        while sby < (*(*f).frame_hdr).tiling.row_start_sb[(tile_row + 1) as usize] as libc::c_int {
+        *(f.lf.start_of_tile_row).offset(fresh33 as isize) = tile_row as uint8_t;
+        while sby < (*f.frame_hdr).tiling.row_start_sb[(tile_row + 1) as usize] as libc::c_int {
             let fresh34 = sby;
             sby = sby + 1;
-            *((*f).lf.start_of_tile_row).offset(fresh34 as isize) = 0;
+            *(f.lf.start_of_tile_row).offset(fresh34 as isize) = 0;
         }
         tile_row += 1;
     }
-    let n_ts = (*(*f).frame_hdr).tiling.cols * (*(*f).frame_hdr).tiling.rows;
-    if n_ts != (*f).n_ts {
+    let n_ts = (*f.frame_hdr).tiling.cols * (*f.frame_hdr).tiling.rows;
+    if n_ts != f.n_ts {
         if (*c).n_fc > 1 {
-            freep(
-                &mut (*f).frame_thread.tile_start_off as *mut *mut libc::c_int as *mut libc::c_void,
-            );
-            (*f).frame_thread.tile_start_off = malloc(
+            freep(&mut f.frame_thread.tile_start_off as *mut *mut libc::c_int as *mut libc::c_void);
+            f.frame_thread.tile_start_off = malloc(
                 (::core::mem::size_of::<libc::c_int>() as libc::c_ulong)
                     .wrapping_mul(n_ts as libc::c_ulong),
             ) as *mut libc::c_int;
-            if ((*f).frame_thread.tile_start_off).is_null() {
-                (*f).n_ts = 0;
+            if (f.frame_thread.tile_start_off).is_null() {
+                f.n_ts = 0;
                 return retval;
             }
         }
-        dav1d_free_aligned((*f).ts as *mut libc::c_void);
-        (*f).ts = dav1d_alloc_aligned(
+        dav1d_free_aligned(f.ts as *mut libc::c_void);
+        f.ts = dav1d_alloc_aligned(
             (::core::mem::size_of::<Dav1dTileState>()).wrapping_mul(n_ts as size_t),
             32,
         ) as *mut Dav1dTileState;
-        if ((*f).ts).is_null() {
+        if (f.ts).is_null() {
             return retval;
         }
-        (*f).n_ts = n_ts;
+        f.n_ts = n_ts;
     }
-    let a_sz = (*f).sb128w
-        * (*(*f).frame_hdr).tiling.rows
+    let a_sz = f.sb128w
+        * (*f.frame_hdr).tiling.rows
         * (1 + ((*c).n_fc > 1 && (*c).n_tc > 1) as libc::c_int);
-    if a_sz != (*f).a_sz {
-        freep(&mut (*f).a as *mut *mut BlockContext as *mut libc::c_void);
-        (*f).a = malloc(
+    if a_sz != f.a_sz {
+        freep(&mut f.a as *mut *mut BlockContext as *mut libc::c_void);
+        f.a = malloc(
             (::core::mem::size_of::<BlockContext>() as libc::c_ulong)
                 .wrapping_mul(a_sz as libc::c_ulong),
         ) as *mut BlockContext;
-        if ((*f).a).is_null() {
-            (*f).a_sz = 0;
+        if (f.a).is_null() {
+            f.a_sz = 0;
             return retval;
         }
-        (*f).a_sz = a_sz;
+        f.a_sz = a_sz;
     }
-    let num_sb128 = (*f).sb128w * (*f).sb128h;
-    let size_mul = (ss_size_mul[(*f).cur.p.layout as usize]).as_ptr();
-    let hbd = ((*(*f).seq_hdr).hbd != 0) as libc::c_int;
+    let num_sb128 = f.sb128w * f.sb128h;
+    let size_mul = (ss_size_mul[f.cur.p.layout as usize]).as_ptr();
+    let hbd = ((*f.seq_hdr).hbd != 0) as libc::c_int;
     if (*c).n_fc > 1 {
         let mut tile_idx = 0;
         let mut tile_row = 0;
-        while tile_row < (*(*f).frame_hdr).tiling.rows {
-            let row_off = (*(*f).frame_hdr).tiling.row_start_sb[tile_row as usize] as libc::c_int
-                * (*f).sb_step
+        while tile_row < (*f.frame_hdr).tiling.rows {
+            let row_off = (*f.frame_hdr).tiling.row_start_sb[tile_row as usize] as libc::c_int
+                * f.sb_step
                 * 4
-                * (*f).sb128w
+                * f.sb128w
                 * 128;
-            let b_diff = ((*(*f).frame_hdr).tiling.row_start_sb[(tile_row + 1) as usize]
+            let b_diff = ((*f.frame_hdr).tiling.row_start_sb[(tile_row + 1) as usize]
                 as libc::c_int
-                - (*(*f).frame_hdr).tiling.row_start_sb[tile_row as usize] as libc::c_int)
-                * (*f).sb_step
+                - (*f.frame_hdr).tiling.row_start_sb[tile_row as usize] as libc::c_int)
+                * f.sb_step
                 * 4;
             let mut tile_col = 0;
-            while tile_col < (*(*f).frame_hdr).tiling.cols {
+            while tile_col < (*f.frame_hdr).tiling.cols {
                 let fresh35 = tile_idx;
                 tile_idx = tile_idx + 1;
-                *((*f).frame_thread.tile_start_off).offset(fresh35 as isize) = row_off
+                *(f.frame_thread.tile_start_off).offset(fresh35 as isize) = row_off
                     + b_diff
-                        * (*(*f).frame_hdr).tiling.col_start_sb[tile_col as usize] as libc::c_int
-                        * (*f).sb_step
+                        * (*f.frame_hdr).tiling.col_start_sb[tile_col as usize] as libc::c_int
+                        * f.sb_step
                         * 4;
                 tile_col += 1;
             }
             tile_row += 1;
         }
-        let lowest_pixel_mem_sz = (*(*f).frame_hdr).tiling.cols * (*f).sbh;
-        if lowest_pixel_mem_sz != (*f).tile_thread.lowest_pixel_mem_sz {
-            free((*f).tile_thread.lowest_pixel_mem as *mut libc::c_void);
-            (*f).tile_thread.lowest_pixel_mem = malloc(
+        let lowest_pixel_mem_sz = (*f.frame_hdr).tiling.cols * f.sbh;
+        if lowest_pixel_mem_sz != f.tile_thread.lowest_pixel_mem_sz {
+            free(f.tile_thread.lowest_pixel_mem as *mut libc::c_void);
+            f.tile_thread.lowest_pixel_mem = malloc(
                 (lowest_pixel_mem_sz as libc::c_ulong)
                     .wrapping_mul(::core::mem::size_of::<[[libc::c_int; 2]; 7]>() as libc::c_ulong),
             ) as *mut [[libc::c_int; 2]; 7];
-            if ((*f).tile_thread.lowest_pixel_mem).is_null() {
-                (*f).tile_thread.lowest_pixel_mem_sz = 0;
+            if (f.tile_thread.lowest_pixel_mem).is_null() {
+                f.tile_thread.lowest_pixel_mem_sz = 0;
                 return retval;
             }
-            (*f).tile_thread.lowest_pixel_mem_sz = lowest_pixel_mem_sz;
+            f.tile_thread.lowest_pixel_mem_sz = lowest_pixel_mem_sz;
         }
-        let mut lowest_pixel_ptr = (*f).tile_thread.lowest_pixel_mem;
+        let mut lowest_pixel_ptr = f.tile_thread.lowest_pixel_mem;
         let mut tile_row = 0;
         let mut tile_row_base = 0;
-        while tile_row < (*(*f).frame_hdr).tiling.rows {
-            let tile_row_sb_h = (*(*f).frame_hdr).tiling.row_start_sb[(tile_row + 1) as usize]
+        while tile_row < (*f.frame_hdr).tiling.rows {
+            let tile_row_sb_h = (*f.frame_hdr).tiling.row_start_sb[(tile_row + 1) as usize]
                 as libc::c_int
-                - (*(*f).frame_hdr).tiling.row_start_sb[tile_row as usize] as libc::c_int;
+                - (*f.frame_hdr).tiling.row_start_sb[tile_row as usize] as libc::c_int;
             let mut tile_col = 0;
-            while tile_col < (*(*f).frame_hdr).tiling.cols {
+            while tile_col < (*f.frame_hdr).tiling.cols {
                 let ref mut fresh36 =
-                    (*((*f).ts).offset((tile_row_base + tile_col) as isize)).lowest_pixel;
+                    (*(f.ts).offset((tile_row_base + tile_col) as isize)).lowest_pixel;
                 *fresh36 = lowest_pixel_ptr;
                 lowest_pixel_ptr = lowest_pixel_ptr.offset(tile_row_sb_h as isize);
                 tile_col += 1;
             }
             tile_row += 1;
-            tile_row_base += (*(*f).frame_hdr).tiling.cols;
+            tile_row_base += (*f.frame_hdr).tiling.cols;
         }
         let cf_sz = (num_sb128 * *size_mul.offset(0) as libc::c_int) << hbd;
-        if cf_sz != (*f).frame_thread.cf_sz {
+        if cf_sz != f.frame_thread.cf_sz {
             dav1d_freep_aligned(
-                &mut (*f).frame_thread.cf as *mut *mut libc::c_void as *mut libc::c_void,
+                &mut f.frame_thread.cf as *mut *mut libc::c_void as *mut libc::c_void,
             );
-            (*f).frame_thread.cf = dav1d_alloc_aligned(
+            f.frame_thread.cf = dav1d_alloc_aligned(
                 (cf_sz as size_t)
                     .wrapping_mul(128)
                     .wrapping_mul(128)
                     .wrapping_div(2),
                 64,
             );
-            if ((*f).frame_thread.cf).is_null() {
-                (*f).frame_thread.cf_sz = 0;
+            if (f.frame_thread.cf).is_null() {
+                f.frame_thread.cf_sz = 0;
                 return retval;
             }
             memset(
-                (*f).frame_thread.cf,
+                f.frame_thread.cf,
                 0,
                 (cf_sz as size_t)
                     .wrapping_mul(128)
                     .wrapping_mul(128)
                     .wrapping_div(2),
             );
-            (*f).frame_thread.cf_sz = cf_sz;
+            f.frame_thread.cf_sz = cf_sz;
         }
-        if (*(*f).frame_hdr).allow_screen_content_tools != 0 {
-            if num_sb128 != (*f).frame_thread.pal_sz {
+        if (*f.frame_hdr).allow_screen_content_tools != 0 {
+            if num_sb128 != f.frame_thread.pal_sz {
                 dav1d_freep_aligned(
-                    &mut (*f).frame_thread.pal as *mut *mut [[uint16_t; 8]; 3] as *mut libc::c_void,
+                    &mut f.frame_thread.pal as *mut *mut [[uint16_t; 8]; 3] as *mut libc::c_void,
                 );
-                (*f).frame_thread.pal = dav1d_alloc_aligned(
+                f.frame_thread.pal = dav1d_alloc_aligned(
                     (::core::mem::size_of::<[[uint16_t; 8]; 3]>())
                         .wrapping_mul(num_sb128 as size_t)
                         .wrapping_mul(16)
                         .wrapping_mul(16),
                     64,
                 ) as *mut [[uint16_t; 8]; 3];
-                if ((*f).frame_thread.pal).is_null() {
-                    (*f).frame_thread.pal_sz = 0;
+                if (f.frame_thread.pal).is_null() {
+                    f.frame_thread.pal_sz = 0;
                     return retval;
                 }
-                (*f).frame_thread.pal_sz = num_sb128;
+                f.frame_thread.pal_sz = num_sb128;
             }
             let pal_idx_sz = num_sb128 * *size_mul.offset(1) as libc::c_int;
-            if pal_idx_sz != (*f).frame_thread.pal_idx_sz {
+            if pal_idx_sz != f.frame_thread.pal_idx_sz {
                 dav1d_freep_aligned(
-                    &mut (*f).frame_thread.pal_idx as *mut *mut uint8_t as *mut libc::c_void,
+                    &mut f.frame_thread.pal_idx as *mut *mut uint8_t as *mut libc::c_void,
                 );
-                (*f).frame_thread.pal_idx = dav1d_alloc_aligned(
+                f.frame_thread.pal_idx = dav1d_alloc_aligned(
                     (::core::mem::size_of::<uint8_t>())
                         .wrapping_mul(pal_idx_sz as size_t)
                         .wrapping_mul(128)
@@ -5226,116 +5226,116 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                         .wrapping_div(4),
                     64,
                 ) as *mut uint8_t;
-                if ((*f).frame_thread.pal_idx).is_null() {
-                    (*f).frame_thread.pal_idx_sz = 0;
+                if (f.frame_thread.pal_idx).is_null() {
+                    f.frame_thread.pal_idx_sz = 0;
                     return retval;
                 }
-                (*f).frame_thread.pal_idx_sz = pal_idx_sz;
+                f.frame_thread.pal_idx_sz = pal_idx_sz;
             }
-        } else if !((*f).frame_thread.pal).is_null() {
+        } else if !(f.frame_thread.pal).is_null() {
             dav1d_freep_aligned(
-                &mut (*f).frame_thread.pal as *mut *mut [[uint16_t; 8]; 3] as *mut libc::c_void,
+                &mut f.frame_thread.pal as *mut *mut [[uint16_t; 8]; 3] as *mut libc::c_void,
             );
             dav1d_freep_aligned(
-                &mut (*f).frame_thread.pal_idx as *mut *mut uint8_t as *mut libc::c_void,
+                &mut f.frame_thread.pal_idx as *mut *mut uint8_t as *mut libc::c_void,
             );
-            (*f).frame_thread.pal_idx_sz = 0;
-            (*f).frame_thread.pal_sz = (*f).frame_thread.pal_idx_sz;
+            f.frame_thread.pal_idx_sz = 0;
+            f.frame_thread.pal_sz = f.frame_thread.pal_idx_sz;
         }
     }
-    let mut y_stride = (*f).cur.stride[0];
-    let mut uv_stride = (*f).cur.stride[1];
-    let has_resize = ((*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1]) as libc::c_int;
+    let mut y_stride = f.cur.stride[0];
+    let mut uv_stride = f.cur.stride[1];
+    let has_resize = ((*f.frame_hdr).width[0] != (*f.frame_hdr).width[1]) as libc::c_int;
     let need_cdef_lpf_copy = ((*c).n_tc > 1 && has_resize != 0) as libc::c_int;
-    if y_stride * (*f).sbh as isize * 4 != (*f).lf.cdef_buf_plane_sz[0] as isize
-        || uv_stride * (*f).sbh as isize * 8 != (*f).lf.cdef_buf_plane_sz[1] as isize
-        || need_cdef_lpf_copy != (*f).lf.need_cdef_lpf_copy
-        || (*f).sbh != (*f).lf.cdef_buf_sbh
+    if y_stride * f.sbh as isize * 4 != f.lf.cdef_buf_plane_sz[0] as isize
+        || uv_stride * f.sbh as isize * 8 != f.lf.cdef_buf_plane_sz[1] as isize
+        || need_cdef_lpf_copy != f.lf.need_cdef_lpf_copy
+        || f.sbh != f.lf.cdef_buf_sbh
     {
-        dav1d_free_aligned((*f).lf.cdef_line_buf as *mut libc::c_void);
+        dav1d_free_aligned(f.lf.cdef_line_buf as *mut libc::c_void);
         let mut alloc_sz: size_t = 64;
         alloc_sz = alloc_sz.wrapping_add(
             (y_stride.abs() as size_t)
                 .wrapping_mul(4)
-                .wrapping_mul((*f).sbh as size_t)
+                .wrapping_mul(f.sbh as size_t)
                 << need_cdef_lpf_copy,
         );
         alloc_sz = alloc_sz.wrapping_add(
             (uv_stride.abs() as size_t)
                 .wrapping_mul(8)
-                .wrapping_mul((*f).sbh as size_t)
+                .wrapping_mul(f.sbh as size_t)
                 << need_cdef_lpf_copy,
         );
-        (*f).lf.cdef_line_buf = dav1d_alloc_aligned(alloc_sz, 32) as *mut uint8_t;
-        let mut ptr = (*f).lf.cdef_line_buf;
+        f.lf.cdef_line_buf = dav1d_alloc_aligned(alloc_sz, 32) as *mut uint8_t;
+        let mut ptr = f.lf.cdef_line_buf;
         if ptr.is_null() {
-            (*f).lf.cdef_buf_plane_sz[1] = 0;
-            (*f).lf.cdef_buf_plane_sz[0] = (*f).lf.cdef_buf_plane_sz[1];
+            f.lf.cdef_buf_plane_sz[1] = 0;
+            f.lf.cdef_buf_plane_sz[0] = f.lf.cdef_buf_plane_sz[1];
             return retval;
         }
         ptr = ptr.offset(32);
         if y_stride < 0 {
-            (*f).lf.cdef_line[0][0] =
-                ptr.offset(-(y_stride * ((*f).sbh as isize * 4 - 1))) as *mut libc::c_void;
-            (*f).lf.cdef_line[1][0] =
-                ptr.offset(-(y_stride * ((*f).sbh as isize * 4 - 3))) as *mut libc::c_void;
+            f.lf.cdef_line[0][0] =
+                ptr.offset(-(y_stride * (f.sbh as isize * 4 - 1))) as *mut libc::c_void;
+            f.lf.cdef_line[1][0] =
+                ptr.offset(-(y_stride * (f.sbh as isize * 4 - 3))) as *mut libc::c_void;
         } else {
-            (*f).lf.cdef_line[0][0] = ptr.offset(y_stride * 0) as *mut libc::c_void;
-            (*f).lf.cdef_line[1][0] = ptr.offset(y_stride * 2) as *mut libc::c_void;
+            f.lf.cdef_line[0][0] = ptr.offset(y_stride * 0) as *mut libc::c_void;
+            f.lf.cdef_line[1][0] = ptr.offset(y_stride * 2) as *mut libc::c_void;
         }
-        ptr = ptr.offset(y_stride.abs() * (*f).sbh as isize * 4);
+        ptr = ptr.offset(y_stride.abs() * f.sbh as isize * 4);
         if uv_stride < 0 {
-            (*f).lf.cdef_line[0][1] =
-                ptr.offset(-(uv_stride * ((*f).sbh as isize * 8 - 1))) as *mut libc::c_void;
-            (*f).lf.cdef_line[0][2] =
-                ptr.offset(-(uv_stride * ((*f).sbh as isize * 8 - 3))) as *mut libc::c_void;
-            (*f).lf.cdef_line[1][1] =
-                ptr.offset(-(uv_stride * ((*f).sbh as isize * 8 - 5))) as *mut libc::c_void;
-            (*f).lf.cdef_line[1][2] =
-                ptr.offset(-(uv_stride * ((*f).sbh as isize * 8 - 7))) as *mut libc::c_void;
+            f.lf.cdef_line[0][1] =
+                ptr.offset(-(uv_stride * (f.sbh as isize * 8 - 1))) as *mut libc::c_void;
+            f.lf.cdef_line[0][2] =
+                ptr.offset(-(uv_stride * (f.sbh as isize * 8 - 3))) as *mut libc::c_void;
+            f.lf.cdef_line[1][1] =
+                ptr.offset(-(uv_stride * (f.sbh as isize * 8 - 5))) as *mut libc::c_void;
+            f.lf.cdef_line[1][2] =
+                ptr.offset(-(uv_stride * (f.sbh as isize * 8 - 7))) as *mut libc::c_void;
         } else {
-            (*f).lf.cdef_line[0][1] = ptr.offset(uv_stride * 0) as *mut libc::c_void;
-            (*f).lf.cdef_line[0][2] = ptr.offset(uv_stride * 2) as *mut libc::c_void;
-            (*f).lf.cdef_line[1][1] = ptr.offset(uv_stride * 4) as *mut libc::c_void;
-            (*f).lf.cdef_line[1][2] = ptr.offset(uv_stride * 6) as *mut libc::c_void;
+            f.lf.cdef_line[0][1] = ptr.offset(uv_stride * 0) as *mut libc::c_void;
+            f.lf.cdef_line[0][2] = ptr.offset(uv_stride * 2) as *mut libc::c_void;
+            f.lf.cdef_line[1][1] = ptr.offset(uv_stride * 4) as *mut libc::c_void;
+            f.lf.cdef_line[1][2] = ptr.offset(uv_stride * 6) as *mut libc::c_void;
         }
         if need_cdef_lpf_copy != 0 {
-            ptr = ptr.offset(uv_stride.abs() * (*f).sbh as isize * 8);
+            ptr = ptr.offset(uv_stride.abs() * f.sbh as isize * 8);
             if y_stride < 0 {
-                (*f).lf.cdef_lpf_line[0] =
-                    ptr.offset(-(y_stride * ((*f).sbh as isize * 4 - 1))) as *mut libc::c_void;
+                f.lf.cdef_lpf_line[0] =
+                    ptr.offset(-(y_stride * (f.sbh as isize * 4 - 1))) as *mut libc::c_void;
             } else {
-                (*f).lf.cdef_lpf_line[0] = ptr as *mut libc::c_void;
+                f.lf.cdef_lpf_line[0] = ptr as *mut libc::c_void;
             }
-            ptr = ptr.offset(y_stride.abs() * (*f).sbh as isize * 4);
+            ptr = ptr.offset(y_stride.abs() * f.sbh as isize * 4);
             if uv_stride < 0 {
-                (*f).lf.cdef_lpf_line[1] =
-                    ptr.offset(-(uv_stride * ((*f).sbh as isize * 4 - 1))) as *mut libc::c_void;
-                (*f).lf.cdef_lpf_line[2] =
-                    ptr.offset(-(uv_stride * ((*f).sbh as isize * 8 - 1))) as *mut libc::c_void;
+                f.lf.cdef_lpf_line[1] =
+                    ptr.offset(-(uv_stride * (f.sbh as isize * 4 - 1))) as *mut libc::c_void;
+                f.lf.cdef_lpf_line[2] =
+                    ptr.offset(-(uv_stride * (f.sbh as isize * 8 - 1))) as *mut libc::c_void;
             } else {
-                (*f).lf.cdef_lpf_line[1] = ptr as *mut libc::c_void;
-                (*f).lf.cdef_lpf_line[2] =
-                    ptr.offset(uv_stride * (*f).sbh as isize * 4) as *mut libc::c_void;
+                f.lf.cdef_lpf_line[1] = ptr as *mut libc::c_void;
+                f.lf.cdef_lpf_line[2] =
+                    ptr.offset(uv_stride * f.sbh as isize * 4) as *mut libc::c_void;
             }
         }
-        (*f).lf.cdef_buf_plane_sz[0] = y_stride as libc::c_int * (*f).sbh * 4;
-        (*f).lf.cdef_buf_plane_sz[1] = uv_stride as libc::c_int * (*f).sbh * 8;
-        (*f).lf.need_cdef_lpf_copy = need_cdef_lpf_copy;
-        (*f).lf.cdef_buf_sbh = (*f).sbh;
+        f.lf.cdef_buf_plane_sz[0] = y_stride as libc::c_int * f.sbh * 4;
+        f.lf.cdef_buf_plane_sz[1] = uv_stride as libc::c_int * f.sbh * 8;
+        f.lf.need_cdef_lpf_copy = need_cdef_lpf_copy;
+        f.lf.cdef_buf_sbh = f.sbh;
     }
-    let sb128 = (*(*f).seq_hdr).sb128;
+    let sb128 = (*f.seq_hdr).sb128;
     let num_lines = if (*c).n_tc > 1 {
-        ((*f).sbh * 4) << sb128
+        (f.sbh * 4) << sb128
     } else {
         12
     };
-    y_stride = (*f).sr_cur.p.stride[0];
-    uv_stride = (*f).sr_cur.p.stride[1];
-    if y_stride * num_lines as isize != (*f).lf.lr_buf_plane_sz[0] as isize
-        || uv_stride * num_lines as isize * 2 != (*f).lf.lr_buf_plane_sz[1] as isize
+    y_stride = f.sr_cur.p.stride[0];
+    uv_stride = f.sr_cur.p.stride[1];
+    if y_stride * num_lines as isize != f.lf.lr_buf_plane_sz[0] as isize
+        || uv_stride * num_lines as isize * 2 != f.lf.lr_buf_plane_sz[1] as isize
     {
-        dav1d_free_aligned((*f).lf.lr_line_buf as *mut libc::c_void);
+        dav1d_free_aligned(f.lf.lr_line_buf as *mut libc::c_void);
         let mut alloc_sz: size_t = 128;
         alloc_sz =
             alloc_sz.wrapping_add((y_stride.abs() as size_t).wrapping_mul(num_lines as size_t));
@@ -5344,197 +5344,191 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 .wrapping_mul(num_lines as size_t)
                 .wrapping_mul(2),
         );
-        (*f).lf.lr_line_buf = dav1d_alloc_aligned(alloc_sz, 64) as *mut uint8_t;
-        let mut ptr = (*f).lf.lr_line_buf;
+        f.lf.lr_line_buf = dav1d_alloc_aligned(alloc_sz, 64) as *mut uint8_t;
+        let mut ptr = f.lf.lr_line_buf;
         if ptr.is_null() {
-            (*f).lf.lr_buf_plane_sz[1] = 0;
-            (*f).lf.lr_buf_plane_sz[0] = (*f).lf.lr_buf_plane_sz[1];
+            f.lf.lr_buf_plane_sz[1] = 0;
+            f.lf.lr_buf_plane_sz[0] = f.lf.lr_buf_plane_sz[1];
             return retval;
         }
         ptr = ptr.offset(64);
         if y_stride < 0 {
-            (*f).lf.lr_lpf_line[0] =
+            f.lf.lr_lpf_line[0] =
                 ptr.offset(-(y_stride * (num_lines as isize - 1))) as *mut libc::c_void;
         } else {
-            (*f).lf.lr_lpf_line[0] = ptr as *mut libc::c_void;
+            f.lf.lr_lpf_line[0] = ptr as *mut libc::c_void;
         }
         ptr = ptr.offset(y_stride.abs() * num_lines as isize);
         if uv_stride < 0 {
-            (*f).lf.lr_lpf_line[1] =
+            f.lf.lr_lpf_line[1] =
                 ptr.offset(-(uv_stride * (num_lines as isize * 1 - 1))) as *mut libc::c_void;
-            (*f).lf.lr_lpf_line[2] =
+            f.lf.lr_lpf_line[2] =
                 ptr.offset(-(uv_stride * (num_lines as isize * 2 - 1))) as *mut libc::c_void;
         } else {
-            (*f).lf.lr_lpf_line[1] = ptr as *mut libc::c_void;
-            (*f).lf.lr_lpf_line[2] =
-                ptr.offset(uv_stride * num_lines as isize) as *mut libc::c_void;
+            f.lf.lr_lpf_line[1] = ptr as *mut libc::c_void;
+            f.lf.lr_lpf_line[2] = ptr.offset(uv_stride * num_lines as isize) as *mut libc::c_void;
         }
-        (*f).lf.lr_buf_plane_sz[0] = y_stride as libc::c_int * num_lines;
-        (*f).lf.lr_buf_plane_sz[1] = uv_stride as libc::c_int * num_lines * 2;
+        f.lf.lr_buf_plane_sz[0] = y_stride as libc::c_int * num_lines;
+        f.lf.lr_buf_plane_sz[1] = uv_stride as libc::c_int * num_lines * 2;
     }
-    if num_sb128 != (*f).lf.mask_sz {
-        freep(&mut (*f).lf.mask as *mut *mut Av1Filter as *mut libc::c_void);
-        freep(&mut (*f).lf.level as *mut *mut [uint8_t; 4] as *mut libc::c_void);
-        (*f).lf.mask = malloc(
+    if num_sb128 != f.lf.mask_sz {
+        freep(&mut f.lf.mask as *mut *mut Av1Filter as *mut libc::c_void);
+        freep(&mut f.lf.level as *mut *mut [uint8_t; 4] as *mut libc::c_void);
+        f.lf.mask = malloc(
             (::core::mem::size_of::<Av1Filter>() as libc::c_ulong)
                 .wrapping_mul(num_sb128 as libc::c_ulong),
         ) as *mut Av1Filter;
-        (*f).lf.level = malloc(
+        f.lf.level = malloc(
             (::core::mem::size_of::<[uint8_t; 4]>() as libc::c_ulong)
                 .wrapping_mul(num_sb128 as libc::c_ulong)
                 .wrapping_mul(32)
                 .wrapping_mul(32)
                 .wrapping_add(3),
         ) as *mut [uint8_t; 4];
-        if ((*f).lf.mask).is_null() || ((*f).lf.level).is_null() {
-            (*f).lf.mask_sz = 0;
+        if (f.lf.mask).is_null() || (f.lf.level).is_null() {
+            f.lf.mask_sz = 0;
             return retval;
         }
         if (*c).n_fc > 1 {
-            freep(&mut (*f).frame_thread.b as *mut *mut Av1Block as *mut libc::c_void);
-            freep(&mut (*f).frame_thread.cbi as *mut *mut CodedBlockInfo as *mut libc::c_void);
-            (*f).frame_thread.b = malloc(
+            freep(&mut f.frame_thread.b as *mut *mut Av1Block as *mut libc::c_void);
+            freep(&mut f.frame_thread.cbi as *mut *mut CodedBlockInfo as *mut libc::c_void);
+            f.frame_thread.b = malloc(
                 (::core::mem::size_of::<Av1Block>() as libc::c_ulong)
                     .wrapping_mul(num_sb128 as libc::c_ulong)
                     .wrapping_mul(32)
                     .wrapping_mul(32),
             ) as *mut Av1Block;
-            (*f).frame_thread.cbi = malloc(
+            f.frame_thread.cbi = malloc(
                 (::core::mem::size_of::<CodedBlockInfo>() as libc::c_ulong)
                     .wrapping_mul(num_sb128 as libc::c_ulong)
                     .wrapping_mul(32)
                     .wrapping_mul(32),
             ) as *mut CodedBlockInfo;
-            if ((*f).frame_thread.b).is_null() || ((*f).frame_thread.cbi).is_null() {
-                (*f).lf.mask_sz = 0;
+            if (f.frame_thread.b).is_null() || (f.frame_thread.cbi).is_null() {
+                f.lf.mask_sz = 0;
                 return retval;
             }
         }
-        (*f).lf.mask_sz = num_sb128;
+        f.lf.mask_sz = num_sb128;
     }
-    (*f).sr_sb128w = (*f).sr_cur.p.p.w + 127 >> 7;
-    let lr_mask_sz = (*f).sr_sb128w * (*f).sb128h;
-    if lr_mask_sz != (*f).lf.lr_mask_sz {
-        freep(&mut (*f).lf.lr_mask as *mut *mut Av1Restoration as *mut libc::c_void);
-        (*f).lf.lr_mask = malloc(
+    f.sr_sb128w = f.sr_cur.p.p.w + 127 >> 7;
+    let lr_mask_sz = f.sr_sb128w * f.sb128h;
+    if lr_mask_sz != f.lf.lr_mask_sz {
+        freep(&mut f.lf.lr_mask as *mut *mut Av1Restoration as *mut libc::c_void);
+        f.lf.lr_mask = malloc(
             (::core::mem::size_of::<Av1Restoration>() as libc::c_ulong)
                 .wrapping_mul(lr_mask_sz as libc::c_ulong),
         ) as *mut Av1Restoration;
-        if ((*f).lf.lr_mask).is_null() {
-            (*f).lf.lr_mask_sz = 0;
+        if (f.lf.lr_mask).is_null() {
+            f.lf.lr_mask_sz = 0;
             return retval;
         }
-        (*f).lf.lr_mask_sz = lr_mask_sz;
+        f.lf.lr_mask_sz = lr_mask_sz;
     }
-    (*f).lf.restore_planes = ((((*(*f).frame_hdr).restoration.type_0[0] != DAV1D_RESTORATION_NONE)
+    f.lf.restore_planes = ((((*f.frame_hdr).restoration.type_0[0] != DAV1D_RESTORATION_NONE)
         as libc::c_int)
         << 0)
-        + ((((*(*f).frame_hdr).restoration.type_0[1] != DAV1D_RESTORATION_NONE) as libc::c_int)
-            << 1)
-        + ((((*(*f).frame_hdr).restoration.type_0[2] != DAV1D_RESTORATION_NONE) as libc::c_int)
-            << 2);
-    if (*(*f).frame_hdr).loopfilter.sharpness != (*f).lf.last_sharpness {
-        dav1d_calc_eih(
-            &mut (*f).lf.lim_lut.0,
-            (*(*f).frame_hdr).loopfilter.sharpness,
-        );
-        (*f).lf.last_sharpness = (*(*f).frame_hdr).loopfilter.sharpness;
+        + ((((*f.frame_hdr).restoration.type_0[1] != DAV1D_RESTORATION_NONE) as libc::c_int) << 1)
+        + ((((*f.frame_hdr).restoration.type_0[2] != DAV1D_RESTORATION_NONE) as libc::c_int) << 2);
+    if (*f.frame_hdr).loopfilter.sharpness != f.lf.last_sharpness {
+        dav1d_calc_eih(&mut f.lf.lim_lut.0, (*f.frame_hdr).loopfilter.sharpness);
+        f.lf.last_sharpness = (*f.frame_hdr).loopfilter.sharpness;
     }
-    dav1d_calc_lf_values(&mut (*f).lf.lvl, &*(*f).frame_hdr, &[0, 0, 0, 0]);
+    dav1d_calc_lf_values(&mut f.lf.lvl, &*f.frame_hdr, &[0, 0, 0, 0]);
     memset(
-        (*f).lf.mask as *mut libc::c_void,
+        f.lf.mask as *mut libc::c_void,
         0,
         (::core::mem::size_of::<Av1Filter>()).wrapping_mul(num_sb128 as size_t),
     );
-    let ipred_edge_sz = (*f).sbh * (*f).sb128w << hbd;
-    if ipred_edge_sz != (*f).ipred_edge_sz {
+    let ipred_edge_sz = f.sbh * f.sb128w << hbd;
+    if ipred_edge_sz != f.ipred_edge_sz {
         dav1d_freep_aligned(
-            &mut *((*f).ipred_edge).as_mut_ptr().offset(0) as *mut *mut libc::c_void
+            &mut *(f.ipred_edge).as_mut_ptr().offset(0) as *mut *mut libc::c_void
                 as *mut libc::c_void,
         );
-        (*f).ipred_edge[0] = dav1d_alloc_aligned(ipred_edge_sz as size_t * 128 * 3, 64);
-        let ptr = (*f).ipred_edge[0] as *mut uint8_t;
+        f.ipred_edge[0] = dav1d_alloc_aligned(ipred_edge_sz as size_t * 128 * 3, 64);
+        let ptr = f.ipred_edge[0] as *mut uint8_t;
         if ptr.is_null() {
-            (*f).ipred_edge_sz = 0;
+            f.ipred_edge_sz = 0;
             return retval;
         }
-        (*f).ipred_edge[1] = ptr.offset(ipred_edge_sz as isize * 128 * 1) as *mut libc::c_void;
-        (*f).ipred_edge[2] = ptr.offset(ipred_edge_sz as isize * 128 * 2) as *mut libc::c_void;
-        (*f).ipred_edge_sz = ipred_edge_sz;
+        f.ipred_edge[1] = ptr.offset(ipred_edge_sz as isize * 128 * 1) as *mut libc::c_void;
+        f.ipred_edge[2] = ptr.offset(ipred_edge_sz as isize * 128 * 2) as *mut libc::c_void;
+        f.ipred_edge_sz = ipred_edge_sz;
     }
-    let re_sz = (*f).sb128h * (*(*f).frame_hdr).tiling.cols;
-    if re_sz != (*f).lf.re_sz {
+    let re_sz = f.sb128h * (*f.frame_hdr).tiling.cols;
+    if re_sz != f.lf.re_sz {
         freep(
-            &mut *((*f).lf.tx_lpf_right_edge).as_mut_ptr().offset(0) as *mut *mut uint8_t
+            &mut *(f.lf.tx_lpf_right_edge).as_mut_ptr().offset(0) as *mut *mut uint8_t
                 as *mut libc::c_void,
         );
-        (*f).lf.tx_lpf_right_edge[0] = malloc(re_sz as libc::c_ulong * 32 * 2) as *mut uint8_t;
-        if ((*f).lf.tx_lpf_right_edge[0]).is_null() {
-            (*f).lf.re_sz = 0;
+        f.lf.tx_lpf_right_edge[0] = malloc(re_sz as libc::c_ulong * 32 * 2) as *mut uint8_t;
+        if (f.lf.tx_lpf_right_edge[0]).is_null() {
+            f.lf.re_sz = 0;
             return retval;
         }
-        (*f).lf.tx_lpf_right_edge[1] = ((*f).lf.tx_lpf_right_edge[0]).offset((re_sz * 32) as isize);
-        (*f).lf.re_sz = re_sz;
+        f.lf.tx_lpf_right_edge[1] = (f.lf.tx_lpf_right_edge[0]).offset((re_sz * 32) as isize);
+        f.lf.re_sz = re_sz;
     }
-    if (*(*f).frame_hdr).frame_type & 1 != 0 || (*(*f).frame_hdr).allow_intrabc != 0 {
+    if (*f.frame_hdr).frame_type & 1 != 0 || (*f.frame_hdr).allow_intrabc != 0 {
         let ret = dav1d_refmvs_init_frame(
-            &mut (*f).rf,
-            (*f).seq_hdr,
-            (*f).frame_hdr,
-            ((*f).refpoc).as_mut_ptr() as *const libc::c_uint,
-            (*f).mvs,
-            ((*f).refrefpoc).as_mut_ptr() as *const [libc::c_uint; 7],
-            ((*f).ref_mvs).as_mut_ptr() as *const *mut refmvs_temporal_block,
-            (*(*f).c).n_tc as libc::c_int,
-            (*(*f).c).n_fc as libc::c_int,
+            &mut f.rf,
+            f.seq_hdr,
+            f.frame_hdr,
+            (f.refpoc).as_mut_ptr() as *const libc::c_uint,
+            f.mvs,
+            (f.refrefpoc).as_mut_ptr() as *const [libc::c_uint; 7],
+            (f.ref_mvs).as_mut_ptr() as *const *mut refmvs_temporal_block,
+            (*f.c).n_tc as libc::c_int,
+            (*f.c).n_fc as libc::c_int,
         );
         if ret < 0 {
             return retval;
         }
     }
     init_quant_tables(
-        &*(*f).seq_hdr,
-        &*(*f).frame_hdr,
-        (*(*f).frame_hdr).quant.yac,
-        &mut (*f).dq,
+        &*f.seq_hdr,
+        &*f.frame_hdr,
+        (*f.frame_hdr).quant.yac,
+        &mut f.dq,
     );
-    if (*(*f).frame_hdr).quant.qm != 0 {
+    if (*f.frame_hdr).quant.qm != 0 {
         for i in 0..N_RECT_TX_SIZES {
-            (*f).qm[i][0] = dav1d_qm_tbl[(*(*f).frame_hdr).quant.qm_y as usize][0][i]
+            f.qm[i][0] = dav1d_qm_tbl[(*f.frame_hdr).quant.qm_y as usize][0][i]
                 .map_or(std::ptr::null(), |qm| qm.as_ptr());
-            (*f).qm[i][1] = dav1d_qm_tbl[(*(*f).frame_hdr).quant.qm_u as usize][1][i]
+            f.qm[i][1] = dav1d_qm_tbl[(*f.frame_hdr).quant.qm_u as usize][1][i]
                 .map_or(std::ptr::null(), |qm| qm.as_ptr());
-            (*f).qm[i][2] = dav1d_qm_tbl[(*(*f).frame_hdr).quant.qm_v as usize][1][i]
+            f.qm[i][2] = dav1d_qm_tbl[(*f.frame_hdr).quant.qm_v as usize][1][i]
                 .map_or(std::ptr::null(), |qm| qm.as_ptr());
         }
     } else {
         memset(
-            ((*f).qm).as_mut_ptr() as *mut libc::c_void,
+            (f.qm).as_mut_ptr() as *mut libc::c_void,
             0,
             ::core::mem::size_of::<[[*const uint8_t; 3]; 19]>(),
         );
     }
-    if (*(*f).frame_hdr).switchable_comp_refs != 0 {
+    if (*f.frame_hdr).switchable_comp_refs != 0 {
         let mut i = 0;
         while i < 7 {
-            let ref0poc = (*(*f).refp[i as usize].p.frame_hdr).frame_offset as libc::c_uint;
+            let ref0poc = (*f.refp[i as usize].p.frame_hdr).frame_offset as libc::c_uint;
             let mut j = i + 1;
             while j < 7 {
-                let ref1poc = (*(*f).refp[j as usize].p.frame_hdr).frame_offset as libc::c_uint;
+                let ref1poc = (*f.refp[j as usize].p.frame_hdr).frame_offset as libc::c_uint;
                 let d1 = imin(
                     (get_poc_diff(
-                        (*(*f).seq_hdr).order_hint_n_bits,
+                        (*f.seq_hdr).order_hint_n_bits,
                         ref0poc as libc::c_int,
-                        (*(*f).cur.frame_hdr).frame_offset,
+                        (*f.cur.frame_hdr).frame_offset,
                     ))
                     .abs(),
                     31,
                 ) as libc::c_uint;
                 let d0 = imin(
                     (get_poc_diff(
-                        (*(*f).seq_hdr).order_hint_n_bits,
+                        (*f.seq_hdr).order_hint_n_bits,
                         ref1poc as libc::c_int,
-                        (*(*f).cur.frame_hdr).frame_offset,
+                        (*f.cur.frame_hdr).frame_offset,
                     ))
                     .abs(),
                     31,
@@ -5555,21 +5549,21 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     }
                     k += 1;
                 }
-                (*f).jnt_weights[i as usize][j as usize] =
+                f.jnt_weights[i as usize][j as usize] =
                     quant_dist_lookup_table[k as usize][order as usize];
                 j += 1;
             }
             i += 1;
         }
     }
-    let has_chroma = ((*f).cur.p.layout != DAV1D_PIXEL_LAYOUT_I400) as libc::c_int;
-    (*f).lf.mask_ptr = (*f).lf.mask;
-    (*f).lf.p[0] = (*f).cur.data[0];
-    (*f).lf.p[1] = (*f).cur.data[if has_chroma != 0 { 1 } else { 0 }];
-    (*f).lf.p[2] = (*f).cur.data[if has_chroma != 0 { 2 } else { 0 }];
-    (*f).lf.sr_p[0] = (*f).sr_cur.p.data[0];
-    (*f).lf.sr_p[1] = (*f).sr_cur.p.data[if has_chroma != 0 { 1 } else { 0 }];
-    (*f).lf.sr_p[2] = (*f).sr_cur.p.data[if has_chroma != 0 { 2 } else { 0 }];
+    let has_chroma = (f.cur.p.layout != DAV1D_PIXEL_LAYOUT_I400) as libc::c_int;
+    f.lf.mask_ptr = f.lf.mask;
+    f.lf.p[0] = f.cur.data[0];
+    f.lf.p[1] = f.cur.data[if has_chroma != 0 { 1 } else { 0 }];
+    f.lf.p[2] = f.cur.data[if has_chroma != 0 { 2 } else { 0 }];
+    f.lf.sr_p[0] = f.sr_cur.p.data[0];
+    f.lf.sr_p[1] = f.sr_cur.p.data[if has_chroma != 0 { 1 } else { 0 }];
+    f.lf.sr_p[2] = f.sr_cur.p.data[if has_chroma != 0 { 2 } else { 0 }];
     retval = 0;
     return retval;
 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5059,13 +5059,11 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     let mut sby = 0;
     let mut tile_row = 0;
     while tile_row < (*f.frame_hdr).tiling.rows {
-        let fresh33 = sby;
-        sby = sby + 1;
-        *f.lf.start_of_tile_row.offset(fresh33 as isize) = tile_row as uint8_t;
+        *f.lf.start_of_tile_row.offset(sby as isize) = tile_row as uint8_t;
+        sby += 1;
         while sby < (*f.frame_hdr).tiling.row_start_sb[(tile_row + 1) as usize] as libc::c_int {
-            let fresh34 = sby;
-            sby = sby + 1;
-            *f.lf.start_of_tile_row.offset(fresh34 as isize) = 0;
+            *f.lf.start_of_tile_row.offset(sby as isize) = 0;
+            sby += 1;
         }
         tile_row += 1;
     }
@@ -5123,13 +5121,13 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 * 4;
             let mut tile_col = 0;
             while tile_col < (*f.frame_hdr).tiling.cols {
-                let fresh35 = tile_idx;
-                tile_idx = tile_idx + 1;
-                *f.frame_thread.tile_start_off.offset(fresh35 as isize) = row_off
+                *f.frame_thread.tile_start_off.offset(tile_idx as isize) = row_off
                     + b_diff
                         * (*f.frame_hdr).tiling.col_start_sb[tile_col as usize] as libc::c_int
                         * f.sb_step
                         * 4;
+
+                tile_idx += 1;
                 tile_col += 1;
             }
             tile_row += 1;
@@ -5156,9 +5154,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 - (*f.frame_hdr).tiling.row_start_sb[tile_row as usize] as libc::c_int;
             let mut tile_col = 0;
             while tile_col < (*f.frame_hdr).tiling.cols {
-                let ref mut fresh36 =
-                    (*(f.ts).offset((tile_row_base + tile_col) as isize)).lowest_pixel;
-                *fresh36 = lowest_pixel_ptr;
+                (*f.ts.offset((tile_row_base + tile_col) as isize)).lowest_pixel = lowest_pixel_ptr;
                 lowest_pixel_ptr = lowest_pixel_ptr.offset(tile_row_sb_h as isize);
                 tile_col += 1;
             }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5045,7 +5045,6 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     let f = &mut *f; // TODO(kkysen) propagate to arg once we deduplicate the fn decl
 
     let c = &*f.c;
-    let mut retval = -12;
 
     if f.sbh > f.lf.start_of_tile_row_sz {
         free(f.lf.start_of_tile_row as *mut libc::c_void);
@@ -5054,7 +5053,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 as *mut u8;
         if f.lf.start_of_tile_row.is_null() {
             f.lf.start_of_tile_row_sz = 0;
-            return retval;
+            return -12;
         }
         f.lf.start_of_tile_row_sz = f.sbh;
     }
@@ -5077,14 +5076,14 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             ) as *mut libc::c_int;
             if f.frame_thread.tile_start_off.is_null() {
                 f.n_ts = 0;
-                return retval;
+                return -12;
             }
         }
         dav1d_free_aligned(f.ts as *mut libc::c_void);
         f.ts = dav1d_alloc_aligned(::core::mem::size_of::<Dav1dTileState>() * n_ts as usize, 32)
             as *mut Dav1dTileState;
         if f.ts.is_null() {
-            return retval;
+            return -12;
         }
         f.n_ts = n_ts;
     }
@@ -5098,7 +5097,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 as *mut BlockContext;
         if f.a.is_null() {
             f.a_sz = 0;
-            return retval;
+            return -12;
         }
         f.a_sz = a_sz;
     }
@@ -5139,7 +5138,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             ) as *mut [[libc::c_int; 2]; 7];
             if f.tile_thread.lowest_pixel_mem.is_null() {
                 f.tile_thread.lowest_pixel_mem_sz = 0;
-                return retval;
+                return -12;
             }
             f.tile_thread.lowest_pixel_mem_sz = lowest_pixel_mem_sz;
         }
@@ -5163,7 +5162,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             f.frame_thread.cf = dav1d_alloc_aligned(cf_sz as usize * 128 * 128 / 2, 64);
             if f.frame_thread.cf.is_null() {
                 f.frame_thread.cf_sz = 0;
-                return retval;
+                return -12;
             }
             slice::from_raw_parts_mut(
                 f.frame_thread.cf.cast::<u8>(),
@@ -5184,7 +5183,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 ) as *mut [[u16; 8]; 3];
                 if f.frame_thread.pal.is_null() {
                     f.frame_thread.pal_sz = 0;
-                    return retval;
+                    return -12;
                 }
                 f.frame_thread.pal_sz = num_sb128;
             }
@@ -5200,7 +5199,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 ) as *mut u8;
                 if f.frame_thread.pal_idx.is_null() {
                     f.frame_thread.pal_idx_sz = 0;
-                    return retval;
+                    return -12;
                 }
                 f.frame_thread.pal_idx_sz = pal_idx_sz;
             }
@@ -5233,7 +5232,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         if ptr.is_null() {
             f.lf.cdef_buf_plane_sz[1] = 0;
             f.lf.cdef_buf_plane_sz[0] = f.lf.cdef_buf_plane_sz[1];
-            return retval;
+            return -12;
         }
 
         ptr = ptr.offset(32);
@@ -5307,7 +5306,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         if ptr.is_null() {
             f.lf.lr_buf_plane_sz[1] = 0;
             f.lf.lr_buf_plane_sz[0] = f.lf.lr_buf_plane_sz[1];
-            return retval;
+            return -12;
         }
 
         ptr = ptr.offset(64);
@@ -5350,7 +5349,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         ) as *mut [u8; 4];
         if f.lf.mask.is_null() || f.lf.level.is_null() {
             f.lf.mask_sz = 0;
-            return retval;
+            return -12;
         }
         if c.n_fc > 1 {
             freep(&mut f.frame_thread.b as *mut *mut Av1Block as *mut libc::c_void);
@@ -5369,7 +5368,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             ) as *mut CodedBlockInfo;
             if f.frame_thread.b.is_null() || f.frame_thread.cbi.is_null() {
                 f.lf.mask_sz = 0;
-                return retval;
+                return -12;
             }
         }
         f.lf.mask_sz = num_sb128;
@@ -5384,7 +5383,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         ) as *mut Av1Restoration;
         if f.lf.lr_mask.is_null() {
             f.lf.lr_mask_sz = 0;
-            return retval;
+            return -12;
         }
         f.lf.lr_mask_sz = lr_mask_sz;
     }
@@ -5413,7 +5412,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         let ptr = f.ipred_edge[0] as *mut u8;
         if ptr.is_null() {
             f.ipred_edge_sz = 0;
-            return retval;
+            return -12;
         }
         f.ipred_edge[1] = ptr.offset(ipred_edge_sz as isize * 128 * 1) as *mut libc::c_void;
         f.ipred_edge[2] = ptr.offset(ipred_edge_sz as isize * 128 * 2) as *mut libc::c_void;
@@ -5429,7 +5428,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         f.lf.tx_lpf_right_edge[0] = malloc(re_sz as libc::c_ulong * 32 * 2) as *mut u8;
         if f.lf.tx_lpf_right_edge[0].is_null() {
             f.lf.re_sz = 0;
-            return retval;
+            return -12;
         }
         f.lf.tx_lpf_right_edge[1] = f.lf.tx_lpf_right_edge[0].offset((re_sz * 32) as isize);
         f.lf.re_sz = re_sz;
@@ -5449,7 +5448,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             (*f.c).n_fc as libc::c_int,
         );
         if ret < 0 {
-            return retval;
+            return -12;
         }
     }
 
@@ -5518,8 +5517,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     f.lf.p = array::from_fn(|i| f.cur.data[has_chroma * i]);
     f.lf.sr_p = array::from_fn(|i| f.sr_cur.p.data[has_chroma * i]);
 
-    retval = 0;
-    return retval;
+    0
 }
 
 #[no_mangle]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5048,8 +5048,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     if f.sbh > f.lf.start_of_tile_row_sz {
         free(f.lf.start_of_tile_row as *mut libc::c_void);
         f.lf.start_of_tile_row =
-            malloc(f.sbh as libc::c_ulong * ::core::mem::size_of::<uint8_t>() as libc::c_ulong)
-                as *mut uint8_t;
+            malloc(f.sbh as libc::c_ulong * ::core::mem::size_of::<u8>() as libc::c_ulong)
+                as *mut u8;
         if f.lf.start_of_tile_row.is_null() {
             f.lf.start_of_tile_row_sz = 0;
             return retval;
@@ -5058,7 +5058,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     }
     let mut sby = 0;
     for tile_row in 0..(*f.frame_hdr).tiling.rows {
-        *f.lf.start_of_tile_row.offset(sby as isize) = tile_row as uint8_t;
+        *f.lf.start_of_tile_row.offset(sby as isize) = tile_row as u8;
         sby += 1;
         while sby < (*f.frame_hdr).tiling.row_start_sb[(tile_row + 1) as usize] as libc::c_int {
             *f.lf.start_of_tile_row.offset(sby as isize) = 0;
@@ -5078,10 +5078,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             }
         }
         dav1d_free_aligned(f.ts as *mut libc::c_void);
-        f.ts = dav1d_alloc_aligned(
-            ::core::mem::size_of::<Dav1dTileState>() * n_ts as size_t,
-            32,
-        ) as *mut Dav1dTileState;
+        f.ts = dav1d_alloc_aligned(::core::mem::size_of::<Dav1dTileState>() * n_ts as usize, 32)
+            as *mut Dav1dTileState;
         if f.ts.is_null() {
             return retval;
         }
@@ -5155,7 +5153,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             dav1d_freep_aligned(
                 &mut f.frame_thread.cf as *mut *mut libc::c_void as *mut libc::c_void,
             );
-            f.frame_thread.cf = dav1d_alloc_aligned(cf_sz as size_t * 128 * 128 / 2, 64);
+            f.frame_thread.cf = dav1d_alloc_aligned(cf_sz as usize * 128 * 128 / 2, 64);
             if f.frame_thread.cf.is_null() {
                 f.frame_thread.cf_sz = 0;
                 return retval;
@@ -5170,12 +5168,12 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         if (*f.frame_hdr).allow_screen_content_tools != 0 {
             if num_sb128 != f.frame_thread.pal_sz {
                 dav1d_freep_aligned(
-                    &mut f.frame_thread.pal as *mut *mut [[uint16_t; 8]; 3] as *mut libc::c_void,
+                    &mut f.frame_thread.pal as *mut *mut [[u16; 8]; 3] as *mut libc::c_void,
                 );
                 f.frame_thread.pal = dav1d_alloc_aligned(
-                    ::core::mem::size_of::<[[uint16_t; 8]; 3]>() * num_sb128 as size_t * 16 * 16,
+                    ::core::mem::size_of::<[[u16; 8]; 3]>() * num_sb128 as usize * 16 * 16,
                     64,
-                ) as *mut [[uint16_t; 8]; 3];
+                ) as *mut [[u16; 8]; 3];
                 if f.frame_thread.pal.is_null() {
                     f.frame_thread.pal_sz = 0;
                     return retval;
@@ -5185,12 +5183,12 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             let pal_idx_sz = num_sb128 * size_mul[1] as libc::c_int;
             if pal_idx_sz != f.frame_thread.pal_idx_sz {
                 dav1d_freep_aligned(
-                    &mut f.frame_thread.pal_idx as *mut *mut uint8_t as *mut libc::c_void,
+                    &mut f.frame_thread.pal_idx as *mut *mut u8 as *mut libc::c_void,
                 );
                 f.frame_thread.pal_idx = dav1d_alloc_aligned(
-                    ::core::mem::size_of::<uint8_t>() * pal_idx_sz as size_t * 128 * 128 / 4,
+                    ::core::mem::size_of::<u8>() * pal_idx_sz as usize * 128 * 128 / 4,
                     64,
-                ) as *mut uint8_t;
+                ) as *mut u8;
                 if f.frame_thread.pal_idx.is_null() {
                     f.frame_thread.pal_idx_sz = 0;
                     return retval;
@@ -5199,11 +5197,9 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             }
         } else if !f.frame_thread.pal.is_null() {
             dav1d_freep_aligned(
-                &mut f.frame_thread.pal as *mut *mut [[uint16_t; 8]; 3] as *mut libc::c_void,
+                &mut f.frame_thread.pal as *mut *mut [[u16; 8]; 3] as *mut libc::c_void,
             );
-            dav1d_freep_aligned(
-                &mut f.frame_thread.pal_idx as *mut *mut uint8_t as *mut libc::c_void,
-            );
+            dav1d_freep_aligned(&mut f.frame_thread.pal_idx as *mut *mut u8 as *mut libc::c_void);
             f.frame_thread.pal_idx_sz = 0;
             f.frame_thread.pal_sz = f.frame_thread.pal_idx_sz;
         }
@@ -5218,9 +5214,9 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         || f.sbh != f.lf.cdef_buf_sbh
     {
         dav1d_free_aligned(f.lf.cdef_line_buf as *mut libc::c_void);
-        let mut alloc_sz: size_t = 64;
-        alloc_sz += (y_stride.unsigned_abs() * 4 * f.sbh as size_t) << need_cdef_lpf_copy;
-        alloc_sz += (uv_stride.unsigned_abs() * 8 * f.sbh as size_t) << need_cdef_lpf_copy;
+        let mut alloc_sz: usize = 64;
+        alloc_sz += (y_stride.unsigned_abs() * 4 * f.sbh as usize) << need_cdef_lpf_copy;
+        alloc_sz += (uv_stride.unsigned_abs() * 8 * f.sbh as usize) << need_cdef_lpf_copy;
         f.lf.cdef_line_buf = dav1d_alloc_aligned(alloc_sz, 32) as *mut uint8_t;
         let mut ptr = f.lf.cdef_line_buf;
         if ptr.is_null() {
@@ -5287,9 +5283,9 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         || uv_stride * num_lines as isize * 2 != f.lf.lr_buf_plane_sz[1] as isize
     {
         dav1d_free_aligned(f.lf.lr_line_buf as *mut libc::c_void);
-        let mut alloc_sz: size_t = 128;
-        alloc_sz += y_stride.unsigned_abs() * num_lines as size_t;
-        alloc_sz += uv_stride.unsigned_abs() * num_lines as size_t * 2;
+        let mut alloc_sz: usize = 128;
+        alloc_sz += y_stride.unsigned_abs() * num_lines as usize;
+        alloc_sz += uv_stride.unsigned_abs() * num_lines as usize * 2;
         f.lf.lr_line_buf = dav1d_alloc_aligned(alloc_sz, 64) as *mut uint8_t;
         let mut ptr = f.lf.lr_line_buf;
         if ptr.is_null() {
@@ -5319,17 +5315,17 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     }
     if num_sb128 != f.lf.mask_sz {
         freep(&mut f.lf.mask as *mut *mut Av1Filter as *mut libc::c_void);
-        freep(&mut f.lf.level as *mut *mut [uint8_t; 4] as *mut libc::c_void);
+        freep(&mut f.lf.level as *mut *mut [u8; 4] as *mut libc::c_void);
         f.lf.mask = malloc(
             ::core::mem::size_of::<Av1Filter>() as libc::c_ulong * num_sb128 as libc::c_ulong,
         ) as *mut Av1Filter;
         f.lf.level = malloc(
-            ::core::mem::size_of::<[uint8_t; 4]>() as libc::c_ulong
+            ::core::mem::size_of::<[u8; 4]>() as libc::c_ulong
                 * num_sb128 as libc::c_ulong
                 * 32
                 * 32
                 + 3,
-        ) as *mut [uint8_t; 4];
+        ) as *mut [u8; 4];
         if f.lf.mask.is_null() || f.lf.level.is_null() {
             f.lf.mask_sz = 0;
             return retval;
@@ -5386,8 +5382,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             &mut *f.ipred_edge.as_mut_ptr().offset(0) as *mut *mut libc::c_void
                 as *mut libc::c_void,
         );
-        f.ipred_edge[0] = dav1d_alloc_aligned(ipred_edge_sz as size_t * 128 * 3, 64);
-        let ptr = f.ipred_edge[0] as *mut uint8_t;
+        f.ipred_edge[0] = dav1d_alloc_aligned(ipred_edge_sz as usize * 128 * 3, 64);
+        let ptr = f.ipred_edge[0] as *mut u8;
         if ptr.is_null() {
             f.ipred_edge_sz = 0;
             return retval;
@@ -5399,10 +5395,10 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     let re_sz = f.sb128h * (*f.frame_hdr).tiling.cols;
     if re_sz != f.lf.re_sz {
         freep(
-            &mut *f.lf.tx_lpf_right_edge.as_mut_ptr().offset(0) as *mut *mut uint8_t
+            &mut *f.lf.tx_lpf_right_edge.as_mut_ptr().offset(0) as *mut *mut u8
                 as *mut libc::c_void,
         );
-        f.lf.tx_lpf_right_edge[0] = malloc(re_sz as libc::c_ulong * 32 * 2) as *mut uint8_t;
+        f.lf.tx_lpf_right_edge[0] = malloc(re_sz as libc::c_ulong * 32 * 2) as *mut u8;
         if f.lf.tx_lpf_right_edge[0].is_null() {
             f.lf.re_sz = 0;
             return retval;
@@ -5468,9 +5464,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     31,
                 );
                 let order = d0 <= d1;
-                static quant_dist_weight: [[uint8_t; 2]; 3] = [[2, 3], [2, 5], [2, 7]];
-                static quant_dist_lookup_table: [[uint8_t; 2]; 4] =
-                    [[9, 7], [11, 5], [12, 4], [13, 3]];
+                static quant_dist_weight: [[u8; 2]; 3] = [[2, 3], [2, 5], [2, 7]];
+                static quant_dist_lookup_table: [[u8; 2]; 4] = [[9, 7], [11, 5], [12, 4], [13, 3]];
                 let mut k = 0;
                 while k < 3 {
                     let c0 = quant_dist_weight[k][order as usize] as libc::c_int;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5442,15 +5442,14 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         f.qm = [[ptr::null(); 3]; 19]; // TODO(kkysen) can be Default::default once the type is Option
     }
     if (*f.frame_hdr).switchable_comp_refs != 0 {
-        for i in 0..7 {
-            let ref0poc = (*f.refp[i].p.frame_hdr).frame_offset;
-            for j in i + 1..7 {
-                let ref1poc = (*f.refp[j].p.frame_hdr).frame_offset;
-                let d = [ref1poc, ref0poc].map(|refpoc| {
+        let ref_pocs: [_; 7] = array::from_fn(|i| (*f.refp[i].p.frame_hdr).frame_offset);
+        for i in 0..ref_pocs.len() {
+            for j in i + 1..ref_pocs.len() {
+                let d = [j, i].map(|ij| {
                     std::cmp::min(
                         (get_poc_diff(
                             (*f.seq_hdr).order_hint_n_bits,
-                            refpoc,
+                            ref_pocs[ij],
                             (*f.cur.frame_hdr).frame_offset,
                         ))
                         .unsigned_abs(),

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5510,10 +5510,10 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     // to avoid having additional in-loop branches in various places.
     // We never dereference those pointers, so it doesn't really matter
     // what they point at, as long as the pointers are valid.
-    let has_chroma = f.cur.p.layout != DAV1D_PIXEL_LAYOUT_I400;
+    let has_chroma = (f.cur.p.layout != DAV1D_PIXEL_LAYOUT_I400) as usize;
     f.lf.mask_ptr = f.lf.mask;
-    f.lf.p = array::from_fn(|i| f.cur.data[if has_chroma { i } else { 0 }]);
-    f.lf.sr_p = array::from_fn(|i| f.sr_cur.p.data[if has_chroma { i } else { 0 }]);
+    f.lf.p = array::from_fn(|i| f.cur.data[has_chroma * i]);
+    f.lf.sr_p = array::from_fn(|i| f.sr_cur.p.data[has_chroma * i]);
 
     retval = 0;
     return retval;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5230,8 +5230,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     {
         dav1d_free_aligned(f.lf.cdef_line_buf as *mut libc::c_void);
         let mut alloc_sz: size_t = 64;
-        alloc_sz += (y_stride.abs() as size_t * 4 * f.sbh as size_t) << need_cdef_lpf_copy;
-        alloc_sz += (uv_stride.abs() as size_t * 8 * f.sbh as size_t) << need_cdef_lpf_copy;
+        alloc_sz += (y_stride.unsigned_abs() * 4 * f.sbh as size_t) << need_cdef_lpf_copy;
+        alloc_sz += (uv_stride.unsigned_abs() * 8 * f.sbh as size_t) << need_cdef_lpf_copy;
         f.lf.cdef_line_buf = dav1d_alloc_aligned(alloc_sz, 32) as *mut uint8_t;
         let mut ptr = f.lf.cdef_line_buf;
         if ptr.is_null() {
@@ -5299,8 +5299,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     {
         dav1d_free_aligned(f.lf.lr_line_buf as *mut libc::c_void);
         let mut alloc_sz: size_t = 128;
-        alloc_sz += y_stride.abs() as size_t * num_lines as size_t;
-        alloc_sz += uv_stride.abs() as size_t * num_lines as size_t * 2;
+        alloc_sz += y_stride.unsigned_abs() * num_lines as size_t;
+        alloc_sz += uv_stride.unsigned_abs() * num_lines as size_t * 2;
         f.lf.lr_line_buf = dav1d_alloc_aligned(alloc_sz, 64) as *mut uint8_t;
         let mut ptr = f.lf.lr_line_buf;
         if ptr.is_null() {
@@ -5468,18 +5468,18 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                         ref0poc as libc::c_int,
                         (*f.cur.frame_hdr).frame_offset,
                     ))
-                    .abs(),
+                    .unsigned_abs(),
                     31,
-                ) as libc::c_uint;
+                );
                 let d0 = std::cmp::min(
                     (get_poc_diff(
                         (*f.seq_hdr).order_hint_n_bits,
                         ref1poc as libc::c_int,
                         (*f.cur.frame_hdr).frame_offset,
                     ))
-                    .abs(),
+                    .unsigned_abs(),
                     31,
-                ) as libc::c_uint;
+                );
                 let order = (d0 <= d1) as libc::c_int;
                 static mut quant_dist_weight: [[uint8_t; 2]; 3] = [[2, 3], [2, 5], [2, 7]];
                 static mut quant_dist_lookup_table: [[uint8_t; 2]; 4] =

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5047,10 +5047,9 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     let mut retval = -12;
     if f.sbh > f.lf.start_of_tile_row_sz {
         free(f.lf.start_of_tile_row as *mut libc::c_void);
-        f.lf.start_of_tile_row = malloc(
-            (f.sbh as libc::c_ulong)
-                .wrapping_mul(::core::mem::size_of::<uint8_t>() as libc::c_ulong),
-        ) as *mut uint8_t;
+        f.lf.start_of_tile_row =
+            malloc(f.sbh as libc::c_ulong * ::core::mem::size_of::<uint8_t>() as libc::c_ulong)
+                as *mut uint8_t;
         if f.lf.start_of_tile_row.is_null() {
             f.lf.start_of_tile_row_sz = 0;
             return retval;
@@ -5075,8 +5074,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         if c.n_fc > 1 {
             freep(&mut f.frame_thread.tile_start_off as *mut *mut libc::c_int as *mut libc::c_void);
             f.frame_thread.tile_start_off = malloc(
-                (::core::mem::size_of::<libc::c_int>() as libc::c_ulong)
-                    .wrapping_mul(n_ts as libc::c_ulong),
+                ::core::mem::size_of::<libc::c_int>() as libc::c_ulong * n_ts as libc::c_ulong,
             ) as *mut libc::c_int;
             if f.frame_thread.tile_start_off.is_null() {
                 f.n_ts = 0;
@@ -5085,7 +5083,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         }
         dav1d_free_aligned(f.ts as *mut libc::c_void);
         f.ts = dav1d_alloc_aligned(
-            (::core::mem::size_of::<Dav1dTileState>()).wrapping_mul(n_ts as size_t),
+            ::core::mem::size_of::<Dav1dTileState>() * n_ts as size_t,
             32,
         ) as *mut Dav1dTileState;
         if f.ts.is_null() {
@@ -5097,10 +5095,9 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         f.sb128w * (*f.frame_hdr).tiling.rows * (1 + (c.n_fc > 1 && c.n_tc > 1) as libc::c_int);
     if a_sz != f.a_sz {
         freep(&mut f.a as *mut *mut BlockContext as *mut libc::c_void);
-        f.a = malloc(
-            (::core::mem::size_of::<BlockContext>() as libc::c_ulong)
-                .wrapping_mul(a_sz as libc::c_ulong),
-        ) as *mut BlockContext;
+        f.a =
+            malloc(::core::mem::size_of::<BlockContext>() as libc::c_ulong * a_sz as libc::c_ulong)
+                as *mut BlockContext;
         if f.a.is_null() {
             f.a_sz = 0;
             return retval;
@@ -5141,8 +5138,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         if lowest_pixel_mem_sz != f.tile_thread.lowest_pixel_mem_sz {
             free(f.tile_thread.lowest_pixel_mem as *mut libc::c_void);
             f.tile_thread.lowest_pixel_mem = malloc(
-                (lowest_pixel_mem_sz as libc::c_ulong)
-                    .wrapping_mul(::core::mem::size_of::<[[libc::c_int; 2]; 7]>() as libc::c_ulong),
+                lowest_pixel_mem_sz as libc::c_ulong
+                    * ::core::mem::size_of::<[[libc::c_int; 2]; 7]>() as libc::c_ulong,
             ) as *mut [[libc::c_int; 2]; 7];
             if f.tile_thread.lowest_pixel_mem.is_null() {
                 f.tile_thread.lowest_pixel_mem_sz = 0;
@@ -5173,25 +5170,12 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             dav1d_freep_aligned(
                 &mut f.frame_thread.cf as *mut *mut libc::c_void as *mut libc::c_void,
             );
-            f.frame_thread.cf = dav1d_alloc_aligned(
-                (cf_sz as size_t)
-                    .wrapping_mul(128)
-                    .wrapping_mul(128)
-                    .wrapping_div(2),
-                64,
-            );
+            f.frame_thread.cf = dav1d_alloc_aligned(cf_sz as size_t * 128 * 128 / 2, 64);
             if f.frame_thread.cf.is_null() {
                 f.frame_thread.cf_sz = 0;
                 return retval;
             }
-            memset(
-                f.frame_thread.cf,
-                0,
-                (cf_sz as size_t)
-                    .wrapping_mul(128)
-                    .wrapping_mul(128)
-                    .wrapping_div(2),
-            );
+            memset(f.frame_thread.cf, 0, cf_sz as size_t * 128 * 128 / 2);
             f.frame_thread.cf_sz = cf_sz;
         }
         if (*f.frame_hdr).allow_screen_content_tools != 0 {
@@ -5200,10 +5184,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     &mut f.frame_thread.pal as *mut *mut [[uint16_t; 8]; 3] as *mut libc::c_void,
                 );
                 f.frame_thread.pal = dav1d_alloc_aligned(
-                    (::core::mem::size_of::<[[uint16_t; 8]; 3]>())
-                        .wrapping_mul(num_sb128 as size_t)
-                        .wrapping_mul(16)
-                        .wrapping_mul(16),
+                    ::core::mem::size_of::<[[uint16_t; 8]; 3]>() * num_sb128 as size_t * 16 * 16,
                     64,
                 ) as *mut [[uint16_t; 8]; 3];
                 if f.frame_thread.pal.is_null() {
@@ -5218,11 +5199,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     &mut f.frame_thread.pal_idx as *mut *mut uint8_t as *mut libc::c_void,
                 );
                 f.frame_thread.pal_idx = dav1d_alloc_aligned(
-                    (::core::mem::size_of::<uint8_t>())
-                        .wrapping_mul(pal_idx_sz as size_t)
-                        .wrapping_mul(128)
-                        .wrapping_mul(128)
-                        .wrapping_div(4),
+                    ::core::mem::size_of::<uint8_t>() * pal_idx_sz as size_t * 128 * 128 / 4,
                     64,
                 ) as *mut uint8_t;
                 if f.frame_thread.pal_idx.is_null() {
@@ -5253,18 +5230,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     {
         dav1d_free_aligned(f.lf.cdef_line_buf as *mut libc::c_void);
         let mut alloc_sz: size_t = 64;
-        alloc_sz = alloc_sz.wrapping_add(
-            (y_stride.abs() as size_t)
-                .wrapping_mul(4)
-                .wrapping_mul(f.sbh as size_t)
-                << need_cdef_lpf_copy,
-        );
-        alloc_sz = alloc_sz.wrapping_add(
-            (uv_stride.abs() as size_t)
-                .wrapping_mul(8)
-                .wrapping_mul(f.sbh as size_t)
-                << need_cdef_lpf_copy,
-        );
+        alloc_sz += (y_stride.abs() as size_t * 4 * f.sbh as size_t) << need_cdef_lpf_copy;
+        alloc_sz += (uv_stride.abs() as size_t * 8 * f.sbh as size_t) << need_cdef_lpf_copy;
         f.lf.cdef_line_buf = dav1d_alloc_aligned(alloc_sz, 32) as *mut uint8_t;
         let mut ptr = f.lf.cdef_line_buf;
         if ptr.is_null() {
@@ -5332,13 +5299,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     {
         dav1d_free_aligned(f.lf.lr_line_buf as *mut libc::c_void);
         let mut alloc_sz: size_t = 128;
-        alloc_sz =
-            alloc_sz.wrapping_add((y_stride.abs() as size_t).wrapping_mul(num_lines as size_t));
-        alloc_sz = alloc_sz.wrapping_add(
-            (uv_stride.abs() as size_t)
-                .wrapping_mul(num_lines as size_t)
-                .wrapping_mul(2),
-        );
+        alloc_sz += y_stride.abs() as size_t * num_lines as size_t;
+        alloc_sz += uv_stride.abs() as size_t * num_lines as size_t * 2;
         f.lf.lr_line_buf = dav1d_alloc_aligned(alloc_sz, 64) as *mut uint8_t;
         let mut ptr = f.lf.lr_line_buf;
         if ptr.is_null() {
@@ -5370,15 +5332,14 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         freep(&mut f.lf.mask as *mut *mut Av1Filter as *mut libc::c_void);
         freep(&mut f.lf.level as *mut *mut [uint8_t; 4] as *mut libc::c_void);
         f.lf.mask = malloc(
-            (::core::mem::size_of::<Av1Filter>() as libc::c_ulong)
-                .wrapping_mul(num_sb128 as libc::c_ulong),
+            ::core::mem::size_of::<Av1Filter>() as libc::c_ulong * num_sb128 as libc::c_ulong,
         ) as *mut Av1Filter;
         f.lf.level = malloc(
-            (::core::mem::size_of::<[uint8_t; 4]>() as libc::c_ulong)
-                .wrapping_mul(num_sb128 as libc::c_ulong)
-                .wrapping_mul(32)
-                .wrapping_mul(32)
-                .wrapping_add(3),
+            ::core::mem::size_of::<[uint8_t; 4]>() as libc::c_ulong
+                * num_sb128 as libc::c_ulong
+                * 32
+                * 32
+                + 3,
         ) as *mut [uint8_t; 4];
         if f.lf.mask.is_null() || f.lf.level.is_null() {
             f.lf.mask_sz = 0;
@@ -5388,16 +5349,16 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             freep(&mut f.frame_thread.b as *mut *mut Av1Block as *mut libc::c_void);
             freep(&mut f.frame_thread.cbi as *mut *mut CodedBlockInfo as *mut libc::c_void);
             f.frame_thread.b = malloc(
-                (::core::mem::size_of::<Av1Block>() as libc::c_ulong)
-                    .wrapping_mul(num_sb128 as libc::c_ulong)
-                    .wrapping_mul(32)
-                    .wrapping_mul(32),
+                ::core::mem::size_of::<Av1Block>() as libc::c_ulong
+                    * num_sb128 as libc::c_ulong
+                    * 32
+                    * 32,
             ) as *mut Av1Block;
             f.frame_thread.cbi = malloc(
-                (::core::mem::size_of::<CodedBlockInfo>() as libc::c_ulong)
-                    .wrapping_mul(num_sb128 as libc::c_ulong)
-                    .wrapping_mul(32)
-                    .wrapping_mul(32),
+                ::core::mem::size_of::<CodedBlockInfo>() as libc::c_ulong
+                    * num_sb128 as libc::c_ulong
+                    * 32
+                    * 32,
             ) as *mut CodedBlockInfo;
             if f.frame_thread.b.is_null() || f.frame_thread.cbi.is_null() {
                 f.lf.mask_sz = 0;
@@ -5411,8 +5372,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     if lr_mask_sz != f.lf.lr_mask_sz {
         freep(&mut f.lf.lr_mask as *mut *mut Av1Restoration as *mut libc::c_void);
         f.lf.lr_mask = malloc(
-            (::core::mem::size_of::<Av1Restoration>() as libc::c_ulong)
-                .wrapping_mul(lr_mask_sz as libc::c_ulong),
+            ::core::mem::size_of::<Av1Restoration>() as libc::c_ulong * lr_mask_sz as libc::c_ulong,
         ) as *mut Av1Restoration;
         if f.lf.lr_mask.is_null() {
             f.lf.lr_mask_sz = 0;
@@ -5433,7 +5393,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     memset(
         f.lf.mask as *mut libc::c_void,
         0,
-        (::core::mem::size_of::<Av1Filter>()).wrapping_mul(num_sb128 as size_t),
+        ::core::mem::size_of::<Av1Filter>() * num_sb128 as size_t,
     );
     let ipred_edge_sz = f.sbh * f.sb128w << hbd;
     if ipred_edge_sz != f.ipred_edge_sz {
@@ -5537,8 +5497,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 while k < 3 {
                     let c0 = quant_dist_weight[k as usize][order as usize] as libc::c_int;
                     let c1 = quant_dist_weight[k as usize][(order == 0) as usize] as libc::c_int;
-                    let d0_c0 = d0.wrapping_mul(c0 as libc::c_uint) as libc::c_int;
-                    let d1_c1 = d1.wrapping_mul(c1 as libc::c_uint) as libc::c_int;
+                    let d0_c0 = (d0 * c0 as libc::c_uint) as libc::c_int;
+                    let d1_c1 = (d1 * c1 as libc::c_uint) as libc::c_int;
                     if d0 > d1 && d0_c0 < d1_c1 || d0 <= d1 && d0_c0 > d1_c1 {
                         break;
                     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5462,7 +5462,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             let mut j = i + 1;
             while j < 7 {
                 let ref1poc = (*f.refp[j as usize].p.frame_hdr).frame_offset as libc::c_uint;
-                let d1 = imin(
+                let d1 = std::cmp::min(
                     (get_poc_diff(
                         (*f.seq_hdr).order_hint_n_bits,
                         ref0poc as libc::c_int,
@@ -5471,7 +5471,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     .abs(),
                     31,
                 ) as libc::c_uint;
-                let d0 = imin(
+                let d0 = std::cmp::min(
                     (get_poc_diff(
                         (*f.seq_hdr).order_hint_n_bits,
                         ref1poc as libc::c_int,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5468,8 +5468,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     31,
                 );
                 let order = d0 <= d1;
-                static mut quant_dist_weight: [[uint8_t; 2]; 3] = [[2, 3], [2, 5], [2, 7]];
-                static mut quant_dist_lookup_table: [[uint8_t; 2]; 4] =
+                static quant_dist_weight: [[uint8_t; 2]; 3] = [[2, 3], [2, 5], [2, 7]];
+                static quant_dist_lookup_table: [[uint8_t; 2]; 4] =
                     [[9, 7], [11, 5], [12, 4], [13, 3]];
                 let mut k = 0;
                 while k < 3 {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5486,14 +5486,14 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             }
         }
     }
-    let has_chroma = (f.cur.p.layout != DAV1D_PIXEL_LAYOUT_I400) as libc::c_int;
+    let has_chroma = f.cur.p.layout != DAV1D_PIXEL_LAYOUT_I400;
     f.lf.mask_ptr = f.lf.mask;
     f.lf.p[0] = f.cur.data[0];
-    f.lf.p[1] = f.cur.data[if has_chroma != 0 { 1 } else { 0 }];
-    f.lf.p[2] = f.cur.data[if has_chroma != 0 { 2 } else { 0 }];
+    f.lf.p[1] = f.cur.data[if has_chroma { 1 } else { 0 }];
+    f.lf.p[2] = f.cur.data[if has_chroma { 2 } else { 0 }];
     f.lf.sr_p[0] = f.sr_cur.p.data[0];
-    f.lf.sr_p[1] = f.sr_cur.p.data[if has_chroma != 0 { 1 } else { 0 }];
-    f.lf.sr_p[2] = f.sr_cur.p.data[if has_chroma != 0 { 2 } else { 0 }];
+    f.lf.sr_p[1] = f.sr_cur.p.data[if has_chroma { 1 } else { 0 }];
+    f.lf.sr_p[2] = f.sr_cur.p.data[if has_chroma { 2 } else { 0 }];
     retval = 0;
     return retval;
 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5459,15 +5459,14 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 let order = d[0] <= d[1];
                 static quant_dist_weight: [[u8; 2]; 3] = [[2, 3], [2, 5], [2, 7]];
                 static quant_dist_lookup_table: [[u8; 2]; 4] = [[9, 7], [11, 5], [12, 4], [13, 3]];
-                let mut k = 0;
-                while k < 3 {
-                    let c = [order, !order].map(|order| quant_dist_weight[k][order as usize]);
-                    let dc: [_; 2] = array::from_fn(|i| d[i] * c[i]);
-                    if !order && dc[0] < dc[1] || order && dc[0] > dc[1] {
-                        break;
-                    }
-                    k += 1;
-                }
+                let k = quant_dist_weight
+                    .into_iter()
+                    .position(|weight| {
+                        let c = [order, !order].map(|order| weight[order as usize]);
+                        let dc: [_; 2] = array::from_fn(|i| d[i] * c[i]);
+                        !order && dc[0] < dc[1] || order && dc[0] > dc[1]
+                    })
+                    .unwrap_or(quant_dist_weight.len());
                 f.jnt_weights[i][j] = quant_dist_lookup_table[k][order as usize];
             }
         }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5446,13 +5446,13 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     }
     if (*f.frame_hdr).switchable_comp_refs != 0 {
         for i in 0..7 {
-            let ref0poc = (*f.refp[i].p.frame_hdr).frame_offset as libc::c_uint;
+            let ref0poc = (*f.refp[i].p.frame_hdr).frame_offset;
             for j in i + 1..7 {
-                let ref1poc = (*f.refp[j].p.frame_hdr).frame_offset as libc::c_uint;
+                let ref1poc = (*f.refp[j].p.frame_hdr).frame_offset;
                 let d1 = std::cmp::min(
                     (get_poc_diff(
                         (*f.seq_hdr).order_hint_n_bits,
-                        ref0poc as libc::c_int,
+                        ref0poc,
                         (*f.cur.frame_hdr).frame_offset,
                     ))
                     .unsigned_abs(),
@@ -5461,7 +5461,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 let d0 = std::cmp::min(
                     (get_poc_diff(
                         (*f.seq_hdr).order_hint_n_bits,
-                        ref1poc as libc::c_int,
+                        ref1poc,
                         (*f.cur.frame_hdr).frame_offset,
                     ))
                     .unsigned_abs(),

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5435,7 +5435,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     }
 
     // init ref mvs
-    if (*f.frame_hdr).frame_type & 1 != 0 || (*f.frame_hdr).allow_intrabc != 0 {
+    if is_inter_or_switch(&*f.frame_hdr) || (*f.frame_hdr).allow_intrabc != 0 {
         let ret = dav1d_refmvs_init_frame(
             &mut f.rf,
             f.seq_hdr,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5042,7 +5042,7 @@ pub unsafe extern "C" fn dav1d_decode_tile_sbrow(t: *mut Dav1dTaskContext) -> li
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> libc::c_int {
     let c: *const Dav1dContext = (*f).c;
-    let mut retval: libc::c_int = -(12 as libc::c_int);
+    let mut retval: libc::c_int = -12;
     if (*f).sbh > (*f).lf.start_of_tile_row_sz {
         free((*f).lf.start_of_tile_row as *mut libc::c_void);
         (*f).lf.start_of_tile_row = malloc(
@@ -5050,7 +5050,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 .wrapping_mul(::core::mem::size_of::<uint8_t>() as libc::c_ulong),
         ) as *mut uint8_t;
         if ((*f).lf.start_of_tile_row).is_null() {
-            (*f).lf.start_of_tile_row_sz = 0 as libc::c_int;
+            (*f).lf.start_of_tile_row_sz = 0;
             return retval;
         }
         (*f).lf.start_of_tile_row_sz = (*f).sbh;
@@ -5064,13 +5064,13 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         while sby < (*(*f).frame_hdr).tiling.row_start_sb[(tile_row + 1) as usize] as libc::c_int {
             let fresh34 = sby;
             sby = sby + 1;
-            *((*f).lf.start_of_tile_row).offset(fresh34 as isize) = 0 as libc::c_int as uint8_t;
+            *((*f).lf.start_of_tile_row).offset(fresh34 as isize) = 0;
         }
         tile_row += 1;
     }
     let n_ts: libc::c_int = (*(*f).frame_hdr).tiling.cols * (*(*f).frame_hdr).tiling.rows;
     if n_ts != (*f).n_ts {
-        if (*c).n_fc > 1 as libc::c_uint {
+        if (*c).n_fc > 1 {
             freep(
                 &mut (*f).frame_thread.tile_start_off as *mut *mut libc::c_int as *mut libc::c_void,
             );
@@ -5079,14 +5079,14 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     .wrapping_mul(n_ts as libc::c_ulong),
             ) as *mut libc::c_int;
             if ((*f).frame_thread.tile_start_off).is_null() {
-                (*f).n_ts = 0 as libc::c_int;
+                (*f).n_ts = 0;
                 return retval;
             }
         }
         dav1d_free_aligned((*f).ts as *mut libc::c_void);
         (*f).ts = dav1d_alloc_aligned(
             (::core::mem::size_of::<Dav1dTileState>()).wrapping_mul(n_ts as size_t),
-            32 as libc::c_int as size_t,
+            32,
         ) as *mut Dav1dTileState;
         if ((*f).ts).is_null() {
             return retval;
@@ -5095,8 +5095,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     }
     let a_sz: libc::c_int = (*f).sb128w
         * (*(*f).frame_hdr).tiling.rows
-        * (1 as libc::c_int
-            + ((*c).n_fc > 1 as libc::c_uint && (*c).n_tc > 1 as libc::c_uint) as libc::c_int);
+        * (1 + ((*c).n_fc > 1 && (*c).n_tc > 1) as libc::c_int);
     if a_sz != (*f).a_sz {
         freep(&mut (*f).a as *mut *mut BlockContext as *mut libc::c_void);
         (*f).a = malloc(
@@ -5104,7 +5103,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 .wrapping_mul(a_sz as libc::c_ulong),
         ) as *mut BlockContext;
         if ((*f).a).is_null() {
-            (*f).a_sz = 0 as libc::c_int;
+            (*f).a_sz = 0;
             return retval;
         }
         (*f).a_sz = a_sz;
@@ -5112,7 +5111,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     let num_sb128: libc::c_int = (*f).sb128w * (*f).sb128h;
     let size_mul: *const uint8_t = (ss_size_mul[(*f).cur.p.layout as usize]).as_ptr();
     let hbd: libc::c_int = ((*(*f).seq_hdr).hbd != 0) as libc::c_int;
-    if (*c).n_fc > 1 as libc::c_uint {
+    if (*c).n_fc > 1 {
         let mut tile_idx = 0;
         let mut tile_row_0 = 0;
         while tile_row_0 < (*(*f).frame_hdr).tiling.rows {
@@ -5148,7 +5147,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     .wrapping_mul(::core::mem::size_of::<[[libc::c_int; 2]; 7]>() as libc::c_ulong),
             ) as *mut [[libc::c_int; 2]; 7];
             if ((*f).tile_thread.lowest_pixel_mem).is_null() {
-                (*f).tile_thread.lowest_pixel_mem_sz = 0 as libc::c_int;
+                (*f).tile_thread.lowest_pixel_mem_sz = 0;
                 return retval;
             }
             (*f).tile_thread.lowest_pixel_mem_sz = lowest_pixel_mem_sz;
@@ -5181,15 +5180,15 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     .wrapping_mul(128)
                     .wrapping_mul(128)
                     .wrapping_div(2),
-                64 as libc::c_int as size_t,
+                64,
             );
             if ((*f).frame_thread.cf).is_null() {
-                (*f).frame_thread.cf_sz = 0 as libc::c_int;
+                (*f).frame_thread.cf_sz = 0;
                 return retval;
             }
             memset(
                 (*f).frame_thread.cf,
-                0 as libc::c_int,
+                0,
                 (cf_sz as size_t)
                     .wrapping_mul(128)
                     .wrapping_mul(128)
@@ -5207,10 +5206,10 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                         .wrapping_mul(num_sb128 as size_t)
                         .wrapping_mul(16)
                         .wrapping_mul(16),
-                    64 as libc::c_int as size_t,
+                    64,
                 ) as *mut [[uint16_t; 8]; 3];
                 if ((*f).frame_thread.pal).is_null() {
-                    (*f).frame_thread.pal_sz = 0 as libc::c_int;
+                    (*f).frame_thread.pal_sz = 0;
                     return retval;
                 }
                 (*f).frame_thread.pal_sz = num_sb128;
@@ -5226,10 +5225,10 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                         .wrapping_mul(128)
                         .wrapping_mul(128)
                         .wrapping_div(4),
-                    64 as libc::c_int as size_t,
+                    64,
                 ) as *mut uint8_t;
                 if ((*f).frame_thread.pal_idx).is_null() {
-                    (*f).frame_thread.pal_idx_sz = 0 as libc::c_int;
+                    (*f).frame_thread.pal_idx_sz = 0;
                     return retval;
                 }
                 (*f).frame_thread.pal_idx_sz = pal_idx_sz;
@@ -5241,7 +5240,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             dav1d_freep_aligned(
                 &mut (*f).frame_thread.pal_idx as *mut *mut uint8_t as *mut libc::c_void,
             );
-            (*f).frame_thread.pal_idx_sz = 0 as libc::c_int;
+            (*f).frame_thread.pal_idx_sz = 0;
             (*f).frame_thread.pal_sz = (*f).frame_thread.pal_idx_sz;
         }
     }
@@ -5249,100 +5248,77 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     let mut uv_stride: ptrdiff_t = (*f).cur.stride[1];
     let has_resize: libc::c_int =
         ((*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1]) as libc::c_int;
-    let need_cdef_lpf_copy: libc::c_int =
-        ((*c).n_tc > 1 as libc::c_uint && has_resize != 0) as libc::c_int;
-    if y_stride * (*f).sbh as isize * 4 as isize != (*f).lf.cdef_buf_plane_sz[0] as isize
-        || uv_stride * (*f).sbh as isize * 8 as isize != (*f).lf.cdef_buf_plane_sz[1] as isize
+    let need_cdef_lpf_copy: libc::c_int = ((*c).n_tc > 1 && has_resize != 0) as libc::c_int;
+    if y_stride * (*f).sbh as isize * 4 != (*f).lf.cdef_buf_plane_sz[0] as isize
+        || uv_stride * (*f).sbh as isize * 8 != (*f).lf.cdef_buf_plane_sz[1] as isize
         || need_cdef_lpf_copy != (*f).lf.need_cdef_lpf_copy
         || (*f).sbh != (*f).lf.cdef_buf_sbh
     {
         dav1d_free_aligned((*f).lf.cdef_line_buf as *mut libc::c_void);
-        let mut alloc_sz: size_t = 64 as libc::c_int as size_t;
-        alloc_sz = (alloc_sz as size_t).wrapping_add(
-            ((y_stride as libc::c_longlong).abs() as size_t)
+        let mut alloc_sz: size_t = 64;
+        alloc_sz = alloc_sz.wrapping_add(
+            (y_stride.abs() as size_t)
                 .wrapping_mul(4)
                 .wrapping_mul((*f).sbh as size_t)
                 << need_cdef_lpf_copy,
-        ) as size_t as size_t;
-        alloc_sz = (alloc_sz as size_t).wrapping_add(
-            ((uv_stride as libc::c_longlong).abs() as size_t)
+        );
+        alloc_sz = alloc_sz.wrapping_add(
+            (uv_stride.abs() as size_t)
                 .wrapping_mul(8)
                 .wrapping_mul((*f).sbh as size_t)
                 << need_cdef_lpf_copy,
-        ) as size_t as size_t;
-        (*f).lf.cdef_line_buf =
-            dav1d_alloc_aligned(alloc_sz, 32 as libc::c_int as size_t) as *mut uint8_t;
+        );
+        (*f).lf.cdef_line_buf = dav1d_alloc_aligned(alloc_sz, 32) as *mut uint8_t;
         let mut ptr: *mut uint8_t = (*f).lf.cdef_line_buf;
         if ptr.is_null() {
-            (*f).lf.cdef_buf_plane_sz[1] = 0 as libc::c_int;
+            (*f).lf.cdef_buf_plane_sz[1] = 0;
             (*f).lf.cdef_buf_plane_sz[0] = (*f).lf.cdef_buf_plane_sz[1];
             return retval;
         }
         ptr = ptr.offset(32);
         if y_stride < 0 {
-            (*f).lf.cdef_line[0][0] = ptr
-                .offset(-((y_stride * ((*f).sbh * 4 - 1) as isize) as isize))
-                as *mut libc::c_void;
-            (*f).lf.cdef_line[1][0] = ptr
-                .offset(-((y_stride * ((*f).sbh * 4 - 3) as isize) as isize))
-                as *mut libc::c_void;
+            (*f).lf.cdef_line[0][0] =
+                ptr.offset(-(y_stride * ((*f).sbh as isize * 4 - 1))) as *mut libc::c_void;
+            (*f).lf.cdef_line[1][0] =
+                ptr.offset(-(y_stride * ((*f).sbh as isize * 4 - 3))) as *mut libc::c_void;
         } else {
-            (*f).lf.cdef_line[0][0] = ptr.offset((y_stride * 0) as isize) as *mut libc::c_void;
-            (*f).lf.cdef_line[1][0] = ptr.offset((y_stride * 2) as isize) as *mut libc::c_void;
+            (*f).lf.cdef_line[0][0] = ptr.offset(y_stride * 0) as *mut libc::c_void;
+            (*f).lf.cdef_line[1][0] = ptr.offset(y_stride * 2) as *mut libc::c_void;
         }
-        ptr = ptr.offset(
-            ((y_stride as libc::c_longlong).abs()
-                * (*f).sbh as libc::c_longlong
-                * 4 as libc::c_longlong) as isize,
-        );
+        ptr = ptr.offset(y_stride.abs() * (*f).sbh as isize * 4);
         if uv_stride < 0 {
-            (*f).lf.cdef_line[0][1] = ptr
-                .offset(-((uv_stride * ((*f).sbh * 8 - 1) as isize) as isize))
-                as *mut libc::c_void;
-            (*f).lf.cdef_line[0][2] = ptr
-                .offset(-((uv_stride * ((*f).sbh * 8 - 3) as isize) as isize))
-                as *mut libc::c_void;
-            (*f).lf.cdef_line[1][1] = ptr
-                .offset(-((uv_stride * ((*f).sbh * 8 - 5) as isize) as isize))
-                as *mut libc::c_void;
-            (*f).lf.cdef_line[1][2] = ptr
-                .offset(-((uv_stride * ((*f).sbh * 8 - 7) as isize) as isize))
-                as *mut libc::c_void;
+            (*f).lf.cdef_line[0][1] =
+                ptr.offset(-(uv_stride * ((*f).sbh as isize * 8 - 1))) as *mut libc::c_void;
+            (*f).lf.cdef_line[0][2] =
+                ptr.offset(-(uv_stride * ((*f).sbh as isize * 8 - 3))) as *mut libc::c_void;
+            (*f).lf.cdef_line[1][1] =
+                ptr.offset(-(uv_stride * ((*f).sbh as isize * 8 - 5))) as *mut libc::c_void;
+            (*f).lf.cdef_line[1][2] =
+                ptr.offset(-(uv_stride * ((*f).sbh as isize * 8 - 7))) as *mut libc::c_void;
         } else {
-            (*f).lf.cdef_line[0][1] = ptr.offset((uv_stride * 0) as isize) as *mut libc::c_void;
-            (*f).lf.cdef_line[0][2] = ptr.offset((uv_stride * 2) as isize) as *mut libc::c_void;
-            (*f).lf.cdef_line[1][1] = ptr.offset((uv_stride * 4) as isize) as *mut libc::c_void;
-            (*f).lf.cdef_line[1][2] = ptr.offset((uv_stride * 6) as isize) as *mut libc::c_void;
+            (*f).lf.cdef_line[0][1] = ptr.offset(uv_stride * 0) as *mut libc::c_void;
+            (*f).lf.cdef_line[0][2] = ptr.offset(uv_stride * 2) as *mut libc::c_void;
+            (*f).lf.cdef_line[1][1] = ptr.offset(uv_stride * 4) as *mut libc::c_void;
+            (*f).lf.cdef_line[1][2] = ptr.offset(uv_stride * 6) as *mut libc::c_void;
         }
         if need_cdef_lpf_copy != 0 {
-            ptr = ptr.offset(
-                ((uv_stride as libc::c_longlong).abs()
-                    * (*f).sbh as libc::c_longlong
-                    * 8 as libc::c_longlong) as isize,
-            );
+            ptr = ptr.offset(uv_stride.abs() * (*f).sbh as isize * 8);
             if y_stride < 0 {
-                (*f).lf.cdef_lpf_line[0] = ptr
-                    .offset(-((y_stride * ((*f).sbh * 4 - 1) as isize) as isize))
-                    as *mut libc::c_void;
+                (*f).lf.cdef_lpf_line[0] =
+                    ptr.offset(-(y_stride * ((*f).sbh as isize * 4 - 1))) as *mut libc::c_void;
             } else {
                 (*f).lf.cdef_lpf_line[0] = ptr as *mut libc::c_void;
             }
-            ptr = ptr.offset(
-                ((y_stride as libc::c_longlong).abs()
-                    * (*f).sbh as libc::c_longlong
-                    * 4 as libc::c_longlong) as isize,
-            );
+            ptr = ptr.offset(y_stride.abs() * (*f).sbh as isize * 4);
             if uv_stride < 0 {
-                (*f).lf.cdef_lpf_line[1] = ptr
-                    .offset(-((uv_stride * ((*f).sbh * 4 - 1) as isize) as isize))
-                    as *mut libc::c_void;
-                (*f).lf.cdef_lpf_line[2] = ptr
-                    .offset(-((uv_stride * ((*f).sbh * 8 - 1) as isize) as isize))
-                    as *mut libc::c_void;
+                (*f).lf.cdef_lpf_line[1] =
+                    ptr.offset(-(uv_stride * ((*f).sbh as isize * 4 - 1))) as *mut libc::c_void;
+                (*f).lf.cdef_lpf_line[2] =
+                    ptr.offset(-(uv_stride * ((*f).sbh as isize * 8 - 1))) as *mut libc::c_void;
             } else {
                 (*f).lf.cdef_lpf_line[1] = ptr as *mut libc::c_void;
                 (*f).lf.cdef_lpf_line[2] =
-                    ptr.offset((uv_stride * (*f).sbh as isize * 4) as isize) as *mut libc::c_void;
+                    ptr.offset(uv_stride * (*f).sbh as isize * 4) as *mut libc::c_void;
             }
         }
         (*f).lf.cdef_buf_plane_sz[0] = y_stride as libc::c_int * (*f).sbh * 4;
@@ -5351,10 +5327,10 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         (*f).lf.cdef_buf_sbh = (*f).sbh;
     }
     let sb128: libc::c_int = (*(*f).seq_hdr).sb128;
-    let num_lines: libc::c_int = if (*c).n_tc > 1 as libc::c_uint {
+    let num_lines: libc::c_int = if (*c).n_tc > 1 {
         ((*f).sbh * 4) << sb128
     } else {
-        12 as libc::c_int
+        12
     };
     y_stride = (*f).sr_cur.p.stride[0];
     uv_stride = (*f).sr_cur.p.stride[1];
@@ -5362,44 +5338,38 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         || uv_stride * num_lines as isize * 2 != (*f).lf.lr_buf_plane_sz[1] as isize
     {
         dav1d_free_aligned((*f).lf.lr_line_buf as *mut libc::c_void);
-        let mut alloc_sz_0: size_t = 128 as libc::c_int as size_t;
-        alloc_sz_0 = (alloc_sz_0 as size_t).wrapping_add(
-            ((y_stride as libc::c_longlong).abs() as size_t).wrapping_mul(num_lines as size_t),
-        ) as size_t as size_t;
-        alloc_sz_0 = (alloc_sz_0 as size_t).wrapping_add(
-            ((uv_stride as libc::c_longlong).abs() as size_t)
+        let mut alloc_sz_0: size_t = 128;
+        alloc_sz_0 =
+            alloc_sz_0.wrapping_add((y_stride.abs() as size_t).wrapping_mul(num_lines as size_t));
+        alloc_sz_0 = alloc_sz_0.wrapping_add(
+            (uv_stride.abs() as size_t)
                 .wrapping_mul(num_lines as size_t)
                 .wrapping_mul(2),
-        ) as size_t as size_t;
-        (*f).lf.lr_line_buf =
-            dav1d_alloc_aligned(alloc_sz_0, 64 as libc::c_int as size_t) as *mut uint8_t;
+        );
+        (*f).lf.lr_line_buf = dav1d_alloc_aligned(alloc_sz_0, 64) as *mut uint8_t;
         let mut ptr_0: *mut uint8_t = (*f).lf.lr_line_buf;
         if ptr_0.is_null() {
-            (*f).lf.lr_buf_plane_sz[1] = 0 as libc::c_int;
+            (*f).lf.lr_buf_plane_sz[1] = 0;
             (*f).lf.lr_buf_plane_sz[0] = (*f).lf.lr_buf_plane_sz[1];
             return retval;
         }
         ptr_0 = ptr_0.offset(64);
         if y_stride < 0 {
-            (*f).lf.lr_lpf_line[0] = ptr_0.offset(-((y_stride * (num_lines - 1) as isize) as isize))
-                as *mut libc::c_void;
+            (*f).lf.lr_lpf_line[0] =
+                ptr_0.offset(-(y_stride * (num_lines as isize - 1))) as *mut libc::c_void;
         } else {
             (*f).lf.lr_lpf_line[0] = ptr_0 as *mut libc::c_void;
         }
-        ptr_0 = ptr_0.offset(
-            ((y_stride as libc::c_longlong).abs() * num_lines as libc::c_longlong) as isize,
-        );
+        ptr_0 = ptr_0.offset(y_stride.abs() * num_lines as isize);
         if uv_stride < 0 {
-            (*f).lf.lr_lpf_line[1] = ptr_0
-                .offset(-((uv_stride * (num_lines * 1 - 1) as isize) as isize))
-                as *mut libc::c_void;
-            (*f).lf.lr_lpf_line[2] = ptr_0
-                .offset(-((uv_stride * (num_lines * 2 - 1) as isize) as isize))
-                as *mut libc::c_void;
+            (*f).lf.lr_lpf_line[1] =
+                ptr_0.offset(-(uv_stride * (num_lines as isize * 1 - 1))) as *mut libc::c_void;
+            (*f).lf.lr_lpf_line[2] =
+                ptr_0.offset(-(uv_stride * (num_lines as isize * 2 - 1))) as *mut libc::c_void;
         } else {
             (*f).lf.lr_lpf_line[1] = ptr_0 as *mut libc::c_void;
             (*f).lf.lr_lpf_line[2] =
-                ptr_0.offset((uv_stride * num_lines as isize) as isize) as *mut libc::c_void;
+                ptr_0.offset(uv_stride * num_lines as isize) as *mut libc::c_void;
         }
         (*f).lf.lr_buf_plane_sz[0] = y_stride as libc::c_int * num_lines;
         (*f).lf.lr_buf_plane_sz[1] = uv_stride as libc::c_int * num_lines * 2;
@@ -5414,31 +5384,31 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         (*f).lf.level = malloc(
             (::core::mem::size_of::<[uint8_t; 4]>() as libc::c_ulong)
                 .wrapping_mul(num_sb128 as libc::c_ulong)
-                .wrapping_mul(32 as libc::c_int as libc::c_ulong)
-                .wrapping_mul(32 as libc::c_int as libc::c_ulong)
-                .wrapping_add(3 as libc::c_int as libc::c_ulong),
+                .wrapping_mul(32)
+                .wrapping_mul(32)
+                .wrapping_add(3),
         ) as *mut [uint8_t; 4];
         if ((*f).lf.mask).is_null() || ((*f).lf.level).is_null() {
-            (*f).lf.mask_sz = 0 as libc::c_int;
+            (*f).lf.mask_sz = 0;
             return retval;
         }
-        if (*c).n_fc > 1 as libc::c_uint {
+        if (*c).n_fc > 1 {
             freep(&mut (*f).frame_thread.b as *mut *mut Av1Block as *mut libc::c_void);
             freep(&mut (*f).frame_thread.cbi as *mut *mut CodedBlockInfo as *mut libc::c_void);
             (*f).frame_thread.b = malloc(
                 (::core::mem::size_of::<Av1Block>() as libc::c_ulong)
                     .wrapping_mul(num_sb128 as libc::c_ulong)
-                    .wrapping_mul(32 as libc::c_int as libc::c_ulong)
-                    .wrapping_mul(32 as libc::c_int as libc::c_ulong),
+                    .wrapping_mul(32)
+                    .wrapping_mul(32),
             ) as *mut Av1Block;
             (*f).frame_thread.cbi = malloc(
                 (::core::mem::size_of::<CodedBlockInfo>() as libc::c_ulong)
                     .wrapping_mul(num_sb128 as libc::c_ulong)
-                    .wrapping_mul(32 as libc::c_int as libc::c_ulong)
-                    .wrapping_mul(32 as libc::c_int as libc::c_ulong),
+                    .wrapping_mul(32)
+                    .wrapping_mul(32),
             ) as *mut CodedBlockInfo;
             if ((*f).frame_thread.b).is_null() || ((*f).frame_thread.cbi).is_null() {
-                (*f).lf.mask_sz = 0 as libc::c_int;
+                (*f).lf.mask_sz = 0;
                 return retval;
             }
         }
@@ -5453,20 +5423,17 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 .wrapping_mul(lr_mask_sz as libc::c_ulong),
         ) as *mut Av1Restoration;
         if ((*f).lf.lr_mask).is_null() {
-            (*f).lf.lr_mask_sz = 0 as libc::c_int;
+            (*f).lf.lr_mask_sz = 0;
             return retval;
         }
         (*f).lf.lr_mask_sz = lr_mask_sz;
     }
-    (*f).lf.restore_planes = ((((*(*f).frame_hdr).restoration.type_0[0] as libc::c_uint
-        != DAV1D_RESTORATION_NONE as libc::c_int as libc::c_uint)
+    (*f).lf.restore_planes = ((((*(*f).frame_hdr).restoration.type_0[0] != DAV1D_RESTORATION_NONE)
         as libc::c_int)
         << 0)
-        + ((((*(*f).frame_hdr).restoration.type_0[1] as libc::c_uint
-            != DAV1D_RESTORATION_NONE as libc::c_int as libc::c_uint) as libc::c_int)
+        + ((((*(*f).frame_hdr).restoration.type_0[1] != DAV1D_RESTORATION_NONE) as libc::c_int)
             << 1)
-        + ((((*(*f).frame_hdr).restoration.type_0[2] as libc::c_uint
-            != DAV1D_RESTORATION_NONE as libc::c_int as libc::c_uint) as libc::c_int)
+        + ((((*(*f).frame_hdr).restoration.type_0[2] != DAV1D_RESTORATION_NONE) as libc::c_int)
             << 2);
     if (*(*f).frame_hdr).loopfilter.sharpness != (*f).lf.last_sharpness {
         dav1d_calc_eih(
@@ -5478,7 +5445,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     dav1d_calc_lf_values(&mut (*f).lf.lvl, &*(*f).frame_hdr, &[0, 0, 0, 0]);
     memset(
         (*f).lf.mask as *mut libc::c_void,
-        0 as libc::c_int,
+        0,
         (::core::mem::size_of::<Av1Filter>()).wrapping_mul(num_sb128 as size_t),
     );
     let ipred_edge_sz: libc::c_int = (*f).sbh * (*f).sb128w << hbd;
@@ -5487,17 +5454,14 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             &mut *((*f).ipred_edge).as_mut_ptr().offset(0) as *mut *mut libc::c_void
                 as *mut libc::c_void,
         );
-        (*f).ipred_edge[0] = dav1d_alloc_aligned(
-            (ipred_edge_sz * 128 * 3) as size_t,
-            64 as libc::c_int as size_t,
-        );
+        (*f).ipred_edge[0] = dav1d_alloc_aligned(ipred_edge_sz as size_t * 128 * 3, 64);
         let ptr_1: *mut uint8_t = (*f).ipred_edge[0] as *mut uint8_t;
         if ptr_1.is_null() {
-            (*f).ipred_edge_sz = 0 as libc::c_int;
+            (*f).ipred_edge_sz = 0;
             return retval;
         }
-        (*f).ipred_edge[1] = ptr_1.offset((ipred_edge_sz * 128 * 1) as isize) as *mut libc::c_void;
-        (*f).ipred_edge[2] = ptr_1.offset((ipred_edge_sz * 128 * 2) as isize) as *mut libc::c_void;
+        (*f).ipred_edge[1] = ptr_1.offset(ipred_edge_sz as isize * 128 * 1) as *mut libc::c_void;
+        (*f).ipred_edge[2] = ptr_1.offset(ipred_edge_sz as isize * 128 * 2) as *mut libc::c_void;
         (*f).ipred_edge_sz = ipred_edge_sz;
     }
     let re_sz: libc::c_int = (*f).sb128h * (*(*f).frame_hdr).tiling.cols;
@@ -5506,17 +5470,15 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             &mut *((*f).lf.tx_lpf_right_edge).as_mut_ptr().offset(0) as *mut *mut uint8_t
                 as *mut libc::c_void,
         );
-        (*f).lf.tx_lpf_right_edge[0] = malloc((re_sz * 32 * 2) as libc::c_ulong) as *mut uint8_t;
+        (*f).lf.tx_lpf_right_edge[0] = malloc(re_sz as libc::c_ulong * 32 * 2) as *mut uint8_t;
         if ((*f).lf.tx_lpf_right_edge[0]).is_null() {
-            (*f).lf.re_sz = 0 as libc::c_int;
+            (*f).lf.re_sz = 0;
             return retval;
         }
         (*f).lf.tx_lpf_right_edge[1] = ((*f).lf.tx_lpf_right_edge[0]).offset((re_sz * 32) as isize);
         (*f).lf.re_sz = re_sz;
     }
-    if (*(*f).frame_hdr).frame_type as libc::c_uint & 1 as libc::c_uint != 0
-        || (*(*f).frame_hdr).allow_intrabc != 0
-    {
+    if (*(*f).frame_hdr).frame_type & 1 != 0 || (*(*f).frame_hdr).allow_intrabc != 0 {
         let ret: libc::c_int = dav1d_refmvs_init_frame(
             &mut (*f).rf,
             (*f).seq_hdr,
@@ -5550,7 +5512,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     } else {
         memset(
             ((*f).qm).as_mut_ptr() as *mut libc::c_void,
-            0 as libc::c_int,
+            0,
             ::core::mem::size_of::<[[*const uint8_t; 3]; 19]>(),
         );
     }
@@ -5570,7 +5532,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                         (*(*f).cur.frame_hdr).frame_offset,
                     ))
                     .abs(),
-                    31 as libc::c_int,
+                    31,
                 ) as libc::c_uint;
                 let d0: libc::c_uint = imin(
                     (get_poc_diff(
@@ -5579,28 +5541,19 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                         (*(*f).cur.frame_hdr).frame_offset,
                     ))
                     .abs(),
-                    31 as libc::c_int,
+                    31,
                 ) as libc::c_uint;
                 let order: libc::c_int = (d0 <= d1) as libc::c_int;
-                static mut quant_dist_weight: [[uint8_t; 2]; 3] = [
-                    [2 as libc::c_int as uint8_t, 3 as libc::c_int as uint8_t],
-                    [2 as libc::c_int as uint8_t, 5 as libc::c_int as uint8_t],
-                    [2 as libc::c_int as uint8_t, 7 as libc::c_int as uint8_t],
-                ];
-                static mut quant_dist_lookup_table: [[uint8_t; 2]; 4] = [
-                    [9 as libc::c_int as uint8_t, 7 as libc::c_int as uint8_t],
-                    [11 as libc::c_int as uint8_t, 5 as libc::c_int as uint8_t],
-                    [12 as libc::c_int as uint8_t, 4 as libc::c_int as uint8_t],
-                    [13 as libc::c_int as uint8_t, 3 as libc::c_int as uint8_t],
-                ];
+                static mut quant_dist_weight: [[uint8_t; 2]; 3] = [[2, 3], [2, 5], [2, 7]];
+                static mut quant_dist_lookup_table: [[uint8_t; 2]; 4] =
+                    [[9, 7], [11, 5], [12, 4], [13, 3]];
                 let mut k: libc::c_int;
-                k = 0 as libc::c_int;
+                k = 0;
                 while k < 3 {
                     let c0: libc::c_int =
                         quant_dist_weight[k as usize][order as usize] as libc::c_int;
-                    let c1: libc::c_int = quant_dist_weight[k as usize]
-                        [(order == 0) as libc::c_int as usize]
-                        as libc::c_int;
+                    let c1: libc::c_int =
+                        quant_dist_weight[k as usize][(order == 0) as usize] as libc::c_int;
                     let d0_c0: libc::c_int = d0.wrapping_mul(c0 as libc::c_uint) as libc::c_int;
                     let d1_c1: libc::c_int = d1.wrapping_mul(c1 as libc::c_uint) as libc::c_int;
                     if d0 > d1 && d0_c0 < d1_c1 || d0 <= d1 && d0_c0 > d1_c1 {
@@ -5615,33 +5568,15 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             i_0 += 1;
         }
     }
-    let has_chroma: libc::c_int = ((*f).cur.p.layout as libc::c_uint
-        != DAV1D_PIXEL_LAYOUT_I400 as libc::c_int as libc::c_uint)
-        as libc::c_int;
+    let has_chroma: libc::c_int = ((*f).cur.p.layout != DAV1D_PIXEL_LAYOUT_I400) as libc::c_int;
     (*f).lf.mask_ptr = (*f).lf.mask;
     (*f).lf.p[0] = (*f).cur.data[0];
-    (*f).lf.p[1] = (*f).cur.data[(if has_chroma != 0 {
-        1 as libc::c_int
-    } else {
-        0 as libc::c_int
-    }) as usize];
-    (*f).lf.p[2] = (*f).cur.data[(if has_chroma != 0 {
-        2 as libc::c_int
-    } else {
-        0 as libc::c_int
-    }) as usize];
+    (*f).lf.p[1] = (*f).cur.data[if has_chroma != 0 { 1 } else { 0 }];
+    (*f).lf.p[2] = (*f).cur.data[if has_chroma != 0 { 2 } else { 0 }];
     (*f).lf.sr_p[0] = (*f).sr_cur.p.data[0];
-    (*f).lf.sr_p[1] = (*f).sr_cur.p.data[(if has_chroma != 0 {
-        1 as libc::c_int
-    } else {
-        0 as libc::c_int
-    }) as usize];
-    (*f).lf.sr_p[2] = (*f).sr_cur.p.data[(if has_chroma != 0 {
-        2 as libc::c_int
-    } else {
-        0 as libc::c_int
-    }) as usize];
-    retval = 0 as libc::c_int;
+    (*f).lf.sr_p[1] = (*f).sr_cur.p.data[if has_chroma != 0 { 1 } else { 0 }];
+    (*f).lf.sr_p[2] = (*f).sr_cur.p.data[if has_chroma != 0 { 2 } else { 0 }];
+    retval = 0;
     return retval;
 }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5041,8 +5041,8 @@ pub unsafe extern "C" fn dav1d_decode_tile_sbrow(t: *mut Dav1dTaskContext) -> li
 
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> libc::c_int {
-    let c: *const Dav1dContext = (*f).c;
-    let mut retval: libc::c_int = -12;
+    let c = (*f).c;
+    let mut retval = -12;
     if (*f).sbh > (*f).lf.start_of_tile_row_sz {
         free((*f).lf.start_of_tile_row as *mut libc::c_void);
         (*f).lf.start_of_tile_row = malloc(
@@ -5068,7 +5068,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         }
         tile_row += 1;
     }
-    let n_ts: libc::c_int = (*(*f).frame_hdr).tiling.cols * (*(*f).frame_hdr).tiling.rows;
+    let n_ts = (*(*f).frame_hdr).tiling.cols * (*(*f).frame_hdr).tiling.rows;
     if n_ts != (*f).n_ts {
         if (*c).n_fc > 1 {
             freep(
@@ -5093,7 +5093,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         }
         (*f).n_ts = n_ts;
     }
-    let a_sz: libc::c_int = (*f).sb128w
+    let a_sz = (*f).sb128w
         * (*(*f).frame_hdr).tiling.rows
         * (1 + ((*c).n_fc > 1 && (*c).n_tc > 1) as libc::c_int);
     if a_sz != (*f).a_sz {
@@ -5108,21 +5108,20 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         }
         (*f).a_sz = a_sz;
     }
-    let num_sb128: libc::c_int = (*f).sb128w * (*f).sb128h;
-    let size_mul: *const uint8_t = (ss_size_mul[(*f).cur.p.layout as usize]).as_ptr();
-    let hbd: libc::c_int = ((*(*f).seq_hdr).hbd != 0) as libc::c_int;
+    let num_sb128 = (*f).sb128w * (*f).sb128h;
+    let size_mul = (ss_size_mul[(*f).cur.p.layout as usize]).as_ptr();
+    let hbd = ((*(*f).seq_hdr).hbd != 0) as libc::c_int;
     if (*c).n_fc > 1 {
         let mut tile_idx = 0;
         let mut tile_row_0 = 0;
         while tile_row_0 < (*(*f).frame_hdr).tiling.rows {
-            let row_off: libc::c_int = (*(*f).frame_hdr).tiling.row_start_sb[tile_row_0 as usize]
-                as libc::c_int
+            let row_off = (*(*f).frame_hdr).tiling.row_start_sb[tile_row_0 as usize] as libc::c_int
                 * (*f).sb_step
                 * 4
                 * (*f).sb128w
                 * 128;
-            let b_diff: libc::c_int = ((*(*f).frame_hdr).tiling.row_start_sb
-                [(tile_row_0 + 1) as usize] as libc::c_int
+            let b_diff = ((*(*f).frame_hdr).tiling.row_start_sb[(tile_row_0 + 1) as usize]
+                as libc::c_int
                 - (*(*f).frame_hdr).tiling.row_start_sb[tile_row_0 as usize] as libc::c_int)
                 * (*f).sb_step
                 * 4;
@@ -5139,7 +5138,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             }
             tile_row_0 += 1;
         }
-        let lowest_pixel_mem_sz: libc::c_int = (*(*f).frame_hdr).tiling.cols * (*f).sbh;
+        let lowest_pixel_mem_sz = (*(*f).frame_hdr).tiling.cols * (*f).sbh;
         if lowest_pixel_mem_sz != (*f).tile_thread.lowest_pixel_mem_sz {
             free((*f).tile_thread.lowest_pixel_mem as *mut libc::c_void);
             (*f).tile_thread.lowest_pixel_mem = malloc(
@@ -5152,13 +5151,13 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             }
             (*f).tile_thread.lowest_pixel_mem_sz = lowest_pixel_mem_sz;
         }
-        let mut lowest_pixel_ptr: *mut [[libc::c_int; 2]; 7] = (*f).tile_thread.lowest_pixel_mem;
+        let mut lowest_pixel_ptr = (*f).tile_thread.lowest_pixel_mem;
         let mut tile_row_1 = 0;
         let mut tile_row_base = 0;
         while tile_row_1 < (*(*f).frame_hdr).tiling.rows {
-            let tile_row_sb_h: libc::c_int =
-                (*(*f).frame_hdr).tiling.row_start_sb[(tile_row_1 + 1) as usize] as libc::c_int
-                    - (*(*f).frame_hdr).tiling.row_start_sb[tile_row_1 as usize] as libc::c_int;
+            let tile_row_sb_h = (*(*f).frame_hdr).tiling.row_start_sb[(tile_row_1 + 1) as usize]
+                as libc::c_int
+                - (*(*f).frame_hdr).tiling.row_start_sb[tile_row_1 as usize] as libc::c_int;
             let mut tile_col_0 = 0;
             while tile_col_0 < (*(*f).frame_hdr).tiling.cols {
                 let ref mut fresh36 =
@@ -5170,7 +5169,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             tile_row_1 += 1;
             tile_row_base += (*(*f).frame_hdr).tiling.cols;
         }
-        let cf_sz: libc::c_int = (num_sb128 * *size_mul.offset(0) as libc::c_int) << hbd;
+        let cf_sz = (num_sb128 * *size_mul.offset(0) as libc::c_int) << hbd;
         if cf_sz != (*f).frame_thread.cf_sz {
             dav1d_freep_aligned(
                 &mut (*f).frame_thread.cf as *mut *mut libc::c_void as *mut libc::c_void,
@@ -5214,7 +5213,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 }
                 (*f).frame_thread.pal_sz = num_sb128;
             }
-            let pal_idx_sz: libc::c_int = num_sb128 * *size_mul.offset(1) as libc::c_int;
+            let pal_idx_sz = num_sb128 * *size_mul.offset(1) as libc::c_int;
             if pal_idx_sz != (*f).frame_thread.pal_idx_sz {
                 dav1d_freep_aligned(
                     &mut (*f).frame_thread.pal_idx as *mut *mut uint8_t as *mut libc::c_void,
@@ -5244,11 +5243,10 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             (*f).frame_thread.pal_sz = (*f).frame_thread.pal_idx_sz;
         }
     }
-    let mut y_stride: ptrdiff_t = (*f).cur.stride[0];
-    let mut uv_stride: ptrdiff_t = (*f).cur.stride[1];
-    let has_resize: libc::c_int =
-        ((*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1]) as libc::c_int;
-    let need_cdef_lpf_copy: libc::c_int = ((*c).n_tc > 1 && has_resize != 0) as libc::c_int;
+    let mut y_stride = (*f).cur.stride[0];
+    let mut uv_stride = (*f).cur.stride[1];
+    let has_resize = ((*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1]) as libc::c_int;
+    let need_cdef_lpf_copy = ((*c).n_tc > 1 && has_resize != 0) as libc::c_int;
     if y_stride * (*f).sbh as isize * 4 != (*f).lf.cdef_buf_plane_sz[0] as isize
         || uv_stride * (*f).sbh as isize * 8 != (*f).lf.cdef_buf_plane_sz[1] as isize
         || need_cdef_lpf_copy != (*f).lf.need_cdef_lpf_copy
@@ -5269,7 +5267,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 << need_cdef_lpf_copy,
         );
         (*f).lf.cdef_line_buf = dav1d_alloc_aligned(alloc_sz, 32) as *mut uint8_t;
-        let mut ptr: *mut uint8_t = (*f).lf.cdef_line_buf;
+        let mut ptr = (*f).lf.cdef_line_buf;
         if ptr.is_null() {
             (*f).lf.cdef_buf_plane_sz[1] = 0;
             (*f).lf.cdef_buf_plane_sz[0] = (*f).lf.cdef_buf_plane_sz[1];
@@ -5326,8 +5324,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         (*f).lf.need_cdef_lpf_copy = need_cdef_lpf_copy;
         (*f).lf.cdef_buf_sbh = (*f).sbh;
     }
-    let sb128: libc::c_int = (*(*f).seq_hdr).sb128;
-    let num_lines: libc::c_int = if (*c).n_tc > 1 {
+    let sb128 = (*(*f).seq_hdr).sb128;
+    let num_lines = if (*c).n_tc > 1 {
         ((*f).sbh * 4) << sb128
     } else {
         12
@@ -5347,7 +5345,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 .wrapping_mul(2),
         );
         (*f).lf.lr_line_buf = dav1d_alloc_aligned(alloc_sz_0, 64) as *mut uint8_t;
-        let mut ptr_0: *mut uint8_t = (*f).lf.lr_line_buf;
+        let mut ptr_0 = (*f).lf.lr_line_buf;
         if ptr_0.is_null() {
             (*f).lf.lr_buf_plane_sz[1] = 0;
             (*f).lf.lr_buf_plane_sz[0] = (*f).lf.lr_buf_plane_sz[1];
@@ -5415,7 +5413,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         (*f).lf.mask_sz = num_sb128;
     }
     (*f).sr_sb128w = (*f).sr_cur.p.p.w + 127 >> 7;
-    let lr_mask_sz: libc::c_int = (*f).sr_sb128w * (*f).sb128h;
+    let lr_mask_sz = (*f).sr_sb128w * (*f).sb128h;
     if lr_mask_sz != (*f).lf.lr_mask_sz {
         freep(&mut (*f).lf.lr_mask as *mut *mut Av1Restoration as *mut libc::c_void);
         (*f).lf.lr_mask = malloc(
@@ -5448,14 +5446,14 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         0,
         (::core::mem::size_of::<Av1Filter>()).wrapping_mul(num_sb128 as size_t),
     );
-    let ipred_edge_sz: libc::c_int = (*f).sbh * (*f).sb128w << hbd;
+    let ipred_edge_sz = (*f).sbh * (*f).sb128w << hbd;
     if ipred_edge_sz != (*f).ipred_edge_sz {
         dav1d_freep_aligned(
             &mut *((*f).ipred_edge).as_mut_ptr().offset(0) as *mut *mut libc::c_void
                 as *mut libc::c_void,
         );
         (*f).ipred_edge[0] = dav1d_alloc_aligned(ipred_edge_sz as size_t * 128 * 3, 64);
-        let ptr_1: *mut uint8_t = (*f).ipred_edge[0] as *mut uint8_t;
+        let ptr_1 = (*f).ipred_edge[0] as *mut uint8_t;
         if ptr_1.is_null() {
             (*f).ipred_edge_sz = 0;
             return retval;
@@ -5464,7 +5462,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         (*f).ipred_edge[2] = ptr_1.offset(ipred_edge_sz as isize * 128 * 2) as *mut libc::c_void;
         (*f).ipred_edge_sz = ipred_edge_sz;
     }
-    let re_sz: libc::c_int = (*f).sb128h * (*(*f).frame_hdr).tiling.cols;
+    let re_sz = (*f).sb128h * (*(*f).frame_hdr).tiling.cols;
     if re_sz != (*f).lf.re_sz {
         freep(
             &mut *((*f).lf.tx_lpf_right_edge).as_mut_ptr().offset(0) as *mut *mut uint8_t
@@ -5479,7 +5477,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         (*f).lf.re_sz = re_sz;
     }
     if (*(*f).frame_hdr).frame_type & 1 != 0 || (*(*f).frame_hdr).allow_intrabc != 0 {
-        let ret: libc::c_int = dav1d_refmvs_init_frame(
+        let ret = dav1d_refmvs_init_frame(
             &mut (*f).rf,
             (*f).seq_hdr,
             (*f).frame_hdr,
@@ -5519,13 +5517,11 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     if (*(*f).frame_hdr).switchable_comp_refs != 0 {
         let mut i_0 = 0;
         while i_0 < 7 {
-            let ref0poc: libc::c_uint =
-                (*(*f).refp[i_0 as usize].p.frame_hdr).frame_offset as libc::c_uint;
-            let mut j: libc::c_int = i_0 + 1;
+            let ref0poc = (*(*f).refp[i_0 as usize].p.frame_hdr).frame_offset as libc::c_uint;
+            let mut j = i_0 + 1;
             while j < 7 {
-                let ref1poc: libc::c_uint =
-                    (*(*f).refp[j as usize].p.frame_hdr).frame_offset as libc::c_uint;
-                let d1: libc::c_uint = imin(
+                let ref1poc = (*(*f).refp[j as usize].p.frame_hdr).frame_offset as libc::c_uint;
+                let d1 = imin(
                     (get_poc_diff(
                         (*(*f).seq_hdr).order_hint_n_bits,
                         ref0poc as libc::c_int,
@@ -5534,7 +5530,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     .abs(),
                     31,
                 ) as libc::c_uint;
-                let d0: libc::c_uint = imin(
+                let d0 = imin(
                     (get_poc_diff(
                         (*(*f).seq_hdr).order_hint_n_bits,
                         ref1poc as libc::c_int,
@@ -5543,19 +5539,17 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     .abs(),
                     31,
                 ) as libc::c_uint;
-                let order: libc::c_int = (d0 <= d1) as libc::c_int;
+                let order = (d0 <= d1) as libc::c_int;
                 static mut quant_dist_weight: [[uint8_t; 2]; 3] = [[2, 3], [2, 5], [2, 7]];
                 static mut quant_dist_lookup_table: [[uint8_t; 2]; 4] =
                     [[9, 7], [11, 5], [12, 4], [13, 3]];
-                let mut k: libc::c_int;
+                let mut k;
                 k = 0;
                 while k < 3 {
-                    let c0: libc::c_int =
-                        quant_dist_weight[k as usize][order as usize] as libc::c_int;
-                    let c1: libc::c_int =
-                        quant_dist_weight[k as usize][(order == 0) as usize] as libc::c_int;
-                    let d0_c0: libc::c_int = d0.wrapping_mul(c0 as libc::c_uint) as libc::c_int;
-                    let d1_c1: libc::c_int = d1.wrapping_mul(c1 as libc::c_uint) as libc::c_int;
+                    let c0 = quant_dist_weight[k as usize][order as usize] as libc::c_int;
+                    let c1 = quant_dist_weight[k as usize][(order == 0) as usize] as libc::c_int;
+                    let d0_c0 = d0.wrapping_mul(c0 as libc::c_uint) as libc::c_int;
+                    let d1_c1 = d1.wrapping_mul(c1 as libc::c_uint) as libc::c_int;
                     if d0 > d1 && d0_c0 < d1_c1 || d0 <= d1 && d0_c0 > d1_c1 {
                         break;
                     }
@@ -5568,7 +5562,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
             i_0 += 1;
         }
     }
-    let has_chroma: libc::c_int = ((*f).cur.p.layout != DAV1D_PIXEL_LAYOUT_I400) as libc::c_int;
+    let has_chroma = ((*f).cur.p.layout != DAV1D_PIXEL_LAYOUT_I400) as libc::c_int;
     (*f).lf.mask_ptr = (*f).lf.mask;
     (*f).lf.p[0] = (*f).cur.data[0];
     (*f).lf.p[1] = (*f).cur.data[if has_chroma != 0 { 1 } else { 0 }];

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5457,11 +5457,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                 .map_or(std::ptr::null(), |qm| qm.as_ptr());
         }
     } else {
-        memset(
-            f.qm.as_mut_ptr() as *mut libc::c_void,
-            0,
-            ::core::mem::size_of::<[[*const uint8_t; 3]; 19]>(),
-        );
+        f.qm = [[ptr::null(); 3]; 19]; // TODO(kkysen) can be Default::default once the type is Option
     }
     if (*f.frame_hdr).switchable_comp_refs != 0 {
         let mut i = 0;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5446,9 +5446,9 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     }
     if (*f.frame_hdr).switchable_comp_refs != 0 {
         for i in 0..7 {
-            let ref0poc = (*f.refp[i as usize].p.frame_hdr).frame_offset as libc::c_uint;
+            let ref0poc = (*f.refp[i].p.frame_hdr).frame_offset as libc::c_uint;
             for j in i + 1..7 {
-                let ref1poc = (*f.refp[j as usize].p.frame_hdr).frame_offset as libc::c_uint;
+                let ref1poc = (*f.refp[j].p.frame_hdr).frame_offset as libc::c_uint;
                 let d1 = std::cmp::min(
                     (get_poc_diff(
                         (*f.seq_hdr).order_hint_n_bits,
@@ -5473,8 +5473,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     [[9, 7], [11, 5], [12, 4], [13, 3]];
                 let mut k = 0;
                 while k < 3 {
-                    let c0 = quant_dist_weight[k as usize][order as usize] as libc::c_int;
-                    let c1 = quant_dist_weight[k as usize][(order == 0) as usize] as libc::c_int;
+                    let c0 = quant_dist_weight[k][order as usize] as libc::c_int;
+                    let c1 = quant_dist_weight[k][(order == 0) as usize] as libc::c_int;
                     let d0_c0 = (d0 * c0 as libc::c_uint) as libc::c_int;
                     let d1_c1 = (d1 * c1 as libc::c_uint) as libc::c_int;
                     if d0 > d1 && d0_c0 < d1_c1 || d0 <= d1 && d0_c0 > d1_c1 {
@@ -5482,8 +5482,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     }
                     k += 1;
                 }
-                f.jnt_weights[i as usize][j as usize] =
-                    quant_dist_lookup_table[k as usize][order as usize];
+                f.jnt_weights[i][j] = quant_dist_lookup_table[k][order as usize];
             }
         }
     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5512,12 +5512,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     // what they point at, as long as the pointers are valid.
     let has_chroma = f.cur.p.layout != DAV1D_PIXEL_LAYOUT_I400;
     f.lf.mask_ptr = f.lf.mask;
-    f.lf.p[0] = f.cur.data[0];
-    f.lf.p[1] = f.cur.data[if has_chroma { 1 } else { 0 }];
-    f.lf.p[2] = f.cur.data[if has_chroma { 2 } else { 0 }];
-    f.lf.sr_p[0] = f.sr_cur.p.data[0];
-    f.lf.sr_p[1] = f.sr_cur.p.data[if has_chroma { 1 } else { 0 }];
-    f.lf.sr_p[2] = f.sr_cur.p.data[if has_chroma { 2 } else { 0 }];
+    f.lf.p = array::from_fn(|i| f.cur.data[if has_chroma { i } else { 0 }]);
+    f.lf.sr_p = array::from_fn(|i| f.sr_cur.p.data[if has_chroma { i } else { 0 }]);
 
     retval = 0;
     return retval;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5388,11 +5388,14 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         }
         f.lf.lr_mask_sz = lr_mask_sz;
     }
-    f.lf.restore_planes = ((((*f.frame_hdr).restoration.type_0[0] != DAV1D_RESTORATION_NONE)
-        as libc::c_int)
-        << 0)
-        + ((((*f.frame_hdr).restoration.type_0[1] != DAV1D_RESTORATION_NONE) as libc::c_int) << 1)
-        + ((((*f.frame_hdr).restoration.type_0[2] != DAV1D_RESTORATION_NONE) as libc::c_int) << 2);
+    f.lf.restore_planes = (*f.frame_hdr)
+        .restoration
+        .type_0
+        .into_iter()
+        .enumerate()
+        .map(|(i, r#type)| ((r#type != DAV1D_RESTORATION_NONE) as u8) << i)
+        .sum::<u8>()
+        .into();
     if (*f.frame_hdr).loopfilter.sharpness != f.lf.last_sharpness {
         dav1d_calc_eih(&mut f.lf.lim_lut.0, (*f.frame_hdr).loopfilter.sharpness);
         f.lf.last_sharpness = (*f.frame_hdr).loopfilter.sharpness;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5453,7 +5453,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     ))
                     .unsigned_abs(),
                     31,
-                );
+                ) as u8;
                 let d0 = std::cmp::min(
                     (get_poc_diff(
                         (*f.seq_hdr).order_hint_n_bits,
@@ -5462,16 +5462,16 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
                     ))
                     .unsigned_abs(),
                     31,
-                );
+                ) as u8;
                 let order = d0 <= d1;
                 static quant_dist_weight: [[u8; 2]; 3] = [[2, 3], [2, 5], [2, 7]];
                 static quant_dist_lookup_table: [[u8; 2]; 4] = [[9, 7], [11, 5], [12, 4], [13, 3]];
                 let mut k = 0;
                 while k < 3 {
-                    let c0 = quant_dist_weight[k][order as usize] as libc::c_int;
-                    let c1 = quant_dist_weight[k][!order as usize] as libc::c_int;
-                    let d0_c0 = (d0 * c0 as libc::c_uint) as libc::c_int;
-                    let d1_c1 = (d1 * c1 as libc::c_uint) as libc::c_int;
+                    let c0 = quant_dist_weight[k][order as usize];
+                    let c1 = quant_dist_weight[k][!order as usize];
+                    let d0_c0 = d0 * c0;
+                    let d1_c1 = d1 * c1;
                     if d0 > d1 && d0_c0 < d1_c1 || d0 <= d1 && d0_c0 > d1_c1 {
                         break;
                     }

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -30,6 +30,7 @@ pub struct Av1RestorationUnit {
     pub sgr_weights: [i8; 2],
 }
 
+#[derive(Default)]
 #[repr(C)]
 pub struct Av1Filter {
     pub filter_y: [[[[u16; 2]; 3]; 32]; 2],


### PR DESCRIPTION
I cleaned up a large chunk of this already, but it's getting very long, and there's some more cross-cutting changes I want to make before finishing cleaning this up, like `c_int` ABI-compatible `bool` and `usize`-wrappers and some changes to the memory allocation functions.