### PR TITLE
`struct {D,R}av1dFilmGrainData`: Revert asm changes from #534 and fix a `dav1d` alignment bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ target/
 /retranspile/
 
 .gdb_history
+.gdbinit

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -1031,15 +1031,11 @@ impl From<Rav1dLoopfilterModeRefDeltas> for Dav1dLoopfilterModeRefDeltas {
 }
 
 #[derive(Clone)]
-#[repr(C)]
 pub struct Rav1dFilmGrainData {
     pub seed: c_uint,
     pub num_y_points: c_int,
     pub y_points: [[u8; 2]; 14],
     pub chroma_scaling_from_luma: bool,
-    pub overlap_flag: bool,
-    pub clip_to_restricted_range: bool,
-    // 1 byte of padding
     pub num_uv_points: [c_int; 2],
     pub uv_points: [[[u8; 2]; 10]; 2],
     pub scaling_shift: c_int,
@@ -1051,6 +1047,8 @@ pub struct Rav1dFilmGrainData {
     pub uv_mult: [c_int; 2],
     pub uv_luma_mult: [c_int; 2],
     pub uv_offset: [c_int; 2],
+    pub overlap_flag: bool,
+    pub clip_to_restricted_range: bool,
 }
 
 /// Must be 16-byte aligned for `psrad` on [`Self::ar_coeff_shift`].
@@ -1139,8 +1137,6 @@ impl From<Dav1dFilmGrainData> for Rav1dFilmGrainData {
             num_y_points,
             y_points,
             chroma_scaling_from_luma: chroma_scaling_from_luma != 0,
-            overlap_flag: overlap_flag != 0,
-            clip_to_restricted_range: clip_to_restricted_range != 0,
             num_uv_points,
             uv_points,
             scaling_shift,
@@ -1152,6 +1148,8 @@ impl From<Dav1dFilmGrainData> for Rav1dFilmGrainData {
             uv_mult,
             uv_luma_mult,
             uv_offset,
+            overlap_flag: overlap_flag != 0,
+            clip_to_restricted_range: clip_to_restricted_range != 0,
         }
     }
 }
