### PR TITLE
`build.rs`: Align to `meson.build`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -83,11 +83,8 @@ mod asm {
             defines.push(define);
         };
 
-        // TODO(kkysen) incorrect, dav1d defines these for all arches
-        if matches!(arch, Arch::Arm(..)) {
-            define(Define::bool("CONFIG_ASM", true));
-            define(Define::bool("CONFIG_LOG", true));
-        }
+        define(Define::bool("CONFIG_ASM", true));
+        define(Define::bool("CONFIG_LOG", true)); // TODO(kkysen) should be configurable
 
         // TODO(kkysen) incorrect since we may cross compile
         if (matches!(arch, Arch::X86(..)) && cfg!(target_os = "macos"))

--- a/build.rs
+++ b/build.rs
@@ -65,9 +65,11 @@ mod asm {
             .unwrap()
             .parse::<Arch>()
             .unwrap();
+        let os = env::var("CARGO_CFG_TARGET_OS").unwrap();
         let vendor = env::var("CARGO_CFG_TARGET_VENDOR").unwrap();
         let pointer_width = env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap();
 
+        let os = os.as_str();
         let vendor = vendor.as_str();
         let pointer_width = pointer_width.as_str();
 
@@ -86,10 +88,7 @@ mod asm {
         define(Define::bool("CONFIG_ASM", true));
         define(Define::bool("CONFIG_LOG", true)); // TODO(kkysen) should be configurable
 
-        // TODO(kkysen) incorrect since we may cross compile
-        if (matches!(arch, Arch::X86(..)) && cfg!(target_os = "macos"))
-            || (matches!(arch, Arch::Arm(..)) && vendor == "apple")
-        {
+        if vendor == "apple" || (os == "windows" && matches!(arch, Arch::X86(..))) {
             define(Define::bool("PREFIX", true));
         }
 

--- a/build.rs
+++ b/build.rs
@@ -110,13 +110,12 @@ mod asm {
         }
 
         if let Arch::X86(arch) = arch {
-            define(Define::new(
-                "STACK_ALIGNMENT",
-                match arch {
-                    ArchX86::X86_32 => 4,
-                    ArchX86::X86_64 => 16,
-                },
-            ));
+            let stack_alignment = if arch == ArchX86::X86_64 || os == "linux" || vendor == "apple" {
+                16
+            } else {
+                4
+            };
+            define(Define::new("STACK_ALIGNMENT", stack_alignment));
         }
 
         if matches!(arch, Arch::X86(..)) {


### PR DESCRIPTION
`build.rs` diverged in behavior from `meson.build` for some things; this fixes them to match `meson.build`.  `meson.build` still does things somewhat differently, as it always generates `config.h` and generates `config.asm` for `nasm` (x86* only), but `dav1d` needs `config.h` for C code and `*.S` `as`-style asm, while we only need it for the asm.  Thus, I think it's okay that we only generate either `config.h` or `config.asm`.  There are also some remaining configurable options in `meson.build` that should probably turn into `cargo` features, but we should be able to add those later.