### PR TITLE
backport from `dav1d` 1.2.0: picture: fix attaching props to delayed output pictures

### DIFF
--- a/src/obu.c
+++ b/src/obu.c
@@ -1593,7 +1593,14 @@ int dav1d_parse_obus(Dav1dContext *const c, Dav1dData *const in, const int globa
             if (c->n_fc == 1) {
                 dav1d_thread_picture_ref(&c->out,
                                          &c->refs[c->frame_hdr->existing_frame_idx].p);
-                dav1d_data_props_copy(&c->out.p.m, &in->m);
+                dav1d_picture_copy_props(&c->out.p,
+                                         c->content_light, c->content_light_ref,
+                                         c->mastering_display, c->mastering_display_ref,
+                                         c->itut_t35, c->itut_t35_ref,
+                                         &in->m);
+                // Must be removed from the context after being attached to the frame
+                dav1d_ref_dec(&c->itut_t35_ref);
+                c->itut_t35 = NULL;
                 c->event_flags |= dav1d_picture_get_event_flags(&c->refs[c->frame_hdr->existing_frame_idx].p);
             } else {
                 pthread_mutex_lock(&c->task_thread.lock);
@@ -1639,7 +1646,15 @@ int dav1d_parse_obus(Dav1dContext *const c, Dav1dData *const in, const int globa
                 dav1d_thread_picture_ref(out_delayed,
                                          &c->refs[c->frame_hdr->existing_frame_idx].p);
                 out_delayed->visible = 1;
-                dav1d_data_props_copy(&out_delayed->p.m, &in->m);
+                dav1d_picture_copy_props(&out_delayed->p,
+                                         c->content_light, c->content_light_ref,
+                                         c->mastering_display, c->mastering_display_ref,
+                                         c->itut_t35, c->itut_t35_ref,
+                                         &in->m);
+                // Must be removed from the context after being attached to the frame
+                dav1d_ref_dec(&c->itut_t35_ref);
+                c->itut_t35 = NULL;
+
                 pthread_mutex_unlock(&c->task_thread.lock);
             }
             if (c->refs[c->frame_hdr->existing_frame_idx].p.p.frame_hdr->frame_type == DAV1D_FRAME_TYPE_KEY) {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -91,6 +91,7 @@ use crate::src::levels::OBU_META_ITUT_T35;
 use crate::src::levels::OBU_META_SCALABILITY;
 use crate::src::levels::OBU_META_TIMECODE;
 use crate::src::log::dav1d_log;
+use crate::src::picture::dav1d_picture_copy_props;
 use crate::src::picture::dav1d_picture_get_event_flags;
 use crate::src::picture::dav1d_thread_picture_ref;
 use crate::src::picture::dav1d_thread_picture_unref;
@@ -2102,7 +2103,19 @@ pub unsafe fn dav1d_parse_obus(c: *mut Dav1dContext, in_0: *mut Dav1dData, globa
                         .offset((*(*c).frame_hdr).existing_frame_idx as isize))
                     .p,
                 );
-                dav1d_data_props_copy(&mut (*c).out.p.m, &mut (*in_0).m);
+                dav1d_picture_copy_props(
+                    &mut (*c).out.p,
+                    (*c).content_light,
+                    (*c).content_light_ref,
+                    (*c).mastering_display,
+                    (*c).mastering_display_ref,
+                    (*c).itut_t35,
+                    (*c).itut_t35_ref,
+                    &mut (*in_0).m,
+                );
+                // Must be removed from the context after being attached to the frame
+                dav1d_ref_dec(&mut (*c).itut_t35_ref);
+                (*c).itut_t35 = 0 as *mut Dav1dITUTT35;
                 (*c).event_flags = ::core::mem::transmute::<c_uint, Dav1dEventFlags>(
                     (*c).event_flags as c_uint
                         | dav1d_picture_get_event_flags(
@@ -2189,7 +2202,19 @@ pub unsafe fn dav1d_parse_obus(c: *mut Dav1dContext, in_0: *mut Dav1dData, globa
                     .p,
                 );
                 (*out_delayed).visible = true;
-                dav1d_data_props_copy(&mut (*out_delayed).p.m, &mut (*in_0).m);
+                dav1d_picture_copy_props(
+                    &mut (*out_delayed).p,
+                    (*c).content_light,
+                    (*c).content_light_ref,
+                    (*c).mastering_display,
+                    (*c).mastering_display_ref,
+                    (*c).itut_t35,
+                    (*c).itut_t35_ref,
+                    &mut (*in_0).m,
+                );
+                // Must be removed from the context after being attached to the frame
+                dav1d_ref_dec(&mut (*c).itut_t35_ref);
+                (*c).itut_t35 = 0 as *mut Dav1dITUTT35;
                 pthread_mutex_unlock(&mut (*c).task_thread.lock);
             }
             if (*(*c).refs[(*(*c).frame_hdr).existing_frame_idx as usize]

--- a/src/picture.c
+++ b/src/picture.c
@@ -127,9 +127,6 @@ static int picture_alloc_with_edges(Dav1dContext *const c,
     p->p.h = h;
     p->seq_hdr = seq_hdr;
     p->frame_hdr = frame_hdr;
-    p->content_light = content_light;
-    p->mastering_display = mastering_display;
-    p->itut_t35 = itut_t35;
     p->p.layout = seq_hdr->layout;
     p->p.bpc = bpc;
     dav1d_data_props_set_defaults(&p->m);
@@ -155,21 +152,38 @@ static int picture_alloc_with_edges(Dav1dContext *const c,
     p->frame_hdr_ref = frame_hdr_ref;
     if (frame_hdr_ref) dav1d_ref_inc(frame_hdr_ref);
 
-    dav1d_data_props_copy(&p->m, props);
+    dav1d_picture_copy_props(p, content_light, content_light_ref,
+                             mastering_display, mastering_display_ref,
+                             itut_t35, itut_t35_ref, props);
 
     if (extra && extra_ptr)
         *extra_ptr = &pic_ctx->extra_ptr;
 
+    return 0;
+}
+
+void dav1d_picture_copy_props(Dav1dPicture *const p,
+                              Dav1dContentLightLevel *const content_light, Dav1dRef *const content_light_ref,
+                              Dav1dMasteringDisplay *const mastering_display, Dav1dRef *const mastering_display_ref,
+                              Dav1dITUTT35 *const itut_t35, Dav1dRef *const itut_t35_ref,
+                              const Dav1dDataProps *const props)
+{
+    dav1d_data_props_copy(&p->m, props);
+
+    dav1d_ref_dec(&p->content_light_ref);
     p->content_light_ref = content_light_ref;
+    p->content_light = content_light;
     if (content_light_ref) dav1d_ref_inc(content_light_ref);
 
+    dav1d_ref_dec(&p->mastering_display_ref);
     p->mastering_display_ref = mastering_display_ref;
+    p->mastering_display = mastering_display;
     if (mastering_display_ref) dav1d_ref_inc(mastering_display_ref);
 
+    dav1d_ref_dec(&p->itut_t35_ref);
     p->itut_t35_ref = itut_t35_ref;
+    p->itut_t35 = itut_t35;
     if (itut_t35_ref) dav1d_ref_inc(itut_t35_ref);
-
-    return 0;
 }
 
 int dav1d_thread_picture_alloc(Dav1dContext *const c, Dav1dFrameContext *const f,

--- a/src/picture.h
+++ b/src/picture.h
@@ -101,6 +101,12 @@ int dav1d_default_picture_alloc(Dav1dPicture *p, void *cookie);
 void dav1d_default_picture_release(Dav1dPicture *p, void *cookie);
 void dav1d_picture_unref_internal(Dav1dPicture *p);
 
+void dav1d_picture_copy_props(Dav1dPicture *p,
+                              Dav1dContentLightLevel *content_light, Dav1dRef *content_light_ref,
+                              Dav1dMasteringDisplay *mastering_display, Dav1dRef *mastering_display_ref,
+                              Dav1dITUTT35 *itut_t35, Dav1dRef *itut_t35_ref,
+                              const Dav1dDataProps *props);
+
 /**
  * Get event flags from picture flags.
  */

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -175,9 +175,6 @@ unsafe extern "C" fn picture_alloc_with_edges(
     (*p).p.h = h;
     (*p).seq_hdr = seq_hdr;
     (*p).frame_hdr = frame_hdr;
-    (*p).content_light = content_light;
-    (*p).mastering_display = mastering_display;
-    (*p).itut_t35 = itut_t35;
     (*p).p.layout = (*seq_hdr).layout;
     (*p).p.bpc = bpc;
     dav1d_data_props_set_defaults(&mut (*p).m);
@@ -217,23 +214,56 @@ unsafe extern "C" fn picture_alloc_with_edges(
     if !frame_hdr_ref.is_null() {
         dav1d_ref_inc(frame_hdr_ref);
     }
-    dav1d_data_props_copy(&mut (*p).m, props);
+    dav1d_picture_copy_props(
+        p,
+        content_light,
+        content_light_ref,
+        mastering_display,
+        mastering_display_ref,
+        itut_t35,
+        itut_t35_ref,
+        props,
+    );
+
     if extra != 0 && !extra_ptr.is_null() {
         *extra_ptr = &mut (*pic_ctx).extra_ptr as *mut *mut c_void as *mut c_void;
     }
+
+    return 0 as c_int;
+}
+
+pub unsafe fn dav1d_picture_copy_props(
+    p: *mut Dav1dPicture,
+    content_light: *mut Dav1dContentLightLevel,
+    content_light_ref: *mut Dav1dRef,
+    mastering_display: *mut Dav1dMasteringDisplay,
+    mastering_display_ref: *mut Dav1dRef,
+    itut_t35: *mut Dav1dITUTT35,
+    itut_t35_ref: *mut Dav1dRef,
+    props: *const Dav1dDataProps,
+) {
+    dav1d_data_props_copy(&mut (*p).m, props);
+
+    dav1d_ref_dec(&mut (*p).content_light_ref);
     (*p).content_light_ref = content_light_ref;
+    (*p).content_light = content_light;
     if !content_light_ref.is_null() {
         dav1d_ref_inc(content_light_ref);
     }
+
+    dav1d_ref_dec(&mut (*p).mastering_display_ref);
     (*p).mastering_display_ref = mastering_display_ref;
+    (*p).mastering_display = mastering_display;
     if !mastering_display_ref.is_null() {
         dav1d_ref_inc(mastering_display_ref);
     }
+
+    dav1d_ref_dec(&mut (*p).itut_t35_ref);
     (*p).itut_t35_ref = itut_t35_ref;
+    (*p).itut_t35 = itut_t35;
     if !itut_t35_ref.is_null() {
         dav1d_ref_inc(itut_t35_ref);
     }
-    return 0 as c_int;
 }
 
 pub unsafe fn dav1d_thread_picture_alloc(


### PR DESCRIPTION
Partially addresses #224