### PR TITLE
`tools/`: Deduplicate everything trivial

### DIFF
--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -20,6 +20,8 @@ mod output {
 } // mod output
 #[path = "../tools/dav1d_cli_parse.rs"]
 mod dav1d_cli_parse;
+
+use crate::dav1d_cli_parse::CLISettings;
 use rav1d::include::dav1d::common::Dav1dDataProps;
 use rav1d::include::dav1d::common::Dav1dUserData;
 use rav1d::include::dav1d::data::Dav1dData;
@@ -81,23 +83,6 @@ extern "C" {
         cli_settings: *mut CLISettings,
         lib_settings: *mut Dav1dSettings,
     );
-}
-
-#[repr(C)]
-pub struct CLISettings {
-    pub outputfile: *const c_char,
-    pub inputfile: *const c_char,
-    pub demuxer: *const c_char,
-    pub muxer: *const c_char,
-    pub frametimes: *const c_char,
-    pub verify: *const c_char,
-    pub limit: c_uint,
-    pub skip: c_uint,
-    pub quiet: c_int,
-    pub realtime: CLISettings_realtime,
-    pub realtime_fps: c_double,
-    pub realtime_cache: c_uint,
-    pub neg_stride: c_int,
 }
 
 pub type CLISettings_realtime = c_uint;

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -24,6 +24,10 @@ mod dav1d_cli_parse;
 use crate::dav1d_cli_parse::parse;
 use crate::dav1d_cli_parse::CLISettings;
 use crate::dav1d_cli_parse::REALTIME_DISABLE;
+use crate::input::input::input_close;
+use crate::input::input::input_open;
+use crate::input::input::input_read;
+use crate::input::input::input_seek;
 use crate::input::input::DemuxerContext;
 use rav1d::include::dav1d::common::Dav1dDataProps;
 use rav1d::include::dav1d::common::Dav1dUserData;
