### PR TITLE
backport from `dav1d` 1.2.0: threading: Ensure passing the correct retval to decode_frame_exit

### DIFF
--- a/src/thread_task.c
+++ b/src/thread_task.c
@@ -793,6 +793,7 @@ void *dav1d_worker_task(void *data) {
                     atomic_load(&f->task_thread.done[0]) &&
                     (!uses_2pass || atomic_load(&f->task_thread.done[1])))
                 {
+                    error = atomic_load(&f->task_thread.error);
                     dav1d_decode_frame_exit(f, error == 1 ? DAV1D_ERR(EINVAL) :
                                             error ? DAV1D_ERR(ENOMEM) : 0);
                     f->n_tile_data = 0;
@@ -889,6 +890,7 @@ void *dav1d_worker_task(void *data) {
             if (!num_tasks && atomic_load(&f->task_thread.done[0]) &&
                 atomic_load(&f->task_thread.done[1]))
             {
+                error = atomic_load(&f->task_thread.error);
                 dav1d_decode_frame_exit(f, error == 1 ? DAV1D_ERR(EINVAL) :
                                         error ? DAV1D_ERR(ENOMEM) : 0);
                 f->n_tile_data = 0;
@@ -918,6 +920,7 @@ void *dav1d_worker_task(void *data) {
         if (!num_tasks && atomic_load(&f->task_thread.done[0]) &&
             (!uses_2pass || atomic_load(&f->task_thread.done[1])))
         {
+            error = atomic_load(&f->task_thread.error);
             dav1d_decode_frame_exit(f, error == 1 ? DAV1D_ERR(EINVAL) :
                                     error ? DAV1D_ERR(ENOMEM) : 0);
             f->n_tile_data = 0;

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1367,6 +1367,9 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                                         as *mut atomic_int,
                                                 ) != 0)
                                         {
+                                            error_0 = ::core::intrinsics::atomic_load_seqcst(
+                                                &mut (*f).task_thread.error,
+                                            );
                                             rav1d_decode_frame_exit(
                                                 &mut *f,
                                                 if error_0 == 1 {
@@ -1607,6 +1610,9 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                             as *mut atomic_int,
                                     ) != 0
                                 {
+                                    error_0 = ::core::intrinsics::atomic_load_seqcst(
+                                        &mut (*f).task_thread.error,
+                                    );
                                     rav1d_decode_frame_exit(
                                         &mut *f,
                                         if error_0 == 1 {
@@ -1672,6 +1678,9 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                                 as *mut atomic_int,
                                         ) != 0)
                                 {
+                                    error_0 = ::core::intrinsics::atomic_load_seqcst(
+                                        &mut (*f).task_thread.error,
+                                    );
                                     rav1d_decode_frame_exit(
                                         &mut *f,
                                         if error_0 == 1 {


### PR DESCRIPTION
Partially address #224