### PR TITLE
`Cargo.toml`: Set `codegen-units = 1` for `release`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,6 @@ bitdepth_16 = []
 # unless we enable the basic optimizations (`opt-level = 1`),
 # which don't increase compile-time that much.
 opt-level = 1
+
+[profile.release]
+codegen-units = 1

--- a/lib.rs
+++ b/lib.rs
@@ -30,13 +30,13 @@ pub mod include {
 pub mod src {
     pub mod align;
     mod cdef;
-    #[cfg(feature = "bitdepth_16")]
+    #[cfg_attr(not(feature = "bitdepth_16"), allow(dead_code))]
     mod cdef_apply_tmpl_16;
-    #[cfg(feature = "bitdepth_8")]
+    #[cfg_attr(not(feature = "bitdepth_8"), allow(dead_code))]
     mod cdef_apply_tmpl_8;
-    #[cfg(feature = "bitdepth_16")]
+    #[cfg_attr(not(feature = "bitdepth_16"), allow(dead_code))]
     mod cdef_tmpl_16;
-    #[cfg(feature = "bitdepth_8")]
+    #[cfg_attr(not(feature = "bitdepth_8"), allow(dead_code))]
     mod cdef_tmpl_8;
     mod cdf;
     mod const_fn;
@@ -69,9 +69,9 @@ pub mod src {
     mod itx_tmpl_16;
     mod itx_tmpl_8;
     mod levels;
-    #[cfg(feature = "bitdepth_16")]
+    #[cfg_attr(not(feature = "bitdepth_8"), allow(dead_code))]
     mod lf_apply_tmpl_16;
-    #[cfg(feature = "bitdepth_8")]
+    #[cfg_attr(not(feature = "bitdepth_16"), allow(dead_code))]
     mod lf_apply_tmpl_8;
     mod lf_mask;
     pub mod lib;
@@ -83,9 +83,9 @@ pub mod src {
     mod loopfilter_tmpl_8;
     mod looprestoration;
     mod lr_apply;
-    #[cfg(feature = "bitdepth_16")]
+    #[cfg_attr(not(feature = "bitdepth_16"), allow(dead_code))]
     mod lr_apply_tmpl_16;
-    #[cfg(feature = "bitdepth_8")]
+    #[cfg_attr(not(feature = "bitdepth_8"), allow(dead_code))]
     mod lr_apply_tmpl_8;
     mod mc;
     mod mem;

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -112,7 +112,7 @@ use std::ffi::c_void;
 use std::ops::BitOr;
 use std::slice;
 
-#[cfg(feature = "bitdepth_8")]
+#[cfg_attr(not(feature = "bitdepth_8"), allow(dead_code))]
 use crate::{
     src::cdef_apply_tmpl_8::rav1d_cdef_brow_8bpc, src::lf_apply_tmpl_8::rav1d_copy_lpf_8bpc,
     src::lf_apply_tmpl_8::rav1d_loopfilter_sbrow_cols_8bpc,
@@ -120,7 +120,7 @@ use crate::{
     src::lr_apply_tmpl_8::rav1d_lr_sbrow_8bpc,
 };
 
-#[cfg(feature = "bitdepth_16")]
+#[cfg_attr(not(feature = "bitdepth_16"), allow(dead_code))]
 use crate::{
     src::cdef_apply_tmpl_16::rav1d_cdef_brow_16bpc, src::lf_apply_tmpl_16::rav1d_copy_lpf_16bpc,
     src::lf_apply_tmpl_16::rav1d_loopfilter_sbrow_cols_16bpc,


### PR DESCRIPTION
This significantly improves code generation and optimization. In C, translation units correspond to each `*.c` file, and thus things are deliberately grouped together. In Rust, codegen units are chosen with a heuristic and functions are assigned to a codegen unit (passed to LLVM). Thus, to ensure related functions are in the same codegen unit (and are thus inlineable), we should set this to 1. This will also make optimization much more reliable, since a far away change can't suddenly affect an optimization elsewhere.

We probably also want to look at enabling LTO (though we'll need to enable LTO for `dav1d` for equivalent comparisons).