### PR TITLE
`build.rs`: Emit `cargo:rerun-if-changed=` for every asm file

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -244,6 +244,7 @@ mod asm {
                 .flatten()
                 .collect::<PathBuf>();
             path.set_extension(asm_extension);
+            println!("cargo:rerun-if-changed={}", path.to_str().unwrap());
             path
         });
 
@@ -253,7 +254,7 @@ mod asm {
             let mut nasm = nasm_rs::Build::new();
             nasm.min_version(2, 14, 0);
             nasm.files(asm_file_paths);
-            nasm.flag(&format!("-I{}/", out_dir.as_os_str().to_str().unwrap()));
+            nasm.flag(&format!("-I{}/", out_dir.to_str().unwrap()));
             nasm.flag("-Isrc/");
             let obj = nasm.compile_objects().unwrap_or_else(|e| {
                 println!("cargo:warning={e}");


### PR DESCRIPTION
Previously `build.rs` wouldn't re-run if any asm was changed, whether in a PR like #534 or in a backporting PR, and this would often cause segfaults after unless we `cargo clean`ed or ran `touch build.rs`.  This uses `cargo:rerun-if-changed=` to tell `cargo` what other sources we're using that it should use to determine if `build.rs` needs to rerun.  Unfortunately, this can't do fine-grained caching at all and `nasm` if fairly slow, but that's okay, as at least it should always be correct now.