### PR TITLE
`struct Rav1dThreadPicture::progress`: Make a `struct ThreadPictureProgress` of [`AtomicU32; 2]` that is always allocated inline since it's so small

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4987,7 +4987,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
             c.cached_error_props = out_delayed.p.m.clone();
             rav1d_thread_picture_unref(out_delayed);
         } else if !out_delayed.p.data[0].is_null() {
-            let progress = (*out_delayed.progress.add(1)).load(Ordering::Relaxed);
+            let progress = out_delayed.progress.pixel_data().load(Ordering::Relaxed);
             if (out_delayed.visible || c.output_invisible_frames) && progress != FRAME_ERROR {
                 rav1d_thread_picture_ref(&mut c.out, out_delayed);
                 c.event_flags |= out_delayed.flags.into();

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -27,7 +27,6 @@ use crate::include::dav1d::headers::RAV1D_WM_TYPE_AFFINE;
 use crate::include::dav1d::headers::RAV1D_WM_TYPE_IDENTITY;
 use crate::include::dav1d::headers::RAV1D_WM_TYPE_TRANSLATION;
 use crate::include::stdatomic::atomic_int;
-use crate::include::stdatomic::atomic_uint;
 use crate::src::align::Align16;
 use crate::src::cdf::rav1d_cdf_thread_alloc;
 use crate::src::cdf::rav1d_cdf_thread_copy;
@@ -4988,9 +4987,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
             c.cached_error_props = out_delayed.p.m.clone();
             rav1d_thread_picture_unref(out_delayed);
         } else if !out_delayed.p.data[0].is_null() {
-            let progress = ::core::intrinsics::atomic_load_relaxed(
-                &mut *(out_delayed.progress).offset(1) as *mut atomic_uint,
-            );
+            let progress = (*out_delayed.progress.add(1)).load(Ordering::Relaxed);
             if (out_delayed.visible || c.output_invisible_frames) && progress != FRAME_ERROR {
                 rav1d_thread_picture_ref(&mut c.out, out_delayed);
                 c.event_flags |= out_delayed.flags.into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -661,7 +661,7 @@ unsafe fn drain_picture(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRe
             return error;
         }
         if !((*out_delayed).p.data[0]).is_null() {
-            let progress = (*(*out_delayed).progress.add(1)).load(Ordering::Relaxed);
+            let progress = (*out_delayed).progress.pixel_data().load(Ordering::Relaxed);
             if ((*out_delayed).visible || c.output_invisible_frames) && progress != FRAME_ERROR {
                 rav1d_thread_picture_ref(&mut c.out, out_delayed);
                 c.event_flags |= (*out_delayed).flags.into();

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2564,7 +2564,7 @@ unsafe fn parse_obus(c: &mut Rav1dContext, r#in: &Rav1dData, global: bool) -> Ra
                     c.cached_error_props = (*out_delayed).p.m.clone();
                     rav1d_thread_picture_unref(out_delayed);
                 } else if !((*out_delayed).p.data[0]).is_null() {
-                    let progress = (*(*out_delayed).progress.add(1)).load(Ordering::Relaxed);
+                    let progress = (*out_delayed).progress.pixel_data().load(Ordering::Relaxed);
                     if ((*out_delayed).visible || c.output_invisible_frames)
                         && progress != FRAME_ERROR
                     {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -67,6 +67,9 @@ impl From<PictureFlags> for Rav1dEventFlags {
 pub(crate) struct Rav1dThreadPicture {
     pub p: Rav1dPicture,
     pub visible: bool,
+    /// This can be set for inter frames, non-key intra frames,
+    /// or for invisible keyframes that have not yet been made visible
+    /// using the show-existing-frame mechanism.
     pub showable: bool,
     pub flags: PictureFlags,
     pub progress: *mut atomic_uint,

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -72,6 +72,8 @@ pub(crate) struct Rav1dThreadPicture {
     /// using the show-existing-frame mechanism.
     pub showable: bool,
     pub flags: PictureFlags,
+    /// `[0]`: block data (including segmentation map and motion vectors)
+    /// `[1]`: pixel data
     pub progress: *mut atomic_uint,
 }
 

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -52,6 +52,7 @@ use std::ffi::c_long;
 use std::ffi::c_uint;
 use std::ffi::c_void;
 use std::process::abort;
+use std::sync::atomic::Ordering;
 
 #[cfg(target_os = "linux")]
 use libc::prctl;
@@ -625,11 +626,8 @@ unsafe fn check_tile(t: *mut Rav1dTask, f: *mut Rav1dFrameContext, frame_mt: c_i
             }
             match current_block_14 {
                 2370887241019905314 => {
-                    let p3: c_uint = ::core::intrinsics::atomic_load_seqcst(
-                        &mut *((*((*f).refp).as_mut_ptr().offset(n as isize)).progress)
-                            .offset((tp == 0) as c_int as isize)
-                            as *mut atomic_uint,
-                    );
+                    let p3 = (*(*f).refp[n as usize].progress.add((tp == 0) as usize))
+                        .load(Ordering::SeqCst);
                     if p3 < lowest {
                         return 1 as c_int;
                     }
@@ -650,9 +648,7 @@ unsafe fn check_tile(t: *mut Rav1dTask, f: *mut Rav1dFrameContext, frame_mt: c_i
 #[inline]
 unsafe fn get_frame_progress(c: *const Rav1dContext, f: *const Rav1dFrameContext) -> c_int {
     let frame_prog: c_uint = if (*c).n_fc > 1 as c_uint {
-        ::core::intrinsics::atomic_load_seqcst(
-            &mut *((*f).sr_cur.progress).offset(1) as *mut atomic_uint
-        )
+        (*(*f).sr_cur.progress.add(1)).load(Ordering::SeqCst)
     } else {
         0 as c_int as c_uint
     };
@@ -697,14 +693,8 @@ unsafe fn abort_frame(f: *mut Rav1dFrameContext, error: Rav1dResult) {
         &mut *((*f).task_thread.done).as_mut_ptr().offset(1) as *mut atomic_int,
         1 as c_int,
     );
-    ::core::intrinsics::atomic_store_seqcst(
-        &mut *((*f).sr_cur.progress).offset(0) as *mut atomic_uint,
-        FRAME_ERROR,
-    );
-    ::core::intrinsics::atomic_store_seqcst(
-        &mut *((*f).sr_cur.progress).offset(1) as *mut atomic_uint,
-        FRAME_ERROR,
-    );
+    (*(*f).sr_cur.progress.add(0)).store(FRAME_ERROR, Ordering::SeqCst);
+    (*(*f).sr_cur.progress.add(1)).store(FRAME_ERROR, Ordering::SeqCst);
     rav1d_decode_frame_exit(&mut *f, error);
     pthread_cond_signal(&mut (*f).task_thread.cond);
 }
@@ -1207,12 +1197,8 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                                     frame_hdr.tiling.cols * frame_hdr.tiling.rows
                                                         + (*f).sbh,
                                                 );
-                                                ::core::intrinsics::atomic_store_seqcst(
-                                                    &mut *((*f).sr_cur.progress)
-                                                        .offset((p_0 - 1) as isize)
-                                                        as *mut atomic_uint,
-                                                    FRAME_ERROR,
-                                                );
+                                                (*(*f).sr_cur.progress.add((p_0 - 1) as usize))
+                                                    .store(FRAME_ERROR, Ordering::SeqCst);
                                                 if p_0 == 2
                                                     && ::core::intrinsics::atomic_load_seqcst(
                                                         &mut *((*f).task_thread.done)
@@ -1582,9 +1568,9 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                 unreachable!();
                             }
                             if !((*f).sr_cur.p.data[0]).is_null() {
-                                ::core::intrinsics::atomic_store_seqcst(
-                                    &mut *((*f).sr_cur.progress).offset(0) as *mut atomic_uint,
+                                (*(*f).sr_cur.progress.add(0)).store(
                                     if error_0 != 0 { FRAME_ERROR } else { y },
+                                    Ordering::SeqCst,
                                 );
                             }
                             ::core::intrinsics::atomic_store_seqcst(
@@ -1651,9 +1637,9 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                 ((sby + 1) as c_uint).wrapping_mul(sbsz as c_uint)
                             };
                             if (*c).n_fc > 1 as c_uint && !((*f).sr_cur.p.data[0]).is_null() {
-                                ::core::intrinsics::atomic_store_seqcst(
-                                    &mut *((*f).sr_cur.progress).offset(1) as *mut atomic_uint,
+                                (*(*f).sr_cur.progress.add(1)).store(
                                     if error_0 != 0 { FRAME_ERROR } else { y_0 },
+                                    Ordering::SeqCst,
                                 );
                             }
                             pthread_mutex_unlock(&mut (*f).task_thread.lock);


### PR DESCRIPTION
Previously, `progress` was either null or `*const [AtomicU32; 2]`, allocated by the `extra` and `extra_ptr` in `fn picture_alloc_with_edges` as part of the `pic_ctx` allocation.  But since `extra_ptr` is only ever the `*const [AtomicU32; 2]` or null, we can just allocate it inline and avoid this tricky dynamically sized allocation.  This also lets us avoid extra branches and checks that we would have to do if we used an `Option` here.

I made `ThreadPictureProgress` a newtype to `impl Clone` on it, as this has to be done manually for atomics.  It also lets us name the `[0]` and `[1]` indices as `{block,pixel}_data` as the comments say.

@rinon, this may interfere with some of your atomic work, but it wasn't too large of a change to potentially duplicate.  I wasn't intending on touching that part of the codebase, but it's entangled with `Rav1dPicture`, its `Rav1dRef`, and the `pic_ctx`.