### PR TITLE
`wrap_fn_ptr!`: Generate a `decl_fn!` macro inside; also document macros

### DIFF
--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -422,19 +422,23 @@ where
     }
 }
 
-/// Declare and select a [`BitDepth`]-dependent `extern "C" fn`.
+/// Select and declare a [`BitDepth`]-dependent `extern "C" fn`.
+///
+/// That is, it statically selects which [`BitDepth`] `fn`
+/// (i.e., `bpc8` or `bpc16`) to return based on `$BD:ty`,
+/// declares it inline* with `$decl_fn:path`, and then returns it.
 ///
 /// # Args
 ///
 /// * `$decl_fn:path` (optional):
 ///     A path to a macro that, given a `fn $fn_name:ident`,
-///     declares and evaluates to an `extern "C" fn`
+///     declares and returns an `extern "C" fn`
 ///     with the appropriate signature for this `fn`.
 ///     This should usually be `mod::decl_fn`,
 ///     where the `mod` is defined by [`wrap_fn_ptr!`],
 ///     but it doesn't have to be.
 ///
-///     If omitted, this defaults to [`fn_identity`],
+///     \* If omitted, this defaults to [`fn_identity`],
 ///     which returns the `fn` given without declaring one inline.
 ///     This should be used when the `fn` you are selecting
 ///     is already declared elsewhere.

--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -426,13 +426,18 @@ where
 ///
 /// # Args
 ///
-/// * `$decl_fn:path`:
+/// * `$decl_fn:path` (optional):
 ///     A path to a macro that, given a `fn $fn_name:ident`,
 ///     declares and evaluates to an `extern "C" fn`
 ///     with the appropriate signature for this `fn`.
 ///     This should usually be `mod::decl_fn`,
 ///     where the `mod` is defined by [`wrap_fn_ptr!`],
 ///     but it doesn't have to be.
+///
+///     If omitted, this defaults to [`fn_identity`],
+///     which returns the `fn` given without declaring one inline.
+///     This should be used when the `fn` you are selecting
+///     is already declared elsewhere.
 ///
 /// * `$BD:ty`:
 ///     A `<BD: `[`BitDepth`]`>` generic type parameter.

--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -422,6 +422,48 @@ where
     }
 }
 
+/// Declare and select a [`BitDepth`]-dependent `extern "C" fn`.
+///
+/// # Args
+///
+/// * `$decl_fn:path`:
+///     A path to a macro that, given a `fn $fn_name:ident`,
+///     declares and evaluates to an `extern "C" fn`
+///     with the appropriate signature for this `fn`.
+///     This should usually be `mod::decl_fn`,
+///     where the `mod` is defined by [`wrap_fn_ptr!`],
+///     but it doesn't have to be.
+///
+/// * `$BD:ty`:
+///     A `<BD: `[`BitDepth`]`>` generic type parameter.
+///     [`BPC::BPC8`] results in `bpc8` and
+///     [`BPC::BPC16`] results in `bpc16`.
+///
+/// * `$name:ident`:
+///     The inner name of the asm `fn` to be declared and evaluated to.
+///     This excludes the `dav1d_` prefix and the `_bpc{8,16}_$asm` suffix.
+///
+/// * `$asm:ident`:
+///     The asm variant the asm `fn` is named with.
+///     The possible values correspond to the [`CpuFlags`]:
+///     * `x86`, `x86_64`:
+///         * [`sse2`]
+///         * [`ssse3`]
+///         * [`sse41`]
+///     * `x86_64`:
+///         * [`avx2`]
+///         * [`avx512icl`]
+///     * `arm`, `aarch64`:
+///         * [`neon`]
+///
+/// [`wrap_fn_ptr!`]: crate::src::wrap_fn_ptr::wrap_fn_ptr
+/// [`CpuFlags`]: crate::src::cpu::CpuFlags
+/// [`sse2`]: crate::src::cpu::CpuFlags::SSE2
+/// [`sse41`]: crate::src::cpu::CpuFlags::SSE41
+/// [`ssse3`]: crate::src::cpu::CpuFlags::SSSE3
+/// [`avx2`]: crate::src::cpu::CpuFlags::AVX2
+/// [`avx512icl`]: crate::src::cpu::CpuFlags::AVX512ICL
+/// [`neon`]: crate::src::cpu::CpuFlags::NEON
 #[cfg(feature = "asm")]
 macro_rules! bd_fn {
     ($decl_fn:path, $BD:ty, $name:ident, $asm:ident) => {{

--- a/lib.rs
+++ b/lib.rs
@@ -54,7 +54,7 @@ pub mod src {
     mod fg_apply;
     mod filmgrain;
     mod getbits;
-    mod wrap_fn_ptr;
+    pub(crate) mod wrap_fn_ptr;
     // TODO(kkysen) Temporarily `pub(crate)` due to a `pub use` until TAIT.
     pub(super) mod internal;
     mod intra_edge;

--- a/src/wrap_fn_ptr.rs
+++ b/src/wrap_fn_ptr.rs
@@ -3,6 +3,10 @@ pub trait HasFnPtr {
     type FnPtr;
 }
 
+/// A newtype wrapped `fn` ptr.
+///
+/// This allows us to add a safer (type-safe for sure, and increasingly fully safe)
+/// wrapper around calling a `fn` ptr.
 #[repr(transparent)]
 pub struct WrappedFnPtr<F>(F);
 

--- a/src/wrap_fn_ptr.rs
+++ b/src/wrap_fn_ptr.rs
@@ -1,3 +1,4 @@
+/// A `trait` to extract the `fn` ptr type of a [`WrappedFnPtr`].
 pub trait HasFnPtr {
     type FnPtr;
 }

--- a/src/wrap_fn_ptr.rs
+++ b/src/wrap_fn_ptr.rs
@@ -41,6 +41,22 @@ macro_rules! wrap_fn_ptr {
                     Self::new(default_unimplemented)
                 };
             }
+
+            #[cfg(feature = "asm")]
+            #[allow(unused_macros)]
+            macro_rules! decl_fn {
+                (fn $fn_name:ident) => {{
+                    extern "C" {
+                        fn $fn_name($($arg_name: $arg_ty,)*) -> $return_ty;
+                    }
+
+                    $name::Fn::new($fn_name)
+                }};
+            }
+
+            #[cfg(feature = "asm")]
+            #[allow(unused_imports)]
+            pub(crate) use decl_fn;
         }
     };
 }

