### PR TITLE
`offset_of!`: Translate all `offsetof`s

### DIFF
--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -28,6 +28,7 @@ use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_void;
+use std::mem;
 
 #[repr(C)]
 pub struct CdfContext {
@@ -5682,7 +5683,7 @@ pub unsafe fn rav1d_cdf_thread_unref(cdf: *mut CdfThreadContext) {
     memset(
         &mut (*cdf).data as *mut CdfThreadContext_data as *mut c_void,
         0 as c_int,
-        (::core::mem::size_of::<CdfThreadContext>()).wrapping_sub(8),
+        ::core::mem::size_of::<CdfThreadContext>() - mem::offset_of!(CdfThreadContext, data),
     );
     rav1d_ref_dec(&mut (*cdf).r#ref);
 }

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -2,6 +2,7 @@
 #![allow(non_upper_case_globals)]
 #![feature(extern_types)]
 #![feature(c_variadic)]
+#![feature(offset_of)]
 #![allow(clippy::all)]
 
 #[path = "../tools/input"]

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -2,6 +2,7 @@
 #![allow(non_upper_case_globals)]
 #![feature(extern_types)]
 #![feature(c_variadic)]
+#![feature(offset_of)]
 #![allow(clippy::all)]
 
 mod input {

--- a/tools/input/input.rs
+++ b/tools/input/input.rs
@@ -17,6 +17,7 @@ use std::ffi::c_char;
 use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_void;
+use std::mem;
 
 extern "C" {
     pub type DemuxerPriv;
@@ -156,7 +157,7 @@ pub unsafe fn input_open(
     }
     c = calloc(
         1,
-        (16 as usize).wrapping_add((*impl_0).priv_data_size as usize),
+        mem::offset_of!(DemuxerContext, priv_data) + (*impl_0).priv_data_size as usize,
     ) as *mut DemuxerContext;
     if c.is_null() {
         fprintf(

--- a/tools/output/output.rs
+++ b/tools/output/output.rs
@@ -19,6 +19,7 @@ use std::ffi::c_long;
 use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
+use std::mem;
 
 extern "C" {
     pub type MuxerPriv;
@@ -160,7 +161,8 @@ pub unsafe fn output_open(
             return -ENOPROTOOPT;
         }
     }
-    c = malloc((48 as usize).wrapping_add((*impl_0).priv_data_size as usize)) as *mut MuxerContext;
+    c = malloc(mem::offset_of!(MuxerContext, priv_data) + (*impl_0).priv_data_size as usize)
+        as *mut MuxerContext;
     if c.is_null() {
         fprintf(
             stderr,


### PR DESCRIPTION
`offsetof`s from C were translated as `const`s, so these are brittle to types changing without noticing.  This is an unstable feature, but I'll be able to remove all of the `offset_of!`s very soon.