### PR TITLE
`extern "C" fn`s: Remove `extern "C"` from all `fn`s if possible

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -528,7 +528,7 @@ extern "C" {
 }
 
 #[inline]
-pub unsafe extern "C" fn constrain(diff: c_int, threshold: c_int, shift: c_int) -> c_int {
+pub unsafe fn constrain(diff: c_int, threshold: c_int, shift: c_int) -> c_int {
     let adiff = diff.abs();
     return apply_sign(
         cmp::min(adiff, cmp::max(0 as c_int, threshold - (adiff >> shift))),
@@ -537,7 +537,7 @@ pub unsafe extern "C" fn constrain(diff: c_int, threshold: c_int, shift: c_int) 
 }
 
 #[inline]
-pub unsafe extern "C" fn fill(mut tmp: *mut i16, stride: ptrdiff_t, w: c_int, h: c_int) {
+pub unsafe fn fill(mut tmp: *mut i16, stride: ptrdiff_t, w: c_int, h: c_int) {
     let mut y = 0;
     while y < h {
         let mut x = 0;

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -28,14 +28,14 @@ pub const BACKUP_2X8_UV: Backup2x8Flags = 2;
 pub const BACKUP_2X8_Y: Backup2x8Flags = 1;
 
 #[inline]
-unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
+unsafe fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     if x & 1 != 0 {
         unreachable!();
     }
     return x >> 1;
 }
 
-unsafe extern "C" fn backup2lines(
+unsafe fn backup2lines(
     dst: *const *mut pixel,
     src: *const *mut pixel,
     stride: *const ptrdiff_t,
@@ -93,7 +93,7 @@ unsafe extern "C" fn backup2lines(
     }
 }
 
-unsafe extern "C" fn backup2x8(
+unsafe fn backup2x8(
     dst: *mut [[pixel; 2]; 8],
     src: *const *mut pixel,
     src_stride: *const ptrdiff_t,
@@ -143,7 +143,7 @@ unsafe extern "C" fn backup2x8(
     }
 }
 
-unsafe extern "C" fn adjust_strength(strength: c_int, var: c_uint) -> c_int {
+unsafe fn adjust_strength(strength: c_int, var: c_uint) -> c_int {
     if var == 0 {
         return 0 as c_int;
     }

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -27,7 +27,7 @@ pub type Backup2x8Flags = c_uint;
 pub const BACKUP_2X8_UV: Backup2x8Flags = 2;
 pub const BACKUP_2X8_Y: Backup2x8Flags = 1;
 
-unsafe extern "C" fn backup2lines(
+unsafe fn backup2lines(
     dst: *const *mut pixel,
     src: *const *mut pixel,
     stride: *const ptrdiff_t,
@@ -85,7 +85,7 @@ unsafe extern "C" fn backup2lines(
     }
 }
 
-unsafe extern "C" fn backup2x8(
+unsafe fn backup2x8(
     dst: *mut [[pixel; 2]; 8],
     src: *const *mut pixel,
     src_stride: *const ptrdiff_t,
@@ -135,7 +135,7 @@ unsafe extern "C" fn backup2x8(
     }
 }
 
-unsafe extern "C" fn adjust_strength(strength: c_int, var: c_uint) -> c_int {
+unsafe fn adjust_strength(strength: c_int, var: c_uint) -> c_int {
     if var == 0 {
         return 0 as c_int;
     }

--- a/src/cdef_tmpl_16.rs
+++ b/src/cdef_tmpl_16.rs
@@ -26,14 +26,14 @@ use crate::src::cpu::{rav1d_get_cpu_flags, CpuFlags};
 pub type pixel = u16;
 
 #[inline]
-unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
+unsafe fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     if x & 1 != 0 {
         unreachable!();
     }
     return x >> 1;
 }
 
-unsafe extern "C" fn padding(
+unsafe fn padding(
     mut tmp: *mut i16,
     tmp_stride: ptrdiff_t,
     mut src: *const pixel,
@@ -134,7 +134,7 @@ unsafe extern "C" fn padding(
 }
 
 #[inline(never)]
-unsafe extern "C" fn cdef_filter_block_c(
+unsafe fn cdef_filter_block_c(
     mut dst: *mut pixel,
     dst_stride: ptrdiff_t,
     left: *const [pixel; 2],
@@ -500,7 +500,7 @@ unsafe fn cdef_find_dir_rust(
 
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
-unsafe extern "C" fn cdef_dsp_init_x86(c: *mut Rav1dCdefDSPContext) {
+unsafe fn cdef_dsp_init_x86(c: *mut Rav1dCdefDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::cdef::*;
 
@@ -544,7 +544,7 @@ unsafe extern "C" fn cdef_dsp_init_x86(c: *mut Rav1dCdefDSPContext) {
 
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
-unsafe extern "C" fn cdef_dsp_init_arm(c: *mut Rav1dCdefDSPContext) {
+unsafe fn cdef_dsp_init_arm(c: *mut Rav1dCdefDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::cdef::*;
 

--- a/src/cdef_tmpl_8.rs
+++ b/src/cdef_tmpl_8.rs
@@ -24,7 +24,7 @@ use cfg_if::cfg_if;
 
 pub type pixel = u8;
 
-unsafe extern "C" fn padding(
+unsafe fn padding(
     mut tmp: *mut i16,
     tmp_stride: ptrdiff_t,
     mut src: *const pixel,
@@ -126,7 +126,7 @@ unsafe extern "C" fn padding(
 }
 
 #[inline(never)]
-unsafe extern "C" fn cdef_filter_block_c(
+unsafe fn cdef_filter_block_c(
     mut dst: *mut pixel,
     dst_stride: ptrdiff_t,
     left: *const [pixel; 2],
@@ -486,7 +486,7 @@ use crate::src::cpu::{rav1d_get_cpu_flags, CpuFlags};
 
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
-unsafe extern "C" fn cdef_dsp_init_x86(c: *mut Rav1dCdefDSPContext) {
+unsafe fn cdef_dsp_init_x86(c: *mut Rav1dCdefDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::cdef::*;
 
@@ -541,7 +541,7 @@ unsafe extern "C" fn cdef_dsp_init_x86(c: *mut Rav1dCdefDSPContext) {
 
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
-unsafe extern "C" fn cdef_dsp_init_arm(c: *mut Rav1dCdefDSPContext) {
+unsafe fn cdef_dsp_init_arm(c: *mut Rav1dCdefDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::cdef::*;
 

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -5598,7 +5598,7 @@ pub(crate) unsafe fn rav1d_cdf_thread_update(
 }
 
 #[inline]
-unsafe extern "C" fn get_qcat_idx(q: c_int) -> c_int {
+unsafe fn get_qcat_idx(q: c_int) -> c_int {
     if q <= 20 {
         return 0 as c_int;
     }

--- a/src/fg_apply_tmpl_16.rs
+++ b/src/fg_apply_tmpl_16.rs
@@ -21,19 +21,14 @@ pub type pixel = u16;
 pub type entry = i16;
 
 #[inline]
-unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
+unsafe fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     if x & 1 != 0 {
         unreachable!();
     }
     return x >> 1;
 }
 
-unsafe extern "C" fn generate_scaling(
-    bitdepth: c_int,
-    points: *const [u8; 2],
-    num: c_int,
-    scaling: *mut u8,
-) {
+unsafe fn generate_scaling(bitdepth: c_int, points: *const [u8; 2], num: c_int, scaling: *mut u8) {
     if !(bitdepth > 8) {
         unreachable!();
     }

--- a/src/fg_apply_tmpl_8.rs
+++ b/src/fg_apply_tmpl_8.rs
@@ -19,12 +19,7 @@ use std::ffi::c_void;
 pub type pixel = u8;
 pub type entry = i8;
 
-unsafe extern "C" fn generate_scaling(
-    _bitdepth: c_int,
-    points: *const [u8; 2],
-    num: c_int,
-    scaling: *mut u8,
-) {
+unsafe fn generate_scaling(_bitdepth: c_int, points: *const [u8; 2], num: c_int, scaling: *mut u8) {
     let shift_x = 0;
     let scaling_size = 256;
     if num == 0 {

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -7,7 +7,7 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 
 #[inline]
-pub unsafe extern "C" fn get_random_number(bits: c_int, state: *mut c_uint) -> c_int {
+pub unsafe fn get_random_number(bits: c_int, state: *mut c_uint) -> c_int {
     let r = *state as c_int;
     let bit: c_uint = ((r >> 0 ^ r >> 1 ^ r >> 3 ^ r >> 12) & 1) as c_uint;
     *state = (r >> 1) as c_uint | bit << 15;
@@ -15,7 +15,7 @@ pub unsafe extern "C" fn get_random_number(bits: c_int, state: *mut c_uint) -> c
 }
 
 #[inline]
-pub unsafe extern "C" fn round2(x: c_int, shift: u64) -> c_int {
+pub unsafe fn round2(x: c_int, shift: u64) -> c_int {
     return x + ((1 as c_int) << shift >> 1) >> shift;
 }
 

--- a/src/filmgrain_tmpl_16.rs
+++ b/src/filmgrain_tmpl_16.rs
@@ -359,7 +359,7 @@ pub type pixel = u16;
 pub type entry = i16;
 
 #[inline]
-unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
+unsafe fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     if x & 1 != 0 {
         unreachable!();
     }
@@ -374,7 +374,7 @@ unsafe extern "C" fn generate_grain_y_c_erased(
     generate_grain_y_rust(buf.cast(), data, bitdepth_max)
 }
 
-unsafe extern "C" fn generate_grain_y_rust(
+unsafe fn generate_grain_y_rust(
     buf: *mut [entry; 82],
     data: *const Dav1dFilmGrainData,
     bitdepth_max: c_int,
@@ -431,7 +431,7 @@ unsafe extern "C" fn generate_grain_y_rust(
 }
 
 #[inline(never)]
-unsafe extern "C" fn generate_grain_uv_c(
+unsafe fn generate_grain_uv_c(
     buf: *mut [entry; 82],
     buf_y: *const [entry; 82],
     data: *const Dav1dFilmGrainData,
@@ -572,7 +572,7 @@ unsafe extern "C" fn generate_grain_uv_444_c_erased(
 }
 
 #[inline]
-unsafe extern "C" fn sample_lut(
+unsafe fn sample_lut(
     grain_lut: *const [entry; 82],
     offsets: *const [c_int; 2],
     subx: c_int,
@@ -615,7 +615,7 @@ unsafe extern "C" fn fgy_32x32xn_c_erased(
     );
 }
 
-unsafe extern "C" fn fgy_32x32xn_rust(
+unsafe fn fgy_32x32xn_rust(
     dst_row: *mut pixel,
     src_row: *const pixel,
     stride: ptrdiff_t,
@@ -882,7 +882,7 @@ unsafe extern "C" fn fgy_32x32xn_rust(
 }
 
 #[inline(never)]
-unsafe extern "C" fn fguv_32x32xn_c(
+unsafe fn fguv_32x32xn_c(
     dst_row: *mut pixel,
     src_row: *const pixel,
     stride: ptrdiff_t,
@@ -1341,7 +1341,7 @@ unsafe extern "C" fn fguv_32x32xn_444_c_erased(
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
 #[inline(always)]
-unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Rav1dFilmGrainDSPContext) {
+unsafe fn film_grain_dsp_init_x86(c: *mut Rav1dFilmGrainDSPContext) {
     let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSSE3) {
@@ -1404,7 +1404,7 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Rav1dFilmGrainDSPContext) {
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 #[inline(always)]
-unsafe extern "C" fn film_grain_dsp_init_arm(c: *mut Rav1dFilmGrainDSPContext) {
+unsafe fn film_grain_dsp_init_arm(c: *mut Rav1dFilmGrainDSPContext) {
     let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::NEON) {
@@ -1453,7 +1453,7 @@ unsafe extern "C" fn fgy_32x32xn_neon_erased(
 }
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
-unsafe extern "C" fn fgy_32x32xn_neon(
+unsafe fn fgy_32x32xn_neon(
     dst_row: *mut pixel,
     src_row: *const pixel,
     stride: ptrdiff_t,
@@ -1550,7 +1550,7 @@ unsafe extern "C" fn fguv_32x32xn_420_neon_erased(
 }
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
-unsafe extern "C" fn fguv_32x32xn_420_neon(
+unsafe fn fguv_32x32xn_420_neon(
     dst_row: *mut pixel,
     src_row: *const pixel,
     stride: ptrdiff_t,
@@ -1657,7 +1657,7 @@ unsafe extern "C" fn fguv_32x32xn_422_neon_erased(
 }
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
-unsafe extern "C" fn fguv_32x32xn_422_neon(
+unsafe fn fguv_32x32xn_422_neon(
     dst_row: *mut pixel,
     src_row: *const pixel,
     stride: ptrdiff_t,
@@ -1764,7 +1764,7 @@ unsafe extern "C" fn fguv_32x32xn_444_neon_erased(
 }
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
-unsafe extern "C" fn fguv_32x32xn_444_neon(
+unsafe fn fguv_32x32xn_444_neon(
     dst_row: *mut pixel,
     src_row: *const pixel,
     stride: ptrdiff_t,

--- a/src/filmgrain_tmpl_8.rs
+++ b/src/filmgrain_tmpl_8.rs
@@ -362,7 +362,7 @@ unsafe extern "C" fn generate_grain_y_c_erased(
     generate_grain_y_rust(buf.cast(), data);
 }
 
-unsafe extern "C" fn generate_grain_y_rust(buf: *mut [entry; 82], data: *const Dav1dFilmGrainData) {
+unsafe fn generate_grain_y_rust(buf: *mut [entry; 82], data: *const Dav1dFilmGrainData) {
     let bitdepth_min_8 = 8 - 8;
     let mut seed: c_uint = (*data).seed;
     let shift = 4 - bitdepth_min_8 + (*data).grain_scale_shift;
@@ -415,7 +415,7 @@ unsafe extern "C" fn generate_grain_y_rust(buf: *mut [entry; 82], data: *const D
 }
 
 #[inline(never)]
-unsafe extern "C" fn generate_grain_uv_c(
+unsafe fn generate_grain_uv_c(
     buf: *mut [entry; 82],
     buf_y: *const [entry; 82],
     data: *const Dav1dFilmGrainData,
@@ -531,7 +531,7 @@ unsafe extern "C" fn generate_grain_uv_444_c_erased(
 }
 
 #[inline]
-unsafe extern "C" fn sample_lut(
+unsafe fn sample_lut(
     grain_lut: *const [entry; 82],
     offsets: *const [c_int; 2],
     subx: c_int,
@@ -573,7 +573,7 @@ unsafe extern "C" fn fgy_32x32xn_c_erased(
     );
 }
 
-unsafe extern "C" fn fgy_32x32xn_rust(
+unsafe fn fgy_32x32xn_rust(
     dst_row: *mut pixel,
     src_row: *const pixel,
     stride: ptrdiff_t,
@@ -839,7 +839,7 @@ unsafe extern "C" fn fgy_32x32xn_rust(
 }
 
 #[inline(never)]
-unsafe extern "C" fn fguv_32x32xn_c(
+unsafe fn fguv_32x32xn_c(
     dst_row: *mut pixel,
     src_row: *const pixel,
     stride: ptrdiff_t,
@@ -1286,7 +1286,7 @@ unsafe extern "C" fn fguv_32x32xn_444_c_erased(
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
 #[inline(always)]
-unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Rav1dFilmGrainDSPContext) {
+unsafe fn film_grain_dsp_init_x86(c: *mut Rav1dFilmGrainDSPContext) {
     let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSSE3) {
@@ -1349,7 +1349,7 @@ unsafe extern "C" fn film_grain_dsp_init_x86(c: *mut Rav1dFilmGrainDSPContext) {
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 #[inline(always)]
-unsafe extern "C" fn film_grain_dsp_init_arm(c: *mut Rav1dFilmGrainDSPContext) {
+unsafe fn film_grain_dsp_init_arm(c: *mut Rav1dFilmGrainDSPContext) {
     let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::NEON) {
@@ -1397,7 +1397,7 @@ unsafe extern "C" fn fgy_32x32xn_neon_erased(
 }
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
-unsafe extern "C" fn fgy_32x32xn_neon(
+unsafe fn fgy_32x32xn_neon(
     dst_row: *mut pixel,
     src_row: *const pixel,
     stride: ptrdiff_t,
@@ -1491,7 +1491,7 @@ unsafe extern "C" fn fguv_32x32xn_420_neon_erased(
 }
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
-unsafe extern "C" fn fguv_32x32xn_420_neon(
+unsafe fn fguv_32x32xn_420_neon(
     dst_row: *mut pixel,
     src_row: *const pixel,
     stride: ptrdiff_t,
@@ -1595,7 +1595,7 @@ unsafe extern "C" fn fguv_32x32xn_422_neon_erased(
 }
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
-unsafe extern "C" fn fguv_32x32xn_422_neon(
+unsafe fn fguv_32x32xn_422_neon(
     dst_row: *mut pixel,
     src_row: *const pixel,
     stride: ptrdiff_t,
@@ -1699,7 +1699,7 @@ unsafe extern "C" fn fguv_32x32xn_444_neon_erased(
 }
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
-unsafe extern "C" fn fguv_32x32xn_444_neon(
+unsafe fn fguv_32x32xn_444_neon(
     dst_row: *mut pixel,
     src_row: *const pixel,
     stride: ptrdiff_t,

--- a/src/getbits.rs
+++ b/src/getbits.rs
@@ -45,7 +45,7 @@ pub unsafe fn rav1d_get_bit(c: *mut GetBits) -> c_uint {
 }
 
 #[inline]
-unsafe extern "C" fn refill(c: *mut GetBits, n: c_int) {
+unsafe fn refill(c: *mut GetBits, n: c_int) {
     if !((*c).bits_left >= 0 && (*c).bits_left < 32) {
         unreachable!();
     }
@@ -150,7 +150,7 @@ pub unsafe fn rav1d_get_vlc(c: *mut GetBits) -> c_uint {
         .wrapping_add(rav1d_get_bits(c, n_bits));
 }
 
-unsafe extern "C" fn get_bits_subexp_u(c: *mut GetBits, r#ref: c_uint, n: c_uint) -> c_uint {
+unsafe fn get_bits_subexp_u(c: *mut GetBits, r#ref: c_uint, n: c_uint) -> c_uint {
     let mut v: c_uint = 0 as c_int as c_uint;
     let mut i = 0;
     loop {

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -3,7 +3,7 @@ use libc::ptrdiff_t;
 use std::ffi::c_int;
 
 #[inline]
-pub unsafe extern "C" fn get_upsample(wh: c_int, angle: c_int, is_sm: c_int) -> c_int {
+pub unsafe fn get_upsample(wh: c_int, angle: c_int, is_sm: c_int) -> c_int {
     return (angle < 40 && wh <= 16 >> is_sm) as c_int;
 }
 

--- a/src/ipred_tmpl_16.rs
+++ b/src/ipred_tmpl_16.rs
@@ -134,7 +134,7 @@ extern "C" {
 pub type pixel = u16;
 
 #[inline]
-unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
+unsafe fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     if x & 1 != 0 {
         unreachable!();
     }
@@ -142,7 +142,7 @@ unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
 }
 
 #[inline]
-unsafe extern "C" fn pixel_set(dst: *mut pixel, val: c_int, num: c_int) {
+unsafe fn pixel_set(dst: *mut pixel, val: c_int, num: c_int) {
     let mut n = 0;
     while n < num {
         *dst.offset(n as isize) = val as pixel;
@@ -151,7 +151,7 @@ unsafe extern "C" fn pixel_set(dst: *mut pixel, val: c_int, num: c_int) {
 }
 
 #[inline(never)]
-unsafe extern "C" fn splat_dc(
+unsafe fn splat_dc(
     mut dst: *mut pixel,
     stride: ptrdiff_t,
     width: c_int,
@@ -177,7 +177,7 @@ unsafe extern "C" fn splat_dc(
 }
 
 #[inline(never)]
-unsafe extern "C" fn cfl_pred(
+unsafe fn cfl_pred(
     mut dst: *mut pixel,
     stride: ptrdiff_t,
     width: c_int,
@@ -205,7 +205,7 @@ unsafe extern "C" fn cfl_pred(
     }
 }
 
-unsafe extern "C" fn dc_gen_top(topleft: *const pixel, width: c_int) -> c_uint {
+unsafe fn dc_gen_top(topleft: *const pixel, width: c_int) -> c_uint {
     let mut dc: c_uint = (width >> 1) as c_uint;
     let mut i = 0;
     while i < width {
@@ -258,7 +258,7 @@ unsafe extern "C" fn ipred_cfl_top_c_erased(
     );
 }
 
-unsafe extern "C" fn dc_gen_left(topleft: *const pixel, height: c_int) -> c_uint {
+unsafe fn dc_gen_left(topleft: *const pixel, height: c_int) -> c_uint {
     let mut dc: c_uint = (height >> 1) as c_uint;
     let mut i = 0;
     while i < height {
@@ -312,7 +312,7 @@ unsafe extern "C" fn ipred_cfl_left_c_erased(
     );
 }
 
-unsafe extern "C" fn dc_gen(topleft: *const pixel, width: c_int, height: c_int) -> c_uint {
+unsafe fn dc_gen(topleft: *const pixel, width: c_int, height: c_int) -> c_uint {
     let mut dc: c_uint = (width + height >> 1) as c_uint;
     let mut i = 0;
     while i < width {
@@ -732,7 +732,7 @@ unsafe fn ipred_smooth_h_rust(
 }
 
 #[inline(never)]
-unsafe extern "C" fn get_filter_strength(wh: c_int, angle: c_int, is_sm: c_int) -> c_int {
+unsafe fn get_filter_strength(wh: c_int, angle: c_int, is_sm: c_int) -> c_int {
     if is_sm != 0 {
         if wh <= 8 {
             if angle >= 64 {
@@ -788,7 +788,7 @@ unsafe extern "C" fn get_filter_strength(wh: c_int, angle: c_int, is_sm: c_int) 
 }
 
 #[inline(never)]
-unsafe extern "C" fn filter_edge(
+unsafe fn filter_edge(
     out: *mut pixel,
     sz: c_int,
     lim_from: c_int,
@@ -825,7 +825,7 @@ unsafe extern "C" fn filter_edge(
 }
 
 #[inline(never)]
-unsafe extern "C" fn upsample_edge(
+unsafe fn upsample_edge(
     out: *mut pixel,
     hsz: c_int,
     in_0: *const pixel,
@@ -1331,7 +1331,7 @@ unsafe fn ipred_filter_rust(
 }
 
 #[inline(never)]
-unsafe extern "C" fn cfl_ac_c(
+unsafe fn cfl_ac_c(
     mut ac: *mut i16,
     mut ypx: *const pixel,
     stride: ptrdiff_t,
@@ -1493,7 +1493,7 @@ unsafe extern "C" fn pal_pred_c_erased(
     pal_pred_rust(dst.cast(), stride, pal, idx, w, h);
 }
 
-unsafe extern "C" fn pal_pred_rust(
+unsafe fn pal_pred_rust(
     mut dst: *mut pixel,
     stride: ptrdiff_t,
     pal: *const u16,
@@ -1516,7 +1516,7 @@ unsafe extern "C" fn pal_pred_rust(
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
 #[inline(always)]
-unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Rav1dIntraPredDSPContext) {
+unsafe fn intra_pred_dsp_init_x86(c: *mut Rav1dIntraPredDSPContext) {
     use crate::src::ipred::*; // TODO(legare): Temporary import until init fns are deduplicated.
 
     let flags = rav1d_get_cpu_flags();
@@ -1599,7 +1599,7 @@ unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Rav1dIntraPredDSPContext) {
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 #[inline(always)]
-unsafe extern "C" fn intra_pred_dsp_init_arm(c: *mut Rav1dIntraPredDSPContext) {
+unsafe fn intra_pred_dsp_init_arm(c: *mut Rav1dIntraPredDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::ipred::*;
 

--- a/src/ipred_tmpl_16.rs
+++ b/src/ipred_tmpl_16.rs
@@ -1324,12 +1324,8 @@ unsafe fn ipred_filter_rust(
             topleft = &*top.offset(-(1 as c_int) as isize) as *const pixel;
             x += 4 as c_int;
         }
-        top = &mut *dst
-            .offset((PXSTRIDE as unsafe extern "C" fn(ptrdiff_t) -> ptrdiff_t)(stride) as isize)
-            as *mut pixel;
-        dst = &mut *dst.offset(
-            ((PXSTRIDE as unsafe extern "C" fn(ptrdiff_t) -> ptrdiff_t)(stride) * 2) as isize,
-        ) as *mut pixel;
+        top = &mut *dst.offset((PXSTRIDE)(stride) as isize) as *mut pixel;
+        dst = &mut *dst.offset(((PXSTRIDE)(stride) * 2) as isize) as *mut pixel;
         y += 2 as c_int;
     }
 }

--- a/src/ipred_tmpl_8.rs
+++ b/src/ipred_tmpl_8.rs
@@ -130,13 +130,7 @@ extern "C" {
 pub type pixel = u8;
 
 #[inline(never)]
-unsafe extern "C" fn splat_dc(
-    mut dst: *mut pixel,
-    stride: ptrdiff_t,
-    width: c_int,
-    height: c_int,
-    dc: c_int,
-) {
+unsafe fn splat_dc(mut dst: *mut pixel, stride: ptrdiff_t, width: c_int, height: c_int, dc: c_int) {
     if !(dc <= 0xff as c_int) {
         unreachable!();
     }
@@ -170,7 +164,7 @@ unsafe extern "C" fn splat_dc(
 }
 
 #[inline(never)]
-unsafe extern "C" fn cfl_pred(
+unsafe fn cfl_pred(
     mut dst: *mut pixel,
     stride: ptrdiff_t,
     width: c_int,
@@ -194,7 +188,7 @@ unsafe extern "C" fn cfl_pred(
     }
 }
 
-unsafe extern "C" fn dc_gen_top(topleft: *const pixel, width: c_int) -> c_uint {
+unsafe fn dc_gen_top(topleft: *const pixel, width: c_int) -> c_uint {
     let mut dc: c_uint = (width >> 1) as c_uint;
     let mut i = 0;
     while i < width {
@@ -245,7 +239,7 @@ unsafe extern "C" fn ipred_cfl_top_c_erased(
     );
 }
 
-unsafe extern "C" fn dc_gen_left(topleft: *const pixel, height: c_int) -> c_uint {
+unsafe fn dc_gen_left(topleft: *const pixel, height: c_int) -> c_uint {
     let mut dc: c_uint = (height >> 1) as c_uint;
     let mut i = 0;
     while i < height {
@@ -289,7 +283,7 @@ unsafe extern "C" fn ipred_cfl_left_c_erased(
     cfl_pred(dst.cast(), stride, width, height, dc as c_int, ac, alpha);
 }
 
-unsafe extern "C" fn dc_gen(topleft: *const pixel, width: c_int, height: c_int) -> c_uint {
+unsafe fn dc_gen(topleft: *const pixel, width: c_int, height: c_int) -> c_uint {
     let mut dc: c_uint = (width + height >> 1) as c_uint;
     let mut i = 0;
     while i < width {
@@ -682,7 +676,7 @@ unsafe fn ipred_smooth_h_rust(
 }
 
 #[inline(never)]
-unsafe extern "C" fn get_filter_strength(wh: c_int, angle: c_int, is_sm: c_int) -> c_int {
+unsafe fn get_filter_strength(wh: c_int, angle: c_int, is_sm: c_int) -> c_int {
     if is_sm != 0 {
         if wh <= 8 {
             if angle >= 64 {
@@ -738,7 +732,7 @@ unsafe extern "C" fn get_filter_strength(wh: c_int, angle: c_int, is_sm: c_int) 
 }
 
 #[inline(never)]
-unsafe extern "C" fn filter_edge(
+unsafe fn filter_edge(
     out: *mut pixel,
     sz: c_int,
     lim_from: c_int,
@@ -775,13 +769,7 @@ unsafe extern "C" fn filter_edge(
 }
 
 #[inline(never)]
-unsafe extern "C" fn upsample_edge(
-    out: *mut pixel,
-    hsz: c_int,
-    in_0: *const pixel,
-    from: c_int,
-    to: c_int,
-) {
+unsafe fn upsample_edge(out: *mut pixel, hsz: c_int, in_0: *const pixel, from: c_int, to: c_int) {
     static kernel: [i8; 4] = [-1, 9, 9, -1];
     let mut i;
     i = 0 as c_int;
@@ -1260,7 +1248,7 @@ unsafe fn ipred_filter_rust(
 }
 
 #[inline(never)]
-unsafe extern "C" fn cfl_ac_c(
+unsafe fn cfl_ac_c(
     mut ac: *mut i16,
     mut ypx: *const pixel,
     stride: ptrdiff_t,
@@ -1443,7 +1431,7 @@ unsafe fn pal_pred_rust(
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
 #[inline(always)]
-unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Rav1dIntraPredDSPContext) {
+unsafe fn intra_pred_dsp_init_x86(c: *mut Rav1dIntraPredDSPContext) {
     use crate::src::ipred::*; // TODO(legare): Temporary import until init fns are deduplicated.
 
     let flags = rav1d_get_cpu_flags();
@@ -1532,7 +1520,7 @@ unsafe extern "C" fn intra_pred_dsp_init_x86(c: *mut Rav1dIntraPredDSPContext) {
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 #[inline(always)]
-unsafe extern "C" fn intra_pred_dsp_init_arm(c: *mut Rav1dIntraPredDSPContext) {
+unsafe fn intra_pred_dsp_init_arm(c: *mut Rav1dIntraPredDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::ipred::*;
 

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -13,7 +13,7 @@ use std::ffi::c_void;
 
 pub type itx_1d_fn = Option<unsafe extern "C" fn(*mut i32, ptrdiff_t, c_int, c_int) -> ()>;
 
-pub unsafe extern "C" fn inv_txfm_add_rust<BD: BitDepth>(
+pub unsafe fn inv_txfm_add_rust<BD: BitDepth>(
     mut dst: *mut BD::Pixel,
     stride: ptrdiff_t,
     coeff: *mut BD::Coef,

--- a/src/itx_1d.rs
+++ b/src/itx_1d.rs
@@ -3,7 +3,7 @@ use libc::ptrdiff_t;
 use std::ffi::c_int;
 
 #[inline(never)]
-unsafe extern "C" fn inv_dct4_1d_internal_c(
+unsafe fn inv_dct4_1d_internal_c(
     c: *mut i32,
     stride: ptrdiff_t,
     min: c_int,
@@ -48,7 +48,7 @@ pub unsafe extern "C" fn dav1d_inv_dct4_1d_c(
 }
 
 #[inline(never)]
-unsafe extern "C" fn inv_dct8_1d_internal_c(
+unsafe fn inv_dct8_1d_internal_c(
     c: *mut i32,
     stride: ptrdiff_t,
     min: c_int,
@@ -108,7 +108,7 @@ pub unsafe extern "C" fn dav1d_inv_dct8_1d_c(
 }
 
 #[inline(never)]
-unsafe extern "C" fn inv_dct16_1d_internal_c(
+unsafe fn inv_dct16_1d_internal_c(
     c: *mut i32,
     stride: ptrdiff_t,
     min: c_int,
@@ -214,7 +214,7 @@ pub unsafe extern "C" fn dav1d_inv_dct16_1d_c(
 }
 
 #[inline(never)]
-unsafe extern "C" fn inv_dct32_1d_internal_c(
+unsafe fn inv_dct32_1d_internal_c(
     c: *mut i32,
     stride: ptrdiff_t,
     min: c_int,
@@ -772,7 +772,7 @@ pub unsafe extern "C" fn dav1d_inv_dct64_1d_c(
 }
 
 #[inline(never)]
-unsafe extern "C" fn inv_adst4_1d_internal_c(
+unsafe fn inv_adst4_1d_internal_c(
     in_0: *const i32,
     in_s: ptrdiff_t,
     _min: c_int,
@@ -806,7 +806,7 @@ unsafe extern "C" fn inv_adst4_1d_internal_c(
 }
 
 #[inline(never)]
-unsafe extern "C" fn inv_adst8_1d_internal_c(
+unsafe fn inv_adst8_1d_internal_c(
     in_0: *const i32,
     in_s: ptrdiff_t,
     min: c_int,
@@ -860,7 +860,7 @@ unsafe extern "C" fn inv_adst8_1d_internal_c(
 }
 
 #[inline(never)]
-unsafe extern "C" fn inv_adst16_1d_internal_c(
+unsafe fn inv_adst16_1d_internal_c(
     in_0: *const i32,
     in_s: ptrdiff_t,
     min: c_int,
@@ -1120,7 +1120,7 @@ pub unsafe extern "C" fn dav1d_inv_identity32_1d_c(
     }
 }
 
-pub unsafe extern "C" fn dav1d_inv_wht4_1d_c(c: *mut i32, stride: ptrdiff_t) {
+pub unsafe fn dav1d_inv_wht4_1d_c(c: *mut i32, stride: ptrdiff_t) {
     if !(stride > 0) {
         unreachable!();
     }

--- a/src/itx_tmpl_16.rs
+++ b/src/itx_tmpl_16.rs
@@ -54,7 +54,7 @@ pub type pixel = u16;
 pub type coef = i32;
 
 #[inline]
-unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
+unsafe fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     if x & 1 != 0 {
         unreachable!();
     }
@@ -71,7 +71,7 @@ unsafe extern "C" fn inv_txfm_add_wht_wht_4x4_c_erased(
     inv_txfm_add_wht_wht_4x4_rust(dst.cast(), stride, coeff.cast(), eob, bitdepth_max);
 }
 
-unsafe extern "C" fn inv_txfm_add_wht_wht_4x4_rust(
+unsafe fn inv_txfm_add_wht_wht_4x4_rust(
     mut dst: *mut pixel,
     stride: ptrdiff_t,
     coeff: *mut coef,
@@ -130,7 +130,7 @@ unsafe extern "C" fn inv_txfm_add_wht_wht_4x4_rust(
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
 #[rustfmt::skip]
-unsafe extern "C" fn itx_dsp_init_x86(c: *mut Rav1dInvTxfmDSPContext, bpc: c_int) {
+unsafe fn itx_dsp_init_x86(c: *mut Rav1dInvTxfmDSPContext, bpc: c_int) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::itx::*;
 
@@ -709,7 +709,7 @@ unsafe extern "C" fn itx_dsp_init_x86(c: *mut Rav1dInvTxfmDSPContext, bpc: c_int
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]
-unsafe extern "C" fn itx_dsp_init_arm(c: *mut Rav1dInvTxfmDSPContext, bpc: c_int) {
+unsafe fn itx_dsp_init_arm(c: *mut Rav1dInvTxfmDSPContext, bpc: c_int) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::itx::*;
 

--- a/src/itx_tmpl_8.rs
+++ b/src/itx_tmpl_8.rs
@@ -118,7 +118,7 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust(
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
 #[rustfmt::skip]
-unsafe extern "C" fn itx_dsp_init_x86(c: *mut Rav1dInvTxfmDSPContext, _bpc: c_int) {
+unsafe fn itx_dsp_init_x86(c: *mut Rav1dInvTxfmDSPContext, _bpc: c_int) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::itx::*;
 
@@ -622,7 +622,7 @@ unsafe extern "C" fn itx_dsp_init_x86(c: *mut Rav1dInvTxfmDSPContext, _bpc: c_in
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]
 #[rustfmt::skip]
-unsafe extern "C" fn itx_dsp_init_arm(c: *mut Rav1dInvTxfmDSPContext, mut _bpc: c_int) {
+unsafe fn itx_dsp_init_arm(c: *mut Rav1dInvTxfmDSPContext, mut _bpc: c_int) {
         // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::itx::*;
 

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -52,47 +52,31 @@ unsafe extern "C" fn backup_lpf(
         if row != 0 {
             let top = (4 as c_int) << sb128;
             memcpy(
-                &mut *dst.offset(
-                    ((PXSTRIDE as unsafe extern "C" fn(ptrdiff_t) -> ptrdiff_t)(dst_stride)
-                        * 0 as isize) as isize,
-                ) as *mut pixel as *mut c_void,
-                &mut *dst.offset(
-                    ((PXSTRIDE as unsafe extern "C" fn(ptrdiff_t) -> ptrdiff_t)(dst_stride)
-                        * top as isize) as isize,
-                ) as *mut pixel as *const c_void,
+                &mut *dst.offset(((PXSTRIDE)(dst_stride) * 0 as isize) as isize) as *mut pixel
+                    as *mut c_void,
+                &mut *dst.offset(((PXSTRIDE)(dst_stride) * top as isize) as isize) as *mut pixel
+                    as *const c_void,
                 (dst_w << 1) as usize,
             );
             memcpy(
-                &mut *dst.offset(
-                    ((PXSTRIDE as unsafe extern "C" fn(ptrdiff_t) -> ptrdiff_t)(dst_stride)
-                        * 1 as isize) as isize,
-                ) as *mut pixel as *mut c_void,
-                &mut *dst.offset(
-                    ((PXSTRIDE as unsafe extern "C" fn(ptrdiff_t) -> ptrdiff_t)(dst_stride)
-                        * (top + 1) as isize) as isize,
-                ) as *mut pixel as *const c_void,
+                &mut *dst.offset(((PXSTRIDE)(dst_stride) * 1 as isize) as isize) as *mut pixel
+                    as *mut c_void,
+                &mut *dst.offset(((PXSTRIDE)(dst_stride) * (top + 1) as isize) as isize)
+                    as *mut pixel as *const c_void,
                 (dst_w << 1) as usize,
             );
             memcpy(
-                &mut *dst.offset(
-                    ((PXSTRIDE as unsafe extern "C" fn(ptrdiff_t) -> ptrdiff_t)(dst_stride)
-                        * 2 as isize) as isize,
-                ) as *mut pixel as *mut c_void,
-                &mut *dst.offset(
-                    ((PXSTRIDE as unsafe extern "C" fn(ptrdiff_t) -> ptrdiff_t)(dst_stride)
-                        * (top + 2) as isize) as isize,
-                ) as *mut pixel as *const c_void,
+                &mut *dst.offset(((PXSTRIDE)(dst_stride) * 2 as isize) as isize) as *mut pixel
+                    as *mut c_void,
+                &mut *dst.offset(((PXSTRIDE)(dst_stride) * (top + 2) as isize) as isize)
+                    as *mut pixel as *const c_void,
                 (dst_w << 1) as usize,
             );
             memcpy(
-                &mut *dst.offset(
-                    ((PXSTRIDE as unsafe extern "C" fn(ptrdiff_t) -> ptrdiff_t)(dst_stride)
-                        * 3 as isize) as isize,
-                ) as *mut pixel as *mut c_void,
-                &mut *dst.offset(
-                    ((PXSTRIDE as unsafe extern "C" fn(ptrdiff_t) -> ptrdiff_t)(dst_stride)
-                        * (top + 3) as isize) as isize,
-                ) as *mut pixel as *const c_void,
+                &mut *dst.offset(((PXSTRIDE)(dst_stride) * 3 as isize) as isize) as *mut pixel
+                    as *mut c_void,
+                &mut *dst.offset(((PXSTRIDE)(dst_stride) * (top + 3) as isize) as isize)
+                    as *mut pixel as *const c_void,
                 (dst_w << 1) as usize,
             );
         }
@@ -120,9 +104,8 @@ unsafe extern "C" fn backup_lpf(
             if n_lines == 3 {
                 memcpy(
                     dst as *mut c_void,
-                    &mut *dst.offset(-(PXSTRIDE as unsafe extern "C" fn(ptrdiff_t) -> ptrdiff_t)(
-                        dst_stride,
-                    ) as isize) as *mut pixel as *const c_void,
+                    &mut *dst.offset(-(PXSTRIDE)(dst_stride) as isize) as *mut pixel
+                        as *const c_void,
                     (dst_w << 1) as usize,
                 );
                 dst = dst.offset(PXSTRIDE(dst_stride) as isize);
@@ -136,10 +119,8 @@ unsafe extern "C" fn backup_lpf(
                 memcpy(
                     dst as *mut c_void,
                     (if i == n_lines_0 {
-                        &mut *dst
-                            .offset(-(PXSTRIDE as unsafe extern "C" fn(ptrdiff_t) -> ptrdiff_t)(
-                                dst_stride,
-                            ) as isize) as *mut pixel as *const pixel
+                        &mut *dst.offset(-(PXSTRIDE)(dst_stride) as isize) as *mut pixel
+                            as *const pixel
                     } else {
                         src
                     }) as *const c_void,

--- a/src/lf_apply_tmpl_16.rs
+++ b/src/lf_apply_tmpl_16.rs
@@ -18,14 +18,14 @@ use std::ffi::c_void;
 pub type pixel = u16;
 
 #[inline]
-unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
+unsafe fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     if x & 1 != 0 {
         unreachable!();
     }
     return x >> 1;
 }
 
-unsafe extern "C" fn backup_lpf(
+unsafe fn backup_lpf(
     f: *const Rav1dFrameContext,
     mut dst: *mut pixel,
     dst_stride: ptrdiff_t,
@@ -294,7 +294,7 @@ pub(crate) unsafe fn rav1d_copy_lpf_16bpc(
 }
 
 #[inline]
-unsafe extern "C" fn filter_plane_cols_y(
+unsafe fn filter_plane_cols_y(
     f: *const Rav1dFrameContext,
     have_left: c_int,
     lvl: *const [u8; 4],
@@ -342,7 +342,7 @@ unsafe extern "C" fn filter_plane_cols_y(
 }
 
 #[inline]
-unsafe extern "C" fn filter_plane_rows_y(
+unsafe fn filter_plane_rows_y(
     f: *const Rav1dFrameContext,
     have_top: c_int,
     mut lvl: *const [u8; 4],
@@ -385,7 +385,7 @@ unsafe extern "C" fn filter_plane_rows_y(
 }
 
 #[inline]
-unsafe extern "C" fn filter_plane_cols_uv(
+unsafe fn filter_plane_cols_uv(
     f: *const Rav1dFrameContext,
     have_left: c_int,
     lvl: *const [u8; 4],
@@ -442,7 +442,7 @@ unsafe extern "C" fn filter_plane_cols_uv(
 }
 
 #[inline]
-unsafe extern "C" fn filter_plane_rows_uv(
+unsafe fn filter_plane_rows_uv(
     f: *const Rav1dFrameContext,
     have_top: c_int,
     mut lvl: *const [u8; 4],

--- a/src/lf_apply_tmpl_8.rs
+++ b/src/lf_apply_tmpl_8.rs
@@ -17,7 +17,7 @@ use std::ffi::c_void;
 
 pub type pixel = u8;
 
-unsafe extern "C" fn backup_lpf(
+unsafe fn backup_lpf(
     f: *const Rav1dFrameContext,
     mut dst: *mut pixel,
     dst_stride: ptrdiff_t,
@@ -278,7 +278,7 @@ pub(crate) unsafe fn rav1d_copy_lpf_8bpc(
 }
 
 #[inline]
-unsafe extern "C" fn filter_plane_cols_y(
+unsafe fn filter_plane_cols_y(
     f: *const Rav1dFrameContext,
     have_left: c_int,
     lvl: *const [u8; 4],
@@ -326,7 +326,7 @@ unsafe extern "C" fn filter_plane_cols_y(
 }
 
 #[inline]
-unsafe extern "C" fn filter_plane_rows_y(
+unsafe fn filter_plane_rows_y(
     f: *const Rav1dFrameContext,
     have_top: c_int,
     mut lvl: *const [u8; 4],
@@ -369,7 +369,7 @@ unsafe extern "C" fn filter_plane_rows_y(
 }
 
 #[inline]
-unsafe extern "C" fn filter_plane_cols_uv(
+unsafe fn filter_plane_cols_uv(
     f: *const Rav1dFrameContext,
     have_left: c_int,
     lvl: *const [u8; 4],
@@ -426,7 +426,7 @@ unsafe extern "C" fn filter_plane_cols_uv(
 }
 
 #[inline]
-unsafe extern "C" fn filter_plane_rows_uv(
+unsafe fn filter_plane_rows_uv(
     f: *const Rav1dFrameContext,
     have_top: c_int,
     mut lvl: *const [u8; 4],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,16 +402,8 @@ pub(crate) unsafe fn rav1d_open(c_out: *mut *mut Rav1dContext, s: *const Rav1dSe
     {
         return error(c, c_out, &mut thread_attr);
     }
-    if (*c).allocator.alloc_picture_callback
-        == Some(
-            dav1d_default_picture_alloc
-                as unsafe extern "C" fn(*mut Dav1dPicture, *mut c_void) -> c_int,
-        )
-        && (*c).allocator.release_picture_callback
-            == Some(
-                dav1d_default_picture_release
-                    as unsafe extern "C" fn(*mut Dav1dPicture, *mut c_void) -> (),
-            )
+    if (*c).allocator.alloc_picture_callback == Some(dav1d_default_picture_alloc)
+        && (*c).allocator.release_picture_callback == Some(dav1d_default_picture_release)
     {
         if !((*c).allocator.cookie).is_null() {
             return error(c, c_out, &mut thread_attr);
@@ -420,16 +412,8 @@ pub(crate) unsafe fn rav1d_open(c_out: *mut *mut Rav1dContext, s: *const Rav1dSe
             return error(c, c_out, &mut thread_attr);
         }
         (*c).allocator.cookie = (*c).picture_pool as *mut c_void;
-    } else if (*c).allocator.alloc_picture_callback
-        == Some(
-            dav1d_default_picture_alloc
-                as unsafe extern "C" fn(*mut Dav1dPicture, *mut c_void) -> c_int,
-        )
-        || (*c).allocator.release_picture_callback
-            == Some(
-                dav1d_default_picture_release
-                    as unsafe extern "C" fn(*mut Dav1dPicture, *mut c_void) -> (),
-            )
+    } else if (*c).allocator.alloc_picture_callback == Some(dav1d_default_picture_alloc)
+        || (*c).allocator.release_picture_callback == Some(dav1d_default_picture_release)
     {
         return error(c, c_out, &mut thread_attr);
     }
@@ -563,7 +547,7 @@ pub(crate) unsafe fn rav1d_open(c_out: *mut *mut Rav1dContext, s: *const Rav1dSe
             if pthread_create(
                 &mut (*t).task_thread.td.thread,
                 &mut thread_attr,
-                Some(rav1d_worker_task as unsafe extern "C" fn(*mut c_void) -> *mut c_void),
+                Some(rav1d_worker_task),
                 t as *mut c_void,
             ) != 0
             {
@@ -653,13 +637,7 @@ pub(crate) unsafe fn rav1d_parse_sequence_header(
         return res;
     }
     if !ptr.is_null() {
-        res = rav1d_data_wrap_internal(
-            &mut buf,
-            ptr,
-            sz,
-            Some(dummy_free as unsafe extern "C" fn(*const u8, *mut c_void) -> ()),
-            0 as *mut c_void,
-        );
+        res = rav1d_data_wrap_internal(&mut buf, ptr, sz, Some(dummy_free), 0 as *mut c_void);
         if res < 0 {
             current_block = 10647346020414903899;
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@ pub unsafe extern "C" fn dav1d_default_settings(s: *mut Dav1dSettings) {
 }
 
 #[cold]
-unsafe extern "C" fn get_stack_size_internal(_thread_attr: *const pthread_attr_t) -> usize {
+unsafe fn get_stack_size_internal(_thread_attr: *const pthread_attr_t) -> usize {
     if 0 != 0 {
         // TODO(perl): migrate the compile-time guard expression for this:
         // #if defined(__linux__) && defined(HAVE_DLSYM) && defined(__GLIBC__)
@@ -200,7 +200,7 @@ unsafe extern "C" fn get_stack_size_internal(_thread_attr: *const pthread_attr_t
 }
 
 #[cold]
-unsafe extern "C" fn get_num_threads(
+unsafe fn get_num_threads(
     c: *mut Rav1dContext,
     s: *const Rav1dSettings,
     n_tc: *mut c_uint,
@@ -274,7 +274,7 @@ pub unsafe extern "C" fn dav1d_get_frame_delay(s: *const Dav1dSettings) -> c_int
 
 #[cold]
 pub(crate) unsafe fn rav1d_open(c_out: *mut *mut Rav1dContext, s: *const Rav1dSettings) -> c_int {
-    unsafe extern "C" fn error(
+    unsafe fn error(
         c: *mut Rav1dContext,
         c_out: *mut *mut Rav1dContext,
         thread_attr: *mut pthread_attr_t,
@@ -696,7 +696,7 @@ pub unsafe extern "C" fn dav1d_parse_sequence_header(
     result
 }
 
-unsafe extern "C" fn has_grain(pic: *const Rav1dPicture) -> c_int {
+unsafe fn has_grain(pic: *const Rav1dPicture) -> c_int {
     let fgdata: *const Dav1dFilmGrainData = &mut (*(*pic).frame_hdr).film_grain.data;
     return ((*fgdata).num_y_points != 0
         || (*fgdata).num_uv_points[0] != 0
@@ -705,7 +705,7 @@ unsafe extern "C" fn has_grain(pic: *const Rav1dPicture) -> c_int {
         as c_int;
 }
 
-unsafe extern "C" fn output_image(c: *mut Rav1dContext, out: *mut Rav1dPicture) -> c_int {
+unsafe fn output_image(c: *mut Rav1dContext, out: *mut Rav1dPicture) -> c_int {
     let mut res = 0;
     let in_0: *mut Rav1dThreadPicture = if (*c).all_layers != 0 || (*c).max_spatial_id == 0 {
         &mut (*c).out
@@ -840,7 +840,7 @@ unsafe extern "C" fn drain_picture(c: *mut Rav1dContext, out: *mut Rav1dPicture)
     return -(11 as c_int);
 }
 
-unsafe extern "C" fn gen_picture(c: *mut Rav1dContext) -> c_int {
+unsafe fn gen_picture(c: *mut Rav1dContext) -> c_int {
     let mut res;
     let in_0: *mut Rav1dData = &mut (*c).in_0;
     if output_picture_ready(c, 0 as c_int) != 0 {
@@ -1239,7 +1239,7 @@ pub unsafe extern "C" fn dav1d_close(c_out: *mut *mut Dav1dContext) {
 }
 
 #[cold]
-unsafe extern "C" fn close_internal(c_out: *mut *mut Rav1dContext, flush: c_int) {
+unsafe fn close_internal(c_out: *mut *mut Rav1dContext, flush: c_int) {
     let c: *mut Rav1dContext = *c_out;
     if c.is_null() {
         return;
@@ -1528,8 +1528,7 @@ pub unsafe extern "C" fn dav1d_data_unref(buf: *mut Dav1dData) {
     result
 }
 
-#[no_mangle]
-pub(crate) unsafe extern "C" fn rav1d_data_props_unref(props: *mut Rav1dDataProps) {
+pub(crate) unsafe fn rav1d_data_props_unref(props: *mut Rav1dDataProps) {
     rav1d_data_props_unref_internal(props);
 }
 

--- a/src/loopfilter_tmpl_16.rs
+++ b/src/loopfilter_tmpl_16.rs
@@ -17,7 +17,7 @@ use cfg_if::cfg_if;
 pub type pixel = u16;
 
 #[inline]
-unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
+unsafe fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     if x & 1 != 0 {
         unreachable!();
     }
@@ -25,7 +25,7 @@ unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
 }
 
 #[inline(never)]
-unsafe extern "C" fn loop_filter(
+unsafe fn loop_filter(
     mut dst: *mut pixel,
     mut E: c_int,
     mut I: c_int,
@@ -225,7 +225,7 @@ unsafe extern "C" fn loop_filter_h_sb128y_c_erased(
     );
 }
 
-unsafe extern "C" fn loop_filter_h_sb128y_rust(
+unsafe fn loop_filter_h_sb128y_rust(
     mut dst: *mut pixel,
     stride: ptrdiff_t,
     vmask: *const u32,
@@ -293,7 +293,7 @@ unsafe extern "C" fn loop_filter_v_sb128y_c_erased(
     );
 }
 
-unsafe extern "C" fn loop_filter_v_sb128y_rust(
+unsafe fn loop_filter_v_sb128y_rust(
     mut dst: *mut pixel,
     stride: ptrdiff_t,
     vmask: *const u32,
@@ -361,7 +361,7 @@ unsafe extern "C" fn loop_filter_h_sb128uv_c_erased(
     )
 }
 
-unsafe extern "C" fn loop_filter_h_sb128uv_rust(
+unsafe fn loop_filter_h_sb128uv_rust(
     mut dst: *mut pixel,
     stride: ptrdiff_t,
     vmask: *const u32,
@@ -425,7 +425,7 @@ unsafe extern "C" fn loop_filter_v_sb128uv_c_erased(
     )
 }
 
-unsafe extern "C" fn loop_filter_v_sb128uv_rust(
+unsafe fn loop_filter_v_sb128uv_rust(
     mut dst: *mut pixel,
     stride: ptrdiff_t,
     vmask: *const u32,
@@ -469,7 +469,7 @@ unsafe extern "C" fn loop_filter_v_sb128uv_rust(
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
-unsafe extern "C" fn loop_filter_dsp_init_x86(c: *mut Rav1dLoopFilterDSPContext) {
+unsafe fn loop_filter_dsp_init_x86(c: *mut Rav1dLoopFilterDSPContext) {
     // TODO(legare): Temporarily import until init fns are deduplicated.
     use crate::src::loopfilter::*;
 
@@ -508,7 +508,7 @@ unsafe extern "C" fn loop_filter_dsp_init_x86(c: *mut Rav1dLoopFilterDSPContext)
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]
-unsafe extern "C" fn loop_filter_dsp_init_arm(c: *mut Rav1dLoopFilterDSPContext) {
+unsafe fn loop_filter_dsp_init_arm(c: *mut Rav1dLoopFilterDSPContext) {
     // TODO(legare): Temporarily import until init fns are deduplicated.
     use crate::src::loopfilter::*;
 

--- a/src/loopfilter_tmpl_8.rs
+++ b/src/loopfilter_tmpl_8.rs
@@ -17,7 +17,7 @@ use cfg_if::cfg_if;
 pub type pixel = u8;
 
 #[inline(never)]
-unsafe extern "C" fn loop_filter(
+unsafe fn loop_filter(
     mut dst: *mut pixel,
     mut E: c_int,
     mut I: c_int,
@@ -363,7 +363,7 @@ unsafe extern "C" fn loop_filter_v_sb128uv_c_erased(
     loop_filter_v_sb128uv_rust(dst.cast(), stride, vmask, l, b4_stride, lut, w)
 }
 
-unsafe extern "C" fn loop_filter_v_sb128uv_rust(
+unsafe fn loop_filter_v_sb128uv_rust(
     mut dst: *mut pixel,
     stride: ptrdiff_t,
     vmask: *const u32,
@@ -397,7 +397,7 @@ unsafe extern "C" fn loop_filter_v_sb128uv_rust(
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
-unsafe extern "C" fn loop_filter_dsp_init_x86(c: *mut Rav1dLoopFilterDSPContext) {
+unsafe fn loop_filter_dsp_init_x86(c: *mut Rav1dLoopFilterDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::loopfilter::*;
 
@@ -436,7 +436,7 @@ unsafe extern "C" fn loop_filter_dsp_init_x86(c: *mut Rav1dLoopFilterDSPContext)
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]
-unsafe extern "C" fn loop_filter_dsp_init_arm(c: *mut Rav1dLoopFilterDSPContext) {
+unsafe fn loop_filter_dsp_init_arm(c: *mut Rav1dLoopFilterDSPContext) {
     // TODO(legare): Temporary import until init fns are deduplicated.
     use crate::src::loopfilter::*;
 

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -1577,7 +1577,7 @@ unsafe extern "C" fn sgr_filter_mix_neon_erased<BD: BitDepth>(
 }
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
-unsafe extern "C" fn sgr_filter_mix_neon<BD: BitDepth>(
+unsafe fn sgr_filter_mix_neon<BD: BitDepth>(
     dst: *mut BD::Pixel,
     stride: ptrdiff_t,
     left: *const [BD::Pixel; 4],

--- a/src/lr_apply_tmpl_16.rs
+++ b/src/lr_apply_tmpl_16.rs
@@ -28,14 +28,14 @@ use std::ffi::c_void;
 pub type pixel = u16;
 
 #[inline]
-unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
+unsafe fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     if x & 1 != 0 {
         unreachable!();
     }
     return x >> 1;
 }
 
-unsafe extern "C" fn lr_stripe(
+unsafe fn lr_stripe(
     f: *const Rav1dFrameContext,
     mut p: *mut pixel,
     mut left: *const [pixel; 4],
@@ -149,7 +149,7 @@ unsafe extern "C" fn lr_stripe(
     }
 }
 
-unsafe extern "C" fn backup4xU(
+unsafe fn backup4xU(
     mut dst: *mut [pixel; 4],
     mut src: *const pixel,
     src_stride: ptrdiff_t,
@@ -163,7 +163,7 @@ unsafe extern "C" fn backup4xU(
     }
 }
 
-unsafe extern "C" fn lr_sbrow(
+unsafe fn lr_sbrow(
     f: *const Rav1dFrameContext,
     mut p: *mut pixel,
     y: c_int,

--- a/src/lr_apply_tmpl_8.rs
+++ b/src/lr_apply_tmpl_8.rs
@@ -27,7 +27,7 @@ use std::ffi::c_void;
 
 pub type pixel = u8;
 
-unsafe extern "C" fn lr_stripe(
+unsafe fn lr_stripe(
     f: *const Rav1dFrameContext,
     mut p: *mut pixel,
     mut left: *const [pixel; 4],
@@ -139,7 +139,7 @@ unsafe extern "C" fn lr_stripe(
     }
 }
 
-unsafe extern "C" fn backup4xU(
+unsafe fn backup4xU(
     mut dst: *mut [pixel; 4],
     mut src: *const pixel,
     src_stride: ptrdiff_t,
@@ -153,7 +153,7 @@ unsafe extern "C" fn backup4xU(
     }
 }
 
-unsafe extern "C" fn lr_sbrow(
+unsafe fn lr_sbrow(
     f: *const Rav1dFrameContext,
     mut p: *mut pixel,
     y: c_int,

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -2254,7 +2254,7 @@ extern "C" {
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
-unsafe extern "C" fn mc_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dMCDSPContext) {
+unsafe fn mc_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dMCDSPContext) {
     let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSE2) {
@@ -2500,7 +2500,7 @@ unsafe extern "C" fn mc_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dMCDSPContext) {
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]
-unsafe extern "C" fn mc_dsp_init_arm<BD: BitDepth>(c: *mut Rav1dMCDSPContext) {
+unsafe fn mc_dsp_init_arm<BD: BitDepth>(c: *mut Rav1dMCDSPContext) {
     let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::NEON) {
@@ -2546,7 +2546,7 @@ unsafe extern "C" fn mc_dsp_init_arm<BD: BitDepth>(c: *mut Rav1dMCDSPContext) {
 }
 
 #[cold]
-pub unsafe extern "C" fn rav1d_mc_dsp_init<BD: BitDepth>(c: *mut Rav1dMCDSPContext) {
+pub unsafe fn rav1d_mc_dsp_init<BD: BitDepth>(c: *mut Rav1dMCDSPContext) {
     (*c).mc[FILTER_2D_8TAP_REGULAR as usize] = put_8tap_regular_c_erased::<BD>;
     (*c).mc[FILTER_2D_8TAP_REGULAR_SMOOTH as usize] = put_8tap_regular_smooth_c_erased::<BD>;
     (*c).mc[FILTER_2D_8TAP_REGULAR_SHARP as usize] = put_8tap_regular_sharp_c_erased::<BD>;

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -26,7 +26,7 @@ pub struct Rav1dMemPoolBuffer {
 }
 
 #[inline]
-pub unsafe extern "C" fn rav1d_alloc_aligned(sz: usize, align: usize) -> *mut c_void {
+pub unsafe fn rav1d_alloc_aligned(sz: usize, align: usize) -> *mut c_void {
     if align & align.wrapping_sub(1) != 0 {
         unreachable!();
     }
@@ -38,12 +38,12 @@ pub unsafe extern "C" fn rav1d_alloc_aligned(sz: usize, align: usize) -> *mut c_
 }
 
 #[inline]
-pub unsafe extern "C" fn rav1d_free_aligned(ptr: *mut c_void) {
+pub unsafe fn rav1d_free_aligned(ptr: *mut c_void) {
     free(ptr);
 }
 
 #[inline]
-pub unsafe extern "C" fn rav1d_freep_aligned(ptr: *mut c_void) {
+pub unsafe fn rav1d_freep_aligned(ptr: *mut c_void) {
     let mem: *mut *mut c_void = ptr as *mut *mut c_void;
     if !(*mem).is_null() {
         rav1d_free_aligned(*mem);
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn rav1d_freep_aligned(ptr: *mut c_void) {
 }
 
 #[inline]
-pub unsafe extern "C" fn freep(ptr: *mut c_void) {
+pub unsafe fn freep(ptr: *mut c_void) {
     let mem: *mut *mut c_void = ptr as *mut *mut c_void;
     if !(*mem).is_null() {
         free(*mem);
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn freep(ptr: *mut c_void) {
 }
 
 #[cold]
-unsafe extern "C" fn mem_pool_destroy(pool: *mut Rav1dMemPool) {
+unsafe fn mem_pool_destroy(pool: *mut Rav1dMemPool) {
     pthread_mutex_destroy(&mut (*pool).lock);
     free(pool as *mut c_void);
 }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -128,13 +128,13 @@ use std::ffi::c_void;
 use std::ptr::addr_of_mut;
 
 #[inline]
-unsafe extern "C" fn rav1d_get_bits_pos(c: *const GetBits) -> c_uint {
+unsafe fn rav1d_get_bits_pos(c: *const GetBits) -> c_uint {
     return (((*c).ptr).offset_from((*c).ptr_start) as c_long as c_uint)
         .wrapping_mul(8 as c_int as c_uint)
         .wrapping_sub((*c).bits_left as c_uint);
 }
 
-unsafe extern "C" fn parse_seq_hdr_error(c: *mut Rav1dContext) -> c_int {
+unsafe fn parse_seq_hdr_error(c: *mut Rav1dContext) -> c_int {
     rav1d_log(
         c,
         b"Error parsing sequence header\n\0" as *const u8 as *const c_char,
@@ -142,7 +142,7 @@ unsafe extern "C" fn parse_seq_hdr_error(c: *mut Rav1dContext) -> c_int {
     return -(22 as c_int);
 }
 
-unsafe extern "C" fn parse_seq_hdr(
+unsafe fn parse_seq_hdr(
     c: *mut Rav1dContext,
     gb: *mut GetBits,
     hdr: *mut Rav1dSequenceHeader,
@@ -395,11 +395,7 @@ unsafe extern "C" fn parse_seq_hdr(
     return 0 as c_int;
 }
 
-unsafe extern "C" fn read_frame_size(
-    c: *mut Rav1dContext,
-    gb: *mut GetBits,
-    use_ref: c_int,
-) -> c_int {
+unsafe fn read_frame_size(c: *mut Rav1dContext, gb: *mut GetBits, use_ref: c_int) -> c_int {
     let seqhdr: *const Rav1dSequenceHeader = (*c).seq_hdr;
     let hdr: *mut Rav1dFrameHeader = (*c).frame_hdr;
     if use_ref != 0 {
@@ -473,7 +469,7 @@ unsafe extern "C" fn read_frame_size(
 }
 
 #[inline]
-unsafe extern "C" fn tile_log2(sz: c_int, tgt: c_int) -> c_int {
+unsafe fn tile_log2(sz: c_int, tgt: c_int) -> c_int {
     let mut k;
     k = 0 as c_int;
     while sz << k < tgt {
@@ -487,7 +483,7 @@ static default_mode_ref_deltas: Rav1dLoopfilterModeRefDeltas = Rav1dLoopfilterMo
     ref_delta: [1, 0, 0, 0, -1, 0, -1, -1],
 };
 
-unsafe extern "C" fn parse_frame_hdr_error(c: *mut Rav1dContext) -> c_int {
+unsafe fn parse_frame_hdr_error(c: *mut Rav1dContext) -> c_int {
     rav1d_log(
         c,
         b"Error parsing frame header\n\0" as *const u8 as *const c_char,
@@ -495,7 +491,7 @@ unsafe extern "C" fn parse_frame_hdr_error(c: *mut Rav1dContext) -> c_int {
     return -(22 as c_int);
 }
 
-unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> c_int {
+unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> c_int {
     let seqhdr: *const Rav1dSequenceHeader = (*c).seq_hdr;
     let hdr: *mut Rav1dFrameHeader = (*c).frame_hdr;
     (*hdr).show_existing_frame =
@@ -1555,7 +1551,7 @@ unsafe extern "C" fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> 
     return 0 as c_int;
 }
 
-unsafe extern "C" fn parse_tile_hdr(c: *mut Rav1dContext, gb: *mut GetBits) {
+unsafe fn parse_tile_hdr(c: *mut Rav1dContext, gb: *mut GetBits) {
     let n_tiles = (*(*c).frame_hdr).tiling.cols * (*(*c).frame_hdr).tiling.rows;
     let have_tile_pos = (if n_tiles > 1 {
         rav1d_get_bit(gb)
@@ -1573,7 +1569,7 @@ unsafe extern "C" fn parse_tile_hdr(c: *mut Rav1dContext, gb: *mut GetBits) {
     };
 }
 
-unsafe extern "C" fn check_for_overrun(
+unsafe fn check_for_overrun(
     c: *mut Rav1dContext,
     gb: *mut GetBits,
     init_bit_pos: c_uint,
@@ -1600,7 +1596,7 @@ unsafe extern "C" fn check_for_overrun(
     return 0 as c_int;
 }
 
-unsafe extern "C" fn rav1d_parse_obus_error(c: *mut Rav1dContext, in_0: *mut Rav1dData) -> c_int {
+unsafe fn rav1d_parse_obus_error(c: *mut Rav1dContext, in_0: *mut Rav1dData) -> c_int {
     rav1d_data_props_copy(&mut (*c).cached_error_props, &mut (*in_0).m);
     rav1d_log(
         c,
@@ -1609,11 +1605,7 @@ unsafe extern "C" fn rav1d_parse_obus_error(c: *mut Rav1dContext, in_0: *mut Rav
     return -(22 as c_int);
 }
 
-unsafe extern "C" fn rav1d_parse_obus_skip(
-    c: *mut Rav1dContext,
-    len: c_uint,
-    init_byte_pos: c_uint,
-) -> c_int {
+unsafe fn rav1d_parse_obus_skip(c: *mut Rav1dContext, len: c_uint, init_byte_pos: c_uint) -> c_int {
     let mut i = 0;
     while i < 8 {
         if (*(*c).frame_hdr).refresh_frame_flags & (1 as c_int) << i != 0 {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -203,7 +203,7 @@ unsafe extern "C" fn picture_alloc_with_edges(
     (*pic_ctx).pic = (*p).clone();
     (*p).r#ref = rav1d_ref_wrap(
         (*p).data[0] as *const u8,
-        Some(free_buffer as unsafe extern "C" fn(*const u8, *mut c_void) -> ()),
+        Some(free_buffer),
         pic_ctx as *mut c_void,
     );
     if ((*p).r#ref).is_null() {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -144,7 +144,7 @@ unsafe extern "C" fn free_buffer(_data: *const u8, user_data: *mut c_void) {
     free(pic_ctx as *mut c_void);
 }
 
-unsafe extern "C" fn picture_alloc_with_edges(
+unsafe fn picture_alloc_with_edges(
     c: *mut Rav1dContext,
     p: *mut Rav1dPicture,
     w: c_int,

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -109,7 +109,7 @@ pub type pixel = u16;
 pub type coef = i32;
 
 #[inline]
-unsafe extern "C" fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
+unsafe fn PXSTRIDE(x: ptrdiff_t) -> ptrdiff_t {
     if x & 1 != 0 {
         unreachable!();
     }
@@ -1284,7 +1284,7 @@ unsafe fn decode_coefs(
     return eob;
 }
 
-unsafe extern "C" fn read_coef_tree(
+unsafe fn read_coef_tree(
     t: *mut Rav1dTaskContext,
     bs: BlockSize,
     b: *const Av1Block,
@@ -1732,7 +1732,7 @@ pub(crate) unsafe extern "C" fn rav1d_read_coef_blocks_16bpc(
     }
 }
 
-unsafe extern "C" fn mc(
+unsafe fn mc(
     t: *mut Rav1dTaskContext,
     dst8: *mut pixel,
     dst16: *mut i16,
@@ -1935,7 +1935,7 @@ unsafe extern "C" fn mc(
     return 0 as c_int;
 }
 
-unsafe extern "C" fn obmc(
+unsafe fn obmc(
     t: *mut Rav1dTaskContext,
     dst: *mut pixel,
     dst_stride: ptrdiff_t,
@@ -2066,7 +2066,7 @@ unsafe extern "C" fn obmc(
     return 0 as c_int;
 }
 
-unsafe extern "C" fn warp_affine(
+unsafe fn warp_affine(
     t: *mut Rav1dTaskContext,
     mut dst8: *mut pixel,
     mut dst16: *mut i16,

--- a/src/recon_tmpl_16.rs
+++ b/src/recon_tmpl_16.rs
@@ -2051,13 +2051,8 @@ unsafe extern "C" fn obmc(
                     return res;
                 }
                 ((*(*f).dsp).mc.blend_v)(
-                    dst.offset(
-                        ((y * v_mul) as isize
-                            * (PXSTRIDE as unsafe extern "C" fn(ptrdiff_t) -> ptrdiff_t)(
-                                dst_stride,
-                            )) as isize,
-                    )
-                    .cast(),
+                    dst.offset(((y * v_mul) as isize * (PXSTRIDE)(dst_stride)) as isize)
+                        .cast(),
                     dst_stride,
                     lap.cast(),
                     h_mul * ow4_0,

--- a/src/recon_tmpl_8.rs
+++ b/src/recon_tmpl_8.rs
@@ -1274,7 +1274,7 @@ unsafe fn decode_coefs(
     return eob;
 }
 
-unsafe extern "C" fn read_coef_tree(
+unsafe fn read_coef_tree(
     t: *mut Rav1dTaskContext,
     bs: BlockSize,
     b: *const Av1Block,
@@ -1722,7 +1722,7 @@ pub(crate) unsafe extern "C" fn rav1d_read_coef_blocks_8bpc(
     }
 }
 
-unsafe extern "C" fn mc(
+unsafe fn mc(
     t: *mut Rav1dTaskContext,
     dst8: *mut pixel,
     dst16: *mut i16,
@@ -1925,7 +1925,7 @@ unsafe extern "C" fn mc(
     return 0 as c_int;
 }
 
-unsafe extern "C" fn obmc(
+unsafe fn obmc(
     t: *mut Rav1dTaskContext,
     dst: *mut pixel,
     dst_stride: ptrdiff_t,
@@ -2056,7 +2056,7 @@ unsafe extern "C" fn obmc(
     return 0 as c_int;
 }
 
-unsafe extern "C" fn warp_affine(
+unsafe fn warp_affine(
     t: *mut Rav1dTaskContext,
     mut dst8: *mut pixel,
     mut dst16: *mut i16,

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -21,7 +21,7 @@ pub struct Rav1dRef {
 }
 
 #[inline]
-pub unsafe extern "C" fn rav1d_ref_inc(r#ref: *mut Rav1dRef) {
+pub unsafe fn rav1d_ref_inc(r#ref: *mut Rav1dRef) {
     ::core::intrinsics::atomic_xadd_relaxed(&mut (*r#ref).ref_cnt, 1 as c_int);
 }
 

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -50,8 +50,7 @@ pub unsafe fn rav1d_ref_create(mut size: usize) -> *mut Rav1dRef {
     (*res).const_data = (*res).user_data;
     *&mut (*res).ref_cnt = 1 as c_int;
     (*res).free_ref = 0 as c_int;
-    (*res).free_callback =
-        Some(default_free_callback as unsafe extern "C" fn(*const u8, *mut c_void) -> ());
+    (*res).free_callback = Some(default_free_callback);
     return res;
 }
 
@@ -81,8 +80,7 @@ pub unsafe fn rav1d_ref_create_using_pool(
     (*res).const_data = pool as *const c_void;
     *&mut (*res).ref_cnt = 1 as c_int;
     (*res).free_ref = 0 as c_int;
-    (*res).free_callback =
-        Some(pool_free_callback as unsafe extern "C" fn(*const u8, *mut c_void) -> ());
+    (*res).free_callback = Some(pool_free_callback);
     (*res).user_data = buf as *mut c_void;
     return res;
 }

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1611,7 +1611,7 @@ unsafe extern "C" fn splat_mv_rust(
 
 #[inline(always)]
 #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "asm"))]
-unsafe extern "C" fn refmvs_dsp_init_x86(c: *mut Rav1dRefmvsDSPContext) {
+unsafe fn refmvs_dsp_init_x86(c: *mut Rav1dRefmvsDSPContext) {
     let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSE2) {
@@ -1646,7 +1646,7 @@ unsafe extern "C" fn refmvs_dsp_init_x86(c: *mut Rav1dRefmvsDSPContext) {
 
 #[inline(always)]
 #[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), feature = "asm"))]
-unsafe extern "C" fn refmvs_dsp_init_arm(c: *mut Rav1dRefmvsDSPContext) {
+unsafe fn refmvs_dsp_init_arm(c: *mut Rav1dRefmvsDSPContext) {
     let flags = rav1d_get_cpu_flags();
     if flags.contains(CpuFlags::NEON) {
         (*c).splat_mv = Some(ffi::dav1d_splat_mv_neon);

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -71,7 +71,7 @@ use std::ffi::c_uint;
 use std::ffi::c_ulonglong;
 use std::ffi::c_void;
 
-unsafe extern "C" fn get_seed() -> c_uint {
+unsafe fn get_seed() -> c_uint {
     let mut ts: libc::timespec = libc::timespec {
         tv_sec: 0,
         tv_nsec: 0,
@@ -104,11 +104,7 @@ unsafe fn xor128_rand() -> c_int {
 }
 
 #[inline]
-unsafe extern "C" fn decode_frame(
-    p: *mut Dav1dPicture,
-    c: *mut Dav1dContext,
-    data: *mut Dav1dData,
-) -> c_int {
+unsafe fn decode_frame(p: *mut Dav1dPicture, c: *mut Dav1dContext, data: *mut Dav1dData) -> c_int {
     let mut res: c_int;
     libc::memset(p as *mut c_void, 0, ::core::mem::size_of::<Dav1dPicture>());
     res = dav1d_send_data(c, data);
@@ -138,7 +134,7 @@ unsafe extern "C" fn decode_frame(
     return 0 as c_int;
 }
 
-unsafe extern "C" fn decode_rand(
+unsafe fn decode_rand(
     in_0: *mut DemuxerContext,
     c: *mut Dav1dContext,
     data: *mut Dav1dData,
@@ -194,7 +190,7 @@ unsafe extern "C" fn decode_rand(
     return res;
 }
 
-unsafe extern "C" fn decode_all(
+unsafe fn decode_all(
     in_0: *mut DemuxerContext,
     c: *mut Dav1dContext,
     data: *mut Dav1dData,
@@ -246,7 +242,7 @@ unsafe extern "C" fn decode_all(
     return res;
 }
 
-unsafe extern "C" fn seek(
+unsafe fn seek(
     in_0: *mut DemuxerContext,
     c: *mut Dav1dContext,
     pts: u64,

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -88,7 +88,7 @@ use std::ffi::c_uint;
 use std::ffi::c_ulonglong;
 use std::ffi::c_void;
 
-unsafe extern "C" fn get_time_nanos() -> u64 {
+unsafe fn get_time_nanos() -> u64 {
     let mut ts: libc::timespec = libc::timespec {
         tv_sec: 0,
         tv_nsec: 0,
@@ -99,7 +99,7 @@ unsafe extern "C" fn get_time_nanos() -> u64 {
         .wrapping_add(ts.tv_nsec as c_ulonglong) as u64;
 }
 
-unsafe extern "C" fn sleep_nanos(d: u64) {
+unsafe fn sleep_nanos(d: u64) {
     // TODO: C version has Windows specific code path
     let ts: libc::timespec = {
         let init = libc::timespec {
@@ -111,7 +111,7 @@ unsafe extern "C" fn sleep_nanos(d: u64) {
     libc::nanosleep(&ts, std::ptr::null_mut::<libc::timespec>());
 }
 
-unsafe extern "C" fn synchronize(
+unsafe fn synchronize(
     realtime: c_int,
     cache: c_uint,
     n_out: c_uint,
@@ -144,13 +144,7 @@ unsafe extern "C" fn synchronize(
     }
 }
 
-unsafe extern "C" fn print_stats(
-    istty: c_int,
-    n: c_uint,
-    num: c_uint,
-    elapsed: u64,
-    i_fps: c_double,
-) {
+unsafe fn print_stats(istty: c_int, n: c_uint, num: c_uint, elapsed: u64, i_fps: c_double) {
     let mut buf: [c_char; 80] = [0; 80];
     let mut b: *mut c_char = buf.as_mut_ptr();
     let end: *mut c_char = buf.as_mut_ptr().offset(80);

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -377,10 +377,8 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
     }
     parse(argc, argv, &mut cli_settings, &mut lib_settings);
     if cli_settings.neg_stride != 0 {
-        lib_settings.allocator.alloc_picture_callback =
-            Some(picture_alloc as unsafe extern "C" fn(*mut Dav1dPicture, *mut c_void) -> c_int);
-        lib_settings.allocator.release_picture_callback =
-            Some(picture_release as unsafe extern "C" fn(*mut Dav1dPicture, *mut c_void) -> ());
+        lib_settings.allocator.alloc_picture_callback = Some(picture_alloc);
+        lib_settings.allocator.release_picture_callback = Some(picture_release);
     }
     res = input_open(
         &mut in_0,

--- a/tools/dav1d_cli_parse.rs
+++ b/tools/dav1d_cli_parse.rs
@@ -324,7 +324,7 @@ unsafe extern "C" fn usage(app: *const c_char, reason: *const c_char, args: ...)
     exit(1 as c_int);
 }
 
-unsafe extern "C" fn error(
+unsafe fn error(
     app: *const c_char,
     optarg_0: *const c_char,
     option: c_int,
@@ -365,11 +365,7 @@ unsafe extern "C" fn error(
     );
 }
 
-unsafe extern "C" fn parse_unsigned(
-    optarg_0: *const c_char,
-    option: c_int,
-    app: *const c_char,
-) -> c_uint {
+unsafe fn parse_unsigned(optarg_0: *const c_char, option: c_int, app: *const c_char) -> c_uint {
     let mut end: *mut c_char = 0 as *mut c_char;
     let res: c_uint = strtoul(optarg_0, &mut end, 0 as c_int) as c_uint;
     if *end as c_int != 0 || end == optarg_0 as *mut c_char {
@@ -383,7 +379,7 @@ unsafe extern "C" fn parse_unsigned(
     return res;
 }
 
-unsafe extern "C" fn parse_optional_fraction(
+unsafe fn parse_optional_fraction(
     optarg_0: *const c_char,
     option: c_int,
     app: *const c_char,
@@ -533,7 +529,7 @@ static mut decode_frame_type_tbl: [EnumParseTable; 4] = [
     },
 ];
 
-unsafe extern "C" fn parse_enum(
+unsafe fn parse_enum(
     optarg_0: *mut c_char,
     tbl: *const EnumParseTable,
     tbl_sz: c_int,

--- a/tools/input/annexb.rs
+++ b/tools/input/annexb.rs
@@ -310,20 +310,9 @@ pub static mut annexb_demuxer: Demuxer = Demuxer {
     priv_data_size: ::core::mem::size_of::<AnnexbInputContext>() as c_ulong as c_int,
     name: b"annexb\0" as *const u8 as *const c_char,
     probe_sz: 2048 as c_int,
-    probe: Some(annexb_probe as unsafe extern "C" fn(*const u8) -> c_int),
-    open: Some(
-        annexb_open
-            as unsafe extern "C" fn(
-                *mut AnnexbInputContext,
-                *const c_char,
-                *mut c_uint,
-                *mut c_uint,
-                *mut c_uint,
-            ) -> c_int,
-    ),
-    read: Some(
-        annexb_read as unsafe extern "C" fn(*mut AnnexbInputContext, *mut Dav1dData) -> c_int,
-    ),
+    probe: Some(annexb_probe),
+    open: Some(annexb_open),
+    read: Some(annexb_read),
     seek: None,
-    close: Some(annexb_close as unsafe extern "C" fn(*mut AnnexbInputContext) -> ()),
+    close: Some(annexb_close),
 };

--- a/tools/input/annexb.rs
+++ b/tools/input/annexb.rs
@@ -51,7 +51,7 @@ pub struct Demuxer {
 
 pub type AnnexbInputContext = DemuxerPriv;
 
-unsafe extern "C" fn leb128(f: *mut libc::FILE, len: *mut usize) -> c_int {
+unsafe fn leb128(f: *mut libc::FILE, len: *mut usize) -> c_int {
     let mut val: u64 = 0 as c_int as u64;
     let mut i: c_uint = 0 as c_int as c_uint;
     let mut more: c_uint;
@@ -74,7 +74,7 @@ unsafe extern "C" fn leb128(f: *mut libc::FILE, len: *mut usize) -> c_int {
     return i as c_int;
 }
 
-unsafe extern "C" fn leb(mut ptr: *const u8, mut sz: c_int, len: *mut usize) -> c_int {
+unsafe fn leb(mut ptr: *const u8, mut sz: c_int, len: *mut usize) -> c_int {
     let mut val: u64 = 0 as c_int as u64;
     let mut i: c_uint = 0 as c_int as c_uint;
     let mut more: c_uint;
@@ -102,7 +102,7 @@ unsafe extern "C" fn leb(mut ptr: *const u8, mut sz: c_int, len: *mut usize) -> 
 }
 
 #[inline]
-unsafe extern "C" fn parse_obu_header(
+unsafe fn parse_obu_header(
     mut buf: *const u8,
     mut buf_size: c_int,
     obu_size: *mut usize,

--- a/tools/input/ivf.rs
+++ b/tools/input/ivf.rs
@@ -317,18 +317,9 @@ pub static mut ivf_demuxer: Demuxer = Demuxer {
     priv_data_size: ::core::mem::size_of::<IvfInputContext>() as c_ulong as c_int,
     name: b"ivf\0" as *const u8 as *const c_char,
     probe_sz: ::core::mem::size_of::<[u8; 12]>() as c_ulong as c_int,
-    probe: Some(ivf_probe as unsafe extern "C" fn(*const u8) -> c_int),
-    open: Some(
-        ivf_open
-            as unsafe extern "C" fn(
-                *mut IvfInputContext,
-                *const c_char,
-                *mut c_uint,
-                *mut c_uint,
-                *mut c_uint,
-            ) -> c_int,
-    ),
-    read: Some(ivf_read as unsafe extern "C" fn(*mut IvfInputContext, *mut Dav1dData) -> c_int),
-    seek: Some(ivf_seek as unsafe extern "C" fn(*mut IvfInputContext, u64) -> c_int),
-    close: Some(ivf_close as unsafe extern "C" fn(*mut IvfInputContext) -> ()),
+    probe: Some(ivf_probe),
+    open: Some(ivf_open),
+    read: Some(ivf_read),
+    seek: Some(ivf_seek),
+    close: Some(ivf_close),
 };

--- a/tools/input/ivf.rs
+++ b/tools/input/ivf.rs
@@ -62,14 +62,14 @@ unsafe extern "C" fn ivf_probe(data: *const u8) -> c_int {
     ) == 0) as c_int;
 }
 
-unsafe extern "C" fn rl32(p: *const u8) -> c_uint {
+unsafe fn rl32(p: *const u8) -> c_uint {
     return (*p.offset(3) as u32) << 24 as c_uint
         | ((*p.offset(2) as c_int) << 16 as c_uint) as c_uint
         | ((*p.offset(1) as c_int) << 8 as c_uint) as c_uint
         | *p.offset(0) as c_uint;
 }
 
-unsafe extern "C" fn rl64(p: *const u8) -> i64 {
+unsafe fn rl64(p: *const u8) -> i64 {
     return ((rl32(&*p.offset(4)) as u64) << 32 | rl32(p) as u64) as i64;
 }
 
@@ -200,7 +200,7 @@ unsafe extern "C" fn ivf_open(
 
 #[inline]
 
-unsafe extern "C" fn ivf_read_header(
+unsafe fn ivf_read_header(
     c: *mut IvfInputContext,
     sz: *mut ptrdiff_t,
     off_: *mut libc::off_t,

--- a/tools/input/section5.rs
+++ b/tools/input/section5.rs
@@ -49,7 +49,7 @@ pub struct Demuxer {
 
 pub type Section5InputContext = DemuxerPriv;
 
-unsafe extern "C" fn leb(mut ptr: *const u8, mut sz: c_int, len: *mut usize) -> c_int {
+unsafe fn leb(mut ptr: *const u8, mut sz: c_int, len: *mut usize) -> c_int {
     let mut val: u64 = 0 as c_int as u64;
     let mut i: c_uint = 0 as c_int as c_uint;
     let mut more: c_uint;
@@ -77,7 +77,7 @@ unsafe extern "C" fn leb(mut ptr: *const u8, mut sz: c_int, len: *mut usize) -> 
 }
 
 #[inline]
-unsafe extern "C" fn parse_obu_header(
+unsafe fn parse_obu_header(
     mut buf: *const u8,
     mut buf_size: c_int,
     obu_size: *mut usize,
@@ -117,7 +117,7 @@ unsafe extern "C" fn parse_obu_header(
     return buf_size + 1 + extension_flag;
 }
 
-unsafe extern "C" fn leb128(f: *mut libc::FILE, len: *mut usize) -> c_int {
+unsafe fn leb128(f: *mut libc::FILE, len: *mut usize) -> c_int {
     let mut val: u64 = 0 as c_int as u64;
     let mut i: c_uint = 0 as c_int as c_uint;
     let mut more: c_uint;

--- a/tools/input/section5.rs
+++ b/tools/input/section5.rs
@@ -322,20 +322,9 @@ pub static mut section5_demuxer: Demuxer = Demuxer {
     priv_data_size: ::core::mem::size_of::<Section5InputContext>() as c_ulong as c_int,
     name: b"section5\0" as *const u8 as *const c_char,
     probe_sz: 2048 as c_int,
-    probe: Some(section5_probe as unsafe extern "C" fn(*const u8) -> c_int),
-    open: Some(
-        section5_open
-            as unsafe extern "C" fn(
-                *mut Section5InputContext,
-                *const c_char,
-                *mut c_uint,
-                *mut c_uint,
-                *mut c_uint,
-            ) -> c_int,
-    ),
-    read: Some(
-        section5_read as unsafe extern "C" fn(*mut Section5InputContext, *mut Dav1dData) -> c_int,
-    ),
+    probe: Some(section5_probe),
+    open: Some(section5_open),
+    read: Some(section5_read),
     seek: None,
-    close: Some(section5_close as unsafe extern "C" fn(*mut Section5InputContext) -> ()),
+    close: Some(section5_close),
 };

--- a/tools/output/md5.rs
+++ b/tools/output/md5.rs
@@ -97,11 +97,11 @@ unsafe extern "C" fn md5_open(
 }
 
 #[inline]
-unsafe extern "C" fn leftrotate(x: u32, c: c_int) -> u32 {
+unsafe fn leftrotate(x: u32, c: c_int) -> u32 {
     return x << c | x >> 32 - c;
 }
 
-unsafe extern "C" fn md5_body(md5: *mut MD5Context, data: *const u32) {
+unsafe fn md5_body(md5: *mut MD5Context, data: *const u32) {
     let mut a: u32 = (*md5).abcd[0];
     let mut b: u32 = (*md5).abcd[1];
     let mut c: u32 = (*md5).abcd[2];
@@ -496,7 +496,7 @@ unsafe extern "C" fn md5_body(md5: *mut MD5Context, data: *const u32) {
     (*md5).abcd[3] = ((*md5).abcd[3] as c_uint).wrapping_add(d) as u32 as u32;
 }
 
-unsafe extern "C" fn md5_update(md5: *mut MD5Context, mut data: *const u8, mut len: c_uint) {
+unsafe fn md5_update(md5: *mut MD5Context, mut data: *const u8, mut len: c_uint) {
     if len == 0 {
         return;
     }
@@ -571,7 +571,7 @@ unsafe extern "C" fn md5_write(md5: *mut MD5Context, p: *mut Dav1dPicture) -> c_
     return 0 as c_int;
 }
 
-unsafe extern "C" fn md5_finish(md5: *mut MD5Context) {
+unsafe fn md5_finish(md5: *mut MD5Context) {
     static bit: [u8; 2] = [0x80, 0];
     let len: u64 = (*md5).len << 3;
     md5_update(md5, &*bit.as_ptr().offset(0), 1 as c_int as c_uint);

--- a/tools/output/md5.rs
+++ b/tools/output/md5.rs
@@ -632,18 +632,8 @@ pub static mut md5_muxer: Muxer = Muxer {
     priv_data_size: ::core::mem::size_of::<MD5Context>() as c_ulong as c_int,
     name: b"md5\0" as *const u8 as *const c_char,
     extension: b"md5\0" as *const u8 as *const c_char,
-    write_header: Some(
-        md5_open
-            as unsafe extern "C" fn(
-                *mut MD5Context,
-                *const c_char,
-                *const Dav1dPictureParameters,
-                *const c_uint,
-            ) -> c_int,
-    ),
-    write_picture: Some(
-        md5_write as unsafe extern "C" fn(*mut MD5Context, *mut Dav1dPicture) -> c_int,
-    ),
-    write_trailer: Some(md5_close as unsafe extern "C" fn(*mut MD5Context) -> ()),
-    verify: Some(md5_verify as unsafe extern "C" fn(*mut MD5Context, *const c_char) -> c_int),
+    write_header: Some(md5_open),
+    write_picture: Some(md5_write),
+    write_trailer: Some(md5_close),
+    verify: Some(md5_verify),
 };

--- a/tools/output/null.rs
+++ b/tools/output/null.rs
@@ -40,9 +40,7 @@ pub static mut null_muxer: Muxer = Muxer {
     name: b"null\0" as *const u8 as *const c_char,
     extension: b"null\0" as *const u8 as *const c_char,
     write_header: None,
-    write_picture: Some(
-        null_write as unsafe extern "C" fn(*mut NullOutputContext, *mut Dav1dPicture) -> c_int,
-    ),
+    write_picture: Some(null_write),
     write_trailer: None,
     verify: None,
 };

--- a/tools/output/output.rs
+++ b/tools/output/output.rs
@@ -65,7 +65,7 @@ static mut muxers: [*const Muxer; 5] = unsafe {
     ]
 };
 
-unsafe extern "C" fn find_extension(f: *const c_char) -> *const c_char {
+unsafe fn find_extension(f: *const c_char) -> *const c_char {
     let l: usize = strlen(f);
     if l == 0 {
         return 0 as *const c_char;
@@ -205,12 +205,7 @@ pub unsafe fn output_open(
     return 0 as c_int;
 }
 
-unsafe extern "C" fn safe_strncat(
-    dst: *mut c_char,
-    dst_len: c_int,
-    src: *const c_char,
-    src_len: c_int,
-) {
+unsafe fn safe_strncat(dst: *mut c_char, dst_len: c_int, src: *const c_char, src_len: c_int) {
     if src_len == 0 {
         return;
     }
@@ -230,7 +225,7 @@ unsafe extern "C" fn safe_strncat(
     *dst.offset((dst_fill + to_copy) as isize) = 0 as c_int as c_char;
 }
 
-unsafe extern "C" fn assemble_field(
+unsafe fn assemble_field(
     dst: *mut c_char,
     dst_len: c_int,
     fmt: *const c_char,
@@ -275,7 +270,7 @@ unsafe extern "C" fn assemble_field(
     );
 }
 
-unsafe extern "C" fn assemble_filename(
+unsafe fn assemble_filename(
     ctx: *mut MuxerContext,
     filename: *mut c_char,
     filename_size: c_int,

--- a/tools/output/y4m2.rs
+++ b/tools/output/y4m2.rs
@@ -73,7 +73,7 @@ unsafe extern "C" fn y4m2_open(
     return 0 as c_int;
 }
 
-unsafe extern "C" fn write_header(c: *mut Y4m2OutputContext, p: *const Dav1dPicture) -> c_int {
+unsafe fn write_header(c: *mut Y4m2OutputContext, p: *const Dav1dPicture) -> c_int {
     static mut ss_names: [[*const c_char; 3]; 4] = [
         [
             b"mono\0" as *const u8 as *const c_char,

--- a/tools/output/y4m2.rs
+++ b/tools/output/y4m2.rs
@@ -229,18 +229,8 @@ pub static mut y4m2_muxer: Muxer = Muxer {
     priv_data_size: ::core::mem::size_of::<Y4m2OutputContext>() as c_ulong as c_int,
     name: b"yuv4mpeg2\0" as *const u8 as *const c_char,
     extension: b"y4m\0" as *const u8 as *const c_char,
-    write_header: Some(
-        y4m2_open
-            as unsafe extern "C" fn(
-                *mut Y4m2OutputContext,
-                *const c_char,
-                *const Dav1dPictureParameters,
-                *const c_uint,
-            ) -> c_int,
-    ),
-    write_picture: Some(
-        y4m2_write as unsafe extern "C" fn(*mut Y4m2OutputContext, *mut Dav1dPicture) -> c_int,
-    ),
-    write_trailer: Some(y4m2_close as unsafe extern "C" fn(*mut Y4m2OutputContext) -> ()),
+    write_header: Some(y4m2_open),
+    write_picture: Some(y4m2_write),
+    write_trailer: Some(y4m2_close),
     verify: None,
 };

--- a/tools/output/yuv.rs
+++ b/tools/output/yuv.rs
@@ -145,18 +145,8 @@ pub static mut yuv_muxer: Muxer = Muxer {
     priv_data_size: ::core::mem::size_of::<YuvOutputContext>() as c_ulong as c_int,
     name: b"yuv\0" as *const u8 as *const c_char,
     extension: b"yuv\0" as *const u8 as *const c_char,
-    write_header: Some(
-        yuv_open
-            as unsafe extern "C" fn(
-                *mut YuvOutputContext,
-                *const c_char,
-                *const Dav1dPictureParameters,
-                *const c_uint,
-            ) -> c_int,
-    ),
-    write_picture: Some(
-        yuv_write as unsafe extern "C" fn(*mut YuvOutputContext, *mut Dav1dPicture) -> c_int,
-    ),
-    write_trailer: Some(yuv_close as unsafe extern "C" fn(*mut YuvOutputContext) -> ()),
+    write_header: Some(yuv_open),
+    write_picture: Some(yuv_write),
+    write_trailer: Some(yuv_close),
     verify: None,
 };


### PR DESCRIPTION
That is, this removes `extern "C"`s from all `fn`s that are not:
* a `#[no_mangle]`/`DAV1D-API`
* a `fn` ptr
* vararg