### PR TITLE
CI: Increase timeout multiplier for aarch64

### DIFF
--- a/.github/workflows/build-and-test-aarch64.yml
+++ b/.github/workflows/build-and-test-aarch64.yml
@@ -49,7 +49,7 @@ jobs:
             -w ${{ github.workspace }} \
             --platform linux/arm64 \
             ghcr.io/immunant/rav1d/debian-bullseye-aarch64:latest \
-            .github/workflows/test.sh \
+            .github/workflows/test.sh -t 2 \
                 -r ../target/aarch64-unknown-linux-gnu/release/dav1d \
                 -s ../target/aarch64-unknown-linux-gnu/release/seek_stress
       - name: upload build artifacts


### PR DESCRIPTION
Arm7 and x86 debug builds run with a timeout multiplier of 2. Use the same setting for aarch64 to avoid timeouts on Github runners.