### PR TITLE
Revert "Add custom profile for debug builds with basic optimizations"

### DIFF
--- a/.github/workflows/build-and-test-aarch64.yml
+++ b/.github/workflows/build-and-test-aarch64.yml
@@ -50,8 +50,8 @@ jobs:
             --platform linux/arm64 \
             ghcr.io/immunant/rav1d/debian-bullseye-aarch64:latest \
             .github/workflows/test.sh -t 2 \
-                -r target/aarch64-unknown-linux-gnu/release/dav1d \
-                -s target/aarch64-unknown-linux-gnu/release/seek_stress
+                -r ../target/aarch64-unknown-linux-gnu/release/dav1d \
+                -s ../target/aarch64-unknown-linux-gnu/release/seek_stress
       - name: upload build artifacts
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-and-test-arm7.yml
+++ b/.github/workflows/build-and-test-arm7.yml
@@ -50,8 +50,8 @@ jobs:
             --platform linux/arm/v7 \
             ghcr.io/immunant/rav1d/debian-bullseye-arm7:latest \
             .github/workflows/test.sh -t 2 \
-                -r target/armv7-unknown-linux-gnueabihf/release/dav1d \
-                -s target/armv7-unknown-linux-gnueabihf/release/seek_stress
+                -r ../target/armv7-unknown-linux-gnueabihf/release/dav1d \
+                -s ../target/armv7-unknown-linux-gnueabihf/release/seek_stress
       - name: upload build artifacts
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-and-test-x86.yml
+++ b/.github/workflows/build-and-test-x86.yml
@@ -11,7 +11,7 @@ jobs:
         build: [
           # release build without optimized assembly routines
           {name: "release", flags: "--release --no-default-features --features=bitdepth_8,bitdepth_16", timeout_multiplier: 1},
-          # debug build with optimizations to catch overflows with optimized assembly routines
+          # debug build to catch overflows with optimized assembly routines
           {name: "opt-dev", flags: "--profile opt-dev", timeout_multiplier: 2}
         ]
     runs-on: ubuntu-latest
@@ -51,8 +51,8 @@ jobs:
       - name: meson test for ${{ matrix.target }} ${{ matrix.build.name }}
         run: |
           .github/workflows/test.sh \
-              -r target/${{ matrix.target }}/${{ matrix.build.name }}/dav1d \
-              -s target/${{ matrix.target }}/${{ matrix.build.name }}/seek_stress \
+              -r ../target/${{ matrix.target }}/${{ matrix.build.name }}/dav1d \
+              -s ../target/${{ matrix.target }}/${{ matrix.build.name }}/seek_stress \
               -t ${{ matrix.build.timeout_multiplier }}
       - name: copy log files
         if: ${{ !cancelled() }}
@@ -100,9 +100,8 @@ jobs:
           cargo build --release
       - name: meson test for x86_64-apple-darwin
         run: |
-          .github/workflows/test.sh \
-              -r target/release/dav1d \
-              -s target/release/seek_stress
+          .github/workflows/test.sh -r ../target/release/dav1d \
+              -s ../target/release/seek_stress
       - name: copy log files
         if: ${{ !cancelled() }}
         run: |

--- a/.github/workflows/build-and-test-x86.yml
+++ b/.github/workflows/build-and-test-x86.yml
@@ -12,7 +12,7 @@ jobs:
           # release build without optimized assembly routines
           {name: "release", flags: "--release --no-default-features --features=bitdepth_8,bitdepth_16", timeout_multiplier: 1},
           # debug build to catch overflows with optimized assembly routines
-          {name: "opt-dev", flags: "--profile opt-dev", timeout_multiplier: 2}
+          {name: "debug", flags: "", timeout_multiplier: 2}
         ]
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,11 @@ asm = []
 bitdepth_8 = []
 bitdepth_16 = []
 
-[profile.opt-dev]
-# The debug builds run tests very slowly so this profile keeps debug assertions
-# while enabling basic optimizations. The profile is not suitable for debugging.
-inherits = "dev"
+[profile.dev]
+# As we port, we increasingly use operations that require more optimizations to be zero-cost,
+# so while `--release` perf stays the same, debug perf suffers a lot,
+# unless we enable the basic optimizations (`opt-level = 1`),
+# which don't increase compile-time that much.
 opt-level = 1
 
 [profile.release]

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -149,27 +149,26 @@ if get_option('test_rust')
     test_rust_path = get_option('test_rust_path')
     seek_stress_test_rust_path = get_option('seek_stress_test_rust_path')
 
+    if test_rust_path == '' or seek_stress_test_rust_path == ''
+        message('running cargo build since "test_rust" is set but ' +
+                '"test_rust_path" or "seek_stress_test_rust_path" isn\'t set...'
+        )
+        if get_option('debug')
+            run_command('cargo', 'build', check: true)
+            test_rust_path = '../target/debug/dav1d'
+            seek_stress_test_rust_path  = '../target/debug/seek_stress'
+        else
+            run_command('cargo', 'build', '--release', check: true)
+            test_rust_path = '../target/release/dav1d'
+            seek_stress_test_rust_path  = '../target/release/seek_stress'
+        endif
+    endif
+
     # HACK: If we're trying to test the Rust build, override the `dav1d` and
     # `seek_stress` executables to point to the versions produced by Cargo.
-    # This will test the Rust executables instead of the C versions.
-    if test_rust_path == ''
-        if get_option('debug')
-            profile = 'debug'
-        else
-            profile = 'release'
-        endif
-        test_rust_path = '../target/' + profile + '/dav1d'
-        test_rust_path = join_paths(meson.current_source_dir(), test_rust_path)
-        dav1d = find_program(test_rust_path, required: true)
-        seek_stress_test_rust_path = '../target/' + profile + '/seek_stress'
-        seek_stress_test_rust_path = join_paths(meson.current_source_dir(), seek_stress_test_rust_path)
-        seek_stress = find_program(seek_stress_test_rust_path, required: true)
-    else
-        # Adjust relative paths so one can use binary paths relative to project
-        # top dir rather than relative to the location of the test subdirectory.
-        dav1d = files(join_paths('../', get_option('test_rust_path')))
-        seek_stress = files(join_paths('../', get_option('seek_stress_test_rust_path')))
-    endif
+    # This will cause the Rust executables to be tested instead of the C versions.
+    dav1d = files(test_rust_path)
+    seek_stress = files(seek_stress_test_rust_path)
 endif
 
 # Include dav1d test data repository with additional tests


### PR DESCRIPTION
Revert #605, as it breaks `cargo build`.  We should fix it, but I'd rather not spend time on it now.