### PR TITLE
`mod {cdef,{cdef,lf,lr}_apply}_tmpl_{8,16}`: Always compile both and dead-code eliminate

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -30,13 +30,13 @@ pub mod include {
 pub mod src {
     pub mod align;
     mod cdef;
-    #[cfg(feature = "bitdepth_16")]
+    #[cfg_attr(not(feature = "bitdepth_16"), allow(dead_code))]
     mod cdef_apply_tmpl_16;
-    #[cfg(feature = "bitdepth_8")]
+    #[cfg_attr(not(feature = "bitdepth_8"), allow(dead_code))]
     mod cdef_apply_tmpl_8;
-    #[cfg(feature = "bitdepth_16")]
+    #[cfg_attr(not(feature = "bitdepth_16"), allow(dead_code))]
     mod cdef_tmpl_16;
-    #[cfg(feature = "bitdepth_8")]
+    #[cfg_attr(not(feature = "bitdepth_8"), allow(dead_code))]
     mod cdef_tmpl_8;
     mod cdf;
     mod const_fn;
@@ -69,9 +69,9 @@ pub mod src {
     mod itx_tmpl_16;
     mod itx_tmpl_8;
     mod levels;
-    #[cfg(feature = "bitdepth_16")]
+    #[cfg_attr(not(feature = "bitdepth_8"), allow(dead_code))]
     mod lf_apply_tmpl_16;
-    #[cfg(feature = "bitdepth_8")]
+    #[cfg_attr(not(feature = "bitdepth_16"), allow(dead_code))]
     mod lf_apply_tmpl_8;
     mod lf_mask;
     pub mod lib;
@@ -83,9 +83,9 @@ pub mod src {
     mod loopfilter_tmpl_8;
     mod looprestoration;
     mod lr_apply;
-    #[cfg(feature = "bitdepth_16")]
+    #[cfg_attr(not(feature = "bitdepth_16"), allow(dead_code))]
     mod lr_apply_tmpl_16;
-    #[cfg(feature = "bitdepth_8")]
+    #[cfg_attr(not(feature = "bitdepth_8"), allow(dead_code))]
     mod lr_apply_tmpl_8;
     mod mc;
     mod mem;

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -409,7 +409,6 @@ unsafe fn generate_grain_y_rust<BD: BitDepth>(
     }
 }
 
-#[inline(never)]
 unsafe fn generate_grain_uv_rust<BD: BitDepth>(
     buf: &mut GrainLut<BD::Entry>,
     buf_y: &GrainLut<BD::Entry>,
@@ -492,6 +491,7 @@ unsafe fn generate_grain_uv_rust<BD: BitDepth>(
     }
 }
 
+#[inline(never)]
 unsafe extern "C" fn generate_grain_uv_c_erased<
     BD: BitDepth,
     const NM: usize,
@@ -693,7 +693,6 @@ unsafe fn fgy_32x32xn_rust<BD: BitDepth>(
     }
 }
 
-#[inline(never)]
 unsafe fn fguv_32x32xn_rust<BD: BitDepth>(
     dst_row: *mut BD::Pixel,
     src_row: *const BD::Pixel,
@@ -850,6 +849,7 @@ unsafe fn fguv_32x32xn_rust<BD: BitDepth>(
     }
 }
 
+#[inline(never)]
 unsafe extern "C" fn fguv_32x32xn_c_erased<
     BD: BitDepth,
     const NM: usize,

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -112,7 +112,7 @@ use std::ffi::c_void;
 use std::ops::BitOr;
 use std::slice;
 
-#[cfg(feature = "bitdepth_8")]
+#[cfg_attr(not(feature = "bitdepth_8"), allow(dead_code))]
 use crate::{
     src::cdef_apply_tmpl_8::rav1d_cdef_brow_8bpc, src::lf_apply_tmpl_8::rav1d_copy_lpf_8bpc,
     src::lf_apply_tmpl_8::rav1d_loopfilter_sbrow_cols_8bpc,
@@ -120,7 +120,7 @@ use crate::{
     src::lr_apply_tmpl_8::rav1d_lr_sbrow_8bpc,
 };
 
-#[cfg(feature = "bitdepth_16")]
+#[cfg_attr(not(feature = "bitdepth_16"), allow(dead_code))]
 use crate::{
     src::cdef_apply_tmpl_16::rav1d_cdef_brow_16bpc, src::lf_apply_tmpl_16::rav1d_copy_lpf_16bpc,
     src::lf_apply_tmpl_16::rav1d_loopfilter_sbrow_cols_16bpc,


### PR DESCRIPTION
Since these bitdepth-specific `fn`s are Rust `fn`s, not asm `fn`s, we can't use `bd_fn!` in the same way, so when `mod recon` got deduplicated, it broke compiling for a single bitdepth. If we just compile both bitdepths for these `mod`s and rely on dead code elimination, it works again. And once we deduplicate these `mod`s, it will all be for naught since they'll be generic instead.