### PR TITLE
`struct CpuFlags`: Make `bitflags!`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,16 @@
 version = 3
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "c2rust_out"
 version = "0.0.0"
 dependencies = [
+ "bitflags",
  "cc",
  "cfg-if",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ name = "dav1d"
 path = "tests/seek_stress.rs"
 name = "seek_stress"
 [dependencies]
+bitflags = "2.4.0"
 cfg-if = "1.0.0"
 libc = "0.2"
 num_cpus = "1.0"

--- a/src/cdef_tmpl_8.rs
+++ b/src/cdef_tmpl_8.rs
@@ -482,18 +482,17 @@ unsafe fn cdef_find_dir_rust(mut img: *const pixel, stride: ptrdiff_t, var: *mut
 }
 
 #[cfg(feature = "asm")]
-use crate::src::cpu::dav1d_get_cpu_flags;
+use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
 
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
 unsafe extern "C" fn cdef_dsp_init_x86(c: *mut Dav1dCdefDSPContext) {
-    use crate::src::x86::cpu::*;
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::cdef::*;
 
-    let flags: c_uint = dav1d_get_cpu_flags();
+    let flags = dav1d_get_cpu_flags();
 
-    if flags & DAV1D_X86_CPU_FLAG_SSE2 == 0 {
+    if !flags.contains(CpuFlags::SSE2) {
         return;
     }
 
@@ -501,7 +500,7 @@ unsafe extern "C" fn cdef_dsp_init_x86(c: *mut Dav1dCdefDSPContext) {
     (*c).fb[1] = dav1d_cdef_filter_4x8_8bpc_sse2;
     (*c).fb[2] = dav1d_cdef_filter_4x4_8bpc_sse2;
 
-    if flags & DAV1D_X86_CPU_FLAG_SSSE3 == 0 {
+    if !flags.contains(CpuFlags::SSSE3) {
         return;
     }
 
@@ -510,7 +509,7 @@ unsafe extern "C" fn cdef_dsp_init_x86(c: *mut Dav1dCdefDSPContext) {
     (*c).fb[1] = dav1d_cdef_filter_4x8_8bpc_ssse3;
     (*c).fb[2] = dav1d_cdef_filter_4x4_8bpc_ssse3;
 
-    if flags & DAV1D_X86_CPU_FLAG_SSE41 == 0 {
+    if !flags.contains(CpuFlags::SSE41) {
         return;
     }
 
@@ -521,7 +520,7 @@ unsafe extern "C" fn cdef_dsp_init_x86(c: *mut Dav1dCdefDSPContext) {
 
     #[cfg(target_arch = "x86_64")]
     {
-        if flags & DAV1D_X86_CPU_FLAG_AVX2 == 0 {
+        if !flags.contains(CpuFlags::AVX2) {
             return;
         }
 
@@ -530,7 +529,7 @@ unsafe extern "C" fn cdef_dsp_init_x86(c: *mut Dav1dCdefDSPContext) {
         (*c).fb[1] = dav1d_cdef_filter_4x8_8bpc_avx2;
         (*c).fb[2] = dav1d_cdef_filter_4x4_8bpc_avx2;
 
-        if flags & DAV1D_X86_CPU_FLAG_AVX512ICL == 0 {
+        if !flags.contains(CpuFlags::AVX512ICL) {
             return;
         }
 
@@ -543,13 +542,12 @@ unsafe extern "C" fn cdef_dsp_init_x86(c: *mut Dav1dCdefDSPContext) {
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 unsafe extern "C" fn cdef_dsp_init_arm(c: *mut Dav1dCdefDSPContext) {
-    use crate::src::arm::cpu::DAV1D_ARM_CPU_FLAG_NEON;
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::cdef::*;
 
-    let flags: c_uint = dav1d_get_cpu_flags();
+    let flags = dav1d_get_cpu_flags();
 
-    if flags & DAV1D_ARM_CPU_FLAG_NEON == 0 {
+    if !flags.contains(CpuFlags::NEON) {
         return;
     }
 

--- a/src/filmgrain_tmpl_16.rs
+++ b/src/filmgrain_tmpl_16.rs
@@ -19,7 +19,7 @@ use std::ffi::c_uint;
 use std::ffi::c_ulong;
 
 #[cfg(feature = "asm")]
-use crate::src::cpu::dav1d_get_cpu_flags;
+use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
 
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
@@ -1342,11 +1342,9 @@ unsafe extern "C" fn fguv_32x32xn_444_c_erased(
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
 #[inline(always)]
 unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Dav1dFilmGrainDSPContext) {
-    use crate::src::x86::cpu::*;
-
     let flags = dav1d_get_cpu_flags();
 
-    if flags & DAV1D_X86_CPU_FLAG_SSSE3 == 0 {
+    if !flags.contains(CpuFlags::SSSE3) {
         return;
     }
 
@@ -1368,7 +1366,7 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Dav1dFilmGrainDSPContext) {
 
     #[cfg(target_arch = "x86_64")]
     {
-        if flags & DAV1D_X86_CPU_FLAG_AVX2 == 0 {
+        if !flags.contains(CpuFlags::AVX2) {
             return;
         }
 
@@ -1380,7 +1378,7 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Dav1dFilmGrainDSPContext) {
         (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
             Some(dav1d_generate_grain_uv_444_16bpc_avx2);
 
-        if flags & DAV1D_X86_CPU_FLAG_SLOW_GATHER == 0 {
+        if !flags.contains(CpuFlags::SLOW_GATHER) {
             (*c).fgy_32x32xn = Some(dav1d_fgy_32x32xn_16bpc_avx2);
             (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
                 Some(dav1d_fguv_32x32xn_i420_16bpc_avx2);
@@ -1390,7 +1388,7 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Dav1dFilmGrainDSPContext) {
                 Some(dav1d_fguv_32x32xn_i444_16bpc_avx2);
         }
 
-        if flags & DAV1D_X86_CPU_FLAG_AVX512ICL == 0 {
+        if !flags.contains(CpuFlags::AVX512ICL) {
             return;
         }
 
@@ -1407,11 +1405,9 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Dav1dFilmGrainDSPContext) {
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 #[inline(always)]
 unsafe extern "C" fn film_grain_dsp_init_arm(c: *mut Dav1dFilmGrainDSPContext) {
-    use crate::src::arm::cpu::DAV1D_ARM_CPU_FLAG_NEON;
-
     let flags = dav1d_get_cpu_flags();
 
-    if flags & DAV1D_ARM_CPU_FLAG_NEON == 0 {
+    if !flags.contains(CpuFlags::NEON) {
         return;
     }
 

--- a/src/filmgrain_tmpl_8.rs
+++ b/src/filmgrain_tmpl_8.rs
@@ -19,7 +19,7 @@ use std::ffi::c_uint;
 use std::ffi::c_ulong;
 
 #[cfg(feature = "asm")]
-use crate::src::cpu::dav1d_get_cpu_flags;
+use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
 
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
@@ -1287,11 +1287,9 @@ unsafe extern "C" fn fguv_32x32xn_444_c_erased(
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
 #[inline(always)]
 unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Dav1dFilmGrainDSPContext) {
-    use crate::src::x86::cpu::*;
-
     let flags = dav1d_get_cpu_flags();
 
-    if flags & DAV1D_X86_CPU_FLAG_SSSE3 == 0 {
+    if !flags.contains(CpuFlags::SSSE3) {
         return;
     }
 
@@ -1313,7 +1311,7 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Dav1dFilmGrainDSPContext) {
 
     #[cfg(target_arch = "x86_64")]
     {
-        if flags & DAV1D_X86_CPU_FLAG_AVX2 == 0 {
+        if !flags.contains(CpuFlags::AVX2) {
             return;
         }
 
@@ -1325,7 +1323,7 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Dav1dFilmGrainDSPContext) {
         (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
             Some(dav1d_generate_grain_uv_444_8bpc_avx2);
 
-        if flags & DAV1D_X86_CPU_FLAG_SLOW_GATHER == 0 {
+        if !flags.contains(CpuFlags::SLOW_GATHER) {
             (*c).fgy_32x32xn = Some(dav1d_fgy_32x32xn_8bpc_avx2);
             (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
                 Some(dav1d_fguv_32x32xn_i420_8bpc_avx2);
@@ -1335,7 +1333,7 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Dav1dFilmGrainDSPContext) {
                 Some(dav1d_fguv_32x32xn_i444_8bpc_avx2);
         }
 
-        if flags & DAV1D_X86_CPU_FLAG_AVX512ICL == 0 {
+        if !flags.contains(CpuFlags::AVX512ICL) {
             return;
         }
 
@@ -1352,11 +1350,9 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Dav1dFilmGrainDSPContext) {
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 #[inline(always)]
 unsafe extern "C" fn film_grain_dsp_init_arm(c: *mut Dav1dFilmGrainDSPContext) {
-    use crate::src::arm::cpu::DAV1D_ARM_CPU_FLAG_NEON;
-
     let flags = dav1d_get_cpu_flags();
 
-    if flags & DAV1D_ARM_CPU_FLAG_NEON == 0 {
+    if !flags.contains(CpuFlags::NEON) {
         return;
     }
 

--- a/src/ipred_tmpl_8.rs
+++ b/src/ipred_tmpl_8.rs
@@ -36,7 +36,7 @@ use std::ffi::c_ulonglong;
 use std::ffi::c_void;
 
 #[cfg(feature = "asm")]
-use crate::src::cpu::dav1d_get_cpu_flags;
+use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
 
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
@@ -1445,13 +1445,10 @@ unsafe fn pal_pred_rust(
 #[inline(always)]
 unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Dav1dIntraPredDSPContext) {
     use crate::src::ipred::*; // TODO(legare): Temporary import until init fns are deduplicated.
-    use crate::src::x86::cpu::DAV1D_X86_CPU_FLAG_AVX2;
-    use crate::src::x86::cpu::DAV1D_X86_CPU_FLAG_AVX512ICL;
-    use crate::src::x86::cpu::DAV1D_X86_CPU_FLAG_SSSE3;
 
     let flags = dav1d_get_cpu_flags();
 
-    if flags & DAV1D_X86_CPU_FLAG_SSSE3 == 0 {
+    if !flags.contains(CpuFlags::SSSE3) {
         return;
     }
 
@@ -1483,7 +1480,7 @@ unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Dav1dIntraPredDSPContext) {
 
     #[cfg(target_arch = "x86_64")]
     {
-        if flags & DAV1D_X86_CPU_FLAG_AVX2 == 0 {
+        if !flags.contains(CpuFlags::AVX2) {
             return;
         }
 
@@ -1513,7 +1510,7 @@ unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Dav1dIntraPredDSPContext) {
 
         (*c).pal_pred = dav1d_pal_pred_8bpc_avx2;
 
-        if flags & DAV1D_X86_CPU_FLAG_AVX512ICL == 0 {
+        if !flags.contains(CpuFlags::AVX512ICL) {
             return;
         }
 
@@ -1536,13 +1533,12 @@ unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Dav1dIntraPredDSPContext) {
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 #[inline(always)]
 unsafe extern "C" fn intra_pred_dsp_init_arm(c: *mut Dav1dIntraPredDSPContext) {
-    use crate::src::arm::cpu::DAV1D_ARM_CPU_FLAG_NEON;
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::ipred::*;
 
     let flags = dav1d_get_cpu_flags();
 
-    if flags & DAV1D_ARM_CPU_FLAG_NEON == 0 {
+    if !flags.contains(CpuFlags::NEON) {
         return;
     }
 

--- a/src/itx_tmpl_8.rs
+++ b/src/itx_tmpl_8.rs
@@ -45,7 +45,7 @@ use std::ffi::c_int;
 use std::ffi::c_void;
 
 #[cfg(feature = "asm")]
-use crate::src::cpu::dav1d_get_cpu_flags;
+use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
 
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
@@ -119,19 +119,18 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust(
 #[inline(always)]
 #[rustfmt::skip]
 unsafe extern "C" fn itx_dsp_init_x86(c: *mut Dav1dInvTxfmDSPContext, _bpc: c_int) {
-    use crate::src::x86::cpu::*;
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::itx::*;
 
     let flags = dav1d_get_cpu_flags();
 
-    if flags & DAV1D_X86_CPU_FLAG_SSE2 == 0 {
+    if !flags.contains(CpuFlags::SSE2) {
         return;
     }
 
     (*c).itxfm_add[TX_4X4 as usize][WHT_WHT as usize] = Some(dav1d_inv_txfm_add_wht_wht_4x4_8bpc_sse2);
 
-    if flags & DAV1D_X86_CPU_FLAG_SSSE3 == 0 {
+    if !flags.contains(CpuFlags::SSSE3) {
         return;
     }
 
@@ -291,13 +290,13 @@ unsafe extern "C" fn itx_dsp_init_x86(c: *mut Dav1dInvTxfmDSPContext, _bpc: c_in
     (*c).itxfm_add[RTX_64X32 as usize][DCT_DCT as usize] = Some(dav1d_inv_txfm_add_dct_dct_64x32_8bpc_ssse3);
     (*c).itxfm_add[TX_64X64 as usize][DCT_DCT as usize] = Some(dav1d_inv_txfm_add_dct_dct_64x64_8bpc_ssse3);
 
-    if flags & DAV1D_X86_CPU_FLAG_SSE41 == 0 {
+    if !flags.contains(CpuFlags::SSE41) {
         return;
     }
 
     #[cfg(target_arch = "x86_64")]
     {
-        if flags & DAV1D_X86_CPU_FLAG_AVX2 == 0 {
+        if !flags.contains(CpuFlags::AVX2) {
             return;
         }
 
@@ -458,7 +457,7 @@ unsafe extern "C" fn itx_dsp_init_x86(c: *mut Dav1dInvTxfmDSPContext, _bpc: c_in
         (*c).itxfm_add[RTX_64X32 as usize][DCT_DCT as usize] = Some(dav1d_inv_txfm_add_dct_dct_64x32_8bpc_avx2);
         (*c).itxfm_add[TX_64X64 as usize][DCT_DCT as usize] = Some(dav1d_inv_txfm_add_dct_dct_64x64_8bpc_avx2);
 
-        if flags & DAV1D_X86_CPU_FLAG_AVX512ICL == 0 {
+        if !flags.contains(CpuFlags::AVX512ICL) {
             return;
         }
 
@@ -624,13 +623,12 @@ unsafe extern "C" fn itx_dsp_init_x86(c: *mut Dav1dInvTxfmDSPContext, _bpc: c_in
 #[inline(always)]
 #[rustfmt::skip]
 unsafe extern "C" fn itx_dsp_init_arm(c: *mut Dav1dInvTxfmDSPContext, mut _bpc: c_int) {
-    use crate::src::arm::cpu::DAV1D_ARM_CPU_FLAG_NEON;
-    // TODO(legare): Temporary import until init fns are deduplicated.
+        // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::itx::*;
 
     let flags = dav1d_get_cpu_flags();
 
-    if flags & DAV1D_ARM_CPU_FLAG_NEON == 0 {
+    if !flags.contains(CpuFlags::NEON) {
         return;
     }
 

--- a/src/loopfilter_tmpl_16.rs
+++ b/src/loopfilter_tmpl_16.rs
@@ -9,7 +9,7 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 
 #[cfg(feature = "asm")]
-use crate::src::cpu::dav1d_get_cpu_flags;
+use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
 
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
@@ -470,13 +470,12 @@ unsafe extern "C" fn loop_filter_v_sb128uv_rust(
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
 unsafe extern "C" fn loop_filter_dsp_init_x86(c: *mut Dav1dLoopFilterDSPContext) {
-    use crate::src::x86::cpu::*;
     // TODO(legare): Temporarily import until init fns are deduplicated.
     use crate::src::loopfilter::*;
 
     let flags = dav1d_get_cpu_flags();
 
-    if flags & DAV1D_X86_CPU_FLAG_SSSE3 == 0 {
+    if !flags.contains(CpuFlags::SSSE3) {
         return;
     }
 
@@ -487,7 +486,7 @@ unsafe extern "C" fn loop_filter_dsp_init_x86(c: *mut Dav1dLoopFilterDSPContext)
 
     #[cfg(target_arch = "x86_64")]
     {
-        if flags & DAV1D_X86_CPU_FLAG_AVX2 == 0 {
+        if !flags.contains(CpuFlags::AVX2) {
             return;
         }
 
@@ -496,7 +495,7 @@ unsafe extern "C" fn loop_filter_dsp_init_x86(c: *mut Dav1dLoopFilterDSPContext)
         (*c).loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_16bpc_avx2;
         (*c).loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_16bpc_avx2;
 
-        if flags & DAV1D_X86_CPU_FLAG_AVX512ICL == 0 {
+        if !flags.contains(CpuFlags::AVX512ICL) {
             return;
         }
 
@@ -510,13 +509,12 @@ unsafe extern "C" fn loop_filter_dsp_init_x86(c: *mut Dav1dLoopFilterDSPContext)
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]
 unsafe extern "C" fn loop_filter_dsp_init_arm(c: *mut Dav1dLoopFilterDSPContext) {
-    use crate::src::arm::cpu::DAV1D_ARM_CPU_FLAG_NEON;
     // TODO(legare): Temporarily import until init fns are deduplicated.
     use crate::src::loopfilter::*;
 
     let flags = dav1d_get_cpu_flags();
 
-    if flags & DAV1D_ARM_CPU_FLAG_NEON == 0 {
+    if !flags.contains(CpuFlags::NEON) {
         return;
     }
 

--- a/src/loopfilter_tmpl_8.rs
+++ b/src/loopfilter_tmpl_8.rs
@@ -9,7 +9,7 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 
 #[cfg(feature = "asm")]
-use crate::src::cpu::dav1d_get_cpu_flags;
+use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
 
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
@@ -398,13 +398,12 @@ unsafe extern "C" fn loop_filter_v_sb128uv_rust(
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
 unsafe extern "C" fn loop_filter_dsp_init_x86(c: *mut Dav1dLoopFilterDSPContext) {
-    use crate::src::x86::cpu::*;
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::loopfilter::*;
 
     let flags = dav1d_get_cpu_flags();
 
-    if flags & DAV1D_X86_CPU_FLAG_SSSE3 == 0 {
+    if !flags.contains(CpuFlags::SSSE3) {
         return;
     }
 
@@ -415,7 +414,7 @@ unsafe extern "C" fn loop_filter_dsp_init_x86(c: *mut Dav1dLoopFilterDSPContext)
 
     #[cfg(target_arch = "x86_64")]
     {
-        if flags & DAV1D_X86_CPU_FLAG_AVX2 == 0 {
+        if !flags.contains(CpuFlags::AVX2) {
             return;
         }
 
@@ -424,7 +423,7 @@ unsafe extern "C" fn loop_filter_dsp_init_x86(c: *mut Dav1dLoopFilterDSPContext)
         (*c).loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_8bpc_avx2;
         (*c).loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_8bpc_avx2;
 
-        if flags & DAV1D_X86_CPU_FLAG_AVX512ICL == 0 {
+        if !flags.contains(CpuFlags::AVX512ICL) {
             return;
         }
 
@@ -438,13 +437,12 @@ unsafe extern "C" fn loop_filter_dsp_init_x86(c: *mut Dav1dLoopFilterDSPContext)
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]
 unsafe extern "C" fn loop_filter_dsp_init_arm(c: *mut Dav1dLoopFilterDSPContext) {
-    use crate::src::arm::cpu::DAV1D_ARM_CPU_FLAG_NEON;
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::loopfilter::*;
 
     let flags = dav1d_get_cpu_flags();
 
-    if flags & DAV1D_ARM_CPU_FLAG_NEON == 0 {
+    if !flags.contains(CpuFlags::NEON) {
         return;
     }
 

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -27,7 +27,7 @@ use libc::intptr_t;
 use crate::include::common::bitdepth::bd_fn;
 
 #[cfg(feature = "asm")]
-use crate::src::cpu::dav1d_get_cpu_flags;
+use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 extern "C" {
@@ -1632,11 +1632,9 @@ unsafe extern "C" fn sgr_filter_mix_neon<BD: BitDepth>(
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
 fn loop_restoration_dsp_init_x86<BD: BitDepth>(c: &mut Dav1dLoopRestorationDSPContext, bpc: c_int) {
-    use crate::src::x86::cpu::*;
-
     let flags = dav1d_get_cpu_flags();
 
-    if flags & DAV1D_X86_CPU_FLAG_SSE2 == 0 {
+    if !flags.contains(CpuFlags::SSE2) {
         return;
     }
 
@@ -1645,7 +1643,7 @@ fn loop_restoration_dsp_init_x86<BD: BitDepth>(c: &mut Dav1dLoopRestorationDSPCo
         c.wiener[1] = decl_looprestorationfilter_fn!(fn dav1d_wiener_filter5_8bpc_sse2);
     }
 
-    if flags & DAV1D_X86_CPU_FLAG_SSSE3 == 0 {
+    if !flags.contains(CpuFlags::SSSE3) {
         return;
     }
 
@@ -1660,7 +1658,7 @@ fn loop_restoration_dsp_init_x86<BD: BitDepth>(c: &mut Dav1dLoopRestorationDSPCo
 
     #[cfg(target_arch = "x86_64")]
     {
-        if flags & DAV1D_X86_CPU_FLAG_AVX2 == 0 {
+        if !flags.contains(CpuFlags::AVX2) {
             return;
         }
 
@@ -1673,7 +1671,7 @@ fn loop_restoration_dsp_init_x86<BD: BitDepth>(c: &mut Dav1dLoopRestorationDSPCo
             c.sgr[2] = bd_fn!(decl_looprestorationfilter_fn, BD, sgr_filter_mix, avx2);
         }
 
-        if flags & DAV1D_X86_CPU_FLAG_AVX512ICL == 0 {
+        if !flags.contains(CpuFlags::AVX512ICL) {
             return;
         }
 
@@ -1695,11 +1693,9 @@ fn loop_restoration_dsp_init_x86<BD: BitDepth>(c: &mut Dav1dLoopRestorationDSPCo
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]
 fn loop_restoration_dsp_init_arm<BD: BitDepth>(c: &mut Dav1dLoopRestorationDSPContext, bpc: c_int) {
-    use crate::src::arm::cpu::DAV1D_ARM_CPU_FLAG_NEON;
-
     let flags = dav1d_get_cpu_flags();
 
-    if flags & DAV1D_ARM_CPU_FLAG_NEON == 0 {
+    if !flags.contains(CpuFlags::NEON) {
         return;
     }
 

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -128,15 +128,13 @@ pub fn dav1d_msac_decode_uniform(s: &mut MsacContext, n: c_uint) -> c_int {
 #[cfg(all(feature = "asm", target_arch = "x86_64"))]
 #[inline(always)]
 fn msac_init_x86(s: &mut MsacContext) {
-    use crate::src::cpu::dav1d_get_cpu_flags;
-    use crate::src::x86::cpu::DAV1D_X86_CPU_FLAG_AVX2;
-    use crate::src::x86::cpu::DAV1D_X86_CPU_FLAG_SSE2;
+    use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
 
     let flags = dav1d_get_cpu_flags();
-    if flags & DAV1D_X86_CPU_FLAG_SSE2 != 0 {
+    if flags.contains(CpuFlags::SSE2) {
         s.symbol_adapt16 = dav1d_msac_decode_symbol_adapt16_sse2;
     }
-    if flags & DAV1D_X86_CPU_FLAG_AVX2 != 0 {
+    if flags.contains(CpuFlags::AVX2) {
         s.symbol_adapt16 = dav1d_msac_decode_symbol_adapt16_avx2;
     }
 }

--- a/src/x86/cpu.rs
+++ b/src/x86/cpu.rs
@@ -1,3 +1,4 @@
+use bitflags::bitflags;
 use libc::memcmp;
 use std::ffi::c_char;
 use std::ffi::c_int;
@@ -11,13 +12,16 @@ extern "C" {
     fn dav1d_cpu_xgetbv(xcr: c_uint) -> u64;
 }
 
-pub type CpuFlags = c_uint;
-pub const DAV1D_X86_CPU_FLAG_SLOW_GATHER: CpuFlags = 32;
-pub const DAV1D_X86_CPU_FLAG_AVX512ICL: CpuFlags = 16;
-pub const DAV1D_X86_CPU_FLAG_AVX2: CpuFlags = 8;
-pub const DAV1D_X86_CPU_FLAG_SSE41: CpuFlags = 4;
-pub const DAV1D_X86_CPU_FLAG_SSSE3: CpuFlags = 2;
-pub const DAV1D_X86_CPU_FLAG_SSE2: CpuFlags = 1;
+bitflags! {
+    pub struct CpuFlags: c_uint {
+        const SSE2 = 1 << 0;
+        const SSSE3 = 1 << 1;
+        const SSE41 = 1 << 2;
+        const AVX2 = 1 << 3;
+        const AVX512ICL = 1 << 4;
+        const SLOW_GATHER = 1 << 5;
+    }
+}
 
 #[derive(Clone, Copy)]
 #[repr(C)]
@@ -42,7 +46,7 @@ pub union C2RustUnnamed_0 {
 }
 
 #[cold]
-pub unsafe fn dav1d_get_cpu_flags_x86() -> c_uint {
+pub unsafe fn dav1d_get_cpu_flags_x86() -> CpuFlags {
     let mut cpu: C2RustUnnamed_0 = C2RustUnnamed_0 {
         r: CpuidRegisters {
             eax: 0,
@@ -52,7 +56,7 @@ pub unsafe fn dav1d_get_cpu_flags_x86() -> c_uint {
         },
     };
     dav1d_cpu_cpuid(&mut cpu.r, 0 as c_int as c_uint, 0 as c_int as c_uint);
-    let mut flags: c_uint = 0 as c_int as c_uint;
+    let mut flags = CpuFlags::empty();
     if cpu.c2rust_unnamed.max_leaf >= 1 as c_uint {
         let mut r: CpuidRegisters = CpuidRegisters {
             eax: 0,
@@ -66,11 +70,11 @@ pub unsafe fn dav1d_get_cpu_flags_x86() -> c_uint {
         let family: c_uint = (r.eax >> 8 & 0xf as c_int as c_uint)
             .wrapping_add(r.eax >> 20 & 0xff as c_int as c_uint);
         if r.edx & 0x6008000 as c_int as c_uint == 0x6008000 as c_int as c_uint {
-            flags |= DAV1D_X86_CPU_FLAG_SSE2 as c_int as c_uint;
+            flags |= CpuFlags::SSE2;
             if r.ecx & 0x201 as c_int as c_uint == 0x201 as c_int as c_uint {
-                flags |= DAV1D_X86_CPU_FLAG_SSSE3 as c_int as c_uint;
+                flags |= CpuFlags::SSSE3;
                 if r.ecx & 0x80000 as c_int as c_uint == 0x80000 as c_int as c_uint {
-                    flags |= DAV1D_X86_CPU_FLAG_SSE41 as c_int as c_uint;
+                    flags |= CpuFlags::SSE41;
                 }
             }
         }
@@ -83,12 +87,12 @@ pub unsafe fn dav1d_get_cpu_flags_x86() -> c_uint {
                 if cpu.c2rust_unnamed.max_leaf >= 7 as c_uint {
                     dav1d_cpu_cpuid(&mut r, 7 as c_int as c_uint, 0 as c_int as c_uint);
                     if r.ebx & 0x128 as c_int as c_uint == 0x128 as c_int as c_uint {
-                        flags |= DAV1D_X86_CPU_FLAG_AVX2 as c_int as c_uint;
+                        flags |= CpuFlags::AVX2;
                         if xcr0 & 0xe0 as c_int as c_ulong == 0xe0 as c_int as c_ulong {
                             if r.ebx & 0xd0230000 as c_uint == 0xd0230000 as c_uint
                                 && r.ecx & 0x5f42 as c_int as c_uint == 0x5f42 as c_int as c_uint
                             {
-                                flags |= DAV1D_X86_CPU_FLAG_AVX512ICL as c_int as c_uint;
+                                flags |= CpuFlags::AVX512ICL;
                             }
                         }
                     }
@@ -102,13 +106,13 @@ pub unsafe fn dav1d_get_cpu_flags_x86() -> c_uint {
             ::core::mem::size_of::<[c_char; 12]>(),
         ) == 0
         {
-            if flags & DAV1D_X86_CPU_FLAG_AVX2 as c_int as c_uint != 0
+            if flags.contains(CpuFlags::AVX2)
                 && (family < 0x19 as c_int as c_uint
                     || family == 0x19 as c_int as c_uint
                         && (model < 0x10 as c_int as c_uint
                             || model >= 0x20 as c_int as c_uint && model < 0x60 as c_int as c_uint))
             {
-                flags |= DAV1D_X86_CPU_FLAG_SLOW_GATHER as c_int as c_uint;
+                flags |= CpuFlags::SLOW_GATHER;
             }
         }
     }


### PR DESCRIPTION
I wanted to test out using `bitflags!` for things that were manually bitflags, as there are some other uses of this, too.

In hindsight, I think I could've also made #497 just use `bitflags!` instead.