### PR TITLE
`src/filmgrain.rs`: Cleanup part 3 (mostly `fn sample_lut`)

### DIFF
--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -388,7 +388,7 @@ unsafe extern "C" fn generate_grain_uv_c_erased<
 /// while taking into account the offsets
 /// provided by the offsets cache.
 #[inline]
-unsafe fn sample_lut<BD: BitDepth>(
+fn sample_lut<BD: BitDepth>(
     grain_lut: &GrainLut<BD::Entry>,
     offsets: &[[c_int; 2]; 2],
     is_subx: bool,

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -402,7 +402,7 @@ fn sample_lut<BD: BitDepth>(
 
     let randval = offsets[bx][by];
     let offx = 3 + (2 >> subx) * (3 + (randval >> 4));
-    let offy = 3 + (2 >> suby) * (3 + (randval & 0xf as c_int));
+    let offy = 3 + (2 >> suby) * (3 + (randval & 0xF));
     grain_lut[(offy + y) as usize + (BLOCK_SIZE >> suby) * by]
         [(offx + x) as usize + (BLOCK_SIZE >> subx) * bx]
 }

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -528,44 +528,40 @@ unsafe fn fgy_32x32xn_rust<BD: BitDepth>(
 
             // Special case for overlapped column
             for x in 0..xstart {
-                let mut grain =
-                    sample_lut::<BD>(grain_lut, &offsets, false, false, false, false, x, y);
+                let grain = sample_lut::<BD>(grain_lut, &offsets, false, false, false, false, x, y);
                 let old = sample_lut::<BD>(grain_lut, &offsets, false, false, true, false, x, y);
-                grain = round2(old * w[x as usize][0] + grain * w[x as usize][1], 5);
-                grain = iclip(grain, grain_min, grain_max);
+                let grain = round2(old * w[x as usize][0] + grain * w[x as usize][1], 5);
+                let grain = iclip(grain, grain_min, grain_max);
                 add_noise_y(x, y, grain);
             }
         }
         for y in 0..ystart {
             // Special case for overlapped row (sans corner)
             for x in xstart..bw {
-                let mut grain =
-                    sample_lut::<BD>(grain_lut, &offsets, false, false, false, false, x, y);
+                let grain = sample_lut::<BD>(grain_lut, &offsets, false, false, false, false, x, y);
                 let old = sample_lut::<BD>(grain_lut, &offsets, false, false, false, true, x, y);
-                grain = round2(old * w[y as usize][0] + grain * w[y as usize][1], 5);
-                grain = iclip(grain, grain_min, grain_max);
+                let grain = round2(old * w[y as usize][0] + grain * w[y as usize][1], 5);
+                let grain = iclip(grain, grain_min, grain_max);
                 add_noise_y(x, y, grain);
             }
 
             // Special case for doubly-overlapped corner
             for x in 0..xstart {
                 // Blend the top pixel with the top left block
-                let mut top =
-                    sample_lut::<BD>(grain_lut, &offsets, false, false, false, true, x, y);
-                let mut old = sample_lut::<BD>(grain_lut, &offsets, false, false, true, true, x, y);
-                top = round2(old * w[x as usize][0] + top * w[x as usize][1], 5);
-                top = iclip(top, grain_min, grain_max);
+                let top = sample_lut::<BD>(grain_lut, &offsets, false, false, false, true, x, y);
+                let old = sample_lut::<BD>(grain_lut, &offsets, false, false, true, true, x, y);
+                let top = round2(old * w[x as usize][0] + top * w[x as usize][1], 5);
+                let top = iclip(top, grain_min, grain_max);
 
                 // Blend the current pixel with the left block
-                let mut grain =
-                    sample_lut::<BD>(grain_lut, &offsets, false, false, false, false, x, y);
-                old = sample_lut::<BD>(grain_lut, &offsets, false, false, true, false, x, y);
+                let grain = sample_lut::<BD>(grain_lut, &offsets, false, false, false, false, x, y);
+                let old = sample_lut::<BD>(grain_lut, &offsets, false, false, true, false, x, y);
 
                 // Mix the row rows together and apply grain
-                grain = round2(old * w[x as usize][0] + grain * w[x as usize][1], 5);
-                grain = iclip(grain, grain_min, grain_max);
-                grain = round2(top * w[y as usize][0] + grain * w[y as usize][1], 5);
-                grain = iclip(grain, grain_min, grain_max);
+                let grain = round2(old * w[x as usize][0] + grain * w[x as usize][1], 5);
+                let grain = iclip(grain, grain_min, grain_max);
+                let grain = round2(top * w[y as usize][0] + grain * w[y as usize][1], 5);
+                let grain = iclip(grain, grain_min, grain_max);
                 add_noise_y(x, y, grain);
             }
         }
@@ -699,59 +695,55 @@ unsafe fn fguv_32x32xn_rust<BD: BitDepth>(
 
             // Special case for overlapped column
             for x in 0..xstart {
-                let mut grain =
-                    sample_lut::<BD>(grain_lut, &offsets, is_sx, is_sy, false, false, x, y);
+                let grain = sample_lut::<BD>(grain_lut, &offsets, is_sx, is_sy, false, false, x, y);
                 let old = sample_lut::<BD>(grain_lut, &offsets, is_sx, is_sy, true, false, x, y);
-                grain = round2(
+                let grain = round2(
                     old * w[sx as usize][x as usize][0] + grain * w[sx as usize][x as usize][1],
                     5,
                 );
-                grain = iclip(grain, grain_min, grain_max);
+                let grain = iclip(grain, grain_min, grain_max);
                 add_noise_uv(x, y, grain);
             }
         }
         for y in 0..ystart {
             // Special case for overlapped row (sans corner)
             for x in xstart..bw {
-                let mut grain =
-                    sample_lut::<BD>(grain_lut, &offsets, is_sx, is_sy, false, false, x, y);
+                let grain = sample_lut::<BD>(grain_lut, &offsets, is_sx, is_sy, false, false, x, y);
                 let old = sample_lut::<BD>(grain_lut, &offsets, is_sx, is_sy, false, true, x, y);
-                grain = round2(
+                let grain = round2(
                     old * w[sy as usize][y as usize][0] + grain * w[sy as usize][y as usize][1],
                     5,
                 );
-                grain = iclip(grain, grain_min, grain_max);
+                let grain = iclip(grain, grain_min, grain_max);
                 add_noise_uv(x, y, grain);
             }
 
             // Special case for doubly-overlapped corner
             for x in 0..xstart {
                 // Blend the top pixel with the top left block
-                let mut top =
-                    sample_lut::<BD>(grain_lut, &offsets, is_sx, is_sy, false, true, x, y);
-                let mut old = sample_lut::<BD>(grain_lut, &offsets, is_sx, is_sy, true, true, x, y);
-                top = round2(
+                let top = sample_lut::<BD>(grain_lut, &offsets, is_sx, is_sy, false, true, x, y);
+                let old = sample_lut::<BD>(grain_lut, &offsets, is_sx, is_sy, true, true, x, y);
+                let top = round2(
                     old * w[sx as usize][x as usize][0] + top * w[sx as usize][x as usize][1],
                     5,
                 );
-                top = iclip(top, grain_min, grain_max);
+                let top = iclip(top, grain_min, grain_max);
 
                 // Blend the current pixel with the left block
-                let mut grain =
-                    sample_lut::<BD>(grain_lut, &offsets, is_sx, is_sy, false, false, x, y);
-                old = sample_lut::<BD>(grain_lut, &offsets, is_sx, is_sy, true, false, x, y);
+                let grain = sample_lut::<BD>(grain_lut, &offsets, is_sx, is_sy, false, false, x, y);
+                let old = sample_lut::<BD>(grain_lut, &offsets, is_sx, is_sy, true, false, x, y);
 
                 // Mix the row rows together and apply to image
-                grain = round2(
+                let grain = round2(
                     old * w[sx as usize][x as usize][0] + grain * w[sx as usize][x as usize][1],
                     5,
                 );
-                grain = iclip(grain, grain_min, grain_max);
-                grain = round2(
+                let grain = iclip(grain, grain_min, grain_max);
+                let grain = round2(
                     top * w[sy as usize][y as usize][0] + grain * w[sy as usize][y as usize][1],
                     5,
                 );
-                grain = iclip(grain, grain_min, grain_max);
+                let grain = iclip(grain, grain_min, grain_max);
                 add_noise_uv(x, y, grain);
             }
         }

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -398,13 +398,13 @@ fn sample_lut<BD: BitDepth>(
     x: c_int,
     y: c_int,
 ) -> BD::Entry {
-    let [subx, suby, bx, by] = [is_subx, is_suby, is_bx, is_by].map(|it| it as c_int);
+    let [subx, suby, bx, by] = [is_subx, is_suby, is_bx, is_by].map(|it| it as usize);
 
-    let randval = offsets[bx as usize][by as usize];
+    let randval = offsets[bx][by];
     let offx = 3 + (2 >> subx) * (3 + (randval >> 4));
     let offy = 3 + (2 >> suby) * (3 + (randval & 0xf as c_int));
-    grain_lut[(offy + y + (BLOCK_SIZE as c_int >> suby) * by) as usize]
-        [(offx + x + (BLOCK_SIZE as c_int >> subx) * bx) as usize]
+    grain_lut[(offy + y) as usize + (BLOCK_SIZE >> suby) * by]
+        [(offx + x) as usize + (BLOCK_SIZE >> subx) * bx]
 }
 
 unsafe extern "C" fn fgy_32x32xn_c_erased<BD: BitDepth>(

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -400,11 +400,10 @@ fn sample_lut<BD: BitDepth>(
 ) -> BD::Entry {
     let [subx, suby, bx, by] = [is_subx, is_suby, is_bx, is_by].map(|it| it as usize);
 
-    let randval = offsets[bx][by];
+    let randval = offsets[bx][by] as usize;
     let offx = 3 + (2 >> subx) * (3 + (randval >> 4));
     let offy = 3 + (2 >> suby) * (3 + (randval & ((1 << 4) - 1)));
-    grain_lut[offy as usize + y + (BLOCK_SIZE >> suby) * by]
-        [offx as usize + x + (BLOCK_SIZE >> subx) * bx]
+    grain_lut[offy + y + (BLOCK_SIZE >> suby) * by][offx + x + (BLOCK_SIZE >> subx) * bx]
 }
 
 unsafe extern "C" fn fgy_32x32xn_c_erased<BD: BitDepth>(

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -485,8 +485,7 @@ unsafe fn fgy_32x32xn_rust<BD: BitDepth>(
 
         // update current offsets
         for i in 0..rows {
-            offsets[0][i as usize] =
-                get_random_number(8, &mut *seed.as_mut_ptr().offset(i as isize));
+            offsets[0][i as usize] = get_random_number(8, &mut seed[i as usize]);
         }
 
         // x/y block offsets to compensate for overlapped regions
@@ -647,8 +646,7 @@ unsafe fn fguv_32x32xn_rust<BD: BitDepth>(
 
         // update current offsets
         for i in 0..rows {
-            offsets[0][i as usize] =
-                get_random_number(8, &mut *seed.as_mut_ptr().offset(i as isize));
+            offsets[0][i as usize] = get_random_number(8, &mut seed[i as usize]);
         }
 
         // x/y block offsets to compensate for overlapped regions
@@ -948,8 +946,7 @@ unsafe fn fgy_32x32xn_neon<BD: BitDepth>(
 
         // update current offsets
         for i in 0..rows {
-            offsets[0][i as usize] =
-                get_random_number(8, &mut *seed.as_mut_ptr().offset(i as isize));
+            offsets[0][i as usize] = get_random_number(8, &mut seed[i as usize]);
         }
 
         let mut r#type = 0;
@@ -1064,8 +1061,7 @@ unsafe fn fguv_32x32xn_neon<BD: BitDepth, const NM: usize, const IS_SX: bool, co
 
         // update current offsets
         for i in 0..rows {
-            offsets[0][i as usize] =
-                get_random_number(8, &mut *seed.as_mut_ptr().offset(i as isize));
+            offsets[0][i as usize] = get_random_number(8, &mut seed[i as usize]);
         }
 
         let mut r#type = 0;

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -402,7 +402,7 @@ fn sample_lut<BD: BitDepth>(
 
     let randval = offsets[bx][by];
     let offx = 3 + (2 >> subx) * (3 + (randval >> 4));
-    let offy = 3 + (2 >> suby) * (3 + (randval & 0xF));
+    let offy = 3 + (2 >> suby) * (3 + (randval & ((1 << 4) - 1)));
     grain_lut[(offy + y) as usize + (BLOCK_SIZE >> suby) * by]
         [(offx + x) as usize + (BLOCK_SIZE >> subx) * bx]
 }


### PR DESCRIPTION
Mostly cleaning up `fn sample_lut` and making it safe.