### PR TITLE
`#![feature(extern_types)]`: Remove for the `rav1d` library

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -3,7 +3,6 @@
 #![allow(non_upper_case_globals)]
 #![feature(c_variadic)]
 #![feature(core_intrinsics)]
-#![feature(extern_types)]
 #![cfg_attr(target_arch = "arm", feature(stdsimd))]
 #![allow(clippy::all)]
 


### PR DESCRIPTION
This removes #![feature(extern_types)] just for the `rav1d` library, which is what really matters (unlike the binaries).

All types have been deduplicated now, so we don't need this anymore.

Fixes part of #592.