### PR TITLE
`struct {D,R}av1d{Sequence,Frame}Header`: Replace `Rav1dRef`s with `Option<Arc<DRav1d<_, _>>>`s

### DIFF
--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -2,6 +2,7 @@ use crate::src::enum_map::EnumKey;
 use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ops::BitAnd;
+use std::ops::Deref;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use strum::EnumCount;
@@ -17,20 +18,22 @@ pub struct DRav1d<R, D> {
 
 impl<R, D> DRav1d<R, D>
 where
-    D: Clone + Into<R>,
-{
-    pub fn update_rav1d(&mut self) {
-        self.rav1d = self.dav1d.clone().into();
-    }
-}
-
-impl<R, D> DRav1d<R, D>
-where
     R: Clone + Into<D>,
 {
     pub fn from_rav1d(rav1d: R) -> Self {
         let dav1d = rav1d.clone().into();
         Self { rav1d, dav1d }
+    }
+}
+
+/// Since the `D`/`Dav1d*` type is only used externally by C,
+/// it's reasonable to `.deref()`
+/// to the `R`/`Rav1d*` type used everywhere internally.
+impl<R, D> Deref for DRav1d<R, D> {
+    type Target = R;
+
+    fn deref(&self) -> &Self::Target {
+        &self.rav1d
     }
 }
 
@@ -346,7 +349,7 @@ impl From<Rav1dPixelLayoutSubSampled> for Rav1dPixelLayout {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, FromRepr)]
-pub(crate) enum Rav1dFrameType {
+pub enum Rav1dFrameType {
     Key = 0,
     Inter = 1,
     Intra = 2,
@@ -569,7 +572,7 @@ pub struct Dav1dSequenceHeaderOperatingPoint {
 
 #[derive(Clone, Copy, Default, PartialEq, Eq)]
 #[repr(C)]
-pub(crate) struct Rav1dSequenceHeaderOperatingPoint {
+pub struct Rav1dSequenceHeaderOperatingPoint {
     pub major_level: c_int,
     pub minor_level: c_int,
     pub initial_display_delay: c_int,
@@ -635,7 +638,7 @@ pub struct Dav1dSequenceHeaderOperatingParameterInfo {
 
 #[derive(Clone, Copy, Default, PartialEq, Eq)]
 #[repr(C)]
-pub(crate) struct Rav1dSequenceHeaderOperatingParameterInfo {
+pub struct Rav1dSequenceHeaderOperatingParameterInfo {
     pub decoder_buffer_delay: c_int,
     pub encoder_buffer_delay: c_int,
     pub low_delay_mode: c_int,
@@ -732,7 +735,7 @@ pub struct Dav1dSequenceHeader {
 
 #[derive(Clone)]
 #[repr(C)]
-pub(crate) struct Rav1dSequenceHeader {
+pub struct Rav1dSequenceHeader {
     pub profile: c_int,
     pub max_width: c_int,
     pub max_height: c_int,
@@ -1151,7 +1154,7 @@ pub struct Dav1dSegmentationData {
 
 #[derive(Clone, Default)]
 #[repr(C)]
-pub(crate) struct Rav1dSegmentationData {
+pub struct Rav1dSegmentationData {
     pub delta_q: c_int,
     pub delta_lf_y_v: c_int,
     pub delta_lf_y_h: c_int,
@@ -1222,7 +1225,7 @@ pub struct Dav1dSegmentationDataSet {
 
 #[derive(Clone, Default)]
 #[repr(C)]
-pub(crate) struct Rav1dSegmentationDataSet {
+pub struct Rav1dSegmentationDataSet {
     pub d: [Rav1dSegmentationData; RAV1D_MAX_SEGMENTS as usize],
     pub preskip: c_int,
     pub last_active_segid: c_int,
@@ -1267,7 +1270,7 @@ pub struct Dav1dLoopfilterModeRefDeltas {
 
 #[derive(Clone)]
 #[repr(C)]
-pub(crate) struct Rav1dLoopfilterModeRefDeltas {
+pub struct Rav1dLoopfilterModeRefDeltas {
     pub mode_delta: [c_int; 2],
     pub ref_delta: [c_int; RAV1D_TOTAL_REFS_PER_FRAME],
 }
@@ -1475,7 +1478,7 @@ pub struct Dav1dFrameHeader_film_grain {
 
 #[derive(Clone)]
 #[repr(C)]
-pub(crate) struct Rav1dFrameHeader_film_grain {
+pub struct Rav1dFrameHeader_film_grain {
     pub data: Rav1dFilmGrainData,
     pub present: c_int,
     pub update: c_int,
@@ -1519,7 +1522,7 @@ pub struct Dav1dFrameHeaderOperatingPoint {
 
 #[derive(Clone, Copy, Default)]
 #[repr(C)]
-pub(crate) struct Rav1dFrameHeaderOperatingPoint {
+pub struct Rav1dFrameHeaderOperatingPoint {
     pub buffer_removal_time: c_int,
 }
 
@@ -1554,7 +1557,7 @@ pub struct Dav1dFrameHeader_super_res {
 
 #[derive(Clone)]
 #[repr(C)]
-pub(crate) struct Rav1dFrameHeader_super_res {
+pub struct Rav1dFrameHeader_super_res {
     pub width_scale_denominator: c_int,
     pub enabled: c_int,
 }
@@ -1605,7 +1608,7 @@ pub struct Dav1dFrameHeader_tiling {
 
 #[derive(Clone)]
 #[repr(C)]
-pub(crate) struct Rav1dFrameHeader_tiling {
+pub struct Rav1dFrameHeader_tiling {
     pub uniform: c_int,
     pub n_bytes: c_uint,
     pub min_log2_cols: c_int,
@@ -1708,7 +1711,7 @@ pub struct Dav1dFrameHeader_quant {
 
 #[derive(Clone)]
 #[repr(C)]
-pub(crate) struct Rav1dFrameHeader_quant {
+pub struct Rav1dFrameHeader_quant {
     pub yac: c_int,
     pub ydc_delta: c_int,
     pub udc_delta: c_int,
@@ -1793,7 +1796,7 @@ pub struct Dav1dFrameHeader_segmentation {
 
 #[derive(Clone)]
 #[repr(C)]
-pub(crate) struct Rav1dFrameHeader_segmentation {
+pub struct Rav1dFrameHeader_segmentation {
     pub enabled: c_int,
     pub update_map: c_int,
     pub temporal: c_int,
@@ -1858,7 +1861,7 @@ pub struct Dav1dFrameHeader_delta_q {
 
 #[derive(Clone)]
 #[repr(C)]
-pub(crate) struct Rav1dFrameHeader_delta_q {
+pub struct Rav1dFrameHeader_delta_q {
     pub present: c_int,
     pub res_log2: c_int,
 }
@@ -1887,7 +1890,7 @@ pub struct Dav1dFrameHeader_delta_lf {
 
 #[derive(Clone)]
 #[repr(C)]
-pub(crate) struct Rav1dFrameHeader_delta_lf {
+pub struct Rav1dFrameHeader_delta_lf {
     pub present: c_int,
     pub res_log2: c_int,
     pub multi: c_int,
@@ -1932,7 +1935,7 @@ pub struct Dav1dFrameHeader_delta {
 
 #[derive(Clone)]
 #[repr(C)]
-pub(crate) struct Rav1dFrameHeader_delta {
+pub struct Rav1dFrameHeader_delta {
     pub q: Rav1dFrameHeader_delta_q,
     pub lf: Rav1dFrameHeader_delta_lf,
 }
@@ -1971,7 +1974,7 @@ pub struct Dav1dFrameHeader_loopfilter {
 
 #[derive(Clone)]
 #[repr(C)]
-pub(crate) struct Rav1dFrameHeader_loopfilter {
+pub struct Rav1dFrameHeader_loopfilter {
     pub level_y: [c_int; 2],
     pub level_u: c_int,
     pub level_v: c_int,
@@ -2038,7 +2041,7 @@ pub struct Dav1dFrameHeader_cdef {
 
 #[derive(Clone)]
 #[repr(C)]
-pub(crate) struct Rav1dFrameHeader_cdef {
+pub struct Rav1dFrameHeader_cdef {
     pub damping: c_int,
     pub n_bits: c_int,
     pub y_strength: [c_int; RAV1D_MAX_CDEF_STRENGTHS],
@@ -2088,7 +2091,7 @@ pub struct Dav1dFrameHeader_restoration {
 
 #[derive(Clone)]
 #[repr(C)]
-pub(crate) struct Rav1dFrameHeader_restoration {
+pub struct Rav1dFrameHeader_restoration {
     pub r#type: [Rav1dRestorationType; 3],
     pub unit_size: [c_int; 2],
 }
@@ -2164,7 +2167,7 @@ pub struct Dav1dFrameHeader {
 
 #[derive(Clone)]
 #[repr(C)]
-pub(crate) struct Rav1dFrameSize {
+pub struct Rav1dFrameSize {
     pub width: [c_int; 2],
     pub height: c_int,
     pub render_width: c_int,
@@ -2175,7 +2178,7 @@ pub(crate) struct Rav1dFrameSize {
 
 #[derive(Clone)]
 #[repr(C)]
-pub(crate) struct Rav1dFrameSkipMode {
+pub struct Rav1dFrameSkipMode {
     pub allowed: c_int,
     pub enabled: c_int,
     pub refs: [c_int; 2],
@@ -2183,7 +2186,7 @@ pub(crate) struct Rav1dFrameSkipMode {
 
 #[derive(Clone)]
 #[repr(C)]
-pub(crate) struct Rav1dFrameHeader {
+pub struct Rav1dFrameHeader {
     pub size: Rav1dFrameSize,
     pub film_grain: Rav1dFrameHeader_film_grain,
     pub frame_type: Rav1dFrameType,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -9,7 +9,9 @@ use crate::include::dav1d::dav1d::Rav1dDecodeFrameType;
 use crate::include::dav1d::dav1d::Rav1dEventFlags;
 use crate::include::dav1d::dav1d::Rav1dInloopFilterType;
 use crate::include::dav1d::headers::DRav1d;
+use crate::include::dav1d::headers::Dav1dFrameHeader;
 use crate::include::dav1d::headers::Dav1dITUTT35;
+use crate::include::dav1d::headers::Dav1dSequenceHeader;
 use crate::include::dav1d::headers::Rav1dContentLightLevel;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
 use crate::include::dav1d::headers::Rav1dITUTT35;
@@ -207,12 +209,8 @@ pub struct Rav1dContext {
     /// to a frame worker to be decoded.
     pub(crate) tiles: Vec<Rav1dTileGroup>,
     pub(crate) n_tiles: c_int,
-    pub(crate) seq_hdr_pool: *mut Rav1dMemPool,
-    pub(crate) seq_hdr_ref: *mut Rav1dRef,
-    pub(crate) seq_hdr: *mut Rav1dSequenceHeader,
-    pub(crate) frame_hdr_pool: *mut Rav1dMemPool,
-    pub(crate) frame_hdr_ref: *mut Rav1dRef,
-    pub(crate) frame_hdr: *mut Rav1dFrameHeader,
+    pub(crate) seq_hdr: Option<Arc<DRav1d<Rav1dSequenceHeader, Dav1dSequenceHeader>>>, // TODO(kkysen) Previously pooled.
+    pub(crate) frame_hdr: Option<Arc<DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>>>, // TODO(kkysen) Previously pooled.
     pub(crate) content_light: Option<Arc<Rav1dContentLightLevel>>,
     pub(crate) mastering_display: Option<Arc<Rav1dMasteringDisplay>>,
     pub(crate) itut_t35: Option<Arc<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>>,
@@ -456,10 +454,8 @@ pub struct FrameTileThreadData {
 
 #[repr(C)]
 pub(crate) struct Rav1dFrameContext {
-    pub seq_hdr_ref: *mut Rav1dRef,
-    pub seq_hdr: *mut Rav1dSequenceHeader,
-    pub frame_hdr_ref: *mut Rav1dRef,
-    pub frame_hdr: *mut Rav1dFrameHeader,
+    pub seq_hdr: Option<Arc<DRav1d<Rav1dSequenceHeader, Dav1dSequenceHeader>>>,
+    pub frame_hdr: Option<Arc<DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>>>,
     pub refp: [Rav1dThreadPicture; 7],
     // during block coding / reconstruction
     pub cur: Rav1dPicture,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,7 @@ use std::mem;
 use std::mem::MaybeUninit;
 use std::process::abort;
 use std::ptr::NonNull;
+use std::sync::Arc;
 use std::sync::Once;
 use to_method::To as _;
 
@@ -508,8 +509,8 @@ pub(crate) unsafe fn rav1d_parse_sequence_header(
             return Err(ENOENT);
         }
 
-        let seq_hdr = &***(*c).seq_hdr.as_ref().unwrap();
-        Ok(seq_hdr.clone())
+        let seq_hdr = (*c).seq_hdr.take().and_then(Arc::into_inner).unwrap();
+        Ok(seq_hdr.rav1d)
     }()
     .inspect_err(|_| {
         rav1d_data_unref_internal(&mut buf);

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -125,8 +125,3 @@ pub unsafe fn rav1d_ref_dec(pref: *mut *mut Rav1dRef) {
         }
     }
 }
-
-pub unsafe fn rav1d_ref_is_writable(r#ref: *mut Rav1dRef) -> c_int {
-    return (::core::intrinsics::atomic_load_seqcst(&mut (*r#ref).ref_cnt as *mut atomic_int) == 1
-        && !((*r#ref).data).is_null()) as c_int;
-}

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -360,10 +360,12 @@ unsafe fn create_filter_sbrow(
     pass: c_int,
     res_t: *mut *mut Rav1dTask,
 ) -> c_int {
-    let has_deblock = ((*(*f).frame_hdr).loopfilter.level_y[0] != 0
-        || (*(*f).frame_hdr).loopfilter.level_y[1] != 0) as c_int;
-    let has_cdef = (*(*f).seq_hdr).cdef;
-    let has_resize = ((*(*f).frame_hdr).size.width[0] != (*(*f).frame_hdr).size.width[1]) as c_int;
+    let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+    let has_deblock =
+        (frame_hdr.loopfilter.level_y[0] != 0 || frame_hdr.loopfilter.level_y[1] != 0) as c_int;
+    let seq_hdr = &***(*f).seq_hdr.as_ref().unwrap();
+    let has_cdef = seq_hdr.cdef;
+    let has_resize = (frame_hdr.size.width[0] != frame_hdr.size.width[1]) as c_int;
     let has_lr = (*f).lf.restore_planes;
     let mut tasks: *mut Rav1dTask = (*f).task_thread.tasks;
     let uses_2pass = ((*(*f).c).n_fc > 1 as c_uint) as c_int;
@@ -423,7 +425,8 @@ pub(crate) unsafe fn rav1d_task_create_tile_sbrow(
 ) -> Rav1dResult {
     let mut tasks: *mut Rav1dTask = (*f).task_thread.tile_tasks[0];
     let uses_2pass = ((*(*f).c).n_fc > 1 as c_uint) as c_int;
-    let num_tasks = (*(*f).frame_hdr).tiling.cols * (*(*f).frame_hdr).tiling.rows;
+    let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+    let num_tasks = frame_hdr.tiling.cols * frame_hdr.tiling.rows;
     if pass < 2 {
         let alloc_num_tasks = num_tasks * (1 + uses_2pass);
         if alloc_num_tasks > (*f).task_thread.num_tile_tasks {
@@ -573,7 +576,8 @@ unsafe fn check_tile(t: *mut Rav1dTask, f: *mut Rav1dFrameContext, frame_mt: c_i
         error = (p2 == TILE_ERROR) as c_int;
         error |= ::core::intrinsics::atomic_or_seqcst(&mut (*f).task_thread.error, error);
     }
-    if error == 0 && frame_mt != 0 && !(*(*f).frame_hdr).frame_type.is_key_or_intra() {
+    let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+    if error == 0 && frame_mt != 0 && !frame_hdr.frame_type.is_key_or_intra() {
         let p: *const Rav1dThreadPicture = &mut (*f).sr_cur;
         let ss_ver =
             ((*p).p.p.layout as c_uint == Rav1dPixelLayout::I420 as c_int as c_uint) as c_int;
@@ -937,7 +941,8 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                             {
                                                 unreachable!();
                                             }
-                                            let tile_row_base = (*(*f).frame_hdr).tiling.cols
+                                            let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+                                            let tile_row_base = frame_hdr.tiling.cols
                                                 * (*f).frame_thread.next_tile_row[p as usize];
                                             if p != 0 {
                                                 let p1_0 = (*f)
@@ -959,9 +964,11 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                             match current_block {
                                                 5395695591151878490 => {}
                                                 _ => {
+                                                    let frame_hdr =
+                                                        &***(*f).frame_hdr.as_ref().unwrap();
                                                     let mut tc_0 = 0;
                                                     loop {
-                                                        if !(tc_0 < (*(*f).frame_hdr).tiling.cols) {
+                                                        if !(tc_0 < frame_hdr.tiling.cols) {
                                                             current_block = 3222590281903869779;
                                                             break;
                                                         }
@@ -999,11 +1006,10 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                                                     (*f).frame_thread.next_tile_row
                                                                         [p as usize]
                                                                         + 1;
-                                                                let start = (*(*f).frame_hdr)
-                                                                    .tiling
-                                                                    .row_start_sb
-                                                                    [ntr as usize]
-                                                                    as c_int;
+                                                                let start =
+                                                                    frame_hdr.tiling.row_start_sb
+                                                                        [ntr as usize]
+                                                                        as c_int;
                                                                 if (*next_t).sby == start {
                                                                     (*f).frame_thread
                                                                         .next_tile_row
@@ -1144,7 +1150,8 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                     {
                                         res_0 = rav1d_decode_frame_init_cdf(&mut *f);
                                     }
-                                    if (*(*f).frame_hdr).refresh_context != 0
+                                    let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+                                    if frame_hdr.refresh_context != 0
                                         && !(*f).task_thread.update_set
                                     {
                                         ::core::intrinsics::atomic_store_seqcst(
@@ -1180,8 +1187,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                                 );
                                                 ::core::intrinsics::atomic_xsub_seqcst(
                                                     &mut (*f).task_thread.task_counter,
-                                                    (*(*f).frame_hdr).tiling.cols
-                                                        * (*(*f).frame_hdr).tiling.rows
+                                                    frame_hdr.tiling.cols * frame_hdr.tiling.rows
                                                         + (*f).sbh,
                                                 );
                                                 ::core::intrinsics::atomic_store_seqcst(
@@ -1304,18 +1310,18 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                         error_0 = ::core::intrinsics::atomic_load_seqcst(
                                             &mut (*f).task_thread.error,
                                         );
-                                        if (*(*f).frame_hdr).refresh_context != 0
+                                        let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+                                        if frame_hdr.refresh_context != 0
                                             && (*tc).frame_thread.pass <= 1
                                             && (*f).task_thread.update_set
-                                            && (*(*f).frame_hdr).tiling.update == tile_idx
+                                            && frame_hdr.tiling.update == tile_idx
                                         {
                                             if error_0 == 0 {
                                                 rav1d_cdf_thread_update(
-                                                    (*f).frame_hdr,
+                                                    frame_hdr,
                                                     (*f).out_cdf.data.cdf,
-                                                    &mut (*((*f).ts).offset(
-                                                        (*(*f).frame_hdr).tiling.update as isize,
-                                                    ))
+                                                    &mut (*((*f).ts)
+                                                        .offset(frame_hdr.tiling.update as isize))
                                                     .cdf,
                                                 );
                                             }
@@ -1438,8 +1444,10 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                 {
                                     ((*f).bd_fn.filter_sbrow_deblock_rows)(&mut *f, sby);
                                 }
-                                if (*(*f).frame_hdr).loopfilter.level_y[0] != 0
-                                    || (*(*f).frame_hdr).loopfilter.level_y[1] != 0
+                                let seq_hdr = &***(*f).seq_hdr.as_ref().unwrap();
+                                let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+                                if frame_hdr.loopfilter.level_y[0] != 0
+                                    || frame_hdr.loopfilter.level_y[1] != 0
                                 {
                                     error_0 = ::core::intrinsics::atomic_load_seqcst(
                                         &mut (*f).task_thread.error,
@@ -1456,7 +1464,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                     {
                                         pthread_cond_signal(&mut (*ttd).cond);
                                     }
-                                } else if (*(*f).seq_hdr).cdef != 0 || (*f).lf.restore_planes != 0 {
+                                } else if seq_hdr.cdef != 0 || (*f).lf.restore_planes != 0 {
                                     (*f).frame_thread.copy_lpf_progress[(sby >> 5) as usize]
                                         .fetch_or((1 as c_uint) << (sby & 31), Ordering::SeqCst);
                                     if sby != 0 {
@@ -1480,7 +1488,8 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                         }
                         match current_block {
                             5292528706010880565 => {
-                                if (*(*f).seq_hdr).cdef != 0 {
+                                let seq_hdr = &***(*f).seq_hdr.as_ref().unwrap();
+                                if seq_hdr.cdef != 0 {
                                     if ::core::intrinsics::atomic_load_seqcst(
                                         &mut (*f).task_thread.error as *mut atomic_int,
                                     ) == 0
@@ -1502,9 +1511,8 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                         }
                         match current_block {
                             12196494833634779273 => {
-                                if (*(*f).frame_hdr).size.width[0]
-                                    != (*(*f).frame_hdr).size.width[1]
-                                {
+                                let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+                                if frame_hdr.size.width[0] != frame_hdr.size.width[1] {
                                     if ::core::intrinsics::atomic_load_seqcst(
                                         &mut (*f).task_thread.error as *mut atomic_int,
                                     ) == 0

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -47,7 +47,6 @@ use rav1d::include::dav1d::dav1d::Dav1dSettings;
 use rav1d::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
 use rav1d::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
 use rav1d::include::dav1d::headers::Dav1dColorPrimaries;
-use rav1d::include::dav1d::headers::Dav1dFrameHeader;
 use rav1d::include::dav1d::headers::Dav1dSequenceHeader;
 use rav1d::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
 use rav1d::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
@@ -146,8 +145,8 @@ unsafe fn decode_rand(
 ) -> c_int {
     let mut res = 0;
     let mut p: Dav1dPicture = Dav1dPicture {
-        seq_hdr: 0 as *mut Dav1dSequenceHeader,
-        frame_hdr: 0 as *mut Dav1dFrameHeader,
+        seq_hdr: None,
+        frame_hdr: None,
         data: [0 as *mut c_void; 3],
         stride: [0; 2],
         p: Dav1dPictureParameters {
@@ -170,8 +169,8 @@ unsafe fn decode_rand(
         mastering_display: None,
         itut_t35: None,
         reserved: [0; 4],
-        frame_hdr_ref: 0 as *mut Dav1dRef,
-        seq_hdr_ref: 0 as *mut Dav1dRef,
+        frame_hdr_ref: None,
+        seq_hdr_ref: None,
         content_light_ref: None,
         mastering_display_ref: None,
         itut_t35_ref: None,
@@ -201,8 +200,8 @@ unsafe fn decode_all(
 ) -> c_int {
     let mut res: c_int;
     let mut p: Dav1dPicture = Dav1dPicture {
-        seq_hdr: 0 as *mut Dav1dSequenceHeader,
-        frame_hdr: 0 as *mut Dav1dFrameHeader,
+        seq_hdr: None,
+        frame_hdr: None,
         data: [0 as *mut c_void; 3],
         stride: [0; 2],
         p: Dav1dPictureParameters {
@@ -225,8 +224,8 @@ unsafe fn decode_all(
         mastering_display: None,
         itut_t35: None,
         reserved: [0; 4],
-        frame_hdr_ref: 0 as *mut Dav1dRef,
-        seq_hdr_ref: 0 as *mut Dav1dRef,
+        frame_hdr_ref: None,
+        seq_hdr_ref: None,
         content_light_ref: None,
         mastering_display_ref: None,
         itut_t35_ref: None,

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -64,7 +64,6 @@ use rav1d::include::dav1d::dav1d::Dav1dSettings;
 use rav1d::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
 use rav1d::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
 use rav1d::include::dav1d::headers::Dav1dColorPrimaries;
-use rav1d::include::dav1d::headers::Dav1dFrameHeader;
 use rav1d::include::dav1d::headers::Dav1dSequenceHeader;
 use rav1d::include::dav1d::headers::Dav1dSequenceHeaderOperatingParameterInfo;
 use rav1d::include::dav1d::headers::Dav1dSequenceHeaderOperatingPoint;
@@ -303,8 +302,8 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
     let mut in_0: *mut DemuxerContext = 0 as *mut DemuxerContext;
     let mut out: *mut MuxerContext = 0 as *mut MuxerContext;
     let mut p: Dav1dPicture = Dav1dPicture {
-        seq_hdr: 0 as *mut Dav1dSequenceHeader,
-        frame_hdr: 0 as *mut Dav1dFrameHeader,
+        seq_hdr: None,
+        frame_hdr: None,
         data: [0 as *mut c_void; 3],
         stride: [0; 2],
         p: Dav1dPictureParameters {
@@ -327,8 +326,8 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
         mastering_display: None,
         itut_t35: None,
         reserved: [0; 4],
-        frame_hdr_ref: 0 as *mut Dav1dRef,
-        seq_hdr_ref: 0 as *mut Dav1dRef,
+        frame_hdr_ref: None,
+        seq_hdr_ref: None,
         content_light_ref: None,
         mastering_display_ref: None,
         itut_t35_ref: None,

--- a/tools/output/y4m2.rs
+++ b/tools/output/y4m2.rs
@@ -101,21 +101,23 @@ unsafe fn write_header(c: *mut Y4m2OutputContext, p: *const Dav1dPicture) -> c_i
         b"420mpeg2\0" as *const u8 as *const c_char,
         b"420\0" as *const u8 as *const c_char,
     ];
+    let seq_hdr = (*p).seq_hdr.unwrap().as_ref();
+    let frame_hdr = (*p).frame_hdr.unwrap().as_ref();
     let ss_name: *const c_char =
         if (*p).p.layout as c_uint == DAV1D_PIXEL_LAYOUT_I420 as c_int as c_uint && (*p).p.bpc == 8
         {
-            chr_names_8bpc_i420[(if (*(*p).seq_hdr).chr as c_uint > 2 as c_uint {
+            chr_names_8bpc_i420[(if seq_hdr.chr as c_uint > 2 as c_uint {
                 DAV1D_CHR_UNKNOWN as c_int as c_uint
             } else {
-                (*(*p).seq_hdr).chr as c_uint
+                seq_hdr.chr as c_uint
             }) as usize]
         } else {
-            ss_names[(*p).p.layout as usize][(*(*p).seq_hdr).hbd as usize]
+            ss_names[(*p).p.layout as usize][seq_hdr.hbd as usize]
         };
     let fw: c_uint = (*p).p.w as c_uint;
     let fh: c_uint = (*p).p.h as c_uint;
-    let mut aw: u64 = (fh as u64).wrapping_mul((*(*p).frame_hdr).render_width as u64);
-    let mut ah: u64 = (fw as u64).wrapping_mul((*(*p).frame_hdr).render_height as u64);
+    let mut aw: u64 = (fh as u64).wrapping_mul(frame_hdr.render_width as u64);
+    let mut ah: u64 = (fw as u64).wrapping_mul(frame_hdr.render_height as u64);
     let mut gcd: u64 = ah;
     let mut a: u64 = aw;
     let mut b: u64;


### PR DESCRIPTION
As these types are heavily used unlike the other `Rav1dRef`ed types, `impl Deref for DRav1d` is added, `deref`ing to `R` as that's the type used primarily in Rust.

And to simplify uses and avoid triple derefs (including an `Arc` deref and `Option::unwrap`) at use sites, a `let {frame,seq}_hdr = &***{f,c}.{frame,seq}_hdr.as_ref().unwrap();` is refactored out in each `fn` where it's used.

Furthermore, similarly to #661, `.update_rav1d()`s are skipped.  Although these types are indeed read, they are meant to be read-only, so this should be okay to do.

Unlike the previous `Arc`ified types in #659 and #661, these `Rav1dRef`s were pooled, which the `Arc` replacement is not.  However, those pools were not thread-local, so it's not clear if it is a perf regression to remove them (we'll check).  Either way, the API of `Arc` should be similar enough to a pooled `Arc` (e.x. [`refpool`](https://docs.rs/refpool)) that we can switch to it later if perf demands it.