### PR TITLE
`fn libc::*`: Use `libc` `fn`s instead of directly declaring them

### DIFF
--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -14,15 +14,12 @@ use crate::src::internal::Dav1dDSPContext;
 use crate::src::internal::Dav1dFrameContext;
 use crate::src::internal::Dav1dTaskContext;
 use crate::src::lf_mask::Av1Filter;
+use libc::memcpy;
 use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_void;
-
-extern "C" {
-    fn memcpy(_: *mut c_void, _: *const c_void, _: usize) -> *mut c_void;
-}
 
 pub type pixel = u16;
 

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -14,15 +14,12 @@ use crate::src::internal::Dav1dDSPContext;
 use crate::src::internal::Dav1dFrameContext;
 use crate::src::internal::Dav1dTaskContext;
 use crate::src::lf_mask::Av1Filter;
+use libc::memcpy;
 use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_void;
-
-extern "C" {
-    fn memcpy(_: *mut c_void, _: *const c_void, _: usize) -> *mut c_void;
-}
 
 pub type pixel = u8;
 

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -19,16 +19,12 @@ use crate::src::r#ref::dav1d_ref_dec;
 use crate::src::r#ref::dav1d_ref_inc;
 use crate::src::r#ref::Dav1dRef;
 use crate::src::tables::dav1d_partition_type_count;
+use libc::memcpy;
+use libc::memset;
 use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
