### PR TITLE
`mod obu`: Cleanup part 1

### DIFF
--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -113,7 +113,7 @@ pub const RAV1D_WM_TYPE_IDENTITY: Rav1dWarpedMotionType = DAV1D_WM_TYPE_IDENTITY
 #[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dWarpedMotionParams {
-    pub type_0: Dav1dWarpedMotionType,
+    pub r#type: Dav1dWarpedMotionType,
     pub matrix: [i32; 6],
     pub abcd: [i16; 4],
 }
@@ -139,7 +139,7 @@ impl Dav1dWarpedMotionParams {
 #[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dWarpedMotionParams {
-    pub type_0: Rav1dWarpedMotionType,
+    pub r#type: Rav1dWarpedMotionType,
     pub matrix: [i32; 6],
     pub abcd: [i16; 4],
 }
@@ -169,12 +169,12 @@ impl Rav1dWarpedMotionParams {
 impl From<Dav1dWarpedMotionParams> for Rav1dWarpedMotionParams {
     fn from(value: Dav1dWarpedMotionParams) -> Self {
         let Dav1dWarpedMotionParams {
-            type_0,
+            r#type,
             matrix,
             abcd,
         } = value;
         Self {
-            type_0,
+            r#type,
             matrix,
             abcd,
         }
@@ -184,12 +184,12 @@ impl From<Dav1dWarpedMotionParams> for Rav1dWarpedMotionParams {
 impl From<Rav1dWarpedMotionParams> for Dav1dWarpedMotionParams {
     fn from(value: Rav1dWarpedMotionParams) -> Self {
         let Rav1dWarpedMotionParams {
-            type_0,
+            r#type,
             matrix,
             abcd,
         } = value;
         Self {
-            type_0,
+            r#type,
             matrix,
             abcd,
         }

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -1902,28 +1902,28 @@ impl From<Rav1dFrameHeader_cdef> for Dav1dFrameHeader_cdef {
 #[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_restoration {
-    pub type_0: [Dav1dRestorationType; 3],
+    pub r#type: [Dav1dRestorationType; 3],
     pub unit_size: [c_int; 2],
 }
 
 #[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dFrameHeader_restoration {
-    pub type_0: [Rav1dRestorationType; 3],
+    pub r#type: [Rav1dRestorationType; 3],
     pub unit_size: [c_int; 2],
 }
 
 impl From<Dav1dFrameHeader_restoration> for Rav1dFrameHeader_restoration {
     fn from(value: Dav1dFrameHeader_restoration) -> Self {
-        let Dav1dFrameHeader_restoration { type_0, unit_size } = value;
-        Self { type_0, unit_size }
+        let Dav1dFrameHeader_restoration { r#type, unit_size } = value;
+        Self { r#type, unit_size }
     }
 }
 
 impl From<Rav1dFrameHeader_restoration> for Dav1dFrameHeader_restoration {
     fn from(value: Rav1dFrameHeader_restoration) -> Self {
-        let Rav1dFrameHeader_restoration { type_0, unit_size } = value;
-        Self { type_0, unit_size }
+        let Rav1dFrameHeader_restoration { r#type, unit_size } = value;
+        Self { r#type, unit_size }
     }
 }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4155,7 +4155,7 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(t: &mut Rav1dTaskContext) -> Result
                 continue;
             }
 
-            let frame_type = (*f.frame_hdr).restoration.type_0[p as usize];
+            let frame_type = (*f.frame_hdr).restoration.r#type[p as usize];
 
             if (*f.frame_hdr).width[0] != (*f.frame_hdr).width[1] {
                 let w = f.sr_cur.p.p.w + ss_hor >> ss_hor;
@@ -4561,7 +4561,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init(f: &mut Rav1dFrameContext) -> Rav1d
     }
     f.lf.restore_planes = (*f.frame_hdr)
         .restoration
-        .type_0
+        .r#type
         .iter()
         .enumerate()
         .map(|(i, &r#type)| ((r#type != RAV1D_RESTORATION_NONE) as u8) << i)

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -676,7 +676,7 @@ unsafe fn derive_warpmv(
         }
     }
 
-    wmp.type_0 = if !rav1d_find_affine_int(&pts, ret, bw4, bh4, mv, &mut wmp, t.bx, t.by)
+    wmp.r#type = if !rav1d_find_affine_int(&pts, ret, bw4, bh4, mv, &mut wmp, t.bx, t.by)
         && !rav1d_get_shear_params(&mut wmp)
     {
         RAV1D_WM_TYPE_AFFINE
@@ -1546,9 +1546,9 @@ unsafe fn decode_b(
                 && b.motion_mode() as MotionMode == MM_WARP
             {
                 if b.matrix()[0] == i16::MIN {
-                    t.warpmv.type_0 = RAV1D_WM_TYPE_IDENTITY;
+                    t.warpmv.r#type = RAV1D_WM_TYPE_IDENTITY;
                 } else {
-                    t.warpmv.type_0 = RAV1D_WM_TYPE_AFFINE;
+                    t.warpmv.r#type = RAV1D_WM_TYPE_AFFINE;
                     t.warpmv.matrix[2] = b.matrix()[0] as i32 + 0x10000;
                     t.warpmv.matrix[3] = b.matrix()[1] as i32;
                     t.warpmv.matrix[4] = b.matrix()[2] as i32;
@@ -2646,7 +2646,7 @@ unsafe fn decode_b(
                 }
                 GLOBALMV => {
                     has_subpel_filter |=
-                        frame_hdr.gmv[b.r#ref()[idx] as usize].type_0 == RAV1D_WM_TYPE_TRANSLATION;
+                        frame_hdr.gmv[b.r#ref()[idx] as usize].r#type == RAV1D_WM_TYPE_TRANSLATION;
                     b.mv_mut()[idx] = get_gmv_2d(
                         &frame_hdr.gmv[b.r#ref()[idx] as usize],
                         t.bx,
@@ -2852,7 +2852,7 @@ unsafe fn decode_b(
                         frame_hdr,
                     );
                     has_subpel_filter = cmp::min(bw4, bh4) == 1
-                        || frame_hdr.gmv[b.r#ref()[0] as usize].type_0 == RAV1D_WM_TYPE_TRANSLATION;
+                        || frame_hdr.gmv[b.r#ref()[0] as usize].r#type == RAV1D_WM_TYPE_TRANSLATION;
                 } else {
                     has_subpel_filter = true;
                     if rav1d_msac_decode_bool_adapt(
@@ -3006,7 +3006,7 @@ unsafe fn decode_b(
                 // is not warped global motion
                 && !(frame_hdr.force_integer_mv == 0
                     && b.inter_mode() == GLOBALMV
-                    && frame_hdr.gmv[b.r#ref()[0] as usize].type_0 > RAV1D_WM_TYPE_TRANSLATION)
+                    && frame_hdr.gmv[b.r#ref()[0] as usize].r#type > RAV1D_WM_TYPE_TRANSLATION)
                 // has overlappable neighbours
                 && (have_left && findoddzero(&t.l.intra.0[by4 as usize..][..h4 as usize])
                     || have_top && findoddzero(&(*t.a).intra.0[bx4 as usize..][..w4 as usize]))
@@ -3063,7 +3063,7 @@ unsafe fn decode_b(
                         );
                     }
                     if t.frame_thread.pass != 0 {
-                        if t.warpmv.type_0 == RAV1D_WM_TYPE_AFFINE {
+                        if t.warpmv.r#type == RAV1D_WM_TYPE_AFFINE {
                             b.matrix_mut()[0] = (t.warpmv.matrix[2] - 0x10000) as i16;
                             b.matrix_mut()[1] = t.warpmv.matrix[3] as i16;
                             b.matrix_mut()[2] = t.warpmv.matrix[4] as i16;
@@ -3273,7 +3273,7 @@ unsafe fn decode_b(
             if cmp::min(bw4, bh4) > 1
                 && (b.inter_mode() == GLOBALMV && f.gmv_warp_allowed[b.r#ref()[0] as usize] != 0
                     || b.motion_mode() == MM_WARP as u8
-                        && t.warpmv.type_0 > RAV1D_WM_TYPE_TRANSLATION)
+                        && t.warpmv.r#type > RAV1D_WM_TYPE_TRANSLATION)
             {
                 affine_lowest_px_luma(
                     t,
@@ -3371,7 +3371,7 @@ unsafe fn decode_b(
                     && (b.inter_mode() == GLOBALMV
                         && f.gmv_warp_allowed[b.r#ref()[0] as usize] != 0
                         || b.motion_mode() == MM_WARP as u8
-                            && t.warpmv.type_0 > RAV1D_WM_TYPE_TRANSLATION)
+                            && t.warpmv.r#type > RAV1D_WM_TYPE_TRANSLATION)
                 {
                     affine_lowest_px_chroma(
                         t,
@@ -5135,7 +5135,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
                 f.svc[i][1].scale = 0;
                 f.svc[i][0].scale = f.svc[i][1].scale;
             }
-            f.gmv_warp_allowed[i] = ((*f.frame_hdr).gmv[i].type_0 > RAV1D_WM_TYPE_TRANSLATION
+            f.gmv_warp_allowed[i] = ((*f.frame_hdr).gmv[i].r#type > RAV1D_WM_TYPE_TRANSLATION
                 && (*f.frame_hdr).force_integer_mv == 0
                 && !rav1d_get_shear_params(&mut (*f.frame_hdr).gmv[i])
                 && f.svc[i][0].scale == 0) as u8;

--- a/src/env.rs
+++ b/src/env.rs
@@ -658,7 +658,7 @@ pub(crate) fn get_gmv_2d(
     bh4: c_int,
     hdr: &Rav1dFrameHeader,
 ) -> mv {
-    match gmv.type_0 {
+    match gmv.r#type {
         2 => {
             assert!(gmv.matrix[5] == gmv.matrix[2]);
             assert!(gmv.matrix[4] == -gmv.matrix[3]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -737,7 +737,7 @@ unsafe fn gen_picture(c: *mut Rav1dContext) -> Rav1dResult {
         return Ok(());
     }
     while (*in_0).sz > 0 {
-        res = rav1d_parse_obus(&mut *c, in_0, 0 as c_int);
+        res = rav1d_parse_obus(&mut *c, &mut *in_0, 0 as c_int);
         match res {
             Err(_) => rav1d_data_unref_internal(in_0),
             Ok(res) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -544,7 +544,7 @@ pub(crate) unsafe fn rav1d_parse_sequence_header(
     }
 
     while buf.sz > 0 {
-        let res = rav1d_parse_obus(c, &mut buf, 1 as c_int);
+        let res = rav1d_parse_obus(&mut *c, &mut buf, 1 as c_int);
         let res = match res {
             Ok(res) => res,
             Err(res) => return rav1d_parse_sequence_header_error(Err(res), c, &mut buf),
@@ -737,7 +737,7 @@ unsafe fn gen_picture(c: *mut Rav1dContext) -> Rav1dResult {
         return Ok(());
     }
     while (*in_0).sz > 0 {
-        res = rav1d_parse_obus(c, in_0, 0 as c_int);
+        res = rav1d_parse_obus(&mut *c, in_0, 0 as c_int);
         match res {
             Err(_) => rav1d_data_unref_internal(in_0),
             Ok(res) => {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -399,7 +399,7 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
                     let d = hdr.super_res.width_scale_denominator;
                     hdr.width[0] = cmp::max(
                         (hdr.width[1] * 8 + (d >> 1)) / d,
-                        cmp::min(16 as c_int, hdr.width[1]),
+                        cmp::min(16, hdr.width[1]),
                     );
                 } else {
                     hdr.super_res.width_scale_denominator = 8;
@@ -424,7 +424,7 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
         let d = hdr.super_res.width_scale_denominator;
         hdr.width[0] = cmp::max(
             (hdr.width[1] * 8 + (d >> 1)) / d,
-            cmp::min(16 as c_int, hdr.width[1]),
+            cmp::min(16, hdr.width[1]),
         );
     } else {
         hdr.super_res.width_scale_denominator = 8;
@@ -640,7 +640,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                     );
                 i += 1;
             }
-            let mut used_frame: [c_int; 8] = [0 as c_int, 0, 0, 0, 0, 0, 0, 0];
+            let mut used_frame: [c_int; 8] = [0, 0, 0, 0, 0, 0, 0, 0];
             used_frame[hdr.refidx[0] as usize] = 1;
             used_frame[hdr.refidx[3] as usize] = 1;
             let mut latest_frame_offset: c_int = -(1);
@@ -780,8 +780,8 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
     let max_tile_width_sb = 4096 >> sbsz_log2;
     let max_tile_area_sb = 4096 * 2304 >> 2 * sbsz_log2;
     hdr.tiling.min_log2_cols = tile_log2(max_tile_width_sb, sbw);
-    hdr.tiling.max_log2_cols = tile_log2(1 as c_int, cmp::min(sbw, 64));
-    hdr.tiling.max_log2_rows = tile_log2(1 as c_int, cmp::min(sbh, 64));
+    hdr.tiling.max_log2_cols = tile_log2(1, cmp::min(sbw, 64));
+    hdr.tiling.max_log2_rows = tile_log2(1, cmp::min(sbh, 64));
     let min_log2_tiles: c_int = cmp::max(
         tile_log2(max_tile_area_sb, sbw * sbh),
         hdr.tiling.min_log2_cols,
@@ -829,7 +829,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             widest_tile = cmp::max(widest_tile, tile_w);
             hdr.tiling.cols += 1;
         }
-        hdr.tiling.log2_cols = tile_log2(1 as c_int, hdr.tiling.cols);
+        hdr.tiling.log2_cols = tile_log2(1, hdr.tiling.cols);
         if min_log2_tiles != 0 {
             max_tile_area_sb >>= min_log2_tiles + 1;
         }
@@ -847,7 +847,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             sby += tile_h;
             hdr.tiling.rows += 1;
         }
-        hdr.tiling.log2_rows = tile_log2(1 as c_int, hdr.tiling.rows);
+        hdr.tiling.log2_rows = tile_log2(1, hdr.tiling.rows);
     }
     hdr.tiling.col_start_sb[hdr.tiling.cols as usize] = sbw as u16;
     hdr.tiling.row_start_sb[hdr.tiling.rows as usize] = sbh as u16;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1530,21 +1530,20 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
     Ok(())
 }
 
-unsafe fn parse_tile_hdr(c: *mut Rav1dContext, gb: *mut GetBits) {
-    let n_tiles = (*(*c).frame_hdr).tiling.cols * (*(*c).frame_hdr).tiling.rows;
+unsafe fn parse_tile_hdr(c: &mut Rav1dContext, gb: *mut GetBits) {
+    let n_tiles = (*c.frame_hdr).tiling.cols * (*c.frame_hdr).tiling.rows;
     let have_tile_pos = (if n_tiles > 1 {
         rav1d_get_bit(gb)
     } else {
         0 as c_int as c_uint
     }) as c_int;
     if have_tile_pos != 0 {
-        let n_bits = (*(*c).frame_hdr).tiling.log2_cols + (*(*c).frame_hdr).tiling.log2_rows;
-        (*((*c).tile).offset((*c).n_tile_data as isize)).start =
-            rav1d_get_bits(gb, n_bits) as c_int;
-        (*((*c).tile).offset((*c).n_tile_data as isize)).end = rav1d_get_bits(gb, n_bits) as c_int;
+        let n_bits = (*c.frame_hdr).tiling.log2_cols + (*c.frame_hdr).tiling.log2_rows;
+        (*(c.tile).offset(c.n_tile_data as isize)).start = rav1d_get_bits(gb, n_bits) as c_int;
+        (*(c.tile).offset(c.n_tile_data as isize)).end = rav1d_get_bits(gb, n_bits) as c_int;
     } else {
-        (*((*c).tile).offset((*c).n_tile_data as isize)).start = 0 as c_int;
-        (*((*c).tile).offset((*c).n_tile_data as isize)).end = n_tiles - 1;
+        (*(c.tile).offset(c.n_tile_data as isize)).start = 0 as c_int;
+        (*(c.tile).offset(c.n_tile_data as isize)).end = n_tiles - 1;
     };
 }
 

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -127,7 +127,7 @@ use std::ptr::addr_of_mut;
 #[inline]
 unsafe fn rav1d_get_bits_pos(c: &GetBits) -> c_uint {
     (c.ptr.offset_from(c.ptr_start) as c_long as c_uint)
-        .wrapping_mul(8 as c_int as c_uint)
+        .wrapping_mul(8 as c_uint)
         .wrapping_sub(c.bits_left as c_uint)
 }
 
@@ -177,26 +177,25 @@ unsafe fn parse_seq_hdr(
                 if num_ticks_per_picture == 0xffffffff as c_uint {
                     return error(c);
                 }
-                hdr.num_ticks_per_picture =
-                    num_ticks_per_picture.wrapping_add(1 as c_int as c_uint);
+                hdr.num_ticks_per_picture = num_ticks_per_picture.wrapping_add(1 as c_uint);
             }
             hdr.decoder_model_info_present = rav1d_get_bit(gb) as c_int;
             if hdr.decoder_model_info_present != 0 {
                 hdr.encoder_decoder_buffer_delay_length =
-                    (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
+                    (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_uint) as c_int;
                 hdr.num_units_in_decoding_tick = rav1d_get_bits(gb, 32 as c_int) as c_int;
                 if c.strict_std_compliance && hdr.num_units_in_decoding_tick == 0 {
                     return error(c);
                 }
                 hdr.buffer_removal_delay_length =
-                    (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
+                    (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_uint) as c_int;
                 hdr.frame_presentation_delay_length =
-                    (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
+                    (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_uint) as c_int;
             }
         }
         hdr.display_model_info_present = rav1d_get_bit(gb) as c_int;
         hdr.num_operating_points =
-            (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
+            (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_uint) as c_int;
         let mut i = 0;
         while i < hdr.num_operating_points {
             let op = &mut hdr.operating_points[i as usize];
@@ -204,8 +203,7 @@ unsafe fn parse_seq_hdr(
             if op.idc != 0 && (op.idc & 0xff as c_int == 0 || op.idc & 0xf00 == 0) {
                 return error(c);
             }
-            op.major_level =
-                (2 as c_int as c_uint).wrapping_add(rav1d_get_bits(gb, 3 as c_int)) as c_int;
+            op.major_level = (2 as c_uint).wrapping_add(rav1d_get_bits(gb, 3 as c_int)) as c_int;
             op.minor_level = rav1d_get_bits(gb, 2 as c_int) as c_int;
             if op.major_level > 3 {
                 op.tier = rav1d_get_bit(gb) as c_int;
@@ -225,9 +223,9 @@ unsafe fn parse_seq_hdr(
                 op.display_model_param_present = rav1d_get_bit(gb) as c_int;
             }
             op.initial_display_delay = (if op.display_model_param_present != 0 {
-                (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(1 as c_int as c_uint)
+                (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(1 as c_uint)
             } else {
-                10 as c_int as c_uint
+                10 as c_uint
             }) as c_int;
             i += 1;
         }
@@ -244,21 +242,18 @@ unsafe fn parse_seq_hdr(
     } else {
         false
     };
-    hdr.width_n_bits = (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
-    hdr.height_n_bits =
-        (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
-    hdr.max_width =
-        (rav1d_get_bits(gb, hdr.width_n_bits)).wrapping_add(1 as c_int as c_uint) as c_int;
-    hdr.max_height =
-        (rav1d_get_bits(gb, hdr.height_n_bits)).wrapping_add(1 as c_int as c_uint) as c_int;
+    hdr.width_n_bits = (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(1 as c_uint) as c_int;
+    hdr.height_n_bits = (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(1 as c_uint) as c_int;
+    hdr.max_width = (rav1d_get_bits(gb, hdr.width_n_bits)).wrapping_add(1 as c_uint) as c_int;
+    hdr.max_height = (rav1d_get_bits(gb, hdr.height_n_bits)).wrapping_add(1 as c_uint) as c_int;
     if hdr.reduced_still_picture_header == 0 {
         hdr.frame_id_numbers_present = rav1d_get_bit(gb) as c_int;
         if hdr.frame_id_numbers_present != 0 {
             hdr.delta_frame_id_n_bits =
-                (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(2 as c_int as c_uint) as c_int;
+                (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(2 as c_uint) as c_int;
             hdr.frame_id_n_bits = (rav1d_get_bits(gb, 3 as c_int))
                 .wrapping_add(hdr.delta_frame_id_n_bits as c_uint)
-                .wrapping_add(1 as c_int as c_uint) as c_int;
+                .wrapping_add(1 as c_uint) as c_int;
         }
     }
     hdr.sb128 = rav1d_get_bit(gb) as c_int;
@@ -289,11 +284,11 @@ unsafe fn parse_seq_hdr(
                 rav1d_get_bit(gb)
             }
         } else {
-            2 as c_int as c_uint
+            2 as c_uint
         }) as Dav1dAdaptiveBoolean;
         if hdr.order_hint != 0 {
             hdr.order_hint_n_bits =
-                (rav1d_get_bits(gb, 3 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
+                (rav1d_get_bits(gb, 3 as c_int)).wrapping_add(1 as c_uint) as c_int;
         }
     }
     hdr.super_res = rav1d_get_bit(gb) as c_int;
@@ -322,7 +317,7 @@ unsafe fn parse_seq_hdr(
         hdr.ss_ver = 1 as c_int;
         hdr.ss_hor = hdr.ss_ver;
         hdr.chr = RAV1D_CHR_UNKNOWN;
-    } else if hdr.pri as c_uint == RAV1D_COLOR_PRI_BT709 as c_int as c_uint
+    } else if hdr.pri as c_uint == RAV1D_COLOR_PRI_BT709 as c_uint
         && hdr.trc as c_uint == RAV1D_TRC_SRGB as c_int as c_uint
         && hdr.mtrx as c_uint == RAV1D_MC_IDENTITY as c_int as c_uint
     {
@@ -371,7 +366,7 @@ unsafe fn parse_seq_hdr(
     }
     if c.strict_std_compliance
         && hdr.mtrx as c_uint == RAV1D_MC_IDENTITY as c_int as c_uint
-        && hdr.layout as c_uint != Rav1dPixelLayout::I444 as c_int as c_uint
+        && hdr.layout as c_uint != Rav1dPixelLayout::I444 as c_uint
     {
         return error(c);
     }
@@ -403,9 +398,8 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
                 hdr.render_height = (*(*r#ref).p.frame_hdr).render_height;
                 hdr.super_res.enabled = (seqhdr.super_res != 0 && rav1d_get_bit(gb) != 0) as c_int;
                 if hdr.super_res.enabled != 0 {
-                    hdr.super_res.width_scale_denominator = (9 as c_int as c_uint)
-                        .wrapping_add(rav1d_get_bits(gb, 3 as c_int))
-                        as c_int;
+                    hdr.super_res.width_scale_denominator =
+                        (9 as c_uint).wrapping_add(rav1d_get_bits(gb, 3 as c_int)) as c_int;
                     let d = hdr.super_res.width_scale_denominator;
                     hdr.width[0] = cmp::max(
                         (hdr.width[1] * 8 + (d >> 1)) / d,
@@ -421,10 +415,8 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
         }
     }
     if hdr.frame_size_override != 0 {
-        hdr.width[1] =
-            (rav1d_get_bits(gb, seqhdr.width_n_bits)).wrapping_add(1 as c_int as c_uint) as c_int;
-        hdr.height =
-            (rav1d_get_bits(gb, seqhdr.height_n_bits)).wrapping_add(1 as c_int as c_uint) as c_int;
+        hdr.width[1] = (rav1d_get_bits(gb, seqhdr.width_n_bits)).wrapping_add(1 as c_uint) as c_int;
+        hdr.height = (rav1d_get_bits(gb, seqhdr.height_n_bits)).wrapping_add(1 as c_uint) as c_int;
     } else {
         hdr.width[1] = seqhdr.max_width;
         hdr.height = seqhdr.max_height;
@@ -432,7 +424,7 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
     hdr.super_res.enabled = (seqhdr.super_res != 0 && rav1d_get_bit(gb) != 0) as c_int;
     if hdr.super_res.enabled != 0 {
         hdr.super_res.width_scale_denominator =
-            (9 as c_int as c_uint).wrapping_add(rav1d_get_bits(gb, 3 as c_int)) as c_int;
+            (9 as c_uint).wrapping_add(rav1d_get_bits(gb, 3 as c_int)) as c_int;
         let d = hdr.super_res.width_scale_denominator;
         hdr.width[0] = cmp::max(
             (hdr.width[1] * 8 + (d >> 1)) / d,
@@ -444,10 +436,8 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
     }
     hdr.have_render_size = rav1d_get_bit(gb) as c_int;
     if hdr.have_render_size != 0 {
-        hdr.render_width =
-            (rav1d_get_bits(gb, 16 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
-        hdr.render_height =
-            (rav1d_get_bits(gb, 16 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
+        hdr.render_width = (rav1d_get_bits(gb, 16 as c_int)).wrapping_add(1 as c_uint) as c_int;
+        hdr.render_height = (rav1d_get_bits(gb, 16 as c_int)).wrapping_add(1 as c_uint) as c_int;
     } else {
         hdr.render_width = hdr.width[1];
         hdr.render_height = hdr.height;
@@ -544,22 +534,22 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         hdr.frame_id = rav1d_get_bits(gb, seqhdr.frame_id_n_bits) as c_int;
     }
     hdr.frame_size_override = (if seqhdr.reduced_still_picture_header != 0 {
-        0 as c_int as c_uint
+        0 as c_uint
     } else if hdr.frame_type as c_uint == RAV1D_FRAME_TYPE_SWITCH as c_int as c_uint {
-        1 as c_int as c_uint
+        1 as c_uint
     } else {
         rav1d_get_bit(gb)
     }) as c_int;
     hdr.frame_offset = (if seqhdr.order_hint != 0 {
         rav1d_get_bits(gb, seqhdr.order_hint_n_bits)
     } else {
-        0 as c_int as c_uint
+        0 as c_uint
     }) as c_int;
     hdr.primary_ref_frame =
         (if hdr.error_resilient_mode == 0 && hdr.frame_type as c_uint & 1 as c_uint != 0 {
             rav1d_get_bits(gb, 3 as c_int)
         } else {
-            7 as c_int as c_uint
+            7 as c_uint
         }) as c_int;
     if seqhdr.decoder_model_info_present != 0 {
         hdr.buffer_removal_time_present = rav1d_get_bit(gb) as c_int;
@@ -836,9 +826,9 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         while sbx < sbw && hdr.tiling.cols < 64 {
             let tile_width_sb: c_int = cmp::min(sbw - sbx, max_tile_width_sb);
             let tile_w: c_int = (if tile_width_sb > 1 {
-                (1 as c_int as c_uint).wrapping_add(rav1d_get_uniform(gb, tile_width_sb as c_uint))
+                (1 as c_uint).wrapping_add(rav1d_get_uniform(gb, tile_width_sb as c_uint))
             } else {
-                1 as c_int as c_uint
+                1 as c_uint
             }) as c_int;
             hdr.tiling.col_start_sb[hdr.tiling.cols as usize] = sbx as u16;
             sbx += tile_w;
@@ -855,9 +845,9 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         while sby < sbh && hdr.tiling.rows < 64 {
             let tile_height_sb: c_int = cmp::min(sbh - sby, max_tile_height_sb);
             let tile_h: c_int = (if tile_height_sb > 1 {
-                (1 as c_int as c_uint).wrapping_add(rav1d_get_uniform(gb, tile_height_sb as c_uint))
+                (1 as c_uint).wrapping_add(rav1d_get_uniform(gb, tile_height_sb as c_uint))
             } else {
-                1 as c_int as c_uint
+                1 as c_uint
             }) as c_int;
             hdr.tiling.row_start_sb[hdr.tiling.rows as usize] = sby as u16;
             sby += tile_h;
@@ -873,7 +863,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         if hdr.tiling.update >= hdr.tiling.cols * hdr.tiling.rows {
             return error(c);
         }
-        hdr.tiling.n_bytes = (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(1 as c_int as c_uint);
+        hdr.tiling.n_bytes = (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(1 as c_uint);
     } else {
         hdr.tiling.update = 0 as c_int;
         hdr.tiling.n_bytes = hdr.tiling.update as c_uint;
@@ -888,7 +878,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         let diff_uv_delta: c_int = (if seqhdr.separate_uv_delta_q != 0 {
             rav1d_get_bit(gb)
         } else {
-            0 as c_int as c_uint
+            0 as c_uint
         }) as c_int;
         hdr.quant.udc_delta = if rav1d_get_bit(gb) != 0 {
             rav1d_get_sbits(gb, 7 as c_int)
@@ -937,7 +927,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             hdr.segmentation.temporal = (if hdr.segmentation.update_map != 0 {
                 rav1d_get_bit(gb)
             } else {
-                0 as c_int as c_uint
+                0 as c_uint
             }) as c_int;
             hdr.segmentation.update_data = rav1d_get_bit(gb) as c_int;
         }
@@ -1025,24 +1015,24 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
     hdr.delta.q.present = (if hdr.quant.yac != 0 {
         rav1d_get_bit(gb)
     } else {
-        0 as c_int as c_uint
+        0 as c_uint
     }) as c_int;
     hdr.delta.q.res_log2 = (if hdr.delta.q.present != 0 {
         rav1d_get_bits(gb, 2 as c_int)
     } else {
-        0 as c_int as c_uint
+        0 as c_uint
     }) as c_int;
     hdr.delta.lf.present =
         (hdr.delta.q.present != 0 && hdr.allow_intrabc == 0 && rav1d_get_bit(gb) != 0) as c_int;
     hdr.delta.lf.res_log2 = (if hdr.delta.lf.present != 0 {
         rav1d_get_bits(gb, 2 as c_int)
     } else {
-        0 as c_int as c_uint
+        0 as c_uint
     }) as c_int;
     hdr.delta.lf.multi = (if hdr.delta.lf.present != 0 {
         rav1d_get_bit(gb)
     } else {
-        0 as c_int as c_uint
+        0 as c_uint
     }) as c_int;
     let delta_lossless: c_int = (hdr.quant.ydc_delta == 0
         && hdr.quant.udc_delta == 0
@@ -1117,8 +1107,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         }
     }
     if hdr.all_lossless == 0 && seqhdr.cdef != 0 && hdr.allow_intrabc == 0 {
-        hdr.cdef.damping =
-            (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(3 as c_int as c_uint) as c_int;
+        hdr.cdef.damping = (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(3 as c_uint) as c_int;
         hdr.cdef.n_bits = rav1d_get_bits(gb, 2 as c_int) as c_int;
         let mut i = 0;
         while i < (1 as c_int) << hdr.cdef.n_bits {
@@ -1186,7 +1175,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
     hdr.switchable_comp_refs = (if hdr.frame_type as c_uint & 1 as c_uint != 0 {
         rav1d_get_bit(gb)
     } else {
-        0 as c_int as c_uint
+        0 as c_uint
     }) as c_int;
     hdr.skip_mode_allowed = 0 as c_int;
     if hdr.switchable_comp_refs != 0
@@ -1269,7 +1258,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
     hdr.skip_mode_enabled = (if hdr.skip_mode_allowed != 0 {
         rav1d_get_bit(gb)
     } else {
-        0 as c_int as c_uint
+        0 as c_uint
     }) as c_int;
     hdr.warp_motion = (hdr.error_resilient_mode == 0
         && hdr.frame_type as c_uint & 1 as c_uint != 0
@@ -1322,10 +1311,10 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                         + 2 * rav1d_get_bits_subexp(
                             gb,
                             *ref_mat.offset(2) - ((1 as c_int) << 16) >> 1,
-                            12 as c_int as c_uint,
+                            12 as c_uint,
                         );
                     *mat.offset(3) = 2 as c_int
-                        * rav1d_get_bits_subexp(gb, *ref_mat.offset(3) >> 1, 12 as c_int as c_uint);
+                        * rav1d_get_bits_subexp(gb, *ref_mat.offset(3) >> 1, 12 as c_uint);
                     bits = 12 as c_int;
                     shift = 10 as c_int;
                 } else {
@@ -1334,12 +1323,12 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 }
                 if hdr.gmv[i as usize].r#type as c_uint == RAV1D_WM_TYPE_AFFINE as c_int as c_uint {
                     *mat.offset(4) = 2 as c_int
-                        * rav1d_get_bits_subexp(gb, *ref_mat.offset(4) >> 1, 12 as c_int as c_uint);
+                        * rav1d_get_bits_subexp(gb, *ref_mat.offset(4) >> 1, 12 as c_uint);
                     *mat.offset(5) = ((1 as c_int) << 16)
                         + 2 * rav1d_get_bits_subexp(
                             gb,
                             *ref_mat.offset(5) - ((1 as c_int) << 16) >> 1,
-                            12 as c_int as c_uint,
+                            12 as c_uint,
                         );
                 } else {
                     *mat.offset(4) = -*mat.offset(3);
@@ -1437,15 +1426,14 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             {
                 return error(c);
             }
-            fgd.scaling_shift =
-                (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(8 as c_int as c_uint) as u8;
+            fgd.scaling_shift = (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(8 as c_uint) as u8;
             fgd.ar_coeff_lag = rav1d_get_bits(gb, 2 as c_int) as c_int;
             let num_y_pos = 2 * fgd.ar_coeff_lag * (fgd.ar_coeff_lag + 1);
             if fgd.num_y_points != 0 {
                 let mut i = 0;
                 while i < num_y_pos {
                     fgd.ar_coeffs_y[i as usize] =
-                        (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128 as c_int as c_uint) as i8;
+                        (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128 as c_uint) as i8;
                     i += 1;
                 }
             }
@@ -1455,32 +1443,27 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                     let num_uv_pos: c_int = num_y_pos + (fgd.num_y_points != 0) as c_int;
                     let mut i = 0;
                     while i < num_uv_pos {
-                        fgd.ar_coeffs_uv[pl as usize][i as usize] = (rav1d_get_bits(gb, 8 as c_int))
-                            .wrapping_sub(128 as c_int as c_uint)
-                            as i8;
+                        fgd.ar_coeffs_uv[pl as usize][i as usize] =
+                            (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128 as c_uint) as i8;
                         i += 1;
                     }
                     if fgd.num_y_points == 0 {
-                        fgd.ar_coeffs_uv[pl as usize][num_uv_pos as usize] = 0 as c_int as i8;
+                        fgd.ar_coeffs_uv[pl as usize][num_uv_pos as usize] = 0 as i8;
                     }
                 }
                 pl += 1;
             }
-            fgd.ar_coeff_shift =
-                (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(6 as c_int as c_uint) as u8;
+            fgd.ar_coeff_shift = (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(6 as c_uint) as u8;
             fgd.grain_scale_shift = rav1d_get_bits(gb, 2 as c_int) as u8;
             let mut pl = 0;
             while pl < 2 {
                 if fgd.num_uv_points[pl as usize] != 0 {
-                    fgd.uv_mult[pl as usize] = (rav1d_get_bits(gb, 8 as c_int))
-                        .wrapping_sub(128 as c_int as c_uint)
-                        as c_int;
-                    fgd.uv_luma_mult[pl as usize] = (rav1d_get_bits(gb, 8 as c_int))
-                        .wrapping_sub(128 as c_int as c_uint)
-                        as c_int;
-                    fgd.uv_offset[pl as usize] = (rav1d_get_bits(gb, 9 as c_int))
-                        .wrapping_sub(256 as c_int as c_uint)
-                        as c_int;
+                    fgd.uv_mult[pl as usize] =
+                        (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128 as c_uint) as c_int;
+                    fgd.uv_luma_mult[pl as usize] =
+                        (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128 as c_uint) as c_int;
+                    fgd.uv_offset[pl as usize] =
+                        (rav1d_get_bits(gb, 9 as c_int)).wrapping_sub(256 as c_uint) as c_int;
                 }
                 pl += 1;
             }
@@ -1508,7 +1491,7 @@ unsafe fn parse_tile_hdr(c: &mut Rav1dContext, gb: &mut GetBits) {
     let have_tile_pos = (if n_tiles > 1 {
         rav1d_get_bit(gb)
     } else {
-        0 as c_int as c_uint
+        0 as c_uint
     }) as c_int;
     if have_tile_pos != 0 {
         let n_bits = (*c.frame_hdr).tiling.log2_cols + (*c.frame_hdr).tiling.log2_rows;
@@ -1535,7 +1518,7 @@ unsafe fn check_for_overrun(
     }
     let pos: c_uint = rav1d_get_bits_pos(gb);
     assert!(init_bit_pos <= pos);
-    if pos.wrapping_sub(init_bit_pos) > (8 as c_int as c_uint).wrapping_mul(obu_len) {
+    if pos.wrapping_sub(init_bit_pos) > (8 as c_uint).wrapping_mul(obu_len) {
         rav1d_log(
             c,
             b"Overrun in OBU bit buffer into next OBU\n\0" as *const u8 as *const c_char,
@@ -1604,7 +1587,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
         rav1d_get_uleb128(&mut gb)
     } else {
         (r#in.sz as c_uint)
-            .wrapping_sub(1 as c_int as c_uint)
+            .wrapping_sub(1 as c_uint)
             .wrapping_sub(has_extension as c_uint)
     };
     if gb.error != 0 {
@@ -1620,7 +1603,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
     if r#type as c_uint != RAV1D_OBU_SEQ_HDR as c_int as c_uint
         && r#type as c_uint != RAV1D_OBU_TD as c_int as c_uint
         && has_extension != 0
-        && c.operating_point_idc != 0 as c_int as c_uint
+        && c.operating_point_idc != 0 as c_uint
     {
         let in_temporal_layer: c_int =
             (c.operating_point_idc >> temporal_id & 1 as c_uint) as c_int;
@@ -1770,8 +1753,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                         && *(r#in.data).offset(
                             init_byte_pos
                                 .wrapping_add(payload_size as c_uint)
-                                .wrapping_sub(1 as c_int as c_uint)
-                                as isize,
+                                .wrapping_sub(1 as c_uint) as isize,
                         ) == 0
                     {
                         payload_size -= 1;
@@ -2058,7 +2040,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 let next = c.frame_thread.next;
                 c.frame_thread.next = (c.frame_thread.next).wrapping_add(1);
                 if c.frame_thread.next == c.n_fc {
-                    c.frame_thread.next = 0 as c_int as c_uint;
+                    c.frame_thread.next = 0 as c_uint;
                 }
                 let f: *mut Rav1dFrameContext =
                     &mut *(c.fc).offset(next as isize) as *mut Rav1dFrameContext;
@@ -2086,7 +2068,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                     } else {
                         ::core::intrinsics::atomic_store_seqcst(
                             &mut c.task_thread.first,
-                            0 as c_int as c_uint,
+                            0 as c_uint,
                         );
                     }
                     ::core::intrinsics::atomic_cxchg_seqcst_seqcst(

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1530,7 +1530,7 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
     Ok(())
 }
 
-unsafe fn parse_tile_hdr(c: &mut Rav1dContext, gb: *mut GetBits) {
+unsafe fn parse_tile_hdr(c: &mut Rav1dContext, gb: &mut GetBits) {
     let n_tiles = (*c.frame_hdr).tiling.cols * (*c.frame_hdr).tiling.rows;
     let have_tile_pos = (if n_tiles > 1 {
         rav1d_get_bit(gb)

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1589,23 +1589,23 @@ pub(crate) unsafe fn rav1d_parse_obus(
         return Err(EINVAL);
     }
 
-    unsafe fn skip(c: *mut Rav1dContext, len: c_uint, init_byte_pos: c_uint) -> c_uint {
+    unsafe fn skip(c: &mut Rav1dContext, len: c_uint, init_byte_pos: c_uint) -> c_uint {
         let mut i = 0;
         while i < 8 {
-            if (*(*c).frame_hdr).refresh_frame_flags & (1 as c_int) << i != 0 {
-                rav1d_thread_picture_unref(&mut (*((*c).refs).as_mut_ptr().offset(i as isize)).p);
-                (*c).refs[i as usize].p.p.frame_hdr = (*c).frame_hdr;
-                (*c).refs[i as usize].p.p.seq_hdr = (*c).seq_hdr;
-                (*c).refs[i as usize].p.p.frame_hdr_ref = (*c).frame_hdr_ref;
-                (*c).refs[i as usize].p.p.seq_hdr_ref = (*c).seq_hdr_ref;
-                rav1d_ref_inc((*c).frame_hdr_ref);
-                rav1d_ref_inc((*c).seq_hdr_ref);
+            if (*c.frame_hdr).refresh_frame_flags & (1 as c_int) << i != 0 {
+                rav1d_thread_picture_unref(&mut (*(c.refs).as_mut_ptr().offset(i as isize)).p);
+                c.refs[i as usize].p.p.frame_hdr = c.frame_hdr;
+                c.refs[i as usize].p.p.seq_hdr = c.seq_hdr;
+                c.refs[i as usize].p.p.frame_hdr_ref = c.frame_hdr_ref;
+                c.refs[i as usize].p.p.seq_hdr_ref = c.seq_hdr_ref;
+                rav1d_ref_inc(c.frame_hdr_ref);
+                rav1d_ref_inc(c.seq_hdr_ref);
             }
             i += 1;
         }
-        rav1d_ref_dec(&mut (*c).frame_hdr_ref);
-        (*c).frame_hdr = 0 as *mut Rav1dFrameHeader;
-        (*c).n_tiles = 0 as c_int;
+        rav1d_ref_dec(&mut c.frame_hdr_ref);
+        c.frame_hdr = 0 as *mut Rav1dFrameHeader;
+        c.n_tiles = 0 as c_int;
         len.wrapping_add(init_byte_pos)
     }
 

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -395,7 +395,7 @@ unsafe fn parse_seq_hdr(
     Ok(())
 }
 
-unsafe fn read_frame_size(c: &mut Rav1dContext, gb: *mut GetBits, use_ref: c_int) -> c_int {
+unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int) -> c_int {
     let seqhdr: *const Rav1dSequenceHeader = c.seq_hdr;
     let hdr: *mut Rav1dFrameHeader = c.frame_hdr;
     if use_ref != 0 {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -446,9 +446,9 @@ unsafe fn read_frame_size(c: *mut Rav1dContext, gb: *mut GetBits, use_ref: c_int
     if (*hdr).super_res.enabled != 0 {
         (*hdr).super_res.width_scale_denominator =
             (9 as c_int as c_uint).wrapping_add(rav1d_get_bits(gb, 3 as c_int)) as c_int;
-        let d_0 = (*hdr).super_res.width_scale_denominator;
+        let d = (*hdr).super_res.width_scale_denominator;
         (*hdr).width[0] = cmp::max(
-            ((*hdr).width[1] * 8 + (d_0 >> 1)) / d_0,
+            ((*hdr).width[1] * 8 + (d >> 1)) / d,
             cmp::min(16 as c_int, (*hdr).width[1]),
         );
     } else {
@@ -612,10 +612,10 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
             && (*hdr).error_resilient_mode != 0
             && (*seqhdr).order_hint != 0
         {
-            let mut i_0 = 0;
-            while i_0 < 8 {
+            let mut i = 0;
+            while i < 8 {
                 rav1d_get_bits(gb, (*seqhdr).order_hint_n_bits);
-                i_0 += 1;
+                i += 1;
             }
         }
         if (*c).strict_std_compliance
@@ -640,10 +640,10 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
                 rav1d_get_bits(gb, 8 as c_int)
             }) as c_int;
         if (*hdr).error_resilient_mode != 0 && (*seqhdr).order_hint != 0 {
-            let mut i_1 = 0;
-            while i_1 < 8 {
+            let mut i = 0;
+            while i < 8 {
                 rav1d_get_bits(gb, (*seqhdr).order_hint_n_bits);
-                i_1 += 1;
+                i += 1;
             }
         }
         (*hdr).frame_ref_short_signaling =
@@ -658,115 +658,115 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
             (*hdr).refidx[4] = (*hdr).refidx[5];
             let mut shifted_frame_offset: [c_int; 8] = [0; 8];
             let current_frame_offset: c_int = (1 as c_int) << (*seqhdr).order_hint_n_bits - 1;
-            let mut i_2 = 0;
-            while i_2 < 8 {
-                if ((*c).refs[i_2 as usize].p.p.frame_hdr).is_null() {
+            let mut i = 0;
+            while i < 8 {
+                if ((*c).refs[i as usize].p.p.frame_hdr).is_null() {
                     return error(c);
                 }
-                shifted_frame_offset[i_2 as usize] = current_frame_offset
+                shifted_frame_offset[i as usize] = current_frame_offset
                     + get_poc_diff(
                         (*seqhdr).order_hint_n_bits,
-                        (*(*c).refs[i_2 as usize].p.p.frame_hdr).frame_offset,
+                        (*(*c).refs[i as usize].p.p.frame_hdr).frame_offset,
                         (*hdr).frame_offset,
                     );
-                i_2 += 1;
+                i += 1;
             }
             let mut used_frame: [c_int; 8] = [0 as c_int, 0, 0, 0, 0, 0, 0, 0];
             used_frame[(*hdr).refidx[0] as usize] = 1 as c_int;
             used_frame[(*hdr).refidx[3] as usize] = 1 as c_int;
             let mut latest_frame_offset: c_int = -(1 as c_int);
-            let mut i_3 = 0;
-            while i_3 < 8 {
-                let hint: c_int = shifted_frame_offset[i_3 as usize];
-                if used_frame[i_3 as usize] == 0
+            let mut i = 0;
+            while i < 8 {
+                let hint: c_int = shifted_frame_offset[i as usize];
+                if used_frame[i as usize] == 0
                     && hint >= current_frame_offset
                     && hint >= latest_frame_offset
                 {
-                    (*hdr).refidx[6] = i_3;
+                    (*hdr).refidx[6] = i;
                     latest_frame_offset = hint;
                 }
-                i_3 += 1;
+                i += 1;
             }
             if latest_frame_offset != -(1 as c_int) {
                 used_frame[(*hdr).refidx[6] as usize] = 1 as c_int;
             }
             let mut earliest_frame_offset = i32::MAX;
-            let mut i_4 = 0;
-            while i_4 < 8 {
-                let hint_0: c_int = shifted_frame_offset[i_4 as usize];
-                if used_frame[i_4 as usize] == 0
-                    && hint_0 >= current_frame_offset
-                    && hint_0 < earliest_frame_offset
+            let mut i = 0;
+            while i < 8 {
+                let hint: c_int = shifted_frame_offset[i as usize];
+                if used_frame[i as usize] == 0
+                    && hint >= current_frame_offset
+                    && hint < earliest_frame_offset
                 {
-                    (*hdr).refidx[4] = i_4;
-                    earliest_frame_offset = hint_0;
+                    (*hdr).refidx[4] = i;
+                    earliest_frame_offset = hint;
                 }
-                i_4 += 1;
+                i += 1;
             }
             if earliest_frame_offset != i32::MAX {
                 used_frame[(*hdr).refidx[4] as usize] = 1 as c_int;
             }
             earliest_frame_offset = i32::MAX;
-            let mut i_5 = 0;
-            while i_5 < 8 {
-                let hint_1: c_int = shifted_frame_offset[i_5 as usize];
-                if used_frame[i_5 as usize] == 0
-                    && hint_1 >= current_frame_offset
-                    && hint_1 < earliest_frame_offset
+            let mut i = 0;
+            while i < 8 {
+                let hint: c_int = shifted_frame_offset[i as usize];
+                if used_frame[i as usize] == 0
+                    && hint >= current_frame_offset
+                    && hint < earliest_frame_offset
                 {
-                    (*hdr).refidx[5] = i_5;
-                    earliest_frame_offset = hint_1;
+                    (*hdr).refidx[5] = i;
+                    earliest_frame_offset = hint;
                 }
-                i_5 += 1;
+                i += 1;
             }
             if earliest_frame_offset != i32::MAX {
                 used_frame[(*hdr).refidx[5] as usize] = 1 as c_int;
             }
-            let mut i_6 = 1;
-            while i_6 < 7 {
-                if (*hdr).refidx[i_6 as usize] < 0 {
+            let mut i = 1;
+            while i < 7 {
+                if (*hdr).refidx[i as usize] < 0 {
                     latest_frame_offset = -(1 as c_int);
                     let mut j = 0;
                     while j < 8 {
-                        let hint_2: c_int = shifted_frame_offset[j as usize];
+                        let hint: c_int = shifted_frame_offset[j as usize];
                         if used_frame[j as usize] == 0
-                            && hint_2 < current_frame_offset
-                            && hint_2 >= latest_frame_offset
+                            && hint < current_frame_offset
+                            && hint >= latest_frame_offset
                         {
-                            (*hdr).refidx[i_6 as usize] = j;
-                            latest_frame_offset = hint_2;
+                            (*hdr).refidx[i as usize] = j;
+                            latest_frame_offset = hint;
                         }
                         j += 1;
                     }
                     if latest_frame_offset != -(1 as c_int) {
-                        used_frame[(*hdr).refidx[i_6 as usize] as usize] = 1 as c_int;
+                        used_frame[(*hdr).refidx[i as usize] as usize] = 1 as c_int;
                     }
                 }
-                i_6 += 1;
+                i += 1;
             }
             earliest_frame_offset = i32::MAX;
-            let mut ref_0: c_int = -(1 as c_int);
-            let mut i_7 = 0;
-            while i_7 < 8 {
-                let hint_3: c_int = shifted_frame_offset[i_7 as usize];
-                if hint_3 < earliest_frame_offset {
-                    ref_0 = i_7;
-                    earliest_frame_offset = hint_3;
+            let mut r#ref: c_int = -(1 as c_int);
+            let mut i = 0;
+            while i < 8 {
+                let hint: c_int = shifted_frame_offset[i as usize];
+                if hint < earliest_frame_offset {
+                    r#ref = i;
+                    earliest_frame_offset = hint;
                 }
-                i_7 += 1;
+                i += 1;
             }
-            let mut i_8 = 0;
-            while i_8 < 7 {
-                if (*hdr).refidx[i_8 as usize] < 0 {
-                    (*hdr).refidx[i_8 as usize] = ref_0;
+            let mut i = 0;
+            while i < 7 {
+                if (*hdr).refidx[i as usize] < 0 {
+                    (*hdr).refidx[i as usize] = r#ref;
                 }
-                i_8 += 1;
+                i += 1;
             }
         }
-        let mut i_9 = 0;
-        while i_9 < 7 {
+        let mut i = 0;
+        while i < 7 {
             if (*hdr).frame_ref_short_signaling == 0 {
-                (*hdr).refidx[i_9 as usize] = rav1d_get_bits(gb, 3 as c_int) as c_int;
+                (*hdr).refidx[i as usize] = rav1d_get_bits(gb, 3 as c_int) as c_int;
             }
             if (*seqhdr).frame_id_numbers_present != 0 {
                 let delta_ref_frame_id_minus_1: c_int =
@@ -776,16 +776,13 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
                     - delta_ref_frame_id_minus_1
                     - 1
                     & ((1 as c_int) << (*seqhdr).frame_id_n_bits) - 1;
-                let ref_frame_hdr_0: *mut Rav1dFrameHeader = (*c).refs
-                    [(*hdr).refidx[i_9 as usize] as usize]
-                    .p
-                    .p
-                    .frame_hdr;
-                if ref_frame_hdr_0.is_null() || (*ref_frame_hdr_0).frame_id != ref_frame_id {
+                let ref_frame_hdr: *mut Rav1dFrameHeader =
+                    (*c).refs[(*hdr).refidx[i as usize] as usize].p.p.frame_hdr;
+                if ref_frame_hdr.is_null() || (*ref_frame_hdr).frame_id != ref_frame_id {
                     return error(c);
                 }
             }
-            i_9 += 1;
+            i += 1;
         }
         let use_ref: c_int =
             ((*hdr).error_resilient_mode == 0 && (*hdr).frame_size_override != 0) as c_int;
@@ -852,36 +849,36 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
     } else {
         (*hdr).tiling.cols = 0 as c_int;
         let mut widest_tile = 0;
-        let mut max_tile_area_sb_0: c_int = sbw * sbh;
-        let mut sbx_0 = 0;
-        while sbx_0 < sbw && (*hdr).tiling.cols < 64 {
-            let tile_width_sb: c_int = cmp::min(sbw - sbx_0, max_tile_width_sb);
-            let tile_w_0: c_int = (if tile_width_sb > 1 {
+        let mut max_tile_area_sb: c_int = sbw * sbh;
+        let mut sbx = 0;
+        while sbx < sbw && (*hdr).tiling.cols < 64 {
+            let tile_width_sb: c_int = cmp::min(sbw - sbx, max_tile_width_sb);
+            let tile_w: c_int = (if tile_width_sb > 1 {
                 (1 as c_int as c_uint).wrapping_add(rav1d_get_uniform(gb, tile_width_sb as c_uint))
             } else {
                 1 as c_int as c_uint
             }) as c_int;
-            (*hdr).tiling.col_start_sb[(*hdr).tiling.cols as usize] = sbx_0 as u16;
-            sbx_0 += tile_w_0;
-            widest_tile = cmp::max(widest_tile, tile_w_0);
+            (*hdr).tiling.col_start_sb[(*hdr).tiling.cols as usize] = sbx as u16;
+            sbx += tile_w;
+            widest_tile = cmp::max(widest_tile, tile_w);
             (*hdr).tiling.cols += 1;
         }
         (*hdr).tiling.log2_cols = tile_log2(1 as c_int, (*hdr).tiling.cols);
         if min_log2_tiles != 0 {
-            max_tile_area_sb_0 >>= min_log2_tiles + 1;
+            max_tile_area_sb >>= min_log2_tiles + 1;
         }
-        let max_tile_height_sb: c_int = cmp::max(max_tile_area_sb_0 / widest_tile, 1 as c_int);
+        let max_tile_height_sb: c_int = cmp::max(max_tile_area_sb / widest_tile, 1 as c_int);
         (*hdr).tiling.rows = 0 as c_int;
-        let mut sby_0 = 0;
-        while sby_0 < sbh && (*hdr).tiling.rows < 64 {
-            let tile_height_sb: c_int = cmp::min(sbh - sby_0, max_tile_height_sb);
-            let tile_h_0: c_int = (if tile_height_sb > 1 {
+        let mut sby = 0;
+        while sby < sbh && (*hdr).tiling.rows < 64 {
+            let tile_height_sb: c_int = cmp::min(sbh - sby, max_tile_height_sb);
+            let tile_h: c_int = (if tile_height_sb > 1 {
                 (1 as c_int as c_uint).wrapping_add(rav1d_get_uniform(gb, tile_height_sb as c_uint))
             } else {
                 1 as c_int as c_uint
             }) as c_int;
-            (*hdr).tiling.row_start_sb[(*hdr).tiling.rows as usize] = sby_0 as u16;
-            sby_0 += tile_h_0;
+            (*hdr).tiling.row_start_sb[(*hdr).tiling.rows as usize] = sby as u16;
+            sby += tile_h;
             (*hdr).tiling.rows += 1;
         }
         (*hdr).tiling.log2_rows = tile_log2(1 as c_int, (*hdr).tiling.rows);
@@ -965,60 +962,60 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
         if (*hdr).segmentation.update_data != 0 {
             (*hdr).segmentation.seg_data.preskip = 0 as c_int;
             (*hdr).segmentation.seg_data.last_active_segid = -(1 as c_int);
-            let mut i_10 = 0;
-            while i_10 < 8 {
+            let mut i = 0;
+            while i < 8 {
                 let seg: *mut Rav1dSegmentationData = &mut *((*hdr).segmentation.seg_data.d)
                     .as_mut_ptr()
-                    .offset(i_10 as isize)
+                    .offset(i as isize)
                     as *mut Rav1dSegmentationData;
                 if rav1d_get_bit(gb) != 0 {
                     (*seg).delta_q = rav1d_get_sbits(gb, 9 as c_int);
-                    (*hdr).segmentation.seg_data.last_active_segid = i_10;
+                    (*hdr).segmentation.seg_data.last_active_segid = i;
                 } else {
                     (*seg).delta_q = 0 as c_int;
                 }
                 if rav1d_get_bit(gb) != 0 {
                     (*seg).delta_lf_y_v = rav1d_get_sbits(gb, 7 as c_int);
-                    (*hdr).segmentation.seg_data.last_active_segid = i_10;
+                    (*hdr).segmentation.seg_data.last_active_segid = i;
                 } else {
                     (*seg).delta_lf_y_v = 0 as c_int;
                 }
                 if rav1d_get_bit(gb) != 0 {
                     (*seg).delta_lf_y_h = rav1d_get_sbits(gb, 7 as c_int);
-                    (*hdr).segmentation.seg_data.last_active_segid = i_10;
+                    (*hdr).segmentation.seg_data.last_active_segid = i;
                 } else {
                     (*seg).delta_lf_y_h = 0 as c_int;
                 }
                 if rav1d_get_bit(gb) != 0 {
                     (*seg).delta_lf_u = rav1d_get_sbits(gb, 7 as c_int);
-                    (*hdr).segmentation.seg_data.last_active_segid = i_10;
+                    (*hdr).segmentation.seg_data.last_active_segid = i;
                 } else {
                     (*seg).delta_lf_u = 0 as c_int;
                 }
                 if rav1d_get_bit(gb) != 0 {
                     (*seg).delta_lf_v = rav1d_get_sbits(gb, 7 as c_int);
-                    (*hdr).segmentation.seg_data.last_active_segid = i_10;
+                    (*hdr).segmentation.seg_data.last_active_segid = i;
                 } else {
                     (*seg).delta_lf_v = 0 as c_int;
                 }
                 if rav1d_get_bit(gb) != 0 {
                     (*seg).r#ref = rav1d_get_bits(gb, 3 as c_int) as c_int;
-                    (*hdr).segmentation.seg_data.last_active_segid = i_10;
+                    (*hdr).segmentation.seg_data.last_active_segid = i;
                     (*hdr).segmentation.seg_data.preskip = 1 as c_int;
                 } else {
                     (*seg).r#ref = -(1 as c_int);
                 }
                 (*seg).skip = rav1d_get_bit(gb) as c_int;
                 if (*seg).skip != 0 {
-                    (*hdr).segmentation.seg_data.last_active_segid = i_10;
+                    (*hdr).segmentation.seg_data.last_active_segid = i;
                     (*hdr).segmentation.seg_data.preskip = 1 as c_int;
                 }
                 (*seg).globalmv = rav1d_get_bit(gb) as c_int;
                 if (*seg).globalmv != 0 {
-                    (*hdr).segmentation.seg_data.last_active_segid = i_10;
+                    (*hdr).segmentation.seg_data.last_active_segid = i;
                     (*hdr).segmentation.seg_data.preskip = 1 as c_int;
                 }
-                i_10 += 1;
+                i += 1;
             }
         } else {
             if !((*hdr).primary_ref_frame != 7 as c_int) {
@@ -1039,10 +1036,10 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
             0 as c_int,
             ::core::mem::size_of::<Rav1dSegmentationDataSet>(),
         );
-        let mut i_11 = 0;
-        while i_11 < 8 {
-            (*hdr).segmentation.seg_data.d[i_11 as usize].r#ref = -(1 as c_int);
-            i_11 += 1;
+        let mut i = 0;
+        while i < 8 {
+            (*hdr).segmentation.seg_data.d[i as usize].r#ref = -(1 as c_int);
+            i += 1;
         }
     }
     (*hdr).delta.q.present = (if (*hdr).quant.yac != 0 {
@@ -1074,17 +1071,17 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
         && (*hdr).quant.vdc_delta == 0
         && (*hdr).quant.vac_delta == 0) as c_int;
     (*hdr).all_lossless = 1 as c_int;
-    let mut i_12 = 0;
-    while i_12 < 8 {
-        (*hdr).segmentation.qidx[i_12 as usize] = if (*hdr).segmentation.enabled != 0 {
-            iclip_u8((*hdr).quant.yac + (*hdr).segmentation.seg_data.d[i_12 as usize].delta_q)
+    let mut i = 0;
+    while i < 8 {
+        (*hdr).segmentation.qidx[i as usize] = if (*hdr).segmentation.enabled != 0 {
+            iclip_u8((*hdr).quant.yac + (*hdr).segmentation.seg_data.d[i as usize].delta_q)
         } else {
             (*hdr).quant.yac
         };
-        (*hdr).segmentation.lossless[i_12 as usize] =
-            ((*hdr).segmentation.qidx[i_12 as usize] == 0 && delta_lossless != 0) as c_int;
-        (*hdr).all_lossless &= (*hdr).segmentation.lossless[i_12 as usize];
-        i_12 += 1;
+        (*hdr).segmentation.lossless[i as usize] =
+            ((*hdr).segmentation.qidx[i as usize] == 0 && delta_lossless != 0) as c_int;
+        (*hdr).all_lossless &= (*hdr).segmentation.lossless[i as usize];
+        i += 1;
     }
     if (*hdr).all_lossless != 0 || (*hdr).allow_intrabc != 0 {
         (*hdr).loopfilter.level_y[1] = 0 as c_int;
@@ -1108,11 +1105,11 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
         if (*hdr).primary_ref_frame == 7 {
             (*hdr).loopfilter.mode_ref_deltas = default_mode_ref_deltas.clone();
         } else {
-            let ref_1: c_int = (*hdr).refidx[(*hdr).primary_ref_frame as usize];
-            if ((*c).refs[ref_1 as usize].p.p.frame_hdr).is_null() {
+            let r#ref: c_int = (*hdr).refidx[(*hdr).primary_ref_frame as usize];
+            if ((*c).refs[r#ref as usize].p.p.frame_hdr).is_null() {
                 return error(c);
             }
-            (*hdr).loopfilter.mode_ref_deltas = (*(*c).refs[ref_1 as usize].p.p.frame_hdr)
+            (*hdr).loopfilter.mode_ref_deltas = (*(*c).refs[r#ref as usize].p.p.frame_hdr)
                 .loopfilter
                 .mode_ref_deltas
                 .clone();
@@ -1121,21 +1118,21 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
         if (*hdr).loopfilter.mode_ref_delta_enabled != 0 {
             (*hdr).loopfilter.mode_ref_delta_update = rav1d_get_bit(gb) as c_int;
             if (*hdr).loopfilter.mode_ref_delta_update != 0 {
-                let mut i_13 = 0;
-                while i_13 < 8 {
+                let mut i = 0;
+                while i < 8 {
                     if rav1d_get_bit(gb) != 0 {
-                        (*hdr).loopfilter.mode_ref_deltas.ref_delta[i_13 as usize] =
+                        (*hdr).loopfilter.mode_ref_deltas.ref_delta[i as usize] =
                             rav1d_get_sbits(gb, 7 as c_int);
                     }
-                    i_13 += 1;
+                    i += 1;
                 }
-                let mut i_14 = 0;
-                while i_14 < 2 {
+                let mut i = 0;
+                while i < 2 {
                     if rav1d_get_bit(gb) != 0 {
-                        (*hdr).loopfilter.mode_ref_deltas.mode_delta[i_14 as usize] =
+                        (*hdr).loopfilter.mode_ref_deltas.mode_delta[i as usize] =
                             rav1d_get_sbits(gb, 7 as c_int);
                     }
-                    i_14 += 1;
+                    i += 1;
                 }
             }
         }
@@ -1144,13 +1141,13 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
         (*hdr).cdef.damping =
             (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(3 as c_int as c_uint) as c_int;
         (*hdr).cdef.n_bits = rav1d_get_bits(gb, 2 as c_int) as c_int;
-        let mut i_15 = 0;
-        while i_15 < (1 as c_int) << (*hdr).cdef.n_bits {
-            (*hdr).cdef.y_strength[i_15 as usize] = rav1d_get_bits(gb, 6 as c_int) as c_int;
+        let mut i = 0;
+        while i < (1 as c_int) << (*hdr).cdef.n_bits {
+            (*hdr).cdef.y_strength[i as usize] = rav1d_get_bits(gb, 6 as c_int) as c_int;
             if (*seqhdr).monochrome == 0 {
-                (*hdr).cdef.uv_strength[i_15 as usize] = rav1d_get_bits(gb, 6 as c_int) as c_int;
+                (*hdr).cdef.uv_strength[i as usize] = rav1d_get_bits(gb, 6 as c_int) as c_int;
             }
-            i_15 += 1;
+            i += 1;
         }
     } else {
         (*hdr).cdef.n_bits = 0 as c_int;
@@ -1222,20 +1219,12 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
         let mut off_after: c_int = -(1 as c_int);
         let mut off_before_idx = 0;
         let mut off_after_idx = 0;
-        let mut i_16 = 0;
-        while i_16 < 7 {
-            if ((*c).refs[(*hdr).refidx[i_16 as usize] as usize]
-                .p
-                .p
-                .frame_hdr)
-                .is_null()
-            {
+        let mut i = 0;
+        while i < 7 {
+            if ((*c).refs[(*hdr).refidx[i as usize] as usize].p.p.frame_hdr).is_null() {
                 return error(c);
             }
-            let refpoc: c_uint = (*(*c).refs[(*hdr).refidx[i_16 as usize] as usize]
-                .p
-                .p
-                .frame_hdr)
+            let refpoc: c_uint = (*(*c).refs[(*hdr).refidx[i as usize] as usize].p.p.frame_hdr)
                 .frame_offset as c_uint;
             let diff: c_int =
                 get_poc_diff((*seqhdr).order_hint_n_bits, refpoc as c_int, poc as c_int);
@@ -1244,7 +1233,7 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
                     || get_poc_diff((*seqhdr).order_hint_n_bits, off_after, refpoc as c_int) > 0
                 {
                     off_after = refpoc as c_int;
-                    off_after_idx = i_16;
+                    off_after_idx = i;
                 }
             } else if diff < 0
                 && (off_before == 0xffffffff as c_uint
@@ -1255,9 +1244,9 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
                     ) > 0)
             {
                 off_before = refpoc;
-                off_before_idx = i_16;
+                off_before_idx = i;
             }
-            i_16 += 1;
+            i += 1;
         }
         if off_before != 0xffffffff as c_uint && off_after != -(1 as c_int) {
             (*hdr).skip_mode_refs[0] = cmp::min(off_before_idx, off_after_idx);
@@ -1266,39 +1255,31 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
         } else if off_before != 0xffffffff as c_uint {
             let mut off_before2: c_uint = 0xffffffff as c_uint;
             let mut off_before2_idx = 0;
-            let mut i_17 = 0;
-            while i_17 < 7 {
-                if ((*c).refs[(*hdr).refidx[i_17 as usize] as usize]
-                    .p
-                    .p
-                    .frame_hdr)
-                    .is_null()
-                {
+            let mut i = 0;
+            while i < 7 {
+                if ((*c).refs[(*hdr).refidx[i as usize] as usize].p.p.frame_hdr).is_null() {
                     return error(c);
                 }
-                let refpoc_0: c_uint = (*(*c).refs[(*hdr).refidx[i_17 as usize] as usize]
-                    .p
-                    .p
-                    .frame_hdr)
+                let refpoc: c_uint = (*(*c).refs[(*hdr).refidx[i as usize] as usize].p.p.frame_hdr)
                     .frame_offset as c_uint;
                 if get_poc_diff(
                     (*seqhdr).order_hint_n_bits,
-                    refpoc_0 as c_int,
+                    refpoc as c_int,
                     off_before as c_int,
                 ) < 0
                 {
                     if off_before2 == 0xffffffff as c_uint
                         || get_poc_diff(
                             (*seqhdr).order_hint_n_bits,
-                            refpoc_0 as c_int,
+                            refpoc as c_int,
                             off_before2 as c_int,
                         ) > 0
                     {
-                        off_before2 = refpoc_0;
-                        off_before2_idx = i_17;
+                        off_before2 = refpoc;
+                        off_before2_idx = i;
                     }
                 }
-                i_17 += 1;
+                i += 1;
             }
             if off_before2 != 0xffffffff as c_uint {
                 (*hdr).skip_mode_refs[0] = cmp::min(off_before_idx, off_before2_idx);
@@ -1317,15 +1298,15 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
         && (*seqhdr).warped_motion != 0
         && rav1d_get_bit(gb) != 0) as c_int;
     (*hdr).reduced_txtp_set = rav1d_get_bit(gb) as c_int;
-    let mut i_18 = 0;
-    while i_18 < 7 {
-        (*hdr).gmv[i_18 as usize] = dav1d_default_wm_params.clone();
-        i_18 += 1;
+    let mut i = 0;
+    while i < 7 {
+        (*hdr).gmv[i as usize] = dav1d_default_wm_params.clone();
+        i += 1;
     }
     if (*hdr).frame_type as c_uint & 1 as c_uint != 0 {
-        let mut i_19 = 0;
-        while i_19 < 7 {
-            (*hdr).gmv[i_19 as usize].r#type = (if rav1d_get_bit(gb) == 0 {
+        let mut i = 0;
+        while i < 7 {
+            (*hdr).gmv[i as usize].r#type = (if rav1d_get_bit(gb) == 0 {
                 RAV1D_WM_TYPE_IDENTITY as c_int
             } else if rav1d_get_bit(gb) != 0 {
                 RAV1D_WM_TYPE_ROT_ZOOM as c_int
@@ -1334,31 +1315,31 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
             } else {
                 RAV1D_WM_TYPE_AFFINE as c_int
             }) as Dav1dWarpedMotionType;
-            if !((*hdr).gmv[i_19 as usize].r#type as c_uint
+            if !((*hdr).gmv[i as usize].r#type as c_uint
                 == RAV1D_WM_TYPE_IDENTITY as c_int as c_uint)
             {
                 let ref_gmv: *const Rav1dWarpedMotionParams;
                 if (*hdr).primary_ref_frame == 7 {
                     ref_gmv = &dav1d_default_wm_params;
                 } else {
-                    let pri_ref_0: c_int = (*hdr).refidx[(*hdr).primary_ref_frame as usize];
-                    if ((*c).refs[pri_ref_0 as usize].p.p.frame_hdr).is_null() {
+                    let pri_ref: c_int = (*hdr).refidx[(*hdr).primary_ref_frame as usize];
+                    if ((*c).refs[pri_ref as usize].p.p.frame_hdr).is_null() {
                         return error(c);
                     }
-                    ref_gmv = &mut *((*(*((*c).refs).as_mut_ptr().offset(pri_ref_0 as isize))
+                    ref_gmv = &mut *((*(*((*c).refs).as_mut_ptr().offset(pri_ref as isize))
                         .p
                         .p
                         .frame_hdr)
                         .gmv)
                         .as_mut_ptr()
-                        .offset(i_19 as isize)
+                        .offset(i as isize)
                         as *mut Rav1dWarpedMotionParams;
                 }
-                let mat: *mut i32 = ((*hdr).gmv[i_19 as usize].matrix).as_mut_ptr();
+                let mat: *mut i32 = ((*hdr).gmv[i as usize].matrix).as_mut_ptr();
                 let ref_mat: *const i32 = ((*ref_gmv).matrix).as_ptr();
                 let bits: c_int;
                 let shift: c_int;
-                if (*hdr).gmv[i_19 as usize].r#type as c_uint
+                if (*hdr).gmv[i as usize].r#type as c_uint
                     >= RAV1D_WM_TYPE_ROT_ZOOM as c_int as c_uint
                 {
                     *mat.offset(2) = ((1 as c_int) << 16)
@@ -1375,7 +1356,7 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
                     bits = 9 - ((*hdr).hp == 0) as c_int;
                     shift = 13 + ((*hdr).hp == 0) as c_int;
                 }
-                if (*hdr).gmv[i_19 as usize].r#type as c_uint
+                if (*hdr).gmv[i as usize].r#type as c_uint
                     == RAV1D_WM_TYPE_AFFINE as c_int as c_uint
                 {
                     *mat.offset(4) = 2 as c_int
@@ -1397,7 +1378,7 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
                     rav1d_get_bits_subexp(gb, *ref_mat.offset(1) >> shift, bits as c_uint)
                         * ((1 as c_int) << shift);
             }
-            i_19 += 1;
+            i += 1;
         }
     }
     (*hdr).film_grain.present = ((*seqhdr).film_grain_present != 0
@@ -1410,15 +1391,15 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
             || rav1d_get_bit(gb) != 0) as c_int;
         if (*hdr).film_grain.update == 0 {
             let refidx: c_int = rav1d_get_bits(gb, 3 as c_int) as c_int;
-            let mut i_20: c_int;
-            i_20 = 0 as c_int;
-            while i_20 < 7 {
-                if (*hdr).refidx[i_20 as usize] == refidx {
+            let mut i: c_int;
+            i = 0 as c_int;
+            while i < 7 {
+                if (*hdr).refidx[i as usize] == refidx {
                     break;
                 }
-                i_20 += 1;
+                i += 1;
             }
-            if i_20 == 7 || ((*c).refs[refidx as usize].p.p.frame_hdr).is_null() {
+            if i == 7 || ((*c).refs[refidx as usize].p.p.frame_hdr).is_null() {
                 return error(c);
             }
             (*hdr).film_grain.data = (*(*c).refs[refidx as usize].p.p.frame_hdr)
@@ -1433,17 +1414,17 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
             if (*fgd).num_y_points > 14 {
                 return error(c);
             }
-            let mut i_21 = 0;
-            while i_21 < (*fgd).num_y_points {
-                (*fgd).y_points[i_21 as usize][0] = rav1d_get_bits(gb, 8 as c_int) as u8;
-                if i_21 != 0
-                    && (*fgd).y_points[(i_21 - 1) as usize][0] as c_int
-                        >= (*fgd).y_points[i_21 as usize][0] as c_int
+            let mut i = 0;
+            while i < (*fgd).num_y_points {
+                (*fgd).y_points[i as usize][0] = rav1d_get_bits(gb, 8 as c_int) as u8;
+                if i != 0
+                    && (*fgd).y_points[(i - 1) as usize][0] as c_int
+                        >= (*fgd).y_points[i as usize][0] as c_int
                 {
                     return error(c);
                 }
-                (*fgd).y_points[i_21 as usize][1] = rav1d_get_bits(gb, 8 as c_int) as u8;
-                i_21 += 1;
+                (*fgd).y_points[i as usize][1] = rav1d_get_bits(gb, 8 as c_int) as u8;
+                i += 1;
             }
             (*fgd).chroma_scaling_from_luma = (*seqhdr).monochrome == 0 && rav1d_get_bit(gb) != 0;
             if (*seqhdr).monochrome != 0
@@ -1459,19 +1440,19 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
                     if (*fgd).num_uv_points[pl as usize] > 10 {
                         return error(c);
                     }
-                    let mut i_22 = 0;
-                    while i_22 < (*fgd).num_uv_points[pl as usize] {
-                        (*fgd).uv_points[pl as usize][i_22 as usize][0] =
+                    let mut i = 0;
+                    while i < (*fgd).num_uv_points[pl as usize] {
+                        (*fgd).uv_points[pl as usize][i as usize][0] =
                             rav1d_get_bits(gb, 8 as c_int) as u8;
-                        if i_22 != 0
-                            && (*fgd).uv_points[pl as usize][(i_22 - 1) as usize][0] as c_int
-                                >= (*fgd).uv_points[pl as usize][i_22 as usize][0] as c_int
+                        if i != 0
+                            && (*fgd).uv_points[pl as usize][(i - 1) as usize][0] as c_int
+                                >= (*fgd).uv_points[pl as usize][i as usize][0] as c_int
                         {
                             return error(c);
                         }
-                        (*fgd).uv_points[pl as usize][i_22 as usize][1] =
+                        (*fgd).uv_points[pl as usize][i as usize][1] =
                             rav1d_get_bits(gb, 8 as c_int) as u8;
-                        i_22 += 1;
+                        i += 1;
                     }
                     pl += 1;
                 }
@@ -1488,47 +1469,47 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
             (*fgd).ar_coeff_lag = rav1d_get_bits(gb, 2 as c_int) as c_int;
             let num_y_pos = 2 * (*fgd).ar_coeff_lag * ((*fgd).ar_coeff_lag + 1);
             if (*fgd).num_y_points != 0 {
-                let mut i_23 = 0;
-                while i_23 < num_y_pos {
-                    (*fgd).ar_coeffs_y[i_23 as usize] =
+                let mut i = 0;
+                while i < num_y_pos {
+                    (*fgd).ar_coeffs_y[i as usize] =
                         (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128 as c_int as c_uint) as i8;
-                    i_23 += 1;
+                    i += 1;
                 }
             }
-            let mut pl_0 = 0;
-            while pl_0 < 2 {
-                if (*fgd).num_uv_points[pl_0 as usize] != 0 || (*fgd).chroma_scaling_from_luma {
+            let mut pl = 0;
+            while pl < 2 {
+                if (*fgd).num_uv_points[pl as usize] != 0 || (*fgd).chroma_scaling_from_luma {
                     let num_uv_pos: c_int = num_y_pos + ((*fgd).num_y_points != 0) as c_int;
-                    let mut i_24 = 0;
-                    while i_24 < num_uv_pos {
-                        (*fgd).ar_coeffs_uv[pl_0 as usize][i_24 as usize] =
+                    let mut i = 0;
+                    while i < num_uv_pos {
+                        (*fgd).ar_coeffs_uv[pl as usize][i as usize] =
                             (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128 as c_int as c_uint)
                                 as i8;
-                        i_24 += 1;
+                        i += 1;
                     }
                     if (*fgd).num_y_points == 0 {
-                        (*fgd).ar_coeffs_uv[pl_0 as usize][num_uv_pos as usize] = 0 as c_int as i8;
+                        (*fgd).ar_coeffs_uv[pl as usize][num_uv_pos as usize] = 0 as c_int as i8;
                     }
                 }
-                pl_0 += 1;
+                pl += 1;
             }
             (*fgd).ar_coeff_shift =
                 (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(6 as c_int as c_uint) as u8;
             (*fgd).grain_scale_shift = rav1d_get_bits(gb, 2 as c_int) as u8;
-            let mut pl_1 = 0;
-            while pl_1 < 2 {
-                if (*fgd).num_uv_points[pl_1 as usize] != 0 {
-                    (*fgd).uv_mult[pl_1 as usize] = (rav1d_get_bits(gb, 8 as c_int))
+            let mut pl = 0;
+            while pl < 2 {
+                if (*fgd).num_uv_points[pl as usize] != 0 {
+                    (*fgd).uv_mult[pl as usize] = (rav1d_get_bits(gb, 8 as c_int))
                         .wrapping_sub(128 as c_int as c_uint)
                         as c_int;
-                    (*fgd).uv_luma_mult[pl_1 as usize] = (rav1d_get_bits(gb, 8 as c_int))
+                    (*fgd).uv_luma_mult[pl as usize] = (rav1d_get_bits(gb, 8 as c_int))
                         .wrapping_sub(128 as c_int as c_uint)
                         as c_int;
-                    (*fgd).uv_offset[pl_1 as usize] = (rav1d_get_bits(gb, 9 as c_int))
+                    (*fgd).uv_offset[pl as usize] = (rav1d_get_bits(gb, 9 as c_int))
                         .wrapping_sub(256 as c_int as c_uint)
                         as c_int;
                 }
-                pl_1 += 1;
+                pl += 1;
             }
             (*fgd).overlap_flag = rav1d_get_bit(gb) != 0;
             (*fgd).clip_to_restricted_range = rav1d_get_bit(gb) != 0;
@@ -1596,11 +1577,11 @@ unsafe fn check_for_overrun(
 
 pub(crate) unsafe fn rav1d_parse_obus(
     c: *mut Rav1dContext,
-    in_0: *mut Rav1dData,
+    r#in: *mut Rav1dData,
     global: c_int,
 ) -> Rav1dResult<c_uint> {
-    unsafe fn error(c: *mut Rav1dContext, in_0: *mut Rav1dData) -> Rav1dResult {
-        rav1d_data_props_copy(&mut (*c).cached_error_props, &mut (*in_0).m);
+    unsafe fn error(c: *mut Rav1dContext, r#in: *mut Rav1dData) -> Rav1dResult {
+        rav1d_data_props_copy(&mut (*c).cached_error_props, &mut (*r#in).m);
         rav1d_log(
             c,
             b"Error parsing OBU data\n\0" as *const u8 as *const c_char,
@@ -1636,9 +1617,9 @@ pub(crate) unsafe fn rav1d_parse_obus(
         ptr_start: 0 as *const u8,
         ptr_end: 0 as *const u8,
     };
-    rav1d_init_get_bits(&mut gb, (*in_0).data, (*in_0).sz);
+    rav1d_init_get_bits(&mut gb, (*r#in).data, (*r#in).sz);
     rav1d_get_bit(&mut gb);
-    let type_0: Rav1dObuType = rav1d_get_bits(&mut gb, 4 as c_int) as Rav1dObuType;
+    let r#type: Rav1dObuType = rav1d_get_bits(&mut gb, 4 as c_int) as Rav1dObuType;
     let has_extension: c_int = rav1d_get_bit(&mut gb) as c_int;
     let has_length_field: c_int = rav1d_get_bit(&mut gb) as c_int;
     rav1d_get_bit(&mut gb);
@@ -1652,26 +1633,26 @@ pub(crate) unsafe fn rav1d_parse_obus(
     let len: c_uint = if has_length_field != 0 {
         rav1d_get_uleb128(&mut gb)
     } else {
-        ((*in_0).sz as c_uint)
+        ((*r#in).sz as c_uint)
             .wrapping_sub(1 as c_int as c_uint)
             .wrapping_sub(has_extension as c_uint)
     };
     if gb.error != 0 {
-        error(c, in_0)?;
+        error(c, r#in)?;
     }
     let init_bit_pos: c_uint = rav1d_get_bits_pos(&mut gb);
     let init_byte_pos: c_uint = init_bit_pos >> 3;
     if !(init_bit_pos & 7 as c_uint == 0 as c_uint) {
         unreachable!();
     }
-    if !((*in_0).sz >= init_byte_pos as usize) {
+    if !((*r#in).sz >= init_byte_pos as usize) {
         unreachable!();
     }
-    if len as usize > ((*in_0).sz).wrapping_sub(init_byte_pos as usize) {
-        error(c, in_0)?;
+    if len as usize > ((*r#in).sz).wrapping_sub(init_byte_pos as usize) {
+        error(c, r#in)?;
     }
-    if type_0 as c_uint != RAV1D_OBU_SEQ_HDR as c_int as c_uint
-        && type_0 as c_uint != RAV1D_OBU_TD as c_int as c_uint
+    if r#type as c_uint != RAV1D_OBU_SEQ_HDR as c_int as c_uint
+        && r#type as c_uint != RAV1D_OBU_TD as c_int as c_uint
         && has_extension != 0
         && (*c).operating_point_idc != 0 as c_int as c_uint
     {
@@ -1684,28 +1665,28 @@ pub(crate) unsafe fn rav1d_parse_obus(
         }
     }
     let mut current_block_188: u64;
-    match type_0 as c_uint {
+    match r#type as c_uint {
         RAV1D_OBU_SEQ_HDR => {
-            let mut ref_0: *mut Rav1dRef = rav1d_ref_create_using_pool(
+            let mut r#ref: *mut Rav1dRef = rav1d_ref_create_using_pool(
                 (*c).seq_hdr_pool,
                 ::core::mem::size_of::<DRav1d<Rav1dSequenceHeader, Dav1dSequenceHeader>>(),
             );
-            if ref_0.is_null() {
+            if r#ref.is_null() {
                 return Err(ENOMEM);
             }
-            let seq_hdrs = (*ref_0)
+            let seq_hdrs = (*r#ref)
                 .data
                 .cast::<DRav1d<Rav1dSequenceHeader, Dav1dSequenceHeader>>();
             let seq_hdr: *mut Rav1dSequenceHeader = addr_of_mut!((*seq_hdrs).rav1d);
             let res = parse_seq_hdr(c, &mut gb, seq_hdr);
             (*seq_hdrs).update_dav1d();
             if res.is_err() {
-                rav1d_ref_dec(&mut ref_0);
-                error(c, in_0)?;
+                rav1d_ref_dec(&mut r#ref);
+                error(c, r#in)?;
             }
             if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
-                rav1d_ref_dec(&mut ref_0);
-                error(c, in_0)?;
+                rav1d_ref_dec(&mut r#ref);
+                error(c, r#in)?;
             }
             if ((*c).seq_hdr).is_null() {
                 (*c).frame_hdr = 0 as *mut Rav1dFrameHeader;
@@ -1749,7 +1730,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 );
             }
             rav1d_ref_dec(&mut (*c).seq_hdr_ref);
-            (*c).seq_hdr_ref = ref_0;
+            (*c).seq_hdr_ref = r#ref;
             (*c).seq_hdr = seq_hdr;
             current_block_188 = 8953117030348968745;
         }
@@ -1771,17 +1752,17 @@ pub(crate) unsafe fn rav1d_parse_obus(
             let meta_type_len: c_int =
                 ((rav1d_get_bits_pos(&mut gb)).wrapping_sub(init_bit_pos) >> 3) as c_int;
             if gb.error != 0 {
-                error(c, in_0)?;
+                error(c, r#in)?;
             }
             match meta_type as c_uint {
                 OBU_META_HDR_CLL => {
-                    let mut ref_1: *mut Rav1dRef =
+                    let mut r#ref: *mut Rav1dRef =
                         rav1d_ref_create(::core::mem::size_of::<Rav1dContentLightLevel>());
-                    if ref_1.is_null() {
+                    if r#ref.is_null() {
                         return Err(ENOMEM);
                     }
                     let content_light: *mut Rav1dContentLightLevel =
-                        (*ref_1).data as *mut Rav1dContentLightLevel;
+                        (*r#ref).data as *mut Rav1dContentLightLevel;
                     (*content_light).max_content_light_level =
                         rav1d_get_bits(&mut gb, 16 as c_int) as c_int;
                     (*content_light).max_frame_average_light_level =
@@ -1789,28 +1770,28 @@ pub(crate) unsafe fn rav1d_parse_obus(
                     rav1d_get_bit(&mut gb);
                     rav1d_bytealign_get_bits(&mut gb);
                     if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
-                        rav1d_ref_dec(&mut ref_1);
-                        error(c, in_0)?;
+                        rav1d_ref_dec(&mut r#ref);
+                        error(c, r#in)?;
                     }
                     rav1d_ref_dec(&mut (*c).content_light_ref);
                     (*c).content_light = content_light;
-                    (*c).content_light_ref = ref_1;
+                    (*c).content_light_ref = r#ref;
                 }
                 OBU_META_HDR_MDCV => {
-                    let mut ref_2: *mut Rav1dRef =
+                    let mut r#ref: *mut Rav1dRef =
                         rav1d_ref_create(::core::mem::size_of::<Rav1dMasteringDisplay>());
-                    if ref_2.is_null() {
+                    if r#ref.is_null() {
                         return Err(ENOMEM);
                     }
                     let mastering_display: *mut Rav1dMasteringDisplay =
-                        (*ref_2).data as *mut Rav1dMasteringDisplay;
-                    let mut i_1 = 0;
-                    while i_1 < 3 {
-                        (*mastering_display).primaries[i_1 as usize][0] =
+                        (*r#ref).data as *mut Rav1dMasteringDisplay;
+                    let mut i = 0;
+                    while i < 3 {
+                        (*mastering_display).primaries[i as usize][0] =
                             rav1d_get_bits(&mut gb, 16 as c_int) as u16;
-                        (*mastering_display).primaries[i_1 as usize][1] =
+                        (*mastering_display).primaries[i as usize][1] =
                             rav1d_get_bits(&mut gb, 16 as c_int) as u16;
-                        i_1 += 1;
+                        i += 1;
                     }
                     (*mastering_display).white_point[0] =
                         rav1d_get_bits(&mut gb, 16 as c_int) as u16;
@@ -1821,17 +1802,17 @@ pub(crate) unsafe fn rav1d_parse_obus(
                     rav1d_get_bit(&mut gb);
                     rav1d_bytealign_get_bits(&mut gb);
                     if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
-                        rav1d_ref_dec(&mut ref_2);
-                        error(c, in_0)?;
+                        rav1d_ref_dec(&mut r#ref);
+                        error(c, r#in)?;
                     }
                     rav1d_ref_dec(&mut (*c).mastering_display_ref);
                     (*c).mastering_display = mastering_display;
-                    (*c).mastering_display_ref = ref_2;
+                    (*c).mastering_display_ref = r#ref;
                 }
                 OBU_META_ITUT_T35 => {
                     let mut payload_size: c_int = len as c_int;
                     while payload_size > 0
-                        && *((*in_0).data).offset(
+                        && *((*r#in).data).offset(
                             init_byte_pos
                                 .wrapping_add(payload_size as c_uint)
                                 .wrapping_sub(1 as c_int as c_uint)
@@ -1856,21 +1837,21 @@ pub(crate) unsafe fn rav1d_parse_obus(
                                 as *const c_char,
                         );
                     } else {
-                        let ref_3: *mut Rav1dRef = rav1d_ref_create(
+                        let r#ref: *mut Rav1dRef = rav1d_ref_create(
                             (::core::mem::size_of::<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>())
                                 .wrapping_add(
                                     (payload_size as usize)
                                         .wrapping_mul(::core::mem::size_of::<u8>()),
                                 ),
                         );
-                        if ref_3.is_null() {
+                        if r#ref.is_null() {
                             return Err(ENOMEM);
                         }
                         let itut_t32_metadatas =
-                            (*ref_3).data.cast::<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>();
+                            (*r#ref).data.cast::<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>();
                         let itut_t35_metadata: *mut Rav1dITUTT35 =
                             addr_of_mut!((*itut_t32_metadatas).rav1d);
-                        (*itut_t35_metadata).payload = (*ref_3)
+                        (*itut_t35_metadata).payload = (*r#ref)
                             .data
                             .cast::<u8>()
                             .offset(::core::mem::size_of::<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>()
@@ -1878,17 +1859,17 @@ pub(crate) unsafe fn rav1d_parse_obus(
                         (*itut_t35_metadata).country_code = country_code as u8;
                         (*itut_t35_metadata).country_code_extension_byte =
                             country_code_extension_byte as u8;
-                        let mut i_2 = 0;
-                        while i_2 < payload_size {
-                            *((*itut_t35_metadata).payload).offset(i_2 as isize) =
+                        let mut i = 0;
+                        while i < payload_size {
+                            *((*itut_t35_metadata).payload).offset(i as isize) =
                                 rav1d_get_bits(&mut gb, 8 as c_int) as u8;
-                            i_2 += 1;
+                            i += 1;
                         }
                         (*itut_t35_metadata).payload_size = payload_size as usize;
                         (*itut_t32_metadatas).update_dav1d();
                         rav1d_ref_dec(&mut (*c).itut_t35_ref);
                         (*c).itut_t35 = itut_t35_metadata;
-                        (*c).itut_t35_ref = ref_3;
+                        (*c).itut_t35_ref = r#ref;
                     }
                 }
                 OBU_META_SCALABILITY | OBU_META_TIMECODE => {}
@@ -1915,7 +1896,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
             rav1d_log(
                 c,
                 b"Unknown OBU type %d of size %u\n\0" as *const u8 as *const c_char,
-                type_0 as c_uint,
+                r#type as c_uint,
                 len,
             );
             current_block_188 = 8953117030348968745;
@@ -1927,7 +1908,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 current_block_188 = 8953117030348968745;
             } else {
                 if ((*c).seq_hdr).is_null() {
-                    error(c, in_0)?;
+                    error(c, r#in)?;
                 }
                 if ((*c).frame_hdr_ref).is_null() {
                     (*c).frame_hdr_ref = rav1d_ref_create_using_pool(
@@ -1953,7 +1934,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 let res = parse_frame_hdr(c, &mut gb);
                 if res.is_err() {
                     (*c).frame_hdr = 0 as *mut Rav1dFrameHeader;
-                    error(c, in_0)?;
+                    error(c, r#in)?;
                 }
                 let mut n = 0;
                 while n < (*c).n_tile_data {
@@ -1962,11 +1943,11 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 }
                 (*c).n_tile_data = 0 as c_int;
                 (*c).n_tiles = 0 as c_int;
-                if type_0 as c_uint != RAV1D_OBU_FRAME as c_int as c_uint {
+                if r#type as c_uint != RAV1D_OBU_FRAME as c_int as c_uint {
                     rav1d_get_bit(&mut gb);
                     if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
                         (*c).frame_hdr = 0 as *mut Rav1dFrameHeader;
-                        error(c, in_0)?;
+                        error(c, r#in)?;
                     }
                 }
                 if (*c).frame_size_limit != 0
@@ -1983,12 +1964,12 @@ pub(crate) unsafe fn rav1d_parse_obus(
                     (*c).frame_hdr = 0 as *mut Rav1dFrameHeader;
                     return Err(ERANGE);
                 }
-                if type_0 as c_uint != RAV1D_OBU_FRAME as c_int as c_uint {
+                if r#type as c_uint != RAV1D_OBU_FRAME as c_int as c_uint {
                     current_block_188 = 8953117030348968745;
                 } else {
                     if (*(*c).frame_hdr).show_existing_frame != 0 {
                         (*c).frame_hdr = 0 as *mut Rav1dFrameHeader;
-                        error(c, in_0)?;
+                        error(c, r#in)?;
                     }
                     rav1d_bytealign_get_bits(&mut gb);
                     current_block_188 = 17787701279558130514;
@@ -2001,13 +1982,13 @@ pub(crate) unsafe fn rav1d_parse_obus(
         17787701279558130514 => {
             if !(global != 0) {
                 if ((*c).frame_hdr).is_null() {
-                    error(c, in_0)?;
+                    error(c, r#in)?;
                 }
                 if (*c).n_tile_data_alloc < (*c).n_tile_data + 1 {
                     if (*c).n_tile_data + 1
                         > i32::MAX / ::core::mem::size_of::<Rav1dTileGroup>() as c_ulong as c_int
                     {
-                        error(c, in_0)?;
+                        error(c, r#in)?;
                     }
                     let tile: *mut Rav1dTileGroup = realloc(
                         (*c).tile as *mut c_void,
@@ -2015,7 +1996,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                             .wrapping_mul(::core::mem::size_of::<Rav1dTileGroup>()),
                     ) as *mut Rav1dTileGroup;
                     if tile.is_null() {
-                        error(c, in_0)?;
+                        error(c, r#in)?;
                     }
                     (*c).tile = tile;
                     memset(
@@ -2028,7 +2009,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 parse_tile_hdr(c, &mut gb);
                 rav1d_bytealign_get_bits(&mut gb);
                 if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
-                    error(c, in_0)?;
+                    error(c, r#in)?;
                 }
                 let pkt_bytelen: c_uint = init_byte_pos.wrapping_add(len);
                 let bit_pos: c_uint = rav1d_get_bits_pos(&mut gb);
@@ -2040,7 +2021,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 }
                 rav1d_data_ref(
                     &mut (*((*c).tile).offset((*c).n_tile_data as isize)).data,
-                    in_0,
+                    r#in,
                 );
                 let ref mut fresh0 = (*((*c).tile).offset((*c).n_tile_data as isize)).data.data;
                 *fresh0 = (*fresh0).offset((bit_pos >> 3) as isize);
@@ -2050,14 +2031,14 @@ pub(crate) unsafe fn rav1d_parse_obus(
                     > (*((*c).tile).offset((*c).n_tile_data as isize)).end
                     || (*((*c).tile).offset((*c).n_tile_data as isize)).start != (*c).n_tiles
                 {
-                    let mut i_0 = 0;
-                    while i_0 <= (*c).n_tile_data {
-                        rav1d_data_unref_internal(&mut (*((*c).tile).offset(i_0 as isize)).data);
-                        i_0 += 1;
+                    let mut i = 0;
+                    while i <= (*c).n_tile_data {
+                        rav1d_data_unref_internal(&mut (*((*c).tile).offset(i as isize)).data);
+                        i += 1;
                     }
                     (*c).n_tile_data = 0 as c_int;
                     (*c).n_tiles = 0 as c_int;
-                    error(c, in_0)?;
+                    error(c, r#in)?;
                 }
                 (*c).n_tiles += 1 as c_int + (*((*c).tile).offset((*c).n_tile_data as isize)).end
                     - (*((*c).tile).offset((*c).n_tile_data as isize)).start;
@@ -2074,7 +2055,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 .frame_hdr)
                 .is_null()
             {
-                error(c, in_0)?;
+                error(c, r#in)?;
             }
             match (*(*c).refs[(*(*c).frame_hdr).existing_frame_idx as usize]
                 .p
@@ -2104,14 +2085,14 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 .data[0])
                 .is_null()
             {
-                error(c, in_0)?;
+                error(c, r#in)?;
             }
             if (*c).strict_std_compliance
                 && !(*c).refs[(*(*c).frame_hdr).existing_frame_idx as usize]
                     .p
                     .showable
             {
-                error(c, in_0)?;
+                error(c, r#in)?;
             }
             if (*c).n_fc == 1 as c_uint {
                 rav1d_thread_picture_ref(
@@ -2121,7 +2102,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                         .offset((*(*c).frame_hdr).existing_frame_idx as isize))
                     .p,
                 );
-                rav1d_data_props_copy(&mut (*c).out.p.m, &mut (*in_0).m);
+                rav1d_data_props_copy(&mut (*c).out.p.m, &mut (*r#in).m);
                 (*c).event_flags = ::core::mem::transmute::<c_uint, Dav1dEventFlags>(
                     (*c).event_flags as c_uint
                         | rav1d_picture_get_event_flags(
@@ -2208,7 +2189,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                     .p,
                 );
                 (*out_delayed).visible = true;
-                rav1d_data_props_copy(&mut (*out_delayed).p.m, &mut (*in_0).m);
+                rav1d_data_props_copy(&mut (*out_delayed).p.m, &mut (*r#in).m);
                 pthread_mutex_unlock(&mut (*c).task_thread.lock);
             }
             if (*(*c).refs[(*(*c).frame_hdr).existing_frame_idx as usize]
@@ -2220,31 +2201,31 @@ pub(crate) unsafe fn rav1d_parse_obus(
             {
                 let r: c_int = (*(*c).frame_hdr).existing_frame_idx;
                 (*c).refs[r as usize].p.showable = false;
-                let mut i_3 = 0;
-                while i_3 < 8 {
-                    if !(i_3 == r) {
-                        if !((*c).refs[i_3 as usize].p.p.frame_hdr).is_null() {
+                let mut i = 0;
+                while i < 8 {
+                    if !(i == r) {
+                        if !((*c).refs[i as usize].p.p.frame_hdr).is_null() {
                             rav1d_thread_picture_unref(
-                                &mut (*((*c).refs).as_mut_ptr().offset(i_3 as isize)).p,
+                                &mut (*((*c).refs).as_mut_ptr().offset(i as isize)).p,
                             );
                         }
                         rav1d_thread_picture_ref(
-                            &mut (*((*c).refs).as_mut_ptr().offset(i_3 as isize)).p,
+                            &mut (*((*c).refs).as_mut_ptr().offset(i as isize)).p,
                             &mut (*((*c).refs).as_mut_ptr().offset(r as isize)).p,
                         );
-                        rav1d_cdf_thread_unref(&mut *((*c).cdf).as_mut_ptr().offset(i_3 as isize));
+                        rav1d_cdf_thread_unref(&mut *((*c).cdf).as_mut_ptr().offset(i as isize));
                         rav1d_cdf_thread_ref(
-                            &mut *((*c).cdf).as_mut_ptr().offset(i_3 as isize),
+                            &mut *((*c).cdf).as_mut_ptr().offset(i as isize),
                             &mut *((*c).cdf).as_mut_ptr().offset(r as isize),
                         );
-                        rav1d_ref_dec(&mut (*((*c).refs).as_mut_ptr().offset(i_3 as isize)).segmap);
-                        (*c).refs[i_3 as usize].segmap = (*c).refs[r as usize].segmap;
+                        rav1d_ref_dec(&mut (*((*c).refs).as_mut_ptr().offset(i as isize)).segmap);
+                        (*c).refs[i as usize].segmap = (*c).refs[r as usize].segmap;
                         if !((*c).refs[r as usize].segmap).is_null() {
                             rav1d_ref_inc((*c).refs[r as usize].segmap);
                         }
-                        rav1d_ref_dec(&mut (*((*c).refs).as_mut_ptr().offset(i_3 as isize)).refmvs);
+                        rav1d_ref_dec(&mut (*((*c).refs).as_mut_ptr().offset(i as isize)).refmvs);
                     }
-                    i_3 += 1;
+                    i += 1;
                 }
             }
             (*c).frame_hdr = 0 as *mut Rav1dFrameHeader;
@@ -2273,7 +2254,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 _ => {}
             }
             if (*c).n_tile_data == 0 {
-                error(c, in_0)?;
+                error(c, r#in)?;
             }
             rav1d_submit_frame(&mut *c)?;
             if (*c).n_tile_data != 0 {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1554,7 +1554,7 @@ unsafe fn check_for_overrun(
     init_bit_pos: c_uint,
     obu_len: c_uint,
 ) -> c_int {
-    if (*gb).error != 0 {
+    if gb.error != 0 {
         rav1d_log(
             c,
             b"Overrun in OBU bit buffer\n\0" as *const u8 as *const c_char,
@@ -1572,7 +1572,7 @@ unsafe fn check_for_overrun(
         );
         return 1 as c_int;
     }
-    return 0 as c_int;
+    0
 }
 
 pub(crate) unsafe fn rav1d_parse_obus(

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1325,7 +1325,7 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
     if (*hdr).frame_type as c_uint & 1 as c_uint != 0 {
         let mut i_19 = 0;
         while i_19 < 7 {
-            (*hdr).gmv[i_19 as usize].type_0 = (if rav1d_get_bit(gb) == 0 {
+            (*hdr).gmv[i_19 as usize].r#type = (if rav1d_get_bit(gb) == 0 {
                 RAV1D_WM_TYPE_IDENTITY as c_int
             } else if rav1d_get_bit(gb) != 0 {
                 RAV1D_WM_TYPE_ROT_ZOOM as c_int
@@ -1334,7 +1334,7 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
             } else {
                 RAV1D_WM_TYPE_AFFINE as c_int
             }) as Dav1dWarpedMotionType;
-            if !((*hdr).gmv[i_19 as usize].type_0 as c_uint
+            if !((*hdr).gmv[i_19 as usize].r#type as c_uint
                 == RAV1D_WM_TYPE_IDENTITY as c_int as c_uint)
             {
                 let ref_gmv: *const Rav1dWarpedMotionParams;
@@ -1358,7 +1358,7 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
                 let ref_mat: *const i32 = ((*ref_gmv).matrix).as_ptr();
                 let bits: c_int;
                 let shift: c_int;
-                if (*hdr).gmv[i_19 as usize].type_0 as c_uint
+                if (*hdr).gmv[i_19 as usize].r#type as c_uint
                     >= RAV1D_WM_TYPE_ROT_ZOOM as c_int as c_uint
                 {
                     *mat.offset(2) = ((1 as c_int) << 16)
@@ -1375,7 +1375,7 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
                     bits = 9 - ((*hdr).hp == 0) as c_int;
                     shift = 13 + ((*hdr).hp == 0) as c_int;
                 }
-                if (*hdr).gmv[i_19 as usize].type_0 as c_uint
+                if (*hdr).gmv[i_19 as usize].r#type as c_uint
                     == RAV1D_WM_TYPE_AFFINE as c_int as c_uint
                 {
                     *mat.offset(4) = 2 as c_int

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -202,22 +202,20 @@ unsafe fn parse_seq_hdr(
             (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
         let mut i = 0;
         while i < hdr.num_operating_points {
-            let op: *mut Rav1dSequenceHeaderOperatingPoint =
-                &mut *(hdr.operating_points).as_mut_ptr().offset(i as isize)
-                    as *mut Rav1dSequenceHeaderOperatingPoint;
-            (*op).idc = rav1d_get_bits(gb, 12 as c_int) as c_int;
-            if (*op).idc != 0 && ((*op).idc & 0xff as c_int == 0 || (*op).idc & 0xf00 == 0) {
+            let op = &mut hdr.operating_points[i as usize];
+            op.idc = rav1d_get_bits(gb, 12 as c_int) as c_int;
+            if op.idc != 0 && (op.idc & 0xff as c_int == 0 || op.idc & 0xf00 == 0) {
                 return error(c);
             }
-            (*op).major_level =
+            op.major_level =
                 (2 as c_int as c_uint).wrapping_add(rav1d_get_bits(gb, 3 as c_int)) as c_int;
-            (*op).minor_level = rav1d_get_bits(gb, 2 as c_int) as c_int;
-            if (*op).major_level > 3 {
-                (*op).tier = rav1d_get_bit(gb) as c_int;
+            op.minor_level = rav1d_get_bits(gb, 2 as c_int) as c_int;
+            if op.major_level > 3 {
+                op.tier = rav1d_get_bit(gb) as c_int;
             }
             if hdr.decoder_model_info_present != 0 {
-                (*op).decoder_model_param_present = rav1d_get_bit(gb) as c_int;
-                if (*op).decoder_model_param_present != 0 {
+                op.decoder_model_param_present = rav1d_get_bit(gb) as c_int;
+                if op.decoder_model_param_present != 0 {
                     let opi: *mut Rav1dSequenceHeaderOperatingParameterInfo = &mut *(hdr
                         .operating_parameter_info)
                         .as_mut_ptr()
@@ -231,9 +229,9 @@ unsafe fn parse_seq_hdr(
                 }
             }
             if hdr.display_model_info_present != 0 {
-                (*op).display_model_param_present = rav1d_get_bit(gb) as c_int;
+                op.display_model_param_present = rav1d_get_bit(gb) as c_int;
             }
-            (*op).initial_display_delay = (if (*op).display_model_param_present != 0 {
+            op.initial_display_delay = (if op.display_model_param_present != 0 {
                 (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(1 as c_int as c_uint)
             } else {
                 10 as c_int as c_uint

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -397,7 +397,7 @@ unsafe fn parse_seq_hdr(
 
 unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int) -> c_int {
     let seqhdr = &*c.seq_hdr;
-    let hdr: *mut Rav1dFrameHeader = c.frame_hdr;
+    let hdr = &mut *c.frame_hdr;
     if use_ref != 0 {
         let mut i = 0;
         while i < 7 {
@@ -409,61 +409,60 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
                 if ((*r#ref).p.frame_hdr).is_null() {
                     return -(1 as c_int);
                 }
-                (*hdr).width[1] = (*(*r#ref).p.frame_hdr).width[1];
-                (*hdr).height = (*(*r#ref).p.frame_hdr).height;
-                (*hdr).render_width = (*(*r#ref).p.frame_hdr).render_width;
-                (*hdr).render_height = (*(*r#ref).p.frame_hdr).render_height;
-                (*hdr).super_res.enabled =
-                    (seqhdr.super_res != 0 && rav1d_get_bit(gb) != 0) as c_int;
-                if (*hdr).super_res.enabled != 0 {
-                    (*hdr).super_res.width_scale_denominator = (9 as c_int as c_uint)
+                hdr.width[1] = (*(*r#ref).p.frame_hdr).width[1];
+                hdr.height = (*(*r#ref).p.frame_hdr).height;
+                hdr.render_width = (*(*r#ref).p.frame_hdr).render_width;
+                hdr.render_height = (*(*r#ref).p.frame_hdr).render_height;
+                hdr.super_res.enabled = (seqhdr.super_res != 0 && rav1d_get_bit(gb) != 0) as c_int;
+                if hdr.super_res.enabled != 0 {
+                    hdr.super_res.width_scale_denominator = (9 as c_int as c_uint)
                         .wrapping_add(rav1d_get_bits(gb, 3 as c_int))
                         as c_int;
-                    let d = (*hdr).super_res.width_scale_denominator;
-                    (*hdr).width[0] = cmp::max(
-                        ((*hdr).width[1] * 8 + (d >> 1)) / d,
-                        cmp::min(16 as c_int, (*hdr).width[1]),
+                    let d = hdr.super_res.width_scale_denominator;
+                    hdr.width[0] = cmp::max(
+                        (hdr.width[1] * 8 + (d >> 1)) / d,
+                        cmp::min(16 as c_int, hdr.width[1]),
                     );
                 } else {
-                    (*hdr).super_res.width_scale_denominator = 8 as c_int;
-                    (*hdr).width[0] = (*hdr).width[1];
+                    hdr.super_res.width_scale_denominator = 8 as c_int;
+                    hdr.width[0] = hdr.width[1];
                 }
                 return 0 as c_int;
             }
             i += 1;
         }
     }
-    if (*hdr).frame_size_override != 0 {
-        (*hdr).width[1] =
+    if hdr.frame_size_override != 0 {
+        hdr.width[1] =
             (rav1d_get_bits(gb, seqhdr.width_n_bits)).wrapping_add(1 as c_int as c_uint) as c_int;
-        (*hdr).height =
+        hdr.height =
             (rav1d_get_bits(gb, seqhdr.height_n_bits)).wrapping_add(1 as c_int as c_uint) as c_int;
     } else {
-        (*hdr).width[1] = seqhdr.max_width;
-        (*hdr).height = seqhdr.max_height;
+        hdr.width[1] = seqhdr.max_width;
+        hdr.height = seqhdr.max_height;
     }
-    (*hdr).super_res.enabled = (seqhdr.super_res != 0 && rav1d_get_bit(gb) != 0) as c_int;
-    if (*hdr).super_res.enabled != 0 {
-        (*hdr).super_res.width_scale_denominator =
+    hdr.super_res.enabled = (seqhdr.super_res != 0 && rav1d_get_bit(gb) != 0) as c_int;
+    if hdr.super_res.enabled != 0 {
+        hdr.super_res.width_scale_denominator =
             (9 as c_int as c_uint).wrapping_add(rav1d_get_bits(gb, 3 as c_int)) as c_int;
-        let d = (*hdr).super_res.width_scale_denominator;
-        (*hdr).width[0] = cmp::max(
-            ((*hdr).width[1] * 8 + (d >> 1)) / d,
-            cmp::min(16 as c_int, (*hdr).width[1]),
+        let d = hdr.super_res.width_scale_denominator;
+        hdr.width[0] = cmp::max(
+            (hdr.width[1] * 8 + (d >> 1)) / d,
+            cmp::min(16 as c_int, hdr.width[1]),
         );
     } else {
-        (*hdr).super_res.width_scale_denominator = 8 as c_int;
-        (*hdr).width[0] = (*hdr).width[1];
+        hdr.super_res.width_scale_denominator = 8 as c_int;
+        hdr.width[0] = hdr.width[1];
     }
-    (*hdr).have_render_size = rav1d_get_bit(gb) as c_int;
-    if (*hdr).have_render_size != 0 {
-        (*hdr).render_width =
+    hdr.have_render_size = rav1d_get_bit(gb) as c_int;
+    if hdr.have_render_size != 0 {
+        hdr.render_width =
             (rav1d_get_bits(gb, 16 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
-        (*hdr).render_height =
+        hdr.render_height =
             (rav1d_get_bits(gb, 16 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
     } else {
-        (*hdr).render_width = (*hdr).width[1];
-        (*hdr).render_height = (*hdr).height;
+        hdr.render_width = hdr.width[1];
+        hdr.render_height = hdr.height;
     }
     0
 }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1580,8 +1580,8 @@ pub(crate) unsafe fn rav1d_parse_obus(
     r#in: &mut Rav1dData,
     global: c_int,
 ) -> Rav1dResult<c_uint> {
-    unsafe fn error(c: &mut Rav1dContext, r#in: *mut Rav1dData) -> Rav1dResult {
-        rav1d_data_props_copy(&mut c.cached_error_props, &mut (*r#in).m);
+    unsafe fn error(c: &mut Rav1dContext, r#in: &mut Rav1dData) -> Rav1dResult {
+        rav1d_data_props_copy(&mut c.cached_error_props, &mut r#in.m);
         rav1d_log(
             c,
             b"Error parsing OBU data\n\0" as *const u8 as *const c_char,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -128,10 +128,10 @@ use std::ffi::c_void;
 use std::ptr::addr_of_mut;
 
 #[inline]
-unsafe fn rav1d_get_bits_pos(c: *const GetBits) -> c_uint {
-    (((*c).ptr).offset_from((*c).ptr_start) as c_long as c_uint)
+unsafe fn rav1d_get_bits_pos(c: &GetBits) -> c_uint {
+    (c.ptr.offset_from(c.ptr_start) as c_long as c_uint)
         .wrapping_mul(8 as c_int as c_uint)
-        .wrapping_sub((*c).bits_left as c_uint)
+        .wrapping_sub(c.bits_left as c_uint)
 }
 
 unsafe fn parse_seq_hdr(

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -396,7 +396,7 @@ unsafe fn parse_seq_hdr(
 }
 
 unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int) -> c_int {
-    let seqhdr: *const Rav1dSequenceHeader = c.seq_hdr;
+    let seqhdr = &*c.seq_hdr;
     let hdr: *mut Rav1dFrameHeader = c.frame_hdr;
     if use_ref != 0 {
         let mut i = 0;
@@ -414,7 +414,7 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
                 (*hdr).render_width = (*(*r#ref).p.frame_hdr).render_width;
                 (*hdr).render_height = (*(*r#ref).p.frame_hdr).render_height;
                 (*hdr).super_res.enabled =
-                    ((*seqhdr).super_res != 0 && rav1d_get_bit(gb) != 0) as c_int;
+                    (seqhdr.super_res != 0 && rav1d_get_bit(gb) != 0) as c_int;
                 if (*hdr).super_res.enabled != 0 {
                     (*hdr).super_res.width_scale_denominator = (9 as c_int as c_uint)
                         .wrapping_add(rav1d_get_bits(gb, 3 as c_int))
@@ -434,15 +434,15 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
         }
     }
     if (*hdr).frame_size_override != 0 {
-        (*hdr).width[1] = (rav1d_get_bits(gb, (*seqhdr).width_n_bits))
-            .wrapping_add(1 as c_int as c_uint) as c_int;
-        (*hdr).height = (rav1d_get_bits(gb, (*seqhdr).height_n_bits))
-            .wrapping_add(1 as c_int as c_uint) as c_int;
+        (*hdr).width[1] =
+            (rav1d_get_bits(gb, seqhdr.width_n_bits)).wrapping_add(1 as c_int as c_uint) as c_int;
+        (*hdr).height =
+            (rav1d_get_bits(gb, seqhdr.height_n_bits)).wrapping_add(1 as c_int as c_uint) as c_int;
     } else {
-        (*hdr).width[1] = (*seqhdr).max_width;
-        (*hdr).height = (*seqhdr).max_height;
+        (*hdr).width[1] = seqhdr.max_width;
+        (*hdr).height = seqhdr.max_height;
     }
-    (*hdr).super_res.enabled = ((*seqhdr).super_res != 0 && rav1d_get_bit(gb) != 0) as c_int;
+    (*hdr).super_res.enabled = (seqhdr.super_res != 0 && rav1d_get_bit(gb) != 0) as c_int;
     if (*hdr).super_res.enabled != 0 {
         (*hdr).super_res.width_scale_denominator =
             (9 as c_int as c_uint).wrapping_add(rav1d_get_bits(gb, 3 as c_int)) as c_int;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -483,7 +483,7 @@ static default_mode_ref_deltas: Rav1dLoopfilterModeRefDeltas = Rav1dLoopfilterMo
     ref_delta: [1, 0, 0, 0, -1, 0, -1, -1],
 };
 
-unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult {
+unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult {
     unsafe fn error(c: *mut Rav1dContext) -> Rav1dResult {
         rav1d_log(
             c,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -139,7 +139,7 @@ unsafe fn parse_seq_hdr(
     gb: &mut GetBits,
     hdr: &mut Rav1dSequenceHeader,
 ) -> Rav1dResult {
-    unsafe fn error(c: *mut Rav1dContext) -> Rav1dResult {
+    unsafe fn error(c: &mut Rav1dContext) -> Rav1dResult {
         rav1d_log(
             c,
             b"Error parsing sequence header\n\0" as *const u8 as *const c_char,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -174,23 +174,21 @@ unsafe fn parse_seq_hdr(
                 if num_ticks_per_picture == 0xffffffff {
                     return error(c);
                 }
-                hdr.num_ticks_per_picture = num_ticks_per_picture.wrapping_add(1);
+                hdr.num_ticks_per_picture = num_ticks_per_picture + 1;
             }
             hdr.decoder_model_info_present = rav1d_get_bit(gb) as c_int;
             if hdr.decoder_model_info_present != 0 {
-                hdr.encoder_decoder_buffer_delay_length =
-                    (rav1d_get_bits(gb, 5)).wrapping_add(1) as c_int;
+                hdr.encoder_decoder_buffer_delay_length = rav1d_get_bits(gb, 5) as c_int + 1;
                 hdr.num_units_in_decoding_tick = rav1d_get_bits(gb, 32) as c_int;
                 if c.strict_std_compliance && hdr.num_units_in_decoding_tick == 0 {
                     return error(c);
                 }
-                hdr.buffer_removal_delay_length = (rav1d_get_bits(gb, 5)).wrapping_add(1) as c_int;
-                hdr.frame_presentation_delay_length =
-                    (rav1d_get_bits(gb, 5)).wrapping_add(1) as c_int;
+                hdr.buffer_removal_delay_length = rav1d_get_bits(gb, 5) as c_int + 1;
+                hdr.frame_presentation_delay_length = rav1d_get_bits(gb, 5) as c_int + 1;
             }
         }
         hdr.display_model_info_present = rav1d_get_bit(gb) as c_int;
-        hdr.num_operating_points = (rav1d_get_bits(gb, 5)).wrapping_add(1) as c_int;
+        hdr.num_operating_points = rav1d_get_bits(gb, 5) as c_int + 1;
         let mut i = 0;
         while i < hdr.num_operating_points {
             let op = &mut hdr.operating_points[i as usize];
@@ -218,7 +216,7 @@ unsafe fn parse_seq_hdr(
                 op.display_model_param_present = rav1d_get_bit(gb) as c_int;
             }
             op.initial_display_delay = if op.display_model_param_present != 0 {
-                (rav1d_get_bits(gb, 4)).wrapping_add(1) as c_int
+                rav1d_get_bits(gb, 4) as c_int + 1
             } else {
                 10
             };
@@ -237,14 +235,14 @@ unsafe fn parse_seq_hdr(
     } else {
         false
     };
-    hdr.width_n_bits = (rav1d_get_bits(gb, 4)).wrapping_add(1) as c_int;
-    hdr.height_n_bits = (rav1d_get_bits(gb, 4)).wrapping_add(1) as c_int;
-    hdr.max_width = (rav1d_get_bits(gb, hdr.width_n_bits)).wrapping_add(1) as c_int;
-    hdr.max_height = (rav1d_get_bits(gb, hdr.height_n_bits)).wrapping_add(1) as c_int;
+    hdr.width_n_bits = rav1d_get_bits(gb, 4) as c_int + 1;
+    hdr.height_n_bits = rav1d_get_bits(gb, 4) as c_int + 1;
+    hdr.max_width = rav1d_get_bits(gb, hdr.width_n_bits) as c_int + 1;
+    hdr.max_height = rav1d_get_bits(gb, hdr.height_n_bits) as c_int + 1;
     if hdr.reduced_still_picture_header == 0 {
         hdr.frame_id_numbers_present = rav1d_get_bit(gb) as c_int;
         if hdr.frame_id_numbers_present != 0 {
-            hdr.delta_frame_id_n_bits = (rav1d_get_bits(gb, 4)).wrapping_add(2) as c_int;
+            hdr.delta_frame_id_n_bits = rav1d_get_bits(gb, 4) as c_int + 2;
             hdr.frame_id_n_bits = (rav1d_get_bits(gb, 3))
                 .wrapping_add(hdr.delta_frame_id_n_bits as c_uint)
                 .wrapping_add(1) as c_int;
@@ -281,7 +279,7 @@ unsafe fn parse_seq_hdr(
             2
         };
         if hdr.order_hint != 0 {
-            hdr.order_hint_n_bits = (rav1d_get_bits(gb, 3)).wrapping_add(1) as c_int;
+            hdr.order_hint_n_bits = rav1d_get_bits(gb, 3) as c_int + 1;
         }
     }
     hdr.super_res = rav1d_get_bit(gb) as c_int;
@@ -382,8 +380,8 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
                     .as_mut_ptr()
                     .offset(*((*c.frame_hdr).refidx).as_mut_ptr().offset(i as isize) as isize))
                 .p;
-                if ((*r#ref).p.frame_hdr).is_null() {
-                    return -(1);
+                if (*r#ref).p.frame_hdr.is_null() {
+                    return -1;
                 }
                 hdr.width[1] = (*(*r#ref).p.frame_hdr).width[1];
                 hdr.height = (*(*r#ref).p.frame_hdr).height;
@@ -408,8 +406,8 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
         }
     }
     if hdr.frame_size_override != 0 {
-        hdr.width[1] = (rav1d_get_bits(gb, seqhdr.width_n_bits)).wrapping_add(1) as c_int;
-        hdr.height = (rav1d_get_bits(gb, seqhdr.height_n_bits)).wrapping_add(1) as c_int;
+        hdr.width[1] = rav1d_get_bits(gb, seqhdr.width_n_bits) as c_int + 1;
+        hdr.height = rav1d_get_bits(gb, seqhdr.height_n_bits) as c_int + 1;
     } else {
         hdr.width[1] = seqhdr.max_width;
         hdr.height = seqhdr.max_height;
@@ -429,8 +427,8 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
     }
     hdr.have_render_size = rav1d_get_bit(gb) as c_int;
     if hdr.have_render_size != 0 {
-        hdr.render_width = (rav1d_get_bits(gb, 16)).wrapping_add(1) as c_int;
-        hdr.render_height = (rav1d_get_bits(gb, 16)).wrapping_add(1) as c_int;
+        hdr.render_width = rav1d_get_bits(gb, 16) as c_int + 1;
+        hdr.render_height = rav1d_get_bits(gb, 16) as c_int + 1;
     } else {
         hdr.render_width = hdr.width[1];
         hdr.render_height = hdr.height;
@@ -606,14 +604,14 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         hdr.frame_ref_short_signaling = (seqhdr.order_hint != 0 && rav1d_get_bit(gb) != 0) as c_int;
         if hdr.frame_ref_short_signaling != 0 {
             hdr.refidx[0] = rav1d_get_bits(gb, 3) as c_int;
-            hdr.refidx[2] = -(1);
+            hdr.refidx[2] = -1;
             hdr.refidx[1] = hdr.refidx[2];
             hdr.refidx[3] = rav1d_get_bits(gb, 3) as c_int;
-            hdr.refidx[6] = -(1);
+            hdr.refidx[6] = -1;
             hdr.refidx[5] = hdr.refidx[6];
             hdr.refidx[4] = hdr.refidx[5];
             let mut shifted_frame_offset: [c_int; 8] = [0; 8];
-            let current_frame_offset: c_int = (1) << seqhdr.order_hint_n_bits - 1;
+            let current_frame_offset: c_int = 1 << seqhdr.order_hint_n_bits - 1;
             let mut i = 0;
             while i < 8 {
                 if (c.refs[i as usize].p.p.frame_hdr).is_null() {
@@ -630,7 +628,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             let mut used_frame: [c_int; 8] = [0, 0, 0, 0, 0, 0, 0, 0];
             used_frame[hdr.refidx[0] as usize] = 1;
             used_frame[hdr.refidx[3] as usize] = 1;
-            let mut latest_frame_offset: c_int = -(1);
+            let mut latest_frame_offset: c_int = -1;
             let mut i = 0;
             while i < 8 {
                 let hint: c_int = shifted_frame_offset[i as usize];
@@ -643,7 +641,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 }
                 i += 1;
             }
-            if latest_frame_offset != -(1) {
+            if latest_frame_offset != -1 {
                 used_frame[hdr.refidx[6] as usize] = 1;
             }
             let mut earliest_frame_offset = i32::MAX;
@@ -681,7 +679,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             let mut i = 1;
             while i < 7 {
                 if hdr.refidx[i as usize] < 0 {
-                    latest_frame_offset = -(1);
+                    latest_frame_offset = -1;
                     let mut j = 0;
                     while j < 8 {
                         let hint: c_int = shifted_frame_offset[j as usize];
@@ -694,14 +692,14 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                         }
                         j += 1;
                     }
-                    if latest_frame_offset != -(1) {
+                    if latest_frame_offset != -1 {
                         used_frame[hdr.refidx[i as usize] as usize] = 1;
                     }
                 }
                 i += 1;
             }
             earliest_frame_offset = i32::MAX;
-            let mut r#ref: c_int = -(1);
+            let mut r#ref: c_int = -1;
             let mut i = 0;
             while i < 8 {
                 let hint: c_int = shifted_frame_offset[i as usize];
@@ -807,7 +805,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         while sbx < sbw && hdr.tiling.cols < 64 {
             let tile_width_sb: c_int = cmp::min(sbw - sbx, max_tile_width_sb);
             let tile_w: c_int = if tile_width_sb > 1 {
-                (1 as c_uint).wrapping_add(rav1d_get_uniform(gb, tile_width_sb as c_uint)) as c_int
+                1 + rav1d_get_uniform(gb, tile_width_sb as c_uint) as c_int
             } else {
                 1
             };
@@ -826,7 +824,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         while sby < sbh && hdr.tiling.rows < 64 {
             let tile_height_sb: c_int = cmp::min(sbh - sby, max_tile_height_sb);
             let tile_h: c_int = if tile_height_sb > 1 {
-                (1 as c_uint).wrapping_add(rav1d_get_uniform(gb, tile_height_sb as c_uint)) as c_int
+                1 + rav1d_get_uniform(gb, tile_height_sb as c_uint) as c_int
             } else {
                 1
             };
@@ -844,7 +842,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         if hdr.tiling.update >= hdr.tiling.cols * hdr.tiling.rows {
             return error(c);
         }
-        hdr.tiling.n_bytes = (rav1d_get_bits(gb, 2)).wrapping_add(1);
+        hdr.tiling.n_bytes = rav1d_get_bits(gb, 2) + 1;
     } else {
         hdr.tiling.update = 0;
         hdr.tiling.n_bytes = hdr.tiling.update as c_uint;
@@ -914,7 +912,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         }
         if hdr.segmentation.update_data != 0 {
             hdr.segmentation.seg_data.preskip = 0;
-            hdr.segmentation.seg_data.last_active_segid = -(1);
+            hdr.segmentation.seg_data.last_active_segid = -1;
             let mut i = 0;
             while i < 8 {
                 let seg: *mut Rav1dSegmentationData = &mut *(hdr.segmentation.seg_data.d)
@@ -988,7 +986,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         );
         let mut i = 0;
         while i < 8 {
-            hdr.segmentation.seg_data.d[i as usize].r#ref = -(1);
+            hdr.segmentation.seg_data.d[i as usize].r#ref = -1;
             i += 1;
         }
     }
@@ -1087,7 +1085,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         }
     }
     if hdr.all_lossless == 0 && seqhdr.cdef != 0 && hdr.allow_intrabc == 0 {
-        hdr.cdef.damping = (rav1d_get_bits(gb, 2)).wrapping_add(3) as c_int;
+        hdr.cdef.damping = rav1d_get_bits(gb, 2) as c_int + 3;
         hdr.cdef.n_bits = rav1d_get_bits(gb, 2) as c_int;
         let mut i = 0;
         while i < (1) << hdr.cdef.n_bits {
@@ -1173,7 +1171,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 (*c.refs[hdr.refidx[i as usize] as usize].p.p.frame_hdr).frame_offset as c_uint;
             let diff: c_int = get_poc_diff(seqhdr.order_hint_n_bits, refpoc as c_int, poc as c_int);
             if diff > 0 {
-                if off_after == -(1)
+                if off_after == -1
                     || get_poc_diff(seqhdr.order_hint_n_bits, off_after, refpoc as c_int) > 0
                 {
                     off_after = refpoc as c_int;
@@ -1192,7 +1190,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             }
             i += 1;
         }
-        if off_before != 0xffffffff && off_after != -(1) {
+        if off_before != 0xffffffff && off_after != -1 {
             hdr.skip_mode_refs[0] = cmp::min(off_before_idx, off_after_idx);
             hdr.skip_mode_refs[1] = cmp::max(off_before_idx, off_after_idx);
             hdr.skip_mode_allowed = 1;
@@ -1387,13 +1385,13 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             {
                 return error(c);
             }
-            fgd.scaling_shift = (rav1d_get_bits(gb, 2)).wrapping_add(8) as u8;
+            fgd.scaling_shift = rav1d_get_bits(gb, 2) as u8 + 8;
             fgd.ar_coeff_lag = rav1d_get_bits(gb, 2) as c_int;
             let num_y_pos = 2 * fgd.ar_coeff_lag * (fgd.ar_coeff_lag + 1);
             if fgd.num_y_points != 0 {
                 let mut i = 0;
                 while i < num_y_pos {
-                    fgd.ar_coeffs_y[i as usize] = (rav1d_get_bits(gb, 8)).wrapping_sub(128) as i8;
+                    fgd.ar_coeffs_y[i as usize] = rav1d_get_bits(gb, 8).wrapping_sub(128) as i8;
                     i += 1;
                 }
             }
@@ -1404,7 +1402,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                     let mut i = 0;
                     while i < num_uv_pos {
                         fgd.ar_coeffs_uv[pl as usize][i as usize] =
-                            (rav1d_get_bits(gb, 8)).wrapping_sub(128) as i8;
+                            rav1d_get_bits(gb, 8).wrapping_sub(128) as i8;
                         i += 1;
                     }
                     if fgd.num_y_points == 0 {
@@ -1413,15 +1411,14 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 }
                 pl += 1;
             }
-            fgd.ar_coeff_shift = (rav1d_get_bits(gb, 2)).wrapping_add(6) as u8;
+            fgd.ar_coeff_shift = rav1d_get_bits(gb, 2) as u8 + 6;
             fgd.grain_scale_shift = rav1d_get_bits(gb, 2) as u8;
             let mut pl = 0;
             while pl < 2 {
                 if fgd.num_uv_points[pl as usize] != 0 {
-                    fgd.uv_mult[pl as usize] = (rav1d_get_bits(gb, 8)).wrapping_sub(128) as c_int;
-                    fgd.uv_luma_mult[pl as usize] =
-                        (rav1d_get_bits(gb, 8)).wrapping_sub(128) as c_int;
-                    fgd.uv_offset[pl as usize] = (rav1d_get_bits(gb, 9)).wrapping_sub(256) as c_int;
+                    fgd.uv_mult[pl as usize] = rav1d_get_bits(gb, 8) as c_int - 128;
+                    fgd.uv_luma_mult[pl as usize] = rav1d_get_bits(gb, 8) as c_int - 128;
+                    fgd.uv_offset[pl as usize] = rav1d_get_bits(gb, 9) as c_int - 256;
                 }
                 pl += 1;
             }
@@ -1555,7 +1552,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
     let init_byte_pos: c_uint = init_bit_pos >> 3;
     assert!(init_bit_pos & 7 == 0);
     assert!(r#in.sz >= init_byte_pos as usize);
-    if len as usize > (r#in.sz).wrapping_sub(init_byte_pos as usize) {
+    if len as usize > r#in.sz.wrapping_sub(init_byte_pos as usize) {
         error(c, r#in)?;
     }
     if r#type != RAV1D_OBU_SEQ_HDR
@@ -1989,7 +1986,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
             } else {
                 pthread_mutex_lock(&mut c.task_thread.lock);
                 let next = c.frame_thread.next;
-                c.frame_thread.next = c.frame_thread.next.wrapping_add(1);
+                c.frame_thread.next += 1;
                 if c.frame_thread.next == c.n_fc {
                     c.frame_thread.next = 0;
                 }
@@ -2009,7 +2006,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 {
                     let first: c_uint =
                         ::core::intrinsics::atomic_load_seqcst(&mut c.task_thread.first);
-                    if first.wrapping_add(1) < c.n_fc {
+                    if first + 1 < c.n_fc {
                         ::core::intrinsics::atomic_xadd_seqcst(&mut c.task_thread.first, 1);
                     } else {
                         ::core::intrinsics::atomic_store_seqcst(&mut c.task_thread.first, 0);
@@ -2020,7 +2017,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                         u32::MAX,
                     );
                     if c.task_thread.cur != 0 && c.task_thread.cur < c.n_fc {
-                        c.task_thread.cur = c.task_thread.cur.wrapping_sub(1);
+                        c.task_thread.cur -= 1;
                     }
                 }
                 let error = (*f).task_thread.retval;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1549,7 +1549,7 @@ unsafe fn parse_tile_hdr(c: *mut Rav1dContext, gb: *mut GetBits) {
 }
 
 unsafe fn check_for_overrun(
-    c: *mut Rav1dContext,
+    c: &mut Rav1dContext,
     gb: &mut GetBits,
     init_bit_pos: c_uint,
     obu_len: c_uint,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1577,7 +1577,7 @@ unsafe fn check_for_overrun(
 
 pub(crate) unsafe fn rav1d_parse_obus(
     c: &mut Rav1dContext,
-    r#in: *mut Rav1dData,
+    r#in: &mut Rav1dData,
     global: c_int,
 ) -> Rav1dResult<c_uint> {
     unsafe fn error(c: *mut Rav1dContext, r#in: *mut Rav1dData) -> Rav1dResult {
@@ -1617,7 +1617,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
         ptr_start: 0 as *const u8,
         ptr_end: 0 as *const u8,
     };
-    rav1d_init_get_bits(&mut gb, (*r#in).data, (*r#in).sz);
+    rav1d_init_get_bits(&mut gb, r#in.data, r#in.sz);
     rav1d_get_bit(&mut gb);
     let r#type: Rav1dObuType = rav1d_get_bits(&mut gb, 4 as c_int) as Rav1dObuType;
     let has_extension: c_int = rav1d_get_bit(&mut gb) as c_int;
@@ -1633,7 +1633,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
     let len: c_uint = if has_length_field != 0 {
         rav1d_get_uleb128(&mut gb)
     } else {
-        ((*r#in).sz as c_uint)
+        (r#in.sz as c_uint)
             .wrapping_sub(1 as c_int as c_uint)
             .wrapping_sub(has_extension as c_uint)
     };
@@ -1645,10 +1645,10 @@ pub(crate) unsafe fn rav1d_parse_obus(
     if !(init_bit_pos & 7 as c_uint == 0 as c_uint) {
         unreachable!();
     }
-    if !((*r#in).sz >= init_byte_pos as usize) {
+    if !(r#in.sz >= init_byte_pos as usize) {
         unreachable!();
     }
-    if len as usize > ((*r#in).sz).wrapping_sub(init_byte_pos as usize) {
+    if len as usize > (r#in.sz).wrapping_sub(init_byte_pos as usize) {
         error(c, r#in)?;
     }
     if r#type as c_uint != RAV1D_OBU_SEQ_HDR as c_int as c_uint
@@ -1807,7 +1807,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 OBU_META_ITUT_T35 => {
                     let mut payload_size: c_int = len as c_int;
                     while payload_size > 0
-                        && *((*r#in).data).offset(
+                        && *(r#in.data).offset(
                             init_byte_pos
                                 .wrapping_add(payload_size as c_uint)
                                 .wrapping_sub(1 as c_int as c_uint)
@@ -2089,7 +2089,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                         .offset((*c.frame_hdr).existing_frame_idx as isize))
                     .p,
                 );
-                rav1d_data_props_copy(&mut c.out.p.m, &mut (*r#in).m);
+                rav1d_data_props_copy(&mut c.out.p.m, &mut r#in.m);
                 c.event_flags = ::core::mem::transmute::<c_uint, Dav1dEventFlags>(
                     c.event_flags as c_uint
                         | rav1d_picture_get_event_flags(
@@ -2176,7 +2176,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                     .p,
                 );
                 (*out_delayed).visible = true;
-                rav1d_data_props_copy(&mut (*out_delayed).p.m, &mut (*r#in).m);
+                rav1d_data_props_copy(&mut (*out_delayed).p.m, &mut r#in.m);
                 pthread_mutex_unlock(&mut c.task_thread.lock);
             }
             if (*c.refs[(*c.frame_hdr).existing_frame_idx as usize]

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -149,7 +149,7 @@ unsafe fn parse_seq_hdr(
         0 as c_int,
         ::core::mem::size_of::<Rav1dSequenceHeader>(),
     );
-    hdr.profile = rav1d_get_bits(gb, 3 as c_int) as c_int;
+    hdr.profile = rav1d_get_bits(gb, 3) as c_int;
     if hdr.profile > 2 {
         return error(c);
     }
@@ -160,14 +160,14 @@ unsafe fn parse_seq_hdr(
     }
     if hdr.reduced_still_picture_header != 0 {
         hdr.num_operating_points = 1 as c_int;
-        hdr.operating_points[0].major_level = rav1d_get_bits(gb, 3 as c_int) as c_int;
-        hdr.operating_points[0].minor_level = rav1d_get_bits(gb, 2 as c_int) as c_int;
+        hdr.operating_points[0].major_level = rav1d_get_bits(gb, 3) as c_int;
+        hdr.operating_points[0].minor_level = rav1d_get_bits(gb, 2) as c_int;
         hdr.operating_points[0].initial_display_delay = 10 as c_int;
     } else {
         hdr.timing_info_present = rav1d_get_bit(gb) as c_int;
         if hdr.timing_info_present != 0 {
-            hdr.num_units_in_tick = rav1d_get_bits(gb, 32 as c_int) as c_int;
-            hdr.time_scale = rav1d_get_bits(gb, 32 as c_int) as c_int;
+            hdr.num_units_in_tick = rav1d_get_bits(gb, 32) as c_int;
+            hdr.time_scale = rav1d_get_bits(gb, 32) as c_int;
             if c.strict_std_compliance && (hdr.num_units_in_tick == 0 || hdr.time_scale == 0) {
                 return error(c);
             }
@@ -182,28 +182,27 @@ unsafe fn parse_seq_hdr(
             hdr.decoder_model_info_present = rav1d_get_bit(gb) as c_int;
             if hdr.decoder_model_info_present != 0 {
                 hdr.encoder_decoder_buffer_delay_length =
-                    (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1) as c_int;
-                hdr.num_units_in_decoding_tick = rav1d_get_bits(gb, 32 as c_int) as c_int;
+                    (rav1d_get_bits(gb, 5)).wrapping_add(1) as c_int;
+                hdr.num_units_in_decoding_tick = rav1d_get_bits(gb, 32) as c_int;
                 if c.strict_std_compliance && hdr.num_units_in_decoding_tick == 0 {
                     return error(c);
                 }
-                hdr.buffer_removal_delay_length =
-                    (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1) as c_int;
+                hdr.buffer_removal_delay_length = (rav1d_get_bits(gb, 5)).wrapping_add(1) as c_int;
                 hdr.frame_presentation_delay_length =
-                    (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1) as c_int;
+                    (rav1d_get_bits(gb, 5)).wrapping_add(1) as c_int;
             }
         }
         hdr.display_model_info_present = rav1d_get_bit(gb) as c_int;
-        hdr.num_operating_points = (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1) as c_int;
+        hdr.num_operating_points = (rav1d_get_bits(gb, 5)).wrapping_add(1) as c_int;
         let mut i = 0;
         while i < hdr.num_operating_points {
             let op = &mut hdr.operating_points[i as usize];
-            op.idc = rav1d_get_bits(gb, 12 as c_int) as c_int;
+            op.idc = rav1d_get_bits(gb, 12) as c_int;
             if op.idc != 0 && (op.idc & 0xff as c_int == 0 || op.idc & 0xf00 == 0) {
                 return error(c);
             }
-            op.major_level = (2 as c_uint).wrapping_add(rav1d_get_bits(gb, 3 as c_int)) as c_int;
-            op.minor_level = rav1d_get_bits(gb, 2 as c_int) as c_int;
+            op.major_level = (2 as c_uint).wrapping_add(rav1d_get_bits(gb, 3)) as c_int;
+            op.minor_level = rav1d_get_bits(gb, 2) as c_int;
             if op.major_level > 3 {
                 op.tier = rav1d_get_bit(gb) as c_int;
             }
@@ -222,7 +221,7 @@ unsafe fn parse_seq_hdr(
                 op.display_model_param_present = rav1d_get_bit(gb) as c_int;
             }
             op.initial_display_delay = (if op.display_model_param_present != 0 {
-                (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(1)
+                (rav1d_get_bits(gb, 4)).wrapping_add(1)
             } else {
                 10 as c_uint
             }) as c_int;
@@ -241,15 +240,15 @@ unsafe fn parse_seq_hdr(
     } else {
         false
     };
-    hdr.width_n_bits = (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(1) as c_int;
-    hdr.height_n_bits = (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(1) as c_int;
+    hdr.width_n_bits = (rav1d_get_bits(gb, 4)).wrapping_add(1) as c_int;
+    hdr.height_n_bits = (rav1d_get_bits(gb, 4)).wrapping_add(1) as c_int;
     hdr.max_width = (rav1d_get_bits(gb, hdr.width_n_bits)).wrapping_add(1) as c_int;
     hdr.max_height = (rav1d_get_bits(gb, hdr.height_n_bits)).wrapping_add(1) as c_int;
     if hdr.reduced_still_picture_header == 0 {
         hdr.frame_id_numbers_present = rav1d_get_bit(gb) as c_int;
         if hdr.frame_id_numbers_present != 0 {
-            hdr.delta_frame_id_n_bits = (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(2) as c_int;
-            hdr.frame_id_n_bits = (rav1d_get_bits(gb, 3 as c_int))
+            hdr.delta_frame_id_n_bits = (rav1d_get_bits(gb, 4)).wrapping_add(2) as c_int;
+            hdr.frame_id_n_bits = (rav1d_get_bits(gb, 3))
                 .wrapping_add(hdr.delta_frame_id_n_bits as c_uint)
                 .wrapping_add(1) as c_int;
         }
@@ -285,7 +284,7 @@ unsafe fn parse_seq_hdr(
             2 as c_uint
         }) as Dav1dAdaptiveBoolean;
         if hdr.order_hint != 0 {
-            hdr.order_hint_n_bits = (rav1d_get_bits(gb, 3 as c_int)).wrapping_add(1) as c_int;
+            hdr.order_hint_n_bits = (rav1d_get_bits(gb, 3)).wrapping_add(1) as c_int;
         }
     }
     hdr.super_res = rav1d_get_bit(gb) as c_int;
@@ -300,9 +299,9 @@ unsafe fn parse_seq_hdr(
     }
     hdr.color_description_present = rav1d_get_bit(gb) as c_int;
     if hdr.color_description_present != 0 {
-        hdr.pri = rav1d_get_bits(gb, 8 as c_int) as Dav1dColorPrimaries;
-        hdr.trc = rav1d_get_bits(gb, 8 as c_int) as Dav1dTransferCharacteristics;
-        hdr.mtrx = rav1d_get_bits(gb, 8 as c_int) as Dav1dMatrixCoefficients;
+        hdr.pri = rav1d_get_bits(gb, 8) as Dav1dColorPrimaries;
+        hdr.trc = rav1d_get_bits(gb, 8) as Dav1dTransferCharacteristics;
+        hdr.mtrx = rav1d_get_bits(gb, 8) as Dav1dMatrixCoefficients;
     } else {
         hdr.pri = RAV1D_COLOR_PRI_UNKNOWN;
         hdr.trc = RAV1D_TRC_UNKNOWN;
@@ -356,7 +355,7 @@ unsafe fn parse_seq_hdr(
             _ => {}
         }
         hdr.chr = (if hdr.ss_hor & hdr.ss_ver != 0 {
-            rav1d_get_bits(gb, 2 as c_int)
+            rav1d_get_bits(gb, 2)
         } else {
             RAV1D_CHR_UNKNOWN as c_int as c_uint
         }) as Dav1dChromaSamplePosition;
@@ -396,7 +395,7 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
                 hdr.super_res.enabled = (seqhdr.super_res != 0 && rav1d_get_bit(gb) != 0) as c_int;
                 if hdr.super_res.enabled != 0 {
                     hdr.super_res.width_scale_denominator =
-                        (9 as c_uint).wrapping_add(rav1d_get_bits(gb, 3 as c_int)) as c_int;
+                        (9 as c_uint).wrapping_add(rav1d_get_bits(gb, 3)) as c_int;
                     let d = hdr.super_res.width_scale_denominator;
                     hdr.width[0] = cmp::max(
                         (hdr.width[1] * 8 + (d >> 1)) / d,
@@ -421,7 +420,7 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
     hdr.super_res.enabled = (seqhdr.super_res != 0 && rav1d_get_bit(gb) != 0) as c_int;
     if hdr.super_res.enabled != 0 {
         hdr.super_res.width_scale_denominator =
-            (9 as c_uint).wrapping_add(rav1d_get_bits(gb, 3 as c_int)) as c_int;
+            (9 as c_uint).wrapping_add(rav1d_get_bits(gb, 3)) as c_int;
         let d = hdr.super_res.width_scale_denominator;
         hdr.width[0] = cmp::max(
             (hdr.width[1] * 8 + (d >> 1)) / d,
@@ -433,8 +432,8 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
     }
     hdr.have_render_size = rav1d_get_bit(gb) as c_int;
     if hdr.have_render_size != 0 {
-        hdr.render_width = (rav1d_get_bits(gb, 16 as c_int)).wrapping_add(1) as c_int;
-        hdr.render_height = (rav1d_get_bits(gb, 16 as c_int)).wrapping_add(1) as c_int;
+        hdr.render_width = (rav1d_get_bits(gb, 16)).wrapping_add(1) as c_int;
+        hdr.render_height = (rav1d_get_bits(gb, 16)).wrapping_add(1) as c_int;
     } else {
         hdr.render_width = hdr.width[1];
         hdr.render_height = hdr.height;
@@ -471,7 +470,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
     hdr.show_existing_frame =
         (seqhdr.reduced_still_picture_header == 0 && rav1d_get_bit(gb) != 0) as c_int;
     if hdr.show_existing_frame != 0 {
-        hdr.existing_frame_idx = rav1d_get_bits(gb, 3 as c_int) as c_int;
+        hdr.existing_frame_idx = rav1d_get_bits(gb, 3) as c_int;
         if seqhdr.decoder_model_info_present != 0 && seqhdr.equal_picture_interval == 0 {
             hdr.frame_presentation_delay =
                 rav1d_get_bits(gb, seqhdr.frame_presentation_delay_length) as c_int;
@@ -489,7 +488,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
     hdr.frame_type = (if seqhdr.reduced_still_picture_header != 0 {
         RAV1D_FRAME_TYPE_KEY as c_int as c_uint
     } else {
-        rav1d_get_bits(gb, 2 as c_int)
+        rav1d_get_bits(gb, 2)
     }) as Dav1dFrameType;
     hdr.show_frame = (seqhdr.reduced_still_picture_header != 0 || rav1d_get_bit(gb) != 0) as c_int;
     if hdr.show_frame != 0 {
@@ -544,7 +543,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
     }) as c_int;
     hdr.primary_ref_frame =
         (if hdr.error_resilient_mode == 0 && hdr.frame_type as c_uint & 1 as c_uint != 0 {
-            rav1d_get_bits(gb, 3 as c_int)
+            rav1d_get_bits(gb, 3)
         } else {
             7 as c_uint
         }) as c_int;
@@ -578,7 +577,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         {
             0xff as c_int as c_uint
         } else {
-            rav1d_get_bits(gb, 8 as c_int)
+            rav1d_get_bits(gb, 8)
         }) as c_int;
         if hdr.refresh_frame_flags != 0xff as c_int
             && hdr.error_resilient_mode != 0
@@ -596,7 +595,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         {
             return error(c);
         }
-        if read_frame_size(c, gb, 0 as c_int) < 0 {
+        if read_frame_size(c, gb, 0) < 0 {
             return error(c);
         }
         hdr.allow_intrabc = (hdr.allow_screen_content_tools != 0
@@ -609,7 +608,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             (if hdr.frame_type as c_uint == RAV1D_FRAME_TYPE_SWITCH as c_int as c_uint {
                 0xff as c_int as c_uint
             } else {
-                rav1d_get_bits(gb, 8 as c_int)
+                rav1d_get_bits(gb, 8)
             }) as c_int;
         if hdr.error_resilient_mode != 0 && seqhdr.order_hint != 0 {
             let mut i = 0;
@@ -620,10 +619,10 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         }
         hdr.frame_ref_short_signaling = (seqhdr.order_hint != 0 && rav1d_get_bit(gb) != 0) as c_int;
         if hdr.frame_ref_short_signaling != 0 {
-            hdr.refidx[0] = rav1d_get_bits(gb, 3 as c_int) as c_int;
+            hdr.refidx[0] = rav1d_get_bits(gb, 3) as c_int;
             hdr.refidx[2] = -(1);
             hdr.refidx[1] = hdr.refidx[2];
-            hdr.refidx[3] = rav1d_get_bits(gb, 3 as c_int) as c_int;
+            hdr.refidx[3] = rav1d_get_bits(gb, 3) as c_int;
             hdr.refidx[6] = -(1);
             hdr.refidx[5] = hdr.refidx[6];
             hdr.refidx[4] = hdr.refidx[5];
@@ -737,7 +736,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         let mut i = 0;
         while i < 7 {
             if hdr.frame_ref_short_signaling == 0 {
-                hdr.refidx[i as usize] = rav1d_get_bits(gb, 3 as c_int) as c_int;
+                hdr.refidx[i as usize] = rav1d_get_bits(gb, 3) as c_int;
             }
             if seqhdr.frame_id_numbers_present != 0 {
                 let delta_ref_frame_id_minus_1: c_int =
@@ -762,7 +761,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         hdr.subpel_filter_mode = (if rav1d_get_bit(gb) != 0 {
             RAV1D_FILTER_SWITCHABLE as c_int as c_uint
         } else {
-            rav1d_get_bits(gb, 2 as c_int)
+            rav1d_get_bits(gb, 2)
         }) as Dav1dFilterMode;
         hdr.switchable_motion_mode = rav1d_get_bit(gb) as c_int;
         hdr.use_ref_frame_mvs = (hdr.error_resilient_mode == 0
@@ -782,8 +781,8 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
     let max_tile_width_sb = 4096 >> sbsz_log2;
     let max_tile_area_sb = 4096 * 2304 >> 2 * sbsz_log2;
     hdr.tiling.min_log2_cols = tile_log2(max_tile_width_sb, sbw);
-    hdr.tiling.max_log2_cols = tile_log2(1 as c_int, cmp::min(sbw, 64 as c_int));
-    hdr.tiling.max_log2_rows = tile_log2(1 as c_int, cmp::min(sbh, 64 as c_int));
+    hdr.tiling.max_log2_cols = tile_log2(1 as c_int, cmp::min(sbw, 64));
+    hdr.tiling.max_log2_rows = tile_log2(1 as c_int, cmp::min(sbh, 64));
     let min_log2_tiles: c_int = cmp::max(
         tile_log2(max_tile_area_sb, sbw * sbh),
         hdr.tiling.min_log2_cols,
@@ -801,7 +800,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             sbx += tile_w;
             hdr.tiling.cols += 1;
         }
-        hdr.tiling.min_log2_rows = cmp::max(min_log2_tiles - hdr.tiling.log2_cols, 0 as c_int);
+        hdr.tiling.min_log2_rows = cmp::max(min_log2_tiles - hdr.tiling.log2_cols, 0);
         hdr.tiling.log2_rows = hdr.tiling.min_log2_rows;
         while hdr.tiling.log2_rows < hdr.tiling.max_log2_rows && rav1d_get_bit(gb) != 0 {
             hdr.tiling.log2_rows += 1;
@@ -835,7 +834,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         if min_log2_tiles != 0 {
             max_tile_area_sb >>= min_log2_tiles + 1;
         }
-        let max_tile_height_sb: c_int = cmp::max(max_tile_area_sb / widest_tile, 1 as c_int);
+        let max_tile_height_sb: c_int = cmp::max(max_tile_area_sb / widest_tile, 1);
         hdr.tiling.rows = 0 as c_int;
         let mut sby = 0;
         while sby < sbh && hdr.tiling.rows < 64 {
@@ -859,14 +858,14 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         if hdr.tiling.update >= hdr.tiling.cols * hdr.tiling.rows {
             return error(c);
         }
-        hdr.tiling.n_bytes = (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(1);
+        hdr.tiling.n_bytes = (rav1d_get_bits(gb, 2)).wrapping_add(1);
     } else {
         hdr.tiling.update = 0 as c_int;
         hdr.tiling.n_bytes = hdr.tiling.update as c_uint;
     }
-    hdr.quant.yac = rav1d_get_bits(gb, 8 as c_int) as c_int;
+    hdr.quant.yac = rav1d_get_bits(gb, 8) as c_int;
     hdr.quant.ydc_delta = if rav1d_get_bit(gb) != 0 {
-        rav1d_get_sbits(gb, 7 as c_int)
+        rav1d_get_sbits(gb, 7)
     } else {
         0 as c_int
     };
@@ -877,23 +876,23 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             0 as c_uint
         }) as c_int;
         hdr.quant.udc_delta = if rav1d_get_bit(gb) != 0 {
-            rav1d_get_sbits(gb, 7 as c_int)
+            rav1d_get_sbits(gb, 7)
         } else {
             0 as c_int
         };
         hdr.quant.uac_delta = if rav1d_get_bit(gb) != 0 {
-            rav1d_get_sbits(gb, 7 as c_int)
+            rav1d_get_sbits(gb, 7)
         } else {
             0 as c_int
         };
         if diff_uv_delta != 0 {
             hdr.quant.vdc_delta = if rav1d_get_bit(gb) != 0 {
-                rav1d_get_sbits(gb, 7 as c_int)
+                rav1d_get_sbits(gb, 7)
             } else {
                 0 as c_int
             };
             hdr.quant.vac_delta = if rav1d_get_bit(gb) != 0 {
-                rav1d_get_sbits(gb, 7 as c_int)
+                rav1d_get_sbits(gb, 7)
             } else {
                 0 as c_int
             };
@@ -904,10 +903,10 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
     }
     hdr.quant.qm = rav1d_get_bit(gb) as c_int;
     if hdr.quant.qm != 0 {
-        hdr.quant.qm_y = rav1d_get_bits(gb, 4 as c_int) as c_int;
-        hdr.quant.qm_u = rav1d_get_bits(gb, 4 as c_int) as c_int;
+        hdr.quant.qm_y = rav1d_get_bits(gb, 4) as c_int;
+        hdr.quant.qm_u = rav1d_get_bits(gb, 4) as c_int;
         hdr.quant.qm_v = if seqhdr.separate_uv_delta_q != 0 {
-            rav1d_get_bits(gb, 4 as c_int) as c_int
+            rav1d_get_bits(gb, 4) as c_int
         } else {
             hdr.quant.qm_u
         };
@@ -937,37 +936,37 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                     .offset(i as isize)
                     as *mut Rav1dSegmentationData;
                 if rav1d_get_bit(gb) != 0 {
-                    (*seg).delta_q = rav1d_get_sbits(gb, 9 as c_int);
+                    (*seg).delta_q = rav1d_get_sbits(gb, 9);
                     hdr.segmentation.seg_data.last_active_segid = i;
                 } else {
                     (*seg).delta_q = 0 as c_int;
                 }
                 if rav1d_get_bit(gb) != 0 {
-                    (*seg).delta_lf_y_v = rav1d_get_sbits(gb, 7 as c_int);
+                    (*seg).delta_lf_y_v = rav1d_get_sbits(gb, 7);
                     hdr.segmentation.seg_data.last_active_segid = i;
                 } else {
                     (*seg).delta_lf_y_v = 0 as c_int;
                 }
                 if rav1d_get_bit(gb) != 0 {
-                    (*seg).delta_lf_y_h = rav1d_get_sbits(gb, 7 as c_int);
+                    (*seg).delta_lf_y_h = rav1d_get_sbits(gb, 7);
                     hdr.segmentation.seg_data.last_active_segid = i;
                 } else {
                     (*seg).delta_lf_y_h = 0 as c_int;
                 }
                 if rav1d_get_bit(gb) != 0 {
-                    (*seg).delta_lf_u = rav1d_get_sbits(gb, 7 as c_int);
+                    (*seg).delta_lf_u = rav1d_get_sbits(gb, 7);
                     hdr.segmentation.seg_data.last_active_segid = i;
                 } else {
                     (*seg).delta_lf_u = 0 as c_int;
                 }
                 if rav1d_get_bit(gb) != 0 {
-                    (*seg).delta_lf_v = rav1d_get_sbits(gb, 7 as c_int);
+                    (*seg).delta_lf_v = rav1d_get_sbits(gb, 7);
                     hdr.segmentation.seg_data.last_active_segid = i;
                 } else {
                     (*seg).delta_lf_v = 0 as c_int;
                 }
                 if rav1d_get_bit(gb) != 0 {
-                    (*seg).r#ref = rav1d_get_bits(gb, 3 as c_int) as c_int;
+                    (*seg).r#ref = rav1d_get_bits(gb, 3) as c_int;
                     hdr.segmentation.seg_data.last_active_segid = i;
                     hdr.segmentation.seg_data.preskip = 1 as c_int;
                 } else {
@@ -1014,14 +1013,14 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         0 as c_uint
     }) as c_int;
     hdr.delta.q.res_log2 = (if hdr.delta.q.present != 0 {
-        rav1d_get_bits(gb, 2 as c_int)
+        rav1d_get_bits(gb, 2)
     } else {
         0 as c_uint
     }) as c_int;
     hdr.delta.lf.present =
         (hdr.delta.q.present != 0 && hdr.allow_intrabc == 0 && rav1d_get_bit(gb) != 0) as c_int;
     hdr.delta.lf.res_log2 = (if hdr.delta.lf.present != 0 {
-        rav1d_get_bits(gb, 2 as c_int)
+        rav1d_get_bits(gb, 2)
     } else {
         0 as c_uint
     }) as c_int;
@@ -1058,15 +1057,15 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         hdr.loopfilter.mode_ref_delta_update = 1 as c_int;
         hdr.loopfilter.mode_ref_deltas = default_mode_ref_deltas.clone();
     } else {
-        hdr.loopfilter.level_y[0] = rav1d_get_bits(gb, 6 as c_int) as c_int;
-        hdr.loopfilter.level_y[1] = rav1d_get_bits(gb, 6 as c_int) as c_int;
+        hdr.loopfilter.level_y[0] = rav1d_get_bits(gb, 6) as c_int;
+        hdr.loopfilter.level_y[1] = rav1d_get_bits(gb, 6) as c_int;
         if seqhdr.monochrome == 0
             && (hdr.loopfilter.level_y[0] != 0 || hdr.loopfilter.level_y[1] != 0)
         {
-            hdr.loopfilter.level_u = rav1d_get_bits(gb, 6 as c_int) as c_int;
-            hdr.loopfilter.level_v = rav1d_get_bits(gb, 6 as c_int) as c_int;
+            hdr.loopfilter.level_u = rav1d_get_bits(gb, 6) as c_int;
+            hdr.loopfilter.level_v = rav1d_get_bits(gb, 6) as c_int;
         }
-        hdr.loopfilter.sharpness = rav1d_get_bits(gb, 3 as c_int) as c_int;
+        hdr.loopfilter.sharpness = rav1d_get_bits(gb, 3) as c_int;
         if hdr.primary_ref_frame == 7 {
             hdr.loopfilter.mode_ref_deltas = default_mode_ref_deltas.clone();
         } else {
@@ -1087,7 +1086,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 while i < 8 {
                     if rav1d_get_bit(gb) != 0 {
                         hdr.loopfilter.mode_ref_deltas.ref_delta[i as usize] =
-                            rav1d_get_sbits(gb, 7 as c_int);
+                            rav1d_get_sbits(gb, 7);
                     }
                     i += 1;
                 }
@@ -1095,7 +1094,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 while i < 2 {
                     if rav1d_get_bit(gb) != 0 {
                         hdr.loopfilter.mode_ref_deltas.mode_delta[i as usize] =
-                            rav1d_get_sbits(gb, 7 as c_int);
+                            rav1d_get_sbits(gb, 7);
                     }
                     i += 1;
                 }
@@ -1103,13 +1102,13 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         }
     }
     if hdr.all_lossless == 0 && seqhdr.cdef != 0 && hdr.allow_intrabc == 0 {
-        hdr.cdef.damping = (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(3) as c_int;
-        hdr.cdef.n_bits = rav1d_get_bits(gb, 2 as c_int) as c_int;
+        hdr.cdef.damping = (rav1d_get_bits(gb, 2)).wrapping_add(3) as c_int;
+        hdr.cdef.n_bits = rav1d_get_bits(gb, 2) as c_int;
         let mut i = 0;
         while i < (1) << hdr.cdef.n_bits {
-            hdr.cdef.y_strength[i as usize] = rav1d_get_bits(gb, 6 as c_int) as c_int;
+            hdr.cdef.y_strength[i as usize] = rav1d_get_bits(gb, 6) as c_int;
             if seqhdr.monochrome == 0 {
-                hdr.cdef.uv_strength[i as usize] = rav1d_get_bits(gb, 6 as c_int) as c_int;
+                hdr.cdef.uv_strength[i as usize] = rav1d_get_bits(gb, 6) as c_int;
             }
             i += 1;
         }
@@ -1122,10 +1121,10 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         && seqhdr.restoration != 0
         && hdr.allow_intrabc == 0
     {
-        hdr.restoration.r#type[0] = rav1d_get_bits(gb, 2 as c_int) as Rav1dRestorationType;
+        hdr.restoration.r#type[0] = rav1d_get_bits(gb, 2) as Rav1dRestorationType;
         if seqhdr.monochrome == 0 {
-            hdr.restoration.r#type[1] = rav1d_get_bits(gb, 2 as c_int) as Rav1dRestorationType;
-            hdr.restoration.r#type[2] = rav1d_get_bits(gb, 2 as c_int) as Rav1dRestorationType;
+            hdr.restoration.r#type[1] = rav1d_get_bits(gb, 2) as Rav1dRestorationType;
+            hdr.restoration.r#type[2] = rav1d_get_bits(gb, 2) as Rav1dRestorationType;
         } else {
             hdr.restoration.r#type[2] = RAV1D_RESTORATION_NONE;
             hdr.restoration.r#type[1] = hdr.restoration.r#type[2];
@@ -1309,8 +1308,8 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                             *ref_mat.offset(2) - ((1) << 16) >> 1,
                             12 as c_uint,
                         );
-                    *mat.offset(3) = 2 as c_int
-                        * rav1d_get_bits_subexp(gb, *ref_mat.offset(3) >> 1, 12 as c_uint);
+                    *mat.offset(3) =
+                        2 as c_int * rav1d_get_bits_subexp(gb, *ref_mat.offset(3) >> 1, 12);
                     bits = 12 as c_int;
                     shift = 10 as c_int;
                 } else {
@@ -1318,8 +1317,8 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                     shift = 13 + (hdr.hp == 0) as c_int;
                 }
                 if hdr.gmv[i as usize].r#type as c_uint == RAV1D_WM_TYPE_AFFINE as c_int as c_uint {
-                    *mat.offset(4) = 2 as c_int
-                        * rav1d_get_bits_subexp(gb, *ref_mat.offset(4) >> 1, 12 as c_uint);
+                    *mat.offset(4) =
+                        2 as c_int * rav1d_get_bits_subexp(gb, *ref_mat.offset(4) >> 1, 12);
                     *mat.offset(5) = ((1) << 16)
                         + 2 * rav1d_get_bits_subexp(
                             gb,
@@ -1344,12 +1343,12 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         && (hdr.show_frame != 0 || hdr.showable_frame != 0)
         && rav1d_get_bit(gb) != 0) as c_int;
     if hdr.film_grain.present != 0 {
-        let seed: c_uint = rav1d_get_bits(gb, 16 as c_int);
+        let seed: c_uint = rav1d_get_bits(gb, 16);
         hdr.film_grain.update = (hdr.frame_type as c_uint
             != RAV1D_FRAME_TYPE_INTER as c_int as c_uint
             || rav1d_get_bit(gb) != 0) as c_int;
         if hdr.film_grain.update == 0 {
-            let refidx: c_int = rav1d_get_bits(gb, 3 as c_int) as c_int;
+            let refidx: c_int = rav1d_get_bits(gb, 3) as c_int;
             let mut i: c_int;
             i = 0 as c_int;
             while i < 7 {
@@ -1369,20 +1368,20 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         } else {
             let fgd = &mut hdr.film_grain.data;
             fgd.seed = seed;
-            fgd.num_y_points = rav1d_get_bits(gb, 4 as c_int) as c_int;
+            fgd.num_y_points = rav1d_get_bits(gb, 4) as c_int;
             if fgd.num_y_points > 14 {
                 return error(c);
             }
             let mut i = 0;
             while i < fgd.num_y_points {
-                fgd.y_points[i as usize][0] = rav1d_get_bits(gb, 8 as c_int) as u8;
+                fgd.y_points[i as usize][0] = rav1d_get_bits(gb, 8) as u8;
                 if i != 0
                     && fgd.y_points[(i - 1) as usize][0] as c_int
                         >= fgd.y_points[i as usize][0] as c_int
                 {
                     return error(c);
                 }
-                fgd.y_points[i as usize][1] = rav1d_get_bits(gb, 8 as c_int) as u8;
+                fgd.y_points[i as usize][1] = rav1d_get_bits(gb, 8) as u8;
                 i += 1;
             }
             fgd.chroma_scaling_from_luma = seqhdr.monochrome == 0 && rav1d_get_bit(gb) != 0;
@@ -1395,22 +1394,20 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             } else {
                 let mut pl = 0;
                 while pl < 2 {
-                    fgd.num_uv_points[pl as usize] = rav1d_get_bits(gb, 4 as c_int) as c_int;
+                    fgd.num_uv_points[pl as usize] = rav1d_get_bits(gb, 4) as c_int;
                     if fgd.num_uv_points[pl as usize] > 10 {
                         return error(c);
                     }
                     let mut i = 0;
                     while i < fgd.num_uv_points[pl as usize] {
-                        fgd.uv_points[pl as usize][i as usize][0] =
-                            rav1d_get_bits(gb, 8 as c_int) as u8;
+                        fgd.uv_points[pl as usize][i as usize][0] = rav1d_get_bits(gb, 8) as u8;
                         if i != 0
                             && fgd.uv_points[pl as usize][(i - 1) as usize][0] as c_int
                                 >= fgd.uv_points[pl as usize][i as usize][0] as c_int
                         {
                             return error(c);
                         }
-                        fgd.uv_points[pl as usize][i as usize][1] =
-                            rav1d_get_bits(gb, 8 as c_int) as u8;
+                        fgd.uv_points[pl as usize][i as usize][1] = rav1d_get_bits(gb, 8) as u8;
                         i += 1;
                     }
                     pl += 1;
@@ -1422,14 +1419,13 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             {
                 return error(c);
             }
-            fgd.scaling_shift = (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(8) as u8;
-            fgd.ar_coeff_lag = rav1d_get_bits(gb, 2 as c_int) as c_int;
+            fgd.scaling_shift = (rav1d_get_bits(gb, 2)).wrapping_add(8) as u8;
+            fgd.ar_coeff_lag = rav1d_get_bits(gb, 2) as c_int;
             let num_y_pos = 2 * fgd.ar_coeff_lag * (fgd.ar_coeff_lag + 1);
             if fgd.num_y_points != 0 {
                 let mut i = 0;
                 while i < num_y_pos {
-                    fgd.ar_coeffs_y[i as usize] =
-                        (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128) as i8;
+                    fgd.ar_coeffs_y[i as usize] = (rav1d_get_bits(gb, 8)).wrapping_sub(128) as i8;
                     i += 1;
                 }
             }
@@ -1440,7 +1436,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                     let mut i = 0;
                     while i < num_uv_pos {
                         fgd.ar_coeffs_uv[pl as usize][i as usize] =
-                            (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128) as i8;
+                            (rav1d_get_bits(gb, 8)).wrapping_sub(128) as i8;
                         i += 1;
                     }
                     if fgd.num_y_points == 0 {
@@ -1449,17 +1445,15 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 }
                 pl += 1;
             }
-            fgd.ar_coeff_shift = (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(6) as u8;
-            fgd.grain_scale_shift = rav1d_get_bits(gb, 2 as c_int) as u8;
+            fgd.ar_coeff_shift = (rav1d_get_bits(gb, 2)).wrapping_add(6) as u8;
+            fgd.grain_scale_shift = rav1d_get_bits(gb, 2) as u8;
             let mut pl = 0;
             while pl < 2 {
                 if fgd.num_uv_points[pl as usize] != 0 {
-                    fgd.uv_mult[pl as usize] =
-                        (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128) as c_int;
+                    fgd.uv_mult[pl as usize] = (rav1d_get_bits(gb, 8)).wrapping_sub(128) as c_int;
                     fgd.uv_luma_mult[pl as usize] =
-                        (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128) as c_int;
-                    fgd.uv_offset[pl as usize] =
-                        (rav1d_get_bits(gb, 9 as c_int)).wrapping_sub(256) as c_int;
+                        (rav1d_get_bits(gb, 8)).wrapping_sub(128) as c_int;
+                    fgd.uv_offset[pl as usize] = (rav1d_get_bits(gb, 9)).wrapping_sub(256) as c_int;
                 }
                 pl += 1;
             }
@@ -1568,16 +1562,16 @@ pub(crate) unsafe fn rav1d_parse_obus(
     };
     rav1d_init_get_bits(&mut gb, r#in.data, r#in.sz);
     rav1d_get_bit(&mut gb);
-    let r#type: Rav1dObuType = rav1d_get_bits(&mut gb, 4 as c_int) as Rav1dObuType;
+    let r#type: Rav1dObuType = rav1d_get_bits(&mut gb, 4) as Rav1dObuType;
     let has_extension: c_int = rav1d_get_bit(&mut gb) as c_int;
     let has_length_field: c_int = rav1d_get_bit(&mut gb) as c_int;
     rav1d_get_bit(&mut gb);
     let mut temporal_id = 0;
     let mut spatial_id = 0;
     if has_extension != 0 {
-        temporal_id = rav1d_get_bits(&mut gb, 3 as c_int) as c_int;
-        spatial_id = rav1d_get_bits(&mut gb, 2 as c_int) as c_int;
-        rav1d_get_bits(&mut gb, 3 as c_int);
+        temporal_id = rav1d_get_bits(&mut gb, 3) as c_int;
+        spatial_id = rav1d_get_bits(&mut gb, 2) as c_int;
+        rav1d_get_bits(&mut gb, 3);
     }
     let len: c_uint = if has_length_field != 0 {
         rav1d_get_uleb128(&mut gb)
@@ -1697,10 +1691,9 @@ pub(crate) unsafe fn rav1d_parse_obus(
                     }
                     let content_light: *mut Rav1dContentLightLevel =
                         (*r#ref).data as *mut Rav1dContentLightLevel;
-                    (*content_light).max_content_light_level =
-                        rav1d_get_bits(&mut gb, 16 as c_int) as c_int;
+                    (*content_light).max_content_light_level = rav1d_get_bits(&mut gb, 16) as c_int;
                     (*content_light).max_frame_average_light_level =
-                        rav1d_get_bits(&mut gb, 16 as c_int) as c_int;
+                        rav1d_get_bits(&mut gb, 16) as c_int;
                     rav1d_get_bit(&mut gb);
                     rav1d_bytealign_get_bits(&mut gb);
                     if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
@@ -1722,17 +1715,15 @@ pub(crate) unsafe fn rav1d_parse_obus(
                     let mut i = 0;
                     while i < 3 {
                         (*mastering_display).primaries[i as usize][0] =
-                            rav1d_get_bits(&mut gb, 16 as c_int) as u16;
+                            rav1d_get_bits(&mut gb, 16) as u16;
                         (*mastering_display).primaries[i as usize][1] =
-                            rav1d_get_bits(&mut gb, 16 as c_int) as u16;
+                            rav1d_get_bits(&mut gb, 16) as u16;
                         i += 1;
                     }
-                    (*mastering_display).white_point[0] =
-                        rav1d_get_bits(&mut gb, 16 as c_int) as u16;
-                    (*mastering_display).white_point[1] =
-                        rav1d_get_bits(&mut gb, 16 as c_int) as u16;
-                    (*mastering_display).max_luminance = rav1d_get_bits(&mut gb, 32 as c_int);
-                    (*mastering_display).min_luminance = rav1d_get_bits(&mut gb, 32 as c_int);
+                    (*mastering_display).white_point[0] = rav1d_get_bits(&mut gb, 16) as u16;
+                    (*mastering_display).white_point[1] = rav1d_get_bits(&mut gb, 16) as u16;
+                    (*mastering_display).max_luminance = rav1d_get_bits(&mut gb, 32);
+                    (*mastering_display).min_luminance = rav1d_get_bits(&mut gb, 32);
                     rav1d_get_bit(&mut gb);
                     rav1d_bytealign_get_bits(&mut gb);
                     if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
@@ -1757,10 +1748,10 @@ pub(crate) unsafe fn rav1d_parse_obus(
                     payload_size -= 1;
                     payload_size -= meta_type_len;
                     let mut country_code_extension_byte = 0;
-                    let country_code: c_int = rav1d_get_bits(&mut gb, 8 as c_int) as c_int;
+                    let country_code: c_int = rav1d_get_bits(&mut gb, 8) as c_int;
                     payload_size -= 1;
                     if country_code == 0xff as c_int {
-                        country_code_extension_byte = rav1d_get_bits(&mut gb, 8 as c_int) as c_int;
+                        country_code_extension_byte = rav1d_get_bits(&mut gb, 8) as c_int;
                         payload_size -= 1;
                     }
                     if payload_size <= 0 {
@@ -1795,7 +1786,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                         let mut i = 0;
                         while i < payload_size {
                             *((*itut_t35_metadata).payload).offset(i as isize) =
-                                rav1d_get_bits(&mut gb, 8 as c_int) as u8;
+                                rav1d_get_bits(&mut gb, 8) as u8;
                             i += 1;
                         }
                         (*itut_t35_metadata).payload_size = payload_size as usize;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -159,10 +159,10 @@ unsafe fn parse_seq_hdr(
         return error(c);
     }
     if hdr.reduced_still_picture_header != 0 {
-        hdr.num_operating_points = 1 as c_int;
+        hdr.num_operating_points = 1;
         hdr.operating_points[0].major_level = rav1d_get_bits(gb, 3) as c_int;
         hdr.operating_points[0].minor_level = rav1d_get_bits(gb, 2) as c_int;
-        hdr.operating_points[0].initial_display_delay = 10 as c_int;
+        hdr.operating_points[0].initial_display_delay = 10;
     } else {
         hdr.timing_info_present = rav1d_get_bit(gb) as c_int;
         if hdr.timing_info_present != 0 {
@@ -310,7 +310,7 @@ unsafe fn parse_seq_hdr(
     if hdr.monochrome != 0 {
         hdr.color_range = rav1d_get_bit(gb) as c_int;
         hdr.layout = Rav1dPixelLayout::I400;
-        hdr.ss_ver = 1 as c_int;
+        hdr.ss_ver = 1;
         hdr.ss_hor = hdr.ss_ver;
         hdr.chr = RAV1D_CHR_UNKNOWN;
     } else if hdr.pri as c_uint == RAV1D_COLOR_PRI_BT709 as c_uint
@@ -318,7 +318,7 @@ unsafe fn parse_seq_hdr(
         && hdr.mtrx as c_uint == RAV1D_MC_IDENTITY as c_int as c_uint
     {
         hdr.layout = Rav1dPixelLayout::I444;
-        hdr.color_range = 1 as c_int;
+        hdr.color_range = 1;
         if hdr.profile != 1 && !(hdr.profile == 2 && hdr.hbd == 2) {
             return error(c);
         }
@@ -327,7 +327,7 @@ unsafe fn parse_seq_hdr(
         match hdr.profile {
             0 => {
                 hdr.layout = Rav1dPixelLayout::I420;
-                hdr.ss_ver = 1 as c_int;
+                hdr.ss_ver = 1;
                 hdr.ss_hor = hdr.ss_ver;
             }
             1 => {
@@ -340,7 +340,7 @@ unsafe fn parse_seq_hdr(
                         hdr.ss_ver = rav1d_get_bit(gb) as c_int;
                     }
                 } else {
-                    hdr.ss_hor = 1 as c_int;
+                    hdr.ss_hor = 1;
                 }
                 hdr.layout = if hdr.ss_hor != 0 {
                     if hdr.ss_ver != 0 {
@@ -402,7 +402,7 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
                         cmp::min(16 as c_int, hdr.width[1]),
                     );
                 } else {
-                    hdr.super_res.width_scale_denominator = 8 as c_int;
+                    hdr.super_res.width_scale_denominator = 8;
                     hdr.width[0] = hdr.width[1];
                 }
                 return 0 as c_int;
@@ -427,7 +427,7 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
             cmp::min(16 as c_int, hdr.width[1]),
         );
     } else {
-        hdr.super_res.width_scale_denominator = 8 as c_int;
+        hdr.super_res.width_scale_denominator = 8;
         hdr.width[0] = hdr.width[1];
     }
     hdr.have_render_size = rav1d_get_bit(gb) as c_int;
@@ -444,7 +444,7 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
 #[inline]
 unsafe fn tile_log2(sz: c_int, tgt: c_int) -> c_int {
     let mut k;
-    k = 0 as c_int;
+    k = 0;
     while sz << k < tgt {
         k += 1;
     }
@@ -521,10 +521,10 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 seqhdr.force_integer_mv as c_uint
             }) as c_int;
     } else {
-        hdr.force_integer_mv = 0 as c_int;
+        hdr.force_integer_mv = 0;
     }
     if hdr.frame_type as c_uint & 1 as c_uint == 0 {
-        hdr.force_integer_mv = 1 as c_int;
+        hdr.force_integer_mv = 1;
     }
     if seqhdr.frame_id_numbers_present != 0 {
         hdr.frame_id = rav1d_get_bits(gb, seqhdr.frame_id_n_bits) as c_int;
@@ -601,9 +601,9 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         hdr.allow_intrabc = (hdr.allow_screen_content_tools != 0
             && hdr.super_res.enabled == 0
             && rav1d_get_bit(gb) != 0) as c_int;
-        hdr.use_ref_frame_mvs = 0 as c_int;
+        hdr.use_ref_frame_mvs = 0;
     } else {
-        hdr.allow_intrabc = 0 as c_int;
+        hdr.allow_intrabc = 0;
         hdr.refresh_frame_flags =
             (if hdr.frame_type as c_uint == RAV1D_FRAME_TYPE_SWITCH as c_int as c_uint {
                 0xff as c_int as c_uint
@@ -642,8 +642,8 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 i += 1;
             }
             let mut used_frame: [c_int; 8] = [0 as c_int, 0, 0, 0, 0, 0, 0, 0];
-            used_frame[hdr.refidx[0] as usize] = 1 as c_int;
-            used_frame[hdr.refidx[3] as usize] = 1 as c_int;
+            used_frame[hdr.refidx[0] as usize] = 1;
+            used_frame[hdr.refidx[3] as usize] = 1;
             let mut latest_frame_offset: c_int = -(1);
             let mut i = 0;
             while i < 8 {
@@ -658,7 +658,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 i += 1;
             }
             if latest_frame_offset != -(1) {
-                used_frame[hdr.refidx[6] as usize] = 1 as c_int;
+                used_frame[hdr.refidx[6] as usize] = 1;
             }
             let mut earliest_frame_offset = i32::MAX;
             let mut i = 0;
@@ -674,7 +674,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 i += 1;
             }
             if earliest_frame_offset != i32::MAX {
-                used_frame[hdr.refidx[4] as usize] = 1 as c_int;
+                used_frame[hdr.refidx[4] as usize] = 1;
             }
             earliest_frame_offset = i32::MAX;
             let mut i = 0;
@@ -690,7 +690,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 i += 1;
             }
             if earliest_frame_offset != i32::MAX {
-                used_frame[hdr.refidx[5] as usize] = 1 as c_int;
+                used_frame[hdr.refidx[5] as usize] = 1;
             }
             let mut i = 1;
             while i < 7 {
@@ -709,7 +709,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                         j += 1;
                     }
                     if latest_frame_offset != -(1) {
-                        used_frame[hdr.refidx[i as usize] as usize] = 1 as c_int;
+                        used_frame[hdr.refidx[i as usize] as usize] = 1;
                     }
                 }
                 i += 1;
@@ -793,7 +793,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             hdr.tiling.log2_cols += 1;
         }
         let tile_w = 1 + (sbw - 1 >> hdr.tiling.log2_cols);
-        hdr.tiling.cols = 0 as c_int;
+        hdr.tiling.cols = 0;
         let mut sbx = 0;
         while sbx < sbw {
             hdr.tiling.col_start_sb[hdr.tiling.cols as usize] = sbx as u16;
@@ -806,7 +806,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             hdr.tiling.log2_rows += 1;
         }
         let tile_h = 1 + (sbh - 1 >> hdr.tiling.log2_rows);
-        hdr.tiling.rows = 0 as c_int;
+        hdr.tiling.rows = 0;
         let mut sby = 0;
         while sby < sbh {
             hdr.tiling.row_start_sb[hdr.tiling.rows as usize] = sby as u16;
@@ -814,7 +814,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             hdr.tiling.rows += 1;
         }
     } else {
-        hdr.tiling.cols = 0 as c_int;
+        hdr.tiling.cols = 0;
         let mut widest_tile = 0;
         let mut max_tile_area_sb: c_int = sbw * sbh;
         let mut sbx = 0;
@@ -835,7 +835,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             max_tile_area_sb >>= min_log2_tiles + 1;
         }
         let max_tile_height_sb: c_int = cmp::max(max_tile_area_sb / widest_tile, 1);
-        hdr.tiling.rows = 0 as c_int;
+        hdr.tiling.rows = 0;
         let mut sby = 0;
         while sby < sbh && hdr.tiling.rows < 64 {
             let tile_height_sb: c_int = cmp::min(sbh - sby, max_tile_height_sb);
@@ -860,7 +860,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         }
         hdr.tiling.n_bytes = (rav1d_get_bits(gb, 2)).wrapping_add(1);
     } else {
-        hdr.tiling.update = 0 as c_int;
+        hdr.tiling.update = 0;
         hdr.tiling.n_bytes = hdr.tiling.update as c_uint;
     }
     hdr.quant.yac = rav1d_get_bits(gb, 8) as c_int;
@@ -914,9 +914,9 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
     hdr.segmentation.enabled = rav1d_get_bit(gb) as c_int;
     if hdr.segmentation.enabled != 0 {
         if hdr.primary_ref_frame == 7 {
-            hdr.segmentation.update_map = 1 as c_int;
-            hdr.segmentation.temporal = 0 as c_int;
-            hdr.segmentation.update_data = 1 as c_int;
+            hdr.segmentation.update_map = 1;
+            hdr.segmentation.temporal = 0;
+            hdr.segmentation.update_data = 1;
         } else {
             hdr.segmentation.update_map = rav1d_get_bit(gb) as c_int;
             hdr.segmentation.temporal = (if hdr.segmentation.update_map != 0 {
@@ -927,7 +927,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             hdr.segmentation.update_data = rav1d_get_bit(gb) as c_int;
         }
         if hdr.segmentation.update_data != 0 {
-            hdr.segmentation.seg_data.preskip = 0 as c_int;
+            hdr.segmentation.seg_data.preskip = 0;
             hdr.segmentation.seg_data.last_active_segid = -(1);
             let mut i = 0;
             while i < 8 {
@@ -939,48 +939,48 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                     (*seg).delta_q = rav1d_get_sbits(gb, 9);
                     hdr.segmentation.seg_data.last_active_segid = i;
                 } else {
-                    (*seg).delta_q = 0 as c_int;
+                    (*seg).delta_q = 0;
                 }
                 if rav1d_get_bit(gb) != 0 {
                     (*seg).delta_lf_y_v = rav1d_get_sbits(gb, 7);
                     hdr.segmentation.seg_data.last_active_segid = i;
                 } else {
-                    (*seg).delta_lf_y_v = 0 as c_int;
+                    (*seg).delta_lf_y_v = 0;
                 }
                 if rav1d_get_bit(gb) != 0 {
                     (*seg).delta_lf_y_h = rav1d_get_sbits(gb, 7);
                     hdr.segmentation.seg_data.last_active_segid = i;
                 } else {
-                    (*seg).delta_lf_y_h = 0 as c_int;
+                    (*seg).delta_lf_y_h = 0;
                 }
                 if rav1d_get_bit(gb) != 0 {
                     (*seg).delta_lf_u = rav1d_get_sbits(gb, 7);
                     hdr.segmentation.seg_data.last_active_segid = i;
                 } else {
-                    (*seg).delta_lf_u = 0 as c_int;
+                    (*seg).delta_lf_u = 0;
                 }
                 if rav1d_get_bit(gb) != 0 {
                     (*seg).delta_lf_v = rav1d_get_sbits(gb, 7);
                     hdr.segmentation.seg_data.last_active_segid = i;
                 } else {
-                    (*seg).delta_lf_v = 0 as c_int;
+                    (*seg).delta_lf_v = 0;
                 }
                 if rav1d_get_bit(gb) != 0 {
                     (*seg).r#ref = rav1d_get_bits(gb, 3) as c_int;
                     hdr.segmentation.seg_data.last_active_segid = i;
-                    hdr.segmentation.seg_data.preskip = 1 as c_int;
+                    hdr.segmentation.seg_data.preskip = 1;
                 } else {
                     (*seg).r#ref = -(1);
                 }
                 (*seg).skip = rav1d_get_bit(gb) as c_int;
                 if (*seg).skip != 0 {
                     hdr.segmentation.seg_data.last_active_segid = i;
-                    hdr.segmentation.seg_data.preskip = 1 as c_int;
+                    hdr.segmentation.seg_data.preskip = 1;
                 }
                 (*seg).globalmv = rav1d_get_bit(gb) as c_int;
                 if (*seg).globalmv != 0 {
                     hdr.segmentation.seg_data.last_active_segid = i;
-                    hdr.segmentation.seg_data.preskip = 1 as c_int;
+                    hdr.segmentation.seg_data.preskip = 1;
                 }
                 i += 1;
             }
@@ -1034,7 +1034,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         && hdr.quant.uac_delta == 0
         && hdr.quant.vdc_delta == 0
         && hdr.quant.vac_delta == 0) as c_int;
-    hdr.all_lossless = 1 as c_int;
+    hdr.all_lossless = 1;
     let mut i = 0;
     while i < 8 {
         hdr.segmentation.qidx[i as usize] = if hdr.segmentation.enabled != 0 {
@@ -1048,13 +1048,13 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         i += 1;
     }
     if hdr.all_lossless != 0 || hdr.allow_intrabc != 0 {
-        hdr.loopfilter.level_y[1] = 0 as c_int;
+        hdr.loopfilter.level_y[1] = 0;
         hdr.loopfilter.level_y[0] = hdr.loopfilter.level_y[1];
-        hdr.loopfilter.level_v = 0 as c_int;
+        hdr.loopfilter.level_v = 0;
         hdr.loopfilter.level_u = hdr.loopfilter.level_v;
-        hdr.loopfilter.sharpness = 0 as c_int;
-        hdr.loopfilter.mode_ref_delta_enabled = 1 as c_int;
-        hdr.loopfilter.mode_ref_delta_update = 1 as c_int;
+        hdr.loopfilter.sharpness = 0;
+        hdr.loopfilter.mode_ref_delta_enabled = 1;
+        hdr.loopfilter.mode_ref_delta_update = 1;
         hdr.loopfilter.mode_ref_deltas = default_mode_ref_deltas.clone();
     } else {
         hdr.loopfilter.level_y[0] = rav1d_get_bits(gb, 6) as c_int;
@@ -1113,9 +1113,9 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             i += 1;
         }
     } else {
-        hdr.cdef.n_bits = 0 as c_int;
-        hdr.cdef.y_strength[0] = 0 as c_int;
-        hdr.cdef.uv_strength[0] = 0 as c_int;
+        hdr.cdef.n_bits = 0;
+        hdr.cdef.y_strength[0] = 0;
+        hdr.cdef.uv_strength[0] = 0;
     }
     if (hdr.all_lossless == 0 || hdr.super_res.enabled != 0)
         && seqhdr.restoration != 0
@@ -1153,7 +1153,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                     as c_int as c_int;
             }
         } else {
-            hdr.restoration.unit_size[0] = 8 as c_int;
+            hdr.restoration.unit_size[0] = 8;
         }
     } else {
         hdr.restoration.r#type[0] = RAV1D_RESTORATION_NONE;
@@ -1172,7 +1172,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
     } else {
         0 as c_uint
     }) as c_int;
-    hdr.skip_mode_allowed = 0 as c_int;
+    hdr.skip_mode_allowed = 0;
     if hdr.switchable_comp_refs != 0
         && hdr.frame_type as c_uint & 1 as c_uint != 0
         && seqhdr.order_hint != 0
@@ -1213,7 +1213,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         if off_before != 0xffffffff as c_uint && off_after != -(1) {
             hdr.skip_mode_refs[0] = cmp::min(off_before_idx, off_after_idx);
             hdr.skip_mode_refs[1] = cmp::max(off_before_idx, off_after_idx);
-            hdr.skip_mode_allowed = 1 as c_int;
+            hdr.skip_mode_allowed = 1;
         } else if off_before != 0xffffffff as c_uint {
             let mut off_before2: c_uint = 0xffffffff as c_uint;
             let mut off_before2_idx = 0;
@@ -1246,7 +1246,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             if off_before2 != 0xffffffff as c_uint {
                 hdr.skip_mode_refs[0] = cmp::min(off_before_idx, off_before2_idx);
                 hdr.skip_mode_refs[1] = cmp::max(off_before_idx, off_before2_idx);
-                hdr.skip_mode_allowed = 1 as c_int;
+                hdr.skip_mode_allowed = 1;
             }
         }
     }
@@ -1310,8 +1310,8 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                         );
                     *mat.offset(3) =
                         2 as c_int * rav1d_get_bits_subexp(gb, *ref_mat.offset(3) >> 1, 12);
-                    bits = 12 as c_int;
-                    shift = 10 as c_int;
+                    bits = 12;
+                    shift = 10;
                 } else {
                     bits = 9 - (hdr.hp == 0) as c_int;
                     shift = 13 + (hdr.hp == 0) as c_int;
@@ -1350,7 +1350,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         if hdr.film_grain.update == 0 {
             let refidx: c_int = rav1d_get_bits(gb, 3) as c_int;
             let mut i: c_int;
-            i = 0 as c_int;
+            i = 0;
             while i < 7 {
                 if hdr.refidx[i as usize] == refidx {
                     break;
@@ -1389,7 +1389,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 || fgd.chroma_scaling_from_luma
                 || seqhdr.ss_ver == 1 && seqhdr.ss_hor == 1 && fgd.num_y_points == 0
             {
-                fgd.num_uv_points[1] = 0 as c_int;
+                fgd.num_uv_points[1] = 0;
                 fgd.num_uv_points[0] = fgd.num_uv_points[1];
             } else {
                 let mut pl = 0;
@@ -1440,7 +1440,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                         i += 1;
                     }
                     if fgd.num_y_points == 0 {
-                        fgd.ar_coeffs_uv[pl as usize][num_uv_pos as usize] = 0 as i8;
+                        fgd.ar_coeffs_uv[pl as usize][num_uv_pos as usize] = 0;
                     }
                 }
                 pl += 1;
@@ -1488,7 +1488,7 @@ unsafe fn parse_tile_hdr(c: &mut Rav1dContext, gb: &mut GetBits) {
         (*(c.tile).offset(c.n_tile_data as isize)).start = rav1d_get_bits(gb, n_bits) as c_int;
         (*(c.tile).offset(c.n_tile_data as isize)).end = rav1d_get_bits(gb, n_bits) as c_int;
     } else {
-        (*(c.tile).offset(c.n_tile_data as isize)).start = 0 as c_int;
+        (*(c.tile).offset(c.n_tile_data as isize)).start = 0;
         (*(c.tile).offset(c.n_tile_data as isize)).end = n_tiles - 1;
     };
 }
@@ -1548,7 +1548,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
         }
         rav1d_ref_dec(&mut c.frame_hdr_ref);
         c.frame_hdr = 0 as *mut Rav1dFrameHeader;
-        c.n_tiles = 0 as c_int;
+        c.n_tiles = 0;
         len.wrapping_add(init_byte_pos)
     }
 
@@ -1863,8 +1863,8 @@ pub(crate) unsafe fn rav1d_parse_obus(
                     rav1d_data_unref_internal(&mut (*(c.tile).offset(n as isize)).data);
                     n += 1;
                 }
-                c.n_tile_data = 0 as c_int;
-                c.n_tiles = 0 as c_int;
+                c.n_tile_data = 0;
+                c.n_tiles = 0;
                 if r#type as c_uint != RAV1D_OBU_FRAME as c_int as c_uint {
                     rav1d_get_bit(&mut gb);
                     if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
@@ -1954,8 +1954,8 @@ pub(crate) unsafe fn rav1d_parse_obus(
                         rav1d_data_unref_internal(&mut (*(c.tile).offset(i as isize)).data);
                         i += 1;
                     }
-                    c.n_tile_data = 0 as c_int;
-                    c.n_tiles = 0 as c_int;
+                    c.n_tile_data = 0;
+                    c.n_tiles = 0;
                     error(c, r#in)?;
                 }
                 c.n_tiles += 1 as c_int + (*(c.tile).offset(c.n_tile_data as isize)).end
@@ -2027,7 +2027,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 let next = c.frame_thread.next;
                 c.frame_thread.next = (c.frame_thread.next).wrapping_add(1);
                 if c.frame_thread.next == c.n_fc {
-                    c.frame_thread.next = 0 as c_uint;
+                    c.frame_thread.next = 0;
                 }
                 let f: *mut Rav1dFrameContext =
                     &mut *(c.fc).offset(next as isize) as *mut Rav1dFrameContext;
@@ -2163,7 +2163,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
             rav1d_submit_frame(&mut *c)?;
             assert!(c.n_tile_data == 0);
             c.frame_hdr = 0 as *mut Rav1dFrameHeader;
-            c.n_tiles = 0 as c_int;
+            c.n_tiles = 0;
         }
     }
     Ok(len.wrapping_add(init_byte_pos))

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -135,7 +135,7 @@ unsafe fn rav1d_get_bits_pos(c: &GetBits) -> c_uint {
 }
 
 unsafe fn parse_seq_hdr(
-    c: *mut Rav1dContext,
+    c: &mut Rav1dContext,
     gb: *mut GetBits,
     hdr: *mut Rav1dSequenceHeader,
 ) -> Rav1dResult {
@@ -171,8 +171,7 @@ unsafe fn parse_seq_hdr(
         if (*hdr).timing_info_present != 0 {
             (*hdr).num_units_in_tick = rav1d_get_bits(gb, 32 as c_int) as c_int;
             (*hdr).time_scale = rav1d_get_bits(gb, 32 as c_int) as c_int;
-            if (*c).strict_std_compliance
-                && ((*hdr).num_units_in_tick == 0 || (*hdr).time_scale == 0)
+            if c.strict_std_compliance && ((*hdr).num_units_in_tick == 0 || (*hdr).time_scale == 0)
             {
                 return error(c);
             }
@@ -190,7 +189,7 @@ unsafe fn parse_seq_hdr(
                 (*hdr).encoder_decoder_buffer_delay_length =
                     (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_int as c_uint) as c_int;
                 (*hdr).num_units_in_decoding_tick = rav1d_get_bits(gb, 32 as c_int) as c_int;
-                if (*c).strict_std_compliance && (*hdr).num_units_in_decoding_tick == 0 {
+                if c.strict_std_compliance && (*hdr).num_units_in_decoding_tick == 0 {
                     return error(c);
                 }
                 (*hdr).buffer_removal_delay_length =
@@ -243,14 +242,14 @@ unsafe fn parse_seq_hdr(
             i += 1;
         }
     }
-    let op_idx: c_int = if (*c).operating_point < (*hdr).num_operating_points {
-        (*c).operating_point
+    let op_idx: c_int = if c.operating_point < (*hdr).num_operating_points {
+        c.operating_point
     } else {
         0 as c_int
     };
-    (*c).operating_point_idc = (*hdr).operating_points[op_idx as usize].idc as c_uint;
-    let spatial_mask = (*c).operating_point_idc >> 8;
-    (*c).max_spatial_id = if spatial_mask != 0 {
+    c.operating_point_idc = (*hdr).operating_points[op_idx as usize].idc as c_uint;
+    let spatial_mask = c.operating_point_idc >> 8;
+    c.max_spatial_id = if spatial_mask != 0 {
         ulog2(spatial_mask) != 0
     } else {
         false
@@ -381,7 +380,7 @@ unsafe fn parse_seq_hdr(
             RAV1D_CHR_UNKNOWN as c_int as c_uint
         }) as Dav1dChromaSamplePosition;
     }
-    if (*c).strict_std_compliance
+    if c.strict_std_compliance
         && (*hdr).mtrx as c_uint == RAV1D_MC_IDENTITY as c_int as c_uint
         && (*hdr).layout as c_uint != Rav1dPixelLayout::I444 as c_int as c_uint
     {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1002,9 +1002,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 i += 1;
             }
         } else {
-            if !(hdr.primary_ref_frame != 7 as c_int) {
-                unreachable!();
-            }
+            assert!(hdr.primary_ref_frame != 7 as c_int);
             let pri_ref: c_int = hdr.refidx[hdr.primary_ref_frame as usize];
             if (c.refs[pri_ref as usize].p.p.frame_hdr).is_null() {
                 return error(c);
@@ -1538,9 +1536,7 @@ unsafe fn check_for_overrun(
         return 1 as c_int;
     }
     let pos: c_uint = rav1d_get_bits_pos(gb);
-    if !(init_bit_pos <= pos) {
-        unreachable!();
-    }
+    assert!(init_bit_pos <= pos);
     if pos.wrapping_sub(init_bit_pos) > (8 as c_int as c_uint).wrapping_mul(obu_len) {
         rav1d_log(
             c,
@@ -1618,12 +1614,8 @@ pub(crate) unsafe fn rav1d_parse_obus(
     }
     let init_bit_pos: c_uint = rav1d_get_bits_pos(&mut gb);
     let init_byte_pos: c_uint = init_bit_pos >> 3;
-    if !(init_bit_pos & 7 as c_uint == 0 as c_uint) {
-        unreachable!();
-    }
-    if !(r#in.sz >= init_byte_pos as usize) {
-        unreachable!();
-    }
+    assert!(init_bit_pos & 7 as c_uint == 0 as c_uint);
+    assert!(r#in.sz >= init_byte_pos as usize);
     if len as usize > (r#in.sz).wrapping_sub(init_byte_pos as usize) {
         error(c, r#in)?;
     }
@@ -1984,12 +1976,8 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 }
                 let pkt_bytelen: c_uint = init_byte_pos.wrapping_add(len);
                 let bit_pos: c_uint = rav1d_get_bits_pos(&mut gb);
-                if !(bit_pos & 7 as c_uint == 0 as c_uint) {
-                    unreachable!();
-                }
-                if !(pkt_bytelen >= bit_pos >> 3) {
-                    unreachable!();
-                }
+                assert!(bit_pos & 7 as c_uint == 0 as c_uint);
+                assert!(pkt_bytelen >= bit_pos >> 3);
                 rav1d_data_ref(&mut (*(c.tile).offset(c.n_tile_data as isize)).data, r#in);
                 (*(c.tile).offset(c.n_tile_data as isize)).data.data = (*(c.tile)
                     .offset(c.n_tile_data as isize))
@@ -2220,9 +2208,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 error(c, r#in)?;
             }
             rav1d_submit_frame(&mut *c)?;
-            if c.n_tile_data != 0 {
-                unreachable!();
-            }
+            assert!(c.n_tile_data == 0);
             c.frame_hdr = 0 as *mut Rav1dFrameHeader;
             c.n_tiles = 0 as c_int;
         }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1161,17 +1161,17 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
         && (*seqhdr).restoration != 0
         && (*hdr).allow_intrabc == 0
     {
-        (*hdr).restoration.type_0[0] = rav1d_get_bits(gb, 2 as c_int) as Rav1dRestorationType;
+        (*hdr).restoration.r#type[0] = rav1d_get_bits(gb, 2 as c_int) as Rav1dRestorationType;
         if (*seqhdr).monochrome == 0 {
-            (*hdr).restoration.type_0[1] = rav1d_get_bits(gb, 2 as c_int) as Rav1dRestorationType;
-            (*hdr).restoration.type_0[2] = rav1d_get_bits(gb, 2 as c_int) as Rav1dRestorationType;
+            (*hdr).restoration.r#type[1] = rav1d_get_bits(gb, 2 as c_int) as Rav1dRestorationType;
+            (*hdr).restoration.r#type[2] = rav1d_get_bits(gb, 2 as c_int) as Rav1dRestorationType;
         } else {
-            (*hdr).restoration.type_0[2] = RAV1D_RESTORATION_NONE;
-            (*hdr).restoration.type_0[1] = (*hdr).restoration.type_0[2];
+            (*hdr).restoration.r#type[2] = RAV1D_RESTORATION_NONE;
+            (*hdr).restoration.r#type[1] = (*hdr).restoration.r#type[2];
         }
-        if (*hdr).restoration.type_0[0] as c_uint != 0
-            || (*hdr).restoration.type_0[1] as c_uint != 0
-            || (*hdr).restoration.type_0[2] as c_uint != 0
+        if (*hdr).restoration.r#type[0] as c_uint != 0
+            || (*hdr).restoration.r#type[1] as c_uint != 0
+            || (*hdr).restoration.r#type[2] as c_uint != 0
         {
             (*hdr).restoration.unit_size[0] = 6 + (*seqhdr).sb128;
             if rav1d_get_bit(gb) != 0 {
@@ -1183,8 +1183,8 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
                 }
             }
             (*hdr).restoration.unit_size[1] = (*hdr).restoration.unit_size[0];
-            if ((*hdr).restoration.type_0[1] as c_uint != 0
-                || (*hdr).restoration.type_0[2] as c_uint != 0)
+            if ((*hdr).restoration.r#type[1] as c_uint != 0
+                || (*hdr).restoration.r#type[2] as c_uint != 0)
                 && (*seqhdr).ss_hor == 1
                 && (*seqhdr).ss_ver == 1
             {
@@ -1196,9 +1196,9 @@ unsafe fn parse_frame_hdr(c: *mut Rav1dContext, gb: *mut GetBits) -> Rav1dResult
             (*hdr).restoration.unit_size[0] = 8 as c_int;
         }
     } else {
-        (*hdr).restoration.type_0[0] = RAV1D_RESTORATION_NONE;
-        (*hdr).restoration.type_0[1] = RAV1D_RESTORATION_NONE;
-        (*hdr).restoration.type_0[2] = RAV1D_RESTORATION_NONE;
+        (*hdr).restoration.r#type[0] = RAV1D_RESTORATION_NONE;
+        (*hdr).restoration.r#type[1] = RAV1D_RESTORATION_NONE;
+        (*hdr).restoration.r#type[2] = RAV1D_RESTORATION_NONE;
     }
     (*hdr).txfm_mode = (if (*hdr).all_lossless != 0 {
         RAV1D_TX_4X4_ONLY as c_int

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -127,7 +127,7 @@ use std::ptr::addr_of_mut;
 #[inline]
 unsafe fn rav1d_get_bits_pos(c: &GetBits) -> c_uint {
     (c.ptr.offset_from(c.ptr_start) as c_long as c_uint)
-        .wrapping_mul(8 as c_uint)
+        .wrapping_mul(8)
         .wrapping_sub(c.bits_left as c_uint)
 }
 
@@ -177,25 +177,24 @@ unsafe fn parse_seq_hdr(
                 if num_ticks_per_picture == 0xffffffff as c_uint {
                     return error(c);
                 }
-                hdr.num_ticks_per_picture = num_ticks_per_picture.wrapping_add(1 as c_uint);
+                hdr.num_ticks_per_picture = num_ticks_per_picture.wrapping_add(1);
             }
             hdr.decoder_model_info_present = rav1d_get_bit(gb) as c_int;
             if hdr.decoder_model_info_present != 0 {
                 hdr.encoder_decoder_buffer_delay_length =
-                    (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_uint) as c_int;
+                    (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1) as c_int;
                 hdr.num_units_in_decoding_tick = rav1d_get_bits(gb, 32 as c_int) as c_int;
                 if c.strict_std_compliance && hdr.num_units_in_decoding_tick == 0 {
                     return error(c);
                 }
                 hdr.buffer_removal_delay_length =
-                    (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_uint) as c_int;
+                    (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1) as c_int;
                 hdr.frame_presentation_delay_length =
-                    (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_uint) as c_int;
+                    (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1) as c_int;
             }
         }
         hdr.display_model_info_present = rav1d_get_bit(gb) as c_int;
-        hdr.num_operating_points =
-            (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1 as c_uint) as c_int;
+        hdr.num_operating_points = (rav1d_get_bits(gb, 5 as c_int)).wrapping_add(1) as c_int;
         let mut i = 0;
         while i < hdr.num_operating_points {
             let op = &mut hdr.operating_points[i as usize];
@@ -223,7 +222,7 @@ unsafe fn parse_seq_hdr(
                 op.display_model_param_present = rav1d_get_bit(gb) as c_int;
             }
             op.initial_display_delay = (if op.display_model_param_present != 0 {
-                (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(1 as c_uint)
+                (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(1)
             } else {
                 10 as c_uint
             }) as c_int;
@@ -242,18 +241,17 @@ unsafe fn parse_seq_hdr(
     } else {
         false
     };
-    hdr.width_n_bits = (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(1 as c_uint) as c_int;
-    hdr.height_n_bits = (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(1 as c_uint) as c_int;
-    hdr.max_width = (rav1d_get_bits(gb, hdr.width_n_bits)).wrapping_add(1 as c_uint) as c_int;
-    hdr.max_height = (rav1d_get_bits(gb, hdr.height_n_bits)).wrapping_add(1 as c_uint) as c_int;
+    hdr.width_n_bits = (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(1) as c_int;
+    hdr.height_n_bits = (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(1) as c_int;
+    hdr.max_width = (rav1d_get_bits(gb, hdr.width_n_bits)).wrapping_add(1) as c_int;
+    hdr.max_height = (rav1d_get_bits(gb, hdr.height_n_bits)).wrapping_add(1) as c_int;
     if hdr.reduced_still_picture_header == 0 {
         hdr.frame_id_numbers_present = rav1d_get_bit(gb) as c_int;
         if hdr.frame_id_numbers_present != 0 {
-            hdr.delta_frame_id_n_bits =
-                (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(2 as c_uint) as c_int;
+            hdr.delta_frame_id_n_bits = (rav1d_get_bits(gb, 4 as c_int)).wrapping_add(2) as c_int;
             hdr.frame_id_n_bits = (rav1d_get_bits(gb, 3 as c_int))
                 .wrapping_add(hdr.delta_frame_id_n_bits as c_uint)
-                .wrapping_add(1 as c_uint) as c_int;
+                .wrapping_add(1) as c_int;
         }
     }
     hdr.sb128 = rav1d_get_bit(gb) as c_int;
@@ -287,8 +285,7 @@ unsafe fn parse_seq_hdr(
             2 as c_uint
         }) as Dav1dAdaptiveBoolean;
         if hdr.order_hint != 0 {
-            hdr.order_hint_n_bits =
-                (rav1d_get_bits(gb, 3 as c_int)).wrapping_add(1 as c_uint) as c_int;
+            hdr.order_hint_n_bits = (rav1d_get_bits(gb, 3 as c_int)).wrapping_add(1) as c_int;
         }
     }
     hdr.super_res = rav1d_get_bit(gb) as c_int;
@@ -390,7 +387,7 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
                     .offset(*((*c.frame_hdr).refidx).as_mut_ptr().offset(i as isize) as isize))
                 .p;
                 if ((*r#ref).p.frame_hdr).is_null() {
-                    return -(1 as c_int);
+                    return -(1);
                 }
                 hdr.width[1] = (*(*r#ref).p.frame_hdr).width[1];
                 hdr.height = (*(*r#ref).p.frame_hdr).height;
@@ -415,8 +412,8 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
         }
     }
     if hdr.frame_size_override != 0 {
-        hdr.width[1] = (rav1d_get_bits(gb, seqhdr.width_n_bits)).wrapping_add(1 as c_uint) as c_int;
-        hdr.height = (rav1d_get_bits(gb, seqhdr.height_n_bits)).wrapping_add(1 as c_uint) as c_int;
+        hdr.width[1] = (rav1d_get_bits(gb, seqhdr.width_n_bits)).wrapping_add(1) as c_int;
+        hdr.height = (rav1d_get_bits(gb, seqhdr.height_n_bits)).wrapping_add(1) as c_int;
     } else {
         hdr.width[1] = seqhdr.max_width;
         hdr.height = seqhdr.max_height;
@@ -436,8 +433,8 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
     }
     hdr.have_render_size = rav1d_get_bit(gb) as c_int;
     if hdr.have_render_size != 0 {
-        hdr.render_width = (rav1d_get_bits(gb, 16 as c_int)).wrapping_add(1 as c_uint) as c_int;
-        hdr.render_height = (rav1d_get_bits(gb, 16 as c_int)).wrapping_add(1 as c_uint) as c_int;
+        hdr.render_width = (rav1d_get_bits(gb, 16 as c_int)).wrapping_add(1) as c_int;
+        hdr.render_height = (rav1d_get_bits(gb, 16 as c_int)).wrapping_add(1) as c_int;
     } else {
         hdr.render_width = hdr.width[1];
         hdr.render_height = hdr.height;
@@ -624,14 +621,14 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         hdr.frame_ref_short_signaling = (seqhdr.order_hint != 0 && rav1d_get_bit(gb) != 0) as c_int;
         if hdr.frame_ref_short_signaling != 0 {
             hdr.refidx[0] = rav1d_get_bits(gb, 3 as c_int) as c_int;
-            hdr.refidx[2] = -(1 as c_int);
+            hdr.refidx[2] = -(1);
             hdr.refidx[1] = hdr.refidx[2];
             hdr.refidx[3] = rav1d_get_bits(gb, 3 as c_int) as c_int;
-            hdr.refidx[6] = -(1 as c_int);
+            hdr.refidx[6] = -(1);
             hdr.refidx[5] = hdr.refidx[6];
             hdr.refidx[4] = hdr.refidx[5];
             let mut shifted_frame_offset: [c_int; 8] = [0; 8];
-            let current_frame_offset: c_int = (1 as c_int) << seqhdr.order_hint_n_bits - 1;
+            let current_frame_offset: c_int = (1) << seqhdr.order_hint_n_bits - 1;
             let mut i = 0;
             while i < 8 {
                 if (c.refs[i as usize].p.p.frame_hdr).is_null() {
@@ -648,7 +645,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             let mut used_frame: [c_int; 8] = [0 as c_int, 0, 0, 0, 0, 0, 0, 0];
             used_frame[hdr.refidx[0] as usize] = 1 as c_int;
             used_frame[hdr.refidx[3] as usize] = 1 as c_int;
-            let mut latest_frame_offset: c_int = -(1 as c_int);
+            let mut latest_frame_offset: c_int = -(1);
             let mut i = 0;
             while i < 8 {
                 let hint: c_int = shifted_frame_offset[i as usize];
@@ -661,7 +658,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 }
                 i += 1;
             }
-            if latest_frame_offset != -(1 as c_int) {
+            if latest_frame_offset != -(1) {
                 used_frame[hdr.refidx[6] as usize] = 1 as c_int;
             }
             let mut earliest_frame_offset = i32::MAX;
@@ -699,7 +696,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             let mut i = 1;
             while i < 7 {
                 if hdr.refidx[i as usize] < 0 {
-                    latest_frame_offset = -(1 as c_int);
+                    latest_frame_offset = -(1);
                     let mut j = 0;
                     while j < 8 {
                         let hint: c_int = shifted_frame_offset[j as usize];
@@ -712,14 +709,14 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                         }
                         j += 1;
                     }
-                    if latest_frame_offset != -(1 as c_int) {
+                    if latest_frame_offset != -(1) {
                         used_frame[hdr.refidx[i as usize] as usize] = 1 as c_int;
                     }
                 }
                 i += 1;
             }
             earliest_frame_offset = i32::MAX;
-            let mut r#ref: c_int = -(1 as c_int);
+            let mut r#ref: c_int = -(1);
             let mut i = 0;
             while i < 8 {
                 let hint: c_int = shifted_frame_offset[i as usize];
@@ -745,10 +742,9 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             if seqhdr.frame_id_numbers_present != 0 {
                 let delta_ref_frame_id_minus_1: c_int =
                     rav1d_get_bits(gb, seqhdr.delta_frame_id_n_bits) as c_int;
-                let ref_frame_id: c_int = hdr.frame_id + ((1 as c_int) << seqhdr.frame_id_n_bits)
-                    - delta_ref_frame_id_minus_1
-                    - 1
-                    & ((1 as c_int) << seqhdr.frame_id_n_bits) - 1;
+                let ref_frame_id: c_int =
+                    hdr.frame_id + ((1) << seqhdr.frame_id_n_bits) - delta_ref_frame_id_minus_1 - 1
+                        & ((1) << seqhdr.frame_id_n_bits) - 1;
                 let ref_frame_hdr: *mut Rav1dFrameHeader =
                     c.refs[hdr.refidx[i as usize] as usize].p.p.frame_hdr;
                 if ref_frame_hdr.is_null() || (*ref_frame_hdr).frame_id != ref_frame_id {
@@ -779,7 +775,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         && hdr.disable_cdf_update == 0
         && rav1d_get_bit(gb) == 0) as c_int;
     hdr.tiling.uniform = rav1d_get_bit(gb) as c_int;
-    let sbsz_min1: c_int = ((64 as c_int) << seqhdr.sb128) - 1;
+    let sbsz_min1: c_int = ((64) << seqhdr.sb128) - 1;
     let sbsz_log2 = 6 + seqhdr.sb128;
     let sbw: c_int = hdr.width[0] + sbsz_min1 >> sbsz_log2;
     let sbh: c_int = hdr.height + sbsz_min1 >> sbsz_log2;
@@ -863,7 +859,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         if hdr.tiling.update >= hdr.tiling.cols * hdr.tiling.rows {
             return error(c);
         }
-        hdr.tiling.n_bytes = (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(1 as c_uint);
+        hdr.tiling.n_bytes = (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(1);
     } else {
         hdr.tiling.update = 0 as c_int;
         hdr.tiling.n_bytes = hdr.tiling.update as c_uint;
@@ -933,7 +929,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         }
         if hdr.segmentation.update_data != 0 {
             hdr.segmentation.seg_data.preskip = 0 as c_int;
-            hdr.segmentation.seg_data.last_active_segid = -(1 as c_int);
+            hdr.segmentation.seg_data.last_active_segid = -(1);
             let mut i = 0;
             while i < 8 {
                 let seg: *mut Rav1dSegmentationData = &mut *(hdr.segmentation.seg_data.d)
@@ -975,7 +971,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                     hdr.segmentation.seg_data.last_active_segid = i;
                     hdr.segmentation.seg_data.preskip = 1 as c_int;
                 } else {
-                    (*seg).r#ref = -(1 as c_int);
+                    (*seg).r#ref = -(1);
                 }
                 (*seg).skip = rav1d_get_bit(gb) as c_int;
                 if (*seg).skip != 0 {
@@ -1008,7 +1004,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         );
         let mut i = 0;
         while i < 8 {
-            hdr.segmentation.seg_data.d[i as usize].r#ref = -(1 as c_int);
+            hdr.segmentation.seg_data.d[i as usize].r#ref = -(1);
             i += 1;
         }
     }
@@ -1107,10 +1103,10 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         }
     }
     if hdr.all_lossless == 0 && seqhdr.cdef != 0 && hdr.allow_intrabc == 0 {
-        hdr.cdef.damping = (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(3 as c_uint) as c_int;
+        hdr.cdef.damping = (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(3) as c_int;
         hdr.cdef.n_bits = rav1d_get_bits(gb, 2 as c_int) as c_int;
         let mut i = 0;
-        while i < (1 as c_int) << hdr.cdef.n_bits {
+        while i < (1) << hdr.cdef.n_bits {
             hdr.cdef.y_strength[i as usize] = rav1d_get_bits(gb, 6 as c_int) as c_int;
             if seqhdr.monochrome == 0 {
                 hdr.cdef.uv_strength[i as usize] = rav1d_get_bits(gb, 6 as c_int) as c_int;
@@ -1184,7 +1180,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
     {
         let poc: c_uint = hdr.frame_offset as c_uint;
         let mut off_before: c_uint = 0xffffffff as c_uint;
-        let mut off_after: c_int = -(1 as c_int);
+        let mut off_after: c_int = -(1);
         let mut off_before_idx = 0;
         let mut off_after_idx = 0;
         let mut i = 0;
@@ -1196,7 +1192,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 (*c.refs[hdr.refidx[i as usize] as usize].p.p.frame_hdr).frame_offset as c_uint;
             let diff: c_int = get_poc_diff(seqhdr.order_hint_n_bits, refpoc as c_int, poc as c_int);
             if diff > 0 {
-                if off_after == -(1 as c_int)
+                if off_after == -(1)
                     || get_poc_diff(seqhdr.order_hint_n_bits, off_after, refpoc as c_int) > 0
                 {
                     off_after = refpoc as c_int;
@@ -1215,7 +1211,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             }
             i += 1;
         }
-        if off_before != 0xffffffff as c_uint && off_after != -(1 as c_int) {
+        if off_before != 0xffffffff as c_uint && off_after != -(1) {
             hdr.skip_mode_refs[0] = cmp::min(off_before_idx, off_after_idx);
             hdr.skip_mode_refs[1] = cmp::max(off_before_idx, off_after_idx);
             hdr.skip_mode_allowed = 1 as c_int;
@@ -1307,10 +1303,10 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 let shift: c_int;
                 if hdr.gmv[i as usize].r#type as c_uint >= RAV1D_WM_TYPE_ROT_ZOOM as c_int as c_uint
                 {
-                    *mat.offset(2) = ((1 as c_int) << 16)
+                    *mat.offset(2) = ((1) << 16)
                         + 2 * rav1d_get_bits_subexp(
                             gb,
-                            *ref_mat.offset(2) - ((1 as c_int) << 16) >> 1,
+                            *ref_mat.offset(2) - ((1) << 16) >> 1,
                             12 as c_uint,
                         );
                     *mat.offset(3) = 2 as c_int
@@ -1324,10 +1320,10 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 if hdr.gmv[i as usize].r#type as c_uint == RAV1D_WM_TYPE_AFFINE as c_int as c_uint {
                     *mat.offset(4) = 2 as c_int
                         * rav1d_get_bits_subexp(gb, *ref_mat.offset(4) >> 1, 12 as c_uint);
-                    *mat.offset(5) = ((1 as c_int) << 16)
+                    *mat.offset(5) = ((1) << 16)
                         + 2 * rav1d_get_bits_subexp(
                             gb,
-                            *ref_mat.offset(5) - ((1 as c_int) << 16) >> 1,
+                            *ref_mat.offset(5) - ((1) << 16) >> 1,
                             12 as c_uint,
                         );
                 } else {
@@ -1336,10 +1332,10 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 }
                 *mat.offset(0) =
                     rav1d_get_bits_subexp(gb, *ref_mat.offset(0) >> shift, bits as c_uint)
-                        * ((1 as c_int) << shift);
+                        * ((1) << shift);
                 *mat.offset(1) =
                     rav1d_get_bits_subexp(gb, *ref_mat.offset(1) >> shift, bits as c_uint)
-                        * ((1 as c_int) << shift);
+                        * ((1) << shift);
             }
             i += 1;
         }
@@ -1426,14 +1422,14 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             {
                 return error(c);
             }
-            fgd.scaling_shift = (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(8 as c_uint) as u8;
+            fgd.scaling_shift = (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(8) as u8;
             fgd.ar_coeff_lag = rav1d_get_bits(gb, 2 as c_int) as c_int;
             let num_y_pos = 2 * fgd.ar_coeff_lag * (fgd.ar_coeff_lag + 1);
             if fgd.num_y_points != 0 {
                 let mut i = 0;
                 while i < num_y_pos {
                     fgd.ar_coeffs_y[i as usize] =
-                        (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128 as c_uint) as i8;
+                        (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128) as i8;
                     i += 1;
                 }
             }
@@ -1444,7 +1440,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                     let mut i = 0;
                     while i < num_uv_pos {
                         fgd.ar_coeffs_uv[pl as usize][i as usize] =
-                            (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128 as c_uint) as i8;
+                            (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128) as i8;
                         i += 1;
                     }
                     if fgd.num_y_points == 0 {
@@ -1453,17 +1449,17 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 }
                 pl += 1;
             }
-            fgd.ar_coeff_shift = (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(6 as c_uint) as u8;
+            fgd.ar_coeff_shift = (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(6) as u8;
             fgd.grain_scale_shift = rav1d_get_bits(gb, 2 as c_int) as u8;
             let mut pl = 0;
             while pl < 2 {
                 if fgd.num_uv_points[pl as usize] != 0 {
                     fgd.uv_mult[pl as usize] =
-                        (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128 as c_uint) as c_int;
+                        (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128) as c_int;
                     fgd.uv_luma_mult[pl as usize] =
-                        (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128 as c_uint) as c_int;
+                        (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128) as c_int;
                     fgd.uv_offset[pl as usize] =
-                        (rav1d_get_bits(gb, 9 as c_int)).wrapping_sub(256 as c_uint) as c_int;
+                        (rav1d_get_bits(gb, 9 as c_int)).wrapping_sub(256) as c_int;
                 }
                 pl += 1;
             }
@@ -1545,7 +1541,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
     unsafe fn skip(c: &mut Rav1dContext, len: c_uint, init_byte_pos: c_uint) -> c_uint {
         let mut i = 0;
         while i < 8 {
-            if (*c.frame_hdr).refresh_frame_flags & (1 as c_int) << i != 0 {
+            if (*c.frame_hdr).refresh_frame_flags & (1) << i != 0 {
                 rav1d_thread_picture_unref(&mut (*(c.refs).as_mut_ptr().offset(i as isize)).p);
                 c.refs[i as usize].p.p.frame_hdr = c.frame_hdr;
                 c.refs[i as usize].p.p.seq_hdr = c.seq_hdr;
@@ -1587,7 +1583,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
         rav1d_get_uleb128(&mut gb)
     } else {
         (r#in.sz as c_uint)
-            .wrapping_sub(1 as c_uint)
+            .wrapping_sub(1)
             .wrapping_sub(has_extension as c_uint)
     };
     if gb.error != 0 {
@@ -1753,7 +1749,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                         && *(r#in.data).offset(
                             init_byte_pos
                                 .wrapping_add(payload_size as c_uint)
-                                .wrapping_sub(1 as c_uint) as isize,
+                                .wrapping_sub(1) as isize,
                         ) == 0
                     {
                         payload_size -= 1;
@@ -2060,7 +2056,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 {
                     let first: c_uint =
                         ::core::intrinsics::atomic_load_seqcst(&mut c.task_thread.first);
-                    if first.wrapping_add(1 as c_uint) < c.n_fc {
+                    if first.wrapping_add(1) < c.n_fc {
                         ::core::intrinsics::atomic_xadd_seqcst(
                             &mut c.task_thread.first,
                             1 as c_uint,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -484,7 +484,7 @@ static default_mode_ref_deltas: Rav1dLoopfilterModeRefDeltas = Rav1dLoopfilterMo
 };
 
 unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult {
-    unsafe fn error(c: *mut Rav1dContext) -> Rav1dResult {
+    unsafe fn error(c: &mut Rav1dContext) -> Rav1dResult {
         rav1d_log(
             c,
             b"Error parsing frame header\n\0" as *const u8 as *const c_char,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1398,48 +1398,48 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             hdr.film_grain.data.seed = seed;
         } else {
             let fgd = &mut hdr.film_grain.data;
-            (*fgd).seed = seed;
-            (*fgd).num_y_points = rav1d_get_bits(gb, 4 as c_int) as c_int;
-            if (*fgd).num_y_points > 14 {
+            fgd.seed = seed;
+            fgd.num_y_points = rav1d_get_bits(gb, 4 as c_int) as c_int;
+            if fgd.num_y_points > 14 {
                 return error(c);
             }
             let mut i = 0;
-            while i < (*fgd).num_y_points {
-                (*fgd).y_points[i as usize][0] = rav1d_get_bits(gb, 8 as c_int) as u8;
+            while i < fgd.num_y_points {
+                fgd.y_points[i as usize][0] = rav1d_get_bits(gb, 8 as c_int) as u8;
                 if i != 0
-                    && (*fgd).y_points[(i - 1) as usize][0] as c_int
-                        >= (*fgd).y_points[i as usize][0] as c_int
+                    && fgd.y_points[(i - 1) as usize][0] as c_int
+                        >= fgd.y_points[i as usize][0] as c_int
                 {
                     return error(c);
                 }
-                (*fgd).y_points[i as usize][1] = rav1d_get_bits(gb, 8 as c_int) as u8;
+                fgd.y_points[i as usize][1] = rav1d_get_bits(gb, 8 as c_int) as u8;
                 i += 1;
             }
-            (*fgd).chroma_scaling_from_luma = seqhdr.monochrome == 0 && rav1d_get_bit(gb) != 0;
+            fgd.chroma_scaling_from_luma = seqhdr.monochrome == 0 && rav1d_get_bit(gb) != 0;
             if seqhdr.monochrome != 0
-                || (*fgd).chroma_scaling_from_luma
-                || seqhdr.ss_ver == 1 && seqhdr.ss_hor == 1 && (*fgd).num_y_points == 0
+                || fgd.chroma_scaling_from_luma
+                || seqhdr.ss_ver == 1 && seqhdr.ss_hor == 1 && fgd.num_y_points == 0
             {
-                (*fgd).num_uv_points[1] = 0 as c_int;
-                (*fgd).num_uv_points[0] = (*fgd).num_uv_points[1];
+                fgd.num_uv_points[1] = 0 as c_int;
+                fgd.num_uv_points[0] = fgd.num_uv_points[1];
             } else {
                 let mut pl = 0;
                 while pl < 2 {
-                    (*fgd).num_uv_points[pl as usize] = rav1d_get_bits(gb, 4 as c_int) as c_int;
-                    if (*fgd).num_uv_points[pl as usize] > 10 {
+                    fgd.num_uv_points[pl as usize] = rav1d_get_bits(gb, 4 as c_int) as c_int;
+                    if fgd.num_uv_points[pl as usize] > 10 {
                         return error(c);
                     }
                     let mut i = 0;
-                    while i < (*fgd).num_uv_points[pl as usize] {
-                        (*fgd).uv_points[pl as usize][i as usize][0] =
+                    while i < fgd.num_uv_points[pl as usize] {
+                        fgd.uv_points[pl as usize][i as usize][0] =
                             rav1d_get_bits(gb, 8 as c_int) as u8;
                         if i != 0
-                            && (*fgd).uv_points[pl as usize][(i - 1) as usize][0] as c_int
-                                >= (*fgd).uv_points[pl as usize][i as usize][0] as c_int
+                            && fgd.uv_points[pl as usize][(i - 1) as usize][0] as c_int
+                                >= fgd.uv_points[pl as usize][i as usize][0] as c_int
                         {
                             return error(c);
                         }
-                        (*fgd).uv_points[pl as usize][i as usize][1] =
+                        fgd.uv_points[pl as usize][i as usize][1] =
                             rav1d_get_bits(gb, 8 as c_int) as u8;
                         i += 1;
                     }
@@ -1448,60 +1448,59 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             }
             if seqhdr.ss_hor == 1
                 && seqhdr.ss_ver == 1
-                && ((*fgd).num_uv_points[0] != 0) as c_int
-                    != ((*fgd).num_uv_points[1] != 0) as c_int
+                && (fgd.num_uv_points[0] != 0) as c_int != (fgd.num_uv_points[1] != 0) as c_int
             {
                 return error(c);
             }
-            (*fgd).scaling_shift =
+            fgd.scaling_shift =
                 (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(8 as c_int as c_uint) as u8;
-            (*fgd).ar_coeff_lag = rav1d_get_bits(gb, 2 as c_int) as c_int;
-            let num_y_pos = 2 * (*fgd).ar_coeff_lag * ((*fgd).ar_coeff_lag + 1);
-            if (*fgd).num_y_points != 0 {
+            fgd.ar_coeff_lag = rav1d_get_bits(gb, 2 as c_int) as c_int;
+            let num_y_pos = 2 * fgd.ar_coeff_lag * (fgd.ar_coeff_lag + 1);
+            if fgd.num_y_points != 0 {
                 let mut i = 0;
                 while i < num_y_pos {
-                    (*fgd).ar_coeffs_y[i as usize] =
+                    fgd.ar_coeffs_y[i as usize] =
                         (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128 as c_int as c_uint) as i8;
                     i += 1;
                 }
             }
             let mut pl = 0;
             while pl < 2 {
-                if (*fgd).num_uv_points[pl as usize] != 0 || (*fgd).chroma_scaling_from_luma {
-                    let num_uv_pos: c_int = num_y_pos + ((*fgd).num_y_points != 0) as c_int;
+                if fgd.num_uv_points[pl as usize] != 0 || fgd.chroma_scaling_from_luma {
+                    let num_uv_pos: c_int = num_y_pos + (fgd.num_y_points != 0) as c_int;
                     let mut i = 0;
                     while i < num_uv_pos {
-                        (*fgd).ar_coeffs_uv[pl as usize][i as usize] =
-                            (rav1d_get_bits(gb, 8 as c_int)).wrapping_sub(128 as c_int as c_uint)
-                                as i8;
+                        fgd.ar_coeffs_uv[pl as usize][i as usize] = (rav1d_get_bits(gb, 8 as c_int))
+                            .wrapping_sub(128 as c_int as c_uint)
+                            as i8;
                         i += 1;
                     }
-                    if (*fgd).num_y_points == 0 {
-                        (*fgd).ar_coeffs_uv[pl as usize][num_uv_pos as usize] = 0 as c_int as i8;
+                    if fgd.num_y_points == 0 {
+                        fgd.ar_coeffs_uv[pl as usize][num_uv_pos as usize] = 0 as c_int as i8;
                     }
                 }
                 pl += 1;
             }
-            (*fgd).ar_coeff_shift =
+            fgd.ar_coeff_shift =
                 (rav1d_get_bits(gb, 2 as c_int)).wrapping_add(6 as c_int as c_uint) as u8;
-            (*fgd).grain_scale_shift = rav1d_get_bits(gb, 2 as c_int) as u8;
+            fgd.grain_scale_shift = rav1d_get_bits(gb, 2 as c_int) as u8;
             let mut pl = 0;
             while pl < 2 {
-                if (*fgd).num_uv_points[pl as usize] != 0 {
-                    (*fgd).uv_mult[pl as usize] = (rav1d_get_bits(gb, 8 as c_int))
+                if fgd.num_uv_points[pl as usize] != 0 {
+                    fgd.uv_mult[pl as usize] = (rav1d_get_bits(gb, 8 as c_int))
                         .wrapping_sub(128 as c_int as c_uint)
                         as c_int;
-                    (*fgd).uv_luma_mult[pl as usize] = (rav1d_get_bits(gb, 8 as c_int))
+                    fgd.uv_luma_mult[pl as usize] = (rav1d_get_bits(gb, 8 as c_int))
                         .wrapping_sub(128 as c_int as c_uint)
                         as c_int;
-                    (*fgd).uv_offset[pl as usize] = (rav1d_get_bits(gb, 9 as c_int))
+                    fgd.uv_offset[pl as usize] = (rav1d_get_bits(gb, 9 as c_int))
                         .wrapping_sub(256 as c_int as c_uint)
                         as c_int;
                 }
                 pl += 1;
             }
-            (*fgd).overlap_flag = rav1d_get_bit(gb) != 0;
-            (*fgd).clip_to_restricted_range = rav1d_get_bit(gb) != 0;
+            fgd.overlap_flag = rav1d_get_bit(gb) != 0;
+            fgd.clip_to_restricted_range = rav1d_get_bit(gb) != 0;
         }
     } else {
         memset(

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -31,7 +31,6 @@ use crate::include::dav1d::headers::Rav1dRestorationType;
 use crate::include::dav1d::headers::Rav1dSegmentationData;
 use crate::include::dav1d::headers::Rav1dSegmentationDataSet;
 use crate::include::dav1d::headers::Rav1dSequenceHeader;
-use crate::include::dav1d::headers::Rav1dSequenceHeaderOperatingParameterInfo;
 use crate::include::dav1d::headers::Rav1dSequenceHeaderOperatingPoint;
 use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
 use crate::include::dav1d::headers::RAV1D_ADAPTIVE;
@@ -216,16 +215,12 @@ unsafe fn parse_seq_hdr(
             if hdr.decoder_model_info_present != 0 {
                 op.decoder_model_param_present = rav1d_get_bit(gb) as c_int;
                 if op.decoder_model_param_present != 0 {
-                    let opi: *mut Rav1dSequenceHeaderOperatingParameterInfo = &mut *(hdr
-                        .operating_parameter_info)
-                        .as_mut_ptr()
-                        .offset(i as isize)
-                        as *mut Rav1dSequenceHeaderOperatingParameterInfo;
-                    (*opi).decoder_buffer_delay =
+                    let opi = &mut hdr.operating_parameter_info[i as usize];
+                    opi.decoder_buffer_delay =
                         rav1d_get_bits(gb, hdr.encoder_decoder_buffer_delay_length) as c_int;
-                    (*opi).encoder_buffer_delay =
+                    opi.encoder_buffer_delay =
                         rav1d_get_bits(gb, hdr.encoder_decoder_buffer_delay_length) as c_int;
-                    (*opi).low_delay_mode = rav1d_get_bit(gb) as c_int;
+                    opi.low_delay_mode = rav1d_get_bit(gb) as c_int;
                 }
             }
             if hdr.display_model_info_present != 0 {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -136,7 +136,7 @@ unsafe fn rav1d_get_bits_pos(c: &GetBits) -> c_uint {
 
 unsafe fn parse_seq_hdr(
     c: &mut Rav1dContext,
-    gb: *mut GetBits,
+    gb: &mut GetBits,
     hdr: *mut Rav1dSequenceHeader,
 ) -> Rav1dResult {
     unsafe fn error(c: *mut Rav1dContext) -> Rav1dResult {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -4,26 +4,23 @@ use crate::include::dav1d::data::Rav1dData;
 use crate::include::dav1d::dav1d::RAV1D_DECODEFRAMETYPE_INTRA;
 use crate::include::dav1d::dav1d::RAV1D_DECODEFRAMETYPE_REFERENCE;
 use crate::include::dav1d::headers::DRav1d;
-use crate::include::dav1d::headers::Dav1dAdaptiveBoolean;
-use crate::include::dav1d::headers::Dav1dChromaSamplePosition;
-use crate::include::dav1d::headers::Dav1dColorPrimaries;
-use crate::include::dav1d::headers::Dav1dFilterMode;
 use crate::include::dav1d::headers::Dav1dFrameHeader;
-use crate::include::dav1d::headers::Dav1dFrameType;
 use crate::include::dav1d::headers::Dav1dITUTT35;
-use crate::include::dav1d::headers::Dav1dMatrixCoefficients;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
 use crate::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
-use crate::include::dav1d::headers::Dav1dTransferCharacteristics;
-use crate::include::dav1d::headers::Dav1dTxfmMode;
-use crate::include::dav1d::headers::Dav1dWarpedMotionType;
+use crate::include::dav1d::headers::Rav1dAdaptiveBoolean;
+use crate::include::dav1d::headers::Rav1dChromaSamplePosition;
+use crate::include::dav1d::headers::Rav1dColorPrimaries;
 use crate::include::dav1d::headers::Rav1dContentLightLevel;
 use crate::include::dav1d::headers::Rav1dFilmGrainData;
+use crate::include::dav1d::headers::Rav1dFilterMode;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
 use crate::include::dav1d::headers::Rav1dFrameHeaderOperatingPoint;
+use crate::include::dav1d::headers::Rav1dFrameType;
 use crate::include::dav1d::headers::Rav1dITUTT35;
 use crate::include::dav1d::headers::Rav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Rav1dMasteringDisplay;
+use crate::include::dav1d::headers::Rav1dMatrixCoefficients;
 use crate::include::dav1d::headers::Rav1dObuType;
 use crate::include::dav1d::headers::Rav1dPixelLayout;
 use crate::include::dav1d::headers::Rav1dRestorationType;
@@ -31,6 +28,7 @@ use crate::include::dav1d::headers::Rav1dSegmentationData;
 use crate::include::dav1d::headers::Rav1dSegmentationDataSet;
 use crate::include::dav1d::headers::Rav1dSequenceHeader;
 use crate::include::dav1d::headers::Rav1dSequenceHeaderOperatingPoint;
+use crate::include::dav1d::headers::Rav1dTransferCharacteristics;
 use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
 use crate::include::dav1d::headers::RAV1D_ADAPTIVE;
 use crate::include::dav1d::headers::RAV1D_CHR_UNKNOWN;
@@ -118,7 +116,6 @@ use libc::realloc;
 use std::cmp;
 use std::ffi::c_char;
 use std::ffi::c_int;
-use std::ffi::c_long;
 use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
@@ -126,7 +123,7 @@ use std::ptr::addr_of_mut;
 
 #[inline]
 unsafe fn rav1d_get_bits_pos(c: &GetBits) -> c_uint {
-    (c.ptr.offset_from(c.ptr_start) as c_long as c_uint)
+    (c.ptr.offset_from(c.ptr_start) as c_uint)
         .wrapping_mul(8)
         .wrapping_sub(c.bits_left as c_uint)
 }
@@ -146,7 +143,7 @@ unsafe fn parse_seq_hdr(
 
     memset(
         hdr as *mut Rav1dSequenceHeader as *mut c_void,
-        0 as c_int,
+        0,
         ::core::mem::size_of::<Rav1dSequenceHeader>(),
     );
     hdr.profile = rav1d_get_bits(gb, 3) as c_int;
@@ -174,7 +171,7 @@ unsafe fn parse_seq_hdr(
             hdr.equal_picture_interval = rav1d_get_bit(gb) as c_int;
             if hdr.equal_picture_interval != 0 {
                 let num_ticks_per_picture: c_uint = rav1d_get_vlc(gb);
-                if num_ticks_per_picture == 0xffffffff as c_uint {
+                if num_ticks_per_picture == 0xffffffff {
                     return error(c);
                 }
                 hdr.num_ticks_per_picture = num_ticks_per_picture.wrapping_add(1);
@@ -198,7 +195,7 @@ unsafe fn parse_seq_hdr(
         while i < hdr.num_operating_points {
             let op = &mut hdr.operating_points[i as usize];
             op.idc = rav1d_get_bits(gb, 12) as c_int;
-            if op.idc != 0 && (op.idc & 0xff as c_int == 0 || op.idc & 0xf00 == 0) {
+            if op.idc != 0 && (op.idc & 0xff == 0 || op.idc & 0xf00 == 0) {
                 return error(c);
             }
             op.major_level = (2 as c_uint).wrapping_add(rav1d_get_bits(gb, 3)) as c_int;
@@ -220,18 +217,18 @@ unsafe fn parse_seq_hdr(
             if hdr.display_model_info_present != 0 {
                 op.display_model_param_present = rav1d_get_bit(gb) as c_int;
             }
-            op.initial_display_delay = (if op.display_model_param_present != 0 {
-                (rav1d_get_bits(gb, 4)).wrapping_add(1)
+            op.initial_display_delay = if op.display_model_param_present != 0 {
+                (rav1d_get_bits(gb, 4)).wrapping_add(1) as c_int
             } else {
-                10 as c_uint
-            }) as c_int;
+                10
+            };
             i += 1;
         }
     }
     let op_idx: c_int = if c.operating_point < hdr.num_operating_points {
         c.operating_point
     } else {
-        0 as c_int
+        0
     };
     c.operating_point_idc = hdr.operating_points[op_idx as usize].idc as c_uint;
     let spatial_mask = c.operating_point_idc >> 8;
@@ -269,20 +266,20 @@ unsafe fn parse_seq_hdr(
             hdr.jnt_comp = rav1d_get_bit(gb) as c_int;
             hdr.ref_frame_mvs = rav1d_get_bit(gb) as c_int;
         }
-        hdr.screen_content_tools = (if rav1d_get_bit(gb) != 0 {
-            RAV1D_ADAPTIVE as c_int as c_uint
+        hdr.screen_content_tools = if rav1d_get_bit(gb) != 0 {
+            RAV1D_ADAPTIVE
         } else {
-            rav1d_get_bit(gb)
-        }) as Dav1dAdaptiveBoolean;
-        hdr.force_integer_mv = (if hdr.screen_content_tools as c_uint != 0 {
+            rav1d_get_bit(gb) as Rav1dAdaptiveBoolean
+        };
+        hdr.force_integer_mv = if hdr.screen_content_tools as c_uint != 0 {
             if rav1d_get_bit(gb) != 0 {
-                RAV1D_ADAPTIVE as c_int as c_uint
+                RAV1D_ADAPTIVE
             } else {
-                rav1d_get_bit(gb)
+                rav1d_get_bit(gb) as Rav1dAdaptiveBoolean
             }
         } else {
-            2 as c_uint
-        }) as Dav1dAdaptiveBoolean;
+            2
+        };
         if hdr.order_hint != 0 {
             hdr.order_hint_n_bits = (rav1d_get_bits(gb, 3)).wrapping_add(1) as c_int;
         }
@@ -299,9 +296,9 @@ unsafe fn parse_seq_hdr(
     }
     hdr.color_description_present = rav1d_get_bit(gb) as c_int;
     if hdr.color_description_present != 0 {
-        hdr.pri = rav1d_get_bits(gb, 8) as Dav1dColorPrimaries;
-        hdr.trc = rav1d_get_bits(gb, 8) as Dav1dTransferCharacteristics;
-        hdr.mtrx = rav1d_get_bits(gb, 8) as Dav1dMatrixCoefficients;
+        hdr.pri = rav1d_get_bits(gb, 8) as Rav1dColorPrimaries;
+        hdr.trc = rav1d_get_bits(gb, 8) as Rav1dTransferCharacteristics;
+        hdr.mtrx = rav1d_get_bits(gb, 8) as Rav1dMatrixCoefficients;
     } else {
         hdr.pri = RAV1D_COLOR_PRI_UNKNOWN;
         hdr.trc = RAV1D_TRC_UNKNOWN;
@@ -313,9 +310,9 @@ unsafe fn parse_seq_hdr(
         hdr.ss_ver = 1;
         hdr.ss_hor = hdr.ss_ver;
         hdr.chr = RAV1D_CHR_UNKNOWN;
-    } else if hdr.pri as c_uint == RAV1D_COLOR_PRI_BT709 as c_uint
-        && hdr.trc as c_uint == RAV1D_TRC_SRGB as c_int as c_uint
-        && hdr.mtrx as c_uint == RAV1D_MC_IDENTITY as c_int as c_uint
+    } else if hdr.pri == RAV1D_COLOR_PRI_BT709
+        && hdr.trc == RAV1D_TRC_SRGB
+        && hdr.mtrx == RAV1D_MC_IDENTITY
     {
         hdr.layout = Rav1dPixelLayout::I444;
         hdr.color_range = 1;
@@ -354,15 +351,15 @@ unsafe fn parse_seq_hdr(
             }
             _ => {}
         }
-        hdr.chr = (if hdr.ss_hor & hdr.ss_ver != 0 {
-            rav1d_get_bits(gb, 2)
+        hdr.chr = if hdr.ss_hor & hdr.ss_ver != 0 {
+            rav1d_get_bits(gb, 2) as Rav1dChromaSamplePosition
         } else {
-            RAV1D_CHR_UNKNOWN as c_int as c_uint
-        }) as Dav1dChromaSamplePosition;
+            RAV1D_CHR_UNKNOWN
+        };
     }
     if c.strict_std_compliance
-        && hdr.mtrx as c_uint == RAV1D_MC_IDENTITY as c_int as c_uint
-        && hdr.layout as c_uint != Rav1dPixelLayout::I444 as c_uint
+        && hdr.mtrx == RAV1D_MC_IDENTITY
+        && hdr.layout != Rav1dPixelLayout::I444
     {
         return error(c);
     }
@@ -405,7 +402,7 @@ unsafe fn read_frame_size(c: &mut Rav1dContext, gb: &mut GetBits, use_ref: c_int
                     hdr.super_res.width_scale_denominator = 8;
                     hdr.width[0] = hdr.width[1];
                 }
-                return 0 as c_int;
+                return 0;
             }
             i += 1;
         }
@@ -485,78 +482,72 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         }
         return Ok(());
     }
-    hdr.frame_type = (if seqhdr.reduced_still_picture_header != 0 {
-        RAV1D_FRAME_TYPE_KEY as c_int as c_uint
+    hdr.frame_type = if seqhdr.reduced_still_picture_header != 0 {
+        RAV1D_FRAME_TYPE_KEY
     } else {
-        rav1d_get_bits(gb, 2)
-    }) as Dav1dFrameType;
+        rav1d_get_bits(gb, 2) as Rav1dFrameType
+    };
     hdr.show_frame = (seqhdr.reduced_still_picture_header != 0 || rav1d_get_bit(gb) != 0) as c_int;
     if hdr.show_frame != 0 {
         if seqhdr.decoder_model_info_present != 0 && seqhdr.equal_picture_interval == 0 {
             hdr.frame_presentation_delay =
                 rav1d_get_bits(gb, seqhdr.frame_presentation_delay_length) as c_int;
         }
-        hdr.showable_frame =
-            (hdr.frame_type as c_uint != RAV1D_FRAME_TYPE_KEY as c_int as c_uint) as c_int;
+        hdr.showable_frame = (hdr.frame_type != RAV1D_FRAME_TYPE_KEY) as c_int;
     } else {
         hdr.showable_frame = rav1d_get_bit(gb) as c_int;
     }
-    hdr.error_resilient_mode = (hdr.frame_type as c_uint == RAV1D_FRAME_TYPE_KEY as c_int as c_uint
-        && hdr.show_frame != 0
-        || hdr.frame_type as c_uint == RAV1D_FRAME_TYPE_SWITCH as c_int as c_uint
+    hdr.error_resilient_mode = (hdr.frame_type == RAV1D_FRAME_TYPE_KEY && hdr.show_frame != 0
+        || hdr.frame_type == RAV1D_FRAME_TYPE_SWITCH
         || seqhdr.reduced_still_picture_header != 0
         || rav1d_get_bit(gb) != 0) as c_int;
     hdr.disable_cdf_update = rav1d_get_bit(gb) as c_int;
-    hdr.allow_screen_content_tools =
-        (if seqhdr.screen_content_tools as c_uint == RAV1D_ADAPTIVE as c_int as c_uint {
+    hdr.allow_screen_content_tools = (if seqhdr.screen_content_tools == RAV1D_ADAPTIVE {
+        rav1d_get_bit(gb)
+    } else {
+        seqhdr.screen_content_tools
+    }) as c_int;
+    if hdr.allow_screen_content_tools != 0 {
+        hdr.force_integer_mv = (if seqhdr.force_integer_mv == RAV1D_ADAPTIVE {
             rav1d_get_bit(gb)
         } else {
-            seqhdr.screen_content_tools as c_uint
+            seqhdr.force_integer_mv
         }) as c_int;
-    if hdr.allow_screen_content_tools != 0 {
-        hdr.force_integer_mv =
-            (if seqhdr.force_integer_mv as c_uint == RAV1D_ADAPTIVE as c_int as c_uint {
-                rav1d_get_bit(gb)
-            } else {
-                seqhdr.force_integer_mv as c_uint
-            }) as c_int;
     } else {
         hdr.force_integer_mv = 0;
     }
-    if hdr.frame_type as c_uint & 1 == 0 {
+    if hdr.frame_type & 1 == 0 {
         hdr.force_integer_mv = 1;
     }
     if seqhdr.frame_id_numbers_present != 0 {
         hdr.frame_id = rav1d_get_bits(gb, seqhdr.frame_id_n_bits) as c_int;
     }
     hdr.frame_size_override = (if seqhdr.reduced_still_picture_header != 0 {
-        0 as c_uint
-    } else if hdr.frame_type as c_uint == RAV1D_FRAME_TYPE_SWITCH as c_int as c_uint {
-        1 as c_uint
+        0
+    } else if hdr.frame_type == RAV1D_FRAME_TYPE_SWITCH {
+        1
     } else {
         rav1d_get_bit(gb)
     }) as c_int;
-    hdr.frame_offset = (if seqhdr.order_hint != 0 {
-        rav1d_get_bits(gb, seqhdr.order_hint_n_bits)
+    hdr.frame_offset = if seqhdr.order_hint != 0 {
+        rav1d_get_bits(gb, seqhdr.order_hint_n_bits) as c_int
     } else {
-        0 as c_uint
-    }) as c_int;
-    hdr.primary_ref_frame = (if hdr.error_resilient_mode == 0 && hdr.frame_type as c_uint & 1 != 0 {
-        rav1d_get_bits(gb, 3)
+        0
+    };
+    hdr.primary_ref_frame = if hdr.error_resilient_mode == 0 && hdr.frame_type as c_uint & 1 != 0 {
+        rav1d_get_bits(gb, 3) as c_int
     } else {
-        7 as c_uint
-    }) as c_int;
+        7
+    };
     if seqhdr.decoder_model_info_present != 0 {
         hdr.buffer_removal_time_present = rav1d_get_bit(gb) as c_int;
         if hdr.buffer_removal_time_present != 0 {
             let mut i = 0;
             while i < (*c.seq_hdr).num_operating_points {
                 let seqop: *const Rav1dSequenceHeaderOperatingPoint =
-                    &*(seqhdr.operating_points).as_ptr().offset(i as isize)
-                        as *const Rav1dSequenceHeaderOperatingPoint;
+                    &*(seqhdr.operating_points).as_ptr().offset(i as isize);
                 let op: *mut Rav1dFrameHeaderOperatingPoint =
-                    &mut *(hdr.operating_points).as_mut_ptr().offset(i as isize)
-                        as *mut Rav1dFrameHeaderOperatingPoint;
+                    &mut *(hdr.operating_points).as_mut_ptr().offset(i as isize);
                 if (*seqop).decoder_model_param_present != 0 {
                     let in_temporal_layer = (*seqop).idc >> hdr.temporal_id & 1;
                     let in_spatial_layer = (*seqop).idc >> hdr.spatial_id + 8 & 1;
@@ -569,16 +560,13 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             }
         }
     }
-    if hdr.frame_type as c_uint & 1 == 0 {
-        hdr.refresh_frame_flags = (if hdr.frame_type as c_uint
-            == RAV1D_FRAME_TYPE_KEY as c_int as c_uint
-            && hdr.show_frame != 0
-        {
-            0xff as c_int as c_uint
+    if hdr.frame_type & 1 == 0 {
+        hdr.refresh_frame_flags = if hdr.frame_type == RAV1D_FRAME_TYPE_KEY && hdr.show_frame != 0 {
+            0xff
         } else {
-            rav1d_get_bits(gb, 8)
-        }) as c_int;
-        if hdr.refresh_frame_flags != 0xff as c_int
+            rav1d_get_bits(gb, 8) as c_int
+        };
+        if hdr.refresh_frame_flags != 0xff
             && hdr.error_resilient_mode != 0
             && seqhdr.order_hint != 0
         {
@@ -589,8 +577,8 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             }
         }
         if c.strict_std_compliance
-            && hdr.frame_type as c_uint == RAV1D_FRAME_TYPE_INTRA as c_int as c_uint
-            && hdr.refresh_frame_flags == 0xff as c_int
+            && hdr.frame_type == RAV1D_FRAME_TYPE_INTRA
+            && hdr.refresh_frame_flags == 0xff
         {
             return error(c);
         }
@@ -603,12 +591,11 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         hdr.use_ref_frame_mvs = 0;
     } else {
         hdr.allow_intrabc = 0;
-        hdr.refresh_frame_flags =
-            (if hdr.frame_type as c_uint == RAV1D_FRAME_TYPE_SWITCH as c_int as c_uint {
-                0xff as c_int as c_uint
-            } else {
-                rav1d_get_bits(gb, 8)
-            }) as c_int;
+        hdr.refresh_frame_flags = if hdr.frame_type == RAV1D_FRAME_TYPE_SWITCH {
+            0xff
+        } else {
+            rav1d_get_bits(gb, 8) as c_int
+        };
         if hdr.error_resilient_mode != 0 && seqhdr.order_hint != 0 {
             let mut i = 0;
             while i < 8 {
@@ -757,16 +744,16 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             return error(c);
         }
         hdr.hp = (hdr.force_integer_mv == 0 && rav1d_get_bit(gb) != 0) as c_int;
-        hdr.subpel_filter_mode = (if rav1d_get_bit(gb) != 0 {
-            RAV1D_FILTER_SWITCHABLE as c_int as c_uint
+        hdr.subpel_filter_mode = if rav1d_get_bit(gb) != 0 {
+            RAV1D_FILTER_SWITCHABLE
         } else {
-            rav1d_get_bits(gb, 2)
-        }) as Dav1dFilterMode;
+            rav1d_get_bits(gb, 2) as Rav1dFilterMode
+        };
         hdr.switchable_motion_mode = rav1d_get_bit(gb) as c_int;
         hdr.use_ref_frame_mvs = (hdr.error_resilient_mode == 0
             && seqhdr.ref_frame_mvs != 0
             && seqhdr.order_hint != 0
-            && hdr.frame_type as c_uint & 1 != 0
+            && hdr.frame_type & 1 != 0
             && rav1d_get_bit(gb) != 0) as c_int;
     }
     hdr.refresh_context = (seqhdr.reduced_still_picture_header == 0
@@ -819,11 +806,11 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         let mut sbx = 0;
         while sbx < sbw && hdr.tiling.cols < 64 {
             let tile_width_sb: c_int = cmp::min(sbw - sbx, max_tile_width_sb);
-            let tile_w: c_int = (if tile_width_sb > 1 {
-                (1 as c_uint).wrapping_add(rav1d_get_uniform(gb, tile_width_sb as c_uint))
+            let tile_w: c_int = if tile_width_sb > 1 {
+                (1 as c_uint).wrapping_add(rav1d_get_uniform(gb, tile_width_sb as c_uint)) as c_int
             } else {
-                1 as c_uint
-            }) as c_int;
+                1
+            };
             hdr.tiling.col_start_sb[hdr.tiling.cols as usize] = sbx as u16;
             sbx += tile_w;
             widest_tile = cmp::max(widest_tile, tile_w);
@@ -838,11 +825,11 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         let mut sby = 0;
         while sby < sbh && hdr.tiling.rows < 64 {
             let tile_height_sb: c_int = cmp::min(sbh - sby, max_tile_height_sb);
-            let tile_h: c_int = (if tile_height_sb > 1 {
-                (1 as c_uint).wrapping_add(rav1d_get_uniform(gb, tile_height_sb as c_uint))
+            let tile_h: c_int = if tile_height_sb > 1 {
+                (1 as c_uint).wrapping_add(rav1d_get_uniform(gb, tile_height_sb as c_uint)) as c_int
             } else {
-                1 as c_uint
-            }) as c_int;
+                1
+            };
             hdr.tiling.row_start_sb[hdr.tiling.rows as usize] = sby as u16;
             sby += tile_h;
             hdr.tiling.rows += 1;
@@ -866,34 +853,34 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
     hdr.quant.ydc_delta = if rav1d_get_bit(gb) != 0 {
         rav1d_get_sbits(gb, 7)
     } else {
-        0 as c_int
+        0
     };
     if seqhdr.monochrome == 0 {
-        let diff_uv_delta: c_int = (if seqhdr.separate_uv_delta_q != 0 {
-            rav1d_get_bit(gb)
+        let diff_uv_delta: c_int = if seqhdr.separate_uv_delta_q != 0 {
+            rav1d_get_bit(gb) as c_int
         } else {
-            0 as c_uint
-        }) as c_int;
+            0
+        };
         hdr.quant.udc_delta = if rav1d_get_bit(gb) != 0 {
             rav1d_get_sbits(gb, 7)
         } else {
-            0 as c_int
+            0
         };
         hdr.quant.uac_delta = if rav1d_get_bit(gb) != 0 {
             rav1d_get_sbits(gb, 7)
         } else {
-            0 as c_int
+            0
         };
         if diff_uv_delta != 0 {
             hdr.quant.vdc_delta = if rav1d_get_bit(gb) != 0 {
                 rav1d_get_sbits(gb, 7)
             } else {
-                0 as c_int
+                0
             };
             hdr.quant.vac_delta = if rav1d_get_bit(gb) != 0 {
                 rav1d_get_sbits(gb, 7)
             } else {
-                0 as c_int
+                0
             };
         } else {
             hdr.quant.vdc_delta = hdr.quant.udc_delta;
@@ -918,11 +905,11 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             hdr.segmentation.update_data = 1;
         } else {
             hdr.segmentation.update_map = rav1d_get_bit(gb) as c_int;
-            hdr.segmentation.temporal = (if hdr.segmentation.update_map != 0 {
-                rav1d_get_bit(gb)
+            hdr.segmentation.temporal = if hdr.segmentation.update_map != 0 {
+                rav1d_get_bit(gb) as c_int
             } else {
-                0 as c_uint
-            }) as c_int;
+                0
+            };
             hdr.segmentation.update_data = rav1d_get_bit(gb) as c_int;
         }
         if hdr.segmentation.update_data != 0 {
@@ -932,8 +919,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             while i < 8 {
                 let seg: *mut Rav1dSegmentationData = &mut *(hdr.segmentation.seg_data.d)
                     .as_mut_ptr()
-                    .offset(i as isize)
-                    as *mut Rav1dSegmentationData;
+                    .offset(i as isize);
                 if rav1d_get_bit(gb) != 0 {
                     (*seg).delta_q = rav1d_get_sbits(gb, 9);
                     hdr.segmentation.seg_data.last_active_segid = i;
@@ -969,7 +955,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                     hdr.segmentation.seg_data.last_active_segid = i;
                     hdr.segmentation.seg_data.preskip = 1;
                 } else {
-                    (*seg).r#ref = -(1);
+                    (*seg).r#ref = -1;
                 }
                 (*seg).skip = rav1d_get_bit(gb) as c_int;
                 if (*seg).skip != 0 {
@@ -997,7 +983,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
     } else {
         memset(
             &mut hdr.segmentation.seg_data as *mut Rav1dSegmentationDataSet as *mut c_void,
-            0 as c_int,
+            0,
             ::core::mem::size_of::<Rav1dSegmentationDataSet>(),
         );
         let mut i = 0;
@@ -1006,28 +992,28 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             i += 1;
         }
     }
-    hdr.delta.q.present = (if hdr.quant.yac != 0 {
-        rav1d_get_bit(gb)
+    hdr.delta.q.present = if hdr.quant.yac != 0 {
+        rav1d_get_bit(gb) as c_int
     } else {
-        0 as c_uint
-    }) as c_int;
-    hdr.delta.q.res_log2 = (if hdr.delta.q.present != 0 {
-        rav1d_get_bits(gb, 2)
+        0
+    };
+    hdr.delta.q.res_log2 = if hdr.delta.q.present != 0 {
+        rav1d_get_bits(gb, 2) as c_int
     } else {
-        0 as c_uint
-    }) as c_int;
+        0
+    };
     hdr.delta.lf.present =
         (hdr.delta.q.present != 0 && hdr.allow_intrabc == 0 && rav1d_get_bit(gb) != 0) as c_int;
-    hdr.delta.lf.res_log2 = (if hdr.delta.lf.present != 0 {
-        rav1d_get_bits(gb, 2)
+    hdr.delta.lf.res_log2 = if hdr.delta.lf.present != 0 {
+        rav1d_get_bits(gb, 2) as c_int
     } else {
-        0 as c_uint
-    }) as c_int;
-    hdr.delta.lf.multi = (if hdr.delta.lf.present != 0 {
-        rav1d_get_bit(gb)
+        0
+    };
+    hdr.delta.lf.multi = if hdr.delta.lf.present != 0 {
+        rav1d_get_bit(gb) as c_int
     } else {
-        0 as c_uint
-    }) as c_int;
+        0
+    };
     let delta_lossless: c_int = (hdr.quant.ydc_delta == 0
         && hdr.quant.udc_delta == 0
         && hdr.quant.uac_delta == 0
@@ -1128,9 +1114,9 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             hdr.restoration.r#type[2] = RAV1D_RESTORATION_NONE;
             hdr.restoration.r#type[1] = hdr.restoration.r#type[2];
         }
-        if hdr.restoration.r#type[0] as c_uint != 0
-            || hdr.restoration.r#type[1] as c_uint != 0
-            || hdr.restoration.r#type[2] as c_uint != 0
+        if hdr.restoration.r#type[0] != 0
+            || hdr.restoration.r#type[1] != 0
+            || hdr.restoration.r#type[2] != 0
         {
             hdr.restoration.unit_size[0] = 6 + seqhdr.sb128;
             if rav1d_get_bit(gb) != 0 {
@@ -1138,18 +1124,17 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 if seqhdr.sb128 == 0 {
                     hdr.restoration.unit_size[0] = (hdr.restoration.unit_size[0] as c_uint)
                         .wrapping_add(rav1d_get_bit(gb))
-                        as c_int as c_int;
+                        as c_int;
                 }
             }
             hdr.restoration.unit_size[1] = hdr.restoration.unit_size[0];
-            if (hdr.restoration.r#type[1] as c_uint != 0
-                || hdr.restoration.r#type[2] as c_uint != 0)
+            if (hdr.restoration.r#type[1] != 0 || hdr.restoration.r#type[2] != 0)
                 && seqhdr.ss_hor == 1
                 && seqhdr.ss_ver == 1
             {
                 hdr.restoration.unit_size[1] = (hdr.restoration.unit_size[1] as c_uint)
                     .wrapping_sub(rav1d_get_bit(gb))
-                    as c_int as c_int;
+                    as c_int;
             }
         } else {
             hdr.restoration.unit_size[0] = 8;
@@ -1159,24 +1144,24 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         hdr.restoration.r#type[1] = RAV1D_RESTORATION_NONE;
         hdr.restoration.r#type[2] = RAV1D_RESTORATION_NONE;
     }
-    hdr.txfm_mode = (if hdr.all_lossless != 0 {
-        RAV1D_TX_4X4_ONLY as c_int
+    hdr.txfm_mode = if hdr.all_lossless != 0 {
+        RAV1D_TX_4X4_ONLY
     } else if rav1d_get_bit(gb) != 0 {
-        RAV1D_TX_SWITCHABLE as c_int
+        RAV1D_TX_SWITCHABLE
     } else {
-        RAV1D_TX_LARGEST as c_int
-    }) as Dav1dTxfmMode;
-    hdr.switchable_comp_refs = (if hdr.frame_type as c_uint & 1 != 0 {
-        rav1d_get_bit(gb)
+        RAV1D_TX_LARGEST
+    };
+    hdr.switchable_comp_refs = if hdr.frame_type as c_uint & 1 != 0 {
+        rav1d_get_bit(gb) as c_int
     } else {
-        0 as c_uint
-    }) as c_int;
+        0
+    };
     hdr.skip_mode_allowed = 0;
     if hdr.switchable_comp_refs != 0 && hdr.frame_type as c_uint & 1 != 0 && seqhdr.order_hint != 0
     {
         let poc: c_uint = hdr.frame_offset as c_uint;
-        let mut off_before: c_uint = 0xffffffff as c_uint;
-        let mut off_after: c_int = -(1);
+        let mut off_before: c_uint = 0xffffffff;
+        let mut off_after: c_int = -1;
         let mut off_before_idx = 0;
         let mut off_after_idx = 0;
         let mut i = 0;
@@ -1195,7 +1180,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                     off_after_idx = i;
                 }
             } else if diff < 0
-                && (off_before == 0xffffffff as c_uint
+                && (off_before == 0xffffffff
                     || get_poc_diff(
                         seqhdr.order_hint_n_bits,
                         refpoc as c_int,
@@ -1207,12 +1192,12 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             }
             i += 1;
         }
-        if off_before != 0xffffffff as c_uint && off_after != -(1) {
+        if off_before != 0xffffffff && off_after != -(1) {
             hdr.skip_mode_refs[0] = cmp::min(off_before_idx, off_after_idx);
             hdr.skip_mode_refs[1] = cmp::max(off_before_idx, off_after_idx);
             hdr.skip_mode_allowed = 1;
-        } else if off_before != 0xffffffff as c_uint {
-            let mut off_before2: c_uint = 0xffffffff as c_uint;
+        } else if off_before != 0xffffffff {
+            let mut off_before2: c_uint = 0xffffffff;
             let mut off_before2_idx = 0;
             let mut i = 0;
             while i < 7 {
@@ -1227,7 +1212,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                     off_before as c_int,
                 ) < 0
                 {
-                    if off_before2 == 0xffffffff as c_uint
+                    if off_before2 == 0xffffffff
                         || get_poc_diff(
                             seqhdr.order_hint_n_bits,
                             refpoc as c_int,
@@ -1240,20 +1225,20 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 }
                 i += 1;
             }
-            if off_before2 != 0xffffffff as c_uint {
+            if off_before2 != 0xffffffff {
                 hdr.skip_mode_refs[0] = cmp::min(off_before_idx, off_before2_idx);
                 hdr.skip_mode_refs[1] = cmp::max(off_before_idx, off_before2_idx);
                 hdr.skip_mode_allowed = 1;
             }
         }
     }
-    hdr.skip_mode_enabled = (if hdr.skip_mode_allowed != 0 {
-        rav1d_get_bit(gb)
+    hdr.skip_mode_enabled = if hdr.skip_mode_allowed != 0 {
+        rav1d_get_bit(gb) as c_int
     } else {
-        0 as c_uint
-    }) as c_int;
+        0
+    };
     hdr.warp_motion = (hdr.error_resilient_mode == 0
-        && hdr.frame_type as c_uint & 1 != 0
+        && hdr.frame_type & 1 != 0
         && seqhdr.warped_motion != 0
         && rav1d_get_bit(gb) != 0) as c_int;
     hdr.reduced_txtp_set = rav1d_get_bit(gb) as c_int;
@@ -1262,20 +1247,19 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         hdr.gmv[i as usize] = dav1d_default_wm_params.clone();
         i += 1;
     }
-    if hdr.frame_type as c_uint & 1 != 0 {
+    if hdr.frame_type & 1 != 0 {
         let mut i = 0;
         while i < 7 {
-            hdr.gmv[i as usize].r#type = (if rav1d_get_bit(gb) == 0 {
-                RAV1D_WM_TYPE_IDENTITY as c_int
+            hdr.gmv[i as usize].r#type = if rav1d_get_bit(gb) == 0 {
+                RAV1D_WM_TYPE_IDENTITY
             } else if rav1d_get_bit(gb) != 0 {
-                RAV1D_WM_TYPE_ROT_ZOOM as c_int
+                RAV1D_WM_TYPE_ROT_ZOOM
             } else if rav1d_get_bit(gb) != 0 {
-                RAV1D_WM_TYPE_TRANSLATION as c_int
+                RAV1D_WM_TYPE_TRANSLATION
             } else {
-                RAV1D_WM_TYPE_AFFINE as c_int
-            }) as Dav1dWarpedMotionType;
-            if !(hdr.gmv[i as usize].r#type as c_uint == RAV1D_WM_TYPE_IDENTITY as c_int as c_uint)
-            {
+                RAV1D_WM_TYPE_AFFINE
+            };
+            if !(hdr.gmv[i as usize].r#type == RAV1D_WM_TYPE_IDENTITY) {
                 let ref_gmv: *const Rav1dWarpedMotionParams;
                 if hdr.primary_ref_frame == 7 {
                     ref_gmv = &dav1d_default_wm_params;
@@ -1290,23 +1274,16 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                         .frame_hdr)
                         .gmv)
                         .as_mut_ptr()
-                        .offset(i as isize)
-                        as *mut Rav1dWarpedMotionParams;
+                        .offset(i as isize);
                 }
                 let mat: *mut i32 = (hdr.gmv[i as usize].matrix).as_mut_ptr();
                 let ref_mat: *const i32 = ((*ref_gmv).matrix).as_ptr();
                 let bits: c_int;
                 let shift: c_int;
-                if hdr.gmv[i as usize].r#type as c_uint >= RAV1D_WM_TYPE_ROT_ZOOM as c_int as c_uint
-                {
+                if hdr.gmv[i as usize].r#type >= RAV1D_WM_TYPE_ROT_ZOOM {
                     *mat.offset(2) = ((1) << 16)
-                        + 2 * rav1d_get_bits_subexp(
-                            gb,
-                            *ref_mat.offset(2) - ((1) << 16) >> 1,
-                            12 as c_uint,
-                        );
-                    *mat.offset(3) =
-                        2 as c_int * rav1d_get_bits_subexp(gb, *ref_mat.offset(3) >> 1, 12);
+                        + 2 * rav1d_get_bits_subexp(gb, *ref_mat.offset(2) - ((1) << 16) >> 1, 12);
+                    *mat.offset(3) = 2 * rav1d_get_bits_subexp(gb, *ref_mat.offset(3) >> 1, 12);
                     bits = 12;
                     shift = 10;
                 } else {
@@ -1314,24 +1291,19 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                     shift = 13 + (hdr.hp == 0) as c_int;
                 }
                 if hdr.gmv[i as usize].r#type as c_uint == RAV1D_WM_TYPE_AFFINE as c_int as c_uint {
-                    *mat.offset(4) =
-                        2 as c_int * rav1d_get_bits_subexp(gb, *ref_mat.offset(4) >> 1, 12);
+                    *mat.offset(4) = 2 * rav1d_get_bits_subexp(gb, *ref_mat.offset(4) >> 1, 12);
                     *mat.offset(5) = ((1) << 16)
-                        + 2 * rav1d_get_bits_subexp(
-                            gb,
-                            *ref_mat.offset(5) - ((1) << 16) >> 1,
-                            12 as c_uint,
-                        );
+                        + 2 * rav1d_get_bits_subexp(gb, *ref_mat.offset(5) - ((1) << 16) >> 1, 12);
                 } else {
                     *mat.offset(4) = -*mat.offset(3);
                     *mat.offset(5) = *mat.offset(2);
                 }
                 *mat.offset(0) =
                     rav1d_get_bits_subexp(gb, *ref_mat.offset(0) >> shift, bits as c_uint)
-                        * ((1) << shift);
+                        * (1 << shift);
                 *mat.offset(1) =
                     rav1d_get_bits_subexp(gb, *ref_mat.offset(1) >> shift, bits as c_uint)
-                        * ((1) << shift);
+                        * (1 << shift);
             }
             i += 1;
         }
@@ -1341,9 +1313,8 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         && rav1d_get_bit(gb) != 0) as c_int;
     if hdr.film_grain.present != 0 {
         let seed: c_uint = rav1d_get_bits(gb, 16);
-        hdr.film_grain.update = (hdr.frame_type as c_uint
-            != RAV1D_FRAME_TYPE_INTER as c_int as c_uint
-            || rav1d_get_bit(gb) != 0) as c_int;
+        hdr.film_grain.update =
+            (hdr.frame_type != RAV1D_FRAME_TYPE_INTER || rav1d_get_bit(gb) != 0) as c_int;
         if hdr.film_grain.update == 0 {
             let refidx: c_int = rav1d_get_bits(gb, 3) as c_int;
             let mut i: c_int;
@@ -1354,7 +1325,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 }
                 i += 1;
             }
-            if i == 7 || (c.refs[refidx as usize].p.p.frame_hdr).is_null() {
+            if i == 7 || c.refs[refidx as usize].p.p.frame_hdr.is_null() {
                 return error(c);
             }
             hdr.film_grain.data = (*c.refs[refidx as usize].p.p.frame_hdr)
@@ -1412,7 +1383,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             }
             if seqhdr.ss_hor == 1
                 && seqhdr.ss_ver == 1
-                && (fgd.num_uv_points[0] != 0) as c_int != (fgd.num_uv_points[1] != 0) as c_int
+                && (fgd.num_uv_points[0] != 0) != (fgd.num_uv_points[1] != 0)
             {
                 return error(c);
             }
@@ -1460,7 +1431,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
     } else {
         memset(
             &mut hdr.film_grain.data as *mut Rav1dFilmGrainData as *mut c_void,
-            0 as c_int,
+            0,
             ::core::mem::size_of::<Rav1dFilmGrainData>(),
         );
     }
@@ -1475,11 +1446,11 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
 
 unsafe fn parse_tile_hdr(c: &mut Rav1dContext, gb: &mut GetBits) {
     let n_tiles = (*c.frame_hdr).tiling.cols * (*c.frame_hdr).tiling.rows;
-    let have_tile_pos = (if n_tiles > 1 {
-        rav1d_get_bit(gb)
+    let have_tile_pos = if n_tiles > 1 {
+        rav1d_get_bit(gb) as c_int
     } else {
-        0 as c_uint
-    }) as c_int;
+        0
+    };
     if have_tile_pos != 0 {
         let n_bits = (*c.frame_hdr).tiling.log2_cols + (*c.frame_hdr).tiling.log2_rows;
         (*(c.tile).offset(c.n_tile_data as isize)).start = rav1d_get_bits(gb, n_bits) as c_int;
@@ -1501,7 +1472,7 @@ unsafe fn check_for_overrun(
             c,
             b"Overrun in OBU bit buffer\n\0" as *const u8 as *const c_char,
         );
-        return 1 as c_int;
+        return 1;
     }
     let pos: c_uint = rav1d_get_bits_pos(gb);
     assert!(init_bit_pos <= pos);
@@ -1510,7 +1481,7 @@ unsafe fn check_for_overrun(
             c,
             b"Overrun in OBU bit buffer into next OBU\n\0" as *const u8 as *const c_char,
         );
-        return 1 as c_int;
+        return 1;
     }
     0
 }
@@ -1587,8 +1558,8 @@ pub(crate) unsafe fn rav1d_parse_obus(
     if len as usize > (r#in.sz).wrapping_sub(init_byte_pos as usize) {
         error(c, r#in)?;
     }
-    if r#type as c_uint != RAV1D_OBU_SEQ_HDR as c_int as c_uint
-        && r#type as c_uint != RAV1D_OBU_TD as c_int as c_uint
+    if r#type != RAV1D_OBU_SEQ_HDR
+        && r#type != RAV1D_OBU_TD
         && has_extension != 0
         && c.operating_point_idc != 0
     {
@@ -1599,7 +1570,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
         }
     }
     let mut current_block_188: u64;
-    match r#type as c_uint {
+    match r#type {
         RAV1D_OBU_SEQ_HDR => {
             let mut r#ref: *mut Rav1dRef = rav1d_ref_create_using_pool(
                 c.seq_hdr_pool,
@@ -1622,7 +1593,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 rav1d_ref_dec(&mut r#ref);
                 error(c, r#in)?;
             }
-            if (c.seq_hdr).is_null() {
+            if c.seq_hdr.is_null() {
                 c.frame_hdr = 0 as *mut Rav1dFrameHeader;
                 c.frame_flags |= PICTURE_FLAG_NEW_SEQUENCE;
             } else if memcmp(seq_hdr as *const c_void, c.seq_hdr as *const c_void, 1100) != 0 {
@@ -1633,7 +1604,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 rav1d_ref_dec(&mut c.content_light_ref);
                 let mut i = 0;
                 while i < 8 {
-                    if !(c.refs[i as usize].p.p.frame_hdr).is_null() {
+                    if !c.refs[i as usize].p.p.frame_hdr.is_null() {
                         rav1d_thread_picture_unref(
                             &mut (*(c.refs).as_mut_ptr().offset(i as isize)).p,
                         );
@@ -1677,7 +1648,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
             if gb.error != 0 {
                 error(c, r#in)?;
             }
-            match meta_type as c_uint {
+            match meta_type {
                 OBU_META_HDR_CLL => {
                     let mut r#ref: *mut Rav1dRef =
                         rav1d_ref_create(::core::mem::size_of::<Rav1dContentLightLevel>());
@@ -1732,7 +1703,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 OBU_META_ITUT_T35 => {
                     let mut payload_size: c_int = len as c_int;
                     while payload_size > 0
-                        && *(r#in.data).offset(
+                        && *r#in.data.offset(
                             init_byte_pos
                                 .wrapping_add(payload_size as c_uint)
                                 .wrapping_sub(1) as isize,
@@ -1745,7 +1716,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                     let mut country_code_extension_byte = 0;
                     let country_code: c_int = rav1d_get_bits(&mut gb, 8) as c_int;
                     payload_size -= 1;
-                    if country_code == 0xff as c_int {
+                    if country_code == 0xff {
                         country_code_extension_byte = rav1d_get_bits(&mut gb, 8) as c_int;
                         payload_size -= 1;
                     }
@@ -1824,15 +1795,15 @@ pub(crate) unsafe fn rav1d_parse_obus(
             if global != 0 {
                 current_block_188 = 8953117030348968745;
             } else {
-                if (c.seq_hdr).is_null() {
+                if c.seq_hdr.is_null() {
                     error(c, r#in)?;
                 }
-                if (c.frame_hdr_ref).is_null() {
+                if c.frame_hdr_ref.is_null() {
                     c.frame_hdr_ref = rav1d_ref_create_using_pool(
                         c.frame_hdr_pool,
                         ::core::mem::size_of::<DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>>(),
                     );
-                    if (c.frame_hdr_ref).is_null() {
+                    if c.frame_hdr_ref.is_null() {
                         return Err(ENOMEM);
                     }
                 }
@@ -1842,7 +1813,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                     (*c.frame_hdr_ref).data as *mut DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>;
                 memset(
                     frame_hdrs as *mut c_void,
-                    0 as c_int,
+                    0,
                     ::core::mem::size_of::<DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>>(),
                 );
                 c.frame_hdr = &mut (*frame_hdrs).rav1d;
@@ -1860,7 +1831,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 }
                 c.n_tile_data = 0;
                 c.n_tiles = 0;
-                if r#type as c_uint != RAV1D_OBU_FRAME as c_int as c_uint {
+                if r#type != RAV1D_OBU_FRAME {
                     rav1d_get_bit(&mut gb);
                     if check_for_overrun(c, &mut gb, init_bit_pos, len) != 0 {
                         c.frame_hdr = 0 as *mut Rav1dFrameHeader;
@@ -1881,7 +1852,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                     c.frame_hdr = 0 as *mut Rav1dFrameHeader;
                     return Err(ERANGE);
                 }
-                if r#type as c_uint != RAV1D_OBU_FRAME as c_int as c_uint {
+                if r#type != RAV1D_OBU_FRAME {
                     current_block_188 = 8953117030348968745;
                 } else {
                     if (*c.frame_hdr).show_existing_frame != 0 {
@@ -1898,7 +1869,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
     match current_block_188 {
         17787701279558130514 => {
             if !(global != 0) {
-                if (c.frame_hdr).is_null() {
+                if c.frame_hdr.is_null() {
                     error(c, r#in)?;
                 }
                 if c.n_tile_data_alloc < c.n_tile_data + 1 {
@@ -1917,8 +1888,8 @@ pub(crate) unsafe fn rav1d_parse_obus(
                     }
                     c.tile = tile;
                     memset(
-                        (c.tile).offset(c.n_tile_data as isize) as *mut c_void,
-                        0 as c_int,
+                        c.tile.offset(c.n_tile_data as isize) as *mut c_void,
+                        0,
                         ::core::mem::size_of::<Rav1dTileGroup>(),
                     );
                     c.n_tile_data_alloc = c.n_tile_data + 1;
@@ -1932,40 +1903,40 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 let bit_pos: c_uint = rav1d_get_bits_pos(&mut gb);
                 assert!(bit_pos & 7 == 0);
                 assert!(pkt_bytelen >= bit_pos >> 3);
-                rav1d_data_ref(&mut (*(c.tile).offset(c.n_tile_data as isize)).data, r#in);
-                (*(c.tile).offset(c.n_tile_data as isize)).data.data = (*(c.tile)
+                rav1d_data_ref(&mut (*c.tile.offset(c.n_tile_data as isize)).data, r#in);
+                (*c.tile.offset(c.n_tile_data as isize)).data.data = (*(c.tile)
                     .offset(c.n_tile_data as isize))
                 .data
                 .data
                 .offset((bit_pos >> 3) as isize);
-                (*(c.tile).offset(c.n_tile_data as isize)).data.sz =
+                (*c.tile.offset(c.n_tile_data as isize)).data.sz =
                     pkt_bytelen.wrapping_sub(bit_pos >> 3) as usize;
-                if (*(c.tile).offset(c.n_tile_data as isize)).start
-                    > (*(c.tile).offset(c.n_tile_data as isize)).end
-                    || (*(c.tile).offset(c.n_tile_data as isize)).start != c.n_tiles
+                if (*c.tile.offset(c.n_tile_data as isize)).start
+                    > (*c.tile.offset(c.n_tile_data as isize)).end
+                    || (*c.tile.offset(c.n_tile_data as isize)).start != c.n_tiles
                 {
                     let mut i = 0;
                     while i <= c.n_tile_data {
-                        rav1d_data_unref_internal(&mut (*(c.tile).offset(i as isize)).data);
+                        rav1d_data_unref_internal(&mut (*c.tile.offset(i as isize)).data);
                         i += 1;
                     }
                     c.n_tile_data = 0;
                     c.n_tiles = 0;
                     error(c, r#in)?;
                 }
-                c.n_tiles += 1 as c_int + (*(c.tile).offset(c.n_tile_data as isize)).end
+                c.n_tiles += 1 + (*(c.tile).offset(c.n_tile_data as isize)).end
                     - (*(c.tile).offset(c.n_tile_data as isize)).start;
                 c.n_tile_data += 1;
             }
         }
         _ => {}
     }
-    if !(c.seq_hdr).is_null() && !(c.frame_hdr).is_null() {
+    if !c.seq_hdr.is_null() && !c.frame_hdr.is_null() {
         if (*c.frame_hdr).show_existing_frame != 0 {
-            if (c.refs[(*c.frame_hdr).existing_frame_idx as usize]
+            if c.refs[(*c.frame_hdr).existing_frame_idx as usize]
                 .p
                 .p
-                .frame_hdr)
+                .frame_hdr
                 .is_null()
             {
                 error(c, r#in)?;
@@ -1977,22 +1948,18 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 .frame_type as c_uint
             {
                 RAV1D_FRAME_TYPE_INTER | RAV1D_FRAME_TYPE_SWITCH => {
-                    if c.decode_frame_type as c_uint
-                        > RAV1D_DECODEFRAMETYPE_REFERENCE as c_int as c_uint
-                    {
+                    if c.decode_frame_type > RAV1D_DECODEFRAMETYPE_REFERENCE {
                         return Ok(skip(c, len, init_byte_pos));
                     }
                 }
                 RAV1D_FRAME_TYPE_INTRA => {
-                    if c.decode_frame_type as c_uint
-                        > RAV1D_DECODEFRAMETYPE_INTRA as c_int as c_uint
-                    {
+                    if c.decode_frame_type > RAV1D_DECODEFRAMETYPE_INTRA {
                         return Ok(skip(c, len, init_byte_pos));
                     }
                 }
                 _ => {}
             }
-            if (c.refs[(*c.frame_hdr).existing_frame_idx as usize].p.p.data[0]).is_null() {
+            if c.refs[(*c.frame_hdr).existing_frame_idx as usize].p.p.data[0].is_null() {
                 error(c, r#in)?;
             }
             if c.strict_std_compliance
@@ -2005,14 +1972,16 @@ pub(crate) unsafe fn rav1d_parse_obus(
             if c.n_fc == 1 {
                 rav1d_thread_picture_ref(
                     &mut c.out,
-                    &mut (*(c.refs)
+                    &mut (*c
+                        .refs
                         .as_mut_ptr()
                         .offset((*c.frame_hdr).existing_frame_idx as isize))
                     .p,
                 );
                 rav1d_data_props_copy(&mut c.out.p.m, &mut r#in.m);
                 c.event_flags |= rav1d_picture_get_event_flags(
-                    &mut (*(c.refs)
+                    &mut (*c
+                        .refs
                         .as_mut_ptr()
                         .offset((*c.frame_hdr).existing_frame_idx as isize))
                     .p,
@@ -2020,22 +1989,20 @@ pub(crate) unsafe fn rav1d_parse_obus(
             } else {
                 pthread_mutex_lock(&mut c.task_thread.lock);
                 let next = c.frame_thread.next;
-                c.frame_thread.next = (c.frame_thread.next).wrapping_add(1);
+                c.frame_thread.next = c.frame_thread.next.wrapping_add(1);
                 if c.frame_thread.next == c.n_fc {
                     c.frame_thread.next = 0;
                 }
-                let f: *mut Rav1dFrameContext =
-                    &mut *(c.fc).offset(next as isize) as *mut Rav1dFrameContext;
+                let f: *mut Rav1dFrameContext = &mut *c.fc.offset(next as isize);
                 while (*f).n_tile_data > 0 {
                     pthread_cond_wait(
                         &mut (*f).task_thread.cond,
                         &mut (*(*f).task_thread.ttd).lock,
                     );
                 }
-                let out_delayed: *mut Rav1dThreadPicture = &mut *(c.frame_thread.out_delayed)
-                    .offset(next as isize)
-                    as *mut Rav1dThreadPicture;
-                if !((*out_delayed).p.data[0]).is_null()
+                let out_delayed: *mut Rav1dThreadPicture =
+                    &mut *c.frame_thread.out_delayed.offset(next as isize);
+                if !(*out_delayed).p.data[0].is_null()
                     || ::core::intrinsics::atomic_load_seqcst(
                         &mut (*f).task_thread.error as *mut atomic_int,
                     ) != 0
@@ -2043,15 +2010,9 @@ pub(crate) unsafe fn rav1d_parse_obus(
                     let first: c_uint =
                         ::core::intrinsics::atomic_load_seqcst(&mut c.task_thread.first);
                     if first.wrapping_add(1) < c.n_fc {
-                        ::core::intrinsics::atomic_xadd_seqcst(
-                            &mut c.task_thread.first,
-                            1 as c_uint,
-                        );
+                        ::core::intrinsics::atomic_xadd_seqcst(&mut c.task_thread.first, 1);
                     } else {
-                        ::core::intrinsics::atomic_store_seqcst(
-                            &mut c.task_thread.first,
-                            0 as c_uint,
-                        );
+                        ::core::intrinsics::atomic_store_seqcst(&mut c.task_thread.first, 0);
                     }
                     ::core::intrinsics::atomic_cxchg_seqcst_seqcst(
                         &mut c.task_thread.reset_task_cur,
@@ -2059,7 +2020,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
                         u32::MAX,
                     );
                     if c.task_thread.cur != 0 && c.task_thread.cur < c.n_fc {
-                        c.task_thread.cur = (c.task_thread.cur).wrapping_sub(1);
+                        c.task_thread.cur = c.task_thread.cur.wrapping_sub(1);
                     }
                 }
                 let error = (*f).task_thread.retval;
@@ -2082,7 +2043,8 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 }
                 rav1d_thread_picture_ref(
                     out_delayed,
-                    &mut (*(c.refs)
+                    &mut (*c
+                        .refs
                         .as_mut_ptr()
                         .offset((*c.frame_hdr).existing_frame_idx as isize))
                     .p,
@@ -2095,56 +2057,52 @@ pub(crate) unsafe fn rav1d_parse_obus(
                 .p
                 .p
                 .frame_hdr)
-                .frame_type as c_uint
-                == RAV1D_FRAME_TYPE_KEY as c_int as c_uint
+                .frame_type
+                == RAV1D_FRAME_TYPE_KEY
             {
                 let r: c_int = (*c.frame_hdr).existing_frame_idx;
                 c.refs[r as usize].p.showable = false;
                 let mut i = 0;
                 while i < 8 {
                     if !(i == r) {
-                        if !(c.refs[i as usize].p.p.frame_hdr).is_null() {
+                        if !c.refs[i as usize].p.p.frame_hdr.is_null() {
                             rav1d_thread_picture_unref(
                                 &mut (*(c.refs).as_mut_ptr().offset(i as isize)).p,
                             );
                         }
                         rav1d_thread_picture_ref(
-                            &mut (*(c.refs).as_mut_ptr().offset(i as isize)).p,
-                            &mut (*(c.refs).as_mut_ptr().offset(r as isize)).p,
+                            &mut (*c.refs.as_mut_ptr().offset(i as isize)).p,
+                            &mut (*c.refs.as_mut_ptr().offset(r as isize)).p,
                         );
-                        rav1d_cdf_thread_unref(&mut *(c.cdf).as_mut_ptr().offset(i as isize));
+                        rav1d_cdf_thread_unref(&mut *c.cdf.as_mut_ptr().offset(i as isize));
                         rav1d_cdf_thread_ref(
-                            &mut *(c.cdf).as_mut_ptr().offset(i as isize),
-                            &mut *(c.cdf).as_mut_ptr().offset(r as isize),
+                            &mut *c.cdf.as_mut_ptr().offset(i as isize),
+                            &mut *c.cdf.as_mut_ptr().offset(r as isize),
                         );
-                        rav1d_ref_dec(&mut (*(c.refs).as_mut_ptr().offset(i as isize)).segmap);
+                        rav1d_ref_dec(&mut (*c.refs.as_mut_ptr().offset(i as isize)).segmap);
                         c.refs[i as usize].segmap = c.refs[r as usize].segmap;
                         if !(c.refs[r as usize].segmap).is_null() {
                             rav1d_ref_inc(c.refs[r as usize].segmap);
                         }
-                        rav1d_ref_dec(&mut (*(c.refs).as_mut_ptr().offset(i as isize)).refmvs);
+                        rav1d_ref_dec(&mut (*c.refs.as_mut_ptr().offset(i as isize)).refmvs);
                     }
                     i += 1;
                 }
             }
             c.frame_hdr = 0 as *mut Rav1dFrameHeader;
         } else if c.n_tiles == (*c.frame_hdr).tiling.cols * (*c.frame_hdr).tiling.rows {
-            match (*c.frame_hdr).frame_type as c_uint {
+            match (*c.frame_hdr).frame_type {
                 RAV1D_FRAME_TYPE_INTER | RAV1D_FRAME_TYPE_SWITCH => {
-                    if c.decode_frame_type as c_uint
-                        > RAV1D_DECODEFRAMETYPE_REFERENCE as c_int as c_uint
-                        || c.decode_frame_type as c_uint
-                            == RAV1D_DECODEFRAMETYPE_REFERENCE as c_int as c_uint
+                    if c.decode_frame_type > RAV1D_DECODEFRAMETYPE_REFERENCE
+                        || c.decode_frame_type == RAV1D_DECODEFRAMETYPE_REFERENCE
                             && (*c.frame_hdr).refresh_frame_flags == 0
                     {
                         return Ok(skip(c, len, init_byte_pos));
                     }
                 }
                 RAV1D_FRAME_TYPE_INTRA => {
-                    if c.decode_frame_type as c_uint
-                        > RAV1D_DECODEFRAMETYPE_INTRA as c_int as c_uint
-                        || c.decode_frame_type as c_uint
-                            == RAV1D_DECODEFRAMETYPE_REFERENCE as c_int as c_uint
+                    if c.decode_frame_type > RAV1D_DECODEFRAMETYPE_INTRA
+                        || c.decode_frame_type == RAV1D_DECODEFRAMETYPE_REFERENCE
                             && (*c.frame_hdr).refresh_frame_flags == 0
                     {
                         return Ok(skip(c, len, init_byte_pos));

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1580,8 +1580,8 @@ pub(crate) unsafe fn rav1d_parse_obus(
     r#in: &mut Rav1dData,
     global: c_int,
 ) -> Rav1dResult<c_uint> {
-    unsafe fn error(c: *mut Rav1dContext, r#in: *mut Rav1dData) -> Rav1dResult {
-        rav1d_data_props_copy(&mut (*c).cached_error_props, &mut (*r#in).m);
+    unsafe fn error(c: &mut Rav1dContext, r#in: *mut Rav1dData) -> Rav1dResult {
+        rav1d_data_props_copy(&mut c.cached_error_props, &mut (*r#in).m);
         rav1d_log(
             c,
             b"Error parsing OBU data\n\0" as *const u8 as *const c_char,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -395,16 +395,16 @@ unsafe fn parse_seq_hdr(
     Ok(())
 }
 
-unsafe fn read_frame_size(c: *mut Rav1dContext, gb: *mut GetBits, use_ref: c_int) -> c_int {
-    let seqhdr: *const Rav1dSequenceHeader = (*c).seq_hdr;
-    let hdr: *mut Rav1dFrameHeader = (*c).frame_hdr;
+unsafe fn read_frame_size(c: &mut Rav1dContext, gb: *mut GetBits, use_ref: c_int) -> c_int {
+    let seqhdr: *const Rav1dSequenceHeader = c.seq_hdr;
+    let hdr: *mut Rav1dFrameHeader = c.frame_hdr;
     if use_ref != 0 {
         let mut i = 0;
         while i < 7 {
             if rav1d_get_bit(gb) != 0 {
-                let r#ref: *const Rav1dThreadPicture = &mut (*((*c).refs)
+                let r#ref: *const Rav1dThreadPicture = &mut (*(c.refs)
                     .as_mut_ptr()
-                    .offset(*((*(*c).frame_hdr).refidx).as_mut_ptr().offset(i as isize) as isize))
+                    .offset(*((*c.frame_hdr).refidx).as_mut_ptr().offset(i as isize) as isize))
                 .p;
                 if ((*r#ref).p.frame_hdr).is_null() {
                     return -(1 as c_int);

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -129,9 +129,9 @@ use std::ptr::addr_of_mut;
 
 #[inline]
 unsafe fn rav1d_get_bits_pos(c: *const GetBits) -> c_uint {
-    return (((*c).ptr).offset_from((*c).ptr_start) as c_long as c_uint)
+    (((*c).ptr).offset_from((*c).ptr_start) as c_long as c_uint)
         .wrapping_mul(8 as c_int as c_uint)
-        .wrapping_sub((*c).bits_left as c_uint);
+        .wrapping_sub((*c).bits_left as c_uint)
 }
 
 unsafe fn parse_seq_hdr(
@@ -465,7 +465,7 @@ unsafe fn read_frame_size(c: *mut Rav1dContext, gb: *mut GetBits, use_ref: c_int
         (*hdr).render_width = (*hdr).width[1];
         (*hdr).render_height = (*hdr).height;
     }
-    return 0 as c_int;
+    0
 }
 
 #[inline]
@@ -475,7 +475,7 @@ unsafe fn tile_log2(sz: c_int, tgt: c_int) -> c_int {
     while sz << k < tgt {
         k += 1;
     }
-    return k;
+    k
 }
 
 static default_mode_ref_deltas: Rav1dLoopfilterModeRefDeltas = Rav1dLoopfilterModeRefDeltas {
@@ -1550,7 +1550,7 @@ unsafe fn parse_tile_hdr(c: *mut Rav1dContext, gb: *mut GetBits) {
 
 unsafe fn check_for_overrun(
     c: *mut Rav1dContext,
-    gb: *mut GetBits,
+    gb: &mut GetBits,
     init_bit_pos: c_uint,
     obu_len: c_uint,
 ) -> c_int {

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -3362,7 +3362,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     as c_int
                     != 0
                 || b.c2rust_unnamed.c2rust_unnamed_0.motion_mode as c_int == MM_WARP as c_int
-                    && t.warpmv.type_0 as c_uint > RAV1D_WM_TYPE_TRANSLATION as c_int as c_uint)
+                    && t.warpmv.r#type as c_uint > RAV1D_WM_TYPE_TRANSLATION as c_int as c_uint)
         {
             res = warp_affine::<BD>(
                 t,
@@ -3739,7 +3739,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             != 0
                         || b.c2rust_unnamed.c2rust_unnamed_0.motion_mode as c_int
                             == MM_WARP as c_int
-                            && t.warpmv.type_0 as c_uint
+                            && t.warpmv.r#type as c_uint
                                 > RAV1D_WM_TYPE_TRANSLATION as c_int as c_uint)
                 {
                     let mut pl = 0;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -698,7 +698,7 @@ pub(crate) unsafe fn rav1d_refmvs_find(
             &*rf.frm_hdr,
         );
         gmv[0] =
-            if (*rf.frm_hdr).gmv[r#ref.r#ref[0] as usize - 1].type_0 > RAV1D_WM_TYPE_TRANSLATION {
+            if (*rf.frm_hdr).gmv[r#ref.r#ref[0] as usize - 1].r#type > RAV1D_WM_TYPE_TRANSLATION {
                 tgmv[0]
             } else {
                 mv::INVALID
@@ -717,7 +717,7 @@ pub(crate) unsafe fn rav1d_refmvs_find(
             &*rf.frm_hdr,
         );
         gmv[1] =
-            if (*rf.frm_hdr).gmv[r#ref.r#ref[1] as usize - 1].type_0 > RAV1D_WM_TYPE_TRANSLATION {
+            if (*rf.frm_hdr).gmv[r#ref.r#ref[1] as usize - 1].r#type > RAV1D_WM_TYPE_TRANSLATION {
                 tgmv[1]
             } else {
                 mv::INVALID

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -746,7 +746,7 @@ pub const interintra_allowed_mask: c_uint = 0
     | 0;
 
 pub(crate) static dav1d_default_wm_params: Rav1dWarpedMotionParams = Rav1dWarpedMotionParams {
-    type_0: RAV1D_WM_TYPE_IDENTITY,
+    r#type: RAV1D_WM_TYPE_IDENTITY,
     matrix: [0, 0, 1 << 16, 0, 0, 1 << 16],
     abcd: [0; 4],
 };


### PR DESCRIPTION
Main cleanups so far:
* Make args refs.
* Make some vars refs.
* Remove redundant `as` casts.
* Remove redundant type annotations.
* Remove `.wrapping_*` calls.
* Translate `for` loops.
* Use indexing for arrays.
* Add back comments.