### PR TITLE
`mod internal`: Add comments to internal structures

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -234,7 +234,7 @@ pub struct Rav1dContext {
     pub(crate) cdf_pool: *mut Rav1dMemPool,
     pub(crate) cdf: [CdfThreadContext; 8],
 
-    pub(crate) dsp: [Rav1dDSPContext; 3 /* 8, 10, 12 bits/component */],
+    pub(crate) dsp: [Rav1dDSPContext; 3], /* 8, 10, 12 bits/component */
     pub(crate) refmvs_dsp: Rav1dRefmvsDSPContext,
 
     // tree to keep track of which edges are available
@@ -350,13 +350,13 @@ impl Rav1dFrameContext_bd_fn {
 
 #[repr(C)]
 pub struct CodedBlockInfo {
-    pub eob: [i16; 3 /* plane */],
-    pub txtp: [u8; 3 /* plane */],
+    pub eob: [i16; 3], /* plane */
+    pub txtp: [u8; 3], /* plane */
 }
 
 #[repr(C)]
 pub struct Rav1dFrameContext_frame_thread {
-    pub next_tile_row: [c_int; 2 /* 0: reconstruction, 1: entropy */],
+    pub next_tile_row: [c_int; 2], /* 0: reconstruction, 1: entropy */
     pub entropy_progress: atomic_int,
     pub deblock_progress: atomic_int, // in sby units
     pub frame_progress: *mut atomic_uint,
@@ -365,7 +365,7 @@ pub struct Rav1dFrameContext_frame_thread {
     pub b: *mut Av1Block,
     pub cbi: *mut CodedBlockInfo,
     // indexed using (t->by >> 1) * (f->b4_stride >> 1) + (t->bx >> 1)
-    pub pal: *mut [[u16; 8 /* idx */]; 3 /* plane */],
+    pub pal: *mut [[u16; 8]; 3], /* [3 plane][8 idx] */
     // iterated over inside tile state
     pub pal_idx: *mut u8,
     pub cf: *mut DynCoef,
@@ -388,16 +388,16 @@ pub struct Rav1dFrameContext_lf {
     pub cdef_buf_plane_sz: [c_int; 2], /* stride*sbh*4 */
     pub cdef_buf_sbh: c_int,
     pub lr_buf_plane_sz: [c_int; 2], /* (stride*sbh*4) << sb128 if n_tc > 1, else stride*4 */
-    pub re_sz: c_int, /* h */
+    pub re_sz: c_int,                /* h */
     pub lim_lut: Align16<Av1FilterLUT>,
     pub last_sharpness: c_int,
-    pub lvl: [[[[u8; 2 /* is_gmv */]; 8 /* ref */]; 4 /* dir */]; 8 /* seg_id */],
+    pub lvl: [[[[u8; 2]; 8]; 4]; 8], /* [8 seg_id][4 dir][8 ref][2 is_gmv] */
     pub tx_lpf_right_edge: [*mut u8; 2],
     pub cdef_line_buf: *mut u8,
     pub lr_line_buf: *mut u8,
-    pub cdef_line: [[*mut DynPixel; 3 /* plane */]; 2 /* pre, post */],
-    pub cdef_lpf_line: [*mut DynPixel; 3 /* plane */],
-    pub lr_lpf_line: [*mut DynPixel; 3 /* plane */],
+    pub cdef_line: [[*mut DynPixel; 3]; 2], /* [2 pre/post][3 plane] */
+    pub cdef_lpf_line: [*mut DynPixel; 3],  /* plane */
+    pub lr_lpf_line: [*mut DynPixel; 3],    /* plane */
 
     // in-loop filter per-frame state keeping
     pub start_of_tile_row: *mut u8,
@@ -481,9 +481,9 @@ pub(crate) struct Rav1dFrameContext {
     pub n_tile_data: c_int,
 
     // for scalable references
-    pub svc: [[ScalableMotionParams; 2 /* x, y */]; 7],
-    pub resize_step: [c_int; 2 /* y, uv */],
-    pub resize_start: [c_int; 2 /* y, uv */],
+    pub svc: [[ScalableMotionParams; 2]; 7], /* [2 x,y][7] */
+    pub resize_step: [c_int; 2],             /* y, uv */
+    pub resize_start: [c_int; 2],            /* y, uv */
 
     pub c: *const Rav1dContext,
     pub ts: *mut Rav1dTileState,
@@ -504,8 +504,8 @@ pub(crate) struct Rav1dFrameContext {
     pub sb_shift: c_int,
     pub sb_step: c_int,
     pub sr_sb128w: c_int,
-    pub dq: [[[u16; 2 /* dc/ac */]; 3 /* plane */]; RAV1D_MAX_SEGMENTS as usize],
-    pub qm: [[*const u8; 3 /* plane */]; 19],
+    pub dq: [[[u16; 2]; 3]; RAV1D_MAX_SEGMENTS as usize], /* [RAV1D_MAX_SEGMENTS][3 plane][2 dc/ac] */
+    pub qm: [[*const u8; 3]; 19],                         /* [3 plane][19] */
     pub a: *mut BlockContext,
     pub a_sz: c_int, /* w*tile_rows */
     pub rf: refmvs_frame,
@@ -544,18 +544,18 @@ pub struct Rav1dTileState {
     pub tiling: Rav1dTileState_tiling,
 
     // in sby units, TILE_ERROR after a decoding error
-    pub progress: [atomic_int; 2 /* 0: reconstruction, 1: entropy */],
-    pub frame_thread: [Rav1dTileState_frame_thread; 2 /* 0: reconstruction, 1: entropy */],
+    pub progress: [atomic_int; 2], /* 0: reconstruction, 1: entropy */
+    pub frame_thread: [Rav1dTileState_frame_thread; 2], /* 0: reconstruction, 1: entropy */
 
     // in fullpel units, [0] = Y, [1] = UV, used for progress requirements
     // each entry is one tile-sbrow; middle index is refidx
     pub lowest_pixel: *mut [[c_int; 2]; 7],
 
-    pub dqmem: [[[u16; 2]; 3 /* plane */]; RAV1D_MAX_SEGMENTS as usize /* dc/ac */],
+    pub dqmem: [[[u16; 2]; 3]; RAV1D_MAX_SEGMENTS as usize], /* [RAV1D_MAX_SEGMENTS][3 plane][2 dc/ac] */
     pub dq: *const [[u16; 2]; 3],
     pub last_qidx: c_int,
     pub last_delta_lf: [i8; 4],
-    pub lflvlmem: [[[[u8; 2 /* is_gmv */]; 8 /* ref */]; 4 /* dir */]; 8 /* seg_id */],
+    pub lflvlmem: [[[[u8; 2]; 8]; 4]; 8], /* [8 seg_id][4 dir][8 ref][2 is_gmv] */
     pub lflvl: *const [[[u8; 2]; 8]; 4],
 
     pub lr_ref: [Av1RestorationUnit; 3],
@@ -634,7 +634,7 @@ pub struct Rav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
     pub c2rust_unnamed: Rav1dTaskContext_scratch_levels_pal,
     pub ac: [i16; 1024],
     pub pal_idx: [u8; 8192],
-    pub pal: [[u16; 8 /* palette_idx */]; 3 /* plane */],
+    pub pal: [[u16; 8]; 3], /* [3 plane][8 palette_idx] */
     pub interintra_edge: BitDepthUnion<InterIntraEdge>,
 }
 
@@ -671,9 +671,9 @@ pub(crate) struct Rav1dTaskContext {
     pub cf: BitDepthUnion<Cf>,
     // FIXME types can be changed to pixel (and dynamically allocated)
     // which would make copy/assign operations slightly faster?
-    pub al_pal: [[[[u16; 8 /* palette_idx */]; 3 /* plane */]; 32 /* bx/y4 */]; 2 /* a/l */],
-    pub pal_sz_uv: [[u8; 32 /* bx4/by4 */]; 2 /* a/l */],
-    pub txtp_map: [u8; 1024], // inter-only
+    pub al_pal: [[[[u16; 8]; 3]; 32]; 2], /* [2 a/l][32 bx/y4][3 plane][8 palette_idx] */
+    pub pal_sz_uv: [[u8; 32]; 2],         /* [2 a/l][32 bx4/by4] */
+    pub txtp_map: [u8; 1024],             // inter-only
     pub scratch: Rav1dTaskContext_scratch,
 
     pub warpmv: Rav1dWarpedMotionParams,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -150,7 +150,7 @@ pub(crate) struct TaskThreadData_delayed_fg {
     pub in_0: *const Rav1dPicture,
     pub out: *mut Rav1dPicture,
     pub type_0: TaskType,
-    pub progress: [atomic_int; 2],
+    pub progress: [atomic_int; 2], /* [0]=started, [1]=completed */
     pub grain: BitDepthUnion<Grain>,
 }
 
@@ -160,6 +160,10 @@ pub(crate) struct TaskThreadData {
     pub cond: pthread_cond_t,
     pub first: atomic_uint,
     pub cur: c_uint,
+    // This is used for delayed reset of the task cur pointer when
+    // such operation is needed but the thread doesn't enter a critical
+    // section (typically when executing the next sbrow task locklessly).
+    // See src/thread_task.c:reset_task_cur().
     pub reset_task_cur: atomic_uint,
     pub cond_signaled: atomic_int,
     pub delayed_fg: TaskThreadData_delayed_fg,
@@ -187,8 +191,12 @@ pub struct Rav1dContext_intra_edge {
 pub struct Rav1dContext {
     pub(crate) fc: *mut Rav1dFrameContext,
     pub(crate) n_fc: c_uint,
+
     pub(crate) tc: *mut Rav1dTaskContext,
     pub(crate) n_tc: c_uint,
+
+    // cache of OBUs that make up a single frame before we submit them
+    // to a frame worker to be decoded
     pub(crate) tile: *mut Rav1dTileGroup,
     pub(crate) n_tile_data_alloc: c_int,
     pub(crate) n_tile_data: c_int,
@@ -205,21 +213,33 @@ pub struct Rav1dContext {
     pub(crate) mastering_display: *mut Rav1dMasteringDisplay,
     pub(crate) itut_t35_ref: *mut Rav1dRef,
     pub(crate) itut_t35: *mut Rav1dITUTT35,
+
+    // decoded output picture queue
     pub(crate) in_0: Rav1dData,
     pub(crate) out: Rav1dThreadPicture,
     pub(crate) cache: Rav1dThreadPicture,
+    // flush is a pointer to prevent compiler errors about atomic_load()
+    // not taking const arguments
     pub(crate) flush_mem: atomic_int,
     pub(crate) flush: *mut atomic_int,
     pub(crate) frame_thread: Rav1dContext_frame_thread,
+
+    // task threading (refer to tc[] for per_thread thingies)
     pub(crate) task_thread: TaskThreadData,
+
+    // reference/entropy state
     pub(crate) segmap_pool: *mut Rav1dMemPool,
     pub(crate) refmvs_pool: *mut Rav1dMemPool,
     pub(crate) refs: [Rav1dContext_refs; 8],
     pub(crate) cdf_pool: *mut Rav1dMemPool,
     pub(crate) cdf: [CdfThreadContext; 8],
-    pub(crate) dsp: [Rav1dDSPContext; 3],
+
+    pub(crate) dsp: [Rav1dDSPContext; 3 /* 8, 10, 12 bits/component */],
     pub(crate) refmvs_dsp: Rav1dRefmvsDSPContext,
+
+    // tree to keep track of which edges are available
     pub(crate) intra_edge: Rav1dContext_intra_edge,
+
     pub(crate) allocator: Rav1dPicAllocator,
     pub(crate) apply_grain: bool,
     pub(crate) operating_point: c_int,
@@ -236,25 +256,33 @@ pub struct Rav1dContext {
     pub(crate) event_flags: Rav1dEventFlags,
     pub(crate) cached_error_props: Rav1dDataProps,
     pub(crate) cached_error: Rav1dResult,
+
     pub(crate) logger: Rav1dLogger,
+
     pub(crate) picture_pool: *mut Rav1dMemPool,
 }
 
 #[derive(Clone)]
 #[repr(C)]
 pub struct Rav1dTask {
+    // frame thread id
     pub frame_idx: c_uint,
+    // task work
     pub type_0: TaskType,
+    // sbrow
     pub sby: c_int,
+
+    // task dependencies
     pub recon_progress: c_int,
     pub deblock_progress: c_int,
     pub deps_skip: c_int,
+    // only used in task queue
     pub next: *mut Rav1dTask,
 }
 
 #[repr(C)]
 pub struct ScalableMotionParams {
-    pub scale: c_int,
+    pub scale: c_int, // if no scaling, this is 0
     pub step: c_int,
 }
 
@@ -322,49 +350,56 @@ impl Rav1dFrameContext_bd_fn {
 
 #[repr(C)]
 pub struct CodedBlockInfo {
-    pub eob: [i16; 3],
-    pub txtp: [u8; 3],
+    pub eob: [i16; 3 /* plane */],
+    pub txtp: [u8; 3 /* plane */],
 }
 
 #[repr(C)]
 pub struct Rav1dFrameContext_frame_thread {
-    pub next_tile_row: [c_int; 2],
+    pub next_tile_row: [c_int; 2 /* 0: reconstruction, 1: entropy */],
     pub entropy_progress: atomic_int,
-    pub deblock_progress: atomic_int,
+    pub deblock_progress: atomic_int, // in sby units
     pub frame_progress: *mut atomic_uint,
     pub copy_lpf_progress: *mut atomic_uint,
+    // indexed using t->by * f->b4_stride + t->bx
     pub b: *mut Av1Block,
     pub cbi: *mut CodedBlockInfo,
-    pub pal: *mut [[u16; 8]; 3],
+    // indexed using (t->by >> 1) * (f->b4_stride >> 1) + (t->bx >> 1)
+    pub pal: *mut [[u16; 8 /* idx */]; 3 /* plane */],
+    // iterated over inside tile state
     pub pal_idx: *mut u8,
     pub cf: *mut DynCoef,
     pub prog_sz: c_int,
     pub pal_sz: c_int,
     pub pal_idx_sz: c_int,
     pub cf_sz: c_int,
+    // start offsets per tile
     pub tile_start_off: *mut c_int,
 }
 
+/// loopfilter
 #[repr(C)]
 pub struct Rav1dFrameContext_lf {
     pub level: *mut [u8; 4],
     pub mask: *mut Av1Filter,
     pub lr_mask: *mut Av1Restoration,
-    pub mask_sz: c_int,
+    pub mask_sz: c_int, /* w*h */
     pub lr_mask_sz: c_int,
-    pub cdef_buf_plane_sz: [c_int; 2],
+    pub cdef_buf_plane_sz: [c_int; 2], /* stride*sbh*4 */
     pub cdef_buf_sbh: c_int,
-    pub lr_buf_plane_sz: [c_int; 2],
-    pub re_sz: c_int,
+    pub lr_buf_plane_sz: [c_int; 2], /* (stride*sbh*4) << sb128 if n_tc > 1, else stride*4 */
+    pub re_sz: c_int, /* h */
     pub lim_lut: Align16<Av1FilterLUT>,
     pub last_sharpness: c_int,
-    pub lvl: [[[[u8; 2]; 8]; 4]; 8],
+    pub lvl: [[[[u8; 2 /* is_gmv */]; 8 /* ref */]; 4 /* dir */]; 8 /* seg_id */],
     pub tx_lpf_right_edge: [*mut u8; 2],
     pub cdef_line_buf: *mut u8,
     pub lr_line_buf: *mut u8,
-    pub cdef_line: [[*mut DynPixel; 3]; 2],
-    pub cdef_lpf_line: [*mut DynPixel; 3],
-    pub lr_lpf_line: [*mut DynPixel; 3],
+    pub cdef_line: [[*mut DynPixel; 3 /* plane */]; 2 /* pre, post */],
+    pub cdef_lpf_line: [*mut DynPixel; 3 /* plane */],
+    pub lr_lpf_line: [*mut DynPixel; 3 /* plane */],
+
+    // in-loop filter per-frame state keeping
     pub start_of_tile_row: *mut u8,
     pub start_of_tile_row_sz: c_int,
     pub need_cdef_lpf_copy: c_int,
@@ -372,7 +407,7 @@ pub struct Rav1dFrameContext_lf {
     pub sr_p: [*mut DynPixel; 3],
     pub mask_ptr: *mut Av1Filter,
     pub prev_mask_ptr: *mut Av1Filter,
-    pub restore_planes: c_int,
+    pub restore_planes: c_int, // enum LrRestorePlanes
 }
 
 #[repr(C)]
@@ -396,15 +431,21 @@ pub(crate) struct Rav1dFrameContext_task_thread {
     pub init_done: atomic_int,
     pub done: [atomic_int; 2],
     pub retval: Rav1dResult,
-    pub update_set: bool,
+    pub update_set: bool, // whether we need to update CDF reference
     pub error: atomic_int,
     pub task_counter: atomic_int,
     pub task_head: *mut Rav1dTask,
     pub task_tail: *mut Rav1dTask,
+    // Points to the task directly before the cur pointer in the queue.
+    // This cur pointer is theoretical here, we actually keep track of the
+    // "prev_t" variable. This is needed to not loose the tasks in
+    // [head;cur-1] when picking one for execution.
     pub task_cur_prev: *mut Rav1dTask,
+    // async task insertion
     pub pending_tasks: Rav1dFrameContext_task_thread_pending_tasks,
 }
 
+// threading (refer to tc[] for per-thread things)
 #[repr(C)]
 pub struct FrameTileThreadData {
     pub lowest_pixel_mem: *mut [[c_int; 2]; 7],
@@ -418,7 +459,9 @@ pub(crate) struct Rav1dFrameContext {
     pub frame_hdr_ref: *mut Rav1dRef,
     pub frame_hdr: *mut Rav1dFrameHeader,
     pub refp: [Rav1dThreadPicture; 7],
+    // during block coding / reconstruction
     pub cur: Rav1dPicture,
+    // after super-resolution upscaling
     pub sr_cur: Rav1dThreadPicture,
     pub mvs_ref: *mut Rav1dRef,
     pub mvs: *mut refmvs_temporal_block,
@@ -436,14 +479,18 @@ pub(crate) struct Rav1dFrameContext {
     pub tile: *mut Rav1dTileGroup,
     pub n_tile_data_alloc: c_int,
     pub n_tile_data: c_int,
-    pub svc: [[ScalableMotionParams; 2]; 7],
-    pub resize_step: [c_int; 2],
-    pub resize_start: [c_int; 2],
+
+    // for scalable references
+    pub svc: [[ScalableMotionParams; 2 /* x, y */]; 7],
+    pub resize_step: [c_int; 2 /* y, uv */],
+    pub resize_start: [c_int; 2 /* y, uv */],
+
     pub c: *const Rav1dContext,
     pub ts: *mut Rav1dTileState,
     pub n_ts: c_int,
     pub dsp: *const Rav1dDSPContext,
     pub bd_fn: Rav1dFrameContext_bd_fn,
+
     pub ipred_edge_sz: c_int,
     pub ipred_edge: [*mut DynPixel; 3],
     pub b4_stride: ptrdiff_t,
@@ -457,13 +504,14 @@ pub(crate) struct Rav1dFrameContext {
     pub sb_shift: c_int,
     pub sb_step: c_int,
     pub sr_sb128w: c_int,
-    pub dq: [[[u16; 2]; 3]; RAV1D_MAX_SEGMENTS as usize],
-    pub qm: [[*const u8; 3]; 19],
+    pub dq: [[[u16; 2 /* dc/ac */]; 3 /* plane */]; RAV1D_MAX_SEGMENTS as usize],
+    pub qm: [[*const u8; 3 /* plane */]; 19],
     pub a: *mut BlockContext,
-    pub a_sz: c_int,
+    pub a_sz: c_int, /* w*tile_rows */
     pub rf: refmvs_frame,
     pub jnt_weights: [[u8; 7]; 7],
     pub bitdepth_max: c_int,
+
     pub frame_thread: Rav1dFrameContext_frame_thread,
     pub lf: Rav1dFrameContext_lf,
     pub task_thread: Rav1dFrameContext_task_thread,
@@ -472,10 +520,13 @@ pub(crate) struct Rav1dFrameContext {
 
 #[repr(C)]
 pub struct Rav1dTileState_tiling {
+    // in 4px units
     pub col_start: c_int,
     pub col_end: c_int,
     pub row_start: c_int,
     pub row_end: c_int,
+
+    // in tile units
     pub col: c_int,
     pub row: c_int,
 }
@@ -491,15 +542,22 @@ pub struct Rav1dTileState {
     pub cdf: CdfContext,
     pub msac: MsacContext,
     pub tiling: Rav1dTileState_tiling,
-    pub progress: [atomic_int; 2],
-    pub frame_thread: [Rav1dTileState_frame_thread; 2],
+
+    // in sby units, TILE_ERROR after a decoding error
+    pub progress: [atomic_int; 2 /* 0: reconstruction, 1: entropy */],
+    pub frame_thread: [Rav1dTileState_frame_thread; 2 /* 0: reconstruction, 1: entropy */],
+
+    // in fullpel units, [0] = Y, [1] = UV, used for progress requirements
+    // each entry is one tile-sbrow; middle index is refidx
     pub lowest_pixel: *mut [[c_int; 2]; 7],
-    pub dqmem: [[[u16; 2]; 3]; RAV1D_MAX_SEGMENTS as usize],
+
+    pub dqmem: [[[u16; 2]; 3 /* plane */]; RAV1D_MAX_SEGMENTS as usize /* dc/ac */],
     pub dq: *const [[u16; 2]; 3],
     pub last_qidx: c_int,
     pub last_delta_lf: [i8; 4],
-    pub lflvlmem: [[[[u8; 2]; 8]; 4]; 8],
+    pub lflvlmem: [[[[u8; 2 /* is_gmv */]; 8 /* ref */]; 4 /* dir */]; 8 /* seg_id */],
     pub lflvl: *const [[[u8; 2]; 8]; 4],
+
     pub lr_ref: [Av1RestorationUnit; 3],
 }
 
@@ -576,7 +634,7 @@ pub struct Rav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
     pub c2rust_unnamed: Rav1dTaskContext_scratch_levels_pal,
     pub ac: [i16; 1024],
     pub pal_idx: [u8; 8192],
-    pub pal: [[u16; 8]; 3],
+    pub pal: [[u16; 8 /* palette_idx */]; 3 /* plane */],
     pub interintra_edge: BitDepthUnion<InterIntraEdge>,
 }
 
@@ -611,14 +669,20 @@ pub(crate) struct Rav1dTaskContext {
     pub a: *mut BlockContext,
     pub rt: refmvs_tile,
     pub cf: BitDepthUnion<Cf>,
-    pub al_pal: [[[[u16; 8]; 3]; 32]; 2],
-    pub pal_sz_uv: [[u8; 32]; 2],
-    pub txtp_map: [u8; 1024],
+    // FIXME types can be changed to pixel (and dynamically allocated)
+    // which would make copy/assign operations slightly faster?
+    pub al_pal: [[[[u16; 8 /* palette_idx */]; 3 /* plane */]; 32 /* bx/y4 */]; 2 /* a/l */],
+    pub pal_sz_uv: [[u8; 32 /* bx4/by4 */]; 2 /* a/l */],
+    pub txtp_map: [u8; 1024], // inter-only
     pub scratch: Rav1dTaskContext_scratch,
+
     pub warpmv: Rav1dWarpedMotionParams,
     pub lf_mask: *mut Av1Filter,
     pub top_pre_cdef_toggle: c_int,
     pub cur_sb_cdef_idx_ptr: *mut i8,
+    // for chroma sub8x8, we need to know the filter for all 4 subblocks in
+    // a 4x4 area, but the top/left one can go out of cache already, so this
+    // keeps it accessible
     pub tl_4x4_filter: Filter2d,
     pub frame_thread: Rav1dTaskContext_frame_thread,
     pub task_thread: Rav1dTaskContext_task_thread,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -160,10 +160,10 @@ pub(crate) struct TaskThreadData {
     pub cond: pthread_cond_t,
     pub first: atomic_uint,
     pub cur: c_uint,
-    // This is used for delayed reset of the task cur pointer when
-    // such operation is needed but the thread doesn't enter a critical
-    // section (typically when executing the next sbrow task locklessly).
-    // See src/thread_task.c:reset_task_cur().
+    /// This is used for delayed reset of the task cur pointer when
+    /// such operation is needed but the thread doesn't enter a critical
+    /// section (typically when executing the next sbrow task locklessly).
+    /// See [crate::src::thread_task::reset_task_cur].
     pub reset_task_cur: atomic_uint,
     pub cond_signaled: atomic_int,
     pub delayed_fg: TaskThreadData_delayed_fg,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -163,7 +163,7 @@ pub(crate) struct TaskThreadData {
     /// This is used for delayed reset of the task cur pointer when
     /// such operation is needed but the thread doesn't enter a critical
     /// section (typically when executing the next sbrow task locklessly).
-    /// See [crate::src::thread_task::reset_task_cur].
+    /// See [`crate::src::thread_task::reset_task_cur`].
     pub reset_task_cur: atomic_uint,
     pub cond_signaled: atomic_int,
     pub delayed_fg: TaskThreadData_delayed_fg,


### PR DESCRIPTION
Copies all comments from internal.h to our Rust version. Preparing to make core internal structures safe Rust types.