--- a/src/wrap_fn_ptr.rs
+++ b/src/wrap_fn_ptr.rs
@@ -24,6 +24,33 @@ impl<F> WrappedFnPtr<F> {
     }
 }
 
+/// This declares a wrapper for a `fn` ptr
+/// and defines related, useful things for that `fn` ptr.
+///
+/// The API for [`wrap_fn_ptr!`] is a `fn` signature with no body.
+/// This generates a `mod` with the name of the `fn` provided that contains:
+///
+/// * `type Fn`:
+///     A [`WrappedFnPtr`] wrapping the `fn` ptr signature provided.
+///
+/// * `impl ` [`DefaultValue`] ` for Fn`:
+///     A `const`-compatible default implementation of `Fn`
+///     that just calls [`unimplemented!`].
+///     This lets `Fn` be used by [`enum_map!`] without wrapping it in an [`Option`],
+///     and removes any need for an [`Option::unwrap`] check,
+///     as the check is moved to inside the `fn` call.
+///
+/// * `decl_fn!`:
+///     A macro that, given a `fn $fn_name:ident`,
+///     declares an `extern "C" fn` with the `fn` signature provided.
+///     This macro can and is meant to be used with [`bd_fn!`].
+///
+/// This ensures that the `fn` signature is consistent between all of these
+/// and reduces the need to repeat the `fn` signature many times.
+///
+/// [`DefaultValue`]: crate::src::enum_map::DefaultValue
+/// [`enum_map!`]: crate::src::enum_map::enum_map
+/// [`bd_fn!`]: crate::include::common::bitdepth::bd_fn
 macro_rules! wrap_fn_ptr {
     ($vis:vis unsafe extern "C" fn $name:ident(
             $($arg_name:ident: $arg_ty:ty),*$(,)?

--- a/src/wrap_fn_ptr.rs
+++ b/src/wrap_fn_ptr.rs
@@ -24,14 +24,14 @@ impl<F> WrappedFnPtr<F> {
     }
 }
 
-/// This declares a wrapper for a `fn` ptr
-/// and defines related, useful things for that `fn` ptr.
-///
-/// The API for [`wrap_fn_ptr!`] is a `fn` signature with no body.
-/// This generates a `mod` with the name of the `fn` provided that contains:
+/// Declare a newtype wrapper for a `fn` ptr
+/// and define related, useful items for that `fn` ptr (see below).
+/// Given a `fn` signature with no body,
+/// this generates a `mod` with the name of the `fn` provided that contains:
 ///
 /// * `type Fn`:
 ///     A [`WrappedFnPtr`] wrapping the `fn` ptr signature provided.
+///     This is a newtype wrapper for the purpose of implementing methods on.
 ///
 /// * `impl ` [`DefaultValue`] ` for Fn`:
 ///     A `const`-compatible default implementation of `Fn`

--- a/src/wrap_fn_ptr.rs
+++ b/src/wrap_fn_ptr.rs
@@ -20,23 +20,27 @@ impl<F> WrappedFnPtr<F> {
 }
 
 macro_rules! wrap_fn_ptr {
-    ($vis:vis struct $Wrapper:ident(
-        unsafe extern "C" fn(
+    ($vis:vis unsafe extern "C" fn $name:ident(
             $($arg_name:ident: $arg_ty:ty),*$(,)?
-        ) -> $return_ty:ty
-    )) => {
-        $vis type $Wrapper = WrappedFnPtr<unsafe extern "C" fn($($arg_name: $arg_ty),*) -> $return_ty>;
+    ) -> $return_ty:ty) => {
+        $vis mod $name {
+            use $crate::src::wrap_fn_ptr::WrappedFnPtr;
+            use $crate::src::enum_map::DefaultValue;
+            use super::*;
 
-        impl DefaultValue for $Wrapper {
-            const DEFAULT: Self = {
-                extern "C" fn default_unimplemented(
-                    $($arg_name: $arg_ty,)*
-                ) -> $return_ty {
-                    $(let _ = $arg_name;)*
-                    unimplemented!()
-                }
-                Self::new(default_unimplemented)
-            };
+            pub type Fn = WrappedFnPtr<unsafe extern "C" fn($($arg_name: $arg_ty),*) -> $return_ty>;
+
+            impl DefaultValue for Fn {
+                const DEFAULT: Self = {
+                    extern "C" fn default_unimplemented(
+                        $($arg_name: $arg_ty,)*
+                    ) -> $return_ty {
+                        $(let _ = $arg_name;)*
+                        unimplemented!()
+                    }
+                    Self::new(default_unimplemented)
+                };
+            }
         }
     };
 }


### PR DESCRIPTION
We're already matching the `fn` signature with a macro, so generating the `decl_fn!` macro inside is pretty trivial, and this way we don't have to write all of the `decl_*_fn!` macros ourselves.

This also adds documentation for:
* `trait HasFnPtr`
* `struct WrappedFnPtr`
* `wrap_fn_ptr!`
* `bd_fn!`