### PR TITLE
`fn rav1d_data_props_set_defaults`: Replace with `fn Rav1dDataProps::default`

### DIFF
--- a/include/dav1d/common.rs
+++ b/include/dav1d/common.rs
@@ -58,7 +58,7 @@ pub struct Dav1dDataProps {
     pub user_data: Dav1dUserData,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dDataProps {
     pub timestamp: i64,
@@ -66,6 +66,18 @@ pub(crate) struct Rav1dDataProps {
     pub offset: libc::off_t,
     pub size: usize,
     pub user_data: Rav1dUserData,
+}
+
+impl Default for Rav1dDataProps {
+    fn default() -> Self {
+        Self {
+            timestamp: i64::MIN,
+            duration: 0,
+            offset: -1,
+            size: 0,
+            user_data: Default::default(),
+        }
+    }
 }
 
 impl From<Dav1dDataProps> for Rav1dDataProps {

--- a/src/data.rs
+++ b/src/data.rs
@@ -27,7 +27,7 @@ pub(crate) unsafe fn rav1d_data_create_internal(buf: *mut Rav1dData, sz: usize) 
     }
     (*buf).data = (*(*buf).r#ref).const_data as *const u8;
     (*buf).sz = sz;
-    rav1d_data_props_set_defaults(&mut (*buf).m);
+    (*buf).m = Default::default();
     (*buf).m.size = sz;
     return (*(*buf).r#ref).data as *mut u8;
 }
@@ -48,7 +48,7 @@ pub(crate) unsafe fn rav1d_data_wrap_internal(
     }
     (*buf).data = ptr;
     (*buf).sz = sz;
-    rav1d_data_props_set_defaults(&mut (*buf).m);
+    (*buf).m = Default::default();
     (*buf).m.size = sz;
     Ok(())
 }
@@ -105,25 +105,12 @@ pub(crate) unsafe fn rav1d_data_props_copy(dst: *mut Rav1dDataProps, src: *const
     }
 }
 
-pub(crate) unsafe fn rav1d_data_props_set_defaults(props: *mut Rav1dDataProps) {
-    if props.is_null() {
-        unreachable!();
-    }
-    memset(
-        props as *mut c_void,
-        0 as c_int,
-        ::core::mem::size_of::<Rav1dDataProps>(),
-    );
-    (*props).timestamp = i64::MIN;
-    (*props).offset = -1;
-}
-
 pub(crate) unsafe fn rav1d_data_props_unref_internal(props: *mut Rav1dDataProps) {
     if validate_input!(!props.is_null()).is_err() {
         return;
     }
     let mut user_data_ref: *mut Rav1dRef = (*props).user_data.r#ref;
-    rav1d_data_props_set_defaults(props);
+    (*props) = Default::default();
     rav1d_ref_dec(&mut user_data_ref);
 }
 
@@ -143,6 +130,6 @@ pub(crate) unsafe fn rav1d_data_unref_internal(buf: *mut Rav1dData) {
         0 as c_int,
         ::core::mem::size_of::<Rav1dData>(),
     );
-    rav1d_data_props_set_defaults(&mut (*buf).m);
+    (*buf).m = Default::default();
     rav1d_ref_dec(&mut user_data_ref);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,6 @@ use crate::src::cpu::rav1d_init_cpu;
 use crate::src::cpu::rav1d_num_logical_processors;
 use crate::src::data::rav1d_data_create_internal;
 use crate::src::data::rav1d_data_props_copy;
-use crate::src::data::rav1d_data_props_set_defaults;
 use crate::src::data::rav1d_data_props_unref_internal;
 use crate::src::data::rav1d_data_ref;
 use crate::src::data::rav1d_data_unref_internal;
@@ -291,7 +290,7 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
     (*c).output_invisible_frames = s.output_invisible_frames;
     (*c).inloop_filters = s.inloop_filters;
     (*c).decode_frame_type = s.decode_frame_type;
-    rav1d_data_props_set_defaults(&mut (*c).cached_error_props);
+    (*c).cached_error_props = Default::default();
     if rav1d_mem_pool_init(&mut (*c).seq_hdr_pool).is_err()
         || rav1d_mem_pool_init(&mut (*c).frame_hdr_pool).is_err()
         || rav1d_mem_pool_init(&mut (*c).segmap_pool).is_err()
@@ -1234,7 +1233,7 @@ pub(crate) unsafe fn rav1d_get_decode_error_data_props(
 ) -> Rav1dResult {
     rav1d_data_props_unref_internal(out);
     *out = c.cached_error_props.clone();
-    rav1d_data_props_set_defaults(&mut c.cached_error_props);
+    c.cached_error_props = Default::default();
     Ok(())
 }
 

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -16,7 +16,6 @@ use crate::include::dav1d::picture::Rav1dPicture;
 use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
 use crate::src::data::rav1d_data_props_copy;
-use crate::src::data::rav1d_data_props_set_defaults;
 use crate::src::error::Dav1dResult;
 use crate::src::error::Rav1dError::EGeneric;
 use crate::src::error::Rav1dError::ENOMEM;
@@ -183,7 +182,7 @@ unsafe fn picture_alloc_with_edges(
     (*p).frame_hdr = frame_hdr;
     (*p).p.layout = (*seq_hdr).layout;
     (*p).p.bpc = bpc;
-    rav1d_data_props_set_defaults(&mut (*p).m);
+    (*p).m = Default::default();
     (*p).seq_hdr_ref = seq_hdr_ref;
     (*p).frame_hdr_ref = frame_hdr_ref;
     let res = (*p_allocator).alloc_picture(p);
@@ -445,7 +444,7 @@ pub(crate) unsafe fn rav1d_picture_unref_internal(p: &mut Rav1dPicture) {
         0 as c_int,
         ::core::mem::size_of::<Rav1dPicture>(),
     );
-    rav1d_data_props_set_defaults(&mut p.m);
+    p.m = Default::default();
 }
 
 pub(crate) unsafe fn rav1d_thread_picture_unref(p: *mut Rav1dThreadPicture) {


### PR DESCRIPTION
This is helpful in replacing `Rav1dData`'s `Rav1dRef` with an `Arc`, which I'm doing next.