### PR TITLE
`validate_input!`: Translate macro and all of its uses

### DIFF
--- a/include/common/validate.rs
+++ b/include/common/validate.rs
@@ -1,0 +1,57 @@
+use std::any::type_name;
+use std::process::abort;
+
+fn type_name_of<T>(_: &T) -> &'static str {
+    type_name::<T>()
+}
+
+pub fn parent_type_name_of<T>(t: &T) -> &'static str {
+    let name = type_name_of(&t);
+    let name = name.strip_prefix("&").unwrap();
+    let name = name.strip_suffix("::f").unwrap();
+    name
+}
+
+pub fn debug_abort() {
+    if cfg!(debug_assertions) {
+        abort();
+    }
+}
+
+macro_rules! func_name {
+    () => {{
+        fn f() {}
+        $crate::include::common::validate::parent_type_name_of(&f)
+    }};
+}
+
+pub(crate) use func_name;
+
+macro_rules! validate_input {
+    ($condition:expr, $error:expr, $block:block) => {{
+        match $condition {
+            true => Ok(()),
+            false => {
+                let func_name = $crate::include::common::validate::func_name!();
+                eprintln!(
+                    "Input validation check '{}' failed in {}!",
+                    stringify!($condition),
+                    func_name
+                );
+                $block;
+                $crate::include::common::validate::debug_abort();
+                Err($error)
+            }
+        }
+    }};
+
+    ($condition:expr, $error:expr) => {
+        validate_input!($condition, $error, {})
+    };
+
+    ($condition:expr) => {
+        validate_input!($condition, ())
+    };
+}
+
+pub(crate) use validate_input;

