### PR TITLE
`union BitDepthUnion`: Add a generic `BitDepth` `union` type that can resolve to a `BitDepth` dependent type

### DIFF
--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -174,6 +174,11 @@ pub trait BitDepth: Clone + Copy {
         T: BitDepthDependentType,
         T::T<BitDepth8>: Copy,
         T::T<BitDepth16>: Copy;
+
+    type GrainLut;
+    type Scaling;
+
+    const SCALING_LEN: usize;
 }
 
 #[derive(Clone, Copy)]
@@ -251,6 +256,11 @@ impl BitDepth for BitDepth8 {
     {
         bd.bpc8
     }
+
+    type GrainLut = i8;
+    type Scaling = [u8; Self::SCALING_LEN];
+
+    const SCALING_LEN: usize = 256;
 }
 
 #[derive(Clone, Copy)]
@@ -331,6 +341,11 @@ impl BitDepth for BitDepth16 {
     {
         bd.bpc16
     }
+
+    type GrainLut = i16;
+    type Scaling = [u8; Self::SCALING_LEN];
+
+    const SCALING_LEN: usize = 4096;
 }
 
 pub struct DisplayPixel8(<BitDepth8 as BitDepth>::Pixel);

--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -156,6 +156,24 @@ pub trait BitDepth: Clone + Copy {
     fn get_intermediate_bits(&self) -> u8;
 
     const PREP_BIAS: i16;
+
+    unsafe fn select<T>(bd: &BitDepthUnion<T>) -> &T::T<Self>
+    where
+        T: BitDepthDependentType,
+        T::T<BitDepth8>: Copy,
+        T::T<BitDepth16>: Copy;
+
+    unsafe fn select_mut<T>(bd: &mut BitDepthUnion<T>) -> &mut T::T<Self>
+    where
+        T: BitDepthDependentType,
+        T::T<BitDepth8>: Copy,
+        T::T<BitDepth16>: Copy;
+
+    unsafe fn select_into<T>(bd: BitDepthUnion<T>) -> T::T<Self>
+    where
+        T: BitDepthDependentType,
+        T::T<BitDepth8>: Copy,
+        T::T<BitDepth16>: Copy;
 }
 
 #[derive(Clone, Copy)]
