### PR TITLE
`enum Rav1dError`: Convert internal error-handling to use `Rav1d{Error,Result}`

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -46,6 +46,7 @@ pub mod src {
     mod decode;
     mod dequant_tables;
     mod env;
+    pub(crate) mod error;
     #[cfg(feature = "bitdepth_16")]
     mod fg_apply_tmpl_16;
     #[cfg(feature = "bitdepth_8")]

--- a/lib.rs
+++ b/lib.rs
@@ -114,6 +114,8 @@ pub mod src {
 
 use std::ffi::c_int;
 
+pub use src::error::Dav1dResult;
+
 // NOTE: temporary code to support Linux and macOS, should be removed eventually
 cfg_if::cfg_if! {
     if #[cfg(target_os = "linux")] {

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -5,6 +5,8 @@ use crate::src::align::Align16;
 use crate::src::align::Align32;
 use crate::src::align::Align4;
 use crate::src::align::Align8;
+use crate::src::error::Rav1dError::ENOMEM;
+use crate::src::error::Rav1dResult;
 use crate::src::internal::Rav1dContext;
 use crate::src::levels::N_BL_LEVELS;
 use crate::src::levels::N_BS_SIZES;
@@ -5652,20 +5654,20 @@ pub unsafe fn rav1d_cdf_thread_alloc(
     c: *mut Rav1dContext,
     cdf: *mut CdfThreadContext,
     have_frame_mt: c_int,
-) -> c_int {
+) -> Rav1dResult {
     (*cdf).r#ref = rav1d_ref_create_using_pool(
         (*c).cdf_pool,
         (::core::mem::size_of::<CdfContext>()).wrapping_add(::core::mem::size_of::<atomic_uint>()),
     );
     if ((*cdf).r#ref).is_null() {
-        return -(12 as c_int);
+        return Err(ENOMEM);
     }
     (*cdf).data.cdf = (*(*cdf).r#ref).data as *mut CdfContext;
     if have_frame_mt != 0 {
         (*cdf).progress = &mut *((*cdf).data.cdf).offset(1) as *mut CdfContext as *mut atomic_uint;
         *(*cdf).progress = 0 as c_int as c_uint;
     }
-    return 0 as c_int;
+    Ok(())
 }
 
 pub unsafe fn rav1d_cdf_thread_ref(dst: *mut CdfThreadContext, src: *mut CdfThreadContext) {

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,5 +1,8 @@
 use crate::include::dav1d::common::Rav1dDataProps;
 use crate::include::dav1d::data::Rav1dData;
+use crate::src::error::Rav1dError::EINVAL;
+use crate::src::error::Rav1dError::ENOMEM;
+use crate::src::error::Rav1dResult;
 use crate::src::r#ref::rav1d_ref_create;
 use crate::src::r#ref::rav1d_ref_dec;
 use crate::src::r#ref::rav1d_ref_inc;
@@ -43,7 +46,7 @@ pub(crate) unsafe fn rav1d_data_wrap_internal(
     sz: usize,
     free_callback: Option<unsafe extern "C" fn(*const u8, *mut c_void) -> ()>,
     cookie: *mut c_void,
-) -> c_int {
+) -> Rav1dResult {
     if buf.is_null() {
         fprintf(
             stderr,
@@ -52,7 +55,7 @@ pub(crate) unsafe fn rav1d_data_wrap_internal(
             (*::core::mem::transmute::<&[u8; 25], &[c_char; 25]>(b"dav1d_data_wrap_internal\0"))
                 .as_ptr(),
         );
-        return -(22 as c_int);
+        return Err(EINVAL);
     }
     if ptr.is_null() {
         fprintf(
@@ -62,7 +65,7 @@ pub(crate) unsafe fn rav1d_data_wrap_internal(
             (*::core::mem::transmute::<&[u8; 25], &[c_char; 25]>(b"dav1d_data_wrap_internal\0"))
                 .as_ptr(),
         );
-        return -(22 as c_int);
+        return Err(EINVAL);
     }
     if free_callback.is_none() {
         fprintf(
@@ -72,17 +75,17 @@ pub(crate) unsafe fn rav1d_data_wrap_internal(
             (*::core::mem::transmute::<&[u8; 25], &[c_char; 25]>(b"dav1d_data_wrap_internal\0"))
                 .as_ptr(),
         );
-        return -(22 as c_int);
+        return Err(EINVAL);
     }
     (*buf).r#ref = rav1d_ref_wrap(ptr, free_callback, cookie);
     if ((*buf).r#ref).is_null() {
-        return -(12 as c_int);
+        return Err(ENOMEM);
     }
     (*buf).data = ptr;
     (*buf).sz = sz;
     rav1d_data_props_set_defaults(&mut (*buf).m);
     (*buf).m.size = sz;
-    return 0 as c_int;
+    Ok(())
 }
 
 pub(crate) unsafe fn rav1d_data_wrap_user_data_internal(
@@ -90,7 +93,7 @@ pub(crate) unsafe fn rav1d_data_wrap_user_data_internal(
     user_data: *const u8,
     free_callback: Option<unsafe extern "C" fn(*const u8, *mut c_void) -> ()>,
     cookie: *mut c_void,
-) -> c_int {
+) -> Rav1dResult {
     if buf.is_null() {
         fprintf(
             stderr,
@@ -101,7 +104,7 @@ pub(crate) unsafe fn rav1d_data_wrap_user_data_internal(
             ))
             .as_ptr(),
         );
-        return -(22 as c_int);
+        return Err(EINVAL);
     }
     if free_callback.is_none() {
         fprintf(
@@ -113,14 +116,14 @@ pub(crate) unsafe fn rav1d_data_wrap_user_data_internal(
             ))
             .as_ptr(),
         );
-        return -(22 as c_int);
+        return Err(EINVAL);
     }
     (*buf).m.user_data.r#ref = rav1d_ref_wrap(user_data, free_callback, cookie);
     if ((*buf).m.user_data.r#ref).is_null() {
-        return -(12 as c_int);
+        return Err(ENOMEM);
     }
     (*buf).m.user_data.data = user_data;
-    return 0 as c_int;
+    Ok(())
 }
 
 pub(crate) unsafe fn rav1d_data_ref(dst: *mut Rav1dData, src: *const Rav1dData) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,10 @@ use strum::FromRepr;
 #[derive(Clone, Copy, PartialEq, Eq, FromRepr)]
 #[non_exhaustive]
 pub enum Rav1dError {
+    /// Not actually used (yet), but this forces `0` to be the niche,
+    /// which is more optimal since `0` is no error for [`Dav1dResult`].
+    _EPERM = 1,
+
     ENOENT = 2,
     EIO = 5,
     EAGAIN = 11,
@@ -20,17 +24,23 @@ pub type Rav1dResult<T = ()> = Result<T, Rav1dError>;
 pub struct Dav1dResult(pub c_int);
 
 impl From<Rav1dResult> for Dav1dResult {
+    #[inline]
     fn from(value: Rav1dResult) -> Self {
-        Dav1dResult(match value {
-            Ok(()) => 0,
-            Err(e) => -(e as u8 as c_int),
-        })
+        // Doing the `-` negation on both branches
+        // makes the code short and branchless.
+        Dav1dResult(
+            -(match value {
+                Ok(()) => 0,
+                Err(e) => e as u8 as c_int,
+            }),
+        )
     }
 }
 
 impl TryFrom<Dav1dResult> for Rav1dResult {
     type Error = Dav1dResult;
 
+    #[inline]
     fn try_from(value: Dav1dResult) -> Result<Self, Self::Error> {
         match value.0 {
             0 => Ok(Ok(())),

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use std::ffi::c_uint;
 use strum::FromRepr;
 
 #[derive(Clone, Copy, PartialEq, Eq, FromRepr)]
+#[repr(u8)]
 #[non_exhaustive]
 pub enum Rav1dError {
     /// This represents a generic `rav1d` error.
@@ -16,13 +17,13 @@ pub enum Rav1dError {
     /// which is more optimal since `0` is no error for [`Dav1dResult`].
     EGeneric = 1,
 
-    ENOENT = 2,
-    EIO = 5,
-    EAGAIN = 11,
-    ENOMEM = 12,
-    EINVAL = 22,
-    ERANGE = 34,
-    ENOPROTOOPT = 92,
+    ENOENT = libc::ENOENT as u8,
+    EIO = libc::EIO as u8,
+    EAGAIN = libc::EAGAIN as u8,
+    ENOMEM = libc::ENOMEM as u8,
+    EINVAL = libc::EINVAL as u8,
+    ERANGE = libc::ERANGE as u8,
+    ENOPROTOOPT = libc::ENOPROTOOPT as u8,
 }
 
 pub type Rav1dResult<T = ()> = Result<T, Rav1dError>;
@@ -39,7 +40,7 @@ impl From<Rav1dResult> for Dav1dResult {
         Dav1dResult(
             -(match value {
                 Ok(()) => 0,
-                Err(e) => e as u8 as c_int,
+                Err(e) => e as c_int,
             }),
         )
     }
@@ -50,7 +51,7 @@ impl From<Rav1dResult<c_uint>> for Dav1dResult {
     fn from(value: Rav1dResult<c_uint>) -> Self {
         Dav1dResult(match value {
             Ok(value) => value as c_int,
-            Err(e) => e as u8 as c_int,
+            Err(e) => e as c_int,
         })
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,44 @@
+use std::ffi::c_int;
+use strum::FromRepr;
+
+#[derive(Clone, Copy, PartialEq, Eq, FromRepr)]
+#[non_exhaustive]
+pub enum Rav1dError {
+    ENOENT = 2,
+    EIO = 5,
+    EAGAIN = 11,
+    ENOMEM = 12,
+    EINVAL = 22,
+    ERANGE = 34,
+    ENOPROTOOPT = 92,
+}
+
+pub type Rav1dResult<T = ()> = Result<T, Rav1dError>;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(transparent)]
+pub struct Dav1dResult(pub c_int);
+
+impl From<Rav1dResult> for Dav1dResult {
+    fn from(value: Rav1dResult) -> Self {
+        Dav1dResult(match value {
+            Ok(()) => 0,
+            Err(e) => -(e as u8 as c_int),
+        })
+    }
+}
+
+impl TryFrom<Dav1dResult> for Rav1dResult {
+    type Error = Dav1dResult;
+
+    fn try_from(value: Dav1dResult) -> Result<Self, Self::Error> {
+        match value.0 {
+            0 => Ok(Ok(())),
+            e => {
+                let e = (-e).try_into().map_err(|_| value)?;
+                let e = Rav1dError::from_repr(e).ok_or(value)?;
+                Ok(Err(e))
+            }
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,9 +5,16 @@ use strum::FromRepr;
 #[derive(Clone, Copy, PartialEq, Eq, FromRepr)]
 #[non_exhaustive]
 pub enum Rav1dError {
-    /// Note that this forces `0` to be the niche,
+    /// This represents a generic `rav1d` error.
+    /// It has nothing to do with the other `errno`-based ones
+    /// (and that's why it's not all caps like the other ones).
+    ///
+    /// Normally `EPERM = 1`, but `dav1d` never uses `EPERM`,
+    /// but does use `-1`, as opposed to the normal `DAV1D_ERR(E*)`.
+    ///
+    /// Also Note that this forces `0` to be the niche,
     /// which is more optimal since `0` is no error for [`Dav1dResult`].
-    EPERM = 1,
+    EGeneric = 1,
 
     ENOENT = 2,
     EIO = 5,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,13 @@
 use std::ffi::c_int;
+use std::ffi::c_uint;
 use strum::FromRepr;
 
 #[derive(Clone, Copy, PartialEq, Eq, FromRepr)]
 #[non_exhaustive]
 pub enum Rav1dError {
-    /// Not actually used (yet), but this forces `0` to be the niche,
+    /// Note that this forces `0` to be the niche,
     /// which is more optimal since `0` is no error for [`Dav1dResult`].
-    _EPERM = 1,
+    EPERM = 1,
 
     ENOENT = 2,
     EIO = 5,
@@ -34,6 +35,16 @@ impl From<Rav1dResult> for Dav1dResult {
                 Err(e) => e as u8 as c_int,
             }),
         )
+    }
+}
+
+impl From<Rav1dResult<c_uint>> for Dav1dResult {
+    #[inline]
+    fn from(value: Rav1dResult<c_uint>) -> Self {
+        Dav1dResult(match value {
+            Ok(value) => value as c_int,
+            Err(e) => e as u8 as c_int,
+        })
     }
 }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -21,6 +21,7 @@ use crate::src::cdef::Rav1dCdefDSPContext;
 use crate::src::cdf::CdfContext;
 use crate::src::cdf::CdfThreadContext;
 use crate::src::env::BlockContext;
+use crate::src::error::Rav1dResult;
 use crate::src::filmgrain::Rav1dFilmGrainDSPContext;
 use crate::src::intra_edge::EdgeBranch;
 use crate::src::intra_edge::EdgeFlags;
@@ -211,7 +212,7 @@ pub struct Rav1dContext {
     pub(crate) frame_flags: PictureFlags,
     pub(crate) event_flags: Rav1dEventFlags,
     pub(crate) cached_error_props: Rav1dDataProps,
-    pub(crate) cached_error: c_int,
+    pub(crate) cached_error: Rav1dResult,
     pub(crate) logger: Rav1dLogger,
     pub(crate) picture_pool: *mut Rav1dMemPool,
 }
@@ -353,7 +354,7 @@ pub(crate) struct Rav1dFrameContext_task_thread {
     pub num_tile_tasks: c_int,
     pub init_done: atomic_int,
     pub done: [atomic_int; 2],
-    pub retval: c_int,
+    pub retval: Rav1dResult,
     pub update_set: bool,
     pub error: atomic_int,
     pub task_counter: atomic_int,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,11 +40,11 @@ use crate::src::data::rav1d_data_wrap_internal;
 use crate::src::data::rav1d_data_wrap_user_data_internal;
 use crate::src::decode::rav1d_decode_frame_exit;
 use crate::src::error::Dav1dResult;
+use crate::src::error::Rav1dError::EGeneric;
 use crate::src::error::Rav1dError::EAGAIN;
 use crate::src::error::Rav1dError::EINVAL;
 use crate::src::error::Rav1dError::ENOENT;
 use crate::src::error::Rav1dError::ENOMEM;
-use crate::src::error::Rav1dError::EPERM;
 use crate::src::error::Rav1dResult;
 use crate::src::internal::CodedBlockInfo;
 use crate::src::internal::Rav1dContext;
@@ -1214,8 +1214,7 @@ pub(crate) unsafe fn rav1d_flush(c: *mut Rav1dContext) {
             }
             let f: *mut Rav1dFrameContext =
                 &mut *((*c).fc).offset(next as isize) as *mut Rav1dFrameContext;
-            // TODO(kkysen) Why was this `-1` in C? All others use `DAV1D_ERR(E*)`.
-            rav1d_decode_frame_exit(&mut *f, Err(EPERM));
+            rav1d_decode_frame_exit(&mut *f, Err(EGeneric));
             (*f).n_tile_data = 0 as c_int;
             (*f).task_thread.retval = Ok(());
             let out_delayed: *mut Rav1dThreadPicture = &mut *((*c).frame_thread.out_delayed)

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -1,3 +1,5 @@
+use crate::src::error::Rav1dError::ENOMEM;
+use crate::src::error::Rav1dResult;
 use libc::free;
 use libc::malloc;
 use libc::posix_memalign;
@@ -125,7 +127,7 @@ pub unsafe fn rav1d_mem_pool_pop(pool: *mut Rav1dMemPool, size: usize) -> *mut R
 }
 
 #[cold]
-pub unsafe fn rav1d_mem_pool_init(ppool: *mut *mut Rav1dMemPool) -> c_int {
+pub unsafe fn rav1d_mem_pool_init(ppool: *mut *mut Rav1dMemPool) -> Rav1dResult {
     let pool: *mut Rav1dMemPool =
         malloc(::core::mem::size_of::<Rav1dMemPool>()) as *mut Rav1dMemPool;
     if !pool.is_null() {
@@ -134,12 +136,12 @@ pub unsafe fn rav1d_mem_pool_init(ppool: *mut *mut Rav1dMemPool) -> c_int {
             (*pool).ref_cnt = 1 as c_int;
             (*pool).end = 0 as c_int;
             *ppool = pool;
-            return 0 as c_int;
+            return Ok(());
         }
         free(pool as *mut c_void);
     }
     *ppool = 0 as *mut Rav1dMemPool;
-    return -(12 as c_int);
+    return Err(ENOMEM);
 }
 
 #[cold]

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -20,8 +20,8 @@ use crate::include::stdatomic::atomic_uint;
 use crate::src::data::rav1d_data_props_copy;
 use crate::src::data::rav1d_data_props_set_defaults;
 use crate::src::error::Dav1dResult;
+use crate::src::error::Rav1dError::EGeneric;
 use crate::src::error::Rav1dError::ENOMEM;
-use crate::src::error::Rav1dError::EPERM;
 use crate::src::error::Rav1dResult;
 use crate::src::internal::Rav1dContext;
 use crate::src::internal::Rav1dFrameContext;
@@ -174,8 +174,7 @@ unsafe fn picture_alloc_with_edges(
             c,
             b"Picture already allocated!\n\0" as *const u8 as *const c_char,
         );
-        // TODO(kkysen) Why was this `-1` in C? All others use `DAV1D_ERR(E*)`.
-        return Err(EPERM);
+        return Err(EGeneric);
     }
     if !(bpc > 0 && bpc <= 16) {
         unreachable!();

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -6,6 +6,8 @@ use crate::include::dav1d::headers::RAV1D_WM_TYPE_TRANSLATION;
 use crate::src::env::fix_mv_precision;
 use crate::src::env::get_gmv_2d;
 use crate::src::env::get_poc_diff;
+use crate::src::error::Rav1dError::ENOMEM;
+use crate::src::error::Rav1dResult;
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::intra_edge::EDGE_I444_TOP_HAS_RIGHT;
 use crate::src::levels::mv;
@@ -1384,7 +1386,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
     rp_ref: *const *mut refmvs_temporal_block,
     n_tile_threads: c_int,
     n_frame_threads: c_int,
-) -> c_int {
+) -> Rav1dResult {
     (*rf).sbsz = (16 as c_int) << (*seq_hdr).sb128;
     (*rf).frm_hdr = frm_hdr;
     (*rf).iw8 = (*frm_hdr).width[0] + 7 >> 3;
@@ -1411,7 +1413,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
             64 as c_int as usize,
         ) as *mut refmvs_block;
         if ((*rf).r).is_null() {
-            return -(12 as c_int);
+            return Err(ENOMEM);
         }
         (*rf).r_stride = r_stride;
     }
@@ -1430,7 +1432,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
             64 as usize,
         ) as *mut refmvs_temporal_block;
         if ((*rf).rp_proj).is_null() {
-            return -(12 as c_int);
+            return Err(ENOMEM);
         }
         (*rf).rp_stride = rp_stride;
     }
@@ -1542,7 +1544,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
         }
     }
     (*rf).use_ref_frame_mvs = ((*rf).n_mfmvs > 0) as c_int;
-    return 0 as c_int;
+    Ok(())
 }
 
 pub(crate) unsafe fn rav1d_refmvs_init(rf: *mut refmvs_frame) {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -9,9 +9,9 @@ use crate::src::decode::rav1d_decode_frame_exit;
 use crate::src::decode::rav1d_decode_frame_init;
 use crate::src::decode::rav1d_decode_frame_init_cdf;
 use crate::src::decode::rav1d_decode_tile_sbrow;
+use crate::src::error::Rav1dError::EGeneric;
 use crate::src::error::Rav1dError::EINVAL;
 use crate::src::error::Rav1dError::ENOMEM;
-use crate::src::error::Rav1dError::EPERM;
 use crate::src::error::Rav1dResult;
 use crate::src::internal::Rav1dContext;
 use crate::src::internal::Rav1dFrameContext;
@@ -449,8 +449,7 @@ pub(crate) unsafe fn rav1d_task_create_tile_sbrow(
                 (::core::mem::size_of::<Rav1dTask>()).wrapping_mul(alloc_num_tasks as usize);
             tasks = realloc((*f).task_thread.tile_tasks[0] as *mut c_void, size) as *mut Rav1dTask;
             if tasks.is_null() {
-                // TODO(kkysen) Why was this `-1` in C? All others use `DAV1D_ERR(E*)`.
-                return Err(EPERM);
+                return Err(EGeneric);
             }
             memset(tasks as *mut c_void, 0 as c_int, size);
             (*f).task_thread.tile_tasks[0] = tasks;
@@ -461,8 +460,7 @@ pub(crate) unsafe fn rav1d_task_create_tile_sbrow(
     tasks = tasks.offset((num_tasks * (pass & 1)) as isize);
     let mut pf_t: *mut Rav1dTask = 0 as *mut Rav1dTask;
     if create_filter_sbrow(f, pass, &mut pf_t) != 0 {
-        // TODO(kkysen) Why was this `-1` in C? All others use `DAV1D_ERR(E*)`.
-        return Err(EPERM);
+        return Err(EGeneric);
     }
     let mut prev_t: *mut Rav1dTask = 0 as *mut Rav1dTask;
     let mut tile_idx = 0;

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -29,6 +29,7 @@ use crate::input::input::input_open;
 use crate::input::input::input_read;
 use crate::input::input::input_seek;
 use crate::input::input::DemuxerContext;
+use libc::EAGAIN;
 use rav1d::include::dav1d::common::Dav1dDataProps;
 use rav1d::include::dav1d::common::Dav1dUserData;
 use rav1d::include::dav1d::data::Dav1dData;
@@ -109,7 +110,7 @@ unsafe fn decode_frame(p: *mut Dav1dPicture, c: *mut Dav1dContext, data: *mut Da
     libc::memset(p as *mut c_void, 0, ::core::mem::size_of::<Dav1dPicture>());
     res = dav1d_send_data(c, data).0;
     if res < 0 {
-        if res != -11 {
+        if res != -EAGAIN {
             libc::fprintf(
                 stderr,
                 b"Error decoding frame: %s\n\0" as *const u8 as *const c_char,
@@ -120,7 +121,7 @@ unsafe fn decode_frame(p: *mut Dav1dPicture, c: *mut Dav1dContext, data: *mut Da
     }
     res = dav1d_get_picture(c, p).0;
     if res < 0 {
-        if res != -(11 as c_int) {
+        if res != -EAGAIN {
             libc::fprintf(
                 stderr,
                 b"Error decoding frame: %s\n\0" as *const u8 as *const c_char,
@@ -460,7 +461,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
                         break;
                     }
                     let sign: c_int = if xor128_rand() & 1 != 0 {
-                        -(1 as c_int)
+                        -1
                     } else {
                         1 as c_int
                     };

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -107,7 +107,7 @@ unsafe fn xor128_rand() -> c_int {
 unsafe fn decode_frame(p: *mut Dav1dPicture, c: *mut Dav1dContext, data: *mut Dav1dData) -> c_int {
     let mut res: c_int;
     libc::memset(p as *mut c_void, 0, ::core::mem::size_of::<Dav1dPicture>());
-    res = dav1d_send_data(c, data);
+    res = dav1d_send_data(c, data).0;
     if res < 0 {
         if res != -11 {
             libc::fprintf(
@@ -118,7 +118,7 @@ unsafe fn decode_frame(p: *mut Dav1dPicture, c: *mut Dav1dContext, data: *mut Da
             return res;
         }
     }
-    res = dav1d_get_picture(c, p);
+    res = dav1d_get_picture(c, p).0;
     if res < 0 {
         if res != -(11 as c_int) {
             libc::fprintf(
@@ -325,7 +325,7 @@ unsafe fn seek(
         if res != 0 {
             break;
         }
-        if !(dav1d_parse_sequence_header(&mut seq, (*data).data, (*data).sz) != 0) {
+        if !(dav1d_parse_sequence_header(&mut seq, (*data).data, (*data).sz).0 != 0) {
             break;
         }
     }
@@ -424,7 +424,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
     {
         return libc::EXIT_SUCCESS;
     }
-    if dav1d_open(&mut c, &mut lib_settings) != 0 {
+    if dav1d_open(&mut c, &mut lib_settings).0 != 0 {
         return libc::EXIT_FAILURE;
     }
     timebase = i_timebase[1] as c_double / i_timebase[0] as c_double;

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -46,6 +46,8 @@ use libc::snprintf;
 use libc::strcmp;
 use libc::strcpy;
 use libc::strerror;
+use libc::EAGAIN;
+use libc::EINVAL;
 use rav1d::include::dav1d::common::Dav1dDataProps;
 use rav1d::include::dav1d::common::Dav1dUserData;
 use rav1d::include::dav1d::data::Dav1dData;
@@ -527,27 +529,27 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
         );
         res = dav1d_send_data(c, &mut data).0;
         if res < 0 {
-            if res != -(11 as c_int) {
+            if res != -EAGAIN {
                 dav1d_data_unref(&mut data);
                 fprintf(
                     stderr,
                     b"Error decoding frame: %s\n\0" as *const u8 as *const c_char,
                     strerror(-res),
                 );
-                if res != -(22 as c_int) {
+                if res != -EINVAL {
                     break;
                 }
             }
         }
         res = dav1d_get_picture(c, &mut p).0;
         if res < 0 {
-            if res != -(11 as c_int) {
+            if res != -EAGAIN {
                 fprintf(
                     stderr,
                     b"Error decoding frame: %s\n\0" as *const u8 as *const c_char,
                     strerror(-res),
                 );
-                if res != -(22 as c_int) {
+                if res != -EINVAL {
                     break;
                 }
             }
@@ -602,13 +604,13 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
         while cli_settings.limit == 0 || n_out < cli_settings.limit {
             res = dav1d_get_picture(c, &mut p).0;
             if res < 0 {
-                if res != -(11 as c_int) {
+                if res != -EAGAIN {
                     fprintf(
                         stderr,
                         b"Error decoding frame: %s\n\0" as *const u8 as *const c_char,
                         strerror(-res),
                     );
-                    if res != -(22 as c_int) {
+                    if res != -EINVAL {
                         break;
                     }
                 } else {

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -81,6 +81,7 @@ use rav1d::src::lib::dav1d_parse_sequence_header;
 use rav1d::src::lib::dav1d_send_data;
 use rav1d::src::lib::dav1d_version;
 use rav1d::stderr;
+use rav1d::Dav1dResult;
 use std::ffi::c_char;
 use std::ffi::c_double;
 use std::ffi::c_int;
@@ -204,7 +205,7 @@ unsafe fn print_stats(istty: c_int, n: c_uint, num: c_uint, elapsed: u64, i_fps:
     fputs(buf.as_mut_ptr(), stderr);
 }
 
-unsafe extern "C" fn picture_alloc(p: *mut Dav1dPicture, _: *mut c_void) -> c_int {
+unsafe extern "C" fn picture_alloc(p: *mut Dav1dPicture, _: *mut c_void) -> Dav1dResult {
     let hbd = ((*p).p.bpc > 8) as c_int;
     let aligned_w = (*p).p.w + 127 & !(127 as c_int);
     let aligned_h = (*p).p.h + 127 & !(127 as c_int);
@@ -231,7 +232,7 @@ unsafe extern "C" fn picture_alloc(p: *mut Dav1dPicture, _: *mut c_void) -> c_in
     let pic_size: usize = y_sz.wrapping_add(2 * uv_sz);
     let buf: *mut u8 = malloc(pic_size.wrapping_add(64)) as *mut u8;
     if buf.is_null() {
-        return -(12 as c_int);
+        return Dav1dResult(-12);
     }
     (*p).allocator_data = buf as *mut c_void;
     let align_m1: ptrdiff_t = (64 - 1) as ptrdiff_t;
@@ -251,7 +252,7 @@ unsafe extern "C" fn picture_alloc(p: *mut Dav1dPicture, _: *mut c_void) -> c_in
     } else {
         0 as *mut u8
     }) as *mut c_void;
-    return 0 as c_int;
+    Dav1dResult(0)
 }
 
 unsafe extern "C" fn picture_release(p: *mut Dav1dPicture, _: *mut c_void) {
@@ -473,7 +474,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
             }; 32],
         };
         let mut seq_skip: c_uint = 0 as c_int as c_uint;
-        while dav1d_parse_sequence_header(&mut seq, data.data, data.sz) != 0 {
+        while dav1d_parse_sequence_header(&mut seq, data.data, data.sz).0 != 0 {
             res = input_read(in_0, &mut data);
             if res < 0 {
                 input_close(in_0);
@@ -493,7 +494,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
     if cli_settings.limit != 0 as c_int as c_uint && cli_settings.limit < total {
         total = cli_settings.limit;
     }
-    res = dav1d_open(&mut c, &mut lib_settings);
+    res = dav1d_open(&mut c, &mut lib_settings).0;
     if res != 0 {
         return 1 as c_int;
     }
@@ -524,7 +525,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
             0 as c_int,
             ::core::mem::size_of::<Dav1dPicture>(),
         );
-        res = dav1d_send_data(c, &mut data);
+        res = dav1d_send_data(c, &mut data).0;
         if res < 0 {
             if res != -(11 as c_int) {
                 dav1d_data_unref(&mut data);
@@ -538,7 +539,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
                 }
             }
         }
-        res = dav1d_get_picture(c, &mut p);
+        res = dav1d_get_picture(c, &mut p).0;
         if res < 0 {
             if res != -(11 as c_int) {
                 fprintf(
@@ -599,7 +600,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
     }
     if res == 0 {
         while cli_settings.limit == 0 || n_out < cli_settings.limit {
-            res = dav1d_get_picture(c, &mut p);
+            res = dav1d_get_picture(c, &mut p).0;
             if res < 0 {
                 if res != -(11 as c_int) {
                     fprintf(

--- a/tools/dav1d_cli_parse.rs
+++ b/tools/dav1d_cli_parse.rs
@@ -593,7 +593,7 @@ pub unsafe fn parse(
             long_opts.as_ptr(),
             0 as *mut c_int,
         );
-        if !(o != -(1 as c_int)) {
+        if !(o != -1) {
             break;
         }
         match o {

--- a/tools/input/input.rs
+++ b/tools/input/input.rs
@@ -7,6 +7,8 @@ use libc::free;
 use libc::malloc;
 use libc::strcmp;
 use libc::strerror;
+use libc::ENOMEM;
+use libc::ENOPROTOOPT;
 use rav1d::errno_location;
 use rav1d::include::dav1d::data::Dav1dData;
 use rav1d::stderr;
@@ -87,7 +89,7 @@ pub unsafe fn input_open(
                 b"Failed to find demuxer named \"%s\"\n\0" as *const u8 as *const c_char,
                 name,
             );
-            return -(92 as c_int);
+            return -ENOPROTOOPT;
         }
     } else {
         let mut probe_sz = 0;
@@ -102,7 +104,7 @@ pub unsafe fn input_open(
                 stderr,
                 b"Failed to allocate memory\n\0" as *const u8 as *const c_char,
             );
-            return -(12 as c_int);
+            return -ENOMEM;
         }
         let f: *mut libc::FILE = fopen(filename, b"rb\0" as *const u8 as *const c_char);
         if f.is_null() {
@@ -149,7 +151,7 @@ pub unsafe fn input_open(
                 b"Failed to probe demuxer for file %s\n\0" as *const u8 as *const c_char,
                 filename,
             );
-            return -(92 as c_int);
+            return -ENOPROTOOPT;
         }
     }
     c = calloc(
@@ -161,7 +163,7 @@ pub unsafe fn input_open(
             stderr,
             b"Failed to allocate memory\n\0" as *const u8 as *const c_char,
         );
-        return -(12 as c_int);
+        return -ENOMEM;
     }
     (*c).impl_0 = impl_0;
     (*c).data = ((*c).priv_data).as_mut_ptr() as *mut DemuxerPriv;
@@ -191,7 +193,7 @@ pub unsafe fn input_seek(ctx: *mut DemuxerContext, pts: u64) -> c_int {
     return if ((*(*ctx).impl_0).seek).is_some() {
         ((*(*ctx).impl_0).seek).expect("non-null function pointer")((*ctx).data, pts)
     } else {
-        -(1 as c_int)
+        -1
     };
 }
 

--- a/tools/output/md5.rs
+++ b/tools/output/md5.rs
@@ -85,7 +85,7 @@ unsafe extern "C" fn md5_open(
                 file,
                 strerror(*errno_location()),
             );
-            return -(1 as c_int);
+            return -1;
         }
     }
     (*md5).abcd[0] = 0x67452301 as c_int as u32;
@@ -604,7 +604,7 @@ unsafe extern "C" fn md5_close(md5: *mut MD5Context) {
 unsafe extern "C" fn md5_verify(md5: *mut MD5Context, mut md5_str: *const c_char) -> c_int {
     md5_finish(md5);
     if strlen(md5_str) < 32 {
-        return -(1 as c_int);
+        return -1;
     }
     let mut abcd: [u32; 4] = [0 as c_int as u32, 0, 0, 0];
     let mut t: [c_char; 3] = [0 as c_int as c_char, 0, 0];

--- a/tools/output/output.rs
+++ b/tools/output/output.rs
@@ -7,6 +7,8 @@ use libc::strchr;
 use libc::strcmp;
 use libc::strlen;
 use libc::strncmp;
+use libc::ENOMEM;
+use libc::ENOPROTOOPT;
 use rav1d::include::dav1d::picture::Dav1dPicture;
 use rav1d::include::dav1d::picture::Dav1dPictureParameters;
 use rav1d::stderr;
@@ -81,7 +83,7 @@ unsafe fn find_extension(f: *const c_char) -> *const c_char {
     return if step < end
         && step > f
         && *step as c_int == '.' as i32
-        && *step.offset(-(1 as c_int) as isize) as c_int != '/' as i32
+        && *step.offset(-1 as isize) as c_int != '/' as i32
     {
         &*step.offset(1) as *const c_char
     } else {
@@ -126,7 +128,7 @@ pub unsafe fn output_open(
                 b"Failed to find muxer named \"%s\"\n\0" as *const u8 as *const c_char,
                 name,
             );
-            return -(92 as c_int);
+            return -ENOPROTOOPT;
         }
     } else if strcmp(filename, b"/dev/null\0" as *const u8 as *const c_char) == 0 {
         impl_0 = muxers[0];
@@ -138,7 +140,7 @@ pub unsafe fn output_open(
                 b"No extension found for file %s\n\0" as *const u8 as *const c_char,
                 filename,
             );
-            return -(1 as c_int);
+            return -1;
         }
         i = 0 as c_int as c_uint;
         while !(muxers[i as usize]).is_null() {
@@ -155,7 +157,7 @@ pub unsafe fn output_open(
                 b"Failed to find muxer for extension \"%s\"\n\0" as *const u8 as *const c_char,
                 ext,
             );
-            return -(92 as c_int);
+            return -ENOPROTOOPT;
         }
     }
     c = malloc((48 as usize).wrapping_add((*impl_0).priv_data_size as usize)) as *mut MuxerContext;
@@ -164,7 +166,7 @@ pub unsafe fn output_open(
             stderr,
             b"Failed to allocate memory\n\0" as *const u8 as *const c_char,
         );
-        return -(12 as c_int);
+        return -ENOMEM;
     }
     (*c).impl_0 = impl_0;
     (*c).data = ((*c).priv_data).as_mut_ptr() as *mut MuxerPriv;

--- a/tools/output/y4m2.rs
+++ b/tools/output/y4m2.rs
@@ -64,7 +64,7 @@ unsafe extern "C" fn y4m2_open(
                 file,
                 strerror(*errno_location()),
             );
-            return -(1 as c_int);
+            return -1;
         }
     }
     (*c).first = 1 as c_int;
@@ -215,7 +215,7 @@ unsafe extern "C" fn y4m2_write(c: *mut Y4m2OutputContext, p: *mut Dav1dPicture)
         b"Failed to write frame data: %s\n\0" as *const u8 as *const c_char,
         strerror(*errno_location()),
     );
-    return -(1 as c_int);
+    return -1;
 }
 
 unsafe extern "C" fn y4m2_close(c: *mut Y4m2OutputContext) {

--- a/tools/output/yuv.rs
+++ b/tools/output/yuv.rs
@@ -61,7 +61,7 @@ unsafe extern "C" fn yuv_open(
                 file,
                 strerror(*errno_location()),
             );
-            return -(1 as c_int);
+            return -1;
         }
     }
     return 0 as c_int;
@@ -131,7 +131,7 @@ unsafe extern "C" fn yuv_write(c: *mut YuvOutputContext, p: *mut Dav1dPicture) -
         b"Failed to write frame data: %s\n\0" as *const u8 as *const c_char,
         strerror(*errno_location()),
     );
-    return -(1 as c_int);
+    return -1;
 }
 
 unsafe extern "C" fn yuv_close(c: *mut YuvOutputContext) {


### PR DESCRIPTION
This adds an `enum Rav1dError`, which is a narrowed version of the overloaded `c_int` that `dav1d` uses for errors.  `dav1d` uses `errno` values for errors (except for `-1` sometimes).  This PR does the same (the same constants), but with `enum Rav1dError` instead of `c_int`.  Since `Rav1dError` has a niche at `0`, this makes `type Rav1dResult<T = ()> = Result<T, Rav1dError>` equivalent to how `dav1d` uses `c_int`, with `0` meaning no error, negative values meaning an error, and positive values meaning a stateful result.  `struct Dav1dResult` encapsulates this in Rust using a `#[repr(transparent)]` new-type, and there are efficient conversions between `{D <=> R}av1dResult`.

`Rav1dResult` is used as the return type for all error-returning `fn`s that are not part of the `#[no_mangle] extern "C"` `DAV1D_API`, which now use `Dav1dResult` instead of `c_int`.  This latter change is done to be more clear about errors while remaining ABI compatible with `dav1d`.  It is not, however, API compatible with Rust consumers of the `DAV1D_API` as now they get `Dav1dResult`s instead of `c_int`s.  The difference is trivial, a `.0`, but it is a difference.  I'm assuming this is okay since users of the `DAV1D_API` would be written in C (or other non-Rust language using C as the interop layer) and thus consume the `dav1d` headers, which remain ABI compatible with `rav1d`.  Rust users, on the other hand, would use the fully Rust-ified safe API, including `Rav1dResult`.

To make sure we are staying ABI compatible, it would be nice to also build the `tools/` and `tests/` binaries from C and link against `rav1d`, though trying the same with Chromium also would more than suffice.

This PR also uses the `errno` `const`s from `libc` rather than the hardcoded ones from transpilation, which used the Linux versions of them.  `ENOPROTOOPT` is not cross-platform, so this PR now fixes that bug.