--- a/include/common/validate.rs
+++ b/include/common/validate.rs
@@ -65,9 +65,12 @@ macro_rules! validate_input {
 
         $condition.into_result().map_err(|e| {
             eprintln!(
-                "Input validation check '{}' failed in {}!",
+                "Input validation check `{}` failed in `fn {}` in `{}:{}:{}`!",
                 stringify!($condition),
                 func_name,
+                file!(),
+                line!(),
+                column!(),
             );
             $block;
             debug_abort();

--- a/lib.rs
+++ b/lib.rs
@@ -16,6 +16,7 @@ pub mod include {
         pub(crate) mod dump;
         pub mod frame;
         pub(crate) mod intops;
+        pub(crate) mod validate;
     } // mod common
     pub mod dav1d {
         pub mod common;

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,3 +1,4 @@
+use crate::include::common::validate::validate_input;
 use crate::include::dav1d::common::Rav1dDataProps;
 use crate::include::dav1d::data::Rav1dData;
 use crate::src::error::Rav1dError::EINVAL;
@@ -8,23 +9,14 @@ use crate::src::r#ref::rav1d_ref_dec;
 use crate::src::r#ref::rav1d_ref_inc;
 use crate::src::r#ref::rav1d_ref_wrap;
 use crate::src::r#ref::Rav1dRef;
-use crate::stderr;
-use libc::fprintf;
 use libc::memset;
-use std::ffi::c_char;
 use std::ffi::c_int;
 use std::ffi::c_void;
+use std::ptr;
 
 pub(crate) unsafe fn rav1d_data_create_internal(buf: *mut Rav1dData, sz: usize) -> *mut u8 {
-    if buf.is_null() {
-        fprintf(
-            stderr,
-            b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"buf != NULL\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 27], &[c_char; 27]>(b"dav1d_data_create_internal\0"))
-                .as_ptr(),
-        );
-        return 0 as *mut u8;
+    if let Err(e) = validate_input!((!buf.is_null(), ptr::null_mut())) {
+        return e;
     }
     if sz > usize::MAX / 2 {
         return 0 as *mut u8;
@@ -47,36 +39,9 @@ pub(crate) unsafe fn rav1d_data_wrap_internal(
     free_callback: Option<unsafe extern "C" fn(*const u8, *mut c_void) -> ()>,
     cookie: *mut c_void,
 ) -> Rav1dResult {
-    if buf.is_null() {
-        fprintf(
-            stderr,
-            b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"buf != NULL\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 25], &[c_char; 25]>(b"dav1d_data_wrap_internal\0"))
-                .as_ptr(),
-        );
-        return Err(EINVAL);
-    }
-    if ptr.is_null() {
-        fprintf(
-            stderr,
-            b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"ptr != NULL\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 25], &[c_char; 25]>(b"dav1d_data_wrap_internal\0"))
-                .as_ptr(),
-        );
-        return Err(EINVAL);
-    }
-    if free_callback.is_none() {
-        fprintf(
-            stderr,
-            b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"free_callback != NULL\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 25], &[c_char; 25]>(b"dav1d_data_wrap_internal\0"))
-                .as_ptr(),
-        );
-        return Err(EINVAL);
-    }
+    validate_input!((!buf.is_null(), EINVAL))?;
+    validate_input!((!ptr.is_null(), EINVAL))?;
+    validate_input!((free_callback.is_some(), EINVAL))?;
     (*buf).r#ref = rav1d_ref_wrap(ptr, free_callback, cookie);
     if ((*buf).r#ref).is_null() {
         return Err(ENOMEM);
@@ -94,30 +59,8 @@ pub(crate) unsafe fn rav1d_data_wrap_user_data_internal(
     free_callback: Option<unsafe extern "C" fn(*const u8, *mut c_void) -> ()>,
     cookie: *mut c_void,
 ) -> Rav1dResult {
-    if buf.is_null() {
-        fprintf(
-            stderr,
-            b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"buf != NULL\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 35], &[c_char; 35]>(
-                b"dav1d_data_wrap_user_data_internal\0",
-            ))
-            .as_ptr(),
-        );
-        return Err(EINVAL);
-    }
-    if free_callback.is_none() {
-        fprintf(
-            stderr,
-            b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"free_callback != NULL\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 35], &[c_char; 35]>(
-                b"dav1d_data_wrap_user_data_internal\0",
-            ))
-            .as_ptr(),
-        );
-        return Err(EINVAL);
-    }
+    validate_input!((!buf.is_null(), EINVAL))?;
+    validate_input!((free_callback.is_some(), EINVAL))?;
     (*buf).m.user_data.r#ref = rav1d_ref_wrap(user_data, free_callback, cookie);
     if ((*buf).m.user_data.r#ref).is_null() {
         return Err(ENOMEM);
@@ -127,41 +70,17 @@ pub(crate) unsafe fn rav1d_data_wrap_user_data_internal(
 }
 
 pub(crate) unsafe fn rav1d_data_ref(dst: *mut Rav1dData, src: *const Rav1dData) {
-    if dst.is_null() {
-        fprintf(
-            stderr,
-            b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"dst != ((void*)0)\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 15], &[c_char; 15]>(b"rav1d_data_ref\0")).as_ptr(),
-        );
+    if validate_input!(!dst.is_null()).is_err() {
         return;
     }
-    if !((*dst).data).is_null() {
-        fprintf(
-            stderr,
-            b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"dst->data == ((void*)0)\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 15], &[c_char; 15]>(b"rav1d_data_ref\0")).as_ptr(),
-        );
+    if validate_input!((*dst).data.is_null()).is_err() {
         return;
     }
-    if src.is_null() {
-        fprintf(
-            stderr,
-            b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"src != ((void*)0)\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 15], &[c_char; 15]>(b"rav1d_data_ref\0")).as_ptr(),
-        );
+    if validate_input!(!src.is_null()).is_err() {
         return;
     }
     if !((*src).r#ref).is_null() {
-        if ((*src).data).is_null() {
-            fprintf(
-                stderr,
-                b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-                b"src->data != ((void*)0)\0" as *const u8 as *const c_char,
-                (*::core::mem::transmute::<&[u8; 15], &[c_char; 15]>(b"rav1d_data_ref\0")).as_ptr(),
-            );
+        if validate_input!(!(*src).data.is_null()).is_err() {
             return;
         }
         rav1d_ref_inc((*src).r#ref);
@@ -200,16 +119,7 @@ pub(crate) unsafe fn rav1d_data_props_set_defaults(props: *mut Rav1dDataProps) {
 }
 
 pub(crate) unsafe fn rav1d_data_props_unref_internal(props: *mut Rav1dDataProps) {
-    if props.is_null() {
-        fprintf(
-            stderr,
-            b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"props != ((void*)0)\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 32], &[c_char; 32]>(
-                b"dav1d_data_props_unref_internal\0",
-            ))
-            .as_ptr(),
-        );
+    if validate_input!(!props.is_null()).is_err() {
         return;
     }
     let mut user_data_ref: *mut Rav1dRef = (*props).user_data.r#ref;
@@ -218,28 +128,12 @@ pub(crate) unsafe fn rav1d_data_props_unref_internal(props: *mut Rav1dDataProps)
 }
 
 pub(crate) unsafe fn rav1d_data_unref_internal(buf: *mut Rav1dData) {
-    if buf.is_null() {
-        fprintf(
-            stderr,
-            b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"buf != ((void*)0)\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 26], &[c_char; 26]>(b"dav1d_data_unref_internal\0"))
-                .as_ptr(),
-        );
+    if validate_input!(!buf.is_null()).is_err() {
         return;
     }
     let mut user_data_ref: *mut Rav1dRef = (*buf).m.user_data.r#ref;
     if !((*buf).r#ref).is_null() {
-        if ((*buf).data).is_null() {
-            fprintf(
-                stderr,
-                b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-                b"buf->data != ((void*)0)\0" as *const u8 as *const c_char,
-                (*::core::mem::transmute::<&[u8; 26], &[c_char; 26]>(
-                    b"dav1d_data_unref_internal\0",
-                ))
-                .as_ptr(),
-            );
+        if validate_input!(!(*buf).data.is_null()).is_err() {
             return;
         }
         rav1d_ref_dec(&mut (*buf).r#ref);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1265,15 +1265,19 @@ pub unsafe extern "C" fn dav1d_get_decode_error_data_props(
     .into()
 }
 
-pub(crate) unsafe fn rav1d_picture_unref(p: *mut Rav1dPicture) {
+pub(crate) unsafe fn rav1d_picture_unref(p: &mut Rav1dPicture) {
     rav1d_picture_unref_internal(p);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_picture_unref(p: *mut Dav1dPicture) {
-    let mut p_rust = p.read().into();
+    if validate_input!(!p.is_null()).is_err() {
+        return;
+    }
+    let p = &mut *p;
+    let mut p_rust = p.clone().into();
     rav1d_picture_unref(&mut p_rust);
-    p.write(p_rust.into());
+    *p = p_rust.into();
 }
 
 pub(crate) unsafe fn rav1d_data_create(buf: *mut Rav1dData, sz: usize) -> *mut u8 {

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,7 +1,7 @@
+use crate::include::common::validate::validate_input;
 use crate::include::dav1d::dav1d::Rav1dLogger;
 use crate::src::internal::Rav1dContext;
 use crate::stderr;
-use libc::fprintf;
 use std::ffi::c_char;
 use std::ffi::c_int;
 use std::ffi::c_void;
@@ -31,13 +31,7 @@ impl Default for Rav1dLogger {
 
 #[cold]
 pub unsafe extern "C" fn rav1d_log(c: *mut Rav1dContext, format: *const c_char, args: ...) {
-    if c.is_null() {
-        fprintf(
-            stderr,
-            b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"c != ((void*)0)\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 10], &[c_char; 10]>(b"dav1d_log\0")).as_ptr(),
-        );
+    if validate_input!(!c.is_null()).is_err() {
         return;
     }
     if ((*c).logger.callback).is_none() {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -329,61 +329,49 @@ pub(crate) unsafe fn rav1d_picture_alloc_copy(
     return res;
 }
 
-pub(crate) unsafe fn rav1d_picture_ref(dst: *mut Rav1dPicture, src: *const Rav1dPicture) {
-    if validate_input!(!dst.is_null()).is_err() {
+pub(crate) unsafe fn rav1d_picture_ref(dst: &mut Rav1dPicture, src: &Rav1dPicture) {
+    if validate_input!(dst.data[0].is_null()).is_err() {
         return;
     }
-    if validate_input!((*dst).data[0].is_null()).is_err() {
-        return;
-    }
-    if validate_input!(!src.is_null()).is_err() {
-        return;
-    }
-    if !((*src).r#ref).is_null() {
-        if validate_input!(!(*src).data[0].is_null()).is_err() {
+    if !src.r#ref.is_null() {
+        if validate_input!(!src.data[0].is_null()).is_err() {
             return;
         }
-        rav1d_ref_inc((*src).r#ref);
+        rav1d_ref_inc(src.r#ref);
     }
-    if !((*src).frame_hdr_ref).is_null() {
-        rav1d_ref_inc((*src).frame_hdr_ref);
+    if !src.frame_hdr_ref.is_null() {
+        rav1d_ref_inc(src.frame_hdr_ref);
     }
-    if !((*src).seq_hdr_ref).is_null() {
-        rav1d_ref_inc((*src).seq_hdr_ref);
+    if !src.seq_hdr_ref.is_null() {
+        rav1d_ref_inc(src.seq_hdr_ref);
     }
-    if !((*src).m.user_data.r#ref).is_null() {
-        rav1d_ref_inc((*src).m.user_data.r#ref);
+    if !src.m.user_data.r#ref.is_null() {
+        rav1d_ref_inc(src.m.user_data.r#ref);
     }
-    if !((*src).content_light_ref).is_null() {
-        rav1d_ref_inc((*src).content_light_ref);
+    if !src.content_light_ref.is_null() {
+        rav1d_ref_inc(src.content_light_ref);
     }
-    if !((*src).mastering_display_ref).is_null() {
-        rav1d_ref_inc((*src).mastering_display_ref);
+    if !src.mastering_display_ref.is_null() {
+        rav1d_ref_inc(src.mastering_display_ref);
     }
-    if !((*src).itut_t35_ref).is_null() {
-        rav1d_ref_inc((*src).itut_t35_ref);
+    if !src.itut_t35_ref.is_null() {
+        rav1d_ref_inc(src.itut_t35_ref);
     }
-    *dst = (*src).clone();
+    *dst = src.clone();
 }
 
-pub(crate) unsafe fn rav1d_picture_move_ref(dst: *mut Rav1dPicture, src: *mut Rav1dPicture) {
-    if validate_input!(!dst.is_null()).is_err() {
+pub(crate) unsafe fn rav1d_picture_move_ref(dst: &mut Rav1dPicture, src: &mut Rav1dPicture) {
+    if validate_input!(dst.data[0].is_null()).is_err() {
         return;
     }
-    if validate_input!((*dst).data[0].is_null()).is_err() {
-        return;
-    }
-    if validate_input!(!src.is_null()).is_err() {
-        return;
-    }
-    if !((*src).r#ref).is_null() {
-        if validate_input!(!(*src).data[0].is_null()).is_err() {
+    if !src.r#ref.is_null() {
+        if validate_input!(!src.data[0].is_null()).is_err() {
             return;
         }
     }
-    *dst = (*src).clone();
+    *dst = src.clone();
     memset(
-        src as *mut c_void,
+        src as *mut _ as *mut c_void,
         0 as c_int,
         ::core::mem::size_of::<Rav1dPicture>(),
     );

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -1,4 +1,5 @@
 use crate::errno_location;
+use crate::include::common::validate::validate_input;
 use crate::include::dav1d::common::Rav1dDataProps;
 use crate::include::dav1d::dav1d::Dav1dEventFlags;
 use crate::include::dav1d::dav1d::Rav1dEventFlags;
@@ -34,8 +35,6 @@ use crate::src::r#ref::rav1d_ref_dec;
 use crate::src::r#ref::rav1d_ref_inc;
 use crate::src::r#ref::rav1d_ref_wrap;
 use crate::src::r#ref::Rav1dRef;
-use crate::stderr;
-use libc::fprintf;
 use libc::free;
 use libc::malloc;
 use libc::memset;
@@ -331,42 +330,17 @@ pub(crate) unsafe fn rav1d_picture_alloc_copy(
 }
 
 pub(crate) unsafe fn rav1d_picture_ref(dst: *mut Rav1dPicture, src: *const Rav1dPicture) {
-    if dst.is_null() {
-        fprintf(
-            stderr,
-            b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"dst != ((void*)0)\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 18], &[c_char; 18]>(b"dav1d_picture_ref\0")).as_ptr(),
-        );
+    if validate_input!(!dst.is_null()).is_err() {
         return;
     }
-    if !((*dst).data[0]).is_null() {
-        fprintf(
-            stderr,
-            b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"dst->data[0] == ((void*)0)\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 18], &[c_char; 18]>(b"dav1d_picture_ref\0")).as_ptr(),
-        );
+    if validate_input!((*dst).data[0].is_null()).is_err() {
         return;
     }
-    if src.is_null() {
-        fprintf(
-            stderr,
-            b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"src != ((void*)0)\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 18], &[c_char; 18]>(b"dav1d_picture_ref\0")).as_ptr(),
-        );
+    if validate_input!(!src.is_null()).is_err() {
         return;
     }
     if !((*src).r#ref).is_null() {
-        if ((*src).data[0]).is_null() {
-            fprintf(
-                stderr,
-                b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-                b"src->data[0] != ((void*)0)\0" as *const u8 as *const c_char,
-                (*::core::mem::transmute::<&[u8; 18], &[c_char; 18]>(b"dav1d_picture_ref\0"))
-                    .as_ptr(),
-            );
+        if validate_input!(!(*src).data[0].is_null()).is_err() {
             return;
         }
         rav1d_ref_inc((*src).r#ref);
@@ -393,45 +367,17 @@ pub(crate) unsafe fn rav1d_picture_ref(dst: *mut Rav1dPicture, src: *const Rav1d
 }
 
 pub(crate) unsafe fn rav1d_picture_move_ref(dst: *mut Rav1dPicture, src: *mut Rav1dPicture) {
-    if dst.is_null() {
-        fprintf(
-            stderr,
-            b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"dst != ((void*)0)\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 23], &[c_char; 23]>(b"rav1d_picture_move_ref\0"))
-                .as_ptr(),
-        );
+    if validate_input!(!dst.is_null()).is_err() {
         return;
     }
-    if !((*dst).data[0]).is_null() {
-        fprintf(
-            stderr,
-            b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"dst->data[0] == ((void*)0)\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 23], &[c_char; 23]>(b"rav1d_picture_move_ref\0"))
-                .as_ptr(),
-        );
+    if validate_input!((*dst).data[0].is_null()).is_err() {
         return;
     }
-    if src.is_null() {
-        fprintf(
-            stderr,
-            b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"src != ((void*)0)\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 23], &[c_char; 23]>(b"rav1d_picture_move_ref\0"))
-                .as_ptr(),
-        );
+    if validate_input!(!src.is_null()).is_err() {
         return;
     }
     if !((*src).r#ref).is_null() {
-        if ((*src).data[0]).is_null() {
-            fprintf(
-                stderr,
-                b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-                b"src->data[0] != ((void*)0)\0" as *const u8 as *const c_char,
-                (*::core::mem::transmute::<&[u8; 23], &[c_char; 23]>(b"rav1d_picture_move_ref\0"))
-                    .as_ptr(),
-            );
+        if validate_input!(!(*src).data[0].is_null()).is_err() {
             return;
         }
     }
@@ -471,29 +417,11 @@ pub(crate) unsafe fn rav1d_thread_picture_move_ref(
 }
 
 pub(crate) unsafe fn rav1d_picture_unref_internal(p: *mut Rav1dPicture) {
-    if p.is_null() {
-        fprintf(
-            stderr,
-            b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-            b"p != ((void*)0)\0" as *const u8 as *const c_char,
-            (*::core::mem::transmute::<&[u8; 29], &[c_char; 29]>(
-                b"dav1d_picture_unref_internal\0",
-            ))
-            .as_ptr(),
-        );
+    if validate_input!(!p.is_null()).is_err() {
         return;
     }
     if !((*p).r#ref).is_null() {
-        if ((*p).data[0]).is_null() {
-            fprintf(
-                stderr,
-                b"Input validation check '%s' failed in %s!\n\0" as *const u8 as *const c_char,
-                b"p->data[0] != ((void*)0)\0" as *const u8 as *const c_char,
-                (*::core::mem::transmute::<&[u8; 29], &[c_char; 29]>(
-                    b"dav1d_picture_unref_internal\0",
-                ))
-                .as_ptr(),
-            );
+        if validate_input!(!(*p).data[0].is_null()).is_err() {
             return;
         }
         rav1d_ref_dec(&mut (*p).r#ref);

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -404,28 +404,25 @@ pub(crate) unsafe fn rav1d_thread_picture_move_ref(
     );
 }
 
-pub(crate) unsafe fn rav1d_picture_unref_internal(p: *mut Rav1dPicture) {
-    if validate_input!(!p.is_null()).is_err() {
-        return;
-    }
-    if !((*p).r#ref).is_null() {
-        if validate_input!(!(*p).data[0].is_null()).is_err() {
+pub(crate) unsafe fn rav1d_picture_unref_internal(p: &mut Rav1dPicture) {
+    if !p.r#ref.is_null() {
+        if validate_input!(!p.data[0].is_null()).is_err() {
             return;
         }
-        rav1d_ref_dec(&mut (*p).r#ref);
+        rav1d_ref_dec(&mut p.r#ref);
     }
-    rav1d_ref_dec(&mut (*p).seq_hdr_ref);
-    rav1d_ref_dec(&mut (*p).frame_hdr_ref);
-    rav1d_ref_dec(&mut (*p).m.user_data.r#ref);
-    rav1d_ref_dec(&mut (*p).content_light_ref);
-    rav1d_ref_dec(&mut (*p).mastering_display_ref);
-    rav1d_ref_dec(&mut (*p).itut_t35_ref);
+    rav1d_ref_dec(&mut p.seq_hdr_ref);
+    rav1d_ref_dec(&mut p.frame_hdr_ref);
+    rav1d_ref_dec(&mut p.m.user_data.r#ref);
+    rav1d_ref_dec(&mut p.content_light_ref);
+    rav1d_ref_dec(&mut p.mastering_display_ref);
+    rav1d_ref_dec(&mut p.itut_t35_ref);
     memset(
-        p as *mut c_void,
+        p as *mut _ as *mut c_void,
         0 as c_int,
         ::core::mem::size_of::<Dav1dPicture>(),
     );
-    rav1d_data_props_set_defaults(&mut (*p).m);
+    rav1d_data_props_set_defaults(&mut p.m);
 }
 
 pub(crate) unsafe fn rav1d_thread_picture_unref(p: *mut Rav1dThreadPicture) {


### PR DESCRIPTION
This translates the `validate_input!` macro to (safe) Rust and deduplicates all of its expanded uses.

It also moves null checks that were done with the macro to before those pointers were dereferenced, as some earlier dereferences were added in the `dav1d` to `rav1d` conversions.  Now the `validate_input!` null check happens in the `fn dav1d_*` and safe references are passed to the `fn rav1d_*`, which no longer need to do any null checks.

I also made the `validate_input!` error message a bit more Rusty and also include the source location, which I found useful in debugging things, and seems generally useful for an error message.