### PR TITLE
`struct Dyn{Pixel,Coef}`: Use instead of `c_void` for clarity

### DIFF
--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -1,5 +1,6 @@
 use std::cmp;
 
+use crate::include::common::bitdepth::DynPixel;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 
@@ -48,7 +49,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut libc::c_void; 3],
+    pub ipred_edge: [*mut DynPixel; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -1,5 +1,6 @@
 use std::cmp;
 
+use crate::include::common::bitdepth::DynPixel;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 
@@ -48,7 +49,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut libc::c_void; 3],
+    pub ipred_edge: [*mut DynPixel; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -1,5 +1,6 @@
 use std::cmp;
 
+use crate::include::common::bitdepth::DynPixel;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 use crate::src::align::*;
@@ -54,7 +55,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut libc::c_void; 3],
+    pub ipred_edge: [*mut DynPixel; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -218,7 +218,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut libc::c_void; 3],
+    pub ipred_edge: [*mut DynPixel; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,
@@ -5171,17 +5171,17 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     let ipred_edge_sz = f.sbh * f.sb128w << hbd;
     if ipred_edge_sz != f.ipred_edge_sz {
         dav1d_freep_aligned(
-            &mut *f.ipred_edge.as_mut_ptr().offset(0) as *mut *mut libc::c_void
-                as *mut libc::c_void,
+            &mut *f.ipred_edge.as_mut_ptr().offset(0) as *mut *mut DynPixel as *mut libc::c_void,
         );
-        f.ipred_edge[0] = dav1d_alloc_aligned(ipred_edge_sz as usize * 128 * 3, 64);
+        f.ipred_edge[0] =
+            dav1d_alloc_aligned(ipred_edge_sz as usize * 128 * 3, 64) as *mut DynPixel;
         let ptr = f.ipred_edge[0] as *mut u8;
         if ptr.is_null() {
             f.ipred_edge_sz = 0;
             return -12;
         }
-        f.ipred_edge[1] = ptr.offset(ipred_edge_sz as isize * 128 * 1) as *mut libc::c_void;
-        f.ipred_edge[2] = ptr.offset(ipred_edge_sz as isize * 128 * 2) as *mut libc::c_void;
+        f.ipred_edge[1] = ptr.offset(ipred_edge_sz as isize * 128 * 1) as *mut DynPixel;
+        f.ipred_edge[2] = ptr.offset(ipred_edge_sz as isize * 128 * 2) as *mut DynPixel;
         f.ipred_edge_sz = ipred_edge_sz;
     }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -11,6 +11,8 @@ use std::sync::atomic::Ordering;
 use crate::include::common::bitdepth::BitDepth16;
 #[cfg(feature = "bitdepth_8")]
 use crate::include::common::bitdepth::BitDepth8;
+use crate::include::common::bitdepth::DynCoef;
+use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::frame::is_inter_or_switch;
 use crate::include::common::frame::is_key_or_intra;
 use crate::include::dav1d::headers::Dav1dFrameHeader_tiling;
@@ -4018,8 +4020,8 @@ unsafe fn decode_sb(
                         // can end up misaligned due to skips here.
                         // Work around the issue by explicitly realigning the buffer.
                         let p = (t.frame_thread.pass & 1) as usize;
-                        ts.frame_thread[p].cf = (((ts.frame_thread[p].cf as uintptr_t) + 63) & !63)
-                            as *mut libc::c_void;
+                        ts.frame_thread[p].cf =
+                            (((ts.frame_thread[p].cf as uintptr_t) + 63) & !63) as *mut DynCoef;
                     }
                 } else {
                     let branch = &*(node as *const EdgeBranch);
@@ -4352,7 +4354,7 @@ unsafe fn setup_tile(
                     (tile_start_off * size_mul[0] as size_t
                         >> ((*f.seq_hdr).hbd == 0) as libc::c_int) as isize,
                 )
-                .cast::<libc::c_void>()
+                .cast::<DynCoef>()
         } else {
             ptr::null_mut()
         };
