### PR TITLE
`enum Wedge{Direction,MasterLine}Type`: Make `enum`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "d3cbc102e2597c9744c8bd8c15915d554300601c91a079430d309816b0912545"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -33,6 +33,7 @@ dependencies = [
  "nasm-rs",
  "num_cpus",
  "paste",
+ "strum",
 ]
 
 [[package]]
@@ -49,6 +50,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -103,10 +110,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.32",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ cfg-if = "1.0.0"
 libc = "0.2"
 num_cpus = "1.0"
 paste = "1.0.14"
+strum = { version = "0.25.0", features = ["derive"] }
 
 [build-dependencies]
 cc = "1.0.79"

--- a/src/wedge.rs
+++ b/src/wedge.rs
@@ -338,13 +338,14 @@ impl<const LEN_444: usize, const LEN_422: usize, const LEN_420: usize>
 }
 
 const fn build_master() -> [[[u8; 64]; 64]; WedgeDirectionType::COUNT] {
-    const WEDGE_MASTER_LINE_ODD: WedgeMasterLineType = 0;
-    const WEDGE_MASTER_LINE_EVEN: WedgeMasterLineType = 1;
-    const WEDGE_MASTER_LINE_VERT: WedgeMasterLineType = 2;
-    type WedgeMasterLineType = libc::c_uint;
-    const N_WEDGE_MASTER_LINES: usize = 3;
+    #[derive(EnumCount)]
+    enum WedgeMasterLineType {
+        ODD,
+        EVEN,
+        VERT,
+    }
 
-    const wedge_master_border: [[u8; 8]; N_WEDGE_MASTER_LINES] = [
+    const wedge_master_border: [[u8; 8]; WedgeMasterLineType::COUNT] = [
         [1, 2, 6, 18, 37, 53, 60, 63],
         [1, 4, 11, 27, 46, 58, 62, 63],
         [0, 2, 7, 21, 43, 57, 62, 64],
@@ -356,7 +357,7 @@ const fn build_master() -> [[[u8; 64]; 64]; WedgeDirectionType::COUNT] {
         master[WedgeDirectionType::Vertical as usize] = insert_border(
             master[WedgeDirectionType::Vertical as usize],
             y,
-            &wedge_master_border[WEDGE_MASTER_LINE_VERT as usize],
+            &wedge_master_border[WedgeMasterLineType::VERT as usize],
             32,
         );
     });
@@ -365,13 +366,13 @@ const fn build_master() -> [[[u8; 64]; 64]; WedgeDirectionType::COUNT] {
         master[WedgeDirectionType::Oblique63 as usize] = insert_border(
             master[WedgeDirectionType::Oblique63 as usize],
             y,
-            &wedge_master_border[WEDGE_MASTER_LINE_EVEN as usize],
+            &wedge_master_border[WedgeMasterLineType::EVEN as usize],
             ctr,
         );
         master[WedgeDirectionType::Oblique63 as usize] = insert_border(
             master[WedgeDirectionType::Oblique63 as usize],
             y + 1,
-            &wedge_master_border[WEDGE_MASTER_LINE_ODD as usize],
+            &wedge_master_border[WedgeMasterLineType::ODD as usize],
             ctr - 1,
         );
     });

--- a/src/wedge.rs
+++ b/src/wedge.rs
@@ -26,12 +26,12 @@ use strum::EnumCount;
 
 #[derive(Clone, Copy, EnumCount)]
 enum WedgeDirectionType {
-    HORIZONTAL,
-    VERTICAL,
-    OBLIQUE27,
-    OBLIQUE63,
-    OBLIQUE117,
-    OBLIQUE153,
+    Horizontal,
+    Vertical,
+    Oblique27,
+    Oblique63,
+    Oblique117,
+    Oblique153,
 }
 
 struct WedgeCodeType {
@@ -61,58 +61,58 @@ impl WedgeCodeBook {
         use WedgeDirectionType::*;
         Self {
             hgtw: [
-                WedgeCodeType::new(4, 4, OBLIQUE27),
-                WedgeCodeType::new(4, 4, OBLIQUE63),
-                WedgeCodeType::new(4, 4, OBLIQUE117),
-                WedgeCodeType::new(4, 4, OBLIQUE153),
-                WedgeCodeType::new(4, 2, HORIZONTAL),
-                WedgeCodeType::new(4, 4, HORIZONTAL),
-                WedgeCodeType::new(4, 6, HORIZONTAL),
-                WedgeCodeType::new(4, 4, VERTICAL),
-                WedgeCodeType::new(4, 2, OBLIQUE27),
-                WedgeCodeType::new(4, 6, OBLIQUE27),
-                WedgeCodeType::new(4, 2, OBLIQUE153),
-                WedgeCodeType::new(4, 6, OBLIQUE153),
-                WedgeCodeType::new(2, 4, OBLIQUE63),
-                WedgeCodeType::new(6, 4, OBLIQUE63),
-                WedgeCodeType::new(2, 4, OBLIQUE117),
-                WedgeCodeType::new(6, 4, OBLIQUE117),
+                WedgeCodeType::new(4, 4, Oblique27),
+                WedgeCodeType::new(4, 4, Oblique63),
+                WedgeCodeType::new(4, 4, Oblique117),
+                WedgeCodeType::new(4, 4, Oblique153),
+                WedgeCodeType::new(4, 2, Horizontal),
+                WedgeCodeType::new(4, 4, Horizontal),
+                WedgeCodeType::new(4, 6, Horizontal),
+                WedgeCodeType::new(4, 4, Vertical),
+                WedgeCodeType::new(4, 2, Oblique27),
+                WedgeCodeType::new(4, 6, Oblique27),
+                WedgeCodeType::new(4, 2, Oblique153),
+                WedgeCodeType::new(4, 6, Oblique153),
+                WedgeCodeType::new(2, 4, Oblique63),
+                WedgeCodeType::new(6, 4, Oblique63),
+                WedgeCodeType::new(2, 4, Oblique117),
+                WedgeCodeType::new(6, 4, Oblique117),
             ],
             hltw: [
-                WedgeCodeType::new(4, 4, OBLIQUE27),
-                WedgeCodeType::new(4, 4, OBLIQUE63),
-                WedgeCodeType::new(4, 4, OBLIQUE117),
-                WedgeCodeType::new(4, 4, OBLIQUE153),
-                WedgeCodeType::new(2, 4, VERTICAL),
-                WedgeCodeType::new(4, 4, VERTICAL),
-                WedgeCodeType::new(6, 4, VERTICAL),
-                WedgeCodeType::new(4, 4, HORIZONTAL),
-                WedgeCodeType::new(4, 2, OBLIQUE27),
-                WedgeCodeType::new(4, 6, OBLIQUE27),
-                WedgeCodeType::new(4, 2, OBLIQUE153),
-                WedgeCodeType::new(4, 6, OBLIQUE153),
-                WedgeCodeType::new(2, 4, OBLIQUE63),
-                WedgeCodeType::new(6, 4, OBLIQUE63),
-                WedgeCodeType::new(2, 4, OBLIQUE117),
-                WedgeCodeType::new(6, 4, OBLIQUE117),
+                WedgeCodeType::new(4, 4, Oblique27),
+                WedgeCodeType::new(4, 4, Oblique63),
+                WedgeCodeType::new(4, 4, Oblique117),
+                WedgeCodeType::new(4, 4, Oblique153),
+                WedgeCodeType::new(2, 4, Vertical),
+                WedgeCodeType::new(4, 4, Vertical),
+                WedgeCodeType::new(6, 4, Vertical),
+                WedgeCodeType::new(4, 4, Horizontal),
+                WedgeCodeType::new(4, 2, Oblique27),
+                WedgeCodeType::new(4, 6, Oblique27),
+                WedgeCodeType::new(4, 2, Oblique153),
+                WedgeCodeType::new(4, 6, Oblique153),
+                WedgeCodeType::new(2, 4, Oblique63),
+                WedgeCodeType::new(6, 4, Oblique63),
+                WedgeCodeType::new(2, 4, Oblique117),
+                WedgeCodeType::new(6, 4, Oblique117),
             ],
             heqw: [
-                WedgeCodeType::new(4, 4, OBLIQUE27),
-                WedgeCodeType::new(4, 4, OBLIQUE63),
-                WedgeCodeType::new(4, 4, OBLIQUE117),
-                WedgeCodeType::new(4, 4, OBLIQUE153),
-                WedgeCodeType::new(4, 2, HORIZONTAL),
-                WedgeCodeType::new(4, 6, HORIZONTAL),
-                WedgeCodeType::new(2, 4, VERTICAL),
-                WedgeCodeType::new(6, 4, VERTICAL),
-                WedgeCodeType::new(4, 2, OBLIQUE27),
-                WedgeCodeType::new(4, 6, OBLIQUE27),
-                WedgeCodeType::new(4, 2, OBLIQUE153),
-                WedgeCodeType::new(4, 6, OBLIQUE153),
-                WedgeCodeType::new(2, 4, OBLIQUE63),
-                WedgeCodeType::new(6, 4, OBLIQUE63),
-                WedgeCodeType::new(2, 4, OBLIQUE117),
-                WedgeCodeType::new(6, 4, OBLIQUE117),
+                WedgeCodeType::new(4, 4, Oblique27),
+                WedgeCodeType::new(4, 4, Oblique63),
+                WedgeCodeType::new(4, 4, Oblique117),
+                WedgeCodeType::new(4, 4, Oblique153),
+                WedgeCodeType::new(4, 2, Horizontal),
+                WedgeCodeType::new(4, 6, Horizontal),
+                WedgeCodeType::new(2, 4, Vertical),
+                WedgeCodeType::new(6, 4, Vertical),
+                WedgeCodeType::new(4, 2, Oblique27),
+                WedgeCodeType::new(4, 6, Oblique27),
+                WedgeCodeType::new(4, 2, Oblique153),
+                WedgeCodeType::new(4, 6, Oblique153),
+                WedgeCodeType::new(2, 4, Oblique63),
+                WedgeCodeType::new(6, 4, Oblique63),
+                WedgeCodeType::new(2, 4, Oblique117),
+                WedgeCodeType::new(6, 4, Oblique117),
             ],
         }
     }
@@ -353,8 +353,8 @@ const fn build_master() -> [[[u8; 64]; 64]; WedgeDirectionType::COUNT] {
 
     // create master templates
     const_for!(y in 0..64 => {
-        master[WedgeDirectionType::VERTICAL as usize] = insert_border(
-            master[WedgeDirectionType::VERTICAL as usize],
+        master[WedgeDirectionType::Vertical as usize] = insert_border(
+            master[WedgeDirectionType::Vertical as usize],
             y,
             &wedge_master_border[WEDGE_MASTER_LINE_VERT as usize],
             32,
@@ -362,28 +362,28 @@ const fn build_master() -> [[[u8; 64]; 64]; WedgeDirectionType::COUNT] {
     });
     const_for!(y in 0..64, step_by 2 => {
         let ctr = 48 - (y / 2);
-        master[WedgeDirectionType::OBLIQUE63 as usize] = insert_border(
-            master[WedgeDirectionType::OBLIQUE63 as usize],
+        master[WedgeDirectionType::Oblique63 as usize] = insert_border(
+            master[WedgeDirectionType::Oblique63 as usize],
             y,
             &wedge_master_border[WEDGE_MASTER_LINE_EVEN as usize],
             ctr,
         );
-        master[WedgeDirectionType::OBLIQUE63 as usize] = insert_border(
-            master[WedgeDirectionType::OBLIQUE63 as usize],
+        master[WedgeDirectionType::Oblique63 as usize] = insert_border(
+            master[WedgeDirectionType::Oblique63 as usize],
             y + 1,
             &wedge_master_border[WEDGE_MASTER_LINE_ODD as usize],
             ctr - 1,
         );
     });
 
-    master[WedgeDirectionType::OBLIQUE27 as usize] =
-        transposed(&master[WedgeDirectionType::OBLIQUE63 as usize]);
-    master[WedgeDirectionType::HORIZONTAL as usize] =
-        transposed(&master[WedgeDirectionType::VERTICAL as usize]);
-    master[WedgeDirectionType::OBLIQUE117 as usize] =
-        hflip(&master[WedgeDirectionType::OBLIQUE63 as usize]);
-    master[WedgeDirectionType::OBLIQUE153 as usize] =
-        hflip(&master[WedgeDirectionType::OBLIQUE27 as usize]);
+    master[WedgeDirectionType::Oblique27 as usize] =
+        transposed(&master[WedgeDirectionType::Oblique63 as usize]);
+    master[WedgeDirectionType::Horizontal as usize] =
+        transposed(&master[WedgeDirectionType::Vertical as usize]);
+    master[WedgeDirectionType::Oblique117 as usize] =
+        hflip(&master[WedgeDirectionType::Oblique63 as usize]);
+    master[WedgeDirectionType::Oblique153 as usize] =
+        hflip(&master[WedgeDirectionType::Oblique27 as usize]);
 
     master
 }

--- a/src/wedge.rs
+++ b/src/wedge.rs
@@ -340,9 +340,9 @@ impl<const LEN_444: usize, const LEN_422: usize, const LEN_420: usize>
 const fn build_master() -> [[[u8; 64]; 64]; WedgeDirectionType::COUNT] {
     #[derive(EnumCount)]
     enum WedgeMasterLineType {
-        ODD,
-        EVEN,
-        VERT,
+        Odd,
+        Even,
+        Vert,
     }
 
     const wedge_master_border: [[u8; 8]; WedgeMasterLineType::COUNT] = [
@@ -357,7 +357,7 @@ const fn build_master() -> [[[u8; 64]; 64]; WedgeDirectionType::COUNT] {
         master[WedgeDirectionType::Vertical as usize] = insert_border(
             master[WedgeDirectionType::Vertical as usize],
             y,
-            &wedge_master_border[WedgeMasterLineType::VERT as usize],
+            &wedge_master_border[WedgeMasterLineType::Vert as usize],
             32,
         );
     });
@@ -366,13 +366,13 @@ const fn build_master() -> [[[u8; 64]; 64]; WedgeDirectionType::COUNT] {
         master[WedgeDirectionType::Oblique63 as usize] = insert_border(
             master[WedgeDirectionType::Oblique63 as usize],
             y,
-            &wedge_master_border[WedgeMasterLineType::EVEN as usize],
+            &wedge_master_border[WedgeMasterLineType::Even as usize],
             ctr,
         );
         master[WedgeDirectionType::Oblique63 as usize] = insert_border(
             master[WedgeDirectionType::Oblique63 as usize],
             y + 1,
-            &wedge_master_border[WedgeMasterLineType::ODD as usize],
+            &wedge_master_border[WedgeMasterLineType::Odd as usize],
             ctr - 1,
         );
     });

--- a/src/wedge.rs
+++ b/src/wedge.rs
@@ -32,8 +32,7 @@ pub const WEDGE_OBLIQUE117: WedgeDirectionType = 4;
 pub const WEDGE_OBLIQUE153: WedgeDirectionType = 5;
 pub const N_WEDGE_DIRECTIONS: usize = 6;
 
-#[repr(C)]
-pub struct WedgeCodeType {
+struct WedgeCodeType {
     pub direction: WedgeDirectionType,
     pub x_offset: u8,
     pub y_offset: u8,

--- a/src/wedge.rs
+++ b/src/wedge.rs
@@ -23,14 +23,14 @@ use crate::src::levels::N_INTER_INTRA_PRED_MODES;
 
 use paste::paste;
 
-pub type WedgeDirectionType = u8;
-pub const WEDGE_HORIZONTAL: WedgeDirectionType = 0;
-pub const WEDGE_VERTICAL: WedgeDirectionType = 1;
-pub const WEDGE_OBLIQUE27: WedgeDirectionType = 2;
-pub const WEDGE_OBLIQUE63: WedgeDirectionType = 3;
-pub const WEDGE_OBLIQUE117: WedgeDirectionType = 4;
-pub const WEDGE_OBLIQUE153: WedgeDirectionType = 5;
-pub const N_WEDGE_DIRECTIONS: usize = 6;
+type WedgeDirectionType = u8;
+const WEDGE_HORIZONTAL: WedgeDirectionType = 0;
+const WEDGE_VERTICAL: WedgeDirectionType = 1;
+const WEDGE_OBLIQUE27: WedgeDirectionType = 2;
+const WEDGE_OBLIQUE63: WedgeDirectionType = 3;
+const WEDGE_OBLIQUE117: WedgeDirectionType = 4;
+const WEDGE_OBLIQUE153: WedgeDirectionType = 5;
+const N_WEDGE_DIRECTIONS: usize = 6;
 
 struct WedgeCodeType {
     pub direction: WedgeDirectionType,
@@ -335,11 +335,11 @@ impl<const LEN_444: usize, const LEN_422: usize, const LEN_420: usize>
 }
 
 const fn build_master() -> [[[u8; 64]; 64]; N_WEDGE_DIRECTIONS] {
-    pub const WEDGE_MASTER_LINE_ODD: WedgeMasterLineType = 0;
-    pub const WEDGE_MASTER_LINE_EVEN: WedgeMasterLineType = 1;
-    pub const WEDGE_MASTER_LINE_VERT: WedgeMasterLineType = 2;
-    pub type WedgeMasterLineType = libc::c_uint;
-    pub const N_WEDGE_MASTER_LINES: usize = 3;
+    const WEDGE_MASTER_LINE_ODD: WedgeMasterLineType = 0;
+    const WEDGE_MASTER_LINE_EVEN: WedgeMasterLineType = 1;
+    const WEDGE_MASTER_LINE_VERT: WedgeMasterLineType = 2;
+    type WedgeMasterLineType = libc::c_uint;
+    const N_WEDGE_MASTER_LINES: usize = 3;
 
     const wedge_master_border: [[u8; 8]; N_WEDGE_MASTER_LINES] = [
         [1, 2, 6, 18, 37, 53, 60, 63],

--- a/src/wedge.rs
+++ b/src/wedge.rs
@@ -22,15 +22,17 @@ use crate::src::levels::N_BS_SIZES;
 use crate::src::levels::N_INTER_INTRA_PRED_MODES;
 
 use paste::paste;
+use strum::EnumCount;
 
-type WedgeDirectionType = u8;
-const WEDGE_HORIZONTAL: WedgeDirectionType = 0;
-const WEDGE_VERTICAL: WedgeDirectionType = 1;
-const WEDGE_OBLIQUE27: WedgeDirectionType = 2;
-const WEDGE_OBLIQUE63: WedgeDirectionType = 3;
-const WEDGE_OBLIQUE117: WedgeDirectionType = 4;
-const WEDGE_OBLIQUE153: WedgeDirectionType = 5;
-const N_WEDGE_DIRECTIONS: usize = 6;
+#[derive(Clone, Copy, EnumCount)]
+enum WedgeDirectionType {
+    HORIZONTAL,
+    VERTICAL,
+    OBLIQUE27,
+    OBLIQUE63,
+    OBLIQUE117,
+    OBLIQUE153,
+}
 
 struct WedgeCodeType {
     pub direction: WedgeDirectionType,
@@ -56,60 +58,61 @@ struct WedgeCodeBook {
 
 impl WedgeCodeBook {
     const fn build() -> Self {
+        use WedgeDirectionType::*;
         Self {
             hgtw: [
-                WedgeCodeType::new(4, 4, WEDGE_OBLIQUE27),
-                WedgeCodeType::new(4, 4, WEDGE_OBLIQUE63),
-                WedgeCodeType::new(4, 4, WEDGE_OBLIQUE117),
-                WedgeCodeType::new(4, 4, WEDGE_OBLIQUE153),
-                WedgeCodeType::new(4, 2, WEDGE_HORIZONTAL),
-                WedgeCodeType::new(4, 4, WEDGE_HORIZONTAL),
-                WedgeCodeType::new(4, 6, WEDGE_HORIZONTAL),
-                WedgeCodeType::new(4, 4, WEDGE_VERTICAL),
-                WedgeCodeType::new(4, 2, WEDGE_OBLIQUE27),
-                WedgeCodeType::new(4, 6, WEDGE_OBLIQUE27),
-                WedgeCodeType::new(4, 2, WEDGE_OBLIQUE153),
-                WedgeCodeType::new(4, 6, WEDGE_OBLIQUE153),
-                WedgeCodeType::new(2, 4, WEDGE_OBLIQUE63),
-                WedgeCodeType::new(6, 4, WEDGE_OBLIQUE63),
-                WedgeCodeType::new(2, 4, WEDGE_OBLIQUE117),
-                WedgeCodeType::new(6, 4, WEDGE_OBLIQUE117),
+                WedgeCodeType::new(4, 4, OBLIQUE27),
+                WedgeCodeType::new(4, 4, OBLIQUE63),
+                WedgeCodeType::new(4, 4, OBLIQUE117),
+                WedgeCodeType::new(4, 4, OBLIQUE153),
+                WedgeCodeType::new(4, 2, HORIZONTAL),
+                WedgeCodeType::new(4, 4, HORIZONTAL),
+                WedgeCodeType::new(4, 6, HORIZONTAL),
+                WedgeCodeType::new(4, 4, VERTICAL),
+                WedgeCodeType::new(4, 2, OBLIQUE27),
+                WedgeCodeType::new(4, 6, OBLIQUE27),
+                WedgeCodeType::new(4, 2, OBLIQUE153),
+                WedgeCodeType::new(4, 6, OBLIQUE153),
+                WedgeCodeType::new(2, 4, OBLIQUE63),
+                WedgeCodeType::new(6, 4, OBLIQUE63),
+                WedgeCodeType::new(2, 4, OBLIQUE117),
+                WedgeCodeType::new(6, 4, OBLIQUE117),
             ],
             hltw: [
-                WedgeCodeType::new(4, 4, WEDGE_OBLIQUE27),
-                WedgeCodeType::new(4, 4, WEDGE_OBLIQUE63),
-                WedgeCodeType::new(4, 4, WEDGE_OBLIQUE117),
-                WedgeCodeType::new(4, 4, WEDGE_OBLIQUE153),
-                WedgeCodeType::new(2, 4, WEDGE_VERTICAL),
-                WedgeCodeType::new(4, 4, WEDGE_VERTICAL),
-                WedgeCodeType::new(6, 4, WEDGE_VERTICAL),
-                WedgeCodeType::new(4, 4, WEDGE_HORIZONTAL),
-                WedgeCodeType::new(4, 2, WEDGE_OBLIQUE27),
-                WedgeCodeType::new(4, 6, WEDGE_OBLIQUE27),
-                WedgeCodeType::new(4, 2, WEDGE_OBLIQUE153),
-                WedgeCodeType::new(4, 6, WEDGE_OBLIQUE153),
-                WedgeCodeType::new(2, 4, WEDGE_OBLIQUE63),
-                WedgeCodeType::new(6, 4, WEDGE_OBLIQUE63),
-                WedgeCodeType::new(2, 4, WEDGE_OBLIQUE117),
-                WedgeCodeType::new(6, 4, WEDGE_OBLIQUE117),
+                WedgeCodeType::new(4, 4, OBLIQUE27),
+                WedgeCodeType::new(4, 4, OBLIQUE63),
+                WedgeCodeType::new(4, 4, OBLIQUE117),
+                WedgeCodeType::new(4, 4, OBLIQUE153),
+                WedgeCodeType::new(2, 4, VERTICAL),
+                WedgeCodeType::new(4, 4, VERTICAL),
+                WedgeCodeType::new(6, 4, VERTICAL),
+                WedgeCodeType::new(4, 4, HORIZONTAL),
+                WedgeCodeType::new(4, 2, OBLIQUE27),
+                WedgeCodeType::new(4, 6, OBLIQUE27),
+                WedgeCodeType::new(4, 2, OBLIQUE153),
+                WedgeCodeType::new(4, 6, OBLIQUE153),
+                WedgeCodeType::new(2, 4, OBLIQUE63),
+                WedgeCodeType::new(6, 4, OBLIQUE63),
+                WedgeCodeType::new(2, 4, OBLIQUE117),
+                WedgeCodeType::new(6, 4, OBLIQUE117),
             ],
             heqw: [
-                WedgeCodeType::new(4, 4, WEDGE_OBLIQUE27),
-                WedgeCodeType::new(4, 4, WEDGE_OBLIQUE63),
-                WedgeCodeType::new(4, 4, WEDGE_OBLIQUE117),
-                WedgeCodeType::new(4, 4, WEDGE_OBLIQUE153),
-                WedgeCodeType::new(4, 2, WEDGE_HORIZONTAL),
-                WedgeCodeType::new(4, 6, WEDGE_HORIZONTAL),
-                WedgeCodeType::new(2, 4, WEDGE_VERTICAL),
-                WedgeCodeType::new(6, 4, WEDGE_VERTICAL),
-                WedgeCodeType::new(4, 2, WEDGE_OBLIQUE27),
-                WedgeCodeType::new(4, 6, WEDGE_OBLIQUE27),
-                WedgeCodeType::new(4, 2, WEDGE_OBLIQUE153),
-                WedgeCodeType::new(4, 6, WEDGE_OBLIQUE153),
-                WedgeCodeType::new(2, 4, WEDGE_OBLIQUE63),
-                WedgeCodeType::new(6, 4, WEDGE_OBLIQUE63),
-                WedgeCodeType::new(2, 4, WEDGE_OBLIQUE117),
-                WedgeCodeType::new(6, 4, WEDGE_OBLIQUE117),
+                WedgeCodeType::new(4, 4, OBLIQUE27),
+                WedgeCodeType::new(4, 4, OBLIQUE63),
+                WedgeCodeType::new(4, 4, OBLIQUE117),
+                WedgeCodeType::new(4, 4, OBLIQUE153),
+                WedgeCodeType::new(4, 2, HORIZONTAL),
+                WedgeCodeType::new(4, 6, HORIZONTAL),
+                WedgeCodeType::new(2, 4, VERTICAL),
+                WedgeCodeType::new(6, 4, VERTICAL),
+                WedgeCodeType::new(4, 2, OBLIQUE27),
+                WedgeCodeType::new(4, 6, OBLIQUE27),
+                WedgeCodeType::new(4, 2, OBLIQUE153),
+                WedgeCodeType::new(4, 6, OBLIQUE153),
+                WedgeCodeType::new(2, 4, OBLIQUE63),
+                WedgeCodeType::new(6, 4, OBLIQUE63),
+                WedgeCodeType::new(2, 4, OBLIQUE117),
+                WedgeCodeType::new(6, 4, OBLIQUE117),
             ],
         }
     }
@@ -263,7 +266,7 @@ impl<const LEN_444: usize, const LEN_422: usize, const LEN_420: usize>
     const fn fill2d_16x2(
         w: usize,
         h: usize,
-        master: &[[[u8; 64]; 64]; N_WEDGE_DIRECTIONS],
+        master: &[[[u8; 64]; 64]; WedgeDirectionType::COUNT],
         cb: &[WedgeCodeType; 16],
         signs: u16,
     ) -> Self {
@@ -334,7 +337,7 @@ impl<const LEN_444: usize, const LEN_422: usize, const LEN_420: usize>
     }
 }
 
-const fn build_master() -> [[[u8; 64]; 64]; N_WEDGE_DIRECTIONS] {
+const fn build_master() -> [[[u8; 64]; 64]; WedgeDirectionType::COUNT] {
     const WEDGE_MASTER_LINE_ODD: WedgeMasterLineType = 0;
     const WEDGE_MASTER_LINE_EVEN: WedgeMasterLineType = 1;
     const WEDGE_MASTER_LINE_VERT: WedgeMasterLineType = 2;
@@ -346,12 +349,12 @@ const fn build_master() -> [[[u8; 64]; 64]; N_WEDGE_DIRECTIONS] {
         [1, 4, 11, 27, 46, 58, 62, 63],
         [0, 2, 7, 21, 43, 57, 62, 64],
     ];
-    let mut master = [[[0; 64]; 64]; N_WEDGE_DIRECTIONS];
+    let mut master = [[[0; 64]; 64]; WedgeDirectionType::COUNT];
 
     // create master templates
     const_for!(y in 0..64 => {
-        master[WEDGE_VERTICAL as usize] = insert_border(
-            master[WEDGE_VERTICAL as usize],
+        master[WedgeDirectionType::VERTICAL as usize] = insert_border(
+            master[WedgeDirectionType::VERTICAL as usize],
             y,
             &wedge_master_border[WEDGE_MASTER_LINE_VERT as usize],
             32,
@@ -359,30 +362,34 @@ const fn build_master() -> [[[u8; 64]; 64]; N_WEDGE_DIRECTIONS] {
     });
     const_for!(y in 0..64, step_by 2 => {
         let ctr = 48 - (y / 2);
-        master[WEDGE_OBLIQUE63 as usize] = insert_border(
-            master[WEDGE_OBLIQUE63 as usize],
+        master[WedgeDirectionType::OBLIQUE63 as usize] = insert_border(
+            master[WedgeDirectionType::OBLIQUE63 as usize],
             y,
             &wedge_master_border[WEDGE_MASTER_LINE_EVEN as usize],
             ctr,
         );
-        master[WEDGE_OBLIQUE63 as usize] = insert_border(
-            master[WEDGE_OBLIQUE63 as usize],
+        master[WedgeDirectionType::OBLIQUE63 as usize] = insert_border(
+            master[WedgeDirectionType::OBLIQUE63 as usize],
             y + 1,
             &wedge_master_border[WEDGE_MASTER_LINE_ODD as usize],
             ctr - 1,
         );
     });
 
-    master[WEDGE_OBLIQUE27 as usize] = transposed(&master[WEDGE_OBLIQUE63 as usize]);
-    master[WEDGE_HORIZONTAL as usize] = transposed(&master[WEDGE_VERTICAL as usize]);
-    master[WEDGE_OBLIQUE117 as usize] = hflip(&master[WEDGE_OBLIQUE63 as usize]);
-    master[WEDGE_OBLIQUE153 as usize] = hflip(&master[WEDGE_OBLIQUE27 as usize]);
+    master[WedgeDirectionType::OBLIQUE27 as usize] =
+        transposed(&master[WedgeDirectionType::OBLIQUE63 as usize]);
+    master[WedgeDirectionType::HORIZONTAL as usize] =
+        transposed(&master[WedgeDirectionType::VERTICAL as usize]);
+    master[WedgeDirectionType::OBLIQUE117 as usize] =
+        hflip(&master[WedgeDirectionType::OBLIQUE63 as usize]);
+    master[WedgeDirectionType::OBLIQUE153 as usize] =
+        hflip(&master[WedgeDirectionType::OBLIQUE27 as usize]);
 
     master
 }
 
 pub static dav1d_wedge_masks: [[[[&'static [u8]; 16]; 2]; 3]; N_BS_SIZES] = {
-    const master: [[[u8; 64]; 64]; N_WEDGE_DIRECTIONS] = build_master();
+    const master: [[[u8; 64]; 64]; WedgeDirectionType::COUNT] = build_master();
     const wedge_codebook_16: WedgeCodeBook = WedgeCodeBook::build();
 
     let mut masks = [[[[&[] as &'static [u8]; 16]; 2]; 3]; N_BS_SIZES];


### PR DESCRIPTION
This makes them real `enum`s instead of just integer constants.  To replicate the `const N_*: usize`s, I used `strum`'s `#[derive(EnumCount)]`.

This isn't super necessary for this file, but I wanted to get the hang of converting the integer constant "enum"s to real `enum`s, as it is necessary for performance in other places (due to the stronger `enum` guarantees), and this is an easy place to do as I just finished completely cleaning up the file.