### PR TITLE
`struct Rav1dFrameContext_frame_thread`: Replace atomic intrinsics w/ `Atomic*` types

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -78,6 +78,7 @@ use libc::ptrdiff_t;
 use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::sync::atomic::AtomicI32;
+use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 
 #[repr(C)]
@@ -361,8 +362,8 @@ pub struct Rav1dFrameContext_frame_thread {
     pub next_tile_row: [c_int; 2], /* 0: reconstruction, 1: entropy */
     pub entropy_progress: AtomicI32,
     pub deblock_progress: AtomicI32, // in sby units
-    pub frame_progress: *mut atomic_uint,
-    pub copy_lpf_progress: *mut atomic_uint,
+    pub frame_progress: Vec<AtomicU32>,
+    pub copy_lpf_progress: Vec<AtomicU32>,
     // indexed using t->by * f->b4_stride + t->bx
     pub b: *mut Av1Block,
     pub cbi: *mut CodedBlockInfo,
@@ -371,7 +372,6 @@ pub struct Rav1dFrameContext_frame_thread {
     // iterated over inside tile state
     pub pal_idx: *mut u8,
     pub cf: *mut DynCoef,
-    pub prog_sz: c_int,
     pub pal_sz: c_int,
     pub pal_idx_sz: c_int,
     pub cf_sz: c_int,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -77,6 +77,7 @@ use libc::pthread_mutex_t;
 use libc::ptrdiff_t;
 use std::ffi::c_int;
 use std::ffi::c_uint;
+use std::sync::atomic::AtomicI32;
 use std::sync::Arc;
 
 #[repr(C)]
@@ -358,7 +359,7 @@ pub struct CodedBlockInfo {
 #[repr(C)]
 pub struct Rav1dFrameContext_frame_thread {
     pub next_tile_row: [c_int; 2], /* 0: reconstruction, 1: entropy */
-    pub entropy_progress: atomic_int,
+    pub entropy_progress: AtomicI32,
     pub deblock_progress: atomic_int, // in sby units
     pub frame_progress: *mut atomic_uint,
     pub copy_lpf_progress: *mut atomic_uint,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -360,7 +360,7 @@ pub struct CodedBlockInfo {
 pub struct Rav1dFrameContext_frame_thread {
     pub next_tile_row: [c_int; 2], /* 0: reconstruction, 1: entropy */
     pub entropy_progress: AtomicI32,
-    pub deblock_progress: atomic_int, // in sby units
+    pub deblock_progress: AtomicI32, // in sby units
     pub frame_progress: *mut atomic_uint,
     pub copy_lpf_progress: *mut atomic_uint,
     // indexed using t->by * f->b4_stride + t->bx

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1029,7 +1029,8 @@ unsafe fn close_internal(c_out: &mut *mut Rav1dContext, flush: c_int) {
             pthread_cond_destroy(&mut (*f).task_thread.cond);
             pthread_mutex_destroy(&mut (*f).task_thread.lock);
         }
-        freep(&mut (*f).frame_thread.frame_progress as *mut *mut atomic_uint as *mut c_void);
+        mem::take(&mut (*f).frame_thread.frame_progress); // TODO: remove when context is owned
+        mem::take(&mut (*f).frame_thread.copy_lpf_progress); // TODO: remove when context is owned
         freep(&mut (*f).task_thread.tasks as *mut *mut Rav1dTask as *mut c_void);
         freep(
             &mut *((*f).task_thread.tile_tasks).as_mut_ptr().offset(0) as *mut *mut Rav1dTask


### PR DESCRIPTION
Replace C atomics in `Rav1dFrameContext.frame_thread` with Rust atomics.