### PR TITLE
Add threaded testing to CI

### DIFF
--- a/.github/workflows/build-and-test-x86.yml
+++ b/.github/workflows/build-and-test-x86.yml
@@ -14,6 +14,12 @@ jobs:
           # debug build with optimizations to catch overflows with optimized assembly routines
           {name: "opt-dev", flags: "--profile opt-dev", timeout_multiplier: 2}
         ]
+        # Test with threads and framedelay
+        framedelay: [
+          "",
+          "-f 1",
+          "-f 2"
+        ]
     runs-on: ubuntu-latest
     steps:
       - name: install prerequisites
@@ -53,7 +59,8 @@ jobs:
           .github/workflows/test.sh \
               -r target/${{ matrix.target }}/${{ matrix.build.name }}/dav1d \
               -s target/${{ matrix.target }}/${{ matrix.build.name }}/seek_stress \
-              -t ${{ matrix.build.timeout_multiplier }}
+              -t ${{ matrix.build.timeout_multiplier }} \
+              ${{ matrix.framedelay }}
       - name: copy log files
         if: ${{ !cancelled() }}
         run: |

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -7,13 +7,15 @@ timeout_multiplier=1
 rust_test_path=
 seek_stress_test_rust_path=
 debug_opt=
-while getopts t:r:d:s: flag
+frame_delay=
+while getopts t:r:d:s:f: flag
 do
     case "${flag}" in
         t) timeout_multiplier=${OPTARG};;
         r) rust_test_path="-Dtest_rust_path=${OPTARG}";;
         s) seek_stress_test_rust_path="-Dseek_stress_test_rust_path=${OPTARG}";;
         d) debug_opt="-Ddebug=true";;
+        f) frame_delay=${OPTARG};;
     esac
 done
 
@@ -47,6 +49,12 @@ if [[ -z $seek_stress_test_rust_path ]]; then
     : # stress test binary not provided; don't include seek stress tests
 else
     test_args+=(--suite testdata_seek-stress)
+fi
+
+if [[ -n $frame_delay ]]; then
+    # These test args override the args from test-data, resulting in 2 threads
+    # and a frame delay
+    test_args+=(--test-args "--threads 2 --framedelay $frame_delay")
 fi
 
 cd build && meson test "${test_args[@]}"


### PR DESCRIPTION
The upstream dav1d project tests with threads=2 and framedelay=1,2 in CI, we should be doing the same.

Closes #644