@@ -4922,10 +4924,9 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
 
         let cf_sz = (num_sb128 * size_mul[0] as libc::c_int) << hbd;
         if cf_sz != f.frame_thread.cf_sz {
-            dav1d_freep_aligned(
-                &mut f.frame_thread.cf as *mut *mut libc::c_void as *mut libc::c_void,
-            );
-            f.frame_thread.cf = dav1d_alloc_aligned(cf_sz as usize * 128 * 128 / 2, 64);
+            dav1d_freep_aligned(&mut f.frame_thread.cf as *mut *mut DynCoef as *mut libc::c_void);
+            f.frame_thread.cf =
+                dav1d_alloc_aligned(cf_sz as usize * 128 * 128 / 2, 64) as *mut DynCoef;
             if f.frame_thread.cf.is_null() {
                 f.frame_thread.cf_sz = 0;
                 return -12;
@@ -5004,48 +5005,47 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         ptr = ptr.offset(32);
         if y_stride < 0 {
             f.lf.cdef_line[0][0] =
-                ptr.offset(-(y_stride * (f.sbh as isize * 4 - 1))) as *mut libc::c_void;
+                ptr.offset(-(y_stride * (f.sbh as isize * 4 - 1))) as *mut DynPixel;
             f.lf.cdef_line[1][0] =
-                ptr.offset(-(y_stride * (f.sbh as isize * 4 - 3))) as *mut libc::c_void;
+                ptr.offset(-(y_stride * (f.sbh as isize * 4 - 3))) as *mut DynPixel;
         } else {
-            f.lf.cdef_line[0][0] = ptr.offset(y_stride * 0) as *mut libc::c_void;
-            f.lf.cdef_line[1][0] = ptr.offset(y_stride * 2) as *mut libc::c_void;
+            f.lf.cdef_line[0][0] = ptr.offset(y_stride * 0) as *mut DynPixel;
+            f.lf.cdef_line[1][0] = ptr.offset(y_stride * 2) as *mut DynPixel;
         }
         ptr = ptr.offset(y_stride.abs() * f.sbh as isize * 4);
         if uv_stride < 0 {
             f.lf.cdef_line[0][1] =
-                ptr.offset(-(uv_stride * (f.sbh as isize * 8 - 1))) as *mut libc::c_void;
+                ptr.offset(-(uv_stride * (f.sbh as isize * 8 - 1))) as *mut DynPixel;
             f.lf.cdef_line[0][2] =
-                ptr.offset(-(uv_stride * (f.sbh as isize * 8 - 3))) as *mut libc::c_void;
+                ptr.offset(-(uv_stride * (f.sbh as isize * 8 - 3))) as *mut DynPixel;
             f.lf.cdef_line[1][1] =
-                ptr.offset(-(uv_stride * (f.sbh as isize * 8 - 5))) as *mut libc::c_void;
+                ptr.offset(-(uv_stride * (f.sbh as isize * 8 - 5))) as *mut DynPixel;
             f.lf.cdef_line[1][2] =
-                ptr.offset(-(uv_stride * (f.sbh as isize * 8 - 7))) as *mut libc::c_void;
+                ptr.offset(-(uv_stride * (f.sbh as isize * 8 - 7))) as *mut DynPixel;
         } else {
-            f.lf.cdef_line[0][1] = ptr.offset(uv_stride * 0) as *mut libc::c_void;
-            f.lf.cdef_line[0][2] = ptr.offset(uv_stride * 2) as *mut libc::c_void;
-            f.lf.cdef_line[1][1] = ptr.offset(uv_stride * 4) as *mut libc::c_void;
-            f.lf.cdef_line[1][2] = ptr.offset(uv_stride * 6) as *mut libc::c_void;
+            f.lf.cdef_line[0][1] = ptr.offset(uv_stride * 0) as *mut DynPixel;
+            f.lf.cdef_line[0][2] = ptr.offset(uv_stride * 2) as *mut DynPixel;
+            f.lf.cdef_line[1][1] = ptr.offset(uv_stride * 4) as *mut DynPixel;
+            f.lf.cdef_line[1][2] = ptr.offset(uv_stride * 6) as *mut DynPixel;
         }
 
         if need_cdef_lpf_copy != 0 {
             ptr = ptr.offset(uv_stride.abs() * f.sbh as isize * 8);
             if y_stride < 0 {
                 f.lf.cdef_lpf_line[0] =
-                    ptr.offset(-(y_stride * (f.sbh as isize * 4 - 1))) as *mut libc::c_void;
+                    ptr.offset(-(y_stride * (f.sbh as isize * 4 - 1))) as *mut DynPixel;
             } else {
-                f.lf.cdef_lpf_line[0] = ptr as *mut libc::c_void;
+                f.lf.cdef_lpf_line[0] = ptr as *mut DynPixel;
             }
             ptr = ptr.offset(y_stride.abs() * f.sbh as isize * 4);
             if uv_stride < 0 {
                 f.lf.cdef_lpf_line[1] =
-                    ptr.offset(-(uv_stride * (f.sbh as isize * 4 - 1))) as *mut libc::c_void;
+                    ptr.offset(-(uv_stride * (f.sbh as isize * 4 - 1))) as *mut DynPixel;
                 f.lf.cdef_lpf_line[2] =
-                    ptr.offset(-(uv_stride * (f.sbh as isize * 8 - 1))) as *mut libc::c_void;
+                    ptr.offset(-(uv_stride * (f.sbh as isize * 8 - 1))) as *mut DynPixel;
             } else {
-                f.lf.cdef_lpf_line[1] = ptr as *mut libc::c_void;
-                f.lf.cdef_lpf_line[2] =
-                    ptr.offset(uv_stride * f.sbh as isize * 4) as *mut libc::c_void;
+                f.lf.cdef_lpf_line[1] = ptr as *mut DynPixel;
+                f.lf.cdef_lpf_line[2] = ptr.offset(uv_stride * f.sbh as isize * 4) as *mut DynPixel;
             }
         }
 
@@ -5078,19 +5078,19 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
         ptr = ptr.offset(64);
         if y_stride < 0 {
             f.lf.lr_lpf_line[0] =
-                ptr.offset(-(y_stride * (num_lines as isize - 1))) as *mut libc::c_void;
+                ptr.offset(-(y_stride * (num_lines as isize - 1))) as *mut DynPixel;
         } else {
-            f.lf.lr_lpf_line[0] = ptr as *mut libc::c_void;
+            f.lf.lr_lpf_line[0] = ptr as *mut DynPixel;
         }
         ptr = ptr.offset(y_stride.abs() * num_lines as isize);
         if uv_stride < 0 {
             f.lf.lr_lpf_line[1] =
-                ptr.offset(-(uv_stride * (num_lines as isize * 1 - 1))) as *mut libc::c_void;
+                ptr.offset(-(uv_stride * (num_lines as isize * 1 - 1))) as *mut DynPixel;
             f.lf.lr_lpf_line[2] =
-                ptr.offset(-(uv_stride * (num_lines as isize * 2 - 1))) as *mut libc::c_void;
+                ptr.offset(-(uv_stride * (num_lines as isize * 2 - 1))) as *mut DynPixel;
         } else {
-            f.lf.lr_lpf_line[1] = ptr as *mut libc::c_void;
-            f.lf.lr_lpf_line[2] = ptr.offset(uv_stride * num_lines as isize) as *mut libc::c_void;
+            f.lf.lr_lpf_line[1] = ptr as *mut DynPixel;
+            f.lf.lr_lpf_line[2] = ptr.offset(uv_stride * num_lines as isize) as *mut DynPixel;
         }
 
         f.lf.lr_buf_plane_sz[0] = y_stride as libc::c_int * num_lines;
@@ -5280,8 +5280,8 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> l
     // what they point at, as long as the pointers are valid.
     let has_chroma = (f.cur.p.layout != DAV1D_PIXEL_LAYOUT_I400) as usize;
     f.lf.mask_ptr = f.lf.mask;
-    f.lf.p = array::from_fn(|i| f.cur.data[has_chroma * i]);
-    f.lf.sr_p = array::from_fn(|i| f.sr_cur.p.data[has_chroma * i]);
+    f.lf.p = array::from_fn(|i| f.cur.data[has_chroma * i].cast());
+    f.lf.sr_p = array::from_fn(|i| f.sr_cur.p.data[has_chroma * i].cast());
 
     0
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,3 +1,5 @@
+use crate::include::common::bitdepth::DynCoef;
+use crate::include::common::bitdepth::DynPixel;
 use crate::include::dav1d::data::Dav1dData;
 use crate::include::dav1d::picture::Dav1dPicture;
 use crate::include::stdatomic::atomic_int;
@@ -148,7 +150,7 @@ pub struct Dav1dFrameContext_frame_thread {
     pub cbi: *mut CodedBlockInfo,
     pub pal: *mut [[uint16_t; 8]; 3],
     pub pal_idx: *mut uint8_t,
-    pub cf: *mut libc::c_void,
+    pub cf: *mut DynCoef,
     pub prog_sz: libc::c_int,
     pub pal_sz: libc::c_int,
     pub pal_idx_sz: libc::c_int,
@@ -173,14 +175,14 @@ pub struct Dav1dFrameContext_lf {
     pub tx_lpf_right_edge: [*mut uint8_t; 2],
     pub cdef_line_buf: *mut uint8_t,
     pub lr_line_buf: *mut uint8_t,
-    pub cdef_line: [[*mut libc::c_void; 3]; 2],
-    pub cdef_lpf_line: [*mut libc::c_void; 3],
-    pub lr_lpf_line: [*mut libc::c_void; 3],
+    pub cdef_line: [[*mut DynPixel; 3]; 2],
+    pub cdef_lpf_line: [*mut DynPixel; 3],
+    pub lr_lpf_line: [*mut DynPixel; 3],
     pub start_of_tile_row: *mut uint8_t,
     pub start_of_tile_row_sz: libc::c_int,
     pub need_cdef_lpf_copy: libc::c_int,
-    pub p: [*mut libc::c_void; 3],
-    pub sr_p: [*mut libc::c_void; 3],
+    pub p: [*mut DynPixel; 3],
+    pub sr_p: [*mut DynPixel; 3],
     pub mask_ptr: *mut Av1Filter,
     pub prev_mask_ptr: *mut Av1Filter,
     pub restore_planes: libc::c_int,
@@ -235,7 +237,7 @@ pub struct Dav1dTileState_tiling {
 #[repr(C)]
 pub struct Dav1dTileState_frame_thread {
     pub pal_idx: *mut uint8_t,
-    pub cf: *mut libc::c_void,
+    pub cf: *mut DynCoef,
 }
 
 #[repr(C)]

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -1,5 +1,6 @@
 use std::cmp;
 
+use crate::include::common::bitdepth::DynPixel;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 
@@ -48,7 +49,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut libc::c_void; 3],
+    pub ipred_edge: [*mut DynPixel; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -1,5 +1,6 @@
 use std::cmp;
 
+use crate::include::common::bitdepth::DynPixel;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 
@@ -48,7 +49,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut libc::c_void; 3],
+    pub ipred_edge: [*mut DynPixel; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use std::cmp;
 
 use crate::include::common::bitdepth::DynCoef;
+use crate::include::common::bitdepth::DynPixel;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 use crate::src::intra_edge::dav1d_init_mode_tree;
@@ -335,7 +336,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut libc::c_void; 3],
+    pub ipred_edge: [*mut DynPixel; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,
@@ -1602,7 +1603,7 @@ unsafe extern "C" fn close_internal(c_out: *mut *mut Dav1dContext, flush: libc::
                 as *mut libc::c_void,
         );
         dav1d_free_aligned((*f).ts as *mut libc::c_void);
-        dav1d_free_aligned((*f).ipred_edge[0]);
+        dav1d_free_aligned((*f).ipred_edge[0] as *mut libc::c_void);
         free((*f).a as *mut libc::c_void);
         free((*f).tile as *mut libc::c_void);
         free((*f).lf.mask as *mut libc::c_void);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use std::cmp;
 
+use crate::include::common::bitdepth::DynCoef;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 use crate::src::intra_edge::dav1d_init_mode_tree;
@@ -1579,7 +1580,7 @@ unsafe extern "C" fn close_internal(c_out: *mut *mut Dav1dContext, flush: libc::
                 &mut (*f).frame_thread.pal_idx as *mut *mut uint8_t as *mut libc::c_void,
             );
             dav1d_freep_aligned(
-                &mut (*f).frame_thread.cf as *mut *mut libc::c_void as *mut libc::c_void,
+                &mut (*f).frame_thread.cf as *mut *mut DynCoef as *mut libc::c_void,
             );
             freep(
                 &mut (*f).frame_thread.tile_start_off as *mut *mut libc::c_int as *mut libc::c_void,

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,3 +1,4 @@
+use crate::include::common::bitdepth::DynPixel;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 
@@ -237,7 +238,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut libc::c_void; 3],
+    pub ipred_edge: [*mut DynPixel; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -1,5 +1,6 @@
 use std::cmp;
 
+use crate::include::common::bitdepth::DynPixel;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 
@@ -50,7 +51,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut libc::c_void; 3],
+    pub ipred_edge: [*mut DynPixel; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -1,5 +1,6 @@
 use std::cmp;
 
+use crate::include::common::bitdepth::DynPixel;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 
@@ -50,7 +51,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut libc::c_void; 3],
+    pub ipred_edge: [*mut DynPixel; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1,5 +1,6 @@
 use std::cmp;
 
+use crate::include::common::bitdepth::DynPixel;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 
@@ -60,7 +61,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut libc::c_void; 3],
+    pub ipred_edge: [*mut DynPixel; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -1,3 +1,4 @@
+use crate::include::common::bitdepth::DynPixel;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 
@@ -54,7 +55,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut libc::c_void; 3],
+    pub ipred_edge: [*mut DynPixel; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -2,6 +2,7 @@ use std::cmp;
 
 use crate::include::common::bitdepth::BitDepth16;
 use crate::include::common::bitdepth::DynCoef;
+use crate::include::common::bitdepth::DynPixel;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 use crate::src::ctx::CaseSet;
@@ -115,7 +116,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut libc::c_void; 3],
+    pub ipred_edge: [*mut DynPixel; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1,6 +1,7 @@
 use std::cmp;
 
 use crate::include::common::bitdepth::BitDepth16;
+use crate::include::common::bitdepth::DynCoef;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 use crate::src::ctx::CaseSet;
@@ -1763,7 +1764,7 @@ unsafe extern "C" fn read_coef_tree(
                     (cmp::min((*t_dim).w as libc::c_int, 8 as libc::c_int)
                         * cmp::min((*t_dim).h as libc::c_int, 8 as libc::c_int)
                         * 16) as isize,
-                ) as *mut libc::c_void;
+                ) as *mut DynCoef;
             cbi = &mut *((*f).frame_thread.cbi)
                 .offset(((*t).by as isize * (*f).b4_stride + (*t).bx as isize) as isize)
                 as *mut CodedBlockInfo;
@@ -1988,7 +1989,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                             (cmp::min((*t_dim).w as libc::c_int, 8 as libc::c_int)
                                 * cmp::min((*t_dim).h as libc::c_int, 8 as libc::c_int)
                                 * 16) as isize,
-                        ) as *mut libc::c_void;
+                        ) as *mut DynCoef;
                         CaseSet::<16, true>::many(
                             [&mut (*t).l, &mut *(*t).a],
                             [
@@ -2067,7 +2068,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
                                     ((*uv_t_dim).w as libc::c_int
                                         * (*uv_t_dim).h as libc::c_int
                                         * 16) as isize,
-                                ) as *mut libc::c_void;
+                                ) as *mut DynCoef;
                             CaseSet::<16, true>::many(
                                 [&mut (*t).l, &mut *(*t).a],
                                 [
@@ -2798,7 +2799,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                     (cmp::min((*t_dim).w as libc::c_int, 8 as libc::c_int)
                                         * cmp::min((*t_dim).h as libc::c_int, 8 as libc::c_int)
                                         * 16) as isize,
-                                ) as *mut libc::c_void;
+                                ) as *mut DynCoef;
                             let cbi: *const CodedBlockInfo = &mut *((*f).frame_thread.cbi).offset(
                                 ((*t).by as isize * (*f).b4_stride + (*t).bx as isize) as isize,
                             )
@@ -3223,8 +3224,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                                 * (*uv_t_dim).h as libc::c_int
                                                 * 16)
                                                 as isize,
-                                        )
-                                            as *mut libc::c_void;
+                                        ) as *mut DynCoef;
                                     let cbi_0: *const CodedBlockInfo = &mut *((*f).frame_thread.cbi)
                                         .offset(
                                             ((*t).by as isize * (*f).b4_stride + (*t).bx as isize)
@@ -4487,7 +4487,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                                     ((*ts).frame_thread[p as usize].cf as *mut coef).offset(
                                         ((*uvtx).w as libc::c_int * (*uvtx).h as libc::c_int * 16)
                                             as isize,
-                                    ) as *mut libc::c_void;
+                                    ) as *mut DynCoef;
                                 let cbi: *const CodedBlockInfo =
                                     &mut *((*f).frame_thread.cbi).offset(
                                         ((*t).by as isize * (*f).b4_stride + (*t).bx as isize)

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -2,6 +2,7 @@ use std::cmp;
 
 use crate::include::common::bitdepth::BitDepth8;
 use crate::include::common::bitdepth::DynCoef;
+use crate::include::common::bitdepth::DynPixel;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 use crate::src::ctx::CaseSet;
@@ -114,7 +115,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut libc::c_void; 3],
+    pub ipred_edge: [*mut DynPixel; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1,6 +1,7 @@
 use std::cmp;
 
 use crate::include::common::bitdepth::BitDepth8;
+use crate::include::common::bitdepth::DynCoef;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 use crate::src::ctx::CaseSet;
@@ -1751,7 +1752,7 @@ unsafe extern "C" fn read_coef_tree(
                     (cmp::min((*t_dim).w as libc::c_int, 8 as libc::c_int)
                         * cmp::min((*t_dim).h as libc::c_int, 8 as libc::c_int)
                         * 16) as isize,
-                ) as *mut libc::c_void;
+                ) as *mut DynCoef;
             cbi = &mut *((*f).frame_thread.cbi)
                 .offset(((*t).by as isize * (*f).b4_stride + (*t).bx as isize) as isize)
                 as *mut CodedBlockInfo;
