### PR TITLE
`test.sh`: Pass `--print-errorlogs` to `meson test` so `stderr` is saved in `testlog.txt`

### DIFF
--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -33,6 +33,7 @@ fi
 
 test_args=(
     --no-rebuild
+    --print-errorlogs
     --timeout-multiplier $timeout_multiplier
     --suite testdata-8
     --suite testdata-10

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -31,22 +31,21 @@ else
         $seek_stress_test_rust_path
 fi
 
+test_args=(
+    --no-rebuild
+    --timeout-multiplier $timeout_multiplier
+    --suite testdata-8
+    --suite testdata-10
+    --suite testdata-12
+    --suite testdata-multi
+)
+
+export RUST_BACKTRACE=1
+
 if [[ -z $seek_stress_test_rust_path ]]; then
-    # stress test binary not provided; don't include seek stress tests
-    cd build && meson test --no-rebuild \
-    --suite testdata-8 \
-    --suite testdata-10 \
-    --suite testdata-12 \
-    --suite testdata-multi \
-    --timeout-multiplier $timeout_multiplier
+    : # stress test binary not provided; don't include seek stress tests
 else
-    cd build && meson test --no-rebuild \
-    --suite testdata-8 \
-    --suite testdata-10 \
-    --suite testdata-12 \
-    --suite testdata-multi \
-    --suite testdata_seek-stress \
-    --timeout-multiplier $timeout_multiplier
+    test_args+=(--suite testdata_seek-stress)
 fi
 
-
+cd build && meson test "${test_args[@]}"


### PR DESCRIPTION
Now we'll be able to see actual errors in CI, which is very important for flaky tests and macOS (in particular, #513 is failing on macOS and I'm not sure why, and #514 is failing on `aarch64` but I can't reproduce it locally).