### PR TITLE
`fn {generate_grain_uv,fguv_32x32xn}_{rust,c_erased}`: Put `#[inline(never)]` on the `fn *_c_erased`s, not the `fn *_rust`s

### DIFF
--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -409,7 +409,6 @@ unsafe fn generate_grain_y_rust<BD: BitDepth>(
     }
 }
 
-#[inline(never)]
 unsafe fn generate_grain_uv_rust<BD: BitDepth>(
     buf: &mut GrainLut<BD::Entry>,
     buf_y: &GrainLut<BD::Entry>,
@@ -492,6 +491,7 @@ unsafe fn generate_grain_uv_rust<BD: BitDepth>(
     }
 }
 
+#[inline(never)]
 unsafe extern "C" fn generate_grain_uv_c_erased<
     BD: BitDepth,
     const NM: usize,
@@ -693,7 +693,6 @@ unsafe fn fgy_32x32xn_rust<BD: BitDepth>(
     }
 }
 
-#[inline(never)]
 unsafe fn fguv_32x32xn_rust<BD: BitDepth>(
     dst_row: *mut BD::Pixel,
     src_row: *const BD::Pixel,
@@ -850,6 +849,7 @@ unsafe fn fguv_32x32xn_rust<BD: BitDepth>(
     }
 }
 
+#[inline(never)]
 unsafe extern "C" fn fguv_32x32xn_c_erased<
     BD: BitDepth,
     const NM: usize,


### PR DESCRIPTION
The C `NOINLINE`s were originally on the `*_c` functions, which are called through `fn` ptrs and makes sense. The `fn *_rust`s are called only by the `fn *_c_erased`s, which are called through `fn` ptrs, so we were accidentally forcing an extra `fn` call due to mixing this up.

I'm not sure if this noticeably hurt perf, but it's not what the C is doing and seems like it would hurt perf, so we should fix this.