### PR TITLE
`mod obu`: Deduplicate macros

### DIFF
--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -1035,7 +1035,7 @@ impl From<Rav1dSegmentationData> for Dav1dSegmentationData {
 #[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dSegmentationDataSet {
-    pub d: [Dav1dSegmentationData; 8],
+    pub d: [Dav1dSegmentationData; DAV1D_MAX_SEGMENTS as usize],
     pub preskip: c_int,
     pub last_active_segid: c_int,
 }
@@ -1043,7 +1043,7 @@ pub struct Dav1dSegmentationDataSet {
 #[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dSegmentationDataSet {
-    pub d: [Rav1dSegmentationData; 8],
+    pub d: [Rav1dSegmentationData; RAV1D_MAX_SEGMENTS as usize],
     pub preskip: c_int,
     pub last_active_segid: c_int,
 }
@@ -1607,8 +1607,8 @@ pub struct Dav1dFrameHeader_segmentation {
     pub temporal: c_int,
     pub update_data: c_int,
     pub seg_data: Dav1dSegmentationDataSet,
-    pub lossless: [c_int; 8],
-    pub qidx: [c_int; 8],
+    pub lossless: [c_int; DAV1D_MAX_SEGMENTS as usize],
+    pub qidx: [c_int; DAV1D_MAX_SEGMENTS as usize],
 }
 
 #[derive(Clone)]
