### PR TITLE
`mod ipred`: Use `wrap_fn_ptr!` to generate `decl_fn!`s and add type-safe wrappers

### DIFF
--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -55,7 +55,7 @@ impl generate_grain_y::Fn {
         let buf = (buf as *mut GrainLut<BD::Entry>).cast();
         let data = &data.clone().into();
         let bd = bd.into_c();
-        (self.get())(buf, data, bd)
+        self.get()(buf, data, bd)
     }
 }
 
@@ -81,7 +81,7 @@ impl generate_grain_uv::Fn {
         let data = &data.clone().into();
         let uv = is_uv.into();
         let bd = bd.into_c();
-        (self.get())(buf, buf_y, data, uv, bd)
+        self.get()(buf, buf_y, data, uv, bd)
     }
 }
 
@@ -120,7 +120,7 @@ impl fgy_32x32xn::Fn {
         let bh = bh as c_int;
         let row_num = row_num as c_int;
         let bd = bd.into_c();
-        (self.get())(
+        self.get()(
             dst_row, src_row, stride, data, pw, scaling, grain_lut, bh, row_num, bd,
         )
     }
@@ -172,7 +172,7 @@ impl fguv_32x32xn::Fn {
         let uv_pl = is_uv as c_int;
         let is_id = is_id as c_int;
         let bd = bd.into_c();
-        (self.get())(
+        self.get()(
             dst_row,
             src_row,
             stride,

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -173,117 +173,155 @@ pub struct Rav1dIntraPredDSPContext {
 }
 
 #[cfg(all(feature = "asm", target_arch = "aarch64"))]
-macro_rules! decl_z1_fill_fn {
-    (fn $name:ident) => {{
-        extern "C" {
-            fn $name(
-                dst: *mut DynPixel,
-                stride: ptrdiff_t,
-                top: *const DynPixel,
-                width: c_int,
-                height: c_int,
-                dx: c_int,
-                max_base_x: c_int,
-            );
-        }
+wrap_fn_ptr!(unsafe extern "C" fn z13_fill(
+    dst: *mut DynPixel,
+    stride: ptrdiff_t,
+    topleft: *const DynPixel,
+    width: c_int,
+    height: c_int,
+    dxy: c_int,
+    max_base_xy: c_int,
+) -> ());
 
-        $name
-    }};
+#[cfg(all(feature = "asm", target_arch = "aarch64"))]
+impl z13_fill::Fn {
+    pub unsafe fn call<BD: BitDepth>(
+        &self,
+        dst: *mut BD::Pixel,
+        stride: ptrdiff_t,
+        topleft: *const BD::Pixel,
+        width: c_int,
+        height: c_int,
+        dxy: c_int,
+        max_base_xy: c_int,
+    ) {
+        let dst = dst.cast();
+        let topleft = topleft.cast();
+        self.get()(dst, stride, topleft, width, height, dxy, max_base_xy)
+    }
 }
 
 #[cfg(all(feature = "asm", target_arch = "aarch64"))]
-macro_rules! decl_z2_fill_fn {
-    (fn $name:ident) => {{
-        extern "C" {
-            fn $name(
-                dst: *mut DynPixel,
-                stride: ptrdiff_t,
-                top: *const DynPixel,
-                left: *const DynPixel,
-                width: c_int,
-                height: c_int,
-                dx: c_int,
-                dy: c_int,
-            );
-        }
+wrap_fn_ptr!(unsafe extern "C" fn z2_fill(
+    dst: *mut DynPixel,
+    stride: ptrdiff_t,
+    top: *const DynPixel,
+    left: *const DynPixel,
+    width: c_int,
+    height: c_int,
+    dx: c_int,
+    dy: c_int,
+) -> ());
 
-        $name
-    }};
+#[cfg(all(feature = "asm", target_arch = "aarch64"))]
+impl z2_fill::Fn {
+    pub unsafe fn call<BD: BitDepth>(
+        &self,
+        dst: *mut BD::Pixel,
+        stride: ptrdiff_t,
+        top: *const BD::Pixel,
+        left: *const BD::Pixel,
+        width: c_int,
+        height: c_int,
+        dx: c_int,
+        dy: c_int,
+    ) {
+        let dst = dst.cast();
+        let top = top.cast();
+        let left = left.cast();
+        self.get()(dst, stride, top, left, width, height, dx, dy)
+    }
 }
 
 #[cfg(all(feature = "asm", target_arch = "aarch64"))]
-macro_rules! decl_z3_fill_fn {
-    (fn $name:ident) => {{
-        extern "C" {
-            fn $name(
-                dst: *mut DynPixel,
-                stride: ptrdiff_t,
-                left: *const DynPixel,
-                width: c_int,
-                height: c_int,
-                dy: c_int,
-                max_base_y: c_int,
-            );
-        }
+wrap_fn_ptr!(unsafe extern "C" fn z1_upsample_edge(
+    out: *mut DynPixel,
+    hsz: c_int,
+    in_0: *const DynPixel,
+    end: c_int,
+    _bitdepth_max: c_int,
+) -> ());
 
-        $name
-    }};
+#[cfg(all(feature = "asm", target_arch = "aarch64"))]
+impl z1_upsample_edge::Fn {
+    pub unsafe fn call<BD: BitDepth>(
+        &self,
+        out: *mut BD::Pixel,
+        hsz: c_int,
+        in_0: *const BD::Pixel,
+        end: c_int,
+        bd: BD,
+    ) {
+        let out = out.cast();
+        let in_0 = in_0.cast();
+        let bd = bd.into_c();
+        self.get()(out, hsz, in_0, end, bd)
+    }
 }
 
 #[cfg(all(feature = "asm", target_arch = "aarch64"))]
-macro_rules! decl_z1_upsample_edge_fn {
-    (fn $name:ident) => {{
-        extern "C" {
-            fn $name(
-                out: *mut DynPixel,
-                hsz: c_int,
-                in_0: *const DynPixel,
-                end: c_int,
-                _bitdepth_max: c_int,
-            );
-        }
+wrap_fn_ptr!(unsafe extern "C" fn z1_filter_edge(
+    out: *mut DynPixel,
+    sz: c_int,
+    in_0: *const DynPixel,
+    end: c_int,
+    strength: c_int,
+) -> ());
 
-        $name
-    }};
+#[cfg(all(feature = "asm", target_arch = "aarch64"))]
+impl z1_filter_edge::Fn {
+    pub unsafe fn call<BD: BitDepth>(
+        &self,
+        out: *mut BD::Pixel,
+        sz: c_int,
+        in_0: *const BD::Pixel,
+        end: c_int,
+        strength: c_int,
+    ) {
+        let out = out.cast();
+        let in_0 = in_0.cast();
+        self.get()(out, sz, in_0, end, strength)
+    }
 }
 
 #[cfg(all(feature = "asm", target_arch = "aarch64"))]
-macro_rules! decl_z1_filter_edge_fn {
-    (fn $name:ident) => {{
-        extern "C" {
-            fn $name(
-                out: *mut DynPixel,
-                sz: c_int,
-                in_0: *const DynPixel,
-                end: c_int,
-                strength: c_int,
-            );
-        }
+wrap_fn_ptr!(unsafe extern "C" fn z2_upsample_edge(
+    out: *mut DynPixel,
+    hsz: c_int,
+    in_0: *const DynPixel,
+    _bitdepth_max: c_int,
+) -> ());
 
-        $name
-    }};
+#[cfg(all(feature = "asm", target_arch = "aarch64"))]
+impl z2_upsample_edge::Fn {
+    pub unsafe fn call<BD: BitDepth>(
+        &self,
+        out: *mut BD::Pixel,
+        hsz: c_int,
+        in_0: *const BD::Pixel,
+        bd: BD,
+    ) {
+        let out = out.cast();
+        let in_0 = in_0.cast();
+        let bd = bd.into_c();
+        self.get()(out, hsz, in_0, bd)
+    }
 }
 
 #[cfg(all(feature = "asm", target_arch = "aarch64"))]
-macro_rules! decl_z2_upsample_edge_fn {
-    (fn $name:ident) => {{
-        extern "C" {
-            fn $name(out: *mut DynPixel, hsz: c_int, in_0: *const DynPixel, _bitdepth_max: c_int);
-        }
-
-        $name
-    }};
-}
+wrap_fn_ptr!(unsafe extern "C" fn reverse(
+    dst: *mut DynPixel,
+    src: *const DynPixel,
+    n: c_int,
+) -> ());
 
 #[cfg(all(feature = "asm", target_arch = "aarch64"))]
-macro_rules! decl_reverse_fn {
-    (fn $name:ident) => {{
-        extern "C" {
-            fn $name(dst: *mut DynPixel, src: *const DynPixel, n: c_int);
-        }
-
-        $name
-    }};
+impl reverse::Fn {
+    pub unsafe fn call<BD: BitDepth>(&self, dst: *mut BD::Pixel, src: *const BD::Pixel, n: c_int) {
+        let dst = dst.cast();
+        let src = src.cast();
+        self.get()(dst, src, n)
+    }
 }
 
 #[cfg(all(feature = "asm", target_arch = "aarch64"))]
@@ -1646,12 +1684,12 @@ unsafe fn ipred_z1_neon<BD: BitDepth>(
         0 as c_int
     };
     if upsample_above != 0 {
-        bd_fn!(decl_z1_upsample_edge_fn, BD, ipred_z1_upsample_edge, neon)(
-            top_out.as_mut_ptr().cast(),
+        bd_fn!(z1_upsample_edge::decl_fn, BD, ipred_z1_upsample_edge, neon).call(
+            top_out.as_mut_ptr(),
             width + height,
-            topleft_in.cast(),
+            topleft_in,
             width + cmp::min(width, height),
-            bd.into_c(),
+            bd,
         );
         max_base_x = 2 * (width + height) - 2;
         dx <<= 1;
@@ -1662,10 +1700,10 @@ unsafe fn ipred_z1_neon<BD: BitDepth>(
             0 as c_int
         };
         if filter_strength != 0 {
-            bd_fn!(decl_z1_filter_edge_fn, BD, ipred_z1_filter_edge, neon)(
-                top_out.as_mut_ptr().cast(),
+            bd_fn!(z1_filter_edge::decl_fn, BD, ipred_z1_filter_edge, neon).call::<BD>(
+                top_out.as_mut_ptr(),
                 width + height,
-                topleft_in.cast(),
+                topleft_in,
                 width + cmp::min(width, height),
                 filter_strength,
             );
@@ -1687,20 +1725,20 @@ unsafe fn ipred_z1_neon<BD: BitDepth>(
         (pad_pixels * base_inc) as c_int,
     );
     if upsample_above != 0 {
-        bd_fn!(decl_z1_fill_fn, BD, ipred_z1_fill2, neon)(
-            dst.cast(),
+        bd_fn!(z13_fill::decl_fn, BD, ipred_z1_fill2, neon).call::<BD>(
+            dst,
             stride,
-            top_out.as_mut_ptr().cast(),
+            top_out.as_mut_ptr(),
             width,
             height,
             dx,
             max_base_x,
         );
     } else {
-        bd_fn!(decl_z1_fill_fn, BD, ipred_z1_fill1, neon)(
-            dst.cast(),
+        bd_fn!(z13_fill::decl_fn, BD, ipred_z1_fill1, neon).call::<BD>(
+            dst,
             stride,
-            top_out.as_mut_ptr().cast(),
+            top_out.as_mut_ptr(),
             width,
             height,
             dx,
@@ -1749,11 +1787,11 @@ unsafe fn ipred_z2_neon<BD: BitDepth>(
     };
 
     if upsample_above != 0 {
-        bd_fn!(decl_z2_upsample_edge_fn, BD, ipred_z2_upsample_edge, neon)(
-            buf.as_mut_ptr().offset(top_offset).cast(),
+        bd_fn!(z2_upsample_edge::decl_fn, BD, ipred_z2_upsample_edge, neon).call(
+            buf.as_mut_ptr().offset(top_offset),
             width,
-            topleft_in.cast(),
-            bd.into_c(),
+            topleft_in,
+            bd,
         );
         dx <<= 1;
     } else {
@@ -1764,10 +1802,10 @@ unsafe fn ipred_z2_neon<BD: BitDepth>(
         };
 
         if filter_strength != 0 {
-            bd_fn!(decl_z1_filter_edge_fn, BD, ipred_z1_filter_edge, neon)(
-                buf.as_mut_ptr().offset(1 + top_offset).cast(),
+            bd_fn!(z1_filter_edge::decl_fn, BD, ipred_z1_filter_edge, neon).call::<BD>(
+                buf.as_mut_ptr().offset(1 + top_offset),
                 cmp::min(max_width, width),
-                topleft_in.cast(),
+                topleft_in,
                 width,
                 filter_strength,
             );
@@ -1791,16 +1829,16 @@ unsafe fn ipred_z2_neon<BD: BitDepth>(
 
     if upsample_left != 0 {
         buf[flipped_offset as usize] = *topleft_in;
-        bd_fn!(decl_reverse_fn, BD, ipred_reverse, neon)(
-            buf.as_mut_ptr().offset(1 + flipped_offset).cast(),
-            topleft_in.cast(),
+        bd_fn!(reverse::decl_fn, BD, ipred_reverse, neon).call::<BD>(
+            buf.as_mut_ptr().offset(1 + flipped_offset),
+            topleft_in,
             height,
         );
-        bd_fn!(decl_z2_upsample_edge_fn, BD, ipred_z2_upsample_edge, neon)(
-            buf.as_mut_ptr().offset(left_offset).cast(),
+        bd_fn!(z2_upsample_edge::decl_fn, BD, ipred_z2_upsample_edge, neon).call(
+            buf.as_mut_ptr().offset(left_offset),
             height,
-            buf.as_ptr().offset(flipped_offset).cast(),
-            bd.into_c(),
+            buf.as_ptr().offset(flipped_offset),
+            bd,
         );
         dy <<= 1;
     } else {
@@ -1811,15 +1849,15 @@ unsafe fn ipred_z2_neon<BD: BitDepth>(
         };
         if filter_strength != 0 {
             buf[flipped_offset as usize] = *topleft_in;
-            bd_fn!(decl_reverse_fn, BD, ipred_reverse, neon)(
-                buf.as_mut_ptr().offset(1 + flipped_offset).cast(),
-                topleft_in.cast(),
+            bd_fn!(reverse::decl_fn, BD, ipred_reverse, neon).call::<BD>(
+                buf.as_mut_ptr().offset(1 + flipped_offset),
+                topleft_in,
                 height,
             );
-            bd_fn!(decl_z1_filter_edge_fn, BD, ipred_z1_filter_edge, neon)(
-                buf.as_mut_ptr().offset(1 + left_offset).cast(),
+            bd_fn!(z1_filter_edge::decl_fn, BD, ipred_z1_filter_edge, neon).call::<BD>(
+                buf.as_mut_ptr().offset(1 + left_offset),
                 cmp::min(max_height, height),
-                buf.as_ptr().offset(flipped_offset).cast(),
+                buf.as_ptr().offset(flipped_offset),
                 height,
                 filter_strength,
             );
@@ -1836,9 +1874,9 @@ unsafe fn ipred_z2_neon<BD: BitDepth>(
                 );
             }
         } else {
-            bd_fn!(decl_reverse_fn, BD, ipred_reverse, neon)(
-                buf.as_mut_ptr().offset(left_offset + 1).cast(),
-                topleft_in.cast(),
+            bd_fn!(reverse::decl_fn, BD, ipred_reverse, neon).call::<BD>(
+                buf.as_mut_ptr().offset(left_offset + 1),
+                topleft_in,
                 height,
             );
         }
@@ -1851,33 +1889,33 @@ unsafe fn ipred_z2_neon<BD: BitDepth>(
     }
 
     if upsample_above == 0 && upsample_left == 0 {
-        bd_fn!(decl_z2_fill_fn, BD, ipred_z2_fill1, neon)(
-            dst.cast(),
+        bd_fn!(z2_fill::decl_fn, BD, ipred_z2_fill1, neon).call::<BD>(
+            dst,
             stride,
-            buf.as_ptr().offset(top_offset).cast(),
-            buf.as_ptr().offset(left_offset).cast(),
+            buf.as_ptr().offset(top_offset),
+            buf.as_ptr().offset(left_offset),
             width,
             height,
             dx,
             dy,
         );
     } else if upsample_above != 0 {
-        bd_fn!(decl_z2_fill_fn, BD, ipred_z2_fill2, neon)(
-            dst.cast(),
+        bd_fn!(z2_fill::decl_fn, BD, ipred_z2_fill2, neon).call::<BD>(
+            dst,
             stride,
-            buf.as_ptr().offset(top_offset).cast(),
-            buf.as_ptr().offset(left_offset).cast(),
+            buf.as_ptr().offset(top_offset),
+            buf.as_ptr().offset(left_offset),
             width,
             height,
             dx,
             dy,
         );
     } else {
-        bd_fn!(decl_z2_fill_fn, BD, ipred_z2_fill3, neon)(
-            dst.cast(),
+        bd_fn!(z2_fill::decl_fn, BD, ipred_z2_fill3, neon).call::<BD>(
+            dst,
             stride,
-            buf.as_ptr().offset(top_offset).cast(),
-            buf.as_ptr().offset(left_offset).cast(),
+            buf.as_ptr().offset(top_offset),
+            buf.as_ptr().offset(left_offset),
             width,
             height,
             dx,
@@ -1915,17 +1953,17 @@ unsafe fn ipred_z3_neon<BD: BitDepth>(
     };
     if upsample_left != 0 {
         flipped[0] = *topleft_in.offset(0);
-        bd_fn!(decl_reverse_fn, BD, ipred_reverse, neon)(
-            flipped.as_mut_ptr().offset(1).cast(),
-            topleft_in.offset(0).cast(),
+        bd_fn!(reverse::decl_fn, BD, ipred_reverse, neon).call::<BD>(
+            flipped.as_mut_ptr().offset(1),
+            topleft_in.offset(0),
             height + cmp::max(width, height),
         );
-        bd_fn!(decl_z1_upsample_edge_fn, BD, ipred_z1_upsample_edge, neon)(
-            left_out.as_mut_ptr().cast(),
+        bd_fn!(z1_upsample_edge::decl_fn, BD, ipred_z1_upsample_edge, neon).call(
+            left_out.as_mut_ptr(),
             width + height,
-            flipped.as_mut_ptr().cast(),
+            flipped.as_mut_ptr(),
             height + cmp::min(width, height),
-            bd.into_c(),
+            bd,
         );
         max_base_y = 2 * (width + height) - 2;
         dy <<= 1;
@@ -1937,23 +1975,23 @@ unsafe fn ipred_z3_neon<BD: BitDepth>(
         };
         if filter_strength != 0 {
             flipped[0] = *topleft_in.offset(0);
-            bd_fn!(decl_reverse_fn, BD, ipred_reverse, neon)(
-                flipped.as_mut_ptr().offset(1).cast(),
-                topleft_in.offset(0).cast(),
+            bd_fn!(reverse::decl_fn, BD, ipred_reverse, neon).call::<BD>(
+                flipped.as_mut_ptr().offset(1),
+                topleft_in.offset(0),
                 height + cmp::max(width, height),
             );
-            bd_fn!(decl_z1_filter_edge_fn, BD, ipred_z1_filter_edge, neon)(
-                left_out.as_mut_ptr().cast(),
+            bd_fn!(z1_filter_edge::decl_fn, BD, ipred_z1_filter_edge, neon).call::<BD>(
+                left_out.as_mut_ptr(),
                 width + height,
-                flipped.as_mut_ptr().cast(),
+                flipped.as_mut_ptr(),
                 height + cmp::min(width, height),
                 filter_strength,
             );
             max_base_y = width + height - 1;
         } else {
-            bd_fn!(decl_reverse_fn, BD, ipred_reverse, neon)(
-                left_out.as_mut_ptr().cast(),
-                topleft_in.offset(0).cast(),
+            bd_fn!(reverse::decl_fn, BD, ipred_reverse, neon).call::<BD>(
+                left_out.as_mut_ptr(),
+                topleft_in.offset(0),
                 height + cmp::min(width, height),
             );
             max_base_y = height + cmp::min(width, height) - 1;
@@ -1967,20 +2005,20 @@ unsafe fn ipred_z3_neon<BD: BitDepth>(
         (pad_pixels * base_inc) as c_int,
     );
     if upsample_left != 0 {
-        bd_fn!(decl_z3_fill_fn, BD, ipred_z3_fill2, neon)(
-            dst.cast(),
+        bd_fn!(z13_fill::decl_fn, BD, ipred_z3_fill2, neon).call::<BD>(
+            dst,
             stride,
-            left_out.as_mut_ptr().cast(),
+            left_out.as_mut_ptr(),
             width,
             height,
             dy,
             max_base_y,
         );
     } else {
-        bd_fn!(decl_z3_fill_fn, BD, ipred_z3_fill1, neon)(
-            dst.cast(),
+        bd_fn!(z13_fill::decl_fn, BD, ipred_z3_fill1, neon).call::<BD>(
+            dst,
             stride,
-            left_out.as_mut_ptr().cast(),
+            left_out.as_mut_ptr(),
             width,
             height,
             dy,

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -60,6 +60,28 @@ wrap_fn_ptr!(pub unsafe extern "C" fn angular_ipred(
     bitdepth_max: c_int,
 ) -> ());
 
+impl angular_ipred::Fn {
+    pub unsafe fn call<BD: BitDepth>(
+        &self,
+        dst: *mut BD::Pixel,
+        stride: ptrdiff_t,
+        topleft: *const BD::Pixel,
+        width: c_int,
+        height: c_int,
+        angle: c_int,
+        max_width: c_int,
+        max_height: c_int,
+        bd: BD,
+    ) {
+        let dst = dst.cast();
+        let topleft = topleft.cast();
+        let bd = bd.into_c();
+        self.get()(
+            dst, stride, topleft, width, height, angle, max_width, max_height, bd,
+        )
+    }
+}
+
 wrap_fn_ptr!(pub unsafe extern "C" fn cfl_ac(
     ac: *mut i16,
     y: *const DynPixel,
@@ -69,6 +91,22 @@ wrap_fn_ptr!(pub unsafe extern "C" fn cfl_ac(
     cw: c_int,
     ch: c_int,
 ) -> ());
+
+impl cfl_ac::Fn {
+    pub unsafe fn call<BD: BitDepth>(
+        &self,
+        ac: *mut i16,
+        y: *const BD::Pixel,
+        stride: ptrdiff_t,
+        w_pad: c_int,
+        h_pad: c_int,
+        cw: c_int,
+        ch: c_int,
+    ) {
+        let y = y.cast();
+        self.get()(ac, y, stride, w_pad, h_pad, cw, ch)
+    }
+}
 
 wrap_fn_ptr!(pub unsafe extern "C" fn cfl_pred(
     dst: *mut DynPixel,
@@ -81,6 +119,25 @@ wrap_fn_ptr!(pub unsafe extern "C" fn cfl_pred(
     bitdepth_max: c_int,
 ) -> ());
 
+impl cfl_pred::Fn {
+    pub unsafe fn call<BD: BitDepth>(
+        &self,
+        dst: *mut BD::Pixel,
+        stride: ptrdiff_t,
+        topleft: *const BD::Pixel,
+        width: c_int,
+        height: c_int,
+        ac: *const i16,
+        alpha: c_int,
+        bd: BD,
+    ) {
+        let dst = dst.cast();
+        let topleft = topleft.cast();
+        let bd = bd.into_c();
+        self.get()(dst, stride, topleft, width, height, ac, alpha, bd)
+    }
+}
+
 wrap_fn_ptr!(pub unsafe extern "C" fn pal_pred(
     dst: *mut DynPixel,
     stride: ptrdiff_t,
@@ -89,6 +146,21 @@ wrap_fn_ptr!(pub unsafe extern "C" fn pal_pred(
     w: c_int,
     h: c_int,
 ) -> ());
+
+impl pal_pred::Fn {
+    pub unsafe fn call<BD: BitDepth>(
+        &self,
+        dst: *mut BD::Pixel,
+        stride: ptrdiff_t,
+        pal: *const u16,
+        idx: *const u8,
+        w: c_int,
+        h: c_int,
+    ) {
+        let dst = dst.cast();
+        self.get()(dst, stride, pal, idx, w, h)
+    }
+}
 
 #[repr(C)]
 pub struct Rav1dIntraPredDSPContext {

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -60,7 +60,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn angular_ipred(
     bitdepth_max: c_int,
 ) -> ());
 
-pub type cfl_ac_fn = unsafe extern "C" fn(
+wrap_fn_ptr!(pub unsafe extern "C" fn cfl_ac(
     ac: *mut i16,
     y: *const DynPixel,
     stride: ptrdiff_t,
@@ -68,7 +68,7 @@ pub type cfl_ac_fn = unsafe extern "C" fn(
     h_pad: c_int,
     cw: c_int,
     ch: c_int,
-) -> ();
+) -> ());
 
 pub type cfl_pred_fn = unsafe extern "C" fn(
     dst: *mut DynPixel,
@@ -95,7 +95,7 @@ pub struct Rav1dIntraPredDSPContext {
     // TODO(legare): Remove `Option` once `dav1d_submit_frame` is no longer checking
     // this field with `is_none`.
     pub intra_pred: [Option<angular_ipred::Fn>; 14],
-    pub cfl_ac: [cfl_ac_fn; 3],
+    pub cfl_ac: [cfl_ac::Fn; 3],
     pub cfl_pred: [cfl_pred_fn; 6],
     pub pal_pred: pal_pred_fn,
 }
@@ -113,25 +113,6 @@ macro_rules! decl_cfl_pred_fn {
                 ac: *const i16,
                 alpha: c_int,
                 bitdepth_max: c_int,
-            );
-        }
-
-        $name
-    }};
-}
-
-#[cfg(feature = "asm")]
-macro_rules! decl_cfl_ac_fn {
-    (fn $name:ident) => {{
-        extern "C" {
-            fn $name(
-                ac: *mut i16,
-                y: *const DynPixel,
-                stride: ptrdiff_t,
-                w_pad: c_int,
-                h_pad: c_int,
-                cw: c_int,
-                ch: c_int,
             );
         }
 
@@ -2037,11 +2018,11 @@ unsafe fn intra_pred_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dIntraPredDSPContext
     (*c).cfl_pred[LEFT_DC_PRED as usize] = bd_fn!(decl_cfl_pred_fn, BD, ipred_cfl_left, ssse3);
 
     (*c).cfl_ac[Rav1dPixelLayout::I420 as usize - 1] =
-        bd_fn!(decl_cfl_ac_fn, BD, ipred_cfl_ac_420, ssse3);
+        bd_fn!(cfl_ac::decl_fn, BD, ipred_cfl_ac_420, ssse3);
     (*c).cfl_ac[Rav1dPixelLayout::I422 as usize - 1] =
-        bd_fn!(decl_cfl_ac_fn, BD, ipred_cfl_ac_422, ssse3);
+        bd_fn!(cfl_ac::decl_fn, BD, ipred_cfl_ac_422, ssse3);
     (*c).cfl_ac[Rav1dPixelLayout::I444 as usize - 1] =
-        bd_fn!(decl_cfl_ac_fn, BD, ipred_cfl_ac_444, ssse3);
+        bd_fn!(cfl_ac::decl_fn, BD, ipred_cfl_ac_444, ssse3);
 
     (*c).pal_pred = bd_fn!(decl_pal_pred_fn, BD, pal_pred, ssse3);
 
@@ -2086,11 +2067,11 @@ unsafe fn intra_pred_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dIntraPredDSPContext
         (*c).cfl_pred[LEFT_DC_PRED as usize] = bd_fn!(decl_cfl_pred_fn, BD, ipred_cfl_left, avx2);
 
         (*c).cfl_ac[Rav1dPixelLayout::I420 as usize - 1] =
-            bd_fn!(decl_cfl_ac_fn, BD, ipred_cfl_ac_420, avx2);
+            bd_fn!(cfl_ac::decl_fn, BD, ipred_cfl_ac_420, avx2);
         (*c).cfl_ac[Rav1dPixelLayout::I422 as usize - 1] =
-            bd_fn!(decl_cfl_ac_fn, BD, ipred_cfl_ac_422, avx2);
+            bd_fn!(cfl_ac::decl_fn, BD, ipred_cfl_ac_422, avx2);
         (*c).cfl_ac[Rav1dPixelLayout::I444 as usize - 1] =
-            bd_fn!(decl_cfl_ac_fn, BD, ipred_cfl_ac_444, avx2);
+            bd_fn!(cfl_ac::decl_fn, BD, ipred_cfl_ac_444, avx2);
 
         (*c).pal_pred = bd_fn!(decl_pal_pred_fn, BD, pal_pred, avx2);
 
@@ -2180,11 +2161,11 @@ unsafe fn intra_pred_dsp_init_arm<BD: BitDepth>(c: *mut Rav1dIntraPredDSPContext
     (*c).cfl_pred[LEFT_DC_PRED as usize] = bd_fn!(decl_cfl_pred_fn, BD, ipred_cfl_left, neon);
 
     (*c).cfl_ac[Rav1dPixelLayout::I420 as usize - 1] =
-        bd_fn!(decl_cfl_ac_fn, BD, ipred_cfl_ac_420, neon);
+        bd_fn!(cfl_ac::decl_fn, BD, ipred_cfl_ac_420, neon);
     (*c).cfl_ac[Rav1dPixelLayout::I422 as usize - 1] =
-        bd_fn!(decl_cfl_ac_fn, BD, ipred_cfl_ac_422, neon);
+        bd_fn!(cfl_ac::decl_fn, BD, ipred_cfl_ac_422, neon);
     (*c).cfl_ac[Rav1dPixelLayout::I444 as usize - 1] =
-        bd_fn!(decl_cfl_ac_fn, BD, ipred_cfl_ac_444, neon);
+        bd_fn!(cfl_ac::decl_fn, BD, ipred_cfl_ac_444, neon);
 
     (*c).pal_pred = bd_fn!(decl_pal_pred_fn, BD, pal_pred, neon);
 }
@@ -2217,9 +2198,12 @@ pub unsafe fn rav1d_intra_pred_dsp_init<BD: BitDepth>(c: *mut Rav1dIntraPredDSPC
     (*c).intra_pred[FILTER_PRED as usize] =
         Some(angular_ipred::Fn::new(ipred_filter_c_erased::<BD>));
 
-    (*c).cfl_ac[Rav1dPixelLayout::I420 as usize - 1] = cfl_ac_c_erased::<BD, true, true>;
-    (*c).cfl_ac[Rav1dPixelLayout::I422 as usize - 1] = cfl_ac_c_erased::<BD, true, false>;
-    (*c).cfl_ac[Rav1dPixelLayout::I444 as usize - 1] = cfl_ac_c_erased::<BD, false, false>;
+    (*c).cfl_ac[Rav1dPixelLayout::I420 as usize - 1] =
+        cfl_ac::Fn::new(cfl_ac_c_erased::<BD, true, true>);
+    (*c).cfl_ac[Rav1dPixelLayout::I422 as usize - 1] =
+        cfl_ac::Fn::new(cfl_ac_c_erased::<BD, true, false>);
+    (*c).cfl_ac[Rav1dPixelLayout::I444 as usize - 1] =
+        cfl_ac::Fn::new(cfl_ac_c_erased::<BD, false, false>);
     (*c).cfl_pred[DC_PRED as usize] = ipred_cfl_c_erased::<BD, { DcGen::TopLeft as u8 }>;
 
     (*c).cfl_pred[DC_128_PRED as usize] = ipred_cfl_128_c_erased::<BD>;

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2681,7 +2681,9 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             edge,
                             BD::from_c((*f).bitdepth_max),
                         );
-                        ((*dsp).ipred.intra_pred[m as usize]).expect("non-null function pointer")(
+                        (*dsp).ipred.intra_pred[m as usize]
+                            .expect("non-null function pointer")
+                            .get()(
                             dst.cast(),
                             (*f).cur.stride[0],
                             edge.cast(),
@@ -3092,8 +3094,9 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                     BD::from_c((*f).bitdepth_max),
                                 );
                                 angle |= intra_edge_filter_flag;
-                                ((*dsp).ipred.intra_pred[m as usize])
-                                    .expect("non-null function pointer")(
+                                (*dsp).ipred.intra_pred[m as usize]
+                                    .expect("non-null function pointer")
+                                    .get()(
                                     dst.cast(),
                                     stride,
                                     edge.cast(),
@@ -3480,7 +3483,9 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 tl_edge,
                 BD::from_c((*f).bitdepth_max),
             );
-            ((*dsp).ipred.intra_pred[m as usize]).expect("non-null function pointer")(
+            (*dsp).ipred.intra_pred[m as usize]
+                .expect("non-null function pointer")
+                .get()(
                 tmp.cast(),
                 ((4 * bw4) as c_ulong).wrapping_mul(::core::mem::size_of::<BD::Pixel>() as c_ulong)
                     as ptrdiff_t,
@@ -3901,7 +3906,9 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             tl_edge,
                             BD::from_c((*f).bitdepth_max),
                         );
-                        ((*dsp).ipred.intra_pred[m as usize]).expect("non-null function pointer")(
+                        (*dsp).ipred.intra_pred[m as usize]
+                            .expect("non-null function pointer")
+                            .get()(
                             tmp.cast(),
                             ((cbw4 * 4) as c_ulong)
                                 .wrapping_mul(::core::mem::size_of::<BD::Pixel>() as c_ulong)

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2587,7 +2587,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                 } else {
                     (t.scratch.c2rust_unnamed_0.pal[0]).as_mut_ptr()
                 };
-                ((*(*f).dsp).ipred.pal_pred)(
+                (*(*f).dsp).ipred.pal_pred.get()(
                     dst.cast(),
                     (*f).cur.stride[0],
                     pal,
@@ -2952,7 +2952,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             .offset((bw4 * bh4 * 16) as isize)
                             as *mut u8;
                     }
-                    ((*(*f).dsp).ipred.pal_pred)(
+                    (*(*f).dsp).ipred.pal_pred.get()(
                         ((*f).cur.data[1] as *mut BD::Pixel)
                             .offset(uv_dstoff as isize)
                             .cast(),
@@ -2962,7 +2962,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         cbw4 * 4,
                         cbh4 * 4,
                     );
-                    ((*(*f).dsp).ipred.pal_pred)(
+                    (*(*f).dsp).ipred.pal_pred.get()(
                         ((*f).cur.data[2] as *mut BD::Pixel)
                             .offset(uv_dstoff as isize)
                             .cast(),

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2587,8 +2587,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                 } else {
                     (t.scratch.c2rust_unnamed_0.pal[0]).as_mut_ptr()
                 };
-                (*(*f).dsp).ipred.pal_pred.get()(
-                    dst.cast(),
+                (*(*f).dsp).ipred.pal_pred.call::<BD>(
+                    dst,
                     (*f).cur.stride[0],
                     pal,
                     pal_idx,
@@ -2683,17 +2683,17 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         );
                         (*dsp).ipred.intra_pred[m as usize]
                             .expect("non-null function pointer")
-                            .get()(
-                            dst.cast(),
-                            (*f).cur.stride[0],
-                            edge.cast(),
-                            (*t_dim).w as c_int * 4,
-                            (*t_dim).h as c_int * 4,
-                            angle | intra_flags,
-                            4 * (*f).bw - 4 * t.bx,
-                            4 * (*f).bh - 4 * t.by,
-                            (*f).bitdepth_max,
-                        );
+                            .call(
+                                dst,
+                                (*f).cur.stride[0],
+                                edge,
+                                (*t_dim).w as c_int * 4,
+                                (*t_dim).h as c_int * 4,
+                                angle | intra_flags,
+                                4 * (*f).bw - 4 * t.bx,
+                                4 * (*f).bh - 4 * t.by,
+                                BD::from_c((*f).bitdepth_max),
+                            );
                         if DEBUG_BLOCK_INFO(&*f, t) && 0 != 0 {
                             hex_dump::<BD>(
                                 edge.offset(-(((*t_dim).h as c_int * 4) as isize)),
@@ -2850,15 +2850,15 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         (ch4 << ss_ver) + (*t_dim).h as c_int - 1 & !((*t_dim).h as c_int - 1);
                     (*dsp).ipred.cfl_ac
                         [((*f).cur.p.layout as c_uint).wrapping_sub(1 as c_int as c_uint) as usize]
-                        .get()(
-                        ac.as_mut_ptr(),
-                        y_src.cast(),
-                        (*f).cur.stride[0],
-                        cbw4 - (furthest_r >> ss_hor),
-                        cbh4 - (furthest_b >> ss_ver),
-                        cbw4 * 4,
-                        cbh4 * 4,
-                    );
+                        .call::<BD>(
+                            ac.as_mut_ptr(),
+                            y_src,
+                            (*f).cur.stride[0],
+                            cbw4 - (furthest_r >> ss_hor),
+                            cbh4 - (furthest_b >> ss_ver),
+                            cbw4 * 4,
+                            cbh4 * 4,
+                        );
                     let mut pl = 0;
                     while pl < 2 {
                         if !(b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[pl as usize] == 0) {
@@ -2893,15 +2893,15 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                 edge,
                                 BD::from_c((*f).bitdepth_max),
                             );
-                            (*dsp).ipred.cfl_pred[m as usize].get()(
-                                uv_dst[pl as usize].cast(),
+                            (*dsp).ipred.cfl_pred[m as usize].call(
+                                uv_dst[pl as usize],
                                 stride,
-                                edge.cast(),
+                                edge,
                                 (*uv_t_dim).w as c_int * 4,
                                 (*uv_t_dim).h as c_int * 4,
                                 ac.as_mut_ptr(),
                                 b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[pl as usize] as c_int,
-                                (*f).bitdepth_max,
+                                BD::from_c((*f).bitdepth_max),
                             );
                         }
                         pl += 1;
@@ -2952,20 +2952,16 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             .offset((bw4 * bh4 * 16) as isize)
                             as *mut u8;
                     }
-                    (*(*f).dsp).ipred.pal_pred.get()(
-                        ((*f).cur.data[1] as *mut BD::Pixel)
-                            .offset(uv_dstoff as isize)
-                            .cast(),
+                    (*(*f).dsp).ipred.pal_pred.call::<BD>(
+                        ((*f).cur.data[1] as *mut BD::Pixel).offset(uv_dstoff as isize),
                         (*f).cur.stride[1],
                         (*pal.offset(1)).as_ptr(),
                         pal_idx,
                         cbw4 * 4,
                         cbh4 * 4,
                     );
-                    (*(*f).dsp).ipred.pal_pred.get()(
-                        ((*f).cur.data[2] as *mut BD::Pixel)
-                            .offset(uv_dstoff as isize)
-                            .cast(),
+                    (*(*f).dsp).ipred.pal_pred.call::<BD>(
+                        ((*f).cur.data[2] as *mut BD::Pixel).offset(uv_dstoff as isize),
                         (*f).cur.stride[1],
                         (*pal.offset(2)).as_ptr(),
                         pal_idx,
@@ -3097,17 +3093,17 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                 angle |= intra_edge_filter_flag;
                                 (*dsp).ipred.intra_pred[m as usize]
                                     .expect("non-null function pointer")
-                                    .get()(
-                                    dst.cast(),
-                                    stride,
-                                    edge.cast(),
-                                    (*uv_t_dim).w as c_int * 4,
-                                    (*uv_t_dim).h as c_int * 4,
-                                    angle | sm_uv_fl,
-                                    4 * (*f).bw + ss_hor - 4 * (t.bx & !ss_hor) >> ss_hor,
-                                    4 * (*f).bh + ss_ver - 4 * (t.by & !ss_ver) >> ss_ver,
-                                    (*f).bitdepth_max,
-                                );
+                                    .call(
+                                        dst,
+                                        stride,
+                                        edge,
+                                        (*uv_t_dim).w as c_int * 4,
+                                        (*uv_t_dim).h as c_int * 4,
+                                        angle | sm_uv_fl,
+                                        4 * (*f).bw + ss_hor - 4 * (t.bx & !ss_hor) >> ss_hor,
+                                        4 * (*f).bh + ss_ver - 4 * (t.by & !ss_ver) >> ss_ver,
+                                        BD::from_c((*f).bitdepth_max),
+                                    );
                                 if DEBUG_BLOCK_INFO(&*f, t) && 0 != 0 {
                                     hex_dump::<BD>(
                                         edge.offset(-(((*uv_t_dim).h as c_int * 4) as isize)),
@@ -3486,18 +3482,19 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
             );
             (*dsp).ipred.intra_pred[m as usize]
                 .expect("non-null function pointer")
-                .get()(
-                tmp.cast(),
-                ((4 * bw4) as c_ulong).wrapping_mul(::core::mem::size_of::<BD::Pixel>() as c_ulong)
-                    as ptrdiff_t,
-                tl_edge.cast(),
-                bw4 * 4,
-                bh4 * 4,
-                0 as c_int,
-                0 as c_int,
-                0 as c_int,
-                (*f).bitdepth_max,
-            );
+                .call(
+                    tmp,
+                    ((4 * bw4) as c_ulong)
+                        .wrapping_mul(::core::mem::size_of::<BD::Pixel>() as c_ulong)
+                        as ptrdiff_t,
+                    tl_edge,
+                    bw4 * 4,
+                    bh4 * 4,
+                    0 as c_int,
+                    0 as c_int,
+                    0 as c_int,
+                    BD::from_c((*f).bitdepth_max),
+                );
             let ii_mask = if b.c2rust_unnamed.c2rust_unnamed_0.interintra_type as c_int
                 == INTER_INTRA_BLEND as c_int
             {
@@ -3909,19 +3906,19 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                         );
                         (*dsp).ipred.intra_pred[m as usize]
                             .expect("non-null function pointer")
-                            .get()(
-                            tmp.cast(),
-                            ((cbw4 * 4) as c_ulong)
-                                .wrapping_mul(::core::mem::size_of::<BD::Pixel>() as c_ulong)
-                                as ptrdiff_t,
-                            tl_edge.cast(),
-                            cbw4 * 4,
-                            cbh4 * 4,
-                            0 as c_int,
-                            0 as c_int,
-                            0 as c_int,
-                            (*f).bitdepth_max,
-                        );
+                            .call(
+                                tmp,
+                                ((cbw4 * 4) as c_ulong)
+                                    .wrapping_mul(::core::mem::size_of::<BD::Pixel>() as c_ulong)
+                                    as ptrdiff_t,
+                                tl_edge,
+                                cbw4 * 4,
+                                cbh4 * 4,
+                                0 as c_int,
+                                0 as c_int,
+                                0 as c_int,
+                                BD::from_c((*f).bitdepth_max),
+                            );
                         ((*dsp).mc.blend)(
                             uvdst.cast(),
                             (*f).cur.stride[1],

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2849,7 +2849,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     let furthest_b =
                         (ch4 << ss_ver) + (*t_dim).h as c_int - 1 & !((*t_dim).h as c_int - 1);
                     (*dsp).ipred.cfl_ac
-                        [((*f).cur.p.layout as c_uint).wrapping_sub(1 as c_int as c_uint) as usize](
+                        [((*f).cur.p.layout as c_uint).wrapping_sub(1 as c_int as c_uint) as usize]
+                        .get()(
                         ac.as_mut_ptr(),
                         y_src.cast(),
                         (*f).cur.stride[0],

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2893,7 +2893,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                 edge,
                                 BD::from_c((*f).bitdepth_max),
                             );
-                            (*dsp).ipred.cfl_pred[m as usize](
+                            (*dsp).ipred.cfl_pred[m as usize].get()(
                                 uv_dst[pl as usize].cast(),
                                 stride,
                                 edge.cast(),

--- a/src/wrap_fn_ptr.rs
+++ b/src/wrap_fn_ptr.rs
@@ -52,7 +52,7 @@ macro_rules! wrap_fn_ptr {
             ///
             /// This allows us to add a safer
             /// (type-safe for sure, and increasingly fully safe)
-            /// wrapper around calling a `fn` ptr.
+            /// interface for calling a `fn` ptr.
             #[derive(Clone, Copy, PartialEq, Eq)]
             #[repr(transparent)]
             pub struct Fn(FnPtr);

--- a/src/wrap_fn_ptr.rs
+++ b/src/wrap_fn_ptr.rs
@@ -14,8 +14,9 @@
 ///     These methods are marked `pub(super)`
 ///     as they are meant to be used in the module calling [`wrap_fn_ptr!`].
 ///
-///     It is meant for a `fn call` to also be added
-///     to call the `fn` in a type-safe (e.x. [`BitDepth`]-wise)
+///     It is meant for a `fn call` method to also be implemented
+///     for this type to allow users to call the `fn`
+///     in a type-safe (e.x. [`BitDepth`]-wise)
 ///     and generally safer (memory safety-wise) way.
 ///
 /// * `impl ` [`DefaultValue`] ` for Fn`:

--- a/src/wrap_fn_ptr.rs
+++ b/src/wrap_fn_ptr.rs
@@ -7,6 +7,7 @@ pub trait HasFnPtr {
 ///
 /// This allows us to add a safer (type-safe for sure, and increasingly fully safe)
 /// wrapper around calling a `fn` ptr.
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct WrappedFnPtr<F>(F);
 


### PR DESCRIPTION
This also reworks `wrap_fn_ptr!` to declare `Fn` as a newtype `struct` inside the macro rather than a type alias to the generic `WrappedFnPtr`, which needed a type token for disambiguation.  This results in mode code inside the macro vs. out of it, but the code is much simpler and easier to understand this way.