### PR TITLE
`struct Rav1dIntraPredDspContext::cfl_ac`: Make an `EnumMap` over `Rav1dPixelLayoutSubSampled`

### DIFF
--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -210,7 +210,7 @@ pub(crate) enum Rav1dPixelLayout {
     I444,
 }
 
-impl EnumKey<4> for Rav1dPixelLayout {
+impl EnumKey<{ Self::COUNT }> for Rav1dPixelLayout {
     const VALUES: [Self; Self::COUNT] = [Self::I400, Self::I420, Self::I422, Self::I444];
 
     fn as_usize(self) -> usize {
@@ -260,7 +260,7 @@ pub(crate) enum Rav1dPixelLayoutSubSampled {
     I444,
 }
 
-impl EnumKey<3> for Rav1dPixelLayoutSubSampled {
+impl EnumKey<{ Self::COUNT }> for Rav1dPixelLayoutSubSampled {
     const VALUES: [Self; Self::COUNT] = [Self::I420, Self::I422, Self::I444];
 
     fn as_usize(self) -> usize {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -45,7 +45,6 @@ use crate::src::dequant_tables::dav1d_dq_tbl;
 use crate::src::enum_map::enum_map;
 use crate::src::enum_map::enum_map_ty;
 use crate::src::enum_map::DefaultValue;
-use crate::src::enum_map::EnumMap;
 use crate::src::env::av1_get_bwd_ref_1_ctx;
 use crate::src::env::av1_get_bwd_ref_ctx;
 use crate::src::env::av1_get_fwd_ref_1_ctx;

--- a/src/enum_map.rs
+++ b/src/enum_map.rs
@@ -32,7 +32,7 @@ where
 // Has to be a macro until we have `#![feature(generic_const_exprs)]`.
 macro_rules! enum_map_ty {
     ($K:ty, $V:ty) => {
-        EnumMap<$K, $V, { <$K as ::strum::EnumCount>::COUNT }>
+        $crate::src::enum_map::EnumMap<$K, $V, { <$K as ::strum::EnumCount>::COUNT }>
     }
 }
 

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -14,7 +14,6 @@ use crate::src::assume::assume;
 use crate::src::enum_map::enum_map;
 use crate::src::enum_map::enum_map_ty;
 use crate::src::enum_map::DefaultValue;
-use crate::src::enum_map::EnumMap;
 use crate::src::internal::GrainLut;
 use crate::src::tables::dav1d_gaussian_sequence;
 use crate::src::wrap_fn_ptr::wrap_fn_ptr;

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2840,17 +2840,15 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         (cw4 << ss_hor) + (*t_dim).w as c_int - 1 & !((*t_dim).w as c_int - 1);
                     let furthest_b =
                         (ch4 << ss_ver) + (*t_dim).h as c_int - 1 & !((*t_dim).h as c_int - 1);
-                    (*dsp).ipred.cfl_ac
-                        [((*f).cur.p.layout as c_uint).wrapping_sub(1 as c_int as c_uint) as usize]
-                        .call::<BD>(
-                            ac.as_mut_ptr(),
-                            y_src,
-                            (*f).cur.stride[0],
-                            cbw4 - (furthest_r >> ss_hor),
-                            cbh4 - (furthest_b >> ss_ver),
-                            cbw4 * 4,
-                            cbh4 * 4,
-                        );
+                    (*dsp).ipred.cfl_ac[(*f).cur.p.layout.try_into().unwrap()].call::<BD>(
+                        ac.as_mut_ptr(),
+                        y_src,
+                        (*f).cur.stride[0],
+                        cbw4 - (furthest_r >> ss_hor),
+                        cbh4 - (furthest_b >> ss_ver),
+                        cbw4 * 4,
+                        cbh4 * 4,
+                    );
                     let mut pl = 0;
                     while pl < 2 {
                         if !(b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[pl as usize] == 0) {


### PR DESCRIPTION
I'll do the same for the other array fields, but I need to make the `enum`s for those first; this one already exists from before.