-use std::ffi::c_ulong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn memcpy(_: *mut c_void, _: *const c_void, _: c_ulong) -> *mut c_void;
-    fn memset(_: *mut c_void, _: c_int, _: c_ulong) -> *mut c_void;
-}
 
 #[repr(C)]
 pub struct CdfContext {
@@ -4897,7 +4893,7 @@ pub unsafe fn dav1d_cdf_thread_update(
     memcpy(
         ((*dst).m.filter_intra).0.as_mut_ptr() as *mut c_void,
         ((*src).m.filter_intra).0.as_ptr() as *const c_void,
-        ::core::mem::size_of::<[u16; 8]>() as c_ulong,
+        ::core::mem::size_of::<[u16; 8]>(),
     );
     (*dst).m.filter_intra[4] = 0 as c_int as u16;
     let mut k = 0;
@@ -4907,7 +4903,7 @@ pub unsafe fn dav1d_cdf_thread_update(
             memcpy(
                 ((*dst).m.uv_mode[k as usize][j as usize]).as_mut_ptr() as *mut c_void,
                 ((*src).m.uv_mode[k as usize][j as usize]).as_ptr() as *const c_void,
-                ::core::mem::size_of::<[u16; 16]>() as c_ulong,
+                ::core::mem::size_of::<[u16; 16]>(),
             );
             (*dst).m.uv_mode[k as usize][j as usize]
                 [(N_UV_INTRA_PRED_MODES as c_int - 1 - (k == 0) as c_int) as usize] =
@@ -4921,7 +4917,7 @@ pub unsafe fn dav1d_cdf_thread_update(
         memcpy(
             ((*dst).m.angle_delta[j_0 as usize]).as_mut_ptr() as *mut c_void,
             ((*src).m.angle_delta[j_0 as usize]).as_ptr() as *const c_void,
-            ::core::mem::size_of::<[u16; 8]>() as c_ulong,
+            ::core::mem::size_of::<[u16; 8]>(),
         );
         (*dst).m.angle_delta[j_0 as usize][6] = 0 as c_int as u16;
         j_0 += 1;
@@ -4933,7 +4929,7 @@ pub unsafe fn dav1d_cdf_thread_update(
             memcpy(
                 ((*dst).m.txsz[k_0 as usize][j_1 as usize]).as_mut_ptr() as *mut c_void,
                 ((*src).m.txsz[k_0 as usize][j_1 as usize]).as_ptr() as *const c_void,
-                ::core::mem::size_of::<[u16; 4]>() as c_ulong,
+                ::core::mem::size_of::<[u16; 4]>(),
             );
             (*dst).m.txsz[k_0 as usize][j_1 as usize][cmp::min(k_0 + 1, 2 as c_int) as usize] =
                 0 as c_int as u16;
@@ -4948,7 +4944,7 @@ pub unsafe fn dav1d_cdf_thread_update(
             memcpy(
                 ((*dst).m.txtp_intra1[k_1 as usize][j_2 as usize]).as_mut_ptr() as *mut c_void,
                 ((*src).m.txtp_intra1[k_1 as usize][j_2 as usize]).as_ptr() as *const c_void,
-                ::core::mem::size_of::<[u16; 8]>() as c_ulong,
+                ::core::mem::size_of::<[u16; 8]>(),
             );
             (*dst).m.txtp_intra1[k_1 as usize][j_2 as usize][6] = 0 as c_int as u16;
             j_2 += 1;
@@ -4962,7 +4958,7 @@ pub unsafe fn dav1d_cdf_thread_update(
             memcpy(
                 ((*dst).m.txtp_intra2[k_2 as usize][j_3 as usize]).as_mut_ptr() as *mut c_void,
                 ((*src).m.txtp_intra2[k_2 as usize][j_3 as usize]).as_ptr() as *const c_void,
-                ::core::mem::size_of::<[u16; 8]>() as c_ulong,
+                ::core::mem::size_of::<[u16; 8]>(),
             );
             (*dst).m.txtp_intra2[k_2 as usize][j_3 as usize][4] = 0 as c_int as u16;
             j_3 += 1;
@@ -4982,7 +4978,7 @@ pub unsafe fn dav1d_cdf_thread_update(
             memcpy(
                 ((*dst).m.partition[k_3 as usize][j_4 as usize]).as_mut_ptr() as *mut c_void,
                 ((*src).m.partition[k_3 as usize][j_4 as usize]).as_ptr() as *const c_void,
-                ::core::mem::size_of::<[u16; 16]>() as c_ulong,
+                ::core::mem::size_of::<[u16; 16]>(),
             );
             (*dst).m.partition[k_3 as usize][j_4 as usize]
                 [dav1d_partition_type_count[k_3 as usize] as usize] = 0 as c_int as u16;
@@ -5008,7 +5004,7 @@ pub unsafe fn dav1d_cdf_thread_update(
             memcpy(
                 ((*dst).coef.eob_bin_16[k_4 as usize][j_6 as usize]).as_mut_ptr() as *mut c_void,
                 ((*src).coef.eob_bin_16[k_4 as usize][j_6 as usize]).as_ptr() as *const c_void,
-                ::core::mem::size_of::<[u16; 8]>() as c_ulong,
+                ::core::mem::size_of::<[u16; 8]>(),
             );
             (*dst).coef.eob_bin_16[k_4 as usize][j_6 as usize][4] = 0 as c_int as u16;
             j_6 += 1;
@@ -5022,7 +5018,7 @@ pub unsafe fn dav1d_cdf_thread_update(
             memcpy(
                 ((*dst).coef.eob_bin_32[k_5 as usize][j_7 as usize]).as_mut_ptr() as *mut c_void,
                 ((*src).coef.eob_bin_32[k_5 as usize][j_7 as usize]).as_ptr() as *const c_void,
-                ::core::mem::size_of::<[u16; 8]>() as c_ulong,
+                ::core::mem::size_of::<[u16; 8]>(),
             );
             (*dst).coef.eob_bin_32[k_5 as usize][j_7 as usize][5] = 0 as c_int as u16;
             j_7 += 1;
@@ -5036,7 +5032,7 @@ pub unsafe fn dav1d_cdf_thread_update(
             memcpy(
                 ((*dst).coef.eob_bin_64[k_6 as usize][j_8 as usize]).as_mut_ptr() as *mut c_void,
                 ((*src).coef.eob_bin_64[k_6 as usize][j_8 as usize]).as_ptr() as *const c_void,
-                ::core::mem::size_of::<[u16; 8]>() as c_ulong,
+                ::core::mem::size_of::<[u16; 8]>(),
             );
             (*dst).coef.eob_bin_64[k_6 as usize][j_8 as usize][6] = 0 as c_int as u16;
             j_8 += 1;
@@ -5050,7 +5046,7 @@ pub unsafe fn dav1d_cdf_thread_update(
             memcpy(
                 ((*dst).coef.eob_bin_128[k_7 as usize][j_9 as usize]).as_mut_ptr() as *mut c_void,
                 ((*src).coef.eob_bin_128[k_7 as usize][j_9 as usize]).as_ptr() as *const c_void,
-                ::core::mem::size_of::<[u16; 8]>() as c_ulong,
+                ::core::mem::size_of::<[u16; 8]>(),
             );
             (*dst).coef.eob_bin_128[k_7 as usize][j_9 as usize][7] = 0 as c_int as u16;
             j_9 += 1;
@@ -5064,7 +5060,7 @@ pub unsafe fn dav1d_cdf_thread_update(
             memcpy(
                 ((*dst).coef.eob_bin_256[k_8 as usize][j_10 as usize]).as_mut_ptr() as *mut c_void,
                 ((*src).coef.eob_bin_256[k_8 as usize][j_10 as usize]).as_ptr() as *const c_void,
-                ::core::mem::size_of::<[u16; 16]>() as c_ulong,
+                ::core::mem::size_of::<[u16; 16]>(),
             );
             (*dst).coef.eob_bin_256[k_8 as usize][j_10 as usize][8] = 0 as c_int as u16;
             j_10 += 1;
@@ -5076,7 +5072,7 @@ pub unsafe fn dav1d_cdf_thread_update(
         memcpy(
             ((*dst).coef.eob_bin_512[j_11 as usize]).as_mut_ptr() as *mut c_void,
             ((*src).coef.eob_bin_512[j_11 as usize]).as_ptr() as *const c_void,
-            ::core::mem::size_of::<[u16; 16]>() as c_ulong,
+            ::core::mem::size_of::<[u16; 16]>(),
         );
         (*dst).coef.eob_bin_512[j_11 as usize][9] = 0 as c_int as u16;
         j_11 += 1;
@@ -5086,7 +5082,7 @@ pub unsafe fn dav1d_cdf_thread_update(
         memcpy(
             ((*dst).coef.eob_bin_1024[j_12 as usize]).as_mut_ptr() as *mut c_void,
             ((*src).coef.eob_bin_1024[j_12 as usize]).as_ptr() as *const c_void,
-            ::core::mem::size_of::<[u16; 16]>() as c_ulong,
+            ::core::mem::size_of::<[u16; 16]>(),
         );
         (*dst).coef.eob_bin_1024[j_12 as usize][10] = 0 as c_int as u16;
         j_12 += 1;
@@ -5118,7 +5114,7 @@ pub unsafe fn dav1d_cdf_thread_update(
                         .as_mut_ptr() as *mut c_void,
                     ((*src).coef.eob_base_tok[l as usize][k_10 as usize][j_14 as usize]).as_ptr()
                         as *const c_void,
-                    ::core::mem::size_of::<[u16; 4]>() as c_ulong,
+                    ::core::mem::size_of::<[u16; 4]>(),
                 );
                 (*dst).coef.eob_base_tok[l as usize][k_10 as usize][j_14 as usize][2] =
                     0 as c_int as u16;
@@ -5139,7 +5135,7 @@ pub unsafe fn dav1d_cdf_thread_update(
                         as *mut c_void,
                     ((*src).coef.base_tok[l_0 as usize][k_11 as usize][j_15 as usize]).as_ptr()
                         as *const c_void,
-                    ::core::mem::size_of::<[u16; 4]>() as c_ulong,
+                    ::core::mem::size_of::<[u16; 4]>(),
                 );
                 (*dst).coef.base_tok[l_0 as usize][k_11 as usize][j_15 as usize][3] =
                     0 as c_int as u16;
@@ -5171,7 +5167,7 @@ pub unsafe fn dav1d_cdf_thread_update(
                         as *mut c_void,
                     ((*src).coef.br_tok[l_1 as usize][k_12 as usize][j_17 as usize]).as_ptr()
                         as *const c_void,
-                    ::core::mem::size_of::<[u16; 4]>() as c_ulong,
+                    ::core::mem::size_of::<[u16; 4]>(),
                 );
                 (*dst).coef.br_tok[l_1 as usize][k_12 as usize][j_17 as usize][3] =
                     0 as c_int as u16;
@@ -5186,7 +5182,7 @@ pub unsafe fn dav1d_cdf_thread_update(
         memcpy(
             ((*dst).m.seg_id[j_18 as usize]).as_mut_ptr() as *mut c_void,
             ((*src).m.seg_id[j_18 as usize]).as_ptr() as *const c_void,
-            ::core::mem::size_of::<[u16; 8]>() as c_ulong,
+            ::core::mem::size_of::<[u16; 8]>(),
         );
         (*dst).m.seg_id[j_18 as usize][(8 - 1) as usize] = 0 as c_int as u16;
         j_18 += 1;
@@ -5194,7 +5190,7 @@ pub unsafe fn dav1d_cdf_thread_update(
     memcpy(
         ((*dst).m.cfl_sign).0.as_mut_ptr() as *mut c_void,
         ((*src).m.cfl_sign).0.as_ptr() as *const c_void,
-        ::core::mem::size_of::<[u16; 8]>() as c_ulong,
+        ::core::mem::size_of::<[u16; 8]>(),
     );
     (*dst).m.cfl_sign[7] = 0 as c_int as u16;
     let mut j_19 = 0;
@@ -5202,7 +5198,7 @@ pub unsafe fn dav1d_cdf_thread_update(
         memcpy(
             ((*dst).m.cfl_alpha[j_19 as usize]).as_mut_ptr() as *mut c_void,
             ((*src).m.cfl_alpha[j_19 as usize]).as_ptr() as *const c_void,
-            ::core::mem::size_of::<[u16; 16]>() as c_ulong,
+            ::core::mem::size_of::<[u16; 16]>(),
         );
         (*dst).m.cfl_alpha[j_19 as usize][15] = 0 as c_int as u16;
         j_19 += 1;
@@ -5214,13 +5210,13 @@ pub unsafe fn dav1d_cdf_thread_update(
     memcpy(
         ((*dst).m.restore_switchable).0.as_mut_ptr() as *mut c_void,
         ((*src).m.restore_switchable).0.as_ptr() as *const c_void,
-        ::core::mem::size_of::<[u16; 4]>() as c_ulong,
+        ::core::mem::size_of::<[u16; 4]>(),
     );
     (*dst).m.restore_switchable[2] = 0 as c_int as u16;
     memcpy(
         ((*dst).m.delta_q).0.as_mut_ptr() as *mut c_void,
         ((*src).m.delta_q).0.as_ptr() as *const c_void,
-        ::core::mem::size_of::<[u16; 4]>() as c_ulong,
+        ::core::mem::size_of::<[u16; 4]>(),
     );
     (*dst).m.delta_q[3] = 0 as c_int as u16;
     let mut j_20 = 0;
@@ -5228,7 +5224,7 @@ pub unsafe fn dav1d_cdf_thread_update(
         memcpy(
             ((*dst).m.delta_lf[j_20 as usize]).as_mut_ptr() as *mut c_void,
             ((*src).m.delta_lf[j_20 as usize]).as_ptr() as *const c_void,
-            ::core::mem::size_of::<[u16; 4]>() as c_ulong,
+            ::core::mem::size_of::<[u16; 4]>(),
         );
         (*dst).m.delta_lf[j_20 as usize][3] = 0 as c_int as u16;
         j_20 += 1;
@@ -5257,7 +5253,7 @@ pub unsafe fn dav1d_cdf_thread_update(
             memcpy(
                 ((*dst).m.pal_sz[k_13 as usize][j_22 as usize]).as_mut_ptr() as *mut c_void,
                 ((*src).m.pal_sz[k_13 as usize][j_22 as usize]).as_ptr() as *const c_void,
-                ::core::mem::size_of::<[u16; 8]>() as c_ulong,
+                ::core::mem::size_of::<[u16; 8]>(),
             );
             (*dst).m.pal_sz[k_13 as usize][j_22 as usize][6] = 0 as c_int as u16;
             j_22 += 1;
@@ -5275,7 +5271,7 @@ pub unsafe fn dav1d_cdf_thread_update(
                         as *mut c_void,
                     ((*src).m.color_map[l_2 as usize][k_14 as usize][j_23 as usize]).as_ptr()
                         as *const c_void,
-                    ::core::mem::size_of::<[u16; 8]>() as c_ulong,
+                    ::core::mem::size_of::<[u16; 8]>(),
                 );
                 (*dst).m.color_map[l_2 as usize][k_14 as usize][j_23 as usize]
                     [(k_14 + 1) as usize] = 0 as c_int as u16;
@@ -5301,7 +5297,7 @@ pub unsafe fn dav1d_cdf_thread_update(
         memcpy(
             ((*dst).m.txtp_inter1[j_25 as usize]).as_mut_ptr() as *mut c_void,
             ((*src).m.txtp_inter1[j_25 as usize]).as_ptr() as *const c_void,
-            ::core::mem::size_of::<[u16; 16]>() as c_ulong,
+            ::core::mem::size_of::<[u16; 16]>(),
         );
         (*dst).m.txtp_inter1[j_25 as usize][15] = 0 as c_int as u16;
         j_25 += 1;
@@ -5309,7 +5305,7 @@ pub unsafe fn dav1d_cdf_thread_update(
     memcpy(
         ((*dst).m.txtp_inter2.0).as_mut_ptr() as *mut c_void,
         ((*src).m.txtp_inter2.0).as_ptr() as *const c_void,
-        ::core::mem::size_of::<[u16; 16]>() as c_ulong,
+        ::core::mem::size_of::<[u16; 16]>(),
     );
     (*dst).m.txtp_inter2[11] = 0 as c_int as u16;
     let mut i_7 = 0;
@@ -5324,7 +5320,7 @@ pub unsafe fn dav1d_cdf_thread_update(
         memcpy(
             ((*dst).dmv.joint.0).as_mut_ptr() as *mut c_void,
             ((*src).dmv.joint.0).as_ptr() as *const c_void,
-            ::core::mem::size_of::<[u16; 4]>() as c_ulong,
+            ::core::mem::size_of::<[u16; 4]>(),
         );
         (*dst).dmv.joint[(N_MV_JOINTS as c_int - 1) as usize] = 0 as c_int as u16;
         let mut k_15 = 0;
@@ -5332,7 +5328,7 @@ pub unsafe fn dav1d_cdf_thread_update(
             memcpy(
                 ((*dst).dmv.comp[k_15 as usize].classes.0).as_mut_ptr() as *mut c_void,
                 ((*src).dmv.comp[k_15 as usize].classes.0).as_ptr() as *const c_void,
-                ::core::mem::size_of::<[u16; 16]>() as c_ulong,
+                ::core::mem::size_of::<[u16; 16]>(),
             );
             (*dst).dmv.comp[k_15 as usize].classes[10] = 0 as c_int as u16;
             (*dst).dmv.comp[k_15 as usize].class0[0] = (*src).dmv.comp[k_15 as usize].class0[0];
@@ -5361,7 +5357,7 @@ pub unsafe fn dav1d_cdf_thread_update(
         memcpy(
             ((*dst).m.y_mode.0[j_26 as usize]).as_mut_ptr() as *mut c_void,
             ((*src).m.y_mode.0[j_26 as usize]).as_ptr() as *const c_void,
-            ::core::mem::size_of::<[u16; 16]>() as c_ulong,
+            ::core::mem::size_of::<[u16; 16]>(),
         );
         (*dst).m.y_mode.0[j_26 as usize][(N_INTRA_PRED_MODES as c_int - 1) as usize] =
             0 as c_int as u16;
@@ -5374,7 +5370,7 @@ pub unsafe fn dav1d_cdf_thread_update(
             memcpy(
                 ((*dst).m.filter.0[k_16 as usize][j_27 as usize]).as_mut_ptr() as *mut c_void,
                 ((*src).m.filter.0[k_16 as usize][j_27 as usize]).as_ptr() as *const c_void,
-                ::core::mem::size_of::<[u16; 4]>() as c_ulong,
+                ::core::mem::size_of::<[u16; 4]>(),
             );
             (*dst).m.filter.0[k_16 as usize][j_27 as usize]
                 [(DAV1D_N_SWITCHABLE_FILTERS as c_int - 1) as usize] = 0 as c_int as u16;
@@ -5411,7 +5407,7 @@ pub unsafe fn dav1d_cdf_thread_update(
         memcpy(
             ((*dst).m.comp_inter_mode.0[j_28 as usize]).as_mut_ptr() as *mut c_void,
             ((*src).m.comp_inter_mode.0[j_28 as usize]).as_ptr() as *const c_void,
-            ::core::mem::size_of::<[u16; 8]>() as c_ulong,
+            ::core::mem::size_of::<[u16; 8]>(),
         );
         (*dst).m.comp_inter_mode.0[j_28 as usize]
             [(N_COMP_INTER_PRED_MODES as c_int - 1) as usize] = 0 as c_int as u16;
@@ -5458,7 +5454,7 @@ pub unsafe fn dav1d_cdf_thread_update(
         memcpy(
             ((*dst).m.wedge_idx.0[j_29 as usize]).as_mut_ptr() as *mut c_void,
             ((*src).m.wedge_idx.0[j_29 as usize]).as_ptr() as *const c_void,
-            ::core::mem::size_of::<[u16; 16]>() as c_ulong,
+            ::core::mem::size_of::<[u16; 16]>(),
         );
         (*dst).m.wedge_idx[j_29 as usize][15] = 0 as c_int as u16;
         j_29 += 1;
@@ -5530,7 +5526,7 @@ pub unsafe fn dav1d_cdf_thread_update(
         memcpy(
             ((*dst).m.interintra_mode[j_34 as usize]).as_mut_ptr() as *mut c_void,
             ((*src).m.interintra_mode[j_34 as usize]).as_ptr() as *const c_void,
-            ::core::mem::size_of::<[u16; 4]>() as c_ulong,
+            ::core::mem::size_of::<[u16; 4]>(),
         );
         (*dst).m.interintra_mode[j_34 as usize][3] = 0 as c_int as u16;
         j_34 += 1;
@@ -5540,7 +5536,7 @@ pub unsafe fn dav1d_cdf_thread_update(
         memcpy(
             ((*dst).m.motion_mode[j_35 as usize]).as_mut_ptr() as *mut c_void,
             ((*src).m.motion_mode[j_35 as usize]).as_ptr() as *const c_void,
-            ::core::mem::size_of::<[u16; 4]>() as c_ulong,
+            ::core::mem::size_of::<[u16; 4]>(),
         );
         (*dst).m.motion_mode[j_35 as usize][2] = 0 as c_int as u16;
         j_35 += 1;
@@ -5554,7 +5550,7 @@ pub unsafe fn dav1d_cdf_thread_update(
     memcpy(
         ((*dst).mv.joint.0).as_mut_ptr() as *mut c_void,
         ((*src).mv.joint.0).as_ptr() as *const c_void,
-        ::core::mem::size_of::<[u16; 4]>() as c_ulong,
+        ::core::mem::size_of::<[u16; 4]>(),
     );
     (*dst).mv.joint[(N_MV_JOINTS as c_int - 1) as usize] = 0 as c_int as u16;
     let mut k_17 = 0;
@@ -5562,7 +5558,7 @@ pub unsafe fn dav1d_cdf_thread_update(
         memcpy(
             ((*dst).mv.comp[k_17 as usize].classes.0).as_mut_ptr() as *mut c_void,
             ((*src).mv.comp[k_17 as usize].classes.0).as_ptr() as *const c_void,
-            ::core::mem::size_of::<[u16; 16]>() as c_ulong,
+            ::core::mem::size_of::<[u16; 16]>(),
         );
         (*dst).mv.comp[k_17 as usize].classes[10] = 0 as c_int as u16;
         (*dst).mv.comp[k_17 as usize].class0[0] = (*src).mv.comp[k_17 as usize].class0[0];
@@ -5580,7 +5576,7 @@ pub unsafe fn dav1d_cdf_thread_update(
                 ((*dst).mv.comp[k_17 as usize].class0_fp[j_36 as usize]).as_mut_ptr()
                     as *mut c_void,
                 ((*src).mv.comp[k_17 as usize].class0_fp[j_36 as usize]).as_ptr() as *const c_void,
-                ::core::mem::size_of::<[u16; 4]>() as c_ulong,
+                ::core::mem::size_of::<[u16; 4]>(),
             );
             (*dst).mv.comp[k_17 as usize].class0_fp[j_36 as usize][3] = 0 as c_int as u16;
             j_36 += 1;
@@ -5588,7 +5584,7 @@ pub unsafe fn dav1d_cdf_thread_update(
         memcpy(
             ((*dst).mv.comp[k_17 as usize].classN_fp.0).as_mut_ptr() as *mut c_void,
             ((*src).mv.comp[k_17 as usize].classN_fp.0).as_ptr() as *const c_void,
-            ::core::mem::size_of::<[u16; 4]>() as c_ulong,
+            ::core::mem::size_of::<[u16; 4]>(),
         );
         (*dst).mv.comp[k_17 as usize].classN_fp[3] = 0 as c_int as u16;
         (*dst).mv.comp[k_17 as usize].class0_hp[0] = (*src).mv.comp[k_17 as usize].class0_hp[0];
@@ -5625,25 +5621,25 @@ pub unsafe fn dav1d_cdf_thread_copy(dst: *mut CdfContext, src: *const CdfThreadC
         memcpy(
             dst as *mut c_void,
             (*src).data.cdf as *const c_void,
-            ::core::mem::size_of::<CdfContext>() as c_ulong,
+            ::core::mem::size_of::<CdfContext>(),
         );
     } else {
         (*dst).m = av1_default_cdf.clone();
         memcpy(
             ((*dst).kfym.0).as_mut_ptr() as *mut c_void,
             default_kf_y_mode_cdf.0.as_ptr() as *const c_void,
-            ::core::mem::size_of::<[[[u16; 16]; 5]; 5]>() as c_ulong,
+            ::core::mem::size_of::<[[[u16; 16]; 5]; 5]>(),
         );
         (*dst).coef = av1_default_coef_cdf[(*src).data.qcat as usize].clone();
         memcpy(
             ((*dst).mv.joint.0).as_mut_ptr() as *mut c_void,
             default_mv_joint_cdf.0.as_ptr() as *const c_void,
-            ::core::mem::size_of::<[u16; 4]>() as c_ulong,
+            ::core::mem::size_of::<[u16; 4]>(),
         );
         memcpy(
             ((*dst).dmv.joint.0).as_mut_ptr() as *mut c_void,
             default_mv_joint_cdf.0.as_ptr() as *const c_void,
-            ::core::mem::size_of::<[u16; 4]>() as c_ulong,
+            ::core::mem::size_of::<[u16; 4]>(),
         );
         (*dst).dmv.comp[1] = default_mv_component_cdf.clone();
         (*dst).dmv.comp[0] = (*dst).dmv.comp[1].clone();
@@ -5684,7 +5680,7 @@ pub unsafe fn dav1d_cdf_thread_unref(cdf: *mut CdfThreadContext) {
     memset(
         &mut (*cdf).data as *mut CdfThreadContext_data as *mut c_void,
         0 as c_int,
-        (::core::mem::size_of::<CdfThreadContext>() as c_ulong).wrapping_sub(8 as c_ulong),
+        (::core::mem::size_of::<CdfThreadContext>()).wrapping_sub(8),
     );
     dav1d_ref_dec(&mut (*cdf).r#ref);
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -6,15 +6,11 @@ use crate::src::r#ref::dav1d_ref_inc;
 use crate::src::r#ref::dav1d_ref_wrap;
 use crate::src::r#ref::Dav1dRef;
 use crate::stderr;
+use libc::fprintf;
+use libc::memset;
 use std::ffi::c_char;
 use std::ffi::c_int;
-use std::ffi::c_ulong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn memset(_: *mut c_void, _: c_int, _: c_ulong) -> *mut c_void;
-    fn fprintf(_: *mut libc::FILE, _: *const c_char, _: ...) -> c_int;
-}
 
 pub unsafe fn dav1d_data_create_internal(buf: *mut Dav1dData, sz: usize) -> *mut u8 {
     if buf.is_null() {
@@ -194,7 +190,7 @@ pub unsafe fn dav1d_data_props_set_defaults(props: *mut Dav1dDataProps) {
     memset(
         props as *mut c_void,
         0 as c_int,
-        ::core::mem::size_of::<Dav1dDataProps>() as c_ulong,
+        ::core::mem::size_of::<Dav1dDataProps>(),
     );
     (*props).timestamp = i64::MIN;
     (*props).offset = -1;
@@ -248,7 +244,7 @@ pub unsafe fn dav1d_data_unref_internal(buf: *mut Dav1dData) {
     memset(
         buf as *mut c_void,
         0 as c_int,
-        ::core::mem::size_of::<Dav1dData>() as c_ulong,
+        ::core::mem::size_of::<Dav1dData>(),
     );
     dav1d_data_props_set_defaults(&mut (*buf).m);
     dav1d_ref_dec(&mut user_data_ref);

--- a/src/fg_apply_tmpl_16.rs
+++ b/src/fg_apply_tmpl_16.rs
@@ -8,17 +8,13 @@ use crate::src::align::Align1;
 use crate::src::align::Align16;
 use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
 use libc::intptr_t;
+use libc::memcpy;
+use libc::memset;
 use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
-use std::ffi::c_ulong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn memcpy(_: *mut c_void, _: *const c_void, _: c_ulong) -> *mut c_void;
-    fn memset(_: *mut c_void, _: c_int, _: c_ulong) -> *mut c_void;
-}
 
 pub type pixel = u16;
 pub type entry = i16;
@@ -43,13 +39,13 @@ unsafe extern "C" fn generate_scaling(
     let shift_x = bitdepth - 8;
     let scaling_size = (1 as c_int) << bitdepth;
     if num == 0 {
-        memset(scaling as *mut c_void, 0 as c_int, scaling_size as c_ulong);
+        memset(scaling as *mut c_void, 0 as c_int, scaling_size as usize);
         return;
     }
     memset(
         scaling as *mut c_void,
         (*points.offset(0))[1] as c_int,
-        (((*points.offset(0))[0] as c_int) << shift_x) as c_ulong,
+        (((*points.offset(0))[0] as c_int) << shift_x) as usize,
     );
     let mut i = 0;
     while i < num - 1 {
@@ -76,7 +72,7 @@ unsafe extern "C" fn generate_scaling(
     memset(
         &mut *scaling.offset(n as isize) as *mut u8 as *mut c_void,
         (*points.offset((num - 1) as isize))[1] as c_int,
-        (scaling_size - n) as c_ulong,
+        (scaling_size - n) as usize,
     );
     let pad = (1 as c_int) << shift_x;
     let rnd = pad >> 1;
@@ -178,10 +174,10 @@ pub unsafe extern "C" fn dav1d_prep_grain_16bpc(
                 ((*in_0).data[0] as *mut u8)
                     .offset(sz as isize)
                     .offset(-(stride as isize)) as *const c_void,
-                -sz as c_ulong,
+                -sz as usize,
             );
         } else {
-            memcpy((*out).data[0], (*in_0).data[0], sz as c_ulong);
+            memcpy((*out).data[0], (*in_0).data[0], sz as usize);
         }
     }
     if (*in_0).p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
@@ -203,7 +199,7 @@ pub unsafe extern "C" fn dav1d_prep_grain_16bpc(
                     ((*in_0).data[1] as *mut u8)
                         .offset(sz_0 as isize)
                         .offset(-(stride_0 as isize)) as *const c_void,
-                    -sz_0 as c_ulong,
+                    -sz_0 as usize,
                 );
             }
             if (*data).num_uv_points[1] == 0 {
@@ -214,15 +210,15 @@ pub unsafe extern "C" fn dav1d_prep_grain_16bpc(
                     ((*in_0).data[2] as *mut u8)
                         .offset(sz_0 as isize)
                         .offset(-(stride_0 as isize)) as *const c_void,
-                    -sz_0 as c_ulong,
+                    -sz_0 as usize,
                 );
             }
         } else {
             if (*data).num_uv_points[0] == 0 {
-                memcpy((*out).data[1], (*in_0).data[1], sz_0 as c_ulong);
+                memcpy((*out).data[1], (*in_0).data[1], sz_0 as usize);
             }
             if (*data).num_uv_points[1] == 0 {
-                memcpy((*out).data[2], (*in_0).data[2], sz_0 as c_ulong);
+                memcpy((*out).data[2], (*in_0).data[2], sz_0 as usize);
             }
         }
     }

--- a/src/fg_apply_tmpl_8.rs
+++ b/src/fg_apply_tmpl_8.rs
@@ -8,17 +8,13 @@ use crate::src::align::Align16;
 use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
 use cfg_if::cfg_if;
 use libc::intptr_t;
+use libc::memcpy;
+use libc::memset;
 use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
-use std::ffi::c_ulong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn memcpy(_: *mut c_void, _: *const c_void, _: c_ulong) -> *mut c_void;
-    fn memset(_: *mut c_void, _: c_int, _: c_ulong) -> *mut c_void;
-}
 
 pub type pixel = u8;
 pub type entry = i8;
@@ -32,13 +28,13 @@ unsafe extern "C" fn generate_scaling(
     let shift_x = 0;
     let scaling_size = 256;
     if num == 0 {
-        memset(scaling as *mut c_void, 0 as c_int, scaling_size as c_ulong);
+        memset(scaling as *mut c_void, 0 as c_int, scaling_size as usize);
         return;
     }
     memset(
         scaling as *mut c_void,
         (*points.offset(0))[1] as c_int,
-        (((*points.offset(0))[0] as c_int) << shift_x) as c_ulong,
+        (((*points.offset(0))[0] as c_int) << shift_x) as usize,
     );
     let mut i = 0;
     while i < num - 1 {
@@ -65,7 +61,7 @@ unsafe extern "C" fn generate_scaling(
     memset(
         &mut *scaling.offset(n as isize) as *mut u8 as *mut c_void,
         (*points.offset((num - 1) as isize))[1] as c_int,
-        (scaling_size - n) as c_ulong,
+        (scaling_size - n) as usize,
     );
 }
 
@@ -143,10 +139,10 @@ pub unsafe extern "C" fn dav1d_prep_grain_8bpc(
                 ((*in_0).data[0] as *mut u8)
                     .offset(sz as isize)
                     .offset(-(stride as isize)) as *const c_void,
-                -sz as c_ulong,
+                -sz as usize,
             );
         } else {
-            memcpy((*out).data[0], (*in_0).data[0], sz as c_ulong);
+            memcpy((*out).data[0], (*in_0).data[0], sz as usize);
         }
     }
     if (*in_0).p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
@@ -168,7 +164,7 @@ pub unsafe extern "C" fn dav1d_prep_grain_8bpc(
                     ((*in_0).data[1] as *mut u8)
                         .offset(sz_0 as isize)
                         .offset(-(stride_0 as isize)) as *const c_void,
-                    -sz_0 as c_ulong,
+                    -sz_0 as usize,
                 );
             }
             if (*data).num_uv_points[1] == 0 {
@@ -179,15 +175,15 @@ pub unsafe extern "C" fn dav1d_prep_grain_8bpc(
                     ((*in_0).data[2] as *mut u8)
                         .offset(sz_0 as isize)
                         .offset(-(stride_0 as isize)) as *const c_void,
-                    -sz_0 as c_ulong,
+                    -sz_0 as usize,
                 );
             }
         } else {
             if (*data).num_uv_points[0] == 0 {
-                memcpy((*out).data[1], (*in_0).data[1], sz_0 as c_ulong);
+                memcpy((*out).data[1], (*in_0).data[1], sz_0 as usize);
             }
             if (*data).num_uv_points[1] == 0 {
-                memcpy((*out).data[2], (*in_0).data[2], sz_0 as c_ulong);
+                memcpy((*out).data[2], (*in_0).data[2], sz_0 as usize);
             }
         }
     }

--- a/src/ipred_prepare_tmpl_16.rs
+++ b/src/ipred_prepare_tmpl_16.rs
@@ -16,16 +16,12 @@ use crate::src::levels::Z1_PRED;
 use crate::src::levels::Z2_PRED;
 use crate::src::levels::Z3_PRED;
 use c2rust_bitfields::BitfieldStruct;
+use libc::memcpy;
 use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
-use std::ffi::c_ulong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn memcpy(_: *mut c_void, _: *const c_void, _: c_ulong) -> *mut c_void;
-}
 
 pub type pixel = u16;
 
@@ -223,7 +219,7 @@ pub unsafe extern "C" fn dav1d_prepare_intra_edges_16bpc(
             memcpy(
                 top as *mut c_void,
                 dst_top as *const c_void,
-                (px_have_1 << 1) as c_ulong,
+                (px_have_1 << 1) as usize,
             );
             if px_have_1 < sz_0 {
                 pixel_set(
@@ -254,7 +250,7 @@ pub unsafe extern "C" fn dav1d_prepare_intra_edges_16bpc(
                 memcpy(
                     top.offset(sz_0 as isize) as *mut c_void,
                     &*dst_top.offset(sz_0 as isize) as *const pixel as *const c_void,
-                    (px_have_2 << 1) as c_ulong,
+                    (px_have_2 << 1) as usize,
                 );
                 if px_have_2 < sz_0 {
                     pixel_set(

--- a/src/ipred_prepare_tmpl_8.rs
+++ b/src/ipred_prepare_tmpl_8.rs
@@ -15,17 +15,13 @@ use crate::src::levels::Z1_PRED;
 use crate::src::levels::Z2_PRED;
 use crate::src::levels::Z3_PRED;
 use c2rust_bitfields::BitfieldStruct;
+use libc::memcpy;
+use libc::memset;
 use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
-use std::ffi::c_ulong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn memcpy(_: *mut c_void, _: *const c_void, _: c_ulong) -> *mut c_void;
-    fn memset(_: *mut c_void, _: c_int, _: c_ulong) -> *mut c_void;
-}
 
 pub type pixel = u8;
 
@@ -155,7 +151,7 @@ pub unsafe extern "C" fn dav1d_prepare_intra_edges_8bpc(
                 memset(
                     left as *mut c_void,
                     *left.offset((sz - px_have) as isize) as c_int,
-                    (sz - px_have) as c_ulong,
+                    (sz - px_have) as usize,
                 );
             }
         } else {
@@ -166,7 +162,7 @@ pub unsafe extern "C" fn dav1d_prepare_intra_edges_8bpc(
                 } else {
                     ((1 as c_int) << bitdepth >> 1) + 1
                 },
-                sz as c_ulong,
+                sz as usize,
             );
         }
         if (av1_intra_prediction_edges[mode as usize]).needs_bottomleft() != 0 {
@@ -187,14 +183,14 @@ pub unsafe extern "C" fn dav1d_prepare_intra_edges_8bpc(
                     memset(
                         left.offset(-(sz as isize)) as *mut c_void,
                         *left.offset(-px_have_0 as isize) as c_int,
-                        (sz - px_have_0) as c_ulong,
+                        (sz - px_have_0) as usize,
                     );
                 }
             } else {
                 memset(
                     left.offset(-(sz as isize)) as *mut c_void,
                     *left.offset(0) as c_int,
-                    sz as c_ulong,
+                    sz as usize,
                 );
             }
         }
@@ -207,13 +203,13 @@ pub unsafe extern "C" fn dav1d_prepare_intra_edges_8bpc(
             memcpy(
                 top as *mut c_void,
                 dst_top as *const c_void,
-                px_have_1 as c_ulong,
+                px_have_1 as usize,
             );
             if px_have_1 < sz_0 {
                 memset(
                     top.offset(px_have_1 as isize) as *mut c_void,
                     *top.offset((px_have_1 - 1) as isize) as c_int,
-                    (sz_0 - px_have_1) as c_ulong,
+                    (sz_0 - px_have_1) as usize,
                 );
             }
         } else {
@@ -224,7 +220,7 @@ pub unsafe extern "C" fn dav1d_prepare_intra_edges_8bpc(
                 } else {
                     ((1 as c_int) << bitdepth >> 1) - 1
                 },
-                sz_0 as c_ulong,
+                sz_0 as usize,
             );
         }
         if (av1_intra_prediction_edges[mode as usize]).needs_topright() != 0 {
@@ -238,20 +234,20 @@ pub unsafe extern "C" fn dav1d_prepare_intra_edges_8bpc(
                 memcpy(
                     top.offset(sz_0 as isize) as *mut c_void,
                     &*dst_top.offset(sz_0 as isize) as *const pixel as *const c_void,
-                    px_have_2 as c_ulong,
+                    px_have_2 as usize,
                 );
                 if px_have_2 < sz_0 {
                     memset(
                         top.offset(sz_0 as isize).offset(px_have_2 as isize) as *mut c_void,
                         *top.offset((sz_0 + px_have_2 - 1) as isize) as c_int,
-                        (sz_0 - px_have_2) as c_ulong,
+                        (sz_0 - px_have_2) as usize,
                     );
                 }
             } else {
                 memset(
                     top.offset(sz_0 as isize) as *mut c_void,
                     *top.offset((sz_0 - 1) as isize) as c_int,
-                    sz_0 as c_ulong,
+                    sz_0 as usize,
                 );
             }
         }

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -5,15 +5,11 @@ use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::intops::iclip;
 use crate::src::levels::N_RECT_TX_SIZES;
 use crate::src::levels::N_TX_TYPES_PLUS_LL;
+use libc::memset;
 use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_int;
-use std::ffi::c_ulong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn memset(_: *mut c_void, _: c_int, _: c_ulong) -> *mut c_void;
-}
 
 pub type itx_1d_fn = Option<unsafe extern "C" fn(*mut i32, ptrdiff_t, c_int, c_int) -> ()>;
 
@@ -108,9 +104,9 @@ pub unsafe extern "C" fn inv_txfm_add_rust<BD: BitDepth>(
     memset(
         coeff as *mut c_void,
         0 as c_int,
-        (::core::mem::size_of::<BD::Coef>() as c_ulong)
-            .wrapping_mul(sw as c_ulong)
-            .wrapping_mul(sh as c_ulong),
+        ::core::mem::size_of::<BD::Coef>()
+            .wrapping_mul(sw as usize)
+            .wrapping_mul(sh as usize),
     );
     let mut i = 0;
     while i < w * sh {

--- a/src/itx_tmpl_16.rs
+++ b/src/itx_tmpl_16.rs
@@ -39,9 +39,9 @@ use crate::src::levels::V_ADST;
 use crate::src::levels::V_DCT;
 use crate::src::levels::V_FLIPADST;
 use crate::src::levels::WHT_WHT;
+use libc::memset;
 use libc::ptrdiff_t;
 use std::ffi::c_int;
-use std::ffi::c_ulong;
 use std::ffi::c_void;
 
 #[cfg(feature = "asm")]
@@ -49,10 +49,6 @@ use crate::src::cpu::dav1d_get_cpu_flags;
 
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
-
-extern "C" {
-    fn memset(_: *mut c_void, _: c_int, _: c_ulong) -> *mut c_void;
-}
 
 pub type pixel = u16;
 pub type coef = i32;
@@ -100,9 +96,9 @@ unsafe extern "C" fn inv_txfm_add_wht_wht_4x4_rust(
     memset(
         coeff as *mut c_void,
         0 as c_int,
-        (::core::mem::size_of::<coef>() as c_ulong)
-            .wrapping_mul(4 as c_int as c_ulong)
-            .wrapping_mul(4 as c_int as c_ulong),
+        ::core::mem::size_of::<coef>()
+            .wrapping_mul(4)
+            .wrapping_mul(4),
     );
     let mut x_0 = 0;
     while x_0 < 4 {

--- a/src/itx_tmpl_8.rs
+++ b/src/itx_tmpl_8.rs
@@ -39,9 +39,9 @@ use crate::src::levels::V_ADST;
 use crate::src::levels::V_DCT;
 use crate::src::levels::V_FLIPADST;
 use crate::src::levels::WHT_WHT;
+use libc::memset;
 use libc::ptrdiff_t;
 use std::ffi::c_int;
-use std::ffi::c_ulong;
 use std::ffi::c_void;
 
 #[cfg(feature = "asm")]
@@ -49,10 +49,6 @@ use crate::src::cpu::dav1d_get_cpu_flags;
 
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
-
-extern "C" {
-    fn memset(_: *mut c_void, _: c_int, _: c_ulong) -> *mut c_void;
-}
 
 pub type pixel = u8;
 pub type coef = i16;
@@ -91,9 +87,9 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust(
     memset(
         coeff as *mut c_void,
         0 as c_int,
-        (::core::mem::size_of::<coef>() as c_ulong)
-            .wrapping_mul(4 as c_int as c_ulong)
-            .wrapping_mul(4 as c_int as c_ulong),
+        ::core::mem::size_of::<coef>()
+            .wrapping_mul(4)
+            .wrapping_mul(4),
     );
     let mut x_0 = 0;
     while x_0 < 4 {

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -8,15 +8,12 @@ use crate::src::lf_mask::Av1Filter;
 use crate::src::lr_apply::LR_RESTORE_U;
 use crate::src::lr_apply::LR_RESTORE_V;
 use crate::src::lr_apply::LR_RESTORE_Y;
+use libc::memcpy;
 use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_void;
-
-extern "C" {
-    fn memcpy(_: *mut c_void, _: *const c_void, _: usize) -> *mut c_void;
-}
 
 pub type pixel = u16;
 

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -8,15 +8,12 @@ use crate::src::lf_mask::Av1Filter;
 use crate::src::lr_apply::LR_RESTORE_U;
 use crate::src::lr_apply::LR_RESTORE_V;
 use crate::src::lr_apply::LR_RESTORE_Y;
+use libc::memcpy;
 use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_void;
-
-extern "C" {
-    fn memcpy(_: *mut c_void, _: *const c_void, _: usize) -> *mut c_void;
-}
 
 pub type pixel = u8;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,11 @@ use crate::src::thread_task::dav1d_worker_task;
 use crate::src::thread_task::FRAME_ERROR;
 use crate::stderr;
 use cfg_if::cfg_if;
+use libc::calloc;
+use libc::fprintf;
+use libc::free;
+use libc::memcpy;
+use libc::memset;
 use libc::pthread_attr_destroy;
 use libc::pthread_attr_init;
 use libc::pthread_attr_setstacksize;
@@ -95,15 +100,11 @@ use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
 
+#[cfg(target_os = "linux")]
+use libc::dlsym;
+
 extern "C" {
-    fn memcpy(_: *mut c_void, _: *const c_void, _: usize) -> *mut c_void;
-    fn memset(_: *mut c_void, _: c_int, _: usize) -> *mut c_void;
-    #[cfg(target_os = "linux")]
-    fn dlsym(__handle: *mut c_void, __name: *const c_char) -> *mut c_void;
-    fn calloc(_: usize, _: usize) -> *mut c_void;
-    fn free(_: *mut c_void);
     fn abort() -> !;
-    fn fprintf(_: *mut libc::FILE, _: *const c_char, _: ...) -> c_int;
     fn dav1d_num_logical_processors(c: *mut Dav1dContext) -> c_int;
     #[cfg(feature = "bitdepth_16")]
     fn dav1d_apply_grain_16bpc(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,12 +99,12 @@ use std::ffi::c_long;
 use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
+use std::process::abort;
 
 #[cfg(target_os = "linux")]
 use libc::dlsym;
 
 extern "C" {
-    fn abort() -> !;
     fn dav1d_num_logical_processors(c: *mut Dav1dContext) -> c_int;
     #[cfg(feature = "bitdepth_16")]
     fn dav1d_apply_grain_16bpc(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,6 @@ use libc::pthread_t;
 use std::cmp;
 use std::ffi::c_char;
 use std::ffi::c_int;
-use std::ffi::c_long;
 use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
@@ -103,6 +102,9 @@ use std::process::abort;
 
 #[cfg(target_os = "linux")]
 use libc::dlsym;
+
+#[cfg(target_os = "linux")]
+use libc::sysconf;
 
 extern "C" {
     fn dav1d_num_logical_processors(c: *mut Dav1dContext) -> c_int;
@@ -124,7 +126,6 @@ extern "C" {
         w: c_int,
         src: *const Dav1dPicture,
     ) -> c_int;
-    fn __sysconf(__name: c_int) -> c_long;
     fn pthread_create(
         __newthread: *mut pthread_t,
         __attr: *const pthread_attr_t,
@@ -219,7 +220,7 @@ unsafe extern "C" fn get_stack_size_internal(_thread_attr: *const pthread_attr_t
                     ));
                 if get_minstack.is_some() {
                     return (get_minstack.expect("non-null function pointer")(_thread_attr))
-                        .wrapping_sub(__sysconf(75) as usize);
+                        .wrapping_sub(sysconf(75) as usize);
                 }
             }
         }

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,11 +1,11 @@
 use crate::src::internal::Dav1dContext;
 use crate::stderr;
+use libc::fprintf;
 use std::ffi::c_char;
 use std::ffi::c_int;
 use std::ffi::c_void;
 
 extern "C" {
-    fn fprintf(_: *mut libc::FILE, _: *const c_char, _: ...) -> c_int;
     fn vfprintf(_: *mut libc::FILE, _: *const c_char, _: ::core::ffi::VaList) -> c_int;
 }
 

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -18,16 +18,12 @@ use crate::src::lr_apply::LR_RESTORE_U;
 use crate::src::lr_apply::LR_RESTORE_V;
 use crate::src::lr_apply::LR_RESTORE_Y;
 use crate::src::tables::dav1d_sgr_params;
+use libc::memcpy;
 use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
-use std::ffi::c_ulong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn memcpy(_: *mut c_void, _: *const c_void, _: c_ulong) -> *mut c_void;
-}
 
 pub type pixel = u16;
 
@@ -160,11 +156,7 @@ unsafe extern "C" fn backup4xU(
     mut u: c_int,
 ) {
     while u > 0 {
-        memcpy(
-            dst as *mut c_void,
-            src as *const c_void,
-            ((4 as c_int) << 1) as c_ulong,
-        );
+        memcpy(dst as *mut c_void, src as *const c_void, 4 << 1);
         u -= 1;
         dst = dst.offset(1);
         src = src.offset(PXSTRIDE(src_stride) as isize);

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -18,16 +18,12 @@ use crate::src::lr_apply::LR_RESTORE_U;
 use crate::src::lr_apply::LR_RESTORE_V;
 use crate::src::lr_apply::LR_RESTORE_Y;
 use crate::src::tables::dav1d_sgr_params;
+use libc::memcpy;
 use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
-use std::ffi::c_ulong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn memcpy(_: *mut c_void, _: *const c_void, _: c_ulong) -> *mut c_void;
-}
 
 pub type pixel = u8;
 
@@ -150,11 +146,7 @@ unsafe extern "C" fn backup4xU(
     mut u: c_int,
 ) {
     while u > 0 {
-        memcpy(
-            dst as *mut c_void,
-            src as *const c_void,
-            4 as c_int as c_ulong,
-        );
+        memcpy(dst as *mut c_void, src as *const c_void, 4);
         u -= 1;
         dst = dst.offset(1);
         src = src.offset(src_stride as isize);

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -1,3 +1,6 @@
+use libc::free;
+use libc::malloc;
+use libc::posix_memalign;
 use libc::pthread_mutex_destroy;
 use libc::pthread_mutex_init;
 use libc::pthread_mutex_lock;
@@ -6,14 +9,7 @@ use libc::pthread_mutex_unlock;
 use libc::pthread_mutexattr_t;
 use libc::uintptr_t;
 use std::ffi::c_int;
-use std::ffi::c_ulong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn malloc(_: c_ulong) -> *mut c_void;
-    fn free(_: *mut c_void);
-    fn posix_memalign(__memptr: *mut *mut c_void, __alignment: usize, __size: usize) -> c_int;
-}
 
 #[repr(C)]
 pub struct Dav1dMemPool {
@@ -131,7 +127,7 @@ pub unsafe fn dav1d_mem_pool_pop(pool: *mut Dav1dMemPool, size: usize) -> *mut D
 #[cold]
 pub unsafe fn dav1d_mem_pool_init(ppool: *mut *mut Dav1dMemPool) -> c_int {
     let pool: *mut Dav1dMemPool =
-        malloc(::core::mem::size_of::<Dav1dMemPool>() as c_ulong) as *mut Dav1dMemPool;
+        malloc(::core::mem::size_of::<Dav1dMemPool>()) as *mut Dav1dMemPool;
     if !pool.is_null() {
         if pthread_mutex_init(&mut (*pool).lock, 0 as *const pthread_mutexattr_t) == 0 {
             (*pool).buf = 0 as *mut Dav1dMemPoolBuffer;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -104,9 +104,12 @@ use crate::src::r#ref::dav1d_ref_inc;
 use crate::src::r#ref::Dav1dRef;
 use crate::src::tables::dav1d_default_wm_params;
 use crate::src::thread_task::FRAME_ERROR;
+use libc::memcmp;
+use libc::memset;
 use libc::pthread_cond_wait;
 use libc::pthread_mutex_lock;
 use libc::pthread_mutex_unlock;
+use libc::realloc;
 use std::cmp;
 use std::ffi::c_char;
 use std::ffi::c_int;
@@ -116,9 +119,6 @@ use std::ffi::c_ulong;
 use std::ffi::c_void;
 
 extern "C" {
-    fn realloc(_: *mut c_void, _: usize) -> *mut c_void;
-    fn memset(_: *mut c_void, _: c_int, _: usize) -> *mut c_void;
-    fn memcmp(_: *const c_void, _: *const c_void, _: usize) -> c_int;
     fn dav1d_submit_frame(c: *mut Dav1dContext) -> c_int;
     fn dav1d_log(c: *mut Dav1dContext, format: *const c_char, _: ...);
 }

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -28,8 +28,12 @@ use crate::src::r#ref::dav1d_ref_inc;
 use crate::src::r#ref::dav1d_ref_wrap;
 use crate::src::r#ref::Dav1dRef;
 use crate::stderr;
+use libc::fprintf;
+use libc::free;
 use libc::malloc;
+use libc::memset;
 use libc::ptrdiff_t;
+use libc::strerror;
 use std::ffi::c_char;
 use std::ffi::c_int;
 use std::ffi::c_uint;
@@ -37,10 +41,6 @@ use std::ffi::c_ulong;
 use std::ffi::c_void;
 
 extern "C" {
-    fn fprintf(_: *mut libc::FILE, _: *const c_char, _: ...) -> c_int;
-    fn free(_: *mut c_void);
-    fn memset(_: *mut c_void, _: c_int, _: usize) -> *mut c_void;
-    fn strerror(_: c_int) -> *mut c_char;
     fn dav1d_log(c: *mut Dav1dContext, format: *const c_char, _: ...);
 }
 

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -86,6 +86,9 @@ use crate::src::tables::TxfmInfo;
 use crate::src::wedge::dav1d_ii_masks;
 use crate::src::wedge::dav1d_wedge_masks;
 use libc::intptr_t;
+use libc::memcpy;
+use libc::memset;
+use libc::printf;
 use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_char;
@@ -96,9 +99,6 @@ use std::ffi::c_ulong;
 use std::ffi::c_void;
 
 extern "C" {
-    fn memcpy(_: *mut c_void, _: *const c_void, _: usize) -> *mut c_void;
-    fn memset(_: *mut c_void, _: c_int, _: usize) -> *mut c_void;
-    fn printf(_: *const c_char, _: ...) -> c_int;
     fn dav1d_cdef_brow_16bpc(
         tc: *mut Dav1dTaskContext,
         p: *const *mut pixel,

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -86,6 +86,9 @@ use crate::src::tables::TxfmInfo;
 use crate::src::wedge::dav1d_ii_masks;
 use crate::src::wedge::dav1d_wedge_masks;
 use libc::intptr_t;
+use libc::memcpy;
+use libc::memset;
+use libc::printf;
 use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_char;
@@ -96,9 +99,6 @@ use std::ffi::c_ulong;
 use std::ffi::c_void;
 
 extern "C" {
-    fn memcpy(_: *mut c_void, _: *const c_void, _: usize) -> *mut c_void;
-    fn memset(_: *mut c_void, _: c_int, _: usize) -> *mut c_void;
-    fn printf(_: *const c_char, _: ...) -> c_int;
     fn dav1d_cdef_brow_8bpc(
         tc: *mut Dav1dTaskContext,
         p: *const *mut pixel,

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -5,14 +5,10 @@ use crate::src::mem::dav1d_mem_pool_pop;
 use crate::src::mem::dav1d_mem_pool_push;
 use crate::src::mem::Dav1dMemPool;
 use crate::src::mem::Dav1dMemPoolBuffer;
+use libc::free;
+use libc::malloc;
 use std::ffi::c_int;
-use std::ffi::c_ulong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn malloc(_: c_ulong) -> *mut c_void;
-    fn free(_: *mut c_void);
-}
 
 #[repr(C)]
 pub struct Dav1dRef {
@@ -96,7 +92,7 @@ pub unsafe fn dav1d_ref_wrap(
     free_callback: Option<unsafe extern "C" fn(*const u8, *mut c_void) -> ()>,
     user_data: *mut c_void,
 ) -> *mut Dav1dRef {
-    let res: *mut Dav1dRef = malloc(::core::mem::size_of::<Dav1dRef>() as c_ulong) as *mut Dav1dRef;
+    let res: *mut Dav1dRef = malloc(::core::mem::size_of::<Dav1dRef>()) as *mut Dav1dRef;
     if res.is_null() {
         return 0 as *mut Dav1dRef;
     }

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -39,6 +39,7 @@ use std::ffi::c_int;
 use std::ffi::c_long;
 use std::ffi::c_uint;
 use std::ffi::c_void;
+use std::process::abort;
 
 #[cfg(target_os = "linux")]
 use libc::prctl;
@@ -47,7 +48,6 @@ use libc::prctl;
 use libc::pthread_setname_np;
 
 extern "C" {
-    fn abort() -> !;
     fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> c_int;
     fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) -> c_int;
     fn dav1d_decode_tile_sbrow(t: *mut Dav1dTaskContext) -> c_int;

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -27,11 +27,12 @@ use crate::src::internal::DAV1D_TASK_TYPE_SUPER_RESOLUTION;
 use crate::src::internal::DAV1D_TASK_TYPE_TILE_ENTROPY;
 use crate::src::internal::DAV1D_TASK_TYPE_TILE_RECONSTRUCTION;
 use crate::src::picture::Dav1dThreadPicture;
-use cfg_if::cfg_if;
+use libc::memset;
 use libc::pthread_cond_signal;
 use libc::pthread_cond_wait;
 use libc::pthread_mutex_lock;
 use libc::pthread_mutex_unlock;
+use libc::realloc;
 use std::cmp;
 use std::ffi::c_char;
 use std::ffi::c_int;
@@ -39,17 +40,14 @@ use std::ffi::c_long;
 use std::ffi::c_uint;
 use std::ffi::c_void;
 
+#[cfg(target_os = "linux")]
+use libc::prctl;
+
+#[cfg(target_os = "macos")]
+use libc::pthread_setname_np;
+
 extern "C" {
-    fn memset(_: *mut c_void, _: c_int, _: usize) -> *mut c_void;
-    fn realloc(_: *mut c_void, _: usize) -> *mut c_void;
     fn abort() -> !;
-    cfg_if! {
-        if #[cfg(target_os = "linux")] {
-            fn prctl(__option: c_int, _: ...) -> c_int;
-        } else if #[cfg(target_os = "macos")] {
-            fn pthread_setname_np(name: *const c_char);
-        }
-    }
     fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> c_int;
     fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) -> c_int;
     fn dav1d_decode_tile_sbrow(t: *mut Dav1dTaskContext) -> c_int;

--- a/src/x86/cpu.rs
+++ b/src/x86/cpu.rs
@@ -1,3 +1,4 @@
+use libc::memcmp;
 use std::ffi::c_char;
 use std::ffi::c_int;
 use std::ffi::c_uint;
@@ -5,7 +6,6 @@ use std::ffi::c_ulong;
 use std::ffi::c_void;
 
 extern "C" {
-    fn memcmp(_: *const c_void, _: *const c_void, _: c_ulong) -> c_int;
     fn dav1d_cpu_cpuid(regs: *mut CpuidRegisters, leaf: c_uint, subleaf: c_uint);
     #[cfg(target_arch = "x86_64")]
     fn dav1d_cpu_xgetbv(xcr: c_uint) -> u64;
@@ -99,7 +99,7 @@ pub unsafe fn dav1d_get_cpu_flags_x86() -> c_uint {
         if memcmp(
             (cpu.c2rust_unnamed.vendor).as_mut_ptr() as *const c_void,
             b"AuthenticAMD\0" as *const u8 as *const c_char as *const c_void,
-            ::core::mem::size_of::<[c_char; 12]>() as c_ulong,
+            ::core::mem::size_of::<[c_char; 12]>(),
         ) == 0
         {
             if flags & DAV1D_X86_CPU_FLAG_AVX2 as c_int as c_uint != 0

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -58,14 +58,12 @@ use std::ffi::c_char;
 use std::ffi::c_double;
 use std::ffi::c_float;
 use std::ffi::c_int;
-use std::ffi::c_longlong;
 use std::ffi::c_uint;
 use std::ffi::c_ulonglong;
 use std::ffi::c_void;
 
 extern "C" {
     pub type DemuxerContext;
-    fn llround(_: c_double) -> c_longlong;
     fn input_open(
         c_out: *mut *mut DemuxerContext,
         name: *const c_char,
@@ -478,9 +476,9 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
                 current_block = 5948590327928692120;
                 break;
             }
-            pts = llround(
-                (xor128_rand() as c_uint).wrapping_rem(total) as c_double * spf * 1000000000.0f64,
-            ) as u64;
+            pts =
+                ((xor128_rand() as c_uint).wrapping_rem(total) as c_double * spf * 1000000000.0f64)
+                    .round() as u64;
             if !(seek(in_0, c, pts, &mut data) != 0) {
                 if decode_rand(in_0, c, &mut data, fps) != 0 {
                     current_block = 1928200949476507836;
@@ -492,7 +490,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
         match current_block {
             1928200949476507836 => {}
             _ => {
-                pts = llround(data.m.timestamp as c_double * timebase * 1000000000.0f64) as u64;
+                pts = (data.m.timestamp as c_double * timebase * 1000000000.0f64).round() as u64;
                 let mut i_0 = 0;
                 let mut tries = 0;
                 loop {
@@ -506,34 +504,31 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
                         1 as c_int
                     };
                     let diff: c_float = (xor128_rand() % 100 as c_int) as c_float / 100.0f32;
-                    let mut new_pts: i64 = pts.wrapping_add(
-                        (sign as u64).wrapping_mul(llround(
-                            diff as c_double * fps * spf * 1000000000.0f64,
-                        ) as u64),
-                    ) as i64;
+                    let mut new_pts: i64 = pts.wrapping_add((sign as u64).wrapping_mul(
+                        (diff as c_double * fps * spf * 1000000000.0f64).round() as u64,
+                    )) as i64;
                     let new_ts: i64 =
-                        llround(new_pts as c_double / (timebase * 1000000000.0f64)) as i64;
+                        (new_pts as c_double / (timebase * 1000000000.0f64)).round() as i64;
                     new_pts =
-                        llround(new_ts as c_double * timebase * 1000000000.0f64) as u64 as i64;
+                        (new_ts as c_double * timebase * 1000000000.0f64).round() as u64 as i64;
                     if new_pts < 0
                         || new_pts as u64
-                            >= llround(total as c_double * spf * 1000000000.0f64) as u64
+                            >= (total as c_double * spf * 1000000000.0f64).round() as u64
                     {
                         if seek(
                             in_0,
                             c,
-                            llround(
-                                total.wrapping_div(2 as c_int as c_uint) as c_double
-                                    * spf
-                                    * 1000000000.0f64,
-                            ) as u64,
+                            (total.wrapping_div(2 as c_int as c_uint) as c_double
+                                * spf
+                                * 1000000000.0f64)
+                                .round() as u64,
                             &mut data,
                         ) != 0
                         {
                             current_block = 8693738493027456495;
                             break;
                         }
-                        pts = llround(data.m.timestamp as c_double * timebase * 1000000000.0f64)
+                        pts = (data.m.timestamp as c_double * timebase * 1000000000.0f64).round()
                             as u64;
                         tries += 1;
                     } else {
@@ -547,7 +542,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
                             current_block = 1928200949476507836;
                             break;
                         }
-                        pts = llround(data.m.timestamp as c_double * timebase * 1000000000.0f64)
+                        pts = (data.m.timestamp as c_double * timebase * 1000000000.0f64).round()
                             as u64;
                     }
                     i_0 += 1;
@@ -564,9 +559,8 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
                             if !(seek(
                                 in_0,
                                 c,
-                                llround(
-                                    total.wrapping_sub(shift) as c_double * spf * 1000000000.0f64,
-                                ) as u64,
+                                (total.wrapping_sub(shift) as c_double * spf * 1000000000.0f64)
+                                    .round() as u64,
                                 &mut data,
                             ) != 0)
                             {
@@ -579,9 +573,8 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
                             if seek(
                                 in_0,
                                 c,
-                                llround(
-                                    total.wrapping_sub(shift) as c_double * spf * 1000000000.0f64,
-                                ) as u64,
+                                (total.wrapping_sub(shift) as c_double * spf * 1000000000.0f64)
+                                    .round() as u64,
                                 &mut data,
                             ) != 0
                             {

--- a/tools/dav1d_cli_parse.rs
+++ b/tools/dav1d_cli_parse.rs
@@ -29,6 +29,7 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
+use std::process::exit;
 
 extern "C" {
     static mut optarg: *mut c_char;
@@ -41,7 +42,6 @@ extern "C" {
         __longind: *mut c_int,
     ) -> c_int;
     fn vfprintf(_: *mut libc::FILE, _: *const c_char, _: ::core::ffi::VaList) -> c_int;
-    fn exit(_: c_int) -> !;
 }
 
 #[repr(C)]

--- a/tools/dav1d_cli_parse.rs
+++ b/tools/dav1d_cli_parse.rs
@@ -1,3 +1,12 @@
+use libc::fprintf;
+use libc::memset;
+use libc::sprintf;
+use libc::strcat;
+use libc::strcmp;
+use libc::strcpy;
+use libc::strncmp;
+use libc::strtod;
+use libc::strtoul;
 use rav1d::include::dav1d::dav1d::Dav1dDecodeFrameType;
 use rav1d::include::dav1d::dav1d::Dav1dInloopFilterType;
 use rav1d::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
@@ -31,17 +40,8 @@ extern "C" {
         __longopts: *const option,
         __longind: *mut c_int,
     ) -> c_int;
-    fn fprintf(_: *mut libc::FILE, _: *const c_char, _: ...) -> c_int;
-    fn sprintf(_: *mut c_char, _: *const c_char, _: ...) -> c_int;
     fn vfprintf(_: *mut libc::FILE, _: *const c_char, _: ::core::ffi::VaList) -> c_int;
-    fn strtod(_: *const c_char, _: *mut *mut c_char) -> c_double;
-    fn strtoul(_: *const c_char, _: *mut *mut c_char, _: c_int) -> c_ulong;
     fn exit(_: c_int) -> !;
-    fn strcpy(_: *mut c_char, _: *const c_char) -> *mut c_char;
-    fn strcat(_: *mut c_char, _: *const c_char) -> *mut c_char;
-    fn strcmp(_: *const c_char, _: *const c_char) -> c_int;
-    fn strncmp(_: *const c_char, _: *const c_char, _: c_ulong) -> c_int;
-    fn memset(_: *mut c_void, _: c_int, _: c_ulong) -> *mut c_void;
 }
 
 #[repr(C)]
@@ -605,12 +605,7 @@ unsafe extern "C" fn parse_enum(
     }
     let mut end: *mut c_char = 0 as *mut c_char;
     let res: c_uint;
-    if strncmp(
-        optarg_0,
-        b"0x\0" as *const u8 as *const c_char,
-        2 as c_int as c_ulong,
-    ) == 0
-    {
+    if strncmp(optarg_0, b"0x\0" as *const u8 as *const c_char, 2) == 0 {
         res = strtoul(&mut *optarg_0.offset(2), &mut end, 16 as c_int) as c_uint;
     } else {
         res = strtoul(optarg_0, &mut end, 0 as c_int) as c_uint;
@@ -636,7 +631,7 @@ pub unsafe extern "C" fn parse(
     memset(
         cli_settings as *mut c_void,
         0 as c_int,
-        ::core::mem::size_of::<CLISettings>() as c_ulong,
+        ::core::mem::size_of::<CLISettings>(),
     );
     dav1d_default_settings(lib_settings);
     (*lib_settings).strict_std_compliance = 1 as c_int;

--- a/tools/input/annexb.rs
+++ b/tools/input/annexb.rs
@@ -1,5 +1,9 @@
+use libc::fclose;
+use libc::fopen;
+use libc::fprintf;
 use libc::fread;
 use libc::fseeko;
+use libc::strerror;
 use rav1d::errno_location;
 use rav1d::include::dav1d::data::Dav1dData;
 use rav1d::include::dav1d::headers::Dav1dObuType;
@@ -17,13 +21,6 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn fclose(__stream: *mut libc::FILE) -> c_int;
-    fn fopen(_: *const c_char, _: *const c_char) -> *mut libc::FILE;
-    fn fprintf(_: *mut libc::FILE, _: *const c_char, _: ...) -> c_int;
-    fn strerror(_: c_int) -> *mut c_char;
-}
 
 #[repr(C)]
 pub struct DemuxerPriv {

--- a/tools/input/ivf.rs
+++ b/tools/input/ivf.rs
@@ -15,14 +15,9 @@ use rav1d::stderr;
 use std::ffi::c_char;
 use std::ffi::c_double;
 use std::ffi::c_int;
-use std::ffi::c_longlong;
 use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn llround(_: c_double) -> c_longlong;
-}
 
 #[repr(C)]
 pub struct DemuxerPriv {
@@ -279,7 +274,7 @@ unsafe extern "C" fn ivf_read(c: *mut IvfInputContext, buf: *mut Dav1dData) -> c
 unsafe extern "C" fn ivf_seek(c: *mut IvfInputContext, pts: u64) -> c_int {
     let mut current_block: u64;
     let mut cur: u64 = 0;
-    let ts: u64 = llround(pts as c_double * (*c).timebase / 1000000000.0f64) as u64;
+    let ts: u64 = (pts as c_double * (*c).timebase / 1000000000.0f64).round() as u64;
     if ts <= (*c).last_ts {
         if fseeko((*c).f, 32, 0) != 0 {
             current_block = 679495355492430298;

--- a/tools/input/section5.rs
+++ b/tools/input/section5.rs
@@ -1,3 +1,10 @@
+use libc::fclose;
+use libc::feof;
+use libc::fopen;
+use libc::fprintf;
+use libc::fread;
+use libc::fseeko;
+use libc::strerror;
 use rav1d::errno_location;
 use rav1d::include::dav1d::data::Dav1dData;
 use rav1d::include::dav1d::headers::Dav1dObuType;
@@ -14,16 +21,6 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn fclose(__stream: *mut libc::FILE) -> c_int;
-    fn fopen(_: *const c_char, _: *const c_char) -> *mut libc::FILE;
-    fn fprintf(_: *mut libc::FILE, _: *const c_char, _: ...) -> c_int;
-    fn fread(_: *mut c_void, _: usize, _: usize, _: *mut libc::FILE) -> usize;
-    fn fseeko(__stream: *mut libc::FILE, __off: libc::off_t, __whence: c_int) -> c_int;
-    fn feof(__stream: *mut libc::FILE) -> c_int;
-    fn strerror(_: c_int) -> *mut c_char;
-}
 
 #[repr(C)]
 pub struct DemuxerPriv {

--- a/tools/output/output.rs
+++ b/tools/output/output.rs
@@ -1,3 +1,12 @@
+use libc::fprintf;
+use libc::free;
+use libc::malloc;
+use libc::memcpy;
+use libc::snprintf;
+use libc::strchr;
+use libc::strcmp;
+use libc::strlen;
+use libc::strncmp;
 use rav1d::include::dav1d::picture::Dav1dPicture;
 use rav1d::include::dav1d::picture::Dav1dPictureParameters;
 use rav1d::stderr;
@@ -11,15 +20,6 @@ use std::ffi::c_void;
 
 extern "C" {
     pub type MuxerPriv;
-    fn fprintf(_: *mut libc::FILE, _: *const c_char, _: ...) -> c_int;
-    fn snprintf(_: *mut c_char, _: usize, _: *const c_char, _: ...) -> c_int;
-    fn malloc(_: usize) -> *mut c_void;
-    fn free(_: *mut c_void);
-    fn memcpy(_: *mut c_void, _: *const c_void, _: usize) -> *mut c_void;
-    fn strcmp(_: *const c_char, _: *const c_char) -> c_int;
-    fn strncmp(_: *const c_char, _: *const c_char, _: usize) -> c_int;
-    fn strchr(_: *const c_char, _: c_int) -> *mut c_char;
-    fn strlen(_: *const c_char) -> usize;
     static null_muxer: Muxer;
     static md5_muxer: Muxer;
     static yuv_muxer: Muxer;

--- a/tools/output/y4m2.rs
+++ b/tools/output/y4m2.rs
@@ -1,3 +1,9 @@
+use libc::fclose;
+use libc::fopen;
+use libc::fprintf;
+use libc::fwrite;
+use libc::strcmp;
+use libc::strerror;
 use rav1d::errno_location;
 use rav1d::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
 use rav1d::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
@@ -13,15 +19,6 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn fclose(__stream: *mut libc::FILE) -> c_int;
-    fn fopen(_: *const c_char, _: *const c_char) -> *mut libc::FILE;
-    fn fprintf(_: *mut libc::FILE, _: *const c_char, _: ...) -> c_int;
-    fn fwrite(_: *const c_void, _: c_ulong, _: c_ulong, _: *mut libc::FILE) -> c_ulong;
-    fn strcmp(_: *const c_char, _: *const c_char) -> c_int;
-    fn strerror(_: c_int) -> *mut c_char;
-}
 
 #[repr(C)]
 pub struct MuxerPriv {
@@ -165,13 +162,7 @@ unsafe extern "C" fn y4m2_write(c: *mut Y4m2OutputContext, p: *mut Dav1dPicture)
             current_block = 11812396948646013369;
             break;
         }
-        if fwrite(
-            ptr as *const c_void,
-            ((*p).p.w << hbd) as c_ulong,
-            1 as c_int as c_ulong,
-            (*c).f,
-        ) != 1 as c_int as c_ulong
-        {
+        if fwrite(ptr as *const c_void, ((*p).p.w << hbd) as usize, 1, (*c).f) != 1 {
             current_block = 11545648641752300099;
             break;
         }
@@ -196,13 +187,7 @@ unsafe extern "C" fn y4m2_write(c: *mut Y4m2OutputContext, p: *mut Dav1dPicture)
                     ptr = (*p).data[pl as usize] as *mut u8;
                     let mut y_0 = 0;
                     while y_0 < ch {
-                        if fwrite(
-                            ptr as *const c_void,
-                            (cw << hbd) as c_ulong,
-                            1 as c_int as c_ulong,
-                            (*c).f,
-                        ) != 1 as c_int as c_ulong
-                        {
+                        if fwrite(ptr as *const c_void, (cw << hbd) as usize, 1, (*c).f) != 1 {
                             current_block = 11545648641752300099;
                             break 's_64;
                         }

--- a/tools/output/yuv.rs
+++ b/tools/output/yuv.rs
@@ -1,3 +1,9 @@
+use libc::fclose;
+use libc::fopen;
+use libc::fprintf;
+use libc::fwrite;
+use libc::strcmp;
+use libc::strerror;
 use rav1d::errno_location;
 use rav1d::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 use rav1d::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
@@ -12,15 +18,6 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn fclose(__stream: *mut libc::FILE) -> c_int;
-    fn fopen(_: *const c_char, _: *const c_char) -> *mut libc::FILE;
-    fn fprintf(_: *mut libc::FILE, _: *const c_char, _: ...) -> c_int;
-    fn fwrite(_: *const c_void, _: c_ulong, _: c_ulong, _: *mut libc::FILE) -> c_ulong;
-    fn strcmp(_: *const c_char, _: *const c_char) -> c_int;
-    fn strerror(_: c_int) -> *mut c_char;
-}
 
 #[repr(C)]
 pub struct MuxerPriv {
@@ -81,13 +78,7 @@ unsafe extern "C" fn yuv_write(c: *mut YuvOutputContext, p: *mut Dav1dPicture) -
             current_block = 7095457783677275021;
             break;
         }
-        if fwrite(
-            ptr as *const c_void,
-            ((*p).p.w << hbd) as c_ulong,
-            1 as c_int as c_ulong,
-            (*c).f,
-        ) != 1 as c_int as c_ulong
-        {
+        if fwrite(ptr as *const c_void, ((*p).p.w << hbd) as usize, 1, (*c).f) != 1 {
             current_block = 11680617278722171943;
             break;
         }
@@ -112,13 +103,7 @@ unsafe extern "C" fn yuv_write(c: *mut YuvOutputContext, p: *mut Dav1dPicture) -
                     ptr = (*p).data[pl as usize] as *mut u8;
                     let mut y_0 = 0;
                     while y_0 < ch {
-                        if fwrite(
-                            ptr as *const c_void,
-                            (cw << hbd) as c_ulong,
-                            1 as c_int as c_ulong,
-                            (*c).f,
-                        ) != 1 as c_int as c_ulong
-                        {
+                        if fwrite(ptr as *const c_void, (cw << hbd) as usize, 1, (*c).f) != 1 {
                             current_block = 11680617278722171943;
                             break 's_40;
                         }


### PR DESCRIPTION
A bunch of these declared `fn`s have slightly incorrect (i.e., non-portable) signatures, so this also fixes that.

Also, where possible they are instead replaced with drop-in compatible `std` `fn`s.