@@ -1976,7 +1977,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                             (cmp::min((*t_dim).w as libc::c_int, 8 as libc::c_int)
                                 * cmp::min((*t_dim).h as libc::c_int, 8 as libc::c_int)
                                 * 16) as isize,
-                        ) as *mut libc::c_void;
+                        ) as *mut DynCoef;
                         CaseSet::<16, true>::many(
                             [&mut (*t).l, &mut *(*t).a],
                             [
@@ -2055,7 +2056,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
                                     ((*uv_t_dim).w as libc::c_int
                                         * (*uv_t_dim).h as libc::c_int
                                         * 16) as isize,
-                                ) as *mut libc::c_void;
+                                ) as *mut DynCoef;
                             CaseSet::<16, true>::many(
                                 [&mut (*t).l, &mut *(*t).a],
                                 [
@@ -2779,7 +2780,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                     (cmp::min((*t_dim).w as libc::c_int, 8 as libc::c_int)
                                         * cmp::min((*t_dim).h as libc::c_int, 8 as libc::c_int)
                                         * 16) as isize,
-                                ) as *mut libc::c_void;
+                                ) as *mut DynCoef;
                             let cbi: *const CodedBlockInfo = &mut *((*f).frame_thread.cbi).offset(
                                 ((*t).by as isize * (*f).b4_stride + (*t).bx as isize) as isize,
                             )
