### PR TITLE
`fn output_image`: Cleanup

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -217,7 +217,7 @@ pub struct Rav1dContext {
     pub(crate) refmvs_dsp: Rav1dRefmvsDSPContext,
     pub(crate) intra_edge: Rav1dContext_intra_edge,
     pub(crate) allocator: Rav1dPicAllocator,
-    pub(crate) apply_grain: c_int,
+    pub(crate) apply_grain: bool,
     pub(crate) operating_point: c_int,
     pub(crate) operating_point_idc: c_uint,
     pub(crate) all_layers: bool,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -220,7 +220,7 @@ pub struct Rav1dContext {
     pub(crate) apply_grain: c_int,
     pub(crate) operating_point: c_int,
     pub(crate) operating_point_idc: c_uint,
-    pub(crate) all_layers: c_int,
+    pub(crate) all_layers: bool,
     pub(crate) max_spatial_id: c_int,
     pub(crate) frame_size_limit: c_uint,
     pub(crate) strict_std_compliance: c_int,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -221,7 +221,7 @@ pub struct Rav1dContext {
     pub(crate) operating_point: c_int,
     pub(crate) operating_point_idc: c_uint,
     pub(crate) all_layers: bool,
-    pub(crate) max_spatial_id: c_int,
+    pub(crate) max_spatial_id: bool,
     pub(crate) frame_size_limit: c_uint,
     pub(crate) strict_std_compliance: c_int,
     pub(crate) output_invisible_frames: c_int,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -619,7 +619,7 @@ unsafe fn output_image(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRes
     if !c.all_layers && c.max_spatial_id && !(c.out.p.data[0]).is_null() {
         rav1d_thread_picture_move_ref(r#in, &mut c.out);
     }
-    return res;
+    res
 }
 
 unsafe extern "C" fn output_picture_ready(c: *mut Rav1dContext, drain: c_int) -> c_int {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,6 +605,7 @@ impl Rav1dPicture {
 
 unsafe fn output_image(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dResult {
     let mut res = Ok(());
+
     let r#in: *mut Rav1dThreadPicture = if c.all_layers || !c.max_spatial_id {
         &mut c.out
     } else {
@@ -616,6 +617,7 @@ unsafe fn output_image(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRes
         res = rav1d_apply_grain(c, out, &(*r#in).p);
     }
     rav1d_thread_picture_unref(r#in);
+
     if !c.all_layers && c.max_spatial_id && !(c.out.p.data[0]).is_null() {
         rav1d_thread_picture_move_ref(r#in, &mut c.out);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -614,7 +614,7 @@ unsafe fn output_image(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRes
         rav1d_picture_move_ref(out, &mut (*r#in).p);
         rav1d_thread_picture_unref(r#in);
     } else {
-        res = rav1d_apply_grain(c, out, &mut (*r#in).p);
+        res = rav1d_apply_grain(c, out, &(*r#in).p);
         rav1d_thread_picture_unref(r#in);
     }
     if c.all_layers == 0 && c.max_spatial_id != 0 && !(c.out.p.data[0]).is_null() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,11 +612,10 @@ unsafe fn output_image(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRes
     };
     if !c.apply_grain || !(*r#in).p.has_grain() {
         rav1d_picture_move_ref(out, &mut (*r#in).p);
-        rav1d_thread_picture_unref(r#in);
     } else {
         res = rav1d_apply_grain(c, out, &(*r#in).p);
-        rav1d_thread_picture_unref(r#in);
     }
+    rav1d_thread_picture_unref(r#in);
     if !c.all_layers && c.max_spatial_id && !(c.out.p.data[0]).is_null() {
         rav1d_thread_picture_move_ref(r#in, &mut c.out);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,20 +605,20 @@ impl Rav1dPicture {
 
 unsafe fn output_image(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dResult {
     let mut res = Ok(());
-    let in_0: *mut Rav1dThreadPicture = if c.all_layers != 0 || c.max_spatial_id == 0 {
+    let r#in: *mut Rav1dThreadPicture = if c.all_layers != 0 || c.max_spatial_id == 0 {
         &mut c.out
     } else {
         &mut c.cache
     };
-    if c.apply_grain == 0 || !(*in_0).p.has_grain() {
-        rav1d_picture_move_ref(out, &mut (*in_0).p);
-        rav1d_thread_picture_unref(in_0);
+    if c.apply_grain == 0 || !(*r#in).p.has_grain() {
+        rav1d_picture_move_ref(out, &mut (*r#in).p);
+        rav1d_thread_picture_unref(r#in);
     } else {
-        res = rav1d_apply_grain(c, out, &mut (*in_0).p);
-        rav1d_thread_picture_unref(in_0);
+        res = rav1d_apply_grain(c, out, &mut (*r#in).p);
+        rav1d_thread_picture_unref(r#in);
     }
     if c.all_layers == 0 && c.max_spatial_id != 0 && !(c.out.p.data[0]).is_null() {
-        rav1d_thread_picture_move_ref(in_0, &mut c.out);
+        rav1d_thread_picture_move_ref(r#in, &mut c.out);
     }
     return res;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,7 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
     );
     (*c).allocator = s.allocator.clone();
     (*c).logger = s.logger.clone();
-    (*c).apply_grain = s.apply_grain;
+    (*c).apply_grain = s.apply_grain != 0;
     (*c).operating_point = s.operating_point;
     (*c).all_layers = s.all_layers != 0;
     (*c).frame_size_limit = s.frame_size_limit;
@@ -610,7 +610,7 @@ unsafe fn output_image(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRes
     } else {
         &mut c.cache
     };
-    if c.apply_grain == 0 || !(*r#in).p.has_grain() {
+    if !c.apply_grain || !(*r#in).p.has_grain() {
         rav1d_picture_move_ref(out, &mut (*r#in).p);
         rav1d_thread_picture_unref(r#in);
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,7 +286,7 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
     (*c).logger = s.logger.clone();
     (*c).apply_grain = s.apply_grain;
     (*c).operating_point = s.operating_point;
-    (*c).all_layers = s.all_layers;
+    (*c).all_layers = s.all_layers != 0;
     (*c).frame_size_limit = s.frame_size_limit;
     (*c).strict_std_compliance = s.strict_std_compliance;
     (*c).output_invisible_frames = s.output_invisible_frames;
@@ -605,7 +605,7 @@ impl Rav1dPicture {
 
 unsafe fn output_image(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dResult {
     let mut res = Ok(());
-    let r#in: *mut Rav1dThreadPicture = if c.all_layers != 0 || c.max_spatial_id == 0 {
+    let r#in: *mut Rav1dThreadPicture = if c.all_layers || c.max_spatial_id == 0 {
         &mut c.out
     } else {
         &mut c.cache
@@ -617,7 +617,7 @@ unsafe fn output_image(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRes
         res = rav1d_apply_grain(c, out, &(*r#in).p);
         rav1d_thread_picture_unref(r#in);
     }
-    if c.all_layers == 0 && c.max_spatial_id != 0 && !(c.out.p.data[0]).is_null() {
+    if !c.all_layers && c.max_spatial_id != 0 && !(c.out.p.data[0]).is_null() {
         rav1d_thread_picture_move_ref(r#in, &mut c.out);
     }
     return res;
@@ -627,7 +627,7 @@ unsafe extern "C" fn output_picture_ready(c: *mut Rav1dContext, drain: c_int) ->
     if (*c).cached_error.is_err() {
         return 1 as c_int;
     }
-    if (*c).all_layers == 0 && (*c).max_spatial_id != 0 {
+    if !(*c).all_layers && (*c).max_spatial_id != 0 {
         if !((*c).out.p.data[0]).is_null() && !((*c).cache.p.data[0]).is_null() {
             if (*c).max_spatial_id == (*(*c).cache.p.frame_hdr).spatial_id
                 || (*c).out.flags as c_uint & PICTURE_FLAG_NEW_TEMPORAL_UNIT as c_int as c_uint != 0

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -255,9 +255,9 @@ unsafe fn parse_seq_hdr(
     (*c).operating_point_idc = (*hdr).operating_points[op_idx as usize].idc as c_uint;
     let spatial_mask = (*c).operating_point_idc >> 8;
     (*c).max_spatial_id = if spatial_mask != 0 {
-        ulog2(spatial_mask)
+        ulog2(spatial_mask) != 0
     } else {
-        0 as c_int
+        false
     };
     (*hdr).width_n_bits =
         (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;


### PR DESCRIPTION
This cleanup included making some fields of `struct Rav1dContext` `bool`s.

Also, cleaning up this `fn` further runs into borrow checker issues that aren't easily fixed.  We'll need to split up `struct Rav1dContext` so that it and one of its fields can be passed as `&mut`.