### PR TITLE
`static ii_{,non}dc_mask*`: Make non-`mut` and safe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,6 @@ use crate::src::r#ref::dav1d_ref_dec;
 use crate::src::r#ref::Dav1dRef;
 use crate::src::thread_task::dav1d_worker_task;
 use crate::src::thread_task::FRAME_ERROR;
-use crate::src::wedge::dav1d_init_interintra_masks;
 use crate::src::wedge::dav1d_init_wedge_masks;
 
 use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
@@ -429,7 +428,6 @@ use crate::src::mem::freep;
 #[cold]
 unsafe extern "C" fn init_internal() {
     dav1d_init_cpu();
-    dav1d_init_interintra_masks();
     dav1d_init_wedge_masks();
 }
 #[no_mangle]

--- a/src/wedge.rs
+++ b/src/wedge.rs
@@ -599,8 +599,3 @@ const fn build_nondc_ii_masks<const N: usize>(
 
     masks
 }
-
-#[cold]
-pub unsafe fn dav1d_init_interintra_masks() {
-    // This function is guaranteed to be called only once
-}


### PR DESCRIPTION
This also removes `fn dav1d_init_interintra_masks` as it's now entirely empty.