### PR TITLE
`rust-toolchain.toml`: Update to the latest `nightly` 

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-08-24"
+channel = "nightly-2023-11-16"
 targets = [
     "x86_64-unknown-linux-gnu",
     "i686-unknown-linux-gnu",


### PR DESCRIPTION
`nightly-2023-08-24` => `nightly-2023-11-16`.

I'm curious how this affects the benchmarks since it did last time.  Also, some potentially useful APIs have been stabilized.