### PR TITLE
`enum Rav1dPixelLayoutSubSampled`: Add separate `enum` for use in `EnumMap`s for `Rav1dFilmGrainDSPContext`

### DIFF
--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -252,6 +252,46 @@ impl From<Rav1dPixelLayout> for Dav1dPixelLayout {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Rav1dPixelLayoutSubSampled {
+    I420,
+    I422,
+    I444,
+}
+
+impl EnumKey<3> for Rav1dPixelLayoutSubSampled {
+    const VALUES: [Self; 3] = [Self::I420, Self::I422, Self::I444];
+
+    fn as_usize(self) -> usize {
+        self as usize
+    }
+}
+
+impl TryFrom<Rav1dPixelLayout> for Rav1dPixelLayoutSubSampled {
+    type Error = ();
+
+    fn try_from(value: Rav1dPixelLayout) -> Result<Self, Self::Error> {
+        use Rav1dPixelLayout::*;
+        Ok(match value {
+            I400 => return Err(()),
+            I420 => Self::I420,
+            I422 => Self::I422,
+            I444 => Self::I444,
+        })
+    }
+}
+
+impl From<Rav1dPixelLayoutSubSampled> for Rav1dPixelLayout {
+    fn from(value: Rav1dPixelLayoutSubSampled) -> Self {
+        use Rav1dPixelLayoutSubSampled::*;
+        match value {
+            I420 => Self::I420,
+            I422 => Self::I422,
+            I444 => Self::I444,
+        }
+    }
+}
+
 pub type Dav1dFrameType = c_uint;
 pub const DAV1D_FRAME_TYPE_SWITCH: Dav1dFrameType = 3;
 pub const DAV1D_FRAME_TYPE_INTRA: Dav1dFrameType = 2;

--- a/src/fg_apply.rs
+++ b/src/fg_apply.rs
@@ -86,7 +86,7 @@ pub(crate) unsafe fn rav1d_prep_grain<BD: BitDepth>(
     let [grain_lut_0, grain_lut_1, grain_lut_2] = &mut grain_lut.0;
     dsp.generate_grain_y.call(grain_lut_0, data, bd);
     if data.num_uv_points[0] != 0 || data.chroma_scaling_from_luma {
-        dsp.generate_grain_uv[r#in.p.layout as usize - 1].call(
+        dsp.generate_grain_uv[r#in.p.layout.try_into().unwrap()].call(
             grain_lut_1,
             grain_lut_0,
             data,
@@ -95,7 +95,7 @@ pub(crate) unsafe fn rav1d_prep_grain<BD: BitDepth>(
         );
     }
     if data.num_uv_points[1] != 0 || data.chroma_scaling_from_luma {
-        dsp.generate_grain_uv[r#in.p.layout as usize - 1].call(
+        dsp.generate_grain_uv[r#in.p.layout.try_into().unwrap()].call(
             grain_lut_2,
             grain_lut_0,
             data,
@@ -226,7 +226,7 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
     let uv_off = (row * 32) as isize * BD::pxstride(out.stride[1] as usize) as isize >> ss_y;
     if data.chroma_scaling_from_luma {
         for pl in 0..2 {
-            dsp.fguv_32x32xn[r#in.p.layout as usize - 1].call(
+            dsp.fguv_32x32xn[r#in.p.layout.try_into().unwrap()].call(
                 (out.data[1 + pl] as *mut BD::Pixel).offset(uv_off as isize),
                 (r#in.data[1 + pl] as *const BD::Pixel).offset(uv_off as isize),
                 r#in.stride[1],
@@ -246,7 +246,7 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
     } else {
         for pl in 0..2 {
             if data.num_uv_points[pl] != 0 {
-                dsp.fguv_32x32xn[r#in.p.layout as usize - 1].call(
+                dsp.fguv_32x32xn[r#in.p.layout.try_into().unwrap()].call(
                     (out.data[1 + pl] as *mut BD::Pixel).offset(uv_off as isize),
                     (r#in.data[1 + pl] as *const BD::Pixel).offset(uv_off as isize),
                     r#in.stride[1],

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -76,7 +76,7 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 
 #[repr(C)]
-pub struct Rav1dDSPContext {
+pub(crate) struct Rav1dDSPContext {
     pub fg: Rav1dFilmGrainDSPContext,
     pub ipred: Rav1dIntraPredDSPContext,
     pub mc: Rav1dMCDSPContext,


### PR DESCRIPTION
This creates a new `enum`, `enum Rav1dPixelLayoutSubSampled`, that is a subset of `enum Rav1dPixelLayout`, the subset used in `struct Rav1dFilmGrainDSPContext`'s arrays as keys/indices.  This allows us to idiomatically use `EnumMap` for those arrays.