@@ -206,6 +224,33 @@ impl BitDepth for BitDepth8 {
 
     /// Output in interval `[-5132, 9212]`; fits in [`i16`] as is.
     const PREP_BIAS: i16 = 0;
+
+    unsafe fn select<T>(bd: &BitDepthUnion<T>) -> &T::T<Self>
+    where
+        T: BitDepthDependentType,
+        T::T<BitDepth8>: Copy,
+        T::T<BitDepth16>: Copy,
+    {
+        &bd.bpc8
+    }
+
+    unsafe fn select_mut<T>(bd: &mut BitDepthUnion<T>) -> &mut T::T<Self>
+    where
+        T: BitDepthDependentType,
+        T::T<BitDepth8>: Copy,
+        T::T<BitDepth16>: Copy,
+    {
+        &mut bd.bpc8
+    }
+
+    unsafe fn select_into<T>(bd: BitDepthUnion<T>) -> T::T<Self>
+    where
+        T: BitDepthDependentType,
+        T::T<BitDepth8>: Copy,
+        T::T<BitDepth16>: Copy,
+    {
+        bd.bpc8
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -259,6 +304,33 @@ impl BitDepth for BitDepth16 {
     /// Output in interval `[-20588, 36956]` (10-bit), `[-20602, 36983]` (12-bit)
     /// Subtract a bias to ensure the output fits in [`i16`].
     const PREP_BIAS: i16 = 8192;
+
+    unsafe fn select<T>(bd: &BitDepthUnion<T>) -> &T::T<Self>
+    where
+        T: BitDepthDependentType,
+        T::T<BitDepth8>: Copy,
+        T::T<BitDepth16>: Copy,
+    {
+        &bd.bpc16
+    }
+
+    unsafe fn select_mut<T>(bd: &mut BitDepthUnion<T>) -> &mut T::T<Self>
+    where
+        T: BitDepthDependentType,
+        T::T<BitDepth8>: Copy,
+        T::T<BitDepth16>: Copy,
+    {
+        &mut bd.bpc16
+    }
+
+    unsafe fn select_into<T>(bd: BitDepthUnion<T>) -> T::T<Self>
+    where
+        T: BitDepthDependentType,
+        T::T<BitDepth8>: Copy,
+        T::T<BitDepth16>: Copy,
+    {
+        bd.bpc16
+    }
 }
 
 pub struct DisplayPixel8(<BitDepth8 as BitDepth>::Pixel);
@@ -288,6 +360,39 @@ pub struct DynEntry(c_void);
 
 pub type LeftPixelRow<Pixel> = [Pixel; 4];
 pub type LeftPixelRow2px<Pixel> = [Pixel; 2];
+
+pub trait BitDepthDependentType {
+    type T<BD: BitDepth>;
+}
+
+// #[derive(Clone, Copy)]
+pub union BitDepthUnion<T: BitDepthDependentType>
+where
+    T::T<BitDepth8>: Copy,
+    T::T<BitDepth16>: Copy,
+{
+    bpc8: T::T<BitDepth8>,
+    bpc16: T::T<BitDepth16>,
+}
+
+// Implemented manually to not require `T: Copy`.
+impl<T: BitDepthDependentType> Copy for BitDepthUnion<T>
+where
+    T::T<BitDepth8>: Copy,
+    T::T<BitDepth16>: Copy,
+{
+}
+
+// Implemented manually to not require `T: Clone`.
+impl<T: BitDepthDependentType> Clone for BitDepthUnion<T>
+where
+    T::T<BitDepth8>: Copy,
+    T::T<BitDepth16>: Copy,
+{
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 
 #[cfg(feature = "asm")]
 macro_rules! bd_fn {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -549,23 +549,15 @@ pub union Rav1dTaskContext_scratch_levels_pal {
 
 #[derive(Clone, Copy)]
 #[repr(C)]
-pub struct Rav1dTaskContext_scratch_interintra_edge_8 {
-    pub interintra_8bpc: [u8; 4096],
-    pub edge_8bpc: [u8; 257],
+pub struct InterIntraEdgeBD<BD: BitDepth> {
+    pub interintra: [BD::Pixel; 64 * 64],
+    pub edge: [BD::Pixel; 257],
 }
 
-#[derive(Clone, Copy)]
-#[repr(C)]
-pub struct Rav1dTaskContext_scratch_interintra_edge_16 {
-    pub interintra_16bpc: [u16; 4096],
-    pub edge_16bpc: [u16; 257],
-}
+pub struct InterIntraEdge;
 
-#[derive(Clone, Copy)]
-#[repr(C, align(64))]
-pub union Rav1dTaskContext_scratch_interintra_edge {
-    pub c2rust_unnamed: Rav1dTaskContext_scratch_interintra_edge_8,
-    pub c2rust_unnamed_0: Rav1dTaskContext_scratch_interintra_edge_16,
+impl BitDepthDependentType for InterIntraEdge {
+    type T<BD: BitDepth> = Align64<InterIntraEdgeBD<BD>>;
 }
 
 #[derive(Clone, Copy)]
@@ -575,7 +567,7 @@ pub struct Rav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
     pub ac: [i16; 1024],
     pub pal_idx: [u8; 8192],
     pub pal: [[u16; 8]; 3],
-    pub c2rust_unnamed_0: Rav1dTaskContext_scratch_interintra_edge,
+    pub interintra_edge: BitDepthUnion<InterIntraEdge>,
 }
 
 #[repr(C, align(64))]

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -506,11 +506,16 @@ pub struct Rav1dTaskContext_scratch_compinter_seg_mask {
     pub seg_mask: [u8; 16384],
 }
 
+pub struct Lap;
+
+impl BitDepthDependentType for Lap {
+    type T<BD: BitDepth> = [BD::Pixel; 128 * 32];
+}
+
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub union Rav1dTaskContext_scratch_lap {
-    pub lap_8bpc: [u8; 4096],
-    pub lap_16bpc: [u16; 4096],
+    pub lap: BitDepthUnion<Lap>,
     pub c2rust_unnamed: Rav1dTaskContext_scratch_compinter_seg_mask,
 }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -115,22 +115,16 @@ pub(crate) struct Rav1dContext_frame_thread {
 
 #[derive(Clone, Copy)]
 #[repr(C)]
-pub struct TaskThreadData_grain_lut_scaling_8 {
-    pub grain_lut_8bpc: Align16<[[[i8; 82]; 74]; 3]>,
-    pub scaling_8bpc: Align64<[[u8; 256]; 3]>,
+pub struct GrainLutScalingBD<BD: BitDepth> {
+    pub grain_lut: Align16<[[[BD::GrainLut; 82]; 73 + 1]; 3]>,
+    // TODO(kkysen) can use `BD::SCALING_LEN`` directly with `#![feature(generic_const_exprs)]` when stabilized
+    pub scaling: Align64<[BD::Scaling; 3]>,
 }
 
-#[derive(Clone, Copy)]
-#[repr(C)]
-pub struct TaskThreadData_grain_lut_scaling_16 {
-    pub grain_lut_16bpc: Align16<[[[i16; 82]; 74]; 3]>,
-    pub scaling_16bpc: Align64<[[u8; 4096]; 3]>,
-}
+pub struct GrainLutScaling;
 
-#[repr(C)]
-pub union TaskThreadData_grain_lut_scaling {
-    pub c2rust_unnamed: TaskThreadData_grain_lut_scaling_8,
-    pub c2rust_unnamed_0: TaskThreadData_grain_lut_scaling_16,
+impl BitDepthDependentType for GrainLutScaling {
+    type T<BD: BitDepth> = GrainLutScalingBD<BD>;
 }
 
 #[repr(C)]
@@ -141,7 +135,7 @@ pub(crate) struct TaskThreadData_delayed_fg {
     pub out: *mut Rav1dPicture,
     pub type_0: TaskType,
     pub progress: [atomic_int; 2],
-    pub c2rust_unnamed: TaskThreadData_grain_lut_scaling,
+    pub grain_lut_scaling: BitDepthUnion<GrainLutScaling>,
 }
 
 #[repr(C)]

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,4 +1,6 @@
 use crate::include::common::bitdepth::BitDepth;
+use crate::include::common::bitdepth::BitDepthDependentType;
+use crate::include::common::bitdepth::BitDepthUnion;
 use crate::include::common::bitdepth::DynCoef;
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::dav1d::common::Rav1dDataProps;
@@ -512,18 +514,18 @@ pub union Rav1dTaskContext_scratch_lap {
     pub c2rust_unnamed: Rav1dTaskContext_scratch_compinter_seg_mask,
 }
 
-#[derive(Clone, Copy)]
-#[repr(C)]
-pub union Rav1dTaskContext_scratch_emu_edge {
-    pub emu_edge_8bpc: [u8; 84160],
-    pub emu_edge_16bpc: [u16; 84160],
+// stride=192 for non-SVC, or 320 for SVC
+pub struct EmuEdge;
+
+impl BitDepthDependentType for EmuEdge {
+    type T<BD: BitDepth> = [BD::Pixel; 320 * (256 + 7)];
 }
 
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct Rav1dTaskContext_scratch_lap_emu_edge {
     pub c2rust_unnamed: Rav1dTaskContext_scratch_lap,
-    pub c2rust_unnamed_0: Rav1dTaskContext_scratch_emu_edge,
+    pub emu_edge: BitDepthUnion<EmuEdge>,
 }
 
 #[derive(Clone, Copy)]

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -493,10 +493,10 @@ pub struct Rav1dTileState {
     pub lr_ref: [Av1RestorationUnit; 3],
 }
 
-#[repr(C, align(64))]
-pub union Rav1dTaskContext_cf {
-    pub cf_8bpc: [i16; 1024],
-    pub cf_16bpc: [i32; 1024],
+pub struct Cf;
+
+impl BitDepthDependentType for Cf {
+    type T<BD: BitDepth> = Align64<[BD::Coef; 32 * 32]>;
 }
 
 #[derive(Clone, Copy)]
@@ -600,7 +600,7 @@ pub(crate) struct Rav1dTaskContext {
     pub l: BlockContext,
     pub a: *mut BlockContext,
     pub rt: refmvs_tile,
-    pub c2rust_unnamed: Rav1dTaskContext_cf,
+    pub cf: BitDepthUnion<Cf>,
     pub al_pal: [[[[u16; 8]; 3]; 32]; 2],
     pub pal_sz_uv: [[u8; 32]; 2],
     pub txtp_map: [u8; 1024],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use crate::include::common::bitdepth::BitDepth;
+use crate::include::common::bitdepth::BitDepth16;
 use crate::include::common::bitdepth::DynCoef;
 use crate::include::common::validate::validate_input;
 use crate::include::dav1d::common::Dav1dDataProps;
@@ -27,6 +29,7 @@ use crate::include::dav1d::picture::Dav1dPicture;
 use crate::include::dav1d::picture::Rav1dPicture;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
+use crate::src::align::Align64;
 use crate::src::cdf::rav1d_cdf_thread_unref;
 use crate::src::cpu::rav1d_init_cpu;
 use crate::src::cpu::rav1d_num_logical_processors;
@@ -425,11 +428,7 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
         (*t).f = &mut *((*c).fc).offset(0) as *mut Rav1dFrameContext;
         (*t).task_thread.ttd = &mut (*c).task_thread;
         (*t).c = c;
-        memset(
-            ((*t).c2rust_unnamed.cf_16bpc).as_mut_ptr() as *mut c_void,
-            0 as c_int,
-            ::core::mem::size_of::<[i32; 1024]>(),
-        );
+        *BitDepth16::select_mut(&mut (*t).cf) = Align64([0; 32 * 32]);
         if (*c).n_tc > 1 as c_uint {
             if pthread_mutex_init(
                 &mut (*t).task_thread.td.lock,

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2120,14 +2120,8 @@ unsafe fn mc<BD: BitDepth>(
             || dx + bw4 * h_mul + (mx != 0) as c_int * 4 > w
             || dy + bh4 * v_mul + (my != 0) as c_int * 4 > h
         {
-            let emu_edge_buf: *mut BD::Pixel = match BD::BPC {
-                BPC::BPC8 => ((*t).scratch.c2rust_unnamed.c2rust_unnamed_0.emu_edge_8bpc)
-                    .as_mut_ptr()
-                    .cast::<BD::Pixel>(),
-                BPC::BPC16 => ((*t).scratch.c2rust_unnamed.c2rust_unnamed_0.emu_edge_16bpc)
-                    .as_mut_ptr()
-                    .cast::<BD::Pixel>(),
-            };
+            let emu_edge_buf =
+                BD::select_mut(&mut (*t).scratch.c2rust_unnamed.emu_edge).as_mut_ptr();
             ((*(*f).dsp).mc.emu_edge)(
                 (bw4 * h_mul + (mx != 0) as c_int * 7) as intptr_t,
                 (bh4 * v_mul + (my != 0) as c_int * 7) as intptr_t,
@@ -2218,14 +2212,8 @@ unsafe fn mc<BD: BitDepth>(
         let w = (*refp).p.p.w + ss_hor >> ss_hor;
         let h = (*refp).p.p.h + ss_ver >> ss_ver;
         if left < 3 || top < 3 || right + 4 > w || bottom + 4 > h {
-            let emu_edge_buf: *mut BD::Pixel = match BD::BPC {
-                BPC::BPC8 => ((*t).scratch.c2rust_unnamed.c2rust_unnamed_0.emu_edge_8bpc)
-                    .as_mut_ptr()
-                    .cast::<BD::Pixel>(),
-                BPC::BPC16 => ((*t).scratch.c2rust_unnamed.c2rust_unnamed_0.emu_edge_16bpc)
-                    .as_mut_ptr()
-                    .cast::<BD::Pixel>(),
-            };
+            let emu_edge_buf =
+                BD::select_mut(&mut (*t).scratch.c2rust_unnamed.emu_edge).as_mut_ptr();
             ((*(*f).dsp).mc.emu_edge)(
                 (right - left + 7) as intptr_t,
                 (bottom - top + 7) as intptr_t,
@@ -2477,14 +2465,8 @@ unsafe fn warp_affine<BD: BitDepth>(
             let ref_ptr: *const BD::Pixel;
             let mut ref_stride: ptrdiff_t = (*refp).p.stride[(pl != 0) as c_int as usize];
             if dx < 3 || dx + 8 + 4 > width || dy < 3 || dy + 8 + 4 > height {
-                let emu_edge_buf: *mut BD::Pixel = match BD::BPC {
-                    BPC::BPC8 => ((*t).scratch.c2rust_unnamed.c2rust_unnamed_0.emu_edge_8bpc)
-                        .as_mut_ptr()
-                        .cast::<BD::Pixel>(),
-                    BPC::BPC16 => ((*t).scratch.c2rust_unnamed.c2rust_unnamed_0.emu_edge_16bpc)
-                        .as_mut_ptr()
-                        .cast::<BD::Pixel>(),
-                };
+                let emu_edge_buf =
+                    BD::select_mut(&mut (*t).scratch.c2rust_unnamed.emu_edge).as_mut_ptr();
                 ((*(*f).dsp).mc.emu_edge)(
                     15 as c_int as intptr_t,
                     15 as c_int as intptr_t,

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2291,14 +2291,7 @@ unsafe fn obmc<BD: BitDepth>(
         .as_mut_ptr()
         .offset((((*t).by & 31) + 5) as isize)
         as *mut *mut refmvs_block;
-    let lap: *mut BD::Pixel = match BD::BPC {
-        BPC::BPC8 => ((*t).scratch.c2rust_unnamed.c2rust_unnamed.lap_8bpc)
-            .as_mut_ptr()
-            .cast::<BD::Pixel>(),
-        BPC::BPC16 => ((*t).scratch.c2rust_unnamed.c2rust_unnamed.lap_16bpc)
-            .as_mut_ptr()
-            .cast::<BD::Pixel>(),
-    };
+    let lap = BD::select_mut(&mut (*t).scratch.c2rust_unnamed.c2rust_unnamed.lap).as_mut_ptr();
     let ss_ver = (pl != 0
         && (*f).cur.p.layout as c_uint == RAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint)
         as c_int;

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2554,25 +2554,10 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
         as *const TxfmInfo;
     let uv_t_dim: *const TxfmInfo =
         &*dav1d_txfm_dimensions.as_ptr().offset(b.uvtx as isize) as *const TxfmInfo;
-    let edge: *mut BD::Pixel = (match BD::BPC {
-        BPC::BPC8 => (t
-            .scratch
-            .c2rust_unnamed_0
-            .c2rust_unnamed_0
-            .c2rust_unnamed
-            .edge_8bpc)
-            .as_mut_ptr()
-            .cast::<BD::Pixel>(),
-        BPC::BPC16 => (t
-            .scratch
-            .c2rust_unnamed_0
-            .c2rust_unnamed_0
-            .c2rust_unnamed_0
-            .edge_16bpc)
-            .as_mut_ptr()
-            .cast::<BD::Pixel>(),
-    })
-    .offset(128);
+    let edge = BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge)
+        .0
+        .edge[128..]
+        .as_mut_ptr();
     let cbw4 = bw4 + ss_hor >> ss_hor;
     let cbh4 = bh4 + ss_ver >> ss_ver;
     let intra_edge_filter_flag = (*(*f).seq_hdr).intra_edge_filter << 10;
@@ -3465,25 +3450,10 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
             }
         }
         if b.c2rust_unnamed.c2rust_unnamed_0.interintra_type != 0 {
-            let tl_edge: *mut BD::Pixel = (match BD::BPC {
-                BPC::BPC8 => (t
-                    .scratch
-                    .c2rust_unnamed_0
-                    .c2rust_unnamed_0
-                    .c2rust_unnamed
-                    .edge_8bpc)
-                    .as_mut_ptr()
-                    .cast::<BD::Pixel>(),
-                BPC::BPC16 => (t
-                    .scratch
-                    .c2rust_unnamed_0
-                    .c2rust_unnamed_0
-                    .c2rust_unnamed_0
-                    .edge_16bpc)
-                    .as_mut_ptr()
-                    .cast::<BD::Pixel>(),
-            })
-            .offset(32);
+            let tl_edge = BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge)
+                .0
+                .edge[32..]
+                .as_mut_ptr();
             let mut m: IntraPredMode = (if b
                 .c2rust_unnamed
                 .c2rust_unnamed_0
@@ -3500,24 +3470,10 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     .c2rust_unnamed
                     .interintra_mode as c_int
             }) as IntraPredMode;
-            let tmp: *mut BD::Pixel = match BD::BPC {
-                BPC::BPC8 => (t
-                    .scratch
-                    .c2rust_unnamed_0
-                    .c2rust_unnamed_0
-                    .c2rust_unnamed
-                    .interintra_8bpc)
-                    .as_mut_ptr()
-                    .cast::<BD::Pixel>(),
-                BPC::BPC16 => (t
-                    .scratch
-                    .c2rust_unnamed_0
-                    .c2rust_unnamed_0
-                    .c2rust_unnamed_0
-                    .interintra_16bpc)
-                    .as_mut_ptr()
-                    .cast::<BD::Pixel>(),
-            };
+            let tmp = BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge)
+                .0
+                .interintra
+                .as_mut_ptr();
             let mut angle = 0;
             let mut top_sb_edge: *const BD::Pixel = 0 as *const BD::Pixel;
             if t.by & (*f).sb_step - 1 == 0 {
@@ -3909,43 +3865,15 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     };
                     let mut pl = 0;
                     while pl < 2 {
-                        let tmp: *mut BD::Pixel = match BD::BPC {
-                            BPC::BPC8 => (t
-                                .scratch
-                                .c2rust_unnamed_0
-                                .c2rust_unnamed_0
-                                .c2rust_unnamed
-                                .interintra_8bpc)
-                                .as_mut_ptr()
-                                .cast::<BD::Pixel>(),
-                            BPC::BPC16 => (t
-                                .scratch
-                                .c2rust_unnamed_0
-                                .c2rust_unnamed_0
-                                .c2rust_unnamed_0
-                                .interintra_16bpc)
-                                .as_mut_ptr()
-                                .cast::<BD::Pixel>(),
-                        };
-                        let tl_edge: *mut BD::Pixel = (match BD::BPC {
-                            BPC::BPC8 => (t
-                                .scratch
-                                .c2rust_unnamed_0
-                                .c2rust_unnamed_0
-                                .c2rust_unnamed
-                                .edge_8bpc)
-                                .as_mut_ptr()
-                                .cast::<BD::Pixel>(),
-                            BPC::BPC16 => (t
-                                .scratch
-                                .c2rust_unnamed_0
-                                .c2rust_unnamed_0
-                                .c2rust_unnamed_0
-                                .edge_16bpc)
-                                .as_mut_ptr()
-                                .cast::<BD::Pixel>(),
-                        })
-                        .offset(32);
+                        let tmp = BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge)
+                            .0
+                            .interintra
+                            .as_mut_ptr();
+                        let tl_edge =
+                            BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge)
+                                .0
+                                .edge[32..]
+                                .as_mut_ptr();
                         let mut m: IntraPredMode = (if b
                             .c2rust_unnamed
                             .c2rust_unnamed_0

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -1734,10 +1734,7 @@ unsafe fn read_coef_tree<BD: BitDepth>(
                 .offset(((*t).by as isize * (*f).b4_stride + (*t).bx as isize) as isize)
                 as *mut CodedBlockInfo;
         } else {
-            cf = match BD::BPC {
-                BPC::BPC8 => (*t).c2rust_unnamed.cf_8bpc.as_mut_ptr().cast::<BD::Coef>(),
-                BPC::BPC16 => (*t).c2rust_unnamed.cf_16bpc.as_mut_ptr().cast::<BD::Coef>(),
-            };
+            cf = BD::select_mut(&mut (*t).cf).0.as_mut_ptr();
         }
         if (*t).frame_thread.pass != 2 as c_int {
             eob = decode_coefs::<BD>(
@@ -2743,14 +2740,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             txtp = (*cbi).txtp[0] as TxfmType;
                         } else {
                             let mut cf_ctx: u8 = 0;
-                            cf = match BD::BPC {
-                                BPC::BPC8 => {
-                                    (t.c2rust_unnamed.cf_8bpc).as_mut_ptr().cast::<BD::Coef>()
-                                }
-                                BPC::BPC16 => {
-                                    (t.c2rust_unnamed.cf_16bpc).as_mut_ptr().cast::<BD::Coef>()
-                                }
-                            };
+                            cf = BD::select_mut(&mut (*t).cf).0.as_mut_ptr();
                             eob = decode_coefs::<BD>(
                                 t,
                                 &mut (*t.a).lcoef.0[(bx4 + x) as usize..],
@@ -3172,14 +3162,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                     txtp = (*cbi).txtp[(pl + 1) as usize] as TxfmType;
                                 } else {
                                     let mut cf_ctx: u8 = 0;
-                                    cf = match BD::BPC {
-                                        BPC::BPC8 => (t.c2rust_unnamed.cf_8bpc)
-                                            .as_mut_ptr()
-                                            .cast::<BD::Coef>(),
-                                        BPC::BPC16 => (t.c2rust_unnamed.cf_16bpc)
-                                            .as_mut_ptr()
-                                            .cast::<BD::Coef>(),
-                                    };
+                                    cf = BD::select_mut(&mut (*t).cf).0.as_mut_ptr();
                                     eob = decode_coefs::<BD>(
                                         t,
                                         &mut (*t.a).ccoef.0[pl as usize][(cbx4 + x) as usize..],
@@ -4398,14 +4381,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                                 txtp = (*cbi).txtp[(1 + pl) as usize] as TxfmType;
                             } else {
                                 let mut cf_ctx: u8 = 0;
-                                cf = match BD::BPC {
-                                    BPC::BPC8 => {
-                                        t.c2rust_unnamed.cf_8bpc.as_mut_ptr().cast::<BD::Coef>()
-                                    }
-                                    BPC::BPC16 => {
-                                        t.c2rust_unnamed.cf_16bpc.as_mut_ptr().cast::<BD::Coef>()
-                                    }
-                                };
+                                cf = BD::select_mut(&mut (*t).cf).0.as_mut_ptr();
                                 txtp = t.txtp_map
                                     [((by4 + (y << ss_ver)) * 32 + bx4 + (x << ss_hor)) as usize]
                                     as TxfmType;

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1,4 +1,7 @@
 use crate::include::common::attributes::ctz;
+use crate::include::common::bitdepth::BitDepth;
+use crate::include::common::bitdepth::BitDepth16;
+use crate::include::common::bitdepth::BitDepth8;
 use crate::include::common::intops::iclip;
 use crate::include::dav1d::headers::RAV1D_PIXEL_LAYOUT_I420;
 use crate::include::dav1d::picture::Rav1dPicture;
@@ -735,46 +738,26 @@ unsafe fn delayed_fg_task(c: *const Rav1dContext, ttd: *mut TaskThreadData) {
             match (*out).p.bpc {
                 #[cfg(feature = "bitdepth_8")]
                 8 => {
+                    let grain_lut_scaling =
+                        BitDepth8::select_mut(&mut (*ttd).delayed_fg.grain_lut_scaling);
                     rav1d_prep_grain_8bpc(
                         &(*((*c).dsp).as_ptr().offset(0)).fg,
                         out,
                         in_0,
-                        ((*ttd)
-                            .delayed_fg
-                            .c2rust_unnamed
-                            .c2rust_unnamed
-                            .scaling_8bpc
-                            .0)
-                            .as_mut_ptr(),
-                        ((*ttd)
-                            .delayed_fg
-                            .c2rust_unnamed
-                            .c2rust_unnamed
-                            .grain_lut_8bpc
-                            .0)
-                            .as_mut_ptr(),
+                        grain_lut_scaling.scaling.0.as_mut_ptr(),
+                        grain_lut_scaling.grain_lut.0.as_mut_ptr(),
                     );
                 }
                 #[cfg(feature = "bitdepth_16")]
                 10 | 12 => {
+                    let grain_lut_scaling =
+                        BitDepth16::select_mut(&mut (*ttd).delayed_fg.grain_lut_scaling);
                     rav1d_prep_grain_16bpc(
                         &(*((*c).dsp).as_ptr().offset(off as isize)).fg,
                         out,
                         in_0,
-                        ((*ttd)
-                            .delayed_fg
-                            .c2rust_unnamed
-                            .c2rust_unnamed_0
-                            .scaling_16bpc
-                            .0)
-                            .as_mut_ptr(),
-                        ((*ttd)
-                            .delayed_fg
-                            .c2rust_unnamed
-                            .c2rust_unnamed_0
-                            .grain_lut_16bpc
-                            .0)
-                            .as_mut_ptr(),
+                        grain_lut_scaling.scaling.0.as_mut_ptr(),
+                        grain_lut_scaling.grain_lut.0.as_mut_ptr(),
                     );
                 }
                 _ => {
@@ -810,47 +793,27 @@ unsafe fn delayed_fg_task(c: *const Rav1dContext, ttd: *mut TaskThreadData) {
         match (*out).p.bpc {
             #[cfg(feature = "bitdepth_8")]
             8 => {
+                let grain_lut_scaling =
+                    BitDepth8::select_mut(&mut (*ttd).delayed_fg.grain_lut_scaling);
                 rav1d_apply_grain_row_8bpc(
                     &(*((*c).dsp).as_ptr().offset(0)).fg,
                     out,
                     in_0,
-                    ((*ttd)
-                        .delayed_fg
-                        .c2rust_unnamed
-                        .c2rust_unnamed
-                        .scaling_8bpc
-                        .0)
-                        .as_mut_ptr(),
-                    ((*ttd)
-                        .delayed_fg
-                        .c2rust_unnamed
-                        .c2rust_unnamed
-                        .grain_lut_8bpc
-                        .0)
-                        .as_mut_ptr(),
+                    grain_lut_scaling.scaling.0.as_mut_ptr(),
+                    grain_lut_scaling.grain_lut.0.as_mut_ptr(),
                     row,
                 );
             }
             #[cfg(feature = "bitdepth_16")]
             10 | 12 => {
+                let grain_lut_scaling =
+                    BitDepth16::select_mut(&mut (*ttd).delayed_fg.grain_lut_scaling);
                 rav1d_apply_grain_row_16bpc(
                     &(*((*c).dsp).as_ptr().offset(off as isize)).fg,
                     out,
                     in_0,
-                    ((*ttd)
-                        .delayed_fg
-                        .c2rust_unnamed
-                        .c2rust_unnamed_0
-                        .scaling_16bpc
-                        .0)
-                        .as_mut_ptr(),
-                    ((*ttd)
-                        .delayed_fg
-                        .c2rust_unnamed
-                        .c2rust_unnamed_0
-                        .grain_lut_16bpc
-                        .0)
-                        .as_mut_ptr(),
+                    grain_lut_scaling.scaling.0.as_mut_ptr(),
+                    grain_lut_scaling.grain_lut.0.as_mut_ptr(),
                     row,
                 );
             }


### PR DESCRIPTION
This adds the generic `BitDepth` `union` type `BitDepthUnion` that can resolve, in a `BitDepth`-generic `fn`, to a `BitDepth`-dependent type.  This is done through `trait BitDepthDependentType`, which has a GAT.  Thus, we're able to abstract over `union`s that store storage for both `BitDepth`s and select the right one in a bitdepth `fn`.  Previously, I had to do this with unchecked ptr casts, but that wouldn't work when things got more cleaned up and the arrays were used directly.  The API in `trait BitDepth`, the `fn select*` methods, is still `unsafe` since `union` field accesses are `unsafe`, but it could easily be adapted to a safe version using `enum`s (which would runtime-check the correct `BitDepth` was used) or even `struct`s (which could just separately store both versions, if extra memory usage in the scratch space is not a concern).