### PR TITLE
`{D => R}av1d*`: Rename all private types from `Dav1d` to `Rav1d`

### DIFF
--- a/include/dav1d/common.rs
+++ b/include/dav1d/common.rs
@@ -1,4 +1,4 @@
-use crate::src::r#ref::Dav1dRef;
+use crate::include::dav1d::dav1d::Dav1dRef;
 use std::ptr;
 
 #[derive(Clone)]

--- a/include/dav1d/data.rs
+++ b/include/dav1d/data.rs
@@ -1,5 +1,5 @@
 use crate::include::dav1d::common::Dav1dDataProps;
-use crate::src::r#ref::Dav1dRef;
+use crate::include::dav1d::dav1d::Dav1dRef;
 use std::ptr;
 
 #[derive(Clone)]

--- a/include/dav1d/dav1d.rs
+++ b/include/dav1d/dav1d.rs
@@ -1,11 +1,13 @@
 use crate::include::dav1d::picture::Dav1dPicAllocator;
+use crate::src::internal::Rav1dContext;
+use crate::src::r#ref::Rav1dRef;
 use std::ffi::c_char;
 use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_void;
 
-pub use crate::src::internal::Dav1dContext;
-pub use crate::src::r#ref::Dav1dRef;
+pub type Dav1dContext = Rav1dContext;
+pub type Dav1dRef = Rav1dRef;
 
 #[derive(Clone)]
 #[repr(C)]

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -1,11 +1,11 @@
 use crate::include::dav1d::common::Dav1dDataProps;
+use crate::include::dav1d::dav1d::Dav1dRef;
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::src::r#ref::Dav1dRef;
 use libc::ptrdiff_t;
 use libc::uintptr_t;
 use std::ffi::c_int;

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -30,7 +30,7 @@ pub type cdef_dir_fn =
     unsafe extern "C" fn(*const DynPixel, ptrdiff_t, *mut c_uint, c_int) -> c_int;
 
 #[repr(C)]
