### PR TITLE
`static av1_intra_prediction_edges`: Make non-`mut` by replacing `#[derive(BitfieldStruct)]` with `bools_bitfield_struct!` for `const fn`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,30 +3,9 @@
 version = 3
 
 [[package]]
-name = "c2rust-bitfields"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b43c3f07ab0ef604fa6f595aa46ec2f8a22172c975e186f6f5bf9829a3b72c41"
-dependencies = [
- "c2rust-bitfields-derive",
-]
-
-[[package]]
-name = "c2rust-bitfields-derive"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3cbc102e2597c9744c8bd8c15915d554300601c91a079430d309816b0912545"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "c2rust_out"
 version = "0.0.0"
 dependencies = [
- "c2rust-bitfields",
  "cc",
  "cfg-if",
  "libc",
@@ -134,18 +113,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.32",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
-members = [
-]
+members = []
 [package]
 name = "c2rust_out"
 authors = ["C2Rust"]
@@ -22,7 +21,6 @@ name = "dav1d"
 path = "tests/seek_stress.rs"
 name = "seek_stress"
 [dependencies]
-c2rust-bitfields = "0.18"
 cfg-if = "1.0.0"
 libc = "0.2"
 num_cpus = "1.0"

--- a/src/ipred_prepare.rs
+++ b/src/ipred_prepare.rs
@@ -149,7 +149,7 @@ struct av1_intra_prediction_edge {
     pub needs: Needs,
 }
 
-static mut av1_intra_prediction_edges: [av1_intra_prediction_edge; N_IMPL_INTRA_PRED_MODES] = {
+static av1_intra_prediction_edges: [av1_intra_prediction_edge; N_IMPL_INTRA_PRED_MODES] = {
     let mut a = [Needs::empty(); N_IMPL_INTRA_PRED_MODES];
     a[DC_PRED as usize] = Needs::empty().set_top().set_left();
     a[VERT_PRED as usize] = Needs::empty().set_top();

--- a/src/ipred_prepare.rs
+++ b/src/ipred_prepare.rs
@@ -1,5 +1,6 @@
 use crate::include::common::bitdepth::AsPrimitive;
 use crate::include::common::bitdepth::BitDepth;
+use crate::src::const_fn::const_for;
 use crate::src::env::BlockContext;
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::intra_edge::EDGE_I444_LEFT_HAS_BOTTOM;
@@ -143,42 +144,36 @@ bools_bitfield_struct! {
     }
 }
 
-impl Needs {
-    const fn edge(self) -> av1_intra_prediction_edge {
-        av1_intra_prediction_edge { needs: self }
-    }
-}
-
 #[derive(Clone, Copy)]
 struct av1_intra_prediction_edge {
     pub needs: Needs,
 }
 
 static mut av1_intra_prediction_edges: [av1_intra_prediction_edge; N_IMPL_INTRA_PRED_MODES] = {
-    let mut a = [Needs::empty().edge(); N_IMPL_INTRA_PRED_MODES];
-    a[DC_PRED as usize] = Needs::empty().set_top().set_left().edge();
-    a[VERT_PRED as usize] = Needs::empty().set_top().edge();
-    a[HOR_PRED as usize] = Needs::empty().set_left().edge();
-    a[LEFT_DC_PRED as usize] = Needs::empty().set_left().edge();
-    a[TOP_DC_PRED as usize] = Needs::empty().set_top().edge();
-    a[DC_128_PRED as usize] = Needs::empty().edge();
-    a[Z1_PRED as usize] = Needs::empty()
-        .set_top()
-        .set_top_right()
-        .set_top_left()
-        .edge();
-    a[Z2_PRED as usize] = Needs::empty().set_left().set_top().set_top_left().edge();
-    a[Z3_PRED as usize] = Needs::empty()
-        .set_left()
-        .set_bottom_left()
-        .set_top_left()
-        .edge();
-    a[SMOOTH_PRED as usize] = Needs::empty().set_left().set_top().edge();
-    a[SMOOTH_V_PRED as usize] = Needs::empty().set_left().set_top().edge();
-    a[SMOOTH_H_PRED as usize] = Needs::empty().set_left().set_top().edge();
-    a[PAETH_PRED as usize] = Needs::empty().set_left().set_top().set_top_left().edge();
-    a[FILTER_PRED as usize] = Needs::empty().set_left().set_top().set_top_left().edge();
-    a
+    let mut a = [Needs::empty(); N_IMPL_INTRA_PRED_MODES];
+    a[DC_PRED as usize] = Needs::empty().set_top().set_left();
+    a[VERT_PRED as usize] = Needs::empty().set_top();
+    a[HOR_PRED as usize] = Needs::empty().set_left();
+    a[LEFT_DC_PRED as usize] = Needs::empty().set_left();
+    a[TOP_DC_PRED as usize] = Needs::empty().set_top();
+    a[DC_128_PRED as usize] = Needs::empty();
+    a[Z1_PRED as usize] = Needs::empty().set_top().set_top_right().set_top_left();
+    a[Z2_PRED as usize] = Needs::empty().set_left().set_top().set_top_left();
+    a[Z3_PRED as usize] = Needs::empty().set_left().set_bottom_left().set_top_left();
+    a[SMOOTH_PRED as usize] = Needs::empty().set_left().set_top();
+    a[SMOOTH_V_PRED as usize] = Needs::empty().set_left().set_top();
+    a[SMOOTH_H_PRED as usize] = Needs::empty().set_left().set_top();
+    a[PAETH_PRED as usize] = Needs::empty().set_left().set_top().set_top_left();
+    a[FILTER_PRED as usize] = Needs::empty().set_left().set_top().set_top_left();
+
+    let mut b = [av1_intra_prediction_edge {
+        needs: Needs::empty(),
+    }; N_IMPL_INTRA_PRED_MODES];
+    const_for!(i in 0..N_IMPL_INTRA_PRED_MODES => {
+        b[i].needs = a[i];
+    });
+
+    b
 };
 
 pub unsafe fn dav1d_prepare_intra_edges<BD: BitDepth>(


### PR DESCRIPTION
`#[derive(c2rust_bitfields::BitfieldStruct)]` doesn't generate `const fn`s (https://github.com/immunant/c2rust/issues/1027), so it can't be used in a `const` block to initialize a `static`.  Thus, the `static` has to made `mut` and `unsafe` and initialized at runtime.

I opened https://github.com/immunant/c2rust/issues/1027 and looked into making the generated `fn`s `const`, but they used a lot of `trait`s, which can't contain `const fn`s, so it seemed like non-trivial work.  I also tried looking for other off-the-shelf bitfield crates, but they all either didn't support `const fn`s or still relied on `trait`s within them, and thus only could create `const fn`s with `nightly` features.

Thus, I rolled my own `macro_rules!` macro, `bools_bitfield_struct!` that generates `const fn`s.  The macro is specific for bitfields that are always `bool`s, which makes things a bit simpler and have a cleaner API.  And it also doesn't have to worry about being `#[repr(C)]` at all, which might makes things a bit simpler, too.  Overall, though, it's quite a simple macro, so it seemed much easier to do it this.  Since `rav1d` only used bitfields here, I kept the macro private in this file, but if we ever need bitfields that are all `bool`s elsewhere, we can extract the macro.  The `c2rust-bitfields` dependency is also now removed as it's unused.