### PR TITLE
`fn parse_seq_hdr`: Initialize and return `Rav1dSequenceHeader` directly

### DIFF
--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -522,7 +522,7 @@ pub struct Dav1dSequenceHeaderOperatingPoint {
     pub display_model_param_present: c_int,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
 #[repr(C)]
 pub(crate) struct Rav1dSequenceHeaderOperatingPoint {
     pub major_level: c_int,
@@ -588,7 +588,7 @@ pub struct Dav1dSequenceHeaderOperatingParameterInfo {
     pub low_delay_mode: c_int,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
 #[repr(C)]
 pub(crate) struct Rav1dSequenceHeaderOperatingParameterInfo {
     pub decoder_buffer_delay: c_int,


### PR DESCRIPTION
I accidentally merged #604 early/into the wrong branch, so re-opening and will merge shortly.