@@ -1163,8 +1161,6 @@ impl From<Rav1dFilmGrainData> for Dav1dFilmGrainData {
             num_y_points,
             y_points,
             chroma_scaling_from_luma,
-            overlap_flag,
-            clip_to_restricted_range,
             num_uv_points,
             uv_points,
             scaling_shift,
@@ -1176,6 +1172,8 @@ impl From<Rav1dFilmGrainData> for Dav1dFilmGrainData {
             uv_mult,
             uv_luma_mult,
             uv_offset,
+            overlap_flag,
+            clip_to_restricted_range,
         } = value;
         Self {
             seed,

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -1053,8 +1053,11 @@ pub struct Rav1dFilmGrainData {
     pub uv_offset: [c_int; 2],
 }
 
+/// Must be 16-byte aligned for `psrad` on [`Self::ar_coeff_shift`].
+/// See the docs for [`Self::ar_coeff_shift`] for an explanation.
 #[derive(Clone)]
 #[repr(C)]
+#[repr(align(16))]
 pub struct Dav1dFilmGrainData {
     pub seed: c_uint,
     pub num_y_points: c_int,
@@ -1066,6 +1069,41 @@ pub struct Dav1dFilmGrainData {
     pub ar_coeff_lag: c_int,
     pub ar_coeffs_y: [i8; 24],
     pub ar_coeffs_uv: [[i8; 28]; 2],
+    /// Must be 16-byte aligned for `psrad`.
+    ///
+    /// TODO(kkysen) This appears to be a bug in `dav1d`.
+    ///
+    /// x86 asm uses `psrad` on a pointer to [`Self::ar_coeff_shift`].
+    /// When `psrad`'s shift operand is a memory address, i.e. a `XMMWORD PTR`,
+    /// it loads 128 bits from it, shifts by the lower 64 bits,
+    /// and requires the 128 bits to be 128-bit/16-byte aligned.
+    ///
+    /// Previously, and still in `dav1d`, [`Self::ar_coeff_shift`]
+    /// is only 8-byte aligned, as is [`Self`]/[`Dav1dFilmGrainData`].
+    /// However, in `dav1d`, [`Dav1dFilmGrainData`] is part of
+    /// [`Dav1dFrameHeader`], which is allocated with [`malloc`].
+    /// [`malloc`] happens to return 16-byte aligned pointers usually,
+    /// but is not required to, so this is UB and will segfault if not aligned.
+    ///
+    /// Due to the [`Rav1dFilmGrainData`] to [`Dav1dFilmGrainData`]
+    /// conversion done now, the [`Dav1dFilmGrainData`] is stored on the stack,
+    /// and often will not be 16-byte aligned, and thus will often segfault.
+    ///
+    /// To fix this, [`Self::ar_coeff_shift`] must be 16-byte aligned.
+    /// This cannot be done only for the field without changing the offsets of
+    /// the subsequent fields, however, so we instead align
+    /// [`Dav1dFilmGrainData`] itself with `#[repr(align(16))]`.
+    /// [`Self::ar_coeff_shift`] is at offset `0xB0`/`176`,
+    /// which is divisible by 16.
+    ///
+    /// `psrad` also loads a full 128 bits, not just the 64 bits of
+    /// [`Self::ar_coeff_shift`], even if it doesn't read them,
+    /// so we must ensure that the following 64 bits are also deferenceable.
+    /// They indeed are in `dav1d`, but we must be careful,
+    /// as [`Self::ar_coeff_shift`] being the last field would
+    /// read 8 bytes out of bounds and be UB.
+    ///
+    /// [`malloc`]: libc::malloc
     pub ar_coeff_shift: u64,
     pub grain_scale_shift: c_int,
     pub uv_mult: [c_int; 2],

--- a/src/arm/32/filmgrain.S
+++ b/src/arm/32/filmgrain.S
@@ -1647,7 +1647,7 @@ function fguv_32x32_\layout\()_8bpc_neon, export=1
         vld1.16         {d4[1]}, [lr]          // uv_mult
 
         ldr             lr,  [r4, #FGD_SCALING_SHIFT]
-        ldrb            r12, [r4, #FGD_CLIP_TO_RESTRICTED_RANGE]
+        ldr             r12, [r4, #FGD_CLIP_TO_RESTRICTED_RANGE]
         neg             lr,  lr                // -scaling_shift
 
         cmp             r12, #0

--- a/src/arm/32/filmgrain16.S
+++ b/src/arm/32/filmgrain16.S
@@ -1582,7 +1582,7 @@ function fguv_32x32_\layout\()_16bpc_neon, export=1
         vld1.16         {d30[1]}, [lr]         // uv_mult
 
         ldr             lr,  [r4, #FGD_SCALING_SHIFT]
-        ldrb            r12, [r4, #FGD_CLIP_TO_RESTRICTED_RANGE]
+        ldr             r12, [r4, #FGD_CLIP_TO_RESTRICTED_RANGE]
         eor             lr,  lr,  #15          // 15 - scaling_shift
 
         vmov.16         d30[2], r10            // uv_offset << bitdepth_min_8

--- a/src/arm/64/filmgrain.S
+++ b/src/arm/64/filmgrain.S
@@ -1584,7 +1584,7 @@ function fguv_32x32_\layout\()_8bpc_neon, export=1
         ldp             x10, x11, [sp, #48]    // uv, is_id
 
         ldr             w13, [x4, #FGD_SCALING_SHIFT]
-        ldrb            w12, [x4, #FGD_CLIP_TO_RESTRICTED_RANGE]
+        ldr             w12, [x4, #FGD_CLIP_TO_RESTRICTED_RANGE]
         neg             w13, w13               // -scaling_shift
 
         // !csfl

--- a/src/arm/64/filmgrain16.S
+++ b/src/arm/64/filmgrain16.S
@@ -1515,7 +1515,7 @@ function fguv_32x32_\layout\()_16bpc_neon, export=1
         ldr             w16,      [sp, #120]   // bitdepth_max
 
         ldr             w13, [x4, #FGD_SCALING_SHIFT]
-        ldrb            w12, [x4, #FGD_CLIP_TO_RESTRICTED_RANGE]
+        ldr             w12, [x4, #FGD_CLIP_TO_RESTRICTED_RANGE]
         dup             v23.8h,  w16           // bitdepth_max
         clz             w16, w16
         eor             w13, w13, #15          // 15 - scaling_shift

--- a/src/arm/asm-offsets.h
+++ b/src/arm/asm-offsets.h
@@ -34,10 +34,10 @@
 #define FGD_AR_COEFF_SHIFT               176
 #define FGD_GRAIN_SCALE_SHIFT            184
 
-#define FGD_CLIP_TO_RESTRICTED_RANGE     38
 #define FGD_SCALING_SHIFT                88
 #define FGD_UV_MULT                      188
 #define FGD_UV_LUMA_MULT                 196
 #define FGD_UV_OFFSET                    204
+#define FGD_CLIP_TO_RESTRICTED_RANGE     216
 
 #endif /* ARM_ASM_OFFSETS_H */

--- a/src/fg_apply.rs
+++ b/src/fg_apply.rs
@@ -81,15 +81,16 @@ pub(crate) unsafe fn rav1d_prep_grain<BD: BitDepth>(
 ) {
     let GrainBD { grain_lut, scaling } = grain;
     let data = &(*out.frame_hdr).film_grain.data;
+    let data_c = &data.clone().into();
     let bitdepth_max = (1 << out.p.bpc) - 1;
 
     // Generate grain LUTs as needed
-    (dsp.generate_grain_y)(grain_lut[0].as_mut_ptr().cast(), data, bitdepth_max);
+    (dsp.generate_grain_y)(grain_lut[0].as_mut_ptr().cast(), data_c, bitdepth_max);
     if data.num_uv_points[0] != 0 || data.chroma_scaling_from_luma {
         (dsp.generate_grain_uv[r#in.p.layout as usize - 1])(
             grain_lut[1].as_mut_ptr().cast(),
             grain_lut[0].as_mut_ptr().cast(),
-            data,
+            data_c,
             0,
             bitdepth_max,
         );
@@ -98,7 +99,7 @@ pub(crate) unsafe fn rav1d_prep_grain<BD: BitDepth>(
         (dsp.generate_grain_uv[r#in.p.layout as usize - 1])(
             grain_lut[2].as_mut_ptr().cast(),
             grain_lut[0].as_mut_ptr().cast(),
-            data,
+            data_c,
             1,
             bitdepth_max,
         );
@@ -180,6 +181,7 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
     // Synthesize grain for the affected planes
     let GrainBD { grain_lut, scaling } = grain;
     let data = &(*out.frame_hdr).film_grain.data;
+    let data_c = &data.clone().into();
     let ss_y = (r#in.p.layout == RAV1D_PIXEL_LAYOUT_I420) as c_int;
     let ss_x = (r#in.p.layout != RAV1D_PIXEL_LAYOUT_I444) as c_int;
     let cpw = out.p.w + ss_x >> ss_x;
@@ -198,7 +200,7 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
                 .cast(),
             luma_src.cast(),
             out.stride[0],
-            data,
+            data_c,
             out.p.w as usize,
             scaling[0].as_ref().as_ptr().cast(),
             grain_lut[0].as_ptr().cast(),
@@ -234,7 +236,7 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
                     .offset(uv_off as isize)
                     .cast(),
                 r#in.stride[1],
-                data,
+                data_c,
                 cpw as usize,
                 scaling[0].as_ref().as_ptr().cast(),
                 grain_lut[1 + pl].as_ptr().cast(),
@@ -258,7 +260,7 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
                         .offset(uv_off as isize)
                         .cast(),
                     r#in.stride[1],
-                    data,
+                    data_c,
                     cpw as usize,
                     scaling[1 + pl].as_ref().as_ptr().cast(),
                     grain_lut[1 + pl].as_ptr().cast(),

--- a/src/x86/filmgrain16_avx2.asm
+++ b/src/x86/filmgrain16_avx2.asm
@@ -875,7 +875,7 @@ cglobal fgy_32x32xn_16bpc, 6, 14, 16, dst, src, stride, fg_data, w, scaling, \
 %define base r11-grain_min
     lea             r11, [grain_min]
     mov             r6d, r9m ; bdmax
-    movzx           r9d, byte [fg_dataq+FGData.clip_to_restricted_range]
+    mov             r9d, [fg_dataq+FGData.clip_to_restricted_range]
     mov             r7d, [fg_dataq+FGData.scaling_shift]
     mov            sbyd, sbym
     vpbroadcastd     m8, r9m
@@ -1347,7 +1347,7 @@ cglobal fguv_32x32xn_i%1_16bpc, 6, 15, 16, dst, src, stride, fg_data, w, scaling
     mov            r11d, is_idm
     mov            sbyd, sbym
     vpbroadcastw    m11, [base+mul_bits+r7*2-12]
-    movzx           r6d, byte [fg_dataq+FGData.clip_to_restricted_range]
+    mov             r6d, [fg_dataq+FGData.clip_to_restricted_range]
     shr             r9d, 11                 ; is_12bpc
     vpbroadcastd     m8, [base+grain_min+r9*4]
     shlx           r10d, r6d, r9d

--- a/src/x86/filmgrain16_avx512.asm
+++ b/src/x86/filmgrain16_avx512.asm
@@ -61,7 +61,7 @@ cglobal fgy_32x32xn_16bpc, 6, 15, 21, dst, src, stride, fg_data, w, scaling, \
 %define base r11-fg_min
     lea             r11, [fg_min]
     mov             r6d, r9m    ; bdmax
-    movzx           r9d, byte [fg_dataq+FGData.clip_to_restricted_range]
+    mov             r9d, [fg_dataq+FGData.clip_to_restricted_range]
     mov             r7d, [fg_dataq+FGData.scaling_shift]
     mov            sbyd, sbym
     vpbroadcastd     m6, r9m
@@ -363,7 +363,7 @@ cglobal fguv_32x32xn_i%1_16bpc, 6, 15, 22, dst, src, stride, fg_data, w, scaling
     lea             r12, [fg_min]
     mov             r9d, r13m            ; bdmax
     mov             r7d, [fg_dataq+FGData.scaling_shift]
-    movzx           r6d, byte [fg_dataq+FGData.clip_to_restricted_range]
+    mov             r6d, [fg_dataq+FGData.clip_to_restricted_range]
     mov            r11d, is_idm
     kxnorw           k1, k1, k1          ; 0xffff
     vpbroadcastd     m5, r13m

--- a/src/x86/filmgrain16_sse.asm
+++ b/src/x86/filmgrain16_sse.asm
@@ -1462,7 +1462,7 @@ cglobal fgy_32x32xn_16bpc, 6, 15, 16, dst, src, stride, fg_data, w, scaling, gra
 %endif
     mov             r6d, [fg_dataq+FGData.scaling_shift]
     SPLATW           m3, [base+mul_bits+r6*2-14]
-    movzx           r6d, byte [fg_dataq+FGData.clip_to_restricted_range]
+    mov             r6d, [fg_dataq+FGData.clip_to_restricted_range]
 %if ARCH_X86_32
     DECLARE_REG_TMP   0, 3
 %else
@@ -2274,7 +2274,7 @@ cglobal fguv_32x32xn_i%1_16bpc, 6, 15, 16, dst, src, stride, fg_data, w, scaling
 %endif
     mov             r6d, [fg_dataq+FGData.scaling_shift]
     SPLATW           m3, [base+mul_bits+r6*2-14]
-    movzx           r6d, byte [fg_dataq+FGData.clip_to_restricted_range]
+    mov             r6d, [fg_dataq+FGData.clip_to_restricted_range]
 %if STACK_ALIGNMENT >= mmsize
     mov             t0d, r13m               ; bdmax
 %endif
@@ -2360,7 +2360,7 @@ cglobal fguv_32x32xn_i%1_16bpc, 6, 15, 16, dst, src, stride, fg_data, w, scaling
 %endif
 
     mov            sbyd, r8m
-    movzx           t0d, byte [fg_dataq+FGData.overlap_flag]
+    mov             t0d, [fg_dataq+FGData.overlap_flag]
     test            t0d, t0d
     jz %%no_vertical_overlap
     test           sbyd, sbyd

--- a/src/x86/filmgrain_avx2.asm
+++ b/src/x86/filmgrain_avx2.asm
@@ -882,9 +882,9 @@ cglobal fgy_32x32xn_8bpc, 6, 13, 15, dst, src, stride, fg_data, w, scaling, \
 %define base r9-pd_m65536
     lea              r9, [pd_m65536]
     mov             r6d, [fg_dataq+FGData.scaling_shift]
-    movzx           r7d, byte [fg_dataq+FGData.clip_to_restricted_range]
+    mov             r7d, [fg_dataq+FGData.clip_to_restricted_range]
     mov            sbyd, sbym
-    movzx      overlapd, byte [fg_dataq+FGData.overlap_flag]
+    mov        overlapd, [fg_dataq+FGData.overlap_flag]
     vpbroadcastd     m8, [base+pd_m65536]
     vpbroadcastw     m9, [base+mul_bits+r6*2-14]
     vpbroadcastd    m10, [base+fg_min+r7*4]
@@ -1311,10 +1311,10 @@ cglobal fguv_32x32xn_i%1_8bpc, 6, 15, 16, dst, src, stride, fg_data, w, scaling,
 %define base r11-pd_m65536
     lea             r11, [pd_m65536]
     mov             r6d, [fg_dataq+FGData.scaling_shift]
-    movzx           r7d, byte [fg_dataq+FGData.clip_to_restricted_range]
+    mov             r7d, [fg_dataq+FGData.clip_to_restricted_range]
     mov             r9d, is_idm
     mov            sbyd, sbym
-    movzx      overlapd, byte [fg_dataq+FGData.overlap_flag]
+    mov        overlapd, [fg_dataq+FGData.overlap_flag]
     vpbroadcastd     m8, [base+pd_m65536]
     vpbroadcastw     m9, [base+mul_bits+r6*2-14]
     vpbroadcastd    m10, [base+fg_min+r7*4]

--- a/src/x86/filmgrain_avx512.asm
+++ b/src/x86/filmgrain_avx512.asm
@@ -65,9 +65,9 @@ cglobal fgy_32x32xn_8bpc, 6, 13, 22, dst, src, stride, fg_data, w, scaling, \
 %define base r11-fg_min
     lea             r11, [fg_min]
     mov             r6d, [fg_dataq+FGData.scaling_shift]
-    movzx           r7d, byte [fg_dataq+FGData.clip_to_restricted_range]
+    mov             r7d, [fg_dataq+FGData.clip_to_restricted_range]
     mov            sbyd, sbym
-    movzx      overlapd, byte [fg_dataq+FGData.overlap_flag]
+    mov        overlapd, [fg_dataq+FGData.overlap_flag]
     mov             r12, 0x0000000f0000000f ; h_overlap mask
     mova             m0, [scalingq+64*0]
     mova             m1, [scalingq+64*1]
@@ -344,10 +344,10 @@ cglobal fguv_32x32xn_i%1_8bpc, 6, 14+%2, 22, dst, src, stride, fg_data, w, \
                                              overlap, uv_pl, is_id, _, stride3
     lea             r11, [fg_min]
     mov             r6d, [fg_dataq+FGData.scaling_shift]
-    movzx           r7d, byte [fg_dataq+FGData.clip_to_restricted_range]
+    mov             r7d, [fg_dataq+FGData.clip_to_restricted_range]
     mov             r9d, is_idm
     mov            sbyd, sbym
-    movzx      overlapd, byte [fg_dataq+FGData.overlap_flag]
+    mov        overlapd, [fg_dataq+FGData.overlap_flag]
 %if %2
     mov             r12, 0x000f000f000f000f ; h_overlap mask
     vpbroadcastq    m10, [base+pb_23_22_0_32]

--- a/src/x86/filmgrain_common.asm
+++ b/src/x86/filmgrain_common.asm
@@ -24,24 +24,23 @@
 ; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 struc FGData
-    .seed:                                 resd 1
-    .num_y_points:                         resd 1
-    .y_points:                             resb 14 * 2
-    .chroma_scaling_from_luma:             resb 1
-    .overlap_flag:                         resb 1
-    .clip_to_restricted_range:             resb 1
-    .padding_for_chroma_scaling_from_luma  resb 1
-    .num_uv_points:                        resd 2
-    .uv_points:                            resb 2 * 10 * 2
-    .scaling_shift:                        resd 1
-    .ar_coeff_lag:                         resd 1
-    .ar_coeffs_y:                          resb 24
-    .ar_coeffs_uv:                         resb 2 * 28 ; includes 2 * 3 bytes of padding
-    .ar_coeff_shift:                       resq 1
-    .grain_scale_shift:                    resd 1
-    .uv_mult:                              resd 2
-    .uv_luma_mult:                         resd 2
-    .uv_offset:                            resd 2
+    .seed:                      resd 1
+    .num_y_points:              resd 1
+    .y_points:                  resb 14 * 2
+    .chroma_scaling_from_luma:  resd 1
+    .num_uv_points:             resd 2
+    .uv_points:                 resb 2 * 10 * 2
+    .scaling_shift:             resd 1
+    .ar_coeff_lag:              resd 1
+    .ar_coeffs_y:               resb 24
+    .ar_coeffs_uv:              resb 2 * 28 ; includes padding
+    .ar_coeff_shift:            resq 1
+    .grain_scale_shift:         resd 1
+    .uv_mult:                   resd 2
+    .uv_luma_mult:              resd 2
+    .uv_offset:                 resd 2
+    .overlap_flag:              resd 1
+    .clip_to_restricted_range:  resd 1
 endstruc
 
 cextern gaussian_sequence

--- a/src/x86/filmgrain_sse.asm
+++ b/src/x86/filmgrain_sse.asm
@@ -1316,7 +1316,7 @@ cglobal fgy_32x32xn_8bpc, 6, 15, 16, dst, src, stride, fg_data, w, scaling, grai
 %endif
     mov             r6d, [fg_dataq+FGData.scaling_shift]
     movd             m3, [base+mul_bits+r6*2-14]
-    movzx           r6d, byte [fg_dataq+FGData.clip_to_restricted_range]
+    mov             r6d, [fg_dataq+FGData.clip_to_restricted_range]
     movd             m4, [base+max+r6*4]
     movd             m5, [base+min+r6*2]
     punpcklwd        m3, m3
@@ -1336,7 +1336,7 @@ cglobal fgy_32x32xn_8bpc, 6, 15, 16, dst, src, stride, fg_data, w, scaling, grai
 %endif
 
     mov            sbyd, r8m
-    movzx      overlapd, byte [fg_dataq+FGData.overlap_flag] ; left_overlap: overlap & 1
+    mov        overlapd, [fg_dataq+FGData.overlap_flag] ; left_overlap: overlap & 1
     test       overlapd, overlapd
     jz .no_vertical_overlap
     mova             m6, [base+pw_1024]
@@ -2100,7 +2100,7 @@ cglobal fguv_32x32xn_i%1_8bpc, 6, 15, 16, dst, src, stride, fg_data, w, scaling,
 %endif
     mov             r6d, [fg_dataq+FGData.scaling_shift]
     movd             m3, [base+mul_bits+r6*2-14]
-    movzx           r6d, byte [fg_dataq+FGData.clip_to_restricted_range]
+    mov             r6d, [fg_dataq+FGData.clip_to_restricted_range]
     lea            tmpd, [r6d*2]
 %if ARCH_X86_32 && STACK_ALIGNMENT < mmsize
     test             r3, r3
@@ -2145,7 +2145,7 @@ cglobal fguv_32x32xn_i%1_8bpc, 6, 15, 16, dst, src, stride, fg_data, w, scaling,
 %endif
 
     mov            sbyd, r8m
-    movzx      overlapd, byte [fg_dataq+FGData.overlap_flag] ; left_overlap: overlap & 1
+    mov        overlapd, [fg_dataq+FGData.overlap_flag] ; left_overlap: overlap & 1
     test       overlapd, overlapd
     jz %%no_vertical_overlap
 %if ARCH_X86_32


### PR DESCRIPTION
# Asm Change Reversion

As discussed in #534, changing the asm at all means we lose upstream testing, review, and other improvements.  Given that e27877e5f, which made `{D <=> R}av1dFilmGrainData` conversions, had no perf regressions, this commit reverts back to that behavior.

The asm changes were reverted with `git checkout main -- src/x86/* src/arm/*`, where `main` is bb68fb8.

I'm doing this as a follow-up PR after all of the intermediary ones to avoid a ton of merge conflicts.  So once this is approved, I can merge all of the PRs up to and including this one.

# `dav1d` Alignment Bug Fix

This PR also fixes a alignment bug in `dav1d` surfaced/triggered by this asm reversion, which places `Dav1dFilmGrainData`s on the stack in a different place (i.e. alignment) than e27877e5f did.

x86 asm uses `psrad` on a pointer to `Dav1dFilmGrainData`::ar_coeff_shift`.  When `psrad`'s shift operand is a memory address, i.e. a `XMMWORD PTR`, it loads 128 bits from it, shifts by the lower 64 bits, and requires the 128 bits to be 128-bit/16-byte aligned.

Previously, and still in `dav1d`, `ar_coeff_shift` is only 8-byte aligned, as is `Dav1dFilmGrainData`.  However, in `dav1d`, `Dav1dFilmGrainData` is part of `Dav1dFrameHeader`, which is allocated with `malloc`.  `malloc` happens to return 16-byte aligned pointers usually, but is not required to, so this is UB and will segfault if not aligned.

Due to the `Rav1dFilmGrainData` to `Dav1dFilmGrainData` conversion done now, the `Dav1dFilmGrainData` is stored on the stack, and often will not be 16-byte aligned, and thus will often segfault.

To fix this, `ar_coeff_shift` must be 16-byte aligned.  This cannot be done only for the field without changing the offsets of
the subsequent fields, however, so we instead align `Dav1dFilmGrainData` itself with `#[repr(align(16))]`.  `ar_coeff_shift` is at offset `0xB0`/`176`, which is divisible by 16.

`psrad` also loads a full 128 bits, not just the 64 bits of `ar_coeff_shift`, even if it doesn't read them, so we must ensure that the following 64 bits are also deferenceable.  They indeed are in `dav1d`, but we must be careful, as `ar_coeff_shift` being the last field would read 8 bytes out of bounds and be UB.

Note that this bug fix comes before the next commit, which actually triggered the bug due to putting `Dav1dFilmGrainData` on the stack and at a slightly different spot than previously.  However, this was always a bug and UB all along, just not triggered by a segfault yet.  Putting this bug fix commit first means all the commits will continue to pass all tests.