### PR TITLE
`fn dav1d_*_{8,16}bpc`: Deduplicate declarations into `use` imports

### DIFF
--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -155,8 +155,7 @@ unsafe extern "C" fn adjust_strength(strength: c_int, var: c_uint) -> c_int {
     return strength * (4 + i) + 8 >> 4;
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_cdef_brow_16bpc(
+pub unsafe fn dav1d_cdef_brow_16bpc(
     tc: *mut Dav1dTaskContext,
     p: *const *mut pixel,
     lflvl: *const Av1Filter,

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -147,8 +147,7 @@ unsafe extern "C" fn adjust_strength(strength: c_int, var: c_uint) -> c_int {
     return strength * (4 + i) + 8 >> 4;
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_cdef_brow_8bpc(
+pub unsafe fn dav1d_cdef_brow_8bpc(
     tc: *mut Dav1dTaskContext,
     p: *const *mut pixel,
     lflvl: *const Av1Filter,

--- a/src/cdef_tmpl_16.rs
+++ b/src/cdef_tmpl_16.rs
@@ -675,9 +675,8 @@ unsafe extern "C" fn cdef_filter_4x4_neon_erased(
     );
 }
 
-#[no_mangle]
 #[cold]
-pub unsafe extern "C" fn dav1d_cdef_dsp_init_16bpc(c: *mut Dav1dCdefDSPContext) {
+pub unsafe fn dav1d_cdef_dsp_init_16bpc(c: *mut Dav1dCdefDSPContext) {
     (*c).dir = cdef_find_dir_c_erased;
     (*c).fb[0] = cdef_filter_block_8x8_c_erased;
     (*c).fb[1] = cdef_filter_block_4x8_c_erased;

--- a/src/cdef_tmpl_8.rs
+++ b/src/cdef_tmpl_8.rs
@@ -669,9 +669,8 @@ unsafe extern "C" fn cdef_filter_8x8_neon_erased(
     );
 }
 
-#[no_mangle]
 #[cold]
-pub unsafe extern "C" fn dav1d_cdef_dsp_init_8bpc(c: *mut Dav1dCdefDSPContext) {
+pub unsafe fn dav1d_cdef_dsp_init_8bpc(c: *mut Dav1dCdefDSPContext) {
     (*c).dir = cdef_find_dir_c_erased;
     (*c).fb[0] = cdef_filter_block_8x8_c_erased;
     (*c).fb[1] = cdef_filter_block_4x8_c_erased;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -243,6 +243,14 @@ use crate::{
     src::filmgrain_tmpl_8::dav1d_film_grain_dsp_init_8bpc,
     src::ipred_tmpl_8::dav1d_intra_pred_dsp_init_8bpc, src::itx_tmpl_8::dav1d_itx_dsp_init_8bpc,
     src::loopfilter_tmpl_8::dav1d_loop_filter_dsp_init_8bpc,
+    src::recon_tmpl_8::dav1d_backup_ipred_edge_8bpc, src::recon_tmpl_8::dav1d_filter_sbrow_8bpc,
+    src::recon_tmpl_8::dav1d_filter_sbrow_cdef_8bpc,
+    src::recon_tmpl_8::dav1d_filter_sbrow_deblock_cols_8bpc,
+    src::recon_tmpl_8::dav1d_filter_sbrow_deblock_rows_8bpc,
+    src::recon_tmpl_8::dav1d_filter_sbrow_lr_8bpc,
+    src::recon_tmpl_8::dav1d_filter_sbrow_resize_8bpc,
+    src::recon_tmpl_8::dav1d_read_coef_blocks_8bpc, src::recon_tmpl_8::dav1d_recon_b_inter_8bpc,
+    src::recon_tmpl_8::dav1d_recon_b_intra_8bpc,
 };
 
 #[cfg(feature = "bitdepth_16")]
@@ -252,68 +260,16 @@ use crate::{
     src::ipred_tmpl_16::dav1d_intra_pred_dsp_init_16bpc,
     src::itx_tmpl_16::dav1d_itx_dsp_init_16bpc,
     src::loopfilter_tmpl_16::dav1d_loop_filter_dsp_init_16bpc,
+    src::recon_tmpl_16::dav1d_backup_ipred_edge_16bpc,
+    src::recon_tmpl_16::dav1d_filter_sbrow_16bpc,
+    src::recon_tmpl_16::dav1d_filter_sbrow_cdef_16bpc,
+    src::recon_tmpl_16::dav1d_filter_sbrow_deblock_cols_16bpc,
+    src::recon_tmpl_16::dav1d_filter_sbrow_deblock_rows_16bpc,
+    src::recon_tmpl_16::dav1d_filter_sbrow_lr_16bpc,
+    src::recon_tmpl_16::dav1d_filter_sbrow_resize_16bpc,
+    src::recon_tmpl_16::dav1d_read_coef_blocks_16bpc,
+    src::recon_tmpl_16::dav1d_recon_b_inter_16bpc, src::recon_tmpl_16::dav1d_recon_b_intra_16bpc,
 };
-
-extern "C" {
-    #[cfg(feature = "bitdepth_8")]
-    fn dav1d_recon_b_intra_8bpc(
-        t: *mut Dav1dTaskContext,
-        bs: BlockSize,
-        intra_edge_flags: EdgeFlags,
-        b: *const Av1Block,
-    );
-    #[cfg(feature = "bitdepth_16")]
-    fn dav1d_recon_b_intra_16bpc(
-        t: *mut Dav1dTaskContext,
-        bs: BlockSize,
-        intra_edge_flags: EdgeFlags,
-        b: *const Av1Block,
-    );
-    #[cfg(feature = "bitdepth_8")]
-    fn dav1d_recon_b_inter_8bpc(
-        t: *mut Dav1dTaskContext,
-        bs: BlockSize,
-        b: *const Av1Block,
-    ) -> c_int;
-    #[cfg(feature = "bitdepth_16")]
-    fn dav1d_recon_b_inter_16bpc(
-        t: *mut Dav1dTaskContext,
-        bs: BlockSize,
-        b: *const Av1Block,
-    ) -> c_int;
-    #[cfg(feature = "bitdepth_8")]
-    fn dav1d_filter_sbrow_8bpc(f: *mut Dav1dFrameContext, sby: c_int);
-    #[cfg(feature = "bitdepth_16")]
-    fn dav1d_filter_sbrow_16bpc(f: *mut Dav1dFrameContext, sby: c_int);
-    #[cfg(feature = "bitdepth_8")]
-    fn dav1d_filter_sbrow_deblock_cols_8bpc(f: *mut Dav1dFrameContext, sby: c_int);
-    #[cfg(feature = "bitdepth_16")]
-    fn dav1d_filter_sbrow_deblock_cols_16bpc(f: *mut Dav1dFrameContext, sby: c_int);
-    #[cfg(feature = "bitdepth_8")]
-    fn dav1d_filter_sbrow_deblock_rows_8bpc(f: *mut Dav1dFrameContext, sby: c_int);
-    #[cfg(feature = "bitdepth_16")]
-    fn dav1d_filter_sbrow_deblock_rows_16bpc(f: *mut Dav1dFrameContext, sby: c_int);
-    #[cfg(feature = "bitdepth_8")]
-    fn dav1d_filter_sbrow_cdef_8bpc(tc: *mut Dav1dTaskContext, sby: c_int);
-    #[cfg(feature = "bitdepth_16")]
-    fn dav1d_filter_sbrow_cdef_16bpc(tc: *mut Dav1dTaskContext, sby: c_int);
-    #[cfg(feature = "bitdepth_8")]
-    fn dav1d_filter_sbrow_resize_8bpc(f: *mut Dav1dFrameContext, sby: c_int);
-    #[cfg(feature = "bitdepth_16")]
-    fn dav1d_filter_sbrow_resize_16bpc(f: *mut Dav1dFrameContext, sby: c_int);
-    #[cfg(feature = "bitdepth_8")]
-    fn dav1d_filter_sbrow_lr_8bpc(f: *mut Dav1dFrameContext, sby: c_int);
-    #[cfg(feature = "bitdepth_16")]
-    fn dav1d_filter_sbrow_lr_16bpc(f: *mut Dav1dFrameContext, sby: c_int);
-    #[cfg(feature = "bitdepth_8")]
-    fn dav1d_backup_ipred_edge_8bpc(t: *mut Dav1dTaskContext);
-    #[cfg(feature = "bitdepth_16")]
-    fn dav1d_backup_ipred_edge_16bpc(t: *mut Dav1dTaskContext);
-    #[cfg(feature = "bitdepth_8")]
-    fn dav1d_read_coef_blocks_8bpc(t: *mut Dav1dTaskContext, bs: BlockSize, b: *const Av1Block);
-    #[cfg(feature = "bitdepth_16")]
-    fn dav1d_read_coef_blocks_16bpc(t: *mut Dav1dTaskContext, bs: BlockSize, b: *const Av1Block);
-}
 
 fn init_quant_tables(
     seq_hdr: &Dav1dSequenceHeader,

--- a/src/fg_apply_tmpl_16.rs
+++ b/src/fg_apply_tmpl_16.rs
@@ -99,8 +99,7 @@ unsafe extern "C" fn generate_scaling(
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_prep_grain_16bpc(
+pub unsafe fn dav1d_prep_grain_16bpc(
     dsp: *const Dav1dFilmGrainDSPContext,
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,
@@ -224,8 +223,7 @@ pub unsafe extern "C" fn dav1d_prep_grain_16bpc(
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_apply_grain_row_16bpc(
+pub unsafe fn dav1d_apply_grain_row_16bpc(
     dsp: *const Dav1dFilmGrainDSPContext,
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,

--- a/src/fg_apply_tmpl_16.rs
+++ b/src/fg_apply_tmpl_16.rs
@@ -332,8 +332,7 @@ pub unsafe fn dav1d_apply_grain_row_16bpc(
     };
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_apply_grain_16bpc(
+pub unsafe fn dav1d_apply_grain_16bpc(
     dsp: *const Dav1dFilmGrainDSPContext,
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,

--- a/src/fg_apply_tmpl_8.rs
+++ b/src/fg_apply_tmpl_8.rs
@@ -65,8 +65,7 @@ unsafe extern "C" fn generate_scaling(
     );
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_prep_grain_8bpc(
+pub unsafe fn dav1d_prep_grain_8bpc(
     dsp: *const Dav1dFilmGrainDSPContext,
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,
@@ -189,8 +188,7 @@ pub unsafe extern "C" fn dav1d_prep_grain_8bpc(
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_apply_grain_row_8bpc(
+pub unsafe fn dav1d_apply_grain_row_8bpc(
     dsp: *const Dav1dFilmGrainDSPContext,
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,

--- a/src/fg_apply_tmpl_8.rs
+++ b/src/fg_apply_tmpl_8.rs
@@ -296,8 +296,7 @@ pub unsafe fn dav1d_apply_grain_row_8bpc(
     };
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_apply_grain_8bpc(
+pub unsafe fn dav1d_apply_grain_8bpc(
     dsp: *const Dav1dFilmGrainDSPContext,
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,

--- a/src/filmgrain_tmpl_16.rs
+++ b/src/filmgrain_tmpl_16.rs
@@ -1842,9 +1842,8 @@ unsafe extern "C" fn fguv_32x32xn_444_neon(
     }
 }
 
-#[no_mangle]
 #[cold]
-pub unsafe extern "C" fn dav1d_film_grain_dsp_init_16bpc(c: *mut Dav1dFilmGrainDSPContext) {
+pub unsafe fn dav1d_film_grain_dsp_init_16bpc(c: *mut Dav1dFilmGrainDSPContext) {
     (*c).generate_grain_y = Some(generate_grain_y_c_erased);
     (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
         Some(generate_grain_uv_420_c_erased);

--- a/src/filmgrain_tmpl_8.rs
+++ b/src/filmgrain_tmpl_8.rs
@@ -1775,9 +1775,8 @@ unsafe extern "C" fn fguv_32x32xn_444_neon(
     }
 }
 
-#[no_mangle]
 #[cold]
-pub unsafe extern "C" fn dav1d_film_grain_dsp_init_8bpc(c: *mut Dav1dFilmGrainDSPContext) {
+pub unsafe fn dav1d_film_grain_dsp_init_8bpc(c: *mut Dav1dFilmGrainDSPContext) {
     (*c).generate_grain_y = Some(generate_grain_y_c_erased);
     (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
         Some(generate_grain_uv_420_c_erased);

--- a/src/ipred_prepare_tmpl_16.rs
+++ b/src/ipred_prepare_tmpl_16.rs
@@ -89,8 +89,7 @@ static mut av1_intra_prediction_edges: [av1_intra_prediction_edge; 14] =
         needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
     }; N_IMPL_INTRA_PRED_MODES];
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_prepare_intra_edges_16bpc(
+pub unsafe fn dav1d_prepare_intra_edges_16bpc(
     x: c_int,
     have_left: c_int,
     y: c_int,

--- a/src/ipred_prepare_tmpl_8.rs
+++ b/src/ipred_prepare_tmpl_8.rs
@@ -72,8 +72,7 @@ static mut av1_intra_prediction_edges: [av1_intra_prediction_edge; 14] =
         needs_left_needs_top_needs_topleft_needs_topright_needs_bottomleft: [0; 1],
     }; N_IMPL_INTRA_PRED_MODES];
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_prepare_intra_edges_8bpc(
+pub unsafe fn dav1d_prepare_intra_edges_8bpc(
     x: c_int,
     have_left: c_int,
     y: c_int,

--- a/src/ipred_tmpl_16.rs
+++ b/src/ipred_tmpl_16.rs
@@ -2117,9 +2117,8 @@ unsafe fn ipred_z1_neon(
     };
 }
 
-#[no_mangle]
 #[cold]
-pub unsafe extern "C" fn dav1d_intra_pred_dsp_init_16bpc(c: *mut Dav1dIntraPredDSPContext) {
+pub unsafe fn dav1d_intra_pred_dsp_init_16bpc(c: *mut Dav1dIntraPredDSPContext) {
     (*c).intra_pred[DC_PRED as usize] = Some(ipred_dc_c_erased);
     (*c).intra_pred[DC_128_PRED as usize] = Some(ipred_dc_128_c_erased);
     (*c).intra_pred[TOP_DC_PRED as usize] = Some(ipred_dc_top_c_erased);

--- a/src/ipred_tmpl_8.rs
+++ b/src/ipred_tmpl_8.rs
@@ -2036,9 +2036,8 @@ unsafe fn ipred_z1_neon(
     };
 }
 
-#[no_mangle]
 #[cold]
-pub unsafe extern "C" fn dav1d_intra_pred_dsp_init_8bpc(c: *mut Dav1dIntraPredDSPContext) {
+pub unsafe fn dav1d_intra_pred_dsp_init_8bpc(c: *mut Dav1dIntraPredDSPContext) {
     (*c).intra_pred[DC_PRED as usize] = Some(ipred_dc_c_erased);
     (*c).intra_pred[DC_128_PRED as usize] = Some(ipred_dc_128_c_erased);
     (*c).intra_pred[TOP_DC_PRED as usize] = Some(ipred_dc_top_c_erased);

--- a/src/itx_tmpl_16.rs
+++ b/src/itx_tmpl_16.rs
@@ -1039,10 +1039,9 @@ unsafe extern "C" fn itx_dsp_init_arm(c: *mut Dav1dInvTxfmDSPContext, bpc: c_int
         Some(dav1d_inv_txfm_add_dct_dct_64x64_16bpc_neon);
 }
 
-#[no_mangle]
 #[cold]
 #[rustfmt::skip]
-pub unsafe extern "C" fn dav1d_itx_dsp_init_16bpc(
+pub unsafe fn dav1d_itx_dsp_init_16bpc(
     c: *mut Dav1dInvTxfmDSPContext,
     mut _bpc: c_int,
 ) {

--- a/src/itx_tmpl_8.rs
+++ b/src/itx_tmpl_8.rs
@@ -792,10 +792,9 @@ unsafe extern "C" fn itx_dsp_init_arm(c: *mut Dav1dInvTxfmDSPContext, mut _bpc: 
     (*c).itxfm_add[TX_64X64 as usize][DCT_DCT as usize] = Some(dav1d_inv_txfm_add_dct_dct_64x64_8bpc_neon);
 }
 
-#[no_mangle]
 #[cold]
 #[rustfmt::skip]
-pub unsafe extern "C" fn dav1d_itx_dsp_init_8bpc(
+pub unsafe fn dav1d_itx_dsp_init_8bpc(
     c: *mut Dav1dInvTxfmDSPContext,
     mut _bpc: c_int,
 ) {

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -156,12 +156,7 @@ unsafe extern "C" fn backup_lpf(
     };
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_copy_lpf_16bpc(
-    f: *mut Dav1dFrameContext,
-    src: *const *mut pixel,
-    sby: c_int,
-) {
+pub unsafe fn dav1d_copy_lpf_16bpc(f: *mut Dav1dFrameContext, src: *const *mut pixel, sby: c_int) {
     let have_tt = ((*(*f).c).n_tc > 1 as c_uint) as c_int;
     let resize = ((*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1]) as c_int;
     let offset = 8 * (sby != 0) as c_int;
@@ -515,8 +510,7 @@ unsafe extern "C" fn filter_plane_rows_uv(
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_loopfilter_sbrow_cols_16bpc(
+pub unsafe fn dav1d_loopfilter_sbrow_cols_16bpc(
     f: *const Dav1dFrameContext,
     p: *const *mut pixel,
     lflvl: *mut Av1Filter,
@@ -721,8 +715,7 @@ pub unsafe extern "C" fn dav1d_loopfilter_sbrow_cols_16bpc(
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_loopfilter_sbrow_rows_16bpc(
+pub unsafe fn dav1d_loopfilter_sbrow_rows_16bpc(
     f: *const Dav1dFrameContext,
     p: *const *mut pixel,
     lflvl: *mut Av1Filter,

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -123,12 +123,7 @@ unsafe extern "C" fn backup_lpf(
     };
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_copy_lpf_8bpc(
-    f: *mut Dav1dFrameContext,
-    src: *const *mut pixel,
-    sby: c_int,
-) {
+pub unsafe fn dav1d_copy_lpf_8bpc(f: *mut Dav1dFrameContext, src: *const *mut pixel, sby: c_int) {
     let have_tt = ((*(*f).c).n_tc > 1 as c_uint) as c_int;
     let resize = ((*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1]) as c_int;
     let offset = 8 * (sby != 0) as c_int;
@@ -480,8 +475,7 @@ unsafe extern "C" fn filter_plane_rows_uv(
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_loopfilter_sbrow_cols_8bpc(
+pub unsafe fn dav1d_loopfilter_sbrow_cols_8bpc(
     f: *const Dav1dFrameContext,
     p: *const *mut pixel,
     lflvl: *mut Av1Filter,
@@ -686,8 +680,7 @@ pub unsafe extern "C" fn dav1d_loopfilter_sbrow_cols_8bpc(
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_loopfilter_sbrow_rows_8bpc(
+pub unsafe fn dav1d_loopfilter_sbrow_rows_8bpc(
     f: *const Dav1dFrameContext,
     p: *const *mut pixel,
     lflvl: *mut Av1Filter,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,6 @@ use crate::src::data::dav1d_data_unref_internal;
 use crate::src::data::dav1d_data_wrap_internal;
 use crate::src::data::dav1d_data_wrap_user_data_internal;
 use crate::src::decode::dav1d_decode_frame_exit;
-use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
 use crate::src::internal::CodedBlockInfo;
 use crate::src::internal::Dav1dContext;
 use crate::src::internal::Dav1dFrameContext;
@@ -106,6 +105,12 @@ use std::ffi::c_ulong;
 use std::ffi::c_void;
 use std::process::abort;
 
+#[cfg(feature = "bitdepth_8")]
+use crate::src::fg_apply_tmpl_8::dav1d_apply_grain_8bpc;
+
+#[cfg(feature = "bitdepth_16")]
+use crate::src::fg_apply_tmpl_16::dav1d_apply_grain_16bpc;
+
 #[cfg(target_os = "linux")]
 use libc::dlsym;
 
@@ -113,18 +118,6 @@ use libc::dlsym;
 use libc::sysconf;
 
 extern "C" {
-    #[cfg(feature = "bitdepth_16")]
-    fn dav1d_apply_grain_16bpc(
-        dsp: *const Dav1dFilmGrainDSPContext,
-        out: *mut Dav1dPicture,
-        in_0: *const Dav1dPicture,
-    );
-    #[cfg(feature = "bitdepth_8")]
-    fn dav1d_apply_grain_8bpc(
-        dsp: *const Dav1dFilmGrainDSPContext,
-        out: *mut Dav1dPicture,
-        in_0: *const Dav1dPicture,
-    );
     fn pthread_create(
         __newthread: *mut pthread_t,
         __attr: *const pthread_attr_t,

--- a/src/loopfilter_tmpl_16.rs
+++ b/src/loopfilter_tmpl_16.rs
@@ -526,9 +526,8 @@ unsafe extern "C" fn loop_filter_dsp_init_arm(c: *mut Dav1dLoopFilterDSPContext)
     (*c).loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_16bpc_neon;
 }
 
-#[no_mangle]
 #[cold]
-pub unsafe extern "C" fn dav1d_loop_filter_dsp_init_16bpc(c: *mut Dav1dLoopFilterDSPContext) {
+pub unsafe fn dav1d_loop_filter_dsp_init_16bpc(c: *mut Dav1dLoopFilterDSPContext) {
     (*c).loop_filter_sb[0][0] = loop_filter_h_sb128y_c_erased;
     (*c).loop_filter_sb[0][1] = loop_filter_v_sb128y_c_erased;
     (*c).loop_filter_sb[1][0] = loop_filter_h_sb128uv_c_erased;

--- a/src/loopfilter_tmpl_8.rs
+++ b/src/loopfilter_tmpl_8.rs
@@ -454,9 +454,8 @@ unsafe extern "C" fn loop_filter_dsp_init_arm(c: *mut Dav1dLoopFilterDSPContext)
     (*c).loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_8bpc_neon;
 }
 
-#[no_mangle]
 #[cold]
-pub unsafe extern "C" fn dav1d_loop_filter_dsp_init_8bpc(c: *mut Dav1dLoopFilterDSPContext) {
+pub unsafe fn dav1d_loop_filter_dsp_init_8bpc(c: *mut Dav1dLoopFilterDSPContext) {
     (*c).loop_filter_sb[0][0] = loop_filter_h_sb128y_c_erased;
     (*c).loop_filter_sb[0][1] = loop_filter_v_sb128y_c_erased;
     (*c).loop_filter_sb[1][0] = loop_filter_h_sb128uv_c_erased;

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -267,12 +267,7 @@ unsafe extern "C" fn lr_sbrow(
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_lr_sbrow_16bpc(
-    f: *mut Dav1dFrameContext,
-    dst: *const *mut pixel,
-    sby: c_int,
-) {
+pub unsafe fn dav1d_lr_sbrow_16bpc(f: *mut Dav1dFrameContext, dst: *const *mut pixel, sby: c_int) {
     let offset_y = 8 * (sby != 0) as c_int;
     let dst_stride: *const ptrdiff_t = ((*f).sr_cur.p.stride).as_mut_ptr();
     let restore_planes = (*f).lf.restore_planes;

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -257,12 +257,7 @@ unsafe extern "C" fn lr_sbrow(
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_lr_sbrow_8bpc(
-    f: *mut Dav1dFrameContext,
-    dst: *const *mut pixel,
-    sby: c_int,
-) {
+pub unsafe fn dav1d_lr_sbrow_8bpc(f: *mut Dav1dFrameContext, dst: *const *mut pixel, sby: c_int) {
     let offset_y = 8 * (sby != 0) as c_int;
     let dst_stride: *const ptrdiff_t = ((*f).sr_cur.p.stride).as_mut_ptr();
     let restore_planes = (*f).lf.restore_planes;

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -13,6 +13,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
+use crate::src::cdef_apply_tmpl_16::dav1d_cdef_brow_16bpc;
 use crate::src::ctx::CaseSet;
 use crate::src::env::get_uv_inter_txtp;
 use crate::src::internal::CodedBlockInfo;
@@ -27,6 +28,7 @@ use crate::src::intra_edge::EDGE_I444_LEFT_HAS_BOTTOM;
 use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
 use crate::src::ipred_prepare::sm_flag;
 use crate::src::ipred_prepare::sm_uv_flag;
+use crate::src::ipred_prepare_tmpl_16::dav1d_prepare_intra_edges_16bpc;
 use crate::src::levels::mv;
 use crate::src::levels::Av1Block;
 use crate::src::levels::BlockSize;
@@ -58,7 +60,11 @@ use crate::src::levels::TX_CLASS_2D;
 use crate::src::levels::TX_CLASS_H;
 use crate::src::levels::TX_CLASS_V;
 use crate::src::levels::WHT_WHT;
+use crate::src::lf_apply_tmpl_16::dav1d_copy_lpf_16bpc;
+use crate::src::lf_apply_tmpl_16::dav1d_loopfilter_sbrow_cols_16bpc;
+use crate::src::lf_apply_tmpl_16::dav1d_loopfilter_sbrow_rows_16bpc;
 use crate::src::lf_mask::Av1Filter;
+use crate::src::lr_apply_tmpl_16::dav1d_lr_sbrow_16bpc;
 use crate::src::msac::dav1d_msac_decode_bool_adapt;
 use crate::src::msac::dav1d_msac_decode_bool_equi;
 use crate::src::msac::dav1d_msac_decode_bools;
@@ -97,52 +103,6 @@ use std::ffi::c_longlong;
 use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn dav1d_cdef_brow_16bpc(
-        tc: *mut Dav1dTaskContext,
-        p: *const *mut pixel,
-        lflvl: *const Av1Filter,
-        by_start: c_int,
-        by_end: c_int,
-        sbrow_start: c_int,
-        sby: c_int,
-    );
-    fn dav1d_prepare_intra_edges_16bpc(
-        x: c_int,
-        have_left: c_int,
-        y: c_int,
-        have_top: c_int,
-        w: c_int,
-        h: c_int,
-        edge_flags: EdgeFlags,
-        dst: *const pixel,
-        stride: ptrdiff_t,
-        prefilter_toplevel_sb_edge: *const pixel,
-        mode: IntraPredMode,
-        angle: *mut c_int,
-        tw: c_int,
-        th: c_int,
-        filter_edge: c_int,
-        topleft_out: *mut pixel,
-        bitdepth_max: c_int,
-    ) -> IntraPredMode;
-    fn dav1d_loopfilter_sbrow_cols_16bpc(
-        f: *const Dav1dFrameContext,
-        p: *const *mut pixel,
-        lflvl: *mut Av1Filter,
-        sby: c_int,
-        start_of_tile_row: c_int,
-    );
-    fn dav1d_loopfilter_sbrow_rows_16bpc(
-        f: *const Dav1dFrameContext,
-        p: *const *mut pixel,
-        lflvl: *mut Av1Filter,
-        sby: c_int,
-    );
-    fn dav1d_copy_lpf_16bpc(f: *mut Dav1dFrameContext, src: *const *mut pixel, sby: c_int);
-    fn dav1d_lr_sbrow_16bpc(f: *mut Dav1dFrameContext, dst: *const *mut pixel, sby: c_int);
-}
 
 pub type pixel = u16;
 pub type coef = i32;
@@ -1527,7 +1487,6 @@ unsafe extern "C" fn read_coef_tree(
     };
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
     t: *mut Dav1dTaskContext,
     bs: BlockSize,

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -2226,7 +2226,6 @@ unsafe extern "C" fn warp_affine(
     return 0 as c_int;
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
     t: *mut Dav1dTaskContext,
     bs: BlockSize,
@@ -2971,7 +2970,6 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
     }
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
     t: *mut Dav1dTaskContext,
     bs: BlockSize,
@@ -4209,7 +4207,6 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
     return 0 as c_int;
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_cols_16bpc(
     f: *mut Dav1dFrameContext,
     sby: c_int,
@@ -4241,7 +4238,6 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_cols_16bpc(
     );
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_rows_16bpc(
     f: *mut Dav1dFrameContext,
     sby: c_int,
@@ -4269,7 +4265,6 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_rows_16bpc(
     }
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_16bpc(tc: *mut Dav1dTaskContext, sby: c_int) {
     let f: *const Dav1dFrameContext = (*tc).f;
     if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_CDEF as c_int as c_uint == 0 {
@@ -4314,7 +4309,6 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_16bpc(tc: *mut Dav1dTaskContext
     dav1d_cdef_brow_16bpc(tc, p.as_ptr(), mask, start, end, 0 as c_int, sby);
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_filter_sbrow_resize_16bpc(f: *mut Dav1dFrameContext, sby: c_int) {
     let sbsz = (*f).sb_step;
     let y = sby * sbsz * 4;
@@ -4374,7 +4368,6 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_resize_16bpc(f: *mut Dav1dFrameConte
     }
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_filter_sbrow_lr_16bpc(f: *mut Dav1dFrameContext, sby: c_int) {
     if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_RESTORATION as c_int as c_uint == 0 {
         return;
@@ -4392,7 +4385,6 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_lr_16bpc(f: *mut Dav1dFrameContext, 
     dav1d_lr_sbrow_16bpc(f, sr_p.as_ptr(), sby);
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_filter_sbrow_16bpc(f: *mut Dav1dFrameContext, sby: c_int) {
     dav1d_filter_sbrow_deblock_cols_16bpc(f, sby);
     dav1d_filter_sbrow_deblock_rows_16bpc(f, sby);
@@ -4407,7 +4399,6 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_16bpc(f: *mut Dav1dFrameContext, sby
     }
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_backup_ipred_edge_16bpc(t: *mut Dav1dTaskContext) {
     let f: *const Dav1dFrameContext = (*t).f;
     let ts: *mut Dav1dTileState = (*t).ts;

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -13,6 +13,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
+use crate::src::cdef_apply_tmpl_8::dav1d_cdef_brow_8bpc;
 use crate::src::ctx::CaseSet;
 use crate::src::env::get_uv_inter_txtp;
 use crate::src::internal::CodedBlockInfo;
@@ -27,6 +28,7 @@ use crate::src::intra_edge::EDGE_I444_LEFT_HAS_BOTTOM;
 use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
 use crate::src::ipred_prepare::sm_flag;
 use crate::src::ipred_prepare::sm_uv_flag;
+use crate::src::ipred_prepare_tmpl_8::dav1d_prepare_intra_edges_8bpc;
 use crate::src::levels::mv;
 use crate::src::levels::Av1Block;
 use crate::src::levels::BlockSize;
@@ -58,7 +60,11 @@ use crate::src::levels::TX_CLASS_2D;
 use crate::src::levels::TX_CLASS_H;
 use crate::src::levels::TX_CLASS_V;
 use crate::src::levels::WHT_WHT;
+use crate::src::lf_apply_tmpl_8::dav1d_copy_lpf_8bpc;
+use crate::src::lf_apply_tmpl_8::dav1d_loopfilter_sbrow_cols_8bpc;
+use crate::src::lf_apply_tmpl_8::dav1d_loopfilter_sbrow_rows_8bpc;
 use crate::src::lf_mask::Av1Filter;
+use crate::src::lr_apply_tmpl_8::dav1d_lr_sbrow_8bpc;
 use crate::src::msac::dav1d_msac_decode_bool_adapt;
 use crate::src::msac::dav1d_msac_decode_bool_equi;
 use crate::src::msac::dav1d_msac_decode_bools;
@@ -97,51 +103,6 @@ use std::ffi::c_longlong;
 use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
-
-extern "C" {
-    fn dav1d_cdef_brow_8bpc(
-        tc: *mut Dav1dTaskContext,
-        p: *const *mut pixel,
-        lflvl: *const Av1Filter,
-        by_start: c_int,
-        by_end: c_int,
-        sbrow_start: c_int,
-        sby: c_int,
-    );
-    fn dav1d_prepare_intra_edges_8bpc(
-        x: c_int,
-        have_left: c_int,
-        y: c_int,
-        have_top: c_int,
-        w: c_int,
-        h: c_int,
-        edge_flags: EdgeFlags,
-        dst: *const pixel,
-        stride: ptrdiff_t,
-        prefilter_toplevel_sb_edge: *const pixel,
-        mode: IntraPredMode,
-        angle: *mut c_int,
-        tw: c_int,
-        th: c_int,
-        filter_edge: c_int,
-        topleft_out: *mut pixel,
-    ) -> IntraPredMode;
-    fn dav1d_loopfilter_sbrow_cols_8bpc(
-        f: *const Dav1dFrameContext,
-        p: *const *mut pixel,
-        lflvl: *mut Av1Filter,
-        sby: c_int,
-        start_of_tile_row: c_int,
-    );
-    fn dav1d_loopfilter_sbrow_rows_8bpc(
-        f: *const Dav1dFrameContext,
-        p: *const *mut pixel,
-        lflvl: *mut Av1Filter,
-        sby: c_int,
-    );
-    fn dav1d_copy_lpf_8bpc(f: *mut Dav1dFrameContext, src: *const *mut pixel, sby: c_int);
-    fn dav1d_lr_sbrow_8bpc(f: *mut Dav1dFrameContext, dst: *const *mut pixel, sby: c_int);
-}
 
 pub type pixel = u8;
 pub type coef = i16;

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1516,7 +1516,6 @@ unsafe extern "C" fn read_coef_tree(
     };
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
     t: *mut Dav1dTaskContext,
     bs: BlockSize,
@@ -2210,7 +2209,6 @@ unsafe extern "C" fn warp_affine(
     return 0 as c_int;
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
     t: *mut Dav1dTaskContext,
     bs: BlockSize,
@@ -2947,7 +2945,6 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
     }
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
     t: *mut Dav1dTaskContext,
     bs: BlockSize,
@@ -4178,7 +4175,6 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
     return 0 as c_int;
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_cols_8bpc(
     f: *mut Dav1dFrameContext,
     sby: c_int,
@@ -4208,7 +4204,6 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_cols_8bpc(
     );
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_rows_8bpc(
     f: *mut Dav1dFrameContext,
     sby: c_int,
@@ -4234,7 +4229,6 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_rows_8bpc(
     }
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_8bpc(tc: *mut Dav1dTaskContext, sby: c_int) {
     let f: *const Dav1dFrameContext = (*tc).f;
     if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_CDEF as c_int as c_uint == 0 {
@@ -4277,7 +4271,6 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_8bpc(tc: *mut Dav1dTaskContext,
     dav1d_cdef_brow_8bpc(tc, p.as_ptr(), mask, start, end, 0 as c_int, sby);
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_filter_sbrow_resize_8bpc(f: *mut Dav1dFrameContext, sby: c_int) {
     let sbsz = (*f).sb_step;
     let y = sby * sbsz * 4;
@@ -4335,7 +4328,6 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_resize_8bpc(f: *mut Dav1dFrameContex
     }
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_filter_sbrow_lr_8bpc(f: *mut Dav1dFrameContext, sby: c_int) {
     if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_RESTORATION as c_int as c_uint == 0 {
         return;
@@ -4353,7 +4345,6 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_lr_8bpc(f: *mut Dav1dFrameContext, s
     dav1d_lr_sbrow_8bpc(f, sr_p.as_ptr(), sby);
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_filter_sbrow_8bpc(f: *mut Dav1dFrameContext, sby: c_int) {
     dav1d_filter_sbrow_deblock_cols_8bpc(f, sby);
     dav1d_filter_sbrow_deblock_rows_8bpc(f, sby);
@@ -4368,7 +4359,6 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_8bpc(f: *mut Dav1dFrameContext, sby:
     }
 }
 
-#[no_mangle]
 pub unsafe extern "C" fn dav1d_backup_ipred_edge_8bpc(t: *mut Dav1dTaskContext) {
     let f: *const Dav1dFrameContext = (*t).f;
     let ts: *mut Dav1dTileState = (*t).ts;


### PR DESCRIPTION
This should be the last of the `#[no_mangle]` `fn`s that aren't `DAV1D_API`, and the only `extern "C" {}` `fn`s imported should be asm `fn`s.

Note that in b62e49e the existing signature was wrong (it used `*mut c_void`) so I have to remove the casts to `*mut c_void`.