### PR TITLE
`Cargo.toml`: Cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,21 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
-name = "c2rust_out"
-version = "0.0.0"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
- "nasm-rs",
- "num_cpus",
- "paste",
- "raw-cpuid",
- "strum",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +79,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rav1d"
+version = "0.0.0"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "nasm-rs",
+ "num_cpus",
+ "paste",
+ "raw-cpuid",
+ "strum",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "rav1d"
-version = "0.0.0"
+version = "0.2.0"
 dependencies = [
  "bitflags",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = []
+
 [package]
 name = "c2rust_out"
 authors = ["C2Rust"]
@@ -14,12 +15,15 @@ default-run = "dav1d"
 name = "rav1d"
 path = "lib.rs"
 crate-type = ["staticlib", "rlib"]
+
 [[bin]]
 path = "tools/dav1d.rs"
 name = "dav1d"
+
 [[bin]]
 path = "tests/seek_stress.rs"
 name = "seek_stress"
+
 [dependencies]
 bitflags = "2.4.0"
 cfg-if = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = []
 [package]
 name = "rav1d"
 authors = ["C2Rust"]
-version = "0.0.0"
+version = "0.2.0"
 publish = false
 edition = "2021"
 autobins = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = []
 
 [package]
-name = "c2rust_out"
+name = "rav1d"
 authors = ["C2Rust"]
 version = "0.0.0"
 publish = false
@@ -12,7 +12,6 @@ autotests = false
 default-run = "dav1d"
 
 [lib]
-name = "rav1d"
 path = "lib.rs"
 crate-type = ["staticlib", "rlib"]
 

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -377,16 +377,18 @@ unsafe fn wiener_rust<BD: BitDepth>(
 ///
 /// Example for a 4x4 block:
 ///
-///     x x x x x x x x x x
-///     x c c c c c c c c x
-///     x i s s s s s s i x
-///     x i s s s s s s i x
-///     x i s s s s s s i x
-///     x i s s s s s s i x
-///     x i s s s s s s i x
-///     x i s s s s s s i x
-///     x c c c c c c c c x
-///     x x x x x x x x x x
+/// ```text
+/// x x x x x x x x x x
+/// x c c c c c c c c x
+/// x i s s s s s s i x
+/// x i s s s s s s i x
+/// x i s s s s s s i x
+/// x i s s s s s s i x
+/// x i s s s s s s i x
+/// x i s s s s s s i x
+/// x c c c c c c c c x
+/// x x x x x x x x x x
+/// ```
 ///
 /// * s: Pixel summed and stored
 /// * i: Pixel summed and stored (between loops)
@@ -467,16 +469,18 @@ fn boxsum3<BD: BitDepth>(
 ///
 /// Example for a 4x4 block:
 ///
-///     c c c c c c c c c c
-///     c c c c c c c c c c
-///     i i s s s s s s i i
-///     i i s s s s s s i i
-///     i i s s s s s s i i
-///     i i s s s s s s i i
-///     i i s s s s s s i i
-///     i i s s s s s s i i
-///     c c c c c c c c c c
-///     c c c c c c c c c c
+/// ```text
+/// c c c c c c c c c c
+/// c c c c c c c c c c
+/// i i s s s s s s i i
+/// i i s s s s s s i i
+/// i i s s s s s s i i
+/// i i s s s s s s i i
+/// i i s s s s s s i i
+/// i i s s s s s s i i
+/// c c c c c c c c c c
+/// c c c c c c c c c c
+/// ```
 ///
 /// * s: Pixel summed and stored
 /// * i: Pixel summed and stored (between loops)


### PR DESCRIPTION
This just cleans up `Cargo.toml`, which was still mostly generated by `c2rust transpile`.  The package is now named `rav1d` (like the `lib` was already changed to) and I set the version to `0.2.0` for future publishing (and so things like #519 don't need to patch it).  The existing `rav1d` crate is at `0.1.0`, and so since we plan on publishing there, we can start at `0.2.0`.  I also fixed some doc comments so `cargo test` can run.