### PR TITLE
`fn parse_frame_size`: Cleanup and make mostly safe

### DIFF
--- a/src/obu.rs
+++ b/src/obu.rs
@@ -614,7 +614,7 @@ unsafe fn parse_frame_size(
     if use_ref != 0 {
         for i in 0..7 {
             if rav1d_get_bit(gb) != 0 {
-                let r#ref = &mut c.refs[hdr.refidx[i as usize] as usize].p;
+                let r#ref = &c.refs[hdr.refidx[i as usize] as usize].p;
                 if (*r#ref).p.frame_hdr.is_null() {
                     return Err(EINVAL);
                 }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -618,10 +618,11 @@ unsafe fn parse_frame_size(
                 if (*r#ref).p.frame_hdr.is_null() {
                     return Err(EINVAL);
                 }
-                let width1 = (*(*r#ref).p.frame_hdr).size.width[1];
-                let height = (*(*r#ref).p.frame_hdr).size.height;
-                let render_width = (*(*r#ref).p.frame_hdr).size.render_width;
-                let render_height = (*(*r#ref).p.frame_hdr).size.render_height;
+                let ref_size = &(*(*r#ref).p.frame_hdr).size;
+                let width1 = ref_size.width[1];
+                let height = ref_size.height;
+                let render_width = ref_size.render_width;
+                let render_height = ref_size.render_height;
                 let enabled = (seqhdr.super_res != 0 && rav1d_get_bit(gb) != 0) as c_int;
                 let width_scale_denominator;
                 let width0;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -614,7 +614,7 @@ unsafe fn parse_frame_size(
     if use_ref != 0 {
         for i in 0..7 {
             if rav1d_get_bit(gb) != 0 {
-                let r#ref = &mut c.refs[(*c.frame_hdr).refidx[i as usize] as usize].p;
+                let r#ref = &mut c.refs[hdr.refidx[i as usize] as usize].p;
                 if (*r#ref).p.frame_hdr.is_null() {
                     return Err(EINVAL);
                 }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -609,7 +609,7 @@ unsafe fn parse_frame_size(
     use_ref: c_int,
 ) -> Rav1dResult<Rav1dFrameSize> {
     let seqhdr = &*c.seq_hdr;
-    let hdr = &mut *c.frame_hdr;
+    let hdr = &*c.frame_hdr;
 
     if use_ref != 0 {
         for i in 0..7 {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -605,12 +605,11 @@ unsafe fn parse_seq_hdr(
 
 unsafe fn parse_frame_size(
     c: &mut Rav1dContext,
+    seqhdr: &Rav1dSequenceHeader,
+    hdr: &Rav1dFrameHeader,
     gb: &mut GetBits,
     use_ref: c_int,
 ) -> Rav1dResult<Rav1dFrameSize> {
-    let seqhdr = &*c.seq_hdr;
-    let hdr = &*c.frame_hdr;
-
     if use_ref != 0 {
         for i in 0..7 {
             if rav1d_get_bit(gb) != 0 {
@@ -849,7 +848,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         {
             return Err(EINVAL);
         }
-        (*c.frame_hdr).size = parse_frame_size(c, gb, 0)?;
+        (*c.frame_hdr).size = parse_frame_size(c, seqhdr, hdr, gb, 0)?;
         hdr.allow_intrabc = (hdr.allow_screen_content_tools != 0
             && hdr.size.super_res.enabled == 0
             && rav1d_get_bit(gb) != 0) as c_int;
@@ -991,7 +990,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
             }
         }
         let use_ref = (hdr.error_resilient_mode == 0 && hdr.frame_size_override != 0) as c_int;
-        (*c.frame_hdr).size = parse_frame_size(c, gb, use_ref)?;
+        (*c.frame_hdr).size = parse_frame_size(c, seqhdr, hdr, gb, use_ref)?;
         hdr.hp = (hdr.force_integer_mv == 0 && rav1d_get_bit(gb) != 0) as c_int;
         hdr.subpel_filter_mode = if rav1d_get_bit(gb) != 0 {
             RAV1D_FILTER_SWITCHABLE

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -604,7 +604,7 @@ unsafe fn parse_seq_hdr(
 }
 
 unsafe fn parse_frame_size(
-    c: &mut Rav1dContext,
+    c: &Rav1dContext,
     seqhdr: &Rav1dSequenceHeader,
     hdr: &Rav1dFrameHeader,
     gb: &mut GetBits,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -608,9 +608,9 @@ unsafe fn parse_frame_size(
     seqhdr: &Rav1dSequenceHeader,
     hdr: &Rav1dFrameHeader,
     gb: &mut GetBits,
-    use_ref: c_int,
+    use_ref: bool,
 ) -> Rav1dResult<Rav1dFrameSize> {
-    if use_ref != 0 {
+    if use_ref {
         for i in 0..7 {
             if rav1d_get_bit(gb) != 0 {
                 let r#ref = &c.refs[hdr.refidx[i as usize] as usize].p;
@@ -848,7 +848,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
         {
             return Err(EINVAL);
         }
-        (*c.frame_hdr).size = parse_frame_size(c, seqhdr, hdr, gb, 0)?;
+        (*c.frame_hdr).size = parse_frame_size(c, seqhdr, hdr, gb, false)?;
         hdr.allow_intrabc = (hdr.allow_screen_content_tools != 0
             && hdr.size.super_res.enabled == 0
             && rav1d_get_bit(gb) != 0) as c_int;
@@ -989,7 +989,7 @@ unsafe fn parse_frame_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult
                 }
             }
         }
-        let use_ref = (hdr.error_resilient_mode == 0 && hdr.frame_size_override != 0) as c_int;
+        let use_ref = hdr.error_resilient_mode == 0 && hdr.frame_size_override != 0;
         (*c.frame_hdr).size = parse_frame_size(c, seqhdr, hdr, gb, use_ref)?;
         hdr.hp = (hdr.force_integer_mv == 0 && rav1d_get_bit(gb) != 0) as c_int;
         hdr.subpel_filter_mode = if rav1d_get_bit(gb) != 0 {


### PR DESCRIPTION
The only remaining `unsafe`ty is `rav1d_get_bit(s)`, which I'll do soon, and `Rav1dPicture::frame_hdr`, which will be `Arc`ed.