### PR TITLE
`struct DRav1d<R, D>`: For ref-counted types, store both and update them when needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ target/
 /tests/large
 
 /retranspile/
+
+.gdb_history

--- a/include/common/frame.rs
+++ b/include/common/frame.rs
@@ -1,7 +1,7 @@
-use crate::include::dav1d::headers::Dav1dFrameHeader;
+use crate::include::dav1d::headers::Rav1dFrameHeader;
 
 /// Checks whether the frame type is `INTER` or `SWITCH`.
-pub fn is_inter_or_switch(frame_header: &Dav1dFrameHeader) -> bool {
+pub(crate) fn is_inter_or_switch(frame_header: &Rav1dFrameHeader) -> bool {
     // Both are defined as odd numbers {1, 3} and therefore have the LSB set.
     // See also: AV1 spec 6.8.2
     frame_header.frame_type & 1 != 0
@@ -9,6 +9,6 @@ pub fn is_inter_or_switch(frame_header: &Dav1dFrameHeader) -> bool {
 
 /// Checks whether Dav1dFrameType == KEY || == INTRA
 /// See also: AV1 spec 6.8.2
-pub fn is_key_or_intra(frame_header: &Dav1dFrameHeader) -> bool {
+pub(crate) fn is_key_or_intra(frame_header: &Rav1dFrameHeader) -> bool {
     !is_inter_or_switch(frame_header)
 }

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -1120,6 +1120,7 @@ pub struct Rav1dFilmGrainData {
 
 pub type Dav1dFilmGrainData = Rav1dFilmGrainData;
 
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
@@ -1127,6 +1128,7 @@ pub struct Dav1dFrameHeader_film_grain {
     pub update: c_int,
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_film_grain {
     pub data: Rav1dFilmGrainData,
@@ -1164,11 +1166,13 @@ impl From<Rav1dFrameHeader_film_grain> for Dav1dFrameHeader_film_grain {
     }
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeaderOperatingPoint {
     pub buffer_removal_time: c_int,
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeaderOperatingPoint {
     pub buffer_removal_time: c_int,
@@ -1196,12 +1200,14 @@ impl From<Rav1dFrameHeaderOperatingPoint> for Dav1dFrameHeaderOperatingPoint {
     }
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_super_res {
     pub width_scale_denominator: c_int,
     pub enabled: c_int,
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_super_res {
     pub width_scale_denominator: c_int,
@@ -1234,6 +1240,7 @@ impl From<Rav1dFrameHeader_super_res> for Dav1dFrameHeader_super_res {
     }
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_tiling {
     pub uniform: c_int,
@@ -1251,6 +1258,7 @@ pub struct Dav1dFrameHeader_tiling {
     pub update: c_int,
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_tiling {
     pub uniform: c_int,
@@ -1338,6 +1346,7 @@ impl From<Rav1dFrameHeader_tiling> for Dav1dFrameHeader_tiling {
     }
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_quant {
     pub yac: c_int,
@@ -1352,6 +1361,7 @@ pub struct Dav1dFrameHeader_quant {
     pub qm_v: c_int,
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_quant {
     pub yac: c_int,
@@ -1424,6 +1434,7 @@ impl From<Rav1dFrameHeader_quant> for Dav1dFrameHeader_quant {
     }
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_segmentation {
     pub enabled: c_int,
@@ -1435,6 +1446,7 @@ pub struct Dav1dFrameHeader_segmentation {
     pub qidx: [c_int; 8],
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_segmentation {
     pub enabled: c_int,
@@ -1492,12 +1504,14 @@ impl From<Rav1dFrameHeader_segmentation> for Dav1dFrameHeader_segmentation {
     }
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_delta_q {
     pub present: c_int,
     pub res_log2: c_int,
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_delta_q {
     pub present: c_int,
@@ -1518,6 +1532,7 @@ impl From<Rav1dFrameHeader_delta_q> for Dav1dFrameHeader_delta_q {
     }
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_delta_lf {
     pub present: c_int,
@@ -1525,6 +1540,7 @@ pub struct Dav1dFrameHeader_delta_lf {
     pub multi: c_int,
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_delta_lf {
     pub present: c_int,
@@ -1562,12 +1578,14 @@ impl From<Rav1dFrameHeader_delta_lf> for Dav1dFrameHeader_delta_lf {
     }
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_delta {
     pub q: Dav1dFrameHeader_delta_q,
     pub lf: Dav1dFrameHeader_delta_lf,
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_delta {
     pub q: Rav1dFrameHeader_delta_q,
@@ -1594,6 +1612,7 @@ impl From<Rav1dFrameHeader_delta> for Dav1dFrameHeader_delta {
     }
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_loopfilter {
     pub level_y: [c_int; 2],
@@ -1605,6 +1624,7 @@ pub struct Dav1dFrameHeader_loopfilter {
     pub sharpness: c_int,
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_loopfilter {
     pub level_y: [c_int; 2],
@@ -1662,6 +1682,7 @@ impl From<Rav1dFrameHeader_loopfilter> for Dav1dFrameHeader_loopfilter {
     }
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_cdef {
     pub damping: c_int,
@@ -1670,6 +1691,7 @@ pub struct Dav1dFrameHeader_cdef {
     pub uv_strength: [c_int; 8],
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_cdef {
     pub damping: c_int,
@@ -1712,12 +1734,14 @@ impl From<Rav1dFrameHeader_cdef> for Dav1dFrameHeader_cdef {
     }
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_restoration {
     pub type_0: [Dav1dRestorationType; 3],
     pub unit_size: [c_int; 2],
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_restoration {
     pub type_0: [Rav1dRestorationType; 3],
@@ -1738,6 +1762,7 @@ impl From<Rav1dFrameHeader_restoration> for Dav1dFrameHeader_restoration {
     }
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
     pub film_grain: Dav1dFrameHeader_film_grain,
@@ -1792,6 +1817,7 @@ pub struct Dav1dFrameHeader {
     pub gmv: [Dav1dWarpedMotionParams; 7],
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader {
     pub film_grain: Rav1dFrameHeader_film_grain,

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -590,6 +590,7 @@ impl From<Rav1dSequenceHeaderOperatingParameterInfo> for Dav1dSequenceHeaderOper
     }
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dSequenceHeader {
     pub profile: c_int,
@@ -647,6 +648,7 @@ pub struct Dav1dSequenceHeader {
     pub operating_parameter_info: [Dav1dSequenceHeaderOperatingParameterInfo; 32],
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dSequenceHeader {
     pub profile: c_int,

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -424,6 +424,7 @@ impl From<Rav1dMasteringDisplay> for Dav1dMasteringDisplay {
     }
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dITUTT35 {
     pub country_code: u8,
@@ -432,6 +433,7 @@ pub struct Dav1dITUTT35 {
     pub payload: *mut u8,
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dITUTT35 {
     pub country_code: u8,

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -1,4 +1,3 @@
-use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
 use crate::include::dav1d::headers::RAV1D_N_SWITCHABLE_FILTERS;
 use crate::include::stdatomic::atomic_uint;
@@ -5596,15 +5595,6 @@ pub(crate) unsafe fn rav1d_cdf_thread_update(
         (*dst).mv.comp[k_17 as usize].sign[1] = 0 as c_int as u16;
         k_17 += 1;
     }
-}
-
-pub unsafe fn dav1d_cdf_thread_update(
-    hdr: *const Dav1dFrameHeader,
-    dst: *mut CdfContext,
-    src: *const CdfContext,
-) {
-    let hdr = hdr.read().into();
-    rav1d_cdf_thread_update(&hdr, dst, src)
 }
 
 #[inline]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -9,10 +9,10 @@ use crate::include::common::intops::iclip_u8;
 use crate::include::common::intops::ulog2;
 use crate::include::dav1d::headers::Dav1dFilterMode;
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::Dav1dSequenceHeader;
 use crate::include::dav1d::headers::Dav1dTxfmMode;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
 use crate::include::dav1d::headers::Rav1dFrameHeader_tiling;
+use crate::include::dav1d::headers::Rav1dSequenceHeader;
 use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
 use crate::include::dav1d::headers::RAV1D_FILTER_8TAP_REGULAR;
 use crate::include::dav1d::headers::RAV1D_FILTER_SWITCHABLE;
@@ -182,8 +182,8 @@ use crate::src::r#ref::rav1d_ref_create_using_pool;
 use crate::src::r#ref::rav1d_ref_dec;
 use crate::src::r#ref::rav1d_ref_inc;
 use crate::src::recon::DEBUG_BLOCK_INFO;
-use crate::src::refmvs::dav1d_refmvs_init_frame;
 use crate::src::refmvs::rav1d_refmvs_find;
+use crate::src::refmvs::rav1d_refmvs_init_frame;
 use crate::src::refmvs::rav1d_refmvs_save_tmvs;
 use crate::src::refmvs::rav1d_refmvs_tile_sbrow_init;
 use crate::src::refmvs::refmvs_block;
@@ -272,7 +272,7 @@ use crate::{
 };
 
 fn init_quant_tables(
-    seq_hdr: &Dav1dSequenceHeader,
+    seq_hdr: &Rav1dSequenceHeader,
     frame_hdr: &Rav1dFrameHeader,
     qidx: c_int,
     dq: &mut [[[u16; 2]; 3]],
@@ -4723,7 +4723,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init(f: &mut Rav1dFrameContext) -> c_int
 
     // init ref mvs
     if is_inter_or_switch(&*f.frame_hdr) || (*f.frame_hdr).allow_intrabc != 0 {
-        let ret = dav1d_refmvs_init_frame(
+        let ret = rav1d_refmvs_init_frame(
             &mut f.rf,
             f.seq_hdr,
             f.frame_hdr,

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,6 +1,6 @@
 use crate::include::common::intops::apply_sign;
-use crate::include::dav1d::headers::Dav1dFrameHeader;
-use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
+use crate::include::dav1d::headers::Rav1dFrameHeader;
+use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
 use crate::include::dav1d::headers::RAV1D_N_SWITCHABLE_FILTERS;
 use crate::src::align::Align8;
 use crate::src::levels::mv;
@@ -640,7 +640,7 @@ fn fix_int_mv_precision(mv: &mut mv) {
 }
 
 #[inline]
-pub fn fix_mv_precision(hdr: &Dav1dFrameHeader, mv: &mut mv) {
+pub(crate) fn fix_mv_precision(hdr: &Rav1dFrameHeader, mv: &mut mv) {
     if hdr.force_integer_mv != 0 {
         fix_int_mv_precision(mv);
     } else if (*hdr).hp == 0 {
@@ -650,13 +650,13 @@ pub fn fix_mv_precision(hdr: &Dav1dFrameHeader, mv: &mut mv) {
 }
 
 #[inline]
-pub fn get_gmv_2d(
-    gmv: &Dav1dWarpedMotionParams,
+pub(crate) fn get_gmv_2d(
+    gmv: &Rav1dWarpedMotionParams,
     bx4: c_int,
     by4: c_int,
     bw4: c_int,
     bh4: c_int,
-    hdr: &Dav1dFrameHeader,
+    hdr: &Rav1dFrameHeader,
 ) -> mv {
     match gmv.type_0 {
         2 => {

--- a/src/fg_apply_tmpl_16.rs
+++ b/src/fg_apply_tmpl_16.rs
@@ -1,4 +1,5 @@
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
+use crate::include::dav1d::headers::Rav1dFilmGrainData;
 use crate::include::dav1d::headers::RAV1D_MC_IDENTITY;
 use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
@@ -106,7 +107,7 @@ pub(crate) unsafe fn rav1d_prep_grain_16bpc(
     scaling: *mut [u8; 4096],
     grain_lut: *mut [[entry; 82]; 74],
 ) {
-    let data: *const Dav1dFilmGrainData = &mut (*(*out).frame_hdr).film_grain.data;
+    let data: *const Rav1dFilmGrainData = &mut (*(*out).frame_hdr).film_grain.data;
     let bitdepth_max = ((1 as c_int) << (*out).p.bpc) - 1;
     ((*dsp).generate_grain_y).expect("non-null function pointer")(
         (*grain_lut.offset(0)).as_mut_ptr().cast(),

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -7,9 +7,9 @@ use crate::include::dav1d::dav1d::Rav1dEventFlags;
 use crate::include::dav1d::dav1d::Rav1dInloopFilterType;
 use crate::include::dav1d::dav1d::Rav1dLogger;
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
-use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
+use crate::include::dav1d::headers::Rav1dITUTT35;
 use crate::include::dav1d::headers::Rav1dSequenceHeader;
 use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
 use crate::include::dav1d::picture::Rav1dPicAllocator;
@@ -180,7 +180,7 @@ pub struct Rav1dContext {
     pub(crate) mastering_display_ref: *mut Rav1dRef,
     pub(crate) mastering_display: *mut Dav1dMasteringDisplay, // TODO(kkysen) make Rav1d
     pub(crate) itut_t35_ref: *mut Rav1dRef,
-    pub(crate) itut_t35: *mut Dav1dITUTT35, // TODO(kkysen) make Rav1d
+    pub(crate) itut_t35: *mut Rav1dITUTT35,
     pub(crate) in_0: Rav1dData,
     pub(crate) out: Rav1dThreadPicture,
     pub(crate) cache: Rav1dThreadPicture,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -7,11 +7,11 @@ use crate::include::dav1d::dav1d::Rav1dEventFlags;
 use crate::include::dav1d::dav1d::Rav1dInloopFilterType;
 use crate::include::dav1d::dav1d::Rav1dLogger;
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
-use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
-use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
+use crate::include::dav1d::headers::Rav1dFrameHeader;
+use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
 use crate::include::dav1d::picture::Rav1dPicAllocator;
 use crate::include::dav1d::picture::Rav1dPicture;
 use crate::include::stdatomic::atomic_int;
@@ -174,7 +174,7 @@ pub struct Rav1dContext {
     pub(crate) seq_hdr: *mut Dav1dSequenceHeader, // TODO(kkysen) make Rav1d
     pub(crate) frame_hdr_pool: *mut Rav1dMemPool,
     pub(crate) frame_hdr_ref: *mut Rav1dRef,
-    pub(crate) frame_hdr: *mut Dav1dFrameHeader, // TODO(kkysen) make Rav1d
+    pub(crate) frame_hdr: *mut Rav1dFrameHeader,
     pub(crate) content_light_ref: *mut Rav1dRef,
     pub(crate) content_light: *mut Dav1dContentLightLevel, // TODO(kkysen) make Rav1d
     pub(crate) mastering_display_ref: *mut Rav1dRef,
@@ -374,7 +374,7 @@ pub(crate) struct Rav1dFrameContext {
     pub seq_hdr_ref: *mut Rav1dRef,
     pub seq_hdr: *mut Dav1dSequenceHeader, // TODO(kkysen) make Rav1d
     pub frame_hdr_ref: *mut Rav1dRef,
-    pub frame_hdr: *mut Dav1dFrameHeader, // TODO(kkysen) make Rav1d
+    pub frame_hdr: *mut Rav1dFrameHeader,
     pub refp: [Rav1dThreadPicture; 7],
     pub cur: Rav1dPicture,
     pub sr_cur: Rav1dThreadPicture,
@@ -576,7 +576,7 @@ pub(crate) struct Rav1dTaskContext {
     pub pal_sz_uv: [[u8; 32]; 2],
     pub txtp_map: [u8; 1024],
     pub scratch: Rav1dTaskContext_scratch,
-    pub warpmv: Dav1dWarpedMotionParams,
+    pub warpmv: Rav1dWarpedMotionParams,
     pub lf_mask: *mut Av1Filter,
     pub top_pre_cdef_toggle: c_int,
     pub cur_sb_cdef_idx_ptr: *mut i8,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -9,8 +9,8 @@ use crate::include::dav1d::dav1d::Rav1dLogger;
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
-use crate::include::dav1d::headers::Dav1dSequenceHeader;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
+use crate::include::dav1d::headers::Rav1dSequenceHeader;
 use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
 use crate::include::dav1d::picture::Rav1dPicAllocator;
 use crate::include::dav1d::picture::Rav1dPicture;
@@ -171,7 +171,7 @@ pub struct Rav1dContext {
     pub(crate) n_tiles: c_int,
     pub(crate) seq_hdr_pool: *mut Rav1dMemPool,
     pub(crate) seq_hdr_ref: *mut Rav1dRef,
-    pub(crate) seq_hdr: *mut Dav1dSequenceHeader, // TODO(kkysen) make Rav1d
+    pub(crate) seq_hdr: *mut Rav1dSequenceHeader,
     pub(crate) frame_hdr_pool: *mut Rav1dMemPool,
     pub(crate) frame_hdr_ref: *mut Rav1dRef,
     pub(crate) frame_hdr: *mut Rav1dFrameHeader,
@@ -372,7 +372,7 @@ pub struct FrameTileThreadData {
 #[repr(C)]
 pub(crate) struct Rav1dFrameContext {
     pub seq_hdr_ref: *mut Rav1dRef,
-    pub seq_hdr: *mut Dav1dSequenceHeader, // TODO(kkysen) make Rav1d
+    pub seq_hdr: *mut Rav1dSequenceHeader,
     pub frame_hdr_ref: *mut Rav1dRef,
     pub frame_hdr: *mut Rav1dFrameHeader,
     pub refp: [Rav1dThreadPicture; 7],

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -1,6 +1,6 @@
 use crate::include::common::intops::iclip;
-use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::Dav1dRestorationType;
+use crate::include::dav1d::headers::Rav1dFrameHeader;
 use crate::include::dav1d::headers::Rav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Rav1dPixelLayout;
 use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
@@ -624,9 +624,9 @@ fn calc_lf_value_chroma(
     };
 }
 
-pub fn dav1d_calc_lf_values(
+pub(crate) fn rav1d_calc_lf_values(
     lflvl_values: &mut [[[[u8; 2]; 8]; 4]; 8],
-    hdr: &Dav1dFrameHeader,
+    hdr: &Rav1dFrameHeader,
     lf_delta: &[i8; 4],
 ) {
     let n_seg = if hdr.segmentation.enabled != 0 { 8 } else { 1 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,12 +15,14 @@ use crate::include::dav1d::dav1d::RAV1D_DECODEFRAMETYPE_ALL;
 use crate::include::dav1d::dav1d::RAV1D_DECODEFRAMETYPE_KEY;
 use crate::include::dav1d::dav1d::RAV1D_INLOOPFILTER_ALL;
 use crate::include::dav1d::dav1d::RAV1D_INLOOPFILTER_NONE;
+use crate::include::dav1d::headers::DRav1d;
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
+use crate::include::dav1d::headers::Rav1dFrameHeader;
 use crate::include::dav1d::headers::Rav1dSequenceHeader;
 use crate::include::dav1d::picture::Dav1dPicture;
 use crate::include::dav1d::picture::Rav1dPicAllocator;
@@ -108,6 +110,7 @@ use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
 use std::process::abort;
+use std::ptr::NonNull;
 use std::sync::Once;
 
 #[cfg(feature = "bitdepth_8")]
@@ -1019,6 +1022,13 @@ pub(crate) unsafe fn rav1d_get_picture(c: *mut Rav1dContext, out: *mut Rav1dPict
 
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_get_picture(c: *mut Dav1dContext, out: *mut Dav1dPicture) -> c_int {
+    if let Some(mut frame_hdr_ref) = NonNull::new((*out).frame_hdr_ref) {
+        (*frame_hdr_ref
+            .as_mut()
+            .data
+            .cast::<DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>>())
+        .update_rav1d();
+    }
     let mut out_rust = out.read().into();
     let result = rav1d_get_picture(c, &mut out_rust);
     out.write(out_rust.into());
@@ -1100,6 +1110,20 @@ pub unsafe extern "C" fn dav1d_apply_grain(
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,
 ) -> c_int {
+    if let Some(mut frame_hdr_ref) = NonNull::new((*in_0).frame_hdr_ref) {
+        (*frame_hdr_ref
+            .as_mut()
+            .data
+            .cast::<DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>>())
+        .update_rav1d();
+    }
+    if let Some(mut frame_hdr_ref) = NonNull::new((*out).frame_hdr_ref) {
+        (*frame_hdr_ref
+            .as_mut()
+            .data
+            .cast::<DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>>())
+        .update_rav1d();
+    }
     let mut out_rust = out.read().into();
     let in_rust = in_0.read().into();
     let result = rav1d_apply_grain(c, &mut out_rust, &in_rust);
@@ -1127,7 +1151,7 @@ pub(crate) unsafe fn rav1d_flush(c: *mut Rav1dContext) {
         rav1d_cdf_thread_unref(&mut *((*c).cdf).as_mut_ptr().offset(i as isize));
         i += 1;
     }
-    (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
+    (*c).frame_hdr = 0 as *mut Rav1dFrameHeader;
     (*c).seq_hdr = 0 as *mut Dav1dSequenceHeader;
     rav1d_ref_dec(&mut (*c).seq_hdr_ref);
     (*c).mastering_display = 0 as *mut Dav1dMasteringDisplay;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
+use crate::include::dav1d::headers::Rav1dITUTT35;
 use crate::include::dav1d::headers::Rav1dSequenceHeader;
 use crate::include::dav1d::picture::Dav1dPicture;
 use crate::include::dav1d::picture::Rav1dPicAllocator;
@@ -1036,6 +1037,13 @@ pub unsafe extern "C" fn dav1d_get_picture(c: *mut Dav1dContext, out: *mut Dav1d
             .cast::<DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>>())
         .update_rav1d();
     }
+    if let Some(mut itut_t35_ref) = NonNull::new((*out).itut_t35_ref) {
+        (*itut_t35_ref
+            .as_mut()
+            .data
+            .cast::<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>())
+        .update_rav1d();
+    }
     let mut out_rust = out.read().into();
     let result = rav1d_get_picture(c, &mut out_rust);
     out.write(out_rust.into());
@@ -1131,6 +1139,13 @@ pub unsafe extern "C" fn dav1d_apply_grain(
             .cast::<DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>>())
         .update_rav1d();
     }
+    if let Some(mut itut_t35_ref) = NonNull::new((*in_0).itut_t35_ref) {
+        (*itut_t35_ref
+            .as_mut()
+            .data
+            .cast::<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>())
+        .update_rav1d();
+    }
     if let Some(mut seq_hdr_ref) = NonNull::new((*out).seq_hdr_ref) {
         (*seq_hdr_ref
             .as_mut()
@@ -1143,6 +1158,13 @@ pub unsafe extern "C" fn dav1d_apply_grain(
             .as_mut()
             .data
             .cast::<DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>>())
+        .update_rav1d();
+    }
+    if let Some(mut itut_t35_ref) = NonNull::new((*out).itut_t35_ref) {
+        (*itut_t35_ref
+            .as_mut()
+            .data
+            .cast::<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>())
         .update_rav1d();
     }
     let mut out_rust = out.read().into();
@@ -1177,7 +1199,7 @@ pub(crate) unsafe fn rav1d_flush(c: *mut Rav1dContext) {
     rav1d_ref_dec(&mut (*c).seq_hdr_ref);
     (*c).mastering_display = 0 as *mut Dav1dMasteringDisplay;
     (*c).content_light = 0 as *mut Dav1dContentLightLevel;
-    (*c).itut_t35 = 0 as *mut Dav1dITUTT35;
+    (*c).itut_t35 = 0 as *mut Rav1dITUTT35;
     rav1d_ref_dec(&mut (*c).mastering_display_ref);
     rav1d_ref_dec(&mut (*c).content_light_ref);
     rav1d_ref_dec(&mut (*c).itut_t35_ref);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1022,6 +1022,13 @@ pub(crate) unsafe fn rav1d_get_picture(c: *mut Rav1dContext, out: *mut Rav1dPict
 
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_get_picture(c: *mut Dav1dContext, out: *mut Dav1dPicture) -> c_int {
+    if let Some(mut seq_hdr_ref) = NonNull::new((*out).seq_hdr_ref) {
+        (*seq_hdr_ref
+            .as_mut()
+            .data
+            .cast::<DRav1d<Rav1dSequenceHeader, Dav1dSequenceHeader>>())
+        .update_rav1d();
+    }
     if let Some(mut frame_hdr_ref) = NonNull::new((*out).frame_hdr_ref) {
         (*frame_hdr_ref
             .as_mut()
@@ -1110,11 +1117,25 @@ pub unsafe extern "C" fn dav1d_apply_grain(
     out: *mut Dav1dPicture,
     in_0: *const Dav1dPicture,
 ) -> c_int {
+    if let Some(mut seq_hdr_ref) = NonNull::new((*in_0).seq_hdr_ref) {
+        (*seq_hdr_ref
+            .as_mut()
+            .data
+            .cast::<DRav1d<Rav1dSequenceHeader, Dav1dSequenceHeader>>())
+        .update_rav1d();
+    }
     if let Some(mut frame_hdr_ref) = NonNull::new((*in_0).frame_hdr_ref) {
         (*frame_hdr_ref
             .as_mut()
             .data
             .cast::<DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>>())
+        .update_rav1d();
+    }
+    if let Some(mut seq_hdr_ref) = NonNull::new((*out).seq_hdr_ref) {
+        (*seq_hdr_ref
+            .as_mut()
+            .data
+            .cast::<DRav1d<Rav1dSequenceHeader, Dav1dSequenceHeader>>())
         .update_rav1d();
     }
     if let Some(mut frame_hdr_ref) = NonNull::new((*out).frame_hdr_ref) {
@@ -1152,7 +1173,7 @@ pub(crate) unsafe fn rav1d_flush(c: *mut Rav1dContext) {
         i += 1;
     }
     (*c).frame_hdr = 0 as *mut Rav1dFrameHeader;
-    (*c).seq_hdr = 0 as *mut Dav1dSequenceHeader;
+    (*c).seq_hdr = 0 as *mut Rav1dSequenceHeader;
     rav1d_ref_dec(&mut (*c).seq_hdr_ref);
     (*c).mastering_display = 0 as *mut Dav1dMasteringDisplay;
     (*c).content_light = 0 as *mut Dav1dContentLightLevel;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -25,6 +25,7 @@ use crate::include::dav1d::headers::Dav1dTxfmMode;
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
 use crate::include::dav1d::headers::Rav1dFrameHeaderOperatingPoint;
+use crate::include::dav1d::headers::Rav1dITUTT35;
 use crate::include::dav1d::headers::Rav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Rav1dObuType;
 use crate::include::dav1d::headers::Rav1dSegmentationData;
@@ -1867,17 +1868,24 @@ pub(crate) unsafe fn rav1d_parse_obus(
                         );
                     } else {
                         let ref_3: *mut Rav1dRef = rav1d_ref_create(
-                            (::core::mem::size_of::<Dav1dITUTT35>()).wrapping_add(
-                                (payload_size as usize).wrapping_mul(::core::mem::size_of::<u8>()),
-                            ),
+                            (::core::mem::size_of::<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>())
+                                .wrapping_add(
+                                    (payload_size as usize)
+                                        .wrapping_mul(::core::mem::size_of::<u8>()),
+                                ),
                         );
                         if ref_3.is_null() {
                             return -(12 as c_int);
                         }
-                        let itut_t35_metadata: *mut Dav1dITUTT35 =
-                            (*ref_3).data as *mut Dav1dITUTT35;
-                        (*itut_t35_metadata).payload =
-                            &mut *itut_t35_metadata.offset(1) as *mut Dav1dITUTT35 as *mut u8;
+                        let itut_t32_metadatas =
+                            (*ref_3).data.cast::<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>();
+                        let itut_t35_metadata: *mut Rav1dITUTT35 =
+                            addr_of_mut!((*itut_t32_metadatas).rav1d);
+                        (*itut_t35_metadata).payload = (*ref_3)
+                            .data
+                            .cast::<u8>()
+                            .offset(::core::mem::size_of::<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>()
+                                as isize);
                         (*itut_t35_metadata).country_code = country_code as u8;
                         (*itut_t35_metadata).country_code_extension_byte =
                             country_code_extension_byte as u8;
@@ -1888,6 +1896,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                             i_2 += 1;
                         }
                         (*itut_t35_metadata).payload_size = payload_size as usize;
+                        (*itut_t32_metadatas).update_dav1d();
                         rav1d_ref_dec(&mut (*c).itut_t35_ref);
                         (*c).itut_t35 = itut_t35_metadata;
                         (*c).itut_t35_ref = ref_3;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -4,6 +4,7 @@ use crate::include::dav1d::data::Rav1dData;
 use crate::include::dav1d::dav1d::Dav1dEventFlags;
 use crate::include::dav1d::dav1d::RAV1D_DECODEFRAMETYPE_INTRA;
 use crate::include::dav1d::dav1d::RAV1D_DECODEFRAMETYPE_REFERENCE;
+use crate::include::dav1d::headers::DRav1d;
 use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
 use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
 use crate::include::dav1d::headers::Dav1dColorPrimaries;
@@ -11,24 +12,25 @@ use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dFilmGrainData;
 use crate::include::dav1d::headers::Dav1dFilterMode;
 use crate::include::dav1d::headers::Dav1dFrameHeader;
-use crate::include::dav1d::headers::Dav1dFrameHeaderOperatingPoint;
 use crate::include::dav1d::headers::Dav1dFrameType;
 use crate::include::dav1d::headers::Dav1dITUTT35;
-use crate::include::dav1d::headers::Dav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
 use crate::include::dav1d::headers::Dav1dPixelLayout;
 use crate::include::dav1d::headers::Dav1dRestorationType;
-use crate::include::dav1d::headers::Dav1dSegmentationData;
-use crate::include::dav1d::headers::Dav1dSegmentationDataSet;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
 use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
 use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
 use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
 use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
 use crate::include::dav1d::headers::Dav1dWarpedMotionType;
+use crate::include::dav1d::headers::Rav1dFrameHeader;
+use crate::include::dav1d::headers::Rav1dFrameHeaderOperatingPoint;
+use crate::include::dav1d::headers::Rav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Rav1dObuType;
+use crate::include::dav1d::headers::Rav1dSegmentationData;
+use crate::include::dav1d::headers::Rav1dSegmentationDataSet;
+use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
 use crate::include::dav1d::headers::RAV1D_ADAPTIVE;
 use crate::include::dav1d::headers::RAV1D_CHR_UNKNOWN;
 use crate::include::dav1d::headers::RAV1D_COLOR_PRI_BT709;
@@ -395,7 +397,7 @@ unsafe extern "C" fn read_frame_size(
     use_ref: c_int,
 ) -> c_int {
     let seqhdr: *const Dav1dSequenceHeader = (*c).seq_hdr;
-    let hdr: *mut Dav1dFrameHeader = (*c).frame_hdr;
+    let hdr: *mut Rav1dFrameHeader = (*c).frame_hdr;
     if use_ref != 0 {
         let mut i = 0;
         while i < 7 {
@@ -476,7 +478,7 @@ unsafe extern "C" fn tile_log2(sz: c_int, tgt: c_int) -> c_int {
     return k;
 }
 
-static default_mode_ref_deltas: Dav1dLoopfilterModeRefDeltas = Dav1dLoopfilterModeRefDeltas {
+static default_mode_ref_deltas: Rav1dLoopfilterModeRefDeltas = Rav1dLoopfilterModeRefDeltas {
     mode_delta: [0, 0],
     ref_delta: [1, 0, 0, 0, -1, 0, -1, -1],
 };
@@ -491,7 +493,7 @@ unsafe extern "C" fn parse_frame_hdr_error(c: *mut Rav1dContext) -> c_int {
 
 unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> c_int {
     let seqhdr: *const Dav1dSequenceHeader = (*c).seq_hdr;
-    let hdr: *mut Dav1dFrameHeader = (*c).frame_hdr;
+    let hdr: *mut Rav1dFrameHeader = (*c).frame_hdr;
     (*hdr).show_existing_frame =
         ((*seqhdr).reduced_still_picture_header == 0 && rav1d_get_bit(gb) != 0) as c_int;
     if (*hdr).show_existing_frame != 0 {
@@ -502,7 +504,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
         }
         if (*seqhdr).frame_id_numbers_present != 0 {
             (*hdr).frame_id = rav1d_get_bits(gb, (*seqhdr).frame_id_n_bits) as c_int;
-            let ref_frame_hdr: *mut Dav1dFrameHeader =
+            let ref_frame_hdr: *mut Rav1dFrameHeader =
                 (*c).refs[(*hdr).existing_frame_idx as usize].p.p.frame_hdr;
             if ref_frame_hdr.is_null() || (*ref_frame_hdr).frame_id != (*hdr).frame_id {
                 return parse_frame_hdr_error(c);
@@ -582,9 +584,9 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
                 let seqop: *const Dav1dSequenceHeaderOperatingPoint =
                     &*((*seqhdr).operating_points).as_ptr().offset(i as isize)
                         as *const Dav1dSequenceHeaderOperatingPoint;
-                let op: *mut Dav1dFrameHeaderOperatingPoint =
+                let op: *mut Rav1dFrameHeaderOperatingPoint =
                     &mut *((*hdr).operating_points).as_mut_ptr().offset(i as isize)
-                        as *mut Dav1dFrameHeaderOperatingPoint;
+                        as *mut Rav1dFrameHeaderOperatingPoint;
                 if (*seqop).decoder_model_param_present != 0 {
                     let in_temporal_layer = (*seqop).idc >> (*hdr).temporal_id & 1;
                     let in_spatial_layer = (*seqop).idc >> (*hdr).spatial_id + 8 & 1;
@@ -774,7 +776,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
                     - delta_ref_frame_id_minus_1
                     - 1
                     & ((1 as c_int) << (*seqhdr).frame_id_n_bits) - 1;
-                let ref_frame_hdr_0: *mut Dav1dFrameHeader = (*c).refs
+                let ref_frame_hdr_0: *mut Rav1dFrameHeader = (*c).refs
                     [(*hdr).refidx[i_9 as usize] as usize]
                     .p
                     .p
@@ -965,10 +967,10 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
             (*hdr).segmentation.seg_data.last_active_segid = -(1 as c_int);
             let mut i_10 = 0;
             while i_10 < 8 {
-                let seg: *mut Dav1dSegmentationData = &mut *((*hdr).segmentation.seg_data.d)
+                let seg: *mut Rav1dSegmentationData = &mut *((*hdr).segmentation.seg_data.d)
                     .as_mut_ptr()
                     .offset(i_10 as isize)
-                    as *mut Dav1dSegmentationData;
+                    as *mut Rav1dSegmentationData;
                 if rav1d_get_bit(gb) != 0 {
                     (*seg).delta_q = rav1d_get_sbits(gb, 9 as c_int);
                     (*hdr).segmentation.seg_data.last_active_segid = i_10;
@@ -1033,9 +1035,9 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
         }
     } else {
         memset(
-            &mut (*hdr).segmentation.seg_data as *mut Dav1dSegmentationDataSet as *mut c_void,
+            &mut (*hdr).segmentation.seg_data as *mut Rav1dSegmentationDataSet as *mut c_void,
             0 as c_int,
-            ::core::mem::size_of::<Dav1dSegmentationDataSet>(),
+            ::core::mem::size_of::<Rav1dSegmentationDataSet>(),
         );
         let mut i_11 = 0;
         while i_11 < 8 {
@@ -1335,7 +1337,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
             if !((*hdr).gmv[i_19 as usize].type_0 as c_uint
                 == RAV1D_WM_TYPE_IDENTITY as c_int as c_uint)
             {
-                let ref_gmv: *const Dav1dWarpedMotionParams;
+                let ref_gmv: *const Rav1dWarpedMotionParams;
                 if (*hdr).primary_ref_frame == 7 {
                     ref_gmv = &dav1d_default_wm_params;
                 } else {
@@ -1350,7 +1352,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
                         .gmv)
                         .as_mut_ptr()
                         .offset(i_19 as isize)
-                        as *mut Dav1dWarpedMotionParams;
+                        as *mut Rav1dWarpedMotionParams;
                 }
                 let mat: *mut i32 = ((*hdr).gmv[i_19 as usize].matrix).as_mut_ptr();
                 let ref_mat: *const i32 = ((*ref_gmv).matrix).as_ptr();
@@ -1540,6 +1542,12 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
             ::core::mem::size_of::<Dav1dFilmGrainData>(),
         );
     }
+
+    (*(*(*c).frame_hdr_ref)
+        .data
+        .cast::<DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>>())
+    .update_dav1d();
+
     return 0 as c_int;
 }
 
@@ -1616,7 +1624,7 @@ unsafe extern "C" fn rav1d_parse_obus_skip(
         i += 1;
     }
     rav1d_ref_dec(&mut (*c).frame_hdr_ref);
-    (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
+    (*c).frame_hdr = 0 as *mut Rav1dFrameHeader;
     (*c).n_tiles = 0 as c_int;
     return len.wrapping_add(init_byte_pos) as c_int;
 }
@@ -1703,7 +1711,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 return rav1d_parse_obus_error(c, in_0);
             }
             if ((*c).seq_hdr).is_null() {
-                (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
+                (*c).frame_hdr = 0 as *mut Rav1dFrameHeader;
                 (*c).frame_flags = ::core::mem::transmute::<c_uint, PictureFlags>(
                     (*c).frame_flags as c_uint | PICTURE_FLAG_NEW_SEQUENCE as c_int as c_uint,
                 );
@@ -1713,7 +1721,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 1100,
             ) != 0
             {
-                (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
+                (*c).frame_hdr = 0 as *mut Rav1dFrameHeader;
                 (*c).mastering_display = 0 as *mut Dav1dMasteringDisplay;
                 (*c).content_light = 0 as *mut Dav1dContentLightLevel;
                 rav1d_ref_dec(&mut (*c).mastering_display_ref);
@@ -1919,7 +1927,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 if ((*c).frame_hdr_ref).is_null() {
                     (*c).frame_hdr_ref = rav1d_ref_create_using_pool(
                         (*c).frame_hdr_pool,
-                        ::core::mem::size_of::<Dav1dFrameHeader>(),
+                        ::core::mem::size_of::<DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>>(),
                     );
                     if ((*c).frame_hdr_ref).is_null() {
                         return -(12 as c_int);
@@ -1927,17 +1935,19 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 }
                 // ensure that the reference is writable
                 debug_assert!(rav1d_ref_is_writable((*c).frame_hdr_ref) != 0);
-                (*c).frame_hdr = (*(*c).frame_hdr_ref).data as *mut Dav1dFrameHeader;
+                let frame_hdrs =
+                    (*(*c).frame_hdr_ref).data as *mut DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>;
                 memset(
-                    (*c).frame_hdr as *mut c_void,
+                    frame_hdrs as *mut c_void,
                     0 as c_int,
-                    ::core::mem::size_of::<Dav1dFrameHeader>(),
+                    ::core::mem::size_of::<DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>>(),
                 );
+                (*c).frame_hdr = &mut (*frame_hdrs).rav1d;
                 (*(*c).frame_hdr).temporal_id = temporal_id;
                 (*(*c).frame_hdr).spatial_id = spatial_id;
                 res = parse_frame_hdr(c, &mut gb);
                 if res < 0 {
-                    (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
+                    (*c).frame_hdr = 0 as *mut Rav1dFrameHeader;
                     return rav1d_parse_obus_error(c, in_0);
                 }
                 let mut n = 0;
@@ -1950,7 +1960,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 if type_0 as c_uint != RAV1D_OBU_FRAME as c_int as c_uint {
                     rav1d_get_bit(&mut gb);
                     if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
-                        (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
+                        (*c).frame_hdr = 0 as *mut Rav1dFrameHeader;
                         return rav1d_parse_obus_error(c, in_0);
                     }
                 }
@@ -1965,14 +1975,14 @@ pub(crate) unsafe fn rav1d_parse_obus(
                         (*(*c).frame_hdr).height,
                         (*c).frame_size_limit,
                     );
-                    (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
+                    (*c).frame_hdr = 0 as *mut Rav1dFrameHeader;
                     return -(34 as c_int);
                 }
                 if type_0 as c_uint != RAV1D_OBU_FRAME as c_int as c_uint {
                     current_block_188 = 8953117030348968745;
                 } else {
                     if (*(*c).frame_hdr).show_existing_frame != 0 {
-                        (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
+                        (*c).frame_hdr = 0 as *mut Rav1dFrameHeader;
                         return rav1d_parse_obus_error(c, in_0);
                     }
                     rav1d_bytealign_get_bits(&mut gb);
@@ -2232,7 +2242,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                     i_3 += 1;
                 }
             }
-            (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
+            (*c).frame_hdr = 0 as *mut Rav1dFrameHeader;
         } else if (*c).n_tiles == (*(*c).frame_hdr).tiling.cols * (*(*c).frame_hdr).tiling.rows {
             match (*(*c).frame_hdr).frame_type as c_uint {
                 RAV1D_FRAME_TYPE_INTER | RAV1D_FRAME_TYPE_SWITCH => {
@@ -2267,7 +2277,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
             if (*c).n_tile_data != 0 {
                 unreachable!();
             }
-            (*c).frame_hdr = 0 as *mut Dav1dFrameHeader;
+            (*c).frame_hdr = 0 as *mut Rav1dFrameHeader;
             (*c).n_tiles = 0 as c_int;
         }
     }

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -5,10 +5,10 @@ use crate::include::dav1d::dav1d::Rav1dEventFlags;
 use crate::include::dav1d::dav1d::RAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
 use crate::include::dav1d::dav1d::RAV1D_EVENT_FLAG_NEW_SEQUENCE;
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
-use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
+use crate::include::dav1d::headers::Rav1dFrameHeader;
 use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
@@ -140,7 +140,7 @@ unsafe extern "C" fn picture_alloc_with_edges(
     h: c_int,
     seq_hdr: *mut Dav1dSequenceHeader,
     seq_hdr_ref: *mut Rav1dRef,
-    frame_hdr: *mut Dav1dFrameHeader,
+    frame_hdr: *mut Rav1dFrameHeader,
     frame_hdr_ref: *mut Rav1dRef,
     content_light: *mut Dav1dContentLightLevel,
     content_light_ref: *mut Rav1dRef,
@@ -180,6 +180,7 @@ unsafe extern "C" fn picture_alloc_with_edges(
     (*p).p.layout = (*seq_hdr).layout;
     (*p).p.bpc = bpc;
     rav1d_data_props_set_defaults(&mut (*p).m);
+    (*p).frame_hdr_ref = frame_hdr_ref;
     let res = (*p_allocator).alloc_picture(p);
     if res < 0 {
         free(pic_ctx as *mut c_void);
@@ -206,7 +207,6 @@ unsafe extern "C" fn picture_alloc_with_edges(
     if !seq_hdr_ref.is_null() {
         rav1d_ref_inc(seq_hdr_ref);
     }
-    (*p).frame_hdr_ref = frame_hdr_ref;
     if !frame_hdr_ref.is_null() {
         rav1d_ref_inc(frame_hdr_ref);
     }

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -5,9 +5,9 @@ use crate::include::dav1d::dav1d::Rav1dEventFlags;
 use crate::include::dav1d::dav1d::RAV1D_EVENT_FLAG_NEW_OP_PARAMS_INFO;
 use crate::include::dav1d::dav1d::RAV1D_EVENT_FLAG_NEW_SEQUENCE;
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
-use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
+use crate::include::dav1d::headers::Rav1dITUTT35;
 use crate::include::dav1d::headers::Rav1dSequenceHeader;
 use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
@@ -146,7 +146,7 @@ unsafe extern "C" fn picture_alloc_with_edges(
     content_light_ref: *mut Rav1dRef,
     mastering_display: *mut Dav1dMasteringDisplay,
     mastering_display_ref: *mut Rav1dRef,
-    itut_t35: *mut Dav1dITUTT35,
+    itut_t35: *mut Rav1dITUTT35,
     itut_t35_ref: *mut Rav1dRef,
     bpc: c_int,
     props: *const Rav1dDataProps,
@@ -182,6 +182,7 @@ unsafe extern "C" fn picture_alloc_with_edges(
     rav1d_data_props_set_defaults(&mut (*p).m);
     (*p).seq_hdr_ref = seq_hdr_ref;
     (*p).frame_hdr_ref = frame_hdr_ref;
+    (*p).itut_t35_ref = itut_t35_ref;
     let res = (*p_allocator).alloc_picture(p);
     if res < 0 {
         free(pic_ctx as *mut c_void);
@@ -222,7 +223,6 @@ unsafe extern "C" fn picture_alloc_with_edges(
     if !mastering_display_ref.is_null() {
         rav1d_ref_inc(mastering_display_ref);
     }
-    (*p).itut_t35_ref = itut_t35_ref;
     if !itut_t35_ref.is_null() {
         rav1d_ref_inc(itut_t35_ref);
     }
@@ -265,7 +265,7 @@ pub(crate) unsafe fn rav1d_thread_picture_alloc(
         return res;
     }
     rav1d_ref_dec(&mut (*c).itut_t35_ref);
-    (*c).itut_t35 = 0 as *mut Dav1dITUTT35;
+    (*c).itut_t35 = 0 as *mut Rav1dITUTT35;
     let flags_mask = if (*(*f).frame_hdr).show_frame != 0 || (*c).output_invisible_frames != 0 {
         0 as c_int
     } else {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -7,8 +7,8 @@ use crate::include::dav1d::dav1d::RAV1D_EVENT_FLAG_NEW_SEQUENCE;
 use crate::include::dav1d::headers::Dav1dContentLightLevel;
 use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dMasteringDisplay;
-use crate::include::dav1d::headers::Dav1dSequenceHeader;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
+use crate::include::dav1d::headers::Rav1dSequenceHeader;
 use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
@@ -138,7 +138,7 @@ unsafe extern "C" fn picture_alloc_with_edges(
     p: *mut Rav1dPicture,
     w: c_int,
     h: c_int,
-    seq_hdr: *mut Dav1dSequenceHeader,
+    seq_hdr: *mut Rav1dSequenceHeader,
     seq_hdr_ref: *mut Rav1dRef,
     frame_hdr: *mut Rav1dFrameHeader,
     frame_hdr_ref: *mut Rav1dRef,
@@ -180,6 +180,7 @@ unsafe extern "C" fn picture_alloc_with_edges(
     (*p).p.layout = (*seq_hdr).layout;
     (*p).p.bpc = bpc;
     rav1d_data_props_set_defaults(&mut (*p).m);
+    (*p).seq_hdr_ref = seq_hdr_ref;
     (*p).frame_hdr_ref = frame_hdr_ref;
     let res = (*p_allocator).alloc_picture(p);
     if res < 0 {
@@ -203,7 +204,6 @@ unsafe extern "C" fn picture_alloc_with_edges(
         );
         return -(12 as c_int);
     }
-    (*p).seq_hdr_ref = seq_hdr_ref;
     if !seq_hdr_ref.is_null() {
         rav1d_ref_inc(seq_hdr_ref);
     }

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -9,7 +9,7 @@ use crate::include::common::intops::iclip;
 use crate::include::dav1d::dav1d::RAV1D_INLOOPFILTER_CDEF;
 use crate::include::dav1d::dav1d::RAV1D_INLOOPFILTER_DEBLOCK;
 use crate::include::dav1d::dav1d::RAV1D_INLOOPFILTER_RESTORATION;
-use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
+use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
 use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
@@ -2079,7 +2079,7 @@ unsafe extern "C" fn warp_affine(
     b_dim: *const u8,
     pl: c_int,
     refp: *const Rav1dThreadPicture,
-    wmp: *const Dav1dWarpedMotionParams,
+    wmp: *const Rav1dWarpedMotionParams,
 ) -> c_int {
     if (dst8 != 0 as *mut c_void as *mut pixel) as c_int
         ^ (dst16 != 0 as *mut c_void as *mut i16) as c_int

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -9,7 +9,7 @@ use crate::include::common::intops::iclip;
 use crate::include::dav1d::dav1d::RAV1D_INLOOPFILTER_CDEF;
 use crate::include::dav1d::dav1d::RAV1D_INLOOPFILTER_DEBLOCK;
 use crate::include::dav1d::dav1d::RAV1D_INLOOPFILTER_RESTORATION;
-use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
+use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
 use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I400;
 use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
@@ -2064,7 +2064,7 @@ unsafe extern "C" fn warp_affine(
     b_dim: *const u8,
     pl: c_int,
     refp: *const Rav1dThreadPicture,
-    wmp: *const Dav1dWarpedMotionParams,
+    wmp: *const Rav1dWarpedMotionParams,
 ) -> c_int {
     if (dst8 != 0 as *mut c_void as *mut pixel) as c_int
         ^ (dst16 != 0 as *mut c_void as *mut i16) as c_int

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1,7 +1,7 @@
 use crate::include::common::intops::apply_sign;
 use crate::include::common::intops::iclip;
-use crate::include::dav1d::headers::Dav1dSequenceHeader;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
+use crate::include::dav1d::headers::Rav1dSequenceHeader;
 use crate::include::dav1d::headers::RAV1D_WM_TYPE_TRANSLATION;
 use crate::src::env::fix_mv_precision;
 use crate::src::env::get_gmv_2d;
@@ -1374,9 +1374,9 @@ unsafe extern "C" fn save_tmvs_c(
     }
 }
 
-pub(crate) unsafe fn dav1d_refmvs_init_frame(
+pub(crate) unsafe fn rav1d_refmvs_init_frame(
     rf: *mut refmvs_frame,
-    seq_hdr: *const Dav1dSequenceHeader,
+    seq_hdr: *const Rav1dSequenceHeader,
     frm_hdr: *const Rav1dFrameHeader,
     ref_poc: *const c_uint,
     rp: *mut refmvs_temporal_block,

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1,7 +1,7 @@
 use crate::include::common::intops::apply_sign;
 use crate::include::common::intops::iclip;
-use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
+use crate::include::dav1d::headers::Rav1dFrameHeader;
 use crate::include::dav1d::headers::RAV1D_WM_TYPE_TRANSLATION;
 use crate::src::env::fix_mv_precision;
 use crate::src::env::get_gmv_2d;
@@ -140,8 +140,8 @@ pub struct refmvs_block_unaligned {
 pub struct refmvs_block(pub refmvs_block_unaligned);
 
 #[repr(C)]
-pub struct refmvs_frame {
-    pub frm_hdr: *const Dav1dFrameHeader,
+pub(crate) struct refmvs_frame {
+    pub frm_hdr: *const Rav1dFrameHeader,
     pub iw4: c_int,
     pub ih4: c_int,
     pub iw8: c_int,
@@ -173,7 +173,7 @@ pub struct refmvs_tile_range {
 }
 
 #[repr(C)]
-pub struct refmvs_tile {
+pub(crate) struct refmvs_tile {
     pub rf: *const refmvs_frame,
     pub r: [*mut refmvs_block; 37],
     pub rp_proj: *mut refmvs_temporal_block,
@@ -188,7 +188,7 @@ pub struct refmvs_candidate {
     pub weight: c_int,
 }
 
-pub type load_tmvs_fn =
+pub(crate) type load_tmvs_fn =
     Option<unsafe extern "C" fn(*const refmvs_frame, c_int, c_int, c_int, c_int, c_int) -> ()>;
 
 pub type save_tmvs_fn = Option<
@@ -209,7 +209,7 @@ pub type splat_mv_fn = Option<
 >;
 
 #[repr(C)]
-pub struct Rav1dRefmvsDSPContext {
+pub(crate) struct Rav1dRefmvsDSPContext {
     pub load_tmvs: load_tmvs_fn,
     pub save_tmvs: save_tmvs_fn,
     pub splat_mv: splat_mv_fn,
@@ -662,7 +662,7 @@ fn add_single_extended_candidate(
 /// enabled) or at the start of each interleaved sbrow (when tile column
 /// threading is disabled), we call load_tmvs(), which will project the MVs to
 /// their respective position in the current frame.
-pub unsafe fn rav1d_refmvs_find(
+pub(crate) unsafe fn rav1d_refmvs_find(
     rt: &refmvs_tile,
     mvstack: &mut [refmvs_candidate; 8],
     cnt: &mut usize,
@@ -1096,7 +1096,7 @@ pub unsafe fn rav1d_refmvs_find(
 
 // cache the current tile/sbrow (or frame/sbrow)'s projectable motion vectors
 // into buffers for use in future frame's temporal MV prediction
-pub unsafe fn rav1d_refmvs_save_tmvs(
+pub(crate) unsafe fn rav1d_refmvs_save_tmvs(
     dsp: *const Rav1dRefmvsDSPContext,
     rt: *const refmvs_tile,
     col_start8: c_int,
@@ -1129,7 +1129,7 @@ pub unsafe fn rav1d_refmvs_save_tmvs(
     );
 }
 
-pub unsafe fn rav1d_refmvs_tile_sbrow_init(
+pub(crate) unsafe fn rav1d_refmvs_tile_sbrow_init(
     rt: *mut refmvs_tile,
     rf: *const refmvs_frame,
     tile_col_start4: c_int,
@@ -1374,10 +1374,10 @@ unsafe extern "C" fn save_tmvs_c(
     }
 }
 
-pub unsafe fn dav1d_refmvs_init_frame(
+pub(crate) unsafe fn dav1d_refmvs_init_frame(
     rf: *mut refmvs_frame,
     seq_hdr: *const Dav1dSequenceHeader,
-    frm_hdr: *const Dav1dFrameHeader,
+    frm_hdr: *const Rav1dFrameHeader,
     ref_poc: *const c_uint,
     rp: *mut refmvs_temporal_block,
     ref_ref_poc: *const [c_uint; 7],
@@ -1545,14 +1545,14 @@ pub unsafe fn dav1d_refmvs_init_frame(
     return 0 as c_int;
 }
 
-pub unsafe fn rav1d_refmvs_init(rf: *mut refmvs_frame) {
+pub(crate) unsafe fn rav1d_refmvs_init(rf: *mut refmvs_frame) {
     (*rf).r = 0 as *mut refmvs_block;
     (*rf).r_stride = 0 as c_int as ptrdiff_t;
     (*rf).rp_proj = 0 as *mut refmvs_temporal_block;
     (*rf).rp_stride = 0 as c_int as ptrdiff_t;
 }
 
-pub unsafe fn rav1d_refmvs_clear(rf: *mut refmvs_frame) {
+pub(crate) unsafe fn rav1d_refmvs_clear(rf: *mut refmvs_frame) {
     if !((*rf).r).is_null() {
         rav1d_freep_aligned(&mut (*rf).r as *mut *mut refmvs_block as *mut c_void);
     }
@@ -1654,7 +1654,7 @@ unsafe extern "C" fn refmvs_dsp_init_arm(c: *mut Rav1dRefmvsDSPContext) {
 }
 
 #[cold]
-pub unsafe fn rav1d_refmvs_dsp_init(c: *mut Rav1dRefmvsDSPContext) {
+pub(crate) unsafe fn rav1d_refmvs_dsp_init(c: *mut Rav1dRefmvsDSPContext) {
     (*c).load_tmvs = Some(load_tmvs_c);
     (*c).save_tmvs = Some(save_tmvs_c);
     (*c).splat_mv = Some(splat_mv_rust);

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -1,4 +1,4 @@
-use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
+use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
 use crate::include::dav1d::headers::RAV1D_FILTER_8TAP_REGULAR;
 use crate::include::dav1d::headers::RAV1D_FILTER_8TAP_SHARP;
 use crate::include::dav1d::headers::RAV1D_FILTER_8TAP_SMOOTH;
@@ -745,7 +745,7 @@ pub const interintra_allowed_mask: c_uint = 0
     | 1 << BS_8x8
     | 0;
 
-pub static dav1d_default_wm_params: Dav1dWarpedMotionParams = Dav1dWarpedMotionParams {
+pub(crate) static dav1d_default_wm_params: Rav1dWarpedMotionParams = Rav1dWarpedMotionParams {
     type_0: RAV1D_WM_TYPE_IDENTITY,
     matrix: [0, 0, 1 << 16, 0, 0, 1 << 16],
     abcd: [0; 4],

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -4,7 +4,7 @@ use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::picture::Rav1dPicture;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
-use crate::src::cdf::dav1d_cdf_thread_update;
+use crate::src::cdf::rav1d_cdf_thread_update;
 use crate::src::decode::rav1d_decode_frame_exit;
 use crate::src::decode::rav1d_decode_frame_init;
 use crate::src::decode::rav1d_decode_frame_init_cdf;
@@ -1387,7 +1387,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                             && (*(*f).frame_hdr).tiling.update == tile_idx
                                         {
                                             if error_0 == 0 {
-                                                dav1d_cdf_thread_update(
+                                                rav1d_cdf_thread_update(
                                                     (*f).frame_hdr,
                                                     (*f).out_cdf.data.cdf,
                                                     &mut (*((*f).ts).offset(

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -3,7 +3,7 @@ use crate::include::common::intops::apply_sign64;
 use crate::include::common::intops::iclip;
 use crate::include::common::intops::u64log2;
 use crate::include::common::intops::ulog2;
-use crate::include::dav1d::headers::Dav1dWarpedMotionParams;
+use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
 use crate::src::levels::mv;
 use std::ffi::c_int;
 
@@ -48,7 +48,7 @@ fn resolve_divisor_32(d: u32) -> (c_int, c_int) {
     (shift + 14, div_lut[f as usize] as c_int)
 }
 
-pub fn dav1d_get_shear_params(wm: &mut Dav1dWarpedMotionParams) -> bool {
+pub(crate) fn rav1d_get_shear_params(wm: &mut Rav1dWarpedMotionParams) -> bool {
     let mat = &wm.matrix;
 
     if mat[2] <= 0 {
@@ -97,11 +97,11 @@ fn get_mult_shift_diag(px: i64, idet: c_int, shift: c_int) -> c_int {
     iclip(v2, 0xe001, 0x11fff)
 }
 
-pub fn dav1d_set_affine_mv2d(
+pub(crate) fn rav1d_set_affine_mv2d(
     bw4: c_int,
     bh4: c_int,
     mv: mv,
-    wm: &mut Dav1dWarpedMotionParams,
+    wm: &mut Rav1dWarpedMotionParams,
     bx4: c_int,
     by4: c_int,
 ) {
@@ -123,13 +123,13 @@ pub fn dav1d_set_affine_mv2d(
     );
 }
 
-pub fn dav1d_find_affine_int(
+pub(crate) fn rav1d_find_affine_int(
     pts: &[[[c_int; 2]; 2]; 8],
     np: usize,
     bw4: c_int,
     bh4: c_int,
     mv: mv,
-    wm: &mut Dav1dWarpedMotionParams,
+    wm: &mut Rav1dWarpedMotionParams,
     bx4: c_int,
     by4: c_int,
 ) -> bool {


### PR DESCRIPTION
This adds the generic `struct DRav1d<R, D>` that stores both the `R` `Rav1d*` and `D` `Dav1d` types.  These are meant to be stored in ref-counted `Rav1dRef`s.  This allows us to store pointers to both the `Rav1d*` and `Dav1d*` versions in their containing types, mainly `{D,R}av1dPicture`.  During `DAV1D_API`s, `.update_rav1d()` is called, which updates the `rav1d` version to match the `dav1d` version for internal `rav1d` use.  And after parsing these types (after which no more modifications are done), we call `.update_dav1d()` so that the `dav1d` version is always up-to-date when returning it from `DAV1D_API`s.

There are 5 types that are like this:
* `{D,R}av1dSequenceHeader`
* `{D,R}av1dFrameHeader`
* `{D,R}av1dContentLightLevel`
* `{D,R}av1dMasteringDisplay`
* `{D,R}av1dITUTT35`

Of these, `Dav1dMasteringDisplay` is already fully narrowed integer types, and `Dav1dContentLightLevel` will be after #505 is finished.  So for those, we don't need separate `Rav1d*` and `Dav1d*` types.  But `Dav1d{Sequence,Frame}Header` are much larger and complex, and `Dav1dITUTT35` is simple but contains a pointer, so we want separate types.  Thus, we use the `DRav1d<R, D>` approach for those 3 types.