### PR TITLE
`enum {Task,ObuMeta,Dav1dObu,Dav1dFrame}Type`: Symbolicate `match`/`case` uses

### DIFF
--- a/src/obu.rs
+++ b/src/obu.rs
@@ -158,6 +158,11 @@ use crate::src::lf_mask::Av1Filter;
 use crate::src::internal::Dav1dFrameContext_frame_thread;
 
 use crate::src::levels::Av1Block;
+use crate::src::levels::OBU_META_HDR_CLL;
+use crate::src::levels::OBU_META_HDR_MDCV;
+use crate::src::levels::OBU_META_ITUT_T35;
+use crate::src::levels::OBU_META_SCALABILITY;
+use crate::src::levels::OBU_META_TIMECODE;
 use crate::src::refmvs::refmvs_frame;
 
 use crate::src::env::BlockContext;
@@ -2122,7 +2127,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                 return dav1d_parse_obus_error(c, in_0);
             }
             match meta_type as libc::c_uint {
-                1 => {
+                OBU_META_HDR_CLL => {
                     let mut ref_1: *mut Dav1dRef =
                         dav1d_ref_create(::core::mem::size_of::<Dav1dContentLightLevel>());
                     if ref_1.is_null() {
@@ -2144,7 +2149,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                     (*c).content_light = content_light;
                     (*c).content_light_ref = ref_1;
                 }
-                2 => {
+                OBU_META_HDR_MDCV => {
                     let mut ref_2: *mut Dav1dRef =
                         dav1d_ref_create(::core::mem::size_of::<Dav1dMasteringDisplay>());
                     if ref_2.is_null() {
@@ -2176,7 +2181,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                     (*c).mastering_display = mastering_display;
                     (*c).mastering_display_ref = ref_2;
                 }
-                4 => {
+                OBU_META_ITUT_T35 => {
                     let mut payload_size: libc::c_int = len as libc::c_int;
                     while payload_size > 0
                         && *((*in_0).data).offset(
@@ -2234,7 +2239,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                         (*c).itut_t35_ref = ref_3;
                     }
                 }
-                3 | 5 => {}
+                OBU_META_SCALABILITY | OBU_META_TIMECODE => {}
                 _ => {
                     dav1d_log(
                         c,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2435,14 +2435,14 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                 .frame_hdr)
                 .frame_type as libc::c_uint
             {
-                1 | 3 => {
+                DAV1D_FRAME_TYPE_INTER | DAV1D_FRAME_TYPE_SWITCH => {
                     if (*c).decode_frame_type as libc::c_uint
                         > DAV1D_DECODEFRAMETYPE_REFERENCE as libc::c_int as libc::c_uint
                     {
                         return dav1d_parse_obus_skip(c, len, init_byte_pos);
                     }
                 }
-                2 => {
+                DAV1D_FRAME_TYPE_INTRA => {
                     if (*c).decode_frame_type as libc::c_uint
                         > DAV1D_DECODEFRAMETYPE_INTRA as libc::c_int as libc::c_uint
                     {
@@ -2603,7 +2603,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
             (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
         } else if (*c).n_tiles == (*(*c).frame_hdr).tiling.cols * (*(*c).frame_hdr).tiling.rows {
             match (*(*c).frame_hdr).frame_type as libc::c_uint {
-                1 | 3 => {
+                DAV1D_FRAME_TYPE_INTER | DAV1D_FRAME_TYPE_SWITCH => {
                     if (*c).decode_frame_type as libc::c_uint
                         > DAV1D_DECODEFRAMETYPE_REFERENCE as libc::c_int as libc::c_uint
                         || (*c).decode_frame_type as libc::c_uint
@@ -2613,7 +2613,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                         return dav1d_parse_obus_skip(c, len, init_byte_pos);
                     }
                 }
-                2 => {
+                DAV1D_FRAME_TYPE_INTRA => {
                     if (*c).decode_frame_type as libc::c_uint
                         > DAV1D_DECODEFRAMETYPE_INTRA as libc::c_int as libc::c_uint
                         || (*c).decode_frame_type as libc::c_uint

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -378,10 +378,14 @@ pub type recon_b_intra_fn = Option<
 >;
 use crate::include::dav1d::headers::Dav1dObuType;
 use crate::include::dav1d::headers::DAV1D_OBU_FRAME;
-use crate::src::internal::ScalableMotionParams;
-
+use crate::include::dav1d::headers::DAV1D_OBU_FRAME_HDR;
+use crate::include::dav1d::headers::DAV1D_OBU_METADATA;
+use crate::include::dav1d::headers::DAV1D_OBU_PADDING;
+use crate::include::dav1d::headers::DAV1D_OBU_REDUNDANT_FRAME_HDR;
 use crate::include::dav1d::headers::DAV1D_OBU_SEQ_HDR;
 use crate::include::dav1d::headers::DAV1D_OBU_TD;
+use crate::include::dav1d::headers::DAV1D_OBU_TILE_GRP;
+use crate::src::internal::ScalableMotionParams;
 use crate::src::levels::ObuMetaType;
 
 use crate::include::common::intops::iclip_u8;
@@ -2039,7 +2043,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
     }
     let mut current_block_188: u64;
     match type_0 as libc::c_uint {
-        1 => {
+        DAV1D_OBU_SEQ_HDR => {
             let mut ref_0: *mut Dav1dRef = dav1d_ref_create_using_pool(
                 (*c).seq_hdr_pool,
                 ::core::mem::size_of::<Dav1dSequenceHeader>(),
@@ -2106,20 +2110,20 @@ pub unsafe extern "C" fn dav1d_parse_obus(
             (*c).seq_hdr = seq_hdr;
             current_block_188 = 8953117030348968745;
         }
-        7 => {
+        DAV1D_OBU_REDUNDANT_FRAME_HDR => {
             if !((*c).frame_hdr).is_null() {
                 current_block_188 = 8953117030348968745;
             } else {
                 current_block_188 = 14065157188459580465;
             }
         }
-        6 | 3 => {
+        DAV1D_OBU_FRAME | DAV1D_OBU_FRAME_HDR => {
             current_block_188 = 14065157188459580465;
         }
-        4 => {
+        DAV1D_OBU_TILE_GRP => {
             current_block_188 = 17787701279558130514;
         }
-        5 => {
+        DAV1D_OBU_METADATA => {
             let meta_type: ObuMetaType = dav1d_get_uleb128(&mut gb) as ObuMetaType;
             let meta_type_len: libc::c_int =
                 ((dav1d_get_bits_pos(&mut gb)).wrapping_sub(init_bit_pos) >> 3) as libc::c_int;
@@ -2250,14 +2254,14 @@ pub unsafe extern "C" fn dav1d_parse_obus(
             }
             current_block_188 = 8953117030348968745;
         }
-        2 => {
+        DAV1D_OBU_TD => {
             (*c).frame_flags = ::core::mem::transmute::<libc::c_uint, PictureFlags>(
                 (*c).frame_flags as libc::c_uint
                     | PICTURE_FLAG_NEW_TEMPORAL_UNIT as libc::c_int as libc::c_uint,
             );
             current_block_188 = 8953117030348968745;
         }
-        15 => {
+        DAV1D_OBU_PADDING => {
             current_block_188 = 8953117030348968745;
         }
         _ => {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -123,16 +123,16 @@ use crate::src::internal::FrameTileThreadData;
 
 use crate::src::internal::Dav1dTask;
 use crate::src::internal::TaskType;
-use crate::src::internal::DAV1D_TASK_TYPE_FG_APPLY;
-use crate::src::internal::DAV1D_TASK_TYPE_FG_PREP;
-use crate::src::internal::DAV1D_TASK_TYPE_RECONSTRUCTION_PROGRESS;
-
 use crate::src::internal::DAV1D_TASK_TYPE_CDEF;
 use crate::src::internal::DAV1D_TASK_TYPE_DEBLOCK_COLS;
 use crate::src::internal::DAV1D_TASK_TYPE_DEBLOCK_ROWS;
 use crate::src::internal::DAV1D_TASK_TYPE_ENTROPY_PROGRESS;
+use crate::src::internal::DAV1D_TASK_TYPE_FG_APPLY;
+use crate::src::internal::DAV1D_TASK_TYPE_FG_PREP;
 use crate::src::internal::DAV1D_TASK_TYPE_INIT;
 use crate::src::internal::DAV1D_TASK_TYPE_INIT_CDF;
+use crate::src::internal::DAV1D_TASK_TYPE_LOOP_RESTORATION;
+use crate::src::internal::DAV1D_TASK_TYPE_RECONSTRUCTION_PROGRESS;
 use crate::src::internal::DAV1D_TASK_TYPE_SUPER_RESOLUTION;
 use crate::src::internal::DAV1D_TASK_TYPE_TILE_ENTROPY;
 use crate::src::internal::DAV1D_TASK_TYPE_TILE_RECONSTRUCTION;
@@ -1524,7 +1524,7 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut libc::c_void) -> *mut libc
                             (*tc).f = f;
                             sby = (*t).sby;
                             match (*t).type_0 as libc::c_uint {
-                                0 => {
+                                DAV1D_TASK_TYPE_INIT => {
                                     if !((*c).n_fc > 1 as libc::c_uint) {
                                         unreachable!();
                                     }
@@ -1553,7 +1553,7 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut libc::c_void) -> *mut libc
                                         continue 's_18;
                                     }
                                 }
-                                1 => {
+                                DAV1D_TASK_TYPE_INIT_CDF => {
                                     if !((*c).n_fc > 1 as libc::c_uint) {
                                         unreachable!();
                                     }
@@ -1652,7 +1652,8 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut libc::c_void) -> *mut libc
                                     }
                                     continue 's_18;
                                 }
-                                2 | 4 => {
+                                DAV1D_TASK_TYPE_TILE_ENTROPY
+                                | DAV1D_TASK_TYPE_TILE_RECONSTRUCTION => {
                                     let p_1 = ((*t).type_0 as libc::c_uint
                                         == DAV1D_TASK_TYPE_TILE_ENTROPY as libc::c_int
                                             as libc::c_uint)
@@ -1802,7 +1803,7 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut libc::c_void) -> *mut libc
                                         continue 's_18;
                                     }
                                 }
-                                5 => {
+                                DAV1D_TASK_TYPE_DEBLOCK_COLS => {
                                     if ::core::intrinsics::atomic_load_seqcst(
                                         &mut (*f).task_thread.error as *mut atomic_int,
                                     ) == 0
@@ -1827,27 +1828,27 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut libc::c_void) -> *mut libc
                                         break;
                                     }
                                 }
-                                6 => {
+                                DAV1D_TASK_TYPE_DEBLOCK_ROWS => {
                                     current_block = 16164772378964453469;
                                     break;
                                 }
-                                7 => {
+                                DAV1D_TASK_TYPE_CDEF => {
                                     current_block = 5292528706010880565;
                                     break;
                                 }
-                                8 => {
+                                DAV1D_TASK_TYPE_SUPER_RESOLUTION => {
                                     current_block = 12196494833634779273;
                                     break;
                                 }
-                                9 => {
+                                DAV1D_TASK_TYPE_LOOP_RESTORATION => {
                                     current_block = 563177965161376451;
                                     break;
                                 }
-                                10 => {
+                                DAV1D_TASK_TYPE_RECONSTRUCTION_PROGRESS => {
                                     current_block = 18238912670629178022;
                                     break;
                                 }
-                                3 => {
+                                DAV1D_TASK_TYPE_ENTROPY_PROGRESS => {
                                     current_block = 7729400755948011248;
                                     break;
                                 }

--- a/tools/input/annexb.rs
+++ b/tools/input/annexb.rs
@@ -18,7 +18,11 @@ extern "C" {
 }
 
 use rav1d::include::dav1d::headers::Dav1dObuType;
+use rav1d::include::dav1d::headers::DAV1D_OBU_FRAME;
+use rav1d::include::dav1d::headers::DAV1D_OBU_FRAME_HDR;
+use rav1d::include::dav1d::headers::DAV1D_OBU_SEQ_HDR;
 use rav1d::include::dav1d::headers::DAV1D_OBU_TD;
+use rav1d::include::dav1d::headers::DAV1D_OBU_TILE_GRP;
 
 use rav1d::include::dav1d::data::Dav1dData;
 #[repr(C)]
@@ -210,11 +214,11 @@ unsafe extern "C" fn annexb_probe(data: *const uint8_t) -> libc::c_int {
         }
         cnt += obu_unit_size as libc::c_int;
         match type_0 as libc::c_uint {
-            1 => {
+            DAV1D_OBU_SEQ_HDR => {
                 seq = 1 as libc::c_int;
             }
-            6 | 3 => return seq,
-            2 | 4 => return 0 as libc::c_int,
+            DAV1D_OBU_FRAME | DAV1D_OBU_FRAME_HDR => return seq,
+            DAV1D_OBU_TD | DAV1D_OBU_TILE_GRP => return 0 as libc::c_int,
             _ => {}
         }
         temporal_unit_size = temporal_unit_size.wrapping_sub(obu_unit_size);

--- a/tools/input/section5.rs
+++ b/tools/input/section5.rs
@@ -16,7 +16,11 @@ extern "C" {
     fn dav1d_data_create(data: *mut Dav1dData, sz: size_t) -> *mut uint8_t;
 }
 use rav1d::include::dav1d::headers::Dav1dObuType;
+use rav1d::include::dav1d::headers::DAV1D_OBU_FRAME;
+use rav1d::include::dav1d::headers::DAV1D_OBU_FRAME_HDR;
+use rav1d::include::dav1d::headers::DAV1D_OBU_SEQ_HDR;
 use rav1d::include::dav1d::headers::DAV1D_OBU_TD;
+use rav1d::include::dav1d::headers::DAV1D_OBU_TILE_GRP;
 
 use rav1d::include::dav1d::data::Dav1dData;
 #[repr(C)]
@@ -170,11 +174,11 @@ unsafe extern "C" fn section5_probe(data: *const uint8_t) -> libc::c_int {
         }
         cnt += ret;
         match type_0 as libc::c_uint {
-            1 => {
+            DAV1D_OBU_SEQ_HDR => {
                 seq = 1 as libc::c_int;
             }
-            6 | 3 => return seq,
-            2 | 4 => return 0 as libc::c_int,
+            DAV1D_OBU_FRAME | DAV1D_OBU_FRAME_HDR => return seq,
+            DAV1D_OBU_TD | DAV1D_OBU_TILE_GRP => return 0 as libc::c_int,
             _ => {}
         }
     }


### PR DESCRIPTION
Most of these were marked unused since they were lost during `case` to `match` transpilation.