### PR TITLE
`{struct,enum} Rav1d*`: Create crate-private `Rav1d*` versions of all `pub` `Dav1d*` types and use them internally

### DIFF
--- a/include/dav1d/common.rs
+++ b/include/dav1d/common.rs
@@ -87,16 +87,16 @@ impl From<Dav1dDataProps> for Rav1dDataProps {
     }
 }
 
-impl Rav1dDataProps {
-    pub fn into_c(self) -> Dav1dDataProps {
-        let Self {
+impl From<Rav1dDataProps> for Dav1dDataProps {
+    fn from(value: Rav1dDataProps) -> Self {
+        let Rav1dDataProps {
             timestamp,
             duration,
             offset,
             size,
             user_data,
-        } = self;
-        Dav1dDataProps {
+        } = value;
+        Self {
             timestamp,
             duration,
             offset,

--- a/include/dav1d/common.rs
+++ b/include/dav1d/common.rs
@@ -1,4 +1,5 @@
 use crate::include::dav1d::dav1d::Dav1dRef;
+use crate::src::r#ref::Rav1dRef;
 use std::ptr;
 
 #[derive(Clone)]
@@ -17,6 +18,36 @@ impl Default for Dav1dUserData {
     }
 }
 
+impl Dav1dUserData {
+    pub(crate) fn into_rust(self) -> Rav1dUserData {
+        let Self { data, r#ref } = self;
+        Rav1dUserData { data, r#ref }
+    }
+}
+
+#[derive(Clone)]
+#[repr(C)]
+pub(crate) struct Rav1dUserData {
+    pub data: *const u8,
+    pub r#ref: *mut Rav1dRef,
+}
+
+impl Default for Rav1dUserData {
+    fn default() -> Self {
+        Self {
+            data: ptr::null(),
+            r#ref: ptr::null_mut(),
+        }
+    }
+}
+
+impl Rav1dUserData {
+    pub fn into_c(self) -> Dav1dUserData {
+        let Self { data, r#ref } = self;
+        Dav1dUserData { data, r#ref }
+    }
+}
+
 #[derive(Clone, Default)]
 #[repr(C)]
 pub struct Dav1dDataProps {
@@ -25,4 +56,52 @@ pub struct Dav1dDataProps {
     pub offset: libc::off_t,
     pub size: usize,
     pub user_data: Dav1dUserData,
+}
+
+impl Dav1dDataProps {
+    pub(crate) fn into_rust(self) -> Rav1dDataProps {
+        let Self {
+            timestamp,
+            duration,
+            offset,
+            size,
+            user_data,
+        } = self;
+        Rav1dDataProps {
+            timestamp,
+            duration,
+            offset,
+            size,
+            user_data: user_data.into_rust(),
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+#[repr(C)]
+pub(crate) struct Rav1dDataProps {
+    pub timestamp: i64,
+    pub duration: i64,
+    pub offset: libc::off_t,
+    pub size: usize,
+    pub user_data: Rav1dUserData,
+}
+
+impl Rav1dDataProps {
+    pub fn into_c(self) -> Dav1dDataProps {
+        let Self {
+            timestamp,
+            duration,
+            offset,
+            size,
+            user_data,
+        } = self;
+        Dav1dDataProps {
+            timestamp,
+            duration,
+            offset,
+            size,
+            user_data: user_data.into_c(),
+        }
+    }
 }

--- a/include/dav1d/common.rs
+++ b/include/dav1d/common.rs
@@ -18,13 +18,6 @@ impl Default for Dav1dUserData {
     }
 }
 
-impl Dav1dUserData {
-    pub(crate) fn into_rust(self) -> Rav1dUserData {
-        let Self { data, r#ref } = self;
-        Rav1dUserData { data, r#ref }
-    }
-}
-
 #[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dUserData {
@@ -41,10 +34,17 @@ impl Default for Rav1dUserData {
     }
 }
 
-impl Rav1dUserData {
-    pub fn into_c(self) -> Dav1dUserData {
-        let Self { data, r#ref } = self;
-        Dav1dUserData { data, r#ref }
+impl From<Dav1dUserData> for Rav1dUserData {
+    fn from(value: Dav1dUserData) -> Self {
+        let Dav1dUserData { data, r#ref } = value;
+        Self { data, r#ref }
+    }
+}
+
+impl From<Rav1dUserData> for Dav1dUserData {
+    fn from(value: Rav1dUserData) -> Self {
+        let Rav1dUserData { data, r#ref } = value;
+        Self { data, r#ref }
     }
 }
 
@@ -58,25 +58,6 @@ pub struct Dav1dDataProps {
     pub user_data: Dav1dUserData,
 }
 
-impl Dav1dDataProps {
-    pub(crate) fn into_rust(self) -> Rav1dDataProps {
-        let Self {
-            timestamp,
-            duration,
-            offset,
-            size,
-            user_data,
-        } = self;
-        Rav1dDataProps {
-            timestamp,
-            duration,
-            offset,
-            size,
-            user_data: user_data.into_rust(),
-        }
-    }
-}
-
 #[derive(Clone, Default)]
 #[repr(C)]
 pub(crate) struct Rav1dDataProps {
@@ -85,6 +66,25 @@ pub(crate) struct Rav1dDataProps {
     pub offset: libc::off_t,
     pub size: usize,
     pub user_data: Rav1dUserData,
+}
+
+impl From<Dav1dDataProps> for Rav1dDataProps {
+    fn from(value: Dav1dDataProps) -> Self {
+        let Dav1dDataProps {
+            timestamp,
+            duration,
+            offset,
+            size,
+            user_data,
+        } = value;
+        Self {
+            timestamp,
+            duration,
+            offset,
+            size,
+            user_data: user_data.into(),
+        }
+    }
 }
 
 impl Rav1dDataProps {
@@ -101,7 +101,7 @@ impl Rav1dDataProps {
             duration,
             offset,
             size,
-            user_data: user_data.into_c(),
+            user_data: user_data.into(),
         }
     }
 }

--- a/include/dav1d/data.rs
+++ b/include/dav1d/data.rs
@@ -56,14 +56,14 @@ impl From<Dav1dData> for Rav1dData {
     }
 }
 
-impl Rav1dData {
-    pub fn into_c(self) -> Dav1dData {
-        let Self { data, sz, r#ref, m } = self;
-        Dav1dData {
+impl From<Rav1dData> for Dav1dData {
+    fn from(value: Rav1dData) -> Self {
+        let Rav1dData { data, sz, r#ref, m } = value;
+        Self {
             data,
             sz,
             r#ref,
-            m: m.into_c(),
+            m: m.into(),
         }
     }
 }

--- a/include/dav1d/data.rs
+++ b/include/dav1d/data.rs
@@ -1,5 +1,7 @@
 use crate::include::dav1d::common::Dav1dDataProps;
+use crate::include::dav1d::common::Rav1dDataProps;
 use crate::include::dav1d::dav1d::Dav1dRef;
+use crate::src::r#ref::Rav1dRef;
 use std::ptr;
 
 #[derive(Clone)]
@@ -18,6 +20,50 @@ impl Default for Dav1dData {
             sz: Default::default(),
             r#ref: ptr::null_mut(),
             m: Default::default(),
+        }
+    }
+}
+
+impl Dav1dData {
+    pub(crate) fn into_rust(self) -> Rav1dData {
+        let Self { data, sz, r#ref, m } = self;
+        Rav1dData {
+            data,
+            sz,
+            r#ref,
+            m: m.into_rust(),
+        }
+    }
+}
+
+#[derive(Clone)]
+#[repr(C)]
+pub(crate) struct Rav1dData {
+    pub data: *const u8,
+    pub sz: usize,
+    pub r#ref: *mut Rav1dRef,
+    pub m: Rav1dDataProps,
+}
+
+impl Default for Rav1dData {
+    fn default() -> Self {
+        Self {
+            data: ptr::null(),
+            sz: Default::default(),
+            r#ref: ptr::null_mut(),
+            m: Default::default(),
+        }
+    }
+}
+
+impl Rav1dData {
+    pub fn into_c(self) -> Dav1dData {
+        let Self { data, sz, r#ref, m } = self;
+        Dav1dData {
+            data,
+            sz,
+            r#ref,
+            m: m.into_c(),
         }
     }
 }

--- a/include/dav1d/data.rs
+++ b/include/dav1d/data.rs
@@ -24,18 +24,6 @@ impl Default for Dav1dData {
     }
 }
 
-impl Dav1dData {
-    pub(crate) fn into_rust(self) -> Rav1dData {
-        let Self { data, sz, r#ref, m } = self;
-        Rav1dData {
-            data,
-            sz,
-            r#ref,
-            m: m.into_rust(),
-        }
-    }
-}
-
 #[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dData {
@@ -52,6 +40,18 @@ impl Default for Rav1dData {
             sz: Default::default(),
             r#ref: ptr::null_mut(),
             m: Default::default(),
+        }
+    }
+}
+
+impl From<Dav1dData> for Rav1dData {
+    fn from(value: Dav1dData) -> Self {
+        let Dav1dData { data, sz, r#ref, m } = value;
+        Self {
+            data,
+            sz,
+            r#ref,
+            m: m.into(),
         }
     }
 }

--- a/include/dav1d/dav1d.rs
+++ b/include/dav1d/dav1d.rs
@@ -33,10 +33,10 @@ impl From<Dav1dLogger> for Rav1dLogger {
     }
 }
 
-impl Rav1dLogger {
-    pub fn into_c(self) -> Dav1dLogger {
-        let Self { cookie, callback } = self;
-        Dav1dLogger { cookie, callback }
+impl From<Rav1dLogger> for Dav1dLogger {
+    fn from(value: Rav1dLogger) -> Self {
+        let Rav1dLogger { cookie, callback } = value;
+        Self { cookie, callback }
     }
 }
 
@@ -146,9 +146,9 @@ impl From<Dav1dSettings> for Rav1dSettings {
     }
 }
 
-impl Rav1dSettings {
-    pub fn into_c(self) -> Dav1dSettings {
-        let Self {
+impl From<Rav1dSettings> for Dav1dSettings {
+    fn from(value: Rav1dSettings) -> Self {
+        let Rav1dSettings {
             n_threads,
             max_frame_delay,
             apply_grain,
@@ -162,16 +162,16 @@ impl Rav1dSettings {
             inloop_filters,
             decode_frame_type,
             reserved,
-        } = self;
-        Dav1dSettings {
+        } = value;
+        Self {
             n_threads,
             max_frame_delay,
             apply_grain,
             operating_point,
             all_layers,
             frame_size_limit,
-            allocator: allocator.into_c(),
-            logger: logger.into_c(),
+            allocator: allocator.into(),
+            logger: logger.into(),
             strict_std_compliance,
             output_invisible_frames,
             inloop_filters,

--- a/include/dav1d/dav1d.rs
+++ b/include/dav1d/dav1d.rs
@@ -1,4 +1,5 @@
 use crate::include::dav1d::picture::Dav1dPicAllocator;
+use crate::include::dav1d::picture::Rav1dPicAllocator;
 use crate::src::internal::Rav1dContext;
 use crate::src::r#ref::Rav1dRef;
 use std::ffi::c_char;
@@ -17,6 +18,28 @@ pub struct Dav1dLogger {
         Option<unsafe extern "C" fn(*mut c_void, *const c_char, ::core::ffi::VaList) -> ()>,
 }
 
+impl Dav1dLogger {
+    pub(crate) fn into_rust(self) -> Rav1dLogger {
+        let Self { cookie, callback } = self;
+        Rav1dLogger { cookie, callback }
+    }
+}
+
+#[derive(Clone)]
+#[repr(C)]
+pub(crate) struct Rav1dLogger {
+    pub cookie: *mut c_void,
+    pub callback:
+        Option<unsafe extern "C" fn(*mut c_void, *const c_char, ::core::ffi::VaList) -> ()>,
+}
+
+impl Rav1dLogger {
+    pub fn into_c(self) -> Dav1dLogger {
+        let Self { cookie, callback } = self;
+        Dav1dLogger { cookie, callback }
+    }
+}
+
 pub type Dav1dInloopFilterType = c_uint;
 pub const DAV1D_INLOOPFILTER_ALL: Dav1dInloopFilterType = 7;
 pub const DAV1D_INLOOPFILTER_RESTORATION: Dav1dInloopFilterType = 4;
@@ -24,15 +47,35 @@ pub const DAV1D_INLOOPFILTER_CDEF: Dav1dInloopFilterType = 2;
 pub const DAV1D_INLOOPFILTER_DEBLOCK: Dav1dInloopFilterType = 1;
 pub const DAV1D_INLOOPFILTER_NONE: Dav1dInloopFilterType = 0;
 
+pub(crate) type Rav1dInloopFilterType = c_uint;
+pub(crate) const RAV1D_INLOOPFILTER_ALL: Rav1dInloopFilterType = DAV1D_INLOOPFILTER_ALL;
+pub(crate) const RAV1D_INLOOPFILTER_RESTORATION: Rav1dInloopFilterType =
+    DAV1D_INLOOPFILTER_RESTORATION;
+pub(crate) const RAV1D_INLOOPFILTER_CDEF: Rav1dInloopFilterType = DAV1D_INLOOPFILTER_CDEF;
+pub(crate) const RAV1D_INLOOPFILTER_DEBLOCK: Rav1dInloopFilterType = DAV1D_INLOOPFILTER_DEBLOCK;
+pub(crate) const RAV1D_INLOOPFILTER_NONE: Rav1dInloopFilterType = DAV1D_INLOOPFILTER_NONE;
+
 pub type Dav1dDecodeFrameType = c_uint;
 pub const DAV1D_DECODEFRAMETYPE_KEY: Dav1dDecodeFrameType = 3;
 pub const DAV1D_DECODEFRAMETYPE_INTRA: Dav1dDecodeFrameType = 2;
 pub const DAV1D_DECODEFRAMETYPE_REFERENCE: Dav1dDecodeFrameType = 1;
 pub const DAV1D_DECODEFRAMETYPE_ALL: Dav1dDecodeFrameType = 0;
 
+pub(crate) type Rav1dDecodeFrameType = c_uint;
+pub(crate) const RAV1D_DECODEFRAMETYPE_KEY: Rav1dDecodeFrameType = DAV1D_DECODEFRAMETYPE_KEY;
+pub(crate) const RAV1D_DECODEFRAMETYPE_INTRA: Rav1dDecodeFrameType = DAV1D_DECODEFRAMETYPE_INTRA;
+pub(crate) const RAV1D_DECODEFRAMETYPE_REFERENCE: Rav1dDecodeFrameType =
+    DAV1D_DECODEFRAMETYPE_REFERENCE;
+pub(crate) const RAV1D_DECODEFRAMETYPE_ALL: Rav1dDecodeFrameType = DAV1D_DECODEFRAMETYPE_ALL;
+
 pub type Dav1dEventFlags = c_uint;
 pub const DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO: Dav1dEventFlags = 2;
 pub const DAV1D_EVENT_FLAG_NEW_SEQUENCE: Dav1dEventFlags = 1;
+
+pub(crate) type Rav1dEventFlags = c_uint;
+pub(crate) const RAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO: Rav1dEventFlags =
+    DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
+pub(crate) const RAV1D_EVENT_FLAG_NEW_SEQUENCE: Rav1dEventFlags = DAV1D_EVENT_FLAG_NEW_SEQUENCE;
 
 #[repr(C)]
 pub struct Dav1dSettings {
@@ -49,4 +92,91 @@ pub struct Dav1dSettings {
     pub inloop_filters: Dav1dInloopFilterType,
     pub decode_frame_type: Dav1dDecodeFrameType,
     pub reserved: [u8; 16],
+}
+
+impl Dav1dSettings {
+    pub(crate) fn into_rust(self) -> Rav1dSettings {
+        let Self {
+            n_threads,
+            max_frame_delay,
+            apply_grain,
+            operating_point,
+            all_layers,
+            frame_size_limit,
+            allocator,
+            logger,
+            strict_std_compliance,
+            output_invisible_frames,
+            inloop_filters,
+            decode_frame_type,
+            reserved,
+        } = self;
+        Rav1dSettings {
+            n_threads,
+            max_frame_delay,
+            apply_grain,
+            operating_point,
+            all_layers,
+            frame_size_limit,
+            allocator: allocator.into_rust(),
+            logger: logger.into_rust(),
+            strict_std_compliance,
+            output_invisible_frames,
+            inloop_filters,
+            decode_frame_type,
+            reserved,
+        }
+    }
+}
+
+#[repr(C)]
+pub(crate) struct Rav1dSettings {
+    pub n_threads: c_int,
+    pub max_frame_delay: c_int,
+    pub apply_grain: c_int,
+    pub operating_point: c_int,
+    pub all_layers: c_int,
+    pub frame_size_limit: c_uint,
+    pub allocator: Rav1dPicAllocator,
+    pub logger: Rav1dLogger,
+    pub strict_std_compliance: c_int,
+    pub output_invisible_frames: c_int,
+    pub inloop_filters: Rav1dInloopFilterType,
+    pub decode_frame_type: Rav1dDecodeFrameType,
+    pub reserved: [u8; 16],
+}
+
+impl Rav1dSettings {
+    pub fn into_c(self) -> Dav1dSettings {
+        let Self {
+            n_threads,
+            max_frame_delay,
+            apply_grain,
+            operating_point,
+            all_layers,
+            frame_size_limit,
+            allocator,
+            logger,
+            strict_std_compliance,
+            output_invisible_frames,
+            inloop_filters,
+            decode_frame_type,
+            reserved,
+        } = self;
+        Dav1dSettings {
+            n_threads,
+            max_frame_delay,
+            apply_grain,
+            operating_point,
+            all_layers,
+            frame_size_limit,
+            allocator: allocator.into_c(),
+            logger: logger.into_c(),
+            strict_std_compliance,
+            output_invisible_frames,
+            inloop_filters,
+            decode_frame_type,
+            reserved,
+        }
+    }
 }

--- a/include/dav1d/dav1d.rs
+++ b/include/dav1d/dav1d.rs
@@ -18,19 +18,19 @@ pub struct Dav1dLogger {
         Option<unsafe extern "C" fn(*mut c_void, *const c_char, ::core::ffi::VaList) -> ()>,
 }
 
-impl Dav1dLogger {
-    pub(crate) fn into_rust(self) -> Rav1dLogger {
-        let Self { cookie, callback } = self;
-        Rav1dLogger { cookie, callback }
-    }
-}
-
 #[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dLogger {
     pub cookie: *mut c_void,
     pub callback:
         Option<unsafe extern "C" fn(*mut c_void, *const c_char, ::core::ffi::VaList) -> ()>,
+}
+
+impl From<Dav1dLogger> for Rav1dLogger {
+    fn from(value: Dav1dLogger) -> Self {
+        let Dav1dLogger { cookie, callback } = value;
+        Self { cookie, callback }
+    }
 }
 
 impl Rav1dLogger {
@@ -94,41 +94,6 @@ pub struct Dav1dSettings {
     pub reserved: [u8; 16],
 }
 
-impl Dav1dSettings {
-    pub(crate) fn into_rust(self) -> Rav1dSettings {
-        let Self {
-            n_threads,
-            max_frame_delay,
-            apply_grain,
-            operating_point,
-            all_layers,
-            frame_size_limit,
-            allocator,
-            logger,
-            strict_std_compliance,
-            output_invisible_frames,
-            inloop_filters,
-            decode_frame_type,
-            reserved,
-        } = self;
-        Rav1dSettings {
-            n_threads,
-            max_frame_delay,
-            apply_grain,
-            operating_point,
-            all_layers,
-            frame_size_limit,
-            allocator: allocator.into_rust(),
-            logger: logger.into_rust(),
-            strict_std_compliance,
-            output_invisible_frames,
-            inloop_filters,
-            decode_frame_type,
-            reserved,
-        }
-    }
-}
-
 #[repr(C)]
 pub(crate) struct Rav1dSettings {
     pub n_threads: c_int,
@@ -144,6 +109,41 @@ pub(crate) struct Rav1dSettings {
     pub inloop_filters: Rav1dInloopFilterType,
     pub decode_frame_type: Rav1dDecodeFrameType,
     pub reserved: [u8; 16],
+}
+
+impl From<Dav1dSettings> for Rav1dSettings {
+    fn from(value: Dav1dSettings) -> Self {
+        let Dav1dSettings {
+            n_threads,
+            max_frame_delay,
+            apply_grain,
+            operating_point,
+            all_layers,
+            frame_size_limit,
+            allocator,
+            logger,
+            strict_std_compliance,
+            output_invisible_frames,
+            inloop_filters,
+            decode_frame_type,
+            reserved,
+        } = value;
+        Self {
+            n_threads,
+            max_frame_delay,
+            apply_grain,
+            operating_point,
+            all_layers,
+            frame_size_limit,
+            allocator: allocator.into(),
+            logger: logger.into(),
+            strict_std_compliance,
+            output_invisible_frames,
+            inloop_filters,
+            decode_frame_type,
+            reserved,
+        }
+    }
 }
 
 impl Rav1dSettings {

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -11,11 +11,27 @@ pub const DAV1D_OBU_FRAME_HDR: Dav1dObuType = 3;
 pub const DAV1D_OBU_TD: Dav1dObuType = 2;
 pub const DAV1D_OBU_SEQ_HDR: Dav1dObuType = 1;
 
+pub(crate) type Rav1dObuType = c_uint;
+pub(crate) const RAV1D_OBU_PADDING: Rav1dObuType = DAV1D_OBU_PADDING;
+pub(crate) const RAV1D_OBU_REDUNDANT_FRAME_HDR: Rav1dObuType = DAV1D_OBU_REDUNDANT_FRAME_HDR;
+pub(crate) const RAV1D_OBU_FRAME: Rav1dObuType = DAV1D_OBU_FRAME;
+pub(crate) const RAV1D_OBU_METADATA: Rav1dObuType = DAV1D_OBU_METADATA;
+pub(crate) const RAV1D_OBU_TILE_GRP: Rav1dObuType = DAV1D_OBU_TILE_GRP;
+pub(crate) const RAV1D_OBU_FRAME_HDR: Rav1dObuType = DAV1D_OBU_FRAME_HDR;
+pub(crate) const RAV1D_OBU_TD: Rav1dObuType = DAV1D_OBU_TD;
+pub(crate) const RAV1D_OBU_SEQ_HDR: Rav1dObuType = DAV1D_OBU_SEQ_HDR;
+
 pub type Dav1dTxfmMode = c_uint;
 pub const DAV1D_N_TX_MODES: usize = 3;
 pub const DAV1D_TX_SWITCHABLE: Dav1dTxfmMode = 2;
 pub const DAV1D_TX_LARGEST: Dav1dTxfmMode = 1;
 pub const DAV1D_TX_4X4_ONLY: Dav1dTxfmMode = 0;
+
+pub(crate) type Rav1dTxfmMode = c_uint;
+pub(crate) const RAV1D_N_TX_MODES: usize = DAV1D_N_TX_MODES;
+pub(crate) const RAV1D_TX_SWITCHABLE: Rav1dTxfmMode = DAV1D_TX_SWITCHABLE;
+pub(crate) const RAV1D_TX_LARGEST: Rav1dTxfmMode = DAV1D_TX_LARGEST;
+pub(crate) const RAV1D_TX_4X4_ONLY: Rav1dTxfmMode = DAV1D_TX_4X4_ONLY;
 
 pub type Dav1dFilterMode = u8;
 pub const DAV1D_FILTER_SWITCHABLE: Dav1dFilterMode = 4;
@@ -26,10 +42,24 @@ pub const DAV1D_FILTER_8TAP_SHARP: Dav1dFilterMode = 2;
 pub const DAV1D_FILTER_8TAP_SMOOTH: Dav1dFilterMode = 1;
 pub const DAV1D_FILTER_8TAP_REGULAR: Dav1dFilterMode = 0;
 
+pub type Rav1dFilterMode = u8;
+pub const RAV1D_FILTER_SWITCHABLE: Rav1dFilterMode = DAV1D_FILTER_SWITCHABLE;
+pub const RAV1D_N_FILTERS: usize = DAV1D_N_FILTERS;
+pub const RAV1D_FILTER_BILINEAR: Rav1dFilterMode = DAV1D_FILTER_BILINEAR;
+pub const RAV1D_N_SWITCHABLE_FILTERS: usize = DAV1D_N_SWITCHABLE_FILTERS;
+pub const RAV1D_FILTER_8TAP_SHARP: Rav1dFilterMode = DAV1D_FILTER_8TAP_SHARP;
+pub const RAV1D_FILTER_8TAP_SMOOTH: Rav1dFilterMode = DAV1D_FILTER_8TAP_SMOOTH;
+pub const RAV1D_FILTER_8TAP_REGULAR: Rav1dFilterMode = DAV1D_FILTER_8TAP_REGULAR;
+
 pub type Dav1dAdaptiveBoolean = c_uint;
 pub const DAV1D_ADAPTIVE: Dav1dAdaptiveBoolean = 2;
 pub const DAV1D_ON: Dav1dAdaptiveBoolean = 1;
 pub const DAV1D_OFF: Dav1dAdaptiveBoolean = 0;
+
+pub(crate) type Rav1dAdaptiveBoolean = c_uint;
+pub(crate) const RAV1D_ADAPTIVE: Rav1dAdaptiveBoolean = DAV1D_ADAPTIVE;
+pub(crate) const RAV1D_ON: Rav1dAdaptiveBoolean = DAV1D_ON;
+pub(crate) const RAV1D_OFF: Rav1dAdaptiveBoolean = DAV1D_OFF;
 
 pub type Dav1dRestorationType = u8;
 pub const DAV1D_RESTORATION_SGRPROJ: Dav1dRestorationType = 3;
@@ -37,11 +67,23 @@ pub const DAV1D_RESTORATION_WIENER: Dav1dRestorationType = 2;
 pub const DAV1D_RESTORATION_SWITCHABLE: Dav1dRestorationType = 1;
 pub const DAV1D_RESTORATION_NONE: Dav1dRestorationType = 0;
 
+pub type Rav1dRestorationType = u8;
+pub const RAV1D_RESTORATION_SGRPROJ: Rav1dRestorationType = DAV1D_RESTORATION_SGRPROJ;
+pub const RAV1D_RESTORATION_WIENER: Rav1dRestorationType = DAV1D_RESTORATION_WIENER;
+pub const RAV1D_RESTORATION_SWITCHABLE: Rav1dRestorationType = DAV1D_RESTORATION_SWITCHABLE;
+pub const RAV1D_RESTORATION_NONE: Rav1dRestorationType = DAV1D_RESTORATION_NONE;
+
 pub type Dav1dWarpedMotionType = c_uint;
 pub const DAV1D_WM_TYPE_AFFINE: Dav1dWarpedMotionType = 3;
 pub const DAV1D_WM_TYPE_ROT_ZOOM: Dav1dWarpedMotionType = 2;
 pub const DAV1D_WM_TYPE_TRANSLATION: Dav1dWarpedMotionType = 1;
 pub const DAV1D_WM_TYPE_IDENTITY: Dav1dWarpedMotionType = 0;
+
+pub type Rav1dWarpedMotionType = c_uint;
+pub const RAV1D_WM_TYPE_AFFINE: Rav1dWarpedMotionType = DAV1D_WM_TYPE_AFFINE;
+pub const RAV1D_WM_TYPE_ROT_ZOOM: Rav1dWarpedMotionType = DAV1D_WM_TYPE_ROT_ZOOM;
+pub const RAV1D_WM_TYPE_TRANSLATION: Rav1dWarpedMotionType = DAV1D_WM_TYPE_TRANSLATION;
+pub const RAV1D_WM_TYPE_IDENTITY: Rav1dWarpedMotionType = DAV1D_WM_TYPE_IDENTITY;
 
 #[derive(Clone)]
 #[repr(C)]
@@ -69,17 +111,85 @@ impl Dav1dWarpedMotionParams {
     }
 }
 
+impl Dav1dWarpedMotionParams {
+    pub(crate) fn into_rust(self) -> Rav1dWarpedMotionParams {
+        let Self {
+            type_0,
+            matrix,
+            abcd,
+        } = self;
+        Rav1dWarpedMotionParams {
+            type_0,
+            matrix,
+            abcd,
+        }
+    }
+}
+
+#[derive(Clone)]
+#[repr(C)]
+pub(crate) struct Rav1dWarpedMotionParams {
+    pub type_0: Rav1dWarpedMotionType,
+    pub matrix: [i32; 6],
+    pub abcd: [i16; 4],
+}
+
+impl Rav1dWarpedMotionParams {
+    pub const fn alpha(&self) -> i16 {
+        self.abcd[0]
+    }
+
+    pub const fn beta(&self) -> i16 {
+        self.abcd[1]
+    }
+
+    pub const fn gamma(&self) -> i16 {
+        self.abcd[2]
+    }
+
+    pub const fn delta(&self) -> i16 {
+        self.abcd[3]
+    }
+}
+
+impl Rav1dWarpedMotionParams {
+    pub fn into_c(self) -> Dav1dWarpedMotionParams {
+        let Self {
+            type_0,
+            matrix,
+            abcd,
+        } = self;
+        Dav1dWarpedMotionParams {
+            type_0,
+            matrix,
+            abcd,
+        }
+    }
+}
+
 pub type Dav1dPixelLayout = c_uint;
 pub const DAV1D_PIXEL_LAYOUT_I444: Dav1dPixelLayout = 3;
 pub const DAV1D_PIXEL_LAYOUT_I422: Dav1dPixelLayout = 2;
 pub const DAV1D_PIXEL_LAYOUT_I420: Dav1dPixelLayout = 1;
 pub const DAV1D_PIXEL_LAYOUT_I400: Dav1dPixelLayout = 0;
 
+pub(crate) type Rav1dPixelLayout = c_uint;
+pub(crate) const RAV1D_PIXEL_LAYOUT_I444: Rav1dPixelLayout = DAV1D_PIXEL_LAYOUT_I444;
+pub(crate) const RAV1D_PIXEL_LAYOUT_I422: Rav1dPixelLayout = DAV1D_PIXEL_LAYOUT_I422;
+pub(crate) const RAV1D_PIXEL_LAYOUT_I420: Rav1dPixelLayout = DAV1D_PIXEL_LAYOUT_I420;
+pub(crate) const RAV1D_PIXEL_LAYOUT_I400: Rav1dPixelLayout = DAV1D_PIXEL_LAYOUT_I400;
+
 pub type Dav1dFrameType = c_uint;
 pub const DAV1D_FRAME_TYPE_SWITCH: Dav1dFrameType = 3;
 pub const DAV1D_FRAME_TYPE_INTRA: Dav1dFrameType = 2;
 pub const DAV1D_FRAME_TYPE_INTER: Dav1dFrameType = 1;
 pub const DAV1D_FRAME_TYPE_KEY: Dav1dFrameType = 0;
+
+pub(crate) type Rav1dFrameType = c_uint;
+pub(crate) const RAV1D_FRAME_TYPE_SWITCH: Rav1dFrameType = DAV1D_FRAME_TYPE_SWITCH;
+pub(crate) const RAV1D_FRAME_TYPE_INTRA: Rav1dFrameType = DAV1D_FRAME_TYPE_INTRA;
+pub(crate) const RAV1D_FRAME_TYPE_INTER: Rav1dFrameType = DAV1D_FRAME_TYPE_INTER;
+pub(crate) const RAV1D_FRAME_TYPE_KEY: Rav1dFrameType = DAV1D_FRAME_TYPE_KEY;
 
 pub type Dav1dColorPrimaries = c_uint;
 pub const DAV1D_COLOR_PRI_RESERVED: Dav1dColorPrimaries = 255;
@@ -95,6 +205,21 @@ pub const DAV1D_COLOR_PRI_BT470BG: Dav1dColorPrimaries = 5;
 pub const DAV1D_COLOR_PRI_BT470M: Dav1dColorPrimaries = 4;
 pub const DAV1D_COLOR_PRI_UNKNOWN: Dav1dColorPrimaries = 2;
 pub const DAV1D_COLOR_PRI_BT709: Dav1dColorPrimaries = 1;
+
+pub(crate) type Rav1dColorPrimaries = c_uint;
+pub(crate) const RAV1D_COLOR_PRI_RESERVED: Rav1dColorPrimaries = DAV1D_COLOR_PRI_RESERVED;
+pub(crate) const RAV1D_COLOR_PRI_EBU3213: Rav1dColorPrimaries = DAV1D_COLOR_PRI_EBU3213;
+pub(crate) const RAV1D_COLOR_PRI_SMPTE432: Rav1dColorPrimaries = DAV1D_COLOR_PRI_SMPTE432;
+pub(crate) const RAV1D_COLOR_PRI_SMPTE431: Rav1dColorPrimaries = DAV1D_COLOR_PRI_SMPTE431;
+pub(crate) const RAV1D_COLOR_PRI_XYZ: Rav1dColorPrimaries = DAV1D_COLOR_PRI_XYZ;
+pub(crate) const RAV1D_COLOR_PRI_BT2020: Rav1dColorPrimaries = DAV1D_COLOR_PRI_BT2020;
+pub(crate) const RAV1D_COLOR_PRI_FILM: Rav1dColorPrimaries = DAV1D_COLOR_PRI_FILM;
+pub(crate) const RAV1D_COLOR_PRI_SMPTE240: Rav1dColorPrimaries = DAV1D_COLOR_PRI_SMPTE240;
+pub(crate) const RAV1D_COLOR_PRI_BT601: Rav1dColorPrimaries = DAV1D_COLOR_PRI_BT601;
+pub(crate) const RAV1D_COLOR_PRI_BT470BG: Rav1dColorPrimaries = DAV1D_COLOR_PRI_BT470BG;
+pub(crate) const RAV1D_COLOR_PRI_BT470M: Rav1dColorPrimaries = DAV1D_COLOR_PRI_BT470M;
+pub(crate) const RAV1D_COLOR_PRI_UNKNOWN: Rav1dColorPrimaries = DAV1D_COLOR_PRI_UNKNOWN;
+pub(crate) const RAV1D_COLOR_PRI_BT709: Rav1dColorPrimaries = DAV1D_COLOR_PRI_BT709;
 
 pub type Dav1dTransferCharacteristics = c_uint;
 pub const DAV1D_TRC_RESERVED: Dav1dTransferCharacteristics = 255;
@@ -116,6 +241,26 @@ pub const DAV1D_TRC_BT470M: Dav1dTransferCharacteristics = 4;
 pub const DAV1D_TRC_UNKNOWN: Dav1dTransferCharacteristics = 2;
 pub const DAV1D_TRC_BT709: Dav1dTransferCharacteristics = 1;
 
+pub(crate) type Rav1dTransferCharacteristics = c_uint;
+pub(crate) const RAV1D_TRC_RESERVED: Rav1dTransferCharacteristics = DAV1D_TRC_RESERVED;
+pub(crate) const RAV1D_TRC_HLG: Rav1dTransferCharacteristics = DAV1D_TRC_HLG;
+pub(crate) const RAV1D_TRC_SMPTE428: Rav1dTransferCharacteristics = DAV1D_TRC_SMPTE428;
+pub(crate) const RAV1D_TRC_SMPTE2084: Rav1dTransferCharacteristics = DAV1D_TRC_SMPTE2084;
+pub(crate) const RAV1D_TRC_BT2020_12BIT: Rav1dTransferCharacteristics = DAV1D_TRC_BT2020_12BIT;
+pub(crate) const RAV1D_TRC_BT2020_10BIT: Rav1dTransferCharacteristics = DAV1D_TRC_BT2020_10BIT;
+pub(crate) const RAV1D_TRC_SRGB: Rav1dTransferCharacteristics = DAV1D_TRC_SRGB;
+pub(crate) const RAV1D_TRC_BT1361: Rav1dTransferCharacteristics = DAV1D_TRC_BT1361;
+pub(crate) const RAV1D_TRC_IEC61966: Rav1dTransferCharacteristics = DAV1D_TRC_IEC61966;
+pub(crate) const RAV1D_TRC_LOG100_SQRT10: Rav1dTransferCharacteristics = DAV1D_TRC_LOG100_SQRT10;
+pub(crate) const RAV1D_TRC_LOG100: Rav1dTransferCharacteristics = DAV1D_TRC_LOG100;
+pub(crate) const RAV1D_TRC_LINEAR: Rav1dTransferCharacteristics = DAV1D_TRC_LINEAR;
+pub(crate) const RAV1D_TRC_SMPTE240: Rav1dTransferCharacteristics = DAV1D_TRC_SMPTE240;
+pub(crate) const RAV1D_TRC_BT601: Rav1dTransferCharacteristics = DAV1D_TRC_BT601;
+pub(crate) const RAV1D_TRC_BT470BG: Rav1dTransferCharacteristics = DAV1D_TRC_BT470BG;
+pub(crate) const RAV1D_TRC_BT470M: Rav1dTransferCharacteristics = DAV1D_TRC_BT470M;
+pub(crate) const RAV1D_TRC_UNKNOWN: Rav1dTransferCharacteristics = DAV1D_TRC_UNKNOWN;
+pub(crate) const RAV1D_TRC_BT709: Rav1dTransferCharacteristics = DAV1D_TRC_BT709;
+
 pub type Dav1dMatrixCoefficients = c_uint;
 pub const DAV1D_MC_RESERVED: Dav1dMatrixCoefficients = 255;
 pub const DAV1D_MC_ICTCP: Dav1dMatrixCoefficients = 14;
@@ -133,18 +278,74 @@ pub const DAV1D_MC_UNKNOWN: Dav1dMatrixCoefficients = 2;
 pub const DAV1D_MC_BT709: Dav1dMatrixCoefficients = 1;
 pub const DAV1D_MC_IDENTITY: Dav1dMatrixCoefficients = 0;
 
+pub(crate) type Rav1dMatrixCoefficients = c_uint;
+pub(crate) const RAV1D_MC_RESERVED: Rav1dMatrixCoefficients = DAV1D_MC_RESERVED;
+pub(crate) const RAV1D_MC_ICTCP: Rav1dMatrixCoefficients = DAV1D_MC_ICTCP;
+pub(crate) const RAV1D_MC_CHROMAT_CL: Rav1dMatrixCoefficients = DAV1D_MC_CHROMAT_CL;
+pub(crate) const RAV1D_MC_CHROMAT_NCL: Rav1dMatrixCoefficients = DAV1D_MC_CHROMAT_NCL;
+pub(crate) const RAV1D_MC_SMPTE2085: Rav1dMatrixCoefficients = DAV1D_MC_SMPTE2085;
+pub(crate) const RAV1D_MC_BT2020_CL: Rav1dMatrixCoefficients = DAV1D_MC_BT2020_CL;
+pub(crate) const RAV1D_MC_BT2020_NCL: Rav1dMatrixCoefficients = DAV1D_MC_BT2020_NCL;
+pub(crate) const RAV1D_MC_SMPTE_YCGCO: Rav1dMatrixCoefficients = DAV1D_MC_SMPTE_YCGCO;
+pub(crate) const RAV1D_MC_SMPTE240: Rav1dMatrixCoefficients = DAV1D_MC_SMPTE240;
+pub(crate) const RAV1D_MC_BT601: Rav1dMatrixCoefficients = DAV1D_MC_BT601;
+pub(crate) const RAV1D_MC_BT470BG: Rav1dMatrixCoefficients = DAV1D_MC_BT470BG;
+pub(crate) const RAV1D_MC_FCC: Rav1dMatrixCoefficients = DAV1D_MC_FCC;
+pub(crate) const RAV1D_MC_UNKNOWN: Rav1dMatrixCoefficients = DAV1D_MC_UNKNOWN;
+pub(crate) const RAV1D_MC_BT709: Rav1dMatrixCoefficients = DAV1D_MC_BT709;
+pub(crate) const RAV1D_MC_IDENTITY: Rav1dMatrixCoefficients = DAV1D_MC_IDENTITY;
+
 pub type Dav1dChromaSamplePosition = c_uint;
 pub const DAV1D_CHR_COLOCATED: Dav1dChromaSamplePosition = 2;
 pub const DAV1D_CHR_VERTICAL: Dav1dChromaSamplePosition = 1;
 pub const DAV1D_CHR_UNKNOWN: Dav1dChromaSamplePosition = 0;
 
+pub(crate) type Rav1dChromaSamplePosition = c_uint;
+pub(crate) const RAV1D_CHR_COLOCATED: Rav1dChromaSamplePosition = DAV1D_CHR_COLOCATED;
+pub(crate) const RAV1D_CHR_VERTICAL: Rav1dChromaSamplePosition = DAV1D_CHR_VERTICAL;
+pub(crate) const RAV1D_CHR_UNKNOWN: Rav1dChromaSamplePosition = DAV1D_CHR_UNKNOWN;
+
 // Constants from Section 3. "Symbols and abbreviated terms"
 pub const DAV1D_MAX_SEGMENTS: u8 = 8;
+
+pub(crate) const RAV1D_MAX_SEGMENTS: u8 = DAV1D_MAX_SEGMENTS;
 
 #[repr(C)]
 pub struct Dav1dContentLightLevel {
     pub max_content_light_level: c_int,
     pub max_frame_average_light_level: c_int,
+}
+
+impl Dav1dContentLightLevel {
+    pub(crate) fn into_rust(self) -> Rav1dContentLightLevel {
+        let Self {
+            max_content_light_level,
+            max_frame_average_light_level,
+        } = self;
+        Rav1dContentLightLevel {
+            max_content_light_level,
+            max_frame_average_light_level,
+        }
+    }
+}
+
+#[repr(C)]
+pub(crate) struct Rav1dContentLightLevel {
+    pub max_content_light_level: c_int,
+    pub max_frame_average_light_level: c_int,
+}
+
+impl Rav1dContentLightLevel {
+    pub fn into_c(self) -> Dav1dContentLightLevel {
+        let Self {
+            max_content_light_level,
+            max_frame_average_light_level,
+        } = self;
+        Dav1dContentLightLevel {
+            max_content_light_level,
+            max_frame_average_light_level,
+        }
+    }
 }
 
 #[repr(C)]
@@ -155,12 +356,96 @@ pub struct Dav1dMasteringDisplay {
     pub min_luminance: u32,
 }
 
+impl Dav1dMasteringDisplay {
+    pub(crate) fn into_rust(self) -> Rav1dMasteringDisplay {
+        let Self {
+            primaries,
+            white_point,
+            max_luminance,
+            min_luminance,
+        } = self;
+        Rav1dMasteringDisplay {
+            primaries,
+            white_point,
+            max_luminance,
+            min_luminance,
+        }
+    }
+}
+
+#[repr(C)]
+pub(crate) struct Rav1dMasteringDisplay {
+    pub primaries: [[u16; 2]; 3],
+    pub white_point: [u16; 2],
+    pub max_luminance: u32,
+    pub min_luminance: u32,
+}
+
+impl Rav1dMasteringDisplay {
+    pub fn into_c(self) -> Dav1dMasteringDisplay {
+        let Self {
+            primaries,
+            white_point,
+            max_luminance,
+            min_luminance,
+        } = self;
+        Dav1dMasteringDisplay {
+            primaries,
+            white_point,
+            max_luminance,
+            min_luminance,
+        }
+    }
+}
+
 #[repr(C)]
 pub struct Dav1dITUTT35 {
     pub country_code: u8,
     pub country_code_extension_byte: u8,
     pub payload_size: usize,
     pub payload: *mut u8,
+}
+
+impl Dav1dITUTT35 {
+    pub(crate) fn into_rust(self) -> Rav1dITUTT35 {
+        let Self {
+            country_code,
+            country_code_extension_byte,
+            payload_size,
+            payload,
+        } = self;
+        Rav1dITUTT35 {
+            country_code,
+            country_code_extension_byte,
+            payload_size,
+            payload,
+        }
+    }
+}
+
+#[repr(C)]
+pub(crate) struct Rav1dITUTT35 {
+    pub country_code: u8,
+    pub country_code_extension_byte: u8,
+    pub payload_size: usize,
+    pub payload: *mut u8,
+}
+
+impl Rav1dITUTT35 {
+    pub fn into_c(self) -> Dav1dITUTT35 {
+        let Self {
+            country_code,
+            country_code_extension_byte,
+            payload_size,
+            payload,
+        } = self;
+        Dav1dITUTT35 {
+            country_code,
+            country_code_extension_byte,
+            payload_size,
+            payload,
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -175,12 +460,108 @@ pub struct Dav1dSequenceHeaderOperatingPoint {
     pub display_model_param_present: c_int,
 }
 
+impl Dav1dSequenceHeaderOperatingPoint {
+    pub(crate) fn into_rust(self) -> Rav1dSequenceHeaderOperatingPoint {
+        let Self {
+            major_level,
+            minor_level,
+            initial_display_delay,
+            idc,
+            tier,
+            decoder_model_param_present,
+            display_model_param_present,
+        } = self;
+        Rav1dSequenceHeaderOperatingPoint {
+            major_level,
+            minor_level,
+            initial_display_delay,
+            idc,
+            tier,
+            decoder_model_param_present,
+            display_model_param_present,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub(crate) struct Rav1dSequenceHeaderOperatingPoint {
+    pub major_level: c_int,
+    pub minor_level: c_int,
+    pub initial_display_delay: c_int,
+    pub idc: c_int,
+    pub tier: c_int,
+    pub decoder_model_param_present: c_int,
+    pub display_model_param_present: c_int,
+}
+
+impl Rav1dSequenceHeaderOperatingPoint {
+    pub fn into_c(self) -> Dav1dSequenceHeaderOperatingPoint {
+        let Self {
+            major_level,
+            minor_level,
+            initial_display_delay,
+            idc,
+            tier,
+            decoder_model_param_present,
+            display_model_param_present,
+        } = self;
+        Dav1dSequenceHeaderOperatingPoint {
+            major_level,
+            minor_level,
+            initial_display_delay,
+            idc,
+            tier,
+            decoder_model_param_present,
+            display_model_param_present,
+        }
+    }
+}
+
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct Dav1dSequenceHeaderOperatingParameterInfo {
     pub decoder_buffer_delay: c_int,
     pub encoder_buffer_delay: c_int,
     pub low_delay_mode: c_int,
+}
+
+impl Dav1dSequenceHeaderOperatingParameterInfo {
+    pub(crate) fn into_rust(self) -> Rav1dSequenceHeaderOperatingParameterInfo {
+        let Self {
+            decoder_buffer_delay,
+            encoder_buffer_delay,
+            low_delay_mode,
+        } = self;
+        Rav1dSequenceHeaderOperatingParameterInfo {
+            decoder_buffer_delay,
+            encoder_buffer_delay,
+            low_delay_mode,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub(crate) struct Rav1dSequenceHeaderOperatingParameterInfo {
+    pub decoder_buffer_delay: c_int,
+    pub encoder_buffer_delay: c_int,
+    pub low_delay_mode: c_int,
+}
+
+impl Rav1dSequenceHeaderOperatingParameterInfo {
+    pub fn into_c(self) -> Dav1dSequenceHeaderOperatingParameterInfo {
+        let Self {
+            decoder_buffer_delay,
+            encoder_buffer_delay,
+            low_delay_mode,
+        } = self;
+        Dav1dSequenceHeaderOperatingParameterInfo {
+            decoder_buffer_delay,
+            encoder_buffer_delay,
+            low_delay_mode,
+        }
+    }
 }
 
 #[repr(C)]
@@ -240,6 +621,293 @@ pub struct Dav1dSequenceHeader {
     pub operating_parameter_info: [Dav1dSequenceHeaderOperatingParameterInfo; 32],
 }
 
+impl Dav1dSequenceHeader {
+    pub(crate) fn into_rust(self) -> Rav1dSequenceHeader {
+        let Self {
+            profile,
+            max_width,
+            max_height,
+            layout,
+            pri,
+            trc,
+            mtrx,
+            chr,
+            hbd,
+            color_range,
+            num_operating_points,
+            operating_points,
+            still_picture,
+            reduced_still_picture_header,
+            timing_info_present,
+            num_units_in_tick,
+            time_scale,
+            equal_picture_interval,
+            num_ticks_per_picture,
+            decoder_model_info_present,
+            encoder_decoder_buffer_delay_length,
+            num_units_in_decoding_tick,
+            buffer_removal_delay_length,
+            frame_presentation_delay_length,
+            display_model_info_present,
+            width_n_bits,
+            height_n_bits,
+            frame_id_numbers_present,
+            delta_frame_id_n_bits,
+            frame_id_n_bits,
+            sb128,
+            filter_intra,
+            intra_edge_filter,
+            inter_intra,
+            masked_compound,
+            warped_motion,
+            dual_filter,
+            order_hint,
+            jnt_comp,
+            ref_frame_mvs,
+            screen_content_tools,
+            force_integer_mv,
+            order_hint_n_bits,
+            super_res,
+            cdef,
+            restoration,
+            ss_hor,
+            ss_ver,
+            monochrome,
+            color_description_present,
+            separate_uv_delta_q,
+            film_grain_present,
+            operating_parameter_info,
+        } = self;
+        Rav1dSequenceHeader {
+            profile,
+            max_width,
+            max_height,
+            layout,
+            pri,
+            trc,
+            mtrx,
+            chr,
+            hbd,
+            color_range,
+            num_operating_points,
+            operating_points: operating_points.map(|c| c.into_rust()),
+            still_picture,
+            reduced_still_picture_header,
+            timing_info_present,
+            num_units_in_tick,
+            time_scale,
+            equal_picture_interval,
+            num_ticks_per_picture,
+            decoder_model_info_present,
+            encoder_decoder_buffer_delay_length,
+            num_units_in_decoding_tick,
+            buffer_removal_delay_length,
+            frame_presentation_delay_length,
+            display_model_info_present,
+            width_n_bits,
+            height_n_bits,
+            frame_id_numbers_present,
+            delta_frame_id_n_bits,
+            frame_id_n_bits,
+            sb128,
+            filter_intra,
+            intra_edge_filter,
+            inter_intra,
+            masked_compound,
+            warped_motion,
+            dual_filter,
+            order_hint,
+            jnt_comp,
+            ref_frame_mvs,
+            screen_content_tools,
+            force_integer_mv,
+            order_hint_n_bits,
+            super_res,
+            cdef,
+            restoration,
+            ss_hor,
+            ss_ver,
+            monochrome,
+            color_description_present,
+            separate_uv_delta_q,
+            film_grain_present,
+            operating_parameter_info: operating_parameter_info.map(|c| c.into_rust()),
+        }
+    }
+}
+
+#[repr(C)]
+pub(crate) struct Rav1dSequenceHeader {
+    pub profile: c_int,
+    pub max_width: c_int,
+    pub max_height: c_int,
+    pub layout: Rav1dPixelLayout,
+    pub pri: Rav1dColorPrimaries,
+    pub trc: Rav1dTransferCharacteristics,
+    pub mtrx: Rav1dMatrixCoefficients,
+    pub chr: Rav1dChromaSamplePosition,
+    pub hbd: c_int,
+    pub color_range: c_int,
+    pub num_operating_points: c_int,
+    pub operating_points: [Rav1dSequenceHeaderOperatingPoint; 32],
+    pub still_picture: c_int,
+    pub reduced_still_picture_header: c_int,
+    pub timing_info_present: c_int,
+    pub num_units_in_tick: c_int,
+    pub time_scale: c_int,
+    pub equal_picture_interval: c_int,
+    pub num_ticks_per_picture: c_uint,
+    pub decoder_model_info_present: c_int,
+    pub encoder_decoder_buffer_delay_length: c_int,
+    pub num_units_in_decoding_tick: c_int,
+    pub buffer_removal_delay_length: c_int,
+    pub frame_presentation_delay_length: c_int,
+    pub display_model_info_present: c_int,
+    pub width_n_bits: c_int,
+    pub height_n_bits: c_int,
+    pub frame_id_numbers_present: c_int,
+    pub delta_frame_id_n_bits: c_int,
+    pub frame_id_n_bits: c_int,
+    pub sb128: c_int,
+    pub filter_intra: c_int,
+    pub intra_edge_filter: c_int,
+    pub inter_intra: c_int,
+    pub masked_compound: c_int,
+    pub warped_motion: c_int,
+    pub dual_filter: c_int,
+    pub order_hint: c_int,
+    pub jnt_comp: c_int,
+    pub ref_frame_mvs: c_int,
+    pub screen_content_tools: Rav1dAdaptiveBoolean,
+    pub force_integer_mv: Rav1dAdaptiveBoolean,
+    pub order_hint_n_bits: c_int,
+    pub super_res: c_int,
+    pub cdef: c_int,
+    pub restoration: c_int,
+    pub ss_hor: c_int,
+    pub ss_ver: c_int,
+    pub monochrome: c_int,
+    pub color_description_present: c_int,
+    pub separate_uv_delta_q: c_int,
+    pub film_grain_present: c_int,
+    pub operating_parameter_info: [Rav1dSequenceHeaderOperatingParameterInfo; 32],
+}
+
+impl Rav1dSequenceHeader {
+    pub fn into_c(self) -> Dav1dSequenceHeader {
+        let Self {
+            profile,
+            max_width,
+            max_height,
+            layout,
+            pri,
+            trc,
+            mtrx,
+            chr,
+            hbd,
+            color_range,
+            num_operating_points,
+            operating_points,
+            still_picture,
+            reduced_still_picture_header,
+            timing_info_present,
+            num_units_in_tick,
+            time_scale,
+            equal_picture_interval,
+            num_ticks_per_picture,
+            decoder_model_info_present,
+            encoder_decoder_buffer_delay_length,
+            num_units_in_decoding_tick,
+            buffer_removal_delay_length,
+            frame_presentation_delay_length,
+            display_model_info_present,
+            width_n_bits,
+            height_n_bits,
+            frame_id_numbers_present,
+            delta_frame_id_n_bits,
+            frame_id_n_bits,
+            sb128,
+            filter_intra,
+            intra_edge_filter,
+            inter_intra,
+            masked_compound,
+            warped_motion,
+            dual_filter,
+            order_hint,
+            jnt_comp,
+            ref_frame_mvs,
+            screen_content_tools,
+            force_integer_mv,
+            order_hint_n_bits,
+            super_res,
+            cdef,
+            restoration,
+            ss_hor,
+            ss_ver,
+            monochrome,
+            color_description_present,
+            separate_uv_delta_q,
+            film_grain_present,
+            operating_parameter_info,
+        } = self;
+        Dav1dSequenceHeader {
+            profile,
+            max_width,
+            max_height,
+            layout,
+            pri,
+            trc,
+            mtrx,
+            chr,
+            hbd,
+            color_range,
+            num_operating_points,
+            operating_points: operating_points.map(|rust| rust.into_c()),
+            still_picture,
+            reduced_still_picture_header,
+            timing_info_present,
+            num_units_in_tick,
+            time_scale,
+            equal_picture_interval,
+            num_ticks_per_picture,
+            decoder_model_info_present,
+            encoder_decoder_buffer_delay_length,
+            num_units_in_decoding_tick,
+            buffer_removal_delay_length,
+            frame_presentation_delay_length,
+            display_model_info_present,
+            width_n_bits,
+            height_n_bits,
+            frame_id_numbers_present,
+            delta_frame_id_n_bits,
+            frame_id_n_bits,
+            sb128,
+            filter_intra,
+            intra_edge_filter,
+            inter_intra,
+            masked_compound,
+            warped_motion,
+            dual_filter,
+            order_hint,
+            jnt_comp,
+            ref_frame_mvs,
+            screen_content_tools,
+            force_integer_mv,
+            order_hint_n_bits,
+            super_res,
+            cdef,
+            restoration,
+            ss_hor,
+            ss_ver,
+            monochrome,
+            color_description_present,
+            separate_uv_delta_q,
+            film_grain_present,
+            operating_parameter_info: operating_parameter_info.map(|rust| rust.into_c()),
+        }
+    }
+}
+
 #[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dSegmentationData {
@@ -253,6 +921,69 @@ pub struct Dav1dSegmentationData {
     pub globalmv: c_int,
 }
 
+impl Dav1dSegmentationData {
+    pub(crate) fn into_rust(self) -> Rav1dSegmentationData {
+        let Self {
+            delta_q,
+            delta_lf_y_v,
+            delta_lf_y_h,
+            delta_lf_u,
+            delta_lf_v,
+            r#ref,
+            skip,
+            globalmv,
+        } = self;
+        Rav1dSegmentationData {
+            delta_q,
+            delta_lf_y_v,
+            delta_lf_y_h,
+            delta_lf_u,
+            delta_lf_v,
+            r#ref,
+            skip,
+            globalmv,
+        }
+    }
+}
+
+#[derive(Clone)]
+#[repr(C)]
+pub(crate) struct Rav1dSegmentationData {
+    pub delta_q: c_int,
+    pub delta_lf_y_v: c_int,
+    pub delta_lf_y_h: c_int,
+    pub delta_lf_u: c_int,
+    pub delta_lf_v: c_int,
+    pub r#ref: c_int,
+    pub skip: c_int,
+    pub globalmv: c_int,
+}
+
+impl Rav1dSegmentationData {
+    pub fn into_c(self) -> Dav1dSegmentationData {
+        let Self {
+            delta_q,
+            delta_lf_y_v,
+            delta_lf_y_h,
+            delta_lf_u,
+            delta_lf_v,
+            r#ref,
+            skip,
+            globalmv,
+        } = self;
+        Dav1dSegmentationData {
+            delta_q,
+            delta_lf_y_v,
+            delta_lf_y_h,
+            delta_lf_u,
+            delta_lf_v,
+            r#ref,
+            skip,
+            globalmv,
+        }
+    }
+}
+
 #[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dSegmentationDataSet {
@@ -261,11 +992,82 @@ pub struct Dav1dSegmentationDataSet {
     pub last_active_segid: c_int,
 }
 
+impl Dav1dSegmentationDataSet {
+    pub(crate) fn into_rust(self) -> Rav1dSegmentationDataSet {
+        let Self {
+            d,
+            preskip,
+            last_active_segid,
+        } = self;
+        Rav1dSegmentationDataSet {
+            d: d.map(|c| c.into_rust()),
+            preskip,
+            last_active_segid,
+        }
+    }
+}
+
+#[derive(Clone)]
+#[repr(C)]
+pub(crate) struct Rav1dSegmentationDataSet {
+    pub d: [Rav1dSegmentationData; 8],
+    pub preskip: c_int,
+    pub last_active_segid: c_int,
+}
+
+impl Rav1dSegmentationDataSet {
+    pub fn into_c(self) -> Dav1dSegmentationDataSet {
+        let Self {
+            d,
+            preskip,
+            last_active_segid,
+        } = self;
+        Dav1dSegmentationDataSet {
+            d: d.map(|rust| rust.into_c()),
+            preskip,
+            last_active_segid,
+        }
+    }
+}
+
 #[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dLoopfilterModeRefDeltas {
     pub mode_delta: [c_int; 2],
     pub ref_delta: [c_int; 8],
+}
+
+impl Dav1dLoopfilterModeRefDeltas {
+    pub(crate) fn into_rust(self) -> Rav1dLoopfilterModeRefDeltas {
+        let Self {
+            mode_delta,
+            ref_delta,
+        } = self;
+        Rav1dLoopfilterModeRefDeltas {
+            mode_delta,
+            ref_delta,
+        }
+    }
+}
+
+#[derive(Clone)]
+#[repr(C)]
+pub(crate) struct Rav1dLoopfilterModeRefDeltas {
+    pub mode_delta: [c_int; 2],
+    pub ref_delta: [c_int; 8],
+}
+
+impl Rav1dLoopfilterModeRefDeltas {
+    pub fn into_c(self) -> Dav1dLoopfilterModeRefDeltas {
+        let Self {
+            mode_delta,
+            ref_delta,
+        } = self;
+        Dav1dLoopfilterModeRefDeltas {
+            mode_delta,
+            ref_delta,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -290,6 +1092,114 @@ pub struct Dav1dFilmGrainData {
     pub clip_to_restricted_range: c_int,
 }
 
+impl Dav1dFilmGrainData {
+    pub(crate) fn into_rust(self) -> Rav1dFilmGrainData {
+        let Self {
+            seed,
+            num_y_points,
+            y_points,
+            chroma_scaling_from_luma,
+            num_uv_points,
+            uv_points,
+            scaling_shift,
+            ar_coeff_lag,
+            ar_coeffs_y,
+            ar_coeffs_uv,
+            ar_coeff_shift,
+            grain_scale_shift,
+            uv_mult,
+            uv_luma_mult,
+            uv_offset,
+            overlap_flag,
+            clip_to_restricted_range,
+        } = self;
+        Rav1dFilmGrainData {
+            seed,
+            num_y_points,
+            y_points,
+            chroma_scaling_from_luma,
+            num_uv_points,
+            uv_points,
+            scaling_shift,
+            ar_coeff_lag,
+            ar_coeffs_y,
+            ar_coeffs_uv,
+            ar_coeff_shift,
+            grain_scale_shift,
+            uv_mult,
+            uv_luma_mult,
+            uv_offset,
+            overlap_flag,
+            clip_to_restricted_range,
+        }
+    }
+}
+
+#[derive(Clone)]
+#[repr(C)]
+pub(crate) struct Rav1dFilmGrainData {
+    pub seed: c_uint,
+    pub num_y_points: c_int,
+    pub y_points: [[u8; 2]; 14],
+    pub chroma_scaling_from_luma: c_int,
+    pub num_uv_points: [c_int; 2],
+    pub uv_points: [[[u8; 2]; 10]; 2],
+    pub scaling_shift: c_int,
+    pub ar_coeff_lag: c_int,
+    pub ar_coeffs_y: [i8; 24],
+    pub ar_coeffs_uv: [[i8; 28]; 2],
+    pub ar_coeff_shift: u64,
+    pub grain_scale_shift: c_int,
+    pub uv_mult: [c_int; 2],
+    pub uv_luma_mult: [c_int; 2],
+    pub uv_offset: [c_int; 2],
+    pub overlap_flag: c_int,
+    pub clip_to_restricted_range: c_int,
+}
+
+impl Rav1dFilmGrainData {
+    pub fn into_c(self) -> Dav1dFilmGrainData {
+        let Self {
+            seed,
+            num_y_points,
+            y_points,
+            chroma_scaling_from_luma,
+            num_uv_points,
+            uv_points,
+            scaling_shift,
+            ar_coeff_lag,
+            ar_coeffs_y,
+            ar_coeffs_uv,
+            ar_coeff_shift,
+            grain_scale_shift,
+            uv_mult,
+            uv_luma_mult,
+            uv_offset,
+            overlap_flag,
+            clip_to_restricted_range,
+        } = self;
+        Dav1dFilmGrainData {
+            seed,
+            num_y_points,
+            y_points,
+            chroma_scaling_from_luma,
+            num_uv_points,
+            uv_points,
+            scaling_shift,
+            ar_coeff_lag,
+            ar_coeffs_y,
+            ar_coeffs_uv,
+            ar_coeff_shift,
+            grain_scale_shift,
+            uv_mult,
+            uv_luma_mult,
+            uv_offset,
+            overlap_flag,
+            clip_to_restricted_range,
+        }
+    }
+}
+
 #[repr(C)]
 pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
@@ -297,15 +1207,111 @@ pub struct Dav1dFrameHeader_film_grain {
     pub update: c_int,
 }
 
+impl Dav1dFrameHeader_film_grain {
+    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_film_grain {
+        let Self {
+            data,
+            present,
+            update,
+        } = self;
+        Rav1dFrameHeader_film_grain {
+            data: data.into_rust(),
+            present,
+            update,
+        }
+    }
+}
+
+#[repr(C)]
+pub(crate) struct Rav1dFrameHeader_film_grain {
+    pub data: Rav1dFilmGrainData,
+    pub present: c_int,
+    pub update: c_int,
+}
+
+impl Rav1dFrameHeader_film_grain {
+    pub fn into_c(self) -> Dav1dFrameHeader_film_grain {
+        let Self {
+            data,
+            present,
+            update,
+        } = self;
+        Dav1dFrameHeader_film_grain {
+            data: data.into_c(),
+            present,
+            update,
+        }
+    }
+}
+
 #[repr(C)]
 pub struct Dav1dFrameHeaderOperatingPoint {
     pub buffer_removal_time: c_int,
+}
+
+impl Dav1dFrameHeaderOperatingPoint {
+    pub(crate) fn into_rust(self) -> Rav1dFrameHeaderOperatingPoint {
+        let Self {
+            buffer_removal_time,
+        } = self;
+        Rav1dFrameHeaderOperatingPoint {
+            buffer_removal_time,
+        }
+    }
+}
+
+#[repr(C)]
+pub(crate) struct Rav1dFrameHeaderOperatingPoint {
+    pub buffer_removal_time: c_int,
+}
+
+impl Rav1dFrameHeaderOperatingPoint {
+    pub fn into_c(self) -> Dav1dFrameHeaderOperatingPoint {
+        let Self {
+            buffer_removal_time,
+        } = self;
+        Dav1dFrameHeaderOperatingPoint {
+            buffer_removal_time,
+        }
+    }
 }
 
 #[repr(C)]
 pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: c_int,
     pub enabled: c_int,
+}
+
+impl Dav1dFrameHeader_super_res {
+    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_super_res {
+        let Self {
+            width_scale_denominator,
+            enabled,
+        } = self;
+        Rav1dFrameHeader_super_res {
+            width_scale_denominator,
+            enabled,
+        }
+    }
+}
+
+#[repr(C)]
+pub(crate) struct Rav1dFrameHeader_super_res {
+    pub width_scale_denominator: c_int,
+    pub enabled: c_int,
+}
+
+impl Rav1dFrameHeader_super_res {
+    pub fn into_c(self) -> Dav1dFrameHeader_super_res {
+        let Self {
+            width_scale_denominator,
+            enabled,
+        } = self;
+        Dav1dFrameHeader_super_res {
+            width_scale_denominator,
+            enabled,
+        }
+    }
 }
 
 #[repr(C)]
@@ -325,6 +1331,93 @@ pub struct Dav1dFrameHeader_tiling {
     pub update: c_int,
 }
 
+impl Dav1dFrameHeader_tiling {
+    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_tiling {
+        let Self {
+            uniform,
+            n_bytes,
+            min_log2_cols,
+            max_log2_cols,
+            log2_cols,
+            cols,
+            min_log2_rows,
+            max_log2_rows,
+            log2_rows,
+            rows,
+            col_start_sb,
+            row_start_sb,
+            update,
+        } = self;
+        Rav1dFrameHeader_tiling {
+            uniform,
+            n_bytes,
+            min_log2_cols,
+            max_log2_cols,
+            log2_cols,
+            cols,
+            min_log2_rows,
+            max_log2_rows,
+            log2_rows,
+            rows,
+            col_start_sb,
+            row_start_sb,
+            update,
+        }
+    }
+}
+
+#[repr(C)]
+pub(crate) struct Rav1dFrameHeader_tiling {
+    pub uniform: c_int,
+    pub n_bytes: c_uint,
+    pub min_log2_cols: c_int,
+    pub max_log2_cols: c_int,
+    pub log2_cols: c_int,
+    pub cols: c_int,
+    pub min_log2_rows: c_int,
+    pub max_log2_rows: c_int,
+    pub log2_rows: c_int,
+    pub rows: c_int,
+    pub col_start_sb: [u16; 65],
+    pub row_start_sb: [u16; 65],
+    pub update: c_int,
+}
+
+impl Rav1dFrameHeader_tiling {
+    pub fn into_c(self) -> Dav1dFrameHeader_tiling {
+        let Self {
+            uniform,
+            n_bytes,
+            min_log2_cols,
+            max_log2_cols,
+            log2_cols,
+            cols,
+            min_log2_rows,
+            max_log2_rows,
+            log2_rows,
+            rows,
+            col_start_sb,
+            row_start_sb,
+            update,
+        } = self;
+        Dav1dFrameHeader_tiling {
+            uniform,
+            n_bytes,
+            min_log2_cols,
+            max_log2_cols,
+            log2_cols,
+            cols,
+            min_log2_rows,
+            max_log2_rows,
+            log2_rows,
+            rows,
+            col_start_sb,
+            row_start_sb,
+            update,
+        }
+    }
+}
+
 #[repr(C)]
 pub struct Dav1dFrameHeader_quant {
     pub yac: c_int,
@@ -339,6 +1432,78 @@ pub struct Dav1dFrameHeader_quant {
     pub qm_v: c_int,
 }
 
+impl Dav1dFrameHeader_quant {
+    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_quant {
+        let Self {
+            yac,
+            ydc_delta,
+            udc_delta,
+            uac_delta,
+            vdc_delta,
+            vac_delta,
+            qm,
+            qm_y,
+            qm_u,
+            qm_v,
+        } = self;
+        Rav1dFrameHeader_quant {
+            yac,
+            ydc_delta,
+            udc_delta,
+            uac_delta,
+            vdc_delta,
+            vac_delta,
+            qm,
+            qm_y,
+            qm_u,
+            qm_v,
+        }
+    }
+}
+
+#[repr(C)]
+pub(crate) struct Rav1dFrameHeader_quant {
+    pub yac: c_int,
+    pub ydc_delta: c_int,
+    pub udc_delta: c_int,
+    pub uac_delta: c_int,
+    pub vdc_delta: c_int,
+    pub vac_delta: c_int,
+    pub qm: c_int,
+    pub qm_y: c_int,
+    pub qm_u: c_int,
+    pub qm_v: c_int,
+}
+
+impl Rav1dFrameHeader_quant {
+    pub fn into_c(self) -> Dav1dFrameHeader_quant {
+        let Self {
+            yac,
+            ydc_delta,
+            udc_delta,
+            uac_delta,
+            vdc_delta,
+            vac_delta,
+            qm,
+            qm_y,
+            qm_u,
+            qm_v,
+        } = self;
+        Dav1dFrameHeader_quant {
+            yac,
+            ydc_delta,
+            udc_delta,
+            uac_delta,
+            vdc_delta,
+            vac_delta,
+            qm,
+            qm_y,
+            qm_u,
+            qm_v,
+        }
+    }
+}
+
 #[repr(C)]
 pub struct Dav1dFrameHeader_segmentation {
     pub enabled: c_int,
@@ -350,10 +1515,87 @@ pub struct Dav1dFrameHeader_segmentation {
     pub qidx: [c_int; 8],
 }
 
+impl Dav1dFrameHeader_segmentation {
+    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_segmentation {
+        let Self {
+            enabled,
+            update_map,
+            temporal,
+            update_data,
+            seg_data,
+            lossless,
+            qidx,
+        } = self;
+        Rav1dFrameHeader_segmentation {
+            enabled,
+            update_map,
+            temporal,
+            update_data,
+            seg_data: seg_data.into_rust(),
+            lossless,
+            qidx,
+        }
+    }
+}
+
+#[repr(C)]
+pub(crate) struct Rav1dFrameHeader_segmentation {
+    pub enabled: c_int,
+    pub update_map: c_int,
+    pub temporal: c_int,
+    pub update_data: c_int,
+    pub seg_data: Rav1dSegmentationDataSet,
+    pub lossless: [c_int; 8],
+    pub qidx: [c_int; 8],
+}
+
+impl Rav1dFrameHeader_segmentation {
+    pub fn into_c(self) -> Dav1dFrameHeader_segmentation {
+        let Self {
+            enabled,
+            update_map,
+            temporal,
+            update_data,
+            seg_data,
+            lossless,
+            qidx,
+        } = self;
+        Dav1dFrameHeader_segmentation {
+            enabled,
+            update_map,
+            temporal,
+            update_data,
+            seg_data: seg_data.into_c(),
+            lossless,
+            qidx,
+        }
+    }
+}
+
 #[repr(C)]
 pub struct Dav1dFrameHeader_delta_q {
     pub present: c_int,
     pub res_log2: c_int,
+}
+
+impl Dav1dFrameHeader_delta_q {
+    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_delta_q {
+        let Self { present, res_log2 } = self;
+        Rav1dFrameHeader_delta_q { present, res_log2 }
+    }
+}
+
+#[repr(C)]
+pub(crate) struct Rav1dFrameHeader_delta_q {
+    pub present: c_int,
+    pub res_log2: c_int,
+}
+
+impl Rav1dFrameHeader_delta_q {
+    pub fn into_c(self) -> Dav1dFrameHeader_delta_q {
+        let Self { present, res_log2 } = self;
+        Dav1dFrameHeader_delta_q { present, res_log2 }
+    }
 }
 
 #[repr(C)]
@@ -363,10 +1605,73 @@ pub struct Dav1dFrameHeader_delta_lf {
     pub multi: c_int,
 }
 
+impl Dav1dFrameHeader_delta_lf {
+    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_delta_lf {
+        let Self {
+            present,
+            res_log2,
+            multi,
+        } = self;
+        Rav1dFrameHeader_delta_lf {
+            present,
+            res_log2,
+            multi,
+        }
+    }
+}
+
+#[repr(C)]
+pub(crate) struct Rav1dFrameHeader_delta_lf {
+    pub present: c_int,
+    pub res_log2: c_int,
+    pub multi: c_int,
+}
+
+impl Rav1dFrameHeader_delta_lf {
+    pub fn into_c(self) -> Dav1dFrameHeader_delta_lf {
+        let Self {
+            present,
+            res_log2,
+            multi,
+        } = self;
+        Dav1dFrameHeader_delta_lf {
+            present,
+            res_log2,
+            multi,
+        }
+    }
+}
+
 #[repr(C)]
 pub struct Dav1dFrameHeader_delta {
     pub q: Dav1dFrameHeader_delta_q,
     pub lf: Dav1dFrameHeader_delta_lf,
+}
+
+impl Dav1dFrameHeader_delta {
+    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_delta {
+        let Self { q, lf } = self;
+        Rav1dFrameHeader_delta {
+            q: q.into_rust(),
+            lf: lf.into_rust(),
+        }
+    }
+}
+
+#[repr(C)]
+pub(crate) struct Rav1dFrameHeader_delta {
+    pub q: Rav1dFrameHeader_delta_q,
+    pub lf: Rav1dFrameHeader_delta_lf,
+}
+
+impl Rav1dFrameHeader_delta {
+    pub fn into_c(self) -> Dav1dFrameHeader_delta {
+        let Self { q, lf } = self;
+        Dav1dFrameHeader_delta {
+            q: q.into_c(),
+            lf: lf.into_c(),
+        }
+    }
 }
 
 #[repr(C)]
@@ -380,6 +1685,63 @@ pub struct Dav1dFrameHeader_loopfilter {
     pub sharpness: c_int,
 }
 
+impl Dav1dFrameHeader_loopfilter {
+    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_loopfilter {
+        let Self {
+            level_y,
+            level_u,
+            level_v,
+            mode_ref_delta_enabled,
+            mode_ref_delta_update,
+            mode_ref_deltas,
+            sharpness,
+        } = self;
+        Rav1dFrameHeader_loopfilter {
+            level_y,
+            level_u,
+            level_v,
+            mode_ref_delta_enabled,
+            mode_ref_delta_update,
+            mode_ref_deltas: mode_ref_deltas.into_rust(),
+            sharpness,
+        }
+    }
+}
+
+#[repr(C)]
+pub(crate) struct Rav1dFrameHeader_loopfilter {
+    pub level_y: [c_int; 2],
+    pub level_u: c_int,
+    pub level_v: c_int,
+    pub mode_ref_delta_enabled: c_int,
+    pub mode_ref_delta_update: c_int,
+    pub mode_ref_deltas: Rav1dLoopfilterModeRefDeltas,
+    pub sharpness: c_int,
+}
+
+impl Rav1dFrameHeader_loopfilter {
+    pub fn into_c(self) -> Dav1dFrameHeader_loopfilter {
+        let Self {
+            level_y,
+            level_u,
+            level_v,
+            mode_ref_delta_enabled,
+            mode_ref_delta_update,
+            mode_ref_deltas,
+            sharpness,
+        } = self;
+        Dav1dFrameHeader_loopfilter {
+            level_y,
+            level_u,
+            level_v,
+            mode_ref_delta_enabled,
+            mode_ref_delta_update,
+            mode_ref_deltas: mode_ref_deltas.into_c(),
+            sharpness,
+        }
+    }
+}
+
 #[repr(C)]
 pub struct Dav1dFrameHeader_cdef {
     pub damping: c_int,
@@ -388,10 +1750,72 @@ pub struct Dav1dFrameHeader_cdef {
     pub uv_strength: [c_int; 8],
 }
 
+impl Dav1dFrameHeader_cdef {
+    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_cdef {
+        let Self {
+            damping,
+            n_bits,
+            y_strength,
+            uv_strength,
+        } = self;
+        Rav1dFrameHeader_cdef {
+            damping,
+            n_bits,
+            y_strength,
+            uv_strength,
+        }
+    }
+}
+
+#[repr(C)]
+pub(crate) struct Rav1dFrameHeader_cdef {
+    pub damping: c_int,
+    pub n_bits: c_int,
+    pub y_strength: [c_int; 8],
+    pub uv_strength: [c_int; 8],
+}
+
+impl Rav1dFrameHeader_cdef {
+    pub fn into_c(self) -> Dav1dFrameHeader_cdef {
+        let Self {
+            damping,
+            n_bits,
+            y_strength,
+            uv_strength,
+        } = self;
+        Dav1dFrameHeader_cdef {
+            damping,
+            n_bits,
+            y_strength,
+            uv_strength,
+        }
+    }
+}
+
 #[repr(C)]
 pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [c_int; 2],
+}
+
+impl Dav1dFrameHeader_restoration {
+    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_restoration {
+        let Self { type_0, unit_size } = self;
+        Rav1dFrameHeader_restoration { type_0, unit_size }
+    }
+}
+
+#[repr(C)]
+pub(crate) struct Rav1dFrameHeader_restoration {
+    pub type_0: [Rav1dRestorationType; 3],
+    pub unit_size: [c_int; 2],
+}
+
+impl Rav1dFrameHeader_restoration {
+    pub fn into_c(self) -> Dav1dFrameHeader_restoration {
+        let Self { type_0, unit_size } = self;
+        Dav1dFrameHeader_restoration { type_0, unit_size }
+    }
 }
 
 #[repr(C)]
@@ -446,4 +1870,276 @@ pub struct Dav1dFrameHeader {
     pub warp_motion: c_int,
     pub reduced_txtp_set: c_int,
     pub gmv: [Dav1dWarpedMotionParams; 7],
+}
+
+impl Dav1dFrameHeader {
+    pub(crate) fn into_rust(self) -> Rav1dFrameHeader {
+        let Self {
+            film_grain,
+            frame_type,
+            width,
+            height,
+            frame_offset,
+            temporal_id,
+            spatial_id,
+            show_existing_frame,
+            existing_frame_idx,
+            frame_id,
+            frame_presentation_delay,
+            show_frame,
+            showable_frame,
+            error_resilient_mode,
+            disable_cdf_update,
+            allow_screen_content_tools,
+            force_integer_mv,
+            frame_size_override,
+            primary_ref_frame,
+            buffer_removal_time_present,
+            operating_points,
+            refresh_frame_flags,
+            render_width,
+            render_height,
+            super_res,
+            have_render_size,
+            allow_intrabc,
+            frame_ref_short_signaling,
+            refidx,
+            hp,
+            subpel_filter_mode,
+            switchable_motion_mode,
+            use_ref_frame_mvs,
+            refresh_context,
+            tiling,
+            quant,
+            segmentation,
+            delta,
+            all_lossless,
+            loopfilter,
+            cdef,
+            restoration,
+            txfm_mode,
+            switchable_comp_refs,
+            skip_mode_allowed,
+            skip_mode_enabled,
+            skip_mode_refs,
+            warp_motion,
+            reduced_txtp_set,
+            gmv,
+        } = self;
+        Rav1dFrameHeader {
+            film_grain: film_grain.into_rust(),
+            frame_type,
+            width,
+            height,
+            frame_offset,
+            temporal_id,
+            spatial_id,
+            show_existing_frame,
+            existing_frame_idx,
+            frame_id,
+            frame_presentation_delay,
+            show_frame,
+            showable_frame,
+            error_resilient_mode,
+            disable_cdf_update,
+            allow_screen_content_tools,
+            force_integer_mv,
+            frame_size_override,
+            primary_ref_frame,
+            buffer_removal_time_present,
+            operating_points: operating_points.map(|c| c.into_rust()),
+            refresh_frame_flags,
+            render_width,
+            render_height,
+            super_res: super_res.into_rust(),
+            have_render_size,
+            allow_intrabc,
+            frame_ref_short_signaling,
+            refidx,
+            hp,
+            subpel_filter_mode,
+            switchable_motion_mode,
+            use_ref_frame_mvs,
+            refresh_context,
+            tiling: tiling.into_rust(),
+            quant: quant.into_rust(),
+            segmentation: segmentation.into_rust(),
+            delta: delta.into_rust(),
+            all_lossless,
+            loopfilter: loopfilter.into_rust(),
+            cdef: cdef.into_rust(),
+            restoration: restoration.into_rust(),
+            txfm_mode,
+            switchable_comp_refs,
+            skip_mode_allowed,
+            skip_mode_enabled,
+            skip_mode_refs,
+            warp_motion,
+            reduced_txtp_set,
+            gmv: gmv.map(|c| c.into_rust()),
+        }
+    }
+}
+
+#[repr(C)]
+pub(crate) struct Rav1dFrameHeader {
+    pub film_grain: Rav1dFrameHeader_film_grain,
+    pub frame_type: Rav1dFrameType,
+    pub width: [c_int; 2],
+    pub height: c_int,
+    pub frame_offset: c_int,
+    pub temporal_id: c_int,
+    pub spatial_id: c_int,
+    pub show_existing_frame: c_int,
+    pub existing_frame_idx: c_int,
+    pub frame_id: c_int,
+    pub frame_presentation_delay: c_int,
+    pub show_frame: c_int,
+    pub showable_frame: c_int,
+    pub error_resilient_mode: c_int,
+    pub disable_cdf_update: c_int,
+    pub allow_screen_content_tools: c_int,
+    pub force_integer_mv: c_int,
+    pub frame_size_override: c_int,
+    pub primary_ref_frame: c_int,
+    pub buffer_removal_time_present: c_int,
+    pub operating_points: [Rav1dFrameHeaderOperatingPoint; 32],
+    pub refresh_frame_flags: c_int,
+    pub render_width: c_int,
+    pub render_height: c_int,
+    pub super_res: Rav1dFrameHeader_super_res,
+    pub have_render_size: c_int,
+    pub allow_intrabc: c_int,
+    pub frame_ref_short_signaling: c_int,
+    pub refidx: [c_int; 7],
+    pub hp: c_int,
+    pub subpel_filter_mode: Rav1dFilterMode,
+    pub switchable_motion_mode: c_int,
+    pub use_ref_frame_mvs: c_int,
+    pub refresh_context: c_int,
+    pub tiling: Rav1dFrameHeader_tiling,
+    pub quant: Rav1dFrameHeader_quant,
+    pub segmentation: Rav1dFrameHeader_segmentation,
+    pub delta: Rav1dFrameHeader_delta,
+    pub all_lossless: c_int,
+    pub loopfilter: Rav1dFrameHeader_loopfilter,
+    pub cdef: Rav1dFrameHeader_cdef,
+    pub restoration: Rav1dFrameHeader_restoration,
+    pub txfm_mode: Rav1dTxfmMode,
+    pub switchable_comp_refs: c_int,
+    pub skip_mode_allowed: c_int,
+    pub skip_mode_enabled: c_int,
+    pub skip_mode_refs: [c_int; 2],
+    pub warp_motion: c_int,
+    pub reduced_txtp_set: c_int,
+    pub gmv: [Rav1dWarpedMotionParams; 7],
+}
+
+impl Rav1dFrameHeader {
+    pub fn into_c(self) -> Dav1dFrameHeader {
+        let Self {
+            film_grain,
+            frame_type,
+            width,
+            height,
+            frame_offset,
+            temporal_id,
+            spatial_id,
+            show_existing_frame,
+            existing_frame_idx,
+            frame_id,
+            frame_presentation_delay,
+            show_frame,
+            showable_frame,
+            error_resilient_mode,
+            disable_cdf_update,
+            allow_screen_content_tools,
+            force_integer_mv,
+            frame_size_override,
+            primary_ref_frame,
+            buffer_removal_time_present,
+            operating_points,
+            refresh_frame_flags,
+            render_width,
+            render_height,
+            super_res,
+            have_render_size,
+            allow_intrabc,
+            frame_ref_short_signaling,
+            refidx,
+            hp,
+            subpel_filter_mode,
+            switchable_motion_mode,
+            use_ref_frame_mvs,
+            refresh_context,
+            tiling,
+            quant,
+            segmentation,
+            delta,
+            all_lossless,
+            loopfilter,
+            cdef,
+            restoration,
+            txfm_mode,
+            switchable_comp_refs,
+            skip_mode_allowed,
+            skip_mode_enabled,
+            skip_mode_refs,
+            warp_motion,
+            reduced_txtp_set,
+            gmv,
+        } = self;
+        Dav1dFrameHeader {
+            film_grain: film_grain.into_c(),
+            frame_type,
+            width,
+            height,
+            frame_offset,
+            temporal_id,
+            spatial_id,
+            show_existing_frame,
+            existing_frame_idx,
+            frame_id,
+            frame_presentation_delay,
+            show_frame,
+            showable_frame,
+            error_resilient_mode,
+            disable_cdf_update,
+            allow_screen_content_tools,
+            force_integer_mv,
+            frame_size_override,
+            primary_ref_frame,
+            buffer_removal_time_present,
+            operating_points: operating_points.map(|rust| rust.into_c()),
+            refresh_frame_flags,
+            render_width,
+            render_height,
+            super_res: super_res.into_c(),
+            have_render_size,
+            allow_intrabc,
+            frame_ref_short_signaling,
+            refidx,
+            hp,
+            subpel_filter_mode,
+            switchable_motion_mode,
+            use_ref_frame_mvs,
+            refresh_context,
+            tiling: tiling.into_c(),
+            quant: quant.into_c(),
+            segmentation: segmentation.into_c(),
+            delta: delta.into_c(),
+            all_lossless,
+            loopfilter: loopfilter.into_c(),
+            cdef: cdef.into_c(),
+            restoration: restoration.into_c(),
+            txfm_mode,
+            switchable_comp_refs,
+            skip_mode_allowed,
+            skip_mode_enabled,
+            skip_mode_refs,
+            warp_motion,
+            reduced_txtp_set,
+            gmv: gmv.map(|rust| rust.into_c()),
+        }
+    }
 }

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -28,7 +28,7 @@ pub const DAV1D_TX_LARGEST: Dav1dTxfmMode = 1;
 pub const DAV1D_TX_4X4_ONLY: Dav1dTxfmMode = 0;
 
 pub(crate) type Rav1dTxfmMode = c_uint;
-pub(crate) const RAV1D_N_TX_MODES: usize = DAV1D_N_TX_MODES;
+pub(crate) const _RAV1D_N_TX_MODES: usize = DAV1D_N_TX_MODES;
 pub(crate) const RAV1D_TX_SWITCHABLE: Rav1dTxfmMode = DAV1D_TX_SWITCHABLE;
 pub(crate) const RAV1D_TX_LARGEST: Rav1dTxfmMode = DAV1D_TX_LARGEST;
 pub(crate) const RAV1D_TX_4X4_ONLY: Rav1dTxfmMode = DAV1D_TX_4X4_ONLY;
@@ -58,8 +58,8 @@ pub const DAV1D_OFF: Dav1dAdaptiveBoolean = 0;
 
 pub(crate) type Rav1dAdaptiveBoolean = c_uint;
 pub(crate) const RAV1D_ADAPTIVE: Rav1dAdaptiveBoolean = DAV1D_ADAPTIVE;
-pub(crate) const RAV1D_ON: Rav1dAdaptiveBoolean = DAV1D_ON;
-pub(crate) const RAV1D_OFF: Rav1dAdaptiveBoolean = DAV1D_OFF;
+pub(crate) const _RAV1D_ON: Rav1dAdaptiveBoolean = DAV1D_ON;
+pub(crate) const _RAV1D_OFF: Rav1dAdaptiveBoolean = DAV1D_OFF;
 
 pub type Dav1dRestorationType = u8;
 pub const DAV1D_RESTORATION_SGRPROJ: Dav1dRestorationType = 3;
@@ -135,18 +135,22 @@ pub(crate) struct Rav1dWarpedMotionParams {
 }
 
 impl Rav1dWarpedMotionParams {
+    #[allow(dead_code)] // TODO(kkysen) remove when we use this
     pub const fn alpha(&self) -> i16 {
         self.abcd[0]
     }
 
+    #[allow(dead_code)] // TODO(kkysen) remove when we use this
     pub const fn beta(&self) -> i16 {
         self.abcd[1]
     }
 
+    #[allow(dead_code)] // TODO(kkysen) remove when we use this
     pub const fn gamma(&self) -> i16 {
         self.abcd[2]
     }
 
+    #[allow(dead_code)] // TODO(kkysen) remove when we use this
     pub const fn delta(&self) -> i16 {
         self.abcd[3]
     }
@@ -207,17 +211,17 @@ pub const DAV1D_COLOR_PRI_UNKNOWN: Dav1dColorPrimaries = 2;
 pub const DAV1D_COLOR_PRI_BT709: Dav1dColorPrimaries = 1;
 
 pub(crate) type Rav1dColorPrimaries = c_uint;
-pub(crate) const RAV1D_COLOR_PRI_RESERVED: Rav1dColorPrimaries = DAV1D_COLOR_PRI_RESERVED;
-pub(crate) const RAV1D_COLOR_PRI_EBU3213: Rav1dColorPrimaries = DAV1D_COLOR_PRI_EBU3213;
-pub(crate) const RAV1D_COLOR_PRI_SMPTE432: Rav1dColorPrimaries = DAV1D_COLOR_PRI_SMPTE432;
-pub(crate) const RAV1D_COLOR_PRI_SMPTE431: Rav1dColorPrimaries = DAV1D_COLOR_PRI_SMPTE431;
-pub(crate) const RAV1D_COLOR_PRI_XYZ: Rav1dColorPrimaries = DAV1D_COLOR_PRI_XYZ;
-pub(crate) const RAV1D_COLOR_PRI_BT2020: Rav1dColorPrimaries = DAV1D_COLOR_PRI_BT2020;
-pub(crate) const RAV1D_COLOR_PRI_FILM: Rav1dColorPrimaries = DAV1D_COLOR_PRI_FILM;
-pub(crate) const RAV1D_COLOR_PRI_SMPTE240: Rav1dColorPrimaries = DAV1D_COLOR_PRI_SMPTE240;
-pub(crate) const RAV1D_COLOR_PRI_BT601: Rav1dColorPrimaries = DAV1D_COLOR_PRI_BT601;
-pub(crate) const RAV1D_COLOR_PRI_BT470BG: Rav1dColorPrimaries = DAV1D_COLOR_PRI_BT470BG;
-pub(crate) const RAV1D_COLOR_PRI_BT470M: Rav1dColorPrimaries = DAV1D_COLOR_PRI_BT470M;
+pub(crate) const _RAV1D_COLOR_PRI_RESERVED: Rav1dColorPrimaries = DAV1D_COLOR_PRI_RESERVED;
+pub(crate) const _RAV1D_COLOR_PRI_EBU3213: Rav1dColorPrimaries = DAV1D_COLOR_PRI_EBU3213;
+pub(crate) const _RAV1D_COLOR_PRI_SMPTE432: Rav1dColorPrimaries = DAV1D_COLOR_PRI_SMPTE432;
+pub(crate) const _RAV1D_COLOR_PRI_SMPTE431: Rav1dColorPrimaries = DAV1D_COLOR_PRI_SMPTE431;
+pub(crate) const _RAV1D_COLOR_PRI_XYZ: Rav1dColorPrimaries = DAV1D_COLOR_PRI_XYZ;
+pub(crate) const _RAV1D_COLOR_PRI_BT2020: Rav1dColorPrimaries = DAV1D_COLOR_PRI_BT2020;
+pub(crate) const _RAV1D_COLOR_PRI_FILM: Rav1dColorPrimaries = DAV1D_COLOR_PRI_FILM;
+pub(crate) const _RAV1D_COLOR_PRI_SMPTE240: Rav1dColorPrimaries = DAV1D_COLOR_PRI_SMPTE240;
+pub(crate) const _RAV1D_COLOR_PRI_BT601: Rav1dColorPrimaries = DAV1D_COLOR_PRI_BT601;
+pub(crate) const _RAV1D_COLOR_PRI_BT470BG: Rav1dColorPrimaries = DAV1D_COLOR_PRI_BT470BG;
+pub(crate) const _RAV1D_COLOR_PRI_BT470M: Rav1dColorPrimaries = DAV1D_COLOR_PRI_BT470M;
 pub(crate) const RAV1D_COLOR_PRI_UNKNOWN: Rav1dColorPrimaries = DAV1D_COLOR_PRI_UNKNOWN;
 pub(crate) const RAV1D_COLOR_PRI_BT709: Rav1dColorPrimaries = DAV1D_COLOR_PRI_BT709;
 
@@ -242,24 +246,24 @@ pub const DAV1D_TRC_UNKNOWN: Dav1dTransferCharacteristics = 2;
 pub const DAV1D_TRC_BT709: Dav1dTransferCharacteristics = 1;
 
 pub(crate) type Rav1dTransferCharacteristics = c_uint;
-pub(crate) const RAV1D_TRC_RESERVED: Rav1dTransferCharacteristics = DAV1D_TRC_RESERVED;
-pub(crate) const RAV1D_TRC_HLG: Rav1dTransferCharacteristics = DAV1D_TRC_HLG;
-pub(crate) const RAV1D_TRC_SMPTE428: Rav1dTransferCharacteristics = DAV1D_TRC_SMPTE428;
-pub(crate) const RAV1D_TRC_SMPTE2084: Rav1dTransferCharacteristics = DAV1D_TRC_SMPTE2084;
-pub(crate) const RAV1D_TRC_BT2020_12BIT: Rav1dTransferCharacteristics = DAV1D_TRC_BT2020_12BIT;
-pub(crate) const RAV1D_TRC_BT2020_10BIT: Rav1dTransferCharacteristics = DAV1D_TRC_BT2020_10BIT;
+pub(crate) const _RAV1D_TRC_RESERVED: Rav1dTransferCharacteristics = DAV1D_TRC_RESERVED;
+pub(crate) const _RAV1D_TRC_HLG: Rav1dTransferCharacteristics = DAV1D_TRC_HLG;
+pub(crate) const _RAV1D_TRC_SMPTE428: Rav1dTransferCharacteristics = DAV1D_TRC_SMPTE428;
+pub(crate) const _RAV1D_TRC_SMPTE2084: Rav1dTransferCharacteristics = DAV1D_TRC_SMPTE2084;
+pub(crate) const _RAV1D_TRC_BT2020_12BIT: Rav1dTransferCharacteristics = DAV1D_TRC_BT2020_12BIT;
+pub(crate) const _RAV1D_TRC_BT2020_10BIT: Rav1dTransferCharacteristics = DAV1D_TRC_BT2020_10BIT;
 pub(crate) const RAV1D_TRC_SRGB: Rav1dTransferCharacteristics = DAV1D_TRC_SRGB;
-pub(crate) const RAV1D_TRC_BT1361: Rav1dTransferCharacteristics = DAV1D_TRC_BT1361;
-pub(crate) const RAV1D_TRC_IEC61966: Rav1dTransferCharacteristics = DAV1D_TRC_IEC61966;
-pub(crate) const RAV1D_TRC_LOG100_SQRT10: Rav1dTransferCharacteristics = DAV1D_TRC_LOG100_SQRT10;
-pub(crate) const RAV1D_TRC_LOG100: Rav1dTransferCharacteristics = DAV1D_TRC_LOG100;
-pub(crate) const RAV1D_TRC_LINEAR: Rav1dTransferCharacteristics = DAV1D_TRC_LINEAR;
-pub(crate) const RAV1D_TRC_SMPTE240: Rav1dTransferCharacteristics = DAV1D_TRC_SMPTE240;
-pub(crate) const RAV1D_TRC_BT601: Rav1dTransferCharacteristics = DAV1D_TRC_BT601;
-pub(crate) const RAV1D_TRC_BT470BG: Rav1dTransferCharacteristics = DAV1D_TRC_BT470BG;
-pub(crate) const RAV1D_TRC_BT470M: Rav1dTransferCharacteristics = DAV1D_TRC_BT470M;
+pub(crate) const _RAV1D_TRC_BT1361: Rav1dTransferCharacteristics = DAV1D_TRC_BT1361;
+pub(crate) const _RAV1D_TRC_IEC61966: Rav1dTransferCharacteristics = DAV1D_TRC_IEC61966;
+pub(crate) const _RAV1D_TRC_LOG100_SQRT10: Rav1dTransferCharacteristics = DAV1D_TRC_LOG100_SQRT10;
+pub(crate) const _RAV1D_TRC_LOG100: Rav1dTransferCharacteristics = DAV1D_TRC_LOG100;
+pub(crate) const _RAV1D_TRC_LINEAR: Rav1dTransferCharacteristics = DAV1D_TRC_LINEAR;
+pub(crate) const _RAV1D_TRC_SMPTE240: Rav1dTransferCharacteristics = DAV1D_TRC_SMPTE240;
+pub(crate) const _RAV1D_TRC_BT601: Rav1dTransferCharacteristics = DAV1D_TRC_BT601;
+pub(crate) const _RAV1D_TRC_BT470BG: Rav1dTransferCharacteristics = DAV1D_TRC_BT470BG;
+pub(crate) const _RAV1D_TRC_BT470M: Rav1dTransferCharacteristics = DAV1D_TRC_BT470M;
 pub(crate) const RAV1D_TRC_UNKNOWN: Rav1dTransferCharacteristics = DAV1D_TRC_UNKNOWN;
-pub(crate) const RAV1D_TRC_BT709: Rav1dTransferCharacteristics = DAV1D_TRC_BT709;
+pub(crate) const _RAV1D_TRC_BT709: Rav1dTransferCharacteristics = DAV1D_TRC_BT709;
 
 pub type Dav1dMatrixCoefficients = c_uint;
 pub const DAV1D_MC_RESERVED: Dav1dMatrixCoefficients = 255;
@@ -279,20 +283,20 @@ pub const DAV1D_MC_BT709: Dav1dMatrixCoefficients = 1;
 pub const DAV1D_MC_IDENTITY: Dav1dMatrixCoefficients = 0;
 
 pub(crate) type Rav1dMatrixCoefficients = c_uint;
-pub(crate) const RAV1D_MC_RESERVED: Rav1dMatrixCoefficients = DAV1D_MC_RESERVED;
-pub(crate) const RAV1D_MC_ICTCP: Rav1dMatrixCoefficients = DAV1D_MC_ICTCP;
-pub(crate) const RAV1D_MC_CHROMAT_CL: Rav1dMatrixCoefficients = DAV1D_MC_CHROMAT_CL;
-pub(crate) const RAV1D_MC_CHROMAT_NCL: Rav1dMatrixCoefficients = DAV1D_MC_CHROMAT_NCL;
-pub(crate) const RAV1D_MC_SMPTE2085: Rav1dMatrixCoefficients = DAV1D_MC_SMPTE2085;
-pub(crate) const RAV1D_MC_BT2020_CL: Rav1dMatrixCoefficients = DAV1D_MC_BT2020_CL;
-pub(crate) const RAV1D_MC_BT2020_NCL: Rav1dMatrixCoefficients = DAV1D_MC_BT2020_NCL;
-pub(crate) const RAV1D_MC_SMPTE_YCGCO: Rav1dMatrixCoefficients = DAV1D_MC_SMPTE_YCGCO;
-pub(crate) const RAV1D_MC_SMPTE240: Rav1dMatrixCoefficients = DAV1D_MC_SMPTE240;
-pub(crate) const RAV1D_MC_BT601: Rav1dMatrixCoefficients = DAV1D_MC_BT601;
-pub(crate) const RAV1D_MC_BT470BG: Rav1dMatrixCoefficients = DAV1D_MC_BT470BG;
-pub(crate) const RAV1D_MC_FCC: Rav1dMatrixCoefficients = DAV1D_MC_FCC;
+pub(crate) const _RAV1D_MC_RESERVED: Rav1dMatrixCoefficients = DAV1D_MC_RESERVED;
+pub(crate) const _RAV1D_MC_ICTCP: Rav1dMatrixCoefficients = DAV1D_MC_ICTCP;
+pub(crate) const _RAV1D_MC_CHROMAT_CL: Rav1dMatrixCoefficients = DAV1D_MC_CHROMAT_CL;
+pub(crate) const _RAV1D_MC_CHROMAT_NCL: Rav1dMatrixCoefficients = DAV1D_MC_CHROMAT_NCL;
+pub(crate) const _RAV1D_MC_SMPTE2085: Rav1dMatrixCoefficients = DAV1D_MC_SMPTE2085;
+pub(crate) const _RAV1D_MC_BT2020_CL: Rav1dMatrixCoefficients = DAV1D_MC_BT2020_CL;
+pub(crate) const _RAV1D_MC_BT2020_NCL: Rav1dMatrixCoefficients = DAV1D_MC_BT2020_NCL;
+pub(crate) const _RAV1D_MC_SMPTE_YCGCO: Rav1dMatrixCoefficients = DAV1D_MC_SMPTE_YCGCO;
+pub(crate) const _RAV1D_MC_SMPTE240: Rav1dMatrixCoefficients = DAV1D_MC_SMPTE240;
+pub(crate) const _RAV1D_MC_BT601: Rav1dMatrixCoefficients = DAV1D_MC_BT601;
+pub(crate) const _RAV1D_MC_BT470BG: Rav1dMatrixCoefficients = DAV1D_MC_BT470BG;
+pub(crate) const _RAV1D_MC_FCC: Rav1dMatrixCoefficients = DAV1D_MC_FCC;
 pub(crate) const RAV1D_MC_UNKNOWN: Rav1dMatrixCoefficients = DAV1D_MC_UNKNOWN;
-pub(crate) const RAV1D_MC_BT709: Rav1dMatrixCoefficients = DAV1D_MC_BT709;
+pub(crate) const _RAV1D_MC_BT709: Rav1dMatrixCoefficients = DAV1D_MC_BT709;
 pub(crate) const RAV1D_MC_IDENTITY: Rav1dMatrixCoefficients = DAV1D_MC_IDENTITY;
 
 pub type Dav1dChromaSamplePosition = c_uint;
@@ -301,8 +305,8 @@ pub const DAV1D_CHR_VERTICAL: Dav1dChromaSamplePosition = 1;
 pub const DAV1D_CHR_UNKNOWN: Dav1dChromaSamplePosition = 0;
 
 pub(crate) type Rav1dChromaSamplePosition = c_uint;
-pub(crate) const RAV1D_CHR_COLOCATED: Rav1dChromaSamplePosition = DAV1D_CHR_COLOCATED;
-pub(crate) const RAV1D_CHR_VERTICAL: Rav1dChromaSamplePosition = DAV1D_CHR_VERTICAL;
+pub(crate) const _RAV1D_CHR_COLOCATED: Rav1dChromaSamplePosition = DAV1D_CHR_COLOCATED;
+pub(crate) const _RAV1D_CHR_VERTICAL: Rav1dChromaSamplePosition = DAV1D_CHR_VERTICAL;
 pub(crate) const RAV1D_CHR_UNKNOWN: Rav1dChromaSamplePosition = DAV1D_CHR_UNKNOWN;
 
 // Constants from Section 3. "Symbols and abbreviated terms"
@@ -317,6 +321,7 @@ pub struct Dav1dContentLightLevel {
 }
 
 impl Dav1dContentLightLevel {
+    #[allow(dead_code)] // TODO(kkysen) remove when we use this
     pub(crate) fn into_rust(self) -> Rav1dContentLightLevel {
         let Self {
             max_content_light_level,
@@ -336,6 +341,7 @@ pub(crate) struct Rav1dContentLightLevel {
 }
 
 impl Rav1dContentLightLevel {
+    #[allow(dead_code)] // TODO(kkysen) remove when we use this
     pub fn into_c(self) -> Dav1dContentLightLevel {
         let Self {
             max_content_light_level,
@@ -357,6 +363,7 @@ pub struct Dav1dMasteringDisplay {
 }
 
 impl Dav1dMasteringDisplay {
+    #[allow(dead_code)] // TODO(kkysen) remove when we use this
     pub(crate) fn into_rust(self) -> Rav1dMasteringDisplay {
         let Self {
             primaries,
@@ -382,6 +389,7 @@ pub(crate) struct Rav1dMasteringDisplay {
 }
 
 impl Rav1dMasteringDisplay {
+    #[allow(dead_code)] // TODO(kkysen) remove when we use this
     pub fn into_c(self) -> Dav1dMasteringDisplay {
         let Self {
             primaries,
@@ -407,6 +415,7 @@ pub struct Dav1dITUTT35 {
 }
 
 impl Dav1dITUTT35 {
+    #[allow(dead_code)] // TODO(kkysen) remove when we use this
     pub(crate) fn into_rust(self) -> Rav1dITUTT35 {
         let Self {
             country_code,
@@ -432,6 +441,7 @@ pub(crate) struct Rav1dITUTT35 {
 }
 
 impl Rav1dITUTT35 {
+    #[allow(dead_code)] // TODO(kkysen) remove when we use this
     pub fn into_c(self) -> Dav1dITUTT35 {
         let Self {
             country_code,
@@ -2036,6 +2046,7 @@ pub(crate) struct Rav1dFrameHeader {
 }
 
 impl Rav1dFrameHeader {
+    #[allow(dead_code)] // TODO(kkysen) remove when we use this
     pub fn into_c(self) -> Dav1dFrameHeader {
         let Self {
             film_grain,

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -111,21 +111,6 @@ impl Dav1dWarpedMotionParams {
     }
 }
 
-impl Dav1dWarpedMotionParams {
-    pub(crate) fn into_rust(self) -> Rav1dWarpedMotionParams {
-        let Self {
-            type_0,
-            matrix,
-            abcd,
-        } = self;
-        Rav1dWarpedMotionParams {
-            type_0,
-            matrix,
-            abcd,
-        }
-    }
-}
-
 #[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dWarpedMotionParams {
@@ -153,6 +138,21 @@ impl Rav1dWarpedMotionParams {
     #[allow(dead_code)] // TODO(kkysen) remove when we use this
     pub const fn delta(&self) -> i16 {
         self.abcd[3]
+    }
+}
+
+impl From<Dav1dWarpedMotionParams> for Rav1dWarpedMotionParams {
+    fn from(value: Dav1dWarpedMotionParams) -> Self {
+        let Dav1dWarpedMotionParams {
+            type_0,
+            matrix,
+            abcd,
+        } = value;
+        Self {
+            type_0,
+            matrix,
+            abcd,
+        }
     }
 }
 
@@ -320,24 +320,23 @@ pub struct Dav1dContentLightLevel {
     pub max_frame_average_light_level: c_int,
 }
 
-impl Dav1dContentLightLevel {
-    #[allow(dead_code)] // TODO(kkysen) remove when we use this
-    pub(crate) fn into_rust(self) -> Rav1dContentLightLevel {
-        let Self {
-            max_content_light_level,
-            max_frame_average_light_level,
-        } = self;
-        Rav1dContentLightLevel {
-            max_content_light_level,
-            max_frame_average_light_level,
-        }
-    }
-}
-
 #[repr(C)]
 pub(crate) struct Rav1dContentLightLevel {
     pub max_content_light_level: c_int,
     pub max_frame_average_light_level: c_int,
+}
+
+impl From<Dav1dContentLightLevel> for Rav1dContentLightLevel {
+    fn from(value: Dav1dContentLightLevel) -> Self {
+        let Dav1dContentLightLevel {
+            max_content_light_level,
+            max_frame_average_light_level,
+        } = value;
+        Self {
+            max_content_light_level,
+            max_frame_average_light_level,
+        }
+    }
 }
 
 impl Rav1dContentLightLevel {
@@ -362,30 +361,29 @@ pub struct Dav1dMasteringDisplay {
     pub min_luminance: u32,
 }
 
-impl Dav1dMasteringDisplay {
-    #[allow(dead_code)] // TODO(kkysen) remove when we use this
-    pub(crate) fn into_rust(self) -> Rav1dMasteringDisplay {
-        let Self {
-            primaries,
-            white_point,
-            max_luminance,
-            min_luminance,
-        } = self;
-        Rav1dMasteringDisplay {
-            primaries,
-            white_point,
-            max_luminance,
-            min_luminance,
-        }
-    }
-}
-
 #[repr(C)]
 pub(crate) struct Rav1dMasteringDisplay {
     pub primaries: [[u16; 2]; 3],
     pub white_point: [u16; 2],
     pub max_luminance: u32,
     pub min_luminance: u32,
+}
+
+impl From<Dav1dMasteringDisplay> for Rav1dMasteringDisplay {
+    fn from(value: Dav1dMasteringDisplay) -> Self {
+        let Dav1dMasteringDisplay {
+            primaries,
+            white_point,
+            max_luminance,
+            min_luminance,
+        } = value;
+        Self {
+            primaries,
+            white_point,
+            max_luminance,
+            min_luminance,
+        }
+    }
 }
 
 impl Rav1dMasteringDisplay {
@@ -414,30 +412,29 @@ pub struct Dav1dITUTT35 {
     pub payload: *mut u8,
 }
 
-impl Dav1dITUTT35 {
-    #[allow(dead_code)] // TODO(kkysen) remove when we use this
-    pub(crate) fn into_rust(self) -> Rav1dITUTT35 {
-        let Self {
-            country_code,
-            country_code_extension_byte,
-            payload_size,
-            payload,
-        } = self;
-        Rav1dITUTT35 {
-            country_code,
-            country_code_extension_byte,
-            payload_size,
-            payload,
-        }
-    }
-}
-
 #[repr(C)]
 pub(crate) struct Rav1dITUTT35 {
     pub country_code: u8,
     pub country_code_extension_byte: u8,
     pub payload_size: usize,
     pub payload: *mut u8,
+}
+
+impl From<Dav1dITUTT35> for Rav1dITUTT35 {
+    fn from(value: Dav1dITUTT35) -> Self {
+        let Dav1dITUTT35 {
+            country_code,
+            country_code_extension_byte,
+            payload_size,
+            payload,
+        } = value;
+        Self {
+            country_code,
+            country_code_extension_byte,
+            payload_size,
+            payload,
+        }
+    }
 }
 
 impl Rav1dITUTT35 {
@@ -470,29 +467,6 @@ pub struct Dav1dSequenceHeaderOperatingPoint {
     pub display_model_param_present: c_int,
 }
 
-impl Dav1dSequenceHeaderOperatingPoint {
-    pub(crate) fn into_rust(self) -> Rav1dSequenceHeaderOperatingPoint {
-        let Self {
-            major_level,
-            minor_level,
-            initial_display_delay,
-            idc,
-            tier,
-            decoder_model_param_present,
-            display_model_param_present,
-        } = self;
-        Rav1dSequenceHeaderOperatingPoint {
-            major_level,
-            minor_level,
-            initial_display_delay,
-            idc,
-            tier,
-            decoder_model_param_present,
-            display_model_param_present,
-        }
-    }
-}
-
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub(crate) struct Rav1dSequenceHeaderOperatingPoint {
@@ -503,6 +477,29 @@ pub(crate) struct Rav1dSequenceHeaderOperatingPoint {
     pub tier: c_int,
     pub decoder_model_param_present: c_int,
     pub display_model_param_present: c_int,
+}
+
+impl From<Dav1dSequenceHeaderOperatingPoint> for Rav1dSequenceHeaderOperatingPoint {
+    fn from(value: Dav1dSequenceHeaderOperatingPoint) -> Self {
+        let Dav1dSequenceHeaderOperatingPoint {
+            major_level,
+            minor_level,
+            initial_display_delay,
+            idc,
+            tier,
+            decoder_model_param_present,
+            display_model_param_present,
+        } = value;
+        Self {
+            major_level,
+            minor_level,
+            initial_display_delay,
+            idc,
+            tier,
+            decoder_model_param_present,
+            display_model_param_present,
+        }
+    }
 }
 
 impl Rav1dSequenceHeaderOperatingPoint {
@@ -536,27 +533,27 @@ pub struct Dav1dSequenceHeaderOperatingParameterInfo {
     pub low_delay_mode: c_int,
 }
 
-impl Dav1dSequenceHeaderOperatingParameterInfo {
-    pub(crate) fn into_rust(self) -> Rav1dSequenceHeaderOperatingParameterInfo {
-        let Self {
-            decoder_buffer_delay,
-            encoder_buffer_delay,
-            low_delay_mode,
-        } = self;
-        Rav1dSequenceHeaderOperatingParameterInfo {
-            decoder_buffer_delay,
-            encoder_buffer_delay,
-            low_delay_mode,
-        }
-    }
-}
-
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub(crate) struct Rav1dSequenceHeaderOperatingParameterInfo {
     pub decoder_buffer_delay: c_int,
     pub encoder_buffer_delay: c_int,
     pub low_delay_mode: c_int,
+}
+
+impl From<Dav1dSequenceHeaderOperatingParameterInfo> for Rav1dSequenceHeaderOperatingParameterInfo {
+    fn from(value: Dav1dSequenceHeaderOperatingParameterInfo) -> Self {
+        let Dav1dSequenceHeaderOperatingParameterInfo {
+            decoder_buffer_delay,
+            encoder_buffer_delay,
+            low_delay_mode,
+        } = value;
+        Self {
+            decoder_buffer_delay,
+            encoder_buffer_delay,
+            low_delay_mode,
+        }
+    }
 }
 
 impl Rav1dSequenceHeaderOperatingParameterInfo {
@@ -631,121 +628,6 @@ pub struct Dav1dSequenceHeader {
     pub operating_parameter_info: [Dav1dSequenceHeaderOperatingParameterInfo; 32],
 }
 
-impl Dav1dSequenceHeader {
-    pub(crate) fn into_rust(self) -> Rav1dSequenceHeader {
-        let Self {
-            profile,
-            max_width,
-            max_height,
-            layout,
-            pri,
-            trc,
-            mtrx,
-            chr,
-            hbd,
-            color_range,
-            num_operating_points,
-            operating_points,
-            still_picture,
-            reduced_still_picture_header,
-            timing_info_present,
-            num_units_in_tick,
-            time_scale,
-            equal_picture_interval,
-            num_ticks_per_picture,
-            decoder_model_info_present,
-            encoder_decoder_buffer_delay_length,
-            num_units_in_decoding_tick,
-            buffer_removal_delay_length,
-            frame_presentation_delay_length,
-            display_model_info_present,
-            width_n_bits,
-            height_n_bits,
-            frame_id_numbers_present,
-            delta_frame_id_n_bits,
-            frame_id_n_bits,
-            sb128,
-            filter_intra,
-            intra_edge_filter,
-            inter_intra,
-            masked_compound,
-            warped_motion,
-            dual_filter,
-            order_hint,
-            jnt_comp,
-            ref_frame_mvs,
-            screen_content_tools,
-            force_integer_mv,
-            order_hint_n_bits,
-            super_res,
-            cdef,
-            restoration,
-            ss_hor,
-            ss_ver,
-            monochrome,
-            color_description_present,
-            separate_uv_delta_q,
-            film_grain_present,
-            operating_parameter_info,
-        } = self;
-        Rav1dSequenceHeader {
-            profile,
-            max_width,
-            max_height,
-            layout,
-            pri,
-            trc,
-            mtrx,
-            chr,
-            hbd,
-            color_range,
-            num_operating_points,
-            operating_points: operating_points.map(|c| c.into_rust()),
-            still_picture,
-            reduced_still_picture_header,
-            timing_info_present,
-            num_units_in_tick,
-            time_scale,
-            equal_picture_interval,
-            num_ticks_per_picture,
-            decoder_model_info_present,
-            encoder_decoder_buffer_delay_length,
-            num_units_in_decoding_tick,
-            buffer_removal_delay_length,
-            frame_presentation_delay_length,
-            display_model_info_present,
-            width_n_bits,
-            height_n_bits,
-            frame_id_numbers_present,
-            delta_frame_id_n_bits,
-            frame_id_n_bits,
-            sb128,
-            filter_intra,
-            intra_edge_filter,
-            inter_intra,
-            masked_compound,
-            warped_motion,
-            dual_filter,
-            order_hint,
-            jnt_comp,
-            ref_frame_mvs,
-            screen_content_tools,
-            force_integer_mv,
-            order_hint_n_bits,
-            super_res,
-            cdef,
-            restoration,
-            ss_hor,
-            ss_ver,
-            monochrome,
-            color_description_present,
-            separate_uv_delta_q,
-            film_grain_present,
-            operating_parameter_info: operating_parameter_info.map(|c| c.into_rust()),
-        }
-    }
-}
-
 #[repr(C)]
 pub(crate) struct Rav1dSequenceHeader {
     pub profile: c_int,
@@ -801,6 +683,121 @@ pub(crate) struct Rav1dSequenceHeader {
     pub separate_uv_delta_q: c_int,
     pub film_grain_present: c_int,
     pub operating_parameter_info: [Rav1dSequenceHeaderOperatingParameterInfo; 32],
+}
+
+impl From<Dav1dSequenceHeader> for Rav1dSequenceHeader {
+    fn from(value: Dav1dSequenceHeader) -> Self {
+        let Dav1dSequenceHeader {
+            profile,
+            max_width,
+            max_height,
+            layout,
+            pri,
+            trc,
+            mtrx,
+            chr,
+            hbd,
+            color_range,
+            num_operating_points,
+            operating_points,
+            still_picture,
+            reduced_still_picture_header,
+            timing_info_present,
+            num_units_in_tick,
+            time_scale,
+            equal_picture_interval,
+            num_ticks_per_picture,
+            decoder_model_info_present,
+            encoder_decoder_buffer_delay_length,
+            num_units_in_decoding_tick,
+            buffer_removal_delay_length,
+            frame_presentation_delay_length,
+            display_model_info_present,
+            width_n_bits,
+            height_n_bits,
+            frame_id_numbers_present,
+            delta_frame_id_n_bits,
+            frame_id_n_bits,
+            sb128,
+            filter_intra,
+            intra_edge_filter,
+            inter_intra,
+            masked_compound,
+            warped_motion,
+            dual_filter,
+            order_hint,
+            jnt_comp,
+            ref_frame_mvs,
+            screen_content_tools,
+            force_integer_mv,
+            order_hint_n_bits,
+            super_res,
+            cdef,
+            restoration,
+            ss_hor,
+            ss_ver,
+            monochrome,
+            color_description_present,
+            separate_uv_delta_q,
+            film_grain_present,
+            operating_parameter_info,
+        } = value;
+        Self {
+            profile,
+            max_width,
+            max_height,
+            layout,
+            pri,
+            trc,
+            mtrx,
+            chr,
+            hbd,
+            color_range,
+            num_operating_points,
+            operating_points: operating_points.map(|c| c.into()),
+            still_picture,
+            reduced_still_picture_header,
+            timing_info_present,
+            num_units_in_tick,
+            time_scale,
+            equal_picture_interval,
+            num_ticks_per_picture,
+            decoder_model_info_present,
+            encoder_decoder_buffer_delay_length,
+            num_units_in_decoding_tick,
+            buffer_removal_delay_length,
+            frame_presentation_delay_length,
+            display_model_info_present,
+            width_n_bits,
+            height_n_bits,
+            frame_id_numbers_present,
+            delta_frame_id_n_bits,
+            frame_id_n_bits,
+            sb128,
+            filter_intra,
+            intra_edge_filter,
+            inter_intra,
+            masked_compound,
+            warped_motion,
+            dual_filter,
+            order_hint,
+            jnt_comp,
+            ref_frame_mvs,
+            screen_content_tools,
+            force_integer_mv,
+            order_hint_n_bits,
+            super_res,
+            cdef,
+            restoration,
+            ss_hor,
+            ss_ver,
+            monochrome,
+            color_description_present,
+            separate_uv_delta_q,
+            film_grain_present,
+            operating_parameter_info: operating_parameter_info.map(|c| c.into()),
+        }
+    }
 }
 
 impl Rav1dSequenceHeader {
@@ -931,31 +928,6 @@ pub struct Dav1dSegmentationData {
     pub globalmv: c_int,
 }
 
-impl Dav1dSegmentationData {
-    pub(crate) fn into_rust(self) -> Rav1dSegmentationData {
-        let Self {
-            delta_q,
-            delta_lf_y_v,
-            delta_lf_y_h,
-            delta_lf_u,
-            delta_lf_v,
-            r#ref,
-            skip,
-            globalmv,
-        } = self;
-        Rav1dSegmentationData {
-            delta_q,
-            delta_lf_y_v,
-            delta_lf_y_h,
-            delta_lf_u,
-            delta_lf_v,
-            r#ref,
-            skip,
-            globalmv,
-        }
-    }
-}
-
 #[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dSegmentationData {
@@ -967,6 +939,31 @@ pub(crate) struct Rav1dSegmentationData {
     pub r#ref: c_int,
     pub skip: c_int,
     pub globalmv: c_int,
+}
+
+impl From<Dav1dSegmentationData> for Rav1dSegmentationData {
+    fn from(value: Dav1dSegmentationData) -> Self {
+        let Dav1dSegmentationData {
+            delta_q,
+            delta_lf_y_v,
+            delta_lf_y_h,
+            delta_lf_u,
+            delta_lf_v,
+            r#ref,
+            skip,
+            globalmv,
+        } = value;
+        Self {
+            delta_q,
+            delta_lf_y_v,
+            delta_lf_y_h,
+            delta_lf_u,
+            delta_lf_v,
+            r#ref,
+            skip,
+            globalmv,
+        }
+    }
 }
 
 impl Rav1dSegmentationData {
@@ -1002,27 +999,27 @@ pub struct Dav1dSegmentationDataSet {
     pub last_active_segid: c_int,
 }
 
-impl Dav1dSegmentationDataSet {
-    pub(crate) fn into_rust(self) -> Rav1dSegmentationDataSet {
-        let Self {
-            d,
-            preskip,
-            last_active_segid,
-        } = self;
-        Rav1dSegmentationDataSet {
-            d: d.map(|c| c.into_rust()),
-            preskip,
-            last_active_segid,
-        }
-    }
-}
-
 #[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dSegmentationDataSet {
     pub d: [Rav1dSegmentationData; 8],
     pub preskip: c_int,
     pub last_active_segid: c_int,
+}
+
+impl From<Dav1dSegmentationDataSet> for Rav1dSegmentationDataSet {
+    fn from(value: Dav1dSegmentationDataSet) -> Self {
+        let Dav1dSegmentationDataSet {
+            d,
+            preskip,
+            last_active_segid,
+        } = value;
+        Self {
+            d: d.map(|c| c.into()),
+            preskip,
+            last_active_segid,
+        }
+    }
 }
 
 impl Rav1dSegmentationDataSet {
@@ -1047,24 +1044,24 @@ pub struct Dav1dLoopfilterModeRefDeltas {
     pub ref_delta: [c_int; 8],
 }
 
-impl Dav1dLoopfilterModeRefDeltas {
-    pub(crate) fn into_rust(self) -> Rav1dLoopfilterModeRefDeltas {
-        let Self {
-            mode_delta,
-            ref_delta,
-        } = self;
-        Rav1dLoopfilterModeRefDeltas {
-            mode_delta,
-            ref_delta,
-        }
-    }
-}
-
 #[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dLoopfilterModeRefDeltas {
     pub mode_delta: [c_int; 2],
     pub ref_delta: [c_int; 8],
+}
+
+impl From<Dav1dLoopfilterModeRefDeltas> for Rav1dLoopfilterModeRefDeltas {
+    fn from(value: Dav1dLoopfilterModeRefDeltas) -> Self {
+        let Dav1dLoopfilterModeRefDeltas {
+            mode_delta,
+            ref_delta,
+        } = value;
+        Self {
+            mode_delta,
+            ref_delta,
+        }
+    }
 }
 
 impl Rav1dLoopfilterModeRefDeltas {
@@ -1102,49 +1099,6 @@ pub struct Dav1dFilmGrainData {
     pub clip_to_restricted_range: c_int,
 }
 
-impl Dav1dFilmGrainData {
-    pub(crate) fn into_rust(self) -> Rav1dFilmGrainData {
-        let Self {
-            seed,
-            num_y_points,
-            y_points,
-            chroma_scaling_from_luma,
-            num_uv_points,
-            uv_points,
-            scaling_shift,
-            ar_coeff_lag,
-            ar_coeffs_y,
-            ar_coeffs_uv,
-            ar_coeff_shift,
-            grain_scale_shift,
-            uv_mult,
-            uv_luma_mult,
-            uv_offset,
-            overlap_flag,
-            clip_to_restricted_range,
-        } = self;
-        Rav1dFilmGrainData {
-            seed,
-            num_y_points,
-            y_points,
-            chroma_scaling_from_luma,
-            num_uv_points,
-            uv_points,
-            scaling_shift,
-            ar_coeff_lag,
-            ar_coeffs_y,
-            ar_coeffs_uv,
-            ar_coeff_shift,
-            grain_scale_shift,
-            uv_mult,
-            uv_luma_mult,
-            uv_offset,
-            overlap_flag,
-            clip_to_restricted_range,
-        }
-    }
-}
-
 #[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dFilmGrainData {
@@ -1165,6 +1119,49 @@ pub(crate) struct Rav1dFilmGrainData {
     pub uv_offset: [c_int; 2],
     pub overlap_flag: c_int,
     pub clip_to_restricted_range: c_int,
+}
+
+impl From<Dav1dFilmGrainData> for Rav1dFilmGrainData {
+    fn from(value: Dav1dFilmGrainData) -> Self {
+        let Dav1dFilmGrainData {
+            seed,
+            num_y_points,
+            y_points,
+            chroma_scaling_from_luma,
+            num_uv_points,
+            uv_points,
+            scaling_shift,
+            ar_coeff_lag,
+            ar_coeffs_y,
+            ar_coeffs_uv,
+            ar_coeff_shift,
+            grain_scale_shift,
+            uv_mult,
+            uv_luma_mult,
+            uv_offset,
+            overlap_flag,
+            clip_to_restricted_range,
+        } = value;
+        Self {
+            seed,
+            num_y_points,
+            y_points,
+            chroma_scaling_from_luma,
+            num_uv_points,
+            uv_points,
+            scaling_shift,
+            ar_coeff_lag,
+            ar_coeffs_y,
+            ar_coeffs_uv,
+            ar_coeff_shift,
+            grain_scale_shift,
+            uv_mult,
+            uv_luma_mult,
+            uv_offset,
+            overlap_flag,
+            clip_to_restricted_range,
+        }
+    }
 }
 
 impl Rav1dFilmGrainData {
@@ -1217,26 +1214,26 @@ pub struct Dav1dFrameHeader_film_grain {
     pub update: c_int,
 }
 
-impl Dav1dFrameHeader_film_grain {
-    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_film_grain {
-        let Self {
-            data,
-            present,
-            update,
-        } = self;
-        Rav1dFrameHeader_film_grain {
-            data: data.into_rust(),
-            present,
-            update,
-        }
-    }
-}
-
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_film_grain {
     pub data: Rav1dFilmGrainData,
     pub present: c_int,
     pub update: c_int,
+}
+
+impl From<Dav1dFrameHeader_film_grain> for Rav1dFrameHeader_film_grain {
+    fn from(value: Dav1dFrameHeader_film_grain) -> Self {
+        let Dav1dFrameHeader_film_grain {
+            data,
+            present,
+            update,
+        } = value;
+        Self {
+            data: data.into(),
+            present,
+            update,
+        }
+    }
 }
 
 impl Rav1dFrameHeader_film_grain {
@@ -1259,20 +1256,20 @@ pub struct Dav1dFrameHeaderOperatingPoint {
     pub buffer_removal_time: c_int,
 }
 
-impl Dav1dFrameHeaderOperatingPoint {
-    pub(crate) fn into_rust(self) -> Rav1dFrameHeaderOperatingPoint {
-        let Self {
-            buffer_removal_time,
-        } = self;
-        Rav1dFrameHeaderOperatingPoint {
-            buffer_removal_time,
-        }
-    }
-}
-
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeaderOperatingPoint {
     pub buffer_removal_time: c_int,
+}
+
+impl From<Dav1dFrameHeaderOperatingPoint> for Rav1dFrameHeaderOperatingPoint {
+    fn from(value: Dav1dFrameHeaderOperatingPoint) -> Self {
+        let Dav1dFrameHeaderOperatingPoint {
+            buffer_removal_time,
+        } = value;
+        Self {
+            buffer_removal_time,
+        }
+    }
 }
 
 impl Rav1dFrameHeaderOperatingPoint {
@@ -1292,23 +1289,23 @@ pub struct Dav1dFrameHeader_super_res {
     pub enabled: c_int,
 }
 
-impl Dav1dFrameHeader_super_res {
-    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_super_res {
-        let Self {
-            width_scale_denominator,
-            enabled,
-        } = self;
-        Rav1dFrameHeader_super_res {
-            width_scale_denominator,
-            enabled,
-        }
-    }
-}
-
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_super_res {
     pub width_scale_denominator: c_int,
     pub enabled: c_int,
+}
+
+impl From<Dav1dFrameHeader_super_res> for Rav1dFrameHeader_super_res {
+    fn from(value: Dav1dFrameHeader_super_res) -> Self {
+        let Dav1dFrameHeader_super_res {
+            width_scale_denominator,
+            enabled,
+        } = value;
+        Self {
+            width_scale_denominator,
+            enabled,
+        }
+    }
 }
 
 impl Rav1dFrameHeader_super_res {
@@ -1341,41 +1338,6 @@ pub struct Dav1dFrameHeader_tiling {
     pub update: c_int,
 }
 
-impl Dav1dFrameHeader_tiling {
-    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_tiling {
-        let Self {
-            uniform,
-            n_bytes,
-            min_log2_cols,
-            max_log2_cols,
-            log2_cols,
-            cols,
-            min_log2_rows,
-            max_log2_rows,
-            log2_rows,
-            rows,
-            col_start_sb,
-            row_start_sb,
-            update,
-        } = self;
-        Rav1dFrameHeader_tiling {
-            uniform,
-            n_bytes,
-            min_log2_cols,
-            max_log2_cols,
-            log2_cols,
-            cols,
-            min_log2_rows,
-            max_log2_rows,
-            log2_rows,
-            rows,
-            col_start_sb,
-            row_start_sb,
-            update,
-        }
-    }
-}
-
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_tiling {
     pub uniform: c_int,
@@ -1391,6 +1353,41 @@ pub(crate) struct Rav1dFrameHeader_tiling {
     pub col_start_sb: [u16; 65],
     pub row_start_sb: [u16; 65],
     pub update: c_int,
+}
+
+impl From<Dav1dFrameHeader_tiling> for Rav1dFrameHeader_tiling {
+    fn from(value: Dav1dFrameHeader_tiling) -> Self {
+        let Dav1dFrameHeader_tiling {
+            uniform,
+            n_bytes,
+            min_log2_cols,
+            max_log2_cols,
+            log2_cols,
+            cols,
+            min_log2_rows,
+            max_log2_rows,
+            log2_rows,
+            rows,
+            col_start_sb,
+            row_start_sb,
+            update,
+        } = value;
+        Self {
+            uniform,
+            n_bytes,
+            min_log2_cols,
+            max_log2_cols,
+            log2_cols,
+            cols,
+            min_log2_rows,
+            max_log2_rows,
+            log2_rows,
+            rows,
+            col_start_sb,
+            row_start_sb,
+            update,
+        }
+    }
 }
 
 impl Rav1dFrameHeader_tiling {
@@ -1442,35 +1439,6 @@ pub struct Dav1dFrameHeader_quant {
     pub qm_v: c_int,
 }
 
-impl Dav1dFrameHeader_quant {
-    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_quant {
-        let Self {
-            yac,
-            ydc_delta,
-            udc_delta,
-            uac_delta,
-            vdc_delta,
-            vac_delta,
-            qm,
-            qm_y,
-            qm_u,
-            qm_v,
-        } = self;
-        Rav1dFrameHeader_quant {
-            yac,
-            ydc_delta,
-            udc_delta,
-            uac_delta,
-            vdc_delta,
-            vac_delta,
-            qm,
-            qm_y,
-            qm_u,
-            qm_v,
-        }
-    }
-}
-
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_quant {
     pub yac: c_int,
@@ -1483,6 +1451,35 @@ pub(crate) struct Rav1dFrameHeader_quant {
     pub qm_y: c_int,
     pub qm_u: c_int,
     pub qm_v: c_int,
+}
+
+impl From<Dav1dFrameHeader_quant> for Rav1dFrameHeader_quant {
+    fn from(value: Dav1dFrameHeader_quant) -> Self {
+        let Dav1dFrameHeader_quant {
+            yac,
+            ydc_delta,
+            udc_delta,
+            uac_delta,
+            vdc_delta,
+            vac_delta,
+            qm,
+            qm_y,
+            qm_u,
+            qm_v,
+        } = value;
+        Self {
+            yac,
+            ydc_delta,
+            udc_delta,
+            uac_delta,
+            vdc_delta,
+            vac_delta,
+            qm,
+            qm_y,
+            qm_u,
+            qm_v,
+        }
+    }
 }
 
 impl Rav1dFrameHeader_quant {
@@ -1525,29 +1522,6 @@ pub struct Dav1dFrameHeader_segmentation {
     pub qidx: [c_int; 8],
 }
 
-impl Dav1dFrameHeader_segmentation {
-    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_segmentation {
-        let Self {
-            enabled,
-            update_map,
-            temporal,
-            update_data,
-            seg_data,
-            lossless,
-            qidx,
-        } = self;
-        Rav1dFrameHeader_segmentation {
-            enabled,
-            update_map,
-            temporal,
-            update_data,
-            seg_data: seg_data.into_rust(),
-            lossless,
-            qidx,
-        }
-    }
-}
-
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_segmentation {
     pub enabled: c_int,
@@ -1557,6 +1531,29 @@ pub(crate) struct Rav1dFrameHeader_segmentation {
     pub seg_data: Rav1dSegmentationDataSet,
     pub lossless: [c_int; 8],
     pub qidx: [c_int; 8],
+}
+
+impl From<Dav1dFrameHeader_segmentation> for Rav1dFrameHeader_segmentation {
+    fn from(value: Dav1dFrameHeader_segmentation) -> Self {
+        let Dav1dFrameHeader_segmentation {
+            enabled,
+            update_map,
+            temporal,
+            update_data,
+            seg_data,
+            lossless,
+            qidx,
+        } = value;
+        Self {
+            enabled,
+            update_map,
+            temporal,
+            update_data,
+            seg_data: seg_data.into(),
+            lossless,
+            qidx,
+        }
+    }
 }
 
 impl Rav1dFrameHeader_segmentation {
@@ -1588,17 +1585,17 @@ pub struct Dav1dFrameHeader_delta_q {
     pub res_log2: c_int,
 }
 
-impl Dav1dFrameHeader_delta_q {
-    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_delta_q {
-        let Self { present, res_log2 } = self;
-        Rav1dFrameHeader_delta_q { present, res_log2 }
-    }
-}
-
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_delta_q {
     pub present: c_int,
     pub res_log2: c_int,
+}
+
+impl From<Dav1dFrameHeader_delta_q> for Rav1dFrameHeader_delta_q {
+    fn from(value: Dav1dFrameHeader_delta_q) -> Self {
+        let Dav1dFrameHeader_delta_q { present, res_log2 } = value;
+        Self { present, res_log2 }
+    }
 }
 
 impl Rav1dFrameHeader_delta_q {
@@ -1615,26 +1612,26 @@ pub struct Dav1dFrameHeader_delta_lf {
     pub multi: c_int,
 }
 
-impl Dav1dFrameHeader_delta_lf {
-    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_delta_lf {
-        let Self {
-            present,
-            res_log2,
-            multi,
-        } = self;
-        Rav1dFrameHeader_delta_lf {
-            present,
-            res_log2,
-            multi,
-        }
-    }
-}
-
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_delta_lf {
     pub present: c_int,
     pub res_log2: c_int,
     pub multi: c_int,
+}
+
+impl From<Dav1dFrameHeader_delta_lf> for Rav1dFrameHeader_delta_lf {
+    fn from(value: Dav1dFrameHeader_delta_lf) -> Self {
+        let Dav1dFrameHeader_delta_lf {
+            present,
+            res_log2,
+            multi,
+        } = value;
+        Self {
+            present,
+            res_log2,
+            multi,
+        }
+    }
 }
 
 impl Rav1dFrameHeader_delta_lf {
@@ -1658,20 +1655,20 @@ pub struct Dav1dFrameHeader_delta {
     pub lf: Dav1dFrameHeader_delta_lf,
 }
 
-impl Dav1dFrameHeader_delta {
-    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_delta {
-        let Self { q, lf } = self;
-        Rav1dFrameHeader_delta {
-            q: q.into_rust(),
-            lf: lf.into_rust(),
-        }
-    }
-}
-
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_delta {
     pub q: Rav1dFrameHeader_delta_q,
     pub lf: Rav1dFrameHeader_delta_lf,
+}
+
+impl From<Dav1dFrameHeader_delta> for Rav1dFrameHeader_delta {
+    fn from(value: Dav1dFrameHeader_delta) -> Self {
+        let Dav1dFrameHeader_delta { q, lf } = value;
+        Self {
+            q: q.into(),
+            lf: lf.into(),
+        }
+    }
 }
 
 impl Rav1dFrameHeader_delta {
@@ -1695,29 +1692,6 @@ pub struct Dav1dFrameHeader_loopfilter {
     pub sharpness: c_int,
 }
 
-impl Dav1dFrameHeader_loopfilter {
-    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_loopfilter {
-        let Self {
-            level_y,
-            level_u,
-            level_v,
-            mode_ref_delta_enabled,
-            mode_ref_delta_update,
-            mode_ref_deltas,
-            sharpness,
-        } = self;
-        Rav1dFrameHeader_loopfilter {
-            level_y,
-            level_u,
-            level_v,
-            mode_ref_delta_enabled,
-            mode_ref_delta_update,
-            mode_ref_deltas: mode_ref_deltas.into_rust(),
-            sharpness,
-        }
-    }
-}
-
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_loopfilter {
     pub level_y: [c_int; 2],
@@ -1727,6 +1701,29 @@ pub(crate) struct Rav1dFrameHeader_loopfilter {
     pub mode_ref_delta_update: c_int,
     pub mode_ref_deltas: Rav1dLoopfilterModeRefDeltas,
     pub sharpness: c_int,
+}
+
+impl From<Dav1dFrameHeader_loopfilter> for Rav1dFrameHeader_loopfilter {
+    fn from(value: Dav1dFrameHeader_loopfilter) -> Self {
+        let Dav1dFrameHeader_loopfilter {
+            level_y,
+            level_u,
+            level_v,
+            mode_ref_delta_enabled,
+            mode_ref_delta_update,
+            mode_ref_deltas,
+            sharpness,
+        } = value;
+        Self {
+            level_y,
+            level_u,
+            level_v,
+            mode_ref_delta_enabled,
+            mode_ref_delta_update,
+            mode_ref_deltas: mode_ref_deltas.into(),
+            sharpness,
+        }
+    }
 }
 
 impl Rav1dFrameHeader_loopfilter {
@@ -1760,29 +1757,29 @@ pub struct Dav1dFrameHeader_cdef {
     pub uv_strength: [c_int; 8],
 }
 
-impl Dav1dFrameHeader_cdef {
-    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_cdef {
-        let Self {
-            damping,
-            n_bits,
-            y_strength,
-            uv_strength,
-        } = self;
-        Rav1dFrameHeader_cdef {
-            damping,
-            n_bits,
-            y_strength,
-            uv_strength,
-        }
-    }
-}
-
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_cdef {
     pub damping: c_int,
     pub n_bits: c_int,
     pub y_strength: [c_int; 8],
     pub uv_strength: [c_int; 8],
+}
+
+impl From<Dav1dFrameHeader_cdef> for Rav1dFrameHeader_cdef {
+    fn from(value: Dav1dFrameHeader_cdef) -> Self {
+        let Dav1dFrameHeader_cdef {
+            damping,
+            n_bits,
+            y_strength,
+            uv_strength,
+        } = value;
+        Self {
+            damping,
+            n_bits,
+            y_strength,
+            uv_strength,
+        }
+    }
 }
 
 impl Rav1dFrameHeader_cdef {
@@ -1808,17 +1805,17 @@ pub struct Dav1dFrameHeader_restoration {
     pub unit_size: [c_int; 2],
 }
 
-impl Dav1dFrameHeader_restoration {
-    pub(crate) fn into_rust(self) -> Rav1dFrameHeader_restoration {
-        let Self { type_0, unit_size } = self;
-        Rav1dFrameHeader_restoration { type_0, unit_size }
-    }
-}
-
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_restoration {
     pub type_0: [Rav1dRestorationType; 3],
     pub unit_size: [c_int; 2],
+}
+
+impl From<Dav1dFrameHeader_restoration> for Rav1dFrameHeader_restoration {
+    fn from(value: Dav1dFrameHeader_restoration) -> Self {
+        let Dav1dFrameHeader_restoration { type_0, unit_size } = value;
+        Self { type_0, unit_size }
+    }
 }
 
 impl Rav1dFrameHeader_restoration {
@@ -1882,115 +1879,6 @@ pub struct Dav1dFrameHeader {
     pub gmv: [Dav1dWarpedMotionParams; 7],
 }
 
-impl Dav1dFrameHeader {
-    pub(crate) fn into_rust(self) -> Rav1dFrameHeader {
-        let Self {
-            film_grain,
-            frame_type,
-            width,
-            height,
-            frame_offset,
-            temporal_id,
-            spatial_id,
-            show_existing_frame,
-            existing_frame_idx,
-            frame_id,
-            frame_presentation_delay,
-            show_frame,
-            showable_frame,
-            error_resilient_mode,
-            disable_cdf_update,
-            allow_screen_content_tools,
-            force_integer_mv,
-            frame_size_override,
-            primary_ref_frame,
-            buffer_removal_time_present,
-            operating_points,
-            refresh_frame_flags,
-            render_width,
-            render_height,
-            super_res,
-            have_render_size,
-            allow_intrabc,
-            frame_ref_short_signaling,
-            refidx,
-            hp,
-            subpel_filter_mode,
-            switchable_motion_mode,
-            use_ref_frame_mvs,
-            refresh_context,
-            tiling,
-            quant,
-            segmentation,
-            delta,
-            all_lossless,
-            loopfilter,
-            cdef,
-            restoration,
-            txfm_mode,
-            switchable_comp_refs,
-            skip_mode_allowed,
-            skip_mode_enabled,
-            skip_mode_refs,
-            warp_motion,
-            reduced_txtp_set,
-            gmv,
-        } = self;
-        Rav1dFrameHeader {
-            film_grain: film_grain.into_rust(),
-            frame_type,
-            width,
-            height,
-            frame_offset,
-            temporal_id,
-            spatial_id,
-            show_existing_frame,
-            existing_frame_idx,
-            frame_id,
-            frame_presentation_delay,
-            show_frame,
-            showable_frame,
-            error_resilient_mode,
-            disable_cdf_update,
-            allow_screen_content_tools,
-            force_integer_mv,
-            frame_size_override,
-            primary_ref_frame,
-            buffer_removal_time_present,
-            operating_points: operating_points.map(|c| c.into_rust()),
-            refresh_frame_flags,
-            render_width,
-            render_height,
-            super_res: super_res.into_rust(),
-            have_render_size,
-            allow_intrabc,
-            frame_ref_short_signaling,
-            refidx,
-            hp,
-            subpel_filter_mode,
-            switchable_motion_mode,
-            use_ref_frame_mvs,
-            refresh_context,
-            tiling: tiling.into_rust(),
-            quant: quant.into_rust(),
-            segmentation: segmentation.into_rust(),
-            delta: delta.into_rust(),
-            all_lossless,
-            loopfilter: loopfilter.into_rust(),
-            cdef: cdef.into_rust(),
-            restoration: restoration.into_rust(),
-            txfm_mode,
-            switchable_comp_refs,
-            skip_mode_allowed,
-            skip_mode_enabled,
-            skip_mode_refs,
-            warp_motion,
-            reduced_txtp_set,
-            gmv: gmv.map(|c| c.into_rust()),
-        }
-    }
-}
-
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader {
     pub film_grain: Rav1dFrameHeader_film_grain,
@@ -2043,6 +1931,115 @@ pub(crate) struct Rav1dFrameHeader {
     pub warp_motion: c_int,
     pub reduced_txtp_set: c_int,
     pub gmv: [Rav1dWarpedMotionParams; 7],
+}
+
+impl From<Dav1dFrameHeader> for Rav1dFrameHeader {
+    fn from(value: Dav1dFrameHeader) -> Self {
+        let Dav1dFrameHeader {
+            film_grain,
+            frame_type,
+            width,
+            height,
+            frame_offset,
+            temporal_id,
+            spatial_id,
+            show_existing_frame,
+            existing_frame_idx,
+            frame_id,
+            frame_presentation_delay,
+            show_frame,
+            showable_frame,
+            error_resilient_mode,
+            disable_cdf_update,
+            allow_screen_content_tools,
+            force_integer_mv,
+            frame_size_override,
+            primary_ref_frame,
+            buffer_removal_time_present,
+            operating_points,
+            refresh_frame_flags,
+            render_width,
+            render_height,
+            super_res,
+            have_render_size,
+            allow_intrabc,
+            frame_ref_short_signaling,
+            refidx,
+            hp,
+            subpel_filter_mode,
+            switchable_motion_mode,
+            use_ref_frame_mvs,
+            refresh_context,
+            tiling,
+            quant,
+            segmentation,
+            delta,
+            all_lossless,
+            loopfilter,
+            cdef,
+            restoration,
+            txfm_mode,
+            switchable_comp_refs,
+            skip_mode_allowed,
+            skip_mode_enabled,
+            skip_mode_refs,
+            warp_motion,
+            reduced_txtp_set,
+            gmv,
+        } = value;
+        Self {
+            film_grain: film_grain.into(),
+            frame_type,
+            width,
+            height,
+            frame_offset,
+            temporal_id,
+            spatial_id,
+            show_existing_frame,
+            existing_frame_idx,
+            frame_id,
+            frame_presentation_delay,
+            show_frame,
+            showable_frame,
+            error_resilient_mode,
+            disable_cdf_update,
+            allow_screen_content_tools,
+            force_integer_mv,
+            frame_size_override,
+            primary_ref_frame,
+            buffer_removal_time_present,
+            operating_points: operating_points.map(|c| c.into()),
+            refresh_frame_flags,
+            render_width,
+            render_height,
+            super_res: super_res.into(),
+            have_render_size,
+            allow_intrabc,
+            frame_ref_short_signaling,
+            refidx,
+            hp,
+            subpel_filter_mode,
+            switchable_motion_mode,
+            use_ref_frame_mvs,
+            refresh_context,
+            tiling: tiling.into(),
+            quant: quant.into(),
+            segmentation: segmentation.into(),
+            delta: delta.into(),
+            all_lossless,
+            loopfilter: loopfilter.into(),
+            cdef: cdef.into(),
+            restoration: restoration.into(),
+            txfm_mode,
+            switchable_comp_refs,
+            skip_mode_allowed,
+            skip_mode_enabled,
+            skip_mode_refs,
+            warp_motion,
+            reduced_txtp_set,
+            gmv: gmv.map(|c| c.into()),
+        }
+    }
 }
 
 impl Rav1dFrameHeader {

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -156,14 +156,14 @@ impl From<Dav1dWarpedMotionParams> for Rav1dWarpedMotionParams {
     }
 }
 
-impl Rav1dWarpedMotionParams {
-    pub fn into_c(self) -> Dav1dWarpedMotionParams {
-        let Self {
+impl From<Rav1dWarpedMotionParams> for Dav1dWarpedMotionParams {
+    fn from(value: Rav1dWarpedMotionParams) -> Self {
+        let Rav1dWarpedMotionParams {
             type_0,
             matrix,
             abcd,
-        } = self;
-        Dav1dWarpedMotionParams {
+        } = value;
+        Self {
             type_0,
             matrix,
             abcd,
@@ -339,14 +339,13 @@ impl From<Dav1dContentLightLevel> for Rav1dContentLightLevel {
     }
 }
 
-impl Rav1dContentLightLevel {
-    #[allow(dead_code)] // TODO(kkysen) remove when we use this
-    pub fn into_c(self) -> Dav1dContentLightLevel {
-        let Self {
+impl From<Rav1dContentLightLevel> for Dav1dContentLightLevel {
+    fn from(value: Rav1dContentLightLevel) -> Self {
+        let Rav1dContentLightLevel {
             max_content_light_level,
             max_frame_average_light_level,
-        } = self;
-        Dav1dContentLightLevel {
+        } = value;
+        Self {
             max_content_light_level,
             max_frame_average_light_level,
         }
@@ -386,16 +385,15 @@ impl From<Dav1dMasteringDisplay> for Rav1dMasteringDisplay {
     }
 }
 
-impl Rav1dMasteringDisplay {
-    #[allow(dead_code)] // TODO(kkysen) remove when we use this
-    pub fn into_c(self) -> Dav1dMasteringDisplay {
-        let Self {
+impl From<Rav1dMasteringDisplay> for Dav1dMasteringDisplay {
+    fn from(value: Rav1dMasteringDisplay) -> Self {
+        let Rav1dMasteringDisplay {
             primaries,
             white_point,
             max_luminance,
             min_luminance,
-        } = self;
-        Dav1dMasteringDisplay {
+        } = value;
+        Self {
             primaries,
             white_point,
             max_luminance,
@@ -437,16 +435,15 @@ impl From<Dav1dITUTT35> for Rav1dITUTT35 {
     }
 }
 
-impl Rav1dITUTT35 {
-    #[allow(dead_code)] // TODO(kkysen) remove when we use this
-    pub fn into_c(self) -> Dav1dITUTT35 {
-        let Self {
+impl From<Rav1dITUTT35> for Dav1dITUTT35 {
+    fn from(value: Rav1dITUTT35) -> Self {
+        let Rav1dITUTT35 {
             country_code,
             country_code_extension_byte,
             payload_size,
             payload,
-        } = self;
-        Dav1dITUTT35 {
+        } = value;
+        Self {
             country_code,
             country_code_extension_byte,
             payload_size,
@@ -502,9 +499,9 @@ impl From<Dav1dSequenceHeaderOperatingPoint> for Rav1dSequenceHeaderOperatingPoi
     }
 }
 
-impl Rav1dSequenceHeaderOperatingPoint {
-    pub fn into_c(self) -> Dav1dSequenceHeaderOperatingPoint {
-        let Self {
+impl From<Rav1dSequenceHeaderOperatingPoint> for Dav1dSequenceHeaderOperatingPoint {
+    fn from(value: Rav1dSequenceHeaderOperatingPoint) -> Self {
+        let Rav1dSequenceHeaderOperatingPoint {
             major_level,
             minor_level,
             initial_display_delay,
@@ -512,8 +509,8 @@ impl Rav1dSequenceHeaderOperatingPoint {
             tier,
             decoder_model_param_present,
             display_model_param_present,
-        } = self;
-        Dav1dSequenceHeaderOperatingPoint {
+        } = value;
+        Self {
             major_level,
             minor_level,
             initial_display_delay,
@@ -556,14 +553,14 @@ impl From<Dav1dSequenceHeaderOperatingParameterInfo> for Rav1dSequenceHeaderOper
     }
 }
 
-impl Rav1dSequenceHeaderOperatingParameterInfo {
-    pub fn into_c(self) -> Dav1dSequenceHeaderOperatingParameterInfo {
-        let Self {
+impl From<Rav1dSequenceHeaderOperatingParameterInfo> for Dav1dSequenceHeaderOperatingParameterInfo {
+    fn from(value: Rav1dSequenceHeaderOperatingParameterInfo) -> Self {
+        let Rav1dSequenceHeaderOperatingParameterInfo {
             decoder_buffer_delay,
             encoder_buffer_delay,
             low_delay_mode,
-        } = self;
-        Dav1dSequenceHeaderOperatingParameterInfo {
+        } = value;
+        Self {
             decoder_buffer_delay,
             encoder_buffer_delay,
             low_delay_mode,
@@ -800,9 +797,9 @@ impl From<Dav1dSequenceHeader> for Rav1dSequenceHeader {
     }
 }
 
-impl Rav1dSequenceHeader {
-    pub fn into_c(self) -> Dav1dSequenceHeader {
-        let Self {
+impl From<Rav1dSequenceHeader> for Dav1dSequenceHeader {
+    fn from(value: Rav1dSequenceHeader) -> Self {
+        let Rav1dSequenceHeader {
             profile,
             max_width,
             max_height,
@@ -856,8 +853,8 @@ impl Rav1dSequenceHeader {
             separate_uv_delta_q,
             film_grain_present,
             operating_parameter_info,
-        } = self;
-        Dav1dSequenceHeader {
+        } = value;
+        Self {
             profile,
             max_width,
             max_height,
@@ -869,7 +866,7 @@ impl Rav1dSequenceHeader {
             hbd,
             color_range,
             num_operating_points,
-            operating_points: operating_points.map(|rust| rust.into_c()),
+            operating_points: operating_points.map(|rust| rust.into()),
             still_picture,
             reduced_still_picture_header,
             timing_info_present,
@@ -910,7 +907,7 @@ impl Rav1dSequenceHeader {
             color_description_present,
             separate_uv_delta_q,
             film_grain_present,
-            operating_parameter_info: operating_parameter_info.map(|rust| rust.into_c()),
+            operating_parameter_info: operating_parameter_info.map(|rust| rust.into()),
         }
     }
 }
@@ -966,9 +963,9 @@ impl From<Dav1dSegmentationData> for Rav1dSegmentationData {
     }
 }
 
-impl Rav1dSegmentationData {
-    pub fn into_c(self) -> Dav1dSegmentationData {
-        let Self {
+impl From<Rav1dSegmentationData> for Dav1dSegmentationData {
+    fn from(value: Rav1dSegmentationData) -> Self {
+        let Rav1dSegmentationData {
             delta_q,
             delta_lf_y_v,
             delta_lf_y_h,
@@ -977,8 +974,8 @@ impl Rav1dSegmentationData {
             r#ref,
             skip,
             globalmv,
-        } = self;
-        Dav1dSegmentationData {
+        } = value;
+        Self {
             delta_q,
             delta_lf_y_v,
             delta_lf_y_h,
@@ -1022,15 +1019,15 @@ impl From<Dav1dSegmentationDataSet> for Rav1dSegmentationDataSet {
     }
 }
 
-impl Rav1dSegmentationDataSet {
-    pub fn into_c(self) -> Dav1dSegmentationDataSet {
-        let Self {
+impl From<Rav1dSegmentationDataSet> for Dav1dSegmentationDataSet {
+    fn from(value: Rav1dSegmentationDataSet) -> Self {
+        let Rav1dSegmentationDataSet {
             d,
             preskip,
             last_active_segid,
-        } = self;
-        Dav1dSegmentationDataSet {
-            d: d.map(|rust| rust.into_c()),
+        } = value;
+        Self {
+            d: d.map(|rust| rust.into()),
             preskip,
             last_active_segid,
         }
@@ -1064,13 +1061,13 @@ impl From<Dav1dLoopfilterModeRefDeltas> for Rav1dLoopfilterModeRefDeltas {
     }
 }
 
-impl Rav1dLoopfilterModeRefDeltas {
-    pub fn into_c(self) -> Dav1dLoopfilterModeRefDeltas {
-        let Self {
+impl From<Rav1dLoopfilterModeRefDeltas> for Dav1dLoopfilterModeRefDeltas {
+    fn from(value: Rav1dLoopfilterModeRefDeltas) -> Self {
+        let Rav1dLoopfilterModeRefDeltas {
             mode_delta,
             ref_delta,
-        } = self;
-        Dav1dLoopfilterModeRefDeltas {
+        } = value;
+        Self {
             mode_delta,
             ref_delta,
         }
@@ -1164,9 +1161,9 @@ impl From<Dav1dFilmGrainData> for Rav1dFilmGrainData {
     }
 }
 
-impl Rav1dFilmGrainData {
-    pub fn into_c(self) -> Dav1dFilmGrainData {
-        let Self {
+impl From<Rav1dFilmGrainData> for Dav1dFilmGrainData {
+    fn from(value: Rav1dFilmGrainData) -> Self {
+        let Rav1dFilmGrainData {
             seed,
             num_y_points,
             y_points,
@@ -1184,8 +1181,8 @@ impl Rav1dFilmGrainData {
             uv_offset,
             overlap_flag,
             clip_to_restricted_range,
-        } = self;
-        Dav1dFilmGrainData {
+        } = value;
+        Self {
             seed,
             num_y_points,
             y_points,
@@ -1236,15 +1233,15 @@ impl From<Dav1dFrameHeader_film_grain> for Rav1dFrameHeader_film_grain {
     }
 }
 
-impl Rav1dFrameHeader_film_grain {
-    pub fn into_c(self) -> Dav1dFrameHeader_film_grain {
-        let Self {
+impl From<Rav1dFrameHeader_film_grain> for Dav1dFrameHeader_film_grain {
+    fn from(value: Rav1dFrameHeader_film_grain) -> Self {
+        let Rav1dFrameHeader_film_grain {
             data,
             present,
             update,
-        } = self;
-        Dav1dFrameHeader_film_grain {
-            data: data.into_c(),
+        } = value;
+        Self {
+            data: data.into(),
             present,
             update,
         }
@@ -1272,12 +1269,12 @@ impl From<Dav1dFrameHeaderOperatingPoint> for Rav1dFrameHeaderOperatingPoint {
     }
 }
 
-impl Rav1dFrameHeaderOperatingPoint {
-    pub fn into_c(self) -> Dav1dFrameHeaderOperatingPoint {
-        let Self {
+impl From<Rav1dFrameHeaderOperatingPoint> for Dav1dFrameHeaderOperatingPoint {
+    fn from(value: Rav1dFrameHeaderOperatingPoint) -> Self {
+        let Rav1dFrameHeaderOperatingPoint {
             buffer_removal_time,
-        } = self;
-        Dav1dFrameHeaderOperatingPoint {
+        } = value;
+        Self {
             buffer_removal_time,
         }
     }
@@ -1308,13 +1305,13 @@ impl From<Dav1dFrameHeader_super_res> for Rav1dFrameHeader_super_res {
     }
 }
 
-impl Rav1dFrameHeader_super_res {
-    pub fn into_c(self) -> Dav1dFrameHeader_super_res {
-        let Self {
+impl From<Rav1dFrameHeader_super_res> for Dav1dFrameHeader_super_res {
+    fn from(value: Rav1dFrameHeader_super_res) -> Self {
+        let Rav1dFrameHeader_super_res {
             width_scale_denominator,
             enabled,
-        } = self;
-        Dav1dFrameHeader_super_res {
+        } = value;
+        Self {
             width_scale_denominator,
             enabled,
         }
@@ -1390,9 +1387,9 @@ impl From<Dav1dFrameHeader_tiling> for Rav1dFrameHeader_tiling {
     }
 }
 
-impl Rav1dFrameHeader_tiling {
-    pub fn into_c(self) -> Dav1dFrameHeader_tiling {
-        let Self {
+impl From<Rav1dFrameHeader_tiling> for Dav1dFrameHeader_tiling {
+    fn from(value: Rav1dFrameHeader_tiling) -> Self {
+        let Rav1dFrameHeader_tiling {
             uniform,
             n_bytes,
             min_log2_cols,
@@ -1406,8 +1403,8 @@ impl Rav1dFrameHeader_tiling {
             col_start_sb,
             row_start_sb,
             update,
-        } = self;
-        Dav1dFrameHeader_tiling {
+        } = value;
+        Self {
             uniform,
             n_bytes,
             min_log2_cols,
@@ -1482,9 +1479,9 @@ impl From<Dav1dFrameHeader_quant> for Rav1dFrameHeader_quant {
     }
 }
 
-impl Rav1dFrameHeader_quant {
-    pub fn into_c(self) -> Dav1dFrameHeader_quant {
-        let Self {
+impl From<Rav1dFrameHeader_quant> for Dav1dFrameHeader_quant {
+    fn from(value: Rav1dFrameHeader_quant) -> Self {
+        let Rav1dFrameHeader_quant {
             yac,
             ydc_delta,
             udc_delta,
@@ -1495,8 +1492,8 @@ impl Rav1dFrameHeader_quant {
             qm_y,
             qm_u,
             qm_v,
-        } = self;
-        Dav1dFrameHeader_quant {
+        } = value;
+        Self {
             yac,
             ydc_delta,
             udc_delta,
@@ -1556,9 +1553,9 @@ impl From<Dav1dFrameHeader_segmentation> for Rav1dFrameHeader_segmentation {
     }
 }
 
-impl Rav1dFrameHeader_segmentation {
-    pub fn into_c(self) -> Dav1dFrameHeader_segmentation {
-        let Self {
+impl From<Rav1dFrameHeader_segmentation> for Dav1dFrameHeader_segmentation {
+    fn from(value: Rav1dFrameHeader_segmentation) -> Self {
+        let Rav1dFrameHeader_segmentation {
             enabled,
             update_map,
             temporal,
@@ -1566,13 +1563,13 @@ impl Rav1dFrameHeader_segmentation {
             seg_data,
             lossless,
             qidx,
-        } = self;
-        Dav1dFrameHeader_segmentation {
+        } = value;
+        Self {
             enabled,
             update_map,
             temporal,
             update_data,
-            seg_data: seg_data.into_c(),
+            seg_data: seg_data.into(),
             lossless,
             qidx,
         }
@@ -1598,10 +1595,10 @@ impl From<Dav1dFrameHeader_delta_q> for Rav1dFrameHeader_delta_q {
     }
 }
 
-impl Rav1dFrameHeader_delta_q {
-    pub fn into_c(self) -> Dav1dFrameHeader_delta_q {
-        let Self { present, res_log2 } = self;
-        Dav1dFrameHeader_delta_q { present, res_log2 }
+impl From<Rav1dFrameHeader_delta_q> for Dav1dFrameHeader_delta_q {
+    fn from(value: Rav1dFrameHeader_delta_q) -> Self {
+        let Rav1dFrameHeader_delta_q { present, res_log2 } = value;
+        Self { present, res_log2 }
     }
 }
 
@@ -1634,14 +1631,14 @@ impl From<Dav1dFrameHeader_delta_lf> for Rav1dFrameHeader_delta_lf {
     }
 }
 
-impl Rav1dFrameHeader_delta_lf {
-    pub fn into_c(self) -> Dav1dFrameHeader_delta_lf {
-        let Self {
+impl From<Rav1dFrameHeader_delta_lf> for Dav1dFrameHeader_delta_lf {
+    fn from(value: Rav1dFrameHeader_delta_lf) -> Self {
+        let Rav1dFrameHeader_delta_lf {
             present,
             res_log2,
             multi,
-        } = self;
-        Dav1dFrameHeader_delta_lf {
+        } = value;
+        Self {
             present,
             res_log2,
             multi,
@@ -1671,12 +1668,12 @@ impl From<Dav1dFrameHeader_delta> for Rav1dFrameHeader_delta {
     }
 }
 
-impl Rav1dFrameHeader_delta {
-    pub fn into_c(self) -> Dav1dFrameHeader_delta {
-        let Self { q, lf } = self;
-        Dav1dFrameHeader_delta {
-            q: q.into_c(),
-            lf: lf.into_c(),
+impl From<Rav1dFrameHeader_delta> for Dav1dFrameHeader_delta {
+    fn from(value: Rav1dFrameHeader_delta) -> Self {
+        let Rav1dFrameHeader_delta { q, lf } = value;
+        Self {
+            q: q.into(),
+            lf: lf.into(),
         }
     }
 }
@@ -1726,9 +1723,9 @@ impl From<Dav1dFrameHeader_loopfilter> for Rav1dFrameHeader_loopfilter {
     }
 }
 
-impl Rav1dFrameHeader_loopfilter {
-    pub fn into_c(self) -> Dav1dFrameHeader_loopfilter {
-        let Self {
+impl From<Rav1dFrameHeader_loopfilter> for Dav1dFrameHeader_loopfilter {
+    fn from(value: Rav1dFrameHeader_loopfilter) -> Self {
+        let Rav1dFrameHeader_loopfilter {
             level_y,
             level_u,
             level_v,
@@ -1736,14 +1733,14 @@ impl Rav1dFrameHeader_loopfilter {
             mode_ref_delta_update,
             mode_ref_deltas,
             sharpness,
-        } = self;
-        Dav1dFrameHeader_loopfilter {
+        } = value;
+        Self {
             level_y,
             level_u,
             level_v,
             mode_ref_delta_enabled,
             mode_ref_delta_update,
-            mode_ref_deltas: mode_ref_deltas.into_c(),
+            mode_ref_deltas: mode_ref_deltas.into(),
             sharpness,
         }
     }
@@ -1782,15 +1779,15 @@ impl From<Dav1dFrameHeader_cdef> for Rav1dFrameHeader_cdef {
     }
 }
 
-impl Rav1dFrameHeader_cdef {
-    pub fn into_c(self) -> Dav1dFrameHeader_cdef {
-        let Self {
+impl From<Rav1dFrameHeader_cdef> for Dav1dFrameHeader_cdef {
+    fn from(value: Rav1dFrameHeader_cdef) -> Self {
+        let Rav1dFrameHeader_cdef {
             damping,
             n_bits,
             y_strength,
             uv_strength,
-        } = self;
-        Dav1dFrameHeader_cdef {
+        } = value;
+        Self {
             damping,
             n_bits,
             y_strength,
@@ -1818,10 +1815,10 @@ impl From<Dav1dFrameHeader_restoration> for Rav1dFrameHeader_restoration {
     }
 }
 
-impl Rav1dFrameHeader_restoration {
-    pub fn into_c(self) -> Dav1dFrameHeader_restoration {
-        let Self { type_0, unit_size } = self;
-        Dav1dFrameHeader_restoration { type_0, unit_size }
+impl From<Rav1dFrameHeader_restoration> for Dav1dFrameHeader_restoration {
+    fn from(value: Rav1dFrameHeader_restoration) -> Self {
+        let Rav1dFrameHeader_restoration { type_0, unit_size } = value;
+        Self { type_0, unit_size }
     }
 }
 
@@ -2042,10 +2039,9 @@ impl From<Dav1dFrameHeader> for Rav1dFrameHeader {
     }
 }
 
-impl Rav1dFrameHeader {
-    #[allow(dead_code)] // TODO(kkysen) remove when we use this
-    pub fn into_c(self) -> Dav1dFrameHeader {
-        let Self {
+impl From<Rav1dFrameHeader> for Dav1dFrameHeader {
+    fn from(value: Rav1dFrameHeader) -> Self {
+        let Rav1dFrameHeader {
             film_grain,
             frame_type,
             width,
@@ -2096,9 +2092,9 @@ impl Rav1dFrameHeader {
             warp_motion,
             reduced_txtp_set,
             gmv,
-        } = self;
-        Dav1dFrameHeader {
-            film_grain: film_grain.into_c(),
+        } = value;
+        Self {
+            film_grain: film_grain.into(),
             frame_type,
             width,
             height,
@@ -2118,11 +2114,11 @@ impl Rav1dFrameHeader {
             frame_size_override,
             primary_ref_frame,
             buffer_removal_time_present,
-            operating_points: operating_points.map(|rust| rust.into_c()),
+            operating_points: operating_points.map(|rust| rust.into()),
             refresh_frame_flags,
             render_width,
             render_height,
-            super_res: super_res.into_c(),
+            super_res: super_res.into(),
             have_render_size,
             allow_intrabc,
             frame_ref_short_signaling,
@@ -2132,14 +2128,14 @@ impl Rav1dFrameHeader {
             switchable_motion_mode,
             use_ref_frame_mvs,
             refresh_context,
-            tiling: tiling.into_c(),
-            quant: quant.into_c(),
-            segmentation: segmentation.into_c(),
-            delta: delta.into_c(),
+            tiling: tiling.into(),
+            quant: quant.into(),
+            segmentation: segmentation.into(),
+            delta: delta.into(),
             all_lossless,
-            loopfilter: loopfilter.into_c(),
-            cdef: cdef.into_c(),
-            restoration: restoration.into_c(),
+            loopfilter: loopfilter.into(),
+            cdef: cdef.into(),
+            restoration: restoration.into(),
             txfm_mode,
             switchable_comp_refs,
             skip_mode_allowed,
@@ -2147,7 +2143,7 @@ impl Rav1dFrameHeader {
             skip_mode_refs,
             warp_motion,
             reduced_txtp_set,
-            gmv: gmv.map(|rust| rust.into_c()),
+            gmv: gmv.map(|rust| rust.into()),
         }
     }
 }

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -1,4 +1,5 @@
 use crate::include::dav1d::common::Dav1dDataProps;
+use crate::include::dav1d::common::Rav1dDataProps;
 use crate::include::dav1d::dav1d::Dav1dRef;
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dFrameHeader;
@@ -6,6 +7,7 @@ use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
+use crate::src::r#ref::Rav1dRef;
 use libc::ptrdiff_t;
 use libc::uintptr_t;
 use std::ffi::c_int;
@@ -18,6 +20,29 @@ pub struct Dav1dPictureParameters {
     pub h: c_int,
     pub layout: Dav1dPixelLayout,
     pub bpc: c_int,
+}
+
+impl Dav1dPictureParameters {
+    pub(crate) fn into_rust(self) -> Rav1dPictureParameters {
+        let Self { w, h, layout, bpc } = self;
+        Rav1dPictureParameters { w, h, layout, bpc }
+    }
+}
+
+#[derive(Clone)]
+#[repr(C)]
+pub(crate) struct Rav1dPictureParameters {
+    pub w: c_int,
+    pub h: c_int,
+    pub layout: Dav1dPixelLayout,
+    pub bpc: c_int,
+}
+
+impl Rav1dPictureParameters {
+    pub fn into_c(self) -> Dav1dPictureParameters {
+        let Self { w, h, layout, bpc } = self;
+        Dav1dPictureParameters { w, h, layout, bpc }
+    }
 }
 
 #[derive(Clone)]
@@ -43,6 +68,119 @@ pub struct Dav1dPicture {
     pub allocator_data: *mut c_void,
 }
 
+impl Dav1dPicture {
+    pub(crate) fn into_rust(self) -> Rav1dPicture {
+        let Self {
+            seq_hdr,
+            frame_hdr,
+            data,
+            stride,
+            p,
+            m,
+            content_light,
+            mastering_display,
+            itut_t35,
+            reserved,
+            frame_hdr_ref,
+            seq_hdr_ref,
+            content_light_ref,
+            mastering_display_ref,
+            itut_t35_ref,
+            reserved_ref,
+            r#ref,
+            allocator_data,
+        } = self;
+        Rav1dPicture {
+            seq_hdr,
+            frame_hdr,
+            data,
+            stride,
+            p: p.into_rust(),
+            m: m.into_rust(),
+            content_light,
+            mastering_display,
+            itut_t35: itut_t35,
+            reserved,
+            frame_hdr_ref,
+            seq_hdr_ref,
+            content_light_ref,
+            mastering_display_ref,
+            itut_t35_ref,
+            reserved_ref,
+            r#ref,
+            allocator_data,
+        }
+    }
+}
+
+#[derive(Clone)]
+#[repr(C)]
+pub(crate) struct Rav1dPicture {
+    pub seq_hdr: *mut Dav1dSequenceHeader, // TODO(kkysen) make Rav1d
+    pub frame_hdr: *mut Dav1dFrameHeader,  // TODO(kkysen) make Rav1d
+    pub data: [*mut c_void; 3],
+    pub stride: [ptrdiff_t; 2],
+    pub p: Rav1dPictureParameters,
+    pub m: Rav1dDataProps,
+    pub content_light: *mut Dav1dContentLightLevel, // TODO(kkysen) make Rav1d
+    pub mastering_display: *mut Dav1dMasteringDisplay, // TODO(kkysen) make Rav1d
+    pub itut_t35: *mut Dav1dITUTT35,                // TODO(kkysen) make Rav1d
+    pub reserved: [uintptr_t; 4],
+    pub frame_hdr_ref: *mut Rav1dRef,
+    pub seq_hdr_ref: *mut Rav1dRef,
+    pub content_light_ref: *mut Rav1dRef,
+    pub mastering_display_ref: *mut Rav1dRef,
+    pub itut_t35_ref: *mut Rav1dRef,
+    pub reserved_ref: [uintptr_t; 4],
+    pub r#ref: *mut Rav1dRef,
+    pub allocator_data: *mut c_void,
+}
+
+impl Rav1dPicture {
+    pub fn into_c(self) -> Dav1dPicture {
+        let Self {
+            seq_hdr,
+            frame_hdr,
+            data,
+            stride,
+            p,
+            m,
+            content_light,
+            mastering_display,
+            itut_t35,
+            reserved,
+            frame_hdr_ref,
+            seq_hdr_ref,
+            content_light_ref,
+            mastering_display_ref,
+            itut_t35_ref,
+            reserved_ref,
+            r#ref,
+            allocator_data,
+        } = self;
+        Dav1dPicture {
+            seq_hdr,
+            frame_hdr,
+            data,
+            stride,
+            p: p.into_c(),
+            m: m.into_c(),
+            content_light,
+            mastering_display,
+            itut_t35: itut_t35,
+            reserved,
+            frame_hdr_ref,
+            seq_hdr_ref,
+            content_light_ref,
+            mastering_display_ref,
+            itut_t35_ref,
+            reserved_ref,
+            r#ref,
+            allocator_data,
+        }
+    }
+}
+
 #[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dPicAllocator {
@@ -51,4 +189,62 @@ pub struct Dav1dPicAllocator {
         Option<unsafe extern "C" fn(*mut Dav1dPicture, *mut c_void) -> c_int>,
     pub release_picture_callback:
         Option<unsafe extern "C" fn(*mut Dav1dPicture, *mut c_void) -> ()>,
+}
+
+impl Dav1dPicAllocator {
+    pub(crate) fn into_rust(self) -> Rav1dPicAllocator {
+        let Self {
+            cookie,
+            alloc_picture_callback,
+            release_picture_callback,
+        } = self;
+        Rav1dPicAllocator {
+            cookie,
+            alloc_picture_callback,
+            release_picture_callback,
+        }
+    }
+}
+
+#[derive(Clone)]
+#[repr(C)]
+pub(crate) struct Rav1dPicAllocator {
+    pub cookie: *mut c_void,
+    pub alloc_picture_callback:
+        Option<unsafe extern "C" fn(*mut Dav1dPicture, *mut c_void) -> c_int>,
+    pub release_picture_callback:
+        Option<unsafe extern "C" fn(*mut Dav1dPicture, *mut c_void) -> ()>,
+}
+
+impl Rav1dPicAllocator {
+    pub fn into_c(self) -> Dav1dPicAllocator {
+        let Self {
+            cookie,
+            alloc_picture_callback,
+            release_picture_callback,
+        } = self;
+        Dav1dPicAllocator {
+            cookie,
+            alloc_picture_callback,
+            release_picture_callback,
+        }
+    }
+}
+
+impl Rav1dPicAllocator {
+    pub unsafe fn alloc_picture(&mut self, p: *mut Rav1dPicture) -> c_int {
+        let mut p_c = p.read().into_c();
+        let result = self
+            .alloc_picture_callback
+            .expect("non-null function pointer")(&mut p_c, self.cookie);
+        p.write(p_c.into_rust());
+        result
+    }
+
+    pub unsafe fn release_picture(&mut self, p: *mut Rav1dPicture) {
+        let mut p_c = p.read().into_c();
+        self.release_picture_callback
+            .expect("non-null function pointer")(&mut p_c, self.cookie);
+        p.write(p_c.into_rust());
+    }
 }

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -22,13 +22,6 @@ pub struct Dav1dPictureParameters {
     pub bpc: c_int,
 }
 
-impl Dav1dPictureParameters {
-    pub(crate) fn into_rust(self) -> Rav1dPictureParameters {
-        let Self { w, h, layout, bpc } = self;
-        Rav1dPictureParameters { w, h, layout, bpc }
-    }
-}
-
 #[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dPictureParameters {
@@ -36,6 +29,13 @@ pub(crate) struct Rav1dPictureParameters {
     pub h: c_int,
     pub layout: Dav1dPixelLayout,
     pub bpc: c_int,
+}
+
+impl From<Dav1dPictureParameters> for Rav1dPictureParameters {
+    fn from(value: Dav1dPictureParameters) -> Self {
+        let Dav1dPictureParameters { w, h, layout, bpc } = value;
+        Self { w, h, layout, bpc }
+    }
 }
 
 impl Rav1dPictureParameters {
@@ -68,51 +68,6 @@ pub struct Dav1dPicture {
     pub allocator_data: *mut c_void,
 }
 
-impl Dav1dPicture {
-    pub(crate) fn into_rust(self) -> Rav1dPicture {
-        let Self {
-            seq_hdr,
-            frame_hdr,
-            data,
-            stride,
-            p,
-            m,
-            content_light,
-            mastering_display,
-            itut_t35,
-            reserved,
-            frame_hdr_ref,
-            seq_hdr_ref,
-            content_light_ref,
-            mastering_display_ref,
-            itut_t35_ref,
-            reserved_ref,
-            r#ref,
-            allocator_data,
-        } = self;
-        Rav1dPicture {
-            seq_hdr,
-            frame_hdr,
-            data,
-            stride,
-            p: p.into_rust(),
-            m: m.into_rust(),
-            content_light,
-            mastering_display,
-            itut_t35: itut_t35,
-            reserved,
-            frame_hdr_ref,
-            seq_hdr_ref,
-            content_light_ref,
-            mastering_display_ref,
-            itut_t35_ref,
-            reserved_ref,
-            r#ref,
-            allocator_data,
-        }
-    }
-}
-
 #[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dPicture {
@@ -134,6 +89,51 @@ pub(crate) struct Rav1dPicture {
     pub reserved_ref: [uintptr_t; 4],
     pub r#ref: *mut Rav1dRef,
     pub allocator_data: *mut c_void,
+}
+
+impl From<Dav1dPicture> for Rav1dPicture {
+    fn from(value: Dav1dPicture) -> Self {
+        let Dav1dPicture {
+            seq_hdr,
+            frame_hdr,
+            data,
+            stride,
+            p,
+            m,
+            content_light,
+            mastering_display,
+            itut_t35,
+            reserved,
+            frame_hdr_ref,
+            seq_hdr_ref,
+            content_light_ref,
+            mastering_display_ref,
+            itut_t35_ref,
+            reserved_ref,
+            r#ref,
+            allocator_data,
+        } = value;
+        Self {
+            seq_hdr,
+            frame_hdr,
+            data,
+            stride,
+            p: p.into(),
+            m: m.into(),
+            content_light,
+            mastering_display,
+            itut_t35: itut_t35,
+            reserved,
+            frame_hdr_ref,
+            seq_hdr_ref,
+            content_light_ref,
+            mastering_display_ref,
+            itut_t35_ref,
+            reserved_ref,
+            r#ref,
+            allocator_data,
+        }
+    }
 }
 
 impl Rav1dPicture {
@@ -191,21 +191,6 @@ pub struct Dav1dPicAllocator {
         Option<unsafe extern "C" fn(*mut Dav1dPicture, *mut c_void) -> ()>,
 }
 
-impl Dav1dPicAllocator {
-    pub(crate) fn into_rust(self) -> Rav1dPicAllocator {
-        let Self {
-            cookie,
-            alloc_picture_callback,
-            release_picture_callback,
-        } = self;
-        Rav1dPicAllocator {
-            cookie,
-            alloc_picture_callback,
-            release_picture_callback,
-        }
-    }
-}
-
 #[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dPicAllocator {
@@ -214,6 +199,21 @@ pub(crate) struct Rav1dPicAllocator {
         Option<unsafe extern "C" fn(*mut Dav1dPicture, *mut c_void) -> c_int>,
     pub release_picture_callback:
         Option<unsafe extern "C" fn(*mut Dav1dPicture, *mut c_void) -> ()>,
+}
+
+impl From<Dav1dPicAllocator> for Rav1dPicAllocator {
+    fn from(value: Dav1dPicAllocator) -> Self {
+        let Dav1dPicAllocator {
+            cookie,
+            alloc_picture_callback,
+            release_picture_callback,
+        } = value;
+        Self {
+            cookie,
+            alloc_picture_callback,
+            release_picture_callback,
+        }
+    }
 }
 
 impl Rav1dPicAllocator {
@@ -237,7 +237,7 @@ impl Rav1dPicAllocator {
         let result = self
             .alloc_picture_callback
             .expect("non-null function pointer")(&mut p_c, self.cookie);
-        p.write(p_c.into_rust());
+        p.write(p_c.into());
         result
     }
 
@@ -245,6 +245,6 @@ impl Rav1dPicAllocator {
         let mut p_c = p.read().into_c();
         self.release_picture_callback
             .expect("non-null function pointer")(&mut p_c, self.cookie);
-        p.write(p_c.into_rust());
+        p.write(p_c.into());
     }
 }

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -38,10 +38,10 @@ impl From<Dav1dPictureParameters> for Rav1dPictureParameters {
     }
 }
 
-impl Rav1dPictureParameters {
-    pub fn into_c(self) -> Dav1dPictureParameters {
-        let Self { w, h, layout, bpc } = self;
-        Dav1dPictureParameters { w, h, layout, bpc }
+impl From<Rav1dPictureParameters> for Dav1dPictureParameters {
+    fn from(value: Rav1dPictureParameters) -> Self {
+        let Rav1dPictureParameters { w, h, layout, bpc } = value;
+        Self { w, h, layout, bpc }
     }
 }
 
@@ -136,9 +136,9 @@ impl From<Dav1dPicture> for Rav1dPicture {
     }
 }
 
-impl Rav1dPicture {
-    pub fn into_c(self) -> Dav1dPicture {
-        let Self {
+impl From<Rav1dPicture> for Dav1dPicture {
+    fn from(value: Rav1dPicture) -> Self {
+        let Rav1dPicture {
             seq_hdr,
             frame_hdr,
             data,
@@ -157,14 +157,14 @@ impl Rav1dPicture {
             reserved_ref,
             r#ref,
             allocator_data,
-        } = self;
-        Dav1dPicture {
+        } = value;
+        Self {
             seq_hdr,
             frame_hdr,
             data,
             stride,
-            p: p.into_c(),
-            m: m.into_c(),
+            p: p.into(),
+            m: m.into(),
             content_light,
             mastering_display,
             itut_t35: itut_t35,
@@ -216,14 +216,14 @@ impl From<Dav1dPicAllocator> for Rav1dPicAllocator {
     }
 }
 
-impl Rav1dPicAllocator {
-    pub fn into_c(self) -> Dav1dPicAllocator {
-        let Self {
+impl From<Rav1dPicAllocator> for Dav1dPicAllocator {
+    fn from(value: Rav1dPicAllocator) -> Self {
+        let Rav1dPicAllocator {
             cookie,
             alloc_picture_callback,
             release_picture_callback,
-        } = self;
-        Dav1dPicAllocator {
+        } = value;
+        Self {
             cookie,
             alloc_picture_callback,
             release_picture_callback,
@@ -233,7 +233,7 @@ impl Rav1dPicAllocator {
 
 impl Rav1dPicAllocator {
     pub unsafe fn alloc_picture(&mut self, p: *mut Rav1dPicture) -> c_int {
-        let mut p_c = p.read().into_c();
+        let mut p_c = p.read().into();
         let result = self
             .alloc_picture_callback
             .expect("non-null function pointer")(&mut p_c, self.cookie);
@@ -242,7 +242,7 @@ impl Rav1dPicAllocator {
     }
 
     pub unsafe fn release_picture(&mut self, p: *mut Rav1dPicture) {
-        let mut p_c = p.read().into_c();
+        let mut p_c = p.read().into();
         self.release_picture_callback
             .expect("non-null function pointer")(&mut p_c, self.cookie);
         p.write(p_c.into());

--- a/src/arm/looprestoration.h
+++ b/src/arm/looprestoration.h
@@ -122,7 +122,7 @@ void BF(dav1d_sgr_finish_filter1, neon)(int16_t *tmp,
                                         const int w, const int h);
 
 /* filter with a 3x3 box (radius=1) */
-static void dav1d_sgr_filter1_neon(int16_t *tmp,
+static void rav1d_sgr_filter1_neon(int16_t *tmp,
                                    const pixel *src, const ptrdiff_t stride,
                                    const pixel (*left)[4], const pixel *lpf,
                                    const int w, const int h, const int strength,
@@ -166,7 +166,7 @@ void BF(dav1d_sgr_finish_filter2, neon)(int16_t *tmp,
                                         const int w, const int h);
 
 /* filter with a 5x5 box (radius=2) */
-static void dav1d_sgr_filter2_neon(int16_t *tmp,
+static void rav1d_sgr_filter2_neon(int16_t *tmp,
                                    const pixel *src, const ptrdiff_t stride,
                                    const pixel (*left)[4], const pixel *lpf,
                                    const int w, const int h, const int strength,
@@ -210,7 +210,7 @@ static void sgr_filter_5x5_neon(pixel *const dst, const ptrdiff_t stride,
                                 const enum LrEdgeFlags edges HIGHBD_DECL_SUFFIX)
 {
     ALIGN_STK_16(int16_t, tmp, 64 * 384,);
-    dav1d_sgr_filter2_neon(tmp, dst, stride, left, lpf,
+    rav1d_sgr_filter2_neon(tmp, dst, stride, left, lpf,
                            w, h, params->sgr.s0, edges HIGHBD_TAIL_SUFFIX);
     BF(dav1d_sgr_weighted1, neon)(dst, stride, dst, stride,
                                   tmp, w, h, params->sgr.w0 HIGHBD_TAIL_SUFFIX);
@@ -223,7 +223,7 @@ static void sgr_filter_3x3_neon(pixel *const dst, const ptrdiff_t stride,
                                 const enum LrEdgeFlags edges HIGHBD_DECL_SUFFIX)
 {
     ALIGN_STK_16(int16_t, tmp, 64 * 384,);
-    dav1d_sgr_filter1_neon(tmp, dst, stride, left, lpf,
+    rav1d_sgr_filter1_neon(tmp, dst, stride, left, lpf,
                            w, h, params->sgr.s1, edges HIGHBD_TAIL_SUFFIX);
     BF(dav1d_sgr_weighted1, neon)(dst, stride, dst, stride,
                                   tmp, w, h, params->sgr.w1 HIGHBD_TAIL_SUFFIX);
@@ -237,9 +237,9 @@ static void sgr_filter_mix_neon(pixel *const dst, const ptrdiff_t stride,
 {
     ALIGN_STK_16(int16_t, tmp1, 64 * 384,);
     ALIGN_STK_16(int16_t, tmp2, 64 * 384,);
-    dav1d_sgr_filter2_neon(tmp1, dst, stride, left, lpf,
+    rav1d_sgr_filter2_neon(tmp1, dst, stride, left, lpf,
                            w, h, params->sgr.s0, edges HIGHBD_TAIL_SUFFIX);
-    dav1d_sgr_filter1_neon(tmp2, dst, stride, left, lpf,
+    rav1d_sgr_filter1_neon(tmp2, dst, stride, left, lpf,
                            w, h, params->sgr.s1, edges HIGHBD_TAIL_SUFFIX);
     const int16_t wt[2] = { params->sgr.w0, params->sgr.w1 };
     BF(dav1d_sgr_weighted2, neon)(dst, stride, dst, stride,

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -1,9 +1,9 @@
 use crate::include::common::intops::ulog2;
 use crate::include::dav1d::headers::Dav1dPixelLayout;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I422;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
 use crate::src::align::Align16;
 use crate::src::cdef::CdefEdgeFlags;
 use crate::src::cdef::CDEF_HAVE_BOTTOM;
@@ -55,10 +55,10 @@ unsafe extern "C" fn backup2lines(
             (2 * y_stride << 1) as usize,
         );
     }
-    if layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint {
+    if layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint {
         let uv_stride: ptrdiff_t = PXSTRIDE(*stride.offset(1));
         if uv_stride < 0 {
-            let uv_off = if layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint {
+            let uv_off = if layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint {
                 3 as c_int
             } else {
                 7 as c_int
@@ -74,7 +74,7 @@ unsafe extern "C" fn backup2lines(
                 (-(2 as c_int) as isize * uv_stride << 1) as usize,
             );
         } else {
-            let uv_off_0 = if layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint {
+            let uv_off_0 = if layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint {
                 2 as c_int
             } else {
                 6 as c_int
@@ -115,13 +115,13 @@ unsafe extern "C" fn backup2x8(
             y_off += PXSTRIDE(*src_stride.offset(0));
         }
     }
-    if layout as c_uint == DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
+    if layout as c_uint == RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
         || flag as c_uint & BACKUP_2X8_UV as c_int as c_uint == 0
     {
         return;
     }
-    let ss_ver = (layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
-    let ss_hor = (layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+    let ss_ver = (layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+    let ss_hor = (layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
     x_off >>= ss_hor;
     y_off = 0 as c_int as ptrdiff_t;
     let mut y_0 = 0;
@@ -183,12 +183,12 @@ pub(crate) unsafe fn rav1d_cdef_brow_16bpc(
     let damping = (*(*f).frame_hdr).cdef.damping + bitdepth_min_8;
     let layout: Dav1dPixelLayout = (*f).cur.p.layout;
     let uv_idx =
-        (DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint).wrapping_sub(layout as c_uint) as c_int;
-    let ss_ver = (layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
-    let ss_hor = (layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+        (RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint).wrapping_sub(layout as c_uint) as c_int;
+    let ss_ver = (layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+    let ss_hor = (layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
     static uv_dirs: [[u8; 8]; 2] = [[0, 1, 2, 3, 4, 5, 6, 7], [7, 0, 2, 4, 5, 6, 6, 6]];
     let uv_dir: *const u8 = (uv_dirs
-        [(layout as c_uint == DAV1D_PIXEL_LAYOUT_I422 as c_int as c_uint) as c_int as usize])
+        [(layout as c_uint == RAV1D_PIXEL_LAYOUT_I422 as c_int as c_uint) as c_int as usize])
         .as_ptr();
     let have_tt = ((*(*f).c).n_tc > 1 as c_uint) as c_int;
     let sb128 = (*(*f).seq_hdr).sb128;
@@ -418,7 +418,7 @@ pub(crate) unsafe fn rav1d_cdef_brow_16bpc(
                             );
                         }
                         if !(uv_lvl == 0) {
-                            if !(layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint) {
+                            if !(layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint) {
                                 unreachable!();
                             }
                             uvdir = if uv_pri_lvl != 0 {

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -155,7 +155,7 @@ unsafe extern "C" fn adjust_strength(strength: c_int, var: c_uint) -> c_int {
     return strength * (4 + i) + 8 >> 4;
 }
 
-pub unsafe fn dav1d_cdef_brow_16bpc(
+pub(crate) unsafe fn rav1d_cdef_brow_16bpc(
     tc: *mut Rav1dTaskContext,
     p: *const *mut pixel,
     lflvl: *const Av1Filter,

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -147,7 +147,7 @@ unsafe extern "C" fn adjust_strength(strength: c_int, var: c_uint) -> c_int {
     return strength * (4 + i) + 8 >> 4;
 }
 
-pub unsafe fn dav1d_cdef_brow_8bpc(
+pub(crate) unsafe fn rav1d_cdef_brow_8bpc(
     tc: *mut Rav1dTaskContext,
     p: *const *mut pixel,
     lflvl: *const Av1Filter,

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -1,9 +1,9 @@
 use crate::include::common::intops::ulog2;
 use crate::include::dav1d::headers::Dav1dPixelLayout;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I422;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
 use crate::src::align::Align16;
 use crate::src::cdef::CdefEdgeFlags;
 use crate::src::cdef::CDEF_HAVE_BOTTOM;
@@ -47,10 +47,10 @@ unsafe extern "C" fn backup2lines(
             (2 * y_stride) as usize,
         );
     }
-    if layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint {
+    if layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint {
         let uv_stride: ptrdiff_t = *stride.offset(1);
         if uv_stride < 0 {
-            let uv_off = if layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint {
+            let uv_off = if layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint {
                 3 as c_int
             } else {
                 7 as c_int
@@ -66,7 +66,7 @@ unsafe extern "C" fn backup2lines(
                 (-(2) * uv_stride) as usize,
             );
         } else {
-            let uv_off_0 = if layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint {
+            let uv_off_0 = if layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint {
                 2 as c_int
             } else {
                 6 as c_int
@@ -107,13 +107,13 @@ unsafe extern "C" fn backup2x8(
             y_off += *src_stride.offset(0);
         }
     }
-    if layout as c_uint == DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
+    if layout as c_uint == RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
         || flag as c_uint & BACKUP_2X8_UV as c_int as c_uint == 0
     {
         return;
     }
-    let ss_ver = (layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
-    let ss_hor = (layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+    let ss_ver = (layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+    let ss_hor = (layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
     x_off >>= ss_hor;
     y_off = 0 as c_int as ptrdiff_t;
     let mut y_0 = 0;
@@ -175,12 +175,12 @@ pub(crate) unsafe fn rav1d_cdef_brow_8bpc(
     let damping = (*(*f).frame_hdr).cdef.damping + bitdepth_min_8;
     let layout: Dav1dPixelLayout = (*f).cur.p.layout;
     let uv_idx =
-        (DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint).wrapping_sub(layout as c_uint) as c_int;
-    let ss_ver = (layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
-    let ss_hor = (layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+        (RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint).wrapping_sub(layout as c_uint) as c_int;
+    let ss_ver = (layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+    let ss_hor = (layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
     static uv_dirs: [[u8; 8]; 2] = [[0, 1, 2, 3, 4, 5, 6, 7], [7, 0, 2, 4, 5, 6, 6, 6]];
     let uv_dir: *const u8 = (uv_dirs
-        [(layout as c_uint == DAV1D_PIXEL_LAYOUT_I422 as c_int as c_uint) as c_int as usize])
+        [(layout as c_uint == RAV1D_PIXEL_LAYOUT_I422 as c_int as c_uint) as c_int as usize])
         .as_ptr();
     let have_tt = ((*(*f).c).n_tc > 1 as c_uint) as c_int;
     let sb128 = (*(*f).seq_hdr).sb128;
@@ -410,7 +410,7 @@ pub(crate) unsafe fn rav1d_cdef_brow_8bpc(
                             );
                         }
                         if !(uv_lvl == 0) {
-                            if !(layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint) {
+                            if !(layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint) {
                                 unreachable!();
                             }
                             uvdir = if uv_pri_lvl != 0 {

--- a/src/cdef_tmpl_16.rs
+++ b/src/cdef_tmpl_16.rs
@@ -21,7 +21,7 @@ use std::ffi::c_uint;
 use cfg_if::cfg_if;
 
 #[cfg(feature = "asm")]
-use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
+use crate::src::cpu::{rav1d_get_cpu_flags, CpuFlags};
 
 pub type pixel = u16;
 
@@ -504,7 +504,7 @@ unsafe extern "C" fn cdef_dsp_init_x86(c: *mut Rav1dCdefDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::cdef::*;
 
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSSE3) {
         return;
@@ -548,7 +548,7 @@ unsafe extern "C" fn cdef_dsp_init_arm(c: *mut Rav1dCdefDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::cdef::*;
 
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::NEON) {
         return;
@@ -666,7 +666,7 @@ unsafe extern "C" fn cdef_filter_4x4_neon_erased(
 }
 
 #[cold]
-pub unsafe fn dav1d_cdef_dsp_init_16bpc(c: *mut Rav1dCdefDSPContext) {
+pub unsafe fn rav1d_cdef_dsp_init_16bpc(c: *mut Rav1dCdefDSPContext) {
     (*c).dir = cdef_find_dir_c_erased;
     (*c).fb[0] = cdef_filter_block_8x8_c_erased;
     (*c).fb[1] = cdef_filter_block_4x8_c_erased;

--- a/src/cdef_tmpl_8.rs
+++ b/src/cdef_tmpl_8.rs
@@ -482,7 +482,7 @@ unsafe fn cdef_find_dir_rust(mut img: *const pixel, stride: ptrdiff_t, var: *mut
 }
 
 #[cfg(feature = "asm")]
-use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
+use crate::src::cpu::{rav1d_get_cpu_flags, CpuFlags};
 
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
@@ -490,7 +490,7 @@ unsafe extern "C" fn cdef_dsp_init_x86(c: *mut Rav1dCdefDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::cdef::*;
 
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSE2) {
         return;
@@ -545,7 +545,7 @@ unsafe extern "C" fn cdef_dsp_init_arm(c: *mut Rav1dCdefDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::cdef::*;
 
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::NEON) {
         return;
@@ -660,7 +660,7 @@ unsafe extern "C" fn cdef_filter_8x8_neon_erased(
 }
 
 #[cold]
-pub unsafe fn dav1d_cdef_dsp_init_8bpc(c: *mut Rav1dCdefDSPContext) {
+pub unsafe fn rav1d_cdef_dsp_init_8bpc(c: *mut Rav1dCdefDSPContext) {
     (*c).dir = cdef_find_dir_c_erased;
     (*c).fb[0] = cdef_filter_block_8x8_c_erased;
     (*c).fb[1] = cdef_filter_block_4x8_c_erased;

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -1,4 +1,5 @@
 use crate::include::dav1d::headers::Dav1dFrameHeader;
+use crate::include::dav1d::headers::Rav1dFrameHeader;
 use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
 use crate::include::stdatomic::atomic_uint;
 use crate::src::align::Align16;
@@ -14,9 +15,9 @@ use crate::src::levels::N_MV_JOINTS;
 use crate::src::levels::N_PARTITIONS;
 use crate::src::levels::N_TX_SIZES;
 use crate::src::levels::N_UV_INTRA_PRED_MODES;
-use crate::src::r#ref::dav1d_ref_create_using_pool;
-use crate::src::r#ref::dav1d_ref_dec;
-use crate::src::r#ref::dav1d_ref_inc;
+use crate::src::r#ref::rav1d_ref_create_using_pool;
+use crate::src::r#ref::rav1d_ref_dec;
+use crate::src::r#ref::rav1d_ref_inc;
 use crate::src::r#ref::Rav1dRef;
 use crate::src::tables::dav1d_partition_type_count;
 use libc::memcpy;
@@ -4879,8 +4880,8 @@ static av1_default_coef_cdf: [CdfCoefContext; 4] = [
     },
 ];
 
-pub unsafe fn dav1d_cdf_thread_update(
-    hdr: *const Dav1dFrameHeader,
+pub(crate) unsafe fn rav1d_cdf_thread_update(
+    hdr: *const Rav1dFrameHeader,
     dst: *mut CdfContext,
     src: *const CdfContext,
 ) {
@@ -5597,6 +5598,15 @@ pub unsafe fn dav1d_cdf_thread_update(
     }
 }
 
+pub unsafe fn dav1d_cdf_thread_update(
+    hdr: *const Dav1dFrameHeader,
+    dst: *mut CdfContext,
+    src: *const CdfContext,
+) {
+    let hdr = hdr.read().into_rust();
+    rav1d_cdf_thread_update(&hdr, dst, src)
+}
+
 #[inline]
 unsafe extern "C" fn get_qcat_idx(q: c_int) -> c_int {
     if q <= 20 {
@@ -5611,12 +5621,12 @@ unsafe extern "C" fn get_qcat_idx(q: c_int) -> c_int {
     return 3 as c_int;
 }
 
-pub unsafe fn dav1d_cdf_thread_init_static(cdf: *mut CdfThreadContext, qidx: c_int) {
+pub unsafe fn rav1d_cdf_thread_init_static(cdf: *mut CdfThreadContext, qidx: c_int) {
     (*cdf).r#ref = 0 as *mut Rav1dRef;
     (*cdf).data.qcat = get_qcat_idx(qidx) as c_uint;
 }
 
-pub unsafe fn dav1d_cdf_thread_copy(dst: *mut CdfContext, src: *const CdfThreadContext) {
+pub unsafe fn rav1d_cdf_thread_copy(dst: *mut CdfContext, src: *const CdfThreadContext) {
     if !((*src).r#ref).is_null() {
         memcpy(
             dst as *mut c_void,
@@ -5648,12 +5658,12 @@ pub unsafe fn dav1d_cdf_thread_copy(dst: *mut CdfContext, src: *const CdfThreadC
     };
 }
 
-pub unsafe fn dav1d_cdf_thread_alloc(
+pub unsafe fn rav1d_cdf_thread_alloc(
     c: *mut Rav1dContext,
     cdf: *mut CdfThreadContext,
     have_frame_mt: c_int,
 ) -> c_int {
-    (*cdf).r#ref = dav1d_ref_create_using_pool(
+    (*cdf).r#ref = rav1d_ref_create_using_pool(
         (*c).cdf_pool,
         (::core::mem::size_of::<CdfContext>()).wrapping_add(::core::mem::size_of::<atomic_uint>()),
     );
@@ -5668,18 +5678,18 @@ pub unsafe fn dav1d_cdf_thread_alloc(
     return 0 as c_int;
 }
 
-pub unsafe fn dav1d_cdf_thread_ref(dst: *mut CdfThreadContext, src: *mut CdfThreadContext) {
+pub unsafe fn rav1d_cdf_thread_ref(dst: *mut CdfThreadContext, src: *mut CdfThreadContext) {
     *dst = (*src).clone();
     if !((*src).r#ref).is_null() {
-        dav1d_ref_inc((*src).r#ref);
+        rav1d_ref_inc((*src).r#ref);
     }
 }
 
-pub unsafe fn dav1d_cdf_thread_unref(cdf: *mut CdfThreadContext) {
+pub unsafe fn rav1d_cdf_thread_unref(cdf: *mut CdfThreadContext) {
     memset(
         &mut (*cdf).data as *mut CdfThreadContext_data as *mut c_void,
         0 as c_int,
         (::core::mem::size_of::<CdfThreadContext>()).wrapping_sub(8),
     );
-    dav1d_ref_dec(&mut (*cdf).r#ref);
+    rav1d_ref_dec(&mut (*cdf).r#ref);
 }

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -5603,7 +5603,7 @@ pub unsafe fn dav1d_cdf_thread_update(
     dst: *mut CdfContext,
     src: *const CdfContext,
 ) {
-    let hdr = hdr.read().into_rust();
+    let hdr = hdr.read().into();
     rav1d_cdf_thread_update(&hdr, dst, src)
 }
 

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -1,6 +1,6 @@
 use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
+use crate::include::dav1d::headers::RAV1D_N_SWITCHABLE_FILTERS;
 use crate::include::stdatomic::atomic_uint;
 use crate::src::align::Align16;
 use crate::src::align::Align32;
@@ -5374,7 +5374,7 @@ pub(crate) unsafe fn rav1d_cdf_thread_update(
                 ::core::mem::size_of::<[u16; 4]>(),
             );
             (*dst).m.filter.0[k_16 as usize][j_27 as usize]
-                [(DAV1D_N_SWITCHABLE_FILTERS as c_int - 1) as usize] = 0 as c_int as u16;
+                [(RAV1D_N_SWITCHABLE_FILTERS as c_int - 1) as usize] = 0 as c_int as u16;
             j_27 += 1;
         }
         k_16 += 1;

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,9 +1,9 @@
-use crate::include::dav1d::common::Dav1dDataProps;
-use crate::include::dav1d::data::Dav1dData;
-use crate::src::r#ref::dav1d_ref_create;
-use crate::src::r#ref::dav1d_ref_dec;
-use crate::src::r#ref::dav1d_ref_inc;
-use crate::src::r#ref::dav1d_ref_wrap;
+use crate::include::dav1d::common::Rav1dDataProps;
+use crate::include::dav1d::data::Rav1dData;
+use crate::src::r#ref::rav1d_ref_create;
+use crate::src::r#ref::rav1d_ref_dec;
+use crate::src::r#ref::rav1d_ref_inc;
+use crate::src::r#ref::rav1d_ref_wrap;
 use crate::src::r#ref::Rav1dRef;
 use crate::stderr;
 use libc::fprintf;
@@ -12,7 +12,7 @@ use std::ffi::c_char;
 use std::ffi::c_int;
 use std::ffi::c_void;
 
-pub unsafe fn dav1d_data_create_internal(buf: *mut Dav1dData, sz: usize) -> *mut u8 {
+pub(crate) unsafe fn rav1d_data_create_internal(buf: *mut Rav1dData, sz: usize) -> *mut u8 {
     if buf.is_null() {
         fprintf(
             stderr,
@@ -26,19 +26,19 @@ pub unsafe fn dav1d_data_create_internal(buf: *mut Dav1dData, sz: usize) -> *mut
     if sz > usize::MAX / 2 {
         return 0 as *mut u8;
     }
-    (*buf).r#ref = dav1d_ref_create(sz);
+    (*buf).r#ref = rav1d_ref_create(sz);
     if ((*buf).r#ref).is_null() {
         return 0 as *mut u8;
     }
     (*buf).data = (*(*buf).r#ref).const_data as *const u8;
     (*buf).sz = sz;
-    dav1d_data_props_set_defaults(&mut (*buf).m);
+    rav1d_data_props_set_defaults(&mut (*buf).m);
     (*buf).m.size = sz;
     return (*(*buf).r#ref).data as *mut u8;
 }
 
-pub unsafe fn dav1d_data_wrap_internal(
-    buf: *mut Dav1dData,
+pub(crate) unsafe fn rav1d_data_wrap_internal(
+    buf: *mut Rav1dData,
     ptr: *const u8,
     sz: usize,
     free_callback: Option<unsafe extern "C" fn(*const u8, *mut c_void) -> ()>,
@@ -74,19 +74,19 @@ pub unsafe fn dav1d_data_wrap_internal(
         );
         return -(22 as c_int);
     }
-    (*buf).r#ref = dav1d_ref_wrap(ptr, free_callback, cookie);
+    (*buf).r#ref = rav1d_ref_wrap(ptr, free_callback, cookie);
     if ((*buf).r#ref).is_null() {
         return -(12 as c_int);
     }
     (*buf).data = ptr;
     (*buf).sz = sz;
-    dav1d_data_props_set_defaults(&mut (*buf).m);
+    rav1d_data_props_set_defaults(&mut (*buf).m);
     (*buf).m.size = sz;
     return 0 as c_int;
 }
 
-pub unsafe fn dav1d_data_wrap_user_data_internal(
-    buf: *mut Dav1dData,
+pub(crate) unsafe fn rav1d_data_wrap_user_data_internal(
+    buf: *mut Rav1dData,
     user_data: *const u8,
     free_callback: Option<unsafe extern "C" fn(*const u8, *mut c_void) -> ()>,
     cookie: *mut c_void,
@@ -115,7 +115,7 @@ pub unsafe fn dav1d_data_wrap_user_data_internal(
         );
         return -(22 as c_int);
     }
-    (*buf).m.user_data.r#ref = dav1d_ref_wrap(user_data, free_callback, cookie);
+    (*buf).m.user_data.r#ref = rav1d_ref_wrap(user_data, free_callback, cookie);
     if ((*buf).m.user_data.r#ref).is_null() {
         return -(12 as c_int);
     }
@@ -123,13 +123,13 @@ pub unsafe fn dav1d_data_wrap_user_data_internal(
     return 0 as c_int;
 }
 
-pub unsafe fn dav1d_data_ref(dst: *mut Dav1dData, src: *const Dav1dData) {
+pub(crate) unsafe fn rav1d_data_ref(dst: *mut Rav1dData, src: *const Rav1dData) {
     if dst.is_null() {
         fprintf(
             stderr,
             b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
             b"dst != ((void*)0)\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 15], &[c_char; 15]>(b"dav1d_data_ref\0")).as_ptr(),
+            (*::core::mem::transmute::<&[u8; 15], &[c_char; 15]>(b"rav1d_data_ref\0")).as_ptr(),
         );
         return;
     }
@@ -138,7 +138,7 @@ pub unsafe fn dav1d_data_ref(dst: *mut Dav1dData, src: *const Dav1dData) {
             stderr,
             b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
             b"dst->data == ((void*)0)\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 15], &[c_char; 15]>(b"dav1d_data_ref\0")).as_ptr(),
+            (*::core::mem::transmute::<&[u8; 15], &[c_char; 15]>(b"rav1d_data_ref\0")).as_ptr(),
         );
         return;
     }
@@ -147,7 +147,7 @@ pub unsafe fn dav1d_data_ref(dst: *mut Dav1dData, src: *const Dav1dData) {
             stderr,
             b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
             b"src != ((void*)0)\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 15], &[c_char; 15]>(b"dav1d_data_ref\0")).as_ptr(),
+            (*::core::mem::transmute::<&[u8; 15], &[c_char; 15]>(b"rav1d_data_ref\0")).as_ptr(),
         );
         return;
     }
@@ -157,46 +157,46 @@ pub unsafe fn dav1d_data_ref(dst: *mut Dav1dData, src: *const Dav1dData) {
                 stderr,
                 b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
                 b"src->data != ((void*)0)\0" as *const u8 as *const c_char,
-                (*::core::mem::transmute::<&[u8; 15], &[c_char; 15]>(b"dav1d_data_ref\0")).as_ptr(),
+                (*::core::mem::transmute::<&[u8; 15], &[c_char; 15]>(b"rav1d_data_ref\0")).as_ptr(),
             );
             return;
         }
-        dav1d_ref_inc((*src).r#ref);
+        rav1d_ref_inc((*src).r#ref);
     }
     if !((*src).m.user_data.r#ref).is_null() {
-        dav1d_ref_inc((*src).m.user_data.r#ref);
+        rav1d_ref_inc((*src).m.user_data.r#ref);
     }
     *dst = (*src).clone();
 }
 
-pub unsafe fn dav1d_data_props_copy(dst: *mut Dav1dDataProps, src: *const Dav1dDataProps) {
+pub(crate) unsafe fn rav1d_data_props_copy(dst: *mut Rav1dDataProps, src: *const Rav1dDataProps) {
     if dst.is_null() {
         unreachable!();
     }
     if src.is_null() {
         unreachable!();
     }
-    dav1d_ref_dec(&mut (*dst).user_data.r#ref);
+    rav1d_ref_dec(&mut (*dst).user_data.r#ref);
     *dst = (*src).clone();
     if !((*dst).user_data.r#ref).is_null() {
-        dav1d_ref_inc((*dst).user_data.r#ref);
+        rav1d_ref_inc((*dst).user_data.r#ref);
     }
 }
 
-pub unsafe fn dav1d_data_props_set_defaults(props: *mut Dav1dDataProps) {
+pub(crate) unsafe fn rav1d_data_props_set_defaults(props: *mut Rav1dDataProps) {
     if props.is_null() {
         unreachable!();
     }
     memset(
         props as *mut c_void,
         0 as c_int,
-        ::core::mem::size_of::<Dav1dDataProps>(),
+        ::core::mem::size_of::<Rav1dDataProps>(),
     );
     (*props).timestamp = i64::MIN;
     (*props).offset = -1;
 }
 
-pub unsafe fn dav1d_data_props_unref_internal(props: *mut Dav1dDataProps) {
+pub(crate) unsafe fn rav1d_data_props_unref_internal(props: *mut Rav1dDataProps) {
     if props.is_null() {
         fprintf(
             stderr,
@@ -210,11 +210,11 @@ pub unsafe fn dav1d_data_props_unref_internal(props: *mut Dav1dDataProps) {
         return;
     }
     let mut user_data_ref: *mut Rav1dRef = (*props).user_data.r#ref;
-    dav1d_data_props_set_defaults(props);
-    dav1d_ref_dec(&mut user_data_ref);
+    rav1d_data_props_set_defaults(props);
+    rav1d_ref_dec(&mut user_data_ref);
 }
 
-pub unsafe fn dav1d_data_unref_internal(buf: *mut Dav1dData) {
+pub(crate) unsafe fn rav1d_data_unref_internal(buf: *mut Rav1dData) {
     if buf.is_null() {
         fprintf(
             stderr,
@@ -239,13 +239,13 @@ pub unsafe fn dav1d_data_unref_internal(buf: *mut Dav1dData) {
             );
             return;
         }
-        dav1d_ref_dec(&mut (*buf).r#ref);
+        rav1d_ref_dec(&mut (*buf).r#ref);
     }
     memset(
         buf as *mut c_void,
         0 as c_int,
-        ::core::mem::size_of::<Dav1dData>(),
+        ::core::mem::size_of::<Rav1dData>(),
     );
-    dav1d_data_props_set_defaults(&mut (*buf).m);
-    dav1d_ref_dec(&mut user_data_ref);
+    rav1d_data_props_set_defaults(&mut (*buf).m);
+    rav1d_ref_dec(&mut user_data_ref);
 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -14,22 +14,22 @@ use crate::include::dav1d::headers::Dav1dRestorationType;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
 use crate::include::dav1d::headers::Dav1dTxfmMode;
 use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_MAX_SEGMENTS;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
+use crate::include::dav1d::headers::RAV1D_FILTER_8TAP_REGULAR;
+use crate::include::dav1d::headers::RAV1D_FILTER_SWITCHABLE;
+use crate::include::dav1d::headers::RAV1D_MAX_SEGMENTS;
+use crate::include::dav1d::headers::RAV1D_N_SWITCHABLE_FILTERS;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I422;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::RAV1D_RESTORATION_NONE;
+use crate::include::dav1d::headers::RAV1D_RESTORATION_SGRPROJ;
+use crate::include::dav1d::headers::RAV1D_RESTORATION_SWITCHABLE;
+use crate::include::dav1d::headers::RAV1D_RESTORATION_WIENER;
+use crate::include::dav1d::headers::RAV1D_TX_SWITCHABLE;
+use crate::include::dav1d::headers::RAV1D_WM_TYPE_AFFINE;
+use crate::include::dav1d::headers::RAV1D_WM_TYPE_IDENTITY;
+use crate::include::dav1d::headers::RAV1D_WM_TYPE_TRANSLATION;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
 use crate::src::align::Align16;
@@ -693,9 +693,9 @@ unsafe fn derive_warpmv(
     wmp.type_0 = if !dav1d_find_affine_int(&pts, ret, bw4, bh4, mv, &mut wmp, t.bx, t.by)
         && !dav1d_get_shear_params(&mut wmp)
     {
-        DAV1D_WM_TYPE_AFFINE
+        RAV1D_WM_TYPE_AFFINE
     } else {
-        DAV1D_WM_TYPE_IDENTITY
+        RAV1D_WM_TYPE_IDENTITY
     };
     wmp
 }
@@ -1099,7 +1099,7 @@ unsafe fn read_vartx_tree(
     {
         b.uvtx = TX_4X4 as u8;
         *b.max_ytx_mut() = b.uvtx;
-        if txfm_mode == DAV1D_TX_SWITCHABLE {
+        if txfm_mode == RAV1D_TX_SWITCHABLE {
             CaseSet::<32, false>::many(
                 [&mut t.l, &mut *t.a],
                 [bh4 as usize, bw4 as usize],
@@ -1109,8 +1109,8 @@ unsafe fn read_vartx_tree(
                 },
             );
         }
-    } else if txfm_mode != DAV1D_TX_SWITCHABLE || b.skip != 0 {
-        if txfm_mode == DAV1D_TX_SWITCHABLE {
+    } else if txfm_mode != RAV1D_TX_SWITCHABLE || b.skip != 0 {
+        if txfm_mode == RAV1D_TX_SWITCHABLE {
             CaseSet::<32, false>::many(
                 [(&mut t.l, 1), (&mut *t.a, 0)],
                 [bh4 as usize, bw4 as usize],
@@ -1382,8 +1382,8 @@ unsafe fn affine_lowest_px_chroma(
     wmp: &Dav1dWarpedMotionParams,
 ) {
     let f = &*t.f;
-    assert!(f.cur.p.layout != DAV1D_PIXEL_LAYOUT_I400);
-    if f.cur.p.layout == DAV1D_PIXEL_LAYOUT_I444 {
+    assert!(f.cur.p.layout != RAV1D_PIXEL_LAYOUT_I400);
+    if f.cur.p.layout == RAV1D_PIXEL_LAYOUT_I444 {
         affine_lowest_px_luma(t, dst, b_dim, wmp);
     } else {
         affine_lowest_px(
@@ -1391,7 +1391,7 @@ unsafe fn affine_lowest_px_chroma(
             dst,
             b_dim,
             wmp,
-            (f.cur.p.layout & DAV1D_PIXEL_LAYOUT_I420) as c_int,
+            (f.cur.p.layout & RAV1D_PIXEL_LAYOUT_I420) as c_int,
             1,
         );
     };
@@ -1410,8 +1410,8 @@ unsafe fn obmc_lowest_px(
     assert!(t.bx & 1 == 0 && t.by & 1 == 0);
     let f = &*t.f;
     let r = &t.rt.r[(t.by as usize & 31) + 5 - 1..];
-    let ss_ver = (is_chroma && f.cur.p.layout == DAV1D_PIXEL_LAYOUT_I420) as c_int;
-    let ss_hor = (is_chroma && f.cur.p.layout != DAV1D_PIXEL_LAYOUT_I444) as c_int;
+    let ss_ver = (is_chroma && f.cur.p.layout == RAV1D_PIXEL_LAYOUT_I420) as c_int;
+    let ss_hor = (is_chroma && f.cur.p.layout != RAV1D_PIXEL_LAYOUT_I444) as c_int;
     let h_mul = 4 >> ss_hor;
     let v_mul = 4 >> ss_ver;
     if t.by > (*t.ts).tiling.row_start
@@ -1494,8 +1494,8 @@ unsafe fn decode_b(
     let b_dim = &dav1d_block_dimensions[bs as usize];
     let bx4 = t.bx & 31;
     let by4 = t.by & 31;
-    let ss_ver = (f.cur.p.layout == DAV1D_PIXEL_LAYOUT_I420) as c_int;
-    let ss_hor = (f.cur.p.layout != DAV1D_PIXEL_LAYOUT_I444) as c_int;
+    let ss_ver = (f.cur.p.layout == RAV1D_PIXEL_LAYOUT_I420) as c_int;
+    let ss_hor = (f.cur.p.layout != RAV1D_PIXEL_LAYOUT_I444) as c_int;
     let cbx4 = bx4 >> ss_hor;
     let cby4 = by4 >> ss_ver;
     let bw4 = b_dim[0] as c_int;
@@ -1506,7 +1506,7 @@ unsafe fn decode_b(
     let cbh4 = bh4 + ss_ver >> ss_ver;
     let have_left = t.bx > ts.tiling.col_start;
     let have_top = t.by > ts.tiling.row_start;
-    let has_chroma = f.cur.p.layout != DAV1D_PIXEL_LAYOUT_I400
+    let has_chroma = f.cur.p.layout != RAV1D_PIXEL_LAYOUT_I400
         && (bw4 > ss_hor || t.bx & 1 != 0)
         && (bh4 > ss_ver || t.by & 1 != 0);
 
@@ -1560,9 +1560,9 @@ unsafe fn decode_b(
                 && b.motion_mode() as MotionMode == MM_WARP
             {
                 if b.matrix()[0] == i16::MIN {
-                    t.warpmv.type_0 = DAV1D_WM_TYPE_IDENTITY;
+                    t.warpmv.type_0 = RAV1D_WM_TYPE_IDENTITY;
                 } else {
-                    t.warpmv.type_0 = DAV1D_WM_TYPE_AFFINE;
+                    t.warpmv.type_0 = RAV1D_WM_TYPE_AFFINE;
                     t.warpmv.matrix[2] = b.matrix()[0] as i32 + 0x10000;
                     t.warpmv.matrix[3] = b.matrix()[1] as i32;
                     t.warpmv.matrix[4] = b.matrix()[2] as i32;
@@ -1653,7 +1653,7 @@ unsafe fn decode_b(
             if !(f.prev_segmap).is_null() {
                 let seg_id =
                     get_prev_frame_segid(f, t.by, t.bx, w4, h4, f.prev_segmap, f.b4_stride);
-                if seg_id >= DAV1D_MAX_SEGMENTS.into() {
+                if seg_id >= RAV1D_MAX_SEGMENTS.into() {
                     return -1;
                 }
                 b.seg_id = seg_id;
@@ -1674,7 +1674,7 @@ unsafe fn decode_b(
                 if !(f.prev_segmap).is_null() {
                     let seg_id =
                         get_prev_frame_segid(f, t.by, t.bx, w4, h4, f.prev_segmap, f.b4_stride);
-                    if seg_id >= DAV1D_MAX_SEGMENTS.into() {
+                    if seg_id >= RAV1D_MAX_SEGMENTS.into() {
                         return -1;
                     }
                     b.seg_id = seg_id;
@@ -1687,7 +1687,7 @@ unsafe fn decode_b(
                 let diff = rav1d_msac_decode_symbol_adapt8(
                     &mut ts.msac,
                     &mut ts.cdf.m.seg_id[seg_ctx as usize],
-                    DAV1D_MAX_SEGMENTS as usize - 1,
+                    RAV1D_MAX_SEGMENTS as usize - 1,
                 );
                 let last_active_seg_id = frame_hdr.segmentation.seg_data.last_active_segid;
                 b.seg_id =
@@ -1696,7 +1696,7 @@ unsafe fn decode_b(
                 if b.seg_id as c_int > last_active_seg_id {
                     b.seg_id = 0; // error?
                 }
-                if b.seg_id >= DAV1D_MAX_SEGMENTS {
+                if b.seg_id >= RAV1D_MAX_SEGMENTS {
                     b.seg_id = 0; // error?
                 }
             }
@@ -1758,7 +1758,7 @@ unsafe fn decode_b(
             if !(f.prev_segmap).is_null() {
                 let seg_id =
                     get_prev_frame_segid(f, t.by, t.bx, w4, h4, f.prev_segmap, f.b4_stride);
-                if seg_id >= DAV1D_MAX_SEGMENTS.into() {
+                if seg_id >= RAV1D_MAX_SEGMENTS.into() {
                     return -1;
                 }
                 b.seg_id = seg_id;
@@ -1774,7 +1774,7 @@ unsafe fn decode_b(
                 let diff = rav1d_msac_decode_symbol_adapt8(
                     &mut ts.msac,
                     &mut ts.cdf.m.seg_id[seg_ctx as usize],
-                    DAV1D_MAX_SEGMENTS as usize - 1,
+                    RAV1D_MAX_SEGMENTS as usize - 1,
                 );
                 let last_active_seg_id = (*f.frame_hdr).segmentation.seg_data.last_active_segid;
                 b.seg_id =
@@ -1784,7 +1784,7 @@ unsafe fn decode_b(
                     b.seg_id = 0; // error?
                 }
             }
-            if b.seg_id >= DAV1D_MAX_SEGMENTS {
+            if b.seg_id >= RAV1D_MAX_SEGMENTS {
                 b.seg_id = 0; // error?
             }
         }
@@ -1864,7 +1864,7 @@ unsafe fn decode_b(
 
             if frame_hdr.delta.lf.present != 0 {
                 let n_lfs = if frame_hdr.delta.lf.multi != 0 {
-                    if f.cur.p.layout != DAV1D_PIXEL_LAYOUT_I400 {
+                    if f.cur.p.layout != RAV1D_PIXEL_LAYOUT_I400 {
                         4
                     } else {
                         2
@@ -2160,7 +2160,7 @@ unsafe fn decode_b(
             *b.tx_mut() = dav1d_max_txfm_size_for_bs[bs as usize][0];
             b.uvtx = dav1d_max_txfm_size_for_bs[bs as usize][f.cur.p.layout as usize];
             let mut t_dim = &dav1d_txfm_dimensions[b.tx() as usize];
-            if frame_hdr.txfm_mode == DAV1D_TX_SWITCHABLE && t_dim.max > TX_4X4 as u8 {
+            if frame_hdr.txfm_mode == RAV1D_TX_SWITCHABLE && t_dim.max > TX_4X4 as u8 {
                 let tctx = get_tx_ctx(&*t.a, &t.l, &*t_dim, by4, bx4);
                 let tx_cdf = &mut ts.cdf.m.txsz[(t_dim.max - 1) as usize][tctx as usize];
                 let depth = rav1d_msac_decode_symbol_adapt4(
@@ -2242,8 +2242,8 @@ unsafe fn decode_b(
                     case.set(&mut dir.comp_type.0, COMP_INTER_NONE);
                     case.set(&mut dir.r#ref[0], -1);
                     case.set(&mut dir.r#ref[1], -1);
-                    case.set(&mut dir.filter.0[0], DAV1D_N_SWITCHABLE_FILTERS as u8);
-                    case.set(&mut dir.filter.0[1], DAV1D_N_SWITCHABLE_FILTERS as u8);
+                    case.set(&mut dir.filter.0[0], RAV1D_N_SWITCHABLE_FILTERS as u8);
+                    case.set(&mut dir.filter.0[1], RAV1D_N_SWITCHABLE_FILTERS as u8);
                 }
             },
         );
@@ -2662,7 +2662,7 @@ unsafe fn decode_b(
                 }
                 GLOBALMV => {
                     has_subpel_filter |=
-                        frame_hdr.gmv[b.r#ref()[idx] as usize].type_0 == DAV1D_WM_TYPE_TRANSLATION;
+                        frame_hdr.gmv[b.r#ref()[idx] as usize].type_0 == RAV1D_WM_TYPE_TRANSLATION;
                     b.mv_mut()[idx] = get_gmv_2d(
                         &frame_hdr.gmv[b.r#ref()[idx] as usize],
                         t.bx,
@@ -2868,7 +2868,7 @@ unsafe fn decode_b(
                         frame_hdr,
                     );
                     has_subpel_filter = cmp::min(bw4, bh4) == 1
-                        || frame_hdr.gmv[b.r#ref()[0] as usize].type_0 == DAV1D_WM_TYPE_TRANSLATION;
+                        || frame_hdr.gmv[b.r#ref()[0] as usize].type_0 == RAV1D_WM_TYPE_TRANSLATION;
                 } else {
                     has_subpel_filter = true;
                     if rav1d_msac_decode_bool_adapt(
@@ -3022,7 +3022,7 @@ unsafe fn decode_b(
                 // is not warped global motion
                 && !(frame_hdr.force_integer_mv == 0
                     && b.inter_mode() == GLOBALMV
-                    && frame_hdr.gmv[b.r#ref()[0] as usize].type_0 > DAV1D_WM_TYPE_TRANSLATION)
+                    && frame_hdr.gmv[b.r#ref()[0] as usize].type_0 > RAV1D_WM_TYPE_TRANSLATION)
                 // has overlappable neighbours
                 && (have_left && findoddzero(&t.l.intra.0[by4 as usize..][..h4 as usize])
                     || have_top && findoddzero(&(*t.a).intra.0[bx4 as usize..][..w4 as usize]))
@@ -3079,7 +3079,7 @@ unsafe fn decode_b(
                         );
                     }
                     if t.frame_thread.pass != 0 {
-                        if t.warpmv.type_0 == DAV1D_WM_TYPE_AFFINE {
+                        if t.warpmv.type_0 == RAV1D_WM_TYPE_AFFINE {
                             b.matrix_mut()[0] = (t.warpmv.matrix[2] - 0x10000) as i16;
                             b.matrix_mut()[1] = t.warpmv.matrix[3] as i16;
                             b.matrix_mut()[2] = t.warpmv.matrix[4] as i16;
@@ -3105,14 +3105,14 @@ unsafe fn decode_b(
         }
 
         // subpel filter
-        let filter = if frame_hdr.subpel_filter_mode == DAV1D_FILTER_SWITCHABLE {
+        let filter = if frame_hdr.subpel_filter_mode == RAV1D_FILTER_SWITCHABLE {
             if has_subpel_filter {
                 let comp = b.comp_type() != COMP_INTER_NONE;
                 let ctx1 = get_filter_ctx(&*t.a, &t.l, comp, false, b.r#ref()[0], by4, bx4);
                 let filter0 = rav1d_msac_decode_symbol_adapt4(
                     &mut ts.msac,
                     &mut ts.cdf.m.filter.0[0][ctx1 as usize],
-                    DAV1D_N_SWITCHABLE_FILTERS as usize - 1,
+                    RAV1D_N_SWITCHABLE_FILTERS as usize - 1,
                 ) as Dav1dFilterMode;
                 if (*f.seq_hdr).dual_filter != 0 {
                     let ctx2 = get_filter_ctx(&*t.a, &t.l, comp, true, b.r#ref()[0], by4, bx4);
@@ -3125,7 +3125,7 @@ unsafe fn decode_b(
                     let filter1 = rav1d_msac_decode_symbol_adapt4(
                         &mut ts.msac,
                         &mut ts.cdf.m.filter.0[1][ctx2 as usize],
-                        DAV1D_N_SWITCHABLE_FILTERS as usize - 1,
+                        RAV1D_N_SWITCHABLE_FILTERS as usize - 1,
                     ) as Dav1dFilterMode;
                     if DEBUG_BLOCK_INFO(f, t) {
                         println!(
@@ -3144,7 +3144,7 @@ unsafe fn decode_b(
                     [filter0; 2]
                 }
             } else {
-                [DAV1D_FILTER_8TAP_REGULAR; 2]
+                [RAV1D_FILTER_8TAP_REGULAR; 2]
             }
         } else {
             [frame_hdr.subpel_filter_mode; 2]
@@ -3289,7 +3289,7 @@ unsafe fn decode_b(
             if cmp::min(bw4, bh4) > 1
                 && (b.inter_mode() == GLOBALMV && f.gmv_warp_allowed[b.r#ref()[0] as usize] != 0
                     || b.motion_mode() == MM_WARP as u8
-                        && t.warpmv.type_0 > DAV1D_WM_TYPE_TRANSLATION)
+                        && t.warpmv.type_0 > RAV1D_WM_TYPE_TRANSLATION)
             {
                 affine_lowest_px_luma(
                     t,
@@ -3387,7 +3387,7 @@ unsafe fn decode_b(
                     && (b.inter_mode() == GLOBALMV
                         && f.gmv_warp_allowed[b.r#ref()[0] as usize] != 0
                         || b.motion_mode() == MM_WARP as u8
-                            && t.warpmv.type_0 > DAV1D_WM_TYPE_TRANSLATION)
+                            && t.warpmv.type_0 > RAV1D_WM_TYPE_TRANSLATION)
                 {
                     affine_lowest_px_chroma(
                         t,
@@ -3529,7 +3529,7 @@ unsafe fn decode_sb(t: &mut Rav1dTaskContext, bl: BlockLevel, node: *const EdgeN
                 pc,
                 dav1d_partition_type_count[bl as usize].into(),
             ) as BlockPartition;
-            if f.cur.p.layout == DAV1D_PIXEL_LAYOUT_I422
+            if f.cur.p.layout == RAV1D_PIXEL_LAYOUT_I422
                 && (bp == PARTITION_V
                     || bp == PARTITION_V4
                     || bp == PARTITION_T_LEFT_SPLIT
@@ -3801,7 +3801,7 @@ unsafe fn decode_sb(t: &mut Rav1dTaskContext, bl: BlockLevel, node: *const EdgeN
         let is_split;
         if let Some(pc) = pc {
             is_split = rav1d_msac_decode_bool(&mut ts.msac, gather_left_partition_prob(pc, bl));
-            if f.cur.p.layout == DAV1D_PIXEL_LAYOUT_I422 && !is_split {
+            if f.cur.p.layout == RAV1D_PIXEL_LAYOUT_I422 && !is_split {
                 return 1;
             }
             if DEBUG_BLOCK_INFO(f, t) {
@@ -3899,7 +3899,7 @@ fn reset_context(ctx: &mut BlockContext, keyframe: bool, pass: c_int) {
         ccoef.fill(0x40);
     }
     for filter in &mut ctx.filter.0 {
-        filter.fill(DAV1D_N_SWITCHABLE_FILTERS as u8);
+        filter.fill(RAV1D_N_SWITCHABLE_FILTERS as u8);
     }
     ctx.seg_pred.0.fill(0);
     ctx.pal_sz.0.fill(0);
@@ -3908,10 +3908,10 @@ fn reset_context(ctx: &mut BlockContext, keyframe: bool, pass: c_int) {
 /// `{ Y+U+V, Y+U } * 4`
 static ss_size_mul: [[u8; 2]; 4] = {
     let mut a = [[0; 2]; 4];
-    a[DAV1D_PIXEL_LAYOUT_I400 as usize] = [4, 4];
-    a[DAV1D_PIXEL_LAYOUT_I420 as usize] = [6, 5];
-    a[DAV1D_PIXEL_LAYOUT_I422 as usize] = [8, 6];
-    a[DAV1D_PIXEL_LAYOUT_I444 as usize] = [12, 8];
+    a[RAV1D_PIXEL_LAYOUT_I400 as usize] = [4, 4];
+    a[RAV1D_PIXEL_LAYOUT_I420 as usize] = [6, 5];
+    a[RAV1D_PIXEL_LAYOUT_I422 as usize] = [8, 6];
+    a[RAV1D_PIXEL_LAYOUT_I444 as usize] = [12, 8];
     a
 };
 
@@ -3991,7 +3991,7 @@ unsafe fn setup_tile(
         }
 
         let lr_ref = if diff_width {
-            let ss_hor = (p != 0 && f.cur.p.layout != DAV1D_PIXEL_LAYOUT_I444) as c_int;
+            let ss_hor = (p != 0 && f.cur.p.layout != RAV1D_PIXEL_LAYOUT_I444) as c_int;
             let d = (*f.frame_hdr).super_res.width_scale_denominator;
             let unit_size_log2 = (*f.frame_hdr).restoration.unit_size[(p != 0) as usize];
             let rnd = (8 << unit_size_log2) - 1;
@@ -4032,22 +4032,22 @@ unsafe fn read_restoration_info(
     let ts = &mut *t.ts;
     let lr_ref = &*ts.lr_ref[p];
 
-    if frame_type == DAV1D_RESTORATION_SWITCHABLE {
+    if frame_type == RAV1D_RESTORATION_SWITCHABLE {
         let filter =
             rav1d_msac_decode_symbol_adapt4(&mut ts.msac, &mut ts.cdf.m.restore_switchable.0, 2);
         lr.r#type = if filter != 0 {
             if filter == 2 {
-                DAV1D_RESTORATION_SGRPROJ
+                RAV1D_RESTORATION_SGRPROJ
             } else {
-                DAV1D_RESTORATION_WIENER
+                RAV1D_RESTORATION_WIENER
             }
         } else {
-            DAV1D_RESTORATION_NONE
+            RAV1D_RESTORATION_NONE
         };
     } else {
         let r#type = rav1d_msac_decode_bool_adapt(
             &mut ts.msac,
-            if frame_type == DAV1D_RESTORATION_WIENER {
+            if frame_type == RAV1D_RESTORATION_WIENER {
                 &mut ts.cdf.m.restore_wiener.0
             } else {
                 &mut ts.cdf.m.restore_sgrproj.0
@@ -4056,7 +4056,7 @@ unsafe fn read_restoration_info(
         lr.r#type = if r#type {
             frame_type
         } else {
-            DAV1D_RESTORATION_NONE
+            RAV1D_RESTORATION_NONE
         };
     }
 
@@ -4069,7 +4069,7 @@ unsafe fn read_restoration_info(
         ) - adjustment as libc::c_int) as i8
     }
 
-    if lr.r#type == DAV1D_RESTORATION_WIENER {
+    if lr.r#type == RAV1D_RESTORATION_WIENER {
         lr.filter_v[0] = if p != 0 {
             0
         } else {
@@ -4100,7 +4100,7 @@ unsafe fn read_restoration_info(
                 ts.msac.rng,
             );
         }
-    } else if lr.r#type == DAV1D_RESTORATION_SGRPROJ {
+    } else if lr.r#type == RAV1D_RESTORATION_SGRPROJ {
         let idx = rav1d_msac_decode_bools(&mut ts.msac, 4) as u8;
         let sgr_params = &dav1d_sgr_params[idx.into()];
         lr.sgr_idx = idx;
@@ -4249,10 +4249,10 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(t: *mut Rav1dTaskContext) -> c_int 
         while p < 3 {
             if !(((*f).lf.restore_planes >> p) as c_uint & 1 as c_uint == 0) {
                 let ss_ver = (p != 0
-                    && (*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
+                    && (*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
                     as c_int;
                 let ss_hor = (p != 0
-                    && (*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint)
+                    && (*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint)
                     as c_int;
                 let unit_size_log2 =
                     (*(*f).frame_hdr).restoration.unit_size[(p != 0) as c_int as usize];
@@ -4346,7 +4346,7 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(t: *mut Rav1dTaskContext) -> c_int 
         sb_step as usize,
     );
     let ss_ver_0 =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     align_h >>= ss_ver_0;
     memcpy(
         &mut *(*((*f).lf.tx_lpf_right_edge).as_ptr().offset(1))
@@ -4682,7 +4682,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init(f: &mut Rav1dFrameContext) -> c_int
         .type_0
         .iter()
         .enumerate()
-        .map(|(i, &r#type)| ((r#type != DAV1D_RESTORATION_NONE) as u8) << i)
+        .map(|(i, &r#type)| ((r#type != RAV1D_RESTORATION_NONE) as u8) << i)
         .sum::<u8>()
         .into();
     if (*f.frame_hdr).loopfilter.sharpness != f.lf.last_sharpness {
@@ -4799,7 +4799,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init(f: &mut Rav1dFrameContext) -> c_int
     // to avoid having additional in-loop branches in various places.
     // We never dereference those pointers, so it doesn't really matter
     // what they point at, as long as the pointers are valid.
-    let has_chroma = (f.cur.p.layout != DAV1D_PIXEL_LAYOUT_I400) as usize;
+    let has_chroma = (f.cur.p.layout != RAV1D_PIXEL_LAYOUT_I400) as usize;
     f.lf.mask_ptr = f.lf.mask;
     f.lf.p = array::from_fn(|i| f.cur.data[has_chroma * i].cast());
     f.lf.sr_p = array::from_fn(|i| f.sr_cur.p.data[has_chroma * i].cast());
@@ -5273,7 +5273,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
                 f.svc[i][1].scale = 0;
                 f.svc[i][0].scale = f.svc[i][1].scale;
             }
-            f.gmv_warp_allowed[i] = ((*f.frame_hdr).gmv[i].type_0 > DAV1D_WM_TYPE_TRANSLATION
+            f.gmv_warp_allowed[i] = ((*f.frame_hdr).gmv[i].type_0 > RAV1D_WM_TYPE_TRANSLATION
                 && (*f.frame_hdr).force_integer_mv == 0
                 && !dav1d_get_shear_params(&mut (*f.frame_hdr).gmv[i])
                 && f.svc[i][0].scale == 0) as u8;
@@ -5335,7 +5335,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
     }
     if (*f.frame_hdr).width[0] != (*f.frame_hdr).width[1] {
         f.resize_step[0] = scale_fac(f.cur.p.w, f.sr_cur.p.p.w);
-        let ss_hor = (f.cur.p.layout != DAV1D_PIXEL_LAYOUT_I444) as c_int;
+        let ss_hor = (f.cur.p.layout != RAV1D_PIXEL_LAYOUT_I444) as c_int;
         let in_cw = f.cur.p.w + ss_hor >> ss_hor;
         let out_cw = f.sr_cur.p.p.w + ss_hor >> ss_hor;
         f.resize_step[1] = scale_fac(in_cw, out_cw);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -33,17 +33,17 @@ use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
 use crate::src::align::Align16;
-use crate::src::cdf::dav1d_cdf_thread_alloc;
-use crate::src::cdf::dav1d_cdf_thread_copy;
-use crate::src::cdf::dav1d_cdf_thread_init_static;
-use crate::src::cdf::dav1d_cdf_thread_ref;
-use crate::src::cdf::dav1d_cdf_thread_unref;
 use crate::src::cdf::dav1d_cdf_thread_update;
+use crate::src::cdf::rav1d_cdf_thread_alloc;
+use crate::src::cdf::rav1d_cdf_thread_copy;
+use crate::src::cdf::rav1d_cdf_thread_init_static;
+use crate::src::cdf::rav1d_cdf_thread_ref;
+use crate::src::cdf::rav1d_cdf_thread_unref;
 use crate::src::cdf::CdfMvComponent;
 use crate::src::cdf::CdfMvContext;
 use crate::src::ctx::CaseSet;
-use crate::src::data::dav1d_data_props_copy;
-use crate::src::data::dav1d_data_unref_internal;
+use crate::src::data::rav1d_data_props_copy;
+use crate::src::data::rav1d_data_unref_internal;
 use crate::src::dequant_tables::dav1d_dq_tbl;
 use crate::src::env::av1_get_bwd_ref_1_ctx;
 use crate::src::env::av1_get_bwd_ref_ctx;
@@ -145,47 +145,47 @@ use crate::src::levels::TX_64X64;
 use crate::src::levels::TX_8X8;
 use crate::src::levels::VERT_LEFT_PRED;
 use crate::src::levels::VERT_PRED;
-use crate::src::lf_mask::dav1d_calc_eih;
 use crate::src::lf_mask::dav1d_calc_lf_values;
-use crate::src::lf_mask::dav1d_create_lf_mask_inter;
-use crate::src::lf_mask::dav1d_create_lf_mask_intra;
+use crate::src::lf_mask::rav1d_calc_eih;
+use crate::src::lf_mask::rav1d_create_lf_mask_inter;
+use crate::src::lf_mask::rav1d_create_lf_mask_intra;
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
-use crate::src::log::dav1d_log;
-use crate::src::looprestoration::dav1d_loop_restoration_dsp_init;
-use crate::src::mc::dav1d_mc_dsp_init;
-use crate::src::mem::dav1d_alloc_aligned;
-use crate::src::mem::dav1d_free_aligned;
-use crate::src::mem::dav1d_freep_aligned;
+use crate::src::log::rav1d_log;
+use crate::src::looprestoration::rav1d_loop_restoration_dsp_init;
+use crate::src::mc::rav1d_mc_dsp_init;
 use crate::src::mem::freep;
-use crate::src::msac::dav1d_msac_decode_bool;
-use crate::src::msac::dav1d_msac_decode_bool_adapt;
-use crate::src::msac::dav1d_msac_decode_bool_equi;
-use crate::src::msac::dav1d_msac_decode_bools;
-use crate::src::msac::dav1d_msac_decode_subexp;
-use crate::src::msac::dav1d_msac_decode_symbol_adapt16;
-use crate::src::msac::dav1d_msac_decode_symbol_adapt4;
-use crate::src::msac::dav1d_msac_decode_symbol_adapt8;
-use crate::src::msac::dav1d_msac_decode_uniform;
-use crate::src::msac::dav1d_msac_init;
-use crate::src::picture::dav1d_picture_alloc_copy;
-use crate::src::picture::dav1d_picture_get_event_flags;
-use crate::src::picture::dav1d_picture_ref;
-use crate::src::picture::dav1d_picture_unref_internal;
-use crate::src::picture::dav1d_thread_picture_alloc;
-use crate::src::picture::dav1d_thread_picture_ref;
-use crate::src::picture::dav1d_thread_picture_unref;
+use crate::src::mem::rav1d_alloc_aligned;
+use crate::src::mem::rav1d_free_aligned;
+use crate::src::mem::rav1d_freep_aligned;
+use crate::src::msac::rav1d_msac_decode_bool;
+use crate::src::msac::rav1d_msac_decode_bool_adapt;
+use crate::src::msac::rav1d_msac_decode_bool_equi;
+use crate::src::msac::rav1d_msac_decode_bools;
+use crate::src::msac::rav1d_msac_decode_subexp;
+use crate::src::msac::rav1d_msac_decode_symbol_adapt16;
+use crate::src::msac::rav1d_msac_decode_symbol_adapt4;
+use crate::src::msac::rav1d_msac_decode_symbol_adapt8;
+use crate::src::msac::rav1d_msac_decode_uniform;
+use crate::src::msac::rav1d_msac_init;
+use crate::src::picture::rav1d_picture_alloc_copy;
+use crate::src::picture::rav1d_picture_get_event_flags;
+use crate::src::picture::rav1d_picture_ref;
+use crate::src::picture::rav1d_picture_unref_internal;
+use crate::src::picture::rav1d_thread_picture_alloc;
+use crate::src::picture::rav1d_thread_picture_ref;
+use crate::src::picture::rav1d_thread_picture_unref;
 use crate::src::picture::Rav1dThreadPicture;
 use crate::src::qm::dav1d_qm_tbl;
-use crate::src::r#ref::dav1d_ref_create_using_pool;
-use crate::src::r#ref::dav1d_ref_dec;
-use crate::src::r#ref::dav1d_ref_inc;
+use crate::src::r#ref::rav1d_ref_create_using_pool;
+use crate::src::r#ref::rav1d_ref_dec;
+use crate::src::r#ref::rav1d_ref_inc;
 use crate::src::recon::DEBUG_BLOCK_INFO;
-use crate::src::refmvs::dav1d_refmvs_find;
 use crate::src::refmvs::dav1d_refmvs_init_frame;
-use crate::src::refmvs::dav1d_refmvs_save_tmvs;
-use crate::src::refmvs::dav1d_refmvs_tile_sbrow_init;
+use crate::src::refmvs::rav1d_refmvs_find;
+use crate::src::refmvs::rav1d_refmvs_save_tmvs;
+use crate::src::refmvs::rav1d_refmvs_tile_sbrow_init;
 use crate::src::refmvs::refmvs_block;
 use crate::src::refmvs::refmvs_block_unaligned;
 use crate::src::refmvs::refmvs_mvpair;
@@ -207,8 +207,8 @@ use crate::src::tables::dav1d_wedge_ctx_lut;
 use crate::src::tables::dav1d_ymode_size_context;
 use crate::src::tables::interintra_allowed_mask;
 use crate::src::tables::wedge_allowed_mask;
-use crate::src::thread_task::dav1d_task_create_tile_sbrow;
-use crate::src::thread_task::dav1d_task_frame_init;
+use crate::src::thread_task::rav1d_task_create_tile_sbrow;
+use crate::src::thread_task::rav1d_task_frame_init;
 use crate::src::thread_task::FRAME_ERROR;
 use crate::src::thread_task::TILE_ERROR;
 use crate::src::warpmv::dav1d_find_affine_int;
@@ -239,36 +239,36 @@ use std::sync::atomic::Ordering;
 
 #[cfg(feature = "bitdepth_8")]
 use crate::{
-    include::common::bitdepth::BitDepth8, src::cdef_tmpl_8::dav1d_cdef_dsp_init_8bpc,
-    src::filmgrain_tmpl_8::dav1d_film_grain_dsp_init_8bpc,
-    src::ipred_tmpl_8::dav1d_intra_pred_dsp_init_8bpc, src::itx_tmpl_8::dav1d_itx_dsp_init_8bpc,
-    src::loopfilter_tmpl_8::dav1d_loop_filter_dsp_init_8bpc,
-    src::recon_tmpl_8::dav1d_backup_ipred_edge_8bpc, src::recon_tmpl_8::dav1d_filter_sbrow_8bpc,
-    src::recon_tmpl_8::dav1d_filter_sbrow_cdef_8bpc,
-    src::recon_tmpl_8::dav1d_filter_sbrow_deblock_cols_8bpc,
-    src::recon_tmpl_8::dav1d_filter_sbrow_deblock_rows_8bpc,
-    src::recon_tmpl_8::dav1d_filter_sbrow_lr_8bpc,
-    src::recon_tmpl_8::dav1d_filter_sbrow_resize_8bpc,
-    src::recon_tmpl_8::dav1d_read_coef_blocks_8bpc, src::recon_tmpl_8::dav1d_recon_b_inter_8bpc,
-    src::recon_tmpl_8::dav1d_recon_b_intra_8bpc,
+    include::common::bitdepth::BitDepth8, src::cdef_tmpl_8::rav1d_cdef_dsp_init_8bpc,
+    src::filmgrain_tmpl_8::rav1d_film_grain_dsp_init_8bpc,
+    src::ipred_tmpl_8::rav1d_intra_pred_dsp_init_8bpc, src::itx_tmpl_8::rav1d_itx_dsp_init_8bpc,
+    src::loopfilter_tmpl_8::rav1d_loop_filter_dsp_init_8bpc,
+    src::recon_tmpl_8::rav1d_backup_ipred_edge_8bpc, src::recon_tmpl_8::rav1d_filter_sbrow_8bpc,
+    src::recon_tmpl_8::rav1d_filter_sbrow_cdef_8bpc,
+    src::recon_tmpl_8::rav1d_filter_sbrow_deblock_cols_8bpc,
+    src::recon_tmpl_8::rav1d_filter_sbrow_deblock_rows_8bpc,
+    src::recon_tmpl_8::rav1d_filter_sbrow_lr_8bpc,
+    src::recon_tmpl_8::rav1d_filter_sbrow_resize_8bpc,
+    src::recon_tmpl_8::rav1d_read_coef_blocks_8bpc, src::recon_tmpl_8::rav1d_recon_b_inter_8bpc,
+    src::recon_tmpl_8::rav1d_recon_b_intra_8bpc,
 };
 
 #[cfg(feature = "bitdepth_16")]
 use crate::{
-    include::common::bitdepth::BitDepth16, src::cdef_tmpl_16::dav1d_cdef_dsp_init_16bpc,
-    src::filmgrain_tmpl_16::dav1d_film_grain_dsp_init_16bpc,
-    src::ipred_tmpl_16::dav1d_intra_pred_dsp_init_16bpc,
-    src::itx_tmpl_16::dav1d_itx_dsp_init_16bpc,
-    src::loopfilter_tmpl_16::dav1d_loop_filter_dsp_init_16bpc,
-    src::recon_tmpl_16::dav1d_backup_ipred_edge_16bpc,
-    src::recon_tmpl_16::dav1d_filter_sbrow_16bpc,
-    src::recon_tmpl_16::dav1d_filter_sbrow_cdef_16bpc,
-    src::recon_tmpl_16::dav1d_filter_sbrow_deblock_cols_16bpc,
-    src::recon_tmpl_16::dav1d_filter_sbrow_deblock_rows_16bpc,
-    src::recon_tmpl_16::dav1d_filter_sbrow_lr_16bpc,
-    src::recon_tmpl_16::dav1d_filter_sbrow_resize_16bpc,
-    src::recon_tmpl_16::dav1d_read_coef_blocks_16bpc,
-    src::recon_tmpl_16::dav1d_recon_b_inter_16bpc, src::recon_tmpl_16::dav1d_recon_b_intra_16bpc,
+    include::common::bitdepth::BitDepth16, src::cdef_tmpl_16::rav1d_cdef_dsp_init_16bpc,
+    src::filmgrain_tmpl_16::rav1d_film_grain_dsp_init_16bpc,
+    src::ipred_tmpl_16::rav1d_intra_pred_dsp_init_16bpc,
+    src::itx_tmpl_16::rav1d_itx_dsp_init_16bpc,
+    src::loopfilter_tmpl_16::rav1d_loop_filter_dsp_init_16bpc,
+    src::recon_tmpl_16::rav1d_backup_ipred_edge_16bpc,
+    src::recon_tmpl_16::rav1d_filter_sbrow_16bpc,
+    src::recon_tmpl_16::rav1d_filter_sbrow_cdef_16bpc,
+    src::recon_tmpl_16::rav1d_filter_sbrow_deblock_cols_16bpc,
+    src::recon_tmpl_16::rav1d_filter_sbrow_deblock_rows_16bpc,
+    src::recon_tmpl_16::rav1d_filter_sbrow_lr_16bpc,
+    src::recon_tmpl_16::rav1d_filter_sbrow_resize_16bpc,
+    src::recon_tmpl_16::rav1d_read_coef_blocks_16bpc,
+    src::recon_tmpl_16::rav1d_recon_b_inter_16bpc, src::recon_tmpl_16::rav1d_recon_b_intra_16bpc,
 };
 
 fn init_quant_tables(
@@ -309,22 +309,22 @@ unsafe fn read_mv_component_diff(
     let ts = &mut *t.ts;
     let f = &*t.f;
     let have_hp = (*f.frame_hdr).hp != 0;
-    let sign = dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut mv_comp.sign.0);
-    let cl = dav1d_msac_decode_symbol_adapt16(&mut ts.msac, &mut mv_comp.classes.0, 10);
+    let sign = rav1d_msac_decode_bool_adapt(&mut ts.msac, &mut mv_comp.sign.0);
+    let cl = rav1d_msac_decode_symbol_adapt16(&mut ts.msac, &mut mv_comp.classes.0, 10);
     let mut up;
     let fp;
     let hp;
 
     if cl == 0 {
-        up = dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut mv_comp.class0.0) as c_uint;
+        up = rav1d_msac_decode_bool_adapt(&mut ts.msac, &mut mv_comp.class0.0) as c_uint;
         if have_fp {
-            fp = dav1d_msac_decode_symbol_adapt4(
+            fp = rav1d_msac_decode_symbol_adapt4(
                 &mut ts.msac,
                 &mut mv_comp.class0_fp[up as usize],
                 3,
             );
             hp = if have_hp {
-                dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut mv_comp.class0_hp.0)
+                rav1d_msac_decode_bool_adapt(&mut ts.msac, &mut mv_comp.class0_hp.0)
             } else {
                 true
             };
@@ -336,12 +336,12 @@ unsafe fn read_mv_component_diff(
         up = 1 << cl;
         for n in 0..cl as usize {
             up |=
-                (dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut mv_comp.classN[n]) as c_uint) << n;
+                (rav1d_msac_decode_bool_adapt(&mut ts.msac, &mut mv_comp.classN[n]) as c_uint) << n;
         }
         if have_fp {
-            fp = dav1d_msac_decode_symbol_adapt4(&mut ts.msac, &mut mv_comp.classN_fp.0, 3);
+            fp = rav1d_msac_decode_symbol_adapt4(&mut ts.msac, &mut mv_comp.classN_fp.0, 3);
             hp = if have_hp {
-                dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut mv_comp.classN_hp.0)
+                rav1d_msac_decode_bool_adapt(&mut ts.msac, &mut mv_comp.classN_hp.0)
             } else {
                 true
             };
@@ -368,7 +368,7 @@ unsafe fn read_mv_residual(
     have_fp: bool,
 ) {
     let ts = &mut *t.ts;
-    match dav1d_msac_decode_symbol_adapt4(
+    match rav1d_msac_decode_symbol_adapt4(
         &mut ts.msac,
         &mut ts.cdf.mv.joint.0,
         N_MV_JOINTS as usize - 1,
@@ -408,7 +408,7 @@ unsafe fn read_tx_tree(
         let a = ((*t.a).tx.0[bx4 as usize] < txw) as c_int;
         let l = (t.l.tx.0[by4 as usize] < txh) as c_int;
 
-        is_split = dav1d_msac_decode_bool_adapt(
+        is_split = rav1d_msac_decode_bool_adapt(
             &mut (*t.ts).msac,
             &mut (*t.ts).cdf.m.txpart[cat as usize][(a + l) as usize],
         );
@@ -728,7 +728,7 @@ unsafe fn read_pal_plane(
     // as well as the borrowck error here if `dbg` is not hoisted.
     let dbg = DEBUG_BLOCK_INFO(f, t);
 
-    let pal_sz = dav1d_msac_decode_symbol_adapt8(
+    let pal_sz = rav1d_msac_decode_symbol_adapt8(
         &mut ts.msac,
         &mut ts.cdf.m.pal_sz[pli][sz_ctx as usize],
         6,
@@ -815,7 +815,7 @@ unsafe fn read_pal_plane(
         if !(i < pal_sz) {
             break;
         }
-        if dav1d_msac_decode_bool_equi(&mut ts.msac) {
+        if rav1d_msac_decode_bool_equi(&mut ts.msac) {
             used_cache[i] = *cache;
             i += 1;
         }
@@ -833,16 +833,16 @@ unsafe fn read_pal_plane(
     };
     let pal = &mut pal[..pal_sz];
     if i < pal.len() {
-        let mut prev = dav1d_msac_decode_bools(&mut ts.msac, f.cur.p.bpc as u32) as u16;
+        let mut prev = rav1d_msac_decode_bools(&mut ts.msac, f.cur.p.bpc as u32) as u16;
         pal[i] = prev;
         i += 1;
 
         if i < pal.len() {
-            let mut bits = f.cur.p.bpc as u32 + dav1d_msac_decode_bools(&mut ts.msac, 2) - 3;
+            let mut bits = f.cur.p.bpc as u32 + rav1d_msac_decode_bools(&mut ts.msac, 2) - 3;
             let max = (1 << f.cur.p.bpc) - 1;
 
             loop {
-                let delta = dav1d_msac_decode_bools(&mut ts.msac, bits) as u16;
+                let delta = rav1d_msac_decode_bools(&mut ts.msac, bits) as u16;
                 prev = cmp::min(prev + delta + not_pl, max);
                 pal[i] = prev;
                 i += 1;
@@ -920,21 +920,21 @@ unsafe fn read_pal_uv(
         &mut t.scratch.c2rust_unnamed_0.pal[2]
     };
     let pal = &mut pal[..b.pal_sz()[1] as usize];
-    if dav1d_msac_decode_bool_equi(&mut ts.msac) {
-        let bits = f.cur.p.bpc as u32 + dav1d_msac_decode_bools(&mut ts.msac, 2) - 4;
-        let mut prev = dav1d_msac_decode_bools(&mut ts.msac, f.cur.p.bpc as c_uint) as u16;
+    if rav1d_msac_decode_bool_equi(&mut ts.msac) {
+        let bits = f.cur.p.bpc as u32 + rav1d_msac_decode_bools(&mut ts.msac, 2) - 4;
+        let mut prev = rav1d_msac_decode_bools(&mut ts.msac, f.cur.p.bpc as c_uint) as u16;
         pal[0] = prev;
         let max = (1 << f.cur.p.bpc) - 1;
         for pal in &mut pal[1..] {
-            let mut delta = dav1d_msac_decode_bools(&mut ts.msac, bits) as i16;
-            if delta != 0 && dav1d_msac_decode_bool_equi(&mut ts.msac) {
+            let mut delta = rav1d_msac_decode_bools(&mut ts.msac, bits) as i16;
+            if delta != 0 && rav1d_msac_decode_bool_equi(&mut ts.msac) {
                 delta = -delta;
             }
             prev = ((prev as i16 + delta) as u16) & max;
             *pal = prev;
         }
     } else {
-        pal.fill_with(|| dav1d_msac_decode_bools(&mut ts.msac, f.cur.p.bpc as c_uint) as u16);
+        pal.fill_with(|| rav1d_msac_decode_bools(&mut ts.msac, f.cur.p.bpc as c_uint) as u16);
     }
     if dbg {
         print!("Post-pal[pl=2]: r={} ", ts.msac.rng);
@@ -1037,7 +1037,7 @@ unsafe fn read_pal_indices(
     let pal_sz = b.pal_sz()[pli] as usize;
 
     let stride = bw4 * 4;
-    pal_idx[0] = dav1d_msac_decode_uniform(&mut ts.msac, pal_sz as c_uint) as u8;
+    pal_idx[0] = rav1d_msac_decode_uniform(&mut ts.msac, pal_sz as c_uint) as u8;
     let color_map_cdf = &mut ts.cdf.m.color_map[pli][pal_sz - 2];
     let Rav1dTaskContext_scratch_pal {
         pal_order: order,
@@ -1049,7 +1049,7 @@ unsafe fn read_pal_indices(
         let last = (i + 1).checked_sub(h4 * 4).unwrap_or(0);
         order_palette(pal_idx, stride, i, first, last, order, ctx);
         for (m, j) in (last..=first).rev().enumerate() {
-            let color_idx = dav1d_msac_decode_symbol_adapt8(
+            let color_idx = rav1d_msac_decode_symbol_adapt8(
                 &mut ts.msac,
                 &mut color_map_cdf[ctx[m] as usize],
                 pal_sz - 1,
@@ -1664,7 +1664,7 @@ unsafe fn decode_b(
         } else if frame_hdr.segmentation.seg_data.preskip != 0 {
             if frame_hdr.segmentation.temporal != 0 && {
                 let index = (*t.a).seg_pred.0[bx4 as usize] + t.l.seg_pred.0[by4 as usize];
-                seg_pred = dav1d_msac_decode_bool_adapt(
+                seg_pred = rav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
                     &mut ts.cdf.m.seg_pred.0[index as usize],
                 );
@@ -1684,7 +1684,7 @@ unsafe fn decode_b(
             } else {
                 let (pred_seg_id, seg_ctx) =
                     get_cur_frame_segid(t.by, t.bx, have_top, have_left, f.cur_segmap, f.b4_stride);
-                let diff = dav1d_msac_decode_symbol_adapt8(
+                let diff = rav1d_msac_decode_symbol_adapt8(
                     &mut ts.msac,
                     &mut ts.cdf.m.seg_id[seg_ctx as usize],
                     DAV1D_MAX_SEGMENTS as usize - 1,
@@ -1720,7 +1720,7 @@ unsafe fn decode_b(
     {
         let smctx = (*t.a).skip_mode.0[bx4 as usize] + t.l.skip_mode.0[by4 as usize];
         b.skip_mode =
-            dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.skip_mode.0[smctx as usize])
+            rav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.skip_mode.0[smctx as usize])
                 as u8;
         if DEBUG_BLOCK_INFO(f, t) {
             println!("Post-skipmode[{}]: r={}", b.skip_mode, ts.msac.rng);
@@ -1735,7 +1735,7 @@ unsafe fn decode_b(
     } else {
         let sctx = (*t.a).skip[bx4 as usize] + t.l.skip[by4 as usize];
         b.skip =
-            dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.skip[sctx as usize]) as u8;
+            rav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.skip[sctx as usize]) as u8;
         if DEBUG_BLOCK_INFO(f, t) {
             println!("Post-skip[{}]: r={}", b.skip, ts.msac.rng);
         }
@@ -1748,7 +1748,7 @@ unsafe fn decode_b(
     {
         if b.skip == 0 && (*f.frame_hdr).segmentation.temporal != 0 && {
             let index = (*t.a).seg_pred.0[bx4 as usize] + t.l.seg_pred.0[by4 as usize];
-            seg_pred = dav1d_msac_decode_bool_adapt(
+            seg_pred = rav1d_msac_decode_bool_adapt(
                 &mut ts.msac,
                 &mut ts.cdf.m.seg_pred.0[index as usize],
             );
@@ -1771,7 +1771,7 @@ unsafe fn decode_b(
             if b.skip != 0 {
                 b.seg_id = pred_seg_id as u8;
             } else {
-                let diff = dav1d_msac_decode_symbol_adapt8(
+                let diff = rav1d_msac_decode_symbol_adapt8(
                     &mut ts.msac,
                     &mut ts.cdf.m.seg_id[seg_ctx as usize],
                     DAV1D_MAX_SEGMENTS as usize - 1,
@@ -1804,7 +1804,7 @@ unsafe fn decode_b(
             0
         } as isize;
         if *(t.cur_sb_cdef_idx_ptr).offset(idx) == -1 {
-            let v = dav1d_msac_decode_bools(&mut ts.msac, frame_hdr.cdef.n_bits as c_uint) as i8;
+            let v = rav1d_msac_decode_bools(&mut ts.msac, frame_hdr.cdef.n_bits as c_uint) as i8;
             *(t.cur_sb_cdef_idx_ptr).offset(idx) = v;
             if bw4 > 16 {
                 *(t.cur_sb_cdef_idx_ptr).offset(idx + 1) = v;
@@ -1842,14 +1842,14 @@ unsafe fn decode_b(
 
         if have_delta_q {
             let mut delta_q =
-                dav1d_msac_decode_symbol_adapt4(&mut ts.msac, &mut ts.cdf.m.delta_q.0, 3) as c_int;
+                rav1d_msac_decode_symbol_adapt4(&mut ts.msac, &mut ts.cdf.m.delta_q.0, 3) as c_int;
             if delta_q == 3 {
-                let n_bits = 1 + dav1d_msac_decode_bools(&mut ts.msac, 3);
+                let n_bits = 1 + rav1d_msac_decode_bools(&mut ts.msac, 3);
                 delta_q =
-                    (dav1d_msac_decode_bools(&mut ts.msac, n_bits) + 1 + (1 << n_bits)) as c_int;
+                    (rav1d_msac_decode_bools(&mut ts.msac, n_bits) + 1 + (1 << n_bits)) as c_int;
             }
             if delta_q != 0 {
-                if dav1d_msac_decode_bool_equi(&mut ts.msac) {
+                if rav1d_msac_decode_bool_equi(&mut ts.msac) {
                     delta_q = -delta_q;
                 }
                 delta_q *= 1 << frame_hdr.delta.q.res_log2;
@@ -1875,19 +1875,19 @@ unsafe fn decode_b(
 
                 for i in 0..n_lfs as usize {
                     let delta_lf_index = i + frame_hdr.delta.lf.multi as usize;
-                    let mut delta_lf = dav1d_msac_decode_symbol_adapt4(
+                    let mut delta_lf = rav1d_msac_decode_symbol_adapt4(
                         &mut ts.msac,
                         &mut ts.cdf.m.delta_lf[delta_lf_index],
                         3,
                     ) as c_int;
                     if delta_lf == 3 {
-                        let n_bits = 1 + dav1d_msac_decode_bools(&mut ts.msac, 3);
-                        delta_lf = (dav1d_msac_decode_bools(&mut ts.msac, n_bits)
+                        let n_bits = 1 + rav1d_msac_decode_bools(&mut ts.msac, 3);
+                        delta_lf = (rav1d_msac_decode_bools(&mut ts.msac, n_bits)
                             + 1
                             + (1 << n_bits)) as c_int;
                     }
                     if delta_lf != 0 {
-                        if dav1d_msac_decode_bool_equi(&mut ts.msac) {
+                        if rav1d_msac_decode_bool_equi(&mut ts.msac) {
                             delta_lf = -delta_lf;
                         }
                         delta_lf *= 1 << frame_hdr.delta.lf.res_log2;
@@ -1926,14 +1926,14 @@ unsafe fn decode_b(
         } else {
             let ictx = get_intra_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
             b.intra =
-                (!dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.intra[ictx.into()]))
+                (!rav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.intra[ictx.into()]))
                     as u8;
             if DEBUG_BLOCK_INFO(f, t) {
                 println!("Post-intra[{}]: r={}", b.intra, ts.msac.rng);
             }
         }
     } else if frame_hdr.allow_intrabc != 0 {
-        b.intra = (!dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.intrabc.0)) as u8;
+        b.intra = (!rav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.intrabc.0)) as u8;
         if DEBUG_BLOCK_INFO(f, t) {
             println!("Post-intrabcflag[{}]: r={}", b.intra, ts.msac.rng);
         }
@@ -1950,7 +1950,7 @@ unsafe fn decode_b(
                 [dav1d_intra_mode_context[(*t.a).mode.0[bx4 as usize] as usize] as usize]
                 [dav1d_intra_mode_context[t.l.mode.0[by4 as usize] as usize] as usize]
         };
-        *b.y_mode_mut() = dav1d_msac_decode_symbol_adapt16(
+        *b.y_mode_mut() = rav1d_msac_decode_symbol_adapt16(
             &mut ts.msac,
             ymode_cdf,
             (N_INTRA_PRED_MODES - 1) as usize,
@@ -1962,7 +1962,7 @@ unsafe fn decode_b(
         // angle delta
         if b_dim[2] + b_dim[3] >= 2 && b.y_mode() >= VERT_PRED && b.y_mode() <= VERT_LEFT_PRED {
             let acdf = &mut ts.cdf.m.angle_delta[b.y_mode() as usize - VERT_PRED as usize];
-            let angle = dav1d_msac_decode_symbol_adapt8(&mut ts.msac, acdf, 6);
+            let angle = rav1d_msac_decode_symbol_adapt8(&mut ts.msac, acdf, 6);
             *b.y_angle_mut() = angle as i8 - 3;
         } else {
             *b.y_angle_mut() = 0;
@@ -1975,7 +1975,7 @@ unsafe fn decode_b(
                 (cfl_allowed_mask & (1 << bs)) != 0
             };
             let uvmode_cdf = &mut ts.cdf.m.uv_mode[cfl_allowed as usize][b.y_mode() as usize];
-            *b.uv_mode_mut() = dav1d_msac_decode_symbol_adapt16(
+            *b.uv_mode_mut() = rav1d_msac_decode_symbol_adapt16(
                 &mut ts.msac,
                 uvmode_cdf,
                 (N_UV_INTRA_PRED_MODES as usize) - 1 - (!cfl_allowed as usize),
@@ -1987,13 +1987,13 @@ unsafe fn decode_b(
             *b.uv_angle_mut() = 0;
             if b.uv_mode() == CFL_PRED {
                 let sign =
-                    dav1d_msac_decode_symbol_adapt8(&mut ts.msac, &mut ts.cdf.m.cfl_sign.0, 7) + 1;
+                    rav1d_msac_decode_symbol_adapt8(&mut ts.msac, &mut ts.cdf.m.cfl_sign.0, 7) + 1;
                 let sign_u = sign * 0x56 >> 8;
                 let sign_v = sign - sign_u * 3;
                 assert!(sign_u == sign / 3);
                 if sign_u != 0 {
                     let ctx = (sign_u == 2) as usize * 3 + sign_v as usize;
-                    b.cfl_alpha_mut()[0] = dav1d_msac_decode_symbol_adapt16(
+                    b.cfl_alpha_mut()[0] = rav1d_msac_decode_symbol_adapt16(
                         &mut ts.msac,
                         &mut ts.cdf.m.cfl_alpha[ctx],
                         15,
@@ -2007,7 +2007,7 @@ unsafe fn decode_b(
                 }
                 if sign_v != 0 {
                     let ctx = (sign_v == 2) as usize * 3 + sign_u as usize;
-                    b.cfl_alpha_mut()[1] = dav1d_msac_decode_symbol_adapt16(
+                    b.cfl_alpha_mut()[1] = rav1d_msac_decode_symbol_adapt16(
                         &mut ts.msac,
                         &mut ts.cdf.m.cfl_alpha[ctx],
                         15,
@@ -2032,7 +2032,7 @@ unsafe fn decode_b(
                 && b.uv_mode() <= VERT_LEFT_PRED as u8
             {
                 let acdf = &mut ts.cdf.m.angle_delta[b.uv_mode() as usize - VERT_PRED as usize];
-                let angle = dav1d_msac_decode_symbol_adapt8(&mut ts.msac, acdf, 6) as c_int;
+                let angle = rav1d_msac_decode_symbol_adapt8(&mut ts.msac, acdf, 6) as c_int;
                 *b.uv_angle_mut() = (angle - 3) as i8;
             }
         }
@@ -2043,7 +2043,7 @@ unsafe fn decode_b(
             if b.y_mode() == DC_PRED {
                 let pal_ctx = ((*t.a).pal_sz.0[bx4 as usize] > 0) as usize
                     + (t.l.pal_sz.0[by4 as usize] > 0) as usize;
-                let use_y_pal = dav1d_msac_decode_bool_adapt(
+                let use_y_pal = rav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
                     &mut ts.cdf.m.pal_y[sz_ctx as usize][pal_ctx],
                 );
@@ -2057,7 +2057,7 @@ unsafe fn decode_b(
 
             if has_chroma && b.uv_mode() == DC_PRED {
                 let pal_ctx = b.pal_sz()[0] > 0;
-                let use_uv_pal = dav1d_msac_decode_bool_adapt(
+                let use_uv_pal = rav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
                     &mut ts.cdf.m.pal_uv[pal_ctx as usize],
                 );
@@ -2076,14 +2076,14 @@ unsafe fn decode_b(
             && cmp::max(b_dim[2], b_dim[3]) <= 3
             && (*f.seq_hdr).filter_intra != 0
         {
-            let is_filter = dav1d_msac_decode_bool_adapt(
+            let is_filter = rav1d_msac_decode_bool_adapt(
                 &mut ts.msac,
                 &mut ts.cdf.m.use_filter_intra[bs as usize],
             );
             if is_filter {
                 *b.y_mode_mut() = FILTER_PRED as u8;
                 *b.y_angle_mut() =
-                    dav1d_msac_decode_symbol_adapt4(&mut ts.msac, &mut ts.cdf.m.filter_intra.0, 4)
+                    rav1d_msac_decode_symbol_adapt4(&mut ts.msac, &mut ts.cdf.m.filter_intra.0, 4)
                         as i8;
             }
             if DEBUG_BLOCK_INFO(f, t) {
@@ -2163,7 +2163,7 @@ unsafe fn decode_b(
             if frame_hdr.txfm_mode == DAV1D_TX_SWITCHABLE && t_dim.max > TX_4X4 as u8 {
                 let tctx = get_tx_ctx(&*t.a, &t.l, &*t_dim, by4, bx4);
                 let tx_cdf = &mut ts.cdf.m.txsz[(t_dim.max - 1) as usize][tctx as usize];
-                let depth = dav1d_msac_decode_symbol_adapt4(
+                let depth = rav1d_msac_decode_symbol_adapt4(
                     &mut ts.msac,
                     tx_cdf,
                     cmp::min(t_dim.max, 2) as usize,
@@ -2188,7 +2188,7 @@ unsafe fn decode_b(
         }
 
         if frame_hdr.loopfilter.level_y != [0, 0] {
-            dav1d_create_lf_mask_intra(
+            rav1d_create_lf_mask_intra(
                 &mut *t.lf_mask,
                 f.lf.level,
                 f.b4_stride,
@@ -2298,7 +2298,7 @@ unsafe fn decode_b(
         let mut mvstack = [Default::default(); 8];
         let mut n_mvs = 0;
         let mut ctx = 0;
-        dav1d_refmvs_find(
+        rav1d_refmvs_find(
             &mut t.rt,
             &mut mvstack,
             &mut n_mvs,
@@ -2448,7 +2448,7 @@ unsafe fn decode_b(
         {
             let ctx = get_comp_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
             let is_comp =
-                dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.comp[ctx as usize]);
+                rav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.comp[ctx as usize]);
             if DEBUG_BLOCK_INFO(f, t) {
                 println!("Post-compflag[{}]: r={}", is_comp, ts.msac.rng);
             }
@@ -2470,7 +2470,7 @@ unsafe fn decode_b(
             let mut mvstack = [Default::default(); 8];
             let mut n_mvs = 0;
             let mut ctx = 0;
-            dav1d_refmvs_find(
+            rav1d_refmvs_find(
                 &mut t.rt,
                 &mut mvstack,
                 &mut n_mvs,
@@ -2498,22 +2498,22 @@ unsafe fn decode_b(
             }
         } else if is_comp {
             let dir_ctx = get_comp_dir_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
-            if dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.comp_dir[dir_ctx as usize])
+            if rav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.comp_dir[dir_ctx as usize])
             {
                 // bidir - first reference (fw)
                 let ctx1 = av1_get_fwd_ref_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
-                if dav1d_msac_decode_bool_adapt(
+                if rav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
                     &mut ts.cdf.m.comp_fwd_ref[0][ctx1 as usize],
                 ) {
                     let ctx2 = av1_get_fwd_ref_2_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
-                    b.ref_mut()[0] = 2 + dav1d_msac_decode_bool_adapt(
+                    b.ref_mut()[0] = 2 + rav1d_msac_decode_bool_adapt(
                         &mut ts.msac,
                         &mut ts.cdf.m.comp_fwd_ref[2][ctx2 as usize],
                     ) as i8;
                 } else {
                     let ctx2 = av1_get_fwd_ref_1_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
-                    b.ref_mut()[0] = dav1d_msac_decode_bool_adapt(
+                    b.ref_mut()[0] = rav1d_msac_decode_bool_adapt(
                         &mut ts.msac,
                         &mut ts.cdf.m.comp_fwd_ref[1][ctx2 as usize],
                     ) as i8;
@@ -2521,14 +2521,14 @@ unsafe fn decode_b(
 
                 // second reference (bw)
                 let ctx3 = av1_get_bwd_ref_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
-                if dav1d_msac_decode_bool_adapt(
+                if rav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
                     &mut ts.cdf.m.comp_bwd_ref[0][ctx3 as usize],
                 ) {
                     b.ref_mut()[1] = 6;
                 } else {
                     let ctx4 = av1_get_bwd_ref_1_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
-                    b.ref_mut()[1] = 4 + dav1d_msac_decode_bool_adapt(
+                    b.ref_mut()[1] = 4 + rav1d_msac_decode_bool_adapt(
                         &mut ts.msac,
                         &mut ts.cdf.m.comp_bwd_ref[1][ctx4 as usize],
                     ) as i8;
@@ -2536,7 +2536,7 @@ unsafe fn decode_b(
             } else {
                 // unidir
                 let uctx_p = av1_get_ref_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
-                if dav1d_msac_decode_bool_adapt(
+                if rav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
                     &mut ts.cdf.m.comp_uni_ref[0][uctx_p as usize],
                 ) {
@@ -2545,7 +2545,7 @@ unsafe fn decode_b(
                     let uctx_p1 = av1_get_uni_p1_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
                     *b.ref_mut() = [
                         0,
-                        1 + dav1d_msac_decode_bool_adapt(
+                        1 + rav1d_msac_decode_bool_adapt(
                             &mut ts.msac,
                             &mut ts.cdf.m.comp_uni_ref[1][uctx_p1 as usize],
                         ) as i8,
@@ -2554,7 +2554,7 @@ unsafe fn decode_b(
                     if b.r#ref()[1] == 2 {
                         let uctx_p2 =
                             av1_get_fwd_ref_2_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
-                        b.ref_mut()[1] += dav1d_msac_decode_bool_adapt(
+                        b.ref_mut()[1] += rav1d_msac_decode_bool_adapt(
                             &mut ts.msac,
                             &mut ts.cdf.m.comp_uni_ref[2][uctx_p2 as usize],
                         ) as i8;
@@ -2573,7 +2573,7 @@ unsafe fn decode_b(
             let mut mvstack = [Default::default(); 8];
             let mut n_mvs = 0;
             let mut ctx = 0;
-            dav1d_refmvs_find(
+            rav1d_refmvs_find(
                 &mut t.rt,
                 &mut mvstack,
                 &mut n_mvs,
@@ -2585,7 +2585,7 @@ unsafe fn decode_b(
                 t.bx,
             );
 
-            *b.inter_mode_mut() = dav1d_msac_decode_symbol_adapt8(
+            *b.inter_mode_mut() = rav1d_msac_decode_symbol_adapt8(
                 &mut ts.msac,
                 &mut ts.cdf.m.comp_inter_mode[ctx as usize],
                 N_COMP_INTER_PRED_MODES as usize - 1,
@@ -2606,13 +2606,13 @@ unsafe fn decode_b(
                 if n_mvs > 1 {
                     // NEARER, NEAR or NEARISH
                     let drl_ctx_v1 = get_drl_context(&mvstack, 0);
-                    *b.drl_idx_mut() += dav1d_msac_decode_bool_adapt(
+                    *b.drl_idx_mut() += rav1d_msac_decode_bool_adapt(
                         &mut ts.msac,
                         &mut ts.cdf.m.drl_bit[drl_ctx_v1 as usize],
                     ) as u8;
                     if b.drl_idx() == NEARER_DRL && n_mvs > 2 {
                         let drl_ctx_v2 = get_drl_context(&mvstack, 1);
-                        *b.drl_idx_mut() += dav1d_msac_decode_bool_adapt(
+                        *b.drl_idx_mut() += rav1d_msac_decode_bool_adapt(
                             &mut ts.msac,
                             &mut ts.cdf.m.drl_bit[drl_ctx_v2 as usize],
                         ) as u8;
@@ -2631,13 +2631,13 @@ unsafe fn decode_b(
                 if n_mvs > 2 {
                     // NEAR or NEARISH
                     let drl_ctx_v2 = get_drl_context(&mvstack, 1);
-                    *b.drl_idx_mut() += dav1d_msac_decode_bool_adapt(
+                    *b.drl_idx_mut() += rav1d_msac_decode_bool_adapt(
                         &mut ts.msac,
                         &mut ts.cdf.m.drl_bit[drl_ctx_v2 as usize],
                     ) as u8;
                     if b.drl_idx() == NEAR_DRL && n_mvs > 3 {
                         let drl_ctx_v3 = get_drl_context(&mvstack, 2);
-                        *b.drl_idx_mut() += dav1d_msac_decode_bool_adapt(
+                        *b.drl_idx_mut() += rav1d_msac_decode_bool_adapt(
                             &mut ts.msac,
                             &mut ts.cdf.m.drl_bit[drl_ctx_v3 as usize],
                         ) as u8;
@@ -2700,7 +2700,7 @@ unsafe fn decode_b(
             let mut is_segwedge = false;
             if (*f.seq_hdr).masked_compound != 0 {
                 let mask_ctx = get_mask_comp_ctx(&*t.a, &t.l, by4, bx4);
-                is_segwedge = dav1d_msac_decode_bool_adapt(
+                is_segwedge = rav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
                     &mut ts.cdf.m.mask_comp[mask_ctx as usize],
                 );
@@ -2725,7 +2725,7 @@ unsafe fn decode_b(
                         bx4,
                     );
                     *b.comp_type_mut() = COMP_INTER_WEIGHTED_AVG
-                        + dav1d_msac_decode_bool_adapt(
+                        + rav1d_msac_decode_bool_adapt(
                             &mut ts.msac,
                             &mut ts.cdf.m.jnt_comp[jnt_ctx as usize],
                         ) as u8;
@@ -2748,10 +2748,10 @@ unsafe fn decode_b(
                 if wedge_allowed_mask & (1 << bs) != 0 {
                     let ctx = dav1d_wedge_ctx_lut[bs as usize] as usize;
                     *b.comp_type_mut() = COMP_INTER_WEDGE
-                        - dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.wedge_comp[ctx])
+                        - rav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.wedge_comp[ctx])
                             as u8;
                     if b.comp_type() == COMP_INTER_WEDGE {
-                        *b.wedge_idx_mut() = dav1d_msac_decode_symbol_adapt16(
+                        *b.wedge_idx_mut() = rav1d_msac_decode_symbol_adapt16(
                             &mut ts.msac,
                             &mut ts.cdf.m.wedge_idx[ctx],
                             15,
@@ -2760,7 +2760,7 @@ unsafe fn decode_b(
                 } else {
                     *b.comp_type_mut() = COMP_INTER_SEG;
                 }
-                *b.mask_sign_mut() = dav1d_msac_decode_bool_equi(&mut ts.msac) as u8;
+                *b.mask_sign_mut() = rav1d_msac_decode_bool_equi(&mut ts.msac) as u8;
                 if DEBUG_BLOCK_INFO(f, t) {
                     println!(
                         "Post-seg/wedge[{},wedge_idx={},sign={}]: r={}",
@@ -2781,10 +2781,10 @@ unsafe fn decode_b(
                 b.ref_mut()[0] = 0;
             } else {
                 let ctx1 = av1_get_ref_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
-                if dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.r#ref[0][ctx1 as usize])
+                if rav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.r#ref[0][ctx1 as usize])
                 {
                     let ctx2 = av1_get_bwd_ref_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
-                    if dav1d_msac_decode_bool_adapt(
+                    if rav1d_msac_decode_bool_adapt(
                         &mut ts.msac,
                         &mut ts.cdf.m.r#ref[1][ctx2 as usize],
                     ) {
@@ -2792,27 +2792,27 @@ unsafe fn decode_b(
                     } else {
                         let ctx3 =
                             av1_get_bwd_ref_1_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
-                        b.ref_mut()[0] = 4 + dav1d_msac_decode_bool_adapt(
+                        b.ref_mut()[0] = 4 + rav1d_msac_decode_bool_adapt(
                             &mut ts.msac,
                             &mut ts.cdf.m.r#ref[5][ctx3 as usize],
                         ) as i8;
                     }
                 } else {
                     let ctx2 = av1_get_fwd_ref_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
-                    if dav1d_msac_decode_bool_adapt(
+                    if rav1d_msac_decode_bool_adapt(
                         &mut ts.msac,
                         &mut ts.cdf.m.r#ref[2][ctx2 as usize],
                     ) {
                         let ctx3 =
                             av1_get_fwd_ref_2_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
-                        b.ref_mut()[0] = 2 + dav1d_msac_decode_bool_adapt(
+                        b.ref_mut()[0] = 2 + rav1d_msac_decode_bool_adapt(
                             &mut ts.msac,
                             &mut ts.cdf.m.r#ref[4][ctx3 as usize],
                         ) as i8;
                     } else {
                         let ctx3 =
                             av1_get_fwd_ref_1_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
-                        b.ref_mut()[0] = dav1d_msac_decode_bool_adapt(
+                        b.ref_mut()[0] = rav1d_msac_decode_bool_adapt(
                             &mut ts.msac,
                             &mut ts.cdf.m.r#ref[3][ctx3 as usize],
                         ) as i8;
@@ -2827,7 +2827,7 @@ unsafe fn decode_b(
             let mut mvstack = [Default::default(); 8];
             let mut n_mvs = 0;
             let mut ctx = 0;
-            dav1d_refmvs_find(
+            rav1d_refmvs_find(
                 &mut t.rt,
                 &mut mvstack,
                 &mut n_mvs,
@@ -2845,7 +2845,7 @@ unsafe fn decode_b(
             if seg
                 .map(|seg| seg.skip != 0 || seg.globalmv != 0)
                 .unwrap_or(false)
-                || dav1d_msac_decode_bool_adapt(
+                || rav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
                     &mut ts.cdf.m.newmv_mode[(ctx & 7) as usize],
                 )
@@ -2853,7 +2853,7 @@ unsafe fn decode_b(
                 if seg
                     .map(|seg| seg.skip != 0 || seg.globalmv != 0)
                     .unwrap_or(false)
-                    || !dav1d_msac_decode_bool_adapt(
+                    || !rav1d_msac_decode_bool_adapt(
                         &mut ts.msac,
                         &mut ts.cdf.m.globalmv_mode[(ctx >> 3 & 1) as usize],
                     )
@@ -2871,7 +2871,7 @@ unsafe fn decode_b(
                         || frame_hdr.gmv[b.r#ref()[0] as usize].type_0 == DAV1D_WM_TYPE_TRANSLATION;
                 } else {
                     has_subpel_filter = true;
-                    if dav1d_msac_decode_bool_adapt(
+                    if rav1d_msac_decode_bool_adapt(
                         &mut ts.msac,
                         &mut ts.cdf.m.refmv_mode[(ctx >> 4 & 15) as usize],
                     ) {
@@ -2882,7 +2882,7 @@ unsafe fn decode_b(
                             // NEARER, NEAR or NEARISH
                             let drl_ctx_v2 = get_drl_context(&mvstack, 1);
                             *b.drl_idx_mut() = b.drl_idx()
-                                + dav1d_msac_decode_bool_adapt(
+                                + rav1d_msac_decode_bool_adapt(
                                     &mut ts.msac,
                                     &mut ts.cdf.m.drl_bit[drl_ctx_v2 as usize],
                                 ) as u8;
@@ -2890,7 +2890,7 @@ unsafe fn decode_b(
                                 // NEAR or NEARISH
                                 let drl_ctx_v3 = get_drl_context(&mvstack, 2);
                                 *b.drl_idx_mut() = b.drl_idx()
-                                    + dav1d_msac_decode_bool_adapt(
+                                    + rav1d_msac_decode_bool_adapt(
                                         &mut ts.msac,
                                         &mut ts.cdf.m.drl_bit[drl_ctx_v3 as usize],
                                     ) as u8;
@@ -2926,7 +2926,7 @@ unsafe fn decode_b(
                     // NEARER, NEAR or NEARISH
                     let drl_ctx_v1 = get_drl_context(&mvstack, 0);
                     *b.drl_idx_mut() = b.drl_idx()
-                        + dav1d_msac_decode_bool_adapt(
+                        + rav1d_msac_decode_bool_adapt(
                             &mut ts.msac,
                             &mut ts.cdf.m.drl_bit[drl_ctx_v1 as usize],
                         ) as u8;
@@ -2934,7 +2934,7 @@ unsafe fn decode_b(
                         // NEAR or NEARISH
                         let drl_ctx_v2 = get_drl_context(&mvstack, 1);
                         *b.drl_idx_mut() = b.drl_idx()
-                            + dav1d_msac_decode_bool_adapt(
+                            + rav1d_msac_decode_bool_adapt(
                                 &mut ts.msac,
                                 &mut ts.cdf.m.drl_bit[drl_ctx_v2 as usize],
                             ) as u8;
@@ -2976,24 +2976,24 @@ unsafe fn decode_b(
             let ii_sz_grp = dav1d_ymode_size_context[bs as usize] as c_int;
             if (*f.seq_hdr).inter_intra != 0
                 && interintra_allowed_mask & (1 << bs) != 0
-                && dav1d_msac_decode_bool_adapt(
+                && rav1d_msac_decode_bool_adapt(
                     &mut ts.msac,
                     &mut ts.cdf.m.interintra[ii_sz_grp as usize],
                 )
             {
-                *b.interintra_mode_mut() = dav1d_msac_decode_symbol_adapt4(
+                *b.interintra_mode_mut() = rav1d_msac_decode_symbol_adapt4(
                     &mut ts.msac,
                     &mut ts.cdf.m.interintra_mode[ii_sz_grp as usize],
                     N_INTER_INTRA_PRED_MODES as usize - 1,
                 ) as u8;
                 let wedge_ctx = dav1d_wedge_ctx_lut[bs as usize] as c_int;
                 *b.interintra_type_mut() = INTER_INTRA_BLEND
-                    + dav1d_msac_decode_bool_adapt(
+                    + rav1d_msac_decode_bool_adapt(
                         &mut ts.msac,
                         &mut ts.cdf.m.interintra_wedge[wedge_ctx as usize],
                     ) as u8;
                 if b.interintra_type() == INTER_INTRA_WEDGE {
-                    *b.wedge_idx_mut() = dav1d_msac_decode_symbol_adapt16(
+                    *b.wedge_idx_mut() = rav1d_msac_decode_symbol_adapt16(
                         &mut ts.msac,
                         &mut ts.cdf.m.wedge_idx[wedge_ctx as usize],
                         15,
@@ -3048,13 +3048,13 @@ unsafe fn decode_b(
                     && mask[0] | mask[1] != 0) as c_int;
 
                 *b.motion_mode_mut() = if allow_warp != 0 {
-                    dav1d_msac_decode_symbol_adapt4(
+                    rav1d_msac_decode_symbol_adapt4(
                         &mut ts.msac,
                         &mut ts.cdf.m.motion_mode[bs as usize],
                         2,
                     ) as u8
                 } else {
-                    dav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.obmc[bs as usize])
+                    rav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.obmc[bs as usize])
                         as u8
                 };
                 if b.motion_mode() == MM_WARP as u8 {
@@ -3109,7 +3109,7 @@ unsafe fn decode_b(
             if has_subpel_filter {
                 let comp = b.comp_type() != COMP_INTER_NONE;
                 let ctx1 = get_filter_ctx(&*t.a, &t.l, comp, false, b.r#ref()[0], by4, bx4);
-                let filter0 = dav1d_msac_decode_symbol_adapt4(
+                let filter0 = rav1d_msac_decode_symbol_adapt4(
                     &mut ts.msac,
                     &mut ts.cdf.m.filter.0[0][ctx1 as usize],
                     DAV1D_N_SWITCHABLE_FILTERS as usize - 1,
@@ -3122,7 +3122,7 @@ unsafe fn decode_b(
                             filter0, ctx1, ts.msac.rng,
                         );
                     }
-                    let filter1 = dav1d_msac_decode_symbol_adapt4(
+                    let filter1 = rav1d_msac_decode_symbol_adapt4(
                         &mut ts.msac,
                         &mut ts.cdf.m.filter.0[1][ctx2 as usize],
                         DAV1D_N_SWITCHABLE_FILTERS as usize - 1,
@@ -3170,7 +3170,7 @@ unsafe fn decode_b(
                 ytx = TX_4X4 as RectTxfmSize;
                 uvtx = TX_4X4 as RectTxfmSize;
             }
-            dav1d_create_lf_mask_inter(
+            rav1d_create_lf_mask_inter(
                 &mut *t.lf_mask,
                 f.lf.level,
                 f.b4_stride,
@@ -3524,7 +3524,7 @@ unsafe fn decode_sb(t: &mut Rav1dTaskContext, bl: BlockLevel, node: *const EdgeN
 
     if have_h_split && have_v_split {
         if let Some(pc) = pc {
-            bp = dav1d_msac_decode_symbol_adapt16(
+            bp = rav1d_msac_decode_symbol_adapt16(
                 &mut ts.msac,
                 pc,
                 dav1d_partition_type_count[bl as usize].into(),
@@ -3749,7 +3749,7 @@ unsafe fn decode_sb(t: &mut Rav1dTaskContext, bl: BlockLevel, node: *const EdgeN
     } else if have_h_split {
         let is_split;
         if let Some(pc) = pc {
-            is_split = dav1d_msac_decode_bool(&mut ts.msac, gather_top_partition_prob(pc, bl));
+            is_split = rav1d_msac_decode_bool(&mut ts.msac, gather_top_partition_prob(pc, bl));
             if DEBUG_BLOCK_INFO(f, t) {
                 println!(
                     "poc={},y={},x={},bl={},ctx={},bp={}: r={}",
@@ -3800,7 +3800,7 @@ unsafe fn decode_sb(t: &mut Rav1dTaskContext, bl: BlockLevel, node: *const EdgeN
         assert!(have_v_split);
         let is_split;
         if let Some(pc) = pc {
-            is_split = dav1d_msac_decode_bool(&mut ts.msac, gather_left_partition_prob(pc, bl));
+            is_split = rav1d_msac_decode_bool(&mut ts.msac, gather_left_partition_prob(pc, bl));
             if f.cur.p.layout == DAV1D_PIXEL_LAYOUT_I422 && !is_split {
                 return 1;
             }
@@ -3953,11 +3953,11 @@ unsafe fn setup_tile(
         };
     }
 
-    dav1d_cdf_thread_copy(&mut ts.cdf, &f.in_cdf);
+    rav1d_cdf_thread_copy(&mut ts.cdf, &f.in_cdf);
     ts.last_qidx = (*f.frame_hdr).quant.yac;
     ts.last_delta_lf.fill(0);
 
-    dav1d_msac_init(
+    rav1d_msac_init(
         &mut ts.msac,
         data.as_ptr(),
         data.len(),
@@ -4034,7 +4034,7 @@ unsafe fn read_restoration_info(
 
     if frame_type == DAV1D_RESTORATION_SWITCHABLE {
         let filter =
-            dav1d_msac_decode_symbol_adapt4(&mut ts.msac, &mut ts.cdf.m.restore_switchable.0, 2);
+            rav1d_msac_decode_symbol_adapt4(&mut ts.msac, &mut ts.cdf.m.restore_switchable.0, 2);
         lr.r#type = if filter != 0 {
             if filter == 2 {
                 DAV1D_RESTORATION_SGRPROJ
@@ -4045,7 +4045,7 @@ unsafe fn read_restoration_info(
             DAV1D_RESTORATION_NONE
         };
     } else {
-        let r#type = dav1d_msac_decode_bool_adapt(
+        let r#type = rav1d_msac_decode_bool_adapt(
             &mut ts.msac,
             if frame_type == DAV1D_RESTORATION_WIENER {
                 &mut ts.cdf.m.restore_wiener.0
@@ -4061,7 +4061,7 @@ unsafe fn read_restoration_info(
     }
 
     fn msac_decode_lr_subexp(ts: &mut Rav1dTileState, r#ref: i8, k: u32, adjustment: i8) -> i8 {
-        (dav1d_msac_decode_subexp(
+        (rav1d_msac_decode_subexp(
             &mut ts.msac,
             (r#ref + adjustment) as libc::c_uint,
             8 << k,
@@ -4101,7 +4101,7 @@ unsafe fn read_restoration_info(
             );
         }
     } else if lr.r#type == DAV1D_RESTORATION_SGRPROJ {
-        let idx = dav1d_msac_decode_bools(&mut ts.msac, 4) as u8;
+        let idx = rav1d_msac_decode_bools(&mut ts.msac, 4) as u8;
         let sgr_params = &dav1d_sgr_params[idx.into()];
         lr.sgr_idx = idx;
         lr.sgr_weights[0] = if sgr_params[0] != 0 {
@@ -4126,7 +4126,7 @@ unsafe fn read_restoration_info(
     }
 }
 
-pub unsafe fn dav1d_decode_tile_sbrow(t: *mut Rav1dTaskContext) -> c_int {
+pub(crate) unsafe fn rav1d_decode_tile_sbrow(t: *mut Rav1dTaskContext) -> c_int {
     let f: *const Rav1dFrameContext = (*t).f;
     let root_bl: BlockLevel = (if (*(*f).seq_hdr).sb128 != 0 {
         BL_128X128 as c_int
@@ -4143,7 +4143,7 @@ pub unsafe fn dav1d_decode_tile_sbrow(t: *mut Rav1dTaskContext) -> c_int {
     if (*(*f).frame_hdr).frame_type as c_uint & 1 as c_uint != 0
         || (*(*f).frame_hdr).allow_intrabc != 0
     {
-        dav1d_refmvs_tile_sbrow_init(
+        rav1d_refmvs_tile_sbrow_init(
             &mut (*t).rt,
             &(*f).rf,
             (*ts).tiling.col_start,
@@ -4324,7 +4324,7 @@ pub unsafe fn dav1d_decode_tile_sbrow(t: *mut Rav1dTaskContext) -> c_int {
         && (*(*f).c).n_tc > 1 as c_uint
         && (*(*f).frame_hdr).frame_type as c_uint & 1 as c_uint != 0
     {
-        dav1d_refmvs_save_tmvs(
+        rav1d_refmvs_save_tmvs(
             &(*(*f).c).refmvs_dsp,
             &mut (*t).rt,
             (*ts).tiling.col_start >> 1,
@@ -4360,7 +4360,7 @@ pub unsafe fn dav1d_decode_tile_sbrow(t: *mut Rav1dTaskContext) -> c_int {
     return 0 as c_int;
 }
 
-pub unsafe fn dav1d_decode_frame_init(f: &mut Rav1dFrameContext) -> c_int {
+pub(crate) unsafe fn rav1d_decode_frame_init(f: &mut Rav1dFrameContext) -> c_int {
     let c = &*f.c;
 
     if f.sbh > f.lf.start_of_tile_row_sz {
@@ -4393,8 +4393,8 @@ pub unsafe fn dav1d_decode_frame_init(f: &mut Rav1dFrameContext) -> c_int {
                 return -12;
             }
         }
-        dav1d_free_aligned(f.ts as *mut c_void);
-        f.ts = dav1d_alloc_aligned(::core::mem::size_of::<Rav1dTileState>() * n_ts as usize, 32)
+        rav1d_free_aligned(f.ts as *mut c_void);
+        f.ts = rav1d_alloc_aligned(::core::mem::size_of::<Rav1dTileState>() * n_ts as usize, 32)
             as *mut Rav1dTileState;
         if f.ts.is_null() {
             return -12;
@@ -4465,9 +4465,9 @@ pub unsafe fn dav1d_decode_frame_init(f: &mut Rav1dFrameContext) -> c_int {
 
         let cf_sz = (num_sb128 * size_mul[0] as c_int) << hbd;
         if cf_sz != f.frame_thread.cf_sz {
-            dav1d_freep_aligned(&mut f.frame_thread.cf as *mut *mut DynCoef as *mut c_void);
+            rav1d_freep_aligned(&mut f.frame_thread.cf as *mut *mut DynCoef as *mut c_void);
             f.frame_thread.cf =
-                dav1d_alloc_aligned(cf_sz as usize * 128 * 128 / 2, 64) as *mut DynCoef;
+                rav1d_alloc_aligned(cf_sz as usize * 128 * 128 / 2, 64) as *mut DynCoef;
             if f.frame_thread.cf.is_null() {
                 f.frame_thread.cf_sz = 0;
                 return -12;
@@ -4482,10 +4482,10 @@ pub unsafe fn dav1d_decode_frame_init(f: &mut Rav1dFrameContext) -> c_int {
 
         if (*f.frame_hdr).allow_screen_content_tools != 0 {
             if num_sb128 != f.frame_thread.pal_sz {
-                dav1d_freep_aligned(
+                rav1d_freep_aligned(
                     &mut f.frame_thread.pal as *mut *mut [[u16; 8]; 3] as *mut c_void,
                 );
-                f.frame_thread.pal = dav1d_alloc_aligned(
+                f.frame_thread.pal = rav1d_alloc_aligned(
                     ::core::mem::size_of::<[[u16; 8]; 3]>() * num_sb128 as usize * 16 * 16,
                     64,
                 ) as *mut [[u16; 8]; 3];
@@ -4498,8 +4498,8 @@ pub unsafe fn dav1d_decode_frame_init(f: &mut Rav1dFrameContext) -> c_int {
 
             let pal_idx_sz = num_sb128 * size_mul[1] as c_int;
             if pal_idx_sz != f.frame_thread.pal_idx_sz {
-                dav1d_freep_aligned(&mut f.frame_thread.pal_idx as *mut *mut u8 as *mut c_void);
-                f.frame_thread.pal_idx = dav1d_alloc_aligned(
+                rav1d_freep_aligned(&mut f.frame_thread.pal_idx as *mut *mut u8 as *mut c_void);
+                f.frame_thread.pal_idx = rav1d_alloc_aligned(
                     ::core::mem::size_of::<u8>() * pal_idx_sz as usize * 128 * 128 / 4,
                     64,
                 ) as *mut u8;
@@ -4510,8 +4510,8 @@ pub unsafe fn dav1d_decode_frame_init(f: &mut Rav1dFrameContext) -> c_int {
                 f.frame_thread.pal_idx_sz = pal_idx_sz;
             }
         } else if !f.frame_thread.pal.is_null() {
-            dav1d_freep_aligned(&mut f.frame_thread.pal as *mut *mut [[u16; 8]; 3] as *mut c_void);
-            dav1d_freep_aligned(&mut f.frame_thread.pal_idx as *mut *mut u8 as *mut c_void);
+            rav1d_freep_aligned(&mut f.frame_thread.pal as *mut *mut [[u16; 8]; 3] as *mut c_void);
+            rav1d_freep_aligned(&mut f.frame_thread.pal_idx as *mut *mut u8 as *mut c_void);
             f.frame_thread.pal_idx_sz = 0;
             f.frame_thread.pal_sz = f.frame_thread.pal_idx_sz;
         }
@@ -4527,11 +4527,11 @@ pub unsafe fn dav1d_decode_frame_init(f: &mut Rav1dFrameContext) -> c_int {
         || need_cdef_lpf_copy != f.lf.need_cdef_lpf_copy
         || f.sbh != f.lf.cdef_buf_sbh
     {
-        dav1d_free_aligned(f.lf.cdef_line_buf as *mut c_void);
+        rav1d_free_aligned(f.lf.cdef_line_buf as *mut c_void);
         let mut alloc_sz: usize = 64;
         alloc_sz += (y_stride.unsigned_abs() * 4 * f.sbh as usize) << need_cdef_lpf_copy;
         alloc_sz += (uv_stride.unsigned_abs() * 8 * f.sbh as usize) << need_cdef_lpf_copy;
-        f.lf.cdef_line_buf = dav1d_alloc_aligned(alloc_sz, 32) as *mut u8;
+        f.lf.cdef_line_buf = rav1d_alloc_aligned(alloc_sz, 32) as *mut u8;
         let mut ptr = f.lf.cdef_line_buf;
         if ptr.is_null() {
             f.lf.cdef_buf_plane_sz[1] = 0;
@@ -4599,12 +4599,12 @@ pub unsafe fn dav1d_decode_frame_init(f: &mut Rav1dFrameContext) -> c_int {
     if y_stride * num_lines as isize != f.lf.lr_buf_plane_sz[0] as isize
         || uv_stride * num_lines as isize * 2 != f.lf.lr_buf_plane_sz[1] as isize
     {
-        dav1d_free_aligned(f.lf.lr_line_buf as *mut c_void);
+        rav1d_free_aligned(f.lf.lr_line_buf as *mut c_void);
         // lr simd may overread the input, so slightly over-allocate the lpf buffer
         let mut alloc_sz: usize = 128;
         alloc_sz += y_stride.unsigned_abs() * num_lines as usize;
         alloc_sz += uv_stride.unsigned_abs() * num_lines as usize * 2;
-        f.lf.lr_line_buf = dav1d_alloc_aligned(alloc_sz, 64) as *mut u8;
+        f.lf.lr_line_buf = rav1d_alloc_aligned(alloc_sz, 64) as *mut u8;
         let mut ptr = f.lf.lr_line_buf;
         if ptr.is_null() {
             f.lf.lr_buf_plane_sz[1] = 0;
@@ -4686,7 +4686,7 @@ pub unsafe fn dav1d_decode_frame_init(f: &mut Rav1dFrameContext) -> c_int {
         .sum::<u8>()
         .into();
     if (*f.frame_hdr).loopfilter.sharpness != f.lf.last_sharpness {
-        dav1d_calc_eih(&mut f.lf.lim_lut.0, (*f.frame_hdr).loopfilter.sharpness);
+        rav1d_calc_eih(&mut f.lf.lim_lut.0, (*f.frame_hdr).loopfilter.sharpness);
         f.lf.last_sharpness = (*f.frame_hdr).loopfilter.sharpness;
     }
     dav1d_calc_lf_values(&mut f.lf.lvl, &*f.frame_hdr, &[0, 0, 0, 0]);
@@ -4694,11 +4694,11 @@ pub unsafe fn dav1d_decode_frame_init(f: &mut Rav1dFrameContext) -> c_int {
 
     let ipred_edge_sz = f.sbh * f.sb128w << hbd;
     if ipred_edge_sz != f.ipred_edge_sz {
-        dav1d_freep_aligned(
+        rav1d_freep_aligned(
             &mut *f.ipred_edge.as_mut_ptr().offset(0) as *mut *mut DynPixel as *mut c_void,
         );
         f.ipred_edge[0] =
-            dav1d_alloc_aligned(ipred_edge_sz as usize * 128 * 3, 64) as *mut DynPixel;
+            rav1d_alloc_aligned(ipred_edge_sz as usize * 128 * 3, 64) as *mut DynPixel;
         let ptr = f.ipred_edge[0] as *mut u8;
         if ptr.is_null() {
             f.ipred_edge_sz = 0;
@@ -4807,11 +4807,11 @@ pub unsafe fn dav1d_decode_frame_init(f: &mut Rav1dFrameContext) -> c_int {
     0
 }
 
-pub unsafe fn dav1d_decode_frame_init_cdf(f: &mut Rav1dFrameContext) -> c_int {
+pub(crate) unsafe fn rav1d_decode_frame_init_cdf(f: &mut Rav1dFrameContext) -> c_int {
     let c = &*f.c;
 
     if (*f.frame_hdr).refresh_context != 0 {
-        dav1d_cdf_thread_copy(f.out_cdf.data.cdf, &mut f.in_cdf);
+        rav1d_cdf_thread_copy(f.out_cdf.data.cdf, &mut f.in_cdf);
     }
 
     let uses_2pass = c.n_fc > 1;
@@ -4902,7 +4902,7 @@ pub unsafe fn dav1d_decode_frame_init_cdf(f: &mut Rav1dFrameContext) -> c_int {
     0
 }
 
-unsafe fn dav1d_decode_frame_main(f: &mut Rav1dFrameContext) -> c_int {
+unsafe fn rav1d_decode_frame_main(f: &mut Rav1dFrameContext) -> c_int {
     let c = &*f.c;
 
     assert!(c.n_tc == 1);
@@ -4948,12 +4948,12 @@ unsafe fn dav1d_decode_frame_main(f: &mut Rav1dFrameContext) -> c_int {
             }
             for tile in &mut ts[..] {
                 t.ts = tile;
-                if dav1d_decode_tile_sbrow(t) != 0 {
+                if rav1d_decode_tile_sbrow(t) != 0 {
                     return -22;
                 }
             }
             if is_inter_or_switch(&*f.frame_hdr) {
-                dav1d_refmvs_save_tmvs(
+                rav1d_refmvs_save_tmvs(
                     &(*f.c).refmvs_dsp,
                     &mut t.rt,
                     0,
@@ -4971,7 +4971,7 @@ unsafe fn dav1d_decode_frame_main(f: &mut Rav1dFrameContext) -> c_int {
     0
 }
 
-pub unsafe fn dav1d_decode_frame_exit(f: &mut Rav1dFrameContext, retval: c_int) {
+pub(crate) unsafe fn rav1d_decode_frame_exit(f: &mut Rav1dFrameContext, retval: c_int) {
     let c = &*f.c;
     if !f.sr_cur.p.data[0].is_null() {
         f.task_thread.error = 0;
@@ -4986,13 +4986,13 @@ pub unsafe fn dav1d_decode_frame_exit(f: &mut Rav1dFrameContext, retval: c_int) 
     // TODO(kkysen) use array::zip when stable
     for i in 0..7 {
         if !f.refp[i].p.frame_hdr.is_null() {
-            dav1d_thread_picture_unref(&mut f.refp[i]);
+            rav1d_thread_picture_unref(&mut f.refp[i]);
         }
-        dav1d_ref_dec(&mut f.ref_mvs_ref[i]);
+        rav1d_ref_dec(&mut f.ref_mvs_ref[i]);
     }
-    dav1d_picture_unref_internal(&mut f.cur);
-    dav1d_thread_picture_unref(&mut f.sr_cur);
-    dav1d_cdf_thread_unref(&mut f.in_cdf);
+    rav1d_picture_unref_internal(&mut f.cur);
+    rav1d_thread_picture_unref(&mut f.sr_cur);
+    rav1d_cdf_thread_unref(&mut f.in_cdf);
     if !f.frame_hdr.is_null() && (*f.frame_hdr).refresh_context != 0 {
         if !f.out_cdf.progress.is_null() {
             ::core::intrinsics::atomic_store_seqcst(
@@ -5000,31 +5000,31 @@ pub unsafe fn dav1d_decode_frame_exit(f: &mut Rav1dFrameContext, retval: c_int) 
                 if retval == 0 { 1 } else { TILE_ERROR as u32 },
             );
         }
-        dav1d_cdf_thread_unref(&mut f.out_cdf);
+        rav1d_cdf_thread_unref(&mut f.out_cdf);
     }
-    dav1d_ref_dec(&mut f.cur_segmap_ref);
-    dav1d_ref_dec(&mut f.prev_segmap_ref);
-    dav1d_ref_dec(&mut f.mvs_ref);
-    dav1d_ref_dec(&mut f.seq_hdr_ref);
-    dav1d_ref_dec(&mut f.frame_hdr_ref);
+    rav1d_ref_dec(&mut f.cur_segmap_ref);
+    rav1d_ref_dec(&mut f.prev_segmap_ref);
+    rav1d_ref_dec(&mut f.mvs_ref);
+    rav1d_ref_dec(&mut f.seq_hdr_ref);
+    rav1d_ref_dec(&mut f.frame_hdr_ref);
     for tile in slice::from_raw_parts_mut(f.tile, f.n_tile_data.try_into().unwrap()) {
-        dav1d_data_unref_internal(&mut tile.data);
+        rav1d_data_unref_internal(&mut tile.data);
     }
     f.task_thread.retval = retval;
 }
 
-pub unsafe fn dav1d_decode_frame(f: &mut Rav1dFrameContext) -> c_int {
+pub(crate) unsafe fn rav1d_decode_frame(f: &mut Rav1dFrameContext) -> c_int {
     assert!((*f.c).n_fc == 1);
     // if n_tc > 1 (but n_fc == 1), we could run init/exit in the task
     // threads also. Not sure it makes a measurable difference.
-    let mut res = dav1d_decode_frame_init(f);
+    let mut res = rav1d_decode_frame_init(f);
     if res == 0 {
-        res = dav1d_decode_frame_init_cdf(f);
+        res = rav1d_decode_frame_init_cdf(f);
     }
     // wait until all threads have completed
     if res == 0 {
         if (*f.c).n_tc > 1 {
-            res = dav1d_task_create_tile_sbrow(f, 0, 1);
+            res = rav1d_task_create_tile_sbrow(f, 0, 1);
             pthread_mutex_lock(&mut (*f.task_thread.ttd).lock);
             pthread_cond_signal(&mut (*f.task_thread.ttd).cond);
             if res == 0 {
@@ -5040,7 +5040,7 @@ pub unsafe fn dav1d_decode_frame(f: &mut Rav1dFrameContext) -> c_int {
             pthread_mutex_unlock(&mut (*f.task_thread.ttd).lock);
             res = f.task_thread.retval;
         } else {
-            res = dav1d_decode_frame_main(f);
+            res = rav1d_decode_frame_main(f);
             if res == 0 && (*f.frame_hdr).refresh_context != 0 && f.task_thread.update_set {
                 dav1d_cdf_thread_update(
                     f.frame_hdr,
@@ -5050,7 +5050,7 @@ pub unsafe fn dav1d_decode_frame(f: &mut Rav1dFrameContext) -> c_int {
             }
         }
     }
-    dav1d_decode_frame_exit(f, res);
+    rav1d_decode_frame_exit(f, res);
     f.n_tile_data = 0;
     res
 }
@@ -5061,7 +5061,7 @@ fn get_upscale_x0(in_w: c_int, out_w: c_int, step: c_int) -> c_int {
     x0 & 0x3fff
 }
 
-pub unsafe fn dav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
+pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
     // wait for c->out_delayed[next] and move into c->out if visible
     let (f, out_delayed) = if c.n_fc > 1 {
         pthread_mutex_lock(&mut c.task_thread.lock);
@@ -5099,17 +5099,17 @@ pub unsafe fn dav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
         if error != 0 {
             f.task_thread.retval = 0;
             c.cached_error = error;
-            dav1d_data_props_copy(&mut c.cached_error_props, &mut out_delayed.p.m);
-            dav1d_thread_picture_unref(out_delayed);
+            rav1d_data_props_copy(&mut c.cached_error_props, &mut out_delayed.p.m);
+            rav1d_thread_picture_unref(out_delayed);
         } else if !out_delayed.p.data[0].is_null() {
             let progress = ::core::intrinsics::atomic_load_relaxed(
                 &mut *(out_delayed.progress).offset(1) as *mut atomic_uint,
             );
             if (out_delayed.visible || c.output_invisible_frames != 0) && progress != FRAME_ERROR {
-                dav1d_thread_picture_ref(&mut c.out, out_delayed);
-                c.event_flags |= dav1d_picture_get_event_flags(out_delayed);
+                rav1d_thread_picture_ref(&mut c.out, out_delayed);
+                c.event_flags |= rav1d_picture_get_event_flags(out_delayed);
             }
-            dav1d_thread_picture_unref(out_delayed);
+            rav1d_thread_picture_unref(out_delayed);
         }
         (f, out_delayed as *mut _)
     } else {
@@ -5118,7 +5118,7 @@ pub unsafe fn dav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
 
     f.seq_hdr = c.seq_hdr;
     f.seq_hdr_ref = c.seq_hdr_ref;
-    dav1d_ref_inc(f.seq_hdr_ref);
+    rav1d_ref_inc(f.seq_hdr_ref);
     f.frame_hdr = c.frame_hdr;
     f.frame_hdr_ref = c.frame_hdr_ref;
     c.frame_hdr = ptr::null_mut();
@@ -5133,30 +5133,30 @@ pub unsafe fn dav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
         out_delayed: *mut Rav1dThreadPicture,
     ) {
         f.task_thread.error = 1;
-        dav1d_cdf_thread_unref(&mut f.in_cdf);
+        rav1d_cdf_thread_unref(&mut f.in_cdf);
         if (*f.frame_hdr).refresh_context != 0 {
-            dav1d_cdf_thread_unref(&mut f.out_cdf);
+            rav1d_cdf_thread_unref(&mut f.out_cdf);
         }
         for i in 0..7 {
             if !f.refp[i].p.frame_hdr.is_null() {
-                dav1d_thread_picture_unref(&mut f.refp[i]);
+                rav1d_thread_picture_unref(&mut f.refp[i]);
             }
-            dav1d_ref_dec(&mut f.ref_mvs_ref[i]);
+            rav1d_ref_dec(&mut f.ref_mvs_ref[i]);
         }
         if c.n_fc == 1 {
-            dav1d_thread_picture_unref(&mut c.out);
+            rav1d_thread_picture_unref(&mut c.out);
         } else {
-            dav1d_thread_picture_unref(out_delayed);
+            rav1d_thread_picture_unref(out_delayed);
         }
-        dav1d_picture_unref_internal(&mut f.cur);
-        dav1d_thread_picture_unref(&mut f.sr_cur);
-        dav1d_ref_dec(&mut f.mvs_ref);
-        dav1d_ref_dec(&mut f.seq_hdr_ref);
-        dav1d_ref_dec(&mut f.frame_hdr_ref);
-        dav1d_data_props_copy(&mut c.cached_error_props, &mut c.in_0.m);
+        rav1d_picture_unref_internal(&mut f.cur);
+        rav1d_thread_picture_unref(&mut f.sr_cur);
+        rav1d_ref_dec(&mut f.mvs_ref);
+        rav1d_ref_dec(&mut f.seq_hdr_ref);
+        rav1d_ref_dec(&mut f.frame_hdr_ref);
+        rav1d_data_props_copy(&mut c.cached_error_props, &mut c.in_0.m);
 
         for tile in slice::from_raw_parts_mut(f.tile, f.n_tile_data.try_into().unwrap()) {
-            dav1d_data_unref_internal(&mut tile.data);
+            rav1d_data_unref_internal(&mut tile.data);
         }
         f.n_tile_data = 0;
 
@@ -5171,26 +5171,26 @@ pub unsafe fn dav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
         match bpc {
             #[cfg(feature = "bitdepth_8")]
             8 => {
-                dav1d_cdef_dsp_init_8bpc(&mut dsp.cdef);
-                dav1d_intra_pred_dsp_init_8bpc(&mut dsp.ipred);
-                dav1d_itx_dsp_init_8bpc(&mut dsp.itx, bpc);
-                dav1d_loop_filter_dsp_init_8bpc(&mut dsp.lf);
-                dav1d_loop_restoration_dsp_init::<BitDepth8>(&mut dsp.lr, bpc);
-                dav1d_mc_dsp_init::<BitDepth8>(&mut dsp.mc);
-                dav1d_film_grain_dsp_init_8bpc(&mut dsp.fg);
+                rav1d_cdef_dsp_init_8bpc(&mut dsp.cdef);
+                rav1d_intra_pred_dsp_init_8bpc(&mut dsp.ipred);
+                rav1d_itx_dsp_init_8bpc(&mut dsp.itx, bpc);
+                rav1d_loop_filter_dsp_init_8bpc(&mut dsp.lf);
+                rav1d_loop_restoration_dsp_init::<BitDepth8>(&mut dsp.lr, bpc);
+                rav1d_mc_dsp_init::<BitDepth8>(&mut dsp.mc);
+                rav1d_film_grain_dsp_init_8bpc(&mut dsp.fg);
             }
             #[cfg(feature = "bitdepth_16")]
             10 | 12 => {
-                dav1d_cdef_dsp_init_16bpc(&mut dsp.cdef);
-                dav1d_intra_pred_dsp_init_16bpc(&mut dsp.ipred);
-                dav1d_itx_dsp_init_16bpc(&mut dsp.itx, bpc);
-                dav1d_loop_filter_dsp_init_16bpc(&mut dsp.lf);
-                dav1d_loop_restoration_dsp_init::<BitDepth16>(&mut dsp.lr, bpc);
-                dav1d_mc_dsp_init::<BitDepth16>(&mut dsp.mc);
-                dav1d_film_grain_dsp_init_16bpc(&mut dsp.fg);
+                rav1d_cdef_dsp_init_16bpc(&mut dsp.cdef);
+                rav1d_intra_pred_dsp_init_16bpc(&mut dsp.ipred);
+                rav1d_itx_dsp_init_16bpc(&mut dsp.itx, bpc);
+                rav1d_loop_filter_dsp_init_16bpc(&mut dsp.lf);
+                rav1d_loop_restoration_dsp_init::<BitDepth16>(&mut dsp.lr, bpc);
+                rav1d_mc_dsp_init::<BitDepth16>(&mut dsp.mc);
+                rav1d_film_grain_dsp_init_16bpc(&mut dsp.fg);
             }
             _ => {
-                dav1d_log(
+                rav1d_log(
                     c,
                     b"Compiled without support for %d-bit decoding\n\0" as *const u8
                         as *const c_char,
@@ -5204,30 +5204,30 @@ pub unsafe fn dav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
     if (*f.seq_hdr).hbd == 0 {
         #[cfg(feature = "bitdepth_8")]
         {
-            f.bd_fn.recon_b_inter = Some(dav1d_recon_b_inter_8bpc);
-            f.bd_fn.recon_b_intra = Some(dav1d_recon_b_intra_8bpc);
-            f.bd_fn.filter_sbrow = Some(dav1d_filter_sbrow_8bpc);
-            f.bd_fn.filter_sbrow_deblock_cols = Some(dav1d_filter_sbrow_deblock_cols_8bpc);
-            f.bd_fn.filter_sbrow_deblock_rows = Some(dav1d_filter_sbrow_deblock_rows_8bpc);
-            f.bd_fn.filter_sbrow_cdef = Some(dav1d_filter_sbrow_cdef_8bpc);
-            f.bd_fn.filter_sbrow_resize = Some(dav1d_filter_sbrow_resize_8bpc);
-            f.bd_fn.filter_sbrow_lr = Some(dav1d_filter_sbrow_lr_8bpc);
-            f.bd_fn.backup_ipred_edge = Some(dav1d_backup_ipred_edge_8bpc);
-            f.bd_fn.read_coef_blocks = Some(dav1d_read_coef_blocks_8bpc);
+            f.bd_fn.recon_b_inter = Some(rav1d_recon_b_inter_8bpc);
+            f.bd_fn.recon_b_intra = Some(rav1d_recon_b_intra_8bpc);
+            f.bd_fn.filter_sbrow = Some(rav1d_filter_sbrow_8bpc);
+            f.bd_fn.filter_sbrow_deblock_cols = Some(rav1d_filter_sbrow_deblock_cols_8bpc);
+            f.bd_fn.filter_sbrow_deblock_rows = Some(rav1d_filter_sbrow_deblock_rows_8bpc);
+            f.bd_fn.filter_sbrow_cdef = Some(rav1d_filter_sbrow_cdef_8bpc);
+            f.bd_fn.filter_sbrow_resize = Some(rav1d_filter_sbrow_resize_8bpc);
+            f.bd_fn.filter_sbrow_lr = Some(rav1d_filter_sbrow_lr_8bpc);
+            f.bd_fn.backup_ipred_edge = Some(rav1d_backup_ipred_edge_8bpc);
+            f.bd_fn.read_coef_blocks = Some(rav1d_read_coef_blocks_8bpc);
         }
     } else {
         #[cfg(feature = "bitdepth_16")]
         {
-            f.bd_fn.recon_b_inter = Some(dav1d_recon_b_inter_16bpc);
-            f.bd_fn.recon_b_intra = Some(dav1d_recon_b_intra_16bpc);
-            f.bd_fn.filter_sbrow = Some(dav1d_filter_sbrow_16bpc);
-            f.bd_fn.filter_sbrow_deblock_cols = Some(dav1d_filter_sbrow_deblock_cols_16bpc);
-            f.bd_fn.filter_sbrow_deblock_rows = Some(dav1d_filter_sbrow_deblock_rows_16bpc);
-            f.bd_fn.filter_sbrow_cdef = Some(dav1d_filter_sbrow_cdef_16bpc);
-            f.bd_fn.filter_sbrow_resize = Some(dav1d_filter_sbrow_resize_16bpc);
-            f.bd_fn.filter_sbrow_lr = Some(dav1d_filter_sbrow_lr_16bpc);
-            f.bd_fn.backup_ipred_edge = Some(dav1d_backup_ipred_edge_16bpc);
-            f.bd_fn.read_coef_blocks = Some(dav1d_read_coef_blocks_16bpc);
+            f.bd_fn.recon_b_inter = Some(rav1d_recon_b_inter_16bpc);
+            f.bd_fn.recon_b_intra = Some(rav1d_recon_b_intra_16bpc);
+            f.bd_fn.filter_sbrow = Some(rav1d_filter_sbrow_16bpc);
+            f.bd_fn.filter_sbrow_deblock_cols = Some(rav1d_filter_sbrow_deblock_cols_16bpc);
+            f.bd_fn.filter_sbrow_deblock_rows = Some(rav1d_filter_sbrow_deblock_rows_16bpc);
+            f.bd_fn.filter_sbrow_cdef = Some(rav1d_filter_sbrow_cdef_16bpc);
+            f.bd_fn.filter_sbrow_resize = Some(rav1d_filter_sbrow_resize_16bpc);
+            f.bd_fn.filter_sbrow_lr = Some(rav1d_filter_sbrow_lr_16bpc);
+            f.bd_fn.backup_ipred_edge = Some(rav1d_backup_ipred_edge_16bpc);
+            f.bd_fn.read_coef_blocks = Some(rav1d_read_coef_blocks_16bpc);
         }
     }
 
@@ -5255,12 +5255,12 @@ pub unsafe fn dav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
                 || bpc != c.refs[refidx].p.p.p.bpc
             {
                 for j in 0..i {
-                    dav1d_thread_picture_unref(&mut f.refp[j]);
+                    rav1d_thread_picture_unref(&mut f.refp[j]);
                 }
                 on_error(f, c, out_delayed);
                 return -22;
             }
-            dav1d_thread_picture_ref(&mut f.refp[i], &mut c.refs[refidx].p);
+            rav1d_thread_picture_ref(&mut f.refp[i], &mut c.refs[refidx].p);
             ref_coded_width[i] = (*c.refs[refidx].p.p.frame_hdr).width[0];
             if (*f.frame_hdr).width[0] != c.refs[refidx].p.p.p.w
                 || (*f.frame_hdr).height != c.refs[refidx].p.p.p.h
@@ -5282,13 +5282,13 @@ pub unsafe fn dav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
 
     // setup entropy
     if (*f.frame_hdr).primary_ref_frame == 7 {
-        dav1d_cdf_thread_init_static(&mut f.in_cdf, (*f.frame_hdr).quant.yac);
+        rav1d_cdf_thread_init_static(&mut f.in_cdf, (*f.frame_hdr).quant.yac);
     } else {
         let pri_ref = (*f.frame_hdr).refidx[(*f.frame_hdr).primary_ref_frame as usize] as usize;
-        dav1d_cdf_thread_ref(&mut f.in_cdf, &mut c.cdf[pri_ref]);
+        rav1d_cdf_thread_ref(&mut f.in_cdf, &mut c.cdf[pri_ref]);
     }
     if (*f.frame_hdr).refresh_context != 0 {
-        let res = dav1d_cdf_thread_alloc(c, &mut f.out_cdf, (c.n_fc > 1) as c_int);
+        let res = rav1d_cdf_thread_alloc(c, &mut f.out_cdf, (c.n_fc > 1) as c_int);
         if res < 0 {
             on_error(f, c, out_delayed);
             return res;
@@ -5318,20 +5318,20 @@ pub unsafe fn dav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
     c.n_tile_data = 0;
 
     // allocate frame
-    let res = dav1d_thread_picture_alloc(c, f, bpc);
+    let res = rav1d_thread_picture_alloc(c, f, bpc);
     if res < 0 {
         on_error(f, c, out_delayed);
         return res;
     }
 
     if (*f.frame_hdr).width[0] != (*f.frame_hdr).width[1] {
-        let res = dav1d_picture_alloc_copy(c, &mut f.cur, (*f.frame_hdr).width[0], &mut f.sr_cur.p);
+        let res = rav1d_picture_alloc_copy(c, &mut f.cur, (*f.frame_hdr).width[0], &mut f.sr_cur.p);
         if res < 0 {
             on_error(f, c, out_delayed);
             return res;
         }
     } else {
-        dav1d_picture_ref(&mut f.cur, &mut f.sr_cur.p);
+        rav1d_picture_ref(&mut f.cur, &mut f.sr_cur.p);
     }
     if (*f.frame_hdr).width[0] != (*f.frame_hdr).width[1] {
         f.resize_step[0] = scale_fac(f.cur.p.w, f.sr_cur.p.p.w);
@@ -5346,11 +5346,11 @@ pub unsafe fn dav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
     // move f->cur into output queue
     if c.n_fc == 1 {
         if (*f.frame_hdr).show_frame != 0 || c.output_invisible_frames != 0 {
-            dav1d_thread_picture_ref(&mut c.out, &mut f.sr_cur);
-            c.event_flags |= dav1d_picture_get_event_flags(&mut f.sr_cur);
+            rav1d_thread_picture_ref(&mut c.out, &mut f.sr_cur);
+            c.event_flags |= rav1d_picture_get_event_flags(&mut f.sr_cur);
         }
     } else {
-        dav1d_thread_picture_ref(out_delayed, &mut f.sr_cur);
+        rav1d_thread_picture_ref(out_delayed, &mut f.sr_cur);
     }
 
     f.w4 = (*f.frame_hdr).width[0] + 3 >> 2;
@@ -5375,7 +5375,7 @@ pub unsafe fn dav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
 
     // ref_mvs
     if is_inter_or_switch(&*f.frame_hdr) || (*f.frame_hdr).allow_intrabc != 0 {
-        f.mvs_ref = dav1d_ref_create_using_pool(
+        f.mvs_ref = rav1d_ref_create_using_pool(
             c.refmvs_pool,
             ::core::mem::size_of::<refmvs_temporal_block>()
                 * f.sb128h as usize
@@ -5401,7 +5401,7 @@ pub unsafe fn dav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
                 let ref_h = (f.refp[i].p.p.h + 7 >> 3) << 1;
                 if !c.refs[refidx].refmvs.is_null() && ref_w == f.bw && ref_h == f.bh {
                     f.ref_mvs_ref[i] = c.refs[refidx].refmvs;
-                    dav1d_ref_inc(f.ref_mvs_ref[i]);
+                    rav1d_ref_inc(f.ref_mvs_ref[i]);
                     f.ref_mvs[i] = (*c.refs[refidx].refmvs)
                         .data
                         .cast::<refmvs_temporal_block>();
@@ -5436,7 +5436,7 @@ pub unsafe fn dav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
             if ref_w == f.bw && ref_h == f.bh {
                 f.prev_segmap_ref = c.refs[(*f.frame_hdr).refidx[pri_ref] as usize].segmap;
                 if !f.prev_segmap_ref.is_null() {
-                    dav1d_ref_inc(f.prev_segmap_ref);
+                    rav1d_ref_inc(f.prev_segmap_ref);
                     f.prev_segmap = (*f.prev_segmap_ref).data.cast::<u8>();
                 }
             }
@@ -5446,12 +5446,12 @@ pub unsafe fn dav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
             // We're updating an existing map,
             // but need somewhere to put the new values.
             // Allocate them here (the data actually gets set elsewhere).
-            f.cur_segmap_ref = dav1d_ref_create_using_pool(
+            f.cur_segmap_ref = rav1d_ref_create_using_pool(
                 c.segmap_pool,
                 ::core::mem::size_of::<u8>() * f.b4_stride as usize * 32 * f.sb128h as usize,
             );
             if f.cur_segmap_ref.is_null() {
-                dav1d_ref_dec(&mut f.prev_segmap_ref);
+                rav1d_ref_dec(&mut f.prev_segmap_ref);
                 on_error(f, c, out_delayed);
                 return -12;
             }
@@ -5460,13 +5460,13 @@ pub unsafe fn dav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
             // We're not updating an existing map,
             // and we have a valid reference. Use that.
             f.cur_segmap_ref = f.prev_segmap_ref;
-            dav1d_ref_inc(f.cur_segmap_ref);
+            rav1d_ref_inc(f.cur_segmap_ref);
             f.cur_segmap = (*f.prev_segmap_ref).data.cast::<u8>();
         } else {
             // We need to make a new map. Allocate one here and zero it out.
             let segmap_size =
                 ::core::mem::size_of::<u8>() * f.b4_stride as usize * 32 * f.sb128h as usize;
-            f.cur_segmap_ref = dav1d_ref_create_using_pool(c.segmap_pool, segmap_size);
+            f.cur_segmap_ref = rav1d_ref_create_using_pool(c.segmap_pool, segmap_size);
             if f.cur_segmap_ref.is_null() {
                 on_error(f, c, out_delayed);
                 return -12;
@@ -5485,27 +5485,27 @@ pub unsafe fn dav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
     for i in 0..8 {
         if refresh_frame_flags & (1 << i) != 0 {
             if !c.refs[i].p.p.frame_hdr.is_null() {
-                dav1d_thread_picture_unref(&mut c.refs[i].p);
+                rav1d_thread_picture_unref(&mut c.refs[i].p);
             }
-            dav1d_thread_picture_ref(&mut c.refs[i].p, &mut f.sr_cur);
+            rav1d_thread_picture_ref(&mut c.refs[i].p, &mut f.sr_cur);
 
-            dav1d_cdf_thread_unref(&mut c.cdf[i]);
+            rav1d_cdf_thread_unref(&mut c.cdf[i]);
             if (*f.frame_hdr).refresh_context != 0 {
-                dav1d_cdf_thread_ref(&mut c.cdf[i], &mut f.out_cdf);
+                rav1d_cdf_thread_ref(&mut c.cdf[i], &mut f.out_cdf);
             } else {
-                dav1d_cdf_thread_ref(&mut c.cdf[i], &mut f.in_cdf);
+                rav1d_cdf_thread_ref(&mut c.cdf[i], &mut f.in_cdf);
             }
 
-            dav1d_ref_dec(&mut c.refs[i].segmap);
+            rav1d_ref_dec(&mut c.refs[i].segmap);
             c.refs[i].segmap = f.cur_segmap_ref;
             if !f.cur_segmap_ref.is_null() {
-                dav1d_ref_inc(f.cur_segmap_ref);
+                rav1d_ref_inc(f.cur_segmap_ref);
             }
-            dav1d_ref_dec(&mut c.refs[i].refmvs);
+            rav1d_ref_dec(&mut c.refs[i].refmvs);
             if (*f.frame_hdr).allow_intrabc == 0 {
                 c.refs[i].refmvs = f.mvs_ref;
                 if !f.mvs_ref.is_null() {
-                    dav1d_ref_inc(f.mvs_ref);
+                    rav1d_ref_inc(f.mvs_ref);
                 }
             }
             c.refs[i].refpoc = f.refpoc;
@@ -5513,24 +5513,24 @@ pub unsafe fn dav1d_submit_frame(c: &mut Rav1dContext) -> c_int {
     }
 
     if c.n_fc == 1 {
-        let res = dav1d_decode_frame(f);
+        let res = rav1d_decode_frame(f);
         if res < 0 {
-            dav1d_thread_picture_unref(&mut c.out);
+            rav1d_thread_picture_unref(&mut c.out);
             for i in 0..8 {
                 if refresh_frame_flags & (1 << i) != 0 {
                     if !c.refs[i].p.p.frame_hdr.is_null() {
-                        dav1d_thread_picture_unref(&mut c.refs[i].p);
+                        rav1d_thread_picture_unref(&mut c.refs[i].p);
                     }
-                    dav1d_cdf_thread_unref(&mut c.cdf[i]);
-                    dav1d_ref_dec(&mut c.refs[i].segmap);
-                    dav1d_ref_dec(&mut c.refs[i].refmvs);
+                    rav1d_cdf_thread_unref(&mut c.cdf[i]);
+                    rav1d_ref_dec(&mut c.refs[i].segmap);
+                    rav1d_ref_dec(&mut c.refs[i].refmvs);
                 }
             }
             on_error(f, c, out_delayed);
             return res;
         }
     } else {
-        dav1d_task_frame_init(f);
+        rav1d_task_frame_init(f);
         pthread_mutex_unlock(&mut c.task_thread.lock);
     }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,7 +1,7 @@
 use crate::include::common::intops::apply_sign;
 use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
-use crate::include::dav1d::headers::DAV1D_N_SWITCHABLE_FILTERS;
+use crate::include::dav1d::headers::RAV1D_N_SWITCHABLE_FILTERS;
 use crate::src::align::Align8;
 use crate::src::levels::mv;
 use crate::src::levels::BlockLevel;
@@ -164,19 +164,19 @@ pub fn get_filter_ctx(
         if al.r#ref[0][b4 as usize] == r#ref || al.r#ref[1][b4 as usize] == r#ref {
             al.filter[dir as usize][b4 as usize]
         } else {
-            DAV1D_N_SWITCHABLE_FILTERS as u8
+            RAV1D_N_SWITCHABLE_FILTERS as u8
         }
     });
 
     (comp as u8) * 4
         + if a_filter == l_filter {
             a_filter
-        } else if a_filter == DAV1D_N_SWITCHABLE_FILTERS as u8 {
+        } else if a_filter == RAV1D_N_SWITCHABLE_FILTERS as u8 {
             l_filter
-        } else if l_filter == DAV1D_N_SWITCHABLE_FILTERS as u8 {
+        } else if l_filter == RAV1D_N_SWITCHABLE_FILTERS as u8 {
             a_filter
         } else {
-            DAV1D_N_SWITCHABLE_FILTERS as u8
+            RAV1D_N_SWITCHABLE_FILTERS as u8
         }
 }
 

--- a/src/fg_apply_tmpl_16.rs
+++ b/src/fg_apply_tmpl_16.rs
@@ -3,7 +3,7 @@ use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::picture::Dav1dPicture;
+use crate::include::dav1d::picture::Rav1dPicture;
 use crate::src::align::Align1;
 use crate::src::align::Align16;
 use crate::src::filmgrain::Rav1dFilmGrainDSPContext;
@@ -99,10 +99,10 @@ unsafe extern "C" fn generate_scaling(
     }
 }
 
-pub unsafe fn dav1d_prep_grain_16bpc(
+pub(crate) unsafe fn rav1d_prep_grain_16bpc(
     dsp: *const Rav1dFilmGrainDSPContext,
-    out: *mut Dav1dPicture,
-    in_0: *const Dav1dPicture,
+    out: *mut Rav1dPicture,
+    in_0: *const Rav1dPicture,
     scaling: *mut [u8; 4096],
     grain_lut: *mut [[entry; 82]; 74],
 ) {
@@ -223,10 +223,10 @@ pub unsafe fn dav1d_prep_grain_16bpc(
     }
 }
 
-pub unsafe fn dav1d_apply_grain_row_16bpc(
+pub(crate) unsafe fn rav1d_apply_grain_row_16bpc(
     dsp: *const Rav1dFilmGrainDSPContext,
-    out: *mut Dav1dPicture,
-    in_0: *const Dav1dPicture,
+    out: *mut Rav1dPicture,
+    in_0: *const Rav1dPicture,
     scaling: *const [u8; 4096],
     grain_lut: *const [[entry; 82]; 74],
     row: c_int,
@@ -332,15 +332,15 @@ pub unsafe fn dav1d_apply_grain_row_16bpc(
     };
 }
 
-pub unsafe fn dav1d_apply_grain_16bpc(
+pub(crate) unsafe fn rav1d_apply_grain_16bpc(
     dsp: *const Rav1dFilmGrainDSPContext,
-    out: *mut Dav1dPicture,
-    in_0: *const Dav1dPicture,
+    out: *mut Rav1dPicture,
+    in_0: *const Rav1dPicture,
 ) {
     let mut grain_lut = Align16([[[0; 82]; 74]; 3]);
     let mut scaling = Align1([[0; 4096]; 3]);
     let rows = (*out).p.h + 31 >> 5;
-    dav1d_prep_grain_16bpc(
+    rav1d_prep_grain_16bpc(
         dsp,
         out,
         in_0,
@@ -349,7 +349,7 @@ pub unsafe fn dav1d_apply_grain_16bpc(
     );
     let mut row = 0;
     while row < rows {
-        dav1d_apply_grain_row_16bpc(
+        rav1d_apply_grain_row_16bpc(
             dsp,
             out,
             in_0,

--- a/src/fg_apply_tmpl_16.rs
+++ b/src/fg_apply_tmpl_16.rs
@@ -1,8 +1,8 @@
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::RAV1D_MC_IDENTITY;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
 use crate::include::dav1d::picture::Rav1dPicture;
 use crate::src::align::Align1;
 use crate::src::align::Align16;
@@ -179,14 +179,14 @@ pub(crate) unsafe fn rav1d_prep_grain_16bpc(
             memcpy((*out).data[0], (*in_0).data[0], sz as usize);
         }
     }
-    if (*in_0).p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
+    if (*in_0).p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
         && (*data).chroma_scaling_from_luma == 0
     {
         if !((*out).stride[1] == (*in_0).stride[1]) {
             unreachable!();
         }
         let ss_ver =
-            ((*in_0).p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+            ((*in_0).p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
         let stride_0: ptrdiff_t = (*out).stride[1];
         let sz_0: ptrdiff_t = ((*out).p.h + ss_ver >> ss_ver) as isize * stride_0;
         if sz_0 < 0 {
@@ -232,10 +232,10 @@ pub(crate) unsafe fn rav1d_apply_grain_row_16bpc(
     row: c_int,
 ) {
     let data: *const Dav1dFilmGrainData = &mut (*(*out).frame_hdr).film_grain.data;
-    let ss_y = ((*in_0).p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
-    let ss_x = ((*in_0).p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+    let ss_y = ((*in_0).p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+    let ss_x = ((*in_0).p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
     let cpw = (*out).p.w + ss_x >> ss_x;
-    let is_id = ((*(*out).seq_hdr).mtrx as c_uint == DAV1D_MC_IDENTITY as c_int as c_uint) as c_int;
+    let is_id = ((*(*out).seq_hdr).mtrx as c_uint == RAV1D_MC_IDENTITY as c_int as c_uint) as c_int;
     let luma_src: *mut pixel = ((*in_0).data[0] as *mut pixel)
         .offset(((row * 32) as isize * PXSTRIDE((*in_0).stride[0])) as isize);
     let bitdepth_max = ((1 as c_int) << (*out).p.bpc) - 1;

--- a/src/fg_apply_tmpl_8.rs
+++ b/src/fg_apply_tmpl_8.rs
@@ -1,8 +1,8 @@
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::RAV1D_MC_IDENTITY;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
 use crate::include::dav1d::picture::Rav1dPicture;
 use crate::src::align::Align16;
 use crate::src::filmgrain::Rav1dFilmGrainDSPContext;
@@ -144,14 +144,14 @@ pub(crate) unsafe fn rav1d_prep_grain_8bpc(
             memcpy((*out).data[0], (*in_0).data[0], sz as usize);
         }
     }
-    if (*in_0).p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
+    if (*in_0).p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
         && (*data).chroma_scaling_from_luma == 0
     {
         if !((*out).stride[1] == (*in_0).stride[1]) {
             unreachable!();
         }
         let ss_ver =
-            ((*in_0).p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+            ((*in_0).p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
         let stride_0: ptrdiff_t = (*out).stride[1];
         let sz_0: ptrdiff_t = ((*out).p.h + ss_ver >> ss_ver) as isize * stride_0;
         if sz_0 < 0 {
@@ -197,10 +197,10 @@ pub(crate) unsafe fn rav1d_apply_grain_row_8bpc(
     row: c_int,
 ) {
     let data: *const Dav1dFilmGrainData = &mut (*(*out).frame_hdr).film_grain.data;
-    let ss_y = ((*in_0).p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
-    let ss_x = ((*in_0).p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+    let ss_y = ((*in_0).p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+    let ss_x = ((*in_0).p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
     let cpw = (*out).p.w + ss_x >> ss_x;
-    let is_id = ((*(*out).seq_hdr).mtrx as c_uint == DAV1D_MC_IDENTITY as c_int as c_uint) as c_int;
+    let is_id = ((*(*out).seq_hdr).mtrx as c_uint == RAV1D_MC_IDENTITY as c_int as c_uint) as c_int;
     let luma_src: *mut pixel =
         ((*in_0).data[0] as *mut pixel).offset(((row * 32) as isize * (*in_0).stride[0]) as isize);
     if (*data).num_y_points != 0 {

--- a/src/fg_apply_tmpl_8.rs
+++ b/src/fg_apply_tmpl_8.rs
@@ -3,7 +3,7 @@ use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::picture::Dav1dPicture;
+use crate::include::dav1d::picture::Rav1dPicture;
 use crate::src::align::Align16;
 use crate::src::filmgrain::Rav1dFilmGrainDSPContext;
 use cfg_if::cfg_if;
@@ -65,10 +65,10 @@ unsafe extern "C" fn generate_scaling(
     );
 }
 
-pub unsafe fn dav1d_prep_grain_8bpc(
+pub(crate) unsafe fn rav1d_prep_grain_8bpc(
     dsp: *const Rav1dFilmGrainDSPContext,
-    out: *mut Dav1dPicture,
-    in_0: *const Dav1dPicture,
+    out: *mut Rav1dPicture,
+    in_0: *const Rav1dPicture,
     scaling: *mut [u8; 256],
     grain_lut: *mut [[entry; 82]; 74],
 ) {
@@ -188,10 +188,10 @@ pub unsafe fn dav1d_prep_grain_8bpc(
     }
 }
 
-pub unsafe fn dav1d_apply_grain_row_8bpc(
+pub(crate) unsafe fn rav1d_apply_grain_row_8bpc(
     dsp: *const Rav1dFilmGrainDSPContext,
-    out: *mut Dav1dPicture,
-    in_0: *const Dav1dPicture,
+    out: *mut Rav1dPicture,
+    in_0: *const Rav1dPicture,
     scaling: *const [u8; 256],
     grain_lut: *const [[entry; 82]; 74],
     row: c_int,
@@ -296,10 +296,10 @@ pub unsafe fn dav1d_apply_grain_row_8bpc(
     };
 }
 
-pub unsafe fn dav1d_apply_grain_8bpc(
+pub(crate) unsafe fn rav1d_apply_grain_8bpc(
     dsp: *const Rav1dFilmGrainDSPContext,
-    out: *mut Dav1dPicture,
-    in_0: *const Dav1dPicture,
+    out: *mut Rav1dPicture,
+    in_0: *const Rav1dPicture,
 ) {
     let mut grain_lut = Align16([[[0; 82]; 74]; 3]);
     cfg_if! {
@@ -314,7 +314,7 @@ pub unsafe fn dav1d_apply_grain_8bpc(
         }
     }
     let rows = (*out).p.h + 31 >> 5;
-    dav1d_prep_grain_8bpc(
+    rav1d_prep_grain_8bpc(
         dsp,
         out,
         in_0,
@@ -323,7 +323,7 @@ pub unsafe fn dav1d_apply_grain_8bpc(
     );
     let mut row = 0;
     while row < rows {
-        dav1d_apply_grain_row_8bpc(
+        rav1d_apply_grain_row_8bpc(
             dsp,
             out,
             in_0,

--- a/src/filmgrain_tmpl_16.rs
+++ b/src/filmgrain_tmpl_16.rs
@@ -19,7 +19,7 @@ use std::ffi::c_uint;
 use std::ffi::c_ulong;
 
 #[cfg(feature = "asm")]
-use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
+use crate::src::cpu::{rav1d_get_cpu_flags, CpuFlags};
 
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
@@ -1342,7 +1342,7 @@ unsafe extern "C" fn fguv_32x32xn_444_c_erased(
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
 #[inline(always)]
 unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Rav1dFilmGrainDSPContext) {
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSSE3) {
         return;
@@ -1405,7 +1405,7 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Rav1dFilmGrainDSPContext) {
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 #[inline(always)]
 unsafe extern "C" fn film_grain_dsp_init_arm(c: *mut Rav1dFilmGrainDSPContext) {
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::NEON) {
         return;
@@ -1836,7 +1836,7 @@ unsafe extern "C" fn fguv_32x32xn_444_neon(
 }
 
 #[cold]
-pub unsafe fn dav1d_film_grain_dsp_init_16bpc(c: *mut Rav1dFilmGrainDSPContext) {
+pub unsafe fn rav1d_film_grain_dsp_init_16bpc(c: *mut Rav1dFilmGrainDSPContext) {
     (*c).generate_grain_y = Some(generate_grain_y_c_erased);
     (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
         Some(generate_grain_uv_420_c_erased);

--- a/src/filmgrain_tmpl_16.rs
+++ b/src/filmgrain_tmpl_16.rs
@@ -3,9 +3,9 @@ use crate::include::common::bitdepth::DynEntry;
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::intops::iclip;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I422;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
 use crate::src::filmgrain::get_random_number;
 use crate::src::filmgrain::round2;
 use crate::src::filmgrain::Rav1dFilmGrainDSPContext;
@@ -1349,19 +1349,19 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Rav1dFilmGrainDSPContext) {
     }
 
     (*c).generate_grain_y = Some(dav1d_generate_grain_y_16bpc_ssse3);
-    (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+    (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
         Some(dav1d_generate_grain_uv_420_16bpc_ssse3);
-    (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+    (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
         Some(dav1d_generate_grain_uv_422_16bpc_ssse3);
-    (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+    (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
         Some(dav1d_generate_grain_uv_444_16bpc_ssse3);
 
     (*c).fgy_32x32xn = Some(dav1d_fgy_32x32xn_16bpc_ssse3);
-    (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+    (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
         Some(dav1d_fguv_32x32xn_i420_16bpc_ssse3);
-    (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+    (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
         Some(dav1d_fguv_32x32xn_i422_16bpc_ssse3);
-    (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+    (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
         Some(dav1d_fguv_32x32xn_i444_16bpc_ssse3);
 
     #[cfg(target_arch = "x86_64")]
@@ -1371,20 +1371,20 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Rav1dFilmGrainDSPContext) {
         }
 
         (*c).generate_grain_y = Some(dav1d_generate_grain_y_16bpc_avx2);
-        (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+        (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
             Some(dav1d_generate_grain_uv_420_16bpc_avx2);
-        (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+        (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
             Some(dav1d_generate_grain_uv_422_16bpc_avx2);
-        (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+        (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
             Some(dav1d_generate_grain_uv_444_16bpc_avx2);
 
         if !flags.contains(CpuFlags::SLOW_GATHER) {
             (*c).fgy_32x32xn = Some(dav1d_fgy_32x32xn_16bpc_avx2);
-            (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+            (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
                 Some(dav1d_fguv_32x32xn_i420_16bpc_avx2);
-            (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+            (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
                 Some(dav1d_fguv_32x32xn_i422_16bpc_avx2);
-            (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+            (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
                 Some(dav1d_fguv_32x32xn_i444_16bpc_avx2);
         }
 
@@ -1393,11 +1393,11 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Rav1dFilmGrainDSPContext) {
         }
 
         (*c).fgy_32x32xn = Some(dav1d_fgy_32x32xn_16bpc_avx512icl);
-        (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+        (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
             Some(dav1d_fguv_32x32xn_i420_16bpc_avx512icl);
-        (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+        (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
             Some(dav1d_fguv_32x32xn_i422_16bpc_avx512icl);
-        (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+        (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
             Some(dav1d_fguv_32x32xn_i444_16bpc_avx512icl);
     }
 }
@@ -1412,17 +1412,17 @@ unsafe extern "C" fn film_grain_dsp_init_arm(c: *mut Rav1dFilmGrainDSPContext) {
     }
 
     (*c).generate_grain_y = Some(dav1d_generate_grain_y_16bpc_neon);
-    (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+    (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
         Some(dav1d_generate_grain_uv_420_16bpc_neon);
-    (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+    (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
         Some(dav1d_generate_grain_uv_422_16bpc_neon);
-    (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+    (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
         Some(dav1d_generate_grain_uv_444_16bpc_neon);
 
     (*c).fgy_32x32xn = Some(fgy_32x32xn_neon_erased);
-    (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(fguv_32x32xn_420_neon_erased);
-    (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(fguv_32x32xn_422_neon_erased);
-    (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(fguv_32x32xn_444_neon_erased);
+    (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(fguv_32x32xn_420_neon_erased);
+    (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(fguv_32x32xn_422_neon_erased);
+    (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(fguv_32x32xn_444_neon_erased);
 }
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
@@ -1838,17 +1838,17 @@ unsafe extern "C" fn fguv_32x32xn_444_neon(
 #[cold]
 pub unsafe fn rav1d_film_grain_dsp_init_16bpc(c: *mut Rav1dFilmGrainDSPContext) {
     (*c).generate_grain_y = Some(generate_grain_y_c_erased);
-    (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+    (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
         Some(generate_grain_uv_420_c_erased);
-    (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+    (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
         Some(generate_grain_uv_422_c_erased);
-    (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+    (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
         Some(generate_grain_uv_444_c_erased);
 
     (*c).fgy_32x32xn = Some(fgy_32x32xn_c_erased);
-    (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(fguv_32x32xn_420_c_erased);
-    (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(fguv_32x32xn_422_c_erased);
-    (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(fguv_32x32xn_444_c_erased);
+    (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(fguv_32x32xn_420_c_erased);
+    (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(fguv_32x32xn_422_c_erased);
+    (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(fguv_32x32xn_444_c_erased);
 
     #[cfg(feature = "asm")]
     cfg_if! {

--- a/src/filmgrain_tmpl_8.rs
+++ b/src/filmgrain_tmpl_8.rs
@@ -19,7 +19,7 @@ use std::ffi::c_uint;
 use std::ffi::c_ulong;
 
 #[cfg(feature = "asm")]
-use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
+use crate::src::cpu::{rav1d_get_cpu_flags, CpuFlags};
 
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
@@ -1287,7 +1287,7 @@ unsafe extern "C" fn fguv_32x32xn_444_c_erased(
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
 #[inline(always)]
 unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Rav1dFilmGrainDSPContext) {
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSSE3) {
         return;
@@ -1350,7 +1350,7 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Rav1dFilmGrainDSPContext) {
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 #[inline(always)]
 unsafe extern "C" fn film_grain_dsp_init_arm(c: *mut Rav1dFilmGrainDSPContext) {
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::NEON) {
         return;
@@ -1769,7 +1769,7 @@ unsafe extern "C" fn fguv_32x32xn_444_neon(
 }
 
 #[cold]
-pub unsafe fn dav1d_film_grain_dsp_init_8bpc(c: *mut Rav1dFilmGrainDSPContext) {
+pub unsafe fn rav1d_film_grain_dsp_init_8bpc(c: *mut Rav1dFilmGrainDSPContext) {
     (*c).generate_grain_y = Some(generate_grain_y_c_erased);
     (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
         Some(generate_grain_uv_420_c_erased);

--- a/src/filmgrain_tmpl_8.rs
+++ b/src/filmgrain_tmpl_8.rs
@@ -3,9 +3,9 @@ use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::intops::iclip;
 use crate::include::common::intops::iclip_u8;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I422;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
 use crate::src::filmgrain::get_random_number;
 use crate::src::filmgrain::round2;
 use crate::src::filmgrain::Rav1dFilmGrainDSPContext;
@@ -1294,19 +1294,19 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Rav1dFilmGrainDSPContext) {
     }
 
     (*c).generate_grain_y = Some(dav1d_generate_grain_y_8bpc_ssse3);
-    (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+    (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
         Some(dav1d_generate_grain_uv_420_8bpc_ssse3);
-    (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+    (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
         Some(dav1d_generate_grain_uv_422_8bpc_ssse3);
-    (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+    (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
         Some(dav1d_generate_grain_uv_444_8bpc_ssse3);
 
     (*c).fgy_32x32xn = Some(dav1d_fgy_32x32xn_8bpc_ssse3);
-    (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+    (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
         Some(dav1d_fguv_32x32xn_i420_8bpc_ssse3);
-    (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+    (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
         Some(dav1d_fguv_32x32xn_i422_8bpc_ssse3);
-    (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+    (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
         Some(dav1d_fguv_32x32xn_i444_8bpc_ssse3);
 
     #[cfg(target_arch = "x86_64")]
@@ -1316,20 +1316,20 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Rav1dFilmGrainDSPContext) {
         }
 
         (*c).generate_grain_y = Some(dav1d_generate_grain_y_8bpc_avx2);
-        (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+        (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
             Some(dav1d_generate_grain_uv_420_8bpc_avx2);
-        (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+        (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
             Some(dav1d_generate_grain_uv_422_8bpc_avx2);
-        (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+        (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
             Some(dav1d_generate_grain_uv_444_8bpc_avx2);
 
         if !flags.contains(CpuFlags::SLOW_GATHER) {
             (*c).fgy_32x32xn = Some(dav1d_fgy_32x32xn_8bpc_avx2);
-            (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+            (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
                 Some(dav1d_fguv_32x32xn_i420_8bpc_avx2);
-            (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+            (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
                 Some(dav1d_fguv_32x32xn_i422_8bpc_avx2);
-            (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+            (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
                 Some(dav1d_fguv_32x32xn_i444_8bpc_avx2);
         }
 
@@ -1338,11 +1338,11 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Rav1dFilmGrainDSPContext) {
         }
 
         (*c).fgy_32x32xn = Some(dav1d_fgy_32x32xn_8bpc_avx512icl);
-        (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+        (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
             Some(dav1d_fguv_32x32xn_i420_8bpc_avx512icl);
-        (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+        (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
             Some(dav1d_fguv_32x32xn_i422_8bpc_avx512icl);
-        (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+        (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
             Some(dav1d_fguv_32x32xn_i444_8bpc_avx512icl);
     }
 }
@@ -1357,17 +1357,17 @@ unsafe extern "C" fn film_grain_dsp_init_arm(c: *mut Rav1dFilmGrainDSPContext) {
     }
 
     (*c).generate_grain_y = Some(dav1d_generate_grain_y_8bpc_neon);
-    (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+    (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
         Some(dav1d_generate_grain_uv_420_8bpc_neon);
-    (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+    (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
         Some(dav1d_generate_grain_uv_422_8bpc_neon);
-    (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+    (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
         Some(dav1d_generate_grain_uv_444_8bpc_neon);
 
     (*c).fgy_32x32xn = Some(fgy_32x32xn_neon_erased);
-    (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(fguv_32x32xn_420_neon_erased);
-    (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(fguv_32x32xn_422_neon_erased);
-    (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(fguv_32x32xn_444_neon_erased);
+    (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(fguv_32x32xn_420_neon_erased);
+    (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(fguv_32x32xn_422_neon_erased);
+    (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(fguv_32x32xn_444_neon_erased);
 }
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
@@ -1771,17 +1771,17 @@ unsafe extern "C" fn fguv_32x32xn_444_neon(
 #[cold]
 pub unsafe fn rav1d_film_grain_dsp_init_8bpc(c: *mut Rav1dFilmGrainDSPContext) {
     (*c).generate_grain_y = Some(generate_grain_y_c_erased);
-    (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
+    (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] =
         Some(generate_grain_uv_420_c_erased);
-    (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
+    (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] =
         Some(generate_grain_uv_422_c_erased);
-    (*c).generate_grain_uv[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
+    (*c).generate_grain_uv[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] =
         Some(generate_grain_uv_444_c_erased);
 
     (*c).fgy_32x32xn = Some(fgy_32x32xn_c_erased);
-    (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(fguv_32x32xn_420_c_erased);
-    (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(fguv_32x32xn_422_c_erased);
-    (*c).fguv_32x32xn[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(fguv_32x32xn_444_c_erased);
+    (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = Some(fguv_32x32xn_420_c_erased);
+    (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = Some(fguv_32x32xn_422_c_erased);
+    (*c).fguv_32x32xn[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = Some(fguv_32x32xn_444_c_erased);
 
     #[cfg(feature = "asm")]
     cfg_if! {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -79,19 +79,19 @@ pub(crate) struct Rav1dTileGroup {
 }
 
 pub type TaskType = c_uint;
-pub const DAV1D_TASK_TYPE_FG_APPLY: TaskType = 12;
-pub const DAV1D_TASK_TYPE_FG_PREP: TaskType = 11;
-pub const DAV1D_TASK_TYPE_RECONSTRUCTION_PROGRESS: TaskType = 10;
-pub const DAV1D_TASK_TYPE_LOOP_RESTORATION: TaskType = 9;
-pub const DAV1D_TASK_TYPE_SUPER_RESOLUTION: TaskType = 8;
-pub const DAV1D_TASK_TYPE_CDEF: TaskType = 7;
-pub const DAV1D_TASK_TYPE_DEBLOCK_ROWS: TaskType = 6;
-pub const DAV1D_TASK_TYPE_DEBLOCK_COLS: TaskType = 5;
-pub const DAV1D_TASK_TYPE_TILE_RECONSTRUCTION: TaskType = 4;
-pub const DAV1D_TASK_TYPE_ENTROPY_PROGRESS: TaskType = 3;
-pub const DAV1D_TASK_TYPE_TILE_ENTROPY: TaskType = 2;
-pub const DAV1D_TASK_TYPE_INIT_CDF: TaskType = 1;
-pub const DAV1D_TASK_TYPE_INIT: TaskType = 0;
+pub const RAV1D_TASK_TYPE_FG_APPLY: TaskType = 12;
+pub const RAV1D_TASK_TYPE_FG_PREP: TaskType = 11;
+pub const RAV1D_TASK_TYPE_RECONSTRUCTION_PROGRESS: TaskType = 10;
+pub const RAV1D_TASK_TYPE_LOOP_RESTORATION: TaskType = 9;
+pub const RAV1D_TASK_TYPE_SUPER_RESOLUTION: TaskType = 8;
+pub const RAV1D_TASK_TYPE_CDEF: TaskType = 7;
+pub const RAV1D_TASK_TYPE_DEBLOCK_ROWS: TaskType = 6;
+pub const RAV1D_TASK_TYPE_DEBLOCK_COLS: TaskType = 5;
+pub const RAV1D_TASK_TYPE_TILE_RECONSTRUCTION: TaskType = 4;
+pub const RAV1D_TASK_TYPE_ENTROPY_PROGRESS: TaskType = 3;
+pub const RAV1D_TASK_TYPE_TILE_ENTROPY: TaskType = 2;
+pub const RAV1D_TASK_TYPE_INIT_CDF: TaskType = 1;
+pub const RAV1D_TASK_TYPE_INIT: TaskType = 0;
 
 #[repr(C)]
 pub(crate) struct Rav1dContext_frame_thread {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,19 +1,19 @@
 use crate::include::common::bitdepth::DynCoef;
 use crate::include::common::bitdepth::DynPixel;
-use crate::include::dav1d::common::Dav1dDataProps;
-use crate::include::dav1d::data::Dav1dData;
-use crate::include::dav1d::dav1d::Dav1dDecodeFrameType;
-use crate::include::dav1d::dav1d::Dav1dEventFlags;
-use crate::include::dav1d::dav1d::Dav1dInloopFilterType;
-use crate::include::dav1d::dav1d::Dav1dLogger;
+use crate::include::dav1d::common::Rav1dDataProps;
+use crate::include::dav1d::data::Rav1dData;
+use crate::include::dav1d::dav1d::Rav1dDecodeFrameType;
+use crate::include::dav1d::dav1d::Rav1dEventFlags;
+use crate::include::dav1d::dav1d::Rav1dInloopFilterType;
+use crate::include::dav1d::dav1d::Rav1dLogger;
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
 use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
-use crate::include::dav1d::picture::Dav1dPicAllocator;
-use crate::include::dav1d::picture::Dav1dPicture;
+use crate::include::dav1d::picture::Rav1dPicAllocator;
+use crate::include::dav1d::picture::Rav1dPicture;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
 use crate::src::align::*;
@@ -72,8 +72,8 @@ pub struct Rav1dDSPContext {
 
 #[derive(Clone, Default)]
 #[repr(C)]
-pub struct Rav1dTileGroup {
-    pub data: Dav1dData,
+pub(crate) struct Rav1dTileGroup {
+    pub data: Rav1dData,
     pub start: c_int,
     pub end: c_int,
 }
@@ -94,7 +94,7 @@ pub const DAV1D_TASK_TYPE_INIT_CDF: TaskType = 1;
 pub const DAV1D_TASK_TYPE_INIT: TaskType = 0;
 
 #[repr(C)]
-pub struct Rav1dContext_frame_thread {
+pub(crate) struct Rav1dContext_frame_thread {
     pub out_delayed: *mut Rav1dThreadPicture,
     pub next: c_uint,
 }
@@ -120,18 +120,18 @@ pub union TaskThreadData_grain_lut_scaling {
 }
 
 #[repr(C)]
-pub struct TaskThreadData_delayed_fg {
+pub(crate) struct TaskThreadData_delayed_fg {
     pub exec: c_int,
     pub cond: pthread_cond_t,
-    pub in_0: *const Dav1dPicture,
-    pub out: *mut Dav1dPicture,
+    pub in_0: *const Rav1dPicture,
+    pub out: *mut Rav1dPicture,
     pub type_0: TaskType,
     pub progress: [atomic_int; 2],
     pub c2rust_unnamed: TaskThreadData_grain_lut_scaling,
 }
 
 #[repr(C)]
-pub struct TaskThreadData {
+pub(crate) struct TaskThreadData {
     pub lock: pthread_mutex_t,
     pub cond: pthread_cond_t,
     pub first: atomic_uint,
@@ -143,7 +143,7 @@ pub struct TaskThreadData {
 }
 
 #[repr(C)]
-pub struct Rav1dContext_refs {
+pub(crate) struct Rav1dContext_refs {
     pub p: Rav1dThreadPicture,
     pub segmap: *mut Rav1dRef,
     pub refmvs: *mut Rav1dRef,
@@ -171,17 +171,17 @@ pub struct Rav1dContext {
     pub(crate) n_tiles: c_int,
     pub(crate) seq_hdr_pool: *mut Rav1dMemPool,
     pub(crate) seq_hdr_ref: *mut Rav1dRef,
-    pub(crate) seq_hdr: *mut Dav1dSequenceHeader,
+    pub(crate) seq_hdr: *mut Dav1dSequenceHeader, // TODO(kkysen) make Rav1d
     pub(crate) frame_hdr_pool: *mut Rav1dMemPool,
     pub(crate) frame_hdr_ref: *mut Rav1dRef,
-    pub(crate) frame_hdr: *mut Dav1dFrameHeader,
+    pub(crate) frame_hdr: *mut Dav1dFrameHeader, // TODO(kkysen) make Rav1d
     pub(crate) content_light_ref: *mut Rav1dRef,
-    pub(crate) content_light: *mut Dav1dContentLightLevel,
+    pub(crate) content_light: *mut Dav1dContentLightLevel, // TODO(kkysen) make Rav1d
     pub(crate) mastering_display_ref: *mut Rav1dRef,
-    pub(crate) mastering_display: *mut Dav1dMasteringDisplay,
+    pub(crate) mastering_display: *mut Dav1dMasteringDisplay, // TODO(kkysen) make Rav1d
     pub(crate) itut_t35_ref: *mut Rav1dRef,
-    pub(crate) itut_t35: *mut Dav1dITUTT35,
-    pub(crate) in_0: Dav1dData,
+    pub(crate) itut_t35: *mut Dav1dITUTT35, // TODO(kkysen) make Rav1d
+    pub(crate) in_0: Rav1dData,
     pub(crate) out: Rav1dThreadPicture,
     pub(crate) cache: Rav1dThreadPicture,
     pub(crate) flush_mem: atomic_int,
@@ -196,7 +196,7 @@ pub struct Rav1dContext {
     pub(crate) dsp: [Rav1dDSPContext; 3],
     pub(crate) refmvs_dsp: Rav1dRefmvsDSPContext,
     pub(crate) intra_edge: Rav1dContext_intra_edge,
-    pub(crate) allocator: Dav1dPicAllocator,
+    pub(crate) allocator: Rav1dPicAllocator,
     pub(crate) apply_grain: c_int,
     pub(crate) operating_point: c_int,
     pub(crate) operating_point_idc: c_uint,
@@ -205,14 +205,14 @@ pub struct Rav1dContext {
     pub(crate) frame_size_limit: c_uint,
     pub(crate) strict_std_compliance: c_int,
     pub(crate) output_invisible_frames: c_int,
-    pub(crate) inloop_filters: Dav1dInloopFilterType,
-    pub(crate) decode_frame_type: Dav1dDecodeFrameType,
+    pub(crate) inloop_filters: Rav1dInloopFilterType,
+    pub(crate) decode_frame_type: Rav1dDecodeFrameType,
     pub(crate) drain: c_int,
     pub(crate) frame_flags: PictureFlags,
-    pub(crate) event_flags: Dav1dEventFlags,
-    pub(crate) cached_error_props: Dav1dDataProps,
+    pub(crate) event_flags: Rav1dEventFlags,
+    pub(crate) cached_error_props: Rav1dDataProps,
     pub(crate) cached_error: c_int,
-    pub(crate) logger: Dav1dLogger,
+    pub(crate) logger: Rav1dLogger,
     pub(crate) picture_pool: *mut Rav1dMemPool,
 }
 
@@ -235,7 +235,7 @@ pub struct ScalableMotionParams {
 }
 
 #[repr(C)]
-pub struct Rav1dFrameContext_bd_fn {
+pub(crate) struct Rav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
     pub recon_b_inter: recon_b_inter_fn,
     pub filter_sbrow: filter_sbrow_fn,
@@ -342,7 +342,7 @@ pub struct Rav1dFrameContext_task_thread_pending_tasks {
 }
 
 #[repr(C)]
-pub struct Rav1dFrameContext_task_thread {
+pub(crate) struct Rav1dFrameContext_task_thread {
     pub lock: pthread_mutex_t,
     pub cond: pthread_cond_t,
     pub ttd: *mut TaskThreadData,
@@ -370,13 +370,13 @@ pub struct FrameTileThreadData {
 }
 
 #[repr(C)]
-pub struct Rav1dFrameContext {
+pub(crate) struct Rav1dFrameContext {
     pub seq_hdr_ref: *mut Rav1dRef,
-    pub seq_hdr: *mut Dav1dSequenceHeader,
+    pub seq_hdr: *mut Dav1dSequenceHeader, // TODO(kkysen) make Rav1d
     pub frame_hdr_ref: *mut Rav1dRef,
-    pub frame_hdr: *mut Dav1dFrameHeader,
+    pub frame_hdr: *mut Dav1dFrameHeader, // TODO(kkysen) make Rav1d
     pub refp: [Rav1dThreadPicture; 7],
-    pub cur: Dav1dPicture,
+    pub cur: Rav1dPicture,
     pub sr_cur: Rav1dThreadPicture,
     pub mvs_ref: *mut Rav1dRef,
     pub mvs: *mut refmvs_temporal_block,
@@ -553,7 +553,7 @@ pub struct Rav1dTaskContext_frame_thread {
 }
 
 #[repr(C)]
-pub struct Rav1dTaskContext_task_thread {
+pub(crate) struct Rav1dTaskContext_task_thread {
     pub td: thread_data,
     pub ttd: *mut TaskThreadData,
     pub fttd: *mut FrameTileThreadData,
@@ -562,7 +562,7 @@ pub struct Rav1dTaskContext_task_thread {
 }
 
 #[repr(C)]
-pub struct Rav1dTaskContext {
+pub(crate) struct Rav1dTaskContext {
     pub c: *const Rav1dContext,
     pub f: *const Rav1dFrameContext,
     pub ts: *mut Rav1dTileState,

--- a/src/intra_edge.rs
+++ b/src/intra_edge.rs
@@ -194,7 +194,7 @@ unsafe fn init_mode_node(
     };
 }
 
-pub unsafe fn dav1d_init_mode_tree(
+pub unsafe fn rav1d_init_mode_tree(
     root_node: *mut EdgeNode,
     nt: &mut [EdgeTip],
     allow_sb128: bool,

--- a/src/ipred_prepare.rs
+++ b/src/ipred_prepare.rs
@@ -120,7 +120,7 @@ static av1_intra_prediction_edges: [av1_intra_prediction_edge; N_IMPL_INTRA_PRED
     b
 };
 
-pub unsafe fn dav1d_prepare_intra_edges<BD: BitDepth>(
+pub unsafe fn rav1d_prepare_intra_edges<BD: BitDepth>(
     x: c_int,
     have_left: c_int,
     y: c_int,

--- a/src/ipred_tmpl_16.rs
+++ b/src/ipred_tmpl_16.rs
@@ -34,7 +34,7 @@ use std::ffi::c_ulonglong;
 use std::ffi::c_void;
 
 #[cfg(feature = "asm")]
-use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
+use crate::src::cpu::{rav1d_get_cpu_flags, CpuFlags};
 
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
@@ -1523,7 +1523,7 @@ unsafe extern "C" fn pal_pred_rust(
 unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Rav1dIntraPredDSPContext) {
     use crate::src::ipred::*; // TODO(legare): Temporary import until init fns are deduplicated.
 
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSSE3) {
         return;
@@ -1607,7 +1607,7 @@ unsafe extern "C" fn intra_pred_dsp_init_arm(c: *mut Rav1dIntraPredDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::ipred::*;
 
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
     if !flags.contains(CpuFlags::NEON) {
         return;
     }
@@ -2087,7 +2087,7 @@ unsafe fn ipred_z1_neon(
 }
 
 #[cold]
-pub unsafe fn dav1d_intra_pred_dsp_init_16bpc(c: *mut Rav1dIntraPredDSPContext) {
+pub unsafe fn rav1d_intra_pred_dsp_init_16bpc(c: *mut Rav1dIntraPredDSPContext) {
     (*c).intra_pred[DC_PRED as usize] = Some(ipred_dc_c_erased);
     (*c).intra_pred[DC_128_PRED as usize] = Some(ipred_dc_128_c_erased);
     (*c).intra_pred[TOP_DC_PRED as usize] = Some(ipred_dc_top_c_erased);

--- a/src/ipred_tmpl_16.rs
+++ b/src/ipred_tmpl_16.rs
@@ -2,9 +2,9 @@ use crate::include::common::attributes::ctz;
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::intops::apply_sign;
 use crate::include::common::intops::iclip;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I422;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
 use crate::src::ipred::get_upsample;
 use crate::src::ipred::Rav1dIntraPredDSPContext;
 use crate::src::levels::DC_128_PRED;
@@ -1549,9 +1549,9 @@ unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Rav1dIntraPredDSPContext) {
     (*c).cfl_pred[TOP_DC_PRED as usize] = dav1d_ipred_cfl_top_16bpc_ssse3;
     (*c).cfl_pred[LEFT_DC_PRED as usize] = dav1d_ipred_cfl_left_16bpc_ssse3;
 
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = dav1d_ipred_cfl_ac_420_16bpc_ssse3;
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = dav1d_ipred_cfl_ac_422_16bpc_ssse3;
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = dav1d_ipred_cfl_ac_444_16bpc_ssse3;
+    (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = dav1d_ipred_cfl_ac_420_16bpc_ssse3;
+    (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = dav1d_ipred_cfl_ac_422_16bpc_ssse3;
+    (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = dav1d_ipred_cfl_ac_444_16bpc_ssse3;
 
     (*c).pal_pred = dav1d_pal_pred_16bpc_ssse3;
 
@@ -1581,9 +1581,9 @@ unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Rav1dIntraPredDSPContext) {
         (*c).cfl_pred[TOP_DC_PRED as usize] = dav1d_ipred_cfl_top_16bpc_avx2;
         (*c).cfl_pred[LEFT_DC_PRED as usize] = dav1d_ipred_cfl_left_16bpc_avx2;
 
-        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = dav1d_ipred_cfl_ac_420_16bpc_avx2;
-        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = dav1d_ipred_cfl_ac_422_16bpc_avx2;
-        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = dav1d_ipred_cfl_ac_444_16bpc_avx2;
+        (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = dav1d_ipred_cfl_ac_420_16bpc_avx2;
+        (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = dav1d_ipred_cfl_ac_422_16bpc_avx2;
+        (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = dav1d_ipred_cfl_ac_444_16bpc_avx2;
 
         (*c).pal_pred = dav1d_pal_pred_16bpc_avx2;
 
@@ -1635,9 +1635,9 @@ unsafe extern "C" fn intra_pred_dsp_init_arm(c: *mut Rav1dIntraPredDSPContext) {
     (*c).cfl_pred[TOP_DC_PRED as usize] = dav1d_ipred_cfl_top_16bpc_neon;
     (*c).cfl_pred[LEFT_DC_PRED as usize] = dav1d_ipred_cfl_left_16bpc_neon;
 
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = dav1d_ipred_cfl_ac_420_16bpc_neon;
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = dav1d_ipred_cfl_ac_422_16bpc_neon;
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = dav1d_ipred_cfl_ac_444_16bpc_neon;
+    (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = dav1d_ipred_cfl_ac_420_16bpc_neon;
+    (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = dav1d_ipred_cfl_ac_422_16bpc_neon;
+    (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = dav1d_ipred_cfl_ac_444_16bpc_neon;
 
     (*c).pal_pred = dav1d_pal_pred_16bpc_neon;
 }
@@ -2103,9 +2103,9 @@ pub unsafe fn rav1d_intra_pred_dsp_init_16bpc(c: *mut Rav1dIntraPredDSPContext) 
     (*c).intra_pred[Z3_PRED as usize] = Some(ipred_z3_c_erased);
     (*c).intra_pred[FILTER_PRED as usize] = Some(ipred_filter_c_erased);
 
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = cfl_ac_420_c_erased;
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = cfl_ac_422_c_erased;
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = cfl_ac_444_c_erased;
+    (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = cfl_ac_420_c_erased;
+    (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = cfl_ac_422_c_erased;
+    (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = cfl_ac_444_c_erased;
     (*c).cfl_pred[DC_PRED as usize] = ipred_cfl_c_erased;
 
     (*c).cfl_pred[DC_128_PRED as usize] = ipred_cfl_128_c_erased;

--- a/src/ipred_tmpl_8.rs
+++ b/src/ipred_tmpl_8.rs
@@ -3,9 +3,9 @@ use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::intops::apply_sign;
 use crate::include::common::intops::iclip;
 use crate::include::common::intops::iclip_u8;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I422;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
 use crate::src::ipred::get_upsample;
 use crate::src::ipred::Rav1dIntraPredDSPContext;
 use crate::src::levels::DC_128_PRED;
@@ -1472,9 +1472,9 @@ unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Rav1dIntraPredDSPContext) {
     (*c).cfl_pred[TOP_DC_PRED as usize] = dav1d_ipred_cfl_top_8bpc_ssse3;
     (*c).cfl_pred[LEFT_DC_PRED as usize] = dav1d_ipred_cfl_left_8bpc_ssse3;
 
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = dav1d_ipred_cfl_ac_420_8bpc_ssse3;
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = dav1d_ipred_cfl_ac_422_8bpc_ssse3;
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = dav1d_ipred_cfl_ac_444_8bpc_ssse3;
+    (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = dav1d_ipred_cfl_ac_420_8bpc_ssse3;
+    (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = dav1d_ipred_cfl_ac_422_8bpc_ssse3;
+    (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = dav1d_ipred_cfl_ac_444_8bpc_ssse3;
 
     (*c).pal_pred = dav1d_pal_pred_8bpc_ssse3;
 
@@ -1504,9 +1504,9 @@ unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Rav1dIntraPredDSPContext) {
         (*c).cfl_pred[TOP_DC_PRED as usize] = dav1d_ipred_cfl_top_8bpc_avx2;
         (*c).cfl_pred[LEFT_DC_PRED as usize] = dav1d_ipred_cfl_left_8bpc_avx2;
 
-        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = dav1d_ipred_cfl_ac_420_8bpc_avx2;
-        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = dav1d_ipred_cfl_ac_422_8bpc_avx2;
-        (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = dav1d_ipred_cfl_ac_444_8bpc_avx2;
+        (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = dav1d_ipred_cfl_ac_420_8bpc_avx2;
+        (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = dav1d_ipred_cfl_ac_422_8bpc_avx2;
+        (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = dav1d_ipred_cfl_ac_444_8bpc_avx2;
 
         (*c).pal_pred = dav1d_pal_pred_8bpc_avx2;
 
@@ -1565,9 +1565,9 @@ unsafe extern "C" fn intra_pred_dsp_init_arm(c: *mut Rav1dIntraPredDSPContext) {
     (*c).cfl_pred[TOP_DC_PRED as usize] = dav1d_ipred_cfl_top_8bpc_neon;
     (*c).cfl_pred[LEFT_DC_PRED as usize] = dav1d_ipred_cfl_left_8bpc_neon;
 
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = dav1d_ipred_cfl_ac_420_8bpc_neon;
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = dav1d_ipred_cfl_ac_422_8bpc_neon;
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = dav1d_ipred_cfl_ac_444_8bpc_neon;
+    (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = dav1d_ipred_cfl_ac_420_8bpc_neon;
+    (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = dav1d_ipred_cfl_ac_422_8bpc_neon;
+    (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = dav1d_ipred_cfl_ac_444_8bpc_neon;
 
     (*c).pal_pred = dav1d_pal_pred_8bpc_neon;
 }
@@ -2022,9 +2022,9 @@ pub unsafe fn rav1d_intra_pred_dsp_init_8bpc(c: *mut Rav1dIntraPredDSPContext) {
     (*c).intra_pred[Z3_PRED as usize] = Some(ipred_z3_c_erased);
     (*c).intra_pred[FILTER_PRED as usize] = Some(ipred_filter_c_erased);
 
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = cfl_ac_420_c_erased;
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = cfl_ac_422_c_erased;
-    (*c).cfl_ac[(DAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = cfl_ac_444_c_erased;
+    (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I420 - 1) as usize] = cfl_ac_420_c_erased;
+    (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I422 - 1) as usize] = cfl_ac_422_c_erased;
+    (*c).cfl_ac[(RAV1D_PIXEL_LAYOUT_I444 - 1) as usize] = cfl_ac_444_c_erased;
     (*c).cfl_pred[DC_PRED as usize] = ipred_cfl_c_erased;
     (*c).cfl_pred[DC_128_PRED as usize] = ipred_cfl_128_c_erased;
     (*c).cfl_pred[TOP_DC_PRED as usize] = ipred_cfl_top_c_erased;

--- a/src/ipred_tmpl_8.rs
+++ b/src/ipred_tmpl_8.rs
@@ -36,7 +36,7 @@ use std::ffi::c_ulonglong;
 use std::ffi::c_void;
 
 #[cfg(feature = "asm")]
-use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
+use crate::src::cpu::{rav1d_get_cpu_flags, CpuFlags};
 
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
@@ -1446,7 +1446,7 @@ unsafe fn pal_pred_rust(
 unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Rav1dIntraPredDSPContext) {
     use crate::src::ipred::*; // TODO(legare): Temporary import until init fns are deduplicated.
 
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSSE3) {
         return;
@@ -1536,7 +1536,7 @@ unsafe extern "C" fn intra_pred_dsp_init_arm(c: *mut Rav1dIntraPredDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::ipred::*;
 
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::NEON) {
         return;
@@ -2006,7 +2006,7 @@ unsafe fn ipred_z1_neon(
 }
 
 #[cold]
-pub unsafe fn dav1d_intra_pred_dsp_init_8bpc(c: *mut Rav1dIntraPredDSPContext) {
+pub unsafe fn rav1d_intra_pred_dsp_init_8bpc(c: *mut Rav1dIntraPredDSPContext) {
     (*c).intra_pred[DC_PRED as usize] = Some(ipred_dc_c_erased);
     (*c).intra_pred[DC_128_PRED as usize] = Some(ipred_dc_128_c_erased);
     (*c).intra_pred[TOP_DC_PRED as usize] = Some(ipred_dc_top_c_erased);

--- a/src/itx_tmpl_16.rs
+++ b/src/itx_tmpl_16.rs
@@ -45,7 +45,7 @@ use std::ffi::c_int;
 use std::ffi::c_void;
 
 #[cfg(feature = "asm")]
-use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
+use crate::src::cpu::{rav1d_get_cpu_flags, CpuFlags};
 
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
@@ -134,7 +134,7 @@ unsafe extern "C" fn itx_dsp_init_x86(c: *mut Rav1dInvTxfmDSPContext, bpc: c_int
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::itx::*;
 
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSE2) {
         return;
@@ -713,7 +713,7 @@ unsafe extern "C" fn itx_dsp_init_arm(c: *mut Rav1dInvTxfmDSPContext, bpc: c_int
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::itx::*;
 
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::NEON) {
         return;
@@ -1039,169 +1039,321 @@ unsafe extern "C" fn itx_dsp_init_arm(c: *mut Rav1dInvTxfmDSPContext, bpc: c_int
 
 #[cold]
 #[rustfmt::skip]
-pub unsafe fn dav1d_itx_dsp_init_16bpc(
-    c: *mut Rav1dInvTxfmDSPContext,
-    mut _bpc: c_int,
-) {
+pub unsafe fn rav1d_itx_dsp_init_16bpc(c: *mut Rav1dInvTxfmDSPContext, mut _bpc: c_int) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::itx::*;
 
     (*c).itxfm_add[TX_4X4 as usize][WHT_WHT as usize] = Some(inv_txfm_add_wht_wht_4x4_c_erased);
-    (*c).itxfm_add[TX_4X4 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_4x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_4X4 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_4x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_4X4 as usize][DCT_ADST as usize] = Some(inv_txfm_add_adst_dct_4x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_4X4 as usize][ADST_DCT as usize] = Some(inv_txfm_add_dct_adst_4x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_4X4 as usize][ADST_ADST as usize] = Some(inv_txfm_add_adst_adst_4x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_4X4 as usize][ADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_adst_4x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_4X4 as usize][FLIPADST_ADST as usize] = Some(inv_txfm_add_adst_flipadst_4x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_4X4 as usize][DCT_FLIPADST as usize] = Some(inv_txfm_add_flipadst_dct_4x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_4X4 as usize][FLIPADST_DCT as usize] = Some(inv_txfm_add_dct_flipadst_4x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_4X4 as usize][FLIPADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_flipadst_4x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_4X4 as usize][H_DCT as usize] = Some(inv_txfm_add_dct_identity_4x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_4X4 as usize][V_DCT as usize] = Some(inv_txfm_add_identity_dct_4x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_4X4 as usize][H_FLIPADST as usize] = Some(inv_txfm_add_flipadst_identity_4x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_4X4 as usize][V_FLIPADST as usize] = Some(inv_txfm_add_identity_flipadst_4x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_4X4 as usize][H_ADST as usize] = Some(inv_txfm_add_adst_identity_4x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_4X4 as usize][V_ADST as usize] = Some(inv_txfm_add_identity_adst_4x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X8 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_4x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X8 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_4x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X8 as usize][DCT_ADST as usize] = Some(inv_txfm_add_adst_dct_4x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X8 as usize][ADST_DCT as usize] = Some(inv_txfm_add_dct_adst_4x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X8 as usize][ADST_ADST as usize] = Some(inv_txfm_add_adst_adst_4x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X8 as usize][ADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_adst_4x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X8 as usize][FLIPADST_ADST as usize] = Some(inv_txfm_add_adst_flipadst_4x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X8 as usize][DCT_FLIPADST as usize] = Some(inv_txfm_add_flipadst_dct_4x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X8 as usize][FLIPADST_DCT as usize] = Some(inv_txfm_add_dct_flipadst_4x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X8 as usize][FLIPADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_flipadst_4x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X8 as usize][H_DCT as usize] = Some(inv_txfm_add_dct_identity_4x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X8 as usize][V_DCT as usize] = Some(inv_txfm_add_identity_dct_4x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X8 as usize][H_FLIPADST as usize] = Some(inv_txfm_add_flipadst_identity_4x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X8 as usize][V_FLIPADST as usize] = Some(inv_txfm_add_identity_flipadst_4x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X8 as usize][H_ADST as usize] = Some(inv_txfm_add_adst_identity_4x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X8 as usize][V_ADST as usize] = Some(inv_txfm_add_identity_adst_4x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X16 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_4x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X16 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_4x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X16 as usize][DCT_ADST as usize] = Some(inv_txfm_add_adst_dct_4x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X16 as usize][ADST_DCT as usize] = Some(inv_txfm_add_dct_adst_4x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X16 as usize][ADST_ADST as usize] = Some(inv_txfm_add_adst_adst_4x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X16 as usize][ADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_adst_4x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X16 as usize][FLIPADST_ADST as usize] = Some(inv_txfm_add_adst_flipadst_4x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X16 as usize][DCT_FLIPADST as usize] = Some(inv_txfm_add_flipadst_dct_4x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X16 as usize][FLIPADST_DCT as usize] = Some(inv_txfm_add_dct_flipadst_4x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X16 as usize][FLIPADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_flipadst_4x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X16 as usize][H_DCT as usize] = Some(inv_txfm_add_dct_identity_4x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X16 as usize][V_DCT as usize] = Some(inv_txfm_add_identity_dct_4x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X16 as usize][H_FLIPADST as usize] = Some(inv_txfm_add_flipadst_identity_4x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X16 as usize][V_FLIPADST as usize] = Some(inv_txfm_add_identity_flipadst_4x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X16 as usize][H_ADST as usize] = Some(inv_txfm_add_adst_identity_4x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_4X16 as usize][V_ADST as usize] = Some(inv_txfm_add_identity_adst_4x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X4 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_8x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X4 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_8x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X4 as usize][DCT_ADST as usize] = Some(inv_txfm_add_adst_dct_8x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X4 as usize][ADST_DCT as usize] = Some(inv_txfm_add_dct_adst_8x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X4 as usize][ADST_ADST as usize] = Some(inv_txfm_add_adst_adst_8x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X4 as usize][ADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_adst_8x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X4 as usize][FLIPADST_ADST as usize] = Some(inv_txfm_add_adst_flipadst_8x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X4 as usize][DCT_FLIPADST as usize] = Some(inv_txfm_add_flipadst_dct_8x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X4 as usize][FLIPADST_DCT as usize] = Some(inv_txfm_add_dct_flipadst_8x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X4 as usize][FLIPADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_flipadst_8x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X4 as usize][H_DCT as usize] = Some(inv_txfm_add_dct_identity_8x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X4 as usize][V_DCT as usize] = Some(inv_txfm_add_identity_dct_8x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X4 as usize][H_FLIPADST as usize] = Some(inv_txfm_add_flipadst_identity_8x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X4 as usize][V_FLIPADST as usize] = Some(inv_txfm_add_identity_flipadst_8x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X4 as usize][H_ADST as usize] = Some(inv_txfm_add_adst_identity_8x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X4 as usize][V_ADST as usize] = Some(inv_txfm_add_identity_adst_8x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_8X8 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_8x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_8X8 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_8x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_8X8 as usize][DCT_ADST as usize] = Some(inv_txfm_add_adst_dct_8x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_8X8 as usize][ADST_DCT as usize] = Some(inv_txfm_add_dct_adst_8x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_8X8 as usize][ADST_ADST as usize] = Some(inv_txfm_add_adst_adst_8x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_8X8 as usize][ADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_adst_8x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_8X8 as usize][FLIPADST_ADST as usize] = Some(inv_txfm_add_adst_flipadst_8x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_8X8 as usize][DCT_FLIPADST as usize] = Some(inv_txfm_add_flipadst_dct_8x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_8X8 as usize][FLIPADST_DCT as usize] = Some(inv_txfm_add_dct_flipadst_8x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_8X8 as usize][FLIPADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_flipadst_8x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_8X8 as usize][H_DCT as usize] = Some(inv_txfm_add_dct_identity_8x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_8X8 as usize][V_DCT as usize] = Some(inv_txfm_add_identity_dct_8x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_8X8 as usize][H_FLIPADST as usize] = Some(inv_txfm_add_flipadst_identity_8x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_8X8 as usize][V_FLIPADST as usize] = Some(inv_txfm_add_identity_flipadst_8x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_8X8 as usize][H_ADST as usize] = Some(inv_txfm_add_adst_identity_8x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_8X8 as usize][V_ADST as usize] = Some(inv_txfm_add_identity_adst_8x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X16 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_8x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X16 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_8x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X16 as usize][DCT_ADST as usize] = Some(inv_txfm_add_adst_dct_8x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X16 as usize][ADST_DCT as usize] = Some(inv_txfm_add_dct_adst_8x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X16 as usize][ADST_ADST as usize] = Some(inv_txfm_add_adst_adst_8x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X16 as usize][ADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_adst_8x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X16 as usize][FLIPADST_ADST as usize] = Some(inv_txfm_add_adst_flipadst_8x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X16 as usize][DCT_FLIPADST as usize] = Some(inv_txfm_add_flipadst_dct_8x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X16 as usize][FLIPADST_DCT as usize] = Some(inv_txfm_add_dct_flipadst_8x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X16 as usize][FLIPADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_flipadst_8x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X16 as usize][H_DCT as usize] = Some(inv_txfm_add_dct_identity_8x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X16 as usize][V_DCT as usize] = Some(inv_txfm_add_identity_dct_8x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X16 as usize][H_FLIPADST as usize] = Some(inv_txfm_add_flipadst_identity_8x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X16 as usize][V_FLIPADST as usize] = Some(inv_txfm_add_identity_flipadst_8x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X16 as usize][H_ADST as usize] = Some(inv_txfm_add_adst_identity_8x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X16 as usize][V_ADST as usize] = Some(inv_txfm_add_identity_adst_8x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X32 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_8x32_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_8X32 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_8x32_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X4 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_16x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X4 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_16x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X4 as usize][DCT_ADST as usize] = Some(inv_txfm_add_adst_dct_16x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X4 as usize][ADST_DCT as usize] = Some(inv_txfm_add_dct_adst_16x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X4 as usize][ADST_ADST as usize] = Some(inv_txfm_add_adst_adst_16x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X4 as usize][ADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_adst_16x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X4 as usize][FLIPADST_ADST as usize] = Some(inv_txfm_add_adst_flipadst_16x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X4 as usize][DCT_FLIPADST as usize] = Some(inv_txfm_add_flipadst_dct_16x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X4 as usize][FLIPADST_DCT as usize] = Some(inv_txfm_add_dct_flipadst_16x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X4 as usize][FLIPADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_flipadst_16x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X4 as usize][H_DCT as usize] = Some(inv_txfm_add_dct_identity_16x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X4 as usize][V_DCT as usize] = Some(inv_txfm_add_identity_dct_16x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X4 as usize][H_FLIPADST as usize] = Some(inv_txfm_add_flipadst_identity_16x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X4 as usize][V_FLIPADST as usize] = Some(inv_txfm_add_identity_flipadst_16x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X4 as usize][H_ADST as usize] = Some(inv_txfm_add_adst_identity_16x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X4 as usize][V_ADST as usize] = Some(inv_txfm_add_identity_adst_16x4_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X8 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_16x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X8 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_16x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X8 as usize][DCT_ADST as usize] = Some(inv_txfm_add_adst_dct_16x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X8 as usize][ADST_DCT as usize] = Some(inv_txfm_add_dct_adst_16x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X8 as usize][ADST_ADST as usize] = Some(inv_txfm_add_adst_adst_16x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X8 as usize][ADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_adst_16x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X8 as usize][FLIPADST_ADST as usize] = Some(inv_txfm_add_adst_flipadst_16x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X8 as usize][DCT_FLIPADST as usize] = Some(inv_txfm_add_flipadst_dct_16x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X8 as usize][FLIPADST_DCT as usize] = Some(inv_txfm_add_dct_flipadst_16x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X8 as usize][FLIPADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_flipadst_16x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X8 as usize][H_DCT as usize] = Some(inv_txfm_add_dct_identity_16x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X8 as usize][V_DCT as usize] = Some(inv_txfm_add_identity_dct_16x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X8 as usize][H_FLIPADST as usize] = Some(inv_txfm_add_flipadst_identity_16x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X8 as usize][V_FLIPADST as usize] = Some(inv_txfm_add_identity_flipadst_16x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X8 as usize][H_ADST as usize] = Some(inv_txfm_add_adst_identity_16x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X8 as usize][V_ADST as usize] = Some(inv_txfm_add_identity_adst_16x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_16X16 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_16x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_16X16 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_16x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_16X16 as usize][DCT_ADST as usize] = Some(inv_txfm_add_adst_dct_16x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_16X16 as usize][ADST_DCT as usize] = Some(inv_txfm_add_dct_adst_16x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_16X16 as usize][ADST_ADST as usize] = Some(inv_txfm_add_adst_adst_16x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_16X16 as usize][ADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_adst_16x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_16X16 as usize][FLIPADST_ADST as usize] = Some(inv_txfm_add_adst_flipadst_16x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_16X16 as usize][DCT_FLIPADST as usize] = Some(inv_txfm_add_flipadst_dct_16x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_16X16 as usize][FLIPADST_DCT as usize] = Some(inv_txfm_add_dct_flipadst_16x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_16X16 as usize][FLIPADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_flipadst_16x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_16X16 as usize][H_DCT as usize] = Some(inv_txfm_add_dct_identity_16x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_16X16 as usize][V_DCT as usize] = Some(inv_txfm_add_identity_dct_16x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X32 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_16x32_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X32 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_16x32_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_16X64 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_16x64_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_32X8 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_32x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_32X8 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_32x8_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_32X16 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_32x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_32X16 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_32x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_32X32 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_32x32_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_32X32 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_32x32_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_32X64 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_32x64_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_64X16 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_64x16_c_erased::<BitDepth16>);
-    (*c).itxfm_add[RTX_64X32 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_64x32_c_erased::<BitDepth16>);
-    (*c).itxfm_add[TX_64X64 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_64x64_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_4X4 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_4x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_4X4 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_4x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_4X4 as usize][DCT_ADST as usize] =
+        Some(inv_txfm_add_adst_dct_4x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_4X4 as usize][ADST_DCT as usize] =
+        Some(inv_txfm_add_dct_adst_4x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_4X4 as usize][ADST_ADST as usize] =
+        Some(inv_txfm_add_adst_adst_4x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_4X4 as usize][ADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_adst_4x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_4X4 as usize][FLIPADST_ADST as usize] =
+        Some(inv_txfm_add_adst_flipadst_4x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_4X4 as usize][DCT_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_dct_4x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_4X4 as usize][FLIPADST_DCT as usize] =
+        Some(inv_txfm_add_dct_flipadst_4x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_4X4 as usize][FLIPADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_flipadst_4x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_4X4 as usize][H_DCT as usize] =
+        Some(inv_txfm_add_dct_identity_4x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_4X4 as usize][V_DCT as usize] =
+        Some(inv_txfm_add_identity_dct_4x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_4X4 as usize][H_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_identity_4x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_4X4 as usize][V_FLIPADST as usize] =
+        Some(inv_txfm_add_identity_flipadst_4x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_4X4 as usize][H_ADST as usize] =
+        Some(inv_txfm_add_adst_identity_4x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_4X4 as usize][V_ADST as usize] =
+        Some(inv_txfm_add_identity_adst_4x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X8 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_4x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X8 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_4x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X8 as usize][DCT_ADST as usize] =
+        Some(inv_txfm_add_adst_dct_4x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X8 as usize][ADST_DCT as usize] =
+        Some(inv_txfm_add_dct_adst_4x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X8 as usize][ADST_ADST as usize] =
+        Some(inv_txfm_add_adst_adst_4x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X8 as usize][ADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_adst_4x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X8 as usize][FLIPADST_ADST as usize] =
+        Some(inv_txfm_add_adst_flipadst_4x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X8 as usize][DCT_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_dct_4x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X8 as usize][FLIPADST_DCT as usize] =
+        Some(inv_txfm_add_dct_flipadst_4x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X8 as usize][FLIPADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_flipadst_4x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X8 as usize][H_DCT as usize] =
+        Some(inv_txfm_add_dct_identity_4x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X8 as usize][V_DCT as usize] =
+        Some(inv_txfm_add_identity_dct_4x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X8 as usize][H_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_identity_4x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X8 as usize][V_FLIPADST as usize] =
+        Some(inv_txfm_add_identity_flipadst_4x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X8 as usize][H_ADST as usize] =
+        Some(inv_txfm_add_adst_identity_4x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X8 as usize][V_ADST as usize] =
+        Some(inv_txfm_add_identity_adst_4x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X16 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_4x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X16 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_4x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X16 as usize][DCT_ADST as usize] =
+        Some(inv_txfm_add_adst_dct_4x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X16 as usize][ADST_DCT as usize] =
+        Some(inv_txfm_add_dct_adst_4x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X16 as usize][ADST_ADST as usize] =
+        Some(inv_txfm_add_adst_adst_4x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X16 as usize][ADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_adst_4x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X16 as usize][FLIPADST_ADST as usize] =
+        Some(inv_txfm_add_adst_flipadst_4x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X16 as usize][DCT_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_dct_4x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X16 as usize][FLIPADST_DCT as usize] =
+        Some(inv_txfm_add_dct_flipadst_4x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X16 as usize][FLIPADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_flipadst_4x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X16 as usize][H_DCT as usize] =
+        Some(inv_txfm_add_dct_identity_4x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X16 as usize][V_DCT as usize] =
+        Some(inv_txfm_add_identity_dct_4x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X16 as usize][H_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_identity_4x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X16 as usize][V_FLIPADST as usize] =
+        Some(inv_txfm_add_identity_flipadst_4x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X16 as usize][H_ADST as usize] =
+        Some(inv_txfm_add_adst_identity_4x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_4X16 as usize][V_ADST as usize] =
+        Some(inv_txfm_add_identity_adst_4x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X4 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_8x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X4 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_8x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X4 as usize][DCT_ADST as usize] =
+        Some(inv_txfm_add_adst_dct_8x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X4 as usize][ADST_DCT as usize] =
+        Some(inv_txfm_add_dct_adst_8x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X4 as usize][ADST_ADST as usize] =
+        Some(inv_txfm_add_adst_adst_8x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X4 as usize][ADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_adst_8x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X4 as usize][FLIPADST_ADST as usize] =
+        Some(inv_txfm_add_adst_flipadst_8x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X4 as usize][DCT_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_dct_8x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X4 as usize][FLIPADST_DCT as usize] =
+        Some(inv_txfm_add_dct_flipadst_8x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X4 as usize][FLIPADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_flipadst_8x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X4 as usize][H_DCT as usize] =
+        Some(inv_txfm_add_dct_identity_8x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X4 as usize][V_DCT as usize] =
+        Some(inv_txfm_add_identity_dct_8x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X4 as usize][H_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_identity_8x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X4 as usize][V_FLIPADST as usize] =
+        Some(inv_txfm_add_identity_flipadst_8x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X4 as usize][H_ADST as usize] =
+        Some(inv_txfm_add_adst_identity_8x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X4 as usize][V_ADST as usize] =
+        Some(inv_txfm_add_identity_adst_8x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_8X8 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_8x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_8X8 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_8x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_8X8 as usize][DCT_ADST as usize] =
+        Some(inv_txfm_add_adst_dct_8x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_8X8 as usize][ADST_DCT as usize] =
+        Some(inv_txfm_add_dct_adst_8x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_8X8 as usize][ADST_ADST as usize] =
+        Some(inv_txfm_add_adst_adst_8x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_8X8 as usize][ADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_adst_8x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_8X8 as usize][FLIPADST_ADST as usize] =
+        Some(inv_txfm_add_adst_flipadst_8x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_8X8 as usize][DCT_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_dct_8x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_8X8 as usize][FLIPADST_DCT as usize] =
+        Some(inv_txfm_add_dct_flipadst_8x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_8X8 as usize][FLIPADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_flipadst_8x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_8X8 as usize][H_DCT as usize] =
+        Some(inv_txfm_add_dct_identity_8x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_8X8 as usize][V_DCT as usize] =
+        Some(inv_txfm_add_identity_dct_8x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_8X8 as usize][H_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_identity_8x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_8X8 as usize][V_FLIPADST as usize] =
+        Some(inv_txfm_add_identity_flipadst_8x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_8X8 as usize][H_ADST as usize] =
+        Some(inv_txfm_add_adst_identity_8x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_8X8 as usize][V_ADST as usize] =
+        Some(inv_txfm_add_identity_adst_8x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X16 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_8x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X16 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_8x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X16 as usize][DCT_ADST as usize] =
+        Some(inv_txfm_add_adst_dct_8x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X16 as usize][ADST_DCT as usize] =
+        Some(inv_txfm_add_dct_adst_8x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X16 as usize][ADST_ADST as usize] =
+        Some(inv_txfm_add_adst_adst_8x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X16 as usize][ADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_adst_8x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X16 as usize][FLIPADST_ADST as usize] =
+        Some(inv_txfm_add_adst_flipadst_8x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X16 as usize][DCT_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_dct_8x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X16 as usize][FLIPADST_DCT as usize] =
+        Some(inv_txfm_add_dct_flipadst_8x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X16 as usize][FLIPADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_flipadst_8x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X16 as usize][H_DCT as usize] =
+        Some(inv_txfm_add_dct_identity_8x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X16 as usize][V_DCT as usize] =
+        Some(inv_txfm_add_identity_dct_8x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X16 as usize][H_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_identity_8x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X16 as usize][V_FLIPADST as usize] =
+        Some(inv_txfm_add_identity_flipadst_8x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X16 as usize][H_ADST as usize] =
+        Some(inv_txfm_add_adst_identity_8x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X16 as usize][V_ADST as usize] =
+        Some(inv_txfm_add_identity_adst_8x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X32 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_8x32_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_8X32 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_8x32_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X4 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_16x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X4 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_16x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X4 as usize][DCT_ADST as usize] =
+        Some(inv_txfm_add_adst_dct_16x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X4 as usize][ADST_DCT as usize] =
+        Some(inv_txfm_add_dct_adst_16x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X4 as usize][ADST_ADST as usize] =
+        Some(inv_txfm_add_adst_adst_16x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X4 as usize][ADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_adst_16x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X4 as usize][FLIPADST_ADST as usize] =
+        Some(inv_txfm_add_adst_flipadst_16x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X4 as usize][DCT_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_dct_16x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X4 as usize][FLIPADST_DCT as usize] =
+        Some(inv_txfm_add_dct_flipadst_16x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X4 as usize][FLIPADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_flipadst_16x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X4 as usize][H_DCT as usize] =
+        Some(inv_txfm_add_dct_identity_16x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X4 as usize][V_DCT as usize] =
+        Some(inv_txfm_add_identity_dct_16x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X4 as usize][H_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_identity_16x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X4 as usize][V_FLIPADST as usize] =
+        Some(inv_txfm_add_identity_flipadst_16x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X4 as usize][H_ADST as usize] =
+        Some(inv_txfm_add_adst_identity_16x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X4 as usize][V_ADST as usize] =
+        Some(inv_txfm_add_identity_adst_16x4_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X8 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_16x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X8 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_16x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X8 as usize][DCT_ADST as usize] =
+        Some(inv_txfm_add_adst_dct_16x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X8 as usize][ADST_DCT as usize] =
+        Some(inv_txfm_add_dct_adst_16x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X8 as usize][ADST_ADST as usize] =
+        Some(inv_txfm_add_adst_adst_16x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X8 as usize][ADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_adst_16x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X8 as usize][FLIPADST_ADST as usize] =
+        Some(inv_txfm_add_adst_flipadst_16x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X8 as usize][DCT_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_dct_16x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X8 as usize][FLIPADST_DCT as usize] =
+        Some(inv_txfm_add_dct_flipadst_16x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X8 as usize][FLIPADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_flipadst_16x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X8 as usize][H_DCT as usize] =
+        Some(inv_txfm_add_dct_identity_16x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X8 as usize][V_DCT as usize] =
+        Some(inv_txfm_add_identity_dct_16x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X8 as usize][H_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_identity_16x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X8 as usize][V_FLIPADST as usize] =
+        Some(inv_txfm_add_identity_flipadst_16x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X8 as usize][H_ADST as usize] =
+        Some(inv_txfm_add_adst_identity_16x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X8 as usize][V_ADST as usize] =
+        Some(inv_txfm_add_identity_adst_16x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_16X16 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_16x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_16X16 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_16x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_16X16 as usize][DCT_ADST as usize] =
+        Some(inv_txfm_add_adst_dct_16x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_16X16 as usize][ADST_DCT as usize] =
+        Some(inv_txfm_add_dct_adst_16x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_16X16 as usize][ADST_ADST as usize] =
+        Some(inv_txfm_add_adst_adst_16x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_16X16 as usize][ADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_adst_16x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_16X16 as usize][FLIPADST_ADST as usize] =
+        Some(inv_txfm_add_adst_flipadst_16x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_16X16 as usize][DCT_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_dct_16x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_16X16 as usize][FLIPADST_DCT as usize] =
+        Some(inv_txfm_add_dct_flipadst_16x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_16X16 as usize][FLIPADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_flipadst_16x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_16X16 as usize][H_DCT as usize] =
+        Some(inv_txfm_add_dct_identity_16x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_16X16 as usize][V_DCT as usize] =
+        Some(inv_txfm_add_identity_dct_16x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X32 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_16x32_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X32 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_16x32_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_16X64 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_16x64_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_32X8 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_32x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_32X8 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_32x8_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_32X16 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_32x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_32X16 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_32x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_32X32 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_32x32_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_32X32 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_32x32_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_32X64 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_32x64_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_64X16 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_64x16_c_erased::<BitDepth16>);
+    (*c).itxfm_add[RTX_64X32 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_64x32_c_erased::<BitDepth16>);
+    (*c).itxfm_add[TX_64X64 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_64x64_c_erased::<BitDepth16>);
 
     #[cfg(feature = "asm")]
     cfg_if! {

--- a/src/itx_tmpl_8.rs
+++ b/src/itx_tmpl_8.rs
@@ -45,7 +45,7 @@ use std::ffi::c_int;
 use std::ffi::c_void;
 
 #[cfg(feature = "asm")]
-use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
+use crate::src::cpu::{rav1d_get_cpu_flags, CpuFlags};
 
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
@@ -122,7 +122,7 @@ unsafe extern "C" fn itx_dsp_init_x86(c: *mut Rav1dInvTxfmDSPContext, _bpc: c_in
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::itx::*;
 
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSE2) {
         return;
@@ -626,7 +626,7 @@ unsafe extern "C" fn itx_dsp_init_arm(c: *mut Rav1dInvTxfmDSPContext, mut _bpc: 
         // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::itx::*;
 
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::NEON) {
         return;
@@ -792,169 +792,321 @@ unsafe extern "C" fn itx_dsp_init_arm(c: *mut Rav1dInvTxfmDSPContext, mut _bpc: 
 
 #[cold]
 #[rustfmt::skip]
-pub unsafe fn dav1d_itx_dsp_init_8bpc(
-    c: *mut Rav1dInvTxfmDSPContext,
-    mut _bpc: c_int,
-) {
+pub unsafe fn rav1d_itx_dsp_init_8bpc(c: *mut Rav1dInvTxfmDSPContext, mut _bpc: c_int) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::itx::*;
 
     (*c).itxfm_add[TX_4X4 as usize][WHT_WHT as usize] = Some(inv_txfm_add_wht_wht_4x4_c_erased);
-    (*c).itxfm_add[TX_4X4 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_4x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_4X4 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_4x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_4X4 as usize][DCT_ADST as usize] = Some(inv_txfm_add_adst_dct_4x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_4X4 as usize][ADST_DCT as usize] = Some(inv_txfm_add_dct_adst_4x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_4X4 as usize][ADST_ADST as usize] = Some(inv_txfm_add_adst_adst_4x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_4X4 as usize][ADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_adst_4x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_4X4 as usize][FLIPADST_ADST as usize] = Some(inv_txfm_add_adst_flipadst_4x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_4X4 as usize][DCT_FLIPADST as usize] = Some(inv_txfm_add_flipadst_dct_4x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_4X4 as usize][FLIPADST_DCT as usize] = Some(inv_txfm_add_dct_flipadst_4x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_4X4 as usize][FLIPADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_flipadst_4x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_4X4 as usize][H_DCT as usize] = Some(inv_txfm_add_dct_identity_4x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_4X4 as usize][V_DCT as usize] = Some(inv_txfm_add_identity_dct_4x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_4X4 as usize][H_FLIPADST as usize] = Some(inv_txfm_add_flipadst_identity_4x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_4X4 as usize][V_FLIPADST as usize] = Some(inv_txfm_add_identity_flipadst_4x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_4X4 as usize][H_ADST as usize] = Some(inv_txfm_add_adst_identity_4x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_4X4 as usize][V_ADST as usize] = Some(inv_txfm_add_identity_adst_4x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X8 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_4x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X8 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_4x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X8 as usize][DCT_ADST as usize] = Some(inv_txfm_add_adst_dct_4x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X8 as usize][ADST_DCT as usize] = Some(inv_txfm_add_dct_adst_4x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X8 as usize][ADST_ADST as usize] = Some(inv_txfm_add_adst_adst_4x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X8 as usize][ADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_adst_4x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X8 as usize][FLIPADST_ADST as usize] = Some(inv_txfm_add_adst_flipadst_4x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X8 as usize][DCT_FLIPADST as usize] = Some(inv_txfm_add_flipadst_dct_4x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X8 as usize][FLIPADST_DCT as usize] = Some(inv_txfm_add_dct_flipadst_4x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X8 as usize][FLIPADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_flipadst_4x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X8 as usize][H_DCT as usize] = Some(inv_txfm_add_dct_identity_4x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X8 as usize][V_DCT as usize] = Some(inv_txfm_add_identity_dct_4x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X8 as usize][H_FLIPADST as usize] = Some(inv_txfm_add_flipadst_identity_4x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X8 as usize][V_FLIPADST as usize] = Some(inv_txfm_add_identity_flipadst_4x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X8 as usize][H_ADST as usize] = Some(inv_txfm_add_adst_identity_4x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X8 as usize][V_ADST as usize] = Some(inv_txfm_add_identity_adst_4x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X16 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_4x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X16 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_4x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X16 as usize][DCT_ADST as usize] = Some(inv_txfm_add_adst_dct_4x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X16 as usize][ADST_DCT as usize] = Some(inv_txfm_add_dct_adst_4x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X16 as usize][ADST_ADST as usize] = Some(inv_txfm_add_adst_adst_4x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X16 as usize][ADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_adst_4x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X16 as usize][FLIPADST_ADST as usize] = Some(inv_txfm_add_adst_flipadst_4x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X16 as usize][DCT_FLIPADST as usize] = Some(inv_txfm_add_flipadst_dct_4x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X16 as usize][FLIPADST_DCT as usize] = Some(inv_txfm_add_dct_flipadst_4x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X16 as usize][FLIPADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_flipadst_4x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X16 as usize][H_DCT as usize] = Some(inv_txfm_add_dct_identity_4x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X16 as usize][V_DCT as usize] = Some(inv_txfm_add_identity_dct_4x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X16 as usize][H_FLIPADST as usize] = Some(inv_txfm_add_flipadst_identity_4x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X16 as usize][V_FLIPADST as usize] = Some(inv_txfm_add_identity_flipadst_4x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X16 as usize][H_ADST as usize] = Some(inv_txfm_add_adst_identity_4x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_4X16 as usize][V_ADST as usize] = Some(inv_txfm_add_identity_adst_4x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X4 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_8x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X4 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_8x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X4 as usize][DCT_ADST as usize] = Some(inv_txfm_add_adst_dct_8x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X4 as usize][ADST_DCT as usize] = Some(inv_txfm_add_dct_adst_8x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X4 as usize][ADST_ADST as usize] = Some(inv_txfm_add_adst_adst_8x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X4 as usize][ADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_adst_8x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X4 as usize][FLIPADST_ADST as usize] = Some(inv_txfm_add_adst_flipadst_8x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X4 as usize][DCT_FLIPADST as usize] = Some(inv_txfm_add_flipadst_dct_8x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X4 as usize][FLIPADST_DCT as usize] = Some(inv_txfm_add_dct_flipadst_8x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X4 as usize][FLIPADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_flipadst_8x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X4 as usize][H_DCT as usize] = Some(inv_txfm_add_dct_identity_8x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X4 as usize][V_DCT as usize] = Some(inv_txfm_add_identity_dct_8x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X4 as usize][H_FLIPADST as usize] = Some(inv_txfm_add_flipadst_identity_8x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X4 as usize][V_FLIPADST as usize] = Some(inv_txfm_add_identity_flipadst_8x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X4 as usize][H_ADST as usize] = Some(inv_txfm_add_adst_identity_8x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X4 as usize][V_ADST as usize] = Some(inv_txfm_add_identity_adst_8x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_8X8 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_8x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_8X8 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_8x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_8X8 as usize][DCT_ADST as usize] = Some(inv_txfm_add_adst_dct_8x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_8X8 as usize][ADST_DCT as usize] = Some(inv_txfm_add_dct_adst_8x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_8X8 as usize][ADST_ADST as usize] = Some(inv_txfm_add_adst_adst_8x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_8X8 as usize][ADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_adst_8x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_8X8 as usize][FLIPADST_ADST as usize] = Some(inv_txfm_add_adst_flipadst_8x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_8X8 as usize][DCT_FLIPADST as usize] = Some(inv_txfm_add_flipadst_dct_8x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_8X8 as usize][FLIPADST_DCT as usize] = Some(inv_txfm_add_dct_flipadst_8x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_8X8 as usize][FLIPADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_flipadst_8x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_8X8 as usize][H_DCT as usize] = Some(inv_txfm_add_dct_identity_8x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_8X8 as usize][V_DCT as usize] = Some(inv_txfm_add_identity_dct_8x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_8X8 as usize][H_FLIPADST as usize] = Some(inv_txfm_add_flipadst_identity_8x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_8X8 as usize][V_FLIPADST as usize] = Some(inv_txfm_add_identity_flipadst_8x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_8X8 as usize][H_ADST as usize] = Some(inv_txfm_add_adst_identity_8x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_8X8 as usize][V_ADST as usize] = Some(inv_txfm_add_identity_adst_8x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X16 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_8x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X16 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_8x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X16 as usize][DCT_ADST as usize] = Some(inv_txfm_add_adst_dct_8x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X16 as usize][ADST_DCT as usize] = Some(inv_txfm_add_dct_adst_8x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X16 as usize][ADST_ADST as usize] = Some(inv_txfm_add_adst_adst_8x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X16 as usize][ADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_adst_8x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X16 as usize][FLIPADST_ADST as usize] = Some(inv_txfm_add_adst_flipadst_8x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X16 as usize][DCT_FLIPADST as usize] = Some(inv_txfm_add_flipadst_dct_8x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X16 as usize][FLIPADST_DCT as usize] = Some(inv_txfm_add_dct_flipadst_8x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X16 as usize][FLIPADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_flipadst_8x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X16 as usize][H_DCT as usize] = Some(inv_txfm_add_dct_identity_8x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X16 as usize][V_DCT as usize] = Some(inv_txfm_add_identity_dct_8x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X16 as usize][H_FLIPADST as usize] = Some(inv_txfm_add_flipadst_identity_8x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X16 as usize][V_FLIPADST as usize] = Some(inv_txfm_add_identity_flipadst_8x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X16 as usize][H_ADST as usize] = Some(inv_txfm_add_adst_identity_8x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X16 as usize][V_ADST as usize] = Some(inv_txfm_add_identity_adst_8x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X32 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_8x32_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_8X32 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_8x32_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X4 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_16x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X4 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_16x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X4 as usize][DCT_ADST as usize] = Some(inv_txfm_add_adst_dct_16x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X4 as usize][ADST_DCT as usize] = Some(inv_txfm_add_dct_adst_16x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X4 as usize][ADST_ADST as usize] = Some(inv_txfm_add_adst_adst_16x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X4 as usize][ADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_adst_16x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X4 as usize][FLIPADST_ADST as usize] = Some(inv_txfm_add_adst_flipadst_16x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X4 as usize][DCT_FLIPADST as usize] = Some(inv_txfm_add_flipadst_dct_16x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X4 as usize][FLIPADST_DCT as usize] = Some(inv_txfm_add_dct_flipadst_16x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X4 as usize][FLIPADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_flipadst_16x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X4 as usize][H_DCT as usize] = Some(inv_txfm_add_dct_identity_16x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X4 as usize][V_DCT as usize] = Some(inv_txfm_add_identity_dct_16x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X4 as usize][H_FLIPADST as usize] = Some(inv_txfm_add_flipadst_identity_16x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X4 as usize][V_FLIPADST as usize] = Some(inv_txfm_add_identity_flipadst_16x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X4 as usize][H_ADST as usize] = Some(inv_txfm_add_adst_identity_16x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X4 as usize][V_ADST as usize] = Some(inv_txfm_add_identity_adst_16x4_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X8 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_16x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X8 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_16x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X8 as usize][DCT_ADST as usize] = Some(inv_txfm_add_adst_dct_16x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X8 as usize][ADST_DCT as usize] = Some(inv_txfm_add_dct_adst_16x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X8 as usize][ADST_ADST as usize] = Some(inv_txfm_add_adst_adst_16x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X8 as usize][ADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_adst_16x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X8 as usize][FLIPADST_ADST as usize] = Some(inv_txfm_add_adst_flipadst_16x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X8 as usize][DCT_FLIPADST as usize] = Some(inv_txfm_add_flipadst_dct_16x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X8 as usize][FLIPADST_DCT as usize] = Some(inv_txfm_add_dct_flipadst_16x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X8 as usize][FLIPADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_flipadst_16x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X8 as usize][H_DCT as usize] = Some(inv_txfm_add_dct_identity_16x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X8 as usize][V_DCT as usize] = Some(inv_txfm_add_identity_dct_16x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X8 as usize][H_FLIPADST as usize] = Some(inv_txfm_add_flipadst_identity_16x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X8 as usize][V_FLIPADST as usize] = Some(inv_txfm_add_identity_flipadst_16x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X8 as usize][H_ADST as usize] = Some(inv_txfm_add_adst_identity_16x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X8 as usize][V_ADST as usize] = Some(inv_txfm_add_identity_adst_16x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_16X16 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_16x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_16X16 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_16x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_16X16 as usize][DCT_ADST as usize] = Some(inv_txfm_add_adst_dct_16x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_16X16 as usize][ADST_DCT as usize] = Some(inv_txfm_add_dct_adst_16x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_16X16 as usize][ADST_ADST as usize] = Some(inv_txfm_add_adst_adst_16x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_16X16 as usize][ADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_adst_16x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_16X16 as usize][FLIPADST_ADST as usize] = Some(inv_txfm_add_adst_flipadst_16x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_16X16 as usize][DCT_FLIPADST as usize] = Some(inv_txfm_add_flipadst_dct_16x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_16X16 as usize][FLIPADST_DCT as usize] = Some(inv_txfm_add_dct_flipadst_16x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_16X16 as usize][FLIPADST_FLIPADST as usize] = Some(inv_txfm_add_flipadst_flipadst_16x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_16X16 as usize][H_DCT as usize] = Some(inv_txfm_add_dct_identity_16x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_16X16 as usize][V_DCT as usize] = Some(inv_txfm_add_identity_dct_16x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X32 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_16x32_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X32 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_16x32_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_16X64 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_16x64_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_32X8 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_32x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_32X8 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_32x8_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_32X16 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_32x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_32X16 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_32x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_32X32 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_32x32_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_32X32 as usize][IDTX as usize] = Some(inv_txfm_add_identity_identity_32x32_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_32X64 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_32x64_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_64X16 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_64x16_c_erased::<BitDepth8>);
-    (*c).itxfm_add[RTX_64X32 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_64x32_c_erased::<BitDepth8>);
-    (*c).itxfm_add[TX_64X64 as usize][DCT_DCT as usize] = Some(inv_txfm_add_dct_dct_64x64_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_4X4 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_4x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_4X4 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_4x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_4X4 as usize][DCT_ADST as usize] =
+        Some(inv_txfm_add_adst_dct_4x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_4X4 as usize][ADST_DCT as usize] =
+        Some(inv_txfm_add_dct_adst_4x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_4X4 as usize][ADST_ADST as usize] =
+        Some(inv_txfm_add_adst_adst_4x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_4X4 as usize][ADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_adst_4x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_4X4 as usize][FLIPADST_ADST as usize] =
+        Some(inv_txfm_add_adst_flipadst_4x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_4X4 as usize][DCT_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_dct_4x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_4X4 as usize][FLIPADST_DCT as usize] =
+        Some(inv_txfm_add_dct_flipadst_4x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_4X4 as usize][FLIPADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_flipadst_4x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_4X4 as usize][H_DCT as usize] =
+        Some(inv_txfm_add_dct_identity_4x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_4X4 as usize][V_DCT as usize] =
+        Some(inv_txfm_add_identity_dct_4x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_4X4 as usize][H_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_identity_4x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_4X4 as usize][V_FLIPADST as usize] =
+        Some(inv_txfm_add_identity_flipadst_4x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_4X4 as usize][H_ADST as usize] =
+        Some(inv_txfm_add_adst_identity_4x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_4X4 as usize][V_ADST as usize] =
+        Some(inv_txfm_add_identity_adst_4x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X8 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_4x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X8 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_4x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X8 as usize][DCT_ADST as usize] =
+        Some(inv_txfm_add_adst_dct_4x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X8 as usize][ADST_DCT as usize] =
+        Some(inv_txfm_add_dct_adst_4x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X8 as usize][ADST_ADST as usize] =
+        Some(inv_txfm_add_adst_adst_4x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X8 as usize][ADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_adst_4x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X8 as usize][FLIPADST_ADST as usize] =
+        Some(inv_txfm_add_adst_flipadst_4x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X8 as usize][DCT_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_dct_4x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X8 as usize][FLIPADST_DCT as usize] =
+        Some(inv_txfm_add_dct_flipadst_4x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X8 as usize][FLIPADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_flipadst_4x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X8 as usize][H_DCT as usize] =
+        Some(inv_txfm_add_dct_identity_4x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X8 as usize][V_DCT as usize] =
+        Some(inv_txfm_add_identity_dct_4x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X8 as usize][H_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_identity_4x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X8 as usize][V_FLIPADST as usize] =
+        Some(inv_txfm_add_identity_flipadst_4x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X8 as usize][H_ADST as usize] =
+        Some(inv_txfm_add_adst_identity_4x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X8 as usize][V_ADST as usize] =
+        Some(inv_txfm_add_identity_adst_4x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X16 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_4x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X16 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_4x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X16 as usize][DCT_ADST as usize] =
+        Some(inv_txfm_add_adst_dct_4x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X16 as usize][ADST_DCT as usize] =
+        Some(inv_txfm_add_dct_adst_4x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X16 as usize][ADST_ADST as usize] =
+        Some(inv_txfm_add_adst_adst_4x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X16 as usize][ADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_adst_4x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X16 as usize][FLIPADST_ADST as usize] =
+        Some(inv_txfm_add_adst_flipadst_4x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X16 as usize][DCT_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_dct_4x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X16 as usize][FLIPADST_DCT as usize] =
+        Some(inv_txfm_add_dct_flipadst_4x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X16 as usize][FLIPADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_flipadst_4x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X16 as usize][H_DCT as usize] =
+        Some(inv_txfm_add_dct_identity_4x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X16 as usize][V_DCT as usize] =
+        Some(inv_txfm_add_identity_dct_4x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X16 as usize][H_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_identity_4x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X16 as usize][V_FLIPADST as usize] =
+        Some(inv_txfm_add_identity_flipadst_4x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X16 as usize][H_ADST as usize] =
+        Some(inv_txfm_add_adst_identity_4x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_4X16 as usize][V_ADST as usize] =
+        Some(inv_txfm_add_identity_adst_4x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X4 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_8x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X4 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_8x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X4 as usize][DCT_ADST as usize] =
+        Some(inv_txfm_add_adst_dct_8x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X4 as usize][ADST_DCT as usize] =
+        Some(inv_txfm_add_dct_adst_8x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X4 as usize][ADST_ADST as usize] =
+        Some(inv_txfm_add_adst_adst_8x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X4 as usize][ADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_adst_8x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X4 as usize][FLIPADST_ADST as usize] =
+        Some(inv_txfm_add_adst_flipadst_8x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X4 as usize][DCT_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_dct_8x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X4 as usize][FLIPADST_DCT as usize] =
+        Some(inv_txfm_add_dct_flipadst_8x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X4 as usize][FLIPADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_flipadst_8x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X4 as usize][H_DCT as usize] =
+        Some(inv_txfm_add_dct_identity_8x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X4 as usize][V_DCT as usize] =
+        Some(inv_txfm_add_identity_dct_8x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X4 as usize][H_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_identity_8x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X4 as usize][V_FLIPADST as usize] =
+        Some(inv_txfm_add_identity_flipadst_8x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X4 as usize][H_ADST as usize] =
+        Some(inv_txfm_add_adst_identity_8x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X4 as usize][V_ADST as usize] =
+        Some(inv_txfm_add_identity_adst_8x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_8X8 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_8x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_8X8 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_8x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_8X8 as usize][DCT_ADST as usize] =
+        Some(inv_txfm_add_adst_dct_8x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_8X8 as usize][ADST_DCT as usize] =
+        Some(inv_txfm_add_dct_adst_8x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_8X8 as usize][ADST_ADST as usize] =
+        Some(inv_txfm_add_adst_adst_8x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_8X8 as usize][ADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_adst_8x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_8X8 as usize][FLIPADST_ADST as usize] =
+        Some(inv_txfm_add_adst_flipadst_8x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_8X8 as usize][DCT_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_dct_8x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_8X8 as usize][FLIPADST_DCT as usize] =
+        Some(inv_txfm_add_dct_flipadst_8x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_8X8 as usize][FLIPADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_flipadst_8x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_8X8 as usize][H_DCT as usize] =
+        Some(inv_txfm_add_dct_identity_8x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_8X8 as usize][V_DCT as usize] =
+        Some(inv_txfm_add_identity_dct_8x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_8X8 as usize][H_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_identity_8x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_8X8 as usize][V_FLIPADST as usize] =
+        Some(inv_txfm_add_identity_flipadst_8x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_8X8 as usize][H_ADST as usize] =
+        Some(inv_txfm_add_adst_identity_8x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_8X8 as usize][V_ADST as usize] =
+        Some(inv_txfm_add_identity_adst_8x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X16 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_8x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X16 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_8x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X16 as usize][DCT_ADST as usize] =
+        Some(inv_txfm_add_adst_dct_8x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X16 as usize][ADST_DCT as usize] =
+        Some(inv_txfm_add_dct_adst_8x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X16 as usize][ADST_ADST as usize] =
+        Some(inv_txfm_add_adst_adst_8x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X16 as usize][ADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_adst_8x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X16 as usize][FLIPADST_ADST as usize] =
+        Some(inv_txfm_add_adst_flipadst_8x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X16 as usize][DCT_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_dct_8x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X16 as usize][FLIPADST_DCT as usize] =
+        Some(inv_txfm_add_dct_flipadst_8x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X16 as usize][FLIPADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_flipadst_8x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X16 as usize][H_DCT as usize] =
+        Some(inv_txfm_add_dct_identity_8x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X16 as usize][V_DCT as usize] =
+        Some(inv_txfm_add_identity_dct_8x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X16 as usize][H_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_identity_8x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X16 as usize][V_FLIPADST as usize] =
+        Some(inv_txfm_add_identity_flipadst_8x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X16 as usize][H_ADST as usize] =
+        Some(inv_txfm_add_adst_identity_8x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X16 as usize][V_ADST as usize] =
+        Some(inv_txfm_add_identity_adst_8x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X32 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_8x32_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_8X32 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_8x32_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X4 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_16x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X4 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_16x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X4 as usize][DCT_ADST as usize] =
+        Some(inv_txfm_add_adst_dct_16x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X4 as usize][ADST_DCT as usize] =
+        Some(inv_txfm_add_dct_adst_16x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X4 as usize][ADST_ADST as usize] =
+        Some(inv_txfm_add_adst_adst_16x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X4 as usize][ADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_adst_16x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X4 as usize][FLIPADST_ADST as usize] =
+        Some(inv_txfm_add_adst_flipadst_16x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X4 as usize][DCT_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_dct_16x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X4 as usize][FLIPADST_DCT as usize] =
+        Some(inv_txfm_add_dct_flipadst_16x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X4 as usize][FLIPADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_flipadst_16x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X4 as usize][H_DCT as usize] =
+        Some(inv_txfm_add_dct_identity_16x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X4 as usize][V_DCT as usize] =
+        Some(inv_txfm_add_identity_dct_16x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X4 as usize][H_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_identity_16x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X4 as usize][V_FLIPADST as usize] =
+        Some(inv_txfm_add_identity_flipadst_16x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X4 as usize][H_ADST as usize] =
+        Some(inv_txfm_add_adst_identity_16x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X4 as usize][V_ADST as usize] =
+        Some(inv_txfm_add_identity_adst_16x4_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X8 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_16x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X8 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_16x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X8 as usize][DCT_ADST as usize] =
+        Some(inv_txfm_add_adst_dct_16x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X8 as usize][ADST_DCT as usize] =
+        Some(inv_txfm_add_dct_adst_16x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X8 as usize][ADST_ADST as usize] =
+        Some(inv_txfm_add_adst_adst_16x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X8 as usize][ADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_adst_16x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X8 as usize][FLIPADST_ADST as usize] =
+        Some(inv_txfm_add_adst_flipadst_16x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X8 as usize][DCT_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_dct_16x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X8 as usize][FLIPADST_DCT as usize] =
+        Some(inv_txfm_add_dct_flipadst_16x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X8 as usize][FLIPADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_flipadst_16x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X8 as usize][H_DCT as usize] =
+        Some(inv_txfm_add_dct_identity_16x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X8 as usize][V_DCT as usize] =
+        Some(inv_txfm_add_identity_dct_16x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X8 as usize][H_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_identity_16x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X8 as usize][V_FLIPADST as usize] =
+        Some(inv_txfm_add_identity_flipadst_16x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X8 as usize][H_ADST as usize] =
+        Some(inv_txfm_add_adst_identity_16x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X8 as usize][V_ADST as usize] =
+        Some(inv_txfm_add_identity_adst_16x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_16X16 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_16x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_16X16 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_16x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_16X16 as usize][DCT_ADST as usize] =
+        Some(inv_txfm_add_adst_dct_16x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_16X16 as usize][ADST_DCT as usize] =
+        Some(inv_txfm_add_dct_adst_16x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_16X16 as usize][ADST_ADST as usize] =
+        Some(inv_txfm_add_adst_adst_16x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_16X16 as usize][ADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_adst_16x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_16X16 as usize][FLIPADST_ADST as usize] =
+        Some(inv_txfm_add_adst_flipadst_16x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_16X16 as usize][DCT_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_dct_16x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_16X16 as usize][FLIPADST_DCT as usize] =
+        Some(inv_txfm_add_dct_flipadst_16x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_16X16 as usize][FLIPADST_FLIPADST as usize] =
+        Some(inv_txfm_add_flipadst_flipadst_16x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_16X16 as usize][H_DCT as usize] =
+        Some(inv_txfm_add_dct_identity_16x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_16X16 as usize][V_DCT as usize] =
+        Some(inv_txfm_add_identity_dct_16x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X32 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_16x32_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X32 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_16x32_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_16X64 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_16x64_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_32X8 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_32x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_32X8 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_32x8_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_32X16 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_32x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_32X16 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_32x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_32X32 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_32x32_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_32X32 as usize][IDTX as usize] =
+        Some(inv_txfm_add_identity_identity_32x32_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_32X64 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_32x64_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_64X16 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_64x16_c_erased::<BitDepth8>);
+    (*c).itxfm_add[RTX_64X32 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_64x32_c_erased::<BitDepth8>);
+    (*c).itxfm_add[TX_64X64 as usize][DCT_DCT as usize] =
+        Some(inv_txfm_add_dct_dct_64x64_c_erased::<BitDepth8>);
 
     #[cfg(feature = "asm")]
     cfg_if! {

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -156,7 +156,11 @@ unsafe extern "C" fn backup_lpf(
     };
 }
 
-pub unsafe fn dav1d_copy_lpf_16bpc(f: *mut Rav1dFrameContext, src: *const *mut pixel, sby: c_int) {
+pub(crate) unsafe fn rav1d_copy_lpf_16bpc(
+    f: *mut Rav1dFrameContext,
+    src: *const *mut pixel,
+    sby: c_int,
+) {
     let have_tt = ((*(*f).c).n_tc > 1 as c_uint) as c_int;
     let resize = ((*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1]) as c_int;
     let offset = 8 * (sby != 0) as c_int;
@@ -510,7 +514,7 @@ unsafe extern "C" fn filter_plane_rows_uv(
     }
 }
 
-pub unsafe fn dav1d_loopfilter_sbrow_cols_16bpc(
+pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols_16bpc(
     f: *const Rav1dFrameContext,
     p: *const *mut pixel,
     lflvl: *mut Av1Filter,
@@ -715,7 +719,7 @@ pub unsafe fn dav1d_loopfilter_sbrow_cols_16bpc(
     }
 }
 
-pub unsafe fn dav1d_loopfilter_sbrow_rows_16bpc(
+pub(crate) unsafe fn rav1d_loopfilter_sbrow_rows_16bpc(
     f: *const Rav1dFrameContext,
     p: *const *mut pixel,
     lflvl: *mut Av1Filter,

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -1,6 +1,6 @@
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
 use crate::src::env::BlockContext;
 use crate::src::internal::Rav1dDSPContext;
 use crate::src::internal::Rav1dFrameContext;
@@ -221,12 +221,12 @@ pub(crate) unsafe fn rav1d_copy_lpf_16bpc(
     }
     if ((*(*f).seq_hdr).cdef != 0
         || restore_planes & (LR_RESTORE_U as c_int | LR_RESTORE_V as c_int) != 0)
-        && (*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
+        && (*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
     {
         let ss_ver = ((*f).sr_cur.p.p.layout as c_uint
-            == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+            == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
         let ss_hor = ((*f).sr_cur.p.p.layout as c_uint
-            != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+            != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
         let h_0 = (*f).cur.p.h + ss_ver >> ss_ver;
         let w_0 = (*f).bw << 2 - ss_hor;
         let row_h_0 = cmp::min((sby + 1) << 6 - ss_ver + (*(*f).seq_hdr).sb128, h_0 - 1);
@@ -529,9 +529,9 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols_16bpc(
     let sbl2 = 5 - is_sb64;
     let halign = (*f).bh + 31 & !(31 as c_int);
     let ss_ver =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let ss_hor =
-        ((*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
     let vmask = 16 >> ss_ver;
     let hmask = 16 >> ss_hor;
     let vmax: c_uint = (1 as c_uint) << vmask;
@@ -579,7 +579,7 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols_16bpc(
             y = y.wrapping_add(1);
             mask <<= 1;
         }
-        if (*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint {
+        if (*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint {
             let uv_hmask: *mut [u16; 2] =
                 ((*lflvl.offset(x as isize)).filter_uv[0][cbx4 as usize]).as_mut_ptr();
             let mut y_0: c_uint = (starty4 >> ss_ver) as c_uint;
@@ -637,7 +637,7 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols_16bpc(
                 mask_0 <<= 1;
                 i = i.wrapping_add(1);
             }
-            if (*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint {
+            if (*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint {
                 let cw: c_uint = w.wrapping_add(ss_hor as c_uint) >> ss_hor;
                 let uv_vmask: *mut [u16; 2] = ((*lflvl.offset(x as isize)).filter_uv[1]
                     [(starty4 >> ss_ver) as usize])
@@ -731,9 +731,9 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_rows_16bpc(
     let starty4 = (sby & is_sb64) << 4;
     let sbsz = 32 >> is_sb64;
     let ss_ver =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let ss_hor =
-        ((*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
     let endy4: c_uint = (starty4 + cmp::min((*f).h4 - sby * sbsz, sbsz)) as c_uint;
     let uv_endy4: c_uint = endy4.wrapping_add(ss_ver as c_uint) >> ss_ver;
     let mut ptr: *mut pixel;

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -123,7 +123,11 @@ unsafe extern "C" fn backup_lpf(
     };
 }
 
-pub unsafe fn dav1d_copy_lpf_8bpc(f: *mut Rav1dFrameContext, src: *const *mut pixel, sby: c_int) {
+pub(crate) unsafe fn rav1d_copy_lpf_8bpc(
+    f: *mut Rav1dFrameContext,
+    src: *const *mut pixel,
+    sby: c_int,
+) {
     let have_tt = ((*(*f).c).n_tc > 1 as c_uint) as c_int;
     let resize = ((*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1]) as c_int;
     let offset = 8 * (sby != 0) as c_int;
@@ -475,7 +479,7 @@ unsafe extern "C" fn filter_plane_rows_uv(
     }
 }
 
-pub unsafe fn dav1d_loopfilter_sbrow_cols_8bpc(
+pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols_8bpc(
     f: *const Rav1dFrameContext,
     p: *const *mut pixel,
     lflvl: *mut Av1Filter,
@@ -680,7 +684,7 @@ pub unsafe fn dav1d_loopfilter_sbrow_cols_8bpc(
     }
 }
 
-pub unsafe fn dav1d_loopfilter_sbrow_rows_8bpc(
+pub(crate) unsafe fn rav1d_loopfilter_sbrow_rows_8bpc(
     f: *const Rav1dFrameContext,
     p: *const *mut pixel,
     lflvl: *mut Av1Filter,

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -1,6 +1,6 @@
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
 use crate::src::env::BlockContext;
 use crate::src::internal::Rav1dDSPContext;
 use crate::src::internal::Rav1dFrameContext;
@@ -186,12 +186,12 @@ pub(crate) unsafe fn rav1d_copy_lpf_8bpc(
     }
     if ((*(*f).seq_hdr).cdef != 0
         || restore_planes & (LR_RESTORE_U as c_int | LR_RESTORE_V as c_int) != 0)
-        && (*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
+        && (*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
     {
         let ss_ver = ((*f).sr_cur.p.p.layout as c_uint
-            == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+            == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
         let ss_hor = ((*f).sr_cur.p.p.layout as c_uint
-            != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+            != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
         let h_0 = (*f).cur.p.h + ss_ver >> ss_ver;
         let w_0 = (*f).bw << 2 - ss_hor;
         let row_h_0 = cmp::min((sby + 1) << 6 - ss_ver + (*(*f).seq_hdr).sb128, h_0 - 1);
@@ -494,9 +494,9 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols_8bpc(
     let sbl2 = 5 - is_sb64;
     let halign = (*f).bh + 31 & !(31 as c_int);
     let ss_ver =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let ss_hor =
-        ((*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
     let vmask = 16 >> ss_ver;
     let hmask = 16 >> ss_hor;
     let vmax: c_uint = (1 as c_uint) << vmask;
@@ -544,7 +544,7 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols_8bpc(
             y = y.wrapping_add(1);
             mask <<= 1;
         }
-        if (*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint {
+        if (*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint {
             let uv_hmask: *mut [u16; 2] =
                 ((*lflvl.offset(x as isize)).filter_uv[0][cbx4 as usize]).as_mut_ptr();
             let mut y_0: c_uint = (starty4 >> ss_ver) as c_uint;
@@ -602,7 +602,7 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols_8bpc(
                 mask_0 <<= 1;
                 i = i.wrapping_add(1);
             }
-            if (*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint {
+            if (*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint {
                 let cw: c_uint = w.wrapping_add(ss_hor as c_uint) >> ss_hor;
                 let uv_vmask: *mut [u16; 2] = ((*lflvl.offset(x as isize)).filter_uv[1]
                     [(starty4 >> ss_ver) as usize])
@@ -696,9 +696,9 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_rows_8bpc(
     let starty4 = (sby & is_sb64) << 4;
     let sbsz = 32 >> is_sb64;
     let ss_ver =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let ss_hor =
-        ((*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
     let endy4: c_uint = (starty4 + cmp::min((*f).h4 - sby * sbsz, sbsz)) as c_uint;
     let uv_endy4: c_uint = endy4.wrapping_add(ss_ver as c_uint) >> ss_ver;
     let mut ptr: *mut pixel;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -1,8 +1,8 @@
 use crate::include::common::intops::iclip;
 use crate::include::dav1d::headers::Dav1dFrameHeader;
-use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
-use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::Dav1dRestorationType;
+use crate::include::dav1d::headers::Rav1dLoopfilterModeRefDeltas;
+use crate::include::dav1d::headers::Rav1dPixelLayout;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::src::align::Align16;
@@ -354,7 +354,7 @@ fn mask_edges_chroma(
     );
 }
 
-pub unsafe fn dav1d_create_lf_mask_intra(
+pub unsafe fn rav1d_create_lf_mask_intra(
     lflvl: &mut Av1Filter,
     level_cache: *mut [u8; 4],
     b4_stride: ptrdiff_t,
@@ -366,7 +366,7 @@ pub unsafe fn dav1d_create_lf_mask_intra(
     bs: BlockSize,
     ytx: RectTxfmSize,
     uvtx: RectTxfmSize,
-    layout: Dav1dPixelLayout,
+    layout: Rav1dPixelLayout,
     ay: &mut [u8],
     ly: &mut [u8],
     aluv: Option<(&mut [u8], &mut [u8])>,
@@ -450,7 +450,7 @@ pub unsafe fn dav1d_create_lf_mask_intra(
     );
 }
 
-pub unsafe fn dav1d_create_lf_mask_inter(
+pub unsafe fn rav1d_create_lf_mask_inter(
     lflvl: &mut Av1Filter,
     level_cache: *mut [u8; 4],
     b4_stride: ptrdiff_t,
@@ -466,7 +466,7 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     max_ytx: RectTxfmSize,
     tx_masks: &[u16; 2],
     uvtx: RectTxfmSize,
-    layout: Dav1dPixelLayout,
+    layout: Rav1dPixelLayout,
     ay: &mut [u8],
     ly: &mut [u8],
     aluv: Option<(&mut [u8], &mut [u8])>,
@@ -562,7 +562,7 @@ pub unsafe fn dav1d_create_lf_mask_inter(
     );
 }
 
-pub fn dav1d_calc_eih(lim_lut: &mut Av1FilterLUT, filter_sharpness: c_int) {
+pub fn rav1d_calc_eih(lim_lut: &mut Av1FilterLUT, filter_sharpness: c_int) {
     // set E/I/H values from loopfilter level
     let sharp = filter_sharpness as u8;
     for level in 0..64 {
@@ -587,7 +587,7 @@ fn calc_lf_value(
     base_lvl: c_int,
     lf_delta: i8,
     seg_delta: c_int,
-    mr_delta: Option<&Dav1dLoopfilterModeRefDeltas>,
+    mr_delta: Option<&Rav1dLoopfilterModeRefDeltas>,
 ) {
     let base = iclip(
         iclip(base_lvl + lf_delta as c_int, 0, 63) + seg_delta,
@@ -615,7 +615,7 @@ fn calc_lf_value_chroma(
     base_lvl: c_int,
     lf_delta: i8,
     seg_delta: c_int,
-    mr_delta: Option<&Dav1dLoopfilterModeRefDeltas>,
+    mr_delta: Option<&Rav1dLoopfilterModeRefDeltas>,
 ) {
     if base_lvl == 0 {
         *lflvl_values = Default::default();
@@ -636,8 +636,9 @@ pub fn dav1d_calc_lf_values(
         return;
     }
 
+    let mr_deltas = hdr.loopfilter.mode_ref_deltas.clone().into_rust();
     let mr_deltas = if hdr.loopfilter.mode_ref_delta_enabled != 0 {
-        Some(&hdr.loopfilter.mode_ref_deltas)
+        Some(&mr_deltas)
     } else {
         None
     };

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -3,8 +3,8 @@ use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::Dav1dRestorationType;
 use crate::include::dav1d::headers::Rav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Rav1dPixelLayout;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
 use crate::src::align::Align16;
 use crate::src::ctx::CaseSet;
 use crate::src::levels::BlockSize;
@@ -403,8 +403,8 @@ pub unsafe fn rav1d_create_lf_mask_intra(
         Some(aluv) => aluv,
     };
 
-    let ss_ver = (layout == DAV1D_PIXEL_LAYOUT_I420) as usize;
-    let ss_hor = (layout != DAV1D_PIXEL_LAYOUT_I444) as usize;
+    let ss_ver = (layout == RAV1D_PIXEL_LAYOUT_I420) as usize;
+    let ss_hor = (layout != RAV1D_PIXEL_LAYOUT_I444) as usize;
     let cbw4 = cmp::min(
         (iw + ss_hor >> ss_hor) - (bx >> ss_hor),
         (b_dim[0] + ss_hor) >> ss_hor,
@@ -515,8 +515,8 @@ pub unsafe fn rav1d_create_lf_mask_inter(
         Some(aluv) => aluv,
     };
 
-    let ss_ver = (layout == DAV1D_PIXEL_LAYOUT_I420) as usize;
-    let ss_hor = (layout != DAV1D_PIXEL_LAYOUT_I444) as usize;
+    let ss_ver = (layout == RAV1D_PIXEL_LAYOUT_I420) as usize;
+    let ss_hor = (layout != RAV1D_PIXEL_LAYOUT_I444) as usize;
     let cbw4 = cmp::min(
         (iw + ss_hor >> ss_hor) - (bx >> ss_hor),
         (b_dim[0] + ss_hor) >> ss_hor,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -636,7 +636,7 @@ pub fn dav1d_calc_lf_values(
         return;
     }
 
-    let mr_deltas = hdr.loopfilter.mode_ref_deltas.clone().into_rust();
+    let mr_deltas = hdr.loopfilter.mode_ref_deltas.clone().into();
     let mr_deltas = if hdr.loopfilter.mode_ref_delta_enabled != 0 {
         Some(&mr_deltas)
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,10 @@ use crate::include::dav1d::dav1d::Dav1dSettings;
 use crate::include::dav1d::dav1d::Rav1dEventFlags;
 use crate::include::dav1d::dav1d::Rav1dLogger;
 use crate::include::dav1d::dav1d::Rav1dSettings;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_KEY;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_ALL;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
+use crate::include::dav1d::dav1d::RAV1D_DECODEFRAMETYPE_ALL;
+use crate::include::dav1d::dav1d::RAV1D_DECODEFRAMETYPE_KEY;
+use crate::include::dav1d::dav1d::RAV1D_INLOOPFILTER_ALL;
+use crate::include::dav1d::dav1d::RAV1D_INLOOPFILTER_NONE;
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::Dav1dFrameHeader;
@@ -171,8 +171,8 @@ pub(crate) unsafe fn rav1d_default_settings(s: *mut Rav1dSettings) {
     (*s).frame_size_limit = 0 as c_int as c_uint;
     (*s).strict_std_compliance = 0 as c_int;
     (*s).output_invisible_frames = 0 as c_int;
-    (*s).inloop_filters = DAV1D_INLOOPFILTER_ALL;
-    (*s).decode_frame_type = DAV1D_DECODEFRAMETYPE_ALL;
+    (*s).inloop_filters = RAV1D_INLOOPFILTER_ALL;
+    (*s).decode_frame_type = RAV1D_DECODEFRAMETYPE_ALL;
 }
 
 #[no_mangle]
@@ -258,7 +258,7 @@ pub(crate) unsafe fn rav1d_get_frame_delay(s: *const Rav1dSettings) -> c_int {
         fprintf(
             stderr,
             b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"s->n_threads >= 0 && s->n_threads <= DAV1D_MAX_THREADS\0" as *const u8
+            b"s->n_threads >= 0 && s->n_threads <= RAV1D_MAX_THREADS\0" as *const u8
                 as *const c_char,
             (*::core::mem::transmute::<&[u8; 22], &[c_char; 22]>(b"dav1d_get_frame_delay\0"))
                 .as_ptr(),
@@ -269,7 +269,7 @@ pub(crate) unsafe fn rav1d_get_frame_delay(s: *const Rav1dSettings) -> c_int {
         fprintf(
             stderr,
             b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"s->max_frame_delay >= 0 && s->max_frame_delay <= DAV1D_MAX_FRAME_DELAY\0" as *const u8
+            b"s->max_frame_delay >= 0 && s->max_frame_delay <= RAV1D_MAX_FRAME_DELAY\0" as *const u8
                 as *const c_char,
             (*::core::mem::transmute::<&[u8; 22], &[c_char; 22]>(b"dav1d_get_frame_delay\0"))
                 .as_ptr(),
@@ -324,7 +324,7 @@ pub(crate) unsafe fn rav1d_open(c_out: *mut *mut Rav1dContext, s: *const Rav1dSe
         fprintf(
             stderr,
             b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"s->n_threads >= 0 && s->n_threads <= DAV1D_MAX_THREADS\0" as *const u8
+            b"s->n_threads >= 0 && s->n_threads <= RAV1D_MAX_THREADS\0" as *const u8
                 as *const c_char,
             (*::core::mem::transmute::<&[u8; 11], &[c_char; 11]>(b"dav1d_open\0")).as_ptr(),
         );
@@ -334,7 +334,7 @@ pub(crate) unsafe fn rav1d_open(c_out: *mut *mut Rav1dContext, s: *const Rav1dSe
         fprintf(
             stderr,
             b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"s->max_frame_delay >= 0 && s->max_frame_delay <= DAV1D_MAX_FRAME_DELAY\0" as *const u8
+            b"s->max_frame_delay >= 0 && s->max_frame_delay <= RAV1D_MAX_FRAME_DELAY\0" as *const u8
                 as *const c_char,
             (*::core::mem::transmute::<&[u8; 11], &[c_char; 11]>(b"dav1d_open\0")).as_ptr(),
         );
@@ -367,14 +367,14 @@ pub(crate) unsafe fn rav1d_open(c_out: *mut *mut Rav1dContext, s: *const Rav1dSe
         );
         return -(22 as c_int);
     }
-    if !((*s).decode_frame_type as c_uint >= DAV1D_DECODEFRAMETYPE_ALL as c_int as c_uint
-        && (*s).decode_frame_type as c_uint <= DAV1D_DECODEFRAMETYPE_KEY as c_int as c_uint)
+    if !((*s).decode_frame_type as c_uint >= RAV1D_DECODEFRAMETYPE_ALL as c_int as c_uint
+        && (*s).decode_frame_type as c_uint <= RAV1D_DECODEFRAMETYPE_KEY as c_int as c_uint)
     {
         fprintf(
             stderr,
             b"Input validation check '%s' failed in %s!\n\0" as *const u8
                 as *const c_char,
-            b"s->decode_frame_type >= DAV1D_DECODEFRAMETYPE_ALL && s->decode_frame_type <= DAV1D_DECODEFRAMETYPE_KEY\0"
+            b"s->decode_frame_type >= RAV1D_DECODEFRAMETYPE_ALL && s->decode_frame_type <= RAV1D_DECODEFRAMETYPE_KEY\0"
                 as *const u8 as *const c_char,
             (*::core::mem::transmute::<&[u8; 11], &[c_char; 11]>(b"dav1d_open\0"))
                 .as_ptr(),
@@ -676,8 +676,8 @@ pub(crate) unsafe fn rav1d_parse_sequence_header(
         },
         strict_std_compliance: 0,
         output_invisible_frames: 0,
-        inloop_filters: DAV1D_INLOOPFILTER_NONE,
-        decode_frame_type: DAV1D_DECODEFRAMETYPE_ALL,
+        inloop_filters: RAV1D_INLOOPFILTER_NONE,
+        decode_frame_type: RAV1D_DECODEFRAMETYPE_ALL,
         reserved: [0; 16],
     };
     rav1d_default_settings(&mut s);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,7 @@ pub(crate) unsafe fn rav1d_default_settings(s: *mut Rav1dSettings) {
 pub unsafe extern "C" fn dav1d_default_settings(s: *mut Dav1dSettings) {
     s.write(
         {
-            let mut s = s.read().into_rust();
+            let mut s = s.read().into();
             rav1d_default_settings(&mut s);
             s
         }
@@ -283,7 +283,7 @@ pub(crate) unsafe fn rav1d_get_frame_delay(s: *const Rav1dSettings) -> c_int {
 #[no_mangle]
 #[cold]
 pub unsafe extern "C" fn dav1d_get_frame_delay(s: *const Dav1dSettings) -> c_int {
-    rav1d_get_frame_delay(&s.read().into_rust())
+    rav1d_get_frame_delay(&s.read().into())
 }
 
 #[cold]
@@ -614,7 +614,7 @@ pub unsafe extern "C" fn dav1d_open(
     c_out: *mut *mut Dav1dContext,
     s: *const Dav1dSettings,
 ) -> c_int {
-    rav1d_open(c_out, &s.read().into_rust())
+    rav1d_open(c_out, &s.read().into())
 }
 
 unsafe extern "C" fn dummy_free(data: *const u8, user_data: *mut c_void) {
@@ -748,7 +748,7 @@ pub unsafe extern "C" fn dav1d_parse_sequence_header(
     ptr: *const u8,
     sz: usize,
 ) -> c_int {
-    let mut out_rust = out.read().into_rust();
+    let mut out_rust = out.read().into();
     let result = rav1d_parse_sequence_header(&mut out_rust, ptr, sz);
     out.write(out_rust.into_c());
     result
@@ -972,7 +972,7 @@ pub(crate) unsafe fn rav1d_send_data(c: *mut Rav1dContext, in_0: *mut Rav1dData)
 
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_send_data(c: *mut Rav1dContext, in_0: *mut Dav1dData) -> c_int {
-    let mut in_rust = in_0.read().into_rust();
+    let mut in_rust = in_0.read().into();
     let result = rav1d_send_data(c, &mut in_rust);
     in_0.write(in_rust.into_c());
     result
@@ -1019,7 +1019,7 @@ pub(crate) unsafe fn rav1d_get_picture(c: *mut Rav1dContext, out: *mut Rav1dPict
 
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_get_picture(c: *mut Dav1dContext, out: *mut Dav1dPicture) -> c_int {
-    let mut out_rust = out.read().into_rust();
+    let mut out_rust = out.read().into();
     let result = rav1d_get_picture(c, &mut out_rust);
     out.write(out_rust.into_c());
     result
@@ -1100,8 +1100,8 @@ pub unsafe extern "C" fn dav1d_apply_grain(
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,
 ) -> c_int {
-    let mut out_rust = out.read().into_rust();
-    let in_rust = in_0.read().into_rust();
+    let mut out_rust = out.read().into();
+    let in_rust = in_0.read().into();
     let result = rav1d_apply_grain(c, &mut out_rust, &in_rust);
     out.write(out_rust.into_c());
     result
@@ -1436,7 +1436,7 @@ pub unsafe extern "C" fn dav1d_get_decode_error_data_props(
     c: *mut Dav1dContext,
     out: *mut Dav1dDataProps,
 ) -> c_int {
-    let mut out_rust = out.read().into_rust();
+    let mut out_rust = out.read().into();
     let result = rav1d_get_decode_error_data_props(c, &mut out_rust);
     out.write(out_rust.into_c());
     result
@@ -1448,7 +1448,7 @@ pub(crate) unsafe fn rav1d_picture_unref(p: *mut Rav1dPicture) {
 
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_picture_unref(p: *mut Dav1dPicture) {
-    let mut p_rust = p.read().into_rust();
+    let mut p_rust = p.read().into();
     rav1d_picture_unref(&mut p_rust);
     p.write(p_rust.into_c());
 }
@@ -1459,7 +1459,7 @@ pub(crate) unsafe fn rav1d_data_create(buf: *mut Rav1dData, sz: usize) -> *mut u
 
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_data_create(buf: *mut Dav1dData, sz: usize) -> *mut u8 {
-    let mut buf_rust = buf.read().into_rust();
+    let mut buf_rust = buf.read().into();
     let result = rav1d_data_create(&mut buf_rust, sz);
     buf.write(buf_rust.into_c());
     result
@@ -1483,7 +1483,7 @@ pub unsafe extern "C" fn dav1d_data_wrap(
     free_callback: Option<unsafe extern "C" fn(*const u8, *mut c_void) -> ()>,
     user_data: *mut c_void,
 ) -> c_int {
-    let mut buf_rust = buf.read().into_rust();
+    let mut buf_rust = buf.read().into();
     let result = rav1d_data_wrap(&mut buf_rust, ptr, sz, free_callback, user_data);
     buf.write(buf_rust.into_c());
     result
@@ -1505,7 +1505,7 @@ pub unsafe extern "C" fn dav1d_data_wrap_user_data(
     free_callback: Option<unsafe extern "C" fn(*const u8, *mut c_void) -> ()>,
     cookie: *mut c_void,
 ) -> c_int {
-    let mut buf_rust = buf.read().into_rust();
+    let mut buf_rust = buf.read().into();
     let result = rav1d_data_wrap_user_data(&mut buf_rust, user_data, free_callback, cookie);
     buf.write(buf_rust.into_c());
     result
@@ -1517,7 +1517,7 @@ pub(crate) unsafe fn rav1d_data_unref(buf: *mut Rav1dData) {
 
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_data_unref(buf: *mut Dav1dData) {
-    let mut buf_rust = buf.read().into_rust();
+    let mut buf_rust = buf.read().into();
     let result = rav1d_data_unref(&mut buf_rust);
     buf.write(buf_rust.into_c());
     result
@@ -1530,7 +1530,7 @@ pub(crate) unsafe extern "C" fn rav1d_data_props_unref(props: *mut Rav1dDataProp
 
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_data_props_unref(props: *mut Dav1dDataProps) {
-    let mut props_rust = props.read().into_rust();
+    let mut props_rust = props.read().into();
     rav1d_data_props_unref(&mut props_rust);
     props.write(props_rust.into_c());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@ pub unsafe extern "C" fn dav1d_default_settings(s: *mut Dav1dSettings) {
             rav1d_default_settings(&mut s);
             s
         }
-        .into_c(),
+        .into(),
     );
 }
 
@@ -750,7 +750,7 @@ pub unsafe extern "C" fn dav1d_parse_sequence_header(
 ) -> c_int {
     let mut out_rust = out.read().into();
     let result = rav1d_parse_sequence_header(&mut out_rust, ptr, sz);
-    out.write(out_rust.into_c());
+    out.write(out_rust.into());
     result
 }
 
@@ -974,7 +974,7 @@ pub(crate) unsafe fn rav1d_send_data(c: *mut Rav1dContext, in_0: *mut Rav1dData)
 pub unsafe extern "C" fn dav1d_send_data(c: *mut Rav1dContext, in_0: *mut Dav1dData) -> c_int {
     let mut in_rust = in_0.read().into();
     let result = rav1d_send_data(c, &mut in_rust);
-    in_0.write(in_rust.into_c());
+    in_0.write(in_rust.into());
     result
 }
 
@@ -1021,7 +1021,7 @@ pub(crate) unsafe fn rav1d_get_picture(c: *mut Rav1dContext, out: *mut Rav1dPict
 pub unsafe extern "C" fn dav1d_get_picture(c: *mut Dav1dContext, out: *mut Dav1dPicture) -> c_int {
     let mut out_rust = out.read().into();
     let result = rav1d_get_picture(c, &mut out_rust);
-    out.write(out_rust.into_c());
+    out.write(out_rust.into());
     result
 }
 
@@ -1103,7 +1103,7 @@ pub unsafe extern "C" fn dav1d_apply_grain(
     let mut out_rust = out.read().into();
     let in_rust = in_0.read().into();
     let result = rav1d_apply_grain(c, &mut out_rust, &in_rust);
-    out.write(out_rust.into_c());
+    out.write(out_rust.into());
     result
 }
 
@@ -1438,7 +1438,7 @@ pub unsafe extern "C" fn dav1d_get_decode_error_data_props(
 ) -> c_int {
     let mut out_rust = out.read().into();
     let result = rav1d_get_decode_error_data_props(c, &mut out_rust);
-    out.write(out_rust.into_c());
+    out.write(out_rust.into());
     result
 }
 
@@ -1450,7 +1450,7 @@ pub(crate) unsafe fn rav1d_picture_unref(p: *mut Rav1dPicture) {
 pub unsafe extern "C" fn dav1d_picture_unref(p: *mut Dav1dPicture) {
     let mut p_rust = p.read().into();
     rav1d_picture_unref(&mut p_rust);
-    p.write(p_rust.into_c());
+    p.write(p_rust.into());
 }
 
 pub(crate) unsafe fn rav1d_data_create(buf: *mut Rav1dData, sz: usize) -> *mut u8 {
@@ -1461,7 +1461,7 @@ pub(crate) unsafe fn rav1d_data_create(buf: *mut Rav1dData, sz: usize) -> *mut u
 pub unsafe extern "C" fn dav1d_data_create(buf: *mut Dav1dData, sz: usize) -> *mut u8 {
     let mut buf_rust = buf.read().into();
     let result = rav1d_data_create(&mut buf_rust, sz);
-    buf.write(buf_rust.into_c());
+    buf.write(buf_rust.into());
     result
 }
 
@@ -1485,7 +1485,7 @@ pub unsafe extern "C" fn dav1d_data_wrap(
 ) -> c_int {
     let mut buf_rust = buf.read().into();
     let result = rav1d_data_wrap(&mut buf_rust, ptr, sz, free_callback, user_data);
-    buf.write(buf_rust.into_c());
+    buf.write(buf_rust.into());
     result
 }
 
@@ -1507,7 +1507,7 @@ pub unsafe extern "C" fn dav1d_data_wrap_user_data(
 ) -> c_int {
     let mut buf_rust = buf.read().into();
     let result = rav1d_data_wrap_user_data(&mut buf_rust, user_data, free_callback, cookie);
-    buf.write(buf_rust.into_c());
+    buf.write(buf_rust.into());
     result
 }
 
@@ -1519,7 +1519,7 @@ pub(crate) unsafe fn rav1d_data_unref(buf: *mut Rav1dData) {
 pub unsafe extern "C" fn dav1d_data_unref(buf: *mut Dav1dData) {
     let mut buf_rust = buf.read().into();
     let result = rav1d_data_unref(&mut buf_rust);
-    buf.write(buf_rust.into_c());
+    buf.write(buf_rust.into());
     result
 }
 
@@ -1532,5 +1532,5 @@ pub(crate) unsafe extern "C" fn rav1d_data_props_unref(props: *mut Rav1dDataProp
 pub unsafe extern "C" fn dav1d_data_props_unref(props: *mut Dav1dDataProps) {
     let mut props_rust = props.read().into();
     rav1d_data_props_unref(&mut props_rust);
-    props.write(props_rust.into_c());
+    props.write(props_rust.into());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,16 @@
 use crate::include::common::bitdepth::DynCoef;
 use crate::include::common::intops::iclip;
 use crate::include::dav1d::common::Dav1dDataProps;
-use crate::include::dav1d::common::Dav1dUserData;
+use crate::include::dav1d::common::Rav1dDataProps;
+use crate::include::dav1d::common::Rav1dUserData;
 use crate::include::dav1d::data::Dav1dData;
+use crate::include::dav1d::data::Rav1dData;
+use crate::include::dav1d::dav1d::Dav1dContext;
 use crate::include::dav1d::dav1d::Dav1dEventFlags;
-use crate::include::dav1d::dav1d::Dav1dLogger;
 use crate::include::dav1d::dav1d::Dav1dSettings;
+use crate::include::dav1d::dav1d::Rav1dEventFlags;
+use crate::include::dav1d::dav1d::Rav1dLogger;
+use crate::include::dav1d::dav1d::Rav1dSettings;
 use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
 use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_KEY;
 use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_ALL;
@@ -16,60 +21,62 @@ use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::picture::Dav1dPicAllocator;
+use crate::include::dav1d::headers::Rav1dSequenceHeader;
 use crate::include::dav1d::picture::Dav1dPicture;
+use crate::include::dav1d::picture::Rav1dPicAllocator;
+use crate::include::dav1d::picture::Rav1dPicture;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
-use crate::src::cdf::dav1d_cdf_thread_unref;
-use crate::src::cpu::dav1d_init_cpu;
-use crate::src::cpu::dav1d_num_logical_processors;
-use crate::src::data::dav1d_data_create_internal;
-use crate::src::data::dav1d_data_props_copy;
-use crate::src::data::dav1d_data_props_set_defaults;
-use crate::src::data::dav1d_data_props_unref_internal;
-use crate::src::data::dav1d_data_ref;
-use crate::src::data::dav1d_data_unref_internal;
-use crate::src::data::dav1d_data_wrap_internal;
-use crate::src::data::dav1d_data_wrap_user_data_internal;
-use crate::src::decode::dav1d_decode_frame_exit;
+use crate::src::cdf::rav1d_cdf_thread_unref;
+use crate::src::cpu::rav1d_init_cpu;
+use crate::src::cpu::rav1d_num_logical_processors;
+use crate::src::data::rav1d_data_create_internal;
+use crate::src::data::rav1d_data_props_copy;
+use crate::src::data::rav1d_data_props_set_defaults;
+use crate::src::data::rav1d_data_props_unref_internal;
+use crate::src::data::rav1d_data_ref;
+use crate::src::data::rav1d_data_unref_internal;
+use crate::src::data::rav1d_data_wrap_internal;
+use crate::src::data::rav1d_data_wrap_user_data_internal;
+use crate::src::decode::rav1d_decode_frame_exit;
 use crate::src::internal::CodedBlockInfo;
 use crate::src::internal::Rav1dContext;
 use crate::src::internal::Rav1dFrameContext;
 use crate::src::internal::Rav1dTask;
 use crate::src::internal::Rav1dTaskContext;
 use crate::src::internal::TaskThreadData;
-use crate::src::intra_edge::dav1d_init_mode_tree;
+use crate::src::intra_edge::rav1d_init_mode_tree;
 use crate::src::levels::Av1Block;
 use crate::src::levels::BL_128X128;
 use crate::src::levels::BL_64X64;
-use crate::src::log::dav1d_log;
-use crate::src::log::dav1d_log_default_callback;
-use crate::src::mem::dav1d_alloc_aligned;
-use crate::src::mem::dav1d_free_aligned;
-use crate::src::mem::dav1d_freep_aligned;
-use crate::src::mem::dav1d_mem_pool_end;
-use crate::src::mem::dav1d_mem_pool_init;
+use crate::src::log::rav1d_log;
+use crate::src::log::rav1d_log_default_callback;
 use crate::src::mem::freep;
-use crate::src::obu::dav1d_parse_obus;
+use crate::src::mem::rav1d_alloc_aligned;
+use crate::src::mem::rav1d_free_aligned;
+use crate::src::mem::rav1d_freep_aligned;
+use crate::src::mem::rav1d_mem_pool_end;
+use crate::src::mem::rav1d_mem_pool_init;
+use crate::src::obu::rav1d_parse_obus;
 use crate::src::picture::dav1d_default_picture_alloc;
 use crate::src::picture::dav1d_default_picture_release;
-use crate::src::picture::dav1d_picture_alloc_copy;
-use crate::src::picture::dav1d_picture_get_event_flags;
-use crate::src::picture::dav1d_picture_move_ref;
-use crate::src::picture::dav1d_picture_ref;
-use crate::src::picture::dav1d_picture_unref_internal;
-use crate::src::picture::dav1d_thread_picture_move_ref;
-use crate::src::picture::dav1d_thread_picture_ref;
-use crate::src::picture::dav1d_thread_picture_unref;
+use crate::src::picture::rav1d_picture_alloc_copy;
+use crate::src::picture::rav1d_picture_get_event_flags;
+use crate::src::picture::rav1d_picture_move_ref;
+use crate::src::picture::rav1d_picture_ref;
+use crate::src::picture::rav1d_picture_unref_internal;
+use crate::src::picture::rav1d_thread_picture_move_ref;
+use crate::src::picture::rav1d_thread_picture_ref;
+use crate::src::picture::rav1d_thread_picture_unref;
 use crate::src::picture::Rav1dThreadPicture;
 use crate::src::picture::PICTURE_FLAG_NEW_TEMPORAL_UNIT;
-use crate::src::r#ref::dav1d_ref_dec;
+use crate::src::r#ref::rav1d_ref_dec;
 use crate::src::r#ref::Rav1dRef;
-use crate::src::refmvs::dav1d_refmvs_clear;
-use crate::src::refmvs::dav1d_refmvs_dsp_init;
-use crate::src::refmvs::dav1d_refmvs_init;
-use crate::src::thread_task::dav1d_task_delayed_fg;
-use crate::src::thread_task::dav1d_worker_task;
+use crate::src::refmvs::rav1d_refmvs_clear;
+use crate::src::refmvs::rav1d_refmvs_dsp_init;
+use crate::src::refmvs::rav1d_refmvs_init;
+use crate::src::thread_task::rav1d_task_delayed_fg;
+use crate::src::thread_task::rav1d_worker_task;
 use crate::src::thread_task::FRAME_ERROR;
 use crate::stderr;
 use cfg_if::cfg_if;
@@ -104,10 +111,10 @@ use std::process::abort;
 use std::sync::Once;
 
 #[cfg(feature = "bitdepth_8")]
-use crate::src::fg_apply_tmpl_8::dav1d_apply_grain_8bpc;
+use crate::src::fg_apply_tmpl_8::rav1d_apply_grain_8bpc;
 
 #[cfg(feature = "bitdepth_16")]
-use crate::src::fg_apply_tmpl_16::dav1d_apply_grain_16bpc;
+use crate::src::fg_apply_tmpl_16::rav1d_apply_grain_16bpc;
 
 #[cfg(target_os = "linux")]
 use libc::dlsym;
@@ -126,18 +133,23 @@ extern "C" {
 
 #[cold]
 fn init_internal() {
-    dav1d_init_cpu();
+    rav1d_init_cpu();
+}
+
+pub fn rav1d_version() -> &'static str {
+    let null_termination_version = "966d63c1\0";
+    &null_termination_version[..null_termination_version.len() - 1]
 }
 
 #[no_mangle]
 #[cold]
 pub unsafe extern "C" fn dav1d_version() -> *const c_char {
-    return b"966d63c1\0" as *const u8 as *const c_char;
+    // Safety: [`rav1d_version`] has a null-terminator.
+    rav1d_version().as_ptr().cast()
 }
 
-#[no_mangle]
 #[cold]
-pub unsafe extern "C" fn dav1d_default_settings(s: *mut Dav1dSettings) {
+pub(crate) unsafe fn rav1d_default_settings(s: *mut Rav1dSettings) {
     (*s).n_threads = 0 as c_int;
     (*s).max_frame_delay = 0 as c_int;
     (*s).apply_grain = 1 as c_int;
@@ -151,7 +163,7 @@ pub unsafe extern "C" fn dav1d_default_settings(s: *mut Dav1dSettings) {
     );
     (*s).logger.cookie = 0 as *mut c_void;
     (*s).logger.callback = Some(
-        dav1d_log_default_callback
+        rav1d_log_default_callback
             as unsafe extern "C" fn(*mut c_void, *const c_char, ::core::ffi::VaList) -> (),
     );
     (*s).operating_point = 0 as c_int;
@@ -161,6 +173,19 @@ pub unsafe extern "C" fn dav1d_default_settings(s: *mut Dav1dSettings) {
     (*s).output_invisible_frames = 0 as c_int;
     (*s).inloop_filters = DAV1D_INLOOPFILTER_ALL;
     (*s).decode_frame_type = DAV1D_DECODEFRAMETYPE_ALL;
+}
+
+#[no_mangle]
+#[cold]
+pub unsafe extern "C" fn dav1d_default_settings(s: *mut Dav1dSettings) {
+    s.write(
+        {
+            let mut s = s.read().into_rust();
+            rav1d_default_settings(&mut s);
+            s
+        }
+        .into_c(),
+    );
 }
 
 #[cold]
@@ -191,7 +216,7 @@ unsafe extern "C" fn get_stack_size_internal(_thread_attr: *const pthread_attr_t
 #[cold]
 unsafe extern "C" fn get_num_threads(
     c: *mut Rav1dContext,
-    s: *const Dav1dSettings,
+    s: *const Rav1dSettings,
     n_tc: *mut c_uint,
     n_fc: *mut c_uint,
 ) {
@@ -202,7 +227,7 @@ unsafe extern "C" fn get_num_threads(
     *n_tc = (if (*s).n_threads != 0 {
         (*s).n_threads
     } else {
-        iclip(dav1d_num_logical_processors(c), 1 as c_int, 256 as c_int)
+        iclip(rav1d_num_logical_processors(c), 1 as c_int, 256 as c_int)
     }) as c_uint;
     *n_fc = if (*s).max_frame_delay != 0 {
         cmp::min((*s).max_frame_delay as c_uint, *n_tc)
@@ -215,9 +240,8 @@ unsafe extern "C" fn get_num_threads(
     };
 }
 
-#[no_mangle]
 #[cold]
-pub unsafe extern "C" fn dav1d_get_frame_delay(s: *const Dav1dSettings) -> c_int {
+pub(crate) unsafe fn rav1d_get_frame_delay(s: *const Rav1dSettings) -> c_int {
     let mut n_tc: c_uint = 0;
     let mut n_fc: c_uint = 0;
     if s.is_null() {
@@ -258,10 +282,12 @@ pub unsafe extern "C" fn dav1d_get_frame_delay(s: *const Dav1dSettings) -> c_int
 
 #[no_mangle]
 #[cold]
-pub unsafe extern "C" fn dav1d_open(
-    c_out: *mut *mut Rav1dContext,
-    s: *const Dav1dSettings,
-) -> c_int {
+pub unsafe extern "C" fn dav1d_get_frame_delay(s: *const Dav1dSettings) -> c_int {
+    rav1d_get_frame_delay(&s.read().into_rust())
+}
+
+#[cold]
+pub(crate) unsafe fn rav1d_open(c_out: *mut *mut Rav1dContext, s: *const Rav1dSettings) -> c_int {
     unsafe extern "C" fn error(
         c: *mut Rav1dContext,
         c_out: *mut *mut Rav1dContext,
@@ -361,7 +387,7 @@ pub unsafe extern "C" fn dav1d_open(
     }
     let stack_size: usize = 1024 * 1024 * get_stack_size_internal(&mut thread_attr);
     pthread_attr_setstacksize(&mut thread_attr, stack_size);
-    *c_out = dav1d_alloc_aligned(::core::mem::size_of::<Rav1dContext>(), 64) as *mut Rav1dContext;
+    *c_out = rav1d_alloc_aligned(::core::mem::size_of::<Rav1dContext>(), 64) as *mut Rav1dContext;
     let c: *mut Rav1dContext = *c_out;
     if c.is_null() {
         return error(c, c_out, &mut thread_attr);
@@ -381,12 +407,12 @@ pub unsafe extern "C" fn dav1d_open(
     (*c).output_invisible_frames = (*s).output_invisible_frames;
     (*c).inloop_filters = (*s).inloop_filters;
     (*c).decode_frame_type = (*s).decode_frame_type;
-    dav1d_data_props_set_defaults(&mut (*c).cached_error_props);
-    if dav1d_mem_pool_init(&mut (*c).seq_hdr_pool) != 0
-        || dav1d_mem_pool_init(&mut (*c).frame_hdr_pool) != 0
-        || dav1d_mem_pool_init(&mut (*c).segmap_pool) != 0
-        || dav1d_mem_pool_init(&mut (*c).refmvs_pool) != 0
-        || dav1d_mem_pool_init(&mut (*c).cdf_pool) != 0
+    rav1d_data_props_set_defaults(&mut (*c).cached_error_props);
+    if rav1d_mem_pool_init(&mut (*c).seq_hdr_pool) != 0
+        || rav1d_mem_pool_init(&mut (*c).frame_hdr_pool) != 0
+        || rav1d_mem_pool_init(&mut (*c).segmap_pool) != 0
+        || rav1d_mem_pool_init(&mut (*c).refmvs_pool) != 0
+        || rav1d_mem_pool_init(&mut (*c).cdf_pool) != 0
     {
         return error(c, c_out, &mut thread_attr);
     }
@@ -404,7 +430,7 @@ pub unsafe extern "C" fn dav1d_open(
         if !((*c).allocator.cookie).is_null() {
             return error(c, c_out, &mut thread_attr);
         }
-        if dav1d_mem_pool_init(&mut (*c).picture_pool) != 0 {
+        if rav1d_mem_pool_init(&mut (*c).picture_pool) != 0 {
             return error(c, c_out, &mut thread_attr);
         }
         (*c).allocator.cookie = (*c).picture_pool as *mut c_void;
@@ -426,7 +452,7 @@ pub unsafe extern "C" fn dav1d_open(
     {
         (*c).frame_size_limit = (8192 * 8192) as c_uint;
         if (*s).frame_size_limit != 0 {
-            dav1d_log(
+            rav1d_log(
                 c,
                 b"Frame size limit reduced from %u to %u.\n\0" as *const u8 as *const c_char,
                 (*s).frame_size_limit,
@@ -437,7 +463,7 @@ pub unsafe extern "C" fn dav1d_open(
     (*c).flush = &mut (*c).flush_mem;
     *(*c).flush = 0 as c_int;
     get_num_threads(c, s, &mut (*c).n_tc, &mut (*c).n_fc);
-    (*c).fc = dav1d_alloc_aligned(
+    (*c).fc = rav1d_alloc_aligned(
         ::core::mem::size_of::<Rav1dFrameContext>().wrapping_mul((*c).n_fc as usize),
         32 as c_int as usize,
     ) as *mut Rav1dFrameContext;
@@ -449,7 +475,7 @@ pub unsafe extern "C" fn dav1d_open(
         0 as c_int,
         ::core::mem::size_of::<Rav1dFrameContext>().wrapping_mul((*c).n_fc as usize),
     );
-    (*c).tc = dav1d_alloc_aligned(
+    (*c).tc = rav1d_alloc_aligned(
         ::core::mem::size_of::<Rav1dTaskContext>().wrapping_mul((*c).n_tc as usize),
         64 as c_int as usize,
     ) as *mut Rav1dTaskContext;
@@ -518,7 +544,7 @@ pub unsafe extern "C" fn dav1d_open(
         (*f).c = c;
         (*f).task_thread.ttd = &mut (*c).task_thread;
         (*f).lf.last_sharpness = -(1 as c_int);
-        dav1d_refmvs_init(&mut (*f).rf);
+        rav1d_refmvs_init(&mut (*f).rf);
         n = n.wrapping_add(1);
     }
     let mut m: c_uint = 0 as c_int as c_uint;
@@ -551,7 +577,7 @@ pub unsafe extern "C" fn dav1d_open(
             if pthread_create(
                 &mut (*t).task_thread.td.thread,
                 &mut thread_attr,
-                Some(dav1d_worker_task as unsafe extern "C" fn(*mut c_void) -> *mut c_void),
+                Some(rav1d_worker_task as unsafe extern "C" fn(*mut c_void) -> *mut c_void),
                 t as *mut c_void,
             ) != 0
             {
@@ -563,17 +589,17 @@ pub unsafe extern "C" fn dav1d_open(
         }
         m = m.wrapping_add(1);
     }
-    dav1d_refmvs_dsp_init(&mut (*c).refmvs_dsp);
+    rav1d_refmvs_dsp_init(&mut (*c).refmvs_dsp);
     (*c).intra_edge.root[BL_128X128 as c_int as usize] =
         &mut (*((*c).intra_edge.branch_sb128).as_mut_ptr().offset(0)).node;
-    dav1d_init_mode_tree(
+    rav1d_init_mode_tree(
         (*c).intra_edge.root[BL_128X128 as c_int as usize],
         &mut (*c).intra_edge.tip_sb128,
         true,
     );
     (*c).intra_edge.root[BL_64X64 as c_int as usize] =
         &mut (*((*c).intra_edge.branch_sb64).as_mut_ptr().offset(0)).node;
-    dav1d_init_mode_tree(
+    rav1d_init_mode_tree(
         (*c).intra_edge.root[BL_64X64 as c_int as usize],
         &mut (*c).intra_edge.tip_sb64,
         false,
@@ -582,30 +608,38 @@ pub unsafe extern "C" fn dav1d_open(
     return 0 as c_int;
 }
 
+#[no_mangle]
+#[cold]
+pub unsafe extern "C" fn dav1d_open(
+    c_out: *mut *mut Dav1dContext,
+    s: *const Dav1dSettings,
+) -> c_int {
+    rav1d_open(c_out, &s.read().into_rust())
+}
+
 unsafe extern "C" fn dummy_free(data: *const u8, user_data: *mut c_void) {
     if !(!data.is_null() && user_data.is_null()) {
         unreachable!();
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_parse_sequence_header(
-    out: *mut Dav1dSequenceHeader,
+pub(crate) unsafe fn rav1d_parse_sequence_header(
+    out: *mut Rav1dSequenceHeader,
     ptr: *const u8,
     sz: usize,
 ) -> c_int {
     let mut current_block: u64;
-    let mut buf: Dav1dData = {
-        let init = Dav1dData {
+    let mut buf: Rav1dData = {
+        let init = Rav1dData {
             data: 0 as *const u8,
             sz: 0,
             r#ref: 0 as *mut Rav1dRef,
-            m: Dav1dDataProps {
+            m: Rav1dDataProps {
                 timestamp: 0,
                 duration: 0,
                 offset: 0,
                 size: 0,
-                user_data: Dav1dUserData {
+                user_data: Rav1dUserData {
                     data: 0 as *const u8,
                     r#ref: 0 as *mut Rav1dRef,
                 },
@@ -624,19 +658,19 @@ pub unsafe extern "C" fn dav1d_parse_sequence_header(
         );
         return -(22 as c_int);
     }
-    let mut s: Dav1dSettings = Dav1dSettings {
+    let mut s: Rav1dSettings = Rav1dSettings {
         n_threads: 0,
         max_frame_delay: 0,
         apply_grain: 0,
         operating_point: 0,
         all_layers: 0,
         frame_size_limit: 0,
-        allocator: Dav1dPicAllocator {
+        allocator: Rav1dPicAllocator {
             cookie: 0 as *mut c_void,
             alloc_picture_callback: None,
             release_picture_callback: None,
         },
-        logger: Dav1dLogger {
+        logger: Rav1dLogger {
             cookie: 0 as *mut c_void,
             callback: None,
         },
@@ -646,16 +680,16 @@ pub unsafe extern "C" fn dav1d_parse_sequence_header(
         decode_frame_type: DAV1D_DECODEFRAMETYPE_ALL,
         reserved: [0; 16],
     };
-    dav1d_default_settings(&mut s);
+    rav1d_default_settings(&mut s);
     s.n_threads = 1 as c_int;
     s.logger.callback = None;
     let mut c: *mut Rav1dContext = 0 as *mut Rav1dContext;
-    res = dav1d_open(&mut c, &mut s);
+    res = rav1d_open(&mut c, &mut s);
     if res < 0 {
         return res;
     }
     if !ptr.is_null() {
-        res = dav1d_data_wrap_internal(
+        res = rav1d_data_wrap_internal(
             &mut buf,
             ptr,
             sz,
@@ -673,12 +707,12 @@ pub unsafe extern "C" fn dav1d_parse_sequence_header(
     loop {
         match current_block {
             10647346020414903899 => {
-                dav1d_data_unref_internal(&mut buf);
+                rav1d_data_unref_internal(&mut buf);
                 break;
             }
             _ => {
                 if buf.sz > 0 {
-                    res = dav1d_parse_obus(c, &mut buf, 1 as c_int);
+                    res = rav1d_parse_obus(c, &mut buf, 1 as c_int);
                     if res < 0 {
                         current_block = 10647346020414903899;
                         continue;
@@ -704,11 +738,23 @@ pub unsafe extern "C" fn dav1d_parse_sequence_header(
             }
         }
     }
-    dav1d_close(&mut c);
+    rav1d_close(&mut c);
     return res;
 }
 
-unsafe extern "C" fn has_grain(pic: *const Dav1dPicture) -> c_int {
+#[no_mangle]
+pub unsafe extern "C" fn dav1d_parse_sequence_header(
+    out: *mut Dav1dSequenceHeader,
+    ptr: *const u8,
+    sz: usize,
+) -> c_int {
+    let mut out_rust = out.read().into_rust();
+    let result = rav1d_parse_sequence_header(&mut out_rust, ptr, sz);
+    out.write(out_rust.into_c());
+    result
+}
+
+unsafe extern "C" fn has_grain(pic: *const Rav1dPicture) -> c_int {
     let fgdata: *const Dav1dFilmGrainData = &mut (*(*pic).frame_hdr).film_grain.data;
     return ((*fgdata).num_y_points != 0
         || (*fgdata).num_uv_points[0] != 0
@@ -717,7 +763,7 @@ unsafe extern "C" fn has_grain(pic: *const Dav1dPicture) -> c_int {
         as c_int;
 }
 
-unsafe extern "C" fn output_image(c: *mut Rav1dContext, out: *mut Dav1dPicture) -> c_int {
+unsafe extern "C" fn output_image(c: *mut Rav1dContext, out: *mut Rav1dPicture) -> c_int {
     let mut res = 0;
     let in_0: *mut Rav1dThreadPicture = if (*c).all_layers != 0 || (*c).max_spatial_id == 0 {
         &mut (*c).out
@@ -725,14 +771,14 @@ unsafe extern "C" fn output_image(c: *mut Rav1dContext, out: *mut Dav1dPicture) 
         &mut (*c).cache
     };
     if (*c).apply_grain == 0 || has_grain(&mut (*in_0).p) == 0 {
-        dav1d_picture_move_ref(out, &mut (*in_0).p);
-        dav1d_thread_picture_unref(in_0);
+        rav1d_picture_move_ref(out, &mut (*in_0).p);
+        rav1d_thread_picture_unref(in_0);
     } else {
-        res = dav1d_apply_grain(c, out, &mut (*in_0).p);
-        dav1d_thread_picture_unref(in_0);
+        res = rav1d_apply_grain(c, out, &mut (*in_0).p);
+        rav1d_thread_picture_unref(in_0);
     }
     if (*c).all_layers == 0 && (*c).max_spatial_id != 0 && !((*c).out.p.data[0]).is_null() {
-        dav1d_thread_picture_move_ref(in_0, &mut (*c).out);
+        rav1d_thread_picture_move_ref(in_0, &mut (*c).out);
     }
     return res;
 }
@@ -748,15 +794,15 @@ unsafe extern "C" fn output_picture_ready(c: *mut Rav1dContext, drain: c_int) ->
             {
                 return 1 as c_int;
             }
-            dav1d_thread_picture_unref(&mut (*c).cache);
-            dav1d_thread_picture_move_ref(&mut (*c).cache, &mut (*c).out);
+            rav1d_thread_picture_unref(&mut (*c).cache);
+            rav1d_thread_picture_move_ref(&mut (*c).cache, &mut (*c).out);
             return 0 as c_int;
         } else {
             if !((*c).cache.p.data[0]).is_null() && drain != 0 {
                 return 1 as c_int;
             } else {
                 if !((*c).out.p.data[0]).is_null() {
-                    dav1d_thread_picture_move_ref(&mut (*c).cache, &mut (*c).out);
+                    rav1d_thread_picture_move_ref(&mut (*c).cache, &mut (*c).out);
                     return 0 as c_int;
                 }
             }
@@ -765,7 +811,7 @@ unsafe extern "C" fn output_picture_ready(c: *mut Rav1dContext, drain: c_int) ->
     return !((*c).out.p.data[0]).is_null() as c_int;
 }
 
-unsafe extern "C" fn drain_picture(c: *mut Rav1dContext, out: *mut Dav1dPicture) -> c_int {
+unsafe extern "C" fn drain_picture(c: *mut Rav1dContext, out: *mut Rav1dPicture) -> c_int {
     let mut drain_count: c_uint = 0 as c_int as c_uint;
     let mut drained = 0;
     loop {
@@ -819,8 +865,8 @@ unsafe extern "C" fn drain_picture(c: *mut Rav1dContext, out: *mut Dav1dPicture)
         let error = (*f).task_thread.retval;
         if error != 0 {
             (*f).task_thread.retval = 0 as c_int;
-            dav1d_data_props_copy(&mut (*c).cached_error_props, &mut (*out_delayed).p.m);
-            dav1d_thread_picture_unref(out_delayed);
+            rav1d_data_props_copy(&mut (*c).cached_error_props, &mut (*out_delayed).p.m);
+            rav1d_thread_picture_unref(out_delayed);
             return error;
         }
         if !((*out_delayed).p.data[0]).is_null() {
@@ -830,13 +876,13 @@ unsafe extern "C" fn drain_picture(c: *mut Rav1dContext, out: *mut Dav1dPicture)
             if ((*out_delayed).visible || (*c).output_invisible_frames != 0)
                 && progress != FRAME_ERROR
             {
-                dav1d_thread_picture_ref(&mut (*c).out, out_delayed);
+                rav1d_thread_picture_ref(&mut (*c).out, out_delayed);
                 (*c).event_flags = ::core::mem::transmute::<c_uint, Dav1dEventFlags>(
                     (*c).event_flags as c_uint
-                        | dav1d_picture_get_event_flags(out_delayed) as c_uint,
+                        | rav1d_picture_get_event_flags(out_delayed) as c_uint,
                 );
             }
-            dav1d_thread_picture_unref(out_delayed);
+            rav1d_thread_picture_unref(out_delayed);
             if output_picture_ready(c, 0 as c_int) != 0 {
                 return output_image(c, out);
             }
@@ -854,14 +900,14 @@ unsafe extern "C" fn drain_picture(c: *mut Rav1dContext, out: *mut Dav1dPicture)
 
 unsafe extern "C" fn gen_picture(c: *mut Rav1dContext) -> c_int {
     let mut res;
-    let in_0: *mut Dav1dData = &mut (*c).in_0;
+    let in_0: *mut Rav1dData = &mut (*c).in_0;
     if output_picture_ready(c, 0 as c_int) != 0 {
         return 0 as c_int;
     }
     while (*in_0).sz > 0 {
-        res = dav1d_parse_obus(c, in_0, 0 as c_int);
+        res = rav1d_parse_obus(c, in_0, 0 as c_int);
         if res < 0 {
-            dav1d_data_unref_internal(in_0);
+            rav1d_data_unref_internal(in_0);
         } else {
             if !(res as usize <= (*in_0).sz) {
                 unreachable!();
@@ -869,7 +915,7 @@ unsafe extern "C" fn gen_picture(c: *mut Rav1dContext) -> c_int {
             (*in_0).sz = ((*in_0).sz as c_ulong).wrapping_sub(res as c_ulong) as usize as usize;
             (*in_0).data = ((*in_0).data).offset(res as isize);
             if (*in_0).sz == 0 {
-                dav1d_data_unref_internal(in_0);
+                rav1d_data_unref_internal(in_0);
             }
         }
         if output_picture_ready(c, 0 as c_int) != 0 {
@@ -882,8 +928,7 @@ unsafe extern "C" fn gen_picture(c: *mut Rav1dContext) -> c_int {
     return 0 as c_int;
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_send_data(c: *mut Rav1dContext, in_0: *mut Dav1dData) -> c_int {
+pub(crate) unsafe fn rav1d_send_data(c: *mut Rav1dContext, in_0: *mut Rav1dData) -> c_int {
     if c.is_null() {
         fprintf(
             stderr,
@@ -917,16 +962,23 @@ pub unsafe extern "C" fn dav1d_send_data(c: *mut Rav1dContext, in_0: *mut Dav1dD
     if !((*c).in_0.data).is_null() {
         return -(11 as c_int);
     }
-    dav1d_data_ref(&mut (*c).in_0, in_0);
+    rav1d_data_ref(&mut (*c).in_0, in_0);
     let res = gen_picture(c);
     if res == 0 {
-        dav1d_data_unref_internal(in_0);
+        rav1d_data_unref_internal(in_0);
     }
     return res;
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dav1d_get_picture(c: *mut Rav1dContext, out: *mut Dav1dPicture) -> c_int {
+pub unsafe extern "C" fn dav1d_send_data(c: *mut Rav1dContext, in_0: *mut Dav1dData) -> c_int {
+    let mut in_rust = in_0.read().into_rust();
+    let result = rav1d_send_data(c, &mut in_rust);
+    in_0.write(in_rust.into_c());
+    result
+}
+
+pub(crate) unsafe fn rav1d_get_picture(c: *mut Rav1dContext, out: *mut Rav1dPicture) -> c_int {
     if c.is_null() {
         fprintf(
             stderr,
@@ -966,17 +1018,24 @@ pub unsafe extern "C" fn dav1d_get_picture(c: *mut Rav1dContext, out: *mut Dav1d
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dav1d_apply_grain(
+pub unsafe extern "C" fn dav1d_get_picture(c: *mut Dav1dContext, out: *mut Dav1dPicture) -> c_int {
+    let mut out_rust = out.read().into_rust();
+    let result = rav1d_get_picture(c, &mut out_rust);
+    out.write(out_rust.into_c());
+    result
+}
+
+pub(crate) unsafe fn rav1d_apply_grain(
     c: *mut Rav1dContext,
-    out: *mut Dav1dPicture,
-    in_0: *const Dav1dPicture,
+    out: *mut Rav1dPicture,
+    in_0: *const Rav1dPicture,
 ) -> c_int {
     if c.is_null() {
         fprintf(
             stderr,
             b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
             b"c != NULL\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 18], &[c_char; 18]>(b"dav1d_apply_grain\0")).as_ptr(),
+            (*::core::mem::transmute::<&[u8; 18], &[c_char; 18]>(b"rav1d_apply_grain\0")).as_ptr(),
         );
         return -(22 as c_int);
     }
@@ -985,7 +1044,7 @@ pub unsafe extern "C" fn dav1d_apply_grain(
             stderr,
             b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
             b"out != NULL\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 18], &[c_char; 18]>(b"dav1d_apply_grain\0")).as_ptr(),
+            (*::core::mem::transmute::<&[u8; 18], &[c_char; 18]>(b"rav1d_apply_grain\0")).as_ptr(),
         );
         return -(22 as c_int);
     }
@@ -994,30 +1053,30 @@ pub unsafe extern "C" fn dav1d_apply_grain(
             stderr,
             b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
             b"in != NULL\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 18], &[c_char; 18]>(b"dav1d_apply_grain\0")).as_ptr(),
+            (*::core::mem::transmute::<&[u8; 18], &[c_char; 18]>(b"rav1d_apply_grain\0")).as_ptr(),
         );
         return -(22 as c_int);
     }
     if has_grain(in_0) == 0 {
-        dav1d_picture_ref(out, in_0);
+        rav1d_picture_ref(out, in_0);
         return 0 as c_int;
     }
-    let res = dav1d_picture_alloc_copy(c, out, (*in_0).p.w, in_0);
+    let res = rav1d_picture_alloc_copy(c, out, (*in_0).p.w, in_0);
     if res < 0 {
-        dav1d_picture_unref_internal(out);
+        rav1d_picture_unref_internal(out);
         return res;
     } else {
         if (*c).n_tc > 1 as c_uint {
-            dav1d_task_delayed_fg(c, out, in_0);
+            rav1d_task_delayed_fg(c, out, in_0);
         } else {
             match (*out).p.bpc {
                 #[cfg(feature = "bitdepth_8")]
                 8 => {
-                    dav1d_apply_grain_8bpc(&mut (*((*c).dsp).as_mut_ptr().offset(0)).fg, out, in_0);
+                    rav1d_apply_grain_8bpc(&mut (*((*c).dsp).as_mut_ptr().offset(0)).fg, out, in_0);
                 }
                 #[cfg(feature = "bitdepth_16")]
                 10 | 12 => {
-                    dav1d_apply_grain_16bpc(
+                    rav1d_apply_grain_16bpc(
                         &mut (*((*c).dsp)
                             .as_mut_ptr()
                             .offset((((*out).p.bpc >> 1) - 4) as isize))
@@ -1036,36 +1095,48 @@ pub unsafe extern "C" fn dav1d_apply_grain(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dav1d_flush(c: *mut Rav1dContext) {
-    dav1d_data_unref_internal(&mut (*c).in_0);
+pub unsafe extern "C" fn dav1d_apply_grain(
+    c: *mut Dav1dContext,
+    out: *mut Dav1dPicture,
+    in_0: *const Dav1dPicture,
+) -> c_int {
+    let mut out_rust = out.read().into_rust();
+    let in_rust = in_0.read().into_rust();
+    let result = rav1d_apply_grain(c, &mut out_rust, &in_rust);
+    out.write(out_rust.into_c());
+    result
+}
+
+pub(crate) unsafe fn rav1d_flush(c: *mut Rav1dContext) {
+    rav1d_data_unref_internal(&mut (*c).in_0);
     if !((*c).out.p.frame_hdr).is_null() {
-        dav1d_thread_picture_unref(&mut (*c).out);
+        rav1d_thread_picture_unref(&mut (*c).out);
     }
     if !((*c).cache.p.frame_hdr).is_null() {
-        dav1d_thread_picture_unref(&mut (*c).cache);
+        rav1d_thread_picture_unref(&mut (*c).cache);
     }
     (*c).drain = 0 as c_int;
     (*c).cached_error = 0 as c_int;
     let mut i = 0;
     while i < 8 {
         if !((*c).refs[i as usize].p.p.frame_hdr).is_null() {
-            dav1d_thread_picture_unref(&mut (*((*c).refs).as_mut_ptr().offset(i as isize)).p);
+            rav1d_thread_picture_unref(&mut (*((*c).refs).as_mut_ptr().offset(i as isize)).p);
         }
-        dav1d_ref_dec(&mut (*((*c).refs).as_mut_ptr().offset(i as isize)).segmap);
-        dav1d_ref_dec(&mut (*((*c).refs).as_mut_ptr().offset(i as isize)).refmvs);
-        dav1d_cdf_thread_unref(&mut *((*c).cdf).as_mut_ptr().offset(i as isize));
+        rav1d_ref_dec(&mut (*((*c).refs).as_mut_ptr().offset(i as isize)).segmap);
+        rav1d_ref_dec(&mut (*((*c).refs).as_mut_ptr().offset(i as isize)).refmvs);
+        rav1d_cdf_thread_unref(&mut *((*c).cdf).as_mut_ptr().offset(i as isize));
         i += 1;
     }
     (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
     (*c).seq_hdr = 0 as *mut Dav1dSequenceHeader;
-    dav1d_ref_dec(&mut (*c).seq_hdr_ref);
+    rav1d_ref_dec(&mut (*c).seq_hdr_ref);
     (*c).mastering_display = 0 as *mut Dav1dMasteringDisplay;
     (*c).content_light = 0 as *mut Dav1dContentLightLevel;
     (*c).itut_t35 = 0 as *mut Dav1dITUTT35;
-    dav1d_ref_dec(&mut (*c).mastering_display_ref);
-    dav1d_ref_dec(&mut (*c).content_light_ref);
-    dav1d_ref_dec(&mut (*c).itut_t35_ref);
-    dav1d_data_props_unref_internal(&mut (*c).cached_error_props);
+    rav1d_ref_dec(&mut (*c).mastering_display_ref);
+    rav1d_ref_dec(&mut (*c).content_light_ref);
+    rav1d_ref_dec(&mut (*c).itut_t35_ref);
+    rav1d_data_props_unref_internal(&mut (*c).cached_error_props);
     if (*c).n_fc == 1 as c_uint && (*c).n_tc == 1 as c_uint {
         return;
     }
@@ -1120,14 +1191,14 @@ pub unsafe extern "C" fn dav1d_flush(c: *mut Rav1dContext) {
             }
             let f: *mut Rav1dFrameContext =
                 &mut *((*c).fc).offset(next as isize) as *mut Rav1dFrameContext;
-            dav1d_decode_frame_exit(&mut *f, -(1 as c_int));
+            rav1d_decode_frame_exit(&mut *f, -(1 as c_int));
             (*f).n_tile_data = 0 as c_int;
             (*f).task_thread.retval = 0 as c_int;
             let out_delayed: *mut Rav1dThreadPicture = &mut *((*c).frame_thread.out_delayed)
                 .offset(next as isize)
                 as *mut Rav1dThreadPicture;
             if !((*out_delayed).p.frame_hdr).is_null() {
-                dav1d_thread_picture_unref(out_delayed);
+                rav1d_thread_picture_unref(out_delayed);
             }
             n = n.wrapping_add(1);
             next = next.wrapping_add(1);
@@ -1138,8 +1209,12 @@ pub unsafe extern "C" fn dav1d_flush(c: *mut Rav1dContext) {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dav1d_flush(c: *mut Dav1dContext) {
+    rav1d_flush(c)
+}
+
 #[cold]
-pub unsafe extern "C" fn dav1d_close(c_out: *mut *mut Rav1dContext) {
+pub(crate) unsafe fn rav1d_close(c_out: *mut *mut Rav1dContext) {
     if c_out.is_null() {
         fprintf(
             stderr,
@@ -1152,6 +1227,12 @@ pub unsafe extern "C" fn dav1d_close(c_out: *mut *mut Rav1dContext) {
     close_internal(c_out, 1 as c_int);
 }
 
+#[no_mangle]
+#[cold]
+pub unsafe extern "C" fn dav1d_close(c_out: *mut *mut Dav1dContext) {
+    rav1d_close(c_out)
+}
+
 #[cold]
 unsafe extern "C" fn close_internal(c_out: *mut *mut Rav1dContext, flush: c_int) {
     let c: *mut Rav1dContext = *c_out;
@@ -1159,7 +1240,7 @@ unsafe extern "C" fn close_internal(c_out: *mut *mut Rav1dContext, flush: c_int)
         return;
     }
     if flush != 0 {
-        dav1d_flush(c);
+        rav1d_flush(c);
     }
     if !((*c).tc).is_null() {
         let ttd: *mut TaskThreadData = &mut (*c).task_thread;
@@ -1188,7 +1269,7 @@ unsafe extern "C" fn close_internal(c_out: *mut *mut Rav1dContext, flush: c_int)
             pthread_cond_destroy(&mut (*ttd).cond);
             pthread_mutex_destroy(&mut (*ttd).lock);
         }
-        dav1d_free_aligned((*c).tc as *mut c_void);
+        rav1d_free_aligned((*c).tc as *mut c_void);
     }
     let mut n_1: c_uint = 0 as c_int as c_uint;
     while !((*c).fc).is_null() && n_1 < (*c).n_fc {
@@ -1199,10 +1280,10 @@ unsafe extern "C" fn close_internal(c_out: *mut *mut Rav1dContext, flush: c_int)
                 &mut (*f).tile_thread.lowest_pixel_mem as *mut *mut [[c_int; 2]; 7] as *mut c_void,
             );
             freep(&mut (*f).frame_thread.b as *mut *mut Av1Block as *mut c_void);
-            dav1d_freep_aligned(&mut (*f).frame_thread.pal_idx as *mut *mut u8 as *mut c_void);
-            dav1d_freep_aligned(&mut (*f).frame_thread.cf as *mut *mut DynCoef as *mut c_void);
+            rav1d_freep_aligned(&mut (*f).frame_thread.pal_idx as *mut *mut u8 as *mut c_void);
+            rav1d_freep_aligned(&mut (*f).frame_thread.cf as *mut *mut DynCoef as *mut c_void);
             freep(&mut (*f).frame_thread.tile_start_off as *mut *mut c_int as *mut c_void);
-            dav1d_freep_aligned(
+            rav1d_freep_aligned(
                 &mut (*f).frame_thread.pal as *mut *mut [[u16; 8]; 3] as *mut c_void,
             );
             freep(&mut (*f).frame_thread.cbi as *mut *mut CodedBlockInfo as *mut c_void);
@@ -1218,8 +1299,8 @@ unsafe extern "C" fn close_internal(c_out: *mut *mut Rav1dContext, flush: c_int)
             &mut *((*f).task_thread.tile_tasks).as_mut_ptr().offset(0) as *mut *mut Rav1dTask
                 as *mut c_void,
         );
-        dav1d_free_aligned((*f).ts as *mut c_void);
-        dav1d_free_aligned((*f).ipred_edge[0] as *mut c_void);
+        rav1d_free_aligned((*f).ts as *mut c_void);
+        rav1d_free_aligned((*f).ipred_edge[0] as *mut c_void);
         free((*f).a as *mut c_void);
         free((*f).tile as *mut c_void);
         free((*f).lf.mask as *mut c_void);
@@ -1227,12 +1308,12 @@ unsafe extern "C" fn close_internal(c_out: *mut *mut Rav1dContext, flush: c_int)
         free((*f).lf.level as *mut c_void);
         free((*f).lf.tx_lpf_right_edge[0] as *mut c_void);
         free((*f).lf.start_of_tile_row as *mut c_void);
-        dav1d_refmvs_clear(&mut (*f).rf);
-        dav1d_free_aligned((*f).lf.cdef_line_buf as *mut c_void);
-        dav1d_free_aligned((*f).lf.lr_line_buf as *mut c_void);
+        rav1d_refmvs_clear(&mut (*f).rf);
+        rav1d_free_aligned((*f).lf.cdef_line_buf as *mut c_void);
+        rav1d_free_aligned((*f).lf.lr_line_buf as *mut c_void);
         n_1 = n_1.wrapping_add(1);
     }
-    dav1d_free_aligned((*c).fc as *mut c_void);
+    rav1d_free_aligned((*c).fc as *mut c_void);
     if (*c).n_fc > 1 as c_uint && !((*c).frame_thread.out_delayed).is_null() {
         let mut n_2: c_uint = 0 as c_int as c_uint;
         while n_2 < (*c).n_fc {
@@ -1241,7 +1322,7 @@ unsafe extern "C" fn close_internal(c_out: *mut *mut Rav1dContext, flush: c_int)
                 .frame_hdr)
                 .is_null()
             {
-                dav1d_thread_picture_unref(
+                rav1d_thread_picture_unref(
                     &mut *((*c).frame_thread.out_delayed).offset(n_2 as isize),
                 );
             }
@@ -1251,38 +1332,37 @@ unsafe extern "C" fn close_internal(c_out: *mut *mut Rav1dContext, flush: c_int)
     }
     let mut n_3 = 0;
     while n_3 < (*c).n_tile_data {
-        dav1d_data_unref_internal(&mut (*((*c).tile).offset(n_3 as isize)).data);
+        rav1d_data_unref_internal(&mut (*((*c).tile).offset(n_3 as isize)).data);
         n_3 += 1;
     }
     free((*c).tile as *mut c_void);
     let mut n_4 = 0;
     while n_4 < 8 {
-        dav1d_cdf_thread_unref(&mut *((*c).cdf).as_mut_ptr().offset(n_4 as isize));
+        rav1d_cdf_thread_unref(&mut *((*c).cdf).as_mut_ptr().offset(n_4 as isize));
         if !((*c).refs[n_4 as usize].p.p.frame_hdr).is_null() {
-            dav1d_thread_picture_unref(&mut (*((*c).refs).as_mut_ptr().offset(n_4 as isize)).p);
+            rav1d_thread_picture_unref(&mut (*((*c).refs).as_mut_ptr().offset(n_4 as isize)).p);
         }
-        dav1d_ref_dec(&mut (*((*c).refs).as_mut_ptr().offset(n_4 as isize)).refmvs);
-        dav1d_ref_dec(&mut (*((*c).refs).as_mut_ptr().offset(n_4 as isize)).segmap);
+        rav1d_ref_dec(&mut (*((*c).refs).as_mut_ptr().offset(n_4 as isize)).refmvs);
+        rav1d_ref_dec(&mut (*((*c).refs).as_mut_ptr().offset(n_4 as isize)).segmap);
         n_4 += 1;
     }
-    dav1d_ref_dec(&mut (*c).seq_hdr_ref);
-    dav1d_ref_dec(&mut (*c).frame_hdr_ref);
-    dav1d_ref_dec(&mut (*c).mastering_display_ref);
-    dav1d_ref_dec(&mut (*c).content_light_ref);
-    dav1d_ref_dec(&mut (*c).itut_t35_ref);
-    dav1d_mem_pool_end((*c).seq_hdr_pool);
-    dav1d_mem_pool_end((*c).frame_hdr_pool);
-    dav1d_mem_pool_end((*c).segmap_pool);
-    dav1d_mem_pool_end((*c).refmvs_pool);
-    dav1d_mem_pool_end((*c).cdf_pool);
-    dav1d_mem_pool_end((*c).picture_pool);
-    dav1d_freep_aligned(c_out as *mut c_void);
+    rav1d_ref_dec(&mut (*c).seq_hdr_ref);
+    rav1d_ref_dec(&mut (*c).frame_hdr_ref);
+    rav1d_ref_dec(&mut (*c).mastering_display_ref);
+    rav1d_ref_dec(&mut (*c).content_light_ref);
+    rav1d_ref_dec(&mut (*c).itut_t35_ref);
+    rav1d_mem_pool_end((*c).seq_hdr_pool);
+    rav1d_mem_pool_end((*c).frame_hdr_pool);
+    rav1d_mem_pool_end((*c).segmap_pool);
+    rav1d_mem_pool_end((*c).refmvs_pool);
+    rav1d_mem_pool_end((*c).cdf_pool);
+    rav1d_mem_pool_end((*c).picture_pool);
+    rav1d_freep_aligned(c_out as *mut c_void);
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dav1d_get_event_flags(
+pub(crate) unsafe fn rav1d_get_event_flags(
     c: *mut Rav1dContext,
-    flags: *mut Dav1dEventFlags,
+    flags: *mut Rav1dEventFlags,
 ) -> c_int {
     if c.is_null() {
         fprintf(
@@ -1310,9 +1390,16 @@ pub unsafe extern "C" fn dav1d_get_event_flags(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dav1d_get_decode_error_data_props(
+pub unsafe extern "C" fn dav1d_get_event_flags(
+    c: *mut Dav1dContext,
+    flags: *mut Dav1dEventFlags,
+) -> c_int {
+    rav1d_get_event_flags(c, flags)
+}
+
+pub(crate) unsafe fn rav1d_get_decode_error_data_props(
     c: *mut Rav1dContext,
-    out: *mut Dav1dDataProps,
+    out: *mut Rav1dDataProps,
 ) -> c_int {
     if c.is_null() {
         fprintf(
@@ -1338,20 +1425,54 @@ pub unsafe extern "C" fn dav1d_get_decode_error_data_props(
         );
         return -(22 as c_int);
     }
-    dav1d_data_props_unref_internal(out);
+    rav1d_data_props_unref_internal(out);
     *out = (*c).cached_error_props.clone();
-    dav1d_data_props_set_defaults(&mut (*c).cached_error_props);
+    rav1d_data_props_set_defaults(&mut (*c).cached_error_props);
     return 0 as c_int;
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dav1d_get_decode_error_data_props(
+    c: *mut Dav1dContext,
+    out: *mut Dav1dDataProps,
+) -> c_int {
+    let mut out_rust = out.read().into_rust();
+    let result = rav1d_get_decode_error_data_props(c, &mut out_rust);
+    out.write(out_rust.into_c());
+    result
+}
+
+pub(crate) unsafe fn rav1d_picture_unref(p: *mut Rav1dPicture) {
+    rav1d_picture_unref_internal(p);
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dav1d_picture_unref(p: *mut Dav1dPicture) {
-    dav1d_picture_unref_internal(p);
+    let mut p_rust = p.read().into_rust();
+    rav1d_picture_unref(&mut p_rust);
+    p.write(p_rust.into_c());
+}
+
+pub(crate) unsafe fn rav1d_data_create(buf: *mut Rav1dData, sz: usize) -> *mut u8 {
+    return rav1d_data_create_internal(buf, sz);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_data_create(buf: *mut Dav1dData, sz: usize) -> *mut u8 {
-    return dav1d_data_create_internal(buf, sz);
+    let mut buf_rust = buf.read().into_rust();
+    let result = rav1d_data_create(&mut buf_rust, sz);
+    buf.write(buf_rust.into_c());
+    result
+}
+
+pub(crate) unsafe fn rav1d_data_wrap(
+    buf: *mut Rav1dData,
+    ptr: *const u8,
+    sz: usize,
+    free_callback: Option<unsafe extern "C" fn(*const u8, *mut c_void) -> ()>,
+    user_data: *mut c_void,
+) -> c_int {
+    return rav1d_data_wrap_internal(buf, ptr, sz, free_callback, user_data);
 }
 
 #[no_mangle]
@@ -1362,7 +1483,19 @@ pub unsafe extern "C" fn dav1d_data_wrap(
     free_callback: Option<unsafe extern "C" fn(*const u8, *mut c_void) -> ()>,
     user_data: *mut c_void,
 ) -> c_int {
-    return dav1d_data_wrap_internal(buf, ptr, sz, free_callback, user_data);
+    let mut buf_rust = buf.read().into_rust();
+    let result = rav1d_data_wrap(&mut buf_rust, ptr, sz, free_callback, user_data);
+    buf.write(buf_rust.into_c());
+    result
+}
+
+pub(crate) unsafe fn rav1d_data_wrap_user_data(
+    buf: *mut Rav1dData,
+    user_data: *const u8,
+    free_callback: Option<unsafe extern "C" fn(*const u8, *mut c_void) -> ()>,
+    cookie: *mut c_void,
+) -> c_int {
+    return rav1d_data_wrap_user_data_internal(buf, user_data, free_callback, cookie);
 }
 
 #[no_mangle]
@@ -1372,15 +1505,32 @@ pub unsafe extern "C" fn dav1d_data_wrap_user_data(
     free_callback: Option<unsafe extern "C" fn(*const u8, *mut c_void) -> ()>,
     cookie: *mut c_void,
 ) -> c_int {
-    return dav1d_data_wrap_user_data_internal(buf, user_data, free_callback, cookie);
+    let mut buf_rust = buf.read().into_rust();
+    let result = rav1d_data_wrap_user_data(&mut buf_rust, user_data, free_callback, cookie);
+    buf.write(buf_rust.into_c());
+    result
+}
+
+pub(crate) unsafe fn rav1d_data_unref(buf: *mut Rav1dData) {
+    rav1d_data_unref_internal(buf);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_data_unref(buf: *mut Dav1dData) {
-    dav1d_data_unref_internal(buf);
+    let mut buf_rust = buf.read().into_rust();
+    let result = rav1d_data_unref(&mut buf_rust);
+    buf.write(buf_rust.into_c());
+    result
+}
+
+#[no_mangle]
+pub(crate) unsafe extern "C" fn rav1d_data_props_unref(props: *mut Rav1dDataProps) {
+    rav1d_data_props_unref_internal(props);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_data_props_unref(props: *mut Dav1dDataProps) {
-    dav1d_data_props_unref_internal(props);
+    let mut props_rust = props.read().into_rust();
+    rav1d_data_props_unref(&mut props_rust);
+    props.write(props_rust.into_c());
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -10,7 +10,7 @@ extern "C" {
 }
 
 #[cold]
-pub unsafe extern "C" fn dav1d_log_default_callback(
+pub unsafe extern "C" fn rav1d_log_default_callback(
     _cookie: *mut c_void,
     format: *const c_char,
     mut ap: ::core::ffi::VaList,
@@ -19,7 +19,7 @@ pub unsafe extern "C" fn dav1d_log_default_callback(
 }
 
 #[cold]
-pub unsafe extern "C" fn dav1d_log(c: *mut Rav1dContext, format: *const c_char, args: ...) {
+pub unsafe extern "C" fn rav1d_log(c: *mut Rav1dContext, format: *const c_char, args: ...) {
     if c.is_null() {
         fprintf(
             stderr,

--- a/src/loopfilter_tmpl_16.rs
+++ b/src/loopfilter_tmpl_16.rs
@@ -9,7 +9,7 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 
 #[cfg(feature = "asm")]
-use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
+use crate::src::cpu::{rav1d_get_cpu_flags, CpuFlags};
 
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
@@ -473,7 +473,7 @@ unsafe extern "C" fn loop_filter_dsp_init_x86(c: *mut Rav1dLoopFilterDSPContext)
     // TODO(legare): Temporarily import until init fns are deduplicated.
     use crate::src::loopfilter::*;
 
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSSE3) {
         return;
@@ -512,7 +512,7 @@ unsafe extern "C" fn loop_filter_dsp_init_arm(c: *mut Rav1dLoopFilterDSPContext)
     // TODO(legare): Temporarily import until init fns are deduplicated.
     use crate::src::loopfilter::*;
 
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::NEON) {
         return;
@@ -525,7 +525,7 @@ unsafe extern "C" fn loop_filter_dsp_init_arm(c: *mut Rav1dLoopFilterDSPContext)
 }
 
 #[cold]
-pub unsafe fn dav1d_loop_filter_dsp_init_16bpc(c: *mut Rav1dLoopFilterDSPContext) {
+pub unsafe fn rav1d_loop_filter_dsp_init_16bpc(c: *mut Rav1dLoopFilterDSPContext) {
     (*c).loop_filter_sb[0][0] = loop_filter_h_sb128y_c_erased;
     (*c).loop_filter_sb[0][1] = loop_filter_v_sb128y_c_erased;
     (*c).loop_filter_sb[1][0] = loop_filter_h_sb128uv_c_erased;

--- a/src/loopfilter_tmpl_8.rs
+++ b/src/loopfilter_tmpl_8.rs
@@ -9,7 +9,7 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 
 #[cfg(feature = "asm")]
-use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
+use crate::src::cpu::{rav1d_get_cpu_flags, CpuFlags};
 
 #[cfg(feature = "asm")]
 use cfg_if::cfg_if;
@@ -401,7 +401,7 @@ unsafe extern "C" fn loop_filter_dsp_init_x86(c: *mut Rav1dLoopFilterDSPContext)
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::loopfilter::*;
 
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSSE3) {
         return;
@@ -440,7 +440,7 @@ unsafe extern "C" fn loop_filter_dsp_init_arm(c: *mut Rav1dLoopFilterDSPContext)
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::loopfilter::*;
 
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::NEON) {
         return;
@@ -453,7 +453,7 @@ unsafe extern "C" fn loop_filter_dsp_init_arm(c: *mut Rav1dLoopFilterDSPContext)
 }
 
 #[cold]
-pub unsafe fn dav1d_loop_filter_dsp_init_8bpc(c: *mut Rav1dLoopFilterDSPContext) {
+pub unsafe fn rav1d_loop_filter_dsp_init_8bpc(c: *mut Rav1dLoopFilterDSPContext) {
     (*c).loop_filter_sb[0][0] = loop_filter_h_sb128y_c_erased;
     (*c).loop_filter_sb[0][1] = loop_filter_v_sb128y_c_erased;
     (*c).loop_filter_sb[1][0] = loop_filter_h_sb128uv_c_erased;

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -267,7 +267,11 @@ unsafe extern "C" fn lr_sbrow(
     }
 }
 
-pub unsafe fn dav1d_lr_sbrow_16bpc(f: *mut Rav1dFrameContext, dst: *const *mut pixel, sby: c_int) {
+pub(crate) unsafe fn rav1d_lr_sbrow_16bpc(
+    f: *mut Rav1dFrameContext,
+    dst: *const *mut pixel,
+    sby: c_int,
+) {
     let offset_y = 8 * (sby != 0) as c_int;
     let dst_stride: *const ptrdiff_t = ((*f).sr_cur.p.stride).as_mut_ptr();
     let restore_planes = (*f).lf.restore_planes;

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -1,8 +1,8 @@
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::RAV1D_RESTORATION_NONE;
+use crate::include::dav1d::headers::RAV1D_RESTORATION_SGRPROJ;
+use crate::include::dav1d::headers::RAV1D_RESTORATION_WIENER;
 use crate::src::align::Align16;
 use crate::src::internal::Rav1dDSPContext;
 use crate::src::internal::Rav1dFrameContext;
@@ -50,7 +50,7 @@ unsafe extern "C" fn lr_stripe(
     let dsp: *const Rav1dDSPContext = (*f).dsp;
     let chroma = (plane != 0) as c_int;
     let ss_ver = chroma
-        & ((*f).sr_cur.p.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        & ((*f).sr_cur.p.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let stride: ptrdiff_t = (*f).sr_cur.p.stride[chroma as usize];
     let sby =
         y + (if y != 0 {
@@ -70,7 +70,7 @@ unsafe extern "C" fn lr_stripe(
     let mut params: LooprestorationParams = LooprestorationParams {
         filter: [[0; 8]; 2].into(),
     };
-    if (*lr).r#type as c_int == DAV1D_RESTORATION_WIENER as c_int {
+    if (*lr).r#type as c_int == RAV1D_RESTORATION_WIENER as c_int {
         let filter: *mut [i16; 8] = (params.filter.0).as_mut_ptr();
         let ref mut fresh0 = (*filter.offset(0))[6];
         *fresh0 = (*lr).filter_h[0] as i16;
@@ -104,7 +104,7 @@ unsafe extern "C" fn lr_stripe(
         lr_fn = (*dsp).lr.wiener[((*filter.offset(0))[0] as c_int | (*filter.offset(1))[0] as c_int
             == 0) as c_int as usize];
     } else {
-        if !((*lr).r#type as c_int == DAV1D_RESTORATION_SGRPROJ as c_int) {
+        if !((*lr).r#type as c_int == RAV1D_RESTORATION_SGRPROJ as c_int) {
             unreachable!();
         }
         let sgr_params: *const u16 = (dav1d_sgr_params[(*lr).sgr_idx as usize]).as_ptr();
@@ -174,9 +174,9 @@ unsafe extern "C" fn lr_sbrow(
 ) {
     let chroma = (plane != 0) as c_int;
     let ss_ver = chroma
-        & ((*f).sr_cur.p.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        & ((*f).sr_cur.p.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let ss_hor = chroma
-        & ((*f).sr_cur.p.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+        & ((*f).sr_cur.p.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
     let p_stride: ptrdiff_t = (*f).sr_cur.p.stride[chroma as usize];
     let unit_size_log2 = (*(*f).frame_hdr).restoration.unit_size[(plane != 0) as c_int as usize];
     let unit_size = (1 as c_int) << unit_size_log2;
@@ -203,7 +203,7 @@ unsafe extern "C" fn lr_sbrow(
         .offset(plane as isize))
     .as_mut_ptr()
     .offset(unit_idx as isize) as *mut Av1RestorationUnit;
-    let mut restore = ((*lr[0]).r#type as c_int != DAV1D_RESTORATION_NONE as c_int) as c_int;
+    let mut restore = ((*lr[0]).r#type as c_int != RAV1D_RESTORATION_NONE as c_int) as c_int;
     let mut x = 0;
     let mut bit = 0;
     while x + max_unit_size <= w {
@@ -216,7 +216,7 @@ unsafe extern "C" fn lr_sbrow(
             .as_mut_ptr()
             .offset(next_u_idx as isize) as *mut Av1RestorationUnit;
         let restore_next = ((*lr[(bit == 0) as c_int as usize]).r#type as c_int
-            != DAV1D_RESTORATION_NONE as c_int) as c_int;
+            != RAV1D_RESTORATION_NONE as c_int) as c_int;
         if restore_next != 0 {
             backup4xU(
                 (pre_lr_border[bit as usize]).as_mut_ptr(),
@@ -295,9 +295,9 @@ pub(crate) unsafe fn rav1d_lr_sbrow_16bpc(
     }
     if restore_planes & (LR_RESTORE_U as c_int | LR_RESTORE_V as c_int) != 0 {
         let ss_ver = ((*f).sr_cur.p.p.layout as c_uint
-            == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+            == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
         let ss_hor = ((*f).sr_cur.p.p.layout as c_uint
-            != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+            != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
         let h_0 = (*f).sr_cur.p.p.h + ss_ver >> ss_ver;
         let w_0 = (*f).sr_cur.p.p.w + ss_hor >> ss_hor;
         let next_row_y_0 = (sby + 1) << 6 - ss_ver + (*(*f).seq_hdr).sb128;

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -1,8 +1,8 @@
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_SGRPROJ;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_WIENER;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::RAV1D_RESTORATION_NONE;
+use crate::include::dav1d::headers::RAV1D_RESTORATION_SGRPROJ;
+use crate::include::dav1d::headers::RAV1D_RESTORATION_WIENER;
 use crate::src::align::Align16;
 use crate::src::internal::Rav1dDSPContext;
 use crate::src::internal::Rav1dFrameContext;
@@ -42,7 +42,7 @@ unsafe extern "C" fn lr_stripe(
     let dsp: *const Rav1dDSPContext = (*f).dsp;
     let chroma = (plane != 0) as c_int;
     let ss_ver = chroma
-        & ((*f).sr_cur.p.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        & ((*f).sr_cur.p.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let stride: ptrdiff_t = (*f).sr_cur.p.stride[chroma as usize];
     let sby =
         y + (if y != 0 {
@@ -62,7 +62,7 @@ unsafe extern "C" fn lr_stripe(
     let mut params: LooprestorationParams = LooprestorationParams {
         filter: [[0; 8]; 2].into(),
     };
-    if (*lr).r#type as c_int == DAV1D_RESTORATION_WIENER as c_int {
+    if (*lr).r#type as c_int == RAV1D_RESTORATION_WIENER as c_int {
         let filter: *mut [i16; 8] = (params.filter.0).as_mut_ptr();
         let ref mut fresh0 = (*filter.offset(0))[6];
         *fresh0 = (*lr).filter_h[0] as i16;
@@ -94,7 +94,7 @@ unsafe extern "C" fn lr_stripe(
         lr_fn = (*dsp).lr.wiener[((*filter.offset(0))[0] as c_int | (*filter.offset(1))[0] as c_int
             == 0) as c_int as usize];
     } else {
-        if !((*lr).r#type as c_int == DAV1D_RESTORATION_SGRPROJ as c_int) {
+        if !((*lr).r#type as c_int == RAV1D_RESTORATION_SGRPROJ as c_int) {
             unreachable!();
         }
         let sgr_params: *const u16 = (dav1d_sgr_params[(*lr).sgr_idx as usize]).as_ptr();
@@ -164,9 +164,9 @@ unsafe extern "C" fn lr_sbrow(
 ) {
     let chroma = (plane != 0) as c_int;
     let ss_ver = chroma
-        & ((*f).sr_cur.p.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        & ((*f).sr_cur.p.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let ss_hor = chroma
-        & ((*f).sr_cur.p.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+        & ((*f).sr_cur.p.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
     let p_stride: ptrdiff_t = (*f).sr_cur.p.stride[chroma as usize];
     let unit_size_log2 = (*(*f).frame_hdr).restoration.unit_size[(plane != 0) as c_int as usize];
     let unit_size = (1 as c_int) << unit_size_log2;
@@ -193,7 +193,7 @@ unsafe extern "C" fn lr_sbrow(
         .offset(plane as isize))
     .as_mut_ptr()
     .offset(unit_idx as isize) as *mut Av1RestorationUnit;
-    let mut restore = ((*lr[0]).r#type as c_int != DAV1D_RESTORATION_NONE as c_int) as c_int;
+    let mut restore = ((*lr[0]).r#type as c_int != RAV1D_RESTORATION_NONE as c_int) as c_int;
     let mut x = 0;
     let mut bit = 0;
     while x + max_unit_size <= w {
@@ -206,7 +206,7 @@ unsafe extern "C" fn lr_sbrow(
             .as_mut_ptr()
             .offset(next_u_idx as isize) as *mut Av1RestorationUnit;
         let restore_next = ((*lr[(bit == 0) as c_int as usize]).r#type as c_int
-            != DAV1D_RESTORATION_NONE as c_int) as c_int;
+            != RAV1D_RESTORATION_NONE as c_int) as c_int;
         if restore_next != 0 {
             backup4xU(
                 (pre_lr_border[bit as usize]).as_mut_ptr(),
@@ -284,9 +284,9 @@ pub(crate) unsafe fn rav1d_lr_sbrow_8bpc(
     }
     if restore_planes & (LR_RESTORE_U as c_int | LR_RESTORE_V as c_int) != 0 {
         let ss_ver = ((*f).sr_cur.p.p.layout as c_uint
-            == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+            == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
         let ss_hor = ((*f).sr_cur.p.p.layout as c_uint
-            != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+            != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
         let h_0 = (*f).sr_cur.p.p.h + ss_ver >> ss_ver;
         let w_0 = (*f).sr_cur.p.p.w + ss_hor >> ss_hor;
         let next_row_y_0 = (sby + 1) << 6 - ss_ver + (*(*f).seq_hdr).sb128;

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -257,7 +257,11 @@ unsafe extern "C" fn lr_sbrow(
     }
 }
 
-pub unsafe fn dav1d_lr_sbrow_8bpc(f: *mut Rav1dFrameContext, dst: *const *mut pixel, sby: c_int) {
+pub(crate) unsafe fn rav1d_lr_sbrow_8bpc(
+    f: *mut Rav1dFrameContext,
+    dst: *const *mut pixel,
+    sby: c_int,
+) {
     let offset_y = 8 * (sby != 0) as c_int;
     let dst_stride: *const ptrdiff_t = ((*f).sr_cur.p.stride).as_mut_ptr();
     let restore_planes = (*f).lf.restore_planes;

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -3,9 +3,9 @@ use crate::include::common::bitdepth::BitDepth;
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::intops::iclip;
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
+use crate::include::dav1d::headers::RAV1D_FILTER_8TAP_REGULAR;
+use crate::include::dav1d::headers::RAV1D_FILTER_8TAP_SHARP;
+use crate::include::dav1d::headers::RAV1D_FILTER_8TAP_SMOOTH;
 use crate::src::levels::FILTER_2D_8TAP_REGULAR;
 use crate::src::levels::FILTER_2D_8TAP_REGULAR_SHARP;
 use crate::src::levels::FILTER_2D_8TAP_REGULAR_SMOOTH;
@@ -1488,40 +1488,40 @@ macro_rules! filter_fns {
 
 filter_fns!(
     regular,
-    DAV1D_FILTER_8TAP_REGULAR,
-    DAV1D_FILTER_8TAP_REGULAR
+    RAV1D_FILTER_8TAP_REGULAR,
+    RAV1D_FILTER_8TAP_REGULAR
 );
 filter_fns!(
     regular_sharp,
-    DAV1D_FILTER_8TAP_REGULAR,
-    DAV1D_FILTER_8TAP_SHARP
+    RAV1D_FILTER_8TAP_REGULAR,
+    RAV1D_FILTER_8TAP_SHARP
 );
 filter_fns!(
     regular_smooth,
-    DAV1D_FILTER_8TAP_REGULAR,
-    DAV1D_FILTER_8TAP_SMOOTH
+    RAV1D_FILTER_8TAP_REGULAR,
+    RAV1D_FILTER_8TAP_SMOOTH
 );
-filter_fns!(smooth, DAV1D_FILTER_8TAP_SMOOTH, DAV1D_FILTER_8TAP_SMOOTH);
+filter_fns!(smooth, RAV1D_FILTER_8TAP_SMOOTH, RAV1D_FILTER_8TAP_SMOOTH);
 filter_fns!(
     smooth_regular,
-    DAV1D_FILTER_8TAP_SMOOTH,
-    DAV1D_FILTER_8TAP_REGULAR
+    RAV1D_FILTER_8TAP_SMOOTH,
+    RAV1D_FILTER_8TAP_REGULAR
 );
 filter_fns!(
     smooth_sharp,
-    DAV1D_FILTER_8TAP_SMOOTH,
-    DAV1D_FILTER_8TAP_SHARP
+    RAV1D_FILTER_8TAP_SMOOTH,
+    RAV1D_FILTER_8TAP_SHARP
 );
-filter_fns!(sharp, DAV1D_FILTER_8TAP_SHARP, DAV1D_FILTER_8TAP_SHARP);
+filter_fns!(sharp, RAV1D_FILTER_8TAP_SHARP, RAV1D_FILTER_8TAP_SHARP);
 filter_fns!(
     sharp_regular,
-    DAV1D_FILTER_8TAP_SHARP,
-    DAV1D_FILTER_8TAP_REGULAR
+    RAV1D_FILTER_8TAP_SHARP,
+    RAV1D_FILTER_8TAP_REGULAR
 );
 filter_fns!(
     sharp_smooth,
-    DAV1D_FILTER_8TAP_SHARP,
-    DAV1D_FILTER_8TAP_SMOOTH
+    RAV1D_FILTER_8TAP_SHARP,
+    RAV1D_FILTER_8TAP_SMOOTH
 );
 
 // TODO(legare): Temporarily pub until init fns are deduplicated.

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1,6 +1,6 @@
 use crate::include::common::intops::iclip_u8;
 use crate::include::common::intops::ulog2;
-use crate::include::dav1d::data::Dav1dData;
+use crate::include::dav1d::data::Rav1dData;
 use crate::include::dav1d::dav1d::Dav1dEventFlags;
 use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_INTRA;
 use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_REFERENCE;
@@ -17,7 +17,6 @@ use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
-use crate::include::dav1d::headers::Dav1dObuType;
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::Dav1dRestorationType;
 use crate::include::dav1d::headers::Dav1dSegmentationData;
@@ -29,6 +28,7 @@ use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
 use crate::include::dav1d::headers::Dav1dTxfmMode;
 use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
+use crate::include::dav1d::headers::Rav1dObuType;
 use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
 use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
 use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
@@ -64,22 +64,22 @@ use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
 use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
-use crate::src::cdf::dav1d_cdf_thread_ref;
-use crate::src::cdf::dav1d_cdf_thread_unref;
-use crate::src::data::dav1d_data_props_copy;
-use crate::src::data::dav1d_data_ref;
-use crate::src::data::dav1d_data_unref_internal;
-use crate::src::decode::dav1d_submit_frame;
+use crate::src::cdf::rav1d_cdf_thread_ref;
+use crate::src::cdf::rav1d_cdf_thread_unref;
+use crate::src::data::rav1d_data_props_copy;
+use crate::src::data::rav1d_data_ref;
+use crate::src::data::rav1d_data_unref_internal;
+use crate::src::decode::rav1d_submit_frame;
 use crate::src::env::get_poc_diff;
-use crate::src::getbits::dav1d_bytealign_get_bits;
-use crate::src::getbits::dav1d_get_bit;
-use crate::src::getbits::dav1d_get_bits;
-use crate::src::getbits::dav1d_get_bits_subexp;
-use crate::src::getbits::dav1d_get_sbits;
-use crate::src::getbits::dav1d_get_uleb128;
-use crate::src::getbits::dav1d_get_uniform;
-use crate::src::getbits::dav1d_get_vlc;
-use crate::src::getbits::dav1d_init_get_bits;
+use crate::src::getbits::rav1d_bytealign_get_bits;
+use crate::src::getbits::rav1d_get_bit;
+use crate::src::getbits::rav1d_get_bits;
+use crate::src::getbits::rav1d_get_bits_subexp;
+use crate::src::getbits::rav1d_get_sbits;
+use crate::src::getbits::rav1d_get_uleb128;
+use crate::src::getbits::rav1d_get_uniform;
+use crate::src::getbits::rav1d_get_vlc;
+use crate::src::getbits::rav1d_init_get_bits;
 use crate::src::getbits::GetBits;
 use crate::src::internal::Rav1dContext;
 use crate::src::internal::Rav1dFrameContext;
@@ -90,20 +90,20 @@ use crate::src::levels::OBU_META_HDR_MDCV;
 use crate::src::levels::OBU_META_ITUT_T35;
 use crate::src::levels::OBU_META_SCALABILITY;
 use crate::src::levels::OBU_META_TIMECODE;
-use crate::src::log::dav1d_log;
-use crate::src::picture::dav1d_picture_get_event_flags;
-use crate::src::picture::dav1d_thread_picture_ref;
-use crate::src::picture::dav1d_thread_picture_unref;
+use crate::src::log::rav1d_log;
+use crate::src::picture::rav1d_picture_get_event_flags;
+use crate::src::picture::rav1d_thread_picture_ref;
+use crate::src::picture::rav1d_thread_picture_unref;
 use crate::src::picture::PictureFlags;
 use crate::src::picture::Rav1dThreadPicture;
 use crate::src::picture::PICTURE_FLAG_NEW_OP_PARAMS_INFO;
 use crate::src::picture::PICTURE_FLAG_NEW_SEQUENCE;
 use crate::src::picture::PICTURE_FLAG_NEW_TEMPORAL_UNIT;
-use crate::src::r#ref::dav1d_ref_create;
-use crate::src::r#ref::dav1d_ref_create_using_pool;
-use crate::src::r#ref::dav1d_ref_dec;
-use crate::src::r#ref::dav1d_ref_inc;
-use crate::src::r#ref::dav1d_ref_is_writable;
+use crate::src::r#ref::rav1d_ref_create;
+use crate::src::r#ref::rav1d_ref_create_using_pool;
+use crate::src::r#ref::rav1d_ref_dec;
+use crate::src::r#ref::rav1d_ref_inc;
+use crate::src::r#ref::rav1d_ref_is_writable;
 use crate::src::r#ref::Rav1dRef;
 use crate::src::tables::dav1d_default_wm_params;
 use crate::src::thread_task::FRAME_ERROR;
@@ -122,14 +122,14 @@ use std::ffi::c_ulong;
 use std::ffi::c_void;
 
 #[inline]
-unsafe extern "C" fn dav1d_get_bits_pos(c: *const GetBits) -> c_uint {
+unsafe extern "C" fn rav1d_get_bits_pos(c: *const GetBits) -> c_uint {
     return (((*c).ptr).offset_from((*c).ptr_start) as c_long as c_uint)
         .wrapping_mul(8 as c_int as c_uint)
         .wrapping_sub((*c).bits_left as c_uint);
 }
 
 unsafe extern "C" fn parse_seq_hdr_error(c: *mut Rav1dContext) -> c_int {
-    dav1d_log(
+    rav1d_log(
         c,
         b"Error parsing sequence header\n\0" as *const u8 as *const c_char,
     );
@@ -146,73 +146,73 @@ unsafe extern "C" fn parse_seq_hdr(
         0 as c_int,
         ::core::mem::size_of::<Dav1dSequenceHeader>(),
     );
-    (*hdr).profile = dav1d_get_bits(gb, 3 as c_int) as c_int;
+    (*hdr).profile = rav1d_get_bits(gb, 3 as c_int) as c_int;
     if (*hdr).profile > 2 {
         return parse_seq_hdr_error(c);
     }
-    (*hdr).still_picture = dav1d_get_bit(gb) as c_int;
-    (*hdr).reduced_still_picture_header = dav1d_get_bit(gb) as c_int;
+    (*hdr).still_picture = rav1d_get_bit(gb) as c_int;
+    (*hdr).reduced_still_picture_header = rav1d_get_bit(gb) as c_int;
     if (*hdr).reduced_still_picture_header != 0 && (*hdr).still_picture == 0 {
         return parse_seq_hdr_error(c);
     }
     if (*hdr).reduced_still_picture_header != 0 {
         (*hdr).num_operating_points = 1 as c_int;
-        (*hdr).operating_points[0].major_level = dav1d_get_bits(gb, 3 as c_int) as c_int;
-        (*hdr).operating_points[0].minor_level = dav1d_get_bits(gb, 2 as c_int) as c_int;
+        (*hdr).operating_points[0].major_level = rav1d_get_bits(gb, 3 as c_int) as c_int;
+        (*hdr).operating_points[0].minor_level = rav1d_get_bits(gb, 2 as c_int) as c_int;
         (*hdr).operating_points[0].initial_display_delay = 10 as c_int;
     } else {
-        (*hdr).timing_info_present = dav1d_get_bit(gb) as c_int;
+        (*hdr).timing_info_present = rav1d_get_bit(gb) as c_int;
         if (*hdr).timing_info_present != 0 {
-            (*hdr).num_units_in_tick = dav1d_get_bits(gb, 32 as c_int) as c_int;
-            (*hdr).time_scale = dav1d_get_bits(gb, 32 as c_int) as c_int;
+            (*hdr).num_units_in_tick = rav1d_get_bits(gb, 32 as c_int) as c_int;
+            (*hdr).time_scale = rav1d_get_bits(gb, 32 as c_int) as c_int;
             if (*c).strict_std_compliance != 0
                 && ((*hdr).num_units_in_tick == 0 || (*hdr).time_scale == 0)
             {
                 return parse_seq_hdr_error(c);
             }
-            (*hdr).equal_picture_interval = dav1d_get_bit(gb) as c_int;
+            (*hdr).equal_picture_interval = rav1d_get_bit(gb) as c_int;
             if (*hdr).equal_picture_interval != 0 {
-                let num_ticks_per_picture: c_uint = dav1d_get_vlc(gb);
+                let num_ticks_per_picture: c_uint = rav1d_get_vlc(gb);
                 if num_ticks_per_picture == 0xffffffff as c_uint {
                     return parse_seq_hdr_error(c);
                 }
                 (*hdr).num_ticks_per_picture =
                     num_ticks_per_picture.wrapping_add(1 as c_int as c_uint);
             }
-            (*hdr).decoder_model_info_present = dav1d_get_bit(gb) as c_int;
+            (*hdr).decoder_model_info_present = rav1d_get_bit(gb) as c_int;
             if (*hdr).decoder_model_info_present != 0 {
                 (*hdr).encoder_decoder_buffer_delay_length =
-                    (dav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
-                (*hdr).num_units_in_decoding_tick = dav1d_get_bits(gb, 32 as c_int) as c_int;
+                    (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
+                (*hdr).num_units_in_decoding_tick = rav1d_get_bits(gb, 32 as c_int) as c_int;
                 if (*c).strict_std_compliance != 0 && (*hdr).num_units_in_decoding_tick == 0 {
                     return parse_seq_hdr_error(c);
                 }
                 (*hdr).buffer_removal_delay_length =
-                    (dav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
+                    (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
                 (*hdr).frame_presentation_delay_length =
-                    (dav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
+                    (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
             }
         }
-        (*hdr).display_model_info_present = dav1d_get_bit(gb) as c_int;
+        (*hdr).display_model_info_present = rav1d_get_bit(gb) as c_int;
         (*hdr).num_operating_points =
-            (dav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
+            (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
         let mut i = 0;
         while i < (*hdr).num_operating_points {
             let op: *mut Dav1dSequenceHeaderOperatingPoint =
                 &mut *((*hdr).operating_points).as_mut_ptr().offset(i as isize)
                     as *mut Dav1dSequenceHeaderOperatingPoint;
-            (*op).idc = dav1d_get_bits(gb, 12 as c_int) as c_int;
+            (*op).idc = rav1d_get_bits(gb, 12 as c_int) as c_int;
             if (*op).idc != 0 && ((*op).idc & 0xff as c_int == 0 || (*op).idc & 0xf00 == 0) {
                 return parse_seq_hdr_error(c);
             }
             (*op).major_level =
-                (2 as c_int as c_uint).wrapping_add(dav1d_get_bits(gb, 3 as c_int)) as c_int;
-            (*op).minor_level = dav1d_get_bits(gb, 2 as c_int) as c_int;
+                (2 as c_int as c_uint).wrapping_add(rav1d_get_bits(gb, 3 as c_int)) as c_int;
+            (*op).minor_level = rav1d_get_bits(gb, 2 as c_int) as c_int;
             if (*op).major_level > 3 {
-                (*op).tier = dav1d_get_bit(gb) as c_int;
+                (*op).tier = rav1d_get_bit(gb) as c_int;
             }
             if (*hdr).decoder_model_info_present != 0 {
-                (*op).decoder_model_param_present = dav1d_get_bit(gb) as c_int;
+                (*op).decoder_model_param_present = rav1d_get_bit(gb) as c_int;
                 if (*op).decoder_model_param_present != 0 {
                     let opi: *mut Dav1dSequenceHeaderOperatingParameterInfo = &mut *((*hdr)
                         .operating_parameter_info)
@@ -220,17 +220,17 @@ unsafe extern "C" fn parse_seq_hdr(
                         .offset(i as isize)
                         as *mut Dav1dSequenceHeaderOperatingParameterInfo;
                     (*opi).decoder_buffer_delay =
-                        dav1d_get_bits(gb, (*hdr).encoder_decoder_buffer_delay_length) as c_int;
+                        rav1d_get_bits(gb, (*hdr).encoder_decoder_buffer_delay_length) as c_int;
                     (*opi).encoder_buffer_delay =
-                        dav1d_get_bits(gb, (*hdr).encoder_decoder_buffer_delay_length) as c_int;
-                    (*opi).low_delay_mode = dav1d_get_bit(gb) as c_int;
+                        rav1d_get_bits(gb, (*hdr).encoder_decoder_buffer_delay_length) as c_int;
+                    (*opi).low_delay_mode = rav1d_get_bit(gb) as c_int;
                 }
             }
             if (*hdr).display_model_info_present != 0 {
-                (*op).display_model_param_present = dav1d_get_bit(gb) as c_int;
+                (*op).display_model_param_present = rav1d_get_bit(gb) as c_int;
             }
             (*op).initial_display_delay = (if (*op).display_model_param_present != 0 {
-                (dav1d_get_bits(gb, 4 as c_int)).wrapping_add(1 as c_int as c_uint)
+                (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(1 as c_int as c_uint)
             } else {
                 10 as c_int as c_uint
             }) as c_int;
@@ -250,80 +250,80 @@ unsafe extern "C" fn parse_seq_hdr(
         0 as c_int
     };
     (*hdr).width_n_bits =
-        (dav1d_get_bits(gb, 4 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
+        (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
     (*hdr).height_n_bits =
-        (dav1d_get_bits(gb, 4 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
+        (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
     (*hdr).max_width =
-        (dav1d_get_bits(gb, (*hdr).width_n_bits)).wrapping_add(1 as c_int as c_uint) as c_int;
+        (rav1d_get_bits(gb, (*hdr).width_n_bits)).wrapping_add(1 as c_int as c_uint) as c_int;
     (*hdr).max_height =
-        (dav1d_get_bits(gb, (*hdr).height_n_bits)).wrapping_add(1 as c_int as c_uint) as c_int;
+        (rav1d_get_bits(gb, (*hdr).height_n_bits)).wrapping_add(1 as c_int as c_uint) as c_int;
     if (*hdr).reduced_still_picture_header == 0 {
-        (*hdr).frame_id_numbers_present = dav1d_get_bit(gb) as c_int;
+        (*hdr).frame_id_numbers_present = rav1d_get_bit(gb) as c_int;
         if (*hdr).frame_id_numbers_present != 0 {
             (*hdr).delta_frame_id_n_bits =
-                (dav1d_get_bits(gb, 4 as c_int)).wrapping_add(2 as c_int as c_uint) as c_int;
-            (*hdr).frame_id_n_bits = (dav1d_get_bits(gb, 3 as c_int))
+                (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(2 as c_int as c_uint) as c_int;
+            (*hdr).frame_id_n_bits = (rav1d_get_bits(gb, 3 as c_int))
                 .wrapping_add((*hdr).delta_frame_id_n_bits as c_uint)
                 .wrapping_add(1 as c_int as c_uint) as c_int;
         }
     }
-    (*hdr).sb128 = dav1d_get_bit(gb) as c_int;
-    (*hdr).filter_intra = dav1d_get_bit(gb) as c_int;
-    (*hdr).intra_edge_filter = dav1d_get_bit(gb) as c_int;
+    (*hdr).sb128 = rav1d_get_bit(gb) as c_int;
+    (*hdr).filter_intra = rav1d_get_bit(gb) as c_int;
+    (*hdr).intra_edge_filter = rav1d_get_bit(gb) as c_int;
     if (*hdr).reduced_still_picture_header != 0 {
         (*hdr).screen_content_tools = DAV1D_ADAPTIVE;
         (*hdr).force_integer_mv = DAV1D_ADAPTIVE;
     } else {
-        (*hdr).inter_intra = dav1d_get_bit(gb) as c_int;
-        (*hdr).masked_compound = dav1d_get_bit(gb) as c_int;
-        (*hdr).warped_motion = dav1d_get_bit(gb) as c_int;
-        (*hdr).dual_filter = dav1d_get_bit(gb) as c_int;
-        (*hdr).order_hint = dav1d_get_bit(gb) as c_int;
+        (*hdr).inter_intra = rav1d_get_bit(gb) as c_int;
+        (*hdr).masked_compound = rav1d_get_bit(gb) as c_int;
+        (*hdr).warped_motion = rav1d_get_bit(gb) as c_int;
+        (*hdr).dual_filter = rav1d_get_bit(gb) as c_int;
+        (*hdr).order_hint = rav1d_get_bit(gb) as c_int;
         if (*hdr).order_hint != 0 {
-            (*hdr).jnt_comp = dav1d_get_bit(gb) as c_int;
-            (*hdr).ref_frame_mvs = dav1d_get_bit(gb) as c_int;
+            (*hdr).jnt_comp = rav1d_get_bit(gb) as c_int;
+            (*hdr).ref_frame_mvs = rav1d_get_bit(gb) as c_int;
         }
-        (*hdr).screen_content_tools = (if dav1d_get_bit(gb) != 0 {
+        (*hdr).screen_content_tools = (if rav1d_get_bit(gb) != 0 {
             DAV1D_ADAPTIVE as c_int as c_uint
         } else {
-            dav1d_get_bit(gb)
+            rav1d_get_bit(gb)
         }) as Dav1dAdaptiveBoolean;
         (*hdr).force_integer_mv = (if (*hdr).screen_content_tools as c_uint != 0 {
-            if dav1d_get_bit(gb) != 0 {
+            if rav1d_get_bit(gb) != 0 {
                 DAV1D_ADAPTIVE as c_int as c_uint
             } else {
-                dav1d_get_bit(gb)
+                rav1d_get_bit(gb)
             }
         } else {
             2 as c_int as c_uint
         }) as Dav1dAdaptiveBoolean;
         if (*hdr).order_hint != 0 {
             (*hdr).order_hint_n_bits =
-                (dav1d_get_bits(gb, 3 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
+                (rav1d_get_bits(gb, 3 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
         }
     }
-    (*hdr).super_res = dav1d_get_bit(gb) as c_int;
-    (*hdr).cdef = dav1d_get_bit(gb) as c_int;
-    (*hdr).restoration = dav1d_get_bit(gb) as c_int;
-    (*hdr).hbd = dav1d_get_bit(gb) as c_int;
+    (*hdr).super_res = rav1d_get_bit(gb) as c_int;
+    (*hdr).cdef = rav1d_get_bit(gb) as c_int;
+    (*hdr).restoration = rav1d_get_bit(gb) as c_int;
+    (*hdr).hbd = rav1d_get_bit(gb) as c_int;
     if (*hdr).profile == 2 && (*hdr).hbd != 0 {
-        (*hdr).hbd = ((*hdr).hbd as c_uint).wrapping_add(dav1d_get_bit(gb)) as c_int as c_int;
+        (*hdr).hbd = ((*hdr).hbd as c_uint).wrapping_add(rav1d_get_bit(gb)) as c_int as c_int;
     }
     if (*hdr).profile != 1 as c_int {
-        (*hdr).monochrome = dav1d_get_bit(gb) as c_int;
+        (*hdr).monochrome = rav1d_get_bit(gb) as c_int;
     }
-    (*hdr).color_description_present = dav1d_get_bit(gb) as c_int;
+    (*hdr).color_description_present = rav1d_get_bit(gb) as c_int;
     if (*hdr).color_description_present != 0 {
-        (*hdr).pri = dav1d_get_bits(gb, 8 as c_int) as Dav1dColorPrimaries;
-        (*hdr).trc = dav1d_get_bits(gb, 8 as c_int) as Dav1dTransferCharacteristics;
-        (*hdr).mtrx = dav1d_get_bits(gb, 8 as c_int) as Dav1dMatrixCoefficients;
+        (*hdr).pri = rav1d_get_bits(gb, 8 as c_int) as Dav1dColorPrimaries;
+        (*hdr).trc = rav1d_get_bits(gb, 8 as c_int) as Dav1dTransferCharacteristics;
+        (*hdr).mtrx = rav1d_get_bits(gb, 8 as c_int) as Dav1dMatrixCoefficients;
     } else {
         (*hdr).pri = DAV1D_COLOR_PRI_UNKNOWN;
         (*hdr).trc = DAV1D_TRC_UNKNOWN;
         (*hdr).mtrx = DAV1D_MC_UNKNOWN;
     }
     if (*hdr).monochrome != 0 {
-        (*hdr).color_range = dav1d_get_bit(gb) as c_int;
+        (*hdr).color_range = rav1d_get_bit(gb) as c_int;
         (*hdr).layout = DAV1D_PIXEL_LAYOUT_I400;
         (*hdr).ss_ver = 1 as c_int;
         (*hdr).ss_hor = (*hdr).ss_ver;
@@ -338,7 +338,7 @@ unsafe extern "C" fn parse_seq_hdr(
             return parse_seq_hdr_error(c);
         }
     } else {
-        (*hdr).color_range = dav1d_get_bit(gb) as c_int;
+        (*hdr).color_range = rav1d_get_bit(gb) as c_int;
         match (*hdr).profile {
             0 => {
                 (*hdr).layout = DAV1D_PIXEL_LAYOUT_I420;
@@ -350,9 +350,9 @@ unsafe extern "C" fn parse_seq_hdr(
             }
             2 => {
                 if (*hdr).hbd == 2 {
-                    (*hdr).ss_hor = dav1d_get_bit(gb) as c_int;
+                    (*hdr).ss_hor = rav1d_get_bit(gb) as c_int;
                     if (*hdr).ss_hor != 0 {
-                        (*hdr).ss_ver = dav1d_get_bit(gb) as c_int;
+                        (*hdr).ss_ver = rav1d_get_bit(gb) as c_int;
                     }
                 } else {
                     (*hdr).ss_hor = 1 as c_int;
@@ -370,7 +370,7 @@ unsafe extern "C" fn parse_seq_hdr(
             _ => {}
         }
         (*hdr).chr = (if (*hdr).ss_hor & (*hdr).ss_ver != 0 {
-            dav1d_get_bits(gb, 2 as c_int)
+            rav1d_get_bits(gb, 2 as c_int)
         } else {
             DAV1D_CHR_UNKNOWN as c_int as c_uint
         }) as Dav1dChromaSamplePosition;
@@ -382,10 +382,10 @@ unsafe extern "C" fn parse_seq_hdr(
         return parse_seq_hdr_error(c);
     }
     if (*hdr).monochrome == 0 {
-        (*hdr).separate_uv_delta_q = dav1d_get_bit(gb) as c_int;
+        (*hdr).separate_uv_delta_q = rav1d_get_bit(gb) as c_int;
     }
-    (*hdr).film_grain_present = dav1d_get_bit(gb) as c_int;
-    dav1d_get_bit(gb);
+    (*hdr).film_grain_present = rav1d_get_bit(gb) as c_int;
+    rav1d_get_bit(gb);
     return 0 as c_int;
 }
 
@@ -399,7 +399,7 @@ unsafe extern "C" fn read_frame_size(
     if use_ref != 0 {
         let mut i = 0;
         while i < 7 {
-            if dav1d_get_bit(gb) != 0 {
+            if rav1d_get_bit(gb) != 0 {
                 let r#ref: *const Rav1dThreadPicture = &mut (*((*c).refs)
                     .as_mut_ptr()
                     .offset(*((*(*c).frame_hdr).refidx).as_mut_ptr().offset(i as isize) as isize))
@@ -412,10 +412,10 @@ unsafe extern "C" fn read_frame_size(
                 (*hdr).render_width = (*(*r#ref).p.frame_hdr).render_width;
                 (*hdr).render_height = (*(*r#ref).p.frame_hdr).render_height;
                 (*hdr).super_res.enabled =
-                    ((*seqhdr).super_res != 0 && dav1d_get_bit(gb) != 0) as c_int;
+                    ((*seqhdr).super_res != 0 && rav1d_get_bit(gb) != 0) as c_int;
                 if (*hdr).super_res.enabled != 0 {
                     (*hdr).super_res.width_scale_denominator = (9 as c_int as c_uint)
-                        .wrapping_add(dav1d_get_bits(gb, 3 as c_int))
+                        .wrapping_add(rav1d_get_bits(gb, 3 as c_int))
                         as c_int;
                     let d = (*hdr).super_res.width_scale_denominator;
                     (*hdr).width[0] = cmp::max(
@@ -432,18 +432,18 @@ unsafe extern "C" fn read_frame_size(
         }
     }
     if (*hdr).frame_size_override != 0 {
-        (*hdr).width[1] = (dav1d_get_bits(gb, (*seqhdr).width_n_bits))
+        (*hdr).width[1] = (rav1d_get_bits(gb, (*seqhdr).width_n_bits))
             .wrapping_add(1 as c_int as c_uint) as c_int;
-        (*hdr).height = (dav1d_get_bits(gb, (*seqhdr).height_n_bits))
+        (*hdr).height = (rav1d_get_bits(gb, (*seqhdr).height_n_bits))
             .wrapping_add(1 as c_int as c_uint) as c_int;
     } else {
         (*hdr).width[1] = (*seqhdr).max_width;
         (*hdr).height = (*seqhdr).max_height;
     }
-    (*hdr).super_res.enabled = ((*seqhdr).super_res != 0 && dav1d_get_bit(gb) != 0) as c_int;
+    (*hdr).super_res.enabled = ((*seqhdr).super_res != 0 && rav1d_get_bit(gb) != 0) as c_int;
     if (*hdr).super_res.enabled != 0 {
         (*hdr).super_res.width_scale_denominator =
-            (9 as c_int as c_uint).wrapping_add(dav1d_get_bits(gb, 3 as c_int)) as c_int;
+            (9 as c_int as c_uint).wrapping_add(rav1d_get_bits(gb, 3 as c_int)) as c_int;
         let d_0 = (*hdr).super_res.width_scale_denominator;
         (*hdr).width[0] = cmp::max(
             ((*hdr).width[1] * 8 + (d_0 >> 1)) / d_0,
@@ -453,12 +453,12 @@ unsafe extern "C" fn read_frame_size(
         (*hdr).super_res.width_scale_denominator = 8 as c_int;
         (*hdr).width[0] = (*hdr).width[1];
     }
-    (*hdr).have_render_size = dav1d_get_bit(gb) as c_int;
+    (*hdr).have_render_size = rav1d_get_bit(gb) as c_int;
     if (*hdr).have_render_size != 0 {
         (*hdr).render_width =
-            (dav1d_get_bits(gb, 16 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
+            (rav1d_get_bits(gb, 16 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
         (*hdr).render_height =
-            (dav1d_get_bits(gb, 16 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
+            (rav1d_get_bits(gb, 16 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
     } else {
         (*hdr).render_width = (*hdr).width[1];
         (*hdr).render_height = (*hdr).height;
@@ -482,7 +482,7 @@ static default_mode_ref_deltas: Dav1dLoopfilterModeRefDeltas = Dav1dLoopfilterMo
 };
 
 unsafe extern "C" fn parse_frame_hdr_error(c: *mut Rav1dContext) -> c_int {
-    dav1d_log(
+    rav1d_log(
         c,
         b"Error parsing frame header\n\0" as *const u8 as *const c_char,
     );
@@ -493,15 +493,15 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
     let seqhdr: *const Dav1dSequenceHeader = (*c).seq_hdr;
     let hdr: *mut Dav1dFrameHeader = (*c).frame_hdr;
     (*hdr).show_existing_frame =
-        ((*seqhdr).reduced_still_picture_header == 0 && dav1d_get_bit(gb) != 0) as c_int;
+        ((*seqhdr).reduced_still_picture_header == 0 && rav1d_get_bit(gb) != 0) as c_int;
     if (*hdr).show_existing_frame != 0 {
-        (*hdr).existing_frame_idx = dav1d_get_bits(gb, 3 as c_int) as c_int;
+        (*hdr).existing_frame_idx = rav1d_get_bits(gb, 3 as c_int) as c_int;
         if (*seqhdr).decoder_model_info_present != 0 && (*seqhdr).equal_picture_interval == 0 {
             (*hdr).frame_presentation_delay =
-                dav1d_get_bits(gb, (*seqhdr).frame_presentation_delay_length) as c_int;
+                rav1d_get_bits(gb, (*seqhdr).frame_presentation_delay_length) as c_int;
         }
         if (*seqhdr).frame_id_numbers_present != 0 {
-            (*hdr).frame_id = dav1d_get_bits(gb, (*seqhdr).frame_id_n_bits) as c_int;
+            (*hdr).frame_id = rav1d_get_bits(gb, (*seqhdr).frame_id_n_bits) as c_int;
             let ref_frame_hdr: *mut Dav1dFrameHeader =
                 (*c).refs[(*hdr).existing_frame_idx as usize].p.p.frame_hdr;
             if ref_frame_hdr.is_null() || (*ref_frame_hdr).frame_id != (*hdr).frame_id {
@@ -513,37 +513,37 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
     (*hdr).frame_type = (if (*seqhdr).reduced_still_picture_header != 0 {
         DAV1D_FRAME_TYPE_KEY as c_int as c_uint
     } else {
-        dav1d_get_bits(gb, 2 as c_int)
+        rav1d_get_bits(gb, 2 as c_int)
     }) as Dav1dFrameType;
     (*hdr).show_frame =
-        ((*seqhdr).reduced_still_picture_header != 0 || dav1d_get_bit(gb) != 0) as c_int;
+        ((*seqhdr).reduced_still_picture_header != 0 || rav1d_get_bit(gb) != 0) as c_int;
     if (*hdr).show_frame != 0 {
         if (*seqhdr).decoder_model_info_present != 0 && (*seqhdr).equal_picture_interval == 0 {
             (*hdr).frame_presentation_delay =
-                dav1d_get_bits(gb, (*seqhdr).frame_presentation_delay_length) as c_int;
+                rav1d_get_bits(gb, (*seqhdr).frame_presentation_delay_length) as c_int;
         }
         (*hdr).showable_frame =
             ((*hdr).frame_type as c_uint != DAV1D_FRAME_TYPE_KEY as c_int as c_uint) as c_int;
     } else {
-        (*hdr).showable_frame = dav1d_get_bit(gb) as c_int;
+        (*hdr).showable_frame = rav1d_get_bit(gb) as c_int;
     }
     (*hdr).error_resilient_mode = ((*hdr).frame_type as c_uint
         == DAV1D_FRAME_TYPE_KEY as c_int as c_uint
         && (*hdr).show_frame != 0
         || (*hdr).frame_type as c_uint == DAV1D_FRAME_TYPE_SWITCH as c_int as c_uint
         || (*seqhdr).reduced_still_picture_header != 0
-        || dav1d_get_bit(gb) != 0) as c_int;
-    (*hdr).disable_cdf_update = dav1d_get_bit(gb) as c_int;
+        || rav1d_get_bit(gb) != 0) as c_int;
+    (*hdr).disable_cdf_update = rav1d_get_bit(gb) as c_int;
     (*hdr).allow_screen_content_tools =
         (if (*seqhdr).screen_content_tools as c_uint == DAV1D_ADAPTIVE as c_int as c_uint {
-            dav1d_get_bit(gb)
+            rav1d_get_bit(gb)
         } else {
             (*seqhdr).screen_content_tools as c_uint
         }) as c_int;
     if (*hdr).allow_screen_content_tools != 0 {
         (*hdr).force_integer_mv =
             (if (*seqhdr).force_integer_mv as c_uint == DAV1D_ADAPTIVE as c_int as c_uint {
-                dav1d_get_bit(gb)
+                rav1d_get_bit(gb)
             } else {
                 (*seqhdr).force_integer_mv as c_uint
             }) as c_int;
@@ -554,28 +554,28 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
         (*hdr).force_integer_mv = 1 as c_int;
     }
     if (*seqhdr).frame_id_numbers_present != 0 {
-        (*hdr).frame_id = dav1d_get_bits(gb, (*seqhdr).frame_id_n_bits) as c_int;
+        (*hdr).frame_id = rav1d_get_bits(gb, (*seqhdr).frame_id_n_bits) as c_int;
     }
     (*hdr).frame_size_override = (if (*seqhdr).reduced_still_picture_header != 0 {
         0 as c_int as c_uint
     } else if (*hdr).frame_type as c_uint == DAV1D_FRAME_TYPE_SWITCH as c_int as c_uint {
         1 as c_int as c_uint
     } else {
-        dav1d_get_bit(gb)
+        rav1d_get_bit(gb)
     }) as c_int;
     (*hdr).frame_offset = (if (*seqhdr).order_hint != 0 {
-        dav1d_get_bits(gb, (*seqhdr).order_hint_n_bits)
+        rav1d_get_bits(gb, (*seqhdr).order_hint_n_bits)
     } else {
         0 as c_int as c_uint
     }) as c_int;
     (*hdr).primary_ref_frame =
         (if (*hdr).error_resilient_mode == 0 && (*hdr).frame_type as c_uint & 1 as c_uint != 0 {
-            dav1d_get_bits(gb, 3 as c_int)
+            rav1d_get_bits(gb, 3 as c_int)
         } else {
             7 as c_int as c_uint
         }) as c_int;
     if (*seqhdr).decoder_model_info_present != 0 {
-        (*hdr).buffer_removal_time_present = dav1d_get_bit(gb) as c_int;
+        (*hdr).buffer_removal_time_present = rav1d_get_bit(gb) as c_int;
         if (*hdr).buffer_removal_time_present != 0 {
             let mut i = 0;
             while i < (*(*c).seq_hdr).num_operating_points {
@@ -590,7 +590,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
                     let in_spatial_layer = (*seqop).idc >> (*hdr).spatial_id + 8 & 1;
                     if (*seqop).idc == 0 || in_temporal_layer != 0 && in_spatial_layer != 0 {
                         (*op).buffer_removal_time =
-                            dav1d_get_bits(gb, (*seqhdr).buffer_removal_delay_length) as c_int;
+                            rav1d_get_bits(gb, (*seqhdr).buffer_removal_delay_length) as c_int;
                     }
                 }
                 i += 1;
@@ -604,7 +604,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
         {
             0xff as c_int as c_uint
         } else {
-            dav1d_get_bits(gb, 8 as c_int)
+            rav1d_get_bits(gb, 8 as c_int)
         }) as c_int;
         if (*hdr).refresh_frame_flags != 0xff as c_int
             && (*hdr).error_resilient_mode != 0
@@ -612,7 +612,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
         {
             let mut i_0 = 0;
             while i_0 < 8 {
-                dav1d_get_bits(gb, (*seqhdr).order_hint_n_bits);
+                rav1d_get_bits(gb, (*seqhdr).order_hint_n_bits);
                 i_0 += 1;
             }
         }
@@ -627,7 +627,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
         }
         (*hdr).allow_intrabc = ((*hdr).allow_screen_content_tools != 0
             && (*hdr).super_res.enabled == 0
-            && dav1d_get_bit(gb) != 0) as c_int;
+            && rav1d_get_bit(gb) != 0) as c_int;
         (*hdr).use_ref_frame_mvs = 0 as c_int;
     } else {
         (*hdr).allow_intrabc = 0 as c_int;
@@ -635,22 +635,22 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
             (if (*hdr).frame_type as c_uint == DAV1D_FRAME_TYPE_SWITCH as c_int as c_uint {
                 0xff as c_int as c_uint
             } else {
-                dav1d_get_bits(gb, 8 as c_int)
+                rav1d_get_bits(gb, 8 as c_int)
             }) as c_int;
         if (*hdr).error_resilient_mode != 0 && (*seqhdr).order_hint != 0 {
             let mut i_1 = 0;
             while i_1 < 8 {
-                dav1d_get_bits(gb, (*seqhdr).order_hint_n_bits);
+                rav1d_get_bits(gb, (*seqhdr).order_hint_n_bits);
                 i_1 += 1;
             }
         }
         (*hdr).frame_ref_short_signaling =
-            ((*seqhdr).order_hint != 0 && dav1d_get_bit(gb) != 0) as c_int;
+            ((*seqhdr).order_hint != 0 && rav1d_get_bit(gb) != 0) as c_int;
         if (*hdr).frame_ref_short_signaling != 0 {
-            (*hdr).refidx[0] = dav1d_get_bits(gb, 3 as c_int) as c_int;
+            (*hdr).refidx[0] = rav1d_get_bits(gb, 3 as c_int) as c_int;
             (*hdr).refidx[2] = -(1 as c_int);
             (*hdr).refidx[1] = (*hdr).refidx[2];
-            (*hdr).refidx[3] = dav1d_get_bits(gb, 3 as c_int) as c_int;
+            (*hdr).refidx[3] = rav1d_get_bits(gb, 3 as c_int) as c_int;
             (*hdr).refidx[6] = -(1 as c_int);
             (*hdr).refidx[5] = (*hdr).refidx[6];
             (*hdr).refidx[4] = (*hdr).refidx[5];
@@ -764,11 +764,11 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
         let mut i_9 = 0;
         while i_9 < 7 {
             if (*hdr).frame_ref_short_signaling == 0 {
-                (*hdr).refidx[i_9 as usize] = dav1d_get_bits(gb, 3 as c_int) as c_int;
+                (*hdr).refidx[i_9 as usize] = rav1d_get_bits(gb, 3 as c_int) as c_int;
             }
             if (*seqhdr).frame_id_numbers_present != 0 {
                 let delta_ref_frame_id_minus_1: c_int =
-                    dav1d_get_bits(gb, (*seqhdr).delta_frame_id_n_bits) as c_int;
+                    rav1d_get_bits(gb, (*seqhdr).delta_frame_id_n_bits) as c_int;
                 let ref_frame_id: c_int = (*hdr).frame_id
                     + ((1 as c_int) << (*seqhdr).frame_id_n_bits)
                     - delta_ref_frame_id_minus_1
@@ -790,23 +790,23 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
         if read_frame_size(c, gb, use_ref) < 0 {
             return parse_frame_hdr_error(c);
         }
-        (*hdr).hp = ((*hdr).force_integer_mv == 0 && dav1d_get_bit(gb) != 0) as c_int;
-        (*hdr).subpel_filter_mode = (if dav1d_get_bit(gb) != 0 {
+        (*hdr).hp = ((*hdr).force_integer_mv == 0 && rav1d_get_bit(gb) != 0) as c_int;
+        (*hdr).subpel_filter_mode = (if rav1d_get_bit(gb) != 0 {
             DAV1D_FILTER_SWITCHABLE as c_int as c_uint
         } else {
-            dav1d_get_bits(gb, 2 as c_int)
+            rav1d_get_bits(gb, 2 as c_int)
         }) as Dav1dFilterMode;
-        (*hdr).switchable_motion_mode = dav1d_get_bit(gb) as c_int;
+        (*hdr).switchable_motion_mode = rav1d_get_bit(gb) as c_int;
         (*hdr).use_ref_frame_mvs = ((*hdr).error_resilient_mode == 0
             && (*seqhdr).ref_frame_mvs != 0
             && (*seqhdr).order_hint != 0
             && (*hdr).frame_type as c_uint & 1 as c_uint != 0
-            && dav1d_get_bit(gb) != 0) as c_int;
+            && rav1d_get_bit(gb) != 0) as c_int;
     }
     (*hdr).refresh_context = ((*seqhdr).reduced_still_picture_header == 0
         && (*hdr).disable_cdf_update == 0
-        && dav1d_get_bit(gb) == 0) as c_int;
-    (*hdr).tiling.uniform = dav1d_get_bit(gb) as c_int;
+        && rav1d_get_bit(gb) == 0) as c_int;
+    (*hdr).tiling.uniform = rav1d_get_bit(gb) as c_int;
     let sbsz_min1: c_int = ((64 as c_int) << (*seqhdr).sb128) - 1;
     let sbsz_log2 = 6 + (*seqhdr).sb128;
     let sbw: c_int = (*hdr).width[0] + sbsz_min1 >> sbsz_log2;
@@ -822,7 +822,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
     );
     if (*hdr).tiling.uniform != 0 {
         (*hdr).tiling.log2_cols = (*hdr).tiling.min_log2_cols;
-        while (*hdr).tiling.log2_cols < (*hdr).tiling.max_log2_cols && dav1d_get_bit(gb) != 0 {
+        while (*hdr).tiling.log2_cols < (*hdr).tiling.max_log2_cols && rav1d_get_bit(gb) != 0 {
             (*hdr).tiling.log2_cols += 1;
         }
         let tile_w = 1 + (sbw - 1 >> (*hdr).tiling.log2_cols);
@@ -836,7 +836,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
         (*hdr).tiling.min_log2_rows =
             cmp::max(min_log2_tiles - (*hdr).tiling.log2_cols, 0 as c_int);
         (*hdr).tiling.log2_rows = (*hdr).tiling.min_log2_rows;
-        while (*hdr).tiling.log2_rows < (*hdr).tiling.max_log2_rows && dav1d_get_bit(gb) != 0 {
+        while (*hdr).tiling.log2_rows < (*hdr).tiling.max_log2_rows && rav1d_get_bit(gb) != 0 {
             (*hdr).tiling.log2_rows += 1;
         }
         let tile_h = 1 + (sbh - 1 >> (*hdr).tiling.log2_rows);
@@ -855,7 +855,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
         while sbx_0 < sbw && (*hdr).tiling.cols < 64 {
             let tile_width_sb: c_int = cmp::min(sbw - sbx_0, max_tile_width_sb);
             let tile_w_0: c_int = (if tile_width_sb > 1 {
-                (1 as c_int as c_uint).wrapping_add(dav1d_get_uniform(gb, tile_width_sb as c_uint))
+                (1 as c_int as c_uint).wrapping_add(rav1d_get_uniform(gb, tile_width_sb as c_uint))
             } else {
                 1 as c_int as c_uint
             }) as c_int;
@@ -874,7 +874,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
         while sby_0 < sbh && (*hdr).tiling.rows < 64 {
             let tile_height_sb: c_int = cmp::min(sbh - sby_0, max_tile_height_sb);
             let tile_h_0: c_int = (if tile_height_sb > 1 {
-                (1 as c_int as c_uint).wrapping_add(dav1d_get_uniform(gb, tile_height_sb as c_uint))
+                (1 as c_int as c_uint).wrapping_add(rav1d_get_uniform(gb, tile_height_sb as c_uint))
             } else {
                 1 as c_int as c_uint
             }) as c_int;
@@ -888,45 +888,45 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
     (*hdr).tiling.row_start_sb[(*hdr).tiling.rows as usize] = sbh as u16;
     if (*hdr).tiling.log2_cols != 0 || (*hdr).tiling.log2_rows != 0 {
         (*hdr).tiling.update =
-            dav1d_get_bits(gb, (*hdr).tiling.log2_cols + (*hdr).tiling.log2_rows) as c_int;
+            rav1d_get_bits(gb, (*hdr).tiling.log2_cols + (*hdr).tiling.log2_rows) as c_int;
         if (*hdr).tiling.update >= (*hdr).tiling.cols * (*hdr).tiling.rows {
             return parse_frame_hdr_error(c);
         }
-        (*hdr).tiling.n_bytes = (dav1d_get_bits(gb, 2 as c_int)).wrapping_add(1 as c_int as c_uint);
+        (*hdr).tiling.n_bytes = (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(1 as c_int as c_uint);
     } else {
         (*hdr).tiling.update = 0 as c_int;
         (*hdr).tiling.n_bytes = (*hdr).tiling.update as c_uint;
     }
-    (*hdr).quant.yac = dav1d_get_bits(gb, 8 as c_int) as c_int;
-    (*hdr).quant.ydc_delta = if dav1d_get_bit(gb) != 0 {
-        dav1d_get_sbits(gb, 7 as c_int)
+    (*hdr).quant.yac = rav1d_get_bits(gb, 8 as c_int) as c_int;
+    (*hdr).quant.ydc_delta = if rav1d_get_bit(gb) != 0 {
+        rav1d_get_sbits(gb, 7 as c_int)
     } else {
         0 as c_int
     };
     if (*seqhdr).monochrome == 0 {
         let diff_uv_delta: c_int = (if (*seqhdr).separate_uv_delta_q != 0 {
-            dav1d_get_bit(gb)
+            rav1d_get_bit(gb)
         } else {
             0 as c_int as c_uint
         }) as c_int;
-        (*hdr).quant.udc_delta = if dav1d_get_bit(gb) != 0 {
-            dav1d_get_sbits(gb, 7 as c_int)
+        (*hdr).quant.udc_delta = if rav1d_get_bit(gb) != 0 {
+            rav1d_get_sbits(gb, 7 as c_int)
         } else {
             0 as c_int
         };
-        (*hdr).quant.uac_delta = if dav1d_get_bit(gb) != 0 {
-            dav1d_get_sbits(gb, 7 as c_int)
+        (*hdr).quant.uac_delta = if rav1d_get_bit(gb) != 0 {
+            rav1d_get_sbits(gb, 7 as c_int)
         } else {
             0 as c_int
         };
         if diff_uv_delta != 0 {
-            (*hdr).quant.vdc_delta = if dav1d_get_bit(gb) != 0 {
-                dav1d_get_sbits(gb, 7 as c_int)
+            (*hdr).quant.vdc_delta = if rav1d_get_bit(gb) != 0 {
+                rav1d_get_sbits(gb, 7 as c_int)
             } else {
                 0 as c_int
             };
-            (*hdr).quant.vac_delta = if dav1d_get_bit(gb) != 0 {
-                dav1d_get_sbits(gb, 7 as c_int)
+            (*hdr).quant.vac_delta = if rav1d_get_bit(gb) != 0 {
+                rav1d_get_sbits(gb, 7 as c_int)
             } else {
                 0 as c_int
             };
@@ -935,30 +935,30 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
             (*hdr).quant.vac_delta = (*hdr).quant.uac_delta;
         }
     }
-    (*hdr).quant.qm = dav1d_get_bit(gb) as c_int;
+    (*hdr).quant.qm = rav1d_get_bit(gb) as c_int;
     if (*hdr).quant.qm != 0 {
-        (*hdr).quant.qm_y = dav1d_get_bits(gb, 4 as c_int) as c_int;
-        (*hdr).quant.qm_u = dav1d_get_bits(gb, 4 as c_int) as c_int;
+        (*hdr).quant.qm_y = rav1d_get_bits(gb, 4 as c_int) as c_int;
+        (*hdr).quant.qm_u = rav1d_get_bits(gb, 4 as c_int) as c_int;
         (*hdr).quant.qm_v = if (*seqhdr).separate_uv_delta_q != 0 {
-            dav1d_get_bits(gb, 4 as c_int) as c_int
+            rav1d_get_bits(gb, 4 as c_int) as c_int
         } else {
             (*hdr).quant.qm_u
         };
     }
-    (*hdr).segmentation.enabled = dav1d_get_bit(gb) as c_int;
+    (*hdr).segmentation.enabled = rav1d_get_bit(gb) as c_int;
     if (*hdr).segmentation.enabled != 0 {
         if (*hdr).primary_ref_frame == 7 {
             (*hdr).segmentation.update_map = 1 as c_int;
             (*hdr).segmentation.temporal = 0 as c_int;
             (*hdr).segmentation.update_data = 1 as c_int;
         } else {
-            (*hdr).segmentation.update_map = dav1d_get_bit(gb) as c_int;
+            (*hdr).segmentation.update_map = rav1d_get_bit(gb) as c_int;
             (*hdr).segmentation.temporal = (if (*hdr).segmentation.update_map != 0 {
-                dav1d_get_bit(gb)
+                rav1d_get_bit(gb)
             } else {
                 0 as c_int as c_uint
             }) as c_int;
-            (*hdr).segmentation.update_data = dav1d_get_bit(gb) as c_int;
+            (*hdr).segmentation.update_data = rav1d_get_bit(gb) as c_int;
         }
         if (*hdr).segmentation.update_data != 0 {
             (*hdr).segmentation.seg_data.preskip = 0 as c_int;
@@ -969,49 +969,49 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
                     .as_mut_ptr()
                     .offset(i_10 as isize)
                     as *mut Dav1dSegmentationData;
-                if dav1d_get_bit(gb) != 0 {
-                    (*seg).delta_q = dav1d_get_sbits(gb, 9 as c_int);
+                if rav1d_get_bit(gb) != 0 {
+                    (*seg).delta_q = rav1d_get_sbits(gb, 9 as c_int);
                     (*hdr).segmentation.seg_data.last_active_segid = i_10;
                 } else {
                     (*seg).delta_q = 0 as c_int;
                 }
-                if dav1d_get_bit(gb) != 0 {
-                    (*seg).delta_lf_y_v = dav1d_get_sbits(gb, 7 as c_int);
+                if rav1d_get_bit(gb) != 0 {
+                    (*seg).delta_lf_y_v = rav1d_get_sbits(gb, 7 as c_int);
                     (*hdr).segmentation.seg_data.last_active_segid = i_10;
                 } else {
                     (*seg).delta_lf_y_v = 0 as c_int;
                 }
-                if dav1d_get_bit(gb) != 0 {
-                    (*seg).delta_lf_y_h = dav1d_get_sbits(gb, 7 as c_int);
+                if rav1d_get_bit(gb) != 0 {
+                    (*seg).delta_lf_y_h = rav1d_get_sbits(gb, 7 as c_int);
                     (*hdr).segmentation.seg_data.last_active_segid = i_10;
                 } else {
                     (*seg).delta_lf_y_h = 0 as c_int;
                 }
-                if dav1d_get_bit(gb) != 0 {
-                    (*seg).delta_lf_u = dav1d_get_sbits(gb, 7 as c_int);
+                if rav1d_get_bit(gb) != 0 {
+                    (*seg).delta_lf_u = rav1d_get_sbits(gb, 7 as c_int);
                     (*hdr).segmentation.seg_data.last_active_segid = i_10;
                 } else {
                     (*seg).delta_lf_u = 0 as c_int;
                 }
-                if dav1d_get_bit(gb) != 0 {
-                    (*seg).delta_lf_v = dav1d_get_sbits(gb, 7 as c_int);
+                if rav1d_get_bit(gb) != 0 {
+                    (*seg).delta_lf_v = rav1d_get_sbits(gb, 7 as c_int);
                     (*hdr).segmentation.seg_data.last_active_segid = i_10;
                 } else {
                     (*seg).delta_lf_v = 0 as c_int;
                 }
-                if dav1d_get_bit(gb) != 0 {
-                    (*seg).r#ref = dav1d_get_bits(gb, 3 as c_int) as c_int;
+                if rav1d_get_bit(gb) != 0 {
+                    (*seg).r#ref = rav1d_get_bits(gb, 3 as c_int) as c_int;
                     (*hdr).segmentation.seg_data.last_active_segid = i_10;
                     (*hdr).segmentation.seg_data.preskip = 1 as c_int;
                 } else {
                     (*seg).r#ref = -(1 as c_int);
                 }
-                (*seg).skip = dav1d_get_bit(gb) as c_int;
+                (*seg).skip = rav1d_get_bit(gb) as c_int;
                 if (*seg).skip != 0 {
                     (*hdr).segmentation.seg_data.last_active_segid = i_10;
                     (*hdr).segmentation.seg_data.preskip = 1 as c_int;
                 }
-                (*seg).globalmv = dav1d_get_bit(gb) as c_int;
+                (*seg).globalmv = rav1d_get_bit(gb) as c_int;
                 if (*seg).globalmv != 0 {
                     (*hdr).segmentation.seg_data.last_active_segid = i_10;
                     (*hdr).segmentation.seg_data.preskip = 1 as c_int;
@@ -1044,25 +1044,25 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
         }
     }
     (*hdr).delta.q.present = (if (*hdr).quant.yac != 0 {
-        dav1d_get_bit(gb)
+        rav1d_get_bit(gb)
     } else {
         0 as c_int as c_uint
     }) as c_int;
     (*hdr).delta.q.res_log2 = (if (*hdr).delta.q.present != 0 {
-        dav1d_get_bits(gb, 2 as c_int)
+        rav1d_get_bits(gb, 2 as c_int)
     } else {
         0 as c_int as c_uint
     }) as c_int;
     (*hdr).delta.lf.present = ((*hdr).delta.q.present != 0
         && (*hdr).allow_intrabc == 0
-        && dav1d_get_bit(gb) != 0) as c_int;
+        && rav1d_get_bit(gb) != 0) as c_int;
     (*hdr).delta.lf.res_log2 = (if (*hdr).delta.lf.present != 0 {
-        dav1d_get_bits(gb, 2 as c_int)
+        rav1d_get_bits(gb, 2 as c_int)
     } else {
         0 as c_int as c_uint
     }) as c_int;
     (*hdr).delta.lf.multi = (if (*hdr).delta.lf.present != 0 {
-        dav1d_get_bit(gb)
+        rav1d_get_bit(gb)
     } else {
         0 as c_int as c_uint
     }) as c_int;
@@ -1094,15 +1094,15 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
         (*hdr).loopfilter.mode_ref_delta_update = 1 as c_int;
         (*hdr).loopfilter.mode_ref_deltas = default_mode_ref_deltas.clone();
     } else {
-        (*hdr).loopfilter.level_y[0] = dav1d_get_bits(gb, 6 as c_int) as c_int;
-        (*hdr).loopfilter.level_y[1] = dav1d_get_bits(gb, 6 as c_int) as c_int;
+        (*hdr).loopfilter.level_y[0] = rav1d_get_bits(gb, 6 as c_int) as c_int;
+        (*hdr).loopfilter.level_y[1] = rav1d_get_bits(gb, 6 as c_int) as c_int;
         if (*seqhdr).monochrome == 0
             && ((*hdr).loopfilter.level_y[0] != 0 || (*hdr).loopfilter.level_y[1] != 0)
         {
-            (*hdr).loopfilter.level_u = dav1d_get_bits(gb, 6 as c_int) as c_int;
-            (*hdr).loopfilter.level_v = dav1d_get_bits(gb, 6 as c_int) as c_int;
+            (*hdr).loopfilter.level_u = rav1d_get_bits(gb, 6 as c_int) as c_int;
+            (*hdr).loopfilter.level_v = rav1d_get_bits(gb, 6 as c_int) as c_int;
         }
-        (*hdr).loopfilter.sharpness = dav1d_get_bits(gb, 3 as c_int) as c_int;
+        (*hdr).loopfilter.sharpness = rav1d_get_bits(gb, 3 as c_int) as c_int;
         if (*hdr).primary_ref_frame == 7 {
             (*hdr).loopfilter.mode_ref_deltas = default_mode_ref_deltas.clone();
         } else {
@@ -1115,23 +1115,23 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
                 .mode_ref_deltas
                 .clone();
         }
-        (*hdr).loopfilter.mode_ref_delta_enabled = dav1d_get_bit(gb) as c_int;
+        (*hdr).loopfilter.mode_ref_delta_enabled = rav1d_get_bit(gb) as c_int;
         if (*hdr).loopfilter.mode_ref_delta_enabled != 0 {
-            (*hdr).loopfilter.mode_ref_delta_update = dav1d_get_bit(gb) as c_int;
+            (*hdr).loopfilter.mode_ref_delta_update = rav1d_get_bit(gb) as c_int;
             if (*hdr).loopfilter.mode_ref_delta_update != 0 {
                 let mut i_13 = 0;
                 while i_13 < 8 {
-                    if dav1d_get_bit(gb) != 0 {
+                    if rav1d_get_bit(gb) != 0 {
                         (*hdr).loopfilter.mode_ref_deltas.ref_delta[i_13 as usize] =
-                            dav1d_get_sbits(gb, 7 as c_int);
+                            rav1d_get_sbits(gb, 7 as c_int);
                     }
                     i_13 += 1;
                 }
                 let mut i_14 = 0;
                 while i_14 < 2 {
-                    if dav1d_get_bit(gb) != 0 {
+                    if rav1d_get_bit(gb) != 0 {
                         (*hdr).loopfilter.mode_ref_deltas.mode_delta[i_14 as usize] =
-                            dav1d_get_sbits(gb, 7 as c_int);
+                            rav1d_get_sbits(gb, 7 as c_int);
                     }
                     i_14 += 1;
                 }
@@ -1140,13 +1140,13 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
     }
     if (*hdr).all_lossless == 0 && (*seqhdr).cdef != 0 && (*hdr).allow_intrabc == 0 {
         (*hdr).cdef.damping =
-            (dav1d_get_bits(gb, 2 as c_int)).wrapping_add(3 as c_int as c_uint) as c_int;
-        (*hdr).cdef.n_bits = dav1d_get_bits(gb, 2 as c_int) as c_int;
+            (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(3 as c_int as c_uint) as c_int;
+        (*hdr).cdef.n_bits = rav1d_get_bits(gb, 2 as c_int) as c_int;
         let mut i_15 = 0;
         while i_15 < (1 as c_int) << (*hdr).cdef.n_bits {
-            (*hdr).cdef.y_strength[i_15 as usize] = dav1d_get_bits(gb, 6 as c_int) as c_int;
+            (*hdr).cdef.y_strength[i_15 as usize] = rav1d_get_bits(gb, 6 as c_int) as c_int;
             if (*seqhdr).monochrome == 0 {
-                (*hdr).cdef.uv_strength[i_15 as usize] = dav1d_get_bits(gb, 6 as c_int) as c_int;
+                (*hdr).cdef.uv_strength[i_15 as usize] = rav1d_get_bits(gb, 6 as c_int) as c_int;
             }
             i_15 += 1;
         }
@@ -1159,10 +1159,10 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
         && (*seqhdr).restoration != 0
         && (*hdr).allow_intrabc == 0
     {
-        (*hdr).restoration.type_0[0] = dav1d_get_bits(gb, 2 as c_int) as Dav1dRestorationType;
+        (*hdr).restoration.type_0[0] = rav1d_get_bits(gb, 2 as c_int) as Dav1dRestorationType;
         if (*seqhdr).monochrome == 0 {
-            (*hdr).restoration.type_0[1] = dav1d_get_bits(gb, 2 as c_int) as Dav1dRestorationType;
-            (*hdr).restoration.type_0[2] = dav1d_get_bits(gb, 2 as c_int) as Dav1dRestorationType;
+            (*hdr).restoration.type_0[1] = rav1d_get_bits(gb, 2 as c_int) as Dav1dRestorationType;
+            (*hdr).restoration.type_0[2] = rav1d_get_bits(gb, 2 as c_int) as Dav1dRestorationType;
         } else {
             (*hdr).restoration.type_0[2] = DAV1D_RESTORATION_NONE;
             (*hdr).restoration.type_0[1] = (*hdr).restoration.type_0[2];
@@ -1172,11 +1172,11 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
             || (*hdr).restoration.type_0[2] as c_uint != 0
         {
             (*hdr).restoration.unit_size[0] = 6 + (*seqhdr).sb128;
-            if dav1d_get_bit(gb) != 0 {
+            if rav1d_get_bit(gb) != 0 {
                 (*hdr).restoration.unit_size[0] += 1;
                 if (*seqhdr).sb128 == 0 {
                     (*hdr).restoration.unit_size[0] = ((*hdr).restoration.unit_size[0] as c_uint)
-                        .wrapping_add(dav1d_get_bit(gb))
+                        .wrapping_add(rav1d_get_bit(gb))
                         as c_int as c_int;
                 }
             }
@@ -1187,7 +1187,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
                 && (*seqhdr).ss_ver == 1
             {
                 (*hdr).restoration.unit_size[1] = ((*hdr).restoration.unit_size[1] as c_uint)
-                    .wrapping_sub(dav1d_get_bit(gb))
+                    .wrapping_sub(rav1d_get_bit(gb))
                     as c_int as c_int;
             }
         } else {
@@ -1200,13 +1200,13 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
     }
     (*hdr).txfm_mode = (if (*hdr).all_lossless != 0 {
         DAV1D_TX_4X4_ONLY as c_int
-    } else if dav1d_get_bit(gb) != 0 {
+    } else if rav1d_get_bit(gb) != 0 {
         DAV1D_TX_SWITCHABLE as c_int
     } else {
         DAV1D_TX_LARGEST as c_int
     }) as Dav1dTxfmMode;
     (*hdr).switchable_comp_refs = (if (*hdr).frame_type as c_uint & 1 as c_uint != 0 {
-        dav1d_get_bit(gb)
+        rav1d_get_bit(gb)
     } else {
         0 as c_int as c_uint
     }) as c_int;
@@ -1306,15 +1306,15 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
         }
     }
     (*hdr).skip_mode_enabled = (if (*hdr).skip_mode_allowed != 0 {
-        dav1d_get_bit(gb)
+        rav1d_get_bit(gb)
     } else {
         0 as c_int as c_uint
     }) as c_int;
     (*hdr).warp_motion = ((*hdr).error_resilient_mode == 0
         && (*hdr).frame_type as c_uint & 1 as c_uint != 0
         && (*seqhdr).warped_motion != 0
-        && dav1d_get_bit(gb) != 0) as c_int;
-    (*hdr).reduced_txtp_set = dav1d_get_bit(gb) as c_int;
+        && rav1d_get_bit(gb) != 0) as c_int;
+    (*hdr).reduced_txtp_set = rav1d_get_bit(gb) as c_int;
     let mut i_18 = 0;
     while i_18 < 7 {
         (*hdr).gmv[i_18 as usize] = dav1d_default_wm_params.clone();
@@ -1323,11 +1323,11 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
     if (*hdr).frame_type as c_uint & 1 as c_uint != 0 {
         let mut i_19 = 0;
         while i_19 < 7 {
-            (*hdr).gmv[i_19 as usize].type_0 = (if dav1d_get_bit(gb) == 0 {
+            (*hdr).gmv[i_19 as usize].type_0 = (if rav1d_get_bit(gb) == 0 {
                 DAV1D_WM_TYPE_IDENTITY as c_int
-            } else if dav1d_get_bit(gb) != 0 {
+            } else if rav1d_get_bit(gb) != 0 {
                 DAV1D_WM_TYPE_ROT_ZOOM as c_int
-            } else if dav1d_get_bit(gb) != 0 {
+            } else if rav1d_get_bit(gb) != 0 {
                 DAV1D_WM_TYPE_TRANSLATION as c_int
             } else {
                 DAV1D_WM_TYPE_AFFINE as c_int
@@ -1360,13 +1360,13 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
                     >= DAV1D_WM_TYPE_ROT_ZOOM as c_int as c_uint
                 {
                     *mat.offset(2) = ((1 as c_int) << 16)
-                        + 2 * dav1d_get_bits_subexp(
+                        + 2 * rav1d_get_bits_subexp(
                             gb,
                             *ref_mat.offset(2) - ((1 as c_int) << 16) >> 1,
                             12 as c_int as c_uint,
                         );
                     *mat.offset(3) = 2 as c_int
-                        * dav1d_get_bits_subexp(gb, *ref_mat.offset(3) >> 1, 12 as c_int as c_uint);
+                        * rav1d_get_bits_subexp(gb, *ref_mat.offset(3) >> 1, 12 as c_int as c_uint);
                     bits = 12 as c_int;
                     shift = 10 as c_int;
                 } else {
@@ -1377,9 +1377,9 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
                     == DAV1D_WM_TYPE_AFFINE as c_int as c_uint
                 {
                     *mat.offset(4) = 2 as c_int
-                        * dav1d_get_bits_subexp(gb, *ref_mat.offset(4) >> 1, 12 as c_int as c_uint);
+                        * rav1d_get_bits_subexp(gb, *ref_mat.offset(4) >> 1, 12 as c_int as c_uint);
                     *mat.offset(5) = ((1 as c_int) << 16)
-                        + 2 * dav1d_get_bits_subexp(
+                        + 2 * rav1d_get_bits_subexp(
                             gb,
                             *ref_mat.offset(5) - ((1 as c_int) << 16) >> 1,
                             12 as c_int as c_uint,
@@ -1389,10 +1389,10 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
                     *mat.offset(5) = *mat.offset(2);
                 }
                 *mat.offset(0) =
-                    dav1d_get_bits_subexp(gb, *ref_mat.offset(0) >> shift, bits as c_uint)
+                    rav1d_get_bits_subexp(gb, *ref_mat.offset(0) >> shift, bits as c_uint)
                         * ((1 as c_int) << shift);
                 *mat.offset(1) =
-                    dav1d_get_bits_subexp(gb, *ref_mat.offset(1) >> shift, bits as c_uint)
+                    rav1d_get_bits_subexp(gb, *ref_mat.offset(1) >> shift, bits as c_uint)
                         * ((1 as c_int) << shift);
             }
             i_19 += 1;
@@ -1400,14 +1400,14 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
     }
     (*hdr).film_grain.present = ((*seqhdr).film_grain_present != 0
         && ((*hdr).show_frame != 0 || (*hdr).showable_frame != 0)
-        && dav1d_get_bit(gb) != 0) as c_int;
+        && rav1d_get_bit(gb) != 0) as c_int;
     if (*hdr).film_grain.present != 0 {
-        let seed: c_uint = dav1d_get_bits(gb, 16 as c_int);
+        let seed: c_uint = rav1d_get_bits(gb, 16 as c_int);
         (*hdr).film_grain.update = ((*hdr).frame_type as c_uint
             != DAV1D_FRAME_TYPE_INTER as c_int as c_uint
-            || dav1d_get_bit(gb) != 0) as c_int;
+            || rav1d_get_bit(gb) != 0) as c_int;
         if (*hdr).film_grain.update == 0 {
-            let refidx: c_int = dav1d_get_bits(gb, 3 as c_int) as c_int;
+            let refidx: c_int = rav1d_get_bits(gb, 3 as c_int) as c_int;
             let mut i_20: c_int;
             i_20 = 0 as c_int;
             while i_20 < 7 {
@@ -1427,24 +1427,24 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
         } else {
             let fgd: *mut Dav1dFilmGrainData = &mut (*hdr).film_grain.data;
             (*fgd).seed = seed;
-            (*fgd).num_y_points = dav1d_get_bits(gb, 4 as c_int) as c_int;
+            (*fgd).num_y_points = rav1d_get_bits(gb, 4 as c_int) as c_int;
             if (*fgd).num_y_points > 14 {
                 return parse_frame_hdr_error(c);
             }
             let mut i_21 = 0;
             while i_21 < (*fgd).num_y_points {
-                (*fgd).y_points[i_21 as usize][0] = dav1d_get_bits(gb, 8 as c_int) as u8;
+                (*fgd).y_points[i_21 as usize][0] = rav1d_get_bits(gb, 8 as c_int) as u8;
                 if i_21 != 0
                     && (*fgd).y_points[(i_21 - 1) as usize][0] as c_int
                         >= (*fgd).y_points[i_21 as usize][0] as c_int
                 {
                     return parse_frame_hdr_error(c);
                 }
-                (*fgd).y_points[i_21 as usize][1] = dav1d_get_bits(gb, 8 as c_int) as u8;
+                (*fgd).y_points[i_21 as usize][1] = rav1d_get_bits(gb, 8 as c_int) as u8;
                 i_21 += 1;
             }
             (*fgd).chroma_scaling_from_luma =
-                ((*seqhdr).monochrome == 0 && dav1d_get_bit(gb) != 0) as c_int;
+                ((*seqhdr).monochrome == 0 && rav1d_get_bit(gb) != 0) as c_int;
             if (*seqhdr).monochrome != 0
                 || (*fgd).chroma_scaling_from_luma != 0
                 || (*seqhdr).ss_ver == 1 && (*seqhdr).ss_hor == 1 && (*fgd).num_y_points == 0
@@ -1454,14 +1454,14 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
             } else {
                 let mut pl = 0;
                 while pl < 2 {
-                    (*fgd).num_uv_points[pl as usize] = dav1d_get_bits(gb, 4 as c_int) as c_int;
+                    (*fgd).num_uv_points[pl as usize] = rav1d_get_bits(gb, 4 as c_int) as c_int;
                     if (*fgd).num_uv_points[pl as usize] > 10 {
                         return parse_frame_hdr_error(c);
                     }
                     let mut i_22 = 0;
                     while i_22 < (*fgd).num_uv_points[pl as usize] {
                         (*fgd).uv_points[pl as usize][i_22 as usize][0] =
-                            dav1d_get_bits(gb, 8 as c_int) as u8;
+                            rav1d_get_bits(gb, 8 as c_int) as u8;
                         if i_22 != 0
                             && (*fgd).uv_points[pl as usize][(i_22 - 1) as usize][0] as c_int
                                 >= (*fgd).uv_points[pl as usize][i_22 as usize][0] as c_int
@@ -1469,7 +1469,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
                             return parse_frame_hdr_error(c);
                         }
                         (*fgd).uv_points[pl as usize][i_22 as usize][1] =
-                            dav1d_get_bits(gb, 8 as c_int) as u8;
+                            rav1d_get_bits(gb, 8 as c_int) as u8;
                         i_22 += 1;
                     }
                     pl += 1;
@@ -1483,14 +1483,14 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
                 return parse_frame_hdr_error(c);
             }
             (*fgd).scaling_shift =
-                (dav1d_get_bits(gb, 2 as c_int)).wrapping_add(8 as c_int as c_uint) as c_int;
-            (*fgd).ar_coeff_lag = dav1d_get_bits(gb, 2 as c_int) as c_int;
+                (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(8 as c_int as c_uint) as c_int;
+            (*fgd).ar_coeff_lag = rav1d_get_bits(gb, 2 as c_int) as c_int;
             let num_y_pos = 2 * (*fgd).ar_coeff_lag * ((*fgd).ar_coeff_lag + 1);
             if (*fgd).num_y_points != 0 {
                 let mut i_23 = 0;
                 while i_23 < num_y_pos {
                     (*fgd).ar_coeffs_y[i_23 as usize] =
-                        (dav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128 as c_int as c_uint) as i8;
+                        (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128 as c_int as c_uint) as i8;
                     i_23 += 1;
                 }
             }
@@ -1502,7 +1502,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
                     let mut i_24 = 0;
                     while i_24 < num_uv_pos {
                         (*fgd).ar_coeffs_uv[pl_0 as usize][i_24 as usize] =
-                            (dav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128 as c_int as c_uint)
+                            (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128 as c_int as c_uint)
                                 as i8;
                         i_24 += 1;
                     }
@@ -1513,25 +1513,25 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
                 pl_0 += 1;
             }
             (*fgd).ar_coeff_shift =
-                (dav1d_get_bits(gb, 2 as c_int)).wrapping_add(6 as c_int as c_uint) as u64;
-            (*fgd).grain_scale_shift = dav1d_get_bits(gb, 2 as c_int) as c_int;
+                (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(6 as c_int as c_uint) as u64;
+            (*fgd).grain_scale_shift = rav1d_get_bits(gb, 2 as c_int) as c_int;
             let mut pl_1 = 0;
             while pl_1 < 2 {
                 if (*fgd).num_uv_points[pl_1 as usize] != 0 {
-                    (*fgd).uv_mult[pl_1 as usize] = (dav1d_get_bits(gb, 8 as c_int))
+                    (*fgd).uv_mult[pl_1 as usize] = (rav1d_get_bits(gb, 8 as c_int))
                         .wrapping_sub(128 as c_int as c_uint)
                         as c_int;
-                    (*fgd).uv_luma_mult[pl_1 as usize] = (dav1d_get_bits(gb, 8 as c_int))
+                    (*fgd).uv_luma_mult[pl_1 as usize] = (rav1d_get_bits(gb, 8 as c_int))
                         .wrapping_sub(128 as c_int as c_uint)
                         as c_int;
-                    (*fgd).uv_offset[pl_1 as usize] = (dav1d_get_bits(gb, 9 as c_int))
+                    (*fgd).uv_offset[pl_1 as usize] = (rav1d_get_bits(gb, 9 as c_int))
                         .wrapping_sub(256 as c_int as c_uint)
                         as c_int;
                 }
                 pl_1 += 1;
             }
-            (*fgd).overlap_flag = dav1d_get_bit(gb) as c_int;
-            (*fgd).clip_to_restricted_range = dav1d_get_bit(gb) as c_int;
+            (*fgd).overlap_flag = rav1d_get_bit(gb) as c_int;
+            (*fgd).clip_to_restricted_range = rav1d_get_bit(gb) as c_int;
         }
     } else {
         memset(
@@ -1546,15 +1546,15 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
 unsafe extern "C" fn parse_tile_hdr(c: *mut Rav1dContext, gb: *mut GetBits) {
     let n_tiles = (*(*c).frame_hdr).tiling.cols * (*(*c).frame_hdr).tiling.rows;
     let have_tile_pos = (if n_tiles > 1 {
-        dav1d_get_bit(gb)
+        rav1d_get_bit(gb)
     } else {
         0 as c_int as c_uint
     }) as c_int;
     if have_tile_pos != 0 {
         let n_bits = (*(*c).frame_hdr).tiling.log2_cols + (*(*c).frame_hdr).tiling.log2_rows;
         (*((*c).tile).offset((*c).n_tile_data as isize)).start =
-            dav1d_get_bits(gb, n_bits) as c_int;
-        (*((*c).tile).offset((*c).n_tile_data as isize)).end = dav1d_get_bits(gb, n_bits) as c_int;
+            rav1d_get_bits(gb, n_bits) as c_int;
+        (*((*c).tile).offset((*c).n_tile_data as isize)).end = rav1d_get_bits(gb, n_bits) as c_int;
     } else {
         (*((*c).tile).offset((*c).n_tile_data as isize)).start = 0 as c_int;
         (*((*c).tile).offset((*c).n_tile_data as isize)).end = n_tiles - 1;
@@ -1568,18 +1568,18 @@ unsafe extern "C" fn check_for_overrun(
     obu_len: c_uint,
 ) -> c_int {
     if (*gb).error != 0 {
-        dav1d_log(
+        rav1d_log(
             c,
             b"Overrun in OBU bit buffer\n\0" as *const u8 as *const c_char,
         );
         return 1 as c_int;
     }
-    let pos: c_uint = dav1d_get_bits_pos(gb);
+    let pos: c_uint = rav1d_get_bits_pos(gb);
     if !(init_bit_pos <= pos) {
         unreachable!();
     }
     if pos.wrapping_sub(init_bit_pos) > (8 as c_int as c_uint).wrapping_mul(obu_len) {
-        dav1d_log(
+        rav1d_log(
             c,
             b"Overrun in OBU bit buffer into next OBU\n\0" as *const u8 as *const c_char,
         );
@@ -1588,16 +1588,16 @@ unsafe extern "C" fn check_for_overrun(
     return 0 as c_int;
 }
 
-unsafe extern "C" fn dav1d_parse_obus_error(c: *mut Rav1dContext, in_0: *mut Dav1dData) -> c_int {
-    dav1d_data_props_copy(&mut (*c).cached_error_props, &mut (*in_0).m);
-    dav1d_log(
+unsafe extern "C" fn rav1d_parse_obus_error(c: *mut Rav1dContext, in_0: *mut Rav1dData) -> c_int {
+    rav1d_data_props_copy(&mut (*c).cached_error_props, &mut (*in_0).m);
+    rav1d_log(
         c,
         b"Error parsing OBU data\n\0" as *const u8 as *const c_char,
     );
     return -(22 as c_int);
 }
 
-unsafe extern "C" fn dav1d_parse_obus_skip(
+unsafe extern "C" fn rav1d_parse_obus_skip(
     c: *mut Rav1dContext,
     len: c_uint,
     init_byte_pos: c_uint,
@@ -1605,23 +1605,27 @@ unsafe extern "C" fn dav1d_parse_obus_skip(
     let mut i = 0;
     while i < 8 {
         if (*(*c).frame_hdr).refresh_frame_flags & (1 as c_int) << i != 0 {
-            dav1d_thread_picture_unref(&mut (*((*c).refs).as_mut_ptr().offset(i as isize)).p);
+            rav1d_thread_picture_unref(&mut (*((*c).refs).as_mut_ptr().offset(i as isize)).p);
             (*c).refs[i as usize].p.p.frame_hdr = (*c).frame_hdr;
             (*c).refs[i as usize].p.p.seq_hdr = (*c).seq_hdr;
             (*c).refs[i as usize].p.p.frame_hdr_ref = (*c).frame_hdr_ref;
             (*c).refs[i as usize].p.p.seq_hdr_ref = (*c).seq_hdr_ref;
-            dav1d_ref_inc((*c).frame_hdr_ref);
-            dav1d_ref_inc((*c).seq_hdr_ref);
+            rav1d_ref_inc((*c).frame_hdr_ref);
+            rav1d_ref_inc((*c).seq_hdr_ref);
         }
         i += 1;
     }
-    dav1d_ref_dec(&mut (*c).frame_hdr_ref);
+    rav1d_ref_dec(&mut (*c).frame_hdr_ref);
     (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
     (*c).n_tiles = 0 as c_int;
     return len.wrapping_add(init_byte_pos) as c_int;
 }
 
-pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, global: c_int) -> c_int {
+pub(crate) unsafe fn rav1d_parse_obus(
+    c: *mut Rav1dContext,
+    in_0: *mut Rav1dData,
+    global: c_int,
+) -> c_int {
     let mut gb: GetBits = GetBits {
         state: 0,
         bits_left: 0,
@@ -1631,30 +1635,30 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
         ptr_end: 0 as *const u8,
     };
     let mut res: c_int;
-    dav1d_init_get_bits(&mut gb, (*in_0).data, (*in_0).sz);
-    dav1d_get_bit(&mut gb);
-    let type_0: Dav1dObuType = dav1d_get_bits(&mut gb, 4 as c_int) as Dav1dObuType;
-    let has_extension: c_int = dav1d_get_bit(&mut gb) as c_int;
-    let has_length_field: c_int = dav1d_get_bit(&mut gb) as c_int;
-    dav1d_get_bit(&mut gb);
+    rav1d_init_get_bits(&mut gb, (*in_0).data, (*in_0).sz);
+    rav1d_get_bit(&mut gb);
+    let type_0: Rav1dObuType = rav1d_get_bits(&mut gb, 4 as c_int) as Rav1dObuType;
+    let has_extension: c_int = rav1d_get_bit(&mut gb) as c_int;
+    let has_length_field: c_int = rav1d_get_bit(&mut gb) as c_int;
+    rav1d_get_bit(&mut gb);
     let mut temporal_id = 0;
     let mut spatial_id = 0;
     if has_extension != 0 {
-        temporal_id = dav1d_get_bits(&mut gb, 3 as c_int) as c_int;
-        spatial_id = dav1d_get_bits(&mut gb, 2 as c_int) as c_int;
-        dav1d_get_bits(&mut gb, 3 as c_int);
+        temporal_id = rav1d_get_bits(&mut gb, 3 as c_int) as c_int;
+        spatial_id = rav1d_get_bits(&mut gb, 2 as c_int) as c_int;
+        rav1d_get_bits(&mut gb, 3 as c_int);
     }
     let len: c_uint = if has_length_field != 0 {
-        dav1d_get_uleb128(&mut gb)
+        rav1d_get_uleb128(&mut gb)
     } else {
         ((*in_0).sz as c_uint)
             .wrapping_sub(1 as c_int as c_uint)
             .wrapping_sub(has_extension as c_uint)
     };
     if gb.error != 0 {
-        return dav1d_parse_obus_error(c, in_0);
+        return rav1d_parse_obus_error(c, in_0);
     }
-    let init_bit_pos: c_uint = dav1d_get_bits_pos(&mut gb);
+    let init_bit_pos: c_uint = rav1d_get_bits_pos(&mut gb);
     let init_byte_pos: c_uint = init_bit_pos >> 3;
     if !(init_bit_pos & 7 as c_uint == 0 as c_uint) {
         unreachable!();
@@ -1663,7 +1667,7 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
         unreachable!();
     }
     if len as usize > ((*in_0).sz).wrapping_sub(init_byte_pos as usize) {
-        return dav1d_parse_obus_error(c, in_0);
+        return rav1d_parse_obus_error(c, in_0);
     }
     if type_0 as c_uint != DAV1D_OBU_SEQ_HDR as c_int as c_uint
         && type_0 as c_uint != DAV1D_OBU_TD as c_int as c_uint
@@ -1681,7 +1685,7 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
     let mut current_block_188: u64;
     match type_0 as c_uint {
         DAV1D_OBU_SEQ_HDR => {
-            let mut ref_0: *mut Rav1dRef = dav1d_ref_create_using_pool(
+            let mut ref_0: *mut Rav1dRef = rav1d_ref_create_using_pool(
                 (*c).seq_hdr_pool,
                 ::core::mem::size_of::<Dav1dSequenceHeader>(),
             );
@@ -1691,12 +1695,12 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
             let seq_hdr: *mut Dav1dSequenceHeader = (*ref_0).data as *mut Dav1dSequenceHeader;
             res = parse_seq_hdr(c, &mut gb, seq_hdr);
             if res < 0 {
-                dav1d_ref_dec(&mut ref_0);
-                return dav1d_parse_obus_error(c, in_0);
+                rav1d_ref_dec(&mut ref_0);
+                return rav1d_parse_obus_error(c, in_0);
             }
             if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
-                dav1d_ref_dec(&mut ref_0);
-                return dav1d_parse_obus_error(c, in_0);
+                rav1d_ref_dec(&mut ref_0);
+                return rav1d_parse_obus_error(c, in_0);
             }
             if ((*c).seq_hdr).is_null() {
                 (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
@@ -1712,18 +1716,18 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                 (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
                 (*c).mastering_display = 0 as *mut Dav1dMasteringDisplay;
                 (*c).content_light = 0 as *mut Dav1dContentLightLevel;
-                dav1d_ref_dec(&mut (*c).mastering_display_ref);
-                dav1d_ref_dec(&mut (*c).content_light_ref);
+                rav1d_ref_dec(&mut (*c).mastering_display_ref);
+                rav1d_ref_dec(&mut (*c).content_light_ref);
                 let mut i = 0;
                 while i < 8 {
                     if !((*c).refs[i as usize].p.p.frame_hdr).is_null() {
-                        dav1d_thread_picture_unref(
+                        rav1d_thread_picture_unref(
                             &mut (*((*c).refs).as_mut_ptr().offset(i as isize)).p,
                         );
                     }
-                    dav1d_ref_dec(&mut (*((*c).refs).as_mut_ptr().offset(i as isize)).segmap);
-                    dav1d_ref_dec(&mut (*((*c).refs).as_mut_ptr().offset(i as isize)).refmvs);
-                    dav1d_cdf_thread_unref(&mut *((*c).cdf).as_mut_ptr().offset(i as isize));
+                    rav1d_ref_dec(&mut (*((*c).refs).as_mut_ptr().offset(i as isize)).segmap);
+                    rav1d_ref_dec(&mut (*((*c).refs).as_mut_ptr().offset(i as isize)).refmvs);
+                    rav1d_cdf_thread_unref(&mut *((*c).cdf).as_mut_ptr().offset(i as isize));
                     i += 1;
                 }
                 (*c).frame_flags = ::core::mem::transmute::<c_uint, PictureFlags>(
@@ -1739,7 +1743,7 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                     (*c).frame_flags as c_uint | PICTURE_FLAG_NEW_OP_PARAMS_INFO as c_int as c_uint,
                 );
             }
-            dav1d_ref_dec(&mut (*c).seq_hdr_ref);
+            rav1d_ref_dec(&mut (*c).seq_hdr_ref);
             (*c).seq_hdr_ref = ref_0;
             (*c).seq_hdr = seq_hdr;
             current_block_188 = 8953117030348968745;
@@ -1758,38 +1762,38 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
             current_block_188 = 17787701279558130514;
         }
         DAV1D_OBU_METADATA => {
-            let meta_type: ObuMetaType = dav1d_get_uleb128(&mut gb) as ObuMetaType;
+            let meta_type: ObuMetaType = rav1d_get_uleb128(&mut gb) as ObuMetaType;
             let meta_type_len: c_int =
-                ((dav1d_get_bits_pos(&mut gb)).wrapping_sub(init_bit_pos) >> 3) as c_int;
+                ((rav1d_get_bits_pos(&mut gb)).wrapping_sub(init_bit_pos) >> 3) as c_int;
             if gb.error != 0 {
-                return dav1d_parse_obus_error(c, in_0);
+                return rav1d_parse_obus_error(c, in_0);
             }
             match meta_type as c_uint {
                 OBU_META_HDR_CLL => {
                     let mut ref_1: *mut Rav1dRef =
-                        dav1d_ref_create(::core::mem::size_of::<Dav1dContentLightLevel>());
+                        rav1d_ref_create(::core::mem::size_of::<Dav1dContentLightLevel>());
                     if ref_1.is_null() {
                         return -(12 as c_int);
                     }
                     let content_light: *mut Dav1dContentLightLevel =
                         (*ref_1).data as *mut Dav1dContentLightLevel;
                     (*content_light).max_content_light_level =
-                        dav1d_get_bits(&mut gb, 16 as c_int) as c_int;
+                        rav1d_get_bits(&mut gb, 16 as c_int) as c_int;
                     (*content_light).max_frame_average_light_level =
-                        dav1d_get_bits(&mut gb, 16 as c_int) as c_int;
-                    dav1d_get_bit(&mut gb);
-                    dav1d_bytealign_get_bits(&mut gb);
+                        rav1d_get_bits(&mut gb, 16 as c_int) as c_int;
+                    rav1d_get_bit(&mut gb);
+                    rav1d_bytealign_get_bits(&mut gb);
                     if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
-                        dav1d_ref_dec(&mut ref_1);
-                        return dav1d_parse_obus_error(c, in_0);
+                        rav1d_ref_dec(&mut ref_1);
+                        return rav1d_parse_obus_error(c, in_0);
                     }
-                    dav1d_ref_dec(&mut (*c).content_light_ref);
+                    rav1d_ref_dec(&mut (*c).content_light_ref);
                     (*c).content_light = content_light;
                     (*c).content_light_ref = ref_1;
                 }
                 OBU_META_HDR_MDCV => {
                     let mut ref_2: *mut Rav1dRef =
-                        dav1d_ref_create(::core::mem::size_of::<Dav1dMasteringDisplay>());
+                        rav1d_ref_create(::core::mem::size_of::<Dav1dMasteringDisplay>());
                     if ref_2.is_null() {
                         return -(12 as c_int);
                     }
@@ -1798,24 +1802,24 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                     let mut i_1 = 0;
                     while i_1 < 3 {
                         (*mastering_display).primaries[i_1 as usize][0] =
-                            dav1d_get_bits(&mut gb, 16 as c_int) as u16;
+                            rav1d_get_bits(&mut gb, 16 as c_int) as u16;
                         (*mastering_display).primaries[i_1 as usize][1] =
-                            dav1d_get_bits(&mut gb, 16 as c_int) as u16;
+                            rav1d_get_bits(&mut gb, 16 as c_int) as u16;
                         i_1 += 1;
                     }
                     (*mastering_display).white_point[0] =
-                        dav1d_get_bits(&mut gb, 16 as c_int) as u16;
+                        rav1d_get_bits(&mut gb, 16 as c_int) as u16;
                     (*mastering_display).white_point[1] =
-                        dav1d_get_bits(&mut gb, 16 as c_int) as u16;
-                    (*mastering_display).max_luminance = dav1d_get_bits(&mut gb, 32 as c_int);
-                    (*mastering_display).min_luminance = dav1d_get_bits(&mut gb, 32 as c_int);
-                    dav1d_get_bit(&mut gb);
-                    dav1d_bytealign_get_bits(&mut gb);
+                        rav1d_get_bits(&mut gb, 16 as c_int) as u16;
+                    (*mastering_display).max_luminance = rav1d_get_bits(&mut gb, 32 as c_int);
+                    (*mastering_display).min_luminance = rav1d_get_bits(&mut gb, 32 as c_int);
+                    rav1d_get_bit(&mut gb);
+                    rav1d_bytealign_get_bits(&mut gb);
                     if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
-                        dav1d_ref_dec(&mut ref_2);
-                        return dav1d_parse_obus_error(c, in_0);
+                        rav1d_ref_dec(&mut ref_2);
+                        return rav1d_parse_obus_error(c, in_0);
                     }
-                    dav1d_ref_dec(&mut (*c).mastering_display_ref);
+                    rav1d_ref_dec(&mut (*c).mastering_display_ref);
                     (*c).mastering_display = mastering_display;
                     (*c).mastering_display_ref = ref_2;
                 }
@@ -1834,20 +1838,20 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                     payload_size -= 1;
                     payload_size -= meta_type_len;
                     let mut country_code_extension_byte = 0;
-                    let country_code: c_int = dav1d_get_bits(&mut gb, 8 as c_int) as c_int;
+                    let country_code: c_int = rav1d_get_bits(&mut gb, 8 as c_int) as c_int;
                     payload_size -= 1;
                     if country_code == 0xff as c_int {
-                        country_code_extension_byte = dav1d_get_bits(&mut gb, 8 as c_int) as c_int;
+                        country_code_extension_byte = rav1d_get_bits(&mut gb, 8 as c_int) as c_int;
                         payload_size -= 1;
                     }
                     if payload_size <= 0 {
-                        dav1d_log(
+                        rav1d_log(
                             c,
                             b"Malformed ITU-T T.35 metadata message format\n\0" as *const u8
                                 as *const c_char,
                         );
                     } else {
-                        let ref_3: *mut Rav1dRef = dav1d_ref_create(
+                        let ref_3: *mut Rav1dRef = rav1d_ref_create(
                             (::core::mem::size_of::<Dav1dITUTT35>()).wrapping_add(
                                 (payload_size as usize).wrapping_mul(::core::mem::size_of::<u8>()),
                             ),
@@ -1865,18 +1869,18 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                         let mut i_2 = 0;
                         while i_2 < payload_size {
                             *((*itut_t35_metadata).payload).offset(i_2 as isize) =
-                                dav1d_get_bits(&mut gb, 8 as c_int) as u8;
+                                rav1d_get_bits(&mut gb, 8 as c_int) as u8;
                             i_2 += 1;
                         }
                         (*itut_t35_metadata).payload_size = payload_size as usize;
-                        dav1d_ref_dec(&mut (*c).itut_t35_ref);
+                        rav1d_ref_dec(&mut (*c).itut_t35_ref);
                         (*c).itut_t35 = itut_t35_metadata;
                         (*c).itut_t35_ref = ref_3;
                     }
                 }
                 OBU_META_SCALABILITY | OBU_META_TIMECODE => {}
                 _ => {
-                    dav1d_log(
+                    rav1d_log(
                         c,
                         b"Unknown Metadata OBU type %d\n\0" as *const u8 as *const c_char,
                         meta_type as c_uint,
@@ -1895,7 +1899,7 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
             current_block_188 = 8953117030348968745;
         }
         _ => {
-            dav1d_log(
+            rav1d_log(
                 c,
                 b"Unknown OBU type %d of size %u\n\0" as *const u8 as *const c_char,
                 type_0 as c_uint,
@@ -1910,10 +1914,10 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                 current_block_188 = 8953117030348968745;
             } else {
                 if ((*c).seq_hdr).is_null() {
-                    return dav1d_parse_obus_error(c, in_0);
+                    return rav1d_parse_obus_error(c, in_0);
                 }
                 if ((*c).frame_hdr_ref).is_null() {
-                    (*c).frame_hdr_ref = dav1d_ref_create_using_pool(
+                    (*c).frame_hdr_ref = rav1d_ref_create_using_pool(
                         (*c).frame_hdr_pool,
                         ::core::mem::size_of::<Dav1dFrameHeader>(),
                     );
@@ -1922,7 +1926,7 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                     }
                 }
                 // ensure that the reference is writable
-                debug_assert!(dav1d_ref_is_writable((*c).frame_hdr_ref) != 0);
+                debug_assert!(rav1d_ref_is_writable((*c).frame_hdr_ref) != 0);
                 (*c).frame_hdr = (*(*c).frame_hdr_ref).data as *mut Dav1dFrameHeader;
                 memset(
                     (*c).frame_hdr as *mut c_void,
@@ -1934,27 +1938,27 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                 res = parse_frame_hdr(c, &mut gb);
                 if res < 0 {
                     (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
-                    return dav1d_parse_obus_error(c, in_0);
+                    return rav1d_parse_obus_error(c, in_0);
                 }
                 let mut n = 0;
                 while n < (*c).n_tile_data {
-                    dav1d_data_unref_internal(&mut (*((*c).tile).offset(n as isize)).data);
+                    rav1d_data_unref_internal(&mut (*((*c).tile).offset(n as isize)).data);
                     n += 1;
                 }
                 (*c).n_tile_data = 0 as c_int;
                 (*c).n_tiles = 0 as c_int;
                 if type_0 as c_uint != DAV1D_OBU_FRAME as c_int as c_uint {
-                    dav1d_get_bit(&mut gb);
+                    rav1d_get_bit(&mut gb);
                     if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
                         (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
-                        return dav1d_parse_obus_error(c, in_0);
+                        return rav1d_parse_obus_error(c, in_0);
                     }
                 }
                 if (*c).frame_size_limit != 0
                     && (*(*c).frame_hdr).width[1] as i64 * (*(*c).frame_hdr).height as i64
                         > (*c).frame_size_limit as i64
                 {
-                    dav1d_log(
+                    rav1d_log(
                         c,
                         b"Frame size %dx%d exceeds limit %u\n\0" as *const u8 as *const c_char,
                         (*(*c).frame_hdr).width[1],
@@ -1969,9 +1973,9 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                 } else {
                     if (*(*c).frame_hdr).show_existing_frame != 0 {
                         (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
-                        return dav1d_parse_obus_error(c, in_0);
+                        return rav1d_parse_obus_error(c, in_0);
                     }
-                    dav1d_bytealign_get_bits(&mut gb);
+                    rav1d_bytealign_get_bits(&mut gb);
                     current_block_188 = 17787701279558130514;
                 }
             }
@@ -1982,13 +1986,13 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
         17787701279558130514 => {
             if !(global != 0) {
                 if ((*c).frame_hdr).is_null() {
-                    return dav1d_parse_obus_error(c, in_0);
+                    return rav1d_parse_obus_error(c, in_0);
                 }
                 if (*c).n_tile_data_alloc < (*c).n_tile_data + 1 {
                     if (*c).n_tile_data + 1
                         > i32::MAX / ::core::mem::size_of::<Rav1dTileGroup>() as c_ulong as c_int
                     {
-                        return dav1d_parse_obus_error(c, in_0);
+                        return rav1d_parse_obus_error(c, in_0);
                     }
                     let tile: *mut Rav1dTileGroup = realloc(
                         (*c).tile as *mut c_void,
@@ -1996,7 +2000,7 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                             .wrapping_mul(::core::mem::size_of::<Rav1dTileGroup>()),
                     ) as *mut Rav1dTileGroup;
                     if tile.is_null() {
-                        return dav1d_parse_obus_error(c, in_0);
+                        return rav1d_parse_obus_error(c, in_0);
                     }
                     (*c).tile = tile;
                     memset(
@@ -2007,19 +2011,19 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                     (*c).n_tile_data_alloc = (*c).n_tile_data + 1;
                 }
                 parse_tile_hdr(c, &mut gb);
-                dav1d_bytealign_get_bits(&mut gb);
+                rav1d_bytealign_get_bits(&mut gb);
                 if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
-                    return dav1d_parse_obus_error(c, in_0);
+                    return rav1d_parse_obus_error(c, in_0);
                 }
                 let pkt_bytelen: c_uint = init_byte_pos.wrapping_add(len);
-                let bit_pos: c_uint = dav1d_get_bits_pos(&mut gb);
+                let bit_pos: c_uint = rav1d_get_bits_pos(&mut gb);
                 if !(bit_pos & 7 as c_uint == 0 as c_uint) {
                     unreachable!();
                 }
                 if !(pkt_bytelen >= bit_pos >> 3) {
                     unreachable!();
                 }
-                dav1d_data_ref(
+                rav1d_data_ref(
                     &mut (*((*c).tile).offset((*c).n_tile_data as isize)).data,
                     in_0,
                 );
@@ -2033,12 +2037,12 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                 {
                     let mut i_0 = 0;
                     while i_0 <= (*c).n_tile_data {
-                        dav1d_data_unref_internal(&mut (*((*c).tile).offset(i_0 as isize)).data);
+                        rav1d_data_unref_internal(&mut (*((*c).tile).offset(i_0 as isize)).data);
                         i_0 += 1;
                     }
                     (*c).n_tile_data = 0 as c_int;
                     (*c).n_tiles = 0 as c_int;
-                    return dav1d_parse_obus_error(c, in_0);
+                    return rav1d_parse_obus_error(c, in_0);
                 }
                 (*c).n_tiles += 1 as c_int + (*((*c).tile).offset((*c).n_tile_data as isize)).end
                     - (*((*c).tile).offset((*c).n_tile_data as isize)).start;
@@ -2055,7 +2059,7 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                 .frame_hdr)
                 .is_null()
             {
-                return dav1d_parse_obus_error(c, in_0);
+                return rav1d_parse_obus_error(c, in_0);
             }
             match (*(*c).refs[(*(*c).frame_hdr).existing_frame_idx as usize]
                 .p
@@ -2067,14 +2071,14 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                     if (*c).decode_frame_type as c_uint
                         > DAV1D_DECODEFRAMETYPE_REFERENCE as c_int as c_uint
                     {
-                        return dav1d_parse_obus_skip(c, len, init_byte_pos);
+                        return rav1d_parse_obus_skip(c, len, init_byte_pos);
                     }
                 }
                 DAV1D_FRAME_TYPE_INTRA => {
                     if (*c).decode_frame_type as c_uint
                         > DAV1D_DECODEFRAMETYPE_INTRA as c_int as c_uint
                     {
-                        return dav1d_parse_obus_skip(c, len, init_byte_pos);
+                        return rav1d_parse_obus_skip(c, len, init_byte_pos);
                     }
                 }
                 _ => {}
@@ -2085,27 +2089,27 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                 .data[0])
                 .is_null()
             {
-                return dav1d_parse_obus_error(c, in_0);
+                return rav1d_parse_obus_error(c, in_0);
             }
             if (*c).strict_std_compliance != 0
                 && !(*c).refs[(*(*c).frame_hdr).existing_frame_idx as usize]
                     .p
                     .showable
             {
-                return dav1d_parse_obus_error(c, in_0);
+                return rav1d_parse_obus_error(c, in_0);
             }
             if (*c).n_fc == 1 as c_uint {
-                dav1d_thread_picture_ref(
+                rav1d_thread_picture_ref(
                     &mut (*c).out,
                     &mut (*((*c).refs)
                         .as_mut_ptr()
                         .offset((*(*c).frame_hdr).existing_frame_idx as isize))
                     .p,
                 );
-                dav1d_data_props_copy(&mut (*c).out.p.m, &mut (*in_0).m);
+                rav1d_data_props_copy(&mut (*c).out.p.m, &mut (*in_0).m);
                 (*c).event_flags = ::core::mem::transmute::<c_uint, Dav1dEventFlags>(
                     (*c).event_flags as c_uint
-                        | dav1d_picture_get_event_flags(
+                        | rav1d_picture_get_event_flags(
                             &mut (*((*c).refs)
                                 .as_mut_ptr()
                                 .offset((*(*c).frame_hdr).existing_frame_idx as isize))
@@ -2164,8 +2168,8 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                 if error != 0 {
                     (*c).cached_error = error;
                     (*f).task_thread.retval = 0 as c_int;
-                    dav1d_data_props_copy(&mut (*c).cached_error_props, &mut (*out_delayed).p.m);
-                    dav1d_thread_picture_unref(out_delayed);
+                    rav1d_data_props_copy(&mut (*c).cached_error_props, &mut (*out_delayed).p.m);
+                    rav1d_thread_picture_unref(out_delayed);
                 } else if !((*out_delayed).p.data[0]).is_null() {
                     let progress: c_uint = ::core::intrinsics::atomic_load_relaxed(
                         &mut *((*out_delayed).progress).offset(1) as *mut atomic_uint,
@@ -2173,15 +2177,15 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                     if ((*out_delayed).visible || (*c).output_invisible_frames != 0)
                         && progress != FRAME_ERROR
                     {
-                        dav1d_thread_picture_ref(&mut (*c).out, out_delayed);
+                        rav1d_thread_picture_ref(&mut (*c).out, out_delayed);
                         (*c).event_flags = ::core::mem::transmute::<c_uint, Dav1dEventFlags>(
                             (*c).event_flags as c_uint
-                                | dav1d_picture_get_event_flags(out_delayed) as c_uint,
+                                | rav1d_picture_get_event_flags(out_delayed) as c_uint,
                         );
                     }
-                    dav1d_thread_picture_unref(out_delayed);
+                    rav1d_thread_picture_unref(out_delayed);
                 }
-                dav1d_thread_picture_ref(
+                rav1d_thread_picture_ref(
                     out_delayed,
                     &mut (*((*c).refs)
                         .as_mut_ptr()
@@ -2189,7 +2193,7 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                     .p,
                 );
                 (*out_delayed).visible = true;
-                dav1d_data_props_copy(&mut (*out_delayed).p.m, &mut (*in_0).m);
+                rav1d_data_props_copy(&mut (*out_delayed).p.m, &mut (*in_0).m);
                 pthread_mutex_unlock(&mut (*c).task_thread.lock);
             }
             if (*(*c).refs[(*(*c).frame_hdr).existing_frame_idx as usize]
@@ -2205,25 +2209,25 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                 while i_3 < 8 {
                     if !(i_3 == r) {
                         if !((*c).refs[i_3 as usize].p.p.frame_hdr).is_null() {
-                            dav1d_thread_picture_unref(
+                            rav1d_thread_picture_unref(
                                 &mut (*((*c).refs).as_mut_ptr().offset(i_3 as isize)).p,
                             );
                         }
-                        dav1d_thread_picture_ref(
+                        rav1d_thread_picture_ref(
                             &mut (*((*c).refs).as_mut_ptr().offset(i_3 as isize)).p,
                             &mut (*((*c).refs).as_mut_ptr().offset(r as isize)).p,
                         );
-                        dav1d_cdf_thread_unref(&mut *((*c).cdf).as_mut_ptr().offset(i_3 as isize));
-                        dav1d_cdf_thread_ref(
+                        rav1d_cdf_thread_unref(&mut *((*c).cdf).as_mut_ptr().offset(i_3 as isize));
+                        rav1d_cdf_thread_ref(
                             &mut *((*c).cdf).as_mut_ptr().offset(i_3 as isize),
                             &mut *((*c).cdf).as_mut_ptr().offset(r as isize),
                         );
-                        dav1d_ref_dec(&mut (*((*c).refs).as_mut_ptr().offset(i_3 as isize)).segmap);
+                        rav1d_ref_dec(&mut (*((*c).refs).as_mut_ptr().offset(i_3 as isize)).segmap);
                         (*c).refs[i_3 as usize].segmap = (*c).refs[r as usize].segmap;
                         if !((*c).refs[r as usize].segmap).is_null() {
-                            dav1d_ref_inc((*c).refs[r as usize].segmap);
+                            rav1d_ref_inc((*c).refs[r as usize].segmap);
                         }
-                        dav1d_ref_dec(&mut (*((*c).refs).as_mut_ptr().offset(i_3 as isize)).refmvs);
+                        rav1d_ref_dec(&mut (*((*c).refs).as_mut_ptr().offset(i_3 as isize)).refmvs);
                     }
                     i_3 += 1;
                 }
@@ -2238,7 +2242,7 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                             == DAV1D_DECODEFRAMETYPE_REFERENCE as c_int as c_uint
                             && (*(*c).frame_hdr).refresh_frame_flags == 0
                     {
-                        return dav1d_parse_obus_skip(c, len, init_byte_pos);
+                        return rav1d_parse_obus_skip(c, len, init_byte_pos);
                     }
                 }
                 DAV1D_FRAME_TYPE_INTRA => {
@@ -2248,15 +2252,15 @@ pub unsafe fn dav1d_parse_obus(c: *mut Rav1dContext, in_0: *mut Dav1dData, globa
                             == DAV1D_DECODEFRAMETYPE_REFERENCE as c_int as c_uint
                             && (*(*c).frame_hdr).refresh_frame_flags == 0
                     {
-                        return dav1d_parse_obus_skip(c, len, init_byte_pos);
+                        return rav1d_parse_obus_skip(c, len, init_byte_pos);
                     }
                 }
                 _ => {}
             }
             if (*c).n_tile_data == 0 {
-                return dav1d_parse_obus_error(c, in_0);
+                return rav1d_parse_obus_error(c, in_0);
             }
-            res = dav1d_submit_frame(&mut *c);
+            res = rav1d_submit_frame(&mut *c);
             if res < 0 {
                 return res;
             }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2,8 +2,8 @@ use crate::include::common::intops::iclip_u8;
 use crate::include::common::intops::ulog2;
 use crate::include::dav1d::data::Rav1dData;
 use crate::include::dav1d::dav1d::Dav1dEventFlags;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_INTRA;
-use crate::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_REFERENCE;
+use crate::include::dav1d::dav1d::RAV1D_DECODEFRAMETYPE_INTRA;
+use crate::include::dav1d::dav1d::RAV1D_DECODEFRAMETYPE_REFERENCE;
 use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
 use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
 use crate::include::dav1d::headers::Dav1dColorPrimaries;
@@ -29,39 +29,39 @@ use crate::include::dav1d::headers::Dav1dTxfmMode;
 use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
 use crate::include::dav1d::headers::Rav1dObuType;
-use crate::include::dav1d::headers::DAV1D_ADAPTIVE;
-use crate::include::dav1d::headers::DAV1D_CHR_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_BT709;
-use crate::include::dav1d::headers::DAV1D_COLOR_PRI_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_FILTER_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTER;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_INTRA;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_KEY;
-use crate::include::dav1d::headers::DAV1D_FRAME_TYPE_SWITCH;
-use crate::include::dav1d::headers::DAV1D_MC_IDENTITY;
-use crate::include::dav1d::headers::DAV1D_MC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_OBU_FRAME;
-use crate::include::dav1d::headers::DAV1D_OBU_FRAME_HDR;
-use crate::include::dav1d::headers::DAV1D_OBU_METADATA;
-use crate::include::dav1d::headers::DAV1D_OBU_PADDING;
-use crate::include::dav1d::headers::DAV1D_OBU_REDUNDANT_FRAME_HDR;
-use crate::include::dav1d::headers::DAV1D_OBU_SEQ_HDR;
-use crate::include::dav1d::headers::DAV1D_OBU_TD;
-use crate::include::dav1d::headers::DAV1D_OBU_TILE_GRP;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I422;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_RESTORATION_NONE;
-use crate::include::dav1d::headers::DAV1D_TRC_SRGB;
-use crate::include::dav1d::headers::DAV1D_TRC_UNKNOWN;
-use crate::include::dav1d::headers::DAV1D_TX_4X4_ONLY;
-use crate::include::dav1d::headers::DAV1D_TX_LARGEST;
-use crate::include::dav1d::headers::DAV1D_TX_SWITCHABLE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_AFFINE;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_ROT_ZOOM;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
+use crate::include::dav1d::headers::RAV1D_ADAPTIVE;
+use crate::include::dav1d::headers::RAV1D_CHR_UNKNOWN;
+use crate::include::dav1d::headers::RAV1D_COLOR_PRI_BT709;
+use crate::include::dav1d::headers::RAV1D_COLOR_PRI_UNKNOWN;
+use crate::include::dav1d::headers::RAV1D_FILTER_SWITCHABLE;
+use crate::include::dav1d::headers::RAV1D_FRAME_TYPE_INTER;
+use crate::include::dav1d::headers::RAV1D_FRAME_TYPE_INTRA;
+use crate::include::dav1d::headers::RAV1D_FRAME_TYPE_KEY;
+use crate::include::dav1d::headers::RAV1D_FRAME_TYPE_SWITCH;
+use crate::include::dav1d::headers::RAV1D_MC_IDENTITY;
+use crate::include::dav1d::headers::RAV1D_MC_UNKNOWN;
+use crate::include::dav1d::headers::RAV1D_OBU_FRAME;
+use crate::include::dav1d::headers::RAV1D_OBU_FRAME_HDR;
+use crate::include::dav1d::headers::RAV1D_OBU_METADATA;
+use crate::include::dav1d::headers::RAV1D_OBU_PADDING;
+use crate::include::dav1d::headers::RAV1D_OBU_REDUNDANT_FRAME_HDR;
+use crate::include::dav1d::headers::RAV1D_OBU_SEQ_HDR;
+use crate::include::dav1d::headers::RAV1D_OBU_TD;
+use crate::include::dav1d::headers::RAV1D_OBU_TILE_GRP;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I422;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::RAV1D_RESTORATION_NONE;
+use crate::include::dav1d::headers::RAV1D_TRC_SRGB;
+use crate::include::dav1d::headers::RAV1D_TRC_UNKNOWN;
+use crate::include::dav1d::headers::RAV1D_TX_4X4_ONLY;
+use crate::include::dav1d::headers::RAV1D_TX_LARGEST;
+use crate::include::dav1d::headers::RAV1D_TX_SWITCHABLE;
+use crate::include::dav1d::headers::RAV1D_WM_TYPE_AFFINE;
+use crate::include::dav1d::headers::RAV1D_WM_TYPE_IDENTITY;
+use crate::include::dav1d::headers::RAV1D_WM_TYPE_ROT_ZOOM;
+use crate::include::dav1d::headers::RAV1D_WM_TYPE_TRANSLATION;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
 use crate::src::cdf::rav1d_cdf_thread_ref;
@@ -271,8 +271,8 @@ unsafe extern "C" fn parse_seq_hdr(
     (*hdr).filter_intra = rav1d_get_bit(gb) as c_int;
     (*hdr).intra_edge_filter = rav1d_get_bit(gb) as c_int;
     if (*hdr).reduced_still_picture_header != 0 {
-        (*hdr).screen_content_tools = DAV1D_ADAPTIVE;
-        (*hdr).force_integer_mv = DAV1D_ADAPTIVE;
+        (*hdr).screen_content_tools = RAV1D_ADAPTIVE;
+        (*hdr).force_integer_mv = RAV1D_ADAPTIVE;
     } else {
         (*hdr).inter_intra = rav1d_get_bit(gb) as c_int;
         (*hdr).masked_compound = rav1d_get_bit(gb) as c_int;
@@ -284,13 +284,13 @@ unsafe extern "C" fn parse_seq_hdr(
             (*hdr).ref_frame_mvs = rav1d_get_bit(gb) as c_int;
         }
         (*hdr).screen_content_tools = (if rav1d_get_bit(gb) != 0 {
-            DAV1D_ADAPTIVE as c_int as c_uint
+            RAV1D_ADAPTIVE as c_int as c_uint
         } else {
             rav1d_get_bit(gb)
         }) as Dav1dAdaptiveBoolean;
         (*hdr).force_integer_mv = (if (*hdr).screen_content_tools as c_uint != 0 {
             if rav1d_get_bit(gb) != 0 {
-                DAV1D_ADAPTIVE as c_int as c_uint
+                RAV1D_ADAPTIVE as c_int as c_uint
             } else {
                 rav1d_get_bit(gb)
             }
@@ -318,21 +318,21 @@ unsafe extern "C" fn parse_seq_hdr(
         (*hdr).trc = rav1d_get_bits(gb, 8 as c_int) as Dav1dTransferCharacteristics;
         (*hdr).mtrx = rav1d_get_bits(gb, 8 as c_int) as Dav1dMatrixCoefficients;
     } else {
-        (*hdr).pri = DAV1D_COLOR_PRI_UNKNOWN;
-        (*hdr).trc = DAV1D_TRC_UNKNOWN;
-        (*hdr).mtrx = DAV1D_MC_UNKNOWN;
+        (*hdr).pri = RAV1D_COLOR_PRI_UNKNOWN;
+        (*hdr).trc = RAV1D_TRC_UNKNOWN;
+        (*hdr).mtrx = RAV1D_MC_UNKNOWN;
     }
     if (*hdr).monochrome != 0 {
         (*hdr).color_range = rav1d_get_bit(gb) as c_int;
-        (*hdr).layout = DAV1D_PIXEL_LAYOUT_I400;
+        (*hdr).layout = RAV1D_PIXEL_LAYOUT_I400;
         (*hdr).ss_ver = 1 as c_int;
         (*hdr).ss_hor = (*hdr).ss_ver;
-        (*hdr).chr = DAV1D_CHR_UNKNOWN;
-    } else if (*hdr).pri as c_uint == DAV1D_COLOR_PRI_BT709 as c_int as c_uint
-        && (*hdr).trc as c_uint == DAV1D_TRC_SRGB as c_int as c_uint
-        && (*hdr).mtrx as c_uint == DAV1D_MC_IDENTITY as c_int as c_uint
+        (*hdr).chr = RAV1D_CHR_UNKNOWN;
+    } else if (*hdr).pri as c_uint == RAV1D_COLOR_PRI_BT709 as c_int as c_uint
+        && (*hdr).trc as c_uint == RAV1D_TRC_SRGB as c_int as c_uint
+        && (*hdr).mtrx as c_uint == RAV1D_MC_IDENTITY as c_int as c_uint
     {
-        (*hdr).layout = DAV1D_PIXEL_LAYOUT_I444;
+        (*hdr).layout = RAV1D_PIXEL_LAYOUT_I444;
         (*hdr).color_range = 1 as c_int;
         if (*hdr).profile != 1 && !((*hdr).profile == 2 && (*hdr).hbd == 2) {
             return parse_seq_hdr_error(c);
@@ -341,12 +341,12 @@ unsafe extern "C" fn parse_seq_hdr(
         (*hdr).color_range = rav1d_get_bit(gb) as c_int;
         match (*hdr).profile {
             0 => {
-                (*hdr).layout = DAV1D_PIXEL_LAYOUT_I420;
+                (*hdr).layout = RAV1D_PIXEL_LAYOUT_I420;
                 (*hdr).ss_ver = 1 as c_int;
                 (*hdr).ss_hor = (*hdr).ss_ver;
             }
             1 => {
-                (*hdr).layout = DAV1D_PIXEL_LAYOUT_I444;
+                (*hdr).layout = RAV1D_PIXEL_LAYOUT_I444;
             }
             2 => {
                 if (*hdr).hbd == 2 {
@@ -359,12 +359,12 @@ unsafe extern "C" fn parse_seq_hdr(
                 }
                 (*hdr).layout = (if (*hdr).ss_hor != 0 {
                     if (*hdr).ss_ver != 0 {
-                        DAV1D_PIXEL_LAYOUT_I420 as c_int
+                        RAV1D_PIXEL_LAYOUT_I420 as c_int
                     } else {
-                        DAV1D_PIXEL_LAYOUT_I422 as c_int
+                        RAV1D_PIXEL_LAYOUT_I422 as c_int
                     }
                 } else {
-                    DAV1D_PIXEL_LAYOUT_I444 as c_int
+                    RAV1D_PIXEL_LAYOUT_I444 as c_int
                 }) as Dav1dPixelLayout;
             }
             _ => {}
@@ -372,12 +372,12 @@ unsafe extern "C" fn parse_seq_hdr(
         (*hdr).chr = (if (*hdr).ss_hor & (*hdr).ss_ver != 0 {
             rav1d_get_bits(gb, 2 as c_int)
         } else {
-            DAV1D_CHR_UNKNOWN as c_int as c_uint
+            RAV1D_CHR_UNKNOWN as c_int as c_uint
         }) as Dav1dChromaSamplePosition;
     }
     if (*c).strict_std_compliance != 0
-        && (*hdr).mtrx as c_uint == DAV1D_MC_IDENTITY as c_int as c_uint
-        && (*hdr).layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint
+        && (*hdr).mtrx as c_uint == RAV1D_MC_IDENTITY as c_int as c_uint
+        && (*hdr).layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint
     {
         return parse_seq_hdr_error(c);
     }
@@ -511,7 +511,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
         return 0 as c_int;
     }
     (*hdr).frame_type = (if (*seqhdr).reduced_still_picture_header != 0 {
-        DAV1D_FRAME_TYPE_KEY as c_int as c_uint
+        RAV1D_FRAME_TYPE_KEY as c_int as c_uint
     } else {
         rav1d_get_bits(gb, 2 as c_int)
     }) as Dav1dFrameType;
@@ -523,26 +523,26 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
                 rav1d_get_bits(gb, (*seqhdr).frame_presentation_delay_length) as c_int;
         }
         (*hdr).showable_frame =
-            ((*hdr).frame_type as c_uint != DAV1D_FRAME_TYPE_KEY as c_int as c_uint) as c_int;
+            ((*hdr).frame_type as c_uint != RAV1D_FRAME_TYPE_KEY as c_int as c_uint) as c_int;
     } else {
         (*hdr).showable_frame = rav1d_get_bit(gb) as c_int;
     }
     (*hdr).error_resilient_mode = ((*hdr).frame_type as c_uint
-        == DAV1D_FRAME_TYPE_KEY as c_int as c_uint
+        == RAV1D_FRAME_TYPE_KEY as c_int as c_uint
         && (*hdr).show_frame != 0
-        || (*hdr).frame_type as c_uint == DAV1D_FRAME_TYPE_SWITCH as c_int as c_uint
+        || (*hdr).frame_type as c_uint == RAV1D_FRAME_TYPE_SWITCH as c_int as c_uint
         || (*seqhdr).reduced_still_picture_header != 0
         || rav1d_get_bit(gb) != 0) as c_int;
     (*hdr).disable_cdf_update = rav1d_get_bit(gb) as c_int;
     (*hdr).allow_screen_content_tools =
-        (if (*seqhdr).screen_content_tools as c_uint == DAV1D_ADAPTIVE as c_int as c_uint {
+        (if (*seqhdr).screen_content_tools as c_uint == RAV1D_ADAPTIVE as c_int as c_uint {
             rav1d_get_bit(gb)
         } else {
             (*seqhdr).screen_content_tools as c_uint
         }) as c_int;
     if (*hdr).allow_screen_content_tools != 0 {
         (*hdr).force_integer_mv =
-            (if (*seqhdr).force_integer_mv as c_uint == DAV1D_ADAPTIVE as c_int as c_uint {
+            (if (*seqhdr).force_integer_mv as c_uint == RAV1D_ADAPTIVE as c_int as c_uint {
                 rav1d_get_bit(gb)
             } else {
                 (*seqhdr).force_integer_mv as c_uint
@@ -558,7 +558,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
     }
     (*hdr).frame_size_override = (if (*seqhdr).reduced_still_picture_header != 0 {
         0 as c_int as c_uint
-    } else if (*hdr).frame_type as c_uint == DAV1D_FRAME_TYPE_SWITCH as c_int as c_uint {
+    } else if (*hdr).frame_type as c_uint == RAV1D_FRAME_TYPE_SWITCH as c_int as c_uint {
         1 as c_int as c_uint
     } else {
         rav1d_get_bit(gb)
@@ -599,7 +599,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
     }
     if (*hdr).frame_type as c_uint & 1 as c_uint == 0 {
         (*hdr).refresh_frame_flags = (if (*hdr).frame_type as c_uint
-            == DAV1D_FRAME_TYPE_KEY as c_int as c_uint
+            == RAV1D_FRAME_TYPE_KEY as c_int as c_uint
             && (*hdr).show_frame != 0
         {
             0xff as c_int as c_uint
@@ -617,7 +617,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
             }
         }
         if (*c).strict_std_compliance != 0
-            && (*hdr).frame_type as c_uint == DAV1D_FRAME_TYPE_INTRA as c_int as c_uint
+            && (*hdr).frame_type as c_uint == RAV1D_FRAME_TYPE_INTRA as c_int as c_uint
             && (*hdr).refresh_frame_flags == 0xff as c_int
         {
             return parse_frame_hdr_error(c);
@@ -632,7 +632,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
     } else {
         (*hdr).allow_intrabc = 0 as c_int;
         (*hdr).refresh_frame_flags =
-            (if (*hdr).frame_type as c_uint == DAV1D_FRAME_TYPE_SWITCH as c_int as c_uint {
+            (if (*hdr).frame_type as c_uint == RAV1D_FRAME_TYPE_SWITCH as c_int as c_uint {
                 0xff as c_int as c_uint
             } else {
                 rav1d_get_bits(gb, 8 as c_int)
@@ -792,7 +792,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
         }
         (*hdr).hp = ((*hdr).force_integer_mv == 0 && rav1d_get_bit(gb) != 0) as c_int;
         (*hdr).subpel_filter_mode = (if rav1d_get_bit(gb) != 0 {
-            DAV1D_FILTER_SWITCHABLE as c_int as c_uint
+            RAV1D_FILTER_SWITCHABLE as c_int as c_uint
         } else {
             rav1d_get_bits(gb, 2 as c_int)
         }) as Dav1dFilterMode;
@@ -1164,7 +1164,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
             (*hdr).restoration.type_0[1] = rav1d_get_bits(gb, 2 as c_int) as Dav1dRestorationType;
             (*hdr).restoration.type_0[2] = rav1d_get_bits(gb, 2 as c_int) as Dav1dRestorationType;
         } else {
-            (*hdr).restoration.type_0[2] = DAV1D_RESTORATION_NONE;
+            (*hdr).restoration.type_0[2] = RAV1D_RESTORATION_NONE;
             (*hdr).restoration.type_0[1] = (*hdr).restoration.type_0[2];
         }
         if (*hdr).restoration.type_0[0] as c_uint != 0
@@ -1194,16 +1194,16 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
             (*hdr).restoration.unit_size[0] = 8 as c_int;
         }
     } else {
-        (*hdr).restoration.type_0[0] = DAV1D_RESTORATION_NONE;
-        (*hdr).restoration.type_0[1] = DAV1D_RESTORATION_NONE;
-        (*hdr).restoration.type_0[2] = DAV1D_RESTORATION_NONE;
+        (*hdr).restoration.type_0[0] = RAV1D_RESTORATION_NONE;
+        (*hdr).restoration.type_0[1] = RAV1D_RESTORATION_NONE;
+        (*hdr).restoration.type_0[2] = RAV1D_RESTORATION_NONE;
     }
     (*hdr).txfm_mode = (if (*hdr).all_lossless != 0 {
-        DAV1D_TX_4X4_ONLY as c_int
+        RAV1D_TX_4X4_ONLY as c_int
     } else if rav1d_get_bit(gb) != 0 {
-        DAV1D_TX_SWITCHABLE as c_int
+        RAV1D_TX_SWITCHABLE as c_int
     } else {
-        DAV1D_TX_LARGEST as c_int
+        RAV1D_TX_LARGEST as c_int
     }) as Dav1dTxfmMode;
     (*hdr).switchable_comp_refs = (if (*hdr).frame_type as c_uint & 1 as c_uint != 0 {
         rav1d_get_bit(gb)
@@ -1324,16 +1324,16 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
         let mut i_19 = 0;
         while i_19 < 7 {
             (*hdr).gmv[i_19 as usize].type_0 = (if rav1d_get_bit(gb) == 0 {
-                DAV1D_WM_TYPE_IDENTITY as c_int
+                RAV1D_WM_TYPE_IDENTITY as c_int
             } else if rav1d_get_bit(gb) != 0 {
-                DAV1D_WM_TYPE_ROT_ZOOM as c_int
+                RAV1D_WM_TYPE_ROT_ZOOM as c_int
             } else if rav1d_get_bit(gb) != 0 {
-                DAV1D_WM_TYPE_TRANSLATION as c_int
+                RAV1D_WM_TYPE_TRANSLATION as c_int
             } else {
-                DAV1D_WM_TYPE_AFFINE as c_int
+                RAV1D_WM_TYPE_AFFINE as c_int
             }) as Dav1dWarpedMotionType;
             if !((*hdr).gmv[i_19 as usize].type_0 as c_uint
-                == DAV1D_WM_TYPE_IDENTITY as c_int as c_uint)
+                == RAV1D_WM_TYPE_IDENTITY as c_int as c_uint)
             {
                 let ref_gmv: *const Dav1dWarpedMotionParams;
                 if (*hdr).primary_ref_frame == 7 {
@@ -1357,7 +1357,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
                 let bits: c_int;
                 let shift: c_int;
                 if (*hdr).gmv[i_19 as usize].type_0 as c_uint
-                    >= DAV1D_WM_TYPE_ROT_ZOOM as c_int as c_uint
+                    >= RAV1D_WM_TYPE_ROT_ZOOM as c_int as c_uint
                 {
                     *mat.offset(2) = ((1 as c_int) << 16)
                         + 2 * rav1d_get_bits_subexp(
@@ -1374,7 +1374,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
                     shift = 13 + ((*hdr).hp == 0) as c_int;
                 }
                 if (*hdr).gmv[i_19 as usize].type_0 as c_uint
-                    == DAV1D_WM_TYPE_AFFINE as c_int as c_uint
+                    == RAV1D_WM_TYPE_AFFINE as c_int as c_uint
                 {
                     *mat.offset(4) = 2 as c_int
                         * rav1d_get_bits_subexp(gb, *ref_mat.offset(4) >> 1, 12 as c_int as c_uint);
@@ -1404,7 +1404,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
     if (*hdr).film_grain.present != 0 {
         let seed: c_uint = rav1d_get_bits(gb, 16 as c_int);
         (*hdr).film_grain.update = ((*hdr).frame_type as c_uint
-            != DAV1D_FRAME_TYPE_INTER as c_int as c_uint
+            != RAV1D_FRAME_TYPE_INTER as c_int as c_uint
             || rav1d_get_bit(gb) != 0) as c_int;
         if (*hdr).film_grain.update == 0 {
             let refidx: c_int = rav1d_get_bits(gb, 3 as c_int) as c_int;
@@ -1669,8 +1669,8 @@ pub(crate) unsafe fn rav1d_parse_obus(
     if len as usize > ((*in_0).sz).wrapping_sub(init_byte_pos as usize) {
         return rav1d_parse_obus_error(c, in_0);
     }
-    if type_0 as c_uint != DAV1D_OBU_SEQ_HDR as c_int as c_uint
-        && type_0 as c_uint != DAV1D_OBU_TD as c_int as c_uint
+    if type_0 as c_uint != RAV1D_OBU_SEQ_HDR as c_int as c_uint
+        && type_0 as c_uint != RAV1D_OBU_TD as c_int as c_uint
         && has_extension != 0
         && (*c).operating_point_idc != 0 as c_int as c_uint
     {
@@ -1684,7 +1684,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
     }
     let mut current_block_188: u64;
     match type_0 as c_uint {
-        DAV1D_OBU_SEQ_HDR => {
+        RAV1D_OBU_SEQ_HDR => {
             let mut ref_0: *mut Rav1dRef = rav1d_ref_create_using_pool(
                 (*c).seq_hdr_pool,
                 ::core::mem::size_of::<Dav1dSequenceHeader>(),
@@ -1748,20 +1748,20 @@ pub(crate) unsafe fn rav1d_parse_obus(
             (*c).seq_hdr = seq_hdr;
             current_block_188 = 8953117030348968745;
         }
-        DAV1D_OBU_REDUNDANT_FRAME_HDR => {
+        RAV1D_OBU_REDUNDANT_FRAME_HDR => {
             if !((*c).frame_hdr).is_null() {
                 current_block_188 = 8953117030348968745;
             } else {
                 current_block_188 = 14065157188459580465;
             }
         }
-        DAV1D_OBU_FRAME | DAV1D_OBU_FRAME_HDR => {
+        RAV1D_OBU_FRAME | RAV1D_OBU_FRAME_HDR => {
             current_block_188 = 14065157188459580465;
         }
-        DAV1D_OBU_TILE_GRP => {
+        RAV1D_OBU_TILE_GRP => {
             current_block_188 = 17787701279558130514;
         }
-        DAV1D_OBU_METADATA => {
+        RAV1D_OBU_METADATA => {
             let meta_type: ObuMetaType = rav1d_get_uleb128(&mut gb) as ObuMetaType;
             let meta_type_len: c_int =
                 ((rav1d_get_bits_pos(&mut gb)).wrapping_sub(init_bit_pos) >> 3) as c_int;
@@ -1889,13 +1889,13 @@ pub(crate) unsafe fn rav1d_parse_obus(
             }
             current_block_188 = 8953117030348968745;
         }
-        DAV1D_OBU_TD => {
+        RAV1D_OBU_TD => {
             (*c).frame_flags = ::core::mem::transmute::<c_uint, PictureFlags>(
                 (*c).frame_flags as c_uint | PICTURE_FLAG_NEW_TEMPORAL_UNIT as c_int as c_uint,
             );
             current_block_188 = 8953117030348968745;
         }
-        DAV1D_OBU_PADDING => {
+        RAV1D_OBU_PADDING => {
             current_block_188 = 8953117030348968745;
         }
         _ => {
@@ -1947,7 +1947,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 }
                 (*c).n_tile_data = 0 as c_int;
                 (*c).n_tiles = 0 as c_int;
-                if type_0 as c_uint != DAV1D_OBU_FRAME as c_int as c_uint {
+                if type_0 as c_uint != RAV1D_OBU_FRAME as c_int as c_uint {
                     rav1d_get_bit(&mut gb);
                     if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
                         (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
@@ -1968,7 +1968,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                     (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
                     return -(34 as c_int);
                 }
-                if type_0 as c_uint != DAV1D_OBU_FRAME as c_int as c_uint {
+                if type_0 as c_uint != RAV1D_OBU_FRAME as c_int as c_uint {
                     current_block_188 = 8953117030348968745;
                 } else {
                     if (*(*c).frame_hdr).show_existing_frame != 0 {
@@ -2067,16 +2067,16 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 .frame_hdr)
                 .frame_type as c_uint
             {
-                DAV1D_FRAME_TYPE_INTER | DAV1D_FRAME_TYPE_SWITCH => {
+                RAV1D_FRAME_TYPE_INTER | RAV1D_FRAME_TYPE_SWITCH => {
                     if (*c).decode_frame_type as c_uint
-                        > DAV1D_DECODEFRAMETYPE_REFERENCE as c_int as c_uint
+                        > RAV1D_DECODEFRAMETYPE_REFERENCE as c_int as c_uint
                     {
                         return rav1d_parse_obus_skip(c, len, init_byte_pos);
                     }
                 }
-                DAV1D_FRAME_TYPE_INTRA => {
+                RAV1D_FRAME_TYPE_INTRA => {
                     if (*c).decode_frame_type as c_uint
-                        > DAV1D_DECODEFRAMETYPE_INTRA as c_int as c_uint
+                        > RAV1D_DECODEFRAMETYPE_INTRA as c_int as c_uint
                     {
                         return rav1d_parse_obus_skip(c, len, init_byte_pos);
                     }
@@ -2201,7 +2201,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 .p
                 .frame_hdr)
                 .frame_type as c_uint
-                == DAV1D_FRAME_TYPE_KEY as c_int as c_uint
+                == RAV1D_FRAME_TYPE_KEY as c_int as c_uint
             {
                 let r: c_int = (*(*c).frame_hdr).existing_frame_idx;
                 (*c).refs[r as usize].p.showable = false;
@@ -2235,21 +2235,21 @@ pub(crate) unsafe fn rav1d_parse_obus(
             (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
         } else if (*c).n_tiles == (*(*c).frame_hdr).tiling.cols * (*(*c).frame_hdr).tiling.rows {
             match (*(*c).frame_hdr).frame_type as c_uint {
-                DAV1D_FRAME_TYPE_INTER | DAV1D_FRAME_TYPE_SWITCH => {
+                RAV1D_FRAME_TYPE_INTER | RAV1D_FRAME_TYPE_SWITCH => {
                     if (*c).decode_frame_type as c_uint
-                        > DAV1D_DECODEFRAMETYPE_REFERENCE as c_int as c_uint
+                        > RAV1D_DECODEFRAMETYPE_REFERENCE as c_int as c_uint
                         || (*c).decode_frame_type as c_uint
-                            == DAV1D_DECODEFRAMETYPE_REFERENCE as c_int as c_uint
+                            == RAV1D_DECODEFRAMETYPE_REFERENCE as c_int as c_uint
                             && (*(*c).frame_hdr).refresh_frame_flags == 0
                     {
                         return rav1d_parse_obus_skip(c, len, init_byte_pos);
                     }
                 }
-                DAV1D_FRAME_TYPE_INTRA => {
+                RAV1D_FRAME_TYPE_INTRA => {
                     if (*c).decode_frame_type as c_uint
-                        > DAV1D_DECODEFRAMETYPE_INTRA as c_int as c_uint
+                        > RAV1D_DECODEFRAMETYPE_INTRA as c_int as c_uint
                         || (*c).decode_frame_type as c_uint
-                            == DAV1D_DECODEFRAMETYPE_REFERENCE as c_int as c_uint
+                            == RAV1D_DECODEFRAMETYPE_REFERENCE as c_int as c_uint
                             && (*(*c).frame_hdr).refresh_frame_flags == 0
                     {
                         return rav1d_parse_obus_skip(c, len, init_byte_pos);

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -2,16 +2,16 @@ use crate::errno_location;
 use crate::include::dav1d::common::Rav1dDataProps;
 use crate::include::dav1d::dav1d::Dav1dEventFlags;
 use crate::include::dav1d::dav1d::Rav1dEventFlags;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
-use crate::include::dav1d::dav1d::DAV1D_EVENT_FLAG_NEW_SEQUENCE;
+use crate::include::dav1d::dav1d::RAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
+use crate::include::dav1d::dav1d::RAV1D_EVENT_FLAG_NEW_SEQUENCE;
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
 use crate::include::dav1d::picture::Dav1dPicture;
 use crate::include::dav1d::picture::Rav1dPicAllocator;
 use crate::include::dav1d::picture::Rav1dPicture;
@@ -75,9 +75,9 @@ pub unsafe extern "C" fn dav1d_default_picture_alloc(
     let aligned_w = (*p).p.w + 127 & !(127 as c_int);
     let aligned_h = (*p).p.h + 127 & !(127 as c_int);
     let has_chroma =
-        ((*p).p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint) as c_int;
-    let ss_ver = ((*p).p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
-    let ss_hor = ((*p).p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+        ((*p).p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint) as c_int;
+    let ss_ver = ((*p).p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+    let ss_hor = ((*p).p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
     let mut y_stride: ptrdiff_t = (aligned_w << hbd) as ptrdiff_t;
     let mut uv_stride: ptrdiff_t = if has_chroma != 0 {
         y_stride >> ss_hor
@@ -511,12 +511,12 @@ pub(crate) unsafe fn rav1d_picture_get_event_flags(
     let mut flags: Dav1dEventFlags = 0 as Dav1dEventFlags;
     if (*p).flags as c_uint & PICTURE_FLAG_NEW_SEQUENCE as c_int as c_uint != 0 {
         flags = ::core::mem::transmute::<c_uint, Dav1dEventFlags>(
-            flags as c_uint | DAV1D_EVENT_FLAG_NEW_SEQUENCE as c_int as c_uint,
+            flags as c_uint | RAV1D_EVENT_FLAG_NEW_SEQUENCE as c_int as c_uint,
         );
     }
     if (*p).flags as c_uint & PICTURE_FLAG_NEW_OP_PARAMS_INFO as c_int as c_uint != 0 {
         flags = ::core::mem::transmute::<c_uint, Dav1dEventFlags>(
-            flags as c_uint | DAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO as c_int as c_uint,
+            flags as c_uint | RAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO as c_int as c_uint,
         );
     }
     return flags;

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -1,6 +1,6 @@
 use crate::include::dav1d::headers::Dav1dPixelLayout;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
 use crate::src::internal::Rav1dFrameContext;
 use crate::src::internal::Rav1dTaskContext;
 use crate::src::intra_edge::EdgeFlags;
@@ -144,8 +144,8 @@ pub fn get_skip_ctx(
 ) -> u8 {
     let b_dim = &dav1d_block_dimensions[bs as usize];
     if chroma != 0 {
-        let ss_ver = layout == DAV1D_PIXEL_LAYOUT_I420;
-        let ss_hor = layout != DAV1D_PIXEL_LAYOUT_I444;
+        let ss_ver = layout == RAV1D_PIXEL_LAYOUT_I420;
+        let ss_hor = layout != RAV1D_PIXEL_LAYOUT_I444;
         let not_one_blk = b_dim[2] - (b_dim[2] != 0 && ss_hor) as u8 > t_dim.lw
             || b_dim[3] - (b_dim[3] != 0 && ss_ver) as u8 > t_dim.lh;
         fn merge_ctx<const N: usize>(dir: &[u8]) -> bool {

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -29,7 +29,7 @@ use crate::src::levels::TX_4X4;
 use crate::src::levels::TX_64X64;
 use crate::src::levels::TX_8X8;
 use crate::src::levels::TX_CLASS_2D;
-use crate::src::msac::dav1d_msac_decode_bool_equi;
+use crate::src::msac::rav1d_msac_decode_bool_equi;
 use crate::src::msac::MsacContext;
 use crate::src::tables::dav1d_block_dimensions;
 use crate::src::tables::dav1d_skip_ctx;
@@ -40,22 +40,22 @@ use std::ffi::c_uint;
 use std::ops::BitOr;
 
 /// TODO: add feature and compile-time guard around this code
-pub unsafe fn DEBUG_BLOCK_INFO(f: &Rav1dFrameContext, t: &Rav1dTaskContext) -> bool {
+pub(crate) unsafe fn DEBUG_BLOCK_INFO(f: &Rav1dFrameContext, t: &Rav1dTaskContext) -> bool {
     false && (*f.frame_hdr).frame_offset == 2 && t.by >= 0 && t.by < 4 && t.bx >= 8 && t.bx < 12
 }
 
-pub type recon_b_intra_fn = Option<
+pub(crate) type recon_b_intra_fn = Option<
     unsafe extern "C" fn(*mut Rav1dTaskContext, BlockSize, EdgeFlags, *const Av1Block) -> (),
 >;
 
-pub type recon_b_inter_fn =
+pub(crate) type recon_b_inter_fn =
     Option<unsafe extern "C" fn(*mut Rav1dTaskContext, BlockSize, *const Av1Block) -> c_int>;
 
-pub type filter_sbrow_fn = Option<unsafe extern "C" fn(*mut Rav1dFrameContext, c_int) -> ()>;
+pub(crate) type filter_sbrow_fn = Option<unsafe extern "C" fn(*mut Rav1dFrameContext, c_int) -> ()>;
 
-pub type backup_ipred_edge_fn = Option<unsafe extern "C" fn(*mut Rav1dTaskContext) -> ()>;
+pub(crate) type backup_ipred_edge_fn = Option<unsafe extern "C" fn(*mut Rav1dTaskContext) -> ()>;
 
-pub type read_coef_blocks_fn =
+pub(crate) type read_coef_blocks_fn =
     Option<unsafe extern "C" fn(*mut Rav1dTaskContext, BlockSize, *const Av1Block) -> ()>;
 
 #[inline]
@@ -63,11 +63,11 @@ pub fn read_golomb(msac: &mut MsacContext) -> c_uint {
     let mut len = 0;
     let mut val = 1;
 
-    while !dav1d_msac_decode_bool_equi(msac) && len < 32 {
+    while !rav1d_msac_decode_bool_equi(msac) && len < 32 {
         len += 1;
     }
     for _ in 0..len {
-        val = (val << 1) + dav1d_msac_decode_bool_equi(msac) as c_uint;
+        val = (val << 1) + rav1d_msac_decode_bool_equi(msac) as c_uint;
     }
 
     val - 1

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -14,7 +14,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::src::cdef_apply_tmpl_16::dav1d_cdef_brow_16bpc;
+use crate::src::cdef_apply_tmpl_16::rav1d_cdef_brow_16bpc;
 use crate::src::ctx::CaseSet;
 use crate::src::env::get_uv_inter_txtp;
 use crate::src::internal::CodedBlockInfo;
@@ -27,7 +27,7 @@ use crate::src::intra_edge::EDGE_I420_LEFT_HAS_BOTTOM;
 use crate::src::intra_edge::EDGE_I420_TOP_HAS_RIGHT;
 use crate::src::intra_edge::EDGE_I444_LEFT_HAS_BOTTOM;
 use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
-use crate::src::ipred_prepare::dav1d_prepare_intra_edges;
+use crate::src::ipred_prepare::rav1d_prepare_intra_edges;
 use crate::src::ipred_prepare::sm_flag;
 use crate::src::ipred_prepare::sm_uv_flag;
 use crate::src::levels::mv;
@@ -61,18 +61,18 @@ use crate::src::levels::TX_CLASS_2D;
 use crate::src::levels::TX_CLASS_H;
 use crate::src::levels::TX_CLASS_V;
 use crate::src::levels::WHT_WHT;
-use crate::src::lf_apply_tmpl_16::dav1d_copy_lpf_16bpc;
-use crate::src::lf_apply_tmpl_16::dav1d_loopfilter_sbrow_cols_16bpc;
-use crate::src::lf_apply_tmpl_16::dav1d_loopfilter_sbrow_rows_16bpc;
+use crate::src::lf_apply_tmpl_16::rav1d_copy_lpf_16bpc;
+use crate::src::lf_apply_tmpl_16::rav1d_loopfilter_sbrow_cols_16bpc;
+use crate::src::lf_apply_tmpl_16::rav1d_loopfilter_sbrow_rows_16bpc;
 use crate::src::lf_mask::Av1Filter;
-use crate::src::lr_apply_tmpl_16::dav1d_lr_sbrow_16bpc;
-use crate::src::msac::dav1d_msac_decode_bool_adapt;
-use crate::src::msac::dav1d_msac_decode_bool_equi;
-use crate::src::msac::dav1d_msac_decode_bools;
-use crate::src::msac::dav1d_msac_decode_hi_tok;
-use crate::src::msac::dav1d_msac_decode_symbol_adapt16;
-use crate::src::msac::dav1d_msac_decode_symbol_adapt4;
-use crate::src::msac::dav1d_msac_decode_symbol_adapt8;
+use crate::src::lr_apply_tmpl_16::rav1d_lr_sbrow_16bpc;
+use crate::src::msac::rav1d_msac_decode_bool_adapt;
+use crate::src::msac::rav1d_msac_decode_bool_equi;
+use crate::src::msac::rav1d_msac_decode_bools;
+use crate::src::msac::rav1d_msac_decode_hi_tok;
+use crate::src::msac::rav1d_msac_decode_symbol_adapt16;
+use crate::src::msac::rav1d_msac_decode_symbol_adapt4;
+use crate::src::msac::rav1d_msac_decode_symbol_adapt8;
 use crate::src::picture::Rav1dThreadPicture;
 use crate::src::recon::get_dc_sign_ctx;
 use crate::src::recon::get_lo_ctx;
@@ -146,7 +146,7 @@ unsafe fn decode_coefs(
         );
     }
     let sctx = get_skip_ctx(t_dim, bs, a, l, chroma, (*f).cur.p.layout) as c_int;
-    let all_skip = dav1d_msac_decode_bool_adapt(
+    let all_skip = rav1d_msac_decode_bool_adapt(
         &mut (*ts).msac,
         &mut (*ts).cdf.coef.skip[(*t_dim).ctx as usize][sctx as usize],
     ) as c_int;
@@ -191,7 +191,7 @@ unsafe fn decode_coefs(
                 }) as IntraPredMode;
             if (*(*f).frame_hdr).reduced_txtp_set != 0 || (*t_dim).min as c_int == TX_16X16 as c_int
             {
-                idx = dav1d_msac_decode_symbol_adapt4(
+                idx = rav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
                     &mut (*ts).cdf.m.txtp_intra2[(*t_dim).min as usize][y_mode_nofilt as usize],
                     4 as c_int as usize,
@@ -199,7 +199,7 @@ unsafe fn decode_coefs(
                 *txtp = dav1d_tx_types_per_set[idx.wrapping_add(0 as c_int as c_uint) as usize]
                     as TxfmType;
             } else {
-                idx = dav1d_msac_decode_symbol_adapt8(
+                idx = rav1d_msac_decode_symbol_adapt8(
                     &mut (*ts).msac,
                     &mut (*ts).cdf.m.txtp_intra1[(*t_dim).min as usize][y_mode_nofilt as usize],
                     6 as c_int as usize,
@@ -221,14 +221,14 @@ unsafe fn decode_coefs(
         } else {
             if (*(*f).frame_hdr).reduced_txtp_set != 0 || (*t_dim).max as c_int == TX_32X32 as c_int
             {
-                idx = dav1d_msac_decode_bool_adapt(
+                idx = rav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
                     &mut (*ts).cdf.m.txtp_inter3[(*t_dim).min as usize],
                 ) as c_uint;
                 *txtp =
                     (idx.wrapping_sub(1 as c_int as c_uint) & IDTX as c_int as c_uint) as TxfmType;
             } else if (*t_dim).min as c_int == TX_16X16 as c_int {
-                idx = dav1d_msac_decode_symbol_adapt16(
+                idx = rav1d_msac_decode_symbol_adapt16(
                     &mut (*ts).msac,
                     &mut (*ts).cdf.m.txtp_inter2.0,
                     11 as c_int as usize,
@@ -236,7 +236,7 @@ unsafe fn decode_coefs(
                 *txtp = dav1d_tx_types_per_set[idx.wrapping_add(12 as c_int as c_uint) as usize]
                     as TxfmType;
             } else {
-                idx = dav1d_msac_decode_symbol_adapt16(
+                idx = rav1d_msac_decode_symbol_adapt16(
                     &mut (*ts).msac,
                     &mut (*ts).cdf.m.txtp_inter1[(*t_dim).min as usize],
                     15 as c_int as usize,
@@ -265,43 +265,43 @@ unsafe fn decode_coefs(
         0 => {
             let eob_bin_cdf = &mut (*ts).cdf.coef.eob_bin_16[chroma as usize][is_1d as usize];
             eob_bin =
-                dav1d_msac_decode_symbol_adapt4(&mut (*ts).msac, eob_bin_cdf, (4 + 0) as usize)
+                rav1d_msac_decode_symbol_adapt4(&mut (*ts).msac, eob_bin_cdf, (4 + 0) as usize)
                     as c_int;
         }
         1 => {
             let eob_bin_cdf_0 = &mut (*ts).cdf.coef.eob_bin_32[chroma as usize][is_1d as usize];
             eob_bin =
-                dav1d_msac_decode_symbol_adapt8(&mut (*ts).msac, eob_bin_cdf_0, (4 + 1) as usize)
+                rav1d_msac_decode_symbol_adapt8(&mut (*ts).msac, eob_bin_cdf_0, (4 + 1) as usize)
                     as c_int;
         }
         2 => {
             let eob_bin_cdf_1 = &mut (*ts).cdf.coef.eob_bin_64[chroma as usize][is_1d as usize];
             eob_bin =
-                dav1d_msac_decode_symbol_adapt8(&mut (*ts).msac, eob_bin_cdf_1, (4 + 2) as usize)
+                rav1d_msac_decode_symbol_adapt8(&mut (*ts).msac, eob_bin_cdf_1, (4 + 2) as usize)
                     as c_int;
         }
         3 => {
             let eob_bin_cdf_2 = &mut (*ts).cdf.coef.eob_bin_128[chroma as usize][is_1d as usize];
             eob_bin =
-                dav1d_msac_decode_symbol_adapt8(&mut (*ts).msac, eob_bin_cdf_2, (4 + 3) as usize)
+                rav1d_msac_decode_symbol_adapt8(&mut (*ts).msac, eob_bin_cdf_2, (4 + 3) as usize)
                     as c_int;
         }
         4 => {
             let eob_bin_cdf_3 = &mut (*ts).cdf.coef.eob_bin_256[chroma as usize][is_1d as usize];
             eob_bin =
-                dav1d_msac_decode_symbol_adapt16(&mut (*ts).msac, eob_bin_cdf_3, (4 + 4) as usize)
+                rav1d_msac_decode_symbol_adapt16(&mut (*ts).msac, eob_bin_cdf_3, (4 + 4) as usize)
                     as c_int;
         }
         5 => {
             let eob_bin_cdf_4 = &mut (*ts).cdf.coef.eob_bin_512[chroma as usize];
             eob_bin =
-                dav1d_msac_decode_symbol_adapt16(&mut (*ts).msac, eob_bin_cdf_4, (4 + 5) as usize)
+                rav1d_msac_decode_symbol_adapt16(&mut (*ts).msac, eob_bin_cdf_4, (4 + 5) as usize)
                     as c_int;
         }
         6 => {
             let eob_bin_cdf_5 = &mut (*ts).cdf.coef.eob_bin_1024[chroma as usize];
             eob_bin =
-                dav1d_msac_decode_symbol_adapt16(&mut (*ts).msac, eob_bin_cdf_5, (4 + 6) as usize)
+                rav1d_msac_decode_symbol_adapt16(&mut (*ts).msac, eob_bin_cdf_5, (4 + 6) as usize)
                     as c_int;
         }
         _ => {}
@@ -320,7 +320,7 @@ unsafe fn decode_coefs(
     if eob_bin > 1 {
         let eob_hi_bit_cdf = &mut (*ts).cdf.coef.eob_hi_bit[(*t_dim).ctx as usize][chroma as usize]
             [eob_bin as usize];
-        let eob_hi_bit = dav1d_msac_decode_bool_adapt(&mut (*ts).msac, eob_hi_bit_cdf) as c_int;
+        let eob_hi_bit = rav1d_msac_decode_bool_adapt(&mut (*ts).msac, eob_hi_bit_cdf) as c_int;
         if dbg != 0 {
             printf(
                 b"Post-eob_hi_bit[%d][%d][%d][%d]: r=%d\n\0" as *const u8 as *const c_char,
@@ -332,7 +332,7 @@ unsafe fn decode_coefs(
             );
         }
         eob = (((eob_hi_bit | 2) << eob_bin - 2) as c_uint
-            | dav1d_msac_decode_bools(&mut (*ts).msac, (eob_bin - 2) as c_uint))
+            | rav1d_msac_decode_bools(&mut (*ts).msac, (eob_bin - 2) as c_uint))
             as c_int;
         if dbg != 0 {
             printf(
@@ -362,7 +362,7 @@ unsafe fn decode_coefs(
         let sh = cmp::min((*t_dim).h as c_int, 8 as c_int);
         let mut ctx: c_uint =
             (1 as c_int + (eob > sw * sh * 2) as c_int + (eob > sw * sh * 4) as c_int) as c_uint;
-        let eob_tok = dav1d_msac_decode_symbol_adapt4(
+        let eob_tok = rav1d_msac_decode_symbol_adapt4(
             &mut (*ts).msac,
             &mut *eob_cdf.offset(ctx as isize),
             2 as c_int as usize,
@@ -432,7 +432,7 @@ unsafe fn decode_coefs(
                     } else {
                         7 as c_int
                     }) as c_uint;
-                    tok = dav1d_msac_decode_hi_tok(
+                    tok = rav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         &mut *hi_cdf.offset(ctx as isize),
                     ) as c_int;
@@ -485,7 +485,7 @@ unsafe fn decode_coefs(
                     if TX_CLASS_2D as c_int == TX_CLASS_2D as c_int {
                         y |= x;
                     }
-                    tok = dav1d_msac_decode_symbol_adapt4(
+                    tok = rav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
                         &mut *lo_cdf.offset(ctx as isize),
                         3 as c_int as usize,
@@ -517,7 +517,7 @@ unsafe fn decode_coefs(
                             } else {
                                 mag.wrapping_add(1 as c_int as c_uint) >> 1
                             });
-                        tok = dav1d_msac_decode_hi_tok(
+                        tok = rav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
                             &mut *hi_cdf.offset(ctx as isize),
                         ) as c_int;
@@ -561,7 +561,7 @@ unsafe fn decode_coefs(
                         stride as usize,
                     ) as c_uint
                 };
-                dc_tok = dav1d_msac_decode_symbol_adapt4(
+                dc_tok = rav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
                     &mut *lo_cdf.offset(ctx as isize),
                     3 as c_int as usize,
@@ -589,7 +589,7 @@ unsafe fn decode_coefs(
                     } else {
                         mag.wrapping_add(1 as c_int as c_uint) >> 1
                     };
-                    dc_tok = dav1d_msac_decode_hi_tok(
+                    dc_tok = rav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         &mut *hi_cdf.offset(ctx as isize),
                     );
@@ -655,7 +655,7 @@ unsafe fn decode_coefs(
                     } else {
                         7 as c_int
                     }) as c_uint;
-                    tok = dav1d_msac_decode_hi_tok(
+                    tok = rav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         &mut *hi_cdf.offset(ctx as isize),
                     ) as c_int;
@@ -709,7 +709,7 @@ unsafe fn decode_coefs(
                     if TX_CLASS_H as c_int == TX_CLASS_2D as c_int {
                         y_0 |= x_0;
                     }
-                    tok = dav1d_msac_decode_symbol_adapt4(
+                    tok = rav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
                         &mut *lo_cdf.offset(ctx as isize),
                         3 as c_int as usize,
@@ -741,7 +741,7 @@ unsafe fn decode_coefs(
                             } else {
                                 mag.wrapping_add(1 as c_int as c_uint) >> 1
                             });
-                        tok = dav1d_msac_decode_hi_tok(
+                        tok = rav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
                             &mut *hi_cdf.offset(ctx as isize),
                         ) as c_int;
@@ -785,7 +785,7 @@ unsafe fn decode_coefs(
                         stride_0 as usize,
                     ) as c_uint
                 };
-                dc_tok = dav1d_msac_decode_symbol_adapt4(
+                dc_tok = rav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
                     &mut *lo_cdf.offset(ctx as isize),
                     3 as c_int as usize,
@@ -813,7 +813,7 @@ unsafe fn decode_coefs(
                     } else {
                         mag.wrapping_add(1 as c_int as c_uint) >> 1
                     };
-                    dc_tok = dav1d_msac_decode_hi_tok(
+                    dc_tok = rav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         &mut *hi_cdf.offset(ctx as isize),
                     );
@@ -879,7 +879,7 @@ unsafe fn decode_coefs(
                     } else {
                         7 as c_int
                     }) as c_uint;
-                    tok = dav1d_msac_decode_hi_tok(
+                    tok = rav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         &mut *hi_cdf.offset(ctx as isize),
                     ) as c_int;
@@ -932,7 +932,7 @@ unsafe fn decode_coefs(
                     if TX_CLASS_V as c_int == TX_CLASS_2D as c_int {
                         y_1 |= x_1;
                     }
-                    tok = dav1d_msac_decode_symbol_adapt4(
+                    tok = rav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
                         &mut *lo_cdf.offset(ctx as isize),
                         3 as c_int as usize,
@@ -964,7 +964,7 @@ unsafe fn decode_coefs(
                             } else {
                                 mag.wrapping_add(1 as c_int as c_uint) >> 1
                             });
-                        tok = dav1d_msac_decode_hi_tok(
+                        tok = rav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
                             &mut *hi_cdf.offset(ctx as isize),
                         ) as c_int;
@@ -1008,7 +1008,7 @@ unsafe fn decode_coefs(
                         stride_1 as usize,
                     ) as c_uint
                 };
-                dc_tok = dav1d_msac_decode_symbol_adapt4(
+                dc_tok = rav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
                     &mut *lo_cdf.offset(ctx as isize),
                     3 as c_int as usize,
@@ -1036,7 +1036,7 @@ unsafe fn decode_coefs(
                     } else {
                         mag.wrapping_add(1 as c_int as c_uint) >> 1
                     };
-                    dc_tok = dav1d_msac_decode_hi_tok(
+                    dc_tok = rav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         &mut *hi_cdf.offset(ctx as isize),
                     );
@@ -1059,7 +1059,7 @@ unsafe fn decode_coefs(
             }
         }
     } else {
-        let tok_br = dav1d_msac_decode_symbol_adapt4(
+        let tok_br = rav1d_msac_decode_symbol_adapt4(
             &mut (*ts).msac,
             &mut *eob_cdf.offset(0),
             2 as c_int as usize,
@@ -1076,7 +1076,7 @@ unsafe fn decode_coefs(
             );
         }
         if tok_br == 2 {
-            dc_tok = dav1d_msac_decode_hi_tok(&mut (*ts).msac, &mut *hi_cdf.offset(0));
+            dc_tok = rav1d_msac_decode_hi_tok(&mut (*ts).msac, &mut *hi_cdf.offset(0));
             if dbg != 0 {
                 printf(
                     b"Post-dc_hi_tok[%d][%d][0][%d]: r=%d\n\0" as *const u8 as *const c_char,
@@ -1111,7 +1111,7 @@ unsafe fn decode_coefs(
     } else {
         dc_sign_ctx = get_dc_sign_ctx(tx, a, l) as c_int;
         let dc_sign_cdf = &mut (*ts).cdf.coef.dc_sign[chroma as usize][dc_sign_ctx as usize];
-        dc_sign = dav1d_msac_decode_bool_adapt(&mut (*ts).msac, dc_sign_cdf) as c_int;
+        dc_sign = rav1d_msac_decode_bool_adapt(&mut (*ts).msac, dc_sign_cdf) as c_int;
         if dbg != 0 {
             printf(
                 b"Post-dc_sign[%d][%d][%d]: r=%d\n\0" as *const u8 as *const c_char,
@@ -1187,7 +1187,7 @@ unsafe fn decode_coefs(
         1669574575799829731 => {
             let ac_dq: c_uint = *dq_tbl.offset(1) as c_uint;
             loop {
-                let sign = dav1d_msac_decode_bool_equi(&mut (*ts).msac) as c_int;
+                let sign = rav1d_msac_decode_bool_equi(&mut (*ts).msac) as c_int;
                 if dbg != 0 {
                     printf(
                         b"Post-sign[%d=%d]: r=%d\n\0" as *const u8 as *const c_char,
@@ -1236,7 +1236,7 @@ unsafe fn decode_coefs(
         2404388531445638768 => {
             let ac_dq_0: c_uint = *dq_tbl.offset(1) as c_uint;
             loop {
-                let sign_0 = dav1d_msac_decode_bool_equi(&mut (*ts).msac) as c_int;
+                let sign_0 = rav1d_msac_decode_bool_equi(&mut (*ts).msac) as c_int;
                 if dbg != 0 {
                     printf(
                         b"Post-sign[%d=%d]: r=%d\n\0" as *const u8 as *const c_char,
@@ -1488,7 +1488,7 @@ unsafe extern "C" fn read_coef_tree(
     };
 }
 
-pub unsafe extern "C" fn dav1d_read_coef_blocks_16bpc(
+pub(crate) unsafe extern "C" fn rav1d_read_coef_blocks_16bpc(
     t: *mut Rav1dTaskContext,
     bs: BlockSize,
     b: *const Av1Block,
@@ -2186,7 +2186,7 @@ unsafe extern "C" fn warp_affine(
     return 0 as c_int;
 }
 
-pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
+pub(crate) unsafe extern "C" fn rav1d_recon_b_intra_16bpc(
     t: *mut Rav1dTaskContext,
     bs: BlockSize,
     intra_edge_flags: EdgeFlags,
@@ -2338,7 +2338,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                             top_sb_edge =
                                 top_sb_edge.offset(((*f).sb128w * 128 * (sby - 1)) as isize);
                         }
-                        m = dav1d_prepare_intra_edges::<BitDepth16>(
+                        m = rav1d_prepare_intra_edges::<BitDepth16>(
                             (*t).bx,
                             ((*t).bx > (*ts).tiling.col_start) as c_int,
                             (*t).by,
@@ -2547,7 +2547,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                             let ypos = (*t).by >> ss_ver;
                             let xstart = (*ts).tiling.col_start >> ss_hor;
                             let ystart = (*ts).tiling.row_start >> ss_ver;
-                            let m_0: IntraPredMode = dav1d_prepare_intra_edges::<BitDepth16>(
+                            let m_0: IntraPredMode = rav1d_prepare_intra_edges::<BitDepth16>(
                                 xpos,
                                 (xpos > xstart) as c_int,
                                 ypos,
@@ -2747,7 +2747,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
                                 ypos_0 = (*t).by >> ss_ver;
                                 xstart_0 = (*ts).tiling.col_start >> ss_hor;
                                 ystart_0 = (*ts).tiling.row_start >> ss_ver;
-                                m_1 = dav1d_prepare_intra_edges::<BitDepth16>(
+                                m_1 = rav1d_prepare_intra_edges::<BitDepth16>(
                                     xpos_0,
                                     (xpos_0 > xstart_0) as c_int,
                                     ypos_0,
@@ -2932,7 +2932,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_16bpc(
     }
 }
 
-pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
+pub(crate) unsafe extern "C" fn rav1d_recon_b_inter_16bpc(
     t: *mut Rav1dTaskContext,
     bs: BlockSize,
     b: *const Av1Block,
@@ -3142,7 +3142,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                 let sby = (*t).by >> (*f).sb_shift;
                 top_sb_edge = top_sb_edge.offset(((*f).sb128w * 128 * (sby - 1)) as isize);
             }
-            m = dav1d_prepare_intra_edges::<BitDepth16>(
+            m = rav1d_prepare_intra_edges::<BitDepth16>(
                 (*t).bx,
                 ((*t).bx > (*ts).tiling.col_start) as c_int,
                 (*t).by,
@@ -3583,7 +3583,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
                             top_sb_edge_0 =
                                 top_sb_edge_0.offset(((*f).sb128w * 128 * (sby_0 - 1)) as isize);
                         }
-                        m_0 = dav1d_prepare_intra_edges::<BitDepth16>(
+                        m_0 = rav1d_prepare_intra_edges::<BitDepth16>(
                             (*t).bx >> ss_hor,
                             ((*t).bx >> ss_hor > (*ts).tiling.col_start >> ss_hor) as c_int,
                             (*t).by >> ss_ver,
@@ -4169,7 +4169,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_16bpc(
     return 0 as c_int;
 }
 
-pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_cols_16bpc(
+pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_deblock_cols_16bpc(
     f: *mut Rav1dFrameContext,
     sby: c_int,
 ) {
@@ -4191,7 +4191,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_cols_16bpc(
     ];
     let mask: *mut Av1Filter = ((*f).lf.mask)
         .offset(((sby >> ((*(*f).seq_hdr).sb128 == 0) as c_int) * (*f).sb128w) as isize);
-    dav1d_loopfilter_sbrow_cols_16bpc(
+    rav1d_loopfilter_sbrow_cols_16bpc(
         f,
         p.as_ptr(),
         mask,
@@ -4200,7 +4200,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_cols_16bpc(
     );
 }
 
-pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_rows_16bpc(
+pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_deblock_rows_16bpc(
     f: *mut Rav1dFrameContext,
     sby: c_int,
 ) {
@@ -4220,14 +4220,17 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_rows_16bpc(
         && ((*(*f).frame_hdr).loopfilter.level_y[0] != 0
             || (*(*f).frame_hdr).loopfilter.level_y[1] != 0)
     {
-        dav1d_loopfilter_sbrow_rows_16bpc(f, p.as_ptr(), mask, sby);
+        rav1d_loopfilter_sbrow_rows_16bpc(f, p.as_ptr(), mask, sby);
     }
     if (*(*f).seq_hdr).cdef != 0 || (*f).lf.restore_planes != 0 {
-        dav1d_copy_lpf_16bpc(f, p.as_ptr(), sby);
+        rav1d_copy_lpf_16bpc(f, p.as_ptr(), sby);
     }
 }
 
-pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_16bpc(tc: *mut Rav1dTaskContext, sby: c_int) {
+pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_cdef_16bpc(
+    tc: *mut Rav1dTaskContext,
+    sby: c_int,
+) {
     let f: *const Rav1dFrameContext = (*tc).f;
     if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_CDEF as c_int as c_uint == 0 {
         return;
@@ -4256,7 +4259,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_16bpc(tc: *mut Rav1dTaskContext
             (p[1]).offset(-((8 * PXSTRIDE((*f).cur.stride[1]) >> ss_ver_0) as isize)),
             (p[2]).offset(-((8 * PXSTRIDE((*f).cur.stride[1]) >> ss_ver_0) as isize)),
         ];
-        dav1d_cdef_brow_16bpc(
+        rav1d_cdef_brow_16bpc(
             tc,
             p_up.as_mut_ptr() as *const *mut pixel,
             prev_mask,
@@ -4268,10 +4271,13 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_16bpc(tc: *mut Rav1dTaskContext
     }
     let n_blks = sbsz - 2 * ((sby + 1) < (*f).sbh) as c_int;
     let end = cmp::min(start + n_blks, (*f).bh);
-    dav1d_cdef_brow_16bpc(tc, p.as_ptr(), mask, start, end, 0 as c_int, sby);
+    rav1d_cdef_brow_16bpc(tc, p.as_ptr(), mask, start, end, 0 as c_int, sby);
 }
 
-pub unsafe extern "C" fn dav1d_filter_sbrow_resize_16bpc(f: *mut Rav1dFrameContext, sby: c_int) {
+pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_resize_16bpc(
+    f: *mut Rav1dFrameContext,
+    sby: c_int,
+) {
     let sbsz = (*f).sb_step;
     let y = sby * sbsz * 4;
     let ss_ver =
@@ -4330,7 +4336,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_resize_16bpc(f: *mut Rav1dFrameConte
     }
 }
 
-pub unsafe extern "C" fn dav1d_filter_sbrow_lr_16bpc(f: *mut Rav1dFrameContext, sby: c_int) {
+pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_lr_16bpc(f: *mut Rav1dFrameContext, sby: c_int) {
     if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_RESTORATION as c_int as c_uint == 0 {
         return;
     }
@@ -4344,24 +4350,24 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_lr_16bpc(f: *mut Rav1dFrameContext, 
         ((*f).lf.sr_p[2] as *mut pixel)
             .offset(y as isize * PXSTRIDE((*f).sr_cur.p.stride[1]) >> ss_ver),
     ];
-    dav1d_lr_sbrow_16bpc(f, sr_p.as_ptr(), sby);
+    rav1d_lr_sbrow_16bpc(f, sr_p.as_ptr(), sby);
 }
 
-pub unsafe extern "C" fn dav1d_filter_sbrow_16bpc(f: *mut Rav1dFrameContext, sby: c_int) {
-    dav1d_filter_sbrow_deblock_cols_16bpc(f, sby);
-    dav1d_filter_sbrow_deblock_rows_16bpc(f, sby);
+pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_16bpc(f: *mut Rav1dFrameContext, sby: c_int) {
+    rav1d_filter_sbrow_deblock_cols_16bpc(f, sby);
+    rav1d_filter_sbrow_deblock_rows_16bpc(f, sby);
     if (*(*f).seq_hdr).cdef != 0 {
-        dav1d_filter_sbrow_cdef_16bpc((*(*f).c).tc, sby);
+        rav1d_filter_sbrow_cdef_16bpc((*(*f).c).tc, sby);
     }
     if (*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1] {
-        dav1d_filter_sbrow_resize_16bpc(f, sby);
+        rav1d_filter_sbrow_resize_16bpc(f, sby);
     }
     if (*f).lf.restore_planes != 0 {
-        dav1d_filter_sbrow_lr_16bpc(f, sby);
+        rav1d_filter_sbrow_lr_16bpc(f, sby);
     }
 }
 
-pub unsafe extern "C" fn dav1d_backup_ipred_edge_16bpc(t: *mut Rav1dTaskContext) {
+pub(crate) unsafe extern "C" fn rav1d_backup_ipred_edge_16bpc(t: *mut Rav1dTaskContext) {
     let f: *const Rav1dFrameContext = (*t).f;
     let ts: *mut Rav1dTileState = (*t).ts;
     let sby = (*t).by >> (*f).sb_shift;

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -6,14 +6,14 @@ use crate::include::common::dump::coef_dump;
 use crate::include::common::dump::hex_dump;
 use crate::include::common::intops::apply_sign64;
 use crate::include::common::intops::iclip;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_CDEF;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_DEBLOCK;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
+use crate::include::dav1d::dav1d::RAV1D_INLOOPFILTER_CDEF;
+use crate::include::dav1d::dav1d::RAV1D_INLOOPFILTER_DEBLOCK;
+use crate::include::dav1d::dav1d::RAV1D_INLOOPFILTER_RESTORATION;
 use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::RAV1D_WM_TYPE_TRANSLATION;
 use crate::src::cdef_apply_tmpl_16::rav1d_cdef_brow_16bpc;
 use crate::src::ctx::CaseSet;
 use crate::src::env::get_uv_inter_txtp;
@@ -1495,9 +1495,9 @@ pub(crate) unsafe extern "C" fn rav1d_read_coef_blocks_16bpc(
 ) {
     let f: *const Rav1dFrameContext = (*t).f;
     let ss_ver =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let ss_hor =
-        ((*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
     let bx4 = (*t).bx & 31;
     let by4 = (*t).by & 31;
     let cbx4 = bx4 >> ss_hor;
@@ -1507,7 +1507,7 @@ pub(crate) unsafe extern "C" fn rav1d_read_coef_blocks_16bpc(
     let bh4 = *b_dim.offset(1) as c_int;
     let cbw4 = bw4 + ss_hor >> ss_hor;
     let cbh4 = bh4 + ss_ver >> ss_ver;
-    let has_chroma = ((*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
+    let has_chroma = ((*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
         && (bw4 > ss_hor || (*t).bx & 1 != 0)
         && (bh4 > ss_ver || (*t).by & 1 != 0)) as c_int;
     if (*b).skip != 0 {
@@ -1755,10 +1755,10 @@ unsafe extern "C" fn mc(
     }
     let f: *const Rav1dFrameContext = (*t).f;
     let ss_ver = (pl != 0
-        && (*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
+        && (*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
         as c_int;
     let ss_hor = (pl != 0
-        && (*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint)
+        && (*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint)
         as c_int;
     let h_mul = 4 >> ss_hor;
     let v_mul = 4 >> ss_ver;
@@ -1956,10 +1956,10 @@ unsafe extern "C" fn obmc(
         as *mut *mut refmvs_block;
     let lap: *mut pixel = ((*t).scratch.c2rust_unnamed.c2rust_unnamed.lap_16bpc).as_mut_ptr();
     let ss_ver = (pl != 0
-        && (*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
+        && (*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
         as c_int;
     let ss_hor = (pl != 0
-        && (*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint)
+        && (*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint)
         as c_int;
     let h_mul = 4 >> ss_hor;
     let v_mul = 4 >> ss_ver;
@@ -2090,10 +2090,10 @@ unsafe extern "C" fn warp_affine(
     let f: *const Rav1dFrameContext = (*t).f;
     let dsp: *const Rav1dDSPContext = (*f).dsp;
     let ss_ver = (pl != 0
-        && (*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
+        && (*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
         as c_int;
     let ss_hor = (pl != 0
-        && (*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint)
+        && (*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint)
         as c_int;
     let h_mul = 4 >> ss_hor;
     let v_mul = 4 >> ss_ver;
@@ -2198,9 +2198,9 @@ pub(crate) unsafe extern "C" fn rav1d_recon_b_intra_16bpc(
     let bx4 = (*t).bx & 31;
     let by4 = (*t).by & 31;
     let ss_ver =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let ss_hor =
-        ((*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
     let cbx4 = bx4 >> ss_hor;
     let cby4 = by4 >> ss_ver;
     let b_dim: *const u8 = (dav1d_block_dimensions[bs as usize]).as_ptr();
@@ -2210,7 +2210,7 @@ pub(crate) unsafe extern "C" fn rav1d_recon_b_intra_16bpc(
     let h4 = cmp::min(bh4, (*f).bh - (*t).by);
     let cw4 = w4 + ss_hor >> ss_hor;
     let ch4 = h4 + ss_ver >> ss_ver;
-    let has_chroma = ((*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
+    let has_chroma = ((*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
         && (bw4 > ss_hor || (*t).bx & 1 != 0)
         && (bh4 > ss_ver || (*t).by & 1 != 0)) as c_int;
     let t_dim: *const TxfmInfo = &*dav1d_txfm_dimensions
@@ -2943,9 +2943,9 @@ pub(crate) unsafe extern "C" fn rav1d_recon_b_inter_16bpc(
     let bx4 = (*t).bx & 31;
     let by4 = (*t).by & 31;
     let ss_ver =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let ss_hor =
-        ((*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
     let cbx4 = bx4 >> ss_hor;
     let cby4 = by4 >> ss_ver;
     let b_dim: *const u8 = (dav1d_block_dimensions[bs as usize]).as_ptr();
@@ -2953,14 +2953,14 @@ pub(crate) unsafe extern "C" fn rav1d_recon_b_inter_16bpc(
     let bh4 = *b_dim.offset(1) as c_int;
     let w4 = cmp::min(bw4, (*f).bw - (*t).bx);
     let h4 = cmp::min(bh4, (*f).bh - (*t).by);
-    let has_chroma = ((*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
+    let has_chroma = ((*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
         && (bw4 > ss_hor || (*t).bx & 1 != 0)
         && (bh4 > ss_ver || (*t).by & 1 != 0)) as c_int;
     let chr_layout_idx =
-        (if (*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint {
+        (if (*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint {
             0 as c_int as c_uint
         } else {
-            (DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint).wrapping_sub((*f).cur.p.layout as c_uint)
+            (RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint).wrapping_sub((*f).cur.p.layout as c_uint)
         }) as c_int;
     let mut res;
     let cbh4 = bh4 + ss_ver >> ss_ver;
@@ -3040,7 +3040,7 @@ pub(crate) unsafe extern "C" fn rav1d_recon_b_inter_16bpc(
                     as c_int
                     != 0
                 || (*b).c2rust_unnamed.c2rust_unnamed_0.motion_mode as c_int == MM_WARP as c_int
-                    && (*t).warpmv.type_0 as c_uint > DAV1D_WM_TYPE_TRANSLATION as c_int as c_uint)
+                    && (*t).warpmv.type_0 as c_uint > RAV1D_WM_TYPE_TRANSLATION as c_int as c_uint)
         {
             res = warp_affine(
                 t,
@@ -3441,7 +3441,7 @@ pub(crate) unsafe extern "C" fn rav1d_recon_b_inter_16bpc(
                         || (*b).c2rust_unnamed.c2rust_unnamed_0.motion_mode as c_int
                             == MM_WARP as c_int
                             && (*t).warpmv.type_0 as c_uint
-                                > DAV1D_WM_TYPE_TRANSLATION as c_int as c_uint)
+                                > RAV1D_WM_TYPE_TRANSLATION as c_int as c_uint)
                 {
                     let mut pl_4 = 0;
                     while pl_4 < 2 {
@@ -4173,7 +4173,7 @@ pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_deblock_cols_16bpc(
     f: *mut Rav1dFrameContext,
     sby: c_int,
 ) {
-    if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_DEBLOCK as c_int as c_uint == 0
+    if (*(*f).c).inloop_filters as c_uint & RAV1D_INLOOPFILTER_DEBLOCK as c_int as c_uint == 0
         || (*(*f).frame_hdr).loopfilter.level_y[0] == 0
             && (*(*f).frame_hdr).loopfilter.level_y[1] == 0
     {
@@ -4181,7 +4181,7 @@ pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_deblock_cols_16bpc(
     }
     let y = sby * (*f).sb_step * 4;
     let ss_ver =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let p: [*mut pixel; 3] = [
         ((*f).lf.p[0] as *mut pixel).offset((y as isize * PXSTRIDE((*f).cur.stride[0])) as isize),
         ((*f).lf.p[1] as *mut pixel)
@@ -4206,7 +4206,7 @@ pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_deblock_rows_16bpc(
 ) {
     let y = sby * (*f).sb_step * 4;
     let ss_ver =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let p: [*mut pixel; 3] = [
         ((*f).lf.p[0] as *mut pixel).offset((y as isize * PXSTRIDE((*f).cur.stride[0])) as isize),
         ((*f).lf.p[1] as *mut pixel)
@@ -4216,7 +4216,7 @@ pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_deblock_rows_16bpc(
     ];
     let mask: *mut Av1Filter = ((*f).lf.mask)
         .offset(((sby >> ((*(*f).seq_hdr).sb128 == 0) as c_int) * (*f).sb128w) as isize);
-    if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_DEBLOCK as c_int as c_uint != 0
+    if (*(*f).c).inloop_filters as c_uint & RAV1D_INLOOPFILTER_DEBLOCK as c_int as c_uint != 0
         && ((*(*f).frame_hdr).loopfilter.level_y[0] != 0
             || (*(*f).frame_hdr).loopfilter.level_y[1] != 0)
     {
@@ -4232,13 +4232,13 @@ pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_cdef_16bpc(
     sby: c_int,
 ) {
     let f: *const Rav1dFrameContext = (*tc).f;
-    if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_CDEF as c_int as c_uint == 0 {
+    if (*(*f).c).inloop_filters as c_uint & RAV1D_INLOOPFILTER_CDEF as c_int as c_uint == 0 {
         return;
     }
     let sbsz = (*f).sb_step;
     let y = sby * sbsz * 4;
     let ss_ver =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let p: [*mut pixel; 3] = [
         ((*f).lf.p[0] as *mut pixel).offset((y as isize * PXSTRIDE((*f).cur.stride[0])) as isize),
         ((*f).lf.p[1] as *mut pixel)
@@ -4253,7 +4253,7 @@ pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_cdef_16bpc(
     let start = sby * sbsz;
     if sby != 0 {
         let ss_ver_0 =
-            ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+            ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
         let mut p_up: [*mut pixel; 3] = [
             (p[0]).offset(-((8 * PXSTRIDE((*f).cur.stride[0])) as isize)),
             (p[1]).offset(-((8 * PXSTRIDE((*f).cur.stride[1]) >> ss_ver_0) as isize)),
@@ -4281,7 +4281,7 @@ pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_resize_16bpc(
     let sbsz = (*f).sb_step;
     let y = sby * sbsz * 4;
     let ss_ver =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let p: [*const pixel; 3] = [
         ((*f).lf.p[0] as *mut pixel).offset((y as isize * PXSTRIDE((*f).cur.stride[0])) as isize)
             as *const pixel,
@@ -4301,11 +4301,11 @@ pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_resize_16bpc(
             .offset((y as isize * PXSTRIDE((*f).sr_cur.p.stride[1]) >> ss_ver) as isize),
     ];
     let has_chroma =
-        ((*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint) as c_int;
     let mut pl = 0;
     while pl < 1 + 2 * has_chroma {
         let ss_ver_0 = (pl != 0
-            && (*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
+            && (*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
             as c_int;
         let h_start = 8 * (sby != 0) as c_int >> ss_ver_0;
         let dst_stride: ptrdiff_t = (*f).sr_cur.p.stride[(pl != 0) as c_int as usize];
@@ -4315,7 +4315,7 @@ pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_resize_16bpc(
         let src: *const pixel = (p[pl as usize]).offset(-(h_start as isize * PXSTRIDE(src_stride)));
         let h_end = 4 * (sbsz - 2 * ((sby + 1) < (*f).sbh) as c_int) >> ss_ver_0;
         let ss_hor = (pl != 0
-            && (*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint)
+            && (*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint)
             as c_int;
         let dst_w = (*f).sr_cur.p.p.w + ss_hor >> ss_hor;
         let src_w = 4 * (*f).bw + ss_hor >> ss_hor;
@@ -4337,12 +4337,12 @@ pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_resize_16bpc(
 }
 
 pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_lr_16bpc(f: *mut Rav1dFrameContext, sby: c_int) {
-    if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_RESTORATION as c_int as c_uint == 0 {
+    if (*(*f).c).inloop_filters as c_uint & RAV1D_INLOOPFILTER_RESTORATION as c_int as c_uint == 0 {
         return;
     }
     let y = sby * (*f).sb_step * 4;
     let ss_ver =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let sr_p: [*mut pixel; 3] = [
         ((*f).lf.sr_p[0] as *mut pixel).offset(y as isize * PXSTRIDE((*f).sr_cur.p.stride[0])),
         ((*f).lf.sr_p[1] as *mut pixel)
@@ -4384,11 +4384,11 @@ pub(crate) unsafe extern "C" fn rav1d_backup_ipred_edge_16bpc(t: *mut Rav1dTaskC
         y as *const c_void,
         (4 * ((*ts).tiling.col_end - x_off) << 1) as usize,
     );
-    if (*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint {
+    if (*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint {
         let ss_ver =
-            ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+            ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
         let ss_hor =
-            ((*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+            ((*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
         let uv_off: ptrdiff_t = (x_off * 4 >> ss_hor) as isize
             + ((((*t).by + (*f).sb_step) * 4 >> ss_ver) - 1) as isize
                 * PXSTRIDE((*f).cur.stride[1]);

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -14,7 +14,7 @@ use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
-use crate::src::cdef_apply_tmpl_8::dav1d_cdef_brow_8bpc;
+use crate::src::cdef_apply_tmpl_8::rav1d_cdef_brow_8bpc;
 use crate::src::ctx::CaseSet;
 use crate::src::env::get_uv_inter_txtp;
 use crate::src::internal::CodedBlockInfo;
@@ -27,7 +27,7 @@ use crate::src::intra_edge::EDGE_I420_LEFT_HAS_BOTTOM;
 use crate::src::intra_edge::EDGE_I420_TOP_HAS_RIGHT;
 use crate::src::intra_edge::EDGE_I444_LEFT_HAS_BOTTOM;
 use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
-use crate::src::ipred_prepare::dav1d_prepare_intra_edges;
+use crate::src::ipred_prepare::rav1d_prepare_intra_edges;
 use crate::src::ipred_prepare::sm_flag;
 use crate::src::ipred_prepare::sm_uv_flag;
 use crate::src::levels::mv;
@@ -61,18 +61,18 @@ use crate::src::levels::TX_CLASS_2D;
 use crate::src::levels::TX_CLASS_H;
 use crate::src::levels::TX_CLASS_V;
 use crate::src::levels::WHT_WHT;
-use crate::src::lf_apply_tmpl_8::dav1d_copy_lpf_8bpc;
-use crate::src::lf_apply_tmpl_8::dav1d_loopfilter_sbrow_cols_8bpc;
-use crate::src::lf_apply_tmpl_8::dav1d_loopfilter_sbrow_rows_8bpc;
+use crate::src::lf_apply_tmpl_8::rav1d_copy_lpf_8bpc;
+use crate::src::lf_apply_tmpl_8::rav1d_loopfilter_sbrow_cols_8bpc;
+use crate::src::lf_apply_tmpl_8::rav1d_loopfilter_sbrow_rows_8bpc;
 use crate::src::lf_mask::Av1Filter;
-use crate::src::lr_apply_tmpl_8::dav1d_lr_sbrow_8bpc;
-use crate::src::msac::dav1d_msac_decode_bool_adapt;
-use crate::src::msac::dav1d_msac_decode_bool_equi;
-use crate::src::msac::dav1d_msac_decode_bools;
-use crate::src::msac::dav1d_msac_decode_hi_tok;
-use crate::src::msac::dav1d_msac_decode_symbol_adapt16;
-use crate::src::msac::dav1d_msac_decode_symbol_adapt4;
-use crate::src::msac::dav1d_msac_decode_symbol_adapt8;
+use crate::src::lr_apply_tmpl_8::rav1d_lr_sbrow_8bpc;
+use crate::src::msac::rav1d_msac_decode_bool_adapt;
+use crate::src::msac::rav1d_msac_decode_bool_equi;
+use crate::src::msac::rav1d_msac_decode_bools;
+use crate::src::msac::rav1d_msac_decode_hi_tok;
+use crate::src::msac::rav1d_msac_decode_symbol_adapt16;
+use crate::src::msac::rav1d_msac_decode_symbol_adapt4;
+use crate::src::msac::rav1d_msac_decode_symbol_adapt8;
 use crate::src::picture::Rav1dThreadPicture;
 use crate::src::recon::get_dc_sign_ctx;
 use crate::src::recon::get_lo_ctx;
@@ -138,7 +138,7 @@ unsafe fn decode_coefs(
         );
     }
     let sctx = get_skip_ctx(t_dim, bs, a, l, chroma, (*f).cur.p.layout) as c_int;
-    let all_skip = dav1d_msac_decode_bool_adapt(
+    let all_skip = rav1d_msac_decode_bool_adapt(
         &mut (*ts).msac,
         &mut (*ts).cdf.coef.skip[(*t_dim).ctx as usize][sctx as usize],
     ) as c_int;
@@ -183,7 +183,7 @@ unsafe fn decode_coefs(
                 }) as IntraPredMode;
             if (*(*f).frame_hdr).reduced_txtp_set != 0 || (*t_dim).min as c_int == TX_16X16 as c_int
             {
-                idx = dav1d_msac_decode_symbol_adapt4(
+                idx = rav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
                     &mut (*ts).cdf.m.txtp_intra2[(*t_dim).min as usize][y_mode_nofilt as usize],
                     4 as c_int as usize,
@@ -191,7 +191,7 @@ unsafe fn decode_coefs(
                 *txtp = dav1d_tx_types_per_set[idx.wrapping_add(0 as c_int as c_uint) as usize]
                     as TxfmType;
             } else {
-                idx = dav1d_msac_decode_symbol_adapt8(
+                idx = rav1d_msac_decode_symbol_adapt8(
                     &mut (*ts).msac,
                     &mut (*ts).cdf.m.txtp_intra1[(*t_dim).min as usize][y_mode_nofilt as usize],
                     6 as c_int as usize,
@@ -213,14 +213,14 @@ unsafe fn decode_coefs(
         } else {
             if (*(*f).frame_hdr).reduced_txtp_set != 0 || (*t_dim).max as c_int == TX_32X32 as c_int
             {
-                idx = dav1d_msac_decode_bool_adapt(
+                idx = rav1d_msac_decode_bool_adapt(
                     &mut (*ts).msac,
                     &mut (*ts).cdf.m.txtp_inter3[(*t_dim).min as usize],
                 ) as c_uint;
                 *txtp =
                     (idx.wrapping_sub(1 as c_int as c_uint) & IDTX as c_int as c_uint) as TxfmType;
             } else if (*t_dim).min as c_int == TX_16X16 as c_int {
-                idx = dav1d_msac_decode_symbol_adapt16(
+                idx = rav1d_msac_decode_symbol_adapt16(
                     &mut (*ts).msac,
                     &mut (*ts).cdf.m.txtp_inter2.0,
                     11 as c_int as usize,
@@ -228,7 +228,7 @@ unsafe fn decode_coefs(
                 *txtp = dav1d_tx_types_per_set[idx.wrapping_add(12 as c_int as c_uint) as usize]
                     as TxfmType;
             } else {
-                idx = dav1d_msac_decode_symbol_adapt16(
+                idx = rav1d_msac_decode_symbol_adapt16(
                     &mut (*ts).msac,
                     &mut (*ts).cdf.m.txtp_inter1[(*t_dim).min as usize],
                     15 as c_int as usize,
@@ -257,43 +257,43 @@ unsafe fn decode_coefs(
         0 => {
             let eob_bin_cdf = &mut (*ts).cdf.coef.eob_bin_16[chroma as usize][is_1d as usize];
             eob_bin =
-                dav1d_msac_decode_symbol_adapt4(&mut (*ts).msac, eob_bin_cdf, (4 + 0) as usize)
+                rav1d_msac_decode_symbol_adapt4(&mut (*ts).msac, eob_bin_cdf, (4 + 0) as usize)
                     as c_int;
         }
         1 => {
             let eob_bin_cdf_0 = &mut (*ts).cdf.coef.eob_bin_32[chroma as usize][is_1d as usize];
             eob_bin =
-                dav1d_msac_decode_symbol_adapt8(&mut (*ts).msac, eob_bin_cdf_0, (4 + 1) as usize)
+                rav1d_msac_decode_symbol_adapt8(&mut (*ts).msac, eob_bin_cdf_0, (4 + 1) as usize)
                     as c_int;
         }
         2 => {
             let eob_bin_cdf_1 = &mut (*ts).cdf.coef.eob_bin_64[chroma as usize][is_1d as usize];
             eob_bin =
-                dav1d_msac_decode_symbol_adapt8(&mut (*ts).msac, eob_bin_cdf_1, (4 + 2) as usize)
+                rav1d_msac_decode_symbol_adapt8(&mut (*ts).msac, eob_bin_cdf_1, (4 + 2) as usize)
                     as c_int;
         }
         3 => {
             let eob_bin_cdf_2 = &mut (*ts).cdf.coef.eob_bin_128[chroma as usize][is_1d as usize];
             eob_bin =
-                dav1d_msac_decode_symbol_adapt8(&mut (*ts).msac, eob_bin_cdf_2, (4 + 3) as usize)
+                rav1d_msac_decode_symbol_adapt8(&mut (*ts).msac, eob_bin_cdf_2, (4 + 3) as usize)
                     as c_int;
         }
         4 => {
             let eob_bin_cdf_3 = &mut (*ts).cdf.coef.eob_bin_256[chroma as usize][is_1d as usize];
             eob_bin =
-                dav1d_msac_decode_symbol_adapt16(&mut (*ts).msac, eob_bin_cdf_3, (4 + 4) as usize)
+                rav1d_msac_decode_symbol_adapt16(&mut (*ts).msac, eob_bin_cdf_3, (4 + 4) as usize)
                     as c_int;
         }
         5 => {
             let eob_bin_cdf_4 = &mut (*ts).cdf.coef.eob_bin_512[chroma as usize];
             eob_bin =
-                dav1d_msac_decode_symbol_adapt16(&mut (*ts).msac, eob_bin_cdf_4, (4 + 5) as usize)
+                rav1d_msac_decode_symbol_adapt16(&mut (*ts).msac, eob_bin_cdf_4, (4 + 5) as usize)
                     as c_int;
         }
         6 => {
             let eob_bin_cdf_5 = &mut (*ts).cdf.coef.eob_bin_1024[chroma as usize];
             eob_bin =
-                dav1d_msac_decode_symbol_adapt16(&mut (*ts).msac, eob_bin_cdf_5, (4 + 6) as usize)
+                rav1d_msac_decode_symbol_adapt16(&mut (*ts).msac, eob_bin_cdf_5, (4 + 6) as usize)
                     as c_int;
         }
         _ => {}
@@ -312,7 +312,7 @@ unsafe fn decode_coefs(
     if eob_bin > 1 {
         let eob_hi_bit_cdf = &mut (*ts).cdf.coef.eob_hi_bit[(*t_dim).ctx as usize][chroma as usize]
             [eob_bin as usize];
-        let eob_hi_bit = dav1d_msac_decode_bool_adapt(&mut (*ts).msac, eob_hi_bit_cdf) as c_int;
+        let eob_hi_bit = rav1d_msac_decode_bool_adapt(&mut (*ts).msac, eob_hi_bit_cdf) as c_int;
         if dbg != 0 {
             printf(
                 b"Post-eob_hi_bit[%d][%d][%d][%d]: r=%d\n\0" as *const u8 as *const c_char,
@@ -324,7 +324,7 @@ unsafe fn decode_coefs(
             );
         }
         eob = (((eob_hi_bit | 2) << eob_bin - 2) as c_uint
-            | dav1d_msac_decode_bools(&mut (*ts).msac, (eob_bin - 2) as c_uint))
+            | rav1d_msac_decode_bools(&mut (*ts).msac, (eob_bin - 2) as c_uint))
             as c_int;
         if dbg != 0 {
             printf(
@@ -354,7 +354,7 @@ unsafe fn decode_coefs(
         let sh = cmp::min((*t_dim).h as c_int, 8 as c_int);
         let mut ctx: c_uint =
             (1 as c_int + (eob > sw * sh * 2) as c_int + (eob > sw * sh * 4) as c_int) as c_uint;
-        let eob_tok = dav1d_msac_decode_symbol_adapt4(
+        let eob_tok = rav1d_msac_decode_symbol_adapt4(
             &mut (*ts).msac,
             &mut *eob_cdf.offset(ctx as isize),
             2 as c_int as usize,
@@ -424,7 +424,7 @@ unsafe fn decode_coefs(
                     } else {
                         7 as c_int
                     }) as c_uint;
-                    tok = dav1d_msac_decode_hi_tok(
+                    tok = rav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         &mut *hi_cdf.offset(ctx as isize),
                     ) as c_int;
@@ -477,7 +477,7 @@ unsafe fn decode_coefs(
                     if TX_CLASS_2D as c_int == TX_CLASS_2D as c_int {
                         y |= x;
                     }
-                    tok = dav1d_msac_decode_symbol_adapt4(
+                    tok = rav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
                         &mut *lo_cdf.offset(ctx as isize),
                         3 as c_int as usize,
@@ -509,7 +509,7 @@ unsafe fn decode_coefs(
                             } else {
                                 mag.wrapping_add(1 as c_int as c_uint) >> 1
                             });
-                        tok = dav1d_msac_decode_hi_tok(
+                        tok = rav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
                             &mut *hi_cdf.offset(ctx as isize),
                         ) as c_int;
@@ -553,7 +553,7 @@ unsafe fn decode_coefs(
                         stride as usize,
                     ) as c_uint
                 };
-                dc_tok = dav1d_msac_decode_symbol_adapt4(
+                dc_tok = rav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
                     &mut *lo_cdf.offset(ctx as isize),
                     3 as c_int as usize,
@@ -581,7 +581,7 @@ unsafe fn decode_coefs(
                     } else {
                         mag.wrapping_add(1 as c_int as c_uint) >> 1
                     };
-                    dc_tok = dav1d_msac_decode_hi_tok(
+                    dc_tok = rav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         &mut *hi_cdf.offset(ctx as isize),
                     );
@@ -647,7 +647,7 @@ unsafe fn decode_coefs(
                     } else {
                         7 as c_int
                     }) as c_uint;
-                    tok = dav1d_msac_decode_hi_tok(
+                    tok = rav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         &mut *hi_cdf.offset(ctx as isize),
                     ) as c_int;
@@ -700,7 +700,7 @@ unsafe fn decode_coefs(
                     if TX_CLASS_H as c_int == TX_CLASS_2D as c_int {
                         y_0 |= x_0;
                     }
-                    tok = dav1d_msac_decode_symbol_adapt4(
+                    tok = rav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
                         &mut *lo_cdf.offset(ctx as isize),
                         3 as c_int as usize,
@@ -732,7 +732,7 @@ unsafe fn decode_coefs(
                             } else {
                                 mag.wrapping_add(1 as c_int as c_uint) >> 1
                             });
-                        tok = dav1d_msac_decode_hi_tok(
+                        tok = rav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
                             &mut *hi_cdf.offset(ctx as isize),
                         ) as c_int;
@@ -776,7 +776,7 @@ unsafe fn decode_coefs(
                         stride_0 as usize,
                     ) as c_uint
                 };
-                dc_tok = dav1d_msac_decode_symbol_adapt4(
+                dc_tok = rav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
                     &mut *lo_cdf.offset(ctx as isize),
                     3 as c_int as usize,
@@ -804,7 +804,7 @@ unsafe fn decode_coefs(
                     } else {
                         mag.wrapping_add(1 as c_int as c_uint) >> 1
                     };
-                    dc_tok = dav1d_msac_decode_hi_tok(
+                    dc_tok = rav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         &mut *hi_cdf.offset(ctx as isize),
                     );
@@ -870,7 +870,7 @@ unsafe fn decode_coefs(
                     } else {
                         7 as c_int
                     }) as c_uint;
-                    tok = dav1d_msac_decode_hi_tok(
+                    tok = rav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         &mut *hi_cdf.offset(ctx as isize),
                     ) as c_int;
@@ -923,7 +923,7 @@ unsafe fn decode_coefs(
                     if TX_CLASS_V as c_int == TX_CLASS_2D as c_int {
                         y_1 |= x_1;
                     }
-                    tok = dav1d_msac_decode_symbol_adapt4(
+                    tok = rav1d_msac_decode_symbol_adapt4(
                         &mut (*ts).msac,
                         &mut *lo_cdf.offset(ctx as isize),
                         3 as c_int as usize,
@@ -955,7 +955,7 @@ unsafe fn decode_coefs(
                             } else {
                                 mag.wrapping_add(1 as c_int as c_uint) >> 1
                             });
-                        tok = dav1d_msac_decode_hi_tok(
+                        tok = rav1d_msac_decode_hi_tok(
                             &mut (*ts).msac,
                             &mut *hi_cdf.offset(ctx as isize),
                         ) as c_int;
@@ -999,7 +999,7 @@ unsafe fn decode_coefs(
                         stride_1 as usize,
                     ) as c_uint
                 };
-                dc_tok = dav1d_msac_decode_symbol_adapt4(
+                dc_tok = rav1d_msac_decode_symbol_adapt4(
                     &mut (*ts).msac,
                     &mut *lo_cdf.offset(ctx as isize),
                     3 as c_int as usize,
@@ -1027,7 +1027,7 @@ unsafe fn decode_coefs(
                     } else {
                         mag.wrapping_add(1 as c_int as c_uint) >> 1
                     };
-                    dc_tok = dav1d_msac_decode_hi_tok(
+                    dc_tok = rav1d_msac_decode_hi_tok(
                         &mut (*ts).msac,
                         &mut *hi_cdf.offset(ctx as isize),
                     );
@@ -1050,7 +1050,7 @@ unsafe fn decode_coefs(
             }
         }
     } else {
-        let tok_br = dav1d_msac_decode_symbol_adapt4(
+        let tok_br = rav1d_msac_decode_symbol_adapt4(
             &mut (*ts).msac,
             &mut *eob_cdf.offset(0),
             2 as c_int as usize,
@@ -1067,7 +1067,7 @@ unsafe fn decode_coefs(
             );
         }
         if tok_br == 2 {
-            dc_tok = dav1d_msac_decode_hi_tok(&mut (*ts).msac, &mut *hi_cdf.offset(0));
+            dc_tok = rav1d_msac_decode_hi_tok(&mut (*ts).msac, &mut *hi_cdf.offset(0));
             if dbg != 0 {
                 printf(
                     b"Post-dc_hi_tok[%d][%d][0][%d]: r=%d\n\0" as *const u8 as *const c_char,
@@ -1101,7 +1101,7 @@ unsafe fn decode_coefs(
     } else {
         dc_sign_ctx = get_dc_sign_ctx(tx, a, l) as c_int;
         let dc_sign_cdf = &mut (*ts).cdf.coef.dc_sign[chroma as usize][dc_sign_ctx as usize];
-        dc_sign = dav1d_msac_decode_bool_adapt(&mut (*ts).msac, dc_sign_cdf) as c_int;
+        dc_sign = rav1d_msac_decode_bool_adapt(&mut (*ts).msac, dc_sign_cdf) as c_int;
         if dbg != 0 {
             printf(
                 b"Post-dc_sign[%d][%d][%d]: r=%d\n\0" as *const u8 as *const c_char,
@@ -1177,7 +1177,7 @@ unsafe fn decode_coefs(
         10687245492419339872 => {
             let ac_dq: c_uint = *dq_tbl.offset(1) as c_uint;
             loop {
-                let sign = dav1d_msac_decode_bool_equi(&mut (*ts).msac) as c_int;
+                let sign = rav1d_msac_decode_bool_equi(&mut (*ts).msac) as c_int;
                 if dbg != 0 {
                     printf(
                         b"Post-sign[%d=%d]: r=%d\n\0" as *const u8 as *const c_char,
@@ -1226,7 +1226,7 @@ unsafe fn decode_coefs(
         16948539754621368774 => {
             let ac_dq_0: c_uint = *dq_tbl.offset(1) as c_uint;
             loop {
-                let sign_0 = dav1d_msac_decode_bool_equi(&mut (*ts).msac) as c_int;
+                let sign_0 = rav1d_msac_decode_bool_equi(&mut (*ts).msac) as c_int;
                 if dbg != 0 {
                     printf(
                         b"Post-sign[%d=%d]: r=%d\n\0" as *const u8 as *const c_char,
@@ -1478,7 +1478,7 @@ unsafe extern "C" fn read_coef_tree(
     };
 }
 
-pub unsafe extern "C" fn dav1d_read_coef_blocks_8bpc(
+pub(crate) unsafe extern "C" fn rav1d_read_coef_blocks_8bpc(
     t: *mut Rav1dTaskContext,
     bs: BlockSize,
     b: *const Av1Block,
@@ -2171,7 +2171,7 @@ unsafe extern "C" fn warp_affine(
     return 0 as c_int;
 }
 
-pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
+pub(crate) unsafe extern "C" fn rav1d_recon_b_intra_8bpc(
     t: *mut Rav1dTaskContext,
     bs: BlockSize,
     intra_edge_flags: EdgeFlags,
@@ -2322,7 +2322,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                             top_sb_edge =
                                 top_sb_edge.offset(((*f).sb128w * 128 * (sby - 1)) as isize);
                         }
-                        m = dav1d_prepare_intra_edges::<BitDepth8>(
+                        m = rav1d_prepare_intra_edges::<BitDepth8>(
                             (*t).bx,
                             ((*t).bx > (*ts).tiling.col_start) as c_int,
                             (*t).by,
@@ -2527,7 +2527,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                             let ypos = (*t).by >> ss_ver;
                             let xstart = (*ts).tiling.col_start >> ss_hor;
                             let ystart = (*ts).tiling.row_start >> ss_ver;
-                            let m_0: IntraPredMode = dav1d_prepare_intra_edges::<BitDepth8>(
+                            let m_0: IntraPredMode = rav1d_prepare_intra_edges::<BitDepth8>(
                                 xpos,
                                 (xpos > xstart) as c_int,
                                 ypos,
@@ -2727,7 +2727,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
                                 ypos_0 = (*t).by >> ss_ver;
                                 xstart_0 = (*ts).tiling.col_start >> ss_hor;
                                 ystart_0 = (*ts).tiling.row_start >> ss_ver;
-                                m_1 = dav1d_prepare_intra_edges::<BitDepth8>(
+                                m_1 = rav1d_prepare_intra_edges::<BitDepth8>(
                                     xpos_0,
                                     (xpos_0 > xstart_0) as c_int,
                                     ypos_0,
@@ -2912,7 +2912,7 @@ pub unsafe extern "C" fn dav1d_recon_b_intra_8bpc(
     }
 }
 
-pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
+pub(crate) unsafe extern "C" fn rav1d_recon_b_inter_8bpc(
     t: *mut Rav1dTaskContext,
     bs: BlockSize,
     b: *const Av1Block,
@@ -3120,7 +3120,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                 let sby = (*t).by >> (*f).sb_shift;
                 top_sb_edge = top_sb_edge.offset(((*f).sb128w * 128 * (sby - 1)) as isize);
             }
-            m = dav1d_prepare_intra_edges::<BitDepth8>(
+            m = rav1d_prepare_intra_edges::<BitDepth8>(
                 (*t).bx,
                 ((*t).bx > (*ts).tiling.col_start) as c_int,
                 (*t).by,
@@ -3561,7 +3561,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
                             top_sb_edge_0 =
                                 top_sb_edge_0.offset(((*f).sb128w * 128 * (sby_0 - 1)) as isize);
                         }
-                        m_0 = dav1d_prepare_intra_edges::<BitDepth8>(
+                        m_0 = rav1d_prepare_intra_edges::<BitDepth8>(
                             (*t).bx >> ss_hor,
                             ((*t).bx >> ss_hor > (*ts).tiling.col_start >> ss_hor) as c_int,
                             (*t).by >> ss_ver,
@@ -4144,7 +4144,7 @@ pub unsafe extern "C" fn dav1d_recon_b_inter_8bpc(
     return 0 as c_int;
 }
 
-pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_cols_8bpc(
+pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_deblock_cols_8bpc(
     f: *mut Rav1dFrameContext,
     sby: c_int,
 ) {
@@ -4164,7 +4164,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_cols_8bpc(
     ];
     let mask: *mut Av1Filter = ((*f).lf.mask)
         .offset(((sby >> ((*(*f).seq_hdr).sb128 == 0) as c_int) * (*f).sb128w) as isize);
-    dav1d_loopfilter_sbrow_cols_8bpc(
+    rav1d_loopfilter_sbrow_cols_8bpc(
         f,
         p.as_ptr(),
         mask,
@@ -4173,7 +4173,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_cols_8bpc(
     );
 }
 
-pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_rows_8bpc(
+pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_deblock_rows_8bpc(
     f: *mut Rav1dFrameContext,
     sby: c_int,
 ) {
@@ -4191,14 +4191,17 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_deblock_rows_8bpc(
         && ((*(*f).frame_hdr).loopfilter.level_y[0] != 0
             || (*(*f).frame_hdr).loopfilter.level_y[1] != 0)
     {
-        dav1d_loopfilter_sbrow_rows_8bpc(f, p.as_ptr(), mask, sby);
+        rav1d_loopfilter_sbrow_rows_8bpc(f, p.as_ptr(), mask, sby);
     }
     if (*(*f).seq_hdr).cdef != 0 || (*f).lf.restore_planes != 0 {
-        dav1d_copy_lpf_8bpc(f, p.as_ptr(), sby);
+        rav1d_copy_lpf_8bpc(f, p.as_ptr(), sby);
     }
 }
 
-pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_8bpc(tc: *mut Rav1dTaskContext, sby: c_int) {
+pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_cdef_8bpc(
+    tc: *mut Rav1dTaskContext,
+    sby: c_int,
+) {
     let f: *const Rav1dFrameContext = (*tc).f;
     if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_CDEF as c_int as c_uint == 0 {
         return;
@@ -4225,7 +4228,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_8bpc(tc: *mut Rav1dTaskContext,
             (p[1]).offset(-((8 * (*f).cur.stride[1] >> ss_ver_0) as isize)),
             (p[2]).offset(-((8 * (*f).cur.stride[1] >> ss_ver_0) as isize)),
         ];
-        dav1d_cdef_brow_8bpc(
+        rav1d_cdef_brow_8bpc(
             tc,
             p_up.as_mut_ptr() as *const *mut pixel,
             prev_mask,
@@ -4237,10 +4240,13 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_cdef_8bpc(tc: *mut Rav1dTaskContext,
     }
     let n_blks = sbsz - 2 * ((sby + 1) < (*f).sbh) as c_int;
     let end = cmp::min(start + n_blks, (*f).bh);
-    dav1d_cdef_brow_8bpc(tc, p.as_ptr(), mask, start, end, 0 as c_int, sby);
+    rav1d_cdef_brow_8bpc(tc, p.as_ptr(), mask, start, end, 0 as c_int, sby);
 }
 
-pub unsafe extern "C" fn dav1d_filter_sbrow_resize_8bpc(f: *mut Rav1dFrameContext, sby: c_int) {
+pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_resize_8bpc(
+    f: *mut Rav1dFrameContext,
+    sby: c_int,
+) {
     let sbsz = (*f).sb_step;
     let y = sby * sbsz * 4;
     let ss_ver =
@@ -4297,7 +4303,7 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_resize_8bpc(f: *mut Rav1dFrameContex
     }
 }
 
-pub unsafe extern "C" fn dav1d_filter_sbrow_lr_8bpc(f: *mut Rav1dFrameContext, sby: c_int) {
+pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_lr_8bpc(f: *mut Rav1dFrameContext, sby: c_int) {
     if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_RESTORATION as c_int as c_uint == 0 {
         return;
     }
@@ -4311,24 +4317,24 @@ pub unsafe extern "C" fn dav1d_filter_sbrow_lr_8bpc(f: *mut Rav1dFrameContext, s
         ((*f).lf.sr_p[2] as *mut pixel)
             .offset((y as isize * (*f).sr_cur.p.stride[1] >> ss_ver) as isize),
     ];
-    dav1d_lr_sbrow_8bpc(f, sr_p.as_ptr(), sby);
+    rav1d_lr_sbrow_8bpc(f, sr_p.as_ptr(), sby);
 }
 
-pub unsafe extern "C" fn dav1d_filter_sbrow_8bpc(f: *mut Rav1dFrameContext, sby: c_int) {
-    dav1d_filter_sbrow_deblock_cols_8bpc(f, sby);
-    dav1d_filter_sbrow_deblock_rows_8bpc(f, sby);
+pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_8bpc(f: *mut Rav1dFrameContext, sby: c_int) {
+    rav1d_filter_sbrow_deblock_cols_8bpc(f, sby);
+    rav1d_filter_sbrow_deblock_rows_8bpc(f, sby);
     if (*(*f).seq_hdr).cdef != 0 {
-        dav1d_filter_sbrow_cdef_8bpc((*(*f).c).tc, sby);
+        rav1d_filter_sbrow_cdef_8bpc((*(*f).c).tc, sby);
     }
     if (*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1] {
-        dav1d_filter_sbrow_resize_8bpc(f, sby);
+        rav1d_filter_sbrow_resize_8bpc(f, sby);
     }
     if (*f).lf.restore_planes != 0 {
-        dav1d_filter_sbrow_lr_8bpc(f, sby);
+        rav1d_filter_sbrow_lr_8bpc(f, sby);
     }
 }
 
-pub unsafe extern "C" fn dav1d_backup_ipred_edge_8bpc(t: *mut Rav1dTaskContext) {
+pub(crate) unsafe extern "C" fn rav1d_backup_ipred_edge_8bpc(t: *mut Rav1dTaskContext) {
     let f: *const Rav1dFrameContext = (*t).f;
     let ts: *mut Rav1dTileState = (*t).ts;
     let sby = (*t).by >> (*f).sb_shift;

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -6,14 +6,14 @@ use crate::include::common::dump::coef_dump;
 use crate::include::common::dump::hex_dump;
 use crate::include::common::intops::apply_sign64;
 use crate::include::common::intops::iclip;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_CDEF;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_DEBLOCK;
-use crate::include::dav1d::dav1d::DAV1D_INLOOPFILTER_RESTORATION;
+use crate::include::dav1d::dav1d::RAV1D_INLOOPFILTER_CDEF;
+use crate::include::dav1d::dav1d::RAV1D_INLOOPFILTER_DEBLOCK;
+use crate::include::dav1d::dav1d::RAV1D_INLOOPFILTER_RESTORATION;
 use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I400;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
+use crate::include::dav1d::headers::RAV1D_WM_TYPE_TRANSLATION;
 use crate::src::cdef_apply_tmpl_8::rav1d_cdef_brow_8bpc;
 use crate::src::ctx::CaseSet;
 use crate::src::env::get_uv_inter_txtp;
@@ -1485,9 +1485,9 @@ pub(crate) unsafe extern "C" fn rav1d_read_coef_blocks_8bpc(
 ) {
     let f: *const Rav1dFrameContext = (*t).f;
     let ss_ver =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let ss_hor =
-        ((*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
     let bx4 = (*t).bx & 31;
     let by4 = (*t).by & 31;
     let cbx4 = bx4 >> ss_hor;
@@ -1497,7 +1497,7 @@ pub(crate) unsafe extern "C" fn rav1d_read_coef_blocks_8bpc(
     let bh4 = *b_dim.offset(1) as c_int;
     let cbw4 = bw4 + ss_hor >> ss_hor;
     let cbh4 = bh4 + ss_ver >> ss_ver;
-    let has_chroma = ((*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
+    let has_chroma = ((*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
         && (bw4 > ss_hor || (*t).bx & 1 != 0)
         && (bh4 > ss_ver || (*t).by & 1 != 0)) as c_int;
     if (*b).skip != 0 {
@@ -1745,10 +1745,10 @@ unsafe extern "C" fn mc(
     }
     let f: *const Rav1dFrameContext = (*t).f;
     let ss_ver = (pl != 0
-        && (*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
+        && (*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
         as c_int;
     let ss_hor = (pl != 0
-        && (*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint)
+        && (*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint)
         as c_int;
     let h_mul = 4 >> ss_hor;
     let v_mul = 4 >> ss_ver;
@@ -1946,10 +1946,10 @@ unsafe extern "C" fn obmc(
         as *mut *mut refmvs_block;
     let lap: *mut pixel = ((*t).scratch.c2rust_unnamed.c2rust_unnamed.lap_8bpc).as_mut_ptr();
     let ss_ver = (pl != 0
-        && (*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
+        && (*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
         as c_int;
     let ss_hor = (pl != 0
-        && (*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint)
+        && (*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint)
         as c_int;
     let h_mul = 4 >> ss_hor;
     let v_mul = 4 >> ss_ver;
@@ -2075,10 +2075,10 @@ unsafe extern "C" fn warp_affine(
     let f: *const Rav1dFrameContext = (*t).f;
     let dsp: *const Rav1dDSPContext = (*f).dsp;
     let ss_ver = (pl != 0
-        && (*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
+        && (*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
         as c_int;
     let ss_hor = (pl != 0
-        && (*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint)
+        && (*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint)
         as c_int;
     let h_mul = 4 >> ss_hor;
     let v_mul = 4 >> ss_ver;
@@ -2183,9 +2183,9 @@ pub(crate) unsafe extern "C" fn rav1d_recon_b_intra_8bpc(
     let bx4 = (*t).bx & 31;
     let by4 = (*t).by & 31;
     let ss_ver =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let ss_hor =
-        ((*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
     let cbx4 = bx4 >> ss_hor;
     let cby4 = by4 >> ss_ver;
     let b_dim: *const u8 = (dav1d_block_dimensions[bs as usize]).as_ptr();
@@ -2195,7 +2195,7 @@ pub(crate) unsafe extern "C" fn rav1d_recon_b_intra_8bpc(
     let h4 = cmp::min(bh4, (*f).bh - (*t).by);
     let cw4 = w4 + ss_hor >> ss_hor;
     let ch4 = h4 + ss_ver >> ss_ver;
-    let has_chroma = ((*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
+    let has_chroma = ((*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
         && (bw4 > ss_hor || (*t).bx & 1 != 0)
         && (bh4 > ss_ver || (*t).by & 1 != 0)) as c_int;
     let t_dim: *const TxfmInfo = &*dav1d_txfm_dimensions
@@ -2923,9 +2923,9 @@ pub(crate) unsafe extern "C" fn rav1d_recon_b_inter_8bpc(
     let bx4 = (*t).bx & 31;
     let by4 = (*t).by & 31;
     let ss_ver =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let ss_hor =
-        ((*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
     let cbx4 = bx4 >> ss_hor;
     let cby4 = by4 >> ss_ver;
     let b_dim: *const u8 = (dav1d_block_dimensions[bs as usize]).as_ptr();
@@ -2933,14 +2933,14 @@ pub(crate) unsafe extern "C" fn rav1d_recon_b_inter_8bpc(
     let bh4 = *b_dim.offset(1) as c_int;
     let w4 = cmp::min(bw4, (*f).bw - (*t).bx);
     let h4 = cmp::min(bh4, (*f).bh - (*t).by);
-    let has_chroma = ((*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
+    let has_chroma = ((*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint
         && (bw4 > ss_hor || (*t).bx & 1 != 0)
         && (bh4 > ss_ver || (*t).by & 1 != 0)) as c_int;
     let chr_layout_idx =
-        (if (*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint {
+        (if (*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint {
             0 as c_int as c_uint
         } else {
-            (DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint).wrapping_sub((*f).cur.p.layout as c_uint)
+            (RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint).wrapping_sub((*f).cur.p.layout as c_uint)
         }) as c_int;
     let mut res;
     let cbh4 = bh4 + ss_ver >> ss_ver;
@@ -3018,7 +3018,7 @@ pub(crate) unsafe extern "C" fn rav1d_recon_b_inter_8bpc(
                     as c_int
                     != 0
                 || (*b).c2rust_unnamed.c2rust_unnamed_0.motion_mode as c_int == MM_WARP as c_int
-                    && (*t).warpmv.type_0 as c_uint > DAV1D_WM_TYPE_TRANSLATION as c_int as c_uint)
+                    && (*t).warpmv.type_0 as c_uint > RAV1D_WM_TYPE_TRANSLATION as c_int as c_uint)
         {
             res = warp_affine(
                 t,
@@ -3419,7 +3419,7 @@ pub(crate) unsafe extern "C" fn rav1d_recon_b_inter_8bpc(
                         || (*b).c2rust_unnamed.c2rust_unnamed_0.motion_mode as c_int
                             == MM_WARP as c_int
                             && (*t).warpmv.type_0 as c_uint
-                                > DAV1D_WM_TYPE_TRANSLATION as c_int as c_uint)
+                                > RAV1D_WM_TYPE_TRANSLATION as c_int as c_uint)
                 {
                     let mut pl_4 = 0;
                     while pl_4 < 2 {
@@ -4148,7 +4148,7 @@ pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_deblock_cols_8bpc(
     f: *mut Rav1dFrameContext,
     sby: c_int,
 ) {
-    if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_DEBLOCK as c_int as c_uint == 0
+    if (*(*f).c).inloop_filters as c_uint & RAV1D_INLOOPFILTER_DEBLOCK as c_int as c_uint == 0
         || (*(*f).frame_hdr).loopfilter.level_y[0] == 0
             && (*(*f).frame_hdr).loopfilter.level_y[1] == 0
     {
@@ -4156,7 +4156,7 @@ pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_deblock_cols_8bpc(
     }
     let y = sby * (*f).sb_step * 4;
     let ss_ver =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let p: [*mut pixel; 3] = [
         ((*f).lf.p[0] as *mut pixel).offset((y as isize * (*f).cur.stride[0]) as isize),
         ((*f).lf.p[1] as *mut pixel).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
@@ -4179,7 +4179,7 @@ pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_deblock_rows_8bpc(
 ) {
     let y = sby * (*f).sb_step * 4;
     let ss_ver =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let p: [*mut pixel; 3] = [
         ((*f).lf.p[0] as *mut pixel).offset((y as isize * (*f).cur.stride[0]) as isize),
         ((*f).lf.p[1] as *mut pixel).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
@@ -4187,7 +4187,7 @@ pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_deblock_rows_8bpc(
     ];
     let mask: *mut Av1Filter = ((*f).lf.mask)
         .offset(((sby >> ((*(*f).seq_hdr).sb128 == 0) as c_int) * (*f).sb128w) as isize);
-    if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_DEBLOCK as c_int as c_uint != 0
+    if (*(*f).c).inloop_filters as c_uint & RAV1D_INLOOPFILTER_DEBLOCK as c_int as c_uint != 0
         && ((*(*f).frame_hdr).loopfilter.level_y[0] != 0
             || (*(*f).frame_hdr).loopfilter.level_y[1] != 0)
     {
@@ -4203,13 +4203,13 @@ pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_cdef_8bpc(
     sby: c_int,
 ) {
     let f: *const Rav1dFrameContext = (*tc).f;
-    if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_CDEF as c_int as c_uint == 0 {
+    if (*(*f).c).inloop_filters as c_uint & RAV1D_INLOOPFILTER_CDEF as c_int as c_uint == 0 {
         return;
     }
     let sbsz = (*f).sb_step;
     let y = sby * sbsz * 4;
     let ss_ver =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let p: [*mut pixel; 3] = [
         ((*f).lf.p[0] as *mut pixel).offset((y as isize * (*f).cur.stride[0]) as isize),
         ((*f).lf.p[1] as *mut pixel).offset((y as isize * (*f).cur.stride[1] >> ss_ver) as isize),
@@ -4222,7 +4222,7 @@ pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_cdef_8bpc(
     let start = sby * sbsz;
     if sby != 0 {
         let ss_ver_0 =
-            ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+            ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
         let mut p_up: [*mut pixel; 3] = [
             (p[0]).offset(-((8 * (*f).cur.stride[0]) as isize)),
             (p[1]).offset(-((8 * (*f).cur.stride[1] >> ss_ver_0) as isize)),
@@ -4250,7 +4250,7 @@ pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_resize_8bpc(
     let sbsz = (*f).sb_step;
     let y = sby * sbsz * 4;
     let ss_ver =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let p: [*const pixel; 3] = [
         ((*f).lf.p[0] as *mut pixel).offset((y as isize * (*f).cur.stride[0]) as isize)
             as *const pixel,
@@ -4267,11 +4267,11 @@ pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_resize_8bpc(
             .offset((y as isize * (*f).sr_cur.p.stride[1] >> ss_ver) as isize),
     ];
     let has_chroma =
-        ((*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint) as c_int;
     let mut pl = 0;
     while pl < 1 + 2 * has_chroma {
         let ss_ver_0 = (pl != 0
-            && (*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
+            && (*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
             as c_int;
         let h_start = 8 * (sby != 0) as c_int >> ss_ver_0;
         let dst_stride: ptrdiff_t = (*f).sr_cur.p.stride[(pl != 0) as c_int as usize];
@@ -4282,7 +4282,7 @@ pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_resize_8bpc(
             (p[pl as usize]).offset(-((h_start as isize * src_stride) as isize));
         let h_end = 4 * (sbsz - 2 * ((sby + 1) < (*f).sbh) as c_int) >> ss_ver_0;
         let ss_hor = (pl != 0
-            && (*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint)
+            && (*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint)
             as c_int;
         let dst_w = (*f).sr_cur.p.p.w + ss_hor >> ss_hor;
         let src_w = 4 * (*f).bw + ss_hor >> ss_hor;
@@ -4304,12 +4304,12 @@ pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_resize_8bpc(
 }
 
 pub(crate) unsafe extern "C" fn rav1d_filter_sbrow_lr_8bpc(f: *mut Rav1dFrameContext, sby: c_int) {
-    if (*(*f).c).inloop_filters as c_uint & DAV1D_INLOOPFILTER_RESTORATION as c_int as c_uint == 0 {
+    if (*(*f).c).inloop_filters as c_uint & RAV1D_INLOOPFILTER_RESTORATION as c_int as c_uint == 0 {
         return;
     }
     let y = sby * (*f).sb_step * 4;
     let ss_ver =
-        ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+        ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
     let sr_p: [*mut pixel; 3] = [
         ((*f).lf.sr_p[0] as *mut pixel).offset((y as isize * (*f).sr_cur.p.stride[0]) as isize),
         ((*f).lf.sr_p[1] as *mut pixel)
@@ -4349,11 +4349,11 @@ pub(crate) unsafe extern "C" fn rav1d_backup_ipred_edge_8bpc(t: *mut Rav1dTaskCo
         y as *const c_void,
         (4 * ((*ts).tiling.col_end - x_off)) as usize,
     );
-    if (*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint {
+    if (*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I400 as c_int as c_uint {
         let ss_ver =
-            ((*f).cur.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+            ((*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
         let ss_hor =
-            ((*f).cur.p.layout as c_uint != DAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
+            ((*f).cur.p.layout as c_uint != RAV1D_PIXEL_LAYOUT_I444 as c_int as c_uint) as c_int;
         let uv_off: ptrdiff_t = (x_off * 4 >> ss_hor) as isize
             + ((((*t).by + (*f).sb_step) * 4 >> ss_ver) - 1) as isize * (*f).cur.stride[1];
         let mut pl = 1;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -2,7 +2,7 @@ use crate::include::common::intops::apply_sign;
 use crate::include::common::intops::iclip;
 use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_TRANSLATION;
+use crate::include::dav1d::headers::RAV1D_WM_TYPE_TRANSLATION;
 use crate::src::env::fix_mv_precision;
 use crate::src::env::get_gmv_2d;
 use crate::src::env::get_poc_diff;
@@ -696,7 +696,7 @@ pub unsafe fn rav1d_refmvs_find(
             &*rf.frm_hdr,
         );
         gmv[0] =
-            if (*rf.frm_hdr).gmv[r#ref.r#ref[0] as usize - 1].type_0 > DAV1D_WM_TYPE_TRANSLATION {
+            if (*rf.frm_hdr).gmv[r#ref.r#ref[0] as usize - 1].type_0 > RAV1D_WM_TYPE_TRANSLATION {
                 tgmv[0]
             } else {
                 mv::INVALID
@@ -715,7 +715,7 @@ pub unsafe fn rav1d_refmvs_find(
             &*rf.frm_hdr,
         );
         gmv[1] =
-            if (*rf.frm_hdr).gmv[r#ref.r#ref[1] as usize - 1].type_0 > DAV1D_WM_TYPE_TRANSLATION {
+            if (*rf.frm_hdr).gmv[r#ref.r#ref[1] as usize - 1].type_0 > RAV1D_WM_TYPE_TRANSLATION {
                 tgmv[1]
             } else {
                 mv::INVALID

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -10,8 +10,8 @@ use crate::src::intra_edge::EdgeFlags;
 use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
 use crate::src::levels::mv;
 use crate::src::levels::BlockSize;
-use crate::src::mem::dav1d_alloc_aligned;
-use crate::src::mem::dav1d_freep_aligned;
+use crate::src::mem::rav1d_alloc_aligned;
+use crate::src::mem::rav1d_freep_aligned;
 use crate::src::tables::dav1d_block_dimensions;
 use cfg_if::cfg_if;
 use libc::ptrdiff_t;
@@ -21,7 +21,7 @@ use std::ffi::c_uint;
 use std::ffi::c_void;
 
 #[cfg(feature = "asm")]
-use crate::src::cpu::{dav1d_get_cpu_flags, CpuFlags};
+use crate::src::cpu::{rav1d_get_cpu_flags, CpuFlags};
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 extern "C" {
@@ -662,7 +662,7 @@ fn add_single_extended_candidate(
 /// enabled) or at the start of each interleaved sbrow (when tile column
 /// threading is disabled), we call load_tmvs(), which will project the MVs to
 /// their respective position in the current frame.
-pub unsafe fn dav1d_refmvs_find(
+pub unsafe fn rav1d_refmvs_find(
     rt: &refmvs_tile,
     mvstack: &mut [refmvs_candidate; 8],
     cnt: &mut usize,
@@ -1096,7 +1096,7 @@ pub unsafe fn dav1d_refmvs_find(
 
 // cache the current tile/sbrow (or frame/sbrow)'s projectable motion vectors
 // into buffers for use in future frame's temporal MV prediction
-pub unsafe fn dav1d_refmvs_save_tmvs(
+pub unsafe fn rav1d_refmvs_save_tmvs(
     dsp: *const Rav1dRefmvsDSPContext,
     rt: *const refmvs_tile,
     col_start8: c_int,
@@ -1129,7 +1129,7 @@ pub unsafe fn dav1d_refmvs_save_tmvs(
     );
 }
 
-pub unsafe fn dav1d_refmvs_tile_sbrow_init(
+pub unsafe fn rav1d_refmvs_tile_sbrow_init(
     rt: *mut refmvs_tile,
     rf: *const refmvs_frame,
     tile_col_start4: c_int,
@@ -1399,10 +1399,10 @@ pub unsafe fn dav1d_refmvs_init_frame(
     };
     if r_stride != (*rf).r_stride || n_tile_rows != (*rf).n_tile_rows {
         if !((*rf).r).is_null() {
-            dav1d_freep_aligned(&mut (*rf).r as *mut *mut refmvs_block as *mut c_void);
+            rav1d_freep_aligned(&mut (*rf).r as *mut *mut refmvs_block as *mut c_void);
         }
         let uses_2pass = (n_tile_threads > 1 && n_frame_threads > 1) as c_int;
-        (*rf).r = dav1d_alloc_aligned(
+        (*rf).r = rav1d_alloc_aligned(
             (::core::mem::size_of::<refmvs_block>())
                 .wrapping_mul(35 as usize)
                 .wrapping_mul(r_stride as usize)
@@ -1418,11 +1418,11 @@ pub unsafe fn dav1d_refmvs_init_frame(
     let rp_stride: ptrdiff_t = r_stride >> 1;
     if rp_stride != (*rf).rp_stride || n_tile_rows != (*rf).n_tile_rows {
         if !((*rf).rp_proj).is_null() {
-            dav1d_freep_aligned(
+            rav1d_freep_aligned(
                 &mut (*rf).rp_proj as *mut *mut refmvs_temporal_block as *mut c_void,
             );
         }
-        (*rf).rp_proj = dav1d_alloc_aligned(
+        (*rf).rp_proj = rav1d_alloc_aligned(
             (::core::mem::size_of::<refmvs_temporal_block>())
                 .wrapping_mul(16 as usize)
                 .wrapping_mul(rp_stride as usize)
@@ -1545,19 +1545,19 @@ pub unsafe fn dav1d_refmvs_init_frame(
     return 0 as c_int;
 }
 
-pub unsafe fn dav1d_refmvs_init(rf: *mut refmvs_frame) {
+pub unsafe fn rav1d_refmvs_init(rf: *mut refmvs_frame) {
     (*rf).r = 0 as *mut refmvs_block;
     (*rf).r_stride = 0 as c_int as ptrdiff_t;
     (*rf).rp_proj = 0 as *mut refmvs_temporal_block;
     (*rf).rp_stride = 0 as c_int as ptrdiff_t;
 }
 
-pub unsafe fn dav1d_refmvs_clear(rf: *mut refmvs_frame) {
+pub unsafe fn rav1d_refmvs_clear(rf: *mut refmvs_frame) {
     if !((*rf).r).is_null() {
-        dav1d_freep_aligned(&mut (*rf).r as *mut *mut refmvs_block as *mut c_void);
+        rav1d_freep_aligned(&mut (*rf).r as *mut *mut refmvs_block as *mut c_void);
     }
     if !((*rf).rp_proj).is_null() {
-        dav1d_freep_aligned(&mut (*rf).rp_proj as *mut *mut refmvs_temporal_block as *mut c_void);
+        rav1d_freep_aligned(&mut (*rf).rp_proj as *mut *mut refmvs_temporal_block as *mut c_void);
     }
 }
 
@@ -1612,7 +1612,7 @@ unsafe extern "C" fn splat_mv_rust(
 #[inline(always)]
 #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "asm"))]
 unsafe extern "C" fn refmvs_dsp_init_x86(c: *mut Rav1dRefmvsDSPContext) {
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSE2) {
         return;
@@ -1647,14 +1647,14 @@ unsafe extern "C" fn refmvs_dsp_init_x86(c: *mut Rav1dRefmvsDSPContext) {
 #[inline(always)]
 #[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), feature = "asm"))]
 unsafe extern "C" fn refmvs_dsp_init_arm(c: *mut Rav1dRefmvsDSPContext) {
-    let flags = dav1d_get_cpu_flags();
+    let flags = rav1d_get_cpu_flags();
     if flags.contains(CpuFlags::NEON) {
         (*c).splat_mv = Some(ffi::dav1d_splat_mv_neon);
     }
 }
 
 #[cold]
-pub unsafe fn dav1d_refmvs_dsp_init(c: *mut Rav1dRefmvsDSPContext) {
+pub unsafe fn rav1d_refmvs_dsp_init(c: *mut Rav1dRefmvsDSPContext) {
     (*c).load_tmvs = Some(load_tmvs_c);
     (*c).save_tmvs = Some(save_tmvs_c);
     (*c).splat_mv = Some(splat_mv_rust);

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -1,10 +1,10 @@
 use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_REGULAR;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SHARP;
-use crate::include::dav1d::headers::DAV1D_FILTER_8TAP_SMOOTH;
-use crate::include::dav1d::headers::DAV1D_FILTER_BILINEAR;
-use crate::include::dav1d::headers::DAV1D_N_FILTERS;
-use crate::include::dav1d::headers::DAV1D_WM_TYPE_IDENTITY;
+use crate::include::dav1d::headers::RAV1D_FILTER_8TAP_REGULAR;
+use crate::include::dav1d::headers::RAV1D_FILTER_8TAP_SHARP;
+use crate::include::dav1d::headers::RAV1D_FILTER_8TAP_SMOOTH;
+use crate::include::dav1d::headers::RAV1D_FILTER_BILINEAR;
+use crate::include::dav1d::headers::RAV1D_N_FILTERS;
+use crate::include::dav1d::headers::RAV1D_WM_TYPE_IDENTITY;
 use crate::src::align::Align16;
 use crate::src::align::Align4;
 use crate::src::align::Align64;
@@ -632,7 +632,7 @@ pub static dav1d_tx_type_class: [u8; N_TX_TYPES_PLUS_LL] = [
     TX_CLASS_2D as u8,
 ];
 
-pub static dav1d_filter_2d: [[u8; DAV1D_N_FILTERS]; DAV1D_N_FILTERS] = [
+pub static dav1d_filter_2d: [[u8; RAV1D_N_FILTERS]; RAV1D_N_FILTERS] = [
     [
         FILTER_2D_8TAP_REGULAR as u8,
         FILTER_2D_8TAP_REGULAR_SMOOTH as u8,
@@ -656,39 +656,39 @@ pub static dav1d_filter_2d: [[u8; DAV1D_N_FILTERS]; DAV1D_N_FILTERS] = [
 
 pub static dav1d_filter_dir: [[u8; 2]; N_2D_FILTERS] = [
     [
-        DAV1D_FILTER_8TAP_REGULAR as u8,
-        DAV1D_FILTER_8TAP_REGULAR as u8,
+        RAV1D_FILTER_8TAP_REGULAR as u8,
+        RAV1D_FILTER_8TAP_REGULAR as u8,
     ],
     [
-        DAV1D_FILTER_8TAP_SMOOTH as u8,
-        DAV1D_FILTER_8TAP_REGULAR as u8,
+        RAV1D_FILTER_8TAP_SMOOTH as u8,
+        RAV1D_FILTER_8TAP_REGULAR as u8,
     ],
     [
-        DAV1D_FILTER_8TAP_SHARP as u8,
-        DAV1D_FILTER_8TAP_REGULAR as u8,
+        RAV1D_FILTER_8TAP_SHARP as u8,
+        RAV1D_FILTER_8TAP_REGULAR as u8,
     ],
     [
-        DAV1D_FILTER_8TAP_REGULAR as u8,
-        DAV1D_FILTER_8TAP_SHARP as u8,
+        RAV1D_FILTER_8TAP_REGULAR as u8,
+        RAV1D_FILTER_8TAP_SHARP as u8,
     ],
     [
-        DAV1D_FILTER_8TAP_SMOOTH as u8,
-        DAV1D_FILTER_8TAP_SHARP as u8,
+        RAV1D_FILTER_8TAP_SMOOTH as u8,
+        RAV1D_FILTER_8TAP_SHARP as u8,
     ],
-    [DAV1D_FILTER_8TAP_SHARP as u8, DAV1D_FILTER_8TAP_SHARP as u8],
+    [RAV1D_FILTER_8TAP_SHARP as u8, RAV1D_FILTER_8TAP_SHARP as u8],
     [
-        DAV1D_FILTER_8TAP_REGULAR as u8,
-        DAV1D_FILTER_8TAP_SMOOTH as u8,
-    ],
-    [
-        DAV1D_FILTER_8TAP_SMOOTH as u8,
-        DAV1D_FILTER_8TAP_SMOOTH as u8,
+        RAV1D_FILTER_8TAP_REGULAR as u8,
+        RAV1D_FILTER_8TAP_SMOOTH as u8,
     ],
     [
-        DAV1D_FILTER_8TAP_SHARP as u8,
-        DAV1D_FILTER_8TAP_SMOOTH as u8,
+        RAV1D_FILTER_8TAP_SMOOTH as u8,
+        RAV1D_FILTER_8TAP_SMOOTH as u8,
     ],
-    [DAV1D_FILTER_BILINEAR as u8, DAV1D_FILTER_BILINEAR as u8],
+    [
+        RAV1D_FILTER_8TAP_SHARP as u8,
+        RAV1D_FILTER_8TAP_SMOOTH as u8,
+    ],
+    [RAV1D_FILTER_BILINEAR as u8, RAV1D_FILTER_BILINEAR as u8],
 ];
 
 pub static dav1d_filter_mode_to_y_mode: [u8; 5] = [
@@ -746,7 +746,7 @@ pub const interintra_allowed_mask: c_uint = 0
     | 0;
 
 pub static dav1d_default_wm_params: Dav1dWarpedMotionParams = Dav1dWarpedMotionParams {
-    type_0: DAV1D_WM_TYPE_IDENTITY,
+    type_0: RAV1D_WM_TYPE_IDENTITY,
     matrix: [0, 0, 1 << 16, 0, 0, 1 << 16],
     abcd: [0; 4],
 };

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1,6 +1,6 @@
 use crate::include::common::attributes::ctz;
 use crate::include::common::intops::iclip;
-use crate::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
+use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::picture::Rav1dPicture;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
@@ -16,19 +16,19 @@ use crate::src::internal::Rav1dTaskContext;
 use crate::src::internal::Rav1dTileState;
 use crate::src::internal::TaskThreadData;
 use crate::src::internal::TaskType;
-use crate::src::internal::DAV1D_TASK_TYPE_CDEF;
-use crate::src::internal::DAV1D_TASK_TYPE_DEBLOCK_COLS;
-use crate::src::internal::DAV1D_TASK_TYPE_DEBLOCK_ROWS;
-use crate::src::internal::DAV1D_TASK_TYPE_ENTROPY_PROGRESS;
-use crate::src::internal::DAV1D_TASK_TYPE_FG_APPLY;
-use crate::src::internal::DAV1D_TASK_TYPE_FG_PREP;
-use crate::src::internal::DAV1D_TASK_TYPE_INIT;
-use crate::src::internal::DAV1D_TASK_TYPE_INIT_CDF;
-use crate::src::internal::DAV1D_TASK_TYPE_LOOP_RESTORATION;
-use crate::src::internal::DAV1D_TASK_TYPE_RECONSTRUCTION_PROGRESS;
-use crate::src::internal::DAV1D_TASK_TYPE_SUPER_RESOLUTION;
-use crate::src::internal::DAV1D_TASK_TYPE_TILE_ENTROPY;
-use crate::src::internal::DAV1D_TASK_TYPE_TILE_RECONSTRUCTION;
+use crate::src::internal::RAV1D_TASK_TYPE_CDEF;
+use crate::src::internal::RAV1D_TASK_TYPE_DEBLOCK_COLS;
+use crate::src::internal::RAV1D_TASK_TYPE_DEBLOCK_ROWS;
+use crate::src::internal::RAV1D_TASK_TYPE_ENTROPY_PROGRESS;
+use crate::src::internal::RAV1D_TASK_TYPE_FG_APPLY;
+use crate::src::internal::RAV1D_TASK_TYPE_FG_PREP;
+use crate::src::internal::RAV1D_TASK_TYPE_INIT;
+use crate::src::internal::RAV1D_TASK_TYPE_INIT_CDF;
+use crate::src::internal::RAV1D_TASK_TYPE_LOOP_RESTORATION;
+use crate::src::internal::RAV1D_TASK_TYPE_RECONSTRUCTION_PROGRESS;
+use crate::src::internal::RAV1D_TASK_TYPE_SUPER_RESOLUTION;
+use crate::src::internal::RAV1D_TASK_TYPE_TILE_ENTROPY;
+use crate::src::internal::RAV1D_TASK_TYPE_TILE_RECONSTRUCTION;
 use crate::src::picture::Rav1dThreadPicture;
 use libc::memset;
 use libc::pthread_cond_signal;
@@ -234,8 +234,8 @@ unsafe extern "C" fn insert_tasks(
     let mut current_block_34: u64;
     t_ptr = (*f).task_thread.task_head;
     while !t_ptr.is_null() {
-        if (*t_ptr).type_0 as c_uint == DAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint {
-            if (*first).type_0 as c_uint > DAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint {
+        if (*t_ptr).type_0 as c_uint == RAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint {
+            if (*first).type_0 as c_uint > RAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint {
                 current_block_34 = 11174649648027449784;
             } else if (*first).sby > (*t_ptr).sby {
                 current_block_34 = 11174649648027449784;
@@ -247,7 +247,7 @@ unsafe extern "C" fn insert_tasks(
                 current_block_34 = 15904375183555213903;
             }
         } else {
-            if (*first).type_0 as c_uint == DAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint {
+            if (*first).type_0 as c_uint == RAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint {
                 insert_tasks_between(f, first, last, prev_t, t_ptr, cond_signal);
                 return;
             }
@@ -272,8 +272,8 @@ unsafe extern "C" fn insert_tasks(
         match current_block_34 {
             15904375183555213903 => {
                 if !((*first).type_0 as c_uint
-                    == DAV1D_TASK_TYPE_TILE_RECONSTRUCTION as c_int as c_uint
-                    || (*first).type_0 as c_uint == DAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint)
+                    == RAV1D_TASK_TYPE_TILE_RECONSTRUCTION as c_int as c_uint
+                    || (*first).type_0 as c_uint == RAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint)
                 {
                     unreachable!();
                 }
@@ -284,7 +284,7 @@ unsafe extern "C" fn insert_tasks(
                     unreachable!();
                 }
                 let p = ((*first).type_0 as c_uint
-                    == DAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint)
+                    == RAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint)
                     as c_int;
                 let t_tile_idx =
                     first.offset_from((*f).task_thread.tile_tasks[p as usize]) as c_long as c_int;
@@ -419,15 +419,15 @@ unsafe extern "C" fn create_filter_sbrow(
     (*t).recon_progress = 1 as c_int;
     (*t).deblock_progress = 0 as c_int;
     (*t).type_0 = (if pass == 1 {
-        DAV1D_TASK_TYPE_ENTROPY_PROGRESS as c_int
+        RAV1D_TASK_TYPE_ENTROPY_PROGRESS as c_int
     } else if has_deblock != 0 {
-        DAV1D_TASK_TYPE_DEBLOCK_COLS as c_int
+        RAV1D_TASK_TYPE_DEBLOCK_COLS as c_int
     } else if has_cdef != 0 || has_lr != 0 {
-        DAV1D_TASK_TYPE_DEBLOCK_ROWS as c_int
+        RAV1D_TASK_TYPE_DEBLOCK_ROWS as c_int
     } else if has_resize != 0 {
-        DAV1D_TASK_TYPE_SUPER_RESOLUTION as c_int
+        RAV1D_TASK_TYPE_SUPER_RESOLUTION as c_int
     } else {
-        DAV1D_TASK_TYPE_RECONSTRUCTION_PROGRESS as c_int
+        RAV1D_TASK_TYPE_RECONSTRUCTION_PROGRESS as c_int
     }) as TaskType;
     (*t).frame_idx = f.offset_from((*(*f).c).fc) as c_long as c_int as c_uint;
     *res_t = t;
@@ -478,9 +478,9 @@ pub(crate) unsafe fn rav1d_task_create_tile_sbrow(
         (*t).deblock_progress = 0 as c_int;
         (*t).deps_skip = 0 as c_int;
         (*t).type_0 = (if pass != 1 as c_int {
-            DAV1D_TASK_TYPE_TILE_RECONSTRUCTION as c_int
+            RAV1D_TASK_TYPE_TILE_RECONSTRUCTION as c_int
         } else {
-            DAV1D_TASK_TYPE_TILE_ENTROPY as c_int
+            RAV1D_TASK_TYPE_TILE_ENTROPY as c_int
         }) as TaskType;
         (*t).frame_idx = f.offset_from((*(*f).c).fc) as c_long as c_int as c_uint;
         if !prev_t.is_null() {
@@ -520,7 +520,7 @@ pub(crate) unsafe fn rav1d_task_frame_init(f: *mut Rav1dFrameContext) {
     let c: *const Rav1dContext = (*f).c;
     ::core::intrinsics::atomic_store_seqcst(&mut (*f).task_thread.init_done, 0 as c_int);
     let t: *mut Rav1dTask = &mut (*f).task_thread.init_task;
-    (*t).type_0 = DAV1D_TASK_TYPE_INIT;
+    (*t).type_0 = RAV1D_TASK_TYPE_INIT;
     (*t).frame_idx = f.offset_from((*c).fc) as c_long as c_int as c_uint;
     (*t).sby = 0 as c_int;
     (*t).deblock_progress = 0 as c_int;
@@ -536,7 +536,7 @@ pub(crate) unsafe fn rav1d_task_delayed_fg(
     let ttd: *mut TaskThreadData = &mut (*c).task_thread;
     (*ttd).delayed_fg.in_0 = in_0;
     (*ttd).delayed_fg.out = out;
-    (*ttd).delayed_fg.type_0 = DAV1D_TASK_TYPE_FG_PREP;
+    (*ttd).delayed_fg.type_0 = RAV1D_TASK_TYPE_FG_PREP;
     *(&mut *((*ttd).delayed_fg.progress).as_mut_ptr().offset(0) as *mut atomic_int) = 0 as c_int;
     *(&mut *((*ttd).delayed_fg.progress).as_mut_ptr().offset(1) as *mut atomic_int) = 0 as c_int;
     pthread_mutex_lock(&mut (*ttd).lock);
@@ -574,7 +574,7 @@ unsafe extern "C" fn check_tile(
     f: *mut Rav1dFrameContext,
     frame_mt: c_int,
 ) -> c_int {
-    let tp = ((*t).type_0 as c_uint == DAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint) as c_int;
+    let tp = ((*t).type_0 as c_uint == RAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint) as c_int;
     let tile_idx = t.offset_from((*f).task_thread.tile_tasks[tp as usize]) as c_long as c_int;
     let ts: *mut Rav1dTileState = &mut *((*f).ts).offset(tile_idx as isize) as *mut Rav1dTileState;
     let p1 = ::core::intrinsics::atomic_load_seqcst(
@@ -598,7 +598,7 @@ unsafe extern "C" fn check_tile(
     if error == 0 && frame_mt != 0 && (*(*f).frame_hdr).frame_type as c_uint & 1 as c_uint != 0 {
         let p: *const Rav1dThreadPicture = &mut (*f).sr_cur;
         let ss_ver =
-            ((*p).p.p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
+            ((*p).p.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint) as c_int;
         let p_b: c_uint = (((*t).sby + 1) << (*f).sb_shift + 2) as c_uint;
         let tile_sby = (*t).sby - ((*ts).tiling.row_start >> (*f).sb_shift);
         let lowest_px: *const [c_int; 2] =
@@ -788,7 +788,7 @@ unsafe extern "C" fn delayed_fg_task(c: *const Rav1dContext, ttd: *mut TaskThrea
                     abort();
                 }
             }
-            (*ttd).delayed_fg.type_0 = DAV1D_TASK_TYPE_FG_APPLY;
+            (*ttd).delayed_fg.type_0 = RAV1D_TASK_TYPE_FG_APPLY;
             pthread_mutex_lock(&mut (*ttd).lock);
             (*ttd).delayed_fg.exec = 1 as c_int;
         }
@@ -937,13 +937,13 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                         {
                             t = (*f).task_thread.task_head;
                             if !t.is_null() {
-                                if (*t).type_0 as c_uint == DAV1D_TASK_TYPE_INIT as c_int as c_uint
+                                if (*t).type_0 as c_uint == RAV1D_TASK_TYPE_INIT as c_int as c_uint
                                 {
                                     current_block = 7012560550443761033;
                                     break;
                                 }
                                 if (*t).type_0 as c_uint
-                                    == DAV1D_TASK_TYPE_INIT_CDF as c_int as c_uint
+                                    == RAV1D_TASK_TYPE_INIT_CDF as c_int as c_uint
                                 {
                                     let p1 = (if !((*f).in_cdf.progress).is_null() {
                                         ::core::intrinsics::atomic_load_seqcst((*f).in_cdf.progress)
@@ -985,12 +985,12 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                 };
                                 while !t.is_null() {
                                     if !((*t).type_0 as c_uint
-                                        == DAV1D_TASK_TYPE_INIT_CDF as c_int as c_uint)
+                                        == RAV1D_TASK_TYPE_INIT_CDF as c_int as c_uint)
                                     {
                                         if (*t).type_0 as c_uint
-                                            == DAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint
+                                            == RAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint
                                             || (*t).type_0 as c_uint
-                                                == DAV1D_TASK_TYPE_TILE_RECONSTRUCTION as c_int
+                                                == RAV1D_TASK_TYPE_TILE_RECONSTRUCTION as c_int
                                                     as c_uint
                                         {
                                             if check_tile(t, f, ((*c).n_fc > 1 as c_uint) as c_int)
@@ -1001,7 +1001,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                             }
                                         } else if (*t).recon_progress != 0 {
                                             let p = ((*t).type_0 as c_uint
-                                                == DAV1D_TASK_TYPE_ENTROPY_PROGRESS as c_int
+                                                == RAV1D_TASK_TYPE_ENTROPY_PROGRESS as c_int
                                                     as c_uint)
                                                 as c_int;
                                             let error = ::core::intrinsics::atomic_load_seqcst(
@@ -1100,7 +1100,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                                 }
                                             }
                                         } else if (*t).type_0 as c_uint
-                                            == DAV1D_TASK_TYPE_CDEF as c_int as c_uint
+                                            == RAV1D_TASK_TYPE_CDEF as c_int as c_uint
                                         {
                                             let prog_0: *mut atomic_uint =
                                                 (*f).frame_thread.copy_lpf_progress;
@@ -1159,7 +1159,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                             if ((*t).next).is_null() {
                                 (*f).task_thread.task_tail = prev_t;
                             }
-                            if (*t).type_0 as c_uint > DAV1D_TASK_TYPE_INIT_CDF as c_int as c_uint
+                            if (*t).type_0 as c_uint > RAV1D_TASK_TYPE_INIT_CDF as c_int as c_uint
                                 && ((*f).task_thread.task_head).is_null()
                             {
                                 (*ttd).cur = ((*ttd).cur).wrapping_add(1);
@@ -1188,7 +1188,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                             (*tc).f = f;
                             sby = (*t).sby;
                             match (*t).type_0 as c_uint {
-                                DAV1D_TASK_TYPE_INIT => {
+                                RAV1D_TASK_TYPE_INIT => {
                                     if !((*c).n_fc > 1 as c_uint) {
                                         unreachable!();
                                     }
@@ -1204,7 +1204,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                         reset_task_cur(c, ttd, (*t).frame_idx);
                                         continue 's_18;
                                     } else {
-                                        (*t).type_0 = DAV1D_TASK_TYPE_INIT_CDF;
+                                        (*t).type_0 = RAV1D_TASK_TYPE_INIT_CDF;
                                         if p1_3 != 0 {
                                             continue;
                                         }
@@ -1213,7 +1213,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                         continue 's_18;
                                     }
                                 }
-                                DAV1D_TASK_TYPE_INIT_CDF => {
+                                RAV1D_TASK_TYPE_INIT_CDF => {
                                     if !((*c).n_fc > 1 as c_uint) {
                                         unreachable!();
                                     }
@@ -1305,10 +1305,10 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                     }
                                     continue 's_18;
                                 }
-                                DAV1D_TASK_TYPE_TILE_ENTROPY
-                                | DAV1D_TASK_TYPE_TILE_RECONSTRUCTION => {
+                                RAV1D_TASK_TYPE_TILE_ENTROPY
+                                | RAV1D_TASK_TYPE_TILE_RECONSTRUCTION => {
                                     let p_1 = ((*t).type_0 as c_uint
-                                        == DAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint)
+                                        == RAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint)
                                         as c_int;
                                     let tile_idx = t
                                         .offset_from((*f).task_thread.tile_tasks[p_1 as usize])
@@ -1325,7 +1325,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                     } else {
                                         1 as c_int
                                             + ((*t).type_0 as c_uint
-                                                == DAV1D_TASK_TYPE_TILE_RECONSTRUCTION as c_int
+                                                == RAV1D_TASK_TYPE_TILE_RECONSTRUCTION as c_int
                                                     as c_uint)
                                                 as c_int
                                     };
@@ -1454,7 +1454,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                         continue 's_18;
                                     }
                                 }
-                                DAV1D_TASK_TYPE_DEBLOCK_COLS => {
+                                RAV1D_TASK_TYPE_DEBLOCK_COLS => {
                                     if ::core::intrinsics::atomic_load_seqcst(
                                         &mut (*f).task_thread.error as *mut atomic_int,
                                     ) == 0
@@ -1468,7 +1468,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                         ttd,
                                         f,
                                         t,
-                                        DAV1D_TASK_TYPE_DEBLOCK_ROWS,
+                                        RAV1D_TASK_TYPE_DEBLOCK_ROWS,
                                         &mut (*f).frame_thread.deblock_progress,
                                         &mut (*t).deblock_progress,
                                     ) != 0
@@ -1479,27 +1479,27 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                         break;
                                     }
                                 }
-                                DAV1D_TASK_TYPE_DEBLOCK_ROWS => {
+                                RAV1D_TASK_TYPE_DEBLOCK_ROWS => {
                                     current_block = 16164772378964453469;
                                     break;
                                 }
-                                DAV1D_TASK_TYPE_CDEF => {
+                                RAV1D_TASK_TYPE_CDEF => {
                                     current_block = 5292528706010880565;
                                     break;
                                 }
-                                DAV1D_TASK_TYPE_SUPER_RESOLUTION => {
+                                RAV1D_TASK_TYPE_SUPER_RESOLUTION => {
                                     current_block = 12196494833634779273;
                                     break;
                                 }
-                                DAV1D_TASK_TYPE_LOOP_RESTORATION => {
+                                RAV1D_TASK_TYPE_LOOP_RESTORATION => {
                                     current_block = 563177965161376451;
                                     break;
                                 }
-                                DAV1D_TASK_TYPE_RECONSTRUCTION_PROGRESS => {
+                                RAV1D_TASK_TYPE_RECONSTRUCTION_PROGRESS => {
                                     current_block = 18238912670629178022;
                                     break;
                                 }
-                                DAV1D_TASK_TYPE_ENTROPY_PROGRESS => {
+                                RAV1D_TASK_TYPE_ENTROPY_PROGRESS => {
                                     current_block = 7729400755948011248;
                                     break;
                                 }
@@ -1553,7 +1553,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                             as c_int;
                                         if !prog_1 as c_uint & (1 as c_uint) << (sby - 1 & 31) != 0
                                         {
-                                            (*t).type_0 = DAV1D_TASK_TYPE_CDEF;
+                                            (*t).type_0 = RAV1D_TASK_TYPE_CDEF;
                                             (*t).deblock_progress = 0 as c_int;
                                             (*t).recon_progress = (*t).deblock_progress;
                                             add_pending(f, t);
@@ -1632,7 +1632,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                         let sbh = (*f).sbh;
                         let sbsz = (*f).sb_step * 4;
                         if (*t).type_0 as c_uint
-                            == DAV1D_TASK_TYPE_ENTROPY_PROGRESS as c_int as c_uint
+                            == RAV1D_TASK_TYPE_ENTROPY_PROGRESS as c_int as c_uint
                         {
                             error_0 =
                                 ::core::intrinsics::atomic_load_seqcst(&mut (*f).task_thread.error);


### PR DESCRIPTION
The reason for this is so that we can make breaking changes to `Rav1d*` types as they are now crate-private, unlike the `Dav1d*` types, which must remain ABI-compatible with `dav1d`, a very strong restriction.  This means that we can make the `Rav1d*` types `#[repr(Rust)]` and store safe, Rusty versions of things.  This is crucial for making `rav1d` safe internally.

For all of these `Rav1d*` types, I added `.into_c()` methods converting them to their `Dav1d*` counterpart, and vice-versa with `.into_rust()` methods.

Most of these types store things by value, and thus writing the `.into_{c,rust}()` methods is pretty trivial, except for when types are stored by raw pointer, as then the conversion must deal with how to store the converter pointer value.  Thus, for these, I left them as `*{const,mut} Dav1d*` pointers, and the conversions are done where those pointers are used.

Although the conversion functions are for now pretty trivial, they are all written out fully, since we'll update them to be non-trivial as we make `Rav1d*` types safe.

In order to stay ABI compatible with `dav1d`, all `DAV1D_API` `fn`s stay `#[no_mangle] pub unsafe extern "C" fn dav1d_*`s
that simply conver their `Dav1d*` types to `Rav1d*` types, call the `pub(crate) fn rav1d_*` counterpart, and convert back to `Dav1d*` types for returns and `*mut`s.

There is definitely an overhead in doing this, but the `DAV1D_API`s are designed to be called rarely enough that the conversion costs shouldn't make that big of a difference.  For users of `rav1d` who don't want this small cost and want a fully safe interface, they can use the `rav1d_*` APIs, which use `Rav1d*` types.  Before releasing, we'll make these `pub`, too.

For the exact cost, the largest `dav1d`-to-`rav1d` boundary crossing types are:
* `struct Dav1dFrameHeader`: 1672 bytes
* `struct Dav1dSequenceHeader`: 1484 bytes
* `struct Dav1dPicture`: 264 bytes

These are somewhat large, but shouldn't incur too much of a cost for what will be mostly `memcpy`s, and ones that are not done in such tight loops.

Due to not yet converting raw pointers within these `Rav1d*` types, the conversions of those types are done at use sites, which are invariably called more often than the `DAV1D_API`s, and thus matter more for performance.  So far, they happen at 2 places:
* in `fn dav1d_cdf_thread_update`:
      `Dav1dFrameHeader::into_rust` is called 1x, converting 1672 bytes
      called 1x by `fn rav1d_worker_task`
      called 1x by `fn rav1d_decode_frame`
* in `fn dav1d_calc_lf_values`:
      `Dav1dLoopfilterModeRefDeltas::into_rust` is called 1x, converting 40 bytes
      called 2x by `fn decode_b`

The former is a large conversion, so it could be bad, but we should be able to hoist this conversion to the `DAV1D_API` level with some more work; I just wanted to break up the very large changes.

The latter is a small conversion even though it's called more often, so I doubt it will make a difference.

Internal `fn dav1d_*`s are also converted to `fn rav1d_*`s when they use `Rav1d*` types.  Thus, the only `fn dav1d_*`s that remain either:
* are `DAV1D_API`s
* still use `Dav1d*` types since the raw pointer field conversion isn't done yet
* are asm functions, which are unchanged from `dav1d`