### PR TITLE
`struct Rav1dThreadPicture::progress`: Replace atomic intrinsics w/ `AtomicU32`

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4987,7 +4987,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
             c.cached_error_props = out_delayed.p.m.clone();
             rav1d_thread_picture_unref(out_delayed);
         } else if !out_delayed.p.data[0].is_null() {
-            let progress = (*out_delayed.progress.add(1)).load(Ordering::Relaxed);
+            let progress = (*out_delayed.progress)[1].load(Ordering::Relaxed);
             if (out_delayed.visible || c.output_invisible_frames) && progress != FRAME_ERROR {
                 rav1d_thread_picture_ref(&mut c.out, out_delayed);
                 c.event_flags |= out_delayed.flags.into();

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -27,7 +27,6 @@ use crate::include::dav1d::headers::RAV1D_WM_TYPE_AFFINE;
 use crate::include::dav1d::headers::RAV1D_WM_TYPE_IDENTITY;
 use crate::include::dav1d::headers::RAV1D_WM_TYPE_TRANSLATION;
 use crate::include::stdatomic::atomic_int;
-use crate::include::stdatomic::atomic_uint;
 use crate::src::align::Align16;
 use crate::src::cdf::rav1d_cdf_thread_alloc;
 use crate::src::cdf::rav1d_cdf_thread_copy;
@@ -4988,9 +4987,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
             c.cached_error_props = out_delayed.p.m.clone();
             rav1d_thread_picture_unref(out_delayed);
         } else if !out_delayed.p.data[0].is_null() {
-            let progress = ::core::intrinsics::atomic_load_relaxed(
-                &mut *(out_delayed.progress).offset(1) as *mut atomic_uint,
-            );
+            let progress = (*out_delayed.progress.add(1)).load(Ordering::Relaxed);
             if (out_delayed.visible || c.output_invisible_frames) && progress != FRAME_ERROR {
                 rav1d_thread_picture_ref(&mut c.out, out_delayed);
                 c.event_flags |= out_delayed.flags.into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@ use crate::include::dav1d::headers::Rav1dSequenceHeader;
 use crate::include::dav1d::picture::Dav1dPicture;
 use crate::include::dav1d::picture::Rav1dPicture;
 use crate::include::stdatomic::atomic_int;
-use crate::include::stdatomic::atomic_uint;
 use crate::src::align::Align64;
 use crate::src::cdf::rav1d_cdf_thread_unref;
 use crate::src::cpu::rav1d_init_cpu;
@@ -105,6 +104,7 @@ use std::mem;
 use std::mem::MaybeUninit;
 use std::process::abort;
 use std::ptr::NonNull;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Once;
 use to_method::To as _;
@@ -660,9 +660,7 @@ unsafe fn drain_picture(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRe
             return error;
         }
         if !((*out_delayed).p.data[0]).is_null() {
-            let progress: c_uint = ::core::intrinsics::atomic_load_relaxed(
-                &mut *((*out_delayed).progress).offset(1) as *mut atomic_uint,
-            );
+            let progress = (*(*out_delayed).progress.add(1)).load(Ordering::Relaxed);
             if ((*out_delayed).visible || c.output_invisible_frames) && progress != FRAME_ERROR {
                 rav1d_thread_picture_ref(&mut c.out, out_delayed);
                 c.event_flags |= (*out_delayed).flags.into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -660,7 +660,7 @@ unsafe fn drain_picture(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRe
             return error;
         }
         if !((*out_delayed).p.data[0]).is_null() {
-            let progress = (*(*out_delayed).progress.add(1)).load(Ordering::Relaxed);
+            let progress = (*(*out_delayed).progress)[1].load(Ordering::Relaxed);
             if ((*out_delayed).visible || c.output_invisible_frames) && progress != FRAME_ERROR {
                 rav1d_thread_picture_ref(&mut c.out, out_delayed);
                 c.event_flags |= (*out_delayed).flags.into();

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2564,7 +2564,7 @@ unsafe fn parse_obus(c: &mut Rav1dContext, r#in: &Rav1dData, global: bool) -> Ra
                     c.cached_error_props = (*out_delayed).p.m.clone();
                     rav1d_thread_picture_unref(out_delayed);
                 } else if !((*out_delayed).p.data[0]).is_null() {
-                    let progress = (*(*out_delayed).progress.add(1)).load(Ordering::Relaxed);
+                    let progress = (*(*out_delayed).progress)[1].load(Ordering::Relaxed);
                     if ((*out_delayed).visible || c.output_invisible_frames)
                         && progress != FRAME_ERROR
                     {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -67,6 +67,9 @@ impl From<PictureFlags> for Rav1dEventFlags {
 pub(crate) struct Rav1dThreadPicture {
     pub p: Rav1dPicture,
     pub visible: bool,
+    /// This can be set for inter frames, non-key intra frames,
+    /// or for invisible keyframes that have not yet been made visible
+    /// using the show-existing-frame mechanism.
     pub showable: bool,
     pub flags: PictureFlags,
     pub progress: *mut atomic_uint,

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -72,6 +72,8 @@ pub(crate) struct Rav1dThreadPicture {
     /// using the show-existing-frame mechanism.
     pub showable: bool,
     pub flags: PictureFlags,
+    /// `[0]`: block data (including segmentation map and motion vectors)
+    /// `[1]`: pixel data
     pub progress: *mut atomic_uint,
 }
 

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -613,7 +613,7 @@ unsafe fn check_tile(t: *mut Rav1dTask, f: *mut Rav1dFrameContext, frame_mt: c_i
             }
             match current_block_14 {
                 2370887241019905314 => {
-                    let p3 = (*(*f).refp[n as usize].progress.add((tp == 0) as usize))
+                    let p3 = (*(*f).refp[n as usize].progress)[(tp == 0) as usize]
                         .load(Ordering::SeqCst);
                     if p3 < lowest {
                         return 1 as c_int;
@@ -635,7 +635,7 @@ unsafe fn check_tile(t: *mut Rav1dTask, f: *mut Rav1dFrameContext, frame_mt: c_i
 #[inline]
 unsafe fn get_frame_progress(c: *const Rav1dContext, f: *const Rav1dFrameContext) -> c_int {
     let frame_prog: c_uint = if (*c).n_fc > 1 as c_uint {
-        (*(*f).sr_cur.progress.add(1)).load(Ordering::SeqCst)
+        (*(*f).sr_cur.progress)[1].load(Ordering::SeqCst)
     } else {
         0 as c_int as c_uint
     };
@@ -678,8 +678,8 @@ unsafe fn abort_frame(f: *mut Rav1dFrameContext, error: Rav1dResult) {
         &mut *((*f).task_thread.done).as_mut_ptr().offset(1) as *mut atomic_int,
         1 as c_int,
     );
-    (*(*f).sr_cur.progress.add(0)).store(FRAME_ERROR, Ordering::SeqCst);
-    (*(*f).sr_cur.progress.add(1)).store(FRAME_ERROR, Ordering::SeqCst);
+    (*(*f).sr_cur.progress)[0].store(FRAME_ERROR, Ordering::SeqCst);
+    (*(*f).sr_cur.progress)[1].store(FRAME_ERROR, Ordering::SeqCst);
     rav1d_decode_frame_exit(&mut *f, error);
     pthread_cond_signal(&mut (*f).task_thread.cond);
 }
@@ -1179,7 +1179,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                                     frame_hdr.tiling.cols * frame_hdr.tiling.rows
                                                         + (*f).sbh,
                                                 );
-                                                (*(*f).sr_cur.progress.add((p_0 - 1) as usize))
+                                                (*(*f).sr_cur.progress)[(p_0 - 1) as usize]
                                                     .store(FRAME_ERROR, Ordering::SeqCst);
                                                 if p_0 == 2
                                                     && ::core::intrinsics::atomic_load_seqcst(
@@ -1543,7 +1543,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                 unreachable!();
                             }
                             if !((*f).sr_cur.p.data[0]).is_null() {
-                                (*(*f).sr_cur.progress.add(0)).store(
+                                (*(*f).sr_cur.progress)[0].store(
                                     if error_0 != 0 { FRAME_ERROR } else { y },
                                     Ordering::SeqCst,
                                 );
@@ -1609,7 +1609,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                 ((sby + 1) as c_uint).wrapping_mul(sbsz as c_uint)
                             };
                             if (*c).n_fc > 1 as c_uint && !((*f).sr_cur.p.data[0]).is_null() {
-                                (*(*f).sr_cur.progress.add(1)).store(
+                                (*(*f).sr_cur.progress)[1].store(
                                     if error_0 != 0 { FRAME_ERROR } else { y_0 },
                                     Ordering::SeqCst,
                                 );


### PR DESCRIPTION
This is split off of #666, which I messed up (`progress` needs to be or be part of an `Arc`).

(Copied from #666) @rinon, this may interfere with some of your atomic work, but it wasn't too large of a change to potentially duplicate. I wasn't intending on touching that part of the codebase, but it's entangled with `Rav1dPicture`, its `Rav1dRef`, and the `pic_ctx`.