@@ -1619,8 +1619,8 @@ pub(crate) struct Rav1dFrameHeader_segmentation {
     pub temporal: c_int,
     pub update_data: c_int,
     pub seg_data: Rav1dSegmentationDataSet,
-    pub lossless: [c_int; 8],
-    pub qidx: [c_int; 8],
+    pub lossless: [c_int; RAV1D_MAX_SEGMENTS as usize],
+    pub qidx: [c_int; RAV1D_MAX_SEGMENTS as usize],
 }
 
 impl From<Dav1dFrameHeader_segmentation> for Rav1dFrameHeader_segmentation {

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -421,8 +421,10 @@ pub(crate) const RAV1D_CHR_UNKNOWN: Rav1dChromaSamplePosition = DAV1D_CHR_UNKNOW
 
 // Constants from Section 3. "Symbols and abbreviated terms"
 pub const DAV1D_MAX_SEGMENTS: u8 = 8;
+pub const DAV1D_PRIMARY_REF_NONE: c_int = 7;
 
 pub(crate) const RAV1D_MAX_SEGMENTS: u8 = DAV1D_MAX_SEGMENTS;
+pub(crate) const RAV1D_PRIMARY_REF_NONE: c_int = DAV1D_PRIMARY_REF_NONE;
 
 #[repr(C)]
 pub struct Rav1dContentLightLevel {

--- a/lib.rs
+++ b/lib.rs
@@ -3,6 +3,7 @@
 #![allow(non_upper_case_globals)]
 #![feature(c_variadic)]
 #![feature(core_intrinsics)]
+#![feature(offset_of)] // TODO(kkysen) Will be removed shortly.
 #![cfg_attr(target_arch = "arm", feature(stdsimd))]
 #![allow(clippy::all)]
 

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -1,4 +1,5 @@
 use crate::include::dav1d::headers::Rav1dFrameHeader;
+use crate::include::dav1d::headers::RAV1D_MAX_SEGMENTS;
 use crate::include::dav1d::headers::RAV1D_N_SWITCHABLE_FILTERS;
 use crate::include::stdatomic::atomic_uint;
 use crate::src::align::Align16;
@@ -89,7 +90,7 @@ pub struct CdfModeContext {
     pub angle_delta: Align16<[[u16; 8]; 8]>,
     pub filter_intra: Align16<[u16; 8]>,
     pub comp_inter_mode: Align16<[[u16; N_COMP_INTER_PRED_MODES]; 8]>,
-    pub seg_id: Align16<[[u16; 8]; 3]>,
+    pub seg_id: Align16<[[u16; RAV1D_MAX_SEGMENTS as usize]; 3]>,
     pub pal_sz: Align16<[[[u16; 8]; 7]; 2]>,
     pub color_map: Align16<[[[[u16; 8]; 5]; 7]; 2]>,
     pub filter: Align8<[[[u16; 4]; 8]; 2]>,
@@ -5186,7 +5187,7 @@ pub(crate) unsafe fn rav1d_cdf_thread_update(
             ((*src).m.seg_id[j_18 as usize]).as_ptr() as *const c_void,
             ::core::mem::size_of::<[u16; 8]>(),
         );
-        (*dst).m.seg_id[j_18 as usize][(8 - 1) as usize] = 0 as c_int as u16;
+        (*dst).m.seg_id[j_18 as usize][(RAV1D_MAX_SEGMENTS - 1) as usize] = 0 as c_int as u16;
         j_18 += 1;
     }
     memcpy(

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -15,6 +15,7 @@ use crate::include::dav1d::headers::Rav1dITUTT35;
 use crate::include::dav1d::headers::Rav1dMasteringDisplay;
 use crate::include::dav1d::headers::Rav1dSequenceHeader;
 use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
+use crate::include::dav1d::headers::RAV1D_MAX_SEGMENTS;
 use crate::include::dav1d::picture::Rav1dPicAllocator;
 use crate::include::dav1d::picture::Rav1dPicture;
 use crate::include::stdatomic::atomic_int;
@@ -455,7 +456,7 @@ pub(crate) struct Rav1dFrameContext {
     pub sb_shift: c_int,
     pub sb_step: c_int,
     pub sr_sb128w: c_int,
-    pub dq: [[[u16; 2]; 3]; 8],
+    pub dq: [[[u16; 2]; 3]; RAV1D_MAX_SEGMENTS as usize],
     pub qm: [[*const u8; 3]; 19],
     pub a: *mut BlockContext,
     pub a_sz: c_int,
@@ -492,7 +493,7 @@ pub struct Rav1dTileState {
     pub progress: [atomic_int; 2],
     pub frame_thread: [Rav1dTileState_frame_thread; 2],
     pub lowest_pixel: *mut [[c_int; 2]; 7],
-    pub dqmem: [[[u16; 2]; 3]; 8],
+    pub dqmem: [[[u16; 2]; 3]; RAV1D_MAX_SEGMENTS as usize],
     pub dq: *const [[u16; 2]; 3],
     pub last_qidx: c_int,
     pub last_delta_lf: [i8; 4],

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -37,6 +37,7 @@ use crate::include::dav1d::headers::RAV1D_FRAME_TYPE_INTER;
 use crate::include::dav1d::headers::RAV1D_FRAME_TYPE_INTRA;
 use crate::include::dav1d::headers::RAV1D_FRAME_TYPE_KEY;
 use crate::include::dav1d::headers::RAV1D_FRAME_TYPE_SWITCH;
+use crate::include::dav1d::headers::RAV1D_MAX_SEGMENTS;
 use crate::include::dav1d::headers::RAV1D_MC_IDENTITY;
 use crate::include::dav1d::headers::RAV1D_MC_UNKNOWN;
 use crate::include::dav1d::headers::RAV1D_OBU_FRAME;
@@ -912,7 +913,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         if hdr.segmentation.update_data != 0 {
             hdr.segmentation.seg_data.preskip = 0;
             hdr.segmentation.seg_data.last_active_segid = -1;
-            for i in 0..8 {
+            for i in 0..RAV1D_MAX_SEGMENTS as c_int {
                 let seg = &mut hdr.segmentation.seg_data.d[i as usize];
                 if rav1d_get_bit(gb) != 0 {
                     seg.delta_q = rav1d_get_sbits(gb, 9);
@@ -981,7 +982,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             0,
             ::core::mem::size_of::<Rav1dSegmentationDataSet>(),
         );
-        for i in 0..8 {
+        for i in 0..RAV1D_MAX_SEGMENTS {
             hdr.segmentation.seg_data.d[i as usize].r#ref = -1;
         }
     }
@@ -1017,7 +1018,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         && hdr.quant.vdc_delta == 0
         && hdr.quant.vac_delta == 0) as c_int;
     hdr.all_lossless = 1;
-    for i in 0..8 {
+    for i in 0..RAV1D_MAX_SEGMENTS {
         hdr.segmentation.qidx[i as usize] = if hdr.segmentation.enabled != 0 {
             iclip_u8(hdr.quant.yac + hdr.segmentation.seg_data.d[i as usize].delta_q)
         } else {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1,3 +1,4 @@
+use crate::include::common::frame::is_key_or_intra;
 use crate::include::common::intops::iclip_u8;
 use crate::include::common::intops::ulog2;
 use crate::include::dav1d::data::Rav1dData;
@@ -514,7 +515,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         hdr.force_integer_mv = 0;
     }
 
-    if hdr.frame_type & 1 == 0 {
+    if is_key_or_intra(hdr) {
         hdr.force_integer_mv = 1;
     }
 
@@ -558,7 +559,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         }
     }
 
-    if hdr.frame_type & 1 == 0 {
+    if is_key_or_intra(hdr) {
         hdr.refresh_frame_flags = if hdr.frame_type == RAV1D_FRAME_TYPE_KEY && hdr.show_frame != 0 {
             0xff
         } else {


### PR DESCRIPTION
Deduplicate these macros:
* `offsetof` (requires `#![feature(offsetof)]`, but this way is `unsafe` and will be replace soon)
* `is_key_or_intra`
* `is_inter_or_switch`
* `RAV1D_MAX_SEGMENTS`
* `DAV1D_MAX_SEGMENTS`