### PR TITLE
`struct Rav1dITUTT35`: Make `payload{,_size}` fields a `Box<[u8]>`

### DIFF
--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -2,6 +2,7 @@ use crate::src::enum_map::EnumKey;
 use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ops::BitAnd;
+use std::slice;
 use strum::EnumCount;
 use strum::FromRepr;
 
@@ -505,8 +506,7 @@ pub struct Dav1dITUTT35 {
 pub(crate) struct Rav1dITUTT35 {
     pub country_code: u8,
     pub country_code_extension_byte: u8,
-    pub payload_size: usize,
-    pub payload: *mut u8,
+    pub payload: Box<[u8]>,
 }
 
 impl From<Dav1dITUTT35> for Rav1dITUTT35 {
@@ -517,10 +517,11 @@ impl From<Dav1dITUTT35> for Rav1dITUTT35 {
             payload_size,
             payload,
         } = value;
+        let payload = unsafe { slice::from_raw_parts_mut(payload, payload_size) };
+        let payload = unsafe { Box::from_raw(payload) };
         Self {
             country_code,
             country_code_extension_byte,
-            payload_size,
             payload,
         }
     }
@@ -531,14 +532,14 @@ impl From<Rav1dITUTT35> for Dav1dITUTT35 {
         let Rav1dITUTT35 {
             country_code,
             country_code_extension_byte,
-            payload_size,
             payload,
         } = value;
         Self {
             country_code,
             country_code_extension_byte,
-            payload_size,
-            payload,
+            payload_size: payload.len(),
+            // Cast to a thin ptr.
+            payload: Box::into_raw(payload).cast::<u8>(),
         }
     }
 }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2462,17 +2462,7 @@ unsafe fn parse_obus(c: &mut Rav1dContext, r#in: &Rav1dData, global: bool) -> Ra
 
                         let country_code = country_code as u8;
                         let country_code_extension_byte = country_code_extension_byte as u8;
-                        // We need our public headers to be C++ compatible, so payload can't be
-                        // a flexible array member
-                        let payload = (*r#ref)
-                            .data
-                            .cast::<u8>()
-                            .offset(::core::mem::size_of::<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>()
-                                as isize);
-                        let payload_size = payload_size as usize;
-                        for i in 0..payload_size {
-                            *payload.offset(i as isize) = gb.get_bits(8) as u8;
-                        }
+                        let payload = (0..payload_size).map(|_| gb.get_bits(8) as u8).collect(); // TODO(kkysen) fallible allocation
 
                         let itut_t35_metadatas =
                             (*r#ref).data.cast::<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>();
@@ -2480,7 +2470,6 @@ unsafe fn parse_obus(c: &mut Rav1dContext, r#in: &Rav1dData, global: bool) -> Ra
                             country_code,
                             country_code_extension_byte,
                             payload,
-                            payload_size,
                         }));
                         rav1d_ref_dec(&mut c.itut_t35_ref);
                         c.itut_t35 = &mut (*itut_t35_metadatas).rav1d;


### PR DESCRIPTION
This makes `Rav1dITUTT35` no longer a DST, which is very tricky (it makes `Arc`ification much more difficult, for example), at the cost of an extra layer of indirection, but since the payload probably won't be accessed through the `Rav1dITUTT35` excessively, I don't think this should be a problem.  Note that having a separate `Rav1dITUTT35` from `Dav1dITUTT35` allows us to do this easily.