### PR TITLE
`#[no_mangle] fn`s: Deduplicate most non-bpc, non-`*_c` declarations into `use` imports

### DIFF
--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -5648,8 +5648,7 @@ pub unsafe fn dav1d_cdf_thread_copy(dst: *mut CdfContext, src: *const CdfThreadC
     };
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_cdf_thread_alloc(
+pub unsafe fn dav1d_cdf_thread_alloc(
     c: *mut Dav1dContext,
     cdf: *mut CdfThreadContext,
     have_frame_mt: c_int,

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -66,7 +66,6 @@ pub extern "C" fn dav1d_set_cpu_flags_mask(mask: c_uint) {
     dav1d_cpu_flags_mask.store(mask, Ordering::SeqCst);
 }
 
-#[no_mangle]
 #[cold]
 pub(crate) fn dav1d_num_logical_processors(_c: *mut Dav1dContext) -> c_int {
     num_cpus::get() as c_int

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -30,7 +30,6 @@ use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
 use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
 use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
 use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::include::dav1d::picture::Dav1dPicture;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
 use crate::src::align::Align16;
@@ -175,6 +174,7 @@ use crate::src::msac::dav1d_msac_decode_symbol_adapt4;
 use crate::src::msac::dav1d_msac_decode_symbol_adapt8;
 use crate::src::msac::dav1d_msac_decode_uniform;
 use crate::src::msac::dav1d_msac_init;
+use crate::src::picture::dav1d_picture_alloc_copy;
 use crate::src::picture::dav1d_picture_get_event_flags;
 use crate::src::picture::dav1d_picture_ref;
 use crate::src::picture::dav1d_picture_unref_internal;
@@ -267,12 +267,6 @@ extern "C" {
     fn dav1d_loop_filter_dsp_init_8bpc(c: *mut Dav1dLoopFilterDSPContext);
     #[cfg(feature = "bitdepth_16")]
     fn dav1d_loop_filter_dsp_init_16bpc(c: *mut Dav1dLoopFilterDSPContext);
-    fn dav1d_picture_alloc_copy(
-        c: *mut Dav1dContext,
-        dst: *mut Dav1dPicture,
-        w: c_int,
-        src: *const Dav1dPicture,
-    ) -> c_int;
     #[cfg(feature = "bitdepth_8")]
     fn dav1d_recon_b_intra_8bpc(
         t: *mut Dav1dTaskContext,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -157,6 +157,7 @@ use crate::src::lf_mask::dav1d_create_lf_mask_intra;
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
+use crate::src::log::dav1d_log;
 use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
 use crate::src::looprestoration::dav1d_loop_restoration_dsp_init;
 use crate::src::mc::dav1d_mc_dsp_init;
@@ -334,7 +335,6 @@ extern "C" {
     fn dav1d_read_coef_blocks_8bpc(t: *mut Dav1dTaskContext, bs: BlockSize, b: *const Av1Block);
     #[cfg(feature = "bitdepth_16")]
     fn dav1d_read_coef_blocks_16bpc(t: *mut Dav1dTaskContext, bs: BlockSize, b: *const Av1Block);
-    fn dav1d_log(c: *mut Dav1dContext, format: *const c_char, _: ...);
     fn dav1d_task_create_tile_sbrow(
         f: *mut Dav1dFrameContext,
         pass: c_int,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -212,6 +212,7 @@ use crate::src::tables::dav1d_wedge_ctx_lut;
 use crate::src::tables::dav1d_ymode_size_context;
 use crate::src::tables::interintra_allowed_mask;
 use crate::src::tables::wedge_allowed_mask;
+use crate::src::thread_task::dav1d_task_create_tile_sbrow;
 use crate::src::thread_task::FRAME_ERROR;
 use crate::src::thread_task::TILE_ERROR;
 use crate::src::warpmv::dav1d_find_affine_int;
@@ -325,11 +326,6 @@ extern "C" {
     fn dav1d_read_coef_blocks_8bpc(t: *mut Dav1dTaskContext, bs: BlockSize, b: *const Av1Block);
     #[cfg(feature = "bitdepth_16")]
     fn dav1d_read_coef_blocks_16bpc(t: *mut Dav1dTaskContext, bs: BlockSize, b: *const Av1Block);
-    fn dav1d_task_create_tile_sbrow(
-        f: *mut Dav1dFrameContext,
-        pass: c_int,
-        cond_signal: c_int,
-    ) -> c_int;
     fn dav1d_task_frame_init(f: *mut Dav1dFrameContext);
 }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4203,8 +4203,7 @@ unsafe fn read_restoration_info(
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_decode_tile_sbrow(t: *mut Dav1dTaskContext) -> c_int {
+pub unsafe fn dav1d_decode_tile_sbrow(t: *mut Dav1dTaskContext) -> c_int {
     let f: *const Dav1dFrameContext = (*t).f;
     let root_bl: BlockLevel = (if (*(*f).seq_hdr).sb128 != 0 {
         BL_128X128 as c_int
@@ -4438,8 +4437,7 @@ pub unsafe extern "C" fn dav1d_decode_tile_sbrow(t: *mut Dav1dTaskContext) -> c_
     return 0 as c_int;
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> c_int {
+pub unsafe fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> c_int {
     let f = &mut *f; // TODO(kkysen) propagate to arg once we deduplicate the fn decl
 
     let c = &*f.c;
@@ -4888,8 +4886,7 @@ pub unsafe extern "C" fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> c
     0
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) -> c_int {
+pub unsafe fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) -> c_int {
     let f = &mut *f; // TODO(kkysen) propagate to arg once we deduplicate the fn decl
 
     let c = &*f.c;
@@ -5055,8 +5052,7 @@ unsafe fn dav1d_decode_frame_main(f: &mut Dav1dFrameContext) -> c_int {
     0
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_decode_frame_exit(f: *mut Dav1dFrameContext, retval: c_int) {
+pub unsafe fn dav1d_decode_frame_exit(f: *mut Dav1dFrameContext, retval: c_int) {
     let f = &mut *f; // TODO(kkysen) propagate to arg once we deduplicate the fn decl
     let c = &*f.c;
     if !f.sr_cur.p.data[0].is_null() {
@@ -5147,8 +5143,7 @@ fn get_upscale_x0(in_w: c_int, out_w: c_int, step: c_int) -> c_int {
     x0 & 0x3fff
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_submit_frame(c: *mut Dav1dContext) -> c_int {
+pub unsafe fn dav1d_submit_frame(c: *mut Dav1dContext) -> c_int {
     let c = &mut *c; // TODO(kkysen) propagate to arg once we deduplicate the fn decl
 
     // wait for c->out_delayed[next] and move into c->out if visible

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -178,6 +178,7 @@ use crate::src::msac::dav1d_msac_init;
 use crate::src::picture::dav1d_picture_get_event_flags;
 use crate::src::picture::dav1d_picture_ref;
 use crate::src::picture::dav1d_picture_unref_internal;
+use crate::src::picture::dav1d_thread_picture_alloc;
 use crate::src::picture::dav1d_thread_picture_ref;
 use crate::src::picture::dav1d_thread_picture_unref;
 use crate::src::picture::Dav1dThreadPicture;
@@ -266,11 +267,6 @@ extern "C" {
     fn dav1d_loop_filter_dsp_init_8bpc(c: *mut Dav1dLoopFilterDSPContext);
     #[cfg(feature = "bitdepth_16")]
     fn dav1d_loop_filter_dsp_init_16bpc(c: *mut Dav1dLoopFilterDSPContext);
-    fn dav1d_thread_picture_alloc(
-        c: *mut Dav1dContext,
-        f: *mut Dav1dFrameContext,
-        bpc: c_int,
-    ) -> c_int;
     fn dav1d_picture_alloc_copy(
         c: *mut Dav1dContext,
         dst: *mut Dav1dPicture,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4437,9 +4437,7 @@ pub unsafe fn dav1d_decode_tile_sbrow(t: *mut Dav1dTaskContext) -> c_int {
     return 0 as c_int;
 }
 
-pub unsafe fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> c_int {
-    let f = &mut *f; // TODO(kkysen) propagate to arg once we deduplicate the fn decl
-
+pub unsafe fn dav1d_decode_frame_init(f: &mut Dav1dFrameContext) -> c_int {
     let c = &*f.c;
 
     if f.sbh > f.lf.start_of_tile_row_sz {
@@ -4886,9 +4884,7 @@ pub unsafe fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> c_int {
     0
 }
 
-pub unsafe fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) -> c_int {
-    let f = &mut *f; // TODO(kkysen) propagate to arg once we deduplicate the fn decl
-
+pub unsafe fn dav1d_decode_frame_init_cdf(f: &mut Dav1dFrameContext) -> c_int {
     let c = &*f.c;
 
     if (*f.frame_hdr).refresh_context != 0 {
@@ -5052,8 +5048,7 @@ unsafe fn dav1d_decode_frame_main(f: &mut Dav1dFrameContext) -> c_int {
     0
 }
 
-pub unsafe fn dav1d_decode_frame_exit(f: *mut Dav1dFrameContext, retval: c_int) {
-    let f = &mut *f; // TODO(kkysen) propagate to arg once we deduplicate the fn decl
+pub unsafe fn dav1d_decode_frame_exit(f: &mut Dav1dFrameContext, retval: c_int) {
     let c = &*f.c;
     if !f.sr_cur.p.data[0].is_null() {
         f.task_thread.error = 0;
@@ -5143,9 +5138,7 @@ fn get_upscale_x0(in_w: c_int, out_w: c_int, step: c_int) -> c_int {
     x0 & 0x3fff
 }
 
-pub unsafe fn dav1d_submit_frame(c: *mut Dav1dContext) -> c_int {
-    let c = &mut *c; // TODO(kkysen) propagate to arg once we deduplicate the fn decl
-
+pub unsafe fn dav1d_submit_frame(c: &mut Dav1dContext) -> c_int {
     // wait for c->out_delayed[next] and move into c->out if visible
     let (f, out_delayed) = if c.n_fc > 1 {
         pthread_mutex_lock(&mut c.task_thread.lock);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -213,6 +213,7 @@ use crate::src::tables::dav1d_ymode_size_context;
 use crate::src::tables::interintra_allowed_mask;
 use crate::src::tables::wedge_allowed_mask;
 use crate::src::thread_task::dav1d_task_create_tile_sbrow;
+use crate::src::thread_task::dav1d_task_frame_init;
 use crate::src::thread_task::FRAME_ERROR;
 use crate::src::thread_task::TILE_ERROR;
 use crate::src::warpmv::dav1d_find_affine_int;
@@ -326,7 +327,6 @@ extern "C" {
     fn dav1d_read_coef_blocks_8bpc(t: *mut Dav1dTaskContext, bs: BlockSize, b: *const Av1Block);
     #[cfg(feature = "bitdepth_16")]
     fn dav1d_read_coef_blocks_16bpc(t: *mut Dav1dTaskContext, bs: BlockSize, b: *const Av1Block);
-    fn dav1d_task_frame_init(f: *mut Dav1dFrameContext);
 }
 
 fn init_quant_tables(

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -35,6 +35,7 @@ use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
 use crate::src::align::Align16;
 use crate::src::cdef::Dav1dCdefDSPContext;
+use crate::src::cdf::dav1d_cdf_thread_alloc;
 use crate::src::cdf::dav1d_cdf_thread_copy;
 use crate::src::cdf::dav1d_cdf_thread_init_static;
 use crate::src::cdf::dav1d_cdf_thread_ref;
@@ -42,7 +43,6 @@ use crate::src::cdf::dav1d_cdf_thread_unref;
 use crate::src::cdf::dav1d_cdf_thread_update;
 use crate::src::cdf::CdfMvComponent;
 use crate::src::cdf::CdfMvContext;
-use crate::src::cdf::CdfThreadContext;
 use crate::src::ctx::CaseSet;
 use crate::src::data::dav1d_data_props_copy;
 use crate::src::data::dav1d_data_unref_internal;
@@ -249,11 +249,6 @@ extern "C" {
     fn dav1d_cdef_dsp_init_8bpc(c: *mut Dav1dCdefDSPContext);
     #[cfg(feature = "bitdepth_16")]
     fn dav1d_cdef_dsp_init_16bpc(c: *mut Dav1dCdefDSPContext);
-    fn dav1d_cdf_thread_alloc(
-        c: *mut Dav1dContext,
-        cdf: *mut CdfThreadContext,
-        have_frame_mt: c_int,
-    ) -> c_int;
     #[cfg(feature = "bitdepth_8")]
     fn dav1d_film_grain_dsp_init_8bpc(c: *mut Dav1dFilmGrainDSPContext);
     #[cfg(feature = "bitdepth_16")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
 use crate::src::cdf::dav1d_cdf_thread_unref;
 use crate::src::cpu::dav1d_init_cpu;
+use crate::src::cpu::dav1d_num_logical_processors;
 use crate::src::data::dav1d_data_create_internal;
 use crate::src::data::dav1d_data_props_copy;
 use crate::src::data::dav1d_data_props_set_defaults;
@@ -112,7 +113,6 @@ use libc::dlsym;
 use libc::sysconf;
 
 extern "C" {
-    fn dav1d_num_logical_processors(c: *mut Dav1dContext) -> c_int;
     #[cfg(feature = "bitdepth_16")]
     fn dav1d_apply_grain_16bpc(
         dsp: *const Dav1dFilmGrainDSPContext,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ use crate::src::intra_edge::dav1d_init_mode_tree;
 use crate::src::levels::Av1Block;
 use crate::src::levels::BL_128X128;
 use crate::src::levels::BL_64X64;
+use crate::src::log::dav1d_log;
 use crate::src::log::dav1d_log_default_callback;
 use crate::src::mem::dav1d_alloc_aligned;
 use crate::src::mem::dav1d_free_aligned;
@@ -138,7 +139,6 @@ extern "C" {
         __once_control: *mut pthread_once_t,
         __init_routine: Option<unsafe extern "C" fn() -> ()>,
     ) -> c_int;
-    fn dav1d_log(c: *mut Dav1dContext, format: *const c_char, _: ...);
     fn dav1d_parse_obus(c: *mut Dav1dContext, in_0: *mut Dav1dData, global: c_int) -> c_int;
     fn dav1d_task_delayed_fg(
         c: *mut Dav1dContext,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,8 @@ use crate::src::picture::PICTURE_FLAG_NEW_TEMPORAL_UNIT;
 use crate::src::r#ref::dav1d_ref_dec;
 use crate::src::r#ref::Dav1dRef;
 use crate::src::refmvs::dav1d_refmvs_clear;
+use crate::src::refmvs::dav1d_refmvs_dsp_init;
 use crate::src::refmvs::dav1d_refmvs_init;
-use crate::src::refmvs::Dav1dRefmvsDSPContext;
 use crate::src::thread_task::dav1d_task_delayed_fg;
 use crate::src::thread_task::dav1d_worker_task;
 use crate::src::thread_task::FRAME_ERROR;
@@ -131,7 +131,6 @@ extern "C" {
         __start_routine: Option<unsafe extern "C" fn(*mut c_void) -> *mut c_void>,
         __arg: *mut c_void,
     ) -> c_int;
-    fn dav1d_refmvs_dsp_init(dsp: *mut Dav1dRefmvsDSPContext);
     fn pthread_once(
         __once_control: *mut pthread_once_t,
         __init_routine: Option<unsafe extern "C" fn() -> ()>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ use crate::src::mem::dav1d_freep_aligned;
 use crate::src::mem::dav1d_mem_pool_end;
 use crate::src::mem::dav1d_mem_pool_init;
 use crate::src::mem::freep;
+use crate::src::obu::dav1d_parse_obus;
 use crate::src::picture::dav1d_default_picture_alloc;
 use crate::src::picture::dav1d_default_picture_release;
 use crate::src::picture::dav1d_picture_get_event_flags;
@@ -139,7 +140,6 @@ extern "C" {
         __once_control: *mut pthread_once_t,
         __init_routine: Option<unsafe extern "C" fn() -> ()>,
     ) -> c_int;
-    fn dav1d_parse_obus(c: *mut Dav1dContext, in_0: *mut Dav1dData, global: c_int) -> c_int;
     fn dav1d_task_delayed_fg(
         c: *mut Dav1dContext,
         out: *mut Dav1dPicture,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ use crate::src::mem::freep;
 use crate::src::obu::dav1d_parse_obus;
 use crate::src::picture::dav1d_default_picture_alloc;
 use crate::src::picture::dav1d_default_picture_release;
+use crate::src::picture::dav1d_picture_alloc_copy;
 use crate::src::picture::dav1d_picture_get_event_flags;
 use crate::src::picture::dav1d_picture_move_ref;
 use crate::src::picture::dav1d_picture_ref;
@@ -123,12 +124,6 @@ extern "C" {
         out: *mut Dav1dPicture,
         in_0: *const Dav1dPicture,
     );
-    fn dav1d_picture_alloc_copy(
-        c: *mut Dav1dContext,
-        dst: *mut Dav1dPicture,
-        w: c_int,
-        src: *const Dav1dPicture,
-    ) -> c_int;
     fn pthread_create(
         __newthread: *mut pthread_t,
         __attr: *const pthread_attr_t,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ use crate::src::r#ref::Dav1dRef;
 use crate::src::refmvs::dav1d_refmvs_clear;
 use crate::src::refmvs::dav1d_refmvs_init;
 use crate::src::refmvs::Dav1dRefmvsDSPContext;
+use crate::src::thread_task::dav1d_task_delayed_fg;
 use crate::src::thread_task::dav1d_worker_task;
 use crate::src::thread_task::FRAME_ERROR;
 use crate::stderr;
@@ -135,11 +136,6 @@ extern "C" {
         __once_control: *mut pthread_once_t,
         __init_routine: Option<unsafe extern "C" fn() -> ()>,
     ) -> c_int;
-    fn dav1d_task_delayed_fg(
-        c: *mut Dav1dContext,
-        out: *mut Dav1dPicture,
-        in_0: *const Dav1dPicture,
-    );
 }
 
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1210,7 +1210,7 @@ pub unsafe extern "C" fn dav1d_flush(c: *mut Dav1dContext) {
             }
             let f: *mut Dav1dFrameContext =
                 &mut *((*c).fc).offset(next as isize) as *mut Dav1dFrameContext;
-            dav1d_decode_frame_exit(f, -(1 as c_int));
+            dav1d_decode_frame_exit(&mut *f, -(1 as c_int));
             (*f).n_tile_data = 0 as c_int;
             (*f).task_thread.retval = 0 as c_int;
             let out_delayed: *mut Dav1dThreadPicture = &mut *((*c).frame_thread.out_delayed)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ use crate::src::data::dav1d_data_ref;
 use crate::src::data::dav1d_data_unref_internal;
 use crate::src::data::dav1d_data_wrap_internal;
 use crate::src::data::dav1d_data_wrap_user_data_internal;
+use crate::src::decode::dav1d_decode_frame_exit;
 use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
 use crate::src::internal::CodedBlockInfo;
 use crate::src::internal::Dav1dContext;
@@ -144,7 +145,6 @@ extern "C" {
         out: *mut Dav1dPicture,
         in_0: *const Dav1dPicture,
     );
-    fn dav1d_decode_frame_exit(f: *mut Dav1dFrameContext, retval: c_int);
 }
 
 #[repr(C)]

--- a/src/log.rs
+++ b/src/log.rs
@@ -18,7 +18,6 @@ pub unsafe extern "C" fn dav1d_log_default_callback(
     vfprintf(stderr, format, ap.as_va_list());
 }
 
-#[no_mangle]
 #[cold]
 pub unsafe extern "C" fn dav1d_log(c: *mut Dav1dContext, format: *const c_char, args: ...) {
     if c.is_null() {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -103,6 +103,7 @@ use crate::src::r#ref::dav1d_ref_create;
 use crate::src::r#ref::dav1d_ref_create_using_pool;
 use crate::src::r#ref::dav1d_ref_dec;
 use crate::src::r#ref::dav1d_ref_inc;
+use crate::src::r#ref::dav1d_ref_is_writable;
 use crate::src::r#ref::Dav1dRef;
 use crate::src::tables::dav1d_default_wm_params;
 use crate::src::thread_task::FRAME_ERROR;
@@ -1937,6 +1938,8 @@ pub unsafe extern "C" fn dav1d_parse_obus(
                         return -(12 as c_int);
                     }
                 }
+                // ensure that the reference is writable
+                debug_assert!(dav1d_ref_is_writable((*c).frame_hdr_ref) != 0);
                 (*c).frame_hdr = (*(*c).frame_hdr_ref).data as *mut Dav1dFrameHeader;
                 memset(
                     (*c).frame_hdr as *mut c_void,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -90,6 +90,7 @@ use crate::src::levels::OBU_META_HDR_MDCV;
 use crate::src::levels::OBU_META_ITUT_T35;
 use crate::src::levels::OBU_META_SCALABILITY;
 use crate::src::levels::OBU_META_TIMECODE;
+use crate::src::log::dav1d_log;
 use crate::src::picture::dav1d_picture_get_event_flags;
 use crate::src::picture::dav1d_thread_picture_ref;
 use crate::src::picture::dav1d_thread_picture_unref;
@@ -118,10 +119,6 @@ use std::ffi::c_long;
 use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn dav1d_log(c: *mut Dav1dContext, format: *const c_char, _: ...);
-}
 
 #[inline]
 unsafe extern "C" fn dav1d_get_bits_pos(c: *const GetBits) -> c_uint {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1633,12 +1633,7 @@ unsafe extern "C" fn dav1d_parse_obus_skip(
     return len.wrapping_add(init_byte_pos) as c_int;
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_parse_obus(
-    c: *mut Dav1dContext,
-    in_0: *mut Dav1dData,
-    global: c_int,
-) -> c_int {
+pub unsafe fn dav1d_parse_obus(c: *mut Dav1dContext, in_0: *mut Dav1dData, global: c_int) -> c_int {
     let mut gb: GetBits = GetBits {
         state: 0,
         bits_left: 0,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2273,7 +2273,7 @@ pub unsafe extern "C" fn dav1d_parse_obus(
             if (*c).n_tile_data == 0 {
                 return dav1d_parse_obus_error(c, in_0);
             }
-            res = dav1d_submit_frame(c);
+            res = dav1d_submit_frame(&mut *c);
             if res < 0 {
                 return res;
             }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -69,6 +69,7 @@ use crate::src::cdf::dav1d_cdf_thread_unref;
 use crate::src::data::dav1d_data_props_copy;
 use crate::src::data::dav1d_data_ref;
 use crate::src::data::dav1d_data_unref_internal;
+use crate::src::decode::dav1d_submit_frame;
 use crate::src::env::get_poc_diff;
 use crate::src::getbits::dav1d_bytealign_get_bits;
 use crate::src::getbits::dav1d_get_bit;
@@ -119,7 +120,6 @@ use std::ffi::c_ulong;
 use std::ffi::c_void;
 
 extern "C" {
-    fn dav1d_submit_frame(c: *mut Dav1dContext) -> c_int;
     fn dav1d_log(c: *mut Dav1dContext, format: *const c_char, _: ...);
 }
 

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -236,8 +236,7 @@ unsafe extern "C" fn picture_alloc_with_edges(
     return 0 as c_int;
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_thread_picture_alloc(
+pub unsafe fn dav1d_thread_picture_alloc(
     c: *mut Dav1dContext,
     f: *mut Dav1dFrameContext,
     bpc: c_int,

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -19,6 +19,7 @@ use crate::src::data::dav1d_data_props_copy;
 use crate::src::data::dav1d_data_props_set_defaults;
 use crate::src::internal::Dav1dContext;
 use crate::src::internal::Dav1dFrameContext;
+use crate::src::log::dav1d_log;
 use crate::src::mem::dav1d_mem_pool_pop;
 use crate::src::mem::dav1d_mem_pool_push;
 use crate::src::mem::Dav1dMemPool;
@@ -39,10 +40,6 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn dav1d_log(c: *mut Dav1dContext, format: *const c_char, _: ...);
-}
 
 pub type PictureFlags = c_uint;
 pub const PICTURE_FLAG_NEW_TEMPORAL_UNIT: PictureFlags = 4;

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -291,8 +291,7 @@ pub unsafe fn dav1d_thread_picture_alloc(
     return res;
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_picture_alloc_copy(
+pub unsafe fn dav1d_picture_alloc_copy(
     c: *mut Dav1dContext,
     dst: *mut Dav1dPicture,
     w: c_int,

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -128,8 +128,7 @@ pub unsafe fn dav1d_ref_dec(pref: *mut *mut Dav1dRef) {
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_ref_is_writable(r#ref: *mut Dav1dRef) -> c_int {
+pub unsafe fn dav1d_ref_is_writable(r#ref: *mut Dav1dRef) -> c_int {
     return (::core::intrinsics::atomic_load_seqcst(&mut (*r#ref).ref_cnt as *mut atomic_int) == 1
         && !((*r#ref).data).is_null()) as c_int;
 }

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1659,9 +1659,8 @@ unsafe extern "C" fn refmvs_dsp_init_arm(c: *mut Dav1dRefmvsDSPContext) {
     }
 }
 
-#[no_mangle]
 #[cold]
-pub unsafe extern "C" fn dav1d_refmvs_dsp_init(c: *mut Dav1dRefmvsDSPContext) {
+pub unsafe fn dav1d_refmvs_dsp_init(c: *mut Dav1dRefmvsDSPContext) {
     (*c).load_tmvs = Some(load_tmvs_c);
     (*c).save_tmvs = Some(save_tmvs_c);
     (*c).splat_mv = Some(splat_mv_rust);

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -555,8 +555,7 @@ pub unsafe fn dav1d_task_frame_init(f: *mut Dav1dFrameContext) {
     insert_task(f, t, 1 as c_int);
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_task_delayed_fg(
+pub unsafe fn dav1d_task_delayed_fg(
     c: *mut Dav1dContext,
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -5,6 +5,10 @@ use crate::include::dav1d::picture::Dav1dPicture;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
 use crate::src::cdf::dav1d_cdf_thread_update;
+use crate::src::decode::dav1d_decode_frame_exit;
+use crate::src::decode::dav1d_decode_frame_init;
+use crate::src::decode::dav1d_decode_frame_init_cdf;
+use crate::src::decode::dav1d_decode_tile_sbrow;
 use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
 use crate::src::internal::Dav1dContext;
 use crate::src::internal::Dav1dFrameContext;
@@ -48,10 +52,6 @@ use libc::prctl;
 use libc::pthread_setname_np;
 
 extern "C" {
-    fn dav1d_decode_frame_init(f: *mut Dav1dFrameContext) -> c_int;
-    fn dav1d_decode_frame_init_cdf(f: *mut Dav1dFrameContext) -> c_int;
-    fn dav1d_decode_tile_sbrow(t: *mut Dav1dTaskContext) -> c_int;
-    fn dav1d_decode_frame_exit(f: *mut Dav1dFrameContext, retval: c_int);
     #[cfg(feature = "bitdepth_8")]
     fn dav1d_prep_grain_8bpc(
         dsp: *const Dav1dFilmGrainDSPContext,

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -543,8 +543,7 @@ pub unsafe fn dav1d_task_create_tile_sbrow(
     return 0 as c_int;
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_task_frame_init(f: *mut Dav1dFrameContext) {
+pub unsafe fn dav1d_task_frame_init(f: *mut Dav1dFrameContext) {
     let c: *const Dav1dContext = (*f).c;
     ::core::intrinsics::atomic_store_seqcst(&mut (*f).task_thread.init_done, 0 as c_int);
     let t: *mut Dav1dTask = &mut (*f).task_thread.init_task;

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -461,8 +461,7 @@ unsafe extern "C" fn create_filter_sbrow(
     return 0 as c_int;
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_task_create_tile_sbrow(
+pub unsafe fn dav1d_task_create_tile_sbrow(
     f: *mut Dav1dFrameContext,
     pass: c_int,
     _cond_signal: c_int,

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -744,7 +744,7 @@ unsafe extern "C" fn abort_frame(f: *mut Dav1dFrameContext, error: c_int) {
         &mut *((*f).sr_cur.progress).offset(1) as *mut atomic_uint,
         FRAME_ERROR,
     );
-    dav1d_decode_frame_exit(f, error);
+    dav1d_decode_frame_exit(&mut *f, error);
     (*f).n_tile_data = 0 as c_int;
     pthread_cond_signal(&mut (*f).task_thread.cond);
 }
@@ -1222,7 +1222,7 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                     if !((*c).n_fc > 1 as c_uint) {
                                         unreachable!();
                                     }
-                                    let res = dav1d_decode_frame_init(f);
+                                    let res = dav1d_decode_frame_init(&mut *f);
                                     let p1_3 = (if !((*f).in_cdf.progress).is_null() {
                                         ::core::intrinsics::atomic_load_seqcst((*f).in_cdf.progress)
                                     } else {
@@ -1252,7 +1252,7 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                         &mut (*f).task_thread.error as *mut atomic_int,
                                     ) == 0
                                     {
-                                        res_0 = dav1d_decode_frame_init_cdf(f);
+                                        res_0 = dav1d_decode_frame_init_cdf(&mut *f);
                                     }
                                     if (*(*f).frame_hdr).refresh_context != 0
                                         && !(*f).task_thread.update_set
@@ -1311,7 +1311,10 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                                     {
                                                         unreachable!();
                                                     }
-                                                    dav1d_decode_frame_exit(f, -(12 as c_int));
+                                                    dav1d_decode_frame_exit(
+                                                        &mut *f,
+                                                        -(12 as c_int),
+                                                    );
                                                     (*f).n_tile_data = 0 as c_int;
                                                     pthread_cond_signal(&mut (*f).task_thread.cond);
                                                 } else {
@@ -1453,7 +1456,7 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                                 ) != 0)
                                         {
                                             dav1d_decode_frame_exit(
-                                                f,
+                                                &mut *f,
                                                 if error_0 == 1 {
                                                     -(22 as c_int)
                                                 } else if error_0 != 0 {
@@ -1708,7 +1711,7 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                     ) != 0
                                 {
                                     dav1d_decode_frame_exit(
-                                        f,
+                                        &mut *f,
                                         if error_0 == 1 {
                                             -(22 as c_int)
                                         } else if error_0 != 0 {
@@ -1773,7 +1776,7 @@ pub unsafe extern "C" fn dav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                         ) != 0)
                                 {
                                     dav1d_decode_frame_exit(
-                                        f,
+                                        &mut *f,
                                         if error_0 == 1 {
                                             -(22 as c_int)
                                         } else if error_0 != 0 {


### PR DESCRIPTION
The `#[no_mangle]`s that are remaining are:
* Bitdepth-specific `fn`s (many of these)
* `*_c` `fn`s (many of these)
* `DAV1D_API` `fn`s, which must remain `#[no_mangle]`
* `static`s used by asm, which must remain `#[no_mangle]`
* `fn`s not in the `rav1d` library (e.x. in `tools/`), which are lower priority