### PR TITLE
`struct {D,R}av1dITUTT35`: Replace `Rav1dRef`s with `Option<Arc<DRav1d<_, _>>>`s

### DIFF
--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -8,7 +8,7 @@ use strum::FromRepr;
 /// This is so we can store both `*mut D` and `*mut R`
 /// for maintaining `dav1d` ABI compatibility,
 /// where `D` is the `Dav1d*` type and `R` is the `Rav1d` type.
-pub(crate) struct DRav1d<R, D> {
+pub struct DRav1d<R, D> {
     pub rav1d: R,
     pub dav1d: D,
 }
@@ -502,7 +502,7 @@ pub struct Dav1dITUTT35 {
 
 #[derive(Clone)]
 #[repr(C)]
-pub(crate) struct Rav1dITUTT35 {
+pub struct Rav1dITUTT35 {
     pub country_code: u8,
     pub country_code_extension_byte: u8,
     pub payload: Box<[u8]>,

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -2,7 +2,6 @@ use crate::src::enum_map::EnumKey;
 use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ops::BitAnd;
-use std::slice;
 use strum::EnumCount;
 use strum::FromRepr;
 
@@ -507,24 +506,6 @@ pub(crate) struct Rav1dITUTT35 {
     pub country_code: u8,
     pub country_code_extension_byte: u8,
     pub payload: Box<[u8]>,
-}
-
-impl From<Dav1dITUTT35> for Rav1dITUTT35 {
-    fn from(value: Dav1dITUTT35) -> Self {
-        let Dav1dITUTT35 {
-            country_code,
-            country_code_extension_byte,
-            payload_size,
-            payload,
-        } = value;
-        let payload = unsafe { slice::from_raw_parts_mut(payload, payload_size) };
-        let payload = unsafe { Box::from_raw(payload) };
-        Self {
-            country_code,
-            country_code_extension_byte,
-            payload,
-        }
-    }
 }
 
 impl From<Rav1dITUTT35> for Dav1dITUTT35 {

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -167,7 +167,7 @@ impl From<Dav1dPicture> for Rav1dPicture {
             content_light: content_light_ref.map(|raw| unsafe { raw.into_arc() }),
             // Safety: `raw` came from [`RawArc::from_arc`].
             mastering_display: mastering_display_ref.map(|raw| unsafe { raw.into_arc() }),
-            // `.update_rav1d()` happens in `#[no_mangle] extern "C"`/`DAV1D_API` calls
+            // We don't `.update_rav1d` [`Rav1dITUTT35`] because never read it.
             itut_t35: if itut_t35.is_null() {
                 ptr::null_mut()
             } else {

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -77,13 +77,13 @@ pub struct Dav1dPicture {
     pub m: Dav1dDataProps,
     pub content_light: Option<NonNull<Rav1dContentLightLevel>>,
     pub mastering_display: Option<NonNull<Rav1dMasteringDisplay>>,
-    pub itut_t35: *mut Dav1dITUTT35,
+    pub itut_t35: Option<NonNull<Dav1dITUTT35>>,
     pub reserved: [uintptr_t; 4],
     pub frame_hdr_ref: *mut Dav1dRef,
     pub seq_hdr_ref: *mut Dav1dRef,
     pub content_light_ref: Option<RawArc<Rav1dContentLightLevel>>, // opaque, so we can change this
     pub mastering_display_ref: Option<RawArc<Rav1dMasteringDisplay>>, // opaque, so we can change this
-    pub itut_t35_ref: *mut Dav1dRef,
+    pub itut_t35_ref: Option<RawArc<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>>, // opaque, so we can change this
     pub reserved_ref: [uintptr_t; 4],
     pub r#ref: *mut Dav1dRef,
     pub allocator_data: *mut c_void,
@@ -100,10 +100,9 @@ pub(crate) struct Rav1dPicture {
     pub m: Rav1dDataProps,
     pub content_light: Option<Arc<Rav1dContentLightLevel>>,
     pub mastering_display: Option<Arc<Rav1dMasteringDisplay>>,
-    pub itut_t35: *mut Rav1dITUTT35,
+    pub itut_t35: Option<Arc<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>>,
     pub frame_hdr_ref: *mut Rav1dRef,
     pub seq_hdr_ref: *mut Rav1dRef,
-    pub itut_t35_ref: *mut Rav1dRef,
     pub r#ref: *mut Rav1dRef,
     pub allocator_data: *mut c_void,
 }
@@ -119,7 +118,7 @@ impl From<Dav1dPicture> for Rav1dPicture {
             m,
             content_light: _,
             mastering_display: _,
-            itut_t35,
+            itut_t35: _,
             reserved: _,
             frame_hdr_ref,
             seq_hdr_ref,
@@ -168,21 +167,10 @@ impl From<Dav1dPicture> for Rav1dPicture {
             // Safety: `raw` came from [`RawArc::from_arc`].
             mastering_display: mastering_display_ref.map(|raw| unsafe { raw.into_arc() }),
             // We don't `.update_rav1d` [`Rav1dITUTT35`] because never read it.
-            itut_t35: if itut_t35.is_null() {
-                ptr::null_mut()
-            } else {
-                unsafe {
-                    addr_of_mut!(
-                        (*(itut_t35_ref.read())
-                            .data
-                            .cast::<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>())
-                        .rav1d
-                    )
-                }
-            },
+            // Safety: `raw` came from [`RawArc::from_arc`].
+            itut_t35: itut_t35_ref.map(|raw| unsafe { raw.into_arc() }),
             frame_hdr_ref,
             seq_hdr_ref,
-            itut_t35_ref,
             r#ref,
             allocator_data,
         }
@@ -203,7 +191,6 @@ impl From<Rav1dPicture> for Dav1dPicture {
             itut_t35,
             frame_hdr_ref,
             seq_hdr_ref,
-            itut_t35_ref,
             r#ref,
             allocator_data,
         } = value;
@@ -243,24 +230,13 @@ impl From<Rav1dPicture> for Dav1dPicture {
             content_light: content_light.as_ref().map(|arc| arc.as_ref().into()),
             mastering_display: mastering_display.as_ref().map(|arc| arc.as_ref().into()),
             // `DRav1d::from_rav1d` is called in [`rav1d_parse_obus`].
-            itut_t35: if itut_t35.is_null() {
-                ptr::null_mut()
-            } else {
-                unsafe {
-                    addr_of_mut!(
-                        (*(itut_t35_ref.read())
-                            .data
-                            .cast::<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>())
-                        .dav1d
-                    )
-                }
-            },
+            itut_t35: itut_t35.as_ref().map(|arc| (&arc.as_ref().dav1d).into()),
             reserved: Default::default(),
             frame_hdr_ref,
             seq_hdr_ref,
             content_light_ref: content_light.map(RawArc::from_arc),
             mastering_display_ref: mastering_display.map(RawArc::from_arc),
-            itut_t35_ref,
+            itut_t35_ref: itut_t35.map(RawArc::from_arc),
             reserved_ref: Default::default(),
             r#ref,
             allocator_data,
@@ -284,10 +260,9 @@ impl Default for Rav1dPicture {
             m: Default::default(),
             content_light: None,
             mastering_display: None,
-            itut_t35: ptr::null_mut(),
+            itut_t35: None,
             frame_hdr_ref: ptr::null_mut(),
             seq_hdr_ref: ptr::null_mut(),
-            itut_t35_ref: ptr::null_mut(),
             r#ref: ptr::null_mut(),
             allocator_data: ptr::null_mut(),
         }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -8,6 +8,8 @@ use crate::include::dav1d::data::Rav1dData;
 use crate::include::dav1d::dav1d::Rav1dDecodeFrameType;
 use crate::include::dav1d::dav1d::Rav1dEventFlags;
 use crate::include::dav1d::dav1d::Rav1dInloopFilterType;
+use crate::include::dav1d::headers::DRav1d;
+use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Rav1dContentLightLevel;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
 use crate::include::dav1d::headers::Rav1dITUTT35;
@@ -211,8 +213,7 @@ pub struct Rav1dContext {
     pub(crate) frame_hdr: *mut Rav1dFrameHeader,
     pub(crate) content_light: Option<Arc<Rav1dContentLightLevel>>,
     pub(crate) mastering_display: Option<Arc<Rav1dMasteringDisplay>>,
-    pub(crate) itut_t35_ref: *mut Rav1dRef,
-    pub(crate) itut_t35: *mut Rav1dITUTT35,
+    pub(crate) itut_t35: Option<Arc<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>>,
 
     // decoded output picture queue
     pub(crate) in_0: Rav1dData,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@ use crate::include::dav1d::dav1d::RAV1D_DECODEFRAMETYPE_KEY;
 use crate::include::dav1d::dav1d::RAV1D_INLOOPFILTER_ALL;
 use crate::include::dav1d::headers::DRav1d;
 use crate::include::dav1d::headers::Dav1dFrameHeader;
-use crate::include::dav1d::headers::Dav1dITUTT35;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
 use crate::include::dav1d::headers::Rav1dFilmGrainData;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
@@ -845,13 +844,7 @@ pub unsafe extern "C" fn dav1d_apply_grain(
                 .cast::<DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>>())
             .update_rav1d();
         }
-        if let Some(mut itut_t35_ref) = NonNull::new(in_0.itut_t35_ref) {
-            (*itut_t35_ref
-                .as_mut()
-                .data
-                .cast::<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>())
-            .update_rav1d();
-        }
+        // Don't `.update_rav1d` [`Rav1dITUTT35`] because we never read it.
         let mut out_rust = MaybeUninit::zeroed().assume_init(); // TODO(kkysen) Temporary until we return it directly.
         let in_rust = in_0.into();
         let result = rav1d_apply_grain(c, &mut out_rust, &in_rust);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@ use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::Dav1dSequenceHeader;
 use crate::include::dav1d::headers::Rav1dFilmGrainData;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
-use crate::include::dav1d::headers::Rav1dITUTT35;
 use crate::include::dav1d::headers::Rav1dSequenceHeader;
 use crate::include::dav1d::picture::Dav1dPicture;
 use crate::include::dav1d::picture::Rav1dPicture;
@@ -844,7 +843,7 @@ pub unsafe extern "C" fn dav1d_apply_grain(
                 .cast::<DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>>())
             .update_rav1d();
         }
-        // Don't `.update_rav1d` [`Rav1dITUTT35`] because we never read it.
+        // Don't `.update_rav1d()` [`Rav1dITUTT35`] because we never read it.
         let mut out_rust = MaybeUninit::zeroed().assume_init(); // TODO(kkysen) Temporary until we return it directly.
         let in_rust = in_0.into();
         let result = rav1d_apply_grain(c, &mut out_rust, &in_rust);
@@ -879,8 +878,7 @@ pub(crate) unsafe fn rav1d_flush(c: *mut Rav1dContext) {
     rav1d_ref_dec(&mut (*c).seq_hdr_ref);
     let _ = mem::take(&mut (*c).content_light);
     let _ = mem::take(&mut (*c).mastering_display);
-    (*c).itut_t35 = 0 as *mut Rav1dITUTT35;
-    rav1d_ref_dec(&mut (*c).itut_t35_ref);
+    let _ = mem::take(&mut (*c).itut_t35);
     let _ = mem::take(&mut (*c).cached_error_props);
     if (*c).n_fc == 1 as c_uint && (*c).n_tc == 1 as c_uint {
         return;
@@ -1086,7 +1084,7 @@ unsafe fn close_internal(c_out: &mut *mut Rav1dContext, flush: c_int) {
     rav1d_ref_dec(&mut (*c).frame_hdr_ref);
     let _ = mem::take(&mut (*c).mastering_display);
     let _ = mem::take(&mut (*c).content_light);
-    rav1d_ref_dec(&mut (*c).itut_t35_ref);
+    let _ = mem::take(&mut (*c).itut_t35);
     rav1d_mem_pool_end((*c).seq_hdr_pool);
     rav1d_mem_pool_end((*c).frame_hdr_pool);
     rav1d_mem_pool_end((*c).segmap_pool);

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -48,7 +48,6 @@ use rav1d::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
 use rav1d::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
 use rav1d::include::dav1d::headers::Dav1dColorPrimaries;
 use rav1d::include::dav1d::headers::Dav1dFrameHeader;
-use rav1d::include::dav1d::headers::Dav1dITUTT35;
 use rav1d::include::dav1d::headers::Dav1dSequenceHeader;
 use rav1d::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
 use rav1d::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
@@ -169,13 +168,13 @@ unsafe fn decode_rand(
         },
         content_light: None,
         mastering_display: None,
-        itut_t35: 0 as *mut Dav1dITUTT35,
+        itut_t35: None,
         reserved: [0; 4],
         frame_hdr_ref: 0 as *mut Dav1dRef,
         seq_hdr_ref: 0 as *mut Dav1dRef,
         content_light_ref: None,
         mastering_display_ref: None,
-        itut_t35_ref: 0 as *mut Dav1dRef,
+        itut_t35_ref: None,
         reserved_ref: [0; 4],
         r#ref: 0 as *mut Dav1dRef,
         allocator_data: 0 as *mut c_void,
@@ -224,13 +223,13 @@ unsafe fn decode_all(
         },
         content_light: None,
         mastering_display: None,
-        itut_t35: 0 as *mut Dav1dITUTT35,
+        itut_t35: None,
         reserved: [0; 4],
         frame_hdr_ref: 0 as *mut Dav1dRef,
         seq_hdr_ref: 0 as *mut Dav1dRef,
         content_light_ref: None,
         mastering_display_ref: None,
-        itut_t35_ref: 0 as *mut Dav1dRef,
+        itut_t35_ref: None,
         reserved_ref: [0; 4],
         r#ref: 0 as *mut Dav1dRef,
         allocator_data: 0 as *mut c_void,

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -65,7 +65,6 @@ use rav1d::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
 use rav1d::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
 use rav1d::include::dav1d::headers::Dav1dColorPrimaries;
 use rav1d::include::dav1d::headers::Dav1dFrameHeader;
-use rav1d::include::dav1d::headers::Dav1dITUTT35;
 use rav1d::include::dav1d::headers::Dav1dSequenceHeader;
 use rav1d::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
 use rav1d::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
@@ -326,13 +325,13 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
         },
         content_light: None,
         mastering_display: None,
-        itut_t35: 0 as *mut Dav1dITUTT35,
+        itut_t35: None,
         reserved: [0; 4],
         frame_hdr_ref: 0 as *mut Dav1dRef,
         seq_hdr_ref: 0 as *mut Dav1dRef,
         content_light_ref: None,
         mastering_display_ref: None,
-        itut_t35_ref: 0 as *mut Dav1dRef,
+        itut_t35_ref: None,
         reserved_ref: [0; 4],
         r#ref: 0 as *mut Dav1dRef,
         allocator_data: 0 as *mut c_void,


### PR DESCRIPTION
Note that we skip `.update_rav1d()`ing it as we never read it.