### PR TITLE
`fn {decode_{b,sb},rav1d_decode_tile_sbrow,recon_b_inter}`: Make return type `Result<(), ()>` to use `?`

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1591,9 +1591,7 @@ unsafe fn decode_b(
                     }
                 }
             }
-            if f.bd_fn.recon_b_inter(t, bs, b) != 0 {
-                return Err(());
-            }
+            f.bd_fn.recon_b_inter(t, bs, b)?;
 
             let filter = &dav1d_filter_dir[b.filter2d() as usize];
             CaseSet::<32, false>::many(
@@ -2404,8 +2402,8 @@ unsafe fn decode_b(
         if t.frame_thread.pass == 1 {
             f.bd_fn.read_coef_blocks(t, bs, b);
             *b.filter2d_mut() = FILTER_2D_BILINEAR as u8;
-        } else if f.bd_fn.recon_b_inter(t, bs, b) != 0 {
-            return Err(());
+        } else {
+            f.bd_fn.recon_b_inter(t, bs, b)?;
         }
 
         splat_intrabc_mv(&*f.c, t, bs, b, bw4 as usize, bh4 as usize);
@@ -3158,8 +3156,8 @@ unsafe fn decode_b(
         // reconstruction
         if t.frame_thread.pass == 1 {
             f.bd_fn.read_coef_blocks(t, bs, b);
-        } else if f.bd_fn.recon_b_inter(t, bs, b) != 0 {
-            return Err(());
+        } else {
+            f.bd_fn.recon_b_inter(t, bs, b)?;
         }
 
         if frame_hdr.loopfilter.level_y != [0, 0] {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -265,8 +265,11 @@ impl Rav1dFrameContext_bd_fn {
         context: *mut Rav1dTaskContext,
         block_size: BlockSize,
         block: *const Av1Block,
-    ) -> c_int {
-        self.recon_b_inter.expect("non-null function pointer")(context, block_size, block)
+    ) -> Result<(), ()> {
+        match self.recon_b_inter.expect("non-null function pointer")(context, block_size, block) {
+            0 => Ok(()),
+            _ => Err(()),
+        }
     }
 
     pub unsafe fn read_coef_blocks(

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1327,7 +1327,10 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                                 as c_int
                                     };
                                     if error_0 == 0 {
-                                        error_0 = rav1d_decode_tile_sbrow(&mut *tc) as c_int;
+                                        error_0 = match rav1d_decode_tile_sbrow(&mut *tc) {
+                                            Ok(()) => 0,
+                                            Err(()) => 1,
+                                        };
                                     }
                                     let progress = if error_0 != 0 { TILE_ERROR } else { 1 + sby };
                                     ::core::intrinsics::atomic_or_seqcst(


### PR DESCRIPTION
This makes error returns much clearer as to when there's an error or not (e.x. `Err(())` instead of `1` or `-1` and `Ok(())` instead of `0`), and it allows us to use `?`, which is very natural for these propagating up the error patterns.