-pub struct Dav1dCdefDSPContext {
+pub struct Rav1dCdefDSPContext {
     pub dir: cdef_dir_fn,
     pub fb: [cdef_fn; 3],
 }

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -10,9 +10,9 @@ use crate::src::cdef::CDEF_HAVE_BOTTOM;
 use crate::src::cdef::CDEF_HAVE_LEFT;
 use crate::src::cdef::CDEF_HAVE_RIGHT;
 use crate::src::cdef::CDEF_HAVE_TOP;
-use crate::src::internal::Dav1dDSPContext;
-use crate::src::internal::Dav1dFrameContext;
-use crate::src::internal::Dav1dTaskContext;
+use crate::src::internal::Rav1dDSPContext;
+use crate::src::internal::Rav1dFrameContext;
+use crate::src::internal::Rav1dTaskContext;
 use crate::src::lf_mask::Av1Filter;
 use libc::memcpy;
 use libc::ptrdiff_t;
@@ -156,7 +156,7 @@ unsafe extern "C" fn adjust_strength(strength: c_int, var: c_uint) -> c_int {
 }
 
 pub unsafe fn dav1d_cdef_brow_16bpc(
-    tc: *mut Dav1dTaskContext,
+    tc: *mut Rav1dTaskContext,
     p: *const *mut pixel,
     lflvl: *const Av1Filter,
     by_start: c_int,
@@ -164,13 +164,13 @@ pub unsafe fn dav1d_cdef_brow_16bpc(
     sbrow_start: c_int,
     sby: c_int,
 ) {
-    let f: *mut Dav1dFrameContext = (*tc).f as *mut Dav1dFrameContext;
+    let f: *mut Rav1dFrameContext = (*tc).f as *mut Rav1dFrameContext;
     let bitdepth_min_8 = if 16 == 8 {
         0 as c_int
     } else {
         (*f).cur.p.bpc - 8
     };
-    let dsp: *const Dav1dDSPContext = (*f).dsp;
+    let dsp: *const Rav1dDSPContext = (*f).dsp;
     let mut edges: CdefEdgeFlags = (CDEF_HAVE_BOTTOM as c_int
         | (if by_start > 0 {
             CDEF_HAVE_TOP as c_int

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -10,9 +10,9 @@ use crate::src::cdef::CDEF_HAVE_BOTTOM;
 use crate::src::cdef::CDEF_HAVE_LEFT;
 use crate::src::cdef::CDEF_HAVE_RIGHT;
 use crate::src::cdef::CDEF_HAVE_TOP;
-use crate::src::internal::Dav1dDSPContext;
-use crate::src::internal::Dav1dFrameContext;
-use crate::src::internal::Dav1dTaskContext;
+use crate::src::internal::Rav1dDSPContext;
+use crate::src::internal::Rav1dFrameContext;
+use crate::src::internal::Rav1dTaskContext;
 use crate::src::lf_mask::Av1Filter;
 use libc::memcpy;
 use libc::ptrdiff_t;
@@ -148,7 +148,7 @@ unsafe extern "C" fn adjust_strength(strength: c_int, var: c_uint) -> c_int {
 }
 
 pub unsafe fn dav1d_cdef_brow_8bpc(
-    tc: *mut Dav1dTaskContext,
+    tc: *mut Rav1dTaskContext,
     p: *const *mut pixel,
     lflvl: *const Av1Filter,
     by_start: c_int,
@@ -156,13 +156,13 @@ pub unsafe fn dav1d_cdef_brow_8bpc(
     sbrow_start: c_int,
     sby: c_int,
 ) {
-    let f: *mut Dav1dFrameContext = (*tc).f as *mut Dav1dFrameContext;
+    let f: *mut Rav1dFrameContext = (*tc).f as *mut Rav1dFrameContext;
     let bitdepth_min_8 = if 8 == 8 {
         0 as c_int
     } else {
         (*f).cur.p.bpc - 8
     };
-    let dsp: *const Dav1dDSPContext = (*f).dsp;
+    let dsp: *const Rav1dDSPContext = (*f).dsp;
     let mut edges: CdefEdgeFlags = (CDEF_HAVE_BOTTOM as c_int
         | (if by_start > 0 {
             CDEF_HAVE_TOP as c_int

--- a/src/cdef_tmpl_16.rs
+++ b/src/cdef_tmpl_16.rs
@@ -6,7 +6,7 @@ use crate::include::common::intops::ulog2;
 use crate::src::cdef::constrain;
 use crate::src::cdef::fill;
 use crate::src::cdef::CdefEdgeFlags;
-use crate::src::cdef::Dav1dCdefDSPContext;
+use crate::src::cdef::Rav1dCdefDSPContext;
 use crate::src::cdef::CDEF_HAVE_BOTTOM;
 use crate::src::cdef::CDEF_HAVE_LEFT;
 use crate::src::cdef::CDEF_HAVE_RIGHT;
@@ -500,7 +500,7 @@ unsafe fn cdef_find_dir_rust(
 
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
-unsafe extern "C" fn cdef_dsp_init_x86(c: *mut Dav1dCdefDSPContext) {
+unsafe extern "C" fn cdef_dsp_init_x86(c: *mut Rav1dCdefDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::cdef::*;
 
@@ -544,7 +544,7 @@ unsafe extern "C" fn cdef_dsp_init_x86(c: *mut Dav1dCdefDSPContext) {
 
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
-unsafe extern "C" fn cdef_dsp_init_arm(c: *mut Dav1dCdefDSPContext) {
+unsafe extern "C" fn cdef_dsp_init_arm(c: *mut Rav1dCdefDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::cdef::*;
 
@@ -666,7 +666,7 @@ unsafe extern "C" fn cdef_filter_4x4_neon_erased(
 }
 
 #[cold]
-pub unsafe fn dav1d_cdef_dsp_init_16bpc(c: *mut Dav1dCdefDSPContext) {
+pub unsafe fn dav1d_cdef_dsp_init_16bpc(c: *mut Rav1dCdefDSPContext) {
     (*c).dir = cdef_find_dir_c_erased;
     (*c).fb[0] = cdef_filter_block_8x8_c_erased;
     (*c).fb[1] = cdef_filter_block_4x8_c_erased;

--- a/src/cdef_tmpl_8.rs
+++ b/src/cdef_tmpl_8.rs
@@ -5,7 +5,7 @@ use crate::include::common::intops::ulog2;
 use crate::src::cdef::constrain;
 use crate::src::cdef::fill;
 use crate::src::cdef::CdefEdgeFlags;
-use crate::src::cdef::Dav1dCdefDSPContext;
+use crate::src::cdef::Rav1dCdefDSPContext;
 use crate::src::cdef::CDEF_HAVE_BOTTOM;
 use crate::src::cdef::CDEF_HAVE_LEFT;
 use crate::src::cdef::CDEF_HAVE_RIGHT;
@@ -486,7 +486,7 @@ use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
 
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
-unsafe extern "C" fn cdef_dsp_init_x86(c: *mut Dav1dCdefDSPContext) {
+unsafe extern "C" fn cdef_dsp_init_x86(c: *mut Rav1dCdefDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::cdef::*;
 
@@ -541,7 +541,7 @@ unsafe extern "C" fn cdef_dsp_init_x86(c: *mut Dav1dCdefDSPContext) {
 
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
-unsafe extern "C" fn cdef_dsp_init_arm(c: *mut Dav1dCdefDSPContext) {
+unsafe extern "C" fn cdef_dsp_init_arm(c: *mut Rav1dCdefDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::cdef::*;
 
@@ -660,7 +660,7 @@ unsafe extern "C" fn cdef_filter_8x8_neon_erased(
 }
 
 #[cold]
-pub unsafe fn dav1d_cdef_dsp_init_8bpc(c: *mut Dav1dCdefDSPContext) {
+pub unsafe fn dav1d_cdef_dsp_init_8bpc(c: *mut Rav1dCdefDSPContext) {
     (*c).dir = cdef_find_dir_c_erased;
     (*c).fb[0] = cdef_filter_block_8x8_c_erased;
     (*c).fb[1] = cdef_filter_block_4x8_c_erased;

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -5,7 +5,7 @@ use crate::src::align::Align16;
 use crate::src::align::Align32;
 use crate::src::align::Align4;
 use crate::src::align::Align8;
-use crate::src::internal::Dav1dContext;
+use crate::src::internal::Rav1dContext;
 use crate::src::levels::N_BL_LEVELS;
 use crate::src::levels::N_BS_SIZES;
 use crate::src::levels::N_COMP_INTER_PRED_MODES;
@@ -17,7 +17,7 @@ use crate::src::levels::N_UV_INTRA_PRED_MODES;
 use crate::src::r#ref::dav1d_ref_create_using_pool;
 use crate::src::r#ref::dav1d_ref_dec;
 use crate::src::r#ref::dav1d_ref_inc;
-use crate::src::r#ref::Dav1dRef;
+use crate::src::r#ref::Rav1dRef;
 use crate::src::tables::dav1d_partition_type_count;
 use libc::memcpy;
 use libc::memset;
@@ -130,7 +130,7 @@ pub struct CdfModeContext {
 #[derive(Clone)]
 #[repr(C)]
 pub struct CdfThreadContext {
-    pub r#ref: *mut Dav1dRef,
+    pub r#ref: *mut Rav1dRef,
     pub data: CdfThreadContext_data,
     pub progress: *mut atomic_uint,
 }
@@ -5612,7 +5612,7 @@ unsafe extern "C" fn get_qcat_idx(q: c_int) -> c_int {
 }
 
 pub unsafe fn dav1d_cdf_thread_init_static(cdf: *mut CdfThreadContext, qidx: c_int) {
-    (*cdf).r#ref = 0 as *mut Dav1dRef;
+    (*cdf).r#ref = 0 as *mut Rav1dRef;
     (*cdf).data.qcat = get_qcat_idx(qidx) as c_uint;
 }
 
@@ -5649,7 +5649,7 @@ pub unsafe fn dav1d_cdf_thread_copy(dst: *mut CdfContext, src: *const CdfThreadC
 }
 
 pub unsafe fn dav1d_cdf_thread_alloc(
-    c: *mut Dav1dContext,
+    c: *mut Rav1dContext,
     cdf: *mut CdfThreadContext,
     have_frame_mt: c_int,
 ) -> c_int {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,5 +1,5 @@
 use crate::src::const_fn::const_for;
-use crate::src::internal::Dav1dContext;
+use crate::src::internal::Rav1dContext;
 use bitflags::bitflags;
 use std::ffi::c_int;
 use std::ffi::c_uint;
@@ -203,6 +203,6 @@ pub extern "C" fn dav1d_set_cpu_flags_mask(mask: c_uint) {
 }
 
 #[cold]
-pub(crate) fn dav1d_num_logical_processors(_c: *mut Dav1dContext) -> c_int {
+pub(crate) fn dav1d_num_logical_processors(_c: *mut Rav1dContext) -> c_int {
     num_cpus::get() as c_int
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -4,7 +4,7 @@ use crate::src::r#ref::dav1d_ref_create;
 use crate::src::r#ref::dav1d_ref_dec;
 use crate::src::r#ref::dav1d_ref_inc;
 use crate::src::r#ref::dav1d_ref_wrap;
-use crate::src::r#ref::Dav1dRef;
+use crate::src::r#ref::Rav1dRef;
 use crate::stderr;
 use libc::fprintf;
 use libc::memset;
@@ -209,7 +209,7 @@ pub unsafe fn dav1d_data_props_unref_internal(props: *mut Dav1dDataProps) {
         );
         return;
     }
-    let mut user_data_ref: *mut Dav1dRef = (*props).user_data.r#ref;
+    let mut user_data_ref: *mut Rav1dRef = (*props).user_data.r#ref;
     dav1d_data_props_set_defaults(props);
     dav1d_ref_dec(&mut user_data_ref);
 }
@@ -225,7 +225,7 @@ pub unsafe fn dav1d_data_unref_internal(buf: *mut Dav1dData) {
         );
         return;
     }
-    let mut user_data_ref: *mut Dav1dRef = (*buf).m.user_data.r#ref;
+    let mut user_data_ref: *mut Rav1dRef = (*buf).m.user_data.r#ref;
     if !((*buf).r#ref).is_null() {
         if ((*buf).data).is_null() {
             fprintf(

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -69,12 +69,12 @@ use crate::src::env::get_poc_diff;
 use crate::src::env::get_tx_ctx;
 use crate::src::env::BlockContext;
 use crate::src::internal::CodedBlockInfo;
-use crate::src::internal::Dav1dContext;
-use crate::src::internal::Dav1dFrameContext;
-use crate::src::internal::Dav1dTaskContext;
-use crate::src::internal::Dav1dTaskContext_scratch_pal;
-use crate::src::internal::Dav1dTileGroup;
-use crate::src::internal::Dav1dTileState;
+use crate::src::internal::Rav1dContext;
+use crate::src::internal::Rav1dFrameContext;
+use crate::src::internal::Rav1dTaskContext;
+use crate::src::internal::Rav1dTaskContext_scratch_pal;
+use crate::src::internal::Rav1dTileGroup;
+use crate::src::internal::Rav1dTileState;
 use crate::src::internal::ScalableMotionParams;
 use crate::src::intra_edge::EdgeBranch;
 use crate::src::intra_edge::EdgeFlags;
@@ -176,7 +176,7 @@ use crate::src::picture::dav1d_picture_unref_internal;
 use crate::src::picture::dav1d_thread_picture_alloc;
 use crate::src::picture::dav1d_thread_picture_ref;
 use crate::src::picture::dav1d_thread_picture_unref;
-use crate::src::picture::Dav1dThreadPicture;
+use crate::src::picture::Rav1dThreadPicture;
 use crate::src::qm::dav1d_qm_tbl;
 use crate::src::r#ref::dav1d_ref_create_using_pool;
 use crate::src::r#ref::dav1d_ref_dec;
@@ -302,7 +302,7 @@ fn init_quant_tables(
 }
 
 unsafe fn read_mv_component_diff(
-    t: &mut Dav1dTaskContext,
+    t: &mut Rav1dTaskContext,
     mv_comp: &mut CdfMvComponent,
     have_fp: bool,
 ) -> c_int {
@@ -362,7 +362,7 @@ unsafe fn read_mv_component_diff(
 }
 
 unsafe fn read_mv_residual(
-    t: &mut Dav1dTaskContext,
+    t: &mut Rav1dTaskContext,
     ref_mv: &mut mv,
     mv_cdf: &mut CdfMvContext,
     have_fp: bool,
@@ -388,7 +388,7 @@ unsafe fn read_mv_residual(
 }
 
 unsafe fn read_tx_tree(
-    t: &mut Dav1dTaskContext,
+    t: &mut Rav1dTaskContext,
     from: RectTxfmSize,
     depth: c_int,
     masks: &mut [u16; 2],
@@ -481,7 +481,7 @@ fn neg_deinterleave(diff: c_int, r#ref: c_int, max: c_int) -> c_int {
 }
 
 unsafe fn find_matching_ref(
-    t: &Dav1dTaskContext,
+    t: &Rav1dTaskContext,
     intra_edge_flags: EdgeFlags,
     bw4: c_int,
     bh4: c_int,
@@ -585,7 +585,7 @@ unsafe fn find_matching_ref(
 }
 
 unsafe fn derive_warpmv(
-    t: &Dav1dTaskContext,
+    t: &Rav1dTaskContext,
     bw4: c_int,
     bh4: c_int,
     masks: &[u64; 2],
@@ -709,7 +709,7 @@ fn findoddzero(buf: &[u8]) -> bool {
 }
 
 unsafe fn read_pal_plane(
-    t: &mut Dav1dTaskContext,
+    t: &mut Rav1dTaskContext,
     b: &mut Av1Block,
     pl: bool,
     sz_ctx: u8,
@@ -895,7 +895,7 @@ unsafe fn read_pal_plane(
 }
 
 unsafe fn read_pal_uv(
-    t: &mut Dav1dTaskContext,
+    t: &mut Rav1dTaskContext,
     b: &mut Av1Block,
     sz_ctx: u8,
     bx4: usize,
@@ -1022,8 +1022,8 @@ fn order_palette(
 }
 
 unsafe fn read_pal_indices(
-    ts: &mut Dav1dTileState,
-    scratch_pal: &mut Dav1dTaskContext_scratch_pal,
+    ts: &mut Rav1dTileState,
+    scratch_pal: &mut Rav1dTaskContext_scratch_pal,
     pal_idx: &mut [u8],
     b: &Av1Block,
     pl: bool,
@@ -1039,7 +1039,7 @@ unsafe fn read_pal_indices(
     let stride = bw4 * 4;
     pal_idx[0] = dav1d_msac_decode_uniform(&mut ts.msac, pal_sz as c_uint) as u8;
     let color_map_cdf = &mut ts.cdf.m.color_map[pli][pal_sz - 2];
-    let Dav1dTaskContext_scratch_pal {
+    let Rav1dTaskContext_scratch_pal {
         pal_order: order,
         pal_ctx: ctx,
     } = scratch_pal;
@@ -1078,7 +1078,7 @@ unsafe fn read_pal_indices(
 }
 
 unsafe fn read_vartx_tree(
-    t: &mut Dav1dTaskContext,
+    t: &mut Rav1dTaskContext,
     b: &mut Av1Block,
     bs: BlockSize,
     bx4: c_int,
@@ -1162,7 +1162,7 @@ unsafe fn read_vartx_tree(
 
 #[inline]
 unsafe fn get_prev_frame_segid(
-    f: &Dav1dFrameContext,
+    f: &Rav1dFrameContext,
     by: c_int,
     bx: c_int,
     w4: c_int,
@@ -1205,8 +1205,8 @@ unsafe fn get_prev_frame_segid(
 
 #[inline]
 unsafe fn splat_oneref_mv(
-    c: &Dav1dContext,
-    t: &mut Dav1dTaskContext,
+    c: &Rav1dContext,
+    t: &mut Rav1dTaskContext,
     bs: BlockSize,
     b: &Av1Block,
     bw4: usize,
@@ -1237,8 +1237,8 @@ unsafe fn splat_oneref_mv(
 
 #[inline]
 unsafe fn splat_intrabc_mv(
-    c: &Dav1dContext,
-    t: &mut Dav1dTaskContext,
+    c: &Rav1dContext,
+    t: &mut Rav1dTaskContext,
     bs: BlockSize,
     b: &Av1Block,
     bw4: usize,
@@ -1263,8 +1263,8 @@ unsafe fn splat_intrabc_mv(
 
 #[inline]
 unsafe fn splat_tworef_mv(
-    c: &Dav1dContext,
-    t: &mut Dav1dTaskContext,
+    c: &Rav1dContext,
+    t: &mut Rav1dTaskContext,
     bs: BlockSize,
     b: &Av1Block,
     bw4: usize,
@@ -1291,8 +1291,8 @@ unsafe fn splat_tworef_mv(
 
 #[inline]
 unsafe fn splat_intraref(
-    c: &Dav1dContext,
-    t: &mut Dav1dTaskContext,
+    c: &Rav1dContext,
+    t: &mut Rav1dTaskContext,
     bs: BlockSize,
     bw4: usize,
     bh4: usize,
@@ -1340,7 +1340,7 @@ fn mc_lowest_px(
 
 #[inline(always)]
 fn affine_lowest_px(
-    t: &Dav1dTaskContext,
+    t: &Rav1dTaskContext,
     dst: &mut c_int,
     b_dim: &[u8; 4],
     wmp: &Dav1dWarpedMotionParams,
@@ -1366,7 +1366,7 @@ fn affine_lowest_px(
 
 #[inline(never)]
 fn affine_lowest_px_luma(
-    t: &Dav1dTaskContext,
+    t: &Rav1dTaskContext,
     dst: &mut c_int,
     b_dim: &[u8; 4],
     wmp: &Dav1dWarpedMotionParams,
@@ -1376,7 +1376,7 @@ fn affine_lowest_px_luma(
 
 #[inline(never)]
 unsafe fn affine_lowest_px_chroma(
-    t: &Dav1dTaskContext,
+    t: &Rav1dTaskContext,
     dst: &mut c_int,
     b_dim: &[u8; 4],
     wmp: &Dav1dWarpedMotionParams,
@@ -1398,7 +1398,7 @@ unsafe fn affine_lowest_px_chroma(
 }
 
 unsafe fn obmc_lowest_px(
-    t: &mut Dav1dTaskContext,
+    t: &mut Rav1dTaskContext,
     dst: &mut [[c_int; 2]; 7],
     is_chroma: bool,
     b_dim: &[u8; 4],
@@ -1461,7 +1461,7 @@ unsafe fn obmc_lowest_px(
 }
 
 unsafe fn decode_b(
-    t: &mut Dav1dTaskContext,
+    t: &mut Rav1dTaskContext,
     bl: BlockLevel,
     bs: BlockSize,
     bp: BlockPartition,
@@ -3487,7 +3487,7 @@ unsafe fn decode_b(
     0
 }
 
-unsafe fn decode_sb(t: &mut Dav1dTaskContext, bl: BlockLevel, node: *const EdgeNode) -> c_int {
+unsafe fn decode_sb(t: &mut Rav1dTaskContext, bl: BlockLevel, node: *const EdgeNode) -> c_int {
     let f = &*t.f;
     let ts = &mut *t.ts;
     let hsz = 16 >> bl;
@@ -3916,8 +3916,8 @@ static ss_size_mul: [[u8; 2]; 4] = {
 };
 
 unsafe fn setup_tile(
-    ts: &mut Dav1dTileState,
-    f: &Dav1dFrameContext,
+    ts: &mut Rav1dTileState,
+    f: &Rav1dFrameContext,
     data: &[u8],
     tile_row: usize,
     tile_col: usize,
@@ -4023,7 +4023,7 @@ unsafe fn setup_tile(
 }
 
 unsafe fn read_restoration_info(
-    t: &mut Dav1dTaskContext,
+    t: &mut Rav1dTaskContext,
     lr: &mut Av1RestorationUnit,
     p: usize,
     frame_type: Dav1dRestorationType,
@@ -4060,7 +4060,7 @@ unsafe fn read_restoration_info(
         };
     }
 
-    fn msac_decode_lr_subexp(ts: &mut Dav1dTileState, r#ref: i8, k: u32, adjustment: i8) -> i8 {
+    fn msac_decode_lr_subexp(ts: &mut Rav1dTileState, r#ref: i8, k: u32, adjustment: i8) -> i8 {
         (dav1d_msac_decode_subexp(
             &mut ts.msac,
             (r#ref + adjustment) as libc::c_uint,
@@ -4126,15 +4126,15 @@ unsafe fn read_restoration_info(
     }
 }
 
-pub unsafe fn dav1d_decode_tile_sbrow(t: *mut Dav1dTaskContext) -> c_int {
-    let f: *const Dav1dFrameContext = (*t).f;
+pub unsafe fn dav1d_decode_tile_sbrow(t: *mut Rav1dTaskContext) -> c_int {
+    let f: *const Rav1dFrameContext = (*t).f;
     let root_bl: BlockLevel = (if (*(*f).seq_hdr).sb128 != 0 {
         BL_128X128 as c_int
     } else {
         BL_64X64 as c_int
     }) as BlockLevel;
-    let ts: *mut Dav1dTileState = (*t).ts;
-    let c: *const Dav1dContext = (*f).c;
+    let ts: *mut Rav1dTileState = (*t).ts;
+    let c: *const Rav1dContext = (*f).c;
     let sb_step = (*f).sb_step;
     let tile_row = (*ts).tiling.row;
     let tile_col = (*ts).tiling.col;
@@ -4360,7 +4360,7 @@ pub unsafe fn dav1d_decode_tile_sbrow(t: *mut Dav1dTaskContext) -> c_int {
     return 0 as c_int;
 }
 
-pub unsafe fn dav1d_decode_frame_init(f: &mut Dav1dFrameContext) -> c_int {
+pub unsafe fn dav1d_decode_frame_init(f: &mut Rav1dFrameContext) -> c_int {
     let c = &*f.c;
 
     if f.sbh > f.lf.start_of_tile_row_sz {
@@ -4394,8 +4394,8 @@ pub unsafe fn dav1d_decode_frame_init(f: &mut Dav1dFrameContext) -> c_int {
             }
         }
         dav1d_free_aligned(f.ts as *mut c_void);
-        f.ts = dav1d_alloc_aligned(::core::mem::size_of::<Dav1dTileState>() * n_ts as usize, 32)
-            as *mut Dav1dTileState;
+        f.ts = dav1d_alloc_aligned(::core::mem::size_of::<Rav1dTileState>() * n_ts as usize, 32)
+            as *mut Rav1dTileState;
         if f.ts.is_null() {
             return -12;
         }
@@ -4807,7 +4807,7 @@ pub unsafe fn dav1d_decode_frame_init(f: &mut Dav1dFrameContext) -> c_int {
     0
 }
 
-pub unsafe fn dav1d_decode_frame_init_cdf(f: &mut Dav1dFrameContext) -> c_int {
+pub unsafe fn dav1d_decode_frame_init_cdf(f: &mut Rav1dFrameContext) -> c_int {
     let c = &*f.c;
 
     if (*f.frame_hdr).refresh_context != 0 {
@@ -4902,12 +4902,12 @@ pub unsafe fn dav1d_decode_frame_init_cdf(f: &mut Dav1dFrameContext) -> c_int {
     0
 }
 
-unsafe fn dav1d_decode_frame_main(f: &mut Dav1dFrameContext) -> c_int {
+unsafe fn dav1d_decode_frame_main(f: &mut Rav1dFrameContext) -> c_int {
     let c = &*f.c;
 
     assert!(c.n_tc == 1);
 
-    let t = &mut *c.tc.offset((f as *mut Dav1dFrameContext).offset_from(c.fc));
+    let t = &mut *c.tc.offset((f as *mut Rav1dFrameContext).offset_from(c.fc));
     t.f = f;
     t.frame_thread.pass = 0;
 
@@ -4971,7 +4971,7 @@ unsafe fn dav1d_decode_frame_main(f: &mut Dav1dFrameContext) -> c_int {
     0
 }
 
-pub unsafe fn dav1d_decode_frame_exit(f: &mut Dav1dFrameContext, retval: c_int) {
+pub unsafe fn dav1d_decode_frame_exit(f: &mut Rav1dFrameContext, retval: c_int) {
     let c = &*f.c;
     if !f.sr_cur.p.data[0].is_null() {
         f.task_thread.error = 0;
@@ -5013,7 +5013,7 @@ pub unsafe fn dav1d_decode_frame_exit(f: &mut Dav1dFrameContext, retval: c_int) 
     f.task_thread.retval = retval;
 }
 
-pub unsafe fn dav1d_decode_frame(f: &mut Dav1dFrameContext) -> c_int {
+pub unsafe fn dav1d_decode_frame(f: &mut Rav1dFrameContext) -> c_int {
     assert!((*f.c).n_fc == 1);
     // if n_tc > 1 (but n_fc == 1), we could run init/exit in the task
     // threads also. Not sure it makes a measurable difference.
@@ -5061,7 +5061,7 @@ fn get_upscale_x0(in_w: c_int, out_w: c_int, step: c_int) -> c_int {
     x0 & 0x3fff
 }
 
-pub unsafe fn dav1d_submit_frame(c: &mut Dav1dContext) -> c_int {
+pub unsafe fn dav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
     // wait for c->out_delayed[next] and move into c->out if visible
     let (f, out_delayed) = if c.n_fc > 1 {
         pthread_mutex_lock(&mut c.task_thread.lock);
@@ -5128,9 +5128,9 @@ pub unsafe fn dav1d_submit_frame(c: &mut Dav1dContext) -> c_int {
     let bpc = 8 + 2 * (*f.seq_hdr).hbd;
 
     unsafe fn on_error(
-        f: &mut Dav1dFrameContext,
-        c: &mut Dav1dContext,
-        out_delayed: *mut Dav1dThreadPicture,
+        f: &mut Rav1dFrameContext,
+        c: &mut Rav1dContext,
+        out_delayed: *mut Rav1dThreadPicture,
     ) {
         f.task_thread.error = 1;
         dav1d_cdf_thread_unref(&mut f.in_cdf);
@@ -5297,10 +5297,10 @@ pub unsafe fn dav1d_submit_frame(c: &mut Dav1dContext) -> c_int {
 
     // FIXME qsort so tiles are in order (for frame threading)
     if f.n_tile_data_alloc < c.n_tile_data {
-        freep(&mut f.tile as *mut *mut Dav1dTileGroup as *mut c_void);
-        assert!(c.n_tile_data < i32::MAX / ::core::mem::size_of::<Dav1dTileGroup>() as c_int);
-        f.tile = malloc(c.n_tile_data as usize * ::core::mem::size_of::<Dav1dTileGroup>())
-            as *mut Dav1dTileGroup;
+        freep(&mut f.tile as *mut *mut Rav1dTileGroup as *mut c_void);
+        assert!(c.n_tile_data < i32::MAX / ::core::mem::size_of::<Rav1dTileGroup>() as c_int);
+        f.tile = malloc(c.n_tile_data as usize * ::core::mem::size_of::<Rav1dTileGroup>())
+            as *mut Rav1dTileGroup;
         if f.tile.is_null() {
             f.n_tile_data = 0;
             f.n_tile_data_alloc = f.n_tile_data;

--- a/src/fg_apply_tmpl_16.rs
+++ b/src/fg_apply_tmpl_16.rs
@@ -6,7 +6,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::include::dav1d::picture::Dav1dPicture;
 use crate::src::align::Align1;
 use crate::src::align::Align16;
-use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
+use crate::src::filmgrain::Rav1dFilmGrainDSPContext;
 use libc::intptr_t;
 use libc::memcpy;
 use libc::memset;
@@ -100,7 +100,7 @@ unsafe extern "C" fn generate_scaling(
 }
 
 pub unsafe fn dav1d_prep_grain_16bpc(
-    dsp: *const Dav1dFilmGrainDSPContext,
+    dsp: *const Rav1dFilmGrainDSPContext,
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,
     scaling: *mut [u8; 4096],
@@ -224,7 +224,7 @@ pub unsafe fn dav1d_prep_grain_16bpc(
 }
 
 pub unsafe fn dav1d_apply_grain_row_16bpc(
-    dsp: *const Dav1dFilmGrainDSPContext,
+    dsp: *const Rav1dFilmGrainDSPContext,
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,
     scaling: *const [u8; 4096],
@@ -333,7 +333,7 @@ pub unsafe fn dav1d_apply_grain_row_16bpc(
 }
 
 pub unsafe fn dav1d_apply_grain_16bpc(
-    dsp: *const Dav1dFilmGrainDSPContext,
+    dsp: *const Rav1dFilmGrainDSPContext,
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,
 ) {

--- a/src/fg_apply_tmpl_8.rs
+++ b/src/fg_apply_tmpl_8.rs
@@ -5,7 +5,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::include::dav1d::picture::Dav1dPicture;
 use crate::src::align::Align16;
-use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
+use crate::src::filmgrain::Rav1dFilmGrainDSPContext;
 use cfg_if::cfg_if;
 use libc::intptr_t;
 use libc::memcpy;
@@ -66,7 +66,7 @@ unsafe extern "C" fn generate_scaling(
 }
 
 pub unsafe fn dav1d_prep_grain_8bpc(
-    dsp: *const Dav1dFilmGrainDSPContext,
+    dsp: *const Rav1dFilmGrainDSPContext,
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,
     scaling: *mut [u8; 256],
@@ -189,7 +189,7 @@ pub unsafe fn dav1d_prep_grain_8bpc(
 }
 
 pub unsafe fn dav1d_apply_grain_row_8bpc(
-    dsp: *const Dav1dFilmGrainDSPContext,
+    dsp: *const Rav1dFilmGrainDSPContext,
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,
     scaling: *const [u8; 256],
@@ -297,7 +297,7 @@ pub unsafe fn dav1d_apply_grain_row_8bpc(
 }
 
 pub unsafe fn dav1d_apply_grain_8bpc(
-    dsp: *const Dav1dFilmGrainDSPContext,
+    dsp: *const Rav1dFilmGrainDSPContext,
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,
 ) {

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -70,7 +70,7 @@ pub type fguv_32x32xn_fn = Option<
 >;
 
 #[repr(C)]
-pub struct Dav1dFilmGrainDSPContext {
+pub struct Rav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y_fn,
     pub generate_grain_uv: [generate_grain_uv_fn; 3],
     pub fgy_32x32xn: fgy_32x32xn_fn,

--- a/src/filmgrain_tmpl_16.rs
+++ b/src/filmgrain_tmpl_16.rs
@@ -8,7 +8,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::src::filmgrain::get_random_number;
 use crate::src::filmgrain::round2;
-use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
+use crate::src::filmgrain::Rav1dFilmGrainDSPContext;
 use crate::src::filmgrain::GRAIN_WIDTH;
 use crate::src::tables::dav1d_gaussian_sequence;
 use libc::intptr_t;
@@ -1341,7 +1341,7 @@ unsafe extern "C" fn fguv_32x32xn_444_c_erased(
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
 #[inline(always)]
-unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Dav1dFilmGrainDSPContext) {
+unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Rav1dFilmGrainDSPContext) {
     let flags = dav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSSE3) {
@@ -1404,7 +1404,7 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Dav1dFilmGrainDSPContext) {
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 #[inline(always)]
-unsafe extern "C" fn film_grain_dsp_init_arm(c: *mut Dav1dFilmGrainDSPContext) {
+unsafe extern "C" fn film_grain_dsp_init_arm(c: *mut Rav1dFilmGrainDSPContext) {
     let flags = dav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::NEON) {
@@ -1836,7 +1836,7 @@ unsafe extern "C" fn fguv_32x32xn_444_neon(
 }
 
 #[cold]
-pub unsafe fn dav1d_film_grain_dsp_init_16bpc(c: *mut Dav1dFilmGrainDSPContext) {
+pub unsafe fn dav1d_film_grain_dsp_init_16bpc(c: *mut Rav1dFilmGrainDSPContext) {
     (*c).generate_grain_y = Some(generate_grain_y_c_erased);
     (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
         Some(generate_grain_uv_420_c_erased);

--- a/src/filmgrain_tmpl_8.rs
+++ b/src/filmgrain_tmpl_8.rs
@@ -8,7 +8,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::src::filmgrain::get_random_number;
 use crate::src::filmgrain::round2;
-use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
+use crate::src::filmgrain::Rav1dFilmGrainDSPContext;
 use crate::src::filmgrain::GRAIN_WIDTH;
 use crate::src::tables::dav1d_gaussian_sequence;
 use libc::intptr_t;
@@ -1286,7 +1286,7 @@ unsafe extern "C" fn fguv_32x32xn_444_c_erased(
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
 #[inline(always)]
-unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Dav1dFilmGrainDSPContext) {
+unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Rav1dFilmGrainDSPContext) {
     let flags = dav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSSE3) {
@@ -1349,7 +1349,7 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Dav1dFilmGrainDSPContext) {
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 #[inline(always)]
-unsafe extern "C" fn film_grain_dsp_init_arm(c: *mut Dav1dFilmGrainDSPContext) {
+unsafe extern "C" fn film_grain_dsp_init_arm(c: *mut Rav1dFilmGrainDSPContext) {
     let flags = dav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::NEON) {
@@ -1769,7 +1769,7 @@ unsafe extern "C" fn fguv_32x32xn_444_neon(
 }
 
 #[cold]
-pub unsafe fn dav1d_film_grain_dsp_init_8bpc(c: *mut Dav1dFilmGrainDSPContext) {
+pub unsafe fn dav1d_film_grain_dsp_init_8bpc(c: *mut Rav1dFilmGrainDSPContext) {
     (*c).generate_grain_y = Some(generate_grain_y_c_erased);
     (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
         Some(generate_grain_uv_420_c_erased);

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -17,17 +17,17 @@ use crate::include::dav1d::picture::Dav1dPicture;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
 use crate::src::align::*;
-use crate::src::cdef::Dav1dCdefDSPContext;
+use crate::src::cdef::Rav1dCdefDSPContext;
 use crate::src::cdf::CdfContext;
 use crate::src::cdf::CdfThreadContext;
 use crate::src::env::BlockContext;
-use crate::src::filmgrain::Dav1dFilmGrainDSPContext;
+use crate::src::filmgrain::Rav1dFilmGrainDSPContext;
 use crate::src::intra_edge::EdgeBranch;
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::intra_edge::EdgeNode;
 use crate::src::intra_edge::EdgeTip;
-use crate::src::ipred::Dav1dIntraPredDSPContext;
-use crate::src::itx::Dav1dInvTxfmDSPContext;
+use crate::src::ipred::Rav1dIntraPredDSPContext;
+use crate::src::itx::Rav1dInvTxfmDSPContext;
 use crate::src::levels::Av1Block;
 use crate::src::levels::BlockSize;
 use crate::src::levels::Filter2d;
@@ -35,14 +35,14 @@ use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
 use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
-use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
-use crate::src::looprestoration::Dav1dLoopRestorationDSPContext;
-use crate::src::mc::Dav1dMCDSPContext;
-use crate::src::mem::Dav1dMemPool;
+use crate::src::loopfilter::Rav1dLoopFilterDSPContext;
+use crate::src::looprestoration::Rav1dLoopRestorationDSPContext;
+use crate::src::mc::Rav1dMCDSPContext;
+use crate::src::mem::Rav1dMemPool;
 use crate::src::msac::MsacContext;
-use crate::src::picture::Dav1dThreadPicture;
 use crate::src::picture::PictureFlags;
-use crate::src::r#ref::Dav1dRef;
+use crate::src::picture::Rav1dThreadPicture;
+use crate::src::r#ref::Rav1dRef;
 use crate::src::recon::backup_ipred_edge_fn;
 use crate::src::recon::filter_sbrow_fn;
 use crate::src::recon::read_coef_blocks_fn;
@@ -51,7 +51,7 @@ use crate::src::recon::recon_b_intra_fn;
 use crate::src::refmvs::refmvs_frame;
 use crate::src::refmvs::refmvs_temporal_block;
 use crate::src::refmvs::refmvs_tile;
-use crate::src::refmvs::Dav1dRefmvsDSPContext;
+use crate::src::refmvs::Rav1dRefmvsDSPContext;
 use crate::src::thread_data::thread_data;
 use libc::pthread_cond_t;
 use libc::pthread_mutex_t;
@@ -60,19 +60,19 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 
 #[repr(C)]
-pub struct Dav1dDSPContext {
-    pub fg: Dav1dFilmGrainDSPContext,
-    pub ipred: Dav1dIntraPredDSPContext,
-    pub mc: Dav1dMCDSPContext,
-    pub itx: Dav1dInvTxfmDSPContext,
-    pub lf: Dav1dLoopFilterDSPContext,
-    pub cdef: Dav1dCdefDSPContext,
-    pub lr: Dav1dLoopRestorationDSPContext,
+pub struct Rav1dDSPContext {
+    pub fg: Rav1dFilmGrainDSPContext,
+    pub ipred: Rav1dIntraPredDSPContext,
+    pub mc: Rav1dMCDSPContext,
+    pub itx: Rav1dInvTxfmDSPContext,
+    pub lf: Rav1dLoopFilterDSPContext,
+    pub cdef: Rav1dCdefDSPContext,
+    pub lr: Rav1dLoopRestorationDSPContext,
 }
 
 #[derive(Clone, Default)]
 #[repr(C)]
-pub struct Dav1dTileGroup {
+pub struct Rav1dTileGroup {
     pub data: Dav1dData,
     pub start: c_int,
     pub end: c_int,
@@ -94,8 +94,8 @@ pub const DAV1D_TASK_TYPE_INIT_CDF: TaskType = 1;
 pub const DAV1D_TASK_TYPE_INIT: TaskType = 0;
 
 #[repr(C)]
-pub struct Dav1dContext_frame_thread {
-    pub out_delayed: *mut Dav1dThreadPicture,
+pub struct Rav1dContext_frame_thread {
+    pub out_delayed: *mut Rav1dThreadPicture,
     pub next: c_uint,
 }
 
@@ -143,15 +143,15 @@ pub struct TaskThreadData {
 }
 
 #[repr(C)]
-pub struct Dav1dContext_refs {
-    pub p: Dav1dThreadPicture,
-    pub segmap: *mut Dav1dRef,
-    pub refmvs: *mut Dav1dRef,
+pub struct Rav1dContext_refs {
+    pub p: Rav1dThreadPicture,
+    pub segmap: *mut Rav1dRef,
+    pub refmvs: *mut Rav1dRef,
     pub refpoc: [c_uint; 7],
 }
 
 #[repr(C)]
-pub struct Dav1dContext_intra_edge {
+pub struct Rav1dContext_intra_edge {
     pub root: [*mut EdgeNode; 2],
     pub branch_sb128: [EdgeBranch; 85],
     pub branch_sb64: [EdgeBranch; 21],
@@ -160,42 +160,42 @@ pub struct Dav1dContext_intra_edge {
 }
 
 #[repr(C)]
-pub struct Dav1dContext {
-    pub(crate) fc: *mut Dav1dFrameContext,
+pub struct Rav1dContext {
+    pub(crate) fc: *mut Rav1dFrameContext,
     pub(crate) n_fc: c_uint,
-    pub(crate) tc: *mut Dav1dTaskContext,
+    pub(crate) tc: *mut Rav1dTaskContext,
     pub(crate) n_tc: c_uint,
-    pub(crate) tile: *mut Dav1dTileGroup,
+    pub(crate) tile: *mut Rav1dTileGroup,
     pub(crate) n_tile_data_alloc: c_int,
     pub(crate) n_tile_data: c_int,
     pub(crate) n_tiles: c_int,
-    pub(crate) seq_hdr_pool: *mut Dav1dMemPool,
-    pub(crate) seq_hdr_ref: *mut Dav1dRef,
+    pub(crate) seq_hdr_pool: *mut Rav1dMemPool,
+    pub(crate) seq_hdr_ref: *mut Rav1dRef,
     pub(crate) seq_hdr: *mut Dav1dSequenceHeader,
-    pub(crate) frame_hdr_pool: *mut Dav1dMemPool,
-    pub(crate) frame_hdr_ref: *mut Dav1dRef,
+    pub(crate) frame_hdr_pool: *mut Rav1dMemPool,
+    pub(crate) frame_hdr_ref: *mut Rav1dRef,
     pub(crate) frame_hdr: *mut Dav1dFrameHeader,
-    pub(crate) content_light_ref: *mut Dav1dRef,
+    pub(crate) content_light_ref: *mut Rav1dRef,
     pub(crate) content_light: *mut Dav1dContentLightLevel,
-    pub(crate) mastering_display_ref: *mut Dav1dRef,
+    pub(crate) mastering_display_ref: *mut Rav1dRef,
     pub(crate) mastering_display: *mut Dav1dMasteringDisplay,
-    pub(crate) itut_t35_ref: *mut Dav1dRef,
+    pub(crate) itut_t35_ref: *mut Rav1dRef,
     pub(crate) itut_t35: *mut Dav1dITUTT35,
     pub(crate) in_0: Dav1dData,
-    pub(crate) out: Dav1dThreadPicture,
-    pub(crate) cache: Dav1dThreadPicture,
+    pub(crate) out: Rav1dThreadPicture,
+    pub(crate) cache: Rav1dThreadPicture,
     pub(crate) flush_mem: atomic_int,
     pub(crate) flush: *mut atomic_int,
-    pub(crate) frame_thread: Dav1dContext_frame_thread,
+    pub(crate) frame_thread: Rav1dContext_frame_thread,
     pub(crate) task_thread: TaskThreadData,
-    pub(crate) segmap_pool: *mut Dav1dMemPool,
-    pub(crate) refmvs_pool: *mut Dav1dMemPool,
-    pub(crate) refs: [Dav1dContext_refs; 8],
-    pub(crate) cdf_pool: *mut Dav1dMemPool,
+    pub(crate) segmap_pool: *mut Rav1dMemPool,
+    pub(crate) refmvs_pool: *mut Rav1dMemPool,
+    pub(crate) refs: [Rav1dContext_refs; 8],
+    pub(crate) cdf_pool: *mut Rav1dMemPool,
     pub(crate) cdf: [CdfThreadContext; 8],
-    pub(crate) dsp: [Dav1dDSPContext; 3],
-    pub(crate) refmvs_dsp: Dav1dRefmvsDSPContext,
-    pub(crate) intra_edge: Dav1dContext_intra_edge,
+    pub(crate) dsp: [Rav1dDSPContext; 3],
+    pub(crate) refmvs_dsp: Rav1dRefmvsDSPContext,
+    pub(crate) intra_edge: Rav1dContext_intra_edge,
     pub(crate) allocator: Dav1dPicAllocator,
     pub(crate) apply_grain: c_int,
     pub(crate) operating_point: c_int,
@@ -213,19 +213,19 @@ pub struct Dav1dContext {
     pub(crate) cached_error_props: Dav1dDataProps,
     pub(crate) cached_error: c_int,
     pub(crate) logger: Dav1dLogger,
-    pub(crate) picture_pool: *mut Dav1dMemPool,
+    pub(crate) picture_pool: *mut Rav1dMemPool,
 }
 
 #[derive(Clone)]
 #[repr(C)]
-pub struct Dav1dTask {
+pub struct Rav1dTask {
     pub frame_idx: c_uint,
     pub type_0: TaskType,
     pub sby: c_int,
     pub recon_progress: c_int,
     pub deblock_progress: c_int,
     pub deps_skip: c_int,
-    pub next: *mut Dav1dTask,
+    pub next: *mut Rav1dTask,
 }
 
 #[repr(C)]
@@ -235,23 +235,23 @@ pub struct ScalableMotionParams {
 }
 
 #[repr(C)]
-pub struct Dav1dFrameContext_bd_fn {
+pub struct Rav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
     pub recon_b_inter: recon_b_inter_fn,
     pub filter_sbrow: filter_sbrow_fn,
     pub filter_sbrow_deblock_cols: filter_sbrow_fn,
     pub filter_sbrow_deblock_rows: filter_sbrow_fn,
-    pub filter_sbrow_cdef: Option<unsafe extern "C" fn(*mut Dav1dTaskContext, c_int) -> ()>,
+    pub filter_sbrow_cdef: Option<unsafe extern "C" fn(*mut Rav1dTaskContext, c_int) -> ()>,
     pub filter_sbrow_resize: filter_sbrow_fn,
     pub filter_sbrow_lr: filter_sbrow_fn,
     pub backup_ipred_edge: backup_ipred_edge_fn,
     pub read_coef_blocks: read_coef_blocks_fn,
 }
 
-impl Dav1dFrameContext_bd_fn {
+impl Rav1dFrameContext_bd_fn {
     pub unsafe fn recon_b_intra(
         &self,
-        context: *mut Dav1dTaskContext,
+        context: *mut Rav1dTaskContext,
         block_size: BlockSize,
         flags: EdgeFlags,
         block: *const Av1Block,
@@ -261,7 +261,7 @@ impl Dav1dFrameContext_bd_fn {
 
     pub unsafe fn recon_b_inter(
         &self,
-        context: *mut Dav1dTaskContext,
+        context: *mut Rav1dTaskContext,
         block_size: BlockSize,
         block: *const Av1Block,
     ) -> c_int {
@@ -270,7 +270,7 @@ impl Dav1dFrameContext_bd_fn {
 
     pub unsafe fn read_coef_blocks(
         &self,
-        context: *mut Dav1dTaskContext,
+        context: *mut Rav1dTaskContext,
         block_size: BlockSize,
         block: *const Av1Block,
     ) {
@@ -285,7 +285,7 @@ pub struct CodedBlockInfo {
 }
 
 #[repr(C)]
-pub struct Dav1dFrameContext_frame_thread {
+pub struct Rav1dFrameContext_frame_thread {
     pub next_tile_row: [c_int; 2],
     pub entropy_progress: atomic_int,
     pub deblock_progress: atomic_int,
@@ -304,7 +304,7 @@ pub struct Dav1dFrameContext_frame_thread {
 }
 
 #[repr(C)]
-pub struct Dav1dFrameContext_lf {
+pub struct Rav1dFrameContext_lf {
     pub level: *mut [u8; 4],
     pub mask: *mut Av1Filter,
     pub lr_mask: *mut Av1Restoration,
@@ -334,21 +334,21 @@ pub struct Dav1dFrameContext_lf {
 }
 
 #[repr(C)]
-pub struct Dav1dFrameContext_task_thread_pending_tasks {
+pub struct Rav1dFrameContext_task_thread_pending_tasks {
     pub merge: atomic_int,
     pub lock: pthread_mutex_t,
-    pub head: *mut Dav1dTask,
-    pub tail: *mut Dav1dTask,
+    pub head: *mut Rav1dTask,
+    pub tail: *mut Rav1dTask,
 }
 
 #[repr(C)]
-pub struct Dav1dFrameContext_task_thread {
+pub struct Rav1dFrameContext_task_thread {
     pub lock: pthread_mutex_t,
     pub cond: pthread_cond_t,
     pub ttd: *mut TaskThreadData,
-    pub tasks: *mut Dav1dTask,
-    pub tile_tasks: [*mut Dav1dTask; 2],
-    pub init_task: Dav1dTask,
+    pub tasks: *mut Rav1dTask,
+    pub tile_tasks: [*mut Rav1dTask; 2],
+    pub init_task: Rav1dTask,
     pub num_tasks: c_int,
     pub num_tile_tasks: c_int,
     pub init_done: atomic_int,
@@ -357,10 +357,10 @@ pub struct Dav1dFrameContext_task_thread {
     pub update_set: bool,
     pub error: atomic_int,
     pub task_counter: atomic_int,
-    pub task_head: *mut Dav1dTask,
-    pub task_tail: *mut Dav1dTask,
-    pub task_cur_prev: *mut Dav1dTask,
-    pub pending_tasks: Dav1dFrameContext_task_thread_pending_tasks,
+    pub task_head: *mut Rav1dTask,
+    pub task_tail: *mut Rav1dTask,
+    pub task_cur_prev: *mut Rav1dTask,
+    pub pending_tasks: Rav1dFrameContext_task_thread_pending_tasks,
 }
 
 #[repr(C)]
@@ -370,20 +370,20 @@ pub struct FrameTileThreadData {
 }
 
 #[repr(C)]
-pub struct Dav1dFrameContext {
-    pub seq_hdr_ref: *mut Dav1dRef,
+pub struct Rav1dFrameContext {
+    pub seq_hdr_ref: *mut Rav1dRef,
     pub seq_hdr: *mut Dav1dSequenceHeader,
-    pub frame_hdr_ref: *mut Dav1dRef,
+    pub frame_hdr_ref: *mut Rav1dRef,
     pub frame_hdr: *mut Dav1dFrameHeader,
-    pub refp: [Dav1dThreadPicture; 7],
+    pub refp: [Rav1dThreadPicture; 7],
     pub cur: Dav1dPicture,
-    pub sr_cur: Dav1dThreadPicture,
-    pub mvs_ref: *mut Dav1dRef,
+    pub sr_cur: Rav1dThreadPicture,
+    pub mvs_ref: *mut Rav1dRef,
     pub mvs: *mut refmvs_temporal_block,
     pub ref_mvs: [*mut refmvs_temporal_block; 7],
-    pub ref_mvs_ref: [*mut Dav1dRef; 7],
-    pub cur_segmap_ref: *mut Dav1dRef,
-    pub prev_segmap_ref: *mut Dav1dRef,
+    pub ref_mvs_ref: [*mut Rav1dRef; 7],
+    pub cur_segmap_ref: *mut Rav1dRef,
+    pub prev_segmap_ref: *mut Rav1dRef,
     pub cur_segmap: *mut u8,
     pub prev_segmap: *const u8,
     pub refpoc: [c_uint; 7],
@@ -391,17 +391,17 @@ pub struct Dav1dFrameContext {
     pub gmv_warp_allowed: [u8; 7],
     pub in_cdf: CdfThreadContext,
     pub out_cdf: CdfThreadContext,
-    pub tile: *mut Dav1dTileGroup,
+    pub tile: *mut Rav1dTileGroup,
     pub n_tile_data_alloc: c_int,
     pub n_tile_data: c_int,
     pub svc: [[ScalableMotionParams; 2]; 7],
     pub resize_step: [c_int; 2],
     pub resize_start: [c_int; 2],
-    pub c: *const Dav1dContext,
-    pub ts: *mut Dav1dTileState,
+    pub c: *const Rav1dContext,
+    pub ts: *mut Rav1dTileState,
     pub n_ts: c_int,
-    pub dsp: *const Dav1dDSPContext,
-    pub bd_fn: Dav1dFrameContext_bd_fn,
+    pub dsp: *const Rav1dDSPContext,
+    pub bd_fn: Rav1dFrameContext_bd_fn,
     pub ipred_edge_sz: c_int,
     pub ipred_edge: [*mut DynPixel; 3],
     pub b4_stride: ptrdiff_t,
@@ -422,14 +422,14 @@ pub struct Dav1dFrameContext {
     pub rf: refmvs_frame,
     pub jnt_weights: [[u8; 7]; 7],
     pub bitdepth_max: c_int,
-    pub frame_thread: Dav1dFrameContext_frame_thread,
-    pub lf: Dav1dFrameContext_lf,
-    pub task_thread: Dav1dFrameContext_task_thread,
+    pub frame_thread: Rav1dFrameContext_frame_thread,
+    pub lf: Rav1dFrameContext_lf,
+    pub task_thread: Rav1dFrameContext_task_thread,
     pub tile_thread: FrameTileThreadData,
 }
 
 #[repr(C)]
-pub struct Dav1dTileState_tiling {
+pub struct Rav1dTileState_tiling {
     pub col_start: c_int,
     pub col_end: c_int,
     pub row_start: c_int,
@@ -439,18 +439,18 @@ pub struct Dav1dTileState_tiling {
 }
 
 #[repr(C)]
-pub struct Dav1dTileState_frame_thread {
+pub struct Rav1dTileState_frame_thread {
     pub pal_idx: *mut u8,
     pub cf: *mut DynCoef,
 }
 
 #[repr(C)]
-pub struct Dav1dTileState {
+pub struct Rav1dTileState {
     pub cdf: CdfContext,
     pub msac: MsacContext,
-    pub tiling: Dav1dTileState_tiling,
+    pub tiling: Rav1dTileState_tiling,
     pub progress: [atomic_int; 2],
-    pub frame_thread: [Dav1dTileState_frame_thread; 2],
+    pub frame_thread: [Rav1dTileState_frame_thread; 2],
     pub lowest_pixel: *mut [[c_int; 2]; 7],
     pub dqmem: [[[u16; 2]; 3]; 8],
     pub dq: *const [[u16; 2]; 3],
@@ -462,98 +462,98 @@ pub struct Dav1dTileState {
 }
 
 #[repr(C, align(64))]
-pub union Dav1dTaskContext_cf {
+pub union Rav1dTaskContext_cf {
     pub cf_8bpc: [i16; 1024],
     pub cf_16bpc: [i32; 1024],
 }
 
 #[derive(Clone, Copy)]
 #[repr(C)]
-pub struct Dav1dTaskContext_scratch_compinter_seg_mask {
+pub struct Rav1dTaskContext_scratch_compinter_seg_mask {
     pub compinter: [[i16; 16384]; 2],
     pub seg_mask: [u8; 16384],
 }
 
 #[derive(Clone, Copy)]
 #[repr(C)]
-pub union Dav1dTaskContext_scratch_lap {
+pub union Rav1dTaskContext_scratch_lap {
     pub lap_8bpc: [u8; 4096],
     pub lap_16bpc: [u16; 4096],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_compinter_seg_mask,
+    pub c2rust_unnamed: Rav1dTaskContext_scratch_compinter_seg_mask,
 }
 
 #[derive(Clone, Copy)]
 #[repr(C)]
-pub union Dav1dTaskContext_scratch_emu_edge {
+pub union Rav1dTaskContext_scratch_emu_edge {
     pub emu_edge_8bpc: [u8; 84160],
     pub emu_edge_16bpc: [u16; 84160],
 }
 
 #[derive(Clone, Copy)]
 #[repr(C)]
-pub struct Dav1dTaskContext_scratch_lap_emu_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_emu_edge,
+pub struct Rav1dTaskContext_scratch_lap_emu_edge {
+    pub c2rust_unnamed: Rav1dTaskContext_scratch_lap,
+    pub c2rust_unnamed_0: Rav1dTaskContext_scratch_emu_edge,
 }
 
 #[derive(Clone, Copy)]
 #[repr(C)]
-pub struct Dav1dTaskContext_scratch_pal {
+pub struct Rav1dTaskContext_scratch_pal {
     pub pal_order: [[u8; 8]; 64],
     pub pal_ctx: [u8; 64],
 }
 
 #[derive(Clone, Copy)]
 #[repr(C)]
-pub union Dav1dTaskContext_scratch_levels_pal {
+pub union Rav1dTaskContext_scratch_levels_pal {
     pub levels: [u8; 1088],
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_pal,
+    pub c2rust_unnamed: Rav1dTaskContext_scratch_pal,
 }
 
 #[derive(Clone, Copy)]
 #[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_8 {
+pub struct Rav1dTaskContext_scratch_interintra_edge_8 {
     pub interintra_8bpc: [u8; 4096],
     pub edge_8bpc: [u8; 257],
 }
 
 #[derive(Clone, Copy)]
 #[repr(C)]
-pub struct Dav1dTaskContext_scratch_interintra_edge_16 {
+pub struct Rav1dTaskContext_scratch_interintra_edge_16 {
     pub interintra_16bpc: [u16; 4096],
     pub edge_16bpc: [u16; 257],
 }
 
 #[derive(Clone, Copy)]
 #[repr(C, align(64))]
-pub union Dav1dTaskContext_scratch_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge_16,
+pub union Rav1dTaskContext_scratch_interintra_edge {
+    pub c2rust_unnamed: Rav1dTaskContext_scratch_interintra_edge_8,
+    pub c2rust_unnamed_0: Rav1dTaskContext_scratch_interintra_edge_16,
 }
 
 #[derive(Clone, Copy)]
 #[repr(C)]
-pub struct Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_levels_pal,
+pub struct Rav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
+    pub c2rust_unnamed: Rav1dTaskContext_scratch_levels_pal,
     pub ac: [i16; 1024],
     pub pal_idx: [u8; 8192],
     pub pal: [[u16; 8]; 3],
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_interintra_edge,
+    pub c2rust_unnamed_0: Rav1dTaskContext_scratch_interintra_edge,
 }
 
 #[repr(C, align(64))]
-pub union Dav1dTaskContext_scratch {
-    pub c2rust_unnamed: Dav1dTaskContext_scratch_lap_emu_edge,
-    pub c2rust_unnamed_0: Dav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
+pub union Rav1dTaskContext_scratch {
+    pub c2rust_unnamed: Rav1dTaskContext_scratch_lap_emu_edge,
+    pub c2rust_unnamed_0: Rav1dTaskContext_scratch_levels_pal_ac_interintra_edge,
 }
 
 #[repr(C)]
-pub struct Dav1dTaskContext_frame_thread {
+pub struct Rav1dTaskContext_frame_thread {
     pub pass: c_int,
 }
 
 #[repr(C)]
-pub struct Dav1dTaskContext_task_thread {
+pub struct Rav1dTaskContext_task_thread {
     pub td: thread_data,
     pub ttd: *mut TaskThreadData,
     pub fttd: *mut FrameTileThreadData,
@@ -562,25 +562,25 @@ pub struct Dav1dTaskContext_task_thread {
 }
 
 #[repr(C)]
-pub struct Dav1dTaskContext {
-    pub c: *const Dav1dContext,
-    pub f: *const Dav1dFrameContext,
-    pub ts: *mut Dav1dTileState,
+pub struct Rav1dTaskContext {
+    pub c: *const Rav1dContext,
+    pub f: *const Rav1dFrameContext,
+    pub ts: *mut Rav1dTileState,
     pub bx: c_int,
     pub by: c_int,
     pub l: BlockContext,
     pub a: *mut BlockContext,
     pub rt: refmvs_tile,
-    pub c2rust_unnamed: Dav1dTaskContext_cf,
+    pub c2rust_unnamed: Rav1dTaskContext_cf,
     pub al_pal: [[[[u16; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[u8; 32]; 2],
     pub txtp_map: [u8; 1024],
-    pub scratch: Dav1dTaskContext_scratch,
+    pub scratch: Rav1dTaskContext_scratch,
     pub warpmv: Dav1dWarpedMotionParams,
     pub lf_mask: *mut Av1Filter,
     pub top_pre_cdef_toggle: c_int,
     pub cur_sb_cdef_idx_ptr: *mut i8,
     pub tl_4x4_filter: Filter2d,
-    pub frame_thread: Dav1dTaskContext_frame_thread,
-    pub task_thread: Dav1dTaskContext_task_thread,
+    pub frame_thread: Rav1dTaskContext_frame_thread,
+    pub task_thread: Rav1dTaskContext_task_thread,
 }

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -37,7 +37,7 @@ pub type pal_pred_fn =
     unsafe extern "C" fn(*mut DynPixel, ptrdiff_t, *const u16, *const u8, c_int, c_int) -> ();
 
 #[repr(C)]
-pub struct Dav1dIntraPredDSPContext {
+pub struct Rav1dIntraPredDSPContext {
     // TODO(legare): Remove `Option` once `dav1d_submit_frame` is no longer checking
     // this field with `is_none`.
     pub intra_pred: [Option<angular_ipred_fn>; 14],

--- a/src/ipred_tmpl_16.rs
+++ b/src/ipred_tmpl_16.rs
@@ -6,7 +6,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::src::ipred::get_upsample;
-use crate::src::ipred::Dav1dIntraPredDSPContext;
+use crate::src::ipred::Rav1dIntraPredDSPContext;
 use crate::src::levels::DC_128_PRED;
 use crate::src::levels::DC_PRED;
 use crate::src::levels::FILTER_PRED;
@@ -1520,7 +1520,7 @@ unsafe extern "C" fn pal_pred_rust(
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
 #[inline(always)]
-unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Dav1dIntraPredDSPContext) {
+unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Rav1dIntraPredDSPContext) {
     use crate::src::ipred::*; // TODO(legare): Temporary import until init fns are deduplicated.
 
     let flags = dav1d_get_cpu_flags();
@@ -1603,7 +1603,7 @@ unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Dav1dIntraPredDSPContext) {
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 #[inline(always)]
-unsafe extern "C" fn intra_pred_dsp_init_arm(c: *mut Dav1dIntraPredDSPContext) {
+unsafe extern "C" fn intra_pred_dsp_init_arm(c: *mut Rav1dIntraPredDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::ipred::*;
 
@@ -2087,7 +2087,7 @@ unsafe fn ipred_z1_neon(
 }
 
 #[cold]
-pub unsafe fn dav1d_intra_pred_dsp_init_16bpc(c: *mut Dav1dIntraPredDSPContext) {
+pub unsafe fn dav1d_intra_pred_dsp_init_16bpc(c: *mut Rav1dIntraPredDSPContext) {
     (*c).intra_pred[DC_PRED as usize] = Some(ipred_dc_c_erased);
     (*c).intra_pred[DC_128_PRED as usize] = Some(ipred_dc_128_c_erased);
     (*c).intra_pred[TOP_DC_PRED as usize] = Some(ipred_dc_top_c_erased);

--- a/src/ipred_tmpl_8.rs
+++ b/src/ipred_tmpl_8.rs
@@ -7,7 +7,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::src::ipred::get_upsample;
-use crate::src::ipred::Dav1dIntraPredDSPContext;
+use crate::src::ipred::Rav1dIntraPredDSPContext;
 use crate::src::levels::DC_128_PRED;
 use crate::src::levels::DC_PRED;
 use crate::src::levels::FILTER_PRED;
@@ -1443,7 +1443,7 @@ unsafe fn pal_pred_rust(
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
 #[inline(always)]
-unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Dav1dIntraPredDSPContext) {
+unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Rav1dIntraPredDSPContext) {
     use crate::src::ipred::*; // TODO(legare): Temporary import until init fns are deduplicated.
 
     let flags = dav1d_get_cpu_flags();
@@ -1532,7 +1532,7 @@ unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Dav1dIntraPredDSPContext) {
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 #[inline(always)]
-unsafe extern "C" fn intra_pred_dsp_init_arm(c: *mut Dav1dIntraPredDSPContext) {
+unsafe extern "C" fn intra_pred_dsp_init_arm(c: *mut Rav1dIntraPredDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::ipred::*;
 
@@ -2006,7 +2006,7 @@ unsafe fn ipred_z1_neon(
 }
 
 #[cold]
-pub unsafe fn dav1d_intra_pred_dsp_init_8bpc(c: *mut Dav1dIntraPredDSPContext) {
+pub unsafe fn dav1d_intra_pred_dsp_init_8bpc(c: *mut Rav1dIntraPredDSPContext) {
     (*c).intra_pred[DC_PRED as usize] = Some(ipred_dc_c_erased);
     (*c).intra_pred[DC_128_PRED as usize] = Some(ipred_dc_128_c_erased);
     (*c).intra_pred[TOP_DC_PRED as usize] = Some(ipred_dc_top_c_erased);

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -143,7 +143,7 @@ pub type itxfm_fn =
     Option<unsafe extern "C" fn(*mut DynPixel, ptrdiff_t, *mut DynCoef, c_int, c_int) -> ()>;
 
 #[repr(C)]
-pub struct Dav1dInvTxfmDSPContext {
+pub struct Rav1dInvTxfmDSPContext {
     pub itxfm_add: [[itxfm_fn; N_TX_TYPES_PLUS_LL]; N_RECT_TX_SIZES],
 }
 

--- a/src/itx_tmpl_16.rs
+++ b/src/itx_tmpl_16.rs
@@ -2,7 +2,7 @@ use crate::include::common::bitdepth::BitDepth16;
 use crate::include::common::bitdepth::DynCoef;
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::intops::iclip;
-use crate::src::itx::Dav1dInvTxfmDSPContext;
+use crate::src::itx::Rav1dInvTxfmDSPContext;
 use crate::src::levels::ADST_ADST;
 use crate::src::levels::ADST_DCT;
 use crate::src::levels::ADST_FLIPADST;
@@ -130,7 +130,7 @@ unsafe extern "C" fn inv_txfm_add_wht_wht_4x4_rust(
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
 #[rustfmt::skip]
-unsafe extern "C" fn itx_dsp_init_x86(c: *mut Dav1dInvTxfmDSPContext, bpc: c_int) {
+unsafe extern "C" fn itx_dsp_init_x86(c: *mut Rav1dInvTxfmDSPContext, bpc: c_int) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::itx::*;
 
@@ -709,7 +709,7 @@ unsafe extern "C" fn itx_dsp_init_x86(c: *mut Dav1dInvTxfmDSPContext, bpc: c_int
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]
-unsafe extern "C" fn itx_dsp_init_arm(c: *mut Dav1dInvTxfmDSPContext, bpc: c_int) {
+unsafe extern "C" fn itx_dsp_init_arm(c: *mut Rav1dInvTxfmDSPContext, bpc: c_int) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::itx::*;
 
@@ -1040,7 +1040,7 @@ unsafe extern "C" fn itx_dsp_init_arm(c: *mut Dav1dInvTxfmDSPContext, bpc: c_int
 #[cold]
 #[rustfmt::skip]
 pub unsafe fn dav1d_itx_dsp_init_16bpc(
-    c: *mut Dav1dInvTxfmDSPContext,
+    c: *mut Rav1dInvTxfmDSPContext,
     mut _bpc: c_int,
 ) {
     // TODO(legare): Temporary import until init fns are deduplicated.

--- a/src/itx_tmpl_8.rs
+++ b/src/itx_tmpl_8.rs
@@ -2,7 +2,7 @@ use crate::include::common::bitdepth::BitDepth8;
 use crate::include::common::bitdepth::DynCoef;
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::intops::iclip_u8;
-use crate::src::itx::Dav1dInvTxfmDSPContext;
+use crate::src::itx::Rav1dInvTxfmDSPContext;
 use crate::src::levels::ADST_ADST;
 use crate::src::levels::ADST_DCT;
 use crate::src::levels::ADST_FLIPADST;
@@ -118,7 +118,7 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust(
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
 #[rustfmt::skip]
-unsafe extern "C" fn itx_dsp_init_x86(c: *mut Dav1dInvTxfmDSPContext, _bpc: c_int) {
+unsafe extern "C" fn itx_dsp_init_x86(c: *mut Rav1dInvTxfmDSPContext, _bpc: c_int) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::itx::*;
 
@@ -622,7 +622,7 @@ unsafe extern "C" fn itx_dsp_init_x86(c: *mut Dav1dInvTxfmDSPContext, _bpc: c_in
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]
 #[rustfmt::skip]
-unsafe extern "C" fn itx_dsp_init_arm(c: *mut Dav1dInvTxfmDSPContext, mut _bpc: c_int) {
+unsafe extern "C" fn itx_dsp_init_arm(c: *mut Rav1dInvTxfmDSPContext, mut _bpc: c_int) {
         // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::itx::*;
 
@@ -793,7 +793,7 @@ unsafe extern "C" fn itx_dsp_init_arm(c: *mut Dav1dInvTxfmDSPContext, mut _bpc: 
 #[cold]
 #[rustfmt::skip]
 pub unsafe fn dav1d_itx_dsp_init_8bpc(
-    c: *mut Dav1dInvTxfmDSPContext,
+    c: *mut Rav1dInvTxfmDSPContext,
     mut _bpc: c_int,
 ) {
     // TODO(legare): Temporary import until init fns are deduplicated.

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -75,7 +75,7 @@ pub const Z1_PRED: IntraPredMode = 6;
 pub const DC_128_PRED: IntraPredMode = 5;
 pub const TOP_DC_PRED: IntraPredMode = 4;
 pub const LEFT_DC_PRED: IntraPredMode = 3;
-pub const N_IMPL_INTRA_PRED_MODES: usize = 14; // TODO(kkysen) symbolicate in struct Dav1dIntraPredDSPContext::intra_pred once deduplicated
+pub const N_IMPL_INTRA_PRED_MODES: usize = 14; // TODO(kkysen) symbolicate in struct Rav1dIntraPredDSPContext::intra_pred once deduplicated
 pub const N_UV_INTRA_PRED_MODES: usize = 14;
 pub const CFL_PRED: IntraPredMode = 13;
 pub const N_INTRA_PRED_MODES: usize = 13;
@@ -140,7 +140,7 @@ pub const BS_128x64: BlockSize = 1;
 pub const BS_128x128: BlockSize = 0;
 
 pub type Filter2d = c_uint;
-pub const N_2D_FILTERS: usize = 10; // TODO(kkysen) symbolicate in struct Dav1dMCDSPContext once deduplicated
+pub const N_2D_FILTERS: usize = 10; // TODO(kkysen) symbolicate in struct Rav1dMCDSPContext once deduplicated
 pub const FILTER_2D_BILINEAR: Filter2d = 9;
 pub const FILTER_2D_8TAP_SMOOTH_SHARP: Filter2d = 8;
 pub const FILTER_2D_8TAP_SMOOTH: Filter2d = 7;

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -2,8 +2,8 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::src::env::BlockContext;
-use crate::src::internal::Dav1dDSPContext;
-use crate::src::internal::Dav1dFrameContext;
+use crate::src::internal::Rav1dDSPContext;
+use crate::src::internal::Rav1dFrameContext;
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lr_apply::LR_RESTORE_U;
 use crate::src::lr_apply::LR_RESTORE_V;
@@ -26,7 +26,7 @@ unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
 }
 
 unsafe extern "C" fn backup_lpf(
-    f: *const Dav1dFrameContext,
+    f: *const Rav1dFrameContext,
     mut dst: *mut pixel,
     dst_stride: ptrdiff_t,
     mut src: *const pixel,
@@ -156,7 +156,7 @@ unsafe extern "C" fn backup_lpf(
     };
 }
 
-pub unsafe fn dav1d_copy_lpf_16bpc(f: *mut Dav1dFrameContext, src: *const *mut pixel, sby: c_int) {
+pub unsafe fn dav1d_copy_lpf_16bpc(f: *mut Rav1dFrameContext, src: *const *mut pixel, sby: c_int) {
     let have_tt = ((*(*f).c).n_tc > 1 as c_uint) as c_int;
     let resize = ((*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1]) as c_int;
     let offset = 8 * (sby != 0) as c_int;
@@ -310,7 +310,7 @@ pub unsafe fn dav1d_copy_lpf_16bpc(f: *mut Dav1dFrameContext, src: *const *mut p
 
 #[inline]
 unsafe extern "C" fn filter_plane_cols_y(
-    f: *const Dav1dFrameContext,
+    f: *const Rav1dFrameContext,
     have_left: c_int,
     lvl: *const [u8; 4],
     b4_stride: ptrdiff_t,
@@ -321,7 +321,7 @@ unsafe extern "C" fn filter_plane_cols_y(
     starty4: c_int,
     endy4: c_int,
 ) {
-    let dsp: *const Dav1dDSPContext = (*f).dsp;
+    let dsp: *const Rav1dDSPContext = (*f).dsp;
     let mut x = 0;
     while x < w {
         if !(have_left == 0 && x == 0) {
@@ -358,7 +358,7 @@ unsafe extern "C" fn filter_plane_cols_y(
 
 #[inline]
 unsafe extern "C" fn filter_plane_rows_y(
-    f: *const Dav1dFrameContext,
+    f: *const Rav1dFrameContext,
     have_top: c_int,
     mut lvl: *const [u8; 4],
     b4_stride: ptrdiff_t,
@@ -369,7 +369,7 @@ unsafe extern "C" fn filter_plane_rows_y(
     starty4: c_int,
     endy4: c_int,
 ) {
-    let dsp: *const Dav1dDSPContext = (*f).dsp;
+    let dsp: *const Rav1dDSPContext = (*f).dsp;
     let mut y = starty4;
     while y < endy4 {
         if !(have_top == 0 && y == 0) {
@@ -401,7 +401,7 @@ unsafe extern "C" fn filter_plane_rows_y(
 
 #[inline]
 unsafe extern "C" fn filter_plane_cols_uv(
-    f: *const Dav1dFrameContext,
+    f: *const Rav1dFrameContext,
     have_left: c_int,
     lvl: *const [u8; 4],
     b4_stride: ptrdiff_t,
@@ -414,7 +414,7 @@ unsafe extern "C" fn filter_plane_cols_uv(
     endy4: c_int,
     ss_ver: c_int,
 ) {
-    let dsp: *const Dav1dDSPContext = (*f).dsp;
+    let dsp: *const Rav1dDSPContext = (*f).dsp;
     let mut x = 0;
     while x < w {
         if !(have_left == 0 && x == 0) {
@@ -458,7 +458,7 @@ unsafe extern "C" fn filter_plane_cols_uv(
 
 #[inline]
 unsafe extern "C" fn filter_plane_rows_uv(
-    f: *const Dav1dFrameContext,
+    f: *const Rav1dFrameContext,
     have_top: c_int,
     mut lvl: *const [u8; 4],
     b4_stride: ptrdiff_t,
@@ -471,7 +471,7 @@ unsafe extern "C" fn filter_plane_rows_uv(
     endy4: c_int,
     ss_hor: c_int,
 ) {
-    let dsp: *const Dav1dDSPContext = (*f).dsp;
+    let dsp: *const Rav1dDSPContext = (*f).dsp;
     let mut off_l: ptrdiff_t = 0 as c_int as ptrdiff_t;
     let mut y = starty4;
     while y < endy4 {
@@ -511,7 +511,7 @@ unsafe extern "C" fn filter_plane_rows_uv(
 }
 
 pub unsafe fn dav1d_loopfilter_sbrow_cols_16bpc(
-    f: *const Dav1dFrameContext,
+    f: *const Rav1dFrameContext,
     p: *const *mut pixel,
     lflvl: *mut Av1Filter,
     sby: c_int,
@@ -716,7 +716,7 @@ pub unsafe fn dav1d_loopfilter_sbrow_cols_16bpc(
 }
 
 pub unsafe fn dav1d_loopfilter_sbrow_rows_16bpc(
-    f: *const Dav1dFrameContext,
+    f: *const Rav1dFrameContext,
     p: *const *mut pixel,
     lflvl: *mut Av1Filter,
     sby: c_int,

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -2,8 +2,8 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::src::env::BlockContext;
-use crate::src::internal::Dav1dDSPContext;
-use crate::src::internal::Dav1dFrameContext;
+use crate::src::internal::Rav1dDSPContext;
+use crate::src::internal::Rav1dFrameContext;
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lr_apply::LR_RESTORE_U;
 use crate::src::lr_apply::LR_RESTORE_V;
@@ -18,7 +18,7 @@ use std::ffi::c_void;
 pub type pixel = u8;
 
 unsafe extern "C" fn backup_lpf(
-    f: *const Dav1dFrameContext,
+    f: *const Rav1dFrameContext,
     mut dst: *mut pixel,
     dst_stride: ptrdiff_t,
     mut src: *const pixel,
@@ -123,7 +123,7 @@ unsafe extern "C" fn backup_lpf(
     };
 }
 
-pub unsafe fn dav1d_copy_lpf_8bpc(f: *mut Dav1dFrameContext, src: *const *mut pixel, sby: c_int) {
+pub unsafe fn dav1d_copy_lpf_8bpc(f: *mut Rav1dFrameContext, src: *const *mut pixel, sby: c_int) {
     let have_tt = ((*(*f).c).n_tc > 1 as c_uint) as c_int;
     let resize = ((*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1]) as c_int;
     let offset = 8 * (sby != 0) as c_int;
@@ -275,7 +275,7 @@ pub unsafe fn dav1d_copy_lpf_8bpc(f: *mut Dav1dFrameContext, src: *const *mut pi
 
 #[inline]
 unsafe extern "C" fn filter_plane_cols_y(
-    f: *const Dav1dFrameContext,
+    f: *const Rav1dFrameContext,
     have_left: c_int,
     lvl: *const [u8; 4],
     b4_stride: ptrdiff_t,
@@ -286,7 +286,7 @@ unsafe extern "C" fn filter_plane_cols_y(
     starty4: c_int,
     endy4: c_int,
 ) {
-    let dsp: *const Dav1dDSPContext = (*f).dsp;
+    let dsp: *const Rav1dDSPContext = (*f).dsp;
     let mut x = 0;
     while x < w {
         if !(have_left == 0 && x == 0) {
@@ -323,7 +323,7 @@ unsafe extern "C" fn filter_plane_cols_y(
 
 #[inline]
 unsafe extern "C" fn filter_plane_rows_y(
-    f: *const Dav1dFrameContext,
+    f: *const Rav1dFrameContext,
     have_top: c_int,
     mut lvl: *const [u8; 4],
     b4_stride: ptrdiff_t,
@@ -334,7 +334,7 @@ unsafe extern "C" fn filter_plane_rows_y(
     starty4: c_int,
     endy4: c_int,
 ) {
-    let dsp: *const Dav1dDSPContext = (*f).dsp;
+    let dsp: *const Rav1dDSPContext = (*f).dsp;
     let mut y = starty4;
     while y < endy4 {
         if !(have_top == 0 && y == 0) {
@@ -366,7 +366,7 @@ unsafe extern "C" fn filter_plane_rows_y(
 
 #[inline]
 unsafe extern "C" fn filter_plane_cols_uv(
-    f: *const Dav1dFrameContext,
+    f: *const Rav1dFrameContext,
     have_left: c_int,
     lvl: *const [u8; 4],
     b4_stride: ptrdiff_t,
@@ -379,7 +379,7 @@ unsafe extern "C" fn filter_plane_cols_uv(
     endy4: c_int,
     ss_ver: c_int,
 ) {
-    let dsp: *const Dav1dDSPContext = (*f).dsp;
+    let dsp: *const Rav1dDSPContext = (*f).dsp;
     let mut x = 0;
     while x < w {
         if !(have_left == 0 && x == 0) {
@@ -423,7 +423,7 @@ unsafe extern "C" fn filter_plane_cols_uv(
 
 #[inline]
 unsafe extern "C" fn filter_plane_rows_uv(
-    f: *const Dav1dFrameContext,
+    f: *const Rav1dFrameContext,
     have_top: c_int,
     mut lvl: *const [u8; 4],
     b4_stride: ptrdiff_t,
@@ -436,7 +436,7 @@ unsafe extern "C" fn filter_plane_rows_uv(
     endy4: c_int,
     ss_hor: c_int,
 ) {
-    let dsp: *const Dav1dDSPContext = (*f).dsp;
+    let dsp: *const Rav1dDSPContext = (*f).dsp;
     let mut off_l: ptrdiff_t = 0 as c_int as ptrdiff_t;
     let mut y = starty4;
     while y < endy4 {
@@ -476,7 +476,7 @@ unsafe extern "C" fn filter_plane_rows_uv(
 }
 
 pub unsafe fn dav1d_loopfilter_sbrow_cols_8bpc(
-    f: *const Dav1dFrameContext,
+    f: *const Rav1dFrameContext,
     p: *const *mut pixel,
     lflvl: *mut Av1Filter,
     sby: c_int,
@@ -681,7 +681,7 @@ pub unsafe fn dav1d_loopfilter_sbrow_cols_8bpc(
 }
 
 pub unsafe fn dav1d_loopfilter_sbrow_rows_8bpc(
-    f: *const Dav1dFrameContext,
+    f: *const Rav1dFrameContext,
     p: *const *mut pixel,
     lflvl: *mut Av1Filter,
     sby: c_int,

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,4 +1,4 @@
-use crate::src::internal::Dav1dContext;
+use crate::src::internal::Rav1dContext;
 use crate::stderr;
 use libc::fprintf;
 use std::ffi::c_char;
@@ -19,7 +19,7 @@ pub unsafe extern "C" fn dav1d_log_default_callback(
 }
 
 #[cold]
-pub unsafe extern "C" fn dav1d_log(c: *mut Dav1dContext, format: *const c_char, args: ...) {
+pub unsafe extern "C" fn dav1d_log(c: *mut Rav1dContext, format: *const c_char, args: ...) {
     if c.is_null() {
         fprintf(
             stderr,

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -15,7 +15,7 @@ pub type loopfilter_sb_fn = unsafe extern "C" fn(
 ) -> ();
 
 #[repr(C)]
-pub struct Dav1dLoopFilterDSPContext {
+pub struct Rav1dLoopFilterDSPContext {
     pub loop_filter_sb: [[loopfilter_sb_fn; 2]; 2],
 }
 

--- a/src/loopfilter_tmpl_16.rs
+++ b/src/loopfilter_tmpl_16.rs
@@ -2,7 +2,7 @@ use crate::include::common::attributes::clz;
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::intops::iclip;
 use crate::src::lf_mask::Av1FilterLUT;
-use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
+use crate::src::loopfilter::Rav1dLoopFilterDSPContext;
 use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_int;
@@ -469,7 +469,7 @@ unsafe extern "C" fn loop_filter_v_sb128uv_rust(
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
-unsafe extern "C" fn loop_filter_dsp_init_x86(c: *mut Dav1dLoopFilterDSPContext) {
+unsafe extern "C" fn loop_filter_dsp_init_x86(c: *mut Rav1dLoopFilterDSPContext) {
     // TODO(legare): Temporarily import until init fns are deduplicated.
     use crate::src::loopfilter::*;
 
@@ -508,7 +508,7 @@ unsafe extern "C" fn loop_filter_dsp_init_x86(c: *mut Dav1dLoopFilterDSPContext)
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]
-unsafe extern "C" fn loop_filter_dsp_init_arm(c: *mut Dav1dLoopFilterDSPContext) {
+unsafe extern "C" fn loop_filter_dsp_init_arm(c: *mut Rav1dLoopFilterDSPContext) {
     // TODO(legare): Temporarily import until init fns are deduplicated.
     use crate::src::loopfilter::*;
 
@@ -525,7 +525,7 @@ unsafe extern "C" fn loop_filter_dsp_init_arm(c: *mut Dav1dLoopFilterDSPContext)
 }
 
 #[cold]
-pub unsafe fn dav1d_loop_filter_dsp_init_16bpc(c: *mut Dav1dLoopFilterDSPContext) {
+pub unsafe fn dav1d_loop_filter_dsp_init_16bpc(c: *mut Rav1dLoopFilterDSPContext) {
     (*c).loop_filter_sb[0][0] = loop_filter_h_sb128y_c_erased;
     (*c).loop_filter_sb[0][1] = loop_filter_v_sb128y_c_erased;
     (*c).loop_filter_sb[1][0] = loop_filter_h_sb128uv_c_erased;

--- a/src/loopfilter_tmpl_8.rs
+++ b/src/loopfilter_tmpl_8.rs
@@ -2,7 +2,7 @@ use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::intops::iclip;
 use crate::include::common::intops::iclip_u8;
 use crate::src::lf_mask::Av1FilterLUT;
-use crate::src::loopfilter::Dav1dLoopFilterDSPContext;
+use crate::src::loopfilter::Rav1dLoopFilterDSPContext;
 use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_int;
@@ -397,7 +397,7 @@ unsafe extern "C" fn loop_filter_v_sb128uv_rust(
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
-unsafe extern "C" fn loop_filter_dsp_init_x86(c: *mut Dav1dLoopFilterDSPContext) {
+unsafe extern "C" fn loop_filter_dsp_init_x86(c: *mut Rav1dLoopFilterDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::loopfilter::*;
 
@@ -436,7 +436,7 @@ unsafe extern "C" fn loop_filter_dsp_init_x86(c: *mut Dav1dLoopFilterDSPContext)
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]
-unsafe extern "C" fn loop_filter_dsp_init_arm(c: *mut Dav1dLoopFilterDSPContext) {
+unsafe extern "C" fn loop_filter_dsp_init_arm(c: *mut Rav1dLoopFilterDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::loopfilter::*;
 
@@ -453,7 +453,7 @@ unsafe extern "C" fn loop_filter_dsp_init_arm(c: *mut Dav1dLoopFilterDSPContext)
 }
 
 #[cold]
-pub unsafe fn dav1d_loop_filter_dsp_init_8bpc(c: *mut Dav1dLoopFilterDSPContext) {
+pub unsafe fn dav1d_loop_filter_dsp_init_8bpc(c: *mut Rav1dLoopFilterDSPContext) {
     (*c).loop_filter_sb[0][0] = loop_filter_h_sb128y_c_erased;
     (*c).loop_filter_sb[0][1] = loop_filter_v_sb128y_c_erased;
     (*c).loop_filter_sb[1][0] = loop_filter_h_sb128uv_c_erased;

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -100,7 +100,7 @@ pub type looprestorationfilter_fn = unsafe extern "C" fn(
 ) -> ();
 
 #[repr(C)]
-pub struct Dav1dLoopRestorationDSPContext {
+pub struct Rav1dLoopRestorationDSPContext {
     pub wiener: [looprestorationfilter_fn; 2],
     pub sgr: [looprestorationfilter_fn; 3],
 }
@@ -1631,7 +1631,7 @@ unsafe extern "C" fn sgr_filter_mix_neon<BD: BitDepth>(
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
-fn loop_restoration_dsp_init_x86<BD: BitDepth>(c: &mut Dav1dLoopRestorationDSPContext, bpc: c_int) {
+fn loop_restoration_dsp_init_x86<BD: BitDepth>(c: &mut Rav1dLoopRestorationDSPContext, bpc: c_int) {
     let flags = dav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSE2) {
@@ -1692,7 +1692,7 @@ fn loop_restoration_dsp_init_x86<BD: BitDepth>(c: &mut Dav1dLoopRestorationDSPCo
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]
-fn loop_restoration_dsp_init_arm<BD: BitDepth>(c: &mut Dav1dLoopRestorationDSPContext, bpc: c_int) {
+fn loop_restoration_dsp_init_arm<BD: BitDepth>(c: &mut Rav1dLoopRestorationDSPContext, bpc: c_int) {
     let flags = dav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::NEON) {
@@ -1718,7 +1718,7 @@ fn loop_restoration_dsp_init_arm<BD: BitDepth>(c: &mut Dav1dLoopRestorationDSPCo
 
 #[cold]
 pub fn dav1d_loop_restoration_dsp_init<BD: BitDepth>(
-    c: &mut Dav1dLoopRestorationDSPContext,
+    c: &mut Rav1dLoopRestorationDSPContext,
     _bpc: c_int,
 ) {
     c.wiener[1] = wiener_c_erased::<BD>;

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -4,8 +4,8 @@ use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
 use crate::src::align::Align16;
-use crate::src::internal::Dav1dDSPContext;
-use crate::src::internal::Dav1dFrameContext;
+use crate::src::internal::Rav1dDSPContext;
+use crate::src::internal::Rav1dFrameContext;
 use crate::src::lf_mask::Av1RestorationUnit;
 use crate::src::looprestoration::looprestorationfilter_fn;
 use crate::src::looprestoration::LooprestorationParams;
@@ -36,7 +36,7 @@ unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
 }
 
 unsafe extern "C" fn lr_stripe(
-    f: *const Dav1dFrameContext,
+    f: *const Rav1dFrameContext,
     mut p: *mut pixel,
     mut left: *const [pixel; 4],
     x: c_int,
@@ -47,7 +47,7 @@ unsafe extern "C" fn lr_stripe(
     lr: *const Av1RestorationUnit,
     mut edges: LrEdgeFlags,
 ) {
-    let dsp: *const Dav1dDSPContext = (*f).dsp;
+    let dsp: *const Rav1dDSPContext = (*f).dsp;
     let chroma = (plane != 0) as c_int;
     let ss_ver = chroma
         & ((*f).sr_cur.p.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
@@ -164,7 +164,7 @@ unsafe extern "C" fn backup4xU(
 }
 
 unsafe extern "C" fn lr_sbrow(
-    f: *const Dav1dFrameContext,
+    f: *const Rav1dFrameContext,
     mut p: *mut pixel,
     y: c_int,
     w: c_int,
@@ -267,7 +267,7 @@ unsafe extern "C" fn lr_sbrow(
     }
 }
 
-pub unsafe fn dav1d_lr_sbrow_16bpc(f: *mut Dav1dFrameContext, dst: *const *mut pixel, sby: c_int) {
+pub unsafe fn dav1d_lr_sbrow_16bpc(f: *mut Rav1dFrameContext, dst: *const *mut pixel, sby: c_int) {
     let offset_y = 8 * (sby != 0) as c_int;
     let dst_stride: *const ptrdiff_t = ((*f).sr_cur.p.stride).as_mut_ptr();
     let restore_planes = (*f).lf.restore_planes;

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -4,8 +4,8 @@ use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
 use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
 use crate::src::align::Align16;
-use crate::src::internal::Dav1dDSPContext;
-use crate::src::internal::Dav1dFrameContext;
+use crate::src::internal::Rav1dDSPContext;
+use crate::src::internal::Rav1dFrameContext;
 use crate::src::lf_mask::Av1RestorationUnit;
 use crate::src::looprestoration::looprestorationfilter_fn;
 use crate::src::looprestoration::LooprestorationParams;
@@ -28,7 +28,7 @@ use std::ffi::c_void;
 pub type pixel = u8;
 
 unsafe extern "C" fn lr_stripe(
-    f: *const Dav1dFrameContext,
+    f: *const Rav1dFrameContext,
     mut p: *mut pixel,
     mut left: *const [pixel; 4],
     x: c_int,
@@ -39,7 +39,7 @@ unsafe extern "C" fn lr_stripe(
     lr: *const Av1RestorationUnit,
     mut edges: LrEdgeFlags,
 ) {
-    let dsp: *const Dav1dDSPContext = (*f).dsp;
+    let dsp: *const Rav1dDSPContext = (*f).dsp;
     let chroma = (plane != 0) as c_int;
     let ss_ver = chroma
         & ((*f).sr_cur.p.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
@@ -154,7 +154,7 @@ unsafe extern "C" fn backup4xU(
 }
 
 unsafe extern "C" fn lr_sbrow(
-    f: *const Dav1dFrameContext,
+    f: *const Rav1dFrameContext,
     mut p: *mut pixel,
     y: c_int,
     w: c_int,
@@ -257,7 +257,7 @@ unsafe extern "C" fn lr_sbrow(
     }
 }
 
-pub unsafe fn dav1d_lr_sbrow_8bpc(f: *mut Dav1dFrameContext, dst: *const *mut pixel, sby: c_int) {
+pub unsafe fn dav1d_lr_sbrow_8bpc(f: *mut Rav1dFrameContext, dst: *const *mut pixel, sby: c_int) {
     let offset_y = 8 * (sby != 0) as c_int;
     let dst_stride: *const ptrdiff_t = ((*f).sr_cur.p.stride).as_mut_ptr();
     let restore_planes = (*f).lf.restore_planes;

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -1354,7 +1354,7 @@ pub type resize_fn = unsafe extern "C" fn(
     c_int,
 ) -> ();
 #[repr(C)]
-pub struct Dav1dMCDSPContext {
+pub struct Rav1dMCDSPContext {
     pub mc: [mc_fn; 10],
     pub mc_scaled: [mc_scaled_fn; 10],
     pub mct: [mct_fn; 10],
@@ -2254,7 +2254,7 @@ extern "C" {
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
-unsafe extern "C" fn mc_dsp_init_x86<BD: BitDepth>(c: *mut Dav1dMCDSPContext) {
+unsafe extern "C" fn mc_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dMCDSPContext) {
     let flags = dav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSE2) {
@@ -2500,7 +2500,7 @@ unsafe extern "C" fn mc_dsp_init_x86<BD: BitDepth>(c: *mut Dav1dMCDSPContext) {
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]
-unsafe extern "C" fn mc_dsp_init_arm<BD: BitDepth>(c: *mut Dav1dMCDSPContext) {
+unsafe extern "C" fn mc_dsp_init_arm<BD: BitDepth>(c: *mut Rav1dMCDSPContext) {
     let flags = dav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::NEON) {
@@ -2546,7 +2546,7 @@ unsafe extern "C" fn mc_dsp_init_arm<BD: BitDepth>(c: *mut Dav1dMCDSPContext) {
 }
 
 #[cold]
-pub unsafe extern "C" fn dav1d_mc_dsp_init<BD: BitDepth>(c: *mut Dav1dMCDSPContext) {
+pub unsafe extern "C" fn dav1d_mc_dsp_init<BD: BitDepth>(c: *mut Rav1dMCDSPContext) {
     (*c).mc[FILTER_2D_8TAP_REGULAR as usize] = put_8tap_regular_c_erased::<BD>;
     (*c).mc[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] = put_8tap_regular_smooth_c_erased::<BD>;
     (*c).mc[FILTER_2D_8TAP_REGULAR_SHARP as usize] = put_8tap_regular_sharp_c_erased::<BD>;

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -12,17 +12,17 @@ use std::ffi::c_int;
 use std::ffi::c_void;
 
 #[repr(C)]
-pub struct Dav1dMemPool {
+pub struct Rav1dMemPool {
     pub lock: pthread_mutex_t,
-    pub buf: *mut Dav1dMemPoolBuffer,
+    pub buf: *mut Rav1dMemPoolBuffer,
     pub ref_cnt: c_int,
     pub end: c_int,
 }
 
 #[repr(C)]
-pub struct Dav1dMemPoolBuffer {
+pub struct Rav1dMemPoolBuffer {
     pub data: *mut c_void,
-    pub next: *mut Dav1dMemPoolBuffer,
+    pub next: *mut Rav1dMemPoolBuffer,
 }
 
 #[inline]
@@ -61,12 +61,12 @@ pub unsafe extern "C" fn freep(ptr: *mut c_void) {
 }
 
 #[cold]
-unsafe extern "C" fn mem_pool_destroy(pool: *mut Dav1dMemPool) {
+unsafe extern "C" fn mem_pool_destroy(pool: *mut Rav1dMemPool) {
     pthread_mutex_destroy(&mut (*pool).lock);
     free(pool as *mut c_void);
 }
 
-pub unsafe fn dav1d_mem_pool_push(pool: *mut Dav1dMemPool, buf: *mut Dav1dMemPoolBuffer) {
+pub unsafe fn dav1d_mem_pool_push(pool: *mut Rav1dMemPool, buf: *mut Rav1dMemPoolBuffer) {
     pthread_mutex_lock(&mut (*pool).lock);
     (*pool).ref_cnt -= 1;
     let ref_cnt = (*pool).ref_cnt;
@@ -86,12 +86,12 @@ pub unsafe fn dav1d_mem_pool_push(pool: *mut Dav1dMemPool, buf: *mut Dav1dMemPoo
     };
 }
 
-pub unsafe fn dav1d_mem_pool_pop(pool: *mut Dav1dMemPool, size: usize) -> *mut Dav1dMemPoolBuffer {
+pub unsafe fn dav1d_mem_pool_pop(pool: *mut Rav1dMemPool, size: usize) -> *mut Rav1dMemPoolBuffer {
     if size & ::core::mem::size_of::<*mut c_void>().wrapping_sub(1) != 0 {
         unreachable!();
     }
     pthread_mutex_lock(&mut (*pool).lock);
-    let mut buf: *mut Dav1dMemPoolBuffer = (*pool).buf;
+    let mut buf: *mut Rav1dMemPoolBuffer = (*pool).buf;
     (*pool).ref_cnt += 1;
     let mut data: *mut u8;
     if !buf.is_null() {
@@ -106,7 +106,7 @@ pub unsafe fn dav1d_mem_pool_pop(pool: *mut Dav1dMemPool, size: usize) -> *mut D
         pthread_mutex_unlock(&mut (*pool).lock);
     }
     data = dav1d_alloc_aligned(
-        size.wrapping_add(::core::mem::size_of::<Dav1dMemPoolBuffer>()),
+        size.wrapping_add(::core::mem::size_of::<Rav1dMemPoolBuffer>()),
         64,
     ) as *mut u8;
     if data.is_null() {
@@ -117,20 +117,20 @@ pub unsafe fn dav1d_mem_pool_pop(pool: *mut Dav1dMemPool, size: usize) -> *mut D
         if ref_cnt == 0 {
             mem_pool_destroy(pool);
         }
-        return 0 as *mut Dav1dMemPoolBuffer;
+        return 0 as *mut Rav1dMemPoolBuffer;
     }
-    buf = data.offset(size as isize) as *mut Dav1dMemPoolBuffer;
+    buf = data.offset(size as isize) as *mut Rav1dMemPoolBuffer;
     (*buf).data = data as *mut c_void;
     return buf;
 }
 
 #[cold]
-pub unsafe fn dav1d_mem_pool_init(ppool: *mut *mut Dav1dMemPool) -> c_int {
-    let pool: *mut Dav1dMemPool =
-        malloc(::core::mem::size_of::<Dav1dMemPool>()) as *mut Dav1dMemPool;
+pub unsafe fn dav1d_mem_pool_init(ppool: *mut *mut Rav1dMemPool) -> c_int {
+    let pool: *mut Rav1dMemPool =
+        malloc(::core::mem::size_of::<Rav1dMemPool>()) as *mut Rav1dMemPool;
     if !pool.is_null() {
         if pthread_mutex_init(&mut (*pool).lock, 0 as *const pthread_mutexattr_t) == 0 {
-            (*pool).buf = 0 as *mut Dav1dMemPoolBuffer;
+            (*pool).buf = 0 as *mut Rav1dMemPoolBuffer;
             (*pool).ref_cnt = 1 as c_int;
             (*pool).end = 0 as c_int;
             *ppool = pool;
@@ -138,18 +138,18 @@ pub unsafe fn dav1d_mem_pool_init(ppool: *mut *mut Dav1dMemPool) -> c_int {
         }
         free(pool as *mut c_void);
     }
-    *ppool = 0 as *mut Dav1dMemPool;
+    *ppool = 0 as *mut Rav1dMemPool;
     return -(12 as c_int);
 }
 
 #[cold]
-pub unsafe fn dav1d_mem_pool_end(pool: *mut Dav1dMemPool) {
+pub unsafe fn dav1d_mem_pool_end(pool: *mut Rav1dMemPool) {
     if !pool.is_null() {
         pthread_mutex_lock(&mut (*pool).lock);
-        let mut buf: *mut Dav1dMemPoolBuffer = (*pool).buf;
+        let mut buf: *mut Rav1dMemPoolBuffer = (*pool).buf;
         (*pool).ref_cnt -= 1;
         let ref_cnt = (*pool).ref_cnt;
-        (*pool).buf = 0 as *mut Dav1dMemPoolBuffer;
+        (*pool).buf = 0 as *mut Rav1dMemPoolBuffer;
         (*pool).end = 1 as c_int;
         pthread_mutex_unlock(&mut (*pool).lock);
         while !buf.is_null() {

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -1,8 +1,8 @@
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::src::internal::Dav1dFrameContext;
-use crate::src::internal::Dav1dTaskContext;
+use crate::src::internal::Rav1dFrameContext;
+use crate::src::internal::Rav1dTaskContext;
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::levels::Av1Block;
 use crate::src::levels::BlockSize;
@@ -40,23 +40,23 @@ use std::ffi::c_uint;
 use std::ops::BitOr;
 
 /// TODO: add feature and compile-time guard around this code
-pub unsafe fn DEBUG_BLOCK_INFO(f: &Dav1dFrameContext, t: &Dav1dTaskContext) -> bool {
+pub unsafe fn DEBUG_BLOCK_INFO(f: &Rav1dFrameContext, t: &Rav1dTaskContext) -> bool {
     false && (*f.frame_hdr).frame_offset == 2 && t.by >= 0 && t.by < 4 && t.bx >= 8 && t.bx < 12
 }
 
 pub type recon_b_intra_fn = Option<
-    unsafe extern "C" fn(*mut Dav1dTaskContext, BlockSize, EdgeFlags, *const Av1Block) -> (),
+    unsafe extern "C" fn(*mut Rav1dTaskContext, BlockSize, EdgeFlags, *const Av1Block) -> (),
 >;
 
 pub type recon_b_inter_fn =
-    Option<unsafe extern "C" fn(*mut Dav1dTaskContext, BlockSize, *const Av1Block) -> c_int>;
+    Option<unsafe extern "C" fn(*mut Rav1dTaskContext, BlockSize, *const Av1Block) -> c_int>;
 
-pub type filter_sbrow_fn = Option<unsafe extern "C" fn(*mut Dav1dFrameContext, c_int) -> ()>;
+pub type filter_sbrow_fn = Option<unsafe extern "C" fn(*mut Rav1dFrameContext, c_int) -> ()>;
 
-pub type backup_ipred_edge_fn = Option<unsafe extern "C" fn(*mut Dav1dTaskContext) -> ()>;
+pub type backup_ipred_edge_fn = Option<unsafe extern "C" fn(*mut Rav1dTaskContext) -> ()>;
 
 pub type read_coef_blocks_fn =
-    Option<unsafe extern "C" fn(*mut Dav1dTaskContext, BlockSize, *const Av1Block) -> ()>;
+    Option<unsafe extern "C" fn(*mut Rav1dTaskContext, BlockSize, *const Av1Block) -> ()>;
 
 #[inline]
 pub fn read_golomb(msac: &mut MsacContext) -> c_uint {

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -18,10 +18,10 @@ use crate::src::cdef_apply_tmpl_16::dav1d_cdef_brow_16bpc;
 use crate::src::ctx::CaseSet;
 use crate::src::env::get_uv_inter_txtp;
 use crate::src::internal::CodedBlockInfo;
-use crate::src::internal::Dav1dDSPContext;
-use crate::src::internal::Dav1dFrameContext;
-use crate::src::internal::Dav1dTaskContext;
-use crate::src::internal::Dav1dTileState;
+use crate::src::internal::Rav1dDSPContext;
+use crate::src::internal::Rav1dFrameContext;
+use crate::src::internal::Rav1dTaskContext;
+use crate::src::internal::Rav1dTileState;
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::intra_edge::EDGE_I420_LEFT_HAS_BOTTOM;
 use crate::src::intra_edge::EDGE_I420_TOP_HAS_RIGHT;
@@ -73,7 +73,7 @@ use crate::src::msac::dav1d_msac_decode_hi_tok;
 use crate::src::msac::dav1d_msac_decode_symbol_adapt16;
 use crate::src::msac::dav1d_msac_decode_symbol_adapt4;
 use crate::src::msac::dav1d_msac_decode_symbol_adapt8;
-use crate::src::picture::Dav1dThreadPicture;
+use crate::src::picture::Rav1dThreadPicture;
 use crate::src::recon::get_dc_sign_ctx;
 use crate::src::recon::get_lo_ctx;
 use crate::src::recon::get_skip_ctx;
@@ -117,7 +117,7 @@ unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
 }
 
 unsafe fn decode_coefs(
-    t: *mut Dav1dTaskContext,
+    t: *mut Rav1dTaskContext,
     a: &mut [u8],
     l: &mut [u8],
     tx: RectTxfmSize,
@@ -133,9 +133,9 @@ unsafe fn decode_coefs(
     let dc_sign;
     let mut dc_dq;
     let current_block: u64;
-    let ts: *mut Dav1dTileState = (*t).ts;
+    let ts: *mut Rav1dTileState = (*t).ts;
     let chroma = (plane != 0) as c_int;
-    let f: *const Dav1dFrameContext = (*t).f;
+    let f: *const Rav1dFrameContext = (*t).f;
     let lossless = (*(*f).frame_hdr).segmentation.lossless[(*b).seg_id as usize];
     let t_dim = &dav1d_txfm_dimensions[tx as usize];
     let dbg = DEBUG_BLOCK_INFO(&*f, &*t) as c_int;
@@ -1285,7 +1285,7 @@ unsafe fn decode_coefs(
 }
 
 unsafe extern "C" fn read_coef_tree(
-    t: *mut Dav1dTaskContext,
+    t: *mut Rav1dTaskContext,
     bs: BlockSize,
     b: *const Av1Block,
     ytx: RectTxfmSize,
@@ -1295,9 +1295,9 @@ unsafe extern "C" fn read_coef_tree(
     y_off: c_int,
     mut dst: *mut pixel,
 ) {
-    let f: *const Dav1dFrameContext = (*t).f;
-    let ts: *mut Dav1dTileState = (*t).ts;
-    let dsp: *const Dav1dDSPContext = (*f).dsp;
+    let f: *const Rav1dFrameContext = (*t).f;
+    let ts: *mut Rav1dTileState = (*t).ts;
+    let dsp: *const Rav1dDSPContext = (*f).dsp;
     let t_dim: *const TxfmInfo =
         &*dav1d_txfm_dimensions.as_ptr().offset(ytx as isize) as *const TxfmInfo;
     let txw = (*t_dim).w as c_int;
@@ -1489,11 +1489,11 @@ unsafe extern "C" fn read_coef_tree(
 }
 
 pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
-    t: *mut Dav1dTaskContext,
+    t: *mut Rav1dTaskContext,
     bs: BlockSize,
     b: *const Av1Block,
 ) {
-    let f: *const Dav1dFrameContext = (*t).f;
+    let f: *const Rav1dFrameContext = (*t).f;
     let ss_ver =
         ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let ss_hor =
@@ -1532,7 +1532,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
         }
         return;
     }
-    let ts: *mut Dav1dTileState = (*t).ts;
+    let ts: *mut Rav1dTileState = (*t).ts;
     let w4 = cmp::min(bw4, (*f).bw - (*t).bx);
     let h4 = cmp::min(bh4, (*f).bh - (*t).by);
     let cw4 = w4 + ss_hor >> ss_hor;
@@ -1733,7 +1733,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
 }
 
 unsafe extern "C" fn mc(
-    t: *mut Dav1dTaskContext,
+    t: *mut Rav1dTaskContext,
     dst8: *mut pixel,
     dst16: *mut i16,
     dst_stride: ptrdiff_t,
@@ -1743,7 +1743,7 @@ unsafe extern "C" fn mc(
     by: c_int,
     pl: c_int,
     mv: mv,
-    refp: *const Dav1dThreadPicture,
+    refp: *const Rav1dThreadPicture,
     refidx: c_int,
     filter_2d: Filter2d,
 ) -> c_int {
@@ -1753,7 +1753,7 @@ unsafe extern "C" fn mc(
     {
         unreachable!();
     }
-    let f: *const Dav1dFrameContext = (*t).f;
+    let f: *const Rav1dFrameContext = (*t).f;
     let ss_ver = (pl != 0
         && (*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
         as c_int;
@@ -1836,7 +1836,7 @@ unsafe extern "C" fn mc(
             );
         }
     } else {
-        if !(refp != &(*f).sr_cur as *const Dav1dThreadPicture) {
+        if !(refp != &(*f).sr_cur as *const Rav1dThreadPicture) {
             unreachable!();
         }
         let orig_pos_y = (by * v_mul << 4) + mvy * ((1 as c_int) << (ss_ver == 0) as c_int);
@@ -1936,7 +1936,7 @@ unsafe extern "C" fn mc(
 }
 
 unsafe extern "C" fn obmc(
-    t: *mut Dav1dTaskContext,
+    t: *mut Rav1dTaskContext,
     dst: *mut pixel,
     dst_stride: ptrdiff_t,
     b_dim: *const u8,
@@ -1949,7 +1949,7 @@ unsafe extern "C" fn obmc(
     if !((*t).bx & 1 == 0 && (*t).by & 1 == 0) {
         unreachable!();
     }
-    let f: *const Dav1dFrameContext = (*t).f;
+    let f: *const Rav1dFrameContext = (*t).f;
     let r: *mut *mut refmvs_block = &mut *((*t).rt.r)
         .as_mut_ptr()
         .offset((((*t).by & 31) + 5) as isize)
@@ -2072,13 +2072,13 @@ unsafe extern "C" fn obmc(
 }
 
 unsafe extern "C" fn warp_affine(
-    t: *mut Dav1dTaskContext,
+    t: *mut Rav1dTaskContext,
     mut dst8: *mut pixel,
     mut dst16: *mut i16,
     dstride: ptrdiff_t,
     b_dim: *const u8,
     pl: c_int,
-    refp: *const Dav1dThreadPicture,
+    refp: *const Rav1dThreadPicture,
     wmp: *const Dav1dWarpedMotionParams,
 ) -> c_int {
     if (dst8 != 0 as *mut c_void as *mut pixel) as c_int
@@ -2087,8 +2087,8 @@ unsafe extern "C" fn warp_affine(
     {
         unreachable!();
     }
-    let f: *const Dav1dFrameContext = (*t).f;
-    let dsp: *const Dav1dDSPContext = (*f).dsp;
+    let f: *const Rav1dFrameContext = (*t).f;
+    let dsp: *const Rav1dDSPContext = (*f).dsp;
     let ss_ver = (pl != 0
         && (*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
         as c_int;
@@ -2187,14 +2187,14 @@ unsafe extern "C" fn warp_affine(
 }
 
 pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
-    t: *mut Dav1dTaskContext,
+    t: *mut Rav1dTaskContext,
     bs: BlockSize,
     intra_edge_flags: EdgeFlags,
     b: *const Av1Block,
 ) {
-    let ts: *mut Dav1dTileState = (*t).ts;
-    let f: *const Dav1dFrameContext = (*t).f;
-    let dsp: *const Dav1dDSPContext = (*f).dsp;
+    let ts: *mut Rav1dTileState = (*t).ts;
+    let f: *const Rav1dFrameContext = (*t).f;
+    let dsp: *const Rav1dDSPContext = (*f).dsp;
     let bx4 = (*t).bx & 31;
     let by4 = (*t).by & 31;
     let ss_ver =
@@ -2933,13 +2933,13 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
 }
 
 pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
-    t: *mut Dav1dTaskContext,
+    t: *mut Rav1dTaskContext,
     bs: BlockSize,
     b: *const Av1Block,
 ) -> c_int {
-    let ts: *mut Dav1dTileState = (*t).ts;
-    let f: *const Dav1dFrameContext = (*t).f;
-    let dsp: *const Dav1dDSPContext = (*f).dsp;
+    let ts: *mut Rav1dTileState = (*t).ts;
+    let f: *const Rav1dFrameContext = (*t).f;
+    let dsp: *const Rav1dDSPContext = (*f).dsp;
     let bx4 = (*t).bx & 31;
     let by4 = (*t).by & 31;
     let ss_ver =
@@ -3028,11 +3028,11 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
     } else if (*b).c2rust_unnamed.c2rust_unnamed_0.comp_type as c_int == COMP_INTER_NONE as c_int {
         let mut is_sub8x8;
         let mut r: *const *mut refmvs_block;
-        let refp: *const Dav1dThreadPicture = &*((*f).refp).as_ptr().offset(
+        let refp: *const Rav1dThreadPicture = &*((*f).refp).as_ptr().offset(
             *((*b).c2rust_unnamed.c2rust_unnamed_0.r#ref)
                 .as_ptr()
                 .offset(0) as isize,
-        ) as *const Dav1dThreadPicture;
+        ) as *const Rav1dThreadPicture;
         let filter_2d: Filter2d = (*b).c2rust_unnamed.c2rust_unnamed_0.filter2d as Filter2d;
         if cmp::min(bw4, bh4) > 1
             && ((*b).c2rust_unnamed.c2rust_unnamed_0.inter_mode as c_int == GLOBALMV as c_int
@@ -3649,11 +3649,11 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
         let mut mask: *const u8 = 0 as *const u8;
         let mut i = 0;
         while i < 2 {
-            let refp_0: *const Dav1dThreadPicture = &*((*f).refp).as_ptr().offset(
+            let refp_0: *const Rav1dThreadPicture = &*((*f).refp).as_ptr().offset(
                 *((*b).c2rust_unnamed.c2rust_unnamed_0.r#ref)
                     .as_ptr()
                     .offset(i as isize) as isize,
-            ) as *const Dav1dThreadPicture;
+            ) as *const Rav1dThreadPicture;
             if (*b).c2rust_unnamed.c2rust_unnamed_0.inter_mode as c_int
                 == GLOBALMV_GLOBALMV as c_int
                 && (*f).gmv_warp_allowed
@@ -3824,12 +3824,12 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
             while pl_7 < 2 {
                 let mut i_0 = 0;
                 while i_0 < 2 {
-                    let refp_1: *const Dav1dThreadPicture = &*((*f).refp).as_ptr().offset(
+                    let refp_1: *const Rav1dThreadPicture = &*((*f).refp).as_ptr().offset(
                         *((*b).c2rust_unnamed.c2rust_unnamed_0.r#ref)
                             .as_ptr()
                             .offset(i_0 as isize) as isize,
                     )
-                        as *const Dav1dThreadPicture;
+                        as *const Rav1dThreadPicture;
                     if (*b).c2rust_unnamed.c2rust_unnamed_0.inter_mode as c_int
                         == GLOBALMV_GLOBALMV as c_int
                         && cmp::min(cbw4, cbh4) > 1
@@ -4170,7 +4170,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
 }
 
 pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_cols_16bpc(
-    f: *mut Dav1dFrameContext,
+    f: *mut Rav1dFrameContext,
     sby: c_int,
 ) {
     if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_DEBLOCK as c_int as c_uint == 0
@@ -4201,7 +4201,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_cols_16bpc(
 }
 
 pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_rows_16bpc(
-    f: *mut Dav1dFrameContext,
+    f: *mut Rav1dFrameContext,
     sby: c_int,
 ) {
     let y = sby * (*f).sb_step * 4;
@@ -4227,8 +4227,8 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_rows_16bpc(
     }
 }
 
-pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_16bpc(tc: *mut Dav1dTaskContext, sby: c_int) {
-    let f: *const Dav1dFrameContext = (*tc).f;
+pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_16bpc(tc: *mut Rav1dTaskContext, sby: c_int) {
+    let f: *const Rav1dFrameContext = (*tc).f;
     if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_CDEF as c_int as c_uint == 0 {
         return;
     }
@@ -4271,7 +4271,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_16bpc(tc: *mut Dav1dTaskContext
     dav1d_cdef_brow_16bpc(tc, p.as_ptr(), mask, start, end, 0 as c_int, sby);
 }
 
-pub unsafe extern "C" fn dav1d_filter_sbrow_resize_16bpc(f: *mut Dav1dFrameContext, sby: c_int) {
+pub unsafe extern "C" fn dav1d_filter_sbrow_resize_16bpc(f: *mut Rav1dFrameContext, sby: c_int) {
     let sbsz = (*f).sb_step;
     let y = sby * sbsz * 4;
     let ss_ver =
@@ -4330,7 +4330,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_resize_16bpc(f: *mut Dav1dFrameConte
     }
 }
 
-pub unsafe extern "C" fn dav1d_filter_sbrow_lr_16bpc(f: *mut Dav1dFrameContext, sby: c_int) {
+pub unsafe extern "C" fn dav1d_filter_sbrow_lr_16bpc(f: *mut Rav1dFrameContext, sby: c_int) {
     if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_RESTORATION as c_int as c_uint == 0 {
         return;
     }
@@ -4347,7 +4347,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_lr_16bpc(f: *mut Dav1dFrameContext, 
     dav1d_lr_sbrow_16bpc(f, sr_p.as_ptr(), sby);
 }
 
-pub unsafe extern "C" fn dav1d_filter_sbrow_16bpc(f: *mut Dav1dFrameContext, sby: c_int) {
+pub unsafe extern "C" fn dav1d_filter_sbrow_16bpc(f: *mut Rav1dFrameContext, sby: c_int) {
     dav1d_filter_sbrow_deblock_cols_16bpc(f, sby);
     dav1d_filter_sbrow_deblock_rows_16bpc(f, sby);
     if (*(*f).seq_hdr).cdef != 0 {
@@ -4361,9 +4361,9 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_16bpc(f: *mut Dav1dFrameContext, sby
     }
 }
 
-pub unsafe extern "C" fn dav1d_backup_ipred_edge_16bpc(t: *mut Dav1dTaskContext) {
-    let f: *const Dav1dFrameContext = (*t).f;
-    let ts: *mut Dav1dTileState = (*t).ts;
+pub unsafe extern "C" fn dav1d_backup_ipred_edge_16bpc(t: *mut Rav1dTaskContext) {
+    let f: *const Rav1dFrameContext = (*t).f;
+    let ts: *mut Rav1dTileState = (*t).ts;
     let sby = (*t).by >> (*f).sb_shift;
     let sby_off = (*f).sb128w * 128 * sby;
     let x_off = (*ts).tiling.col_start;

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -18,10 +18,10 @@ use crate::src::cdef_apply_tmpl_8::dav1d_cdef_brow_8bpc;
 use crate::src::ctx::CaseSet;
 use crate::src::env::get_uv_inter_txtp;
 use crate::src::internal::CodedBlockInfo;
-use crate::src::internal::Dav1dDSPContext;
-use crate::src::internal::Dav1dFrameContext;
-use crate::src::internal::Dav1dTaskContext;
-use crate::src::internal::Dav1dTileState;
+use crate::src::internal::Rav1dDSPContext;
+use crate::src::internal::Rav1dFrameContext;
+use crate::src::internal::Rav1dTaskContext;
+use crate::src::internal::Rav1dTileState;
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::intra_edge::EDGE_I420_LEFT_HAS_BOTTOM;
 use crate::src::intra_edge::EDGE_I420_TOP_HAS_RIGHT;
@@ -73,7 +73,7 @@ use crate::src::msac::dav1d_msac_decode_hi_tok;
 use crate::src::msac::dav1d_msac_decode_symbol_adapt16;
 use crate::src::msac::dav1d_msac_decode_symbol_adapt4;
 use crate::src::msac::dav1d_msac_decode_symbol_adapt8;
-use crate::src::picture::Dav1dThreadPicture;
+use crate::src::picture::Rav1dThreadPicture;
 use crate::src::recon::get_dc_sign_ctx;
 use crate::src::recon::get_lo_ctx;
 use crate::src::recon::get_skip_ctx;
@@ -109,7 +109,7 @@ pub type pixel = u8;
 pub type coef = i16;
 
 unsafe fn decode_coefs(
-    t: *mut Dav1dTaskContext,
+    t: *mut Rav1dTaskContext,
     a: &mut [u8],
     l: &mut [u8],
     tx: RectTxfmSize,
@@ -125,9 +125,9 @@ unsafe fn decode_coefs(
     let dc_sign;
     let mut dc_dq;
     let current_block: u64;
-    let ts: *mut Dav1dTileState = (*t).ts;
+    let ts: *mut Rav1dTileState = (*t).ts;
     let chroma = (plane != 0) as c_int;
-    let f: *const Dav1dFrameContext = (*t).f;
+    let f: *const Rav1dFrameContext = (*t).f;
     let lossless = (*(*f).frame_hdr).segmentation.lossless[(*b).seg_id as usize];
     let t_dim = &dav1d_txfm_dimensions[tx as usize];
     let dbg = DEBUG_BLOCK_INFO(&*f, &*t) as c_int;
@@ -1275,7 +1275,7 @@ unsafe fn decode_coefs(
 }
 
 unsafe extern "C" fn read_coef_tree(
-    t: *mut Dav1dTaskContext,
+    t: *mut Rav1dTaskContext,
     bs: BlockSize,
     b: *const Av1Block,
     ytx: RectTxfmSize,
@@ -1285,9 +1285,9 @@ unsafe extern "C" fn read_coef_tree(
     y_off: c_int,
     mut dst: *mut pixel,
 ) {
-    let f: *const Dav1dFrameContext = (*t).f;
-    let ts: *mut Dav1dTileState = (*t).ts;
-    let dsp: *const Dav1dDSPContext = (*f).dsp;
+    let f: *const Rav1dFrameContext = (*t).f;
+    let ts: *mut Rav1dTileState = (*t).ts;
+    let dsp: *const Rav1dDSPContext = (*f).dsp;
     let t_dim: *const TxfmInfo =
         &*dav1d_txfm_dimensions.as_ptr().offset(ytx as isize) as *const TxfmInfo;
     let txw = (*t_dim).w as c_int;
@@ -1479,11 +1479,11 @@ unsafe extern "C" fn read_coef_tree(
 }
 
 pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
-    t: *mut Dav1dTaskContext,
+    t: *mut Rav1dTaskContext,
     bs: BlockSize,
     b: *const Av1Block,
 ) {
-    let f: *const Dav1dFrameContext = (*t).f;
+    let f: *const Rav1dFrameContext = (*t).f;
     let ss_ver =
         ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let ss_hor =
@@ -1522,7 +1522,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
         }
         return;
     }
-    let ts: *mut Dav1dTileState = (*t).ts;
+    let ts: *mut Rav1dTileState = (*t).ts;
     let w4 = cmp::min(bw4, (*f).bw - (*t).bx);
     let h4 = cmp::min(bh4, (*f).bh - (*t).by);
     let cw4 = w4 + ss_hor >> ss_hor;
@@ -1723,7 +1723,7 @@ pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
 }
 
 unsafe extern "C" fn mc(
-    t: *mut Dav1dTaskContext,
+    t: *mut Rav1dTaskContext,
     dst8: *mut pixel,
     dst16: *mut i16,
     dst_stride: ptrdiff_t,
@@ -1733,7 +1733,7 @@ unsafe extern "C" fn mc(
     by: c_int,
     pl: c_int,
     mv: mv,
-    refp: *const Dav1dThreadPicture,
+    refp: *const Rav1dThreadPicture,
     refidx: c_int,
     filter_2d: Filter2d,
 ) -> c_int {
@@ -1743,7 +1743,7 @@ unsafe extern "C" fn mc(
     {
         unreachable!();
     }
-    let f: *const Dav1dFrameContext = (*t).f;
+    let f: *const Rav1dFrameContext = (*t).f;
     let ss_ver = (pl != 0
         && (*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
         as c_int;
@@ -1826,7 +1826,7 @@ unsafe extern "C" fn mc(
             );
         }
     } else {
-        if !(refp != &(*f).sr_cur as *const Dav1dThreadPicture) {
+        if !(refp != &(*f).sr_cur as *const Rav1dThreadPicture) {
             unreachable!();
         }
         let orig_pos_y = (by * v_mul << 4) + mvy * ((1 as c_int) << (ss_ver == 0) as c_int);
@@ -1926,7 +1926,7 @@ unsafe extern "C" fn mc(
 }
 
 unsafe extern "C" fn obmc(
-    t: *mut Dav1dTaskContext,
+    t: *mut Rav1dTaskContext,
     dst: *mut pixel,
     dst_stride: ptrdiff_t,
     b_dim: *const u8,
@@ -1939,7 +1939,7 @@ unsafe extern "C" fn obmc(
     if !((*t).bx & 1 == 0 && (*t).by & 1 == 0) {
         unreachable!();
     }
-    let f: *const Dav1dFrameContext = (*t).f;
+    let f: *const Rav1dFrameContext = (*t).f;
     let r: *mut *mut refmvs_block = &mut *((*t).rt.r)
         .as_mut_ptr()
         .offset((((*t).by & 31) + 5) as isize)
@@ -2057,13 +2057,13 @@ unsafe extern "C" fn obmc(
 }
 
 unsafe extern "C" fn warp_affine(
-    t: *mut Dav1dTaskContext,
+    t: *mut Rav1dTaskContext,
     mut dst8: *mut pixel,
     mut dst16: *mut i16,
     dstride: ptrdiff_t,
     b_dim: *const u8,
     pl: c_int,
-    refp: *const Dav1dThreadPicture,
+    refp: *const Rav1dThreadPicture,
     wmp: *const Dav1dWarpedMotionParams,
 ) -> c_int {
     if (dst8 != 0 as *mut c_void as *mut pixel) as c_int
@@ -2072,8 +2072,8 @@ unsafe extern "C" fn warp_affine(
     {
         unreachable!();
     }
-    let f: *const Dav1dFrameContext = (*t).f;
-    let dsp: *const Dav1dDSPContext = (*f).dsp;
+    let f: *const Rav1dFrameContext = (*t).f;
+    let dsp: *const Rav1dDSPContext = (*f).dsp;
     let ss_ver = (pl != 0
         && (*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
         as c_int;
@@ -2172,14 +2172,14 @@ unsafe extern "C" fn warp_affine(
 }
 
 pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
-    t: *mut Dav1dTaskContext,
+    t: *mut Rav1dTaskContext,
     bs: BlockSize,
     intra_edge_flags: EdgeFlags,
     b: *const Av1Block,
 ) {
-    let ts: *mut Dav1dTileState = (*t).ts;
-    let f: *const Dav1dFrameContext = (*t).f;
-    let dsp: *const Dav1dDSPContext = (*f).dsp;
+    let ts: *mut Rav1dTileState = (*t).ts;
+    let f: *const Rav1dFrameContext = (*t).f;
+    let dsp: *const Rav1dDSPContext = (*f).dsp;
     let bx4 = (*t).bx & 31;
     let by4 = (*t).by & 31;
     let ss_ver =
@@ -2913,13 +2913,13 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
 }
 
 pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
-    t: *mut Dav1dTaskContext,
+    t: *mut Rav1dTaskContext,
     bs: BlockSize,
     b: *const Av1Block,
 ) -> c_int {
-    let ts: *mut Dav1dTileState = (*t).ts;
-    let f: *const Dav1dFrameContext = (*t).f;
-    let dsp: *const Dav1dDSPContext = (*f).dsp;
+    let ts: *mut Rav1dTileState = (*t).ts;
+    let f: *const Rav1dFrameContext = (*t).f;
+    let dsp: *const Rav1dDSPContext = (*f).dsp;
     let bx4 = (*t).bx & 31;
     let by4 = (*t).by & 31;
     let ss_ver =
@@ -3006,11 +3006,11 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
     } else if (*b).c2rust_unnamed.c2rust_unnamed_0.comp_type as c_int == COMP_INTER_NONE as c_int {
         let mut is_sub8x8;
         let mut r: *const *mut refmvs_block;
-        let refp: *const Dav1dThreadPicture = &*((*f).refp).as_ptr().offset(
+        let refp: *const Rav1dThreadPicture = &*((*f).refp).as_ptr().offset(
             *((*b).c2rust_unnamed.c2rust_unnamed_0.r#ref)
                 .as_ptr()
                 .offset(0) as isize,
-        ) as *const Dav1dThreadPicture;
+        ) as *const Rav1dThreadPicture;
         let filter_2d: Filter2d = (*b).c2rust_unnamed.c2rust_unnamed_0.filter2d as Filter2d;
         if cmp::min(bw4, bh4) > 1
             && ((*b).c2rust_unnamed.c2rust_unnamed_0.inter_mode as c_int == GLOBALMV as c_int
@@ -3627,11 +3627,11 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
         let mut mask: *const u8 = 0 as *const u8;
         let mut i = 0;
         while i < 2 {
-            let refp_0: *const Dav1dThreadPicture = &*((*f).refp).as_ptr().offset(
+            let refp_0: *const Rav1dThreadPicture = &*((*f).refp).as_ptr().offset(
                 *((*b).c2rust_unnamed.c2rust_unnamed_0.r#ref)
                     .as_ptr()
                     .offset(i as isize) as isize,
-            ) as *const Dav1dThreadPicture;
+            ) as *const Rav1dThreadPicture;
             if (*b).c2rust_unnamed.c2rust_unnamed_0.inter_mode as c_int
                 == GLOBALMV_GLOBALMV as c_int
                 && (*f).gmv_warp_allowed
@@ -3802,12 +3802,12 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
             while pl_7 < 2 {
                 let mut i_0 = 0;
                 while i_0 < 2 {
-                    let refp_1: *const Dav1dThreadPicture = &*((*f).refp).as_ptr().offset(
+                    let refp_1: *const Rav1dThreadPicture = &*((*f).refp).as_ptr().offset(
                         *((*b).c2rust_unnamed.c2rust_unnamed_0.r#ref)
                             .as_ptr()
                             .offset(i_0 as isize) as isize,
                     )
-                        as *const Dav1dThreadPicture;
+                        as *const Rav1dThreadPicture;
                     if (*b).c2rust_unnamed.c2rust_unnamed_0.inter_mode as c_int
                         == GLOBALMV_GLOBALMV as c_int
                         && cmp::min(cbw4, cbh4) > 1
@@ -4145,7 +4145,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
 }
 
 pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_cols_8bpc(
-    f: *mut Dav1dFrameContext,
+    f: *mut Rav1dFrameContext,
     sby: c_int,
 ) {
     if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_DEBLOCK as c_int as c_uint == 0
@@ -4174,7 +4174,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_cols_8bpc(
 }
 
 pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_rows_8bpc(
-    f: *mut Dav1dFrameContext,
+    f: *mut Rav1dFrameContext,
     sby: c_int,
 ) {
     let y = sby * (*f).sb_step * 4;
@@ -4198,8 +4198,8 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_rows_8bpc(
     }
 }
 
-pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_8bpc(tc: *mut Dav1dTaskContext, sby: c_int) {
-    let f: *const Dav1dFrameContext = (*tc).f;
+pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_8bpc(tc: *mut Rav1dTaskContext, sby: c_int) {
+    let f: *const Rav1dFrameContext = (*tc).f;
     if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_CDEF as c_int as c_uint == 0 {
         return;
     }
@@ -4240,7 +4240,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_8bpc(tc: *mut Dav1dTaskContext,
     dav1d_cdef_brow_8bpc(tc, p.as_ptr(), mask, start, end, 0 as c_int, sby);
 }
 
-pub unsafe extern "C" fn dav1d_filter_sbrow_resize_8bpc(f: *mut Dav1dFrameContext, sby: c_int) {
+pub unsafe extern "C" fn dav1d_filter_sbrow_resize_8bpc(f: *mut Rav1dFrameContext, sby: c_int) {
     let sbsz = (*f).sb_step;
     let y = sby * sbsz * 4;
     let ss_ver =
@@ -4297,7 +4297,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_resize_8bpc(f: *mut Dav1dFrameContex
     }
 }
 
-pub unsafe extern "C" fn dav1d_filter_sbrow_lr_8bpc(f: *mut Dav1dFrameContext, sby: c_int) {
+pub unsafe extern "C" fn dav1d_filter_sbrow_lr_8bpc(f: *mut Rav1dFrameContext, sby: c_int) {
     if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_RESTORATION as c_int as c_uint == 0 {
         return;
     }
@@ -4314,7 +4314,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_lr_8bpc(f: *mut Dav1dFrameContext, s
     dav1d_lr_sbrow_8bpc(f, sr_p.as_ptr(), sby);
 }
 
-pub unsafe extern "C" fn dav1d_filter_sbrow_8bpc(f: *mut Dav1dFrameContext, sby: c_int) {
+pub unsafe extern "C" fn dav1d_filter_sbrow_8bpc(f: *mut Rav1dFrameContext, sby: c_int) {
     dav1d_filter_sbrow_deblock_cols_8bpc(f, sby);
     dav1d_filter_sbrow_deblock_rows_8bpc(f, sby);
     if (*(*f).seq_hdr).cdef != 0 {
@@ -4328,9 +4328,9 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_8bpc(f: *mut Dav1dFrameContext, sby:
     }
 }
 
-pub unsafe extern "C" fn dav1d_backup_ipred_edge_8bpc(t: *mut Dav1dTaskContext) {
-    let f: *const Dav1dFrameContext = (*t).f;
-    let ts: *mut Dav1dTileState = (*t).ts;
+pub unsafe extern "C" fn dav1d_backup_ipred_edge_8bpc(t: *mut Rav1dTaskContext) {
+    let f: *const Rav1dFrameContext = (*t).f;
+    let ts: *mut Rav1dTileState = (*t).ts;
     let sby = (*t).by >> (*f).sb_shift;
     let sby_off = (*f).sb128w * 128 * sby;
     let x_off = (*ts).tiling.col_start;

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -3,15 +3,15 @@ use crate::src::mem::dav1d_alloc_aligned;
 use crate::src::mem::dav1d_free_aligned;
 use crate::src::mem::dav1d_mem_pool_pop;
 use crate::src::mem::dav1d_mem_pool_push;
-use crate::src::mem::Dav1dMemPool;
-use crate::src::mem::Dav1dMemPoolBuffer;
+use crate::src::mem::Rav1dMemPool;
+use crate::src::mem::Rav1dMemPoolBuffer;
 use libc::free;
 use libc::malloc;
 use std::ffi::c_int;
 use std::ffi::c_void;
 
 #[repr(C)]
-pub struct Dav1dRef {
+pub struct Rav1dRef {
     pub(crate) data: *mut c_void,
     pub(crate) const_data: *const c_void,
     pub(crate) ref_cnt: atomic_int,
@@ -21,7 +21,7 @@ pub struct Dav1dRef {
 }
 
 #[inline]
-pub unsafe extern "C" fn dav1d_ref_inc(r#ref: *mut Dav1dRef) {
+pub unsafe extern "C" fn dav1d_ref_inc(r#ref: *mut Rav1dRef) {
     ::core::intrinsics::atomic_xadd_relaxed(&mut (*r#ref).ref_cnt, 1 as c_int);
 }
 
@@ -32,19 +32,19 @@ unsafe extern "C" fn default_free_callback(data: *const u8, user_data: *mut c_vo
     dav1d_free_aligned(user_data);
 }
 
-pub unsafe fn dav1d_ref_create(mut size: usize) -> *mut Dav1dRef {
+pub unsafe fn dav1d_ref_create(mut size: usize) -> *mut Rav1dRef {
     size = size
         .wrapping_add(::core::mem::size_of::<*mut c_void>())
         .wrapping_sub(1)
         & !(::core::mem::size_of::<*mut c_void>()).wrapping_sub(1);
     let data: *mut u8 = dav1d_alloc_aligned(
-        size.wrapping_add(::core::mem::size_of::<Dav1dRef>()),
+        size.wrapping_add(::core::mem::size_of::<Rav1dRef>()),
         64 as c_int as usize,
     ) as *mut u8;
     if data.is_null() {
-        return 0 as *mut Dav1dRef;
+        return 0 as *mut Rav1dRef;
     }
-    let res: *mut Dav1dRef = data.offset(size as isize) as *mut Dav1dRef;
+    let res: *mut Rav1dRef = data.offset(size as isize) as *mut Rav1dRef;
     (*res).data = data as *mut c_void;
     (*res).user_data = (*res).data;
     (*res).const_data = (*res).user_data;
@@ -57,26 +57,26 @@ pub unsafe fn dav1d_ref_create(mut size: usize) -> *mut Dav1dRef {
 
 unsafe extern "C" fn pool_free_callback(data: *const u8, user_data: *mut c_void) {
     dav1d_mem_pool_push(
-        data as *mut Dav1dMemPool,
-        user_data as *mut Dav1dMemPoolBuffer,
+        data as *mut Rav1dMemPool,
+        user_data as *mut Rav1dMemPoolBuffer,
     );
 }
 
 pub unsafe fn dav1d_ref_create_using_pool(
-    pool: *mut Dav1dMemPool,
+    pool: *mut Rav1dMemPool,
     mut size: usize,
-) -> *mut Dav1dRef {
+) -> *mut Rav1dRef {
     size = size
         .wrapping_add(::core::mem::size_of::<*mut c_void>())
         .wrapping_sub(1)
         & !(::core::mem::size_of::<*mut c_void>()).wrapping_sub(1);
-    let buf: *mut Dav1dMemPoolBuffer =
-        dav1d_mem_pool_pop(pool, size.wrapping_add(::core::mem::size_of::<Dav1dRef>()));
+    let buf: *mut Rav1dMemPoolBuffer =
+        dav1d_mem_pool_pop(pool, size.wrapping_add(::core::mem::size_of::<Rav1dRef>()));
     if buf.is_null() {
-        return 0 as *mut Dav1dRef;
+        return 0 as *mut Rav1dRef;
     }
-    let res: *mut Dav1dRef =
-        &mut *(buf as *mut Dav1dRef).offset(-(1 as c_int) as isize) as *mut Dav1dRef;
+    let res: *mut Rav1dRef =
+        &mut *(buf as *mut Rav1dRef).offset(-(1 as c_int) as isize) as *mut Rav1dRef;
     (*res).data = (*buf).data;
     (*res).const_data = pool as *const c_void;
     *&mut (*res).ref_cnt = 1 as c_int;
@@ -91,10 +91,10 @@ pub unsafe fn dav1d_ref_wrap(
     ptr: *const u8,
     free_callback: Option<unsafe extern "C" fn(*const u8, *mut c_void) -> ()>,
     user_data: *mut c_void,
-) -> *mut Dav1dRef {
-    let res: *mut Dav1dRef = malloc(::core::mem::size_of::<Dav1dRef>()) as *mut Dav1dRef;
+) -> *mut Rav1dRef {
+    let res: *mut Rav1dRef = malloc(::core::mem::size_of::<Rav1dRef>()) as *mut Rav1dRef;
     if res.is_null() {
-        return 0 as *mut Dav1dRef;
+        return 0 as *mut Rav1dRef;
     }
     (*res).data = 0 as *mut c_void;
     (*res).const_data = ptr as *const c_void;
@@ -105,15 +105,15 @@ pub unsafe fn dav1d_ref_wrap(
     return res;
 }
 
-pub unsafe fn dav1d_ref_dec(pref: *mut *mut Dav1dRef) {
+pub unsafe fn dav1d_ref_dec(pref: *mut *mut Rav1dRef) {
     if pref.is_null() {
         unreachable!();
     }
-    let r#ref: *mut Dav1dRef = *pref;
+    let r#ref: *mut Rav1dRef = *pref;
     if r#ref.is_null() {
         return;
     }
-    *pref = 0 as *mut Dav1dRef;
+    *pref = 0 as *mut Rav1dRef;
     if ::core::intrinsics::atomic_xsub_seqcst(&mut (*r#ref).ref_cnt as *mut atomic_int, 1 as c_int)
         == 1
     {
@@ -128,7 +128,7 @@ pub unsafe fn dav1d_ref_dec(pref: *mut *mut Dav1dRef) {
     }
 }
 
-pub unsafe fn dav1d_ref_is_writable(r#ref: *mut Dav1dRef) -> c_int {
+pub unsafe fn dav1d_ref_is_writable(r#ref: *mut Rav1dRef) -> c_int {
     return (::core::intrinsics::atomic_load_seqcst(&mut (*r#ref).ref_cnt as *mut atomic_int) == 1
         && !((*r#ref).data).is_null()) as c_int;
 }

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -209,13 +209,13 @@ pub type splat_mv_fn = Option<
 >;
 
 #[repr(C)]
-pub struct Dav1dRefmvsDSPContext {
+pub struct Rav1dRefmvsDSPContext {
     pub load_tmvs: load_tmvs_fn,
     pub save_tmvs: save_tmvs_fn,
     pub splat_mv: splat_mv_fn,
 }
 
-impl Dav1dRefmvsDSPContext {
+impl Rav1dRefmvsDSPContext {
     pub unsafe fn splat_mv(
         &self,
         rr: &mut [*mut refmvs_block],
@@ -1097,7 +1097,7 @@ pub unsafe fn dav1d_refmvs_find(
 // cache the current tile/sbrow (or frame/sbrow)'s projectable motion vectors
 // into buffers for use in future frame's temporal MV prediction
 pub unsafe fn dav1d_refmvs_save_tmvs(
-    dsp: *const Dav1dRefmvsDSPContext,
+    dsp: *const Rav1dRefmvsDSPContext,
     rt: *const refmvs_tile,
     col_start8: c_int,
     mut col_end8: c_int,
@@ -1611,7 +1611,7 @@ unsafe extern "C" fn splat_mv_rust(
 
 #[inline(always)]
 #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "asm"))]
-unsafe extern "C" fn refmvs_dsp_init_x86(c: *mut Dav1dRefmvsDSPContext) {
+unsafe extern "C" fn refmvs_dsp_init_x86(c: *mut Rav1dRefmvsDSPContext) {
     let flags = dav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSE2) {
@@ -1646,7 +1646,7 @@ unsafe extern "C" fn refmvs_dsp_init_x86(c: *mut Dav1dRefmvsDSPContext) {
 
 #[inline(always)]
 #[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), feature = "asm"))]
-unsafe extern "C" fn refmvs_dsp_init_arm(c: *mut Dav1dRefmvsDSPContext) {
+unsafe extern "C" fn refmvs_dsp_init_arm(c: *mut Rav1dRefmvsDSPContext) {
     let flags = dav1d_get_cpu_flags();
     if flags.contains(CpuFlags::NEON) {
         (*c).splat_mv = Some(ffi::dav1d_splat_mv_neon);
@@ -1654,7 +1654,7 @@ unsafe extern "C" fn refmvs_dsp_init_arm(c: *mut Dav1dRefmvsDSPContext) {
 }
 
 #[cold]
-pub unsafe fn dav1d_refmvs_dsp_init(c: *mut Dav1dRefmvsDSPContext) {
+pub unsafe fn dav1d_refmvs_dsp_init(c: *mut Rav1dRefmvsDSPContext) {
     (*c).load_tmvs = Some(load_tmvs_c);
     (*c).save_tmvs = Some(save_tmvs_c);
     (*c).splat_mv = Some(splat_mv_rust);


### PR DESCRIPTION
Opaque types are made public under `Dav1d*` aliases, but are used as `Rav1d*` internally.

These `Rav1d*` types are free to make ABI changes and thus become Rusty and safe.