### PR TITLE
`fn parse_frame_size`: Initialize and return `Rav1dFrameSize` directly

### DIFF
--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -2124,11 +2124,21 @@ pub struct Dav1dFrameHeader {
 
 #[derive(Clone)]
 #[repr(C)]
-pub(crate) struct Rav1dFrameHeader {
-    pub film_grain: Rav1dFrameHeader_film_grain,
-    pub frame_type: Rav1dFrameType,
+pub(crate) struct Rav1dFrameSize {
     pub width: [c_int; 2],
     pub height: c_int,
+    pub render_width: c_int,
+    pub render_height: c_int,
+    pub super_res: Rav1dFrameHeader_super_res,
+    pub have_render_size: c_int,
+}
+
+#[derive(Clone)]
+#[repr(C)]
+pub(crate) struct Rav1dFrameHeader {
+    pub size: Rav1dFrameSize,
+    pub film_grain: Rav1dFrameHeader_film_grain,
+    pub frame_type: Rav1dFrameType,
     pub frame_offset: c_int,
     pub temporal_id: c_int,
     pub spatial_id: c_int,
@@ -2147,10 +2157,6 @@ pub(crate) struct Rav1dFrameHeader {
     pub buffer_removal_time_present: c_int,
     pub operating_points: [Rav1dFrameHeaderOperatingPoint; RAV1D_MAX_OPERATING_POINTS],
     pub refresh_frame_flags: c_int,
-    pub render_width: c_int,
-    pub render_height: c_int,
-    pub super_res: Rav1dFrameHeader_super_res,
-    pub have_render_size: c_int,
     pub allow_intrabc: c_int,
     pub frame_ref_short_signaling: c_int,
     pub refidx: [c_int; RAV1D_REFS_PER_FRAME],
@@ -2232,10 +2238,16 @@ impl From<Dav1dFrameHeader> for Rav1dFrameHeader {
             gmv,
         } = value;
         Self {
+            size: Rav1dFrameSize {
+                width,
+                height,
+                render_width,
+                render_height,
+                super_res: super_res.into(),
+                have_render_size,
+            },
             film_grain: film_grain.into(),
             frame_type,
-            width,
-            height,
             frame_offset,
             temporal_id,
             spatial_id,
@@ -2254,10 +2266,6 @@ impl From<Dav1dFrameHeader> for Rav1dFrameHeader {
             buffer_removal_time_present,
             operating_points: operating_points.map(|c| c.into()),
             refresh_frame_flags,
-            render_width,
-            render_height,
-            super_res: super_res.into(),
-            have_render_size,
             allow_intrabc,
             frame_ref_short_signaling,
             refidx,
@@ -2289,10 +2297,17 @@ impl From<Dav1dFrameHeader> for Rav1dFrameHeader {
 impl From<Rav1dFrameHeader> for Dav1dFrameHeader {
     fn from(value: Rav1dFrameHeader) -> Self {
         let Rav1dFrameHeader {
+            size:
+                Rav1dFrameSize {
+                    width,
+                    height,
+                    render_width,
+                    render_height,
+                    super_res,
+                    have_render_size,
+                },
             film_grain,
             frame_type,
-            width,
-            height,
             frame_offset,
             temporal_id,
             spatial_id,
@@ -2311,10 +2326,6 @@ impl From<Rav1dFrameHeader> for Dav1dFrameHeader {
             buffer_removal_time_present,
             operating_points,
             refresh_frame_flags,
-            render_width,
-            render_height,
-            super_res,
-            have_render_size,
             allow_intrabc,
             frame_ref_short_signaling,
             refidx,

--- a/src/cdef_apply_tmpl_16.rs
+++ b/src/cdef_apply_tmpl_16.rs
@@ -188,7 +188,7 @@ pub(crate) unsafe fn rav1d_cdef_brow_16bpc(
         .as_ptr();
     let have_tt = ((*(*f).c).n_tc > 1 as c_uint) as c_int;
     let sb128 = (*(*f).seq_hdr).sb128;
-    let resize = ((*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1]) as c_int;
+    let resize = ((*(*f).frame_hdr).size.width[0] != (*(*f).frame_hdr).size.width[1]) as c_int;
     let y_stride: ptrdiff_t = PXSTRIDE((*f).cur.stride[0]);
     let uv_stride: ptrdiff_t = PXSTRIDE((*f).cur.stride[1]);
     let mut bit = 0;

--- a/src/cdef_apply_tmpl_8.rs
+++ b/src/cdef_apply_tmpl_8.rs
@@ -180,7 +180,7 @@ pub(crate) unsafe fn rav1d_cdef_brow_8bpc(
         .as_ptr();
     let have_tt = ((*(*f).c).n_tc > 1 as c_uint) as c_int;
     let sb128 = (*(*f).seq_hdr).sb128;
-    let resize = ((*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1]) as c_int;
+    let resize = ((*(*f).frame_hdr).size.width[0] != (*(*f).frame_hdr).size.width[1]) as c_int;
     let y_stride: ptrdiff_t = (*f).cur.stride[0];
     let uv_stride: ptrdiff_t = (*f).cur.stride[1];
     let mut bit = 0;

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -33,8 +33,8 @@ unsafe fn backup_lpf<BD: BitDepth>(
     lr_backup: c_int,
 ) {
     let cdef_backup = (lr_backup == 0) as c_int;
-    let dst_w = if (*(*f).frame_hdr).super_res.enabled != 0 {
-        (*(*f).frame_hdr).width[1] + ss_hor >> ss_hor
+    let dst_w = if (*(*f).frame_hdr).size.super_res.enabled != 0 {
+        (*(*f).frame_hdr).size.width[1] + ss_hor >> ss_hor
     } else {
         src_w
     };
@@ -104,7 +104,7 @@ unsafe fn backup_lpf<BD: BitDepth>(
         }
         dst = dst.offset(4 * BD::pxstride(dst_stride as usize) as isize);
     }
-    if lr_backup != 0 && (*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1] {
+    if lr_backup != 0 && (*(*f).frame_hdr).size.width[0] != (*(*f).frame_hdr).size.width[1] {
         while row + stripe_h <= row_h {
             let n_lines = 4 - (row + stripe_h + 1 == h) as c_int;
             ((*(*f).dsp).mc.resize)(
@@ -171,7 +171,7 @@ pub(crate) unsafe fn rav1d_copy_lpf<BD: BitDepth>(
     sby: c_int,
 ) {
     let have_tt = ((*(*f).c).n_tc > 1 as c_uint) as c_int;
-    let resize = ((*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1]) as c_int;
+    let resize = ((*(*f).frame_hdr).size.width[0] != (*(*f).frame_hdr).size.width[1]) as c_int;
     let offset = 8 * (sby != 0) as c_int;
     let src_stride: *const ptrdiff_t = ((*f).cur.stride).as_mut_ptr();
     let lr_stride: *const ptrdiff_t = ((*f).sr_cur.p.stride).as_mut_ptr();

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -607,7 +607,7 @@ unsafe fn parse_frame_size(
     c: &mut Rav1dContext,
     gb: &mut GetBits,
     use_ref: c_int,
-) -> Result<Rav1dFrameSize, ()> {
+) -> Rav1dResult<Rav1dFrameSize> {
     let seqhdr = &*c.seq_hdr;
     let hdr = &mut *c.frame_hdr;
 
@@ -616,7 +616,7 @@ unsafe fn parse_frame_size(
             if rav1d_get_bit(gb) != 0 {
                 let r#ref = &mut c.refs[(*c.frame_hdr).refidx[i as usize] as usize].p;
                 if (*r#ref).p.frame_hdr.is_null() {
-                    return Err(());
+                    return Err(EINVAL);
                 }
                 let width1 = (*(*r#ref).p.frame_hdr).size.width[1];
                 let height = (*(*r#ref).p.frame_hdr).size.height;
@@ -848,7 +848,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         {
             return Err(EINVAL);
         }
-        (*c.frame_hdr).size = parse_frame_size(c, gb, 0).map_err(|()| EINVAL)?;
+        (*c.frame_hdr).size = parse_frame_size(c, gb, 0)?;
         hdr.allow_intrabc = (hdr.allow_screen_content_tools != 0
             && hdr.size.super_res.enabled == 0
             && rav1d_get_bit(gb) != 0) as c_int;
@@ -990,7 +990,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             }
         }
         let use_ref = (hdr.error_resilient_mode == 0 && hdr.frame_size_override != 0) as c_int;
-        (*c.frame_hdr).size = parse_frame_size(c, gb, use_ref).map_err(|()| EINVAL)?;
+        (*c.frame_hdr).size = parse_frame_size(c, gb, use_ref)?;
         hdr.hp = (hdr.force_integer_mv == 0 && rav1d_get_bit(gb) != 0) as c_int;
         hdr.subpel_filter_mode = if rav1d_get_bit(gb) != 0 {
             RAV1D_FILTER_SWITCHABLE

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -603,7 +603,7 @@ unsafe fn parse_seq_hdr(
     })
 }
 
-unsafe fn read_frame_size(
+unsafe fn parse_frame_size(
     c: &mut Rav1dContext,
     gb: &mut GetBits,
     use_ref: c_int,
@@ -848,7 +848,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         {
             return Err(EINVAL);
         }
-        (*c.frame_hdr).size = read_frame_size(c, gb, 0).map_err(|()| EINVAL)?;
+        (*c.frame_hdr).size = parse_frame_size(c, gb, 0).map_err(|()| EINVAL)?;
         hdr.allow_intrabc = (hdr.allow_screen_content_tools != 0
             && hdr.size.super_res.enabled == 0
             && rav1d_get_bit(gb) != 0) as c_int;
@@ -990,7 +990,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             }
         }
         let use_ref = (hdr.error_resilient_mode == 0 && hdr.frame_size_override != 0) as c_int;
-        (*c.frame_hdr).size = read_frame_size(c, gb, use_ref).map_err(|()| EINVAL)?;
+        (*c.frame_hdr).size = parse_frame_size(c, gb, use_ref).map_err(|()| EINVAL)?;
         hdr.hp = (hdr.force_integer_mv == 0 && rav1d_get_bit(gb) != 0) as c_int;
         hdr.subpel_filter_mode = if rav1d_get_bit(gb) != 0 {
             RAV1D_FILTER_SWITCHABLE

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -276,8 +276,8 @@ pub(crate) unsafe fn rav1d_thread_picture_alloc(
     let res = picture_alloc_with_edges(
         c,
         &mut (*p).p,
-        (*(*f).frame_hdr).width[1],
-        (*(*f).frame_hdr).height,
+        (*(*f).frame_hdr).size.width[1],
+        (*(*f).frame_hdr).size.height,
         (*f).seq_hdr,
         (*f).seq_hdr_ref,
         (*f).frame_hdr,

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -3289,7 +3289,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
         * ((t.bx >> ss_hor) as isize
             + (t.by >> ss_ver) as isize * BD::pxstride((*f).cur.stride[1] as usize) as isize);
     if (*(*f).frame_hdr).frame_type as c_uint & 1 as c_uint == 0 {
-        if (*(*f).frame_hdr).super_res.enabled != 0 {
+        if (*(*f).frame_hdr).size.super_res.enabled != 0 {
             unreachable!();
         }
         res = mc::<BD>(
@@ -4679,7 +4679,7 @@ pub(crate) unsafe fn rav1d_filter_sbrow<BD: BitDepth>(f: &mut Rav1dFrameContext,
     if (*f.seq_hdr).cdef != 0 {
         rav1d_filter_sbrow_cdef::<BD>(&mut *(*f.c).tc, sby);
     }
-    if (*f.frame_hdr).width[0] != (*f.frame_hdr).width[1] {
+    if (*f.frame_hdr).size.width[0] != (*f.frame_hdr).size.width[1] {
         rav1d_filter_sbrow_resize::<BD>(f, sby);
     }
     if f.lf.restore_planes != 0 {

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1389,11 +1389,12 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
 ) -> Rav1dResult {
     (*rf).sbsz = (16 as c_int) << (*seq_hdr).sb128;
     (*rf).frm_hdr = frm_hdr;
-    (*rf).iw8 = (*frm_hdr).width[0] + 7 >> 3;
-    (*rf).ih8 = (*frm_hdr).height + 7 >> 3;
+    (*rf).iw8 = (*frm_hdr).size.width[0] + 7 >> 3;
+    (*rf).ih8 = (*frm_hdr).size.height + 7 >> 3;
     (*rf).iw4 = (*rf).iw8 << 1;
     (*rf).ih4 = (*rf).ih8 << 1;
-    let r_stride: ptrdiff_t = (((*frm_hdr).width[0] + 127 & !(127 as c_int)) >> 2) as ptrdiff_t;
+    let r_stride: ptrdiff_t =
+        (((*frm_hdr).size.width[0] + 127 & !(127 as c_int)) >> 2) as ptrdiff_t;
     let n_tile_rows = if n_tile_threads > 1 {
         (*frm_hdr).tiling.rows
     } else {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -360,7 +360,7 @@ unsafe fn create_filter_sbrow(
     let has_deblock = ((*(*f).frame_hdr).loopfilter.level_y[0] != 0
         || (*(*f).frame_hdr).loopfilter.level_y[1] != 0) as c_int;
     let has_cdef = (*(*f).seq_hdr).cdef;
-    let has_resize = ((*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1]) as c_int;
+    let has_resize = ((*(*f).frame_hdr).size.width[0] != (*(*f).frame_hdr).size.width[1]) as c_int;
     let has_lr = (*f).lf.restore_planes;
     let mut tasks: *mut Rav1dTask = (*f).task_thread.tasks;
     let uses_2pass = ((*(*f).c).n_fc > 1 as c_uint) as c_int;
@@ -1529,7 +1529,9 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                         }
                         match current_block {
                             12196494833634779273 => {
-                                if (*(*f).frame_hdr).width[0] != (*(*f).frame_hdr).width[1] {
+                                if (*(*f).frame_hdr).size.width[0]
+                                    != (*(*f).frame_hdr).size.width[1]
+                                {
                                     if ::core::intrinsics::atomic_load_seqcst(
                                         &mut (*f).task_thread.error as *mut atomic_int,
                                     ) == 0


### PR DESCRIPTION
`struct Rav1dFrameSize` was extracted from the monolithic `struct Rav1dFrameHeader` to do this.  The `fn` was also renamed from `fn read_frame_size` to match the names and signatures of the other `fn parse_*`s in `mod obu`.

I'd like to double-check perf on this, as due to extracting out `struct Rav1dFrameSize`, the fields were re-arranged, and I just want to make sure that didn't hurt cache perf.