### PR TITLE
`static dav1d_ii_masks`: Use empty slices instead of `None` for defaults

### DIFF
--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -3601,7 +3601,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                     .c2rust_unnamed
                     .c2rust_unnamed
                     .interintra_mode as usize]
-                    .map_or_else(std::ptr::null, |mask| mask.as_ptr())
+                    .as_ptr()
             } else {
                 dav1d_wedge_masks[bs as usize][0][0][(*b)
                     .c2rust_unnamed
@@ -3955,7 +3955,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                 .c2rust_unnamed
                                 .interintra_mode
                                 as usize]
-                                .map_or_else(std::ptr::null, |mask| mask.as_ptr())
+                                .as_ptr()
                         } else {
                             dav1d_wedge_masks[bs as usize][chr_layout_idx as usize][0][(*b)
                                 .c2rust_unnamed

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -3573,7 +3573,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                     .c2rust_unnamed
                     .c2rust_unnamed
                     .interintra_mode as usize]
-                    .map_or_else(std::ptr::null, |mask| mask.as_ptr())
+                    .as_ptr()
             } else {
                 dav1d_wedge_masks[bs as usize][0][0][(*b)
                     .c2rust_unnamed
@@ -3927,7 +3927,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                 .c2rust_unnamed
                                 .interintra_mode
                                 as usize]
-                                .map_or_else(std::ptr::null, |mask| mask.as_ptr())
+                                .as_ptr()
                         } else {
                             dav1d_wedge_masks[bs as usize][chr_layout_idx as usize][0][(*b)
                                 .c2rust_unnamed

--- a/src/wedge.rs
+++ b/src/wedge.rs
@@ -526,17 +526,17 @@ static ii_nondc_mask_4x8: Align32<[[u8; 4 * 8]; N_II_PRED_MODES]> =
 static ii_nondc_mask_4x4: Align16<[[u8; 4 * 4]; N_II_PRED_MODES]> =
     Align16(build_nondc_ii_masks(4, 4, 8));
 
-pub static dav1d_ii_masks: [[[Option<&'static [u8]>; N_INTER_INTRA_PRED_MODES]; 3]; N_BS_SIZES] = {
-    let mut masks = [[[None; N_INTER_INTRA_PRED_MODES]; 3]; N_BS_SIZES];
+pub static dav1d_ii_masks: [[[&'static [u8]; N_INTER_INTRA_PRED_MODES]; 3]; N_BS_SIZES] = {
+    let mut masks = [[[&[] as &'static [u8]; N_INTER_INTRA_PRED_MODES]; 3]; N_BS_SIZES];
 
     macro_rules! set {
         ($h:literal x $w:literal) => {{
-            let mut a: [Option<&'static [u8]>; N_INTER_INTRA_PRED_MODES] = [None; 4];
+            let mut a = [&[] as &'static [u8]; N_INTER_INTRA_PRED_MODES];
             paste! {
-                a[II_DC_PRED as usize] = Some(&ii_dc_mask.0);
-                a[II_VERT_PRED as usize] = Some(&[<ii_nondc_mask _ $h x $w>].0[II_VERT_PRED as usize - 1]);
-                a[II_HOR_PRED as usize] = Some(&[<ii_nondc_mask _ $h x $w>].0[II_HOR_PRED as usize - 1]);
-                a[II_SMOOTH_PRED as usize] = Some(&[<ii_nondc_mask _ $h x $w>].0[II_SMOOTH_PRED as usize - 1]);
+                a[II_DC_PRED as usize] = &ii_dc_mask.0;
+                a[II_VERT_PRED as usize] = &[<ii_nondc_mask _ $h x $w>].0[II_VERT_PRED as usize - 1];
+                a[II_HOR_PRED as usize] = &[<ii_nondc_mask _ $h x $w>].0[II_HOR_PRED as usize - 1];
+                a[II_SMOOTH_PRED as usize] = &[<ii_nondc_mask _ $h x $w>].0[II_SMOOTH_PRED as usize - 1];
             }
             a
         }};


### PR DESCRIPTION
No uses check for null, so we can use empty slices as the default instead of `None`, which requires wrapping everything in `Option`.  For the pure Rust paths (no asm), this means we can avoid a `.unwrap()`.  This is slightly less "safe" for the asm paths, since if there's an error, it'll use a pointer to static memory instead of a null pointer that would error right away, but we have tests for that and the pure Rust path will bounds check (eventually).