@@ -66,20 +70,6 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_ulonglong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn input_open(
-        c_out: *mut *mut DemuxerContext,
-        name: *const c_char,
-        filename: *const c_char,
-        fps: *mut c_uint,
-        num_frames: *mut c_uint,
-        timebase: *mut c_uint,
-    ) -> c_int;
-    fn input_read(ctx: *mut DemuxerContext, data: *mut Dav1dData) -> c_int;
-    fn input_seek(ctx: *mut DemuxerContext, pts: u64) -> c_int;
-    fn input_close(ctx: *mut DemuxerContext);
-}
 
 unsafe extern "C" fn get_seed() -> c_uint {
     let mut ts: libc::timespec = libc::timespec {

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -22,6 +22,7 @@ mod output {
 mod dav1d_cli_parse;
 
 use crate::dav1d_cli_parse::CLISettings;
+use crate::dav1d_cli_parse::REALTIME_DISABLE;
 use rav1d::include::dav1d::common::Dav1dDataProps;
 use rav1d::include::dav1d::common::Dav1dUserData;
 use rav1d::include::dav1d::data::Dav1dData;
@@ -84,12 +85,6 @@ extern "C" {
         lib_settings: *mut Dav1dSettings,
     );
 }
-
-pub type CLISettings_realtime = c_uint;
-
-pub const REALTIME_CUSTOM: CLISettings_realtime = 2;
-pub const REALTIME_INPUT: CLISettings_realtime = 1;
-pub const REALTIME_DISABLE: CLISettings_realtime = 0;
 
 unsafe extern "C" fn get_seed() -> c_uint {
     let mut ts: libc::timespec = libc::timespec {

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -6,7 +6,7 @@
 #[path = "../tools/input"]
 mod input {
     mod annexb;
-    mod input;
+    pub mod input;
     mod ivf;
     mod section5;
 } // mod input
@@ -24,6 +24,7 @@ mod dav1d_cli_parse;
 use crate::dav1d_cli_parse::parse;
 use crate::dav1d_cli_parse::CLISettings;
 use crate::dav1d_cli_parse::REALTIME_DISABLE;
+use crate::input::input::DemuxerContext;
 use rav1d::include::dav1d::common::Dav1dDataProps;
 use rav1d::include::dav1d::common::Dav1dUserData;
 use rav1d::include::dav1d::data::Dav1dData;
@@ -67,7 +68,6 @@ use std::ffi::c_ulonglong;
 use std::ffi::c_void;
 
 extern "C" {
-    pub type DemuxerContext;
     fn input_open(
         c_out: *mut *mut DemuxerContext,
         name: *const c_char,

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -21,6 +21,7 @@ mod output {
 #[path = "../tools/dav1d_cli_parse.rs"]
 mod dav1d_cli_parse;
 
+use crate::dav1d_cli_parse::parse;
 use crate::dav1d_cli_parse::CLISettings;
 use crate::dav1d_cli_parse::REALTIME_DISABLE;
 use rav1d::include::dav1d::common::Dav1dDataProps;
@@ -78,12 +79,6 @@ extern "C" {
     fn input_read(ctx: *mut DemuxerContext, data: *mut Dav1dData) -> c_int;
     fn input_seek(ctx: *mut DemuxerContext, pts: u64) -> c_int;
     fn input_close(ctx: *mut DemuxerContext);
-    fn parse(
-        argc: c_int,
-        argv: *const *mut c_char,
-        cli_settings: *mut CLISettings,
-        lib_settings: *mut Dav1dSettings,
-    );
 }
 
 unsafe extern "C" fn get_seed() -> c_uint {

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -22,7 +22,14 @@ use crate::dav1d_cli_parse::parse;
 use crate::dav1d_cli_parse::CLISettings;
 use crate::dav1d_cli_parse::REALTIME_CUSTOM;
 use crate::dav1d_cli_parse::REALTIME_DISABLE;
+use crate::input::input::input_close;
+use crate::input::input::input_open;
+use crate::input::input::input_read;
 use crate::input::input::DemuxerContext;
+use crate::output::output::output_close;
+use crate::output::output::output_open;
+use crate::output::output::output_verify;
+use crate::output::output::output_write;
 use crate::output::output::MuxerContext;
 use libc::fclose;
 use libc::fflush;
@@ -80,29 +87,6 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_ulonglong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn input_open(
-        c_out: *mut *mut DemuxerContext,
-        name: *const c_char,
-        filename: *const c_char,
-        fps: *mut c_uint,
-        num_frames: *mut c_uint,
-        timebase: *mut c_uint,
-    ) -> c_int;
-    fn input_read(ctx: *mut DemuxerContext, data: *mut Dav1dData) -> c_int;
-    fn input_close(ctx: *mut DemuxerContext);
-    fn output_open(
-        c: *mut *mut MuxerContext,
-        name: *const c_char,
-        filename: *const c_char,
-        p: *const Dav1dPictureParameters,
-        fps: *const c_uint,
-    ) -> c_int;
-    fn output_write(ctx: *mut MuxerContext, pic: *mut Dav1dPicture) -> c_int;
-    fn output_close(ctx: *mut MuxerContext);
-    fn output_verify(ctx: *mut MuxerContext, hash_string: *const c_char) -> c_int;
-}
 
 unsafe extern "C" fn get_time_nanos() -> u64 {
     let mut ts: libc::timespec = libc::timespec {

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -18,6 +18,7 @@ mod output {
 } // mod output
 mod dav1d_cli_parse;
 
+use crate::dav1d_cli_parse::parse;
 use crate::dav1d_cli_parse::CLISettings;
 use crate::dav1d_cli_parse::REALTIME_CUSTOM;
 use crate::dav1d_cli_parse::REALTIME_DISABLE;
@@ -101,12 +102,6 @@ extern "C" {
     fn output_write(ctx: *mut MuxerContext, pic: *mut Dav1dPicture) -> c_int;
     fn output_close(ctx: *mut MuxerContext);
     fn output_verify(ctx: *mut MuxerContext, hash_string: *const c_char) -> c_int;
-    fn parse(
-        argc: c_int,
-        argv: *const *mut c_char,
-        cli_settings: *mut CLISettings,
-        lib_settings: *mut Dav1dSettings,
-    );
 }
 
 unsafe extern "C" fn get_time_nanos() -> u64 {

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -5,7 +5,7 @@
 
 mod input {
     mod annexb;
-    mod input;
+    pub mod input;
     mod ivf;
     mod section5;
 } // mod input
@@ -22,6 +22,7 @@ use crate::dav1d_cli_parse::parse;
 use crate::dav1d_cli_parse::CLISettings;
 use crate::dav1d_cli_parse::REALTIME_CUSTOM;
 use crate::dav1d_cli_parse::REALTIME_DISABLE;
+use crate::input::input::DemuxerContext;
 use crate::output::output::MuxerContext;
 use libc::fclose;
 use libc::fflush;
@@ -81,7 +82,6 @@ use std::ffi::c_ulonglong;
 use std::ffi::c_void;
 
 extern "C" {
-    pub type DemuxerContext;
     fn input_open(
         c_out: *mut *mut DemuxerContext,
         name: *const c_char,

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -19,6 +19,8 @@ mod output {
 mod dav1d_cli_parse;
 
 use crate::dav1d_cli_parse::CLISettings;
+use crate::dav1d_cli_parse::REALTIME_CUSTOM;
+use crate::dav1d_cli_parse::REALTIME_DISABLE;
 use libc::fclose;
 use libc::fflush;
 use libc::fileno;
@@ -106,11 +108,6 @@ extern "C" {
         lib_settings: *mut Dav1dSettings,
     );
 }
-
-pub type CLISettings_realtime = c_uint;
-pub const REALTIME_CUSTOM: CLISettings_realtime = 2;
-pub const REALTIME_INPUT: CLISettings_realtime = 1;
-pub const REALTIME_DISABLE: CLISettings_realtime = 0;
 
 unsafe extern "C" fn get_time_nanos() -> u64 {
     let mut ts: libc::timespec = libc::timespec {

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -17,6 +17,8 @@ mod output {
     mod yuv;
 } // mod output
 mod dav1d_cli_parse;
+
+use crate::dav1d_cli_parse::CLISettings;
 use libc::fclose;
 use libc::fflush;
 use libc::fileno;
@@ -103,23 +105,6 @@ extern "C" {
         cli_settings: *mut CLISettings,
         lib_settings: *mut Dav1dSettings,
     );
-}
-
-#[repr(C)]
-pub struct CLISettings {
-    pub outputfile: *const c_char,
-    pub inputfile: *const c_char,
-    pub demuxer: *const c_char,
-    pub muxer: *const c_char,
-    pub frametimes: *const c_char,
-    pub verify: *const c_char,
-    pub limit: c_uint,
-    pub skip: c_uint,
-    pub quiet: c_int,
-    pub realtime: CLISettings_realtime,
-    pub realtime_fps: c_double,
-    pub realtime_cache: c_uint,
-    pub neg_stride: c_int,
 }
 
 pub type CLISettings_realtime = c_uint;

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -12,7 +12,7 @@ mod input {
 mod output {
     mod md5;
     mod null;
-    mod output;
+    pub mod output;
     mod y4m2;
     mod yuv;
 } // mod output
@@ -22,6 +22,7 @@ use crate::dav1d_cli_parse::parse;
 use crate::dav1d_cli_parse::CLISettings;
 use crate::dav1d_cli_parse::REALTIME_CUSTOM;
 use crate::dav1d_cli_parse::REALTIME_DISABLE;
+use crate::output::output::MuxerContext;
 use libc::fclose;
 use libc::fflush;
 use libc::fileno;
@@ -81,7 +82,6 @@ use std::ffi::c_void;
 
 extern "C" {
     pub type DemuxerContext;
-    pub type MuxerContext;
     fn input_open(
         c_out: *mut *mut DemuxerContext,
         name: *const c_char,

--- a/tools/dav1d_cli_parse.rs
+++ b/tools/dav1d_cli_parse.rs
@@ -52,6 +52,15 @@ pub struct option {
     pub val: c_int,
 }
 
+// TODO(kkysen) These are used in `dav1d.rs` and `seek_stress.rs`
+// but are still marked as unused since `[[bin]]` are only supposed to be one file in `cargo`.
+pub type CLISettings_realtime = c_uint;
+#[allow(dead_code)]
+pub const REALTIME_CUSTOM: CLISettings_realtime = 2;
+#[allow(dead_code)]
+pub const REALTIME_INPUT: CLISettings_realtime = 1;
+pub const REALTIME_DISABLE: CLISettings_realtime = 0;
+
 #[repr(C)]
 pub struct CLISettings {
     pub outputfile: *const c_char,
@@ -68,8 +77,6 @@ pub struct CLISettings {
     pub realtime_cache: c_uint,
     pub neg_stride: c_int,
 }
-
-pub type CLISettings_realtime = c_uint;
 
 #[repr(C)]
 pub struct EnumParseTable {

--- a/tools/dav1d_cli_parse.rs
+++ b/tools/dav1d_cli_parse.rs
@@ -1,4 +1,5 @@
 use libc::fprintf;
+use libc::getopt_long;
 use libc::memset;
 use libc::option;
 use libc::sprintf;
@@ -35,13 +36,6 @@ use std::process::exit;
 extern "C" {
     static mut optarg: *mut c_char;
     static mut optind: c_int;
-    fn getopt_long(
-        ___argc: c_int,
-        ___argv: *const *mut c_char,
-        __shortopts: *const c_char,
-        __longopts: *const option,
-        __longind: *mut c_int,
-    ) -> c_int;
     fn vfprintf(_: *mut libc::FILE, _: *const c_char, _: ::core::ffi::VaList) -> c_int;
 }
 

--- a/tools/dav1d_cli_parse.rs
+++ b/tools/dav1d_cli_parse.rs
@@ -1,5 +1,6 @@
 use libc::fprintf;
 use libc::memset;
+use libc::option;
 use libc::sprintf;
 use libc::strcat;
 use libc::strcmp;
@@ -42,14 +43,6 @@ extern "C" {
         __longind: *mut c_int,
     ) -> c_int;
     fn vfprintf(_: *mut libc::FILE, _: *const c_char, _: ::core::ffi::VaList) -> c_int;
-}
-
-#[repr(C)]
-pub struct option {
-    pub name: *const c_char,
-    pub has_arg: c_int,
-    pub flag: *mut c_int,
-    pub val: c_int,
 }
 
 // TODO(kkysen) These are used in `dav1d.rs` and `seek_stress.rs`

--- a/tools/dav1d_cli_parse.rs
+++ b/tools/dav1d_cli_parse.rs
@@ -627,8 +627,7 @@ unsafe extern "C" fn parse_enum(
     return res;
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn parse(
+pub unsafe fn parse(
     argc: c_int,
     argv: *const *mut c_char,
     cli_settings: *mut CLISettings,

--- a/tools/input/input.rs
+++ b/tools/input/input.rs
@@ -59,8 +59,7 @@ static mut demuxers: [*const Demuxer; 4] = unsafe {
     ]
 };
 
-#[no_mangle]
-pub unsafe extern "C" fn input_open(
+pub unsafe fn input_open(
     c_out: *mut *mut DemuxerContext,
     name: *const c_char,
     filename: *const c_char,
@@ -181,13 +180,14 @@ pub unsafe extern "C" fn input_open(
     return 0 as c_int;
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn input_read(ctx: *mut DemuxerContext, data: *mut Dav1dData) -> c_int {
+pub unsafe fn input_read(ctx: *mut DemuxerContext, data: *mut Dav1dData) -> c_int {
     return ((*(*ctx).impl_0).read).expect("non-null function pointer")((*ctx).data, data);
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn input_seek(ctx: *mut DemuxerContext, pts: u64) -> c_int {
+// TODO(kkysen) These are used in `dav1d.rs` and `seek_stress.rs`
+// but are still marked as unused since `[[bin]]` are only supposed to be one file in `cargo`.
+#[allow(dead_code)]
+pub unsafe fn input_seek(ctx: *mut DemuxerContext, pts: u64) -> c_int {
     return if ((*(*ctx).impl_0).seek).is_some() {
         ((*(*ctx).impl_0).seek).expect("non-null function pointer")((*ctx).data, pts)
     } else {
@@ -195,8 +195,7 @@ pub unsafe extern "C" fn input_seek(ctx: *mut DemuxerContext, pts: u64) -> c_int
     };
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn input_close(ctx: *mut DemuxerContext) {
+pub unsafe fn input_close(ctx: *mut DemuxerContext) {
     ((*(*ctx).impl_0).close).expect("non-null function pointer")((*ctx).data);
     free(ctx as *mut c_void);
 }

--- a/tools/output/output.rs
+++ b/tools/output/output.rs
@@ -89,8 +89,10 @@ unsafe extern "C" fn find_extension(f: *const c_char) -> *const c_char {
     };
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn output_open(
+// TODO(kkysen) These are used in `dav1d.rs` and `seek_stress.rs`
+// but are still marked as unused since `[[bin]]` are only supposed to be one file in `cargo`.
+#[allow(dead_code)]
+pub unsafe fn output_open(
     c_out: *mut *mut MuxerContext,
     name: *const c_char,
     filename: *const c_char,
@@ -348,8 +350,10 @@ unsafe extern "C" fn assemble_filename(
     safe_strncat(filename, filename_size, ptr, strlen(ptr) as c_int);
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn output_write(ctx: *mut MuxerContext, p: *mut Dav1dPicture) -> c_int {
+// TODO(kkysen) These are used in `dav1d.rs` and `seek_stress.rs`
+// but are still marked as unused since `[[bin]]` are only supposed to be one file in `cargo`.
+#[allow(dead_code)]
+pub unsafe fn output_write(ctx: *mut MuxerContext, p: *mut Dav1dPicture) -> c_int {
     let mut res;
     if (*ctx).one_file_per_frame != 0 && ((*(*ctx).impl_0).write_header).is_some() {
         let mut filename: [c_char; 1024] = [0; 1024];
@@ -379,16 +383,20 @@ pub unsafe extern "C" fn output_write(ctx: *mut MuxerContext, p: *mut Dav1dPictu
     return 0 as c_int;
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn output_close(ctx: *mut MuxerContext) {
+// TODO(kkysen) These are used in `dav1d.rs` and `seek_stress.rs`
+// but are still marked as unused since `[[bin]]` are only supposed to be one file in `cargo`.
+#[allow(dead_code)]
+pub unsafe fn output_close(ctx: *mut MuxerContext) {
     if (*ctx).one_file_per_frame == 0 && ((*(*ctx).impl_0).write_trailer).is_some() {
         ((*(*ctx).impl_0).write_trailer).expect("non-null function pointer")((*ctx).data);
     }
     free(ctx as *mut c_void);
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn output_verify(ctx: *mut MuxerContext, md5_str: *const c_char) -> c_int {
+// TODO(kkysen) These are used in `dav1d.rs` and `seek_stress.rs`
+// but are still marked as unused since `[[bin]]` are only supposed to be one file in `cargo`.
+#[allow(dead_code)]
+pub unsafe fn output_verify(ctx: *mut MuxerContext, md5_str: *const c_char) -> c_int {
     let res = if ((*(*ctx).impl_0).verify).is_some() {
         ((*(*ctx).impl_0).verify).expect("non-null function pointer")((*ctx).data, md5_str)
     } else {


### PR DESCRIPTION
There are some non-trivial things with type-erased/dynamic types that I've left as is for now.