### PR TITLE
Cleanup imports

### DIFF
--- a/include/common/attributes.rs
+++ b/include/common/attributes.rs
@@ -1,4 +1,6 @@
-use std::ffi::{c_int, c_uint, c_ulonglong};
+use std::ffi::c_int;
+use std::ffi::c_uint;
+use std::ffi::c_ulonglong;
 
 #[inline]
 pub fn ctz(mask: c_uint) -> c_int {

--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -1,3 +1,4 @@
+use crate::include::common::intops::clip;
 use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_void;
@@ -7,8 +8,6 @@ use std::fmt::Formatter;
 use std::ops::Add;
 use std::ops::Mul;
 use std::ops::Shr;
-
-use crate::include::common::intops::clip;
 
 pub trait FromPrimitive<T> {
     fn from_prim(t: T) -> Self;

--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -1,6 +1,12 @@
-use std::ffi::{c_int, c_uint, c_void};
-use std::fmt::{self, Display, Formatter};
-use std::ops::{Add, Mul, Shr};
+use std::ffi::c_int;
+use std::ffi::c_uint;
+use std::ffi::c_void;
+use std::fmt;
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::ops::Add;
+use std::ops::Mul;
+use std::ops::Shr;
 
 use crate::include::common::intops::clip;
 

--- a/include/common/dump.rs
+++ b/include/common/dump.rs
@@ -1,8 +1,7 @@
+use crate::include::common::bitdepth::BitDepth;
 use std::fmt::Display;
 use std::io;
 use std::io::stdout;
-
-use crate::include::common::bitdepth::BitDepth;
 
 #[inline]
 pub unsafe fn hex_fdump<BD: BitDepth>(

--- a/include/common/intops.rs
+++ b/include/common/intops.rs
@@ -1,9 +1,8 @@
+use crate::include::common::attributes::clz;
+use crate::include::common::attributes::clzll;
 use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_ulonglong;
-
-use crate::include::common::attributes::clz;
-use crate::include::common::attributes::clzll;
 
 /// # Safety
 ///

--- a/include/common/intops.rs
+++ b/include/common/intops.rs
@@ -1,4 +1,6 @@
-use std::ffi::{c_int, c_uint, c_ulonglong};
+use std::ffi::c_int;
+use std::ffi::c_uint;
+use std::ffi::c_ulonglong;
 
 use crate::include::common::attributes::clz;
 use crate::include::common::attributes::clzll;

--- a/include/dav1d/common.rs
+++ b/include/dav1d/common.rs
@@ -1,9 +1,8 @@
-use std::ptr;
-
 use crate::include::stddef::size_t;
 use crate::include::stdint::int64_t;
 use crate::include::stdint::uint8_t;
 use crate::src::r#ref::Dav1dRef;
+use std::ptr;
 
 #[derive(Clone)]
 #[repr(C)]

--- a/include/dav1d/data.rs
+++ b/include/dav1d/data.rs
@@ -1,9 +1,8 @@
-use std::ptr;
-
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::stddef::size_t;
 use crate::include::stdint::uint8_t;
 use crate::src::r#ref::Dav1dRef;
+use std::ptr;
 
 #[derive(Clone)]
 #[repr(C)]

--- a/include/dav1d/dav1d.rs
+++ b/include/dav1d/dav1d.rs
@@ -16,11 +16,13 @@ pub const DAV1D_INLOOPFILTER_RESTORATION: Dav1dInloopFilterType = 4;
 pub const DAV1D_INLOOPFILTER_CDEF: Dav1dInloopFilterType = 2;
 pub const DAV1D_INLOOPFILTER_DEBLOCK: Dav1dInloopFilterType = 1;
 pub const DAV1D_INLOOPFILTER_NONE: Dav1dInloopFilterType = 0;
+
 pub type Dav1dDecodeFrameType = libc::c_uint;
 pub const DAV1D_DECODEFRAMETYPE_KEY: Dav1dDecodeFrameType = 3;
 pub const DAV1D_DECODEFRAMETYPE_INTRA: Dav1dDecodeFrameType = 2;
 pub const DAV1D_DECODEFRAMETYPE_REFERENCE: Dav1dDecodeFrameType = 1;
 pub const DAV1D_DECODEFRAMETYPE_ALL: Dav1dDecodeFrameType = 0;
+
 pub type Dav1dEventFlags = libc::c_uint;
 pub const DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO: Dav1dEventFlags = 2;
 pub const DAV1D_EVENT_FLAG_NEW_SEQUENCE: Dav1dEventFlags = 1;

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -14,11 +14,13 @@ pub const DAV1D_OBU_TILE_GRP: Dav1dObuType = 4;
 pub const DAV1D_OBU_FRAME_HDR: Dav1dObuType = 3;
 pub const DAV1D_OBU_TD: Dav1dObuType = 2;
 pub const DAV1D_OBU_SEQ_HDR: Dav1dObuType = 1;
+
 pub type Dav1dTxfmMode = libc::c_uint;
 pub const DAV1D_N_TX_MODES: usize = 3;
 pub const DAV1D_TX_SWITCHABLE: Dav1dTxfmMode = 2;
 pub const DAV1D_TX_LARGEST: Dav1dTxfmMode = 1;
 pub const DAV1D_TX_4X4_ONLY: Dav1dTxfmMode = 0;
+
 pub type Dav1dFilterMode = u8;
 pub const DAV1D_FILTER_SWITCHABLE: Dav1dFilterMode = 4;
 pub const DAV1D_N_FILTERS: usize = 4;
@@ -27,15 +29,18 @@ pub const DAV1D_N_SWITCHABLE_FILTERS: usize = 3;
 pub const DAV1D_FILTER_8TAP_SHARP: Dav1dFilterMode = 2;
 pub const DAV1D_FILTER_8TAP_SMOOTH: Dav1dFilterMode = 1;
 pub const DAV1D_FILTER_8TAP_REGULAR: Dav1dFilterMode = 0;
+
 pub type Dav1dAdaptiveBoolean = libc::c_uint;
 pub const DAV1D_ADAPTIVE: Dav1dAdaptiveBoolean = 2;
 pub const DAV1D_ON: Dav1dAdaptiveBoolean = 1;
 pub const DAV1D_OFF: Dav1dAdaptiveBoolean = 0;
+
 pub type Dav1dRestorationType = u8;
 pub const DAV1D_RESTORATION_SGRPROJ: Dav1dRestorationType = 3;
 pub const DAV1D_RESTORATION_WIENER: Dav1dRestorationType = 2;
 pub const DAV1D_RESTORATION_SWITCHABLE: Dav1dRestorationType = 1;
 pub const DAV1D_RESTORATION_NONE: Dav1dRestorationType = 0;
+
 pub type Dav1dWarpedMotionType = libc::c_uint;
 pub const DAV1D_WM_TYPE_AFFINE: Dav1dWarpedMotionType = 3;
 pub const DAV1D_WM_TYPE_ROT_ZOOM: Dav1dWarpedMotionType = 2;
@@ -73,11 +78,13 @@ pub const DAV1D_PIXEL_LAYOUT_I444: Dav1dPixelLayout = 3;
 pub const DAV1D_PIXEL_LAYOUT_I422: Dav1dPixelLayout = 2;
 pub const DAV1D_PIXEL_LAYOUT_I420: Dav1dPixelLayout = 1;
 pub const DAV1D_PIXEL_LAYOUT_I400: Dav1dPixelLayout = 0;
+
 pub type Dav1dFrameType = libc::c_uint;
 pub const DAV1D_FRAME_TYPE_SWITCH: Dav1dFrameType = 3;
 pub const DAV1D_FRAME_TYPE_INTRA: Dav1dFrameType = 2;
 pub const DAV1D_FRAME_TYPE_INTER: Dav1dFrameType = 1;
 pub const DAV1D_FRAME_TYPE_KEY: Dav1dFrameType = 0;
+
 pub type Dav1dColorPrimaries = libc::c_uint;
 pub const DAV1D_COLOR_PRI_RESERVED: Dav1dColorPrimaries = 255;
 pub const DAV1D_COLOR_PRI_EBU3213: Dav1dColorPrimaries = 22;
@@ -92,6 +99,7 @@ pub const DAV1D_COLOR_PRI_BT470BG: Dav1dColorPrimaries = 5;
 pub const DAV1D_COLOR_PRI_BT470M: Dav1dColorPrimaries = 4;
 pub const DAV1D_COLOR_PRI_UNKNOWN: Dav1dColorPrimaries = 2;
 pub const DAV1D_COLOR_PRI_BT709: Dav1dColorPrimaries = 1;
+
 pub type Dav1dTransferCharacteristics = libc::c_uint;
 pub const DAV1D_TRC_RESERVED: Dav1dTransferCharacteristics = 255;
 pub const DAV1D_TRC_HLG: Dav1dTransferCharacteristics = 18;
@@ -111,6 +119,7 @@ pub const DAV1D_TRC_BT470BG: Dav1dTransferCharacteristics = 5;
 pub const DAV1D_TRC_BT470M: Dav1dTransferCharacteristics = 4;
 pub const DAV1D_TRC_UNKNOWN: Dav1dTransferCharacteristics = 2;
 pub const DAV1D_TRC_BT709: Dav1dTransferCharacteristics = 1;
+
 pub type Dav1dMatrixCoefficients = libc::c_uint;
 pub const DAV1D_MC_RESERVED: Dav1dMatrixCoefficients = 255;
 pub const DAV1D_MC_ICTCP: Dav1dMatrixCoefficients = 14;
@@ -127,6 +136,7 @@ pub const DAV1D_MC_FCC: Dav1dMatrixCoefficients = 4;
 pub const DAV1D_MC_UNKNOWN: Dav1dMatrixCoefficients = 2;
 pub const DAV1D_MC_BT709: Dav1dMatrixCoefficients = 1;
 pub const DAV1D_MC_IDENTITY: Dav1dMatrixCoefficients = 0;
+
 pub type Dav1dChromaSamplePosition = libc::c_uint;
 pub const DAV1D_CHR_COLOCATED: Dav1dChromaSamplePosition = 2;
 pub const DAV1D_CHR_VERTICAL: Dav1dChromaSamplePosition = 1;
@@ -140,6 +150,7 @@ pub struct Dav1dContentLightLevel {
     pub max_content_light_level: libc::c_int,
     pub max_frame_average_light_level: libc::c_int,
 }
+
 #[repr(C)]
 pub struct Dav1dMasteringDisplay {
     pub primaries: [[uint16_t; 2]; 3],
@@ -147,6 +158,7 @@ pub struct Dav1dMasteringDisplay {
     pub max_luminance: uint32_t,
     pub min_luminance: uint32_t,
 }
+
 #[repr(C)]
 pub struct Dav1dITUTT35 {
     pub country_code: uint8_t,
@@ -281,21 +293,25 @@ pub struct Dav1dFilmGrainData {
     pub overlap_flag: libc::c_int,
     pub clip_to_restricted_range: libc::c_int,
 }
+
 #[repr(C)]
 pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
     pub present: libc::c_int,
     pub update: libc::c_int,
 }
+
 #[repr(C)]
 pub struct Dav1dFrameHeaderOperatingPoint {
     pub buffer_removal_time: libc::c_int,
 }
+
 #[repr(C)]
 pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: libc::c_int,
     pub enabled: libc::c_int,
 }
+
 #[repr(C)]
 pub struct Dav1dFrameHeader_tiling {
     pub uniform: libc::c_int,
@@ -312,6 +328,7 @@ pub struct Dav1dFrameHeader_tiling {
     pub row_start_sb: [uint16_t; 65],
     pub update: libc::c_int,
 }
+
 #[repr(C)]
 pub struct Dav1dFrameHeader_quant {
     pub yac: libc::c_int,
@@ -325,6 +342,7 @@ pub struct Dav1dFrameHeader_quant {
     pub qm_u: libc::c_int,
     pub qm_v: libc::c_int,
 }
+
 #[repr(C)]
 pub struct Dav1dFrameHeader_segmentation {
     pub enabled: libc::c_int,
@@ -335,22 +353,26 @@ pub struct Dav1dFrameHeader_segmentation {
     pub lossless: [libc::c_int; 8],
     pub qidx: [libc::c_int; 8],
 }
+
 #[repr(C)]
 pub struct Dav1dFrameHeader_delta_q {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
 }
+
 #[repr(C)]
 pub struct Dav1dFrameHeader_delta_lf {
     pub present: libc::c_int,
     pub res_log2: libc::c_int,
     pub multi: libc::c_int,
 }
+
 #[repr(C)]
 pub struct Dav1dFrameHeader_delta {
     pub q: Dav1dFrameHeader_delta_q,
     pub lf: Dav1dFrameHeader_delta_lf,
 }
+
 #[repr(C)]
 pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [libc::c_int; 2],
@@ -361,6 +383,7 @@ pub struct Dav1dFrameHeader_loopfilter {
     pub mode_ref_deltas: Dav1dLoopfilterModeRefDeltas,
     pub sharpness: libc::c_int,
 }
+
 #[repr(C)]
 pub struct Dav1dFrameHeader_cdef {
     pub damping: libc::c_int,
@@ -368,11 +391,13 @@ pub struct Dav1dFrameHeader_cdef {
     pub y_strength: [libc::c_int; 8],
     pub uv_strength: [libc::c_int; 8],
 }
+
 #[repr(C)]
 pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [libc::c_int; 2],
 }
+
 #[repr(C)]
 pub struct Dav1dFrameHeader {
     pub film_grain: Dav1dFrameHeader_film_grain,

--- a/include/stdatomic.rs
+++ b/include/stdatomic.rs
@@ -5,5 +5,6 @@ pub const memory_order_release: memory_order = 3;
 pub const memory_order_acquire: memory_order = 2;
 pub const memory_order_consume: memory_order = 1;
 pub const memory_order_relaxed: memory_order = 0;
+
 pub type atomic_int = libc::c_int;
 pub type atomic_uint = libc::c_uint;

--- a/include/stdint.rs
+++ b/include/stdint.rs
@@ -6,6 +6,7 @@ pub type __int32_t = libc::c_int;
 pub type __uint32_t = libc::c_uint;
 pub type __int64_t = i64;
 pub type __uint64_t = u64;
+
 pub type int8_t = __int8_t;
 pub type int16_t = __int16_t;
 pub type int32_t = __int32_t;
@@ -14,5 +15,6 @@ pub type uint8_t = __uint8_t;
 pub type uint16_t = __uint16_t;
 pub type uint32_t = __uint32_t;
 pub type uint64_t = __uint64_t;
+
 pub type intptr_t = libc::intptr_t;
 pub type uintptr_t = libc::uintptr_t;

--- a/lib.rs
+++ b/lib.rs
@@ -130,19 +130,24 @@ pub mod src {
 cfg_if::cfg_if! {
     if #[cfg(target_os = "linux")] {
         extern "C" {
-            static mut stderr: *mut libc::FILE;
+            pub static mut stdout: *mut libc::FILE;
+
+            pub static mut stderr: *mut libc::FILE;
         }
 
-        unsafe fn errno_location() -> *mut libc::c_int {
+        pub unsafe fn errno_location() -> *mut libc::c_int {
             libc::__errno_location()
         }
     } else if #[cfg(target_os = "macos")] {
         extern "C" {
+            #[link_name = "__stdoutp"]
+            pub static mut stdout: *mut libc::FILE;
+
             #[link_name = "__stderrp"]
-            static mut stderr: *mut libc::FILE;
+            pub static mut stderr: *mut libc::FILE;
         }
 
-        unsafe fn errno_location() -> *mut libc::c_int {
+        pub unsafe fn errno_location() -> *mut libc::c_int {
             libc::__error()
         }
     }

--- a/src/align.rs
+++ b/src/align.rs
@@ -6,7 +6,8 @@
 //! [`Index`]/[`IndexMut`] (since it's usually array fields that require
 //! specific aligment for use with SIMD instructions).
 
-use std::ops::{Index, IndexMut};
+use std::ops::Index;
+use std::ops::IndexMut;
 
 macro_rules! def_align {
     ($align:literal, $name:ident) => {

--- a/src/align.rs
+++ b/src/align.rs
@@ -5,7 +5,6 @@
 //! make them easier to use in common cases, e.g. [`From`] and
 //! [`Index`]/[`IndexMut`] (since it's usually array fields that require
 //! specific aligment for use with SIMD instructions).
-
 use std::ops::Index;
 use std::ops::IndexMut;
 

--- a/src/arm/cpu.rs
+++ b/src/arm/cpu.rs
@@ -1,5 +1,4 @@
 use cfg_if::cfg_if;
-use libc;
 
 pub const DAV1D_ARM_CPU_FLAG_NEON: libc::c_uint = 1 << 0;
 pub const NEON_HWCAP: libc::c_ulong = 1 << 12;

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -1,10 +1,9 @@
-use std::cmp;
-
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::bitdepth::LeftPixelRow2px;
 use crate::include::common::intops::apply_sign;
 use crate::include::stddef::ptrdiff_t;
 use crate::include::stdint::int16_t;
+use std::cmp;
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 use crate::include::stddef::size_t;

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -4,9 +4,11 @@ use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::bitdepth::LeftPixelRow2px;
 use crate::include::common::intops::apply_sign;
 use crate::include::stddef::ptrdiff_t;
+use crate::include::stdint::int16_t;
+
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 use crate::include::stddef::size_t;
-use crate::include::stdint::int16_t;
+
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 use crate::include::stdint::uint16_t;
 
@@ -29,8 +31,10 @@ pub type cdef_fn = unsafe extern "C" fn(
     CdefEdgeFlags,
     libc::c_int,
 ) -> ();
+
 pub type cdef_dir_fn =
     unsafe extern "C" fn(*const DynPixel, ptrdiff_t, *mut libc::c_uint, libc::c_int) -> libc::c_int;
+
 #[repr(C)]
 pub struct Dav1dCdefDSPContext {
     pub dir: cdef_dir_fn,

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::common::intops::ulog2;
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
@@ -18,6 +16,7 @@ use crate::src::internal::Dav1dDSPContext;
 use crate::src::internal::Dav1dFrameContext;
 use crate::src::internal::Dav1dTaskContext;
 use crate::src::lf_mask::Av1Filter;
+use std::cmp;
 
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: size_t) -> *mut libc::c_void;

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -1,44 +1,34 @@
 use std::cmp;
 
+use crate::include::common::intops::ulog2;
+use crate::include::dav1d::headers::Dav1dPixelLayout;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
+use crate::src::align::Align16;
+use crate::src::cdef::CdefEdgeFlags;
+use crate::src::cdef::CDEF_HAVE_BOTTOM;
+use crate::src::cdef::CDEF_HAVE_LEFT;
+use crate::src::cdef::CDEF_HAVE_RIGHT;
+use crate::src::cdef::CDEF_HAVE_TOP;
+use crate::src::internal::Dav1dDSPContext;
+use crate::src::internal::Dav1dFrameContext;
+use crate::src::internal::Dav1dTaskContext;
+use crate::src::lf_mask::Av1Filter;
 
-use ::libc;
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: size_t) -> *mut libc::c_void;
 }
 
 pub type pixel = uint16_t;
 
-use crate::src::internal::Dav1dFrameContext;
-
-use crate::include::dav1d::headers::Dav1dPixelLayout;
-
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-
-use crate::src::align::Align16;
-
-use crate::src::lf_mask::Av1Filter;
-
-use crate::src::internal::Dav1dTaskContext;
-
-use crate::src::internal::Dav1dDSPContext;
-
-use crate::src::cdef::CdefEdgeFlags;
-
-use crate::src::cdef::CDEF_HAVE_BOTTOM;
-use crate::src::cdef::CDEF_HAVE_LEFT;
-use crate::src::cdef::CDEF_HAVE_RIGHT;
-use crate::src::cdef::CDEF_HAVE_TOP;
-
 pub type Backup2x8Flags = libc::c_uint;
 pub const BACKUP_2X8_UV: Backup2x8Flags = 2;
 pub const BACKUP_2X8_Y: Backup2x8Flags = 1;
 
-use crate::include::common::intops::ulog2;
 #[inline]
 unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     if x & 1 != 0 {
@@ -46,6 +36,7 @@ unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     }
     return x >> 1;
 }
+
 unsafe extern "C" fn backup2lines(
     dst: *const *mut pixel,
     src: *const *mut pixel,
@@ -112,6 +103,7 @@ unsafe extern "C" fn backup2lines(
         }
     }
 }
+
 unsafe extern "C" fn backup2x8(
     dst: *mut [[pixel; 2]; 8],
     src: *const *mut pixel,
@@ -163,6 +155,7 @@ unsafe extern "C" fn backup2x8(
         y_off += PXSTRIDE(*src_stride.offset(1));
     }
 }
+
 unsafe extern "C" fn adjust_strength(strength: libc::c_int, var: libc::c_uint) -> libc::c_int {
     if var == 0 {
         return 0 as libc::c_int;
@@ -174,6 +167,7 @@ unsafe extern "C" fn adjust_strength(strength: libc::c_int, var: libc::c_uint) -
     };
     return strength * (4 + i) + 8 >> 4;
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
     tc: *mut Dav1dTaskContext,

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::common::intops::ulog2;
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
@@ -18,6 +16,7 @@ use crate::src::internal::Dav1dDSPContext;
 use crate::src::internal::Dav1dFrameContext;
 use crate::src::internal::Dav1dTaskContext;
 use crate::src::lf_mask::Av1Filter;
+use std::cmp;
 
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: size_t) -> *mut libc::c_void;

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -1,43 +1,34 @@
 use std::cmp;
 
+use crate::include::common::intops::ulog2;
+use crate::include::dav1d::headers::Dav1dPixelLayout;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
+use crate::src::align::Align16;
+use crate::src::cdef::CdefEdgeFlags;
+use crate::src::cdef::CDEF_HAVE_BOTTOM;
+use crate::src::cdef::CDEF_HAVE_LEFT;
+use crate::src::cdef::CDEF_HAVE_RIGHT;
+use crate::src::cdef::CDEF_HAVE_TOP;
+use crate::src::internal::Dav1dDSPContext;
+use crate::src::internal::Dav1dFrameContext;
+use crate::src::internal::Dav1dTaskContext;
+use crate::src::lf_mask::Av1Filter;
 
-use ::libc;
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: size_t) -> *mut libc::c_void;
 }
 
 pub type pixel = uint8_t;
 
-use crate::src::internal::Dav1dFrameContext;
-
-use crate::include::dav1d::headers::Dav1dPixelLayout;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-
-use crate::src::align::Align16;
-
-use crate::src::lf_mask::Av1Filter;
-
-use crate::src::internal::Dav1dTaskContext;
-
-use crate::src::internal::Dav1dDSPContext;
-
-use crate::src::cdef::CdefEdgeFlags;
-
-use crate::src::cdef::CDEF_HAVE_BOTTOM;
-use crate::src::cdef::CDEF_HAVE_LEFT;
-use crate::src::cdef::CDEF_HAVE_RIGHT;
-use crate::src::cdef::CDEF_HAVE_TOP;
-
 pub type Backup2x8Flags = libc::c_uint;
 pub const BACKUP_2X8_UV: Backup2x8Flags = 2;
 pub const BACKUP_2X8_Y: Backup2x8Flags = 1;
 
-use crate::include::common::intops::ulog2;
 unsafe extern "C" fn backup2lines(
     dst: *const *mut pixel,
     src: *const *mut pixel,
@@ -103,6 +94,7 @@ unsafe extern "C" fn backup2lines(
         }
     }
 }
+
 unsafe extern "C" fn backup2x8(
     dst: *mut [[pixel; 2]; 8],
     src: *const *mut pixel,
@@ -154,6 +146,7 @@ unsafe extern "C" fn backup2x8(
         y_off += *src_stride.offset(1);
     }
 }
+
 unsafe extern "C" fn adjust_strength(strength: libc::c_int, var: libc::c_uint) -> libc::c_int {
     if var == 0 {
         return 0 as libc::c_int;
@@ -165,6 +158,7 @@ unsafe extern "C" fn adjust_strength(strength: libc::c_int, var: libc::c_uint) -
     };
     return strength * (4 + i) + 8 >> 4;
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
     tc: *mut Dav1dTaskContext,

--- a/src/cdef_tmpl_16.rs
+++ b/src/cdef_tmpl_16.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::common::attributes::clz;
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::bitdepth::LeftPixelRow2px;
@@ -16,6 +14,7 @@ use crate::src::cdef::CDEF_HAVE_LEFT;
 use crate::src::cdef::CDEF_HAVE_RIGHT;
 use crate::src::cdef::CDEF_HAVE_TOP;
 use crate::src::tables::dav1d_cdef_directions;
+use std::cmp;
 
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;

--- a/src/cdef_tmpl_8.rs
+++ b/src/cdef_tmpl_8.rs
@@ -2,28 +2,28 @@ use std::cmp;
 
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::bitdepth::LeftPixelRow2px;
+use crate::include::common::intops::iclip;
+use crate::include::common::intops::ulog2;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
-use crate::src::align::Align16;
-use ::libc;
-#[cfg(feature = "asm")]
-use cfg_if::cfg_if;
-
-use crate::src::tables::dav1d_cdef_directions;
-
-pub type pixel = uint8_t;
-use crate::include::common::intops::iclip;
+use crate::src::cdef::constrain;
+use crate::src::cdef::fill;
 use crate::src::cdef::CdefEdgeFlags;
 use crate::src::cdef::Dav1dCdefDSPContext;
 use crate::src::cdef::CDEF_HAVE_BOTTOM;
 use crate::src::cdef::CDEF_HAVE_LEFT;
 use crate::src::cdef::CDEF_HAVE_RIGHT;
 use crate::src::cdef::CDEF_HAVE_TOP;
+use crate::src::tables::dav1d_cdef_directions;
 
-use crate::include::common::intops::ulog2;
-use crate::src::cdef::constrain;
-use crate::src::cdef::fill;
+#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
+use crate::src::align::Align16;
+
+#[cfg(feature = "asm")]
+use cfg_if::cfg_if;
+
+pub type pixel = uint8_t;
+
 unsafe extern "C" fn padding(
     mut tmp: *mut int16_t,
     tmp_stride: ptrdiff_t,
@@ -124,6 +124,7 @@ unsafe extern "C" fn padding(
         y_2 += 1;
     }
 }
+
 #[inline(never)]
 unsafe extern "C" fn cdef_filter_block_c(
     mut dst: *mut pixel,
@@ -285,6 +286,7 @@ unsafe extern "C" fn cdef_filter_block_c(
         }
     };
 }
+
 unsafe extern "C" fn cdef_filter_block_4x4_c_erased(
     dst: *mut DynPixel,
     stride: ptrdiff_t,
@@ -313,6 +315,7 @@ unsafe extern "C" fn cdef_filter_block_4x4_c_erased(
         edges,
     );
 }
+
 unsafe extern "C" fn cdef_filter_block_4x8_c_erased(
     dst: *mut DynPixel,
     stride: ptrdiff_t,
@@ -341,6 +344,7 @@ unsafe extern "C" fn cdef_filter_block_4x8_c_erased(
         edges,
     );
 }
+
 unsafe extern "C" fn cdef_filter_block_8x8_c_erased(
     dst: *mut DynPixel,
     stride: ptrdiff_t,
@@ -369,6 +373,7 @@ unsafe extern "C" fn cdef_filter_block_8x8_c_erased(
         edges,
     );
 }
+
 unsafe extern "C" fn cdef_find_dir_c_erased(
     img: *const DynPixel,
     stride: ptrdiff_t,
@@ -377,6 +382,7 @@ unsafe extern "C" fn cdef_find_dir_c_erased(
 ) -> libc::c_int {
     cdef_find_dir_rust(img.cast(), stride, var)
 }
+
 unsafe fn cdef_find_dir_rust(
     mut img: *const pixel,
     stride: ptrdiff_t,

--- a/src/cdef_tmpl_8.rs
+++ b/src/cdef_tmpl_8.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::bitdepth::LeftPixelRow2px;
 use crate::include::common::intops::iclip;
@@ -15,6 +13,7 @@ use crate::src::cdef::CDEF_HAVE_LEFT;
 use crate::src::cdef::CDEF_HAVE_RIGHT;
 use crate::src::cdef::CDEF_HAVE_TOP;
 use crate::src::tables::dav1d_cdef_directions;
+use std::cmp;
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 use crate::src::align::Align16;

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
 use crate::include::stdatomic::atomic_uint;
@@ -22,6 +20,7 @@ use crate::src::r#ref::dav1d_ref_dec;
 use crate::src::r#ref::dav1d_ref_inc;
 use crate::src::r#ref::Dav1dRef;
 use crate::src::tables::dav1d_partition_type_count;
+use std::cmp;
 
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,7 +1,6 @@
+use crate::src::internal::Dav1dContext;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
-
-use crate::src::internal::Dav1dContext;
 
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,11 +1,10 @@
-#[cfg(feature = "asm")]
-use cfg_if::cfg_if;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
 
-extern "C" {
-    pub type Dav1dContext;
-}
+use crate::src::internal::Dav1dContext;
+
+#[cfg(feature = "asm")]
+use cfg_if::cfg_if;
 
 /// This is atomic, which has interior mutability,
 /// instead of a `static mut`, since the latter is `unsafe` to access.

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -37,7 +37,6 @@
 //! * is far simpler than the `case_set*` implementation, consisting of a `match` and array writes
 //!
 //! [`BlockContext`]: crate::src::env::BlockContext
-
 use std::iter::zip;
 
 /// Perform a `memset` optimized for lengths that are small powers of 2.

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,4 +1,9 @@
-use std::ops::{Add, AddAssign, Index, IndexMut, Sub, SubAssign};
+use std::ops::Add;
+use std::ops::AddAssign;
+use std::ops::Index;
+use std::ops::IndexMut;
+use std::ops::Sub;
+use std::ops::SubAssign;
 
 pub struct CursorMut<'a, T> {
     data: &'a mut [T],

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,20 +1,18 @@
-use crate::include::stddef::*;
-use crate::include::stdint::*;
-use crate::stderr;
-use ::libc;
-extern "C" {
-    fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong) -> *mut libc::c_void;
-    fn fprintf(_: *mut libc::FILE, _: *const libc::c_char, _: ...) -> libc::c_int;
-}
-
-use crate::src::r#ref::Dav1dRef;
-
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::data::Dav1dData;
+use crate::include::stddef::*;
+use crate::include::stdint::*;
 use crate::src::r#ref::dav1d_ref_create;
 use crate::src::r#ref::dav1d_ref_dec;
 use crate::src::r#ref::dav1d_ref_inc;
 use crate::src::r#ref::dav1d_ref_wrap;
+use crate::src::r#ref::Dav1dRef;
+use crate::stderr;
+
+extern "C" {
+    fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong) -> *mut libc::c_void;
+    fn fprintf(_: *mut libc::FILE, _: *const libc::c_char, _: ...) -> libc::c_int;
+}
 
 pub unsafe fn dav1d_data_create_internal(buf: *mut Dav1dData, sz: size_t) -> *mut uint8_t {
     if buf.is_null() {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -7,29 +7,236 @@ use std::slice;
 use std::sync::atomic::AtomicI32;
 use std::sync::atomic::Ordering;
 
-#[cfg(feature = "bitdepth_16")]
-use crate::include::common::bitdepth::BitDepth16;
-#[cfg(feature = "bitdepth_8")]
-use crate::include::common::bitdepth::BitDepth8;
+use crate::include::common::attributes::ctz;
 use crate::include::common::bitdepth::DynCoef;
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::frame::is_inter_or_switch;
 use crate::include::common::frame::is_key_or_intra;
+use crate::include::common::intops::apply_sign64;
+use crate::include::common::intops::iclip;
+use crate::include::common::intops::iclip_u8;
+use crate::include::common::intops::ulog2;
+use crate::include::dav1d::headers::Dav1dFilterMode;
+use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::Dav1dFrameHeader_tiling;
+use crate::include::dav1d::headers::Dav1dRestorationType;
+use crate::include::dav1d::headers::Dav1dSequenceHeader;
 use crate::include::dav1d::headers::Dav1dTxfmMode;
+use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
+use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
+use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
 use crate::include::dav1d::headers::DAV1D_MAX_SEGMENTS;
+use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
+use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
+use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
+use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
+use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
+use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
+use crate::include::dav1d::picture::Dav1dPicture;
+use crate::include::stdatomic::atomic_int;
+use crate::include::stdatomic::atomic_uint;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 use crate::src::align::Align16;
+use crate::src::cdef::Dav1dCdefDSPContext;
+use crate::src::cdf::dav1d_cdf_thread_copy;
+use crate::src::cdf::dav1d_cdf_thread_init_static;
+use crate::src::cdf::dav1d_cdf_thread_ref;
+use crate::src::cdf::dav1d_cdf_thread_unref;
+use crate::src::cdf::dav1d_cdf_thread_update;
 use crate::src::cdf::CdfMvComponent;
 use crate::src::cdf::CdfMvContext;
+use crate::src::cdf::CdfThreadContext;
 use crate::src::ctx::CaseSet;
+use crate::src::data::dav1d_data_props_copy;
+use crate::src::data::dav1d_data_unref_internal;
+use crate::src::dequant_tables::dav1d_dq_tbl;
+use crate::src::env::av1_get_bwd_ref_1_ctx;
+use crate::src::env::av1_get_bwd_ref_ctx;
+use crate::src::env::av1_get_fwd_ref_1_ctx;
+use crate::src::env::av1_get_fwd_ref_2_ctx;
+use crate::src::env::av1_get_fwd_ref_ctx;
+use crate::src::env::av1_get_ref_ctx;
+use crate::src::env::av1_get_uni_p1_ctx;
+use crate::src::env::fix_mv_precision;
+use crate::src::env::gather_left_partition_prob;
+use crate::src::env::gather_top_partition_prob;
+use crate::src::env::get_comp_ctx;
+use crate::src::env::get_comp_dir_ctx;
+use crate::src::env::get_cur_frame_segid;
+use crate::src::env::get_drl_context;
+use crate::src::env::get_filter_ctx;
+use crate::src::env::get_gmv_2d;
+use crate::src::env::get_intra_ctx;
+use crate::src::env::get_jnt_comp_ctx;
+use crate::src::env::get_mask_comp_ctx;
+use crate::src::env::get_partition_ctx;
+use crate::src::env::get_poc_diff;
+use crate::src::env::get_tx_ctx;
+use crate::src::env::BlockContext;
+use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
+use crate::src::internal::CodedBlockInfo;
+use crate::src::internal::Dav1dContext;
+use crate::src::internal::Dav1dFrameContext;
+use crate::src::internal::Dav1dTaskContext;
+use crate::src::internal::Dav1dTaskContext_scratch_pal;
+use crate::src::internal::Dav1dTileGroup;
+use crate::src::internal::Dav1dTileState;
+use crate::src::internal::ScalableMotionParams;
+use crate::src::intra_edge::EdgeBranch;
+use crate::src::intra_edge::EdgeFlags;
+use crate::src::intra_edge::EdgeNode;
+use crate::src::intra_edge::EdgeTip;
+use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
+use crate::src::ipred::Dav1dIntraPredDSPContext;
+use crate::src::itx::Dav1dInvTxfmDSPContext;
+use crate::src::levels::mv;
+use crate::src::levels::Av1Block;
+use crate::src::levels::BS_128x128;
+use crate::src::levels::BS_4x4;
+use crate::src::levels::BS_64x64;
+use crate::src::levels::BlockLevel;
+use crate::src::levels::BlockPartition;
+use crate::src::levels::BlockSize;
+use crate::src::levels::MotionMode;
+use crate::src::levels::RectTxfmSize;
+use crate::src::levels::TxfmSize;
+use crate::src::levels::BL_128X128;
+use crate::src::levels::BL_64X64;
+use crate::src::levels::BL_8X8;
+use crate::src::levels::CFL_PRED;
+use crate::src::levels::COMP_INTER_AVG;
+use crate::src::levels::COMP_INTER_NONE;
+use crate::src::levels::COMP_INTER_SEG;
+use crate::src::levels::COMP_INTER_WEDGE;
+use crate::src::levels::COMP_INTER_WEIGHTED_AVG;
+use crate::src::levels::DC_PRED;
+use crate::src::levels::FILTER_2D_BILINEAR;
+use crate::src::levels::FILTER_PRED;
+use crate::src::levels::GLOBALMV;
+use crate::src::levels::GLOBALMV_GLOBALMV;
+use crate::src::levels::INTER_INTRA_BLEND;
+use crate::src::levels::INTER_INTRA_NONE;
+use crate::src::levels::INTER_INTRA_WEDGE;
+use crate::src::levels::MM_OBMC;
+use crate::src::levels::MM_TRANSLATION;
+use crate::src::levels::MM_WARP;
+use crate::src::levels::MV_JOINT_H;
+use crate::src::levels::MV_JOINT_HV;
+use crate::src::levels::MV_JOINT_V;
+use crate::src::levels::NEARER_DRL;
+use crate::src::levels::NEARESTMV;
+use crate::src::levels::NEARESTMV_NEARESTMV;
+use crate::src::levels::NEAREST_DRL;
+use crate::src::levels::NEARISH_DRL;
+use crate::src::levels::NEARMV;
+use crate::src::levels::NEAR_DRL;
+use crate::src::levels::NEWMV;
+use crate::src::levels::NEWMV_NEWMV;
+use crate::src::levels::N_COMP_INTER_PRED_MODES;
+use crate::src::levels::N_INTER_INTRA_PRED_MODES;
+use crate::src::levels::N_INTRA_PRED_MODES;
+use crate::src::levels::N_MV_JOINTS;
+use crate::src::levels::N_RECT_TX_SIZES;
+use crate::src::levels::N_UV_INTRA_PRED_MODES;
+use crate::src::levels::PARTITION_H;
+use crate::src::levels::PARTITION_H4;
+use crate::src::levels::PARTITION_NONE;
+use crate::src::levels::PARTITION_SPLIT;
+use crate::src::levels::PARTITION_T_BOTTOM_SPLIT;
+use crate::src::levels::PARTITION_T_LEFT_SPLIT;
+use crate::src::levels::PARTITION_T_RIGHT_SPLIT;
+use crate::src::levels::PARTITION_T_TOP_SPLIT;
+use crate::src::levels::PARTITION_V;
+use crate::src::levels::PARTITION_V4;
+use crate::src::levels::TX_4X4;
+use crate::src::levels::TX_64X64;
+use crate::src::levels::TX_8X8;
+use crate::src::levels::VERT_LEFT_PRED;
+use crate::src::levels::VERT_PRED;
+use crate::src::lf_mask::dav1d_calc_eih;
+use crate::src::lf_mask::dav1d_calc_lf_values;
+use crate::src::lf_mask::dav1d_create_lf_mask_inter;
+use crate::src::lf_mask::dav1d_create_lf_mask_intra;
+use crate::src::lf_mask::Av1Filter;
+use crate::src::lf_mask::Av1Restoration;
+use crate::src::lf_mask::Av1RestorationUnit;
+use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
 use crate::src::looprestoration::dav1d_loop_restoration_dsp_init;
 use crate::src::mc::dav1d_mc_dsp_init;
+use crate::src::mem::dav1d_alloc_aligned;
+use crate::src::mem::dav1d_free_aligned;
+use crate::src::mem::dav1d_freep_aligned;
+use crate::src::mem::freep;
+use crate::src::msac::dav1d_msac_decode_bool;
+use crate::src::msac::dav1d_msac_decode_bool_adapt;
+use crate::src::msac::dav1d_msac_decode_bool_equi;
+use crate::src::msac::dav1d_msac_decode_bools;
+use crate::src::msac::dav1d_msac_decode_subexp;
+use crate::src::msac::dav1d_msac_decode_symbol_adapt16;
+use crate::src::msac::dav1d_msac_decode_symbol_adapt4;
+use crate::src::msac::dav1d_msac_decode_symbol_adapt8;
+use crate::src::msac::dav1d_msac_decode_uniform;
+use crate::src::msac::dav1d_msac_init;
+use crate::src::picture::dav1d_picture_get_event_flags;
+use crate::src::picture::dav1d_picture_ref;
+use crate::src::picture::dav1d_picture_unref_internal;
+use crate::src::picture::dav1d_thread_picture_ref;
+use crate::src::picture::dav1d_thread_picture_unref;
+use crate::src::picture::Dav1dThreadPicture;
+use crate::src::qm::dav1d_qm_tbl;
+use crate::src::r#ref::dav1d_ref_create_using_pool;
+use crate::src::r#ref::dav1d_ref_dec;
+use crate::src::r#ref::dav1d_ref_inc;
+use crate::src::recon::DEBUG_BLOCK_INFO;
+use crate::src::refmvs::dav1d_refmvs_find;
+use crate::src::refmvs::dav1d_refmvs_init_frame;
+use crate::src::refmvs::dav1d_refmvs_save_tmvs;
+use crate::src::refmvs::dav1d_refmvs_tile_sbrow_init;
+use crate::src::refmvs::refmvs_block;
+use crate::src::refmvs::refmvs_block_unaligned;
+use crate::src::refmvs::refmvs_mvpair;
+use crate::src::refmvs::refmvs_refpair;
+use crate::src::refmvs::refmvs_temporal_block;
+use crate::src::tables::cfl_allowed_mask;
+use crate::src::tables::dav1d_al_part_ctx;
+use crate::src::tables::dav1d_block_dimensions;
+use crate::src::tables::dav1d_block_sizes;
+use crate::src::tables::dav1d_comp_inter_pred_modes;
+use crate::src::tables::dav1d_filter_2d;
+use crate::src::tables::dav1d_filter_dir;
+use crate::src::tables::dav1d_intra_mode_context;
+use crate::src::tables::dav1d_max_txfm_size_for_bs;
+use crate::src::tables::dav1d_partition_type_count;
+use crate::src::tables::dav1d_sgr_params;
+use crate::src::tables::dav1d_txfm_dimensions;
+use crate::src::tables::dav1d_wedge_ctx_lut;
+use crate::src::tables::dav1d_ymode_size_context;
+use crate::src::tables::interintra_allowed_mask;
+use crate::src::tables::wedge_allowed_mask;
 use crate::src::thread_task::FRAME_ERROR;
 use crate::src::thread_task::TILE_ERROR;
+use crate::src::warpmv::dav1d_find_affine_int;
+use crate::src::warpmv::dav1d_get_shear_params;
+use crate::src::warpmv::dav1d_set_affine_mv2d;
 
-use libc;
+use libc::pthread_cond_signal;
+use libc::pthread_cond_wait;
+use libc::pthread_mutex_lock;
+use libc::pthread_mutex_unlock;
+
+#[cfg(feature = "bitdepth_16")]
+use crate::include::common::bitdepth::BitDepth16;
+
+#[cfg(feature = "bitdepth_8")]
+use crate::include::common::bitdepth::BitDepth8;
 
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
@@ -138,254 +345,6 @@ extern "C" {
     ) -> libc::c_int;
     fn dav1d_task_frame_init(f: *mut Dav1dFrameContext);
 }
-
-use crate::src::dequant_tables::dav1d_dq_tbl;
-use crate::src::lf_mask::dav1d_calc_eih;
-use crate::src::lf_mask::dav1d_calc_lf_values;
-use crate::src::lf_mask::dav1d_create_lf_mask_inter;
-use crate::src::lf_mask::dav1d_create_lf_mask_intra;
-use crate::src::msac::dav1d_msac_decode_bool;
-use crate::src::msac::dav1d_msac_decode_bool_adapt;
-use crate::src::msac::dav1d_msac_decode_bool_equi;
-use crate::src::msac::dav1d_msac_decode_subexp;
-use crate::src::msac::dav1d_msac_decode_symbol_adapt16;
-use crate::src::msac::dav1d_msac_decode_symbol_adapt4;
-use crate::src::msac::dav1d_msac_decode_symbol_adapt8;
-use crate::src::msac::dav1d_msac_init;
-use crate::src::qm::dav1d_qm_tbl;
-use crate::src::refmvs::dav1d_refmvs_find;
-use crate::src::refmvs::dav1d_refmvs_init_frame;
-use crate::src::refmvs::dav1d_refmvs_save_tmvs;
-use crate::src::refmvs::dav1d_refmvs_tile_sbrow_init;
-use crate::src::tables::dav1d_al_part_ctx;
-use crate::src::tables::dav1d_block_dimensions;
-use crate::src::tables::dav1d_block_sizes;
-use crate::src::tables::dav1d_comp_inter_pred_modes;
-use crate::src::tables::dav1d_filter_2d;
-use crate::src::tables::dav1d_filter_dir;
-use crate::src::tables::dav1d_intra_mode_context;
-use crate::src::tables::dav1d_max_txfm_size_for_bs;
-use crate::src::tables::dav1d_partition_type_count;
-use crate::src::tables::dav1d_sgr_params;
-use crate::src::tables::dav1d_txfm_dimensions;
-use crate::src::tables::dav1d_wedge_ctx_lut;
-use crate::src::tables::dav1d_ymode_size_context;
-use crate::src::warpmv::dav1d_find_affine_int;
-use crate::src::warpmv::dav1d_get_shear_params;
-use crate::src::warpmv::dav1d_set_affine_mv2d;
-
-use crate::include::stdatomic::atomic_int;
-use crate::include::stdatomic::atomic_uint;
-use crate::src::data::dav1d_data_props_copy;
-use crate::src::data::dav1d_data_unref_internal;
-
-use crate::src::internal::Dav1dFrameContext;
-
-use libc::pthread_cond_signal;
-use libc::pthread_cond_wait;
-use libc::pthread_mutex_lock;
-use libc::pthread_mutex_unlock;
-
-use crate::include::dav1d::picture::Dav1dPicture;
-
-use crate::include::dav1d::headers::Dav1dFrameHeader;
-use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-
-use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-
-use crate::src::internal::CodedBlockInfo;
-
-use crate::src::levels::Av1Block;
-use crate::src::levels::MotionMode;
-use crate::src::lf_mask::Av1Filter;
-use crate::src::lf_mask::Av1Restoration;
-use crate::src::lf_mask::Av1RestorationUnit;
-
-use crate::src::levels::mv;
-
-use crate::src::env::BlockContext;
-use crate::src::refmvs::refmvs_block;
-use crate::src::refmvs::refmvs_block_unaligned;
-
-use crate::src::refmvs::refmvs_mvpair;
-use crate::src::refmvs::refmvs_refpair;
-use crate::src::refmvs::refmvs_temporal_block;
-
-use crate::src::levels::BlockSize;
-
-use crate::src::internal::Dav1dTaskContext;
-use crate::src::levels::BS_128x128;
-use crate::src::levels::BS_4x4;
-use crate::src::levels::BS_64x64;
-
-use crate::src::levels::FILTER_2D_BILINEAR;
-
-use crate::src::internal::Dav1dTileState;
-
-use crate::src::internal::Dav1dContext;
-
-use crate::src::intra_edge::EdgeFlags;
-use crate::src::intra_edge::EdgeTip;
-
-use crate::src::intra_edge::EdgeBranch;
-use crate::src::intra_edge::EdgeNode;
-use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
-
-use crate::src::cdef::Dav1dCdefDSPContext;
-use crate::src::cdf::dav1d_cdf_thread_copy;
-use crate::src::cdf::dav1d_cdf_thread_init_static;
-use crate::src::cdf::dav1d_cdf_thread_ref;
-use crate::src::cdf::dav1d_cdf_thread_unref;
-use crate::src::cdf::dav1d_cdf_thread_update;
-use crate::src::cdf::CdfThreadContext;
-use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
-
-use crate::src::ipred::Dav1dIntraPredDSPContext;
-use crate::src::itx::Dav1dInvTxfmDSPContext;
-use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
-
-use crate::src::internal::Dav1dTileGroup;
-use crate::src::picture::dav1d_picture_get_event_flags;
-use crate::src::picture::dav1d_picture_ref;
-use crate::src::picture::dav1d_picture_unref_internal;
-use crate::src::picture::dav1d_thread_picture_ref;
-use crate::src::picture::dav1d_thread_picture_unref;
-use crate::src::picture::Dav1dThreadPicture;
-
-use crate::src::internal::ScalableMotionParams;
-use crate::src::levels::BlockLevel;
-use crate::src::levels::TX_4X4;
-use crate::src::levels::TX_64X64;
-use crate::src::levels::TX_8X8;
-
-use crate::src::levels::RectTxfmSize;
-use crate::src::levels::TxfmSize;
-use crate::src::levels::BL_128X128;
-use crate::src::levels::BL_64X64;
-use crate::src::levels::BL_8X8;
-use crate::src::levels::FILTER_PRED;
-use crate::src::levels::N_RECT_TX_SIZES;
-
-use crate::src::levels::CFL_PRED;
-use crate::src::levels::DC_PRED;
-use crate::src::levels::N_INTRA_PRED_MODES;
-use crate::src::levels::N_UV_INTRA_PRED_MODES;
-use crate::src::levels::VERT_LEFT_PRED;
-use crate::src::levels::VERT_PRED;
-
-use crate::src::levels::BlockPartition;
-use crate::src::levels::N_INTER_INTRA_PRED_MODES;
-use crate::src::levels::PARTITION_H;
-use crate::src::levels::PARTITION_H4;
-use crate::src::levels::PARTITION_NONE;
-use crate::src::levels::PARTITION_SPLIT;
-use crate::src::levels::PARTITION_T_BOTTOM_SPLIT;
-use crate::src::levels::PARTITION_T_LEFT_SPLIT;
-use crate::src::levels::PARTITION_T_RIGHT_SPLIT;
-use crate::src::levels::PARTITION_T_TOP_SPLIT;
-use crate::src::levels::PARTITION_V;
-use crate::src::levels::PARTITION_V4;
-
-use crate::src::levels::MV_JOINT_H;
-use crate::src::levels::MV_JOINT_HV;
-use crate::src::levels::MV_JOINT_V;
-use crate::src::levels::N_MV_JOINTS;
-
-use crate::src::levels::GLOBALMV;
-use crate::src::levels::NEARESTMV;
-use crate::src::levels::NEARMV;
-use crate::src::levels::NEWMV;
-
-use crate::src::levels::GLOBALMV_GLOBALMV;
-use crate::src::levels::NEARER_DRL;
-use crate::src::levels::NEAREST_DRL;
-use crate::src::levels::NEARISH_DRL;
-use crate::src::levels::NEAR_DRL;
-use crate::src::levels::NEWMV_NEWMV;
-use crate::src::levels::N_COMP_INTER_PRED_MODES;
-
-use crate::src::levels::NEARESTMV_NEARESTMV;
-
-use crate::src::levels::COMP_INTER_AVG;
-use crate::src::levels::COMP_INTER_NONE;
-use crate::src::levels::COMP_INTER_SEG;
-use crate::src::levels::COMP_INTER_WEDGE;
-use crate::src::levels::COMP_INTER_WEIGHTED_AVG;
-
-use crate::src::levels::INTER_INTRA_BLEND;
-use crate::src::levels::INTER_INTRA_NONE;
-use crate::src::levels::INTER_INTRA_WEDGE;
-
-use crate::include::common::attributes::ctz;
-use crate::src::levels::MM_OBMC;
-use crate::src::levels::MM_TRANSLATION;
-use crate::src::levels::MM_WARP;
-
-use crate::include::common::intops::iclip;
-use crate::include::common::intops::iclip_u8;
-
-use crate::include::common::intops::apply_sign64;
-use crate::include::common::intops::ulog2;
-use crate::src::mem::dav1d_alloc_aligned;
-use crate::src::mem::dav1d_free_aligned;
-use crate::src::mem::dav1d_freep_aligned;
-use crate::src::mem::freep;
-use crate::src::r#ref::dav1d_ref_create_using_pool;
-use crate::src::r#ref::dav1d_ref_dec;
-use crate::src::r#ref::dav1d_ref_inc;
-
-use crate::src::tables::cfl_allowed_mask;
-use crate::src::tables::interintra_allowed_mask;
-use crate::src::tables::wedge_allowed_mask;
-
-use crate::src::env::av1_get_bwd_ref_1_ctx;
-use crate::src::env::av1_get_bwd_ref_ctx;
-use crate::src::env::av1_get_fwd_ref_1_ctx;
-use crate::src::env::av1_get_fwd_ref_2_ctx;
-use crate::src::env::av1_get_fwd_ref_ctx;
-use crate::src::env::av1_get_ref_ctx;
-use crate::src::env::av1_get_uni_p1_ctx;
-use crate::src::env::fix_mv_precision;
-use crate::src::env::gather_left_partition_prob;
-use crate::src::env::gather_top_partition_prob;
-use crate::src::env::get_comp_ctx;
-use crate::src::env::get_comp_dir_ctx;
-use crate::src::env::get_cur_frame_segid;
-use crate::src::env::get_drl_context;
-use crate::src::env::get_filter_ctx;
-use crate::src::env::get_gmv_2d;
-use crate::src::env::get_intra_ctx;
-use crate::src::env::get_jnt_comp_ctx;
-use crate::src::env::get_mask_comp_ctx;
-use crate::src::env::get_partition_ctx;
-use crate::src::env::get_poc_diff;
-use crate::src::env::get_tx_ctx;
-
-use crate::src::msac::dav1d_msac_decode_bools;
-use crate::src::msac::dav1d_msac_decode_uniform;
-
-use crate::src::internal::Dav1dTaskContext_scratch_pal;
-
-use crate::src::recon::DEBUG_BLOCK_INFO;
 
 fn init_quant_tables(
     seq_hdr: &Dav1dSequenceHeader,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,12 +1,3 @@
-use std::array;
-use std::cmp;
-use std::iter;
-use std::ptr;
-use std::ptr::addr_of_mut;
-use std::slice;
-use std::sync::atomic::AtomicI32;
-use std::sync::atomic::Ordering;
-
 use crate::include::common::attributes::ctz;
 use crate::include::common::bitdepth::DynCoef;
 use crate::include::common::bitdepth::DynPixel;
@@ -226,11 +217,18 @@ use crate::src::thread_task::TILE_ERROR;
 use crate::src::warpmv::dav1d_find_affine_int;
 use crate::src::warpmv::dav1d_get_shear_params;
 use crate::src::warpmv::dav1d_set_affine_mv2d;
-
 use libc::pthread_cond_signal;
 use libc::pthread_cond_wait;
 use libc::pthread_mutex_lock;
 use libc::pthread_mutex_unlock;
+use std::array;
+use std::cmp;
+use std::iter;
+use std::ptr;
+use std::ptr::addr_of_mut;
+use std::slice;
+use std::sync::atomic::AtomicI32;
+use std::sync::atomic::Ordering;
 
 #[cfg(feature = "bitdepth_16")]
 use crate::include::common::bitdepth::BitDepth16;

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,6 +1,3 @@
-use std::cmp;
-use std::cmp::Ordering;
-
 use crate::include::common::intops::apply_sign;
 use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
@@ -35,6 +32,8 @@ use crate::src::levels::V_ADST;
 use crate::src::levels::V_FLIPADST;
 use crate::src::refmvs::refmvs_candidate;
 use crate::src::tables::TxfmInfo;
+use std::cmp;
+use std::cmp::Ordering;
 
 #[repr(C)]
 pub struct BlockContext {

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,6 +1,5 @@
 use std::cmp;
-
-use cmp::Ordering;
+use std::cmp::Ordering;
 
 use crate::include::common::intops::apply_sign;
 use crate::include::dav1d::headers::Dav1dFrameHeader;

--- a/src/fg_apply_tmpl_16.rs
+++ b/src/fg_apply_tmpl_16.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
@@ -11,6 +9,7 @@ use crate::include::stdint::*;
 use crate::src::align::Align1;
 use crate::src::align::Align16;
 use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
+use std::cmp;
 
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;

--- a/src/fg_apply_tmpl_16.rs
+++ b/src/fg_apply_tmpl_16.rs
@@ -1,25 +1,25 @@
 use std::cmp;
 
+use crate::include::dav1d::headers::Dav1dFilmGrainData;
+use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::picture::Dav1dPicture;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use crate::src::align::{Align1, Align16};
-use ::libc;
+use crate::src::align::Align1;
+use crate::src::align::Align16;
+use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
+
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong) -> *mut libc::c_void;
 }
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-
-use crate::include::dav1d::headers::Dav1dFilmGrainData;
-use crate::include::dav1d::picture::Dav1dPicture;
 pub type pixel = uint16_t;
 pub type entry = int16_t;
-use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
+
 #[inline]
 unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     if x & 1 != 0 {
@@ -27,6 +27,7 @@ unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     }
     return x >> 1;
 }
+
 unsafe extern "C" fn generate_scaling(
     bitdepth: libc::c_int,
     points: *const [uint8_t; 2],
@@ -103,6 +104,7 @@ unsafe extern "C" fn generate_scaling(
         i_0 += 1;
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_prep_grain_16bpc(
     dsp: *const Dav1dFilmGrainDSPContext,
@@ -230,6 +232,7 @@ pub unsafe extern "C" fn dav1d_prep_grain_16bpc(
         }
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_apply_grain_row_16bpc(
     dsp: *const Dav1dFilmGrainDSPContext,
@@ -344,6 +347,7 @@ pub unsafe extern "C" fn dav1d_apply_grain_row_16bpc(
         }
     };
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_apply_grain_16bpc(
     dsp: *const Dav1dFilmGrainDSPContext,

--- a/src/fg_apply_tmpl_8.rs
+++ b/src/fg_apply_tmpl_8.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
@@ -10,8 +8,8 @@ use crate::include::stddef::*;
 use crate::include::stdint::*;
 use crate::src::align::Align16;
 use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
-
 use cfg_if::cfg_if;
+use std::cmp;
 
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;

--- a/src/fg_apply_tmpl_8.rs
+++ b/src/fg_apply_tmpl_8.rs
@@ -1,27 +1,26 @@
 use std::cmp;
 
+use crate::include::dav1d::headers::Dav1dFilmGrainData;
+use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::picture::Dav1dPicture;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 use crate::src::align::Align16;
-use ::libc;
+use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
+
 use cfg_if::cfg_if;
+
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong) -> *mut libc::c_void;
 }
 
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-
-use crate::include::dav1d::headers::Dav1dFilmGrainData;
-use crate::include::dav1d::picture::Dav1dPicture;
 pub type pixel = uint8_t;
 pub type entry = int8_t;
-use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
+
 unsafe extern "C" fn generate_scaling(
     _bitdepth: libc::c_int,
     points: *const [uint8_t; 2],
@@ -71,6 +70,7 @@ unsafe extern "C" fn generate_scaling(
         (scaling_size - n) as libc::c_ulong,
     );
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_prep_grain_8bpc(
     dsp: *const Dav1dFilmGrainDSPContext,
@@ -197,6 +197,7 @@ pub unsafe extern "C" fn dav1d_prep_grain_8bpc(
         }
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_apply_grain_row_8bpc(
     dsp: *const Dav1dFilmGrainDSPContext,
@@ -310,6 +311,7 @@ pub unsafe extern "C" fn dav1d_apply_grain_row_8bpc(
         }
     };
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_apply_grain_8bpc(
     dsp: *const Dav1dFilmGrainDSPContext,

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -25,6 +25,7 @@ pub unsafe extern "C" fn round2(x: libc::c_int, shift: uint64_t) -> libc::c_int 
 }
 
 pub const GRAIN_WIDTH: usize = 82;
+
 pub type generate_grain_y_fn = Option<
     unsafe extern "C" fn(
         *mut [DynEntry; GRAIN_WIDTH],
@@ -32,6 +33,7 @@ pub type generate_grain_y_fn = Option<
         libc::c_int,
     ) -> (),
 >;
+
 pub type generate_grain_uv_fn = Option<
     unsafe extern "C" fn(
         *mut [DynEntry; GRAIN_WIDTH],
@@ -41,6 +43,7 @@ pub type generate_grain_uv_fn = Option<
         libc::c_int,
     ) -> (),
 >;
+
 pub type fgy_32x32xn_fn = Option<
     unsafe extern "C" fn(
         *mut DynPixel,
@@ -55,6 +58,7 @@ pub type fgy_32x32xn_fn = Option<
         libc::c_int,
     ) -> (),
 >;
+
 pub type fguv_32x32xn_fn = Option<
     unsafe extern "C" fn(
         *mut DynPixel,
@@ -73,6 +77,7 @@ pub type fguv_32x32xn_fn = Option<
         libc::c_int,
     ) -> (),
 >;
+
 #[repr(C)]
 pub struct Dav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,

--- a/src/filmgrain_tmpl_16.rs
+++ b/src/filmgrain_tmpl_16.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::common::attributes::clz;
 use crate::include::common::bitdepth::DynEntry;
 use crate::include::common::bitdepth::DynPixel;
@@ -15,6 +13,7 @@ use crate::src::filmgrain::round2;
 use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
 use crate::src::filmgrain::GRAIN_WIDTH;
 use crate::src::tables::dav1d_gaussian_sequence;
+use std::cmp;
 
 #[cfg(feature = "asm")]
 use crate::src::cpu::dav1d_get_cpu_flags;

--- a/src/filmgrain_tmpl_8.rs
+++ b/src/filmgrain_tmpl_8.rs
@@ -2,7 +2,27 @@ use std::cmp;
 
 use crate::include::common::bitdepth::DynEntry;
 use crate::include::common::bitdepth::DynPixel;
-use ::libc;
+use crate::include::common::intops::iclip;
+use crate::include::common::intops::iclip_u8;
+use crate::include::dav1d::headers::Dav1dFilmGrainData;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::stddef::ptrdiff_t;
+use crate::include::stddef::size_t;
+use crate::include::stdint::int8_t;
+use crate::include::stdint::intptr_t;
+use crate::include::stdint::uint64_t;
+use crate::include::stdint::uint8_t;
+use crate::src::filmgrain::get_random_number;
+use crate::src::filmgrain::round2;
+use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
+use crate::src::filmgrain::GRAIN_WIDTH;
+use crate::src::tables::dav1d_gaussian_sequence;
+
+#[cfg(feature = "asm")]
+use crate::src::cpu::dav1d_get_cpu_flags;
+
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
 
@@ -333,28 +353,9 @@ extern "C" {
     );
 }
 
-use crate::src::tables::dav1d_gaussian_sequence;
-
 pub type pixel = uint8_t;
-
-use crate::include::dav1d::headers::Dav1dFilmGrainData;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::stddef::ptrdiff_t;
-use crate::include::stddef::size_t;
-use crate::include::stdint::int8_t;
-use crate::include::stdint::intptr_t;
-use crate::include::stdint::uint64_t;
-use crate::include::stdint::uint8_t;
-
 pub type entry = int8_t;
-use crate::include::common::intops::iclip;
-use crate::include::common::intops::iclip_u8;
-use crate::src::filmgrain::get_random_number;
-use crate::src::filmgrain::round2;
-use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
-use crate::src::filmgrain::GRAIN_WIDTH;
+
 unsafe extern "C" fn generate_grain_y_c_erased(
     buf: *mut [DynEntry; GRAIN_WIDTH],
     data: *const Dav1dFilmGrainData,
@@ -362,6 +363,7 @@ unsafe extern "C" fn generate_grain_y_c_erased(
 ) {
     generate_grain_y_rust(buf.cast(), data);
 }
+
 unsafe extern "C" fn generate_grain_y_rust(buf: *mut [entry; 82], data: *const Dav1dFilmGrainData) {
     let bitdepth_min_8 = 8 - 8;
     let mut seed: libc::c_uint = (*data).seed;
@@ -413,6 +415,7 @@ unsafe extern "C" fn generate_grain_y_rust(buf: *mut [entry; 82], data: *const D
         y_0 += 1;
     }
 }
+
 #[inline(never)]
 unsafe extern "C" fn generate_grain_uv_c(
     buf: *mut [entry; 82],
@@ -507,6 +510,7 @@ unsafe extern "C" fn generate_grain_uv_c(
         y_0 += 1;
     }
 }
+
 unsafe extern "C" fn generate_grain_uv_420_c_erased(
     buf: *mut [DynEntry; GRAIN_WIDTH],
     buf_y: *const [DynEntry; GRAIN_WIDTH],
@@ -523,6 +527,7 @@ unsafe extern "C" fn generate_grain_uv_420_c_erased(
         1 as libc::c_int,
     );
 }
+
 unsafe extern "C" fn generate_grain_uv_422_c_erased(
     buf: *mut [DynEntry; GRAIN_WIDTH],
     buf_y: *const [DynEntry; GRAIN_WIDTH],
@@ -539,6 +544,7 @@ unsafe extern "C" fn generate_grain_uv_422_c_erased(
         0 as libc::c_int,
     );
 }
+
 unsafe extern "C" fn generate_grain_uv_444_c_erased(
     buf: *mut [DynEntry; GRAIN_WIDTH],
     buf_y: *const [DynEntry; GRAIN_WIDTH],
@@ -555,6 +561,7 @@ unsafe extern "C" fn generate_grain_uv_444_c_erased(
         0 as libc::c_int,
     );
 }
+
 #[inline]
 unsafe extern "C" fn sample_lut(
     grain_lut: *const [entry; 82],
@@ -572,6 +579,7 @@ unsafe extern "C" fn sample_lut(
     return (*grain_lut.offset((offy + y + (32 >> suby) * by) as isize))
         [(offx + x + (32 >> subx) * bx) as usize];
 }
+
 unsafe extern "C" fn fgy_32x32xn_c_erased(
     dst_row: *mut DynPixel,
     src_row: *const DynPixel,
@@ -596,6 +604,7 @@ unsafe extern "C" fn fgy_32x32xn_c_erased(
         row_num,
     );
 }
+
 unsafe extern "C" fn fgy_32x32xn_rust(
     dst_row: *mut pixel,
     src_row: *const pixel,
@@ -866,6 +875,7 @@ unsafe extern "C" fn fgy_32x32xn_rust(
         bx = bx.wrapping_add(32 as libc::c_int as libc::c_uint);
     }
 }
+
 #[inline(never)]
 unsafe extern "C" fn fguv_32x32xn_c(
     dst_row: *mut pixel,
@@ -1222,6 +1232,7 @@ unsafe extern "C" fn fguv_32x32xn_c(
         bx = bx.wrapping_add((32 >> sx) as libc::c_uint);
     }
 }
+
 unsafe extern "C" fn fguv_32x32xn_420_c_erased(
     dst_row: *mut DynPixel,
     src_row: *const DynPixel,
@@ -1256,6 +1267,7 @@ unsafe extern "C" fn fguv_32x32xn_420_c_erased(
         1 as libc::c_int,
     );
 }
+
 unsafe extern "C" fn fguv_32x32xn_422_c_erased(
     dst_row: *mut DynPixel,
     src_row: *const DynPixel,
@@ -1290,6 +1302,7 @@ unsafe extern "C" fn fguv_32x32xn_422_c_erased(
         0 as libc::c_int,
     );
 }
+
 unsafe extern "C" fn fguv_32x32xn_444_c_erased(
     dst_row: *mut DynPixel,
     src_row: *const DynPixel,
@@ -1820,9 +1833,6 @@ unsafe extern "C" fn fguv_32x32xn_444_neon(
         bx = bx.wrapping_add((32 >> 0) as libc::c_uint);
     }
 }
-
-#[cfg(feature = "asm")]
-use crate::src::cpu::dav1d_get_cpu_flags;
 
 #[no_mangle]
 #[cold]

--- a/src/filmgrain_tmpl_8.rs
+++ b/src/filmgrain_tmpl_8.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::common::bitdepth::DynEntry;
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::intops::iclip;
@@ -19,6 +17,7 @@ use crate::src::filmgrain::round2;
 use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
 use crate::src::filmgrain::GRAIN_WIDTH;
 use crate::src::tables::dav1d_gaussian_sequence;
+use std::cmp;
 
 #[cfg(feature = "asm")]
 use crate::src::cpu::dav1d_get_cpu_flags;

--- a/src/getbits.rs
+++ b/src/getbits.rs
@@ -1,6 +1,7 @@
+use crate::include::common::intops::inv_recenter;
+use crate::include::common::intops::ulog2;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use ::libc;
 
 #[repr(C)]
 pub struct GetBits {
@@ -11,8 +12,6 @@ pub struct GetBits {
     pub ptr_start: *const uint8_t,
     pub ptr_end: *const uint8_t,
 }
-use crate::include::common::intops::inv_recenter;
-use crate::include::common::intops::ulog2;
 
 pub unsafe fn dav1d_init_get_bits(c: *mut GetBits, data: *const uint8_t, sz: size_t) {
     if sz == 0 {
@@ -44,6 +43,7 @@ pub unsafe fn dav1d_get_bit(c: *mut GetBits) -> libc::c_uint {
     (*c).state = state_0 << 1;
     return (state_0 >> 63) as libc::c_uint;
 }
+
 #[inline]
 unsafe extern "C" fn refill(c: *mut GetBits, n: libc::c_int) {
     if !((*c).bits_left >= 0 && (*c).bits_left < 32) {
@@ -149,6 +149,7 @@ pub unsafe fn dav1d_get_vlc(c: *mut GetBits) -> libc::c_uint {
         .wrapping_sub(1 as libc::c_int as libc::c_uint)
         .wrapping_add(dav1d_get_bits(c, n_bits));
 }
+
 unsafe extern "C" fn get_bits_subexp_u(
     c: *mut GetBits,
     r#ref: libc::c_uint,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -59,7 +59,6 @@ use crate::src::refmvs::refmvs_temporal_block;
 use crate::src::refmvs::refmvs_tile;
 use crate::src::refmvs::Dav1dRefmvsDSPContext;
 use crate::src::thread_data::thread_data;
-
 use libc::pthread_cond_t;
 use libc::pthread_mutex_t;
 

--- a/src/intra_edge.rs
+++ b/src/intra_edge.rs
@@ -1,13 +1,12 @@
-use std::iter;
-use std::ptr;
-use std::slice;
-
 use crate::src::levels::BlockLevel;
 use crate::src::levels::BL_128X128;
 use crate::src::levels::BL_16X16;
 use crate::src::levels::BL_32X32;
 use crate::src::levels::BL_64X64;
 use crate::src::levels::BL_8X8;
+use std::iter;
+use std::ptr;
+use std::slice;
 
 pub type EdgeFlags = u8;
 pub const EDGE_I420_LEFT_HAS_BOTTOM: EdgeFlags = 32;

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -24,6 +24,7 @@ pub type angular_ipred_fn = unsafe extern "C" fn(
     libc::c_int,
     libc::c_int,
 ) -> ();
+
 pub type cfl_ac_fn = unsafe extern "C" fn(
     *mut int16_t,
     *const DynPixel,
@@ -33,6 +34,7 @@ pub type cfl_ac_fn = unsafe extern "C" fn(
     libc::c_int,
     libc::c_int,
 ) -> ();
+
 pub type cfl_pred_fn = unsafe extern "C" fn(
     *mut DynPixel,
     ptrdiff_t,
@@ -43,6 +45,7 @@ pub type cfl_pred_fn = unsafe extern "C" fn(
     libc::c_int,
     libc::c_int,
 ) -> ();
+
 pub type pal_pred_fn = unsafe extern "C" fn(
     *mut DynPixel,
     ptrdiff_t,
@@ -51,6 +54,7 @@ pub type pal_pred_fn = unsafe extern "C" fn(
     libc::c_int,
     libc::c_int,
 ) -> ();
+
 #[repr(C)]
 pub struct Dav1dIntraPredDSPContext {
     // TODO(legare): Remove `Option` once `dav1d_submit_frame` is no longer checking

--- a/src/ipred_prepare_tmpl_16.rs
+++ b/src/ipred_prepare_tmpl_16.rs
@@ -1,32 +1,33 @@
 use std::cmp;
 
+use crate::include::common::attributes::clz;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use ::c2rust_bitfields;
-use ::libc;
-use c2rust_bitfields::BitfieldStruct;
-extern "C" {
-    fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
-}
-pub type pixel = uint16_t;
+use crate::src::intra_edge::EdgeFlags;
+use crate::src::intra_edge::EDGE_I444_LEFT_HAS_BOTTOM;
+use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
 use crate::src::levels::IntraPredMode;
-
 use crate::src::levels::DC_128_PRED;
+use crate::src::levels::DC_PRED;
+use crate::src::levels::HOR_PRED;
 use crate::src::levels::LEFT_DC_PRED;
+use crate::src::levels::N_IMPL_INTRA_PRED_MODES;
+use crate::src::levels::N_INTRA_PRED_MODES;
 use crate::src::levels::PAETH_PRED;
 use crate::src::levels::TOP_DC_PRED;
+use crate::src::levels::VERT_PRED;
 use crate::src::levels::Z1_PRED;
 use crate::src::levels::Z2_PRED;
 use crate::src::levels::Z3_PRED;
 
-use crate::src::intra_edge::EdgeFlags;
-use crate::src::intra_edge::EDGE_I444_LEFT_HAS_BOTTOM;
-use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
-use crate::src::levels::DC_PRED;
-use crate::src::levels::HOR_PRED;
-use crate::src::levels::N_IMPL_INTRA_PRED_MODES;
-use crate::src::levels::N_INTRA_PRED_MODES;
-use crate::src::levels::VERT_PRED;
+use c2rust_bitfields::BitfieldStruct;
+
+extern "C" {
+    fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
+}
+
+pub type pixel = uint16_t;
+
 #[derive(Copy, Clone, BitfieldStruct)]
 #[repr(C)]
 pub struct av1_intra_prediction_edge {
@@ -37,7 +38,6 @@ pub struct av1_intra_prediction_edge {
     #[bitfield(name = "needs_bottomleft", ty = "uint8_t", bits = "4..=4")]
     pub needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [u8; 1],
 }
-use crate::include::common::attributes::clz;
 
 #[inline]
 unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
@@ -46,6 +46,7 @@ unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     }
     return x >> 1;
 }
+
 #[inline]
 unsafe extern "C" fn pixel_set(dst: *mut pixel, val: libc::c_int, num: libc::c_int) {
     let mut n = 0;
@@ -54,6 +55,7 @@ unsafe extern "C" fn pixel_set(dst: *mut pixel, val: libc::c_int, num: libc::c_i
         n += 1;
     }
 }
+
 static mut av1_mode_conv: [[[uint8_t; 2]; 2]; N_INTRA_PRED_MODES] = [
     [
         [
@@ -101,6 +103,7 @@ static mut av1_intra_prediction_edges: [av1_intra_prediction_edge; 14] =
     [av1_intra_prediction_edge {
         needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
     }; N_IMPL_INTRA_PRED_MODES];
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_prepare_intra_edges_16bpc(
     x: libc::c_int,
@@ -313,6 +316,7 @@ pub unsafe extern "C" fn dav1d_prepare_intra_edges_16bpc(
     }
     return mode;
 }
+
 unsafe extern "C" fn run_static_initializers() {
     av1_intra_prediction_edges = [
         {
@@ -471,6 +475,7 @@ unsafe extern "C" fn run_static_initializers() {
         },
     ];
 }
+
 #[used]
 #[cfg_attr(target_os = "linux", link_section = ".init_array")]
 #[cfg_attr(target_os = "windows", link_section = ".CRT$XIB")]

--- a/src/ipred_prepare_tmpl_16.rs
+++ b/src/ipred_prepare_tmpl_16.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::common::attributes::clz;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
@@ -19,8 +17,8 @@ use crate::src::levels::VERT_PRED;
 use crate::src::levels::Z1_PRED;
 use crate::src::levels::Z2_PRED;
 use crate::src::levels::Z3_PRED;
-
 use c2rust_bitfields::BitfieldStruct;
+use std::cmp;
 
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;

--- a/src/ipred_prepare_tmpl_8.rs
+++ b/src/ipred_prepare_tmpl_8.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 use crate::src::intra_edge::EdgeFlags;
@@ -18,8 +16,8 @@ use crate::src::levels::VERT_PRED;
 use crate::src::levels::Z1_PRED;
 use crate::src::levels::Z2_PRED;
 use crate::src::levels::Z3_PRED;
-
 use c2rust_bitfields::BitfieldStruct;
+use std::cmp;
 
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;

--- a/src/ipred_prepare_tmpl_8.rs
+++ b/src/ipred_prepare_tmpl_8.rs
@@ -2,32 +2,31 @@ use std::cmp;
 
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use ::c2rust_bitfields;
-use ::libc;
-use c2rust_bitfields::BitfieldStruct;
-extern "C" {
-    fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
-    fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong) -> *mut libc::c_void;
-}
-pub type pixel = uint8_t;
+use crate::src::intra_edge::EdgeFlags;
+use crate::src::intra_edge::EDGE_I444_LEFT_HAS_BOTTOM;
+use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
 use crate::src::levels::IntraPredMode;
-
 use crate::src::levels::DC_128_PRED;
+use crate::src::levels::DC_PRED;
+use crate::src::levels::HOR_PRED;
 use crate::src::levels::LEFT_DC_PRED;
+use crate::src::levels::N_IMPL_INTRA_PRED_MODES;
+use crate::src::levels::N_INTRA_PRED_MODES;
 use crate::src::levels::PAETH_PRED;
 use crate::src::levels::TOP_DC_PRED;
+use crate::src::levels::VERT_PRED;
 use crate::src::levels::Z1_PRED;
 use crate::src::levels::Z2_PRED;
 use crate::src::levels::Z3_PRED;
 
-use crate::src::intra_edge::EdgeFlags;
-use crate::src::intra_edge::EDGE_I444_LEFT_HAS_BOTTOM;
-use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
-use crate::src::levels::DC_PRED;
-use crate::src::levels::HOR_PRED;
-use crate::src::levels::N_IMPL_INTRA_PRED_MODES;
-use crate::src::levels::N_INTRA_PRED_MODES;
-use crate::src::levels::VERT_PRED;
+use c2rust_bitfields::BitfieldStruct;
+
+extern "C" {
+    fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
+    fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong) -> *mut libc::c_void;
+}
+
+pub type pixel = uint8_t;
 
 #[derive(Copy, Clone, BitfieldStruct)]
 #[repr(C)]
@@ -39,6 +38,7 @@ pub struct av1_intra_prediction_edge {
     #[bitfield(name = "needs_bottomleft", ty = "uint8_t", bits = "4..=4")]
     pub needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [u8; 1],
 }
+
 static mut av1_mode_conv: [[[uint8_t; 2]; 2]; N_INTRA_PRED_MODES] = [
     [
         [
@@ -86,6 +86,7 @@ static mut av1_intra_prediction_edges: [av1_intra_prediction_edge; 14] =
     [av1_intra_prediction_edge {
         needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
     }; N_IMPL_INTRA_PRED_MODES];
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_prepare_intra_edges_8bpc(
     x: libc::c_int,
@@ -295,6 +296,7 @@ pub unsafe extern "C" fn dav1d_prepare_intra_edges_8bpc(
     }
     return mode;
 }
+
 unsafe extern "C" fn run_static_initializers() {
     av1_intra_prediction_edges = [
         {
@@ -453,6 +455,7 @@ unsafe extern "C" fn run_static_initializers() {
         },
     ];
 }
+
 #[used]
 #[cfg_attr(target_os = "linux", link_section = ".init_array")]
 #[cfg_attr(target_os = "windows", link_section = ".CRT$XIB")]

--- a/src/ipred_tmpl_16.rs
+++ b/src/ipred_tmpl_16.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::common::attributes::ctz;
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::intops::apply_sign;
@@ -28,6 +26,7 @@ use crate::src::levels::Z3_PRED;
 use crate::src::tables::dav1d_dr_intra_derivative;
 use crate::src::tables::dav1d_filter_intra_taps;
 use crate::src::tables::dav1d_sm_weights;
+use std::cmp;
 
 #[cfg(feature = "asm")]
 use crate::src::cpu::dav1d_get_cpu_flags;

--- a/src/ipred_tmpl_8.rs
+++ b/src/ipred_tmpl_8.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::common::attributes::ctz;
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::intops::apply_sign;
@@ -29,6 +27,7 @@ use crate::src::levels::Z3_PRED;
 use crate::src::tables::dav1d_dr_intra_derivative;
 use crate::src::tables::dav1d_filter_intra_taps;
 use crate::src::tables::dav1d_sm_weights;
+use std::cmp;
 
 #[cfg(feature = "asm")]
 use crate::src::cpu::dav1d_get_cpu_flags;

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::common::bitdepth::AsPrimitive;
 use crate::include::common::bitdepth::BitDepth;
 use crate::include::common::bitdepth::DynCoef;
@@ -9,6 +7,7 @@ use crate::include::stddef::*;
 use crate::include::stdint::*;
 use crate::src::levels::N_RECT_TX_SIZES;
 use crate::src::levels::N_TX_TYPES_PLUS_LL;
+use std::cmp;
 
 extern "C" {
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong) -> *mut libc::c_void;

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -13,6 +13,7 @@ use crate::src::levels::N_TX_TYPES_PLUS_LL;
 extern "C" {
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong) -> *mut libc::c_void;
 }
+
 pub type itx_1d_fn =
     Option<unsafe extern "C" fn(*mut int32_t, ptrdiff_t, libc::c_int, libc::c_int) -> ()>;
 
@@ -146,6 +147,7 @@ pub unsafe extern "C" fn inv_txfm_add_rust<BD: BitDepth>(
 pub type itxfm_fn = Option<
     unsafe extern "C" fn(*mut DynPixel, ptrdiff_t, *mut DynCoef, libc::c_int, libc::c_int) -> (),
 >;
+
 #[repr(C)]
 pub struct Dav1dInvTxfmDSPContext {
     pub itxfm_add: [[itxfm_fn; N_TX_TYPES_PLUS_LL]; N_RECT_TX_SIZES],

--- a/src/itx_1d.rs
+++ b/src/itx_1d.rs
@@ -1,7 +1,7 @@
 use crate::include::common::intops::iclip;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use ::libc;
+
 #[inline(never)]
 unsafe extern "C" fn inv_dct4_1d_internal_c(
     c: *mut int32_t,
@@ -37,6 +37,7 @@ unsafe extern "C" fn inv_dct4_1d_internal_c(
     *c.offset((2 * stride) as isize) = iclip(t1 - t2, min, max);
     *c.offset((3 * stride) as isize) = iclip(t0 - t3, min, max);
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_inv_dct4_1d_c(
     c: *mut int32_t,
@@ -46,6 +47,7 @@ pub unsafe extern "C" fn dav1d_inv_dct4_1d_c(
 ) {
     inv_dct4_1d_internal_c(c, stride, min, max, 0 as libc::c_int);
 }
+
 #[inline(never)]
 unsafe extern "C" fn inv_dct8_1d_internal_c(
     c: *mut int32_t,
@@ -96,6 +98,7 @@ unsafe extern "C" fn inv_dct8_1d_internal_c(
     *c.offset((6 * stride) as isize) = iclip(t1 - t6, min, max);
     *c.offset((7 * stride) as isize) = iclip(t0 - t7, min, max);
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_inv_dct8_1d_c(
     c: *mut int32_t,
@@ -105,6 +108,7 @@ pub unsafe extern "C" fn dav1d_inv_dct8_1d_c(
 ) {
     inv_dct8_1d_internal_c(c, stride, min, max, 0 as libc::c_int);
 }
+
 #[inline(never)]
 unsafe extern "C" fn inv_dct16_1d_internal_c(
     c: *mut int32_t,
@@ -201,6 +205,7 @@ unsafe extern "C" fn inv_dct16_1d_internal_c(
     *c.offset((14 * stride) as isize) = iclip(t1 - t14, min, max);
     *c.offset((15 * stride) as isize) = iclip(t0 - t15a, min, max);
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_inv_dct16_1d_c(
     c: *mut int32_t,
@@ -210,6 +215,7 @@ pub unsafe extern "C" fn dav1d_inv_dct16_1d_c(
 ) {
     inv_dct16_1d_internal_c(c, stride, min, max, 0 as libc::c_int);
 }
+
 #[inline(never)]
 unsafe extern "C" fn inv_dct32_1d_internal_c(
     c: *mut int32_t,
@@ -410,6 +416,7 @@ unsafe extern "C" fn inv_dct32_1d_internal_c(
     *c.offset((30 * stride) as isize) = iclip(t1 - t30a, min, max);
     *c.offset((31 * stride) as isize) = iclip(t0 - t31, min, max);
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_inv_dct32_1d_c(
     c: *mut int32_t,
@@ -419,6 +426,7 @@ pub unsafe extern "C" fn dav1d_inv_dct32_1d_c(
 ) {
     inv_dct32_1d_internal_c(c, stride, min, max, 0 as libc::c_int);
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_inv_dct64_1d_c(
     c: *mut int32_t,
@@ -767,6 +775,7 @@ pub unsafe extern "C" fn dav1d_inv_dct64_1d_c(
     *c.offset((62 * stride) as isize) = iclip(t1 - t62, min, max);
     *c.offset((63 * stride) as isize) = iclip(t0 - t63a, min, max);
 }
+
 #[inline(never)]
 unsafe extern "C" fn inv_adst4_1d_internal_c(
     in_0: *const int32_t,
@@ -800,6 +809,7 @@ unsafe extern "C" fn inv_adst4_1d_internal_c(
             + in2
             - in1;
 }
+
 #[inline(never)]
 unsafe extern "C" fn inv_adst8_1d_internal_c(
     in_0: *const int32_t,
@@ -853,6 +863,7 @@ unsafe extern "C" fn inv_adst8_1d_internal_c(
     *out.offset((2 * out_s) as isize) = (t6 + t7) * 181 + 128 >> 8;
     *out.offset((5 * out_s) as isize) = -((t6 - t7) * 181 + 128 >> 8);
 }
+
 #[inline(never)]
 unsafe extern "C" fn inv_adst16_1d_internal_c(
     in_0: *const int32_t,
@@ -970,6 +981,7 @@ unsafe extern "C" fn inv_adst16_1d_internal_c(
     *out.offset((5 * out_s) as isize) = -((t14a + t15a) * 181 + 128 >> 8);
     *out.offset((10 * out_s) as isize) = (t14a - t15a) * 181 + 128 >> 8;
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_inv_flipadst4_1d_c(
     c: *mut int32_t,
@@ -986,6 +998,7 @@ pub unsafe extern "C" fn dav1d_inv_flipadst4_1d_c(
         -stride,
     );
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_inv_adst4_1d_c(
     c: *mut int32_t,
@@ -995,6 +1008,7 @@ pub unsafe extern "C" fn dav1d_inv_adst4_1d_c(
 ) {
     inv_adst4_1d_internal_c(c, stride, min, max, c, stride);
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_inv_adst8_1d_c(
     c: *mut int32_t,
@@ -1004,6 +1018,7 @@ pub unsafe extern "C" fn dav1d_inv_adst8_1d_c(
 ) {
     inv_adst8_1d_internal_c(c, stride, min, max, c, stride);
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_inv_flipadst8_1d_c(
     c: *mut int32_t,
@@ -1020,6 +1035,7 @@ pub unsafe extern "C" fn dav1d_inv_flipadst8_1d_c(
         -stride,
     );
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_inv_flipadst16_1d_c(
     c: *mut int32_t,
@@ -1036,6 +1052,7 @@ pub unsafe extern "C" fn dav1d_inv_flipadst16_1d_c(
         -stride,
     );
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_inv_adst16_1d_c(
     c: *mut int32_t,
@@ -1045,6 +1062,7 @@ pub unsafe extern "C" fn dav1d_inv_adst16_1d_c(
 ) {
     inv_adst16_1d_internal_c(c, stride, min, max, c, stride);
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_inv_identity4_1d_c(
     c: *mut int32_t,
@@ -1062,6 +1080,7 @@ pub unsafe extern "C" fn dav1d_inv_identity4_1d_c(
         i += 1;
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_inv_identity8_1d_c(
     c: *mut int32_t,
@@ -1079,6 +1098,7 @@ pub unsafe extern "C" fn dav1d_inv_identity8_1d_c(
         i += 1;
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_inv_identity16_1d_c(
     c: *mut int32_t,
@@ -1096,6 +1116,7 @@ pub unsafe extern "C" fn dav1d_inv_identity16_1d_c(
         i += 1;
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_inv_identity32_1d_c(
     c: *mut int32_t,
@@ -1113,6 +1134,7 @@ pub unsafe extern "C" fn dav1d_inv_identity32_1d_c(
         i += 1;
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_inv_wht4_1d_c(c: *mut int32_t, stride: ptrdiff_t) {
     if !(stride > 0) {

--- a/src/itx_tmpl_16.rs
+++ b/src/itx_tmpl_16.rs
@@ -1,41 +1,9 @@
+use crate::include::common::bitdepth::BitDepth16;
 use crate::include::common::bitdepth::DynCoef;
 use crate::include::common::bitdepth::DynPixel;
+use crate::include::common::intops::iclip;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use ::libc;
-#[cfg(feature = "asm")]
-use cfg_if::cfg_if;
-extern "C" {
-    fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong) -> *mut libc::c_void;
-}
-
-pub type pixel = uint16_t;
-pub type coef = int32_t;
-
-use crate::src::levels::TX_16X16;
-use crate::src::levels::TX_32X32;
-use crate::src::levels::TX_4X4;
-use crate::src::levels::TX_64X64;
-use crate::src::levels::TX_8X8;
-
-use crate::src::levels::RTX_16X32;
-use crate::src::levels::RTX_16X4;
-use crate::src::levels::RTX_16X64;
-use crate::src::levels::RTX_16X8;
-use crate::src::levels::RTX_32X16;
-use crate::src::levels::RTX_32X64;
-use crate::src::levels::RTX_32X8;
-use crate::src::levels::RTX_4X16;
-use crate::src::levels::RTX_4X8;
-use crate::src::levels::RTX_64X16;
-use crate::src::levels::RTX_64X32;
-use crate::src::levels::RTX_8X16;
-use crate::src::levels::RTX_8X32;
-use crate::src::levels::RTX_8X4;
-
-use crate::src::levels::WHT_WHT;
-
-use crate::include::common::intops::iclip;
 use crate::src::itx::Dav1dInvTxfmDSPContext;
 use crate::src::levels::ADST_ADST;
 use crate::src::levels::ADST_DCT;
@@ -50,9 +18,43 @@ use crate::src::levels::H_ADST;
 use crate::src::levels::H_DCT;
 use crate::src::levels::H_FLIPADST;
 use crate::src::levels::IDTX;
+use crate::src::levels::RTX_16X32;
+use crate::src::levels::RTX_16X4;
+use crate::src::levels::RTX_16X64;
+use crate::src::levels::RTX_16X8;
+use crate::src::levels::RTX_32X16;
+use crate::src::levels::RTX_32X64;
+use crate::src::levels::RTX_32X8;
+use crate::src::levels::RTX_4X16;
+use crate::src::levels::RTX_4X8;
+use crate::src::levels::RTX_64X16;
+use crate::src::levels::RTX_64X32;
+use crate::src::levels::RTX_8X16;
+use crate::src::levels::RTX_8X32;
+use crate::src::levels::RTX_8X4;
+use crate::src::levels::TX_16X16;
+use crate::src::levels::TX_32X32;
+use crate::src::levels::TX_4X4;
+use crate::src::levels::TX_64X64;
+use crate::src::levels::TX_8X8;
 use crate::src::levels::V_ADST;
 use crate::src::levels::V_DCT;
 use crate::src::levels::V_FLIPADST;
+use crate::src::levels::WHT_WHT;
+
+#[cfg(feature = "asm")]
+use crate::src::cpu::dav1d_get_cpu_flags;
+
+#[cfg(feature = "asm")]
+use cfg_if::cfg_if;
+
+extern "C" {
+    fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong) -> *mut libc::c_void;
+}
+
+pub type pixel = uint16_t;
+pub type coef = int32_t;
+
 #[inline]
 unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     if x & 1 != 0 {
@@ -60,7 +62,6 @@ unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     }
     return x >> 1;
 }
-use crate::include::common::bitdepth::BitDepth16;
 
 unsafe extern "C" fn inv_txfm_add_wht_wht_4x4_c_erased(
     dst: *mut DynPixel,
@@ -708,9 +709,6 @@ unsafe extern "C" fn itx_dsp_init_x86(c: *mut Dav1dInvTxfmDSPContext, bpc: libc:
         }
     }
 }
-
-#[cfg(feature = "asm")]
-use crate::src::cpu::dav1d_get_cpu_flags;
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]

--- a/src/itx_tmpl_8.rs
+++ b/src/itx_tmpl_8.rs
@@ -1,42 +1,9 @@
+use crate::include::common::bitdepth::BitDepth8;
 use crate::include::common::bitdepth::DynCoef;
 use crate::include::common::bitdepth::DynPixel;
+use crate::include::common::intops::iclip_u8;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use ::libc;
-#[cfg(feature = "asm")]
-use cfg_if::cfg_if;
-extern "C" {
-    fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong) -> *mut libc::c_void;
-}
-
-pub type pixel = uint8_t;
-pub type coef = int16_t;
-
-use crate::src::levels::TX_16X16;
-use crate::src::levels::TX_32X32;
-use crate::src::levels::TX_4X4;
-use crate::src::levels::TX_64X64;
-use crate::src::levels::TX_8X8;
-
-use crate::src::levels::RTX_16X32;
-use crate::src::levels::RTX_16X4;
-use crate::src::levels::RTX_16X64;
-use crate::src::levels::RTX_16X8;
-use crate::src::levels::RTX_32X16;
-use crate::src::levels::RTX_32X64;
-use crate::src::levels::RTX_32X8;
-use crate::src::levels::RTX_4X16;
-use crate::src::levels::RTX_4X8;
-use crate::src::levels::RTX_64X16;
-use crate::src::levels::RTX_64X32;
-use crate::src::levels::RTX_8X16;
-use crate::src::levels::RTX_8X32;
-use crate::src::levels::RTX_8X4;
-
-use crate::src::levels::WHT_WHT;
-
-use crate::include::common::bitdepth::BitDepth8;
-use crate::include::common::intops::iclip_u8;
 use crate::src::itx::Dav1dInvTxfmDSPContext;
 use crate::src::levels::ADST_ADST;
 use crate::src::levels::ADST_DCT;
@@ -51,9 +18,42 @@ use crate::src::levels::H_ADST;
 use crate::src::levels::H_DCT;
 use crate::src::levels::H_FLIPADST;
 use crate::src::levels::IDTX;
+use crate::src::levels::RTX_16X32;
+use crate::src::levels::RTX_16X4;
+use crate::src::levels::RTX_16X64;
+use crate::src::levels::RTX_16X8;
+use crate::src::levels::RTX_32X16;
+use crate::src::levels::RTX_32X64;
+use crate::src::levels::RTX_32X8;
+use crate::src::levels::RTX_4X16;
+use crate::src::levels::RTX_4X8;
+use crate::src::levels::RTX_64X16;
+use crate::src::levels::RTX_64X32;
+use crate::src::levels::RTX_8X16;
+use crate::src::levels::RTX_8X32;
+use crate::src::levels::RTX_8X4;
+use crate::src::levels::TX_16X16;
+use crate::src::levels::TX_32X32;
+use crate::src::levels::TX_4X4;
+use crate::src::levels::TX_64X64;
+use crate::src::levels::TX_8X8;
 use crate::src::levels::V_ADST;
 use crate::src::levels::V_DCT;
 use crate::src::levels::V_FLIPADST;
+use crate::src::levels::WHT_WHT;
+
+#[cfg(feature = "asm")]
+use crate::src::cpu::dav1d_get_cpu_flags;
+
+#[cfg(feature = "asm")]
+use cfg_if::cfg_if;
+
+extern "C" {
+    fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong) -> *mut libc::c_void;
+}
+
+pub type pixel = uint8_t;
+pub type coef = int16_t;
 
 unsafe extern "C" fn inv_txfm_add_wht_wht_4x4_c_erased(
     dst: *mut DynPixel,
@@ -64,6 +64,7 @@ unsafe extern "C" fn inv_txfm_add_wht_wht_4x4_c_erased(
 ) {
     inv_txfm_add_wht_wht_4x4_rust(dst.cast(), stride, coeff.cast(), eob);
 }
+
 unsafe fn inv_txfm_add_wht_wht_4x4_rust(
     mut dst: *mut pixel,
     stride: ptrdiff_t,
@@ -115,9 +116,6 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust(
         dst = dst.offset(stride as isize);
     }
 }
-
-#[cfg(feature = "asm")]
-use crate::src::cpu::dav1d_get_cpu_flags;
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -1,9 +1,8 @@
-use std::ops::Neg;
-
 use crate::include::stdint::int16_t;
 use crate::include::stdint::int8_t;
 use crate::include::stdint::uint16_t;
 use crate::include::stdint::uint8_t;
+use std::ops::Neg;
 
 pub type ObuMetaType = libc::c_uint;
 pub const OBU_META_TIMECODE: ObuMetaType = 5;

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -11,6 +11,7 @@ pub const OBU_META_ITUT_T35: ObuMetaType = 4;
 pub const OBU_META_SCALABILITY: ObuMetaType = 3;
 pub const OBU_META_HDR_MDCV: ObuMetaType = 2;
 pub const OBU_META_HDR_CLL: ObuMetaType = 1;
+
 pub type TxfmSize = u8;
 pub const N_TX_SIZES: usize = 5;
 pub const TX_64X64: TxfmSize = 4;
@@ -18,6 +19,7 @@ pub const TX_32X32: TxfmSize = 3;
 pub const TX_16X16: TxfmSize = 2;
 pub const TX_8X8: TxfmSize = 1;
 pub const TX_4X4: TxfmSize = 0;
+
 pub type BlockLevel = u8;
 pub const N_BL_LEVELS: usize = 5;
 pub const BL_8X8: BlockLevel = 4;
@@ -25,6 +27,7 @@ pub const BL_16X16: BlockLevel = 3;
 pub const BL_32X32: BlockLevel = 2;
 pub const BL_64X64: BlockLevel = 1;
 pub const BL_128X128: BlockLevel = 0;
+
 pub type RectTxfmSize = u8;
 pub const N_RECT_TX_SIZES: usize = 19; // TODO(kkysen) symbolicate in Dav1dFrameContext::qm once deduplicated
 pub const RTX_64X16: RectTxfmSize = 18;
@@ -41,6 +44,7 @@ pub const RTX_16X8: RectTxfmSize = 8;
 pub const RTX_8X16: RectTxfmSize = 7;
 pub const RTX_8X4: RectTxfmSize = 6;
 pub const RTX_4X8: RectTxfmSize = 5;
+
 pub type TxfmType = u8;
 pub const N_TX_TYPES_PLUS_LL: usize = 17;
 pub const WHT_WHT: TxfmType = 16;
@@ -61,10 +65,12 @@ pub const ADST_ADST: TxfmType = 3;
 pub const DCT_ADST: TxfmType = 2;
 pub const ADST_DCT: TxfmType = 1;
 pub const DCT_DCT: TxfmType = 0;
+
 pub type TxClass = libc::c_uint;
 pub const TX_CLASS_V: TxClass = 2;
 pub const TX_CLASS_H: TxClass = 1;
 pub const TX_CLASS_2D: TxClass = 0;
+
 pub type IntraPredMode = u8;
 pub const FILTER_PRED: IntraPredMode = 13;
 pub const Z3_PRED: IntraPredMode = 8;
@@ -90,12 +96,14 @@ pub const DIAG_DOWN_LEFT_PRED: IntraPredMode = 3;
 pub const HOR_PRED: IntraPredMode = 2;
 pub const VERT_PRED: IntraPredMode = 1;
 pub const DC_PRED: IntraPredMode = 0;
+
 pub type InterIntraPredMode = libc::c_uint;
 pub const N_INTER_INTRA_PRED_MODES: usize = 4;
 pub const II_SMOOTH_PRED: InterIntraPredMode = 3;
 pub const II_HOR_PRED: InterIntraPredMode = 2;
 pub const II_VERT_PRED: InterIntraPredMode = 1;
 pub const II_DC_PRED: InterIntraPredMode = 0;
+
 pub type BlockPartition = u8;
 pub const N_SUB8X8_PARTITIONS: usize = 4;
 pub const N_PARTITIONS: usize = 10;
@@ -109,6 +117,7 @@ pub const PARTITION_SPLIT: BlockPartition = 3;
 pub const PARTITION_V: BlockPartition = 2;
 pub const PARTITION_H: BlockPartition = 1;
 pub const PARTITION_NONE: BlockPartition = 0;
+
 pub type BlockSize = u8;
 pub const N_BS_SIZES: usize = 22;
 pub const BS_4x4: BlockSize = 21;
@@ -133,6 +142,7 @@ pub const BS_64x64: BlockSize = 3;
 pub const BS_64x128: BlockSize = 2;
 pub const BS_128x64: BlockSize = 1;
 pub const BS_128x128: BlockSize = 0;
+
 pub type Filter2d = libc::c_uint;
 pub const N_2D_FILTERS: usize = 10; // TODO(kkysen) symbolicate in struct Dav1dMCDSPContext once deduplicated
 pub const FILTER_2D_BILINEAR: Filter2d = 9;
@@ -145,23 +155,27 @@ pub const FILTER_2D_8TAP_SHARP_REGULAR: Filter2d = 3;
 pub const FILTER_2D_8TAP_REGULAR_SHARP: Filter2d = 2;
 pub const FILTER_2D_8TAP_REGULAR_SMOOTH: Filter2d = 1;
 pub const FILTER_2D_8TAP_REGULAR: Filter2d = 0;
+
 pub type MVJoint = libc::c_uint;
 pub const N_MV_JOINTS: usize = 4;
 pub const MV_JOINT_HV: MVJoint = 3;
 pub const MV_JOINT_V: MVJoint = 2;
 pub const MV_JOINT_H: MVJoint = 1;
 pub const _MV_JOINT_ZERO: MVJoint = 0;
+
 pub type InterPredMode = u8;
 pub const _N_INTER_PRED_MODES: usize = 4;
 pub const NEWMV: InterPredMode = 3;
 pub const GLOBALMV: InterPredMode = 2;
 pub const NEARMV: InterPredMode = 1;
 pub const NEARESTMV: InterPredMode = 0;
+
 pub type DRL_PROXIMITY = u8;
 pub const NEARISH_DRL: DRL_PROXIMITY = 3;
 pub const NEAR_DRL: DRL_PROXIMITY = 2;
 pub const NEARER_DRL: DRL_PROXIMITY = 1;
 pub const NEAREST_DRL: DRL_PROXIMITY = 0;
+
 pub type CompInterPredMode = u8;
 pub const N_COMP_INTER_PRED_MODES: usize = 8;
 pub const NEWMV_NEWMV: CompInterPredMode = 7;
@@ -172,12 +186,14 @@ pub const NEWMV_NEARESTMV: CompInterPredMode = 3;
 pub const NEARESTMV_NEWMV: CompInterPredMode = 2;
 pub const NEARMV_NEARMV: CompInterPredMode = 1;
 pub const NEARESTMV_NEARESTMV: CompInterPredMode = 0;
+
 pub type CompInterType = u8;
 pub const COMP_INTER_WEDGE: CompInterType = 4;
 pub const COMP_INTER_SEG: CompInterType = 3;
 pub const COMP_INTER_AVG: CompInterType = 2;
 pub const COMP_INTER_WEIGHTED_AVG: CompInterType = 1;
 pub const COMP_INTER_NONE: CompInterType = 0;
+
 pub type InterIntraType = u8;
 pub const INTER_INTRA_WEDGE: InterIntraType = 2;
 pub const INTER_INTRA_BLEND: InterIntraType = 1;

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
@@ -12,6 +10,7 @@ use crate::src::lf_mask::Av1Filter;
 use crate::src::lr_apply::LR_RESTORE_U;
 use crate::src::lr_apply::LR_RESTORE_V;
 use crate::src::lr_apply::LR_RESTORE_Y;
+use std::cmp;
 
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: size_t) -> *mut libc::c_void;

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -1,31 +1,23 @@
 use std::cmp;
 
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
+use crate::src::env::BlockContext;
+use crate::src::internal::Dav1dDSPContext;
+use crate::src::internal::Dav1dFrameContext;
+use crate::src::lf_mask::Av1Filter;
+use crate::src::lr_apply::LR_RESTORE_U;
+use crate::src::lr_apply::LR_RESTORE_V;
+use crate::src::lr_apply::LR_RESTORE_Y;
 
-use ::libc;
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: size_t) -> *mut libc::c_void;
 }
 
 pub type pixel = uint16_t;
-
-use crate::src::internal::Dav1dFrameContext;
-
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-
-use crate::src::lf_mask::Av1Filter;
-
-use crate::src::env::BlockContext;
-
-use crate::src::internal::Dav1dDSPContext;
-
-use crate::src::lr_apply::LR_RESTORE_U;
-use crate::src::lr_apply::LR_RESTORE_V;
-use crate::src::lr_apply::LR_RESTORE_Y;
 
 #[inline]
 unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
@@ -34,6 +26,7 @@ unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     }
     return x >> 1;
 }
+
 unsafe extern "C" fn backup_lpf(
     f: *const Dav1dFrameContext,
     mut dst: *mut pixel,
@@ -165,6 +158,7 @@ unsafe extern "C" fn backup_lpf(
         }
     };
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_copy_lpf_16bpc(
     f: *mut Dav1dFrameContext,
@@ -324,6 +318,7 @@ pub unsafe extern "C" fn dav1d_copy_lpf_16bpc(
         }
     }
 }
+
 #[inline]
 unsafe extern "C" fn filter_plane_cols_y(
     f: *const Dav1dFrameContext,
@@ -372,6 +367,7 @@ unsafe extern "C" fn filter_plane_cols_y(
         x += 1;
     }
 }
+
 #[inline]
 unsafe extern "C" fn filter_plane_rows_y(
     f: *const Dav1dFrameContext,
@@ -414,6 +410,7 @@ unsafe extern "C" fn filter_plane_rows_y(
         lvl = lvl.offset(b4_stride as isize);
     }
 }
+
 #[inline]
 unsafe extern "C" fn filter_plane_cols_uv(
     f: *const Dav1dFrameContext,
@@ -474,6 +471,7 @@ unsafe extern "C" fn filter_plane_cols_uv(
         x += 1;
     }
 }
+
 #[inline]
 unsafe extern "C" fn filter_plane_rows_uv(
     f: *const Dav1dFrameContext,
@@ -527,6 +525,7 @@ unsafe extern "C" fn filter_plane_rows_uv(
         lvl = lvl.offset(b4_stride as isize);
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_loopfilter_sbrow_cols_16bpc(
     f: *const Dav1dFrameContext,
@@ -740,6 +739,7 @@ pub unsafe extern "C" fn dav1d_loopfilter_sbrow_cols_16bpc(
         level_ptr = level_ptr.offset((32 >> ss_hor) as isize);
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_loopfilter_sbrow_rows_16bpc(
     f: *const Dav1dFrameContext,

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -1,31 +1,23 @@
 use std::cmp;
 
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
+use crate::src::env::BlockContext;
+use crate::src::internal::Dav1dDSPContext;
+use crate::src::internal::Dav1dFrameContext;
+use crate::src::lf_mask::Av1Filter;
+use crate::src::lr_apply::LR_RESTORE_U;
+use crate::src::lr_apply::LR_RESTORE_V;
+use crate::src::lr_apply::LR_RESTORE_Y;
 
-use ::libc;
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: size_t) -> *mut libc::c_void;
 }
 
 pub type pixel = uint8_t;
-
-use crate::src::internal::Dav1dFrameContext;
-
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-
-use crate::src::lf_mask::Av1Filter;
-
-use crate::src::env::BlockContext;
-
-use crate::src::internal::Dav1dDSPContext;
-
-use crate::src::lr_apply::LR_RESTORE_U;
-use crate::src::lr_apply::LR_RESTORE_V;
-use crate::src::lr_apply::LR_RESTORE_Y;
 
 unsafe extern "C" fn backup_lpf(
     f: *const Dav1dFrameContext,
@@ -134,6 +126,7 @@ unsafe extern "C" fn backup_lpf(
         }
     };
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_copy_lpf_8bpc(
     f: *mut Dav1dFrameContext,
@@ -291,6 +284,7 @@ pub unsafe extern "C" fn dav1d_copy_lpf_8bpc(
         }
     }
 }
+
 #[inline]
 unsafe extern "C" fn filter_plane_cols_y(
     f: *const Dav1dFrameContext,
@@ -339,6 +333,7 @@ unsafe extern "C" fn filter_plane_cols_y(
         x += 1;
     }
 }
+
 #[inline]
 unsafe extern "C" fn filter_plane_rows_y(
     f: *const Dav1dFrameContext,
@@ -381,6 +376,7 @@ unsafe extern "C" fn filter_plane_rows_y(
         lvl = lvl.offset(b4_stride as isize);
     }
 }
+
 #[inline]
 unsafe extern "C" fn filter_plane_cols_uv(
     f: *const Dav1dFrameContext,
@@ -441,6 +437,7 @@ unsafe extern "C" fn filter_plane_cols_uv(
         x += 1;
     }
 }
+
 #[inline]
 unsafe extern "C" fn filter_plane_rows_uv(
     f: *const Dav1dFrameContext,
@@ -494,6 +491,7 @@ unsafe extern "C" fn filter_plane_rows_uv(
         lvl = lvl.offset(b4_stride as isize);
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_loopfilter_sbrow_cols_8bpc(
     f: *const Dav1dFrameContext,
@@ -707,6 +705,7 @@ pub unsafe extern "C" fn dav1d_loopfilter_sbrow_cols_8bpc(
         level_ptr = level_ptr.offset((32 >> ss_hor) as isize);
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_loopfilter_sbrow_rows_8bpc(
     f: *const Dav1dFrameContext,

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
@@ -12,6 +10,7 @@ use crate::src::lf_mask::Av1Filter;
 use crate::src::lr_apply::LR_RESTORE_U;
 use crate::src::lr_apply::LR_RESTORE_V;
 use crate::src::lr_apply::LR_RESTORE_Y;
+use std::cmp;
 
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: size_t) -> *mut libc::c_void;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::common::intops::iclip;
 use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
@@ -15,6 +13,7 @@ use crate::src::levels::RectTxfmSize;
 use crate::src::levels::TX_4X4;
 use crate::src::tables::dav1d_block_dimensions;
 use crate::src::tables::dav1d_txfm_dimensions;
+use std::cmp;
 
 #[repr(C)]
 pub struct Av1FilterLUT {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::common::bitdepth::DynCoef;
 use crate::include::common::intops::iclip;
 use crate::include::dav1d::common::Dav1dDataProps;
@@ -74,9 +72,7 @@ use crate::src::refmvs::Dav1dRefmvsDSPContext;
 use crate::src::thread_task::dav1d_worker_task;
 use crate::src::thread_task::FRAME_ERROR;
 use crate::stderr;
-
 use cfg_if::cfg_if;
-
 use libc::pthread_attr_destroy;
 use libc::pthread_attr_init;
 use libc::pthread_attr_setstacksize;
@@ -93,6 +89,7 @@ use libc::pthread_mutex_lock;
 use libc::pthread_mutex_unlock;
 use libc::pthread_mutexattr_t;
 use libc::pthread_t;
+use std::cmp;
 
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: size_t) -> *mut libc::c_void;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,11 +1,10 @@
+use crate::src::internal::Dav1dContext;
 use crate::stderr;
-use ::libc;
+
 extern "C" {
     fn fprintf(_: *mut libc::FILE, _: *const libc::c_char, _: ...) -> libc::c_int;
     fn vfprintf(_: *mut libc::FILE, _: *const libc::c_char, _: ::core::ffi::VaList) -> libc::c_int;
 }
-
-use crate::src::internal::Dav1dContext;
 
 #[cold]
 pub unsafe extern "C" fn dav1d_log_default_callback(
@@ -15,6 +14,7 @@ pub unsafe extern "C" fn dav1d_log_default_callback(
 ) {
     vfprintf(stderr, format, ap.as_va_list());
 }
+
 #[no_mangle]
 #[cold]
 pub unsafe extern "C" fn dav1d_log(c: *mut Dav1dContext, format: *const libc::c_char, args: ...) {

--- a/src/loopfilter_tmpl_16.rs
+++ b/src/loopfilter_tmpl_16.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::common::attributes::clz;
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::intops::iclip;
@@ -7,6 +5,7 @@ use crate::include::stddef::*;
 use crate::include::stdint::*;
 use crate::src::lf_mask::Av1FilterLUT;
 use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
+use std::cmp;
 
 #[cfg(feature = "asm")]
 use crate::src::cpu::dav1d_get_cpu_flags;

--- a/src/loopfilter_tmpl_8.rs
+++ b/src/loopfilter_tmpl_8.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::intops::iclip;
 use crate::include::common::intops::iclip_u8;
@@ -7,6 +5,7 @@ use crate::include::stddef::*;
 use crate::include::stdint::*;
 use crate::src::lf_mask::Av1FilterLUT;
 use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
+use std::cmp;
 
 #[cfg(feature = "asm")]
 use crate::src::cpu::dav1d_get_cpu_flags;

--- a/src/loopfilter_tmpl_8.rs
+++ b/src/loopfilter_tmpl_8.rs
@@ -1,17 +1,21 @@
 use std::cmp;
 
 use crate::include::common::bitdepth::DynPixel;
+use crate::include::common::intops::iclip;
+use crate::include::common::intops::iclip_u8;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use ::libc;
+use crate::src::lf_mask::Av1FilterLUT;
+use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
+
+#[cfg(feature = "asm")]
+use crate::src::cpu::dav1d_get_cpu_flags;
+
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
 
 pub type pixel = uint8_t;
-use crate::include::common::intops::iclip;
-use crate::include::common::intops::iclip_u8;
-use crate::src::lf_mask::Av1FilterLUT;
-use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
+
 #[inline(never)]
 unsafe extern "C" fn loop_filter(
     mut dst: *mut pixel,
@@ -406,9 +410,6 @@ unsafe extern "C" fn loop_filter_v_sb128uv_rust(
         l = l.offset(1);
     }
 }
-
-#[cfg(feature = "asm")]
-use crate::src::cpu::dav1d_get_cpu_flags;
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -1,6 +1,3 @@
-use std::cmp;
-use std::ops::Add;
-
 use crate::include::common::bitdepth::AsPrimitive;
 use crate::include::common::bitdepth::BitDepth;
 use crate::include::common::bitdepth::DynPixel;
@@ -16,6 +13,8 @@ use crate::include::stdint::uint32_t;
 use crate::src::align::Align16;
 use crate::src::cursor::CursorMut;
 use crate::src::tables::dav1d_sgr_x_by_x;
+use std::cmp;
+use std::ops::Add;
 
 #[cfg(all(feature = "asm", target_arch = "arm"))]
 use crate::include::stdint::intptr_t;

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -1,46 +1,34 @@
 use std::cmp;
 
-use crate::include::stddef::*;
-use crate::include::stdint::*;
-
-use ::libc;
-extern "C" {
-    fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
-}
-
-use crate::src::tables::dav1d_sgr_params;
-
-pub type pixel = uint16_t;
-
-use crate::src::internal::Dav1dFrameContext;
-
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
-
+use crate::include::stddef::*;
+use crate::include::stdint::*;
 use crate::src::align::Align16;
-
-use crate::src::lf_mask::Av1RestorationUnit;
-
 use crate::src::internal::Dav1dDSPContext;
-
+use crate::src::internal::Dav1dFrameContext;
+use crate::src::lf_mask::Av1RestorationUnit;
 use crate::src::looprestoration::looprestorationfilter_fn;
-
 use crate::src::looprestoration::LooprestorationParams;
 use crate::src::looprestoration::LrEdgeFlags;
 use crate::src::looprestoration::LR_HAVE_BOTTOM;
 use crate::src::looprestoration::LR_HAVE_LEFT;
 use crate::src::looprestoration::LR_HAVE_RIGHT;
 use crate::src::looprestoration::LR_HAVE_TOP;
-
 use crate::src::lr_apply::LR_RESTORE_U;
 use crate::src::lr_apply::LR_RESTORE_V;
 use crate::src::lr_apply::LR_RESTORE_Y;
+use crate::src::tables::dav1d_sgr_params;
+
+extern "C" {
+    fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
+}
+
+pub type pixel = uint16_t;
+
 #[inline]
 unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     if x & 1 != 0 {
@@ -48,6 +36,7 @@ unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     }
     return x >> 1;
 }
+
 unsafe extern "C" fn lr_stripe(
     f: *const Dav1dFrameContext,
     mut p: *mut pixel,
@@ -165,6 +154,7 @@ unsafe extern "C" fn lr_stripe(
         lpf = lpf.offset(4 * PXSTRIDE(stride));
     }
 }
+
 unsafe extern "C" fn backup4xU(
     mut dst: *mut [pixel; 4],
     mut src: *const pixel,
@@ -182,6 +172,7 @@ unsafe extern "C" fn backup4xU(
         src = src.offset(PXSTRIDE(src_stride) as isize);
     }
 }
+
 unsafe extern "C" fn lr_sbrow(
     f: *const Dav1dFrameContext,
     mut p: *mut pixel,
@@ -291,6 +282,7 @@ unsafe extern "C" fn lr_sbrow(
         );
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_lr_sbrow_16bpc(
     f: *mut Dav1dFrameContext,

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
@@ -22,6 +20,7 @@ use crate::src::lr_apply::LR_RESTORE_U;
 use crate::src::lr_apply::LR_RESTORE_V;
 use crate::src::lr_apply::LR_RESTORE_Y;
 use crate::src::tables::dav1d_sgr_params;
+use std::cmp;
 
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
@@ -22,6 +20,7 @@ use crate::src::lr_apply::LR_RESTORE_U;
 use crate::src::lr_apply::LR_RESTORE_V;
 use crate::src::lr_apply::LR_RESTORE_Y;
 use crate::src::tables::dav1d_sgr_params;
+use std::cmp;
 
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -1,46 +1,34 @@
 use std::cmp;
 
-use crate::include::stddef::*;
-use crate::include::stdint::*;
-
-use ::libc;
-extern "C" {
-    fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
-}
-
-use crate::src::tables::dav1d_sgr_params;
-
-pub type pixel = uint8_t;
-
-use crate::src::internal::Dav1dFrameContext;
-
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
-
+use crate::include::stddef::*;
+use crate::include::stdint::*;
 use crate::src::align::Align16;
-
-use crate::src::lf_mask::Av1RestorationUnit;
-
 use crate::src::internal::Dav1dDSPContext;
-
+use crate::src::internal::Dav1dFrameContext;
+use crate::src::lf_mask::Av1RestorationUnit;
 use crate::src::looprestoration::looprestorationfilter_fn;
-
 use crate::src::looprestoration::LooprestorationParams;
 use crate::src::looprestoration::LrEdgeFlags;
 use crate::src::looprestoration::LR_HAVE_BOTTOM;
 use crate::src::looprestoration::LR_HAVE_LEFT;
 use crate::src::looprestoration::LR_HAVE_RIGHT;
 use crate::src::looprestoration::LR_HAVE_TOP;
-
 use crate::src::lr_apply::LR_RESTORE_U;
 use crate::src::lr_apply::LR_RESTORE_V;
 use crate::src::lr_apply::LR_RESTORE_Y;
+use crate::src::tables::dav1d_sgr_params;
+
+extern "C" {
+    fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
+}
+
+pub type pixel = uint8_t;
+
 unsafe extern "C" fn lr_stripe(
     f: *const Dav1dFrameContext,
     mut p: *mut pixel,
@@ -156,6 +144,7 @@ unsafe extern "C" fn lr_stripe(
         lpf = lpf.offset((4 * stride) as isize);
     }
 }
+
 unsafe extern "C" fn backup4xU(
     mut dst: *mut [pixel; 4],
     mut src: *const pixel,
@@ -173,6 +162,7 @@ unsafe extern "C" fn backup4xU(
         src = src.offset(src_stride as isize);
     }
 }
+
 unsafe extern "C" fn lr_sbrow(
     f: *const Dav1dFrameContext,
     mut p: *mut pixel,
@@ -282,6 +272,7 @@ unsafe extern "C" fn lr_sbrow(
         );
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_lr_sbrow_8bpc(
     f: *mut Dav1dFrameContext,

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -1,9 +1,9 @@
-use std::{cmp, iter};
+use std::cmp;
+use std::iter;
 
+use crate::include::common::bitdepth::AsPrimitive;
+use crate::include::common::bitdepth::BitDepth;
 use crate::include::common::bitdepth::DynPixel;
-#[cfg(feature = "asm")]
-use crate::include::common::bitdepth::{bd_fn, BPC};
-use crate::include::common::bitdepth::{AsPrimitive, BitDepth};
 use crate::include::common::intops::iclip;
 use crate::include::dav1d::headers::Dav1dFilterMode;
 use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
@@ -27,6 +27,15 @@ use crate::src::tables::dav1d_mc_subpel_filters;
 use crate::src::tables::dav1d_mc_warp_filter;
 use crate::src::tables::dav1d_obmc_masks;
 use crate::src::tables::dav1d_resize_filter;
+
+#[cfg(feature = "asm")]
+use crate::include::common::bitdepth::bd_fn;
+
+#[cfg(feature = "asm")]
+use crate::include::common::bitdepth::BPC;
+
+#[cfg(feature = "asm")]
+use crate::src::cpu::dav1d_get_cpu_flags;
 
 #[inline(never)]
 unsafe fn put_rust<BD: BitDepth>(
@@ -1240,6 +1249,7 @@ pub type mc_fn = unsafe extern "C" fn(
     libc::c_int,
     libc::c_int,
 ) -> ();
+
 pub type mc_scaled_fn = unsafe extern "C" fn(
     *mut DynPixel,
     ptrdiff_t,
@@ -1253,6 +1263,7 @@ pub type mc_scaled_fn = unsafe extern "C" fn(
     libc::c_int,
     libc::c_int,
 ) -> ();
+
 pub type warp8x8_fn = unsafe extern "C" fn(
     *mut DynPixel,
     ptrdiff_t,
@@ -1263,6 +1274,7 @@ pub type warp8x8_fn = unsafe extern "C" fn(
     libc::c_int,
     libc::c_int,
 ) -> ();
+
 pub type mct_fn = unsafe extern "C" fn(
     *mut int16_t,
     *const DynPixel,
@@ -1273,6 +1285,7 @@ pub type mct_fn = unsafe extern "C" fn(
     libc::c_int,
     libc::c_int,
 ) -> ();
+
 pub type mct_scaled_fn = unsafe extern "C" fn(
     *mut int16_t,
     *const DynPixel,
@@ -1285,6 +1298,7 @@ pub type mct_scaled_fn = unsafe extern "C" fn(
     libc::c_int,
     libc::c_int,
 ) -> ();
+
 pub type warp8x8t_fn = unsafe extern "C" fn(
     *mut int16_t,
     ptrdiff_t,
@@ -1295,6 +1309,7 @@ pub type warp8x8t_fn = unsafe extern "C" fn(
     libc::c_int,
     libc::c_int,
 ) -> ();
+
 pub type avg_fn = unsafe extern "C" fn(
     *mut DynPixel,
     ptrdiff_t,
@@ -1304,6 +1319,7 @@ pub type avg_fn = unsafe extern "C" fn(
     libc::c_int,
     libc::c_int,
 ) -> ();
+
 pub type w_avg_fn = unsafe extern "C" fn(
     *mut DynPixel,
     ptrdiff_t,
@@ -1314,6 +1330,7 @@ pub type w_avg_fn = unsafe extern "C" fn(
     libc::c_int,
     libc::c_int,
 ) -> ();
+
 pub type mask_fn = unsafe extern "C" fn(
     *mut DynPixel,
     ptrdiff_t,
@@ -1324,6 +1341,7 @@ pub type mask_fn = unsafe extern "C" fn(
     *const uint8_t,
     libc::c_int,
 ) -> ();
+
 pub type w_mask_fn = unsafe extern "C" fn(
     *mut DynPixel,
     ptrdiff_t,
@@ -1335,6 +1353,7 @@ pub type w_mask_fn = unsafe extern "C" fn(
     libc::c_int,
     libc::c_int,
 ) -> ();
+
 pub type blend_fn = unsafe extern "C" fn(
     *mut DynPixel,
     ptrdiff_t,
@@ -1343,8 +1362,10 @@ pub type blend_fn = unsafe extern "C" fn(
     libc::c_int,
     *const uint8_t,
 ) -> ();
+
 pub type blend_dir_fn =
     unsafe extern "C" fn(*mut DynPixel, ptrdiff_t, *const DynPixel, libc::c_int, libc::c_int) -> ();
+
 pub type emu_edge_fn = unsafe extern "C" fn(
     intptr_t,
     intptr_t,
@@ -1357,6 +1378,7 @@ pub type emu_edge_fn = unsafe extern "C" fn(
     *const DynPixel,
     ptrdiff_t,
 ) -> ();
+
 pub type resize_fn = unsafe extern "C" fn(
     *mut DynPixel,
     ptrdiff_t,
@@ -2515,9 +2537,6 @@ unsafe extern "C" fn mc_dsp_init_x86<BD: BitDepth>(c: *mut Dav1dMCDSPContext) {
         (*c).resize = bd_fn!(BD, resize, avx512icl);
     }
 }
-
-#[cfg(feature = "asm")]
-use crate::src::cpu::dav1d_get_cpu_flags;
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -1,6 +1,3 @@
-use std::cmp;
-use std::iter;
-
 use crate::include::common::bitdepth::AsPrimitive;
 use crate::include::common::bitdepth::BitDepth;
 use crate::include::common::bitdepth::DynPixel;
@@ -27,6 +24,8 @@ use crate::src::tables::dav1d_mc_subpel_filters;
 use crate::src::tables::dav1d_mc_warp_filter;
 use crate::src::tables::dav1d_obmc_masks;
 use crate::src::tables::dav1d_resize_filter;
+use std::cmp;
+use std::iter;
 
 #[cfg(feature = "asm")]
 use crate::include::common::bitdepth::bd_fn;

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -1,6 +1,5 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-
 use libc::pthread_mutex_destroy;
 use libc::pthread_mutex_init;
 use libc::pthread_mutex_lock;

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -1,6 +1,13 @@
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-use ::libc;
+
+use libc::pthread_mutex_destroy;
+use libc::pthread_mutex_init;
+use libc::pthread_mutex_lock;
+use libc::pthread_mutex_t;
+use libc::pthread_mutex_unlock;
+use libc::pthread_mutexattr_t;
+
 extern "C" {
     fn malloc(_: libc::c_ulong) -> *mut libc::c_void;
     fn free(_: *mut libc::c_void);
@@ -11,12 +18,6 @@ extern "C" {
     ) -> libc::c_int;
 }
 
-use libc::pthread_mutex_destroy;
-use libc::pthread_mutex_init;
-use libc::pthread_mutex_lock;
-use libc::pthread_mutex_t;
-use libc::pthread_mutex_unlock;
-
 #[repr(C)]
 pub struct Dav1dMemPool {
     pub lock: pthread_mutex_t,
@@ -24,12 +25,12 @@ pub struct Dav1dMemPool {
     pub ref_cnt: libc::c_int,
     pub end: libc::c_int,
 }
+
 #[repr(C)]
 pub struct Dav1dMemPoolBuffer {
     pub data: *mut libc::c_void,
     pub next: *mut Dav1dMemPoolBuffer,
 }
-use libc::pthread_mutexattr_t;
 
 #[inline]
 pub unsafe extern "C" fn dav1d_alloc_aligned(sz: size_t, align: size_t) -> *mut libc::c_void {

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -1,11 +1,13 @@
+use std::mem;
+use std::ops::Range;
+
 use crate::include::common::attributes::clz;
 use crate::include::common::intops::inv_recenter;
 use crate::include::common::intops::ulog2;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
+
 use cfg_if::cfg_if;
-use std::mem;
-use std::ops::Range;
 
 #[cfg(all(feature = "asm", target_arch = "x86_64"))]
 extern "C" {

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -1,13 +1,11 @@
-use std::mem;
-use std::ops::Range;
-
 use crate::include::common::attributes::clz;
 use crate::include::common::intops::inv_recenter;
 use crate::include::common::intops::ulog2;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
-
 use cfg_if::cfg_if;
+use std::mem;
+use std::ops::Range;
 
 #[cfg(all(feature = "asm", target_arch = "x86_64"))]
 extern "C" {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::common::intops::iclip_u8;
 use crate::include::common::intops::ulog2;
 use crate::include::dav1d::data::Dav1dData;
@@ -108,10 +106,10 @@ use crate::src::r#ref::dav1d_ref_inc;
 use crate::src::r#ref::Dav1dRef;
 use crate::src::tables::dav1d_default_wm_params;
 use crate::src::thread_task::FRAME_ERROR;
-
 use libc::pthread_cond_wait;
 use libc::pthread_mutex_lock;
 use libc::pthread_mutex_unlock;
+use std::cmp;
 
 extern "C" {
     fn realloc(_: *mut libc::c_void, _: size_t) -> *mut libc::c_void;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1,124 +1,47 @@
 use std::cmp;
 
-use crate::include::stddef::*;
-use crate::include::stdint::*;
-
-use ::libc;
-extern "C" {
-    fn realloc(_: *mut libc::c_void, _: size_t) -> *mut libc::c_void;
-    fn memset(_: *mut libc::c_void, _: libc::c_int, _: size_t) -> *mut libc::c_void;
-    fn memcmp(_: *const libc::c_void, _: *const libc::c_void, _: size_t) -> libc::c_int;
-    fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int;
-    fn dav1d_log(c: *mut Dav1dContext, format: *const libc::c_char, _: ...);
-}
-
-use crate::src::tables::dav1d_default_wm_params;
-
+use crate::include::common::intops::iclip_u8;
+use crate::include::common::intops::ulog2;
 use crate::include::dav1d::data::Dav1dData;
-use crate::include::stdatomic::atomic_int;
-use crate::src::data::dav1d_data_props_copy;
-use crate::src::data::dav1d_data_ref;
-use crate::src::data::dav1d_data_unref_internal;
-use crate::src::r#ref::dav1d_ref_create;
-use crate::src::r#ref::dav1d_ref_create_using_pool;
-use crate::src::r#ref::dav1d_ref_dec;
-use crate::src::r#ref::Dav1dRef;
-
-use crate::include::stdatomic::atomic_uint;
-use crate::src::internal::Dav1dFrameContext;
-
-use libc::pthread_cond_wait;
-use libc::pthread_mutex_lock;
-use libc::pthread_mutex_unlock;
-
+use crate::include::dav1d::dav1d::Dav1dEventFlags;
+use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_INTRA;
+use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_REFERENCE;
+use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
+use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
+use crate::include::dav1d::headers::Dav1dColorPrimaries;
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
-use crate::include::dav1d::headers::Dav1dITUTT35;
-use crate::include::dav1d::headers::Dav1dMasteringDisplay;
-
+use crate::include::dav1d::headers::Dav1dFilmGrainData;
+use crate::include::dav1d::headers::Dav1dFilterMode;
 use crate::include::dav1d::headers::Dav1dFrameHeader;
+use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
+use crate::include::dav1d::headers::Dav1dFrameType;
+use crate::include::dav1d::headers::Dav1dITUTT35;
+use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
+use crate::include::dav1d::headers::Dav1dMasteringDisplay;
+use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
+use crate::include::dav1d::headers::Dav1dObuType;
 use crate::include::dav1d::headers::Dav1dPixelLayout;
+use crate::include::dav1d::headers::Dav1dRestorationType;
+use crate::include::dav1d::headers::Dav1dSegmentationData;
+use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
+use crate::include::dav1d::headers::Dav1dSequenceHeader;
+use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
+use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
+use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
 use crate::include::dav1d::headers::Dav1dTxfmMode;
 use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-
-use crate::include::dav1d::headers::Dav1dRestorationType;
-
-use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
-use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
+use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
+use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
+use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
+use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
 use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
-
-use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
-use crate::include::dav1d::headers::Dav1dFrameType;
 use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
 use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
 use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
 use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::Dav1dFilmGrainData;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
 use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-
-use crate::src::levels::OBU_META_HDR_CLL;
-use crate::src::levels::OBU_META_HDR_MDCV;
-use crate::src::levels::OBU_META_ITUT_T35;
-use crate::src::levels::OBU_META_SCALABILITY;
-use crate::src::levels::OBU_META_TIMECODE;
-
-use crate::src::internal::Dav1dContext;
-
-use crate::include::dav1d::dav1d::Dav1dEventFlags;
-
-use crate::src::picture::PictureFlags;
-use crate::src::picture::PICTURE_FLAG_NEW_OP_PARAMS_INFO;
-use crate::src::picture::PICTURE_FLAG_NEW_SEQUENCE;
-use crate::src::picture::PICTURE_FLAG_NEW_TEMPORAL_UNIT;
-
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_INTRA;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_REFERENCE;
-
-use crate::src::cdf::dav1d_cdf_thread_ref;
-use crate::src::cdf::dav1d_cdf_thread_unref;
-
-use crate::src::internal::Dav1dTileGroup;
-use crate::src::picture::dav1d_picture_get_event_flags;
-use crate::src::picture::dav1d_thread_picture_ref;
-use crate::src::picture::dav1d_thread_picture_unref;
-use crate::src::picture::Dav1dThreadPicture;
-
-use crate::include::dav1d::headers::Dav1dObuType;
+use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
 use crate::include::dav1d::headers::DAV1D_OBU_FRAME;
 use crate::include::dav1d::headers::DAV1D_OBU_FRAME_HDR;
 use crate::include::dav1d::headers::DAV1D_OBU_METADATA;
@@ -127,11 +50,29 @@ use crate::include::dav1d::headers::DAV1D_OBU_REDUNDANT_FRAME_HDR;
 use crate::include::dav1d::headers::DAV1D_OBU_SEQ_HDR;
 use crate::include::dav1d::headers::DAV1D_OBU_TD;
 use crate::include::dav1d::headers::DAV1D_OBU_TILE_GRP;
-
-use crate::src::levels::ObuMetaType;
-
-use crate::include::common::intops::iclip_u8;
-use crate::include::common::intops::ulog2;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
+use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
+use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
+use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
+use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
+use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
+use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
+use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
+use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
+use crate::include::stdatomic::atomic_int;
+use crate::include::stdatomic::atomic_uint;
+use crate::include::stddef::*;
+use crate::include::stdint::*;
+use crate::src::cdf::dav1d_cdf_thread_ref;
+use crate::src::cdf::dav1d_cdf_thread_unref;
+use crate::src::data::dav1d_data_props_copy;
+use crate::src::data::dav1d_data_ref;
+use crate::src::data::dav1d_data_unref_internal;
 use crate::src::env::get_poc_diff;
 use crate::src::getbits::dav1d_bytealign_get_bits;
 use crate::src::getbits::dav1d_get_bit;
@@ -143,8 +84,42 @@ use crate::src::getbits::dav1d_get_uniform;
 use crate::src::getbits::dav1d_get_vlc;
 use crate::src::getbits::dav1d_init_get_bits;
 use crate::src::getbits::GetBits;
+use crate::src::internal::Dav1dContext;
+use crate::src::internal::Dav1dFrameContext;
+use crate::src::internal::Dav1dTileGroup;
+use crate::src::levels::ObuMetaType;
+use crate::src::levels::OBU_META_HDR_CLL;
+use crate::src::levels::OBU_META_HDR_MDCV;
+use crate::src::levels::OBU_META_ITUT_T35;
+use crate::src::levels::OBU_META_SCALABILITY;
+use crate::src::levels::OBU_META_TIMECODE;
+use crate::src::picture::dav1d_picture_get_event_flags;
+use crate::src::picture::dav1d_thread_picture_ref;
+use crate::src::picture::dav1d_thread_picture_unref;
+use crate::src::picture::Dav1dThreadPicture;
+use crate::src::picture::PictureFlags;
+use crate::src::picture::PICTURE_FLAG_NEW_OP_PARAMS_INFO;
+use crate::src::picture::PICTURE_FLAG_NEW_SEQUENCE;
+use crate::src::picture::PICTURE_FLAG_NEW_TEMPORAL_UNIT;
+use crate::src::r#ref::dav1d_ref_create;
+use crate::src::r#ref::dav1d_ref_create_using_pool;
+use crate::src::r#ref::dav1d_ref_dec;
 use crate::src::r#ref::dav1d_ref_inc;
+use crate::src::r#ref::Dav1dRef;
+use crate::src::tables::dav1d_default_wm_params;
 use crate::src::thread_task::FRAME_ERROR;
+
+use libc::pthread_cond_wait;
+use libc::pthread_mutex_lock;
+use libc::pthread_mutex_unlock;
+
+extern "C" {
+    fn realloc(_: *mut libc::c_void, _: size_t) -> *mut libc::c_void;
+    fn memset(_: *mut libc::c_void, _: libc::c_int, _: size_t) -> *mut libc::c_void;
+    fn memcmp(_: *const libc::c_void, _: *const libc::c_void, _: size_t) -> libc::c_int;
+    fn dav1d_submit_frame(c: *mut Dav1dContext) -> libc::c_int;
+    fn dav1d_log(c: *mut Dav1dContext, format: *const libc::c_char, _: ...);
+}
 
 #[inline]
 unsafe extern "C" fn dav1d_get_bits_pos(c: *const GetBits) -> libc::c_uint {
@@ -509,6 +484,7 @@ unsafe extern "C" fn read_frame_size(
     }
     return 0 as libc::c_int;
 }
+
 #[inline]
 unsafe extern "C" fn tile_log2(sz: libc::c_int, tgt: libc::c_int) -> libc::c_int {
     let mut k;
@@ -518,6 +494,7 @@ unsafe extern "C" fn tile_log2(sz: libc::c_int, tgt: libc::c_int) -> libc::c_int
     }
     return k;
 }
+
 static mut default_mode_ref_deltas: Dav1dLoopfilterModeRefDeltas = {
     let init = Dav1dLoopfilterModeRefDeltas {
         mode_delta: [0 as libc::c_int, 0 as libc::c_int],
@@ -1658,6 +1635,7 @@ unsafe extern "C" fn parse_tile_hdr(c: *mut Dav1dContext, gb: *mut GetBits) {
         (*((*c).tile).offset((*c).n_tile_data as isize)).end = n_tiles - 1;
     };
 }
+
 unsafe extern "C" fn check_for_overrun(
     c: *mut Dav1dContext,
     gb: *mut GetBits,

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -30,7 +30,6 @@ use crate::src::r#ref::dav1d_ref_inc;
 use crate::src::r#ref::dav1d_ref_wrap;
 use crate::src::r#ref::Dav1dRef;
 use crate::stderr;
-
 use libc::malloc;
 
 extern "C" {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -1,9 +1,38 @@
+use crate::errno_location;
+use crate::include::dav1d::common::Dav1dDataProps;
+use crate::include::dav1d::dav1d::Dav1dEventFlags;
+use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
+use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_SEQUENCE;
+use crate::include::dav1d::headers::Dav1dContentLightLevel;
+use crate::include::dav1d::headers::Dav1dFrameHeader;
+use crate::include::dav1d::headers::Dav1dITUTT35;
+use crate::include::dav1d::headers::Dav1dMasteringDisplay;
+use crate::include::dav1d::headers::Dav1dSequenceHeader;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::picture::Dav1dPicAllocator;
+use crate::include::dav1d::picture::Dav1dPicture;
+use crate::include::stdatomic::atomic_int;
+use crate::include::stdatomic::atomic_uint;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
+use crate::src::data::dav1d_data_props_copy;
+use crate::src::data::dav1d_data_props_set_defaults;
+use crate::src::internal::Dav1dContext;
+use crate::src::internal::Dav1dFrameContext;
+use crate::src::mem::dav1d_mem_pool_pop;
+use crate::src::mem::dav1d_mem_pool_push;
+use crate::src::mem::Dav1dMemPool;
+use crate::src::mem::Dav1dMemPoolBuffer;
+use crate::src::r#ref::dav1d_ref_dec;
+use crate::src::r#ref::dav1d_ref_inc;
+use crate::src::r#ref::dav1d_ref_wrap;
+use crate::src::r#ref::Dav1dRef;
+use crate::stderr;
 
-use crate::{errno_location, stderr};
-use ::libc;
-use ::libc::malloc;
+use libc::malloc;
+
 extern "C" {
     fn fprintf(_: *mut libc::FILE, _: *const libc::c_char, _: ...) -> libc::c_int;
     fn free(_: *mut libc::c_void);
@@ -11,44 +40,11 @@ extern "C" {
     fn strerror(_: libc::c_int) -> *mut libc::c_char;
     fn dav1d_log(c: *mut Dav1dContext, format: *const libc::c_char, _: ...);
 }
-use crate::include::dav1d::common::Dav1dDataProps;
 
-use crate::include::dav1d::headers::Dav1dContentLightLevel;
-use crate::include::dav1d::headers::Dav1dITUTT35;
-use crate::include::dav1d::headers::Dav1dMasteringDisplay;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::picture::Dav1dPicture;
-use crate::include::stdatomic::atomic_int;
-use crate::include::stdatomic::atomic_uint;
-use crate::src::data::dav1d_data_props_copy;
-use crate::src::data::dav1d_data_props_set_defaults;
-use crate::src::internal::Dav1dFrameContext;
-use crate::src::r#ref::dav1d_ref_dec;
-use crate::src::r#ref::dav1d_ref_wrap;
-use crate::src::r#ref::Dav1dRef;
-
-use crate::include::dav1d::headers::Dav1dFrameHeader;
-
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-
-use crate::include::dav1d::headers::Dav1dSequenceHeader;
-
-use crate::include::dav1d::dav1d::Dav1dEventFlags;
-use crate::src::internal::Dav1dContext;
-
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_SEQUENCE;
-use crate::src::mem::dav1d_mem_pool_pop;
-use crate::src::mem::dav1d_mem_pool_push;
-use crate::src::mem::Dav1dMemPool;
-use crate::src::mem::Dav1dMemPoolBuffer;
 pub type PictureFlags = libc::c_uint;
 pub const PICTURE_FLAG_NEW_TEMPORAL_UNIT: PictureFlags = 4;
 pub const PICTURE_FLAG_NEW_OP_PARAMS_INFO: PictureFlags = 2;
 pub const PICTURE_FLAG_NEW_SEQUENCE: PictureFlags = 1;
-
-use crate::include::dav1d::picture::Dav1dPicAllocator;
 
 #[repr(C)]
 pub struct Dav1dThreadPicture {
@@ -65,7 +61,6 @@ pub struct pic_ctx_context {
     pub pic: Dav1dPicture,
     pub extra_ptr: *mut libc::c_void,
 }
-use crate::src::r#ref::dav1d_ref_inc;
 
 pub unsafe extern "C" fn dav1d_default_picture_alloc(
     p: *mut Dav1dPicture,
@@ -135,6 +130,7 @@ pub unsafe extern "C" fn dav1d_default_picture_release(
         (*p).allocator_data as *mut Dav1dMemPoolBuffer,
     );
 }
+
 unsafe extern "C" fn free_buffer(_data: *const uint8_t, user_data: *mut libc::c_void) {
     let pic_ctx: *mut pic_ctx_context = user_data as *mut pic_ctx_context;
     ((*pic_ctx).allocator.release_picture_callback).expect("non-null function pointer")(
@@ -143,6 +139,7 @@ unsafe extern "C" fn free_buffer(_data: *const uint8_t, user_data: *mut libc::c_
     );
     free(pic_ctx as *mut libc::c_void);
 }
+
 unsafe extern "C" fn picture_alloc_with_edges(
     c: *mut Dav1dContext,
     p: *mut Dav1dPicture,
@@ -244,6 +241,7 @@ unsafe extern "C" fn picture_alloc_with_edges(
     }
     return 0 as libc::c_int;
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_thread_picture_alloc(
     c: *mut Dav1dContext,
@@ -299,6 +297,7 @@ pub unsafe extern "C" fn dav1d_thread_picture_alloc(
     }
     return res;
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_picture_alloc_copy(
     c: *mut Dav1dContext,

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -1,6 +1,3 @@
-use std::cmp;
-use std::ops::BitOr;
-
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
@@ -37,6 +34,8 @@ use crate::src::msac::MsacContext;
 use crate::src::tables::dav1d_block_dimensions;
 use crate::src::tables::dav1d_skip_ctx;
 use crate::src::tables::TxfmInfo;
+use std::cmp;
+use std::ops::BitOr;
 
 /// TODO: add feature and compile-time guard around this code
 pub unsafe fn DEBUG_BLOCK_INFO(f: &Dav1dFrameContext, t: &Dav1dTaskContext) -> bool {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::common::bitdepth::BitDepth16;
 use crate::include::common::bitdepth::DynCoef;
 use crate::include::common::dump::ac_dump;
@@ -89,6 +87,7 @@ use crate::src::tables::dav1d_txtp_from_uvmode;
 use crate::src::tables::TxfmInfo;
 use crate::src::wedge::dav1d_ii_masks;
 use crate::src::wedge::dav1d_wedge_masks;
+use std::cmp;
 
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::size_t) -> *mut libc::c_void;

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -2,11 +2,93 @@ use std::cmp;
 
 use crate::include::common::bitdepth::BitDepth16;
 use crate::include::common::bitdepth::DynCoef;
-
+use crate::include::common::dump::ac_dump;
+use crate::include::common::dump::coef_dump;
+use crate::include::common::dump::hex_dump;
+use crate::include::common::intops::apply_sign64;
+use crate::include::common::intops::iclip;
+use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_CDEF;
+use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_DEBLOCK;
+use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
+use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
 use crate::src::ctx::CaseSet;
-use ::libc;
+use crate::src::env::get_uv_inter_txtp;
+use crate::src::internal::CodedBlockInfo;
+use crate::src::internal::Dav1dDSPContext;
+use crate::src::internal::Dav1dFrameContext;
+use crate::src::internal::Dav1dTaskContext;
+use crate::src::internal::Dav1dTileState;
+use crate::src::intra_edge::EdgeFlags;
+use crate::src::intra_edge::EDGE_I420_LEFT_HAS_BOTTOM;
+use crate::src::intra_edge::EDGE_I420_TOP_HAS_RIGHT;
+use crate::src::intra_edge::EDGE_I444_LEFT_HAS_BOTTOM;
+use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
+use crate::src::ipred_prepare::sm_flag;
+use crate::src::ipred_prepare::sm_uv_flag;
+use crate::src::levels::mv;
+use crate::src::levels::Av1Block;
+use crate::src::levels::BlockSize;
+use crate::src::levels::Filter2d;
+use crate::src::levels::IntraPredMode;
+use crate::src::levels::RectTxfmSize;
+use crate::src::levels::TxClass;
+use crate::src::levels::TxfmType;
+use crate::src::levels::CFL_PRED;
+use crate::src::levels::COMP_INTER_NONE;
+use crate::src::levels::DCT_DCT;
+use crate::src::levels::DC_PRED;
+use crate::src::levels::FILTER_2D_BILINEAR;
+use crate::src::levels::FILTER_PRED;
+use crate::src::levels::GLOBALMV;
+use crate::src::levels::GLOBALMV_GLOBALMV;
+use crate::src::levels::IDTX;
+use crate::src::levels::II_SMOOTH_PRED;
+use crate::src::levels::INTER_INTRA_BLEND;
+use crate::src::levels::MM_OBMC;
+use crate::src::levels::MM_WARP;
+use crate::src::levels::RTX_4X8;
+use crate::src::levels::SMOOTH_PRED;
+use crate::src::levels::TX_16X16;
+use crate::src::levels::TX_32X32;
+use crate::src::levels::TX_4X4;
+use crate::src::levels::TX_64X64;
+use crate::src::levels::TX_CLASS_2D;
+use crate::src::levels::TX_CLASS_H;
+use crate::src::levels::TX_CLASS_V;
+use crate::src::levels::WHT_WHT;
+use crate::src::lf_mask::Av1Filter;
+use crate::src::msac::dav1d_msac_decode_bool_adapt;
+use crate::src::msac::dav1d_msac_decode_bool_equi;
+use crate::src::msac::dav1d_msac_decode_bools;
+use crate::src::msac::dav1d_msac_decode_hi_tok;
+use crate::src::msac::dav1d_msac_decode_symbol_adapt16;
+use crate::src::msac::dav1d_msac_decode_symbol_adapt4;
+use crate::src::msac::dav1d_msac_decode_symbol_adapt8;
+use crate::src::picture::Dav1dThreadPicture;
+use crate::src::recon::get_dc_sign_ctx;
+use crate::src::recon::get_lo_ctx;
+use crate::src::recon::get_skip_ctx;
+use crate::src::recon::read_golomb;
+use crate::src::recon::DEBUG_BLOCK_INFO;
+use crate::src::refmvs::refmvs_block;
+use crate::src::scan::dav1d_scans;
+use crate::src::tables::dav1d_block_dimensions;
+use crate::src::tables::dav1d_filter_2d;
+use crate::src::tables::dav1d_filter_mode_to_y_mode;
+use crate::src::tables::dav1d_lo_ctx_offsets;
+use crate::src::tables::dav1d_tx_type_class;
+use crate::src::tables::dav1d_tx_types_per_set;
+use crate::src::tables::dav1d_txfm_dimensions;
+use crate::src::tables::dav1d_txtp_from_uvmode;
+use crate::src::tables::TxfmInfo;
+use crate::src::wedge::dav1d_ii_masks;
+use crate::src::wedge::dav1d_wedge_masks;
 
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::size_t) -> *mut libc::c_void;
@@ -57,103 +139,8 @@ extern "C" {
     fn dav1d_lr_sbrow_16bpc(f: *mut Dav1dFrameContext, dst: *const *mut pixel, sby: libc::c_int);
 }
 
-use crate::src::msac::dav1d_msac_decode_bool_adapt;
-use crate::src::msac::dav1d_msac_decode_bool_equi;
-use crate::src::msac::dav1d_msac_decode_hi_tok;
-use crate::src::msac::dav1d_msac_decode_symbol_adapt16;
-use crate::src::msac::dav1d_msac_decode_symbol_adapt4;
-use crate::src::msac::dav1d_msac_decode_symbol_adapt8;
-use crate::src::scan::dav1d_scans;
-use crate::src::tables::dav1d_block_dimensions;
-use crate::src::tables::dav1d_filter_2d;
-use crate::src::tables::dav1d_filter_mode_to_y_mode;
-use crate::src::tables::dav1d_lo_ctx_offsets;
-use crate::src::tables::dav1d_tx_type_class;
-use crate::src::tables::dav1d_tx_types_per_set;
-use crate::src::tables::dav1d_txfm_dimensions;
-use crate::src::tables::dav1d_txtp_from_uvmode;
-use crate::src::wedge::dav1d_ii_masks;
-use crate::src::wedge::dav1d_wedge_masks;
-
 pub type pixel = uint16_t;
 pub type coef = int32_t;
-
-use crate::src::internal::Dav1dFrameContext;
-
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-
-use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
-
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-
-use crate::src::internal::CodedBlockInfo;
-
-use crate::src::levels::mv;
-use crate::src::levels::Av1Block;
-use crate::src::lf_mask::Av1Filter;
-
-use crate::src::refmvs::refmvs_block;
-
-use crate::src::levels::BlockSize;
-
-use crate::src::internal::Dav1dTaskContext;
-
-use crate::src::levels::Filter2d;
-
-use crate::src::levels::FILTER_2D_BILINEAR;
-
-use crate::src::internal::Dav1dTileState;
-
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_CDEF;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_DEBLOCK;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
-
-use crate::src::intra_edge::EdgeFlags;
-use crate::src::intra_edge::EDGE_I420_LEFT_HAS_BOTTOM;
-
-use crate::src::intra_edge::EDGE_I420_TOP_HAS_RIGHT;
-use crate::src::intra_edge::EDGE_I444_LEFT_HAS_BOTTOM;
-
-use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
-
-use crate::src::internal::Dav1dDSPContext;
-
-use crate::src::picture::Dav1dThreadPicture;
-
-use crate::src::levels::IntraPredMode;
-use crate::src::levels::RectTxfmSize;
-use crate::src::levels::TxClass;
-use crate::src::levels::TxfmType;
-use crate::src::levels::CFL_PRED;
-use crate::src::levels::COMP_INTER_NONE;
-use crate::src::levels::DCT_DCT;
-use crate::src::levels::DC_PRED;
-use crate::src::levels::FILTER_PRED;
-use crate::src::levels::GLOBALMV;
-use crate::src::levels::GLOBALMV_GLOBALMV;
-use crate::src::levels::IDTX;
-use crate::src::levels::II_SMOOTH_PRED;
-use crate::src::levels::INTER_INTRA_BLEND;
-use crate::src::levels::MM_OBMC;
-use crate::src::levels::MM_WARP;
-use crate::src::levels::RTX_4X8;
-use crate::src::levels::SMOOTH_PRED;
-use crate::src::levels::TX_16X16;
-use crate::src::levels::TX_32X32;
-use crate::src::levels::TX_4X4;
-use crate::src::levels::TX_64X64;
-
-use crate::src::levels::TX_CLASS_2D;
-use crate::src::levels::TX_CLASS_H;
-use crate::src::levels::TX_CLASS_V;
-use crate::src::levels::WHT_WHT;
-
-use crate::src::tables::TxfmInfo;
-
-use crate::src::recon::DEBUG_BLOCK_INFO;
 
 #[inline]
 unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
@@ -162,19 +149,7 @@ unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     }
     return x >> 1;
 }
-use crate::include::common::dump::ac_dump;
-use crate::include::common::dump::coef_dump;
-use crate::include::common::dump::hex_dump;
-use crate::include::common::intops::apply_sign64;
-use crate::include::common::intops::iclip;
-use crate::src::env::get_uv_inter_txtp;
-use crate::src::ipred_prepare::sm_flag;
-use crate::src::ipred_prepare::sm_uv_flag;
-use crate::src::msac::dav1d_msac_decode_bools;
-use crate::src::recon::get_dc_sign_ctx;
-use crate::src::recon::get_lo_ctx;
-use crate::src::recon::get_skip_ctx;
-use crate::src::recon::read_golomb;
+
 unsafe fn decode_coefs(
     t: *mut Dav1dTaskContext,
     a: &mut [u8],
@@ -1386,6 +1361,7 @@ unsafe fn decode_coefs(
     *res_ctx = (cmp::min(cul_level, 63 as libc::c_int as libc::c_uint) | dc_sign_level) as uint8_t;
     return eob;
 }
+
 unsafe extern "C" fn read_coef_tree(
     t: *mut Dav1dTaskContext,
     bs: BlockSize,
@@ -1591,6 +1567,7 @@ unsafe extern "C" fn read_coef_tree(
         }
     };
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
     t: *mut Dav1dTaskContext,
@@ -1838,6 +1815,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
         init_y += 16 as libc::c_int;
     }
 }
+
 unsafe extern "C" fn mc(
     t: *mut Dav1dTaskContext,
     dst8: *mut pixel,
@@ -2046,6 +2024,7 @@ unsafe extern "C" fn mc(
     }
     return 0 as libc::c_int;
 }
+
 unsafe extern "C" fn obmc(
     t: *mut Dav1dTaskContext,
     dst: *mut pixel,
@@ -2193,6 +2172,7 @@ unsafe extern "C" fn obmc(
     }
     return 0 as libc::c_int;
 }
+
 unsafe extern "C" fn warp_affine(
     t: *mut Dav1dTaskContext,
     mut dst8: *mut pixel,
@@ -2313,6 +2293,7 @@ unsafe extern "C" fn warp_affine(
     }
     return 0 as libc::c_int;
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
     t: *mut Dav1dTaskContext,
@@ -3072,6 +3053,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
         init_y += 16 as libc::c_int;
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
     t: *mut Dav1dTaskContext,
@@ -4328,6 +4310,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
     }
     return 0 as libc::c_int;
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_cols_16bpc(
     f: *mut Dav1dFrameContext,
@@ -4361,6 +4344,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_cols_16bpc(
         *((*f).lf.start_of_tile_row).offset(sby as isize) as libc::c_int,
     );
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_rows_16bpc(
     f: *mut Dav1dFrameContext,
@@ -4390,6 +4374,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_rows_16bpc(
         dav1d_copy_lpf_16bpc(f, p.as_ptr(), sby);
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_16bpc(
     tc: *mut Dav1dTaskContext,
@@ -4441,6 +4426,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_16bpc(
     let end = cmp::min(start + n_blks, (*f).bh);
     dav1d_cdef_brow_16bpc(tc, p.as_ptr(), mask, start, end, 0 as libc::c_int, sby);
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_filter_sbrow_resize_16bpc(
     f: *mut Dav1dFrameContext,
@@ -4506,6 +4492,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_resize_16bpc(
         pl += 1;
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_filter_sbrow_lr_16bpc(f: *mut Dav1dFrameContext, sby: libc::c_int) {
     if (*(*f).c).inloop_filters as libc::c_uint
@@ -4526,6 +4513,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_lr_16bpc(f: *mut Dav1dFrameContext, 
     ];
     dav1d_lr_sbrow_16bpc(f, sr_p.as_ptr(), sby);
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_filter_sbrow_16bpc(f: *mut Dav1dFrameContext, sby: libc::c_int) {
     dav1d_filter_sbrow_deblock_cols_16bpc(f, sby);
@@ -4540,6 +4528,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_16bpc(f: *mut Dav1dFrameContext, sby
         dav1d_filter_sbrow_lr_16bpc(f, sby);
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_backup_ipred_edge_16bpc(t: *mut Dav1dTaskContext) {
     let f: *const Dav1dFrameContext = (*t).f;

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::common::bitdepth::BitDepth8;
 use crate::include::common::bitdepth::DynCoef;
 use crate::include::common::dump::ac_dump;
@@ -89,6 +87,7 @@ use crate::src::tables::dav1d_txtp_from_uvmode;
 use crate::src::tables::TxfmInfo;
 use crate::src::wedge::dav1d_ii_masks;
 use crate::src::wedge::dav1d_wedge_masks;
+use std::cmp;
 
 extern "C" {
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::size_t) -> *mut libc::c_void;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::common::intops::apply_sign;
 use crate::include::common::intops::iclip;
 use crate::include::dav1d::headers::Dav1dFrameHeader;
@@ -17,8 +15,8 @@ use crate::src::levels::BlockSize;
 use crate::src::mem::dav1d_alloc_aligned;
 use crate::src::mem::dav1d_freep_aligned;
 use crate::src::tables::dav1d_block_dimensions;
-
 use cfg_if::cfg_if;
+use std::cmp;
 
 #[cfg(feature = "asm")]
 use crate::src::cpu::dav1d_get_cpu_flags;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1,9 +1,27 @@
 use std::cmp;
 
+use crate::include::common::intops::apply_sign;
+use crate::include::common::intops::iclip;
+use crate::include::dav1d::headers::Dav1dFrameHeader;
+use crate::include::dav1d::headers::Dav1dSequenceHeader;
+use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
 use crate::include::stddef::*;
 use crate::include::stdint::*;
+use crate::src::env::fix_mv_precision;
+use crate::src::env::get_gmv_2d;
+use crate::src::env::get_poc_diff;
+use crate::src::intra_edge::EdgeFlags;
+use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
+use crate::src::levels::mv;
+use crate::src::levels::BlockSize;
+use crate::src::mem::dav1d_alloc_aligned;
+use crate::src::mem::dav1d_freep_aligned;
+use crate::src::tables::dav1d_block_dimensions;
+
 use cfg_if::cfg_if;
-use libc;
+
+#[cfg(feature = "asm")]
+use crate::src::cpu::dav1d_get_cpu_flags;
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 extern "C" {
@@ -74,19 +92,6 @@ extern "C" {
         bh4: libc::c_int,
     );
 }
-
-use crate::src::tables::dav1d_block_dimensions;
-
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-
-use crate::include::dav1d::headers::Dav1dFrameHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::src::levels::BlockSize;
-
-use crate::src::intra_edge::EdgeFlags;
-use crate::src::levels::mv;
-
-use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
 
 #[repr(C, packed)]
 pub struct refmvs_temporal_block {
@@ -160,11 +165,13 @@ pub struct refmvs_frame {
     pub n_tile_threads: libc::c_int,
     pub n_frame_threads: libc::c_int,
 }
+
 #[repr(C)]
 pub struct refmvs_tile_range {
     pub start: libc::c_int,
     pub end: libc::c_int,
 }
+
 #[repr(C)]
 pub struct refmvs_tile {
     pub rf: *const refmvs_frame,
@@ -173,12 +180,14 @@ pub struct refmvs_tile {
     pub tile_col: refmvs_tile_range,
     pub tile_row: refmvs_tile_range,
 }
+
 #[derive(Copy, Clone, Default)]
 #[repr(C)]
 pub struct refmvs_candidate {
     pub mv: refmvs_mvpair,
     pub weight: libc::c_int,
 }
+
 pub type load_tmvs_fn = Option<
     unsafe extern "C" fn(
         *const refmvs_frame,
@@ -189,6 +198,7 @@ pub type load_tmvs_fn = Option<
         libc::c_int,
     ) -> (),
 >;
+
 pub type save_tmvs_fn = Option<
     unsafe extern "C" fn(
         *mut refmvs_temporal_block,
@@ -232,16 +242,6 @@ impl Dav1dRefmvsDSPContext {
         );
     }
 }
-
-use crate::include::common::intops::apply_sign;
-use crate::include::common::intops::iclip;
-use crate::src::env::fix_mv_precision;
-use crate::src::env::get_poc_diff;
-
-use crate::src::env::get_gmv_2d;
-use crate::src::mem::dav1d_freep_aligned;
-
-use crate::src::mem::dav1d_alloc_aligned;
 
 fn add_spatial_candidate(
     mvstack: &mut [refmvs_candidate],
@@ -1211,6 +1211,7 @@ pub unsafe fn dav1d_refmvs_tile_sbrow_init(
     (*rt).tile_col.start = tile_col_start4;
     (*rt).tile_col.end = cmp::min(tile_col_end4, (*rf).iw4);
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn load_tmvs_c(
     rf: *const refmvs_frame,
@@ -1329,6 +1330,7 @@ pub unsafe extern "C" fn load_tmvs_c(
         n += 1;
     }
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn save_tmvs_c(
     mut rp: *mut refmvs_temporal_block,
@@ -1650,9 +1652,6 @@ unsafe extern "C" fn splat_mv_rust(
     }
 }
 
-#[cfg(feature = "asm")]
-use crate::src::cpu::dav1d_get_cpu_flags;
-
 #[inline(always)]
 #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "asm"))]
 unsafe extern "C" fn refmvs_dsp_init_x86(c: *mut Dav1dRefmvsDSPContext) {
@@ -1700,6 +1699,7 @@ unsafe extern "C" fn refmvs_dsp_init_arm(c: *mut Dav1dRefmvsDSPContext) {
         (*c).splat_mv = Some(ffi::dav1d_splat_mv_neon);
     }
 }
+
 #[no_mangle]
 #[cold]
 pub unsafe extern "C" fn dav1d_refmvs_dsp_init(c: *mut Dav1dRefmvsDSPContext) {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use crate::include::common::attributes::ctz;
 use crate::include::common::intops::iclip;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
@@ -30,13 +28,12 @@ use crate::src::internal::DAV1D_TASK_TYPE_SUPER_RESOLUTION;
 use crate::src::internal::DAV1D_TASK_TYPE_TILE_ENTROPY;
 use crate::src::internal::DAV1D_TASK_TYPE_TILE_RECONSTRUCTION;
 use crate::src::picture::Dav1dThreadPicture;
-
+use cfg_if::cfg_if;
 use libc::pthread_cond_signal;
 use libc::pthread_cond_wait;
 use libc::pthread_mutex_lock;
 use libc::pthread_mutex_unlock;
-
-use cfg_if::cfg_if;
+use std::cmp;
 
 extern "C" {
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: size_t) -> *mut libc::c_void;

--- a/src/wedge.rs
+++ b/src/wedge.rs
@@ -1,5 +1,3 @@
-use std::cmp::Ordering;
-
 use crate::src::align::Align16;
 use crate::src::align::Align32;
 use crate::src::align::Align64;
@@ -20,8 +18,8 @@ use crate::src::levels::II_SMOOTH_PRED;
 use crate::src::levels::II_VERT_PRED;
 use crate::src::levels::N_BS_SIZES;
 use crate::src::levels::N_INTER_INTRA_PRED_MODES;
-
 use paste::paste;
+use std::cmp::Ordering;
 use strum::EnumCount;
 
 #[derive(Clone, Copy, EnumCount)]

--- a/src/x86/cpu.rs
+++ b/src/x86/cpu.rs
@@ -1,5 +1,5 @@
 use crate::include::stdint::*;
-use ::libc;
+
 extern "C" {
     fn memcmp(_: *const libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> libc::c_int;
     fn dav1d_cpu_cpuid(regs: *mut CpuidRegisters, leaf: libc::c_uint, subleaf: libc::c_uint);
@@ -23,12 +23,14 @@ pub struct CpuidRegisters {
     pub edx: uint32_t,
     pub ecx: uint32_t,
 }
+
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct C2RustUnnamed {
     pub max_leaf: uint32_t,
     pub vendor: [libc::c_char; 12],
 }
+
 #[repr(C)]
 pub union C2RustUnnamed_0 {
     pub r: CpuidRegisters,

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -20,7 +20,6 @@ mod output {
 } // mod output
 #[path = "../tools/dav1d_cli_parse.rs"]
 mod dav1d_cli_parse;
-
 use rav1d::include::dav1d::common::Dav1dDataProps;
 use rav1d::include::dav1d::common::Dav1dUserData;
 use rav1d::include::dav1d::data::Dav1dData;

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -17,7 +17,6 @@ mod output {
     mod yuv;
 } // mod output
 mod dav1d_cli_parse;
-
 use rav1d::include::dav1d::common::Dav1dDataProps;
 use rav1d::include::dav1d::common::Dav1dUserData;
 use rav1d::include::dav1d::data::Dav1dData;

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -2,10 +2,7 @@
 #![allow(non_upper_case_globals)]
 #![feature(extern_types)]
 #![feature(c_variadic)]
-use crate::include::dav1d::dav1d::Dav1dRef;
-use crate::include::stddef::*;
-use crate::include::stdint::*;
-use ::rav1d::*;
+
 mod input {
     mod annexb;
     mod input;
@@ -20,8 +17,46 @@ mod output {
     mod yuv;
 } // mod output
 mod dav1d_cli_parse;
+
+use rav1d::include::dav1d::common::Dav1dDataProps;
+use rav1d::include::dav1d::common::Dav1dUserData;
+use rav1d::include::dav1d::data::Dav1dData;
+use rav1d::include::dav1d::dav1d::Dav1dContext;
+use rav1d::include::dav1d::dav1d::Dav1dLogger;
+use rav1d::include::dav1d::dav1d::Dav1dRef;
+use rav1d::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
+use rav1d::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
+use rav1d::include::dav1d::headers::Dav1dColorPrimaries;
+use rav1d::include::dav1d::headers::Dav1dContentLightLevel;
+use rav1d::include::dav1d::headers::Dav1dFrameHeader;
+use rav1d::include::dav1d::headers::Dav1dITUTT35;
+use rav1d::include::dav1d::headers::Dav1dMasteringDisplay;
+use rav1d::include::dav1d::headers::Dav1dSequenceHeader;
+use rav1d::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
+use rav1d::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
+use rav1d::include::dav1d::headers::Dav1dTransferCharacteristics;
+use rav1d::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
+use rav1d::include::dav1d::headers::DAV1D_MC_IDENTITY;
+use rav1d::include::dav1d::headers::DAV1D_OFF;
+use rav1d::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+use rav1d::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
+use rav1d::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use rav1d::include::dav1d::picture::Dav1dPicAllocator;
+use rav1d::include::dav1d::picture::Dav1dPicture;
+use rav1d::include::dav1d::picture::Dav1dPictureParameters;
+use rav1d::include::stddef::*;
+use rav1d::include::stdint::*;
+use rav1d::src::lib::dav1d_close;
+use rav1d::src::lib::dav1d_data_unref;
+use rav1d::src::lib::dav1d_get_picture;
+use rav1d::src::lib::dav1d_open;
+use rav1d::src::lib::dav1d_parse_sequence_header;
+use rav1d::src::lib::dav1d_send_data;
+use rav1d::src::lib::dav1d_version;
+use rav1d::src::lib::Dav1dSettings;
+use rav1d::stderr;
+
 extern "C" {
-    pub type Dav1dContext;
     pub type DemuxerContext;
     pub type MuxerContext;
     fn malloc(_: size_t) -> *mut libc::c_void;
@@ -43,17 +78,6 @@ extern "C" {
     fn strerror(_: libc::c_int) -> *mut libc::c_char;
     fn strcpy(_: *mut libc::c_char, _: *const libc::c_char) -> *mut libc::c_char;
     fn isatty(__fd: libc::c_int) -> libc::c_int;
-    fn dav1d_data_unref(data: *mut Dav1dData);
-    fn dav1d_close(c_out: *mut *mut Dav1dContext);
-    fn dav1d_parse_sequence_header(
-        out: *mut Dav1dSequenceHeader,
-        buf: *const uint8_t,
-        sz: size_t,
-    ) -> libc::c_int;
-    fn dav1d_send_data(c: *mut Dav1dContext, in_0: *mut Dav1dData) -> libc::c_int;
-    fn dav1d_open(c_out: *mut *mut Dav1dContext, s: *const Dav1dSettings) -> libc::c_int;
-    fn dav1d_get_picture(c: *mut Dav1dContext, out: *mut Dav1dPicture) -> libc::c_int;
-    fn dav1d_version() -> *const libc::c_char;
     fn input_open(
         c_out: *mut *mut DemuxerContext,
         name: *const libc::c_char,
@@ -81,79 +105,7 @@ extern "C" {
         lib_settings: *mut Dav1dSettings,
     );
 }
-// NOTE: temporary code to support Linux and macOS, should be removed eventually
-cfg_if::cfg_if! {
-    if #[cfg(target_os = "linux")] {
-        extern "C" {
-            static mut stdout: *mut libc::FILE;
-            static mut stderr: *mut libc::FILE;
-        }
 
-        unsafe fn errno_location() -> *mut libc::c_int {
-            libc::__errno_location()
-        }
-    } else if #[cfg(target_os = "macos")] {
-        extern "C" {
-            #[link_name = "__stdoutp"]
-            static mut stdout: *mut libc::FILE;
-            #[link_name = "__stderrp"]
-            static mut stderr: *mut libc::FILE;
-        }
-
-        unsafe fn errno_location() -> *mut libc::c_int {
-            libc::__error()
-        }
-    }
-}
-
-use crate::include::dav1d::common::Dav1dDataProps;
-use crate::include::dav1d::common::Dav1dUserData;
-use crate::include::dav1d::headers::DAV1D_OFF;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-
-use crate::include::dav1d::data::Dav1dData;
-use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
-use crate::include::dav1d::dav1d::Dav1dInloopFilterType;
-use crate::include::dav1d::dav1d::Dav1dLogger;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
-use crate::include::dav1d::headers::Dav1dContentLightLevel;
-use crate::include::dav1d::headers::Dav1dFrameHeader;
-use crate::include::dav1d::headers::Dav1dITUTT35;
-use crate::include::dav1d::headers::Dav1dMasteringDisplay;
-use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
-use crate::include::dav1d::picture::Dav1dPicAllocator;
-use crate::include::dav1d::picture::Dav1dPicture;
-use crate::include::dav1d::picture::Dav1dPictureParameters;
-
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
-#[repr(C)]
-pub struct Dav1dSettings {
-    pub n_threads: libc::c_int,
-    pub max_frame_delay: libc::c_int,
-    pub apply_grain: libc::c_int,
-    pub operating_point: libc::c_int,
-    pub all_layers: libc::c_int,
-    pub frame_size_limit: libc::c_uint,
-    pub allocator: Dav1dPicAllocator,
-    pub logger: Dav1dLogger,
-    pub strict_std_compliance: libc::c_int,
-    pub output_invisible_frames: libc::c_int,
-    pub inloop_filters: Dav1dInloopFilterType,
-    pub decode_frame_type: Dav1dDecodeFrameType,
-    pub reserved: [uint8_t; 16],
-}
 #[repr(C)]
 pub struct CLISettings {
     pub outputfile: *const libc::c_char,
@@ -170,10 +122,12 @@ pub struct CLISettings {
     pub realtime_cache: libc::c_uint,
     pub neg_stride: libc::c_int,
 }
+
 pub type CLISettings_realtime = libc::c_uint;
 pub const REALTIME_CUSTOM: CLISettings_realtime = 2;
 pub const REALTIME_INPUT: CLISettings_realtime = 1;
 pub const REALTIME_DISABLE: CLISettings_realtime = 0;
+
 unsafe extern "C" fn get_time_nanos() -> uint64_t {
     let mut ts: libc::timespec = libc::timespec {
         tv_sec: 0,
@@ -184,6 +138,7 @@ unsafe extern "C" fn get_time_nanos() -> uint64_t {
         .wrapping_mul(ts.tv_sec as libc::c_ulonglong)
         .wrapping_add(ts.tv_nsec as libc::c_ulonglong) as uint64_t;
 }
+
 unsafe extern "C" fn sleep_nanos(d: uint64_t) {
     // TODO: C version has Windows specific code path
     let ts: libc::timespec = {
@@ -195,6 +150,7 @@ unsafe extern "C" fn sleep_nanos(d: uint64_t) {
     };
     libc::nanosleep(&ts, std::ptr::null_mut::<libc::timespec>());
 }
+
 unsafe extern "C" fn synchronize(
     realtime: libc::c_int,
     cache: libc::c_uint,
@@ -227,6 +183,7 @@ unsafe extern "C" fn synchronize(
         fflush(frametimes);
     }
 }
+
 unsafe extern "C" fn print_stats(
     istty: libc::c_int,
     n: libc::c_uint,
@@ -292,6 +249,7 @@ unsafe extern "C" fn print_stats(
     }
     fputs(buf.as_mut_ptr(), stderr);
 }
+
 unsafe extern "C" fn picture_alloc(p: *mut Dav1dPicture, _: *mut libc::c_void) -> libc::c_int {
     let hbd = ((*p).p.bpc > 8) as libc::c_int;
     let aligned_w = (*p).p.w + 127 & !(127 as libc::c_int);
@@ -344,9 +302,11 @@ unsafe extern "C" fn picture_alloc(p: *mut Dav1dPicture, _: *mut libc::c_void) -
     }) as *mut libc::c_void;
     return 0 as libc::c_int;
 }
+
 unsafe extern "C" fn picture_release(p: *mut Dav1dPicture, _: *mut libc::c_void) {
     free((*p).allocator_data);
 }
+
 unsafe fn main_0(argc: libc::c_int, argv: *const *mut libc::c_char) -> libc::c_int {
     let istty = isatty(fileno(stderr));
     let mut res;
@@ -774,6 +734,7 @@ unsafe fn main_0(argc: libc::c_int, argv: *const *mut libc::c_char) -> libc::c_i
         1 as libc::c_int
     };
 }
+
 pub fn main() {
     let mut args: Vec<*mut libc::c_char> = Vec::new();
     for arg in ::std::env::args() {

--- a/tools/input/annexb.rs
+++ b/tools/input/annexb.rs
@@ -1,5 +1,5 @@
-use std::cmp;
-
+use libc::fread;
+use libc::fseeko;
 use rav1d::errno_location;
 use rav1d::include::dav1d::data::Dav1dData;
 use rav1d::include::dav1d::headers::Dav1dObuType;
@@ -14,9 +14,7 @@ use rav1d::include::stdint::uint8_t;
 use rav1d::src::lib::dav1d_data_create;
 use rav1d::src::lib::dav1d_data_unref;
 use rav1d::stderr;
-
-use libc::fread;
-use libc::fseeko;
+use std::cmp;
 
 extern "C" {
     fn fclose(__stream: *mut libc::FILE) -> libc::c_int;

--- a/tools/input/input.rs
+++ b/tools/input/input.rs
@@ -1,10 +1,9 @@
-use std::cmp;
-
 use rav1d::errno_location;
 use rav1d::include::dav1d::data::Dav1dData;
 use rav1d::include::stdint::uint64_t;
 use rav1d::include::stdint::uint8_t;
 use rav1d::stderr;
+use std::cmp;
 
 extern "C" {
     pub type DemuxerPriv;

--- a/tools/input/input.rs
+++ b/tools/input/input.rs
@@ -1,10 +1,11 @@
 use std::cmp;
 
-use crate::errno_location;
-use crate::stderr;
-use ::libc;
+use rav1d::errno_location;
+use rav1d::include::dav1d::data::Dav1dData;
 use rav1d::include::stdint::uint64_t;
 use rav1d::include::stdint::uint8_t;
+use rav1d::stderr;
+
 extern "C" {
     pub type DemuxerPriv;
     fn fclose(__stream: *mut libc::FILE) -> libc::c_int;
@@ -25,13 +26,14 @@ extern "C" {
     static annexb_demuxer: Demuxer;
     static section5_demuxer: Demuxer;
 }
-use rav1d::include::dav1d::data::Dav1dData;
+
 #[repr(C)]
 pub struct DemuxerContext {
     pub data: *mut DemuxerPriv,
     pub impl_0: *const Demuxer,
     pub priv_data: [uint64_t; 0],
 }
+
 #[repr(C)]
 pub struct Demuxer {
     pub priv_data_size: libc::c_int,
@@ -51,6 +53,7 @@ pub struct Demuxer {
     pub seek: Option<unsafe extern "C" fn(*mut DemuxerPriv, uint64_t) -> libc::c_int>,
     pub close: Option<unsafe extern "C" fn(*mut DemuxerPriv) -> ()>,
 }
+
 static mut demuxers: [*const Demuxer; 4] = unsafe {
     [
         &ivf_demuxer as *const Demuxer,
@@ -59,6 +62,7 @@ static mut demuxers: [*const Demuxer; 4] = unsafe {
         0 as *const Demuxer,
     ]
 };
+
 #[no_mangle]
 pub unsafe extern "C" fn input_open(
     c_out: *mut *mut DemuxerContext,
@@ -185,10 +189,12 @@ pub unsafe extern "C" fn input_open(
     *c_out = c;
     return 0 as libc::c_int;
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn input_read(ctx: *mut DemuxerContext, data: *mut Dav1dData) -> libc::c_int {
     return ((*(*ctx).impl_0).read).expect("non-null function pointer")((*ctx).data, data);
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn input_seek(ctx: *mut DemuxerContext, pts: uint64_t) -> libc::c_int {
     return if ((*(*ctx).impl_0).seek).is_some() {
@@ -197,6 +203,7 @@ pub unsafe extern "C" fn input_seek(ctx: *mut DemuxerContext, pts: uint64_t) -> 
         -(1 as libc::c_int)
     };
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn input_close(ctx: *mut DemuxerContext) {
     ((*(*ctx).impl_0).close).expect("non-null function pointer")((*ctx).data);

--- a/tools/output/md5.rs
+++ b/tools/output/md5.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 use rav1d::errno_location;
 use rav1d::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 use rav1d::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
@@ -12,6 +10,7 @@ use rav1d::include::stdint::uint8_t;
 use rav1d::src::lib::dav1d_picture_unref;
 use rav1d::stderr;
 use rav1d::stdout;
+use std::cmp;
 
 extern "C" {
     fn fclose(__stream: *mut libc::FILE) -> libc::c_int;

--- a/tools/output/md5.rs
+++ b/tools/output/md5.rs
@@ -1,11 +1,18 @@
 use std::cmp;
 
-use crate::errno_location;
-use crate::{stderr, stdout};
-use ::libc;
+use rav1d::errno_location;
+use rav1d::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
+use rav1d::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
+use rav1d::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use rav1d::include::dav1d::picture::Dav1dPicture;
+use rav1d::include::dav1d::picture::Dav1dPictureParameters;
 use rav1d::include::stdint::uint32_t;
 use rav1d::include::stdint::uint64_t;
 use rav1d::include::stdint::uint8_t;
+use rav1d::src::lib::dav1d_picture_unref;
+use rav1d::stderr;
+use rav1d::stdout;
+
 extern "C" {
     fn fclose(__stream: *mut libc::FILE) -> libc::c_int;
     fn fopen(_: *const libc::c_char, _: *const libc::c_char) -> *mut libc::FILE;
@@ -16,16 +23,8 @@ extern "C" {
     fn strcmp(_: *const libc::c_char, _: *const libc::c_char) -> libc::c_int;
     fn strlen(_: *const libc::c_char) -> libc::c_ulong;
     fn strerror(_: libc::c_int) -> *mut libc::c_char;
-    fn dav1d_picture_unref(p: *mut Dav1dPicture);
 }
 
-use rav1d::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-
-use rav1d::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use rav1d::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-
-use rav1d::include::dav1d::picture::Dav1dPicture;
-use rav1d::include::dav1d::picture::Dav1dPictureParameters;
 #[repr(C)]
 pub struct MuxerPriv {
     pub abcd: [uint32_t; 4],
@@ -33,11 +32,13 @@ pub struct MuxerPriv {
     pub len: uint64_t,
     pub f: *mut libc::FILE,
 }
+
 #[repr(C)]
 pub union C2RustUnnamed {
     pub data: [uint8_t; 64],
     pub data32: [uint32_t; 16],
 }
+
 #[repr(C)]
 pub struct Muxer {
     pub priv_data_size: libc::c_int,
@@ -56,7 +57,9 @@ pub struct Muxer {
     pub write_trailer: Option<unsafe extern "C" fn(*mut MuxerPriv) -> ()>,
     pub verify: Option<unsafe extern "C" fn(*mut MuxerPriv, *const libc::c_char) -> libc::c_int>,
 }
+
 pub type MD5Context = MuxerPriv;
+
 static mut k: [uint32_t; 64] = [
     0xd76aa478 as libc::c_uint,
     0xe8c7b756 as libc::c_uint,
@@ -123,6 +126,7 @@ static mut k: [uint32_t; 64] = [
     0x2ad7d2bb as libc::c_int as uint32_t,
     0xeb86d391 as libc::c_uint,
 ];
+
 unsafe extern "C" fn md5_open(
     md5: *mut MD5Context,
     file: *const libc::c_char,
@@ -150,10 +154,12 @@ unsafe extern "C" fn md5_open(
     (*md5).len = 0 as libc::c_int as uint64_t;
     return 0 as libc::c_int;
 }
+
 #[inline]
 unsafe extern "C" fn leftrotate(x: uint32_t, c: libc::c_int) -> uint32_t {
     return x << c | x >> 32 - c;
 }
+
 unsafe extern "C" fn md5_body(md5: *mut MD5Context, data: *const uint32_t) {
     let mut a: uint32_t = (*md5).abcd[0];
     let mut b: uint32_t = (*md5).abcd[1];
@@ -548,6 +554,7 @@ unsafe extern "C" fn md5_body(md5: *mut MD5Context, data: *const uint32_t) {
     (*md5).abcd[2] = ((*md5).abcd[2] as libc::c_uint).wrapping_add(c) as uint32_t as uint32_t;
     (*md5).abcd[3] = ((*md5).abcd[3] as libc::c_uint).wrapping_add(d) as uint32_t as uint32_t;
 }
+
 unsafe extern "C" fn md5_update(
     md5: *mut MD5Context,
     mut data: *const uint8_t,
@@ -596,6 +603,7 @@ unsafe extern "C" fn md5_update(
             as uint64_t;
     }
 }
+
 unsafe extern "C" fn md5_write(md5: *mut MD5Context, p: *mut Dav1dPicture) -> libc::c_int {
     let hbd = ((*p).p.bpc > 8) as libc::c_int;
     let w = (*p).p.w;
@@ -631,6 +639,7 @@ unsafe extern "C" fn md5_write(md5: *mut MD5Context, p: *mut Dav1dPicture) -> li
     dav1d_picture_unref(p);
     return 0 as libc::c_int;
 }
+
 unsafe extern "C" fn md5_finish(md5: *mut MD5Context) {
     static mut bit: [uint8_t; 2] = [0x80 as libc::c_int as uint8_t, 0 as libc::c_int as uint8_t];
     let len: uint64_t = (*md5).len << 3;
@@ -652,6 +661,7 @@ unsafe extern "C" fn md5_finish(md5: *mut MD5Context) {
         8 as libc::c_int as libc::c_uint,
     );
 }
+
 unsafe extern "C" fn md5_close(md5: *mut MD5Context) {
     md5_finish(md5);
     let mut i = 0;
@@ -671,6 +681,7 @@ unsafe extern "C" fn md5_close(md5: *mut MD5Context) {
         fclose((*md5).f);
     }
 }
+
 unsafe extern "C" fn md5_verify(
     md5: *mut MD5Context,
     mut md5_str: *const libc::c_char,
@@ -704,6 +715,7 @@ unsafe extern "C" fn md5_verify(
         ::core::mem::size_of::<[uint32_t; 4]>() as libc::c_ulong,
     ) != 0) as libc::c_int;
 }
+
 #[no_mangle]
 pub static mut md5_muxer: Muxer = {
     let init = Muxer {

--- a/tools/output/null.rs
+++ b/tools/output/null.rs
@@ -1,11 +1,11 @@
-use ::libc;
-extern "C" {
-    pub type MuxerPriv;
-    fn dav1d_picture_unref(p: *mut Dav1dPicture);
-}
-
 use rav1d::include::dav1d::picture::Dav1dPicture;
 use rav1d::include::dav1d::picture::Dav1dPictureParameters;
+use rav1d::src::lib::dav1d_picture_unref;
+
+extern "C" {
+    pub type MuxerPriv;
+}
+
 #[repr(C)]
 pub struct Muxer {
     pub priv_data_size: libc::c_int,
@@ -24,11 +24,14 @@ pub struct Muxer {
     pub write_trailer: Option<unsafe extern "C" fn(*mut MuxerPriv) -> ()>,
     pub verify: Option<unsafe extern "C" fn(*mut MuxerPriv, *const libc::c_char) -> libc::c_int>,
 }
+
 pub type NullOutputContext = MuxerPriv;
+
 unsafe extern "C" fn null_write(_c: *mut NullOutputContext, p: *mut Dav1dPicture) -> libc::c_int {
     dav1d_picture_unref(p);
     return 0 as libc::c_int;
 }
+
 #[no_mangle]
 pub static mut null_muxer: Muxer = {
     let init = Muxer {

--- a/tools/output/output.rs
+++ b/tools/output/output.rs
@@ -1,11 +1,9 @@
-use std::cmp;
-
+use libc::size_t;
 use rav1d::include::dav1d::picture::Dav1dPicture;
 use rav1d::include::dav1d::picture::Dav1dPictureParameters;
 use rav1d::include::stdint::uint64_t;
 use rav1d::stderr;
-
-use libc::size_t;
+use std::cmp;
 
 extern "C" {
     pub type MuxerPriv;

--- a/tools/output/output.rs
+++ b/tools/output/output.rs
@@ -1,9 +1,12 @@
 use std::cmp;
 
-use crate::stderr;
-use ::libc;
-use libc::size_t;
+use rav1d::include::dav1d::picture::Dav1dPicture;
+use rav1d::include::dav1d::picture::Dav1dPictureParameters;
 use rav1d::include::stdint::uint64_t;
+use rav1d::stderr;
+
+use libc::size_t;
+
 extern "C" {
     pub type MuxerPriv;
     fn fprintf(_: *mut libc::FILE, _: *const libc::c_char, _: ...) -> libc::c_int;
@@ -20,8 +23,7 @@ extern "C" {
     static yuv_muxer: Muxer;
     static y4m2_muxer: Muxer;
 }
-use rav1d::include::dav1d::picture::Dav1dPicture;
-use rav1d::include::dav1d::picture::Dav1dPictureParameters;
+
 #[repr(C)]
 pub struct MuxerContext {
     pub data: *mut MuxerPriv,
@@ -32,6 +34,7 @@ pub struct MuxerContext {
     pub framenum: libc::c_int,
     pub priv_data: [uint64_t; 0],
 }
+
 #[repr(C)]
 pub struct Muxer {
     pub priv_data_size: libc::c_int,
@@ -50,6 +53,7 @@ pub struct Muxer {
     pub write_trailer: Option<unsafe extern "C" fn(*mut MuxerPriv) -> ()>,
     pub verify: Option<unsafe extern "C" fn(*mut MuxerPriv, *const libc::c_char) -> libc::c_int>,
 }
+
 static mut muxers: [*const Muxer; 5] = unsafe {
     [
         &null_muxer as *const Muxer,
@@ -59,6 +63,7 @@ static mut muxers: [*const Muxer; 5] = unsafe {
         0 as *const Muxer,
     ]
 };
+
 unsafe extern "C" fn find_extension(f: *const libc::c_char) -> *const libc::c_char {
     let l: size_t = strlen(f);
     if l == 0 {
@@ -82,6 +87,7 @@ unsafe extern "C" fn find_extension(f: *const libc::c_char) -> *const libc::c_ch
         0 as *const libc::c_char
     };
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn output_open(
     c_out: *mut *mut MuxerContext,
@@ -198,6 +204,7 @@ pub unsafe extern "C" fn output_open(
     *c_out = c;
     return 0 as libc::c_int;
 }
+
 unsafe extern "C" fn safe_strncat(
     dst: *mut libc::c_char,
     dst_len: libc::c_int,
@@ -222,6 +229,7 @@ unsafe extern "C" fn safe_strncat(
     );
     *dst.offset((dst_fill + to_copy) as isize) = 0 as libc::c_int as libc::c_char;
 }
+
 unsafe extern "C" fn assemble_field(
     dst: *mut libc::c_char,
     dst_len: libc::c_int,
@@ -266,6 +274,7 @@ unsafe extern "C" fn assemble_field(
         strlen(tmp.as_mut_ptr()) as libc::c_int,
     );
 }
+
 unsafe extern "C" fn assemble_filename(
     ctx: *mut MuxerContext,
     filename: *mut libc::c_char,
@@ -340,6 +349,7 @@ unsafe extern "C" fn assemble_filename(
     }
     safe_strncat(filename, filename_size, ptr, strlen(ptr) as libc::c_int);
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn output_write(ctx: *mut MuxerContext, p: *mut Dav1dPicture) -> libc::c_int {
     let mut res;
@@ -370,6 +380,7 @@ pub unsafe extern "C" fn output_write(ctx: *mut MuxerContext, p: *mut Dav1dPictu
     }
     return 0 as libc::c_int;
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn output_close(ctx: *mut MuxerContext) {
     if (*ctx).one_file_per_frame == 0 && ((*(*ctx).impl_0).write_trailer).is_some() {
@@ -377,6 +388,7 @@ pub unsafe extern "C" fn output_close(ctx: *mut MuxerContext) {
     }
     free(ctx as *mut libc::c_void);
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn output_verify(
     ctx: *mut MuxerContext,


### PR DESCRIPTION
Now that all of the types are deduplicated,
we can clean up the imports so they're not just all over the place.

I also added spacing between all of the items now.

In cleaning up the imports in the non-`rav1d` crate code, I realized there was still a bunch of duplication left and `extern "C"` imports of `rav1d` types, so those are now all removed and converted to `use rav1d::`s.