### PR TITLE
`struct Rav1dUserData`: Replace `Rav1dRef` with `Option<CArc<u8>>`

### DIFF
--- a/include/dav1d/common.rs
+++ b/include/dav1d/common.rs
@@ -1,36 +1,19 @@
 use crate::include::dav1d::dav1d::Dav1dRef;
 use crate::src::r#ref::Rav1dRef;
-use std::ptr;
+use std::ptr::NonNull;
 
+#[derive(Default)]
 #[repr(C)]
 pub struct Dav1dUserData {
-    pub data: *const u8,
-    pub r#ref: *mut Dav1dRef,
+    pub data: Option<NonNull<u8>>,
+    pub r#ref: Option<NonNull<Dav1dRef>>,
 }
 
-impl Default for Dav1dUserData {
-    fn default() -> Self {
-        Self {
-            data: ptr::null(),
-            r#ref: ptr::null_mut(),
-        }
-    }
-}
-
-#[derive(Clone)]
+#[derive(Clone, Default)]
 #[repr(C)]
 pub(crate) struct Rav1dUserData {
-    pub data: *const u8,
-    pub r#ref: *mut Rav1dRef,
-}
-
-impl Default for Rav1dUserData {
-    fn default() -> Self {
-        Self {
-            data: ptr::null(),
-            r#ref: ptr::null_mut(),
-        }
-    }
+    pub data: Option<NonNull<u8>>,
+    pub r#ref: Option<NonNull<Rav1dRef>>,
 }
 
 impl From<Dav1dUserData> for Rav1dUserData {

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -223,8 +223,10 @@ impl From<Rav1dWarpedMotionParams> for Dav1dWarpedMotionParams {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, EnumCount, FromRepr)]
+// TODO(kkysen) Eventually the [`impl Default`] might not be needed.
+#[derive(Clone, Copy, PartialEq, Eq, EnumCount, FromRepr, Default)]
 pub(crate) enum Rav1dPixelLayout {
+    #[default]
     I400 = 0,
     I420 = 1,
     I422 = 2,

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -30,7 +30,8 @@ pub struct Dav1dPictureParameters {
     pub bpc: c_int,
 }
 
-#[derive(Clone)]
+// TODO(kkysen) Eventually the [`impl Default`] might not be needed.
+#[derive(Clone, Default)]
 #[repr(C)]
 pub(crate) struct Rav1dPictureParameters {
     pub w: c_int,
@@ -270,6 +271,36 @@ impl From<Rav1dPicture> for Dav1dPicture {
             reserved_ref,
             r#ref,
             allocator_data,
+        }
+    }
+}
+
+// TODO(kkysen) Eventually the [`impl Default`] might not be needed.
+// It's needed currently for a [`mem::take`] that simulates a move,
+// but once everything is Rusty, we may not need to clear the `dst` anymore.
+// This also applies to the `#[derive(Default)]`
+// on [`Rav1dPictureParameters`] and [`Rav1dPixelLayout`].
+impl Default for Rav1dPicture {
+    fn default() -> Self {
+        Self {
+            seq_hdr: ptr::null_mut(),
+            frame_hdr: ptr::null_mut(),
+            data: [ptr::null_mut(); 3],
+            stride: Default::default(),
+            p: Default::default(),
+            m: Default::default(),
+            content_light: ptr::null_mut(),
+            mastering_display: ptr::null_mut(),
+            itut_t35: ptr::null_mut(),
+            reserved: Default::default(),
+            frame_hdr_ref: ptr::null_mut(),
+            seq_hdr_ref: ptr::null_mut(),
+            content_light_ref: ptr::null_mut(),
+            mastering_display_ref: ptr::null_mut(),
+            itut_t35_ref: ptr::null_mut(),
+            reserved_ref: Default::default(),
+            r#ref: ptr::null_mut(),
+            allocator_data: ptr::null_mut(),
         }
     }
 }

