### PR TITLE
`mod lib`: Various cleanup in preparation for replacing `Rav1dData`'s `Rav1dRef` with a `CArc<[u8]>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -611,7 +611,7 @@ unsafe fn output_image(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRes
     res
 }
 
-unsafe extern "C" fn output_picture_ready(c: *mut Rav1dContext, drain: c_int) -> c_int {
+unsafe fn output_picture_ready(c: *mut Rav1dContext, drain: c_int) -> c_int {
     if (*c).cached_error.is_err() {
         return 1 as c_int;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -613,25 +613,25 @@ unsafe fn output_image(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRes
 
 unsafe fn output_picture_ready(c: &mut Rav1dContext, drain: c_int) -> c_int {
     if c.cached_error.is_err() {
-        return 1 as c_int;
+        return 1;
     }
     if !c.all_layers && c.max_spatial_id {
         if !(c.out.p.data[0]).is_null() && !(c.cache.p.data[0]).is_null() {
             if c.max_spatial_id == ((*c.cache.p.frame_hdr).spatial_id != 0)
                 || c.out.flags.contains(PictureFlags::NEW_TEMPORAL_UNIT)
             {
-                return 1 as c_int;
+                return 1;
             }
             rav1d_thread_picture_unref(&mut c.cache);
             rav1d_thread_picture_move_ref(&mut c.cache, &mut c.out);
-            return 0 as c_int;
+            return 0;
         } else {
             if !(c.cache.p.data[0]).is_null() && drain != 0 {
-                return 1 as c_int;
+                return 1;
             } else {
                 if !(c.out.p.data[0]).is_null() {
                     rav1d_thread_picture_move_ref(&mut c.cache, &mut c.out);
-                    return 0 as c_int;
+                    return 0;
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,7 +532,7 @@ pub(crate) unsafe fn rav1d_parse_sequence_header(
 
         assert!(len <= buf.sz);
         buf.sz -= len;
-        buf.data = (buf.data).offset(len as isize);
+        buf.data = buf.data.add(len);
     }
 
     if ((*c).seq_hdr).is_null() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -733,7 +733,7 @@ unsafe fn gen_picture(c: *mut Rav1dContext) -> Rav1dResult {
             Ok(len) => {
                 assert!(len <= (*in_0).sz);
                 (*in_0).sz -= len;
-                (*in_0).data = ((*in_0).data).offset(len as isize);
+                (*in_0).data = (*in_0).data.add(len);
                 if (*in_0).sz == 0 {
                     rav1d_data_unref_internal(in_0);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -616,7 +616,7 @@ unsafe fn output_picture_ready(c: &mut Rav1dContext, drain: c_int) -> c_int {
         return 1;
     }
     if !c.all_layers && c.max_spatial_id {
-        if !(c.out.p.data[0]).is_null() && !(c.cache.p.data[0]).is_null() {
+        if !c.out.p.data[0].is_null() && !c.cache.p.data[0].is_null() {
             if c.max_spatial_id == ((*c.cache.p.frame_hdr).spatial_id != 0)
                 || c.out.flags.contains(PictureFlags::NEW_TEMPORAL_UNIT)
             {
@@ -626,17 +626,17 @@ unsafe fn output_picture_ready(c: &mut Rav1dContext, drain: c_int) -> c_int {
             rav1d_thread_picture_move_ref(&mut c.cache, &mut c.out);
             return 0;
         } else {
-            if !(c.cache.p.data[0]).is_null() && drain != 0 {
+            if !c.cache.p.data[0].is_null() && drain != 0 {
                 return 1;
             } else {
-                if !(c.out.p.data[0]).is_null() {
+                if !c.out.p.data[0].is_null() {
                     rav1d_thread_picture_move_ref(&mut c.cache, &mut c.out);
                     return 0;
                 }
             }
         }
     }
-    return !(c.out.p.data[0]).is_null() as c_int;
+    return !c.out.p.data[0].is_null() as c_int;
 }
 
 unsafe fn drain_picture(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dResult {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -722,21 +722,20 @@ unsafe fn drain_picture(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRe
 }
 
 unsafe fn gen_picture(c: *mut Rav1dContext) -> Rav1dResult {
-    let mut res;
     let in_0: *mut Rav1dData = &mut (*c).in_0;
     if output_picture_ready(&mut *c, false) {
         return Ok(());
     }
     while (*in_0).sz > 0 {
-        res = rav1d_parse_obus(&mut *c, &*in_0, 0 as c_int);
-        match res {
+        let len = rav1d_parse_obus(&mut *c, &*in_0, 0 as c_int);
+        match len {
             Err(_) => rav1d_data_unref_internal(in_0),
-            Ok(res) => {
-                if !(res <= (*in_0).sz) {
+            Ok(len) => {
+                if !(len <= (*in_0).sz) {
                     unreachable!();
                 }
-                (*in_0).sz = ((*in_0).sz as c_ulong).wrapping_sub(res as c_ulong) as usize as usize;
-                (*in_0).data = ((*in_0).data).offset(res as isize);
+                (*in_0).sz = ((*in_0).sz as c_ulong).wrapping_sub(len as c_ulong) as usize as usize;
+                (*in_0).data = ((*in_0).data).offset(len as isize);
                 if (*in_0).sz == 0 {
                     rav1d_data_unref_internal(in_0);
                 }
@@ -745,7 +744,7 @@ unsafe fn gen_picture(c: *mut Rav1dContext) -> Rav1dResult {
         if output_picture_ready(&mut *c, false) {
             break;
         }
-        res?;
+        len?;
     }
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -731,9 +731,7 @@ unsafe fn gen_picture(c: *mut Rav1dContext) -> Rav1dResult {
         match len {
             Err(_) => rav1d_data_unref_internal(in_0),
             Ok(len) => {
-                if !(len <= (*in_0).sz) {
-                    unreachable!();
-                }
+                assert!(len <= (*in_0).sz);
                 (*in_0).sz = ((*in_0).sz as c_ulong).wrapping_sub(len as c_ulong) as usize as usize;
                 (*in_0).data = ((*in_0).data).offset(len as isize);
                 if (*in_0).sz == 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,7 +537,7 @@ pub(crate) unsafe fn rav1d_parse_sequence_header(
     }
 
     while buf.sz > 0 {
-        let res = rav1d_parse_obus(&mut *c, &mut buf, 1 as c_int);
+        let res = rav1d_parse_obus(&mut *c, &mut buf, true);
         let res = match res {
             Ok(res) => res,
             Err(res) => return rav1d_parse_sequence_header_error(Err(res), c, &mut buf),
@@ -727,7 +727,7 @@ unsafe fn gen_picture(c: &mut Rav1dContext) -> Rav1dResult {
     }
     while c.in_0.sz > 0 {
         let r#in = mem::take(&mut c.in_0); // Take so we don't have 2 `&mut`s.
-        let len = rav1d_parse_obus(c, &r#in, 0 as c_int);
+        let len = rav1d_parse_obus(c, &r#in, false);
         c.in_0 = r#in; // Restore into `c` right after.
         match len {
             Err(_) => rav1d_data_unref_internal(&mut c.in_0),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -728,7 +728,7 @@ unsafe fn gen_picture(c: *mut Rav1dContext) -> Rav1dResult {
         return Ok(());
     }
     while (*in_0).sz > 0 {
-        res = rav1d_parse_obus(&mut *c, &mut *in_0, 0 as c_int);
+        res = rav1d_parse_obus(&mut *c, &*in_0, 0 as c_int);
         match res {
             Err(_) => rav1d_data_unref_internal(in_0),
             Ok(res) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -611,32 +611,32 @@ unsafe fn output_image(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRes
     res
 }
 
-unsafe fn output_picture_ready(c: *mut Rav1dContext, drain: c_int) -> c_int {
-    if (*c).cached_error.is_err() {
+unsafe fn output_picture_ready(c: &mut Rav1dContext, drain: c_int) -> c_int {
+    if c.cached_error.is_err() {
         return 1 as c_int;
     }
-    if !(*c).all_layers && (*c).max_spatial_id {
-        if !((*c).out.p.data[0]).is_null() && !((*c).cache.p.data[0]).is_null() {
-            if (*c).max_spatial_id == ((*(*c).cache.p.frame_hdr).spatial_id != 0)
-                || (*c).out.flags.contains(PictureFlags::NEW_TEMPORAL_UNIT)
+    if !c.all_layers && c.max_spatial_id {
+        if !(c.out.p.data[0]).is_null() && !(c.cache.p.data[0]).is_null() {
+            if c.max_spatial_id == ((*c.cache.p.frame_hdr).spatial_id != 0)
+                || c.out.flags.contains(PictureFlags::NEW_TEMPORAL_UNIT)
             {
                 return 1 as c_int;
             }
-            rav1d_thread_picture_unref(&mut (*c).cache);
-            rav1d_thread_picture_move_ref(&mut (*c).cache, &mut (*c).out);
+            rav1d_thread_picture_unref(&mut c.cache);
+            rav1d_thread_picture_move_ref(&mut c.cache, &mut c.out);
             return 0 as c_int;
         } else {
-            if !((*c).cache.p.data[0]).is_null() && drain != 0 {
+            if !(c.cache.p.data[0]).is_null() && drain != 0 {
                 return 1 as c_int;
             } else {
-                if !((*c).out.p.data[0]).is_null() {
-                    rav1d_thread_picture_move_ref(&mut (*c).cache, &mut (*c).out);
+                if !(c.out.p.data[0]).is_null() {
+                    rav1d_thread_picture_move_ref(&mut c.cache, &mut c.out);
                     return 0 as c_int;
                 }
             }
         }
     }
-    return !((*c).out.p.data[0]).is_null() as c_int;
+    return !(c.out.p.data[0]).is_null() as c_int;
 }
 
 unsafe fn drain_picture(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dResult {
@@ -724,7 +724,7 @@ unsafe fn drain_picture(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRe
 unsafe fn gen_picture(c: *mut Rav1dContext) -> Rav1dResult {
     let mut res;
     let in_0: *mut Rav1dData = &mut (*c).in_0;
-    if output_picture_ready(c, 0 as c_int) != 0 {
+    if output_picture_ready(&mut *c, 0 as c_int) != 0 {
         return Ok(());
     }
     while (*in_0).sz > 0 {
@@ -742,7 +742,7 @@ unsafe fn gen_picture(c: *mut Rav1dContext) -> Rav1dResult {
                 }
             }
         }
-        if output_picture_ready(c, 0 as c_int) != 0 {
+        if output_picture_ready(&mut *c, 0 as c_int) != 0 {
             break;
         }
         res?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -636,7 +636,7 @@ unsafe fn output_picture_ready(c: &mut Rav1dContext, drain: c_int) -> c_int {
             }
         }
     }
-    return !c.out.p.data[0].is_null() as c_int;
+    !c.out.p.data[0].is_null() as c_int
 }
 
 unsafe fn drain_picture(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dResult {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,11 +506,13 @@ pub(crate) unsafe fn rav1d_parse_sequence_header(
 
     let mut buf = Default::default();
     let mut res;
-    let mut s = Rav1dSettings::default();
-    s.n_threads = 1 as c_int;
-    s.logger = None;
+    let s = Rav1dSettings {
+        n_threads: 1,
+        logger: None,
+        ..Default::default()
+    };
     let mut c: *mut Rav1dContext = 0 as *mut Rav1dContext;
-    res = rav1d_open(&mut c, &mut s);
+    res = rav1d_open(&mut c, &s);
     if res.is_err() {
         return res;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -721,26 +721,26 @@ unsafe fn drain_picture(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRe
     return Err(EAGAIN);
 }
 
-unsafe fn gen_picture(c: *mut Rav1dContext) -> Rav1dResult {
-    if output_picture_ready(&mut *c, false) {
+unsafe fn gen_picture(c: &mut Rav1dContext) -> Rav1dResult {
+    if output_picture_ready(c, false) {
         return Ok(());
     }
-    while (*c).in_0.sz > 0 {
-        let r#in = mem::take(&mut (*c).in_0); // Take so we don't have 2 `&mut`s.
-        let len = rav1d_parse_obus(&mut *c, &r#in, 0 as c_int);
-        (*c).in_0 = r#in; // Restore into `c` right after.
+    while c.in_0.sz > 0 {
+        let r#in = mem::take(&mut c.in_0); // Take so we don't have 2 `&mut`s.
+        let len = rav1d_parse_obus(c, &r#in, 0 as c_int);
+        c.in_0 = r#in; // Restore into `c` right after.
         match len {
-            Err(_) => rav1d_data_unref_internal(&mut (*c).in_0),
+            Err(_) => rav1d_data_unref_internal(&mut c.in_0),
             Ok(len) => {
-                assert!(len <= (*c).in_0.sz);
-                (*c).in_0.sz -= len;
-                (*c).in_0.data = (*c).in_0.data.add(len);
-                if (*c).in_0.sz == 0 {
-                    rav1d_data_unref_internal(&mut (*c).in_0);
+                assert!(len <= c.in_0.sz);
+                c.in_0.sz -= len;
+                c.in_0.data = c.in_0.data.add(len);
+                if c.in_0.sz == 0 {
+                    rav1d_data_unref_internal(&mut c.in_0);
                 }
             }
         }
-        if output_picture_ready(&mut *c, false) {
+        if output_picture_ready(c, false) {
             break;
         }
         len?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,6 @@ use crate::src::picture::rav1d_thread_picture_unref;
 use crate::src::picture::PictureFlags;
 use crate::src::picture::Rav1dThreadPicture;
 use crate::src::r#ref::rav1d_ref_dec;
-use crate::src::r#ref::Rav1dRef;
 use crate::src::refmvs::rav1d_refmvs_clear;
 use crate::src::refmvs::rav1d_refmvs_dsp_init;
 use crate::src::refmvs::rav1d_refmvs_init;
@@ -505,21 +504,7 @@ pub(crate) unsafe fn rav1d_parse_sequence_header(
         res
     }
 
-    let mut buf: Rav1dData = {
-        let init = Rav1dData {
-            data: 0 as *const u8,
-            sz: 0,
-            r#ref: 0 as *mut Rav1dRef,
-            m: Rav1dDataProps {
-                timestamp: 0,
-                duration: 0,
-                offset: 0,
-                size: 0,
-                user_data: Default::default(),
-            },
-        };
-        init
-    };
+    let mut buf = Default::default();
     let mut res;
     let mut s = Rav1dSettings::default();
     s.n_threads = 1 as c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -524,15 +524,15 @@ pub(crate) unsafe fn rav1d_parse_sequence_header(
     }
 
     while buf.sz > 0 {
-        let res = rav1d_parse_obus(&mut *c, &mut buf, true);
-        let res = match res {
-            Ok(res) => res,
-            Err(res) => return rav1d_parse_sequence_header_error(Err(res), c, &mut buf),
+        let len = rav1d_parse_obus(&mut *c, &mut buf, true);
+        let len = match len {
+            Ok(len) => len,
+            Err(e) => return rav1d_parse_sequence_header_error(Err(e), c, &mut buf),
         };
 
-        assert!(res as usize <= buf.sz);
-        buf.sz -= res as usize;
-        buf.data = (buf.data).offset(res as isize);
+        assert!(len <= buf.sz);
+        buf.sz -= len;
+        buf.data = (buf.data).offset(len as isize);
     }
 
     if ((*c).seq_hdr).is_null() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -726,7 +726,9 @@ unsafe fn gen_picture(c: *mut Rav1dContext) -> Rav1dResult {
         return Ok(());
     }
     while (*c).in_0.sz > 0 {
-        let len = rav1d_parse_obus(&mut *c, &(*c).in_0, 0 as c_int);
+        let r#in = mem::take(&mut (*c).in_0); // Take so we don't have 2 `&mut`s.
+        let len = rav1d_parse_obus(&mut *c, &r#in, 0 as c_int);
+        (*c).in_0 = r#in; // Restore into `c` right after.
         match len {
             Err(_) => rav1d_data_unref_internal(&mut (*c).in_0),
             Ok(len) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -732,7 +732,7 @@ unsafe fn gen_picture(c: *mut Rav1dContext) -> Rav1dResult {
             Err(_) => rav1d_data_unref_internal(in_0),
             Ok(len) => {
                 assert!(len <= (*in_0).sz);
-                (*in_0).sz = ((*in_0).sz as c_ulong).wrapping_sub(len as c_ulong) as usize as usize;
+                (*in_0).sz -= len;
                 (*in_0).data = ((*in_0).data).offset(len as isize);
                 if (*in_0).sz == 0 {
                     rav1d_data_unref_internal(in_0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -722,20 +722,19 @@ unsafe fn drain_picture(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRe
 }
 
 unsafe fn gen_picture(c: *mut Rav1dContext) -> Rav1dResult {
-    let in_0: *mut Rav1dData = &mut (*c).in_0;
     if output_picture_ready(&mut *c, false) {
         return Ok(());
     }
-    while (*in_0).sz > 0 {
-        let len = rav1d_parse_obus(&mut *c, &*in_0, 0 as c_int);
+    while (*c).in_0.sz > 0 {
+        let len = rav1d_parse_obus(&mut *c, &(*c).in_0, 0 as c_int);
         match len {
-            Err(_) => rav1d_data_unref_internal(in_0),
+            Err(_) => rav1d_data_unref_internal(&mut (*c).in_0),
             Ok(len) => {
-                assert!(len <= (*in_0).sz);
-                (*in_0).sz -= len;
-                (*in_0).data = (*in_0).data.add(len);
-                if (*in_0).sz == 0 {
-                    rav1d_data_unref_internal(in_0);
+                assert!(len <= (*c).in_0.sz);
+                (*c).in_0.sz -= len;
+                (*c).in_0.data = (*c).in_0.data.add(len);
+                if (*c).in_0.sz == 0 {
+                    rav1d_data_unref_internal(&mut (*c).in_0);
                 }
             }
         }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2101,11 +2101,7 @@ fn check_for_overrun(
     0
 }
 
-unsafe fn parse_obus(
-    c: &mut Rav1dContext,
-    r#in: &mut Rav1dData,
-    global: c_int,
-) -> Rav1dResult<usize> {
+unsafe fn parse_obus(c: &mut Rav1dContext, r#in: &Rav1dData, global: c_int) -> Rav1dResult<usize> {
     unsafe fn skip(c: &mut Rav1dContext, len: usize, init_byte_pos: usize) -> usize {
         // update refs with only the headers in case we skip the frame
         for i in 0..8 {
@@ -2183,7 +2179,7 @@ unsafe fn parse_obus(
 
     unsafe fn parse_tile_grp(
         c: &mut Rav1dContext,
-        r#in: &mut Rav1dData,
+        r#in: &Rav1dData,
         gb: &mut GetBits,
         init_bit_pos: usize,
         init_byte_pos: usize,
@@ -2577,7 +2573,7 @@ unsafe fn parse_obus(
                     c.mastering_display_ref,
                     c.itut_t35,
                     c.itut_t35_ref,
-                    &mut r#in.m,
+                    &r#in.m,
                 );
                 // Must be removed from the context after being attached to the frame
                 rav1d_ref_dec(&mut c.itut_t35_ref);
@@ -2654,7 +2650,7 @@ unsafe fn parse_obus(
                     c.mastering_display_ref,
                     c.itut_t35,
                     c.itut_t35_ref,
-                    &mut r#in.m,
+                    &r#in.m,
                 );
                 // Must be removed from the context after being attached to the frame
                 rav1d_ref_dec(&mut c.itut_t35_ref);
@@ -2727,7 +2723,7 @@ unsafe fn parse_obus(
 
 pub(crate) unsafe fn rav1d_parse_obus(
     c: &mut Rav1dContext,
-    r#in: &mut Rav1dData,
+    r#in: &Rav1dData,
     global: c_int,
 ) -> Rav1dResult<usize> {
     parse_obus(c, r#in, global).inspect_err(|_| {


### PR DESCRIPTION
There are a bunch of various cleanups in here.  A bunch of them make things progressively safer and are pulled from #652, which I'm still debugging, so this will help separate the non-buggy changes from it.