### PR TITLE
`fn parse_frame_hdr`: Extract `fn parse_*`s for complex fields

### DIFF
--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1287,6 +1287,132 @@ unsafe fn parse_gmv(
     Ok(())
 }
 
+unsafe fn parse_film_grain(
+    c: &Rav1dContext,
+    seqhdr: &Rav1dSequenceHeader,
+    hdr: &mut Rav1dFrameHeader,
+    debug: &Debug,
+    gb: &mut GetBits,
+) -> Rav1dResult {
+    hdr.film_grain.present = (seqhdr.film_grain_present != 0
+        && (hdr.show_frame != 0 || hdr.showable_frame != 0)
+        && rav1d_get_bit(gb) != 0) as c_int;
+    if hdr.film_grain.present != 0 {
+        let seed = rav1d_get_bits(gb, 16);
+        hdr.film_grain.update =
+            (hdr.frame_type != Rav1dFrameType::Inter || rav1d_get_bit(gb) != 0) as c_int;
+        if hdr.film_grain.update == 0 {
+            let refidx = rav1d_get_bits(gb, 3) as c_int;
+            let mut found = false;
+            for i in 0..7 {
+                if hdr.refidx[i as usize] == refidx {
+                    found = true;
+                    break;
+                }
+            }
+            if !found || c.refs[refidx as usize].p.p.frame_hdr.is_null() {
+                return Err(EINVAL);
+            }
+            hdr.film_grain.data = (*c.refs[refidx as usize].p.p.frame_hdr)
+                .film_grain
+                .data
+                .clone();
+            hdr.film_grain.data.seed = seed;
+        } else {
+            let fgd = &mut hdr.film_grain.data;
+            fgd.seed = seed;
+
+            fgd.num_y_points = rav1d_get_bits(gb, 4) as c_int;
+            if fgd.num_y_points > 14 {
+                return Err(EINVAL);
+            }
+            for i in 0..fgd.num_y_points {
+                fgd.y_points[i as usize][0] = rav1d_get_bits(gb, 8) as u8;
+                if i != 0
+                    && fgd.y_points[(i - 1) as usize][0] as c_int
+                        >= fgd.y_points[i as usize][0] as c_int
+                {
+                    return Err(EINVAL);
+                }
+                fgd.y_points[i as usize][1] = rav1d_get_bits(gb, 8) as u8;
+            }
+
+            fgd.chroma_scaling_from_luma = seqhdr.monochrome == 0 && rav1d_get_bit(gb) != 0;
+            if seqhdr.monochrome != 0
+                || fgd.chroma_scaling_from_luma
+                || seqhdr.ss_ver == 1 && seqhdr.ss_hor == 1 && fgd.num_y_points == 0
+            {
+                fgd.num_uv_points[1] = 0;
+                fgd.num_uv_points[0] = fgd.num_uv_points[1];
+            } else {
+                for pl in 0..2 {
+                    fgd.num_uv_points[pl as usize] = rav1d_get_bits(gb, 4) as c_int;
+                    if fgd.num_uv_points[pl as usize] > 10 {
+                        return Err(EINVAL);
+                    }
+                    for i in 0..fgd.num_uv_points[pl as usize] {
+                        fgd.uv_points[pl as usize][i as usize][0] = rav1d_get_bits(gb, 8) as u8;
+                        if i != 0
+                            && fgd.uv_points[pl as usize][(i - 1) as usize][0] as c_int
+                                >= fgd.uv_points[pl as usize][i as usize][0] as c_int
+                        {
+                            return Err(EINVAL);
+                        }
+                        fgd.uv_points[pl as usize][i as usize][1] = rav1d_get_bits(gb, 8) as u8;
+                    }
+                }
+            }
+
+            if seqhdr.ss_hor == 1
+                && seqhdr.ss_ver == 1
+                && (fgd.num_uv_points[0] != 0) != (fgd.num_uv_points[1] != 0)
+            {
+                return Err(EINVAL);
+            }
+
+            fgd.scaling_shift = rav1d_get_bits(gb, 2) as u8 + 8;
+            fgd.ar_coeff_lag = rav1d_get_bits(gb, 2) as c_int;
+            let num_y_pos = 2 * fgd.ar_coeff_lag * (fgd.ar_coeff_lag + 1);
+            if fgd.num_y_points != 0 {
+                for i in 0..num_y_pos {
+                    fgd.ar_coeffs_y[i as usize] = rav1d_get_bits(gb, 8).wrapping_sub(128) as i8;
+                }
+            }
+            for pl in 0..2 {
+                if fgd.num_uv_points[pl as usize] != 0 || fgd.chroma_scaling_from_luma {
+                    let num_uv_pos = num_y_pos + (fgd.num_y_points != 0) as c_int;
+                    for i in 0..num_uv_pos {
+                        fgd.ar_coeffs_uv[pl as usize][i as usize] =
+                            rav1d_get_bits(gb, 8).wrapping_sub(128) as i8;
+                    }
+                    if fgd.num_y_points == 0 {
+                        fgd.ar_coeffs_uv[pl as usize][num_uv_pos as usize] = 0;
+                    }
+                }
+            }
+            fgd.ar_coeff_shift = rav1d_get_bits(gb, 2) as u8 + 6;
+            fgd.grain_scale_shift = rav1d_get_bits(gb, 2) as u8;
+            for pl in 0..2 {
+                if fgd.num_uv_points[pl as usize] != 0 {
+                    fgd.uv_mult[pl as usize] = rav1d_get_bits(gb, 8) as c_int - 128;
+                    fgd.uv_luma_mult[pl as usize] = rav1d_get_bits(gb, 8) as c_int - 128;
+                    fgd.uv_offset[pl as usize] = rav1d_get_bits(gb, 9) as c_int - 256;
+                }
+            }
+            fgd.overlap_flag = rav1d_get_bit(gb) != 0;
+            fgd.clip_to_restricted_range = rav1d_get_bit(gb) != 0;
+        }
+    } else {
+        memset(
+            &mut hdr.film_grain.data as *mut Rav1dFilmGrainData as *mut c_void,
+            0,
+            ::core::mem::size_of::<Rav1dFilmGrainData>(),
+        );
+    }
+    debug.post(gb, "filmgrain");
+    Ok(())
+}
+
 unsafe fn parse_frame_hdr(
     c: &Rav1dContext,
     seqhdr: &Rav1dSequenceHeader,
@@ -1636,123 +1762,7 @@ unsafe fn parse_frame_hdr(
     debug.post(gb, "reducedtxtpset");
 
     parse_gmv(c, &mut hdr, &debug, gb)?;
-
-    hdr.film_grain.present = (seqhdr.film_grain_present != 0
-        && (hdr.show_frame != 0 || hdr.showable_frame != 0)
-        && rav1d_get_bit(gb) != 0) as c_int;
-    if hdr.film_grain.present != 0 {
-        let seed = rav1d_get_bits(gb, 16);
-        hdr.film_grain.update =
-            (hdr.frame_type != Rav1dFrameType::Inter || rav1d_get_bit(gb) != 0) as c_int;
-        if hdr.film_grain.update == 0 {
-            let refidx = rav1d_get_bits(gb, 3) as c_int;
-            let mut found = false;
-            for i in 0..7 {
-                if hdr.refidx[i as usize] == refidx {
-                    found = true;
-                    break;
-                }
-            }
-            if !found || c.refs[refidx as usize].p.p.frame_hdr.is_null() {
-                return Err(EINVAL);
-            }
-            hdr.film_grain.data = (*c.refs[refidx as usize].p.p.frame_hdr)
-                .film_grain
-                .data
-                .clone();
-            hdr.film_grain.data.seed = seed;
-        } else {
-            let fgd = &mut hdr.film_grain.data;
-            fgd.seed = seed;
-
-            fgd.num_y_points = rav1d_get_bits(gb, 4) as c_int;
-            if fgd.num_y_points > 14 {
-                return Err(EINVAL);
-            }
-            for i in 0..fgd.num_y_points {
-                fgd.y_points[i as usize][0] = rav1d_get_bits(gb, 8) as u8;
-                if i != 0
-                    && fgd.y_points[(i - 1) as usize][0] as c_int
-                        >= fgd.y_points[i as usize][0] as c_int
-                {
-                    return Err(EINVAL);
-                }
-                fgd.y_points[i as usize][1] = rav1d_get_bits(gb, 8) as u8;
-            }
-
-            fgd.chroma_scaling_from_luma = seqhdr.monochrome == 0 && rav1d_get_bit(gb) != 0;
-            if seqhdr.monochrome != 0
-                || fgd.chroma_scaling_from_luma
-                || seqhdr.ss_ver == 1 && seqhdr.ss_hor == 1 && fgd.num_y_points == 0
-            {
-                fgd.num_uv_points[1] = 0;
-                fgd.num_uv_points[0] = fgd.num_uv_points[1];
-            } else {
-                for pl in 0..2 {
-                    fgd.num_uv_points[pl as usize] = rav1d_get_bits(gb, 4) as c_int;
-                    if fgd.num_uv_points[pl as usize] > 10 {
-                        return Err(EINVAL);
-                    }
-                    for i in 0..fgd.num_uv_points[pl as usize] {
-                        fgd.uv_points[pl as usize][i as usize][0] = rav1d_get_bits(gb, 8) as u8;
-                        if i != 0
-                            && fgd.uv_points[pl as usize][(i - 1) as usize][0] as c_int
-                                >= fgd.uv_points[pl as usize][i as usize][0] as c_int
-                        {
-                            return Err(EINVAL);
-                        }
-                        fgd.uv_points[pl as usize][i as usize][1] = rav1d_get_bits(gb, 8) as u8;
-                    }
-                }
-            }
-
-            if seqhdr.ss_hor == 1
-                && seqhdr.ss_ver == 1
-                && (fgd.num_uv_points[0] != 0) != (fgd.num_uv_points[1] != 0)
-            {
-                return Err(EINVAL);
-            }
-
-            fgd.scaling_shift = rav1d_get_bits(gb, 2) as u8 + 8;
-            fgd.ar_coeff_lag = rav1d_get_bits(gb, 2) as c_int;
-            let num_y_pos = 2 * fgd.ar_coeff_lag * (fgd.ar_coeff_lag + 1);
-            if fgd.num_y_points != 0 {
-                for i in 0..num_y_pos {
-                    fgd.ar_coeffs_y[i as usize] = rav1d_get_bits(gb, 8).wrapping_sub(128) as i8;
-                }
-            }
-            for pl in 0..2 {
-                if fgd.num_uv_points[pl as usize] != 0 || fgd.chroma_scaling_from_luma {
-                    let num_uv_pos = num_y_pos + (fgd.num_y_points != 0) as c_int;
-                    for i in 0..num_uv_pos {
-                        fgd.ar_coeffs_uv[pl as usize][i as usize] =
-                            rav1d_get_bits(gb, 8).wrapping_sub(128) as i8;
-                    }
-                    if fgd.num_y_points == 0 {
-                        fgd.ar_coeffs_uv[pl as usize][num_uv_pos as usize] = 0;
-                    }
-                }
-            }
-            fgd.ar_coeff_shift = rav1d_get_bits(gb, 2) as u8 + 6;
-            fgd.grain_scale_shift = rav1d_get_bits(gb, 2) as u8;
-            for pl in 0..2 {
-                if fgd.num_uv_points[pl as usize] != 0 {
-                    fgd.uv_mult[pl as usize] = rav1d_get_bits(gb, 8) as c_int - 128;
-                    fgd.uv_luma_mult[pl as usize] = rav1d_get_bits(gb, 8) as c_int - 128;
-                    fgd.uv_offset[pl as usize] = rav1d_get_bits(gb, 9) as c_int - 256;
-                }
-            }
-            fgd.overlap_flag = rav1d_get_bit(gb) != 0;
-            fgd.clip_to_restricted_range = rav1d_get_bit(gb) != 0;
-        }
-    } else {
-        memset(
-            &mut hdr.film_grain.data as *mut Rav1dFilmGrainData as *mut c_void,
-            0,
-            ::core::mem::size_of::<Rav1dFilmGrainData>(),
-        );
-    }
-    debug.post(gb, "filmgrain");
+    parse_film_grain(c, seqhdr, &mut hdr, &debug, gb)?;
 
     Ok(hdr)
 }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -793,6 +793,68 @@ unsafe fn parse_tiling(
     Ok(())
 }
 
+unsafe fn parse_quant(
+    seqhdr: &Rav1dSequenceHeader,
+    hdr: &mut Rav1dFrameHeader,
+    debug: &Debug,
+    gb: &mut GetBits,
+) -> Rav1dResult {
+    hdr.quant.yac = rav1d_get_bits(gb, 8) as c_int;
+    hdr.quant.ydc_delta = if rav1d_get_bit(gb) != 0 {
+        rav1d_get_sbits(gb, 7)
+    } else {
+        0
+    };
+    if seqhdr.monochrome == 0 {
+        // If the sequence header says that delta_q might be different
+        // for U, V, we must check whether it actually is for this
+        // frame.
+        let diff_uv_delta = if seqhdr.separate_uv_delta_q != 0 {
+            rav1d_get_bit(gb) as c_int
+        } else {
+            0
+        };
+        hdr.quant.udc_delta = if rav1d_get_bit(gb) != 0 {
+            rav1d_get_sbits(gb, 7)
+        } else {
+            0
+        };
+        hdr.quant.uac_delta = if rav1d_get_bit(gb) != 0 {
+            rav1d_get_sbits(gb, 7)
+        } else {
+            0
+        };
+        if diff_uv_delta != 0 {
+            hdr.quant.vdc_delta = if rav1d_get_bit(gb) != 0 {
+                rav1d_get_sbits(gb, 7)
+            } else {
+                0
+            };
+            hdr.quant.vac_delta = if rav1d_get_bit(gb) != 0 {
+                rav1d_get_sbits(gb, 7)
+            } else {
+                0
+            };
+        } else {
+            hdr.quant.vdc_delta = hdr.quant.udc_delta;
+            hdr.quant.vac_delta = hdr.quant.uac_delta;
+        }
+    }
+    debug.post(gb, "quant");
+    hdr.quant.qm = rav1d_get_bit(gb) as c_int;
+    if hdr.quant.qm != 0 {
+        hdr.quant.qm_y = rav1d_get_bits(gb, 4) as c_int;
+        hdr.quant.qm_u = rav1d_get_bits(gb, 4) as c_int;
+        hdr.quant.qm_v = if seqhdr.separate_uv_delta_q != 0 {
+            rav1d_get_bits(gb, 4) as c_int
+        } else {
+            hdr.quant.qm_u
+        };
+    }
+    debug.post(gb, "qm");
+    Ok(())
+}
+
 unsafe fn parse_frame_hdr(
     c: &Rav1dContext,
     seqhdr: &Rav1dSequenceHeader,
@@ -1092,61 +1154,7 @@ unsafe fn parse_frame_hdr(
     debug.post(gb, "refresh_context");
 
     parse_tiling(seqhdr, &mut hdr, &debug, gb)?;
-
-    // quant data
-    hdr.quant.yac = rav1d_get_bits(gb, 8) as c_int;
-    hdr.quant.ydc_delta = if rav1d_get_bit(gb) != 0 {
-        rav1d_get_sbits(gb, 7)
-    } else {
-        0
-    };
-    if seqhdr.monochrome == 0 {
-        // If the sequence header says that delta_q might be different
-        // for U, V, we must check whether it actually is for this
-        // frame.
-        let diff_uv_delta = if seqhdr.separate_uv_delta_q != 0 {
-            rav1d_get_bit(gb) as c_int
-        } else {
-            0
-        };
-        hdr.quant.udc_delta = if rav1d_get_bit(gb) != 0 {
-            rav1d_get_sbits(gb, 7)
-        } else {
-            0
-        };
-        hdr.quant.uac_delta = if rav1d_get_bit(gb) != 0 {
-            rav1d_get_sbits(gb, 7)
-        } else {
-            0
-        };
-        if diff_uv_delta != 0 {
-            hdr.quant.vdc_delta = if rav1d_get_bit(gb) != 0 {
-                rav1d_get_sbits(gb, 7)
-            } else {
-                0
-            };
-            hdr.quant.vac_delta = if rav1d_get_bit(gb) != 0 {
-                rav1d_get_sbits(gb, 7)
-            } else {
-                0
-            };
-        } else {
-            hdr.quant.vdc_delta = hdr.quant.udc_delta;
-            hdr.quant.vac_delta = hdr.quant.uac_delta;
-        }
-    }
-    debug.post(gb, "quant");
-    hdr.quant.qm = rav1d_get_bit(gb) as c_int;
-    if hdr.quant.qm != 0 {
-        hdr.quant.qm_y = rav1d_get_bits(gb, 4) as c_int;
-        hdr.quant.qm_u = rav1d_get_bits(gb, 4) as c_int;
-        hdr.quant.qm_v = if seqhdr.separate_uv_delta_q != 0 {
-            rav1d_get_bits(gb, 4) as c_int
-        } else {
-            hdr.quant.qm_u
-        };
-    }
-    debug.post(gb, "qm");
+    parse_quant(seqhdr, &mut hdr, &debug, gb)?;
 
     // segmentation data
     hdr.segmentation.enabled = rav1d_get_bit(gb) as c_int;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1046,6 +1046,30 @@ unsafe fn parse_loopfilter(
     Ok(())
 }
 
+unsafe fn parse_cdef(
+    seqhdr: &Rav1dSequenceHeader,
+    hdr: &mut Rav1dFrameHeader,
+    debug: &Debug,
+    gb: &mut GetBits,
+) -> Rav1dResult {
+    if hdr.all_lossless == 0 && seqhdr.cdef != 0 && hdr.allow_intrabc == 0 {
+        hdr.cdef.damping = rav1d_get_bits(gb, 2) as c_int + 3;
+        hdr.cdef.n_bits = rav1d_get_bits(gb, 2) as c_int;
+        for i in 0..1 << hdr.cdef.n_bits {
+            hdr.cdef.y_strength[i as usize] = rav1d_get_bits(gb, 6) as c_int;
+            if seqhdr.monochrome == 0 {
+                hdr.cdef.uv_strength[i as usize] = rav1d_get_bits(gb, 6) as c_int;
+            }
+        }
+    } else {
+        hdr.cdef.n_bits = 0;
+        hdr.cdef.y_strength[0] = 0;
+        hdr.cdef.uv_strength[0] = 0;
+    }
+    debug.post(gb, "cdef");
+    Ok(())
+}
+
 unsafe fn parse_frame_hdr(
     c: &Rav1dContext,
     seqhdr: &Rav1dSequenceHeader,
@@ -1368,23 +1392,7 @@ unsafe fn parse_frame_hdr(
     }
 
     parse_loopfilter(c, seqhdr, &mut hdr, &debug, gb)?;
-
-    // cdef
-    if hdr.all_lossless == 0 && seqhdr.cdef != 0 && hdr.allow_intrabc == 0 {
-        hdr.cdef.damping = rav1d_get_bits(gb, 2) as c_int + 3;
-        hdr.cdef.n_bits = rav1d_get_bits(gb, 2) as c_int;
-        for i in 0..1 << hdr.cdef.n_bits {
-            hdr.cdef.y_strength[i as usize] = rav1d_get_bits(gb, 6) as c_int;
-            if seqhdr.monochrome == 0 {
-                hdr.cdef.uv_strength[i as usize] = rav1d_get_bits(gb, 6) as c_int;
-            }
-        }
-    } else {
-        hdr.cdef.n_bits = 0;
-        hdr.cdef.y_strength[0] = 0;
-        hdr.cdef.uv_strength[0] = 0;
-    }
-    debug.post(gb, "cdef");
+    parse_cdef(seqhdr, &mut hdr, &debug, gb)?;
 
     // restoration
     if (hdr.all_lossless == 0 || hdr.size.super_res.enabled != 0)

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -691,6 +691,108 @@ static default_mode_ref_deltas: Rav1dLoopfilterModeRefDeltas = Rav1dLoopfilterMo
     ref_delta: [1, 0, 0, 0, -1, 0, -1, -1],
 };
 
+unsafe fn parse_tiling(
+    seqhdr: &Rav1dSequenceHeader,
+    hdr: &mut Rav1dFrameHeader,
+    debug: &Debug,
+    gb: &mut GetBits,
+) -> Rav1dResult {
+    hdr.tiling.uniform = rav1d_get_bit(gb) as c_int;
+    let sbsz_min1 = ((64) << seqhdr.sb128) - 1;
+    let sbsz_log2 = 6 + seqhdr.sb128;
+    let sbw = hdr.size.width[0] + sbsz_min1 >> sbsz_log2;
+    let sbh = hdr.size.height + sbsz_min1 >> sbsz_log2;
+    let max_tile_width_sb = 4096 >> sbsz_log2;
+    let max_tile_area_sb = 4096 * 2304 >> 2 * sbsz_log2;
+    hdr.tiling.min_log2_cols = tile_log2(max_tile_width_sb, sbw);
+    hdr.tiling.max_log2_cols = tile_log2(1, cmp::min(sbw, RAV1D_MAX_TILE_COLS as c_int));
+    hdr.tiling.max_log2_rows = tile_log2(1, cmp::min(sbh, RAV1D_MAX_TILE_ROWS as c_int));
+    let min_log2_tiles = cmp::max(
+        tile_log2(max_tile_area_sb, sbw * sbh),
+        hdr.tiling.min_log2_cols,
+    );
+    if hdr.tiling.uniform != 0 {
+        hdr.tiling.log2_cols = hdr.tiling.min_log2_cols;
+        while hdr.tiling.log2_cols < hdr.tiling.max_log2_cols && rav1d_get_bit(gb) != 0 {
+            hdr.tiling.log2_cols += 1;
+        }
+        let tile_w = 1 + (sbw - 1 >> hdr.tiling.log2_cols);
+        hdr.tiling.cols = 0;
+        let mut sbx = 0;
+        while sbx < sbw {
+            hdr.tiling.col_start_sb[hdr.tiling.cols as usize] = sbx as u16;
+            sbx += tile_w;
+            hdr.tiling.cols += 1;
+        }
+        hdr.tiling.min_log2_rows = cmp::max(min_log2_tiles - hdr.tiling.log2_cols, 0);
+
+        hdr.tiling.log2_rows = hdr.tiling.min_log2_rows;
+        while hdr.tiling.log2_rows < hdr.tiling.max_log2_rows && rav1d_get_bit(gb) != 0 {
+            hdr.tiling.log2_rows += 1;
+        }
+        let tile_h = 1 + (sbh - 1 >> hdr.tiling.log2_rows);
+        hdr.tiling.rows = 0;
+        let mut sby = 0;
+        while sby < sbh {
+            hdr.tiling.row_start_sb[hdr.tiling.rows as usize] = sby as u16;
+            sby += tile_h;
+            hdr.tiling.rows += 1;
+        }
+    } else {
+        hdr.tiling.cols = 0;
+        let mut widest_tile = 0;
+        let mut max_tile_area_sb = sbw * sbh;
+        let mut sbx = 0;
+        while sbx < sbw && hdr.tiling.cols < RAV1D_MAX_TILE_COLS as c_int {
+            let tile_width_sb = cmp::min(sbw - sbx, max_tile_width_sb);
+            let tile_w = if tile_width_sb > 1 {
+                1 + rav1d_get_uniform(gb, tile_width_sb as c_uint) as c_int
+            } else {
+                1
+            };
+            hdr.tiling.col_start_sb[hdr.tiling.cols as usize] = sbx as u16;
+            sbx += tile_w;
+            widest_tile = cmp::max(widest_tile, tile_w);
+            hdr.tiling.cols += 1;
+        }
+        hdr.tiling.log2_cols = tile_log2(1, hdr.tiling.cols);
+        if min_log2_tiles != 0 {
+            max_tile_area_sb >>= min_log2_tiles + 1;
+        }
+        let max_tile_height_sb = cmp::max(max_tile_area_sb / widest_tile, 1);
+
+        hdr.tiling.rows = 0;
+        let mut sby = 0;
+        while sby < sbh && hdr.tiling.rows < RAV1D_MAX_TILE_ROWS as c_int {
+            let tile_height_sb = cmp::min(sbh - sby, max_tile_height_sb);
+            let tile_h = if tile_height_sb > 1 {
+                1 + rav1d_get_uniform(gb, tile_height_sb as c_uint) as c_int
+            } else {
+                1
+            };
+            hdr.tiling.row_start_sb[hdr.tiling.rows as usize] = sby as u16;
+            sby += tile_h;
+            hdr.tiling.rows += 1;
+        }
+        hdr.tiling.log2_rows = tile_log2(1, hdr.tiling.rows);
+    }
+    hdr.tiling.col_start_sb[hdr.tiling.cols as usize] = sbw as u16;
+    hdr.tiling.row_start_sb[hdr.tiling.rows as usize] = sbh as u16;
+    if hdr.tiling.log2_cols != 0 || hdr.tiling.log2_rows != 0 {
+        hdr.tiling.update =
+            rav1d_get_bits(gb, hdr.tiling.log2_cols + hdr.tiling.log2_rows) as c_int;
+        if hdr.tiling.update >= hdr.tiling.cols * hdr.tiling.rows {
+            return Err(EINVAL);
+        }
+        hdr.tiling.n_bytes = rav1d_get_bits(gb, 2) + 1;
+    } else {
+        hdr.tiling.update = 0;
+        hdr.tiling.n_bytes = hdr.tiling.update as c_uint;
+    }
+    debug.post(gb, "tiling");
+    Ok(())
+}
+
 unsafe fn parse_frame_hdr(
     c: &Rav1dContext,
     seqhdr: &Rav1dSequenceHeader,
@@ -989,100 +1091,7 @@ unsafe fn parse_frame_hdr(
         && rav1d_get_bit(gb) == 0) as c_int;
     debug.post(gb, "refresh_context");
 
-    // tile data
-    hdr.tiling.uniform = rav1d_get_bit(gb) as c_int;
-    let sbsz_min1 = ((64) << seqhdr.sb128) - 1;
-    let sbsz_log2 = 6 + seqhdr.sb128;
-    let sbw = hdr.size.width[0] + sbsz_min1 >> sbsz_log2;
-    let sbh = hdr.size.height + sbsz_min1 >> sbsz_log2;
-    let max_tile_width_sb = 4096 >> sbsz_log2;
-    let max_tile_area_sb = 4096 * 2304 >> 2 * sbsz_log2;
-    hdr.tiling.min_log2_cols = tile_log2(max_tile_width_sb, sbw);
-    hdr.tiling.max_log2_cols = tile_log2(1, cmp::min(sbw, RAV1D_MAX_TILE_COLS as c_int));
-    hdr.tiling.max_log2_rows = tile_log2(1, cmp::min(sbh, RAV1D_MAX_TILE_ROWS as c_int));
-    let min_log2_tiles = cmp::max(
-        tile_log2(max_tile_area_sb, sbw * sbh),
-        hdr.tiling.min_log2_cols,
-    );
-    if hdr.tiling.uniform != 0 {
-        hdr.tiling.log2_cols = hdr.tiling.min_log2_cols;
-        while hdr.tiling.log2_cols < hdr.tiling.max_log2_cols && rav1d_get_bit(gb) != 0 {
-            hdr.tiling.log2_cols += 1;
-        }
-        let tile_w = 1 + (sbw - 1 >> hdr.tiling.log2_cols);
-        hdr.tiling.cols = 0;
-        let mut sbx = 0;
-        while sbx < sbw {
-            hdr.tiling.col_start_sb[hdr.tiling.cols as usize] = sbx as u16;
-            sbx += tile_w;
-            hdr.tiling.cols += 1;
-        }
-        hdr.tiling.min_log2_rows = cmp::max(min_log2_tiles - hdr.tiling.log2_cols, 0);
-
-        hdr.tiling.log2_rows = hdr.tiling.min_log2_rows;
-        while hdr.tiling.log2_rows < hdr.tiling.max_log2_rows && rav1d_get_bit(gb) != 0 {
-            hdr.tiling.log2_rows += 1;
-        }
-        let tile_h = 1 + (sbh - 1 >> hdr.tiling.log2_rows);
-        hdr.tiling.rows = 0;
-        let mut sby = 0;
-        while sby < sbh {
-            hdr.tiling.row_start_sb[hdr.tiling.rows as usize] = sby as u16;
-            sby += tile_h;
-            hdr.tiling.rows += 1;
-        }
-    } else {
-        hdr.tiling.cols = 0;
-        let mut widest_tile = 0;
-        let mut max_tile_area_sb = sbw * sbh;
-        let mut sbx = 0;
-        while sbx < sbw && hdr.tiling.cols < RAV1D_MAX_TILE_COLS as c_int {
-            let tile_width_sb = cmp::min(sbw - sbx, max_tile_width_sb);
-            let tile_w = if tile_width_sb > 1 {
-                1 + rav1d_get_uniform(gb, tile_width_sb as c_uint) as c_int
-            } else {
-                1
-            };
-            hdr.tiling.col_start_sb[hdr.tiling.cols as usize] = sbx as u16;
-            sbx += tile_w;
-            widest_tile = cmp::max(widest_tile, tile_w);
-            hdr.tiling.cols += 1;
-        }
-        hdr.tiling.log2_cols = tile_log2(1, hdr.tiling.cols);
-        if min_log2_tiles != 0 {
-            max_tile_area_sb >>= min_log2_tiles + 1;
-        }
-        let max_tile_height_sb = cmp::max(max_tile_area_sb / widest_tile, 1);
-
-        hdr.tiling.rows = 0;
-        let mut sby = 0;
-        while sby < sbh && hdr.tiling.rows < RAV1D_MAX_TILE_ROWS as c_int {
-            let tile_height_sb = cmp::min(sbh - sby, max_tile_height_sb);
-            let tile_h = if tile_height_sb > 1 {
-                1 + rav1d_get_uniform(gb, tile_height_sb as c_uint) as c_int
-            } else {
-                1
-            };
-            hdr.tiling.row_start_sb[hdr.tiling.rows as usize] = sby as u16;
-            sby += tile_h;
-            hdr.tiling.rows += 1;
-        }
-        hdr.tiling.log2_rows = tile_log2(1, hdr.tiling.rows);
-    }
-    hdr.tiling.col_start_sb[hdr.tiling.cols as usize] = sbw as u16;
-    hdr.tiling.row_start_sb[hdr.tiling.rows as usize] = sbh as u16;
-    if hdr.tiling.log2_cols != 0 || hdr.tiling.log2_rows != 0 {
-        hdr.tiling.update =
-            rav1d_get_bits(gb, hdr.tiling.log2_cols + hdr.tiling.log2_rows) as c_int;
-        if hdr.tiling.update >= hdr.tiling.cols * hdr.tiling.rows {
-            return Err(EINVAL);
-        }
-        hdr.tiling.n_bytes = rav1d_get_bits(gb, 2) + 1;
-    } else {
-        hdr.tiling.update = 0;
-        hdr.tiling.n_bytes = hdr.tiling.update as c_uint;
-    }
-    debug.post(gb, "tiling");
+    parse_tiling(seqhdr, &mut hdr, &debug, gb)?;
 
     // quant data
     hdr.quant.yac = rav1d_get_bits(gb, 8) as c_int;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -855,6 +855,108 @@ unsafe fn parse_quant(
     Ok(())
 }
 
+unsafe fn parse_segmentation(
+    c: &Rav1dContext,
+    hdr: &mut Rav1dFrameHeader,
+    debug: &Debug,
+    gb: &mut GetBits,
+) -> Rav1dResult {
+    hdr.segmentation.enabled = rav1d_get_bit(gb) as c_int;
+    if hdr.segmentation.enabled != 0 {
+        if hdr.primary_ref_frame == RAV1D_PRIMARY_REF_NONE {
+            hdr.segmentation.update_map = 1;
+            hdr.segmentation.temporal = 0;
+            hdr.segmentation.update_data = 1;
+        } else {
+            hdr.segmentation.update_map = rav1d_get_bit(gb) as c_int;
+            hdr.segmentation.temporal = if hdr.segmentation.update_map != 0 {
+                rav1d_get_bit(gb) as c_int
+            } else {
+                0
+            };
+            hdr.segmentation.update_data = rav1d_get_bit(gb) as c_int;
+        }
+
+        if hdr.segmentation.update_data != 0 {
+            hdr.segmentation.seg_data.preskip = 0;
+            hdr.segmentation.seg_data.last_active_segid = -1;
+            for i in 0..RAV1D_MAX_SEGMENTS as c_int {
+                let seg = &mut hdr.segmentation.seg_data.d[i as usize];
+                if rav1d_get_bit(gb) != 0 {
+                    seg.delta_q = rav1d_get_sbits(gb, 9);
+                    hdr.segmentation.seg_data.last_active_segid = i;
+                } else {
+                    seg.delta_q = 0;
+                }
+                if rav1d_get_bit(gb) != 0 {
+                    seg.delta_lf_y_v = rav1d_get_sbits(gb, 7);
+                    hdr.segmentation.seg_data.last_active_segid = i;
+                } else {
+                    seg.delta_lf_y_v = 0;
+                }
+                if rav1d_get_bit(gb) != 0 {
+                    seg.delta_lf_y_h = rav1d_get_sbits(gb, 7);
+                    hdr.segmentation.seg_data.last_active_segid = i;
+                } else {
+                    seg.delta_lf_y_h = 0;
+                }
+                if rav1d_get_bit(gb) != 0 {
+                    seg.delta_lf_u = rav1d_get_sbits(gb, 7);
+                    hdr.segmentation.seg_data.last_active_segid = i;
+                } else {
+                    seg.delta_lf_u = 0;
+                }
+                if rav1d_get_bit(gb) != 0 {
+                    seg.delta_lf_v = rav1d_get_sbits(gb, 7);
+                    hdr.segmentation.seg_data.last_active_segid = i;
+                } else {
+                    seg.delta_lf_v = 0;
+                }
+                if rav1d_get_bit(gb) != 0 {
+                    seg.r#ref = rav1d_get_bits(gb, 3) as c_int;
+                    hdr.segmentation.seg_data.last_active_segid = i;
+                    hdr.segmentation.seg_data.preskip = 1;
+                } else {
+                    seg.r#ref = -1;
+                }
+                seg.skip = rav1d_get_bit(gb) as c_int;
+                if seg.skip != 0 {
+                    hdr.segmentation.seg_data.last_active_segid = i;
+                    hdr.segmentation.seg_data.preskip = 1;
+                }
+                seg.globalmv = rav1d_get_bit(gb) as c_int;
+                if seg.globalmv != 0 {
+                    hdr.segmentation.seg_data.last_active_segid = i;
+                    hdr.segmentation.seg_data.preskip = 1;
+                }
+            }
+        } else {
+            // segmentation.update_data was false so we should copy
+            // segmentation data from the reference frame.
+            assert!(hdr.primary_ref_frame != RAV1D_PRIMARY_REF_NONE);
+            let pri_ref = hdr.refidx[hdr.primary_ref_frame as usize];
+            if (c.refs[pri_ref as usize].p.p.frame_hdr).is_null() {
+                return Err(EINVAL);
+            }
+            hdr.segmentation.seg_data = (*c.refs[pri_ref as usize].p.p.frame_hdr)
+                .segmentation
+                .seg_data
+                .clone();
+        }
+    } else {
+        memset(
+            &mut hdr.segmentation.seg_data as *mut Rav1dSegmentationDataSet as *mut c_void,
+            0,
+            ::core::mem::size_of::<Rav1dSegmentationDataSet>(),
+        );
+        for i in 0..RAV1D_MAX_SEGMENTS {
+            hdr.segmentation.seg_data.d[i as usize].r#ref = -1;
+        }
+    }
+    debug.post(gb, "segmentation");
+    Ok(())
+}
+
 unsafe fn parse_frame_hdr(
     c: &Rav1dContext,
     seqhdr: &Rav1dSequenceHeader,
@@ -1155,101 +1257,7 @@ unsafe fn parse_frame_hdr(
 
     parse_tiling(seqhdr, &mut hdr, &debug, gb)?;
     parse_quant(seqhdr, &mut hdr, &debug, gb)?;
-
-    // segmentation data
-    hdr.segmentation.enabled = rav1d_get_bit(gb) as c_int;
-    if hdr.segmentation.enabled != 0 {
-        if hdr.primary_ref_frame == RAV1D_PRIMARY_REF_NONE {
-            hdr.segmentation.update_map = 1;
-            hdr.segmentation.temporal = 0;
-            hdr.segmentation.update_data = 1;
-        } else {
-            hdr.segmentation.update_map = rav1d_get_bit(gb) as c_int;
-            hdr.segmentation.temporal = if hdr.segmentation.update_map != 0 {
-                rav1d_get_bit(gb) as c_int
-            } else {
-                0
-            };
-            hdr.segmentation.update_data = rav1d_get_bit(gb) as c_int;
-        }
-
-        if hdr.segmentation.update_data != 0 {
-            hdr.segmentation.seg_data.preskip = 0;
-            hdr.segmentation.seg_data.last_active_segid = -1;
-            for i in 0..RAV1D_MAX_SEGMENTS as c_int {
-                let seg = &mut hdr.segmentation.seg_data.d[i as usize];
-                if rav1d_get_bit(gb) != 0 {
-                    seg.delta_q = rav1d_get_sbits(gb, 9);
-                    hdr.segmentation.seg_data.last_active_segid = i;
-                } else {
-                    seg.delta_q = 0;
-                }
-                if rav1d_get_bit(gb) != 0 {
-                    seg.delta_lf_y_v = rav1d_get_sbits(gb, 7);
-                    hdr.segmentation.seg_data.last_active_segid = i;
-                } else {
-                    seg.delta_lf_y_v = 0;
-                }
-                if rav1d_get_bit(gb) != 0 {
-                    seg.delta_lf_y_h = rav1d_get_sbits(gb, 7);
-                    hdr.segmentation.seg_data.last_active_segid = i;
-                } else {
-                    seg.delta_lf_y_h = 0;
-                }
-                if rav1d_get_bit(gb) != 0 {
-                    seg.delta_lf_u = rav1d_get_sbits(gb, 7);
-                    hdr.segmentation.seg_data.last_active_segid = i;
-                } else {
-                    seg.delta_lf_u = 0;
-                }
-                if rav1d_get_bit(gb) != 0 {
-                    seg.delta_lf_v = rav1d_get_sbits(gb, 7);
-                    hdr.segmentation.seg_data.last_active_segid = i;
-                } else {
-                    seg.delta_lf_v = 0;
-                }
-                if rav1d_get_bit(gb) != 0 {
-                    seg.r#ref = rav1d_get_bits(gb, 3) as c_int;
-                    hdr.segmentation.seg_data.last_active_segid = i;
-                    hdr.segmentation.seg_data.preskip = 1;
-                } else {
-                    seg.r#ref = -1;
-                }
-                seg.skip = rav1d_get_bit(gb) as c_int;
-                if seg.skip != 0 {
-                    hdr.segmentation.seg_data.last_active_segid = i;
-                    hdr.segmentation.seg_data.preskip = 1;
-                }
-                seg.globalmv = rav1d_get_bit(gb) as c_int;
-                if seg.globalmv != 0 {
-                    hdr.segmentation.seg_data.last_active_segid = i;
-                    hdr.segmentation.seg_data.preskip = 1;
-                }
-            }
-        } else {
-            // segmentation.update_data was false so we should copy
-            // segmentation data from the reference frame.
-            assert!(hdr.primary_ref_frame != RAV1D_PRIMARY_REF_NONE);
-            let pri_ref = hdr.refidx[hdr.primary_ref_frame as usize];
-            if (c.refs[pri_ref as usize].p.p.frame_hdr).is_null() {
-                return Err(EINVAL);
-            }
-            hdr.segmentation.seg_data = (*c.refs[pri_ref as usize].p.p.frame_hdr)
-                .segmentation
-                .seg_data
-                .clone();
-        }
-    } else {
-        memset(
-            &mut hdr.segmentation.seg_data as *mut Rav1dSegmentationDataSet as *mut c_void,
-            0,
-            ::core::mem::size_of::<Rav1dSegmentationDataSet>(),
-        );
-        for i in 0..RAV1D_MAX_SEGMENTS {
-            hdr.segmentation.seg_data.d[i as usize].r#ref = -1;
-        }
-    }
-    debug.post(gb, "segmentation");
+    parse_segmentation(c, &mut hdr, &debug, gb)?;
 
     // delta q
     hdr.delta.q.present = if hdr.quant.yac != 0 {


### PR DESCRIPTION
For fields whose initialization is complex, especially for sub-`struct`s, this extracts them to their own `fn parse_*`s.  Besides being easier to read this way since there's not one giant parsing `fn`, it also makes it tremendously simpler to directly initialize and return those sub-`struct`s.