@@ -3198,8 +3199,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                                 * (*uv_t_dim).h as libc::c_int
                                                 * 16)
                                                 as isize,
-                                        )
-                                            as *mut libc::c_void;
+                                        ) as *mut DynCoef;
                                     let cbi_0: *const CodedBlockInfo = &mut *((*f).frame_thread.cbi)
                                         .offset(
                                             ((*t).by as isize * (*f).b4_stride + (*t).bx as isize)
@@ -4456,7 +4456,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                                     ((*ts).frame_thread[p as usize].cf as *mut coef).offset(
                                         ((*uvtx).w as libc::c_int * (*uvtx).h as libc::c_int * 16)
                                             as isize,
-                                    ) as *mut libc::c_void;
+                                    ) as *mut DynCoef;
                                 let cbi: *const CodedBlockInfo =
                                     &mut *((*f).frame_thread.cbi).offset(
                                         ((*t).by as isize * (*f).b4_stride + (*t).bx as isize)

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1,5 +1,6 @@
 use std::cmp;
 
+use crate::include::common::bitdepth::DynPixel;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 use ::libc;
@@ -94,7 +95,7 @@ pub struct Dav1dFrameContext {
     pub dsp: *const Dav1dDSPContext,
     pub bd_fn: Dav1dFrameContext_bd_fn,
     pub ipred_edge_sz: libc::c_int,
-    pub ipred_edge: [*mut libc::c_void; 3],
+    pub ipred_edge: [*mut DynPixel; 3],
     pub b4_stride: ptrdiff_t,
     pub w4: libc::c_int,
     pub h4: libc::c_int,


### PR DESCRIPTION
I replaced these with `c_void`s a while ago before we figured out the type-erasure stuff and added `struct Dyn{Pixel,Coef}`.  For clarity, it's much better to use the specific types.