### PR TITLE
`fn transpose`: Replace with calls to `const fn transposed`

### DIFF
--- a/src/qm.rs
+++ b/src/qm.rs
@@ -2995,7 +2995,11 @@ const fn subsampled<const N: usize, const M: usize>(
     dst
 }
 
-const fn transposed<const N: usize, const M: usize>(src: &[u8; N], w: usize, h: usize) -> [u8; M] {
+pub const fn transposed<const N: usize, const M: usize>(
+    src: &[u8; N],
+    w: usize,
+    h: usize,
+) -> [u8; M] {
     assert!(w * h == N);
     assert!(w * h == M);
     let mut dst = [0; M];


### PR DESCRIPTION
@randomPoison, do you think I should move `const fn transposed` somewhere else more general?  I may also add other similar `const fn` utilities, like an integral `for` loop macro (since `for` loops don't work in `const fn`s).