### PR TITLE
`struct Av1RestorationUnit`: Make `Copy` and change fields and vars to store by value, not pointer

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4018,7 +4018,7 @@ unsafe fn setup_tile(
             sgr_weights: [-32, 31],
             ..*lr_ref
         };
-        ts.lr_ref[p] = lr_ref;
+        ts.lr_ref[p] = *lr_ref;
     }
 
     if (*f.c).n_tc > 1 {
@@ -4034,7 +4034,7 @@ unsafe fn read_restoration_info(
 ) {
     let f = &*t.f;
     let ts = &mut *t.ts;
-    let lr_ref = &*ts.lr_ref[p];
+    let lr_ref = ts.lr_ref[p];
 
     if frame_type == RAV1D_RESTORATION_SWITCHABLE {
         let filter =
@@ -4086,7 +4086,7 @@ unsafe fn read_restoration_info(
         lr.filter_h[1] = msac_decode_lr_subexp(ts, lr_ref.filter_h[1], 2, 23);
         lr.filter_h[2] = msac_decode_lr_subexp(ts, lr_ref.filter_h[2], 3, 17);
         lr.sgr_weights = lr_ref.sgr_weights;
-        ts.lr_ref[p] = lr;
+        ts.lr_ref[p] = *lr;
         if DEBUG_BLOCK_INFO(f, t) {
             println!(
                 "Post-lr_wiener[pl={},v[{},{},{}],h[{},{},{}]]: r={}",
@@ -4116,7 +4116,7 @@ unsafe fn read_restoration_info(
         };
         lr.filter_v = lr_ref.filter_v;
         lr.filter_h = lr_ref.filter_h;
-        ts.lr_ref[p] = lr;
+        ts.lr_ref[p] = *lr;
         if DEBUG_BLOCK_INFO(f, t) {
             println!(
                 "Post-lr_sgrproj[pl={},idx={},w[{},{}]]: r={}",

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -8,10 +8,10 @@ use crate::include::common::intops::iclip;
 use crate::include::common::intops::iclip_u8;
 use crate::include::common::intops::ulog2;
 use crate::include::dav1d::headers::Dav1dFilterMode;
-use crate::include::dav1d::headers::Dav1dRestorationType;
 use crate::include::dav1d::headers::Dav1dTxfmMode;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
 use crate::include::dav1d::headers::Rav1dFrameHeader_tiling;
+use crate::include::dav1d::headers::Rav1dRestorationType;
 use crate::include::dav1d::headers::Rav1dSequenceHeader;
 use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
 use crate::include::dav1d::headers::RAV1D_FILTER_8TAP_REGULAR;
@@ -4030,7 +4030,7 @@ unsafe fn read_restoration_info(
     t: &mut Rav1dTaskContext,
     lr: &mut Av1RestorationUnit,
     p: usize,
-    frame_type: Dav1dRestorationType,
+    frame_type: Rav1dRestorationType,
 ) {
     let f = &*t.f;
     let ts = &mut *t.ts;
@@ -4263,7 +4263,7 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(t: *mut Rav1dTaskContext) -> c_int 
                 if !(y as c_uint & mask != 0) {
                     let half_unit = unit_size >> 1;
                     if !(y != 0 && y + half_unit > h) {
-                        let frame_type: Dav1dRestorationType =
+                        let frame_type: Rav1dRestorationType =
                             (*(*f).frame_hdr).restoration.type_0[p as usize];
                         if (*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1] {
                             let w = (*f).sr_cur.p.p.w + ss_hor >> ss_hor;

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -459,7 +459,7 @@ pub struct Rav1dTileState {
     pub last_delta_lf: [i8; 4],
     pub lflvlmem: [[[[u8; 2]; 8]; 4]; 8],
     pub lflvl: *const [[[u8; 2]; 8]; 4],
-    pub lr_ref: [*mut Av1RestorationUnit; 3],
+    pub lr_ref: [Av1RestorationUnit; 3],
 }
 
 #[repr(C, align(64))]

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -1,8 +1,8 @@
 use crate::include::common::intops::iclip;
-use crate::include::dav1d::headers::Dav1dRestorationType;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
 use crate::include::dav1d::headers::Rav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Rav1dPixelLayout;
+use crate::include::dav1d::headers::Rav1dRestorationType;
 use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I444;
 use crate::src::align::Align16;
@@ -26,7 +26,7 @@ pub struct Av1FilterLUT {
 #[derive(Clone, Copy, Default)]
 #[repr(C)]
 pub struct Av1RestorationUnit {
-    pub r#type: Dav1dRestorationType,
+    pub r#type: Rav1dRestorationType,
     pub filter_h: [i8; 3],
     pub filter_v: [i8; 3],
     pub sgr_idx: u8,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -23,6 +23,7 @@ pub struct Av1FilterLUT {
     pub sharp: [u64; 2],
 }
 
+#[derive(Clone, Copy, Default)]
 #[repr(C)]
 pub struct Av1RestorationUnit {
     pub r#type: Dav1dRestorationType,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -15,7 +15,6 @@ use crate::include::dav1d::headers::Dav1dFrameType;
 use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
 use crate::include::dav1d::headers::Dav1dPixelLayout;
-use crate::include::dav1d::headers::Dav1dRestorationType;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
 use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
 use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
@@ -28,6 +27,7 @@ use crate::include::dav1d::headers::Rav1dITUTT35;
 use crate::include::dav1d::headers::Rav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Rav1dMasteringDisplay;
 use crate::include::dav1d::headers::Rav1dObuType;
+use crate::include::dav1d::headers::Rav1dRestorationType;
 use crate::include::dav1d::headers::Rav1dSegmentationData;
 use crate::include::dav1d::headers::Rav1dSegmentationDataSet;
 use crate::include::dav1d::headers::Rav1dSequenceHeader;
@@ -1165,10 +1165,10 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
         && (*seqhdr).restoration != 0
         && (*hdr).allow_intrabc == 0
     {
-        (*hdr).restoration.type_0[0] = rav1d_get_bits(gb, 2 as c_int) as Dav1dRestorationType;
+        (*hdr).restoration.type_0[0] = rav1d_get_bits(gb, 2 as c_int) as Rav1dRestorationType;
         if (*seqhdr).monochrome == 0 {
-            (*hdr).restoration.type_0[1] = rav1d_get_bits(gb, 2 as c_int) as Dav1dRestorationType;
-            (*hdr).restoration.type_0[2] = rav1d_get_bits(gb, 2 as c_int) as Dav1dRestorationType;
+            (*hdr).restoration.type_0[1] = rav1d_get_bits(gb, 2 as c_int) as Rav1dRestorationType;
+            (*hdr).restoration.type_0[2] = rav1d_get_bits(gb, 2 as c_int) as Rav1dRestorationType;
         } else {
             (*hdr).restoration.type_0[2] = RAV1D_RESTORATION_NONE;
             (*hdr).restoration.type_0[1] = (*hdr).restoration.type_0[2];


### PR DESCRIPTION
`Av1RestorationUnit` is only 10 bytes, just 2 more than the 8 bytes of a pointer, which also comes with indirection.  Thus, this is likely more performant, and it get rid of nasty lifetimes and shared mutability.

The `lr` array var of `*const Av1RestorationUnit` `const` and just used locally, so the change there is simple.

The `lr_ref` array field is `*mut Av1RestorationUnit`, so `mut` and a field.  However, the `mut` is not needed, so the change becomes simple.