### PR TITLE
`struct Rav1dThreadPicture::progress`: Make an `Option<Arc<_>>` separate from the `pic_ctx_context` `Rav1dRef`

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4987,7 +4987,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
             c.cached_error_props = out_delayed.p.m.clone();
             rav1d_thread_picture_unref(out_delayed);
         } else if !out_delayed.p.data[0].is_null() {
-            let progress = (*out_delayed.progress)[1].load(Ordering::Relaxed);
+            let progress = out_delayed.progress.as_ref().unwrap()[1].load(Ordering::Relaxed);
             if (out_delayed.visible || c.output_invisible_frames) && progress != FRAME_ERROR {
                 rav1d_thread_picture_ref(&mut c.out, out_delayed);
                 c.event_flags |= out_delayed.flags.into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -660,7 +660,7 @@ unsafe fn drain_picture(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRe
             return error;
         }
         if !((*out_delayed).p.data[0]).is_null() {
-            let progress = (*(*out_delayed).progress)[1].load(Ordering::Relaxed);
+            let progress = (*out_delayed).progress.as_ref().unwrap()[1].load(Ordering::Relaxed);
             if ((*out_delayed).visible || c.output_invisible_frames) && progress != FRAME_ERROR {
                 rav1d_thread_picture_ref(&mut c.out, out_delayed);
                 c.event_flags |= (*out_delayed).flags.into();

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2564,7 +2564,8 @@ unsafe fn parse_obus(c: &mut Rav1dContext, r#in: &Rav1dData, global: bool) -> Ra
                     c.cached_error_props = (*out_delayed).p.m.clone();
                     rav1d_thread_picture_unref(out_delayed);
                 } else if !((*out_delayed).p.data[0]).is_null() {
-                    let progress = (*(*out_delayed).progress)[1].load(Ordering::Relaxed);
+                    let progress =
+                        (*out_delayed).progress.as_ref().unwrap()[1].load(Ordering::Relaxed);
                     if ((*out_delayed).visible || c.output_invisible_frames)
                         && progress != FRAME_ERROR
                     {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -613,7 +613,7 @@ unsafe fn check_tile(t: *mut Rav1dTask, f: *mut Rav1dFrameContext, frame_mt: c_i
             }
             match current_block_14 {
                 2370887241019905314 => {
-                    let p3 = (*(*f).refp[n as usize].progress)[(tp == 0) as usize]
+                    let p3 = (*f).refp[n as usize].progress.as_ref().unwrap()[(tp == 0) as usize]
                         .load(Ordering::SeqCst);
                     if p3 < lowest {
                         return 1 as c_int;
@@ -635,7 +635,7 @@ unsafe fn check_tile(t: *mut Rav1dTask, f: *mut Rav1dFrameContext, frame_mt: c_i
 #[inline]
 unsafe fn get_frame_progress(c: *const Rav1dContext, f: *const Rav1dFrameContext) -> c_int {
     let frame_prog: c_uint = if (*c).n_fc > 1 as c_uint {
-        (*(*f).sr_cur.progress)[1].load(Ordering::SeqCst)
+        (*f).sr_cur.progress.as_ref().unwrap()[1].load(Ordering::SeqCst)
     } else {
         0 as c_int as c_uint
     };
@@ -678,8 +678,9 @@ unsafe fn abort_frame(f: *mut Rav1dFrameContext, error: Rav1dResult) {
         &mut *((*f).task_thread.done).as_mut_ptr().offset(1) as *mut atomic_int,
         1 as c_int,
     );
-    (*(*f).sr_cur.progress)[0].store(FRAME_ERROR, Ordering::SeqCst);
-    (*(*f).sr_cur.progress)[1].store(FRAME_ERROR, Ordering::SeqCst);
+    let progress = &**(*f).sr_cur.progress.as_ref().unwrap();
+    progress[0].store(FRAME_ERROR, Ordering::SeqCst);
+    progress[1].store(FRAME_ERROR, Ordering::SeqCst);
     rav1d_decode_frame_exit(&mut *f, error);
     pthread_cond_signal(&mut (*f).task_thread.cond);
 }
@@ -1179,7 +1180,8 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                                     frame_hdr.tiling.cols * frame_hdr.tiling.rows
                                                         + (*f).sbh,
                                                 );
-                                                (*(*f).sr_cur.progress)[(p_0 - 1) as usize]
+                                                (*f).sr_cur.progress.as_ref().unwrap()
+                                                    [(p_0 - 1) as usize]
                                                     .store(FRAME_ERROR, Ordering::SeqCst);
                                                 if p_0 == 2
                                                     && ::core::intrinsics::atomic_load_seqcst(
@@ -1543,7 +1545,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                 unreachable!();
                             }
                             if !((*f).sr_cur.p.data[0]).is_null() {
-                                (*(*f).sr_cur.progress)[0].store(
+                                (*f).sr_cur.progress.as_ref().unwrap()[0].store(
                                     if error_0 != 0 { FRAME_ERROR } else { y },
                                     Ordering::SeqCst,
                                 );
@@ -1609,7 +1611,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                 ((sby + 1) as c_uint).wrapping_mul(sbsz as c_uint)
                             };
                             if (*c).n_fc > 1 as c_uint && !((*f).sr_cur.p.data[0]).is_null() {
-                                (*(*f).sr_cur.progress)[1].store(
+                                (*f).sr_cur.progress.as_ref().unwrap()[1].store(
                                     if error_0 != 0 { FRAME_ERROR } else { y_0 },
                                     Ordering::SeqCst,
                                 );


### PR DESCRIPTION
Previously, `progress` was part of the `pic_ctx_context` `Rav1dRef`, but optionally using a DST.  To avoid that at the cost of a separate `Arc` allocation, this moves `progress` to a separate `Option<Arc<_>>`.
The `pic_ctx_context` `Rav1dRef` is especially complex to `Arc`ify due to the `fn` ptrs, etc. in it, so while this does incur an extra allocation cost and an extra `Arc::clone` on `Rav1dThreadPicture::clone`, it should still be worth it.

I also tried to avoid redundant `.unwrap()`s where possible.
  `progress.is_some() == c.n_fc > 1`, so we only need to check one of these.
  Sometimes the `c.n_fc > 1` check is done much earlier, though, so the checks can't be combined.