### PR TITLE
`wrap_fn_ptr!`: Add a macro defining a wrapped `fn` ptr with a `DefaultValue` and use it for `struct Rav1dFilmGrainDSPContext`

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -52,6 +52,7 @@ pub mod src {
     mod fg_apply;
     mod filmgrain;
     mod getbits;
+    mod wrap_fn_ptr;
     // TODO(kkysen) Temporarily `pub(crate)` due to a `pub use` until TAIT.
     pub(super) mod internal;
     mod intra_edge;

--- a/src/wrap_fn_ptr.rs
+++ b/src/wrap_fn_ptr.rs
@@ -1,0 +1,47 @@
+pub trait HasFnPtr {
+    type FnPtr;
+}
+
+#[repr(transparent)]
+pub struct WrappedFnPtr<F>(F);
+
+impl<F> HasFnPtr for WrappedFnPtr<F> {
+    type FnPtr = F;
+}
+
+#[allow(dead_code)]
+impl<F> WrappedFnPtr<F> {
+    pub const fn new(fn_ptr: F) -> Self {
+        Self(fn_ptr)
+    }
+
+    pub const fn get(&self) -> &F {
+        &self.0
+    }
+}
+
+#[allow(unused_macros)]
+macro_rules! wrap_fn_ptr {
+    ($vis:vis struct $Wrapper:ident(
+        unsafe extern "C" fn(
+            $($arg_name:ident: $arg_ty:ty),*$(,)?
+        ) -> $return_ty:ty
+    )) => {
+        $vis type $Wrapper = WrappedFnPtr<unsafe extern "C" fn($($arg_name: $arg_ty),*) -> $return_ty>;
+
+        impl DefaultValue for $Wrapper {
+            const DEFAULT: Self = {
+                extern "C" fn default_unimplemented(
+                    $($arg_name: $arg_ty,)*
+                ) -> $return_ty {
+                    $(let _ = $arg_name;)*
+                    unimplemented!()
+                }
+                Self::new(default_unimplemented)
+            };
+        }
+    };
+}
+
+#[allow(unused_imports)]
+pub(crate) use wrap_fn_ptr;

--- a/src/wrap_fn_ptr.rs
+++ b/src/wrap_fn_ptr.rs
@@ -9,7 +9,6 @@ impl<F> HasFnPtr for WrappedFnPtr<F> {
     type FnPtr = F;
 }
 
-#[allow(dead_code)]
 impl<F> WrappedFnPtr<F> {
     pub const fn new(fn_ptr: F) -> Self {
         Self(fn_ptr)
@@ -20,7 +19,6 @@ impl<F> WrappedFnPtr<F> {
     }
 }
 
-#[allow(unused_macros)]
 macro_rules! wrap_fn_ptr {
     ($vis:vis struct $Wrapper:ident(
         unsafe extern "C" fn(
@@ -43,5 +41,4 @@ macro_rules! wrap_fn_ptr {
     };
 }
 
-#[allow(unused_imports)]
 pub(crate) use wrap_fn_ptr;


### PR DESCRIPTION
This adds the macro `wrap_fn_ptr!` that creates a new-type wrapper of a `fn` ptr and `impl`s` `DefaultValue` for it, with the default value being a `fn` that does nothing and just calls `unimplemented!()`.  This default value isn't actually ever used, but is needed for `enum_map!` to work, which will be done in the next PR.

Also, very importantly, by new-typing the `fn` ptrs, we can make the raw `fn` ptr private
 and only expose a `fn call` method that does the type-erasing bitdepth casts,
 making calls more idiomatic and safer.

This PR then uses this approach for `mod filmgrain`'s `struct Rav1dFilmGrainDSPContext`'s `fn` ptrs.  We should do this for all of the other ones, but we'll get to them later.