--- a/lib.rs
+++ b/lib.rs
@@ -29,9 +29,7 @@ pub mod include {
 pub mod src {
     pub mod align;
     mod assume;
-    #[allow(dead_code)] // TODO(kkysen) Temporary
     pub(crate) mod c_arc;
-    #[allow(dead_code)] // TODO(kkysen) Temporary
     pub(crate) mod c_box;
     mod cdef;
     mod cdef_apply;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -38,7 +38,6 @@ use crate::src::cdf::rav1d_cdf_thread_update;
 use crate::src::cdf::CdfMvComponent;
 use crate::src::cdf::CdfMvContext;
 use crate::src::ctx::CaseSet;
-use crate::src::data::rav1d_data_props_copy;
 use crate::src::data::rav1d_data_unref_internal;
 use crate::src::dequant_tables::dav1d_dq_tbl;
 use crate::src::enum_map::enum_map;
@@ -4976,7 +4975,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
         if error.is_err() {
             f.task_thread.retval = Ok(());
             c.cached_error = error;
-            rav1d_data_props_copy(&mut c.cached_error_props, &mut out_delayed.p.m);
+            c.cached_error_props = out_delayed.p.m.clone();
             rav1d_thread_picture_unref(out_delayed);
         } else if !out_delayed.p.data[0].is_null() {
             let progress = ::core::intrinsics::atomic_load_relaxed(
@@ -5030,7 +5029,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
         rav1d_ref_dec(&mut f.mvs_ref);
         rav1d_ref_dec(&mut f.seq_hdr_ref);
         rav1d_ref_dec(&mut f.frame_hdr_ref);
-        rav1d_data_props_copy(&mut c.cached_error_props, &mut c.in_0.m);
+        c.cached_error_props = c.in_0.m.clone();
 
         for mut tile in f.tiles.drain(..) {
             rav1d_data_unref_internal(&mut tile.data);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -519,8 +519,8 @@ pub(crate) unsafe fn rav1d_parse_sequence_header(
                 offset: 0,
                 size: 0,
                 user_data: Rav1dUserData {
-                    data: 0 as *const u8,
-                    r#ref: 0 as *mut Rav1dRef,
+                    data: None,
+                    r#ref: None,
                 },
             },
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ use crate::include::common::bitdepth::DynCoef;
 use crate::include::common::validate::validate_input;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::common::Rav1dDataProps;
-use crate::include::dav1d::common::Rav1dUserData;
 use crate::include::dav1d::data::Dav1dData;
 use crate::include::dav1d::data::Rav1dData;
 use crate::include::dav1d::dav1d::Dav1dContext;
@@ -34,12 +33,9 @@ use crate::src::cdf::rav1d_cdf_thread_unref;
 use crate::src::cpu::rav1d_init_cpu;
 use crate::src::cpu::rav1d_num_logical_processors;
 use crate::src::data::rav1d_data_create_internal;
-use crate::src::data::rav1d_data_props_copy;
-use crate::src::data::rav1d_data_props_unref_internal;
 use crate::src::data::rav1d_data_ref;
 use crate::src::data::rav1d_data_unref_internal;
 use crate::src::data::rav1d_data_wrap_internal;
-use crate::src::data::rav1d_data_wrap_user_data_internal;
 use crate::src::decode::rav1d_decode_frame_exit;
 use crate::src::error::Dav1dResult;
 use crate::src::error::Rav1dError::EGeneric;
@@ -117,6 +113,7 @@ use std::mem::MaybeUninit;
 use std::process::abort;
 use std::ptr::NonNull;
 use std::sync::Once;
+use to_method::To as _;
 
 #[cfg(target_os = "linux")]
 use libc::dlsym;
@@ -518,10 +515,7 @@ pub(crate) unsafe fn rav1d_parse_sequence_header(
                 duration: 0,
                 offset: 0,
                 size: 0,
-                user_data: Rav1dUserData {
-                    data: None,
-                    r#ref: None,
-                },
+                user_data: Default::default(),
             },
         };
         init
@@ -699,7 +693,7 @@ unsafe fn drain_picture(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRe
         let error = (*f).task_thread.retval;
         if error.is_err() {
             (*f).task_thread.retval = Ok(());
-            rav1d_data_props_copy(&mut c.cached_error_props, &mut (*out_delayed).p.m);
+            c.cached_error_props = (*out_delayed).p.m.clone();
             rav1d_thread_picture_unref(out_delayed);
             return error;
         }
@@ -943,7 +937,7 @@ pub(crate) unsafe fn rav1d_flush(c: *mut Rav1dContext) {
     rav1d_ref_dec(&mut (*c).mastering_display_ref);
     rav1d_ref_dec(&mut (*c).content_light_ref);
     rav1d_ref_dec(&mut (*c).itut_t35_ref);
-    rav1d_data_props_unref_internal(&mut (*c).cached_error_props);
+    let _ = mem::take(&mut (*c).cached_error_props);
     if (*c).n_fc == 1 as c_uint && (*c).n_tc == 1 as c_uint {
         return;
     }
@@ -1176,9 +1170,7 @@ pub(crate) unsafe fn rav1d_get_decode_error_data_props(
     c: &mut Rav1dContext,
     out: &mut Rav1dDataProps,
 ) -> Rav1dResult {
-    rav1d_data_props_unref_internal(out);
-    *out = c.cached_error_props.clone();
-    c.cached_error_props = Default::default();
+    *out = mem::take(&mut c.cached_error_props);
     Ok(())
 }
 
@@ -1248,15 +1240,6 @@ pub unsafe extern "C" fn dav1d_data_wrap(
     result.into()
 }
 
-pub(crate) unsafe fn rav1d_data_wrap_user_data(
-    buf: *mut Rav1dData,
-    user_data: *const u8,
-    free_callback: Option<unsafe extern "C" fn(*const u8, *mut c_void) -> ()>,
-    cookie: *mut c_void,
-) -> Rav1dResult {
-    return rav1d_data_wrap_user_data_internal(buf, user_data, free_callback, cookie);
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_data_wrap_user_data(
     buf: *mut Dav1dData,
@@ -1264,10 +1247,16 @@ pub unsafe extern "C" fn dav1d_data_wrap_user_data(
     free_callback: Option<unsafe extern "C" fn(*const u8, *mut c_void) -> ()>,
     cookie: *mut c_void,
 ) -> Dav1dResult {
-    let mut buf_rust = buf.read().into();
-    let result = rav1d_data_wrap_user_data(&mut buf_rust, user_data, free_callback, cookie);
-    buf.write(buf_rust.into());
-    result.into()
+    || -> Rav1dResult {
+        let buf = validate_input!(NonNull::new(buf).ok_or(EINVAL))?;
+        // Note that `dav1d` doesn't do this check, but they do for the similar [`dav1d_data_wrap`].
+        let user_data = validate_input!(NonNull::new(user_data.cast_mut()).ok_or(EINVAL))?;
+        let mut data = buf.as_ptr().read().to::<Rav1dData>();
+        data.wrap_user_data(user_data, free_callback, cookie)?;
+        buf.as_ptr().write(data.into());
+        Ok(())
+    }()
+    .into()
 }
 
 pub(crate) unsafe fn rav1d_data_unref(buf: *mut Rav1dData) {
@@ -1282,13 +1271,9 @@ pub unsafe extern "C" fn dav1d_data_unref(buf: *mut Dav1dData) {
     result
 }
 
-pub(crate) unsafe fn rav1d_data_props_unref(props: *mut Rav1dDataProps) {
-    rav1d_data_props_unref_internal(props);
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_data_props_unref(props: *mut Dav1dDataProps) {
-    let mut props_rust = props.read().into();
-    rav1d_data_props_unref(&mut props_rust);
-    props.write(props_rust.into());
+    let props = validate_input!(NonNull::new(props).ok_or(()));
+    let Ok(mut props) = props else { return };
+    let _ = mem::take(props.as_mut()).to::<Rav1dDataProps>();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1166,14 +1166,6 @@ pub unsafe extern "C" fn dav1d_get_event_flags(
     .into()
 }
 
-pub(crate) unsafe fn rav1d_get_decode_error_data_props(
-    c: &mut Rav1dContext,
-    out: &mut Rav1dDataProps,
-) -> Rav1dResult {
-    *out = mem::take(&mut c.cached_error_props);
-    Ok(())
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_get_decode_error_data_props(
     c: *mut Dav1dContext,
@@ -1182,10 +1174,8 @@ pub unsafe extern "C" fn dav1d_get_decode_error_data_props(
     (|| {
         validate_input!((!c.is_null(), EINVAL))?;
         validate_input!((!out.is_null(), EINVAL))?;
-        let mut out_rust = MaybeUninit::zeroed().assume_init(); // TODO(kkysen) Temporary until we return it directly.
-        let result = rav1d_get_decode_error_data_props(&mut *c, &mut out_rust);
-        out.write(out_rust.into());
-        result
+        out.write(mem::take(&mut (*c).cached_error_props).into());
+        Ok(())
     })()
     .into()
 }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -78,7 +78,6 @@ use crate::include::stdatomic::atomic_int;
 use crate::include::stdatomic::atomic_uint;
 use crate::src::cdf::rav1d_cdf_thread_ref;
 use crate::src::cdf::rav1d_cdf_thread_unref;
-use crate::src::data::rav1d_data_props_copy;
 use crate::src::data::rav1d_data_ref;
 use crate::src::data::rav1d_data_unref_internal;
 use crate::src::decode::rav1d_submit_frame;
@@ -2628,7 +2627,7 @@ unsafe fn parse_obus(
                 if error.is_err() {
                     c.cached_error = error;
                     (*f).task_thread.retval = Ok(());
-                    rav1d_data_props_copy(&mut c.cached_error_props, &mut (*out_delayed).p.m);
+                    c.cached_error_props = (*out_delayed).p.m.clone();
                     rav1d_thread_picture_unref(out_delayed);
                 } else if !((*out_delayed).p.data[0]).is_null() {
                     let progress = ::core::intrinsics::atomic_load_relaxed(
@@ -2732,7 +2731,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
     global: c_int,
 ) -> Rav1dResult<usize> {
     parse_obus(c, r#in, global).inspect_err(|_| {
-        rav1d_data_props_copy(&mut c.cached_error_props, &mut r#in.m);
+        c.cached_error_props = r#in.m.clone();
         writeln!(c.logger, "Error parsing OBU data");
     })
 }

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -376,8 +376,8 @@ pub(crate) unsafe fn rav1d_picture_ref(dst: &mut Rav1dPicture, src: &Rav1dPictur
     if !src.seq_hdr_ref.is_null() {
         rav1d_ref_inc(src.seq_hdr_ref);
     }
-    if !src.m.user_data.r#ref.is_null() {
-        rav1d_ref_inc(src.m.user_data.r#ref);
+    if let Some(r#ref) = src.m.user_data.r#ref {
+        rav1d_ref_inc(r#ref.as_ptr());
     }
     if !src.content_light_ref.is_null() {
         rav1d_ref_inc(src.content_light_ref);
@@ -444,7 +444,13 @@ pub(crate) unsafe fn rav1d_picture_unref_internal(p: &mut Rav1dPicture) {
     }
     rav1d_ref_dec(&mut p.seq_hdr_ref);
     rav1d_ref_dec(&mut p.frame_hdr_ref);
-    rav1d_ref_dec(&mut p.m.user_data.r#ref);
+    rav1d_ref_dec(
+        &mut p
+            .m
+            .user_data
+            .r#ref
+            .map_or_else(ptr::null_mut, |r#ref| r#ref.as_ptr()),
+    );
     rav1d_ref_dec(&mut p.content_light_ref);
     rav1d_ref_dec(&mut p.mastering_display_ref);
     rav1d_ref_dec(&mut p.itut_t35_ref);

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -165,8 +165,8 @@ unsafe fn decode_rand(
             offset: 0,
             size: 0,
             user_data: Dav1dUserData {
-                data: 0 as *const u8,
-                r#ref: 0 as *mut Dav1dRef,
+                data: None,
+                r#ref: None,
             },
         },
         content_light: 0 as *mut Dav1dContentLightLevel,
@@ -220,8 +220,8 @@ unsafe fn decode_all(
             offset: 0,
             size: 0,
             user_data: Dav1dUserData {
-                data: 0 as *const u8,
-                r#ref: 0 as *mut Dav1dRef,
+                data: None,
+                r#ref: None,
             },
         },
         content_light: 0 as *mut Dav1dContentLightLevel,
@@ -399,8 +399,8 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
             offset: 0,
             size: 0,
             user_data: Dav1dUserData {
-                data: 0 as *const u8,
-                r#ref: 0 as *mut Dav1dRef,
+                data: None,
+                r#ref: None,
             },
         },
     };

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -322,8 +322,8 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
             offset: 0,
             size: 0,
             user_data: Dav1dUserData {
-                data: 0 as *const u8,
-                r#ref: 0 as *mut Dav1dRef,
+                data: None,
+                r#ref: None,
             },
         },
         content_light: 0 as *mut Dav1dContentLightLevel,
@@ -350,8 +350,8 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
             offset: 0,
             size: 0,
             user_data: Dav1dUserData {
-                data: 0 as *const u8,
-                r#ref: 0 as *mut Dav1dRef,
+                data: None,
+                r#ref: None,
             },
         },
     };


### PR DESCRIPTION
This replaces `struct Rav1dUserData`, with its `Rav1dRef`, with `Option<CArc<u8>>`.

This lets us do ref-counting automatically and safely with a `#[derive(Clone)]`.  Thus, this replaces other `fn`s on `Rav1dDataProps`:

* `fn *_unref` s are `fn drop`s that leave the source in a valid, generally zeroed/`Default::default()` state, similar to C++ move constructors.  Thus, I've replaced these with `let _ = mem::take(...)`s.

* `fn *_ref`s and `fn *_copy`s are `fn clone`s that do ref-counting, so I've replaced them with `.clone()`s, where the ref-counting happens automatically with `#[derive(Clone)]` from the `Arc`.

* `fn *_move_ref`s are moves that leave the source in a valid state like `fn *_unref`s.  Thus, I've replaced these with `mem::take`s.

Furthermore, using `memset(0)` to clear droppable types like `Rav1dUserData` is unsound as it may leave the type in an invalid state that is then dropped.  Thus, we `impl Default` types that contain `Rav1dUserData` and use `mem::take` instead.

Also, if you could review this somewhat carefully, that'd be great, as I don't think any of the tests test non-null/`None` user data.