### PR TITLE
`struct GetBits`: Make safe

### DIFF
--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2184,11 +2184,6 @@ unsafe fn parse_obus(
     // when reading the leb128 length field).
     assert!(init_bit_pos & 7 == 0);
 
-    // We also know that we haven't tried to read more than `r#in.sz`
-    // bytes yet (otherwise the error flag would have been set
-    // by the code in [`crate::src::getbits`]).
-    assert!(r#in.sz >= init_byte_pos as usize);
-
     // Make sure that there are enough bits left in the buffer
     // for the rest of the OBU.
     if len as usize > r#in.sz - init_byte_pos as usize {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -118,6 +118,7 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::fmt;
 use std::mem::MaybeUninit;
+use std::slice;
 
 struct Debug {
     enabled: bool,
@@ -126,7 +127,7 @@ struct Debug {
 }
 
 impl Debug {
-    pub const unsafe fn new(enabled: bool, name: &'static str, gb: &GetBits) -> Self {
+    pub const fn new(enabled: bool, name: &'static str, gb: &GetBits) -> Self {
         Self {
             enabled,
             name,
@@ -147,7 +148,7 @@ impl Debug {
         }
     }
 
-    pub unsafe fn log(&self, gb: &GetBits, msg: fmt::Arguments) {
+    pub fn log(&self, gb: &GetBits, msg: fmt::Arguments) {
         let &Self {
             enabled,
             name,
@@ -160,15 +161,12 @@ impl Debug {
         println!("{name}: {msg} [off={offset}]");
     }
 
-    pub unsafe fn post(&self, gb: &GetBits, post: &str) {
+    pub fn post(&self, gb: &GetBits, post: &str) {
         self.log(gb, format_args!("post-{post}"));
     }
 }
 
-unsafe fn parse_seq_hdr(
-    c: &mut Rav1dContext,
-    gb: &mut GetBits,
-) -> Rav1dResult<Rav1dSequenceHeader> {
+fn parse_seq_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult<Rav1dSequenceHeader> {
     let debug = Debug::new(false, "SEQHDR", gb);
 
     let profile = gb.get_bits(3) as c_int;
@@ -818,7 +816,7 @@ unsafe fn parse_refidx(
     Ok(refidx)
 }
 
-unsafe fn parse_tiling(
+fn parse_tiling(
     seqhdr: &Rav1dSequenceHeader,
     size: &Rav1dFrameSize,
     debug: &Debug,
@@ -939,7 +937,7 @@ unsafe fn parse_tiling(
     })
 }
 
-unsafe fn parse_quant(
+fn parse_quant(
     seqhdr: &Rav1dSequenceHeader,
     debug: &Debug,
     gb: &mut GetBits,
@@ -1029,7 +1027,7 @@ unsafe fn parse_quant(
     }
 }
 
-unsafe fn parse_seg_data(gb: &mut GetBits) -> Rav1dSegmentationDataSet {
+fn parse_seg_data(gb: &mut GetBits) -> Rav1dSegmentationDataSet {
     let mut preskip = 0;
     let mut last_active_segid = -1;
     let d = array::from_fn(|i| {
@@ -1186,7 +1184,7 @@ unsafe fn parse_segmentation(
     })
 }
 
-unsafe fn parse_delta(
+fn parse_delta(
     quant: &Rav1dFrameHeader_quant,
     allow_intrabc: c_int,
     debug: &Debug,
@@ -1308,7 +1306,7 @@ unsafe fn parse_loopfilter(
     })
 }
 
-unsafe fn parse_cdef(
+fn parse_cdef(
     seqhdr: &Rav1dSequenceHeader,
     all_lossless: c_int,
     allow_intrabc: c_int,
@@ -1345,7 +1343,7 @@ unsafe fn parse_cdef(
     }
 }
 
-unsafe fn parse_restoration(
+fn parse_restoration(
     seqhdr: &Rav1dSequenceHeader,
     all_lossless: c_int,
     super_res_enabled: c_int,
@@ -1567,7 +1565,7 @@ unsafe fn parse_gmv(
     Ok(gmv)
 }
 
-unsafe fn parse_film_grain_data(
+fn parse_film_grain_data(
     seqhdr: &Rav1dSequenceHeader,
     seed: c_uint,
     gb: &mut GetBits,
@@ -2076,10 +2074,7 @@ unsafe fn parse_frame_hdr(
     })
 }
 
-unsafe fn parse_tile_hdr(
-    tiling: &Rav1dFrameHeader_tiling,
-    gb: &mut GetBits,
-) -> Rav1dTileGroupHeader {
+fn parse_tile_hdr(tiling: &Rav1dFrameHeader_tiling, gb: &mut GetBits) -> Rav1dTileGroupHeader {
     let n_tiles = tiling.cols * tiling.rows;
     let have_tile_pos = if n_tiles > 1 {
         gb.get_bit() as c_int
@@ -2102,7 +2097,7 @@ unsafe fn parse_tile_hdr(
 
 /// Check that we haven't read more than `obu_len`` bytes
 /// from the buffer since `init_bit_pos`.
-unsafe fn check_for_overrun(
+fn check_for_overrun(
     c: &mut Rav1dContext,
     gb: &mut GetBits,
     init_bit_pos: c_uint,
@@ -2154,7 +2149,7 @@ unsafe fn parse_obus(
         len + init_byte_pos
     }
 
-    let mut gb = GetBits::new(r#in.data, r#in.sz);
+    let mut gb = GetBits::new(slice::from_raw_parts(r#in.data, r#in.sz));
 
     // obu header
     gb.get_bit(); // obu_forbidden_bit


### PR DESCRIPTION
`GetBits` is made safe by storing an index and a slice instead of a current, start, and end ptr.