### PR TITLE
`struct Rav1dData`: Replace `Rav1dRef` with `Option<CArc<[u8]>>`

### DIFF
--- a/include/dav1d/data.rs
+++ b/include/dav1d/data.rs
@@ -1,34 +1,37 @@
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::common::Rav1dDataProps;
-use crate::include::dav1d::dav1d::Dav1dRef;
-use crate::src::r#ref::Rav1dRef;
+use crate::src::c_arc::CArc;
+use crate::src::c_arc::RawCArc;
 use std::ptr::NonNull;
+use to_method::To as _;
 
 #[derive(Default)]
 #[repr(C)]
 pub struct Dav1dData {
     pub data: Option<NonNull<u8>>,
     pub sz: usize,
-    pub r#ref: Option<NonNull<Dav1dRef>>,
+    pub r#ref: Option<RawCArc<[u8]>>, // opaque, so we can change this
     pub m: Dav1dDataProps,
 }
 
 #[derive(Clone, Default)]
 #[repr(C)]
 pub(crate) struct Rav1dData {
-    pub data: Option<NonNull<u8>>,
-    pub sz: usize,
-    pub r#ref: Option<NonNull<Rav1dRef>>,
+    pub data: Option<CArc<[u8]>>,
     pub m: Rav1dDataProps,
 }
 
 impl From<Dav1dData> for Rav1dData {
     fn from(value: Dav1dData) -> Self {
-        let Dav1dData { data, sz, r#ref, m } = value;
-        Self {
-            data,
-            sz,
+        let Dav1dData {
+            data: _,
+            sz: _,
             r#ref,
+            m,
+        } = value;
+        Self {
+            // Safety: `r#ref` is a [`RawCArc`] originally from [`CArc`].
+            data: r#ref.map(|r#ref| unsafe { CArc::from_raw(r#ref) }),
             m: m.into(),
         }
     }
@@ -36,11 +39,13 @@ impl From<Dav1dData> for Rav1dData {
 
 impl From<Rav1dData> for Dav1dData {
     fn from(value: Rav1dData) -> Self {
-        let Rav1dData { data, sz, r#ref, m } = value;
+        let Rav1dData { data, m } = value;
         Self {
-            data,
-            sz,
-            r#ref,
+            data: data
+                .as_ref()
+                .map(|data| data.as_ref().to::<NonNull<[u8]>>().cast()),
+            sz: data.as_ref().map(|data| data.len()).unwrap_or_default(),
+            r#ref: data.map(|data| data.into_raw()),
             m: m.into(),
         }
     }

--- a/include/dav1d/data.rs
+++ b/include/dav1d/data.rs
@@ -2,45 +2,24 @@ use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::common::Rav1dDataProps;
 use crate::include::dav1d::dav1d::Dav1dRef;
 use crate::src::r#ref::Rav1dRef;
-use std::ptr;
+use std::ptr::NonNull;
 
+#[derive(Default)]
 #[repr(C)]
 pub struct Dav1dData {
-    pub data: *const u8,
+    pub data: Option<NonNull<u8>>,
     pub sz: usize,
-    pub r#ref: *mut Dav1dRef,
+    pub r#ref: Option<NonNull<Dav1dRef>>,
     pub m: Dav1dDataProps,
 }
 
-impl Default for Dav1dData {
-    fn default() -> Self {
-        Self {
-            data: ptr::null(),
-            sz: Default::default(),
-            r#ref: ptr::null_mut(),
-            m: Default::default(),
-        }
-    }
-}
-
-#[derive(Clone)]
+#[derive(Clone, Default)]
 #[repr(C)]
 pub(crate) struct Rav1dData {
-    pub data: *const u8,
+    pub data: Option<NonNull<u8>>,
     pub sz: usize,
-    pub r#ref: *mut Rav1dRef,
+    pub r#ref: Option<NonNull<Rav1dRef>>,
     pub m: Rav1dDataProps,
-}
-
-impl Default for Rav1dData {
-    fn default() -> Self {
-        Self {
-            data: ptr::null(),
-            sz: Default::default(),
-            r#ref: ptr::null_mut(),
-            m: Default::default(),
-        }
-    }
 }
 
 impl From<Dav1dData> for Rav1dData {

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,61 +1,49 @@
 use crate::include::common::validate::validate_input;
+use crate::include::dav1d::common::Rav1dDataProps;
 use crate::include::dav1d::data::Rav1dData;
 use crate::src::c_arc::CArc;
 use crate::src::c_box::CBox;
 use crate::src::c_box::FnFree;
 use crate::src::c_box::Free;
 use crate::src::error::Rav1dError::EINVAL;
-use crate::src::error::Rav1dError::ENOMEM;
 use crate::src::error::Rav1dResult;
-use crate::src::r#ref::rav1d_ref_create;
-use crate::src::r#ref::rav1d_ref_dec;
-use crate::src::r#ref::rav1d_ref_inc;
-use crate::src::r#ref::rav1d_ref_wrap;
 use std::ffi::c_void;
-use std::mem;
-use std::ptr;
 use std::ptr::NonNull;
 
-pub(crate) unsafe fn rav1d_data_create_internal(buf: *mut Rav1dData, sz: usize) -> *mut u8 {
-    if let Err(e) = validate_input!((!buf.is_null(), ptr::null_mut())) {
-        return e;
+impl From<CArc<[u8]>> for Rav1dData {
+    fn from(data: CArc<[u8]>) -> Self {
+        let size = data.len();
+        Self {
+            data: Some(data),
+            m: Rav1dDataProps {
+                size,
+                ..Default::default()
+            },
+        }
     }
-    if sz > usize::MAX / 2 {
-        return 0 as *mut u8;
-    }
-    (*buf).r#ref = NonNull::new(rav1d_ref_create(sz));
-    let Some(r#ref) = (*buf).r#ref else {
-        return 0 as *mut u8;
-    };
-    (*buf).data = NonNull::new(r#ref.as_ref().const_data as *mut u8);
-    (*buf).sz = sz;
-    (*buf).m = Default::default();
-    (*buf).m.size = sz;
-    return r#ref.as_ref().data as *mut u8;
-}
-
-pub(crate) unsafe fn rav1d_data_wrap_internal(
-    buf: *mut Rav1dData,
-    ptr: *const u8,
-    sz: usize,
-    free_callback: Option<unsafe extern "C" fn(*const u8, *mut c_void) -> ()>,
-    cookie: *mut c_void,
-) -> Rav1dResult {
-    validate_input!((!buf.is_null(), EINVAL))?;
-    validate_input!((!ptr.is_null(), EINVAL))?;
-    validate_input!((free_callback.is_some(), EINVAL))?;
-    (*buf).r#ref = NonNull::new(rav1d_ref_wrap(ptr, free_callback, cookie));
-    if (*buf).r#ref.is_none() {
-        return Err(ENOMEM);
-    }
-    (*buf).data = NonNull::new(ptr.cast_mut());
-    (*buf).sz = sz;
-    (*buf).m = Default::default();
-    (*buf).m.size = sz;
-    Ok(())
 }
 
 impl Rav1dData {
+    pub fn create(size: usize) -> Rav1dResult<Self> {
+        let data = CArc::zeroed_slice(size)?;
+        Ok(data.into())
+    }
+
+    /// # Safety
+    ///
+    /// See [`CBox::from_c`]'s safety for `data`, `free_callback`, `cookie`.
+    pub unsafe fn wrap(
+        data: NonNull<[u8]>,
+        free_callback: Option<FnFree>,
+        cookie: *mut c_void,
+    ) -> Rav1dResult<Self> {
+        let free = validate_input!(free_callback.ok_or(EINVAL))?;
+        let free = Free { free, cookie };
+        let data = CBox::from_c(data, free);
+        let data = CArc::wrap(data)?;
+        Ok(data.into())
+    }
+
     /// # Safety
     ///
     /// See [`CBox::from_c`]'s safety for `user_data`, `free_callback`, `cookie`.
@@ -74,34 +62,11 @@ impl Rav1dData {
     }
 }
 
-pub(crate) unsafe fn rav1d_data_ref(dst: &mut Rav1dData, src: &Rav1dData) {
-    if validate_input!((*dst).data.is_none()).is_err() {
-        return;
-    }
-    if let Some(r#ref) = src.r#ref {
-        if validate_input!(!src.data.is_none()).is_err() {
-            return;
+impl AsRef<[u8]> for Rav1dData {
+    fn as_ref(&self) -> &[u8] {
+        match &self.data {
+            Some(data) => data.as_ref(),
+            None => &[],
         }
-        rav1d_ref_inc(r#ref.as_ptr());
-    }
-    *dst = src.clone();
-}
-
-pub(crate) unsafe fn rav1d_data_unref_internal(buf: *mut Rav1dData) {
-    if validate_input!(!buf.is_null()).is_err() {
-        return;
-    }
-    let Rav1dData {
-        data,
-        sz: _,
-        r#ref,
-        m: _,
-    } = mem::take(&mut *buf);
-    let _ = mem::take(&mut (*buf).m);
-    if let Some(r#ref) = r#ref {
-        if validate_input!(!data.is_none()).is_err() {
-            return;
-        }
-        rav1d_ref_dec(&mut r#ref.as_ptr());
     }
 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4710,7 +4710,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init_cdf(f: &mut Rav1dFrameContext) -> R
         let start = tile.hdr.start.try_into().unwrap();
         let end: usize = tile.hdr.end.try_into().unwrap();
 
-        let mut data = slice::from_raw_parts(tile.data.data, tile.data.sz);
+        let mut data = slice::from_raw_parts(tile.data.data.unwrap().as_ptr(), tile.data.sz);
 
         for (j, (ts, tile_start_off)) in iter::zip(
             slice::from_raw_parts_mut(f.ts, end + 1),

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -37,7 +37,6 @@ use crate::src::cdf::rav1d_cdf_thread_update;
 use crate::src::cdf::CdfMvComponent;
 use crate::src::cdf::CdfMvContext;
 use crate::src::ctx::CaseSet;
-use crate::src::data::rav1d_data_unref_internal;
 use crate::src::dequant_tables::dav1d_dq_tbl;
 use crate::src::enum_map::enum_map;
 use crate::src::enum_map::enum_map_ty;
@@ -4710,8 +4709,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init_cdf(f: &mut Rav1dFrameContext) -> R
         let start = tile.hdr.start.try_into().unwrap();
         let end: usize = tile.hdr.end.try_into().unwrap();
 
-        let mut data = slice::from_raw_parts(tile.data.data.unwrap().as_ptr(), tile.data.sz);
-
+        let mut data = tile.data.as_ref();
         for (j, (ts, tile_start_off)) in iter::zip(
             slice::from_raw_parts_mut(f.ts, end + 1),
             slice::from_raw_parts(
@@ -4891,9 +4889,6 @@ pub(crate) unsafe fn rav1d_decode_frame_exit(f: &mut Rav1dFrameContext, retval: 
     rav1d_ref_dec(&mut f.mvs_ref);
     let _ = mem::take(&mut f.seq_hdr);
     let _ = mem::take(&mut f.frame_hdr);
-    for tile in &mut f.tiles {
-        rav1d_data_unref_internal(&mut tile.data);
-    }
     f.tiles.clear();
     f.task_thread.retval = retval;
 }
@@ -5034,9 +5029,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
         let _ = mem::take(&mut f.frame_hdr);
         c.cached_error_props = c.in_0.m.clone();
 
-        for mut tile in f.tiles.drain(..) {
-            rav1d_data_unref_internal(&mut tile.data);
-        }
+        f.tiles.clear();
 
         if c.n_fc > 1 {
             pthread_mutex_unlock(&mut c.task_thread.lock);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1033,7 +1033,7 @@ unsafe fn close_internal(c_out: &mut *mut Rav1dContext, flush: c_int) {
         rav1d_free_aligned((*f).ts as *mut c_void);
         rav1d_free_aligned((*f).ipred_edge[0] as *mut c_void);
         free((*f).a as *mut c_void);
-        (*f).tiles = Default::default(); // TODO(kkysen) Remove when dropped properly.
+        let _ = mem::take(&mut (*f).tiles);
         free((*f).lf.mask as *mut c_void);
         free((*f).lf.lr_mask as *mut c_void);
         free((*f).lf.level as *mut c_void);

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -328,7 +328,9 @@ unsafe fn seek(
         if res != 0 {
             break;
         }
-        if !(dav1d_parse_sequence_header(&mut seq, (*data).data, (*data).sz).0 != 0) {
+        if !(dav1d_parse_sequence_header(&mut seq, (*data).data.unwrap().as_ptr(), (*data).sz).0
+            != 0)
+        {
             break;
         }
     }
@@ -386,9 +388,9 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
     let mut in_0: *mut DemuxerContext = 0 as *mut DemuxerContext;
     let mut c: *mut Dav1dContext = 0 as *mut Dav1dContext;
     let mut data: Dav1dData = Dav1dData {
-        data: 0 as *const u8,
+        data: None,
         sz: 0,
-        r#ref: 0 as *mut Dav1dRef,
+        r#ref: None,
         m: Dav1dDataProps {
             timestamp: 0,
             duration: 0,

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -337,9 +337,9 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
     };
     let mut c: *mut Dav1dContext = 0 as *mut Dav1dContext;
     let mut data: Dav1dData = Dav1dData {
-        data: 0 as *const u8,
+        data: None,
         sz: 0,
-        r#ref: 0 as *mut Dav1dRef,
+        r#ref: None,
         m: Dav1dDataProps {
             timestamp: 0,
             duration: 0,
@@ -474,7 +474,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
             }; 32],
         };
         let mut seq_skip: c_uint = 0 as c_int as c_uint;
-        while dav1d_parse_sequence_header(&mut seq, data.data, data.sz).0 != 0 {
+        while dav1d_parse_sequence_header(&mut seq, data.data.unwrap().as_ptr(), data.sz).0 != 0 {
             res = input_read(in_0, &mut data);
             if res < 0 {
                 input_close(in_0);


### PR DESCRIPTION
~~This is still buggy on those 3 tests (`00000063`, `redundant_frame_header`, `issue_48`) failing in #652.  The output video is off by a small number of bits for each of them, but the picture parameters and headers and OBU metadata are all the same.  I've now narrowed down the PR to this smaller one (specifically the 2nd commit, 6afc41b), which still evidently contains the bug.  The divergence in the data happens somewhere in `fn rav1d_decode_tile_sbrow`, but the dataflow gets very confusing and I haven't been able to narrow it down further yet.~~

~~Among the changes in 6afc41b, I also tried not splitting up `Rav1dData` into `CArc<[u8]>` and `Rav1dDataProps` within `fn parse_obus`, but that doesn't change anything.  `fn gen_picture` is also changed in a more straightforward manner that is less concise and efficient as in #652, but the bug is still there.~~