### PR TITLE
`fn dav1d_{init_cpu,get_cpu_flags_{x86,arm}}`: Make safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,7 @@ dependencies = [
  "nasm-rs",
  "num_cpus",
  "paste",
+ "raw-cpuid",
  "strum",
 ]
 
@@ -93,6 +94,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ cfg-if = "1.0.0"
 libc = "0.2"
 num_cpus = "1.0"
 paste = "1.0.14"
+raw-cpuid = "11.0.1"
 strum = { version = "0.25.0", features = ["derive"] }
 
 [build-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -58,7 +58,6 @@ fn build_nasm_files(x86_64: bool) {
     let mut asm_files = vec![
         "src/x86/cdef_avx2.asm",
         "src/x86/cdef_sse.asm",
-        "src/x86/cpuid.asm",
         "src/x86/itx_avx2.asm",
         "src/x86/itx_avx512.asm",
         "src/x86/itx_sse.asm",

--- a/lib.rs
+++ b/lib.rs
@@ -4,6 +4,7 @@
 #![feature(c_variadic)]
 #![feature(core_intrinsics)]
 #![feature(extern_types)]
+#![cfg_attr(target_arch = "arm", feature(stdsimd))]
 
 #[cfg(not(any(feature = "bitdepth_8", feature = "bitdepth_16")))]
 compile_error!("No bitdepths enabled. Enable one or more of the following features: `bitdepth_8`, `bitdepth_16`");

--- a/src/arm/cpu.rs
+++ b/src/arm/cpu.rs
@@ -9,7 +9,7 @@ bitflags! {
 }
 
 #[cold]
-pub unsafe fn dav1d_get_cpu_flags_arm() -> CpuFlags {
+pub fn dav1d_get_cpu_flags_arm() -> CpuFlags {
     let mut flags = CpuFlags::empty();
 
     #[cfg(target_arch = "arm")]

--- a/src/arm/cpu.rs
+++ b/src/arm/cpu.rs
@@ -1,7 +1,6 @@
 use bitflags::bitflags;
-use cfg_if::cfg_if;
+use std::arch;
 use std::ffi::c_uint;
-use std::ffi::c_ulong;
 
 bitflags! {
     pub struct CpuFlags: c_uint {
@@ -9,27 +8,18 @@ bitflags! {
     }
 }
 
-pub const NEON_HWCAP: c_ulong = 1 << 12;
-
 #[cold]
 pub unsafe fn dav1d_get_cpu_flags_arm() -> CpuFlags {
     let mut flags = CpuFlags::empty();
 
-    cfg_if! {
-        if #[cfg(any(
-            target_arch = "aarch64",
-            target_os = "windows",
-            target_os = "macos"
-        ))] {
-            flags |= CpuFlags::NEON;
-        } else if #[cfg(target_arch = "arm")] {
-            if (libc::getauxval(libc::AT_HWCAP) & NEON_HWCAP) != 0 {
-                flags |= CpuFlags::NEON;
-            }
-        } else if #[cfg(target_os = "android")] {
-            // TODO: Support Android by parsing `/proc/cpuinfo` the way the original C does.
-            todo!("Android is not yet supported")
-        }
+    #[cfg(target_arch = "arm")]
+    if arch::is_arm_feature_detected!("neon") {
+        flags |= CpuFlags::NEON;
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    if arch::is_aarch64_feature_detected!("neon") {
+        flags |= CpuFlags::NEON;
     }
 
     flags

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -52,7 +52,7 @@ pub(crate) fn dav1d_get_cpu_flags() -> CpuFlags {
 }
 
 #[cold]
-pub(crate) unsafe fn dav1d_init_cpu() {
+pub(crate) fn dav1d_init_cpu() {
     #[cfg(feature = "asm")]
     cfg_if! {
         if #[cfg(target_arch = "x86_64")] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ pub struct Dav1dSettings {
 }
 
 #[cold]
-unsafe fn init_internal() {
+fn init_internal() {
     dav1d_init_cpu();
 }
 

--- a/src/x86/cpu.rs
+++ b/src/x86/cpu.rs
@@ -20,7 +20,7 @@ bitflags! {
 }
 
 #[cold]
-pub unsafe fn dav1d_get_cpu_flags_x86() -> CpuFlags {
+pub fn dav1d_get_cpu_flags_x86() -> CpuFlags {
     let mut flags = CpuFlags::empty();
 
     if is_x86_feature_detected!("sse2") {

--- a/src/x86/cpu.rs
+++ b/src/x86/cpu.rs
@@ -3,13 +3,10 @@ use libc::memcmp;
 use std::ffi::c_char;
 use std::ffi::c_int;
 use std::ffi::c_uint;
-use std::ffi::c_ulong;
 use std::ffi::c_void;
 
 extern "C" {
     fn dav1d_cpu_cpuid(regs: *mut CpuidRegisters, leaf: c_uint, subleaf: c_uint);
-    #[cfg(target_arch = "x86_64")]
-    fn dav1d_cpu_xgetbv(xcr: c_uint) -> u64;
 }
 
 bitflags! {
@@ -53,6 +50,38 @@ pub union C2RustUnnamed_0 {
 
 #[cold]
 pub unsafe fn dav1d_get_cpu_flags_x86() -> CpuFlags {
+    let mut flags = CpuFlags::empty();
+
+    if is_x86_feature_detected!("sse2") {
+        flags |= CpuFlags::SSE2;
+    }
+    if is_x86_feature_detected!("ssse3") {
+        flags |= CpuFlags::SSSE3;
+    }
+    if is_x86_feature_detected!("sse4.1") {
+        flags |= CpuFlags::SSE41;
+    }
+    if is_x86_feature_detected!("avx2") {
+        flags |= CpuFlags::AVX2;
+    }
+    if is_x86_feature_detected!("avx512f")
+        && is_x86_feature_detected!("avx512cd")
+        && is_x86_feature_detected!("avx512bw")
+        && is_x86_feature_detected!("avx512dq")
+        && is_x86_feature_detected!("avx512vl")
+        && is_x86_feature_detected!("avx512vnni")
+        && is_x86_feature_detected!("avx512ifma")
+        && is_x86_feature_detected!("avx512vbmi")
+        && is_x86_feature_detected!("avx512vbmi2")
+        && is_x86_feature_detected!("avx512vpopcntdq")
+        && is_x86_feature_detected!("avx512bitalg")
+        && is_x86_feature_detected!("gfni")
+        && is_x86_feature_detected!("vaes")
+        && is_x86_feature_detected!("vpclmulqdq")
+    {
+        flags |= CpuFlags::AVX512ICL;
+    }
+
     let mut cpu: C2RustUnnamed_0 = C2RustUnnamed_0 {
         r: CpuidRegisters {
             eax: 0,
@@ -62,7 +91,6 @@ pub unsafe fn dav1d_get_cpu_flags_x86() -> CpuFlags {
         },
     };
     dav1d_cpu_cpuid(&mut cpu.r, 0 as c_int as c_uint, 0 as c_int as c_uint);
-    let mut flags = CpuFlags::empty();
     if cpu.c2rust_unnamed.max_leaf >= 1 as c_uint {
         let mut r: CpuidRegisters = CpuidRegisters {
             eax: 0,
@@ -75,37 +103,6 @@ pub unsafe fn dav1d_get_cpu_flags_x86() -> CpuFlags {
             .wrapping_add(r.eax >> 12 & 0xf0 as c_int as c_uint);
         let family: c_uint = (r.eax >> 8 & 0xf as c_int as c_uint)
             .wrapping_add(r.eax >> 20 & 0xff as c_int as c_uint);
-        if r.edx & 0x6008000 as c_int as c_uint == 0x6008000 as c_int as c_uint {
-            flags |= CpuFlags::SSE2;
-            if r.ecx & 0x201 as c_int as c_uint == 0x201 as c_int as c_uint {
-                flags |= CpuFlags::SSSE3;
-                if r.ecx & 0x80000 as c_int as c_uint == 0x80000 as c_int as c_uint {
-                    flags |= CpuFlags::SSE41;
-                }
-            }
-        }
-
-        // We only support >128-bit SIMD on x86-64.
-        #[cfg(target_arch = "x86_64")]
-        if r.ecx & 0x18000000 as c_int as c_uint == 0x18000000 as c_int as c_uint {
-            let xcr0: u64 = dav1d_cpu_xgetbv(0 as c_int as c_uint);
-            if xcr0 & 0x6 as c_int as c_ulong == 0x6 as c_int as c_ulong {
-                if cpu.c2rust_unnamed.max_leaf >= 7 as c_uint {
-                    dav1d_cpu_cpuid(&mut r, 7 as c_int as c_uint, 0 as c_int as c_uint);
-                    if r.ebx & 0x128 as c_int as c_uint == 0x128 as c_int as c_uint {
-                        flags |= CpuFlags::AVX2;
-                        if xcr0 & 0xe0 as c_int as c_ulong == 0xe0 as c_int as c_ulong {
-                            if r.ebx & 0xd0230000 as c_uint == 0xd0230000 as c_uint
-                                && r.ecx & 0x5f42 as c_int as c_uint == 0x5f42 as c_int as c_uint
-                            {
-                                flags |= CpuFlags::AVX512ICL;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
         if memcmp(
             (cpu.c2rust_unnamed.vendor).as_mut_ptr() as *const c_void,
             b"AuthenticAMD\0" as *const u8 as *const c_char as *const c_void,
@@ -122,5 +119,6 @@ pub unsafe fn dav1d_get_cpu_flags_x86() -> CpuFlags {
             }
         }
     }
-    return flags;
+
+    flags
 }

--- a/src/x86/cpu.rs
+++ b/src/x86/cpu.rs
@@ -1,13 +1,6 @@
 use bitflags::bitflags;
-use libc::memcmp;
-use std::ffi::c_char;
-use std::ffi::c_int;
+use raw_cpuid::CpuId;
 use std::ffi::c_uint;
-use std::ffi::c_void;
-
-extern "C" {
-    fn dav1d_cpu_cpuid(regs: *mut CpuidRegisters, leaf: c_uint, subleaf: c_uint);
-}
 
 bitflags! {
     pub struct CpuFlags: c_uint {
@@ -24,28 +17,6 @@ bitflags! {
         /// slow enough to cause performance regressions.
         const SLOW_GATHER = 1 << 5;
     }
-}
-
-#[derive(Clone, Copy)]
-#[repr(C)]
-pub struct CpuidRegisters {
-    pub eax: u32,
-    pub ebx: u32,
-    pub edx: u32,
-    pub ecx: u32,
-}
-
-#[derive(Clone, Copy)]
-#[repr(C)]
-pub struct C2RustUnnamed {
-    pub max_leaf: u32,
-    pub vendor: [c_char; 12],
-}
-
-#[repr(C)]
-pub union C2RustUnnamed_0 {
-    pub r: CpuidRegisters,
-    pub c2rust_unnamed: C2RustUnnamed,
 }
 
 #[cold]
@@ -82,42 +53,25 @@ pub unsafe fn dav1d_get_cpu_flags_x86() -> CpuFlags {
         flags |= CpuFlags::AVX512ICL;
     }
 
-    let mut cpu: C2RustUnnamed_0 = C2RustUnnamed_0 {
-        r: CpuidRegisters {
-            eax: 0,
-            ebx: 0,
-            edx: 0,
-            ecx: 0,
-        },
-    };
-    dav1d_cpu_cpuid(&mut cpu.r, 0 as c_int as c_uint, 0 as c_int as c_uint);
-    if cpu.c2rust_unnamed.max_leaf >= 1 as c_uint {
-        let mut r: CpuidRegisters = CpuidRegisters {
-            eax: 0,
-            ebx: 0,
-            edx: 0,
-            ecx: 0,
-        };
-        dav1d_cpu_cpuid(&mut r, 1 as c_int as c_uint, 0 as c_int as c_uint);
-        let model: c_uint = (r.eax >> 4 & 0xf as c_int as c_uint)
-            .wrapping_add(r.eax >> 12 & 0xf0 as c_int as c_uint);
-        let family: c_uint = (r.eax >> 8 & 0xf as c_int as c_uint)
-            .wrapping_add(r.eax >> 20 & 0xff as c_int as c_uint);
-        if memcmp(
-            (cpu.c2rust_unnamed.vendor).as_mut_ptr() as *const c_void,
-            b"AuthenticAMD\0" as *const u8 as *const c_char as *const c_void,
-            ::core::mem::size_of::<[c_char; 12]>(),
-        ) == 0
-        {
-            if flags.contains(CpuFlags::AVX2)
-                && (family < 0x19 as c_int as c_uint
-                    || family == 0x19 as c_int as c_uint
-                        && (model < 0x10 as c_int as c_uint
-                            || model >= 0x20 as c_int as c_uint && model < 0x60 as c_int as c_uint))
-            {
-                flags |= CpuFlags::SLOW_GATHER;
-            }
+    /// Detect Excavator, Zen, Zen+, Zen 2, Zen 3, Zen 3+.
+    fn is_slow_gather() -> Option<()> {
+        let cpu_id = CpuId::new();
+
+        let vendor = cpu_id.get_vendor_info()?;
+        let is_amd = vendor.as_str() == "AuthenticAMD";
+        if !is_amd {
+            return None;
         }
+
+        let features = cpu_id.get_feature_info()?;
+        let family = features.family_id();
+        let model = features.model_id();
+
+        (family < 0x19 || (family == 0x19 && (model < 0x10 || (model >= 0x20 && model < 0x60))))
+            .then_some(())
+    }
+    if flags.contains(CpuFlags::AVX2) && is_slow_gather().is_some() {
+        flags |= CpuFlags::SLOW_GATHER;
     }
 
     flags

--- a/src/x86/cpu.rs
+++ b/src/x86/cpu.rs
@@ -18,7 +18,13 @@ bitflags! {
         const SSSE3 = 1 << 1;
         const SSE41 = 1 << 2;
         const AVX2 = 1 << 3;
+
+        /// F/CD/BW/DQ/VL/VNNI/IFMA/VBMI/VBMI2/
+        /// VPOPCNTDQ/BITALG/GFNI/VAES/VPCLMULQDQ
         const AVX512ICL = 1 << 4;
+
+        /// Flag CPUs where gather instructions are
+        /// slow enough to cause performance regressions.
         const SLOW_GATHER = 1 << 5;
     }
 }


### PR DESCRIPTION
This makes all of the cpu detection code fully safe and fully in Rust now.

For `x86`, `x86_64`, and `aarch64`, the stable `is_{x86,aarch64}_feature_detected!` macros are used, and for `arm`, the unstable `is_arm_feature_detected!` macro is used.  Thus, `#![feature(stdsimd)]` needs to be enabled on `arm`, but on the other hand, `is_arm_feature_detected!` is probably more correct and stable than what the C was doing, and we also get support for `android` this way (we previously didn't translate this part).

To detect `CpuFlags::SLOW_GATHER`, which looks for specific CPUs, we use the `raw-cpuid` crate instead of `cpuid.asm`.