### PR TITLE
`fn rav1d_worker_task`: Refactor state machine

### DIFF
--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -813,869 +813,738 @@ unsafe fn delayed_fg_task(c: *const Rav1dContext, ttd: *mut TaskThreadData) {
 }
 
 pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
-    let mut flush;
-    let mut error_0;
-    let mut sby;
-    let mut f: *mut Rav1dFrameContext;
-    let mut t: *mut Rav1dTask;
-    let mut prev_t: *mut Rav1dTask;
-    let mut current_block: u64;
     let tc: *mut Rav1dTaskContext = data as *mut Rav1dTaskContext;
     let c: *const Rav1dContext = (*tc).c;
     let ttd: *mut TaskThreadData = (*tc).task_thread.ttd;
+
     rav1d_set_thread_name(b"dav1d-worker\0" as *const u8 as *const c_char);
-    pthread_mutex_lock(&mut (*ttd).lock);
-    's_18: while !(*tc).task_thread.die {
-        if !(::core::intrinsics::atomic_load_seqcst((*c).flush) != 0) {
-            merge_pending(c);
-            if (*ttd).delayed_fg.exec != 0 {
-                delayed_fg_task(c, ttd);
-                continue;
-            } else {
-                f = 0 as *mut Rav1dFrameContext;
-                t = 0 as *mut Rav1dTask;
-                prev_t = 0 as *mut Rav1dTask;
-                if (*c).n_fc > 1 as c_uint {
-                    let mut i: c_uint = 0 as c_int as c_uint;
-                    loop {
-                        if !(i < (*c).n_fc) {
-                            current_block = 5601891728916014340;
-                            break;
-                        }
-                        let first: c_uint =
-                            ::core::intrinsics::atomic_load_seqcst(&mut (*ttd).first);
-                        f = &mut *((*c).fc)
-                            .offset(first.wrapping_add(i).wrapping_rem((*c).n_fc) as isize)
-                            as *mut Rav1dFrameContext;
-                        if !(::core::intrinsics::atomic_load_seqcst(
-                            &mut (*f).task_thread.init_done as *mut atomic_int,
-                        ) != 0)
-                        {
-                            t = (*f).task_thread.task_head;
-                            if !t.is_null() {
-                                if (*t).type_0 as c_uint == RAV1D_TASK_TYPE_INIT as c_int as c_uint
-                                {
-                                    current_block = 7012560550443761033;
-                                    break;
-                                }
-                                if (*t).type_0 as c_uint
-                                    == RAV1D_TASK_TYPE_INIT_CDF as c_int as c_uint
-                                {
-                                    let p1 = (if !((*f).in_cdf.progress).is_null() {
-                                        ::core::intrinsics::atomic_load_seqcst((*f).in_cdf.progress)
-                                    } else {
-                                        1 as c_int as c_uint
-                                    }) as c_int;
-                                    if p1 != 0 {
-                                        ::core::intrinsics::atomic_or_seqcst(
-                                            &mut (*f).task_thread.error,
-                                            (p1 == TILE_ERROR) as c_int,
-                                        );
-                                        current_block = 7012560550443761033;
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                        i = i.wrapping_add(1);
-                    }
-                } else {
-                    current_block = 5601891728916014340;
-                }
-                's_107: loop {
-                    match current_block {
-                        5601891728916014340 => {
-                            if (*ttd).cur < (*c).n_fc {
-                                let first_0: c_uint =
-                                    ::core::intrinsics::atomic_load_seqcst(&mut (*ttd).first);
-                                f = &mut *((*c).fc).offset(
-                                    first_0.wrapping_add((*ttd).cur).wrapping_rem((*c).n_fc)
-                                        as isize,
-                                ) as *mut Rav1dFrameContext;
-                                merge_pending_frame(f);
-                                prev_t = (*f).task_thread.task_cur_prev;
-                                t = if !prev_t.is_null() {
-                                    (*prev_t).next
-                                } else {
-                                    (*f).task_thread.task_head
-                                };
-                                while !t.is_null() {
-                                    if !((*t).type_0 as c_uint
-                                        == RAV1D_TASK_TYPE_INIT_CDF as c_int as c_uint)
-                                    {
-                                        if (*t).type_0 as c_uint
-                                            == RAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint
-                                            || (*t).type_0 as c_uint
-                                                == RAV1D_TASK_TYPE_TILE_RECONSTRUCTION as c_int
-                                                    as c_uint
-                                        {
-                                            if check_tile(t, f, ((*c).n_fc > 1 as c_uint) as c_int)
-                                                == 0
-                                            {
-                                                current_block = 7012560550443761033;
-                                                continue 's_107;
-                                            }
-                                        } else if (*t).recon_progress != 0 {
-                                            let p = ((*t).type_0 as c_uint
-                                                == RAV1D_TASK_TYPE_ENTROPY_PROGRESS as c_int
-                                                    as c_uint)
-                                                as c_int;
-                                            let error = ::core::intrinsics::atomic_load_seqcst(
-                                                &mut (*f).task_thread.error,
-                                            );
-                                            if !(::core::intrinsics::atomic_load_seqcst(
-                                                &mut *((*f).task_thread.done)
-                                                    .as_mut_ptr()
-                                                    .offset(p as isize)
-                                                    as *mut atomic_int,
-                                            ) == 0
-                                                || error != 0)
-                                            {
-                                                unreachable!();
-                                            }
-                                            let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
-                                            let tile_row_base = frame_hdr.tiling.cols
-                                                * (*f).frame_thread.next_tile_row[p as usize];
-                                            if p != 0 {
-                                                let p1_0 = (*f)
-                                                    .frame_thread
-                                                    .entropy_progress
-                                                    .load(Ordering::SeqCst);
-                                                if p1_0 < (*t).sby {
-                                                    current_block = 5395695591151878490;
-                                                } else {
-                                                    ::core::intrinsics::atomic_or_seqcst(
-                                                        &mut (*f).task_thread.error,
-                                                        (p1_0 == TILE_ERROR) as c_int,
-                                                    );
-                                                    current_block = 14832935472441733737;
-                                                }
-                                            } else {
-                                                current_block = 14832935472441733737;
-                                            }
-                                            match current_block {
-                                                5395695591151878490 => {}
-                                                _ => {
-                                                    let frame_hdr =
-                                                        &***(*f).frame_hdr.as_ref().unwrap();
-                                                    let mut tc_0 = 0;
-                                                    loop {
-                                                        if !(tc_0 < frame_hdr.tiling.cols) {
-                                                            current_block = 3222590281903869779;
-                                                            break;
-                                                        }
-                                                        let ts: *mut Rav1dTileState = &mut *((*f)
-                                                            .ts)
-                                                            .offset((tile_row_base + tc_0) as isize)
-                                                            as *mut Rav1dTileState;
-                                                        let p2 =
-                                                            ::core::intrinsics::atomic_load_seqcst(
-                                                                &mut *((*ts).progress)
-                                                                    .as_mut_ptr()
-                                                                    .offset(p as isize)
-                                                                    as *mut atomic_int,
-                                                            );
-                                                        if p2 < (*t).recon_progress {
-                                                            current_block = 5395695591151878490;
-                                                            break;
-                                                        }
-                                                        ::core::intrinsics::atomic_or_seqcst(
-                                                            &mut (*f).task_thread.error,
-                                                            (p2 == TILE_ERROR) as c_int,
-                                                        );
-                                                        tc_0 += 1;
-                                                    }
-                                                    match current_block {
-                                                        5395695591151878490 => {}
-                                                        _ => {
-                                                            if ((*t).sby + 1) < (*f).sbh {
-                                                                let next_t: *mut Rav1dTask = &mut *t
-                                                                    .offset(1)
-                                                                    as *mut Rav1dTask;
-                                                                *next_t = (*t).clone();
-                                                                (*next_t).sby += 1;
-                                                                let ntr =
-                                                                    (*f).frame_thread.next_tile_row
-                                                                        [p as usize]
-                                                                        + 1;
-                                                                let start =
-                                                                    frame_hdr.tiling.row_start_sb
-                                                                        [ntr as usize]
-                                                                        as c_int;
-                                                                if (*next_t).sby == start {
-                                                                    (*f).frame_thread
-                                                                        .next_tile_row
-                                                                        [p as usize] = ntr;
-                                                                }
-                                                                (*next_t).recon_progress =
-                                                                    (*next_t).sby + 1;
-                                                                insert_task(f, next_t, 0 as c_int);
-                                                            }
-                                                            current_block = 7012560550443761033;
-                                                            continue 's_107;
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        } else if (*t).type_0 as c_uint
-                                            == RAV1D_TASK_TYPE_CDEF as c_int as c_uint
-                                        {
-                                            let p1_1 = (*f).frame_thread.copy_lpf_progress
-                                                [((*t).sby - 1 >> 5) as usize]
-                                                .load(Ordering::SeqCst);
-                                            if p1_1 as c_uint & (1 as c_uint) << ((*t).sby - 1 & 31)
-                                                != 0
-                                            {
-                                                current_block = 7012560550443761033;
-                                                continue 's_107;
-                                            }
-                                        } else {
-                                            if (*t).deblock_progress == 0 {
-                                                unreachable!();
-                                            }
-                                            let p1_2 = (*f)
-                                                .frame_thread
-                                                .deblock_progress
-                                                .load(Ordering::SeqCst);
-                                            if p1_2 >= (*t).deblock_progress {
-                                                ::core::intrinsics::atomic_or_seqcst(
-                                                    &mut (*f).task_thread.error,
-                                                    (p1_2 == TILE_ERROR) as c_int,
-                                                );
-                                                current_block = 7012560550443761033;
-                                                continue 's_107;
-                                            }
-                                        }
-                                    }
-                                    prev_t = t;
-                                    t = (*t).next;
-                                    (*f).task_thread.task_cur_prev = prev_t;
-                                }
-                                (*ttd).cur = ((*ttd).cur).wrapping_add(1);
-                                current_block = 5601891728916014340;
-                            } else {
-                                if reset_task_cur(c, ttd, u32::MAX) != 0 {
-                                    continue 's_18;
-                                }
-                                if merge_pending(c) != 0 {
-                                    continue 's_18;
-                                } else {
-                                    current_block = 14728000373531839883;
-                                    break;
-                                }
-                            }
-                        }
-                        _ => {
-                            if !prev_t.is_null() {
-                                (*prev_t).next = (*t).next;
-                            } else {
-                                (*f).task_thread.task_head = (*t).next;
-                            }
-                            if ((*t).next).is_null() {
-                                (*f).task_thread.task_tail = prev_t;
-                            }
-                            if (*t).type_0 as c_uint > RAV1D_TASK_TYPE_INIT_CDF as c_int as c_uint
-                                && ((*f).task_thread.task_head).is_null()
-                            {
-                                (*ttd).cur = ((*ttd).cur).wrapping_add(1);
-                            }
-                            (*t).next = 0 as *mut Rav1dTask;
-                            ::core::intrinsics::atomic_store_seqcst(
-                                &mut (*ttd).cond_signaled,
-                                1 as c_int,
-                            );
-                            pthread_cond_signal(&mut (*ttd).cond);
-                            pthread_mutex_unlock(&mut (*ttd).lock);
-                            current_block = 8464383504555462953;
-                            break;
-                        }
-                    }
-                }
-                match current_block {
-                    14728000373531839883 => {}
-                    _ => {
-                        loop {
-                            flush = ::core::intrinsics::atomic_load_seqcst((*c).flush);
-                            error_0 = ::core::intrinsics::atomic_or_seqcst(
-                                &mut (*f).task_thread.error,
-                                flush,
-                            ) | flush;
-                            (*tc).f = f;
-                            sby = (*t).sby;
-                            match (*t).type_0 as c_uint {
-                                RAV1D_TASK_TYPE_INIT => {
-                                    if !((*c).n_fc > 1 as c_uint) {
-                                        unreachable!();
-                                    }
-                                    let res = rav1d_decode_frame_init(&mut *f);
-                                    let p1_3 = (if !((*f).in_cdf.progress).is_null() {
-                                        ::core::intrinsics::atomic_load_seqcst((*f).in_cdf.progress)
-                                    } else {
-                                        1 as c_int as c_uint
-                                    }) as c_int;
-                                    if res.is_err() || p1_3 == TILE_ERROR {
-                                        pthread_mutex_lock(&mut (*ttd).lock);
-                                        abort_frame(
-                                            f,
-                                            if res.is_err() { res } else { Err(EINVAL) },
-                                        );
-                                        reset_task_cur(c, ttd, (*t).frame_idx);
-                                        continue 's_18;
-                                    } else {
-                                        (*t).type_0 = RAV1D_TASK_TYPE_INIT_CDF;
-                                        if p1_3 != 0 {
-                                            continue;
-                                        }
-                                        add_pending(f, t);
-                                        pthread_mutex_lock(&mut (*ttd).lock);
-                                        continue 's_18;
-                                    }
-                                }
-                                RAV1D_TASK_TYPE_INIT_CDF => {
-                                    if !((*c).n_fc > 1 as c_uint) {
-                                        unreachable!();
-                                    }
-                                    let mut res_0 = Err(EINVAL);
-                                    if ::core::intrinsics::atomic_load_seqcst(
-                                        &mut (*f).task_thread.error as *mut atomic_int,
-                                    ) == 0
-                                    {
-                                        res_0 = rav1d_decode_frame_init_cdf(&mut *f);
-                                    }
-                                    let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
-                                    if frame_hdr.refresh_context != 0
-                                        && !(*f).task_thread.update_set
-                                    {
-                                        ::core::intrinsics::atomic_store_seqcst(
-                                            (*f).out_cdf.progress,
-                                            (if res_0.is_err() {
-                                                TILE_ERROR
-                                            } else {
-                                                1 as c_int
-                                            })
-                                                as c_uint,
-                                        );
-                                    }
-                                    if res_0.is_ok() {
-                                        // Note that `progress.is_some() == (*c).n_fc > 1`.
-                                        let progress = &**(*f).sr_cur.progress.as_ref().unwrap();
-                                        let mut p_0 = 1;
-                                        while p_0 <= 2 {
-                                            let res_1 =
-                                                rav1d_task_create_tile_sbrow(f, p_0, 0 as c_int);
-                                            if res_1.is_err() {
-                                                pthread_mutex_lock(&mut (*ttd).lock);
-                                                ::core::intrinsics::atomic_store_seqcst(
-                                                    &mut *((*f).task_thread.done)
-                                                        .as_mut_ptr()
-                                                        .offset((2 - p_0) as isize)
-                                                        as *mut atomic_int,
-                                                    1 as c_int,
-                                                );
-                                                ::core::intrinsics::atomic_store_seqcst(
-                                                    &mut (*f).task_thread.error,
-                                                    -(1 as c_int),
-                                                );
-                                                ::core::intrinsics::atomic_xsub_seqcst(
-                                                    &mut (*f).task_thread.task_counter,
-                                                    frame_hdr.tiling.cols * frame_hdr.tiling.rows
-                                                        + (*f).sbh,
-                                                );
-                                                progress[(p_0 - 1) as usize]
-                                                    .store(FRAME_ERROR, Ordering::SeqCst);
-                                                if p_0 == 2
-                                                    && ::core::intrinsics::atomic_load_seqcst(
-                                                        &mut *((*f).task_thread.done)
-                                                            .as_mut_ptr()
-                                                            .offset(1)
-                                                            as *mut atomic_int,
-                                                    ) != 0
-                                                {
-                                                    if ::core::intrinsics::atomic_load_seqcst(
-                                                        &mut (*f).task_thread.task_counter
-                                                            as *mut atomic_int,
-                                                    ) != 0
-                                                    {
-                                                        unreachable!();
-                                                    }
-                                                    rav1d_decode_frame_exit(&mut *f, Err(ENOMEM));
-                                                    pthread_cond_signal(&mut (*f).task_thread.cond);
-                                                } else {
-                                                    pthread_mutex_unlock(&mut (*ttd).lock);
-                                                }
-                                            }
-                                            p_0 += 1;
-                                        }
-                                        pthread_mutex_lock(&mut (*ttd).lock);
-                                    } else {
-                                        pthread_mutex_lock(&mut (*ttd).lock);
-                                        abort_frame(f, res_0);
-                                        reset_task_cur(c, ttd, (*t).frame_idx);
-                                        ::core::intrinsics::atomic_store_seqcst(
-                                            &mut (*f).task_thread.init_done,
-                                            1 as c_int,
-                                        );
-                                    }
-                                    continue 's_18;
-                                }
-                                RAV1D_TASK_TYPE_TILE_ENTROPY
-                                | RAV1D_TASK_TYPE_TILE_RECONSTRUCTION => {
-                                    let p_1 = ((*t).type_0 as c_uint
-                                        == RAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint)
-                                        as c_int;
-                                    let tile_idx = t
-                                        .offset_from((*f).task_thread.tile_tasks[p_1 as usize])
-                                        as c_long
-                                        as c_int;
-                                    let ts_0: *mut Rav1dTileState = &mut *((*f).ts)
-                                        .offset(tile_idx as isize)
-                                        as *mut Rav1dTileState;
-                                    (*tc).ts = ts_0;
-                                    (*tc).by = sby << (*f).sb_shift;
-                                    let uses_2pass = ((*c).n_fc > 1 as c_uint) as c_int;
-                                    (*tc).frame_thread.pass = if uses_2pass == 0 {
-                                        0 as c_int
-                                    } else {
-                                        1 as c_int
-                                            + ((*t).type_0 as c_uint
-                                                == RAV1D_TASK_TYPE_TILE_RECONSTRUCTION as c_int
-                                                    as c_uint)
-                                                as c_int
-                                    };
-                                    if error_0 == 0 {
-                                        error_0 = match rav1d_decode_tile_sbrow(&mut *tc) {
-                                            Ok(()) => 0,
-                                            Err(()) => 1,
-                                        };
-                                    }
-                                    let progress = if error_0 != 0 { TILE_ERROR } else { 1 + sby };
-                                    ::core::intrinsics::atomic_or_seqcst(
-                                        &mut (*f).task_thread.error,
-                                        error_0,
-                                    );
-                                    if (sby + 1) << (*f).sb_shift < (*ts_0).tiling.row_end {
-                                        (*t).sby += 1;
-                                        (*t).deps_skip = 0 as c_int;
-                                        if check_tile(t, f, uses_2pass) == 0 {
-                                            ::core::intrinsics::atomic_store_seqcst(
-                                                &mut *((*ts_0).progress)
-                                                    .as_mut_ptr()
-                                                    .offset(p_1 as isize)
-                                                    as *mut atomic_int,
-                                                progress,
-                                            );
-                                            reset_task_cur_async(ttd, (*t).frame_idx, (*c).n_fc);
-                                            if ::core::intrinsics::atomic_or_seqcst(
-                                                &mut (*ttd).cond_signaled as *mut atomic_int,
-                                                1 as c_int,
-                                            ) == 0
-                                            {
-                                                pthread_cond_signal(&mut (*ttd).cond);
-                                            }
-                                        } else {
-                                            ::core::intrinsics::atomic_store_seqcst(
-                                                &mut *((*ts_0).progress)
-                                                    .as_mut_ptr()
-                                                    .offset(p_1 as isize)
-                                                    as *mut atomic_int,
-                                                progress,
-                                            );
-                                            add_pending(f, t);
-                                            pthread_mutex_lock(&mut (*ttd).lock);
-                                            continue 's_18;
-                                        }
-                                    } else {
-                                        pthread_mutex_lock(&mut (*ttd).lock);
-                                        ::core::intrinsics::atomic_store_seqcst(
-                                            &mut *((*ts_0).progress)
-                                                .as_mut_ptr()
-                                                .offset(p_1 as isize)
-                                                as *mut atomic_int,
-                                            progress,
-                                        );
-                                        reset_task_cur(c, ttd, (*t).frame_idx);
-                                        error_0 = ::core::intrinsics::atomic_load_seqcst(
-                                            &mut (*f).task_thread.error,
-                                        );
-                                        let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
-                                        if frame_hdr.refresh_context != 0
-                                            && (*tc).frame_thread.pass <= 1
-                                            && (*f).task_thread.update_set
-                                            && frame_hdr.tiling.update == tile_idx
-                                        {
-                                            if error_0 == 0 {
-                                                rav1d_cdf_thread_update(
-                                                    frame_hdr,
-                                                    (*f).out_cdf.data.cdf,
-                                                    &mut (*((*f).ts)
-                                                        .offset(frame_hdr.tiling.update as isize))
-                                                    .cdf,
-                                                );
-                                            }
-                                            if (*c).n_fc > 1 as c_uint {
-                                                ::core::intrinsics::atomic_store_seqcst(
-                                                    (*f).out_cdf.progress,
-                                                    (if error_0 != 0 {
-                                                        TILE_ERROR
-                                                    } else {
-                                                        1 as c_int
-                                                    })
-                                                        as c_uint,
-                                                );
-                                            }
-                                        }
-                                        if ::core::intrinsics::atomic_xsub_seqcst(
-                                            &mut (*f).task_thread.task_counter as *mut atomic_int,
-                                            1 as c_int,
-                                        ) - 1
-                                            == 0
-                                            && ::core::intrinsics::atomic_load_seqcst(
-                                                &mut *((*f).task_thread.done).as_mut_ptr().offset(0)
-                                                    as *mut atomic_int,
-                                            ) != 0
-                                            && (uses_2pass == 0
-                                                || ::core::intrinsics::atomic_load_seqcst(
-                                                    &mut *((*f).task_thread.done)
-                                                        .as_mut_ptr()
-                                                        .offset(1)
-                                                        as *mut atomic_int,
-                                                ) != 0)
-                                        {
-                                            error_0 = ::core::intrinsics::atomic_load_seqcst(
-                                                &mut (*f).task_thread.error,
-                                            );
-                                            rav1d_decode_frame_exit(
-                                                &mut *f,
-                                                if error_0 == 1 {
-                                                    Err(EINVAL)
-                                                } else if error_0 != 0 {
-                                                    Err(ENOMEM)
-                                                } else {
-                                                    Ok(())
-                                                },
-                                            );
-                                            pthread_cond_signal(&mut (*f).task_thread.cond);
-                                        }
-                                        if !(::core::intrinsics::atomic_load_seqcst(
-                                            &mut (*f).task_thread.task_counter as *mut atomic_int,
-                                        ) >= 0)
-                                        {
-                                            unreachable!();
-                                        }
-                                        if ::core::intrinsics::atomic_or_seqcst(
-                                            &mut (*ttd).cond_signaled as *mut atomic_int,
-                                            1 as c_int,
-                                        ) == 0
-                                        {
-                                            pthread_cond_signal(&mut (*ttd).cond);
-                                        }
-                                        continue 's_18;
-                                    }
-                                }
-                                RAV1D_TASK_TYPE_DEBLOCK_COLS => {
-                                    if ::core::intrinsics::atomic_load_seqcst(
-                                        &mut (*f).task_thread.error as *mut atomic_int,
-                                    ) == 0
-                                    {
-                                        ((*f).bd_fn.filter_sbrow_deblock_cols)(&mut *f, sby);
-                                    }
-                                    if ensure_progress(
-                                        ttd,
-                                        f,
-                                        t,
-                                        RAV1D_TASK_TYPE_DEBLOCK_ROWS,
-                                        &(*f).frame_thread.deblock_progress,
-                                        &mut (*t).deblock_progress,
-                                    ) != 0
-                                    {
-                                        continue 's_18;
-                                    } else {
-                                        current_block = 16164772378964453469;
-                                        break;
-                                    }
-                                }
-                                RAV1D_TASK_TYPE_DEBLOCK_ROWS => {
-                                    current_block = 16164772378964453469;
-                                    break;
-                                }
-                                RAV1D_TASK_TYPE_CDEF => {
-                                    current_block = 5292528706010880565;
-                                    break;
-                                }
-                                RAV1D_TASK_TYPE_SUPER_RESOLUTION => {
-                                    current_block = 12196494833634779273;
-                                    break;
-                                }
-                                RAV1D_TASK_TYPE_LOOP_RESTORATION => {
-                                    current_block = 563177965161376451;
-                                    break;
-                                }
-                                RAV1D_TASK_TYPE_RECONSTRUCTION_PROGRESS => {
-                                    current_block = 18238912670629178022;
-                                    break;
-                                }
-                                RAV1D_TASK_TYPE_ENTROPY_PROGRESS => {
-                                    current_block = 7729400755948011248;
-                                    break;
-                                }
-                                _ => {
-                                    abort();
-                                }
-                            }
-                        }
-                        match current_block {
-                            16164772378964453469 => {
-                                if ::core::intrinsics::atomic_load_seqcst(
-                                    &mut (*f).task_thread.error as *mut atomic_int,
-                                ) == 0
-                                {
-                                    ((*f).bd_fn.filter_sbrow_deblock_rows)(&mut *f, sby);
-                                }
-                                let seq_hdr = &***(*f).seq_hdr.as_ref().unwrap();
-                                let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
-                                if frame_hdr.loopfilter.level_y[0] != 0
-                                    || frame_hdr.loopfilter.level_y[1] != 0
-                                {
-                                    error_0 = ::core::intrinsics::atomic_load_seqcst(
-                                        &mut (*f).task_thread.error,
-                                    );
-                                    (*f).frame_thread.deblock_progress.store(
-                                        if error_0 != 0 { TILE_ERROR } else { sby + 1 },
-                                        Ordering::SeqCst,
-                                    );
-                                    reset_task_cur_async(ttd, (*t).frame_idx, (*c).n_fc);
-                                    if ::core::intrinsics::atomic_or_seqcst(
-                                        &mut (*ttd).cond_signaled as *mut atomic_int,
-                                        1 as c_int,
-                                    ) == 0
-                                    {
-                                        pthread_cond_signal(&mut (*ttd).cond);
-                                    }
-                                } else if seq_hdr.cdef != 0 || (*f).lf.restore_planes != 0 {
-                                    (*f).frame_thread.copy_lpf_progress[(sby >> 5) as usize]
-                                        .fetch_or((1 as c_uint) << (sby & 31), Ordering::SeqCst);
-                                    if sby != 0 {
-                                        let prog_1 = (*f).frame_thread.copy_lpf_progress
-                                            [(sby - 1 >> 5) as usize]
-                                            .load(Ordering::SeqCst);
-                                        if !prog_1 as c_uint & (1 as c_uint) << (sby - 1 & 31) != 0
-                                        {
-                                            (*t).type_0 = RAV1D_TASK_TYPE_CDEF;
-                                            (*t).deblock_progress = 0 as c_int;
-                                            (*t).recon_progress = (*t).deblock_progress;
-                                            add_pending(f, t);
-                                            pthread_mutex_lock(&mut (*ttd).lock);
-                                            continue;
-                                        }
-                                    }
-                                }
-                                current_block = 5292528706010880565;
-                            }
-                            _ => {}
-                        }
-                        match current_block {
-                            5292528706010880565 => {
-                                let seq_hdr = &***(*f).seq_hdr.as_ref().unwrap();
-                                if seq_hdr.cdef != 0 {
-                                    if ::core::intrinsics::atomic_load_seqcst(
-                                        &mut (*f).task_thread.error as *mut atomic_int,
-                                    ) == 0
-                                    {
-                                        ((*f).bd_fn.filter_sbrow_cdef)(&mut *tc, sby);
-                                    }
-                                    reset_task_cur_async(ttd, (*t).frame_idx, (*c).n_fc);
-                                    if ::core::intrinsics::atomic_or_seqcst(
-                                        &mut (*ttd).cond_signaled as *mut atomic_int,
-                                        1 as c_int,
-                                    ) == 0
-                                    {
-                                        pthread_cond_signal(&mut (*ttd).cond);
-                                    }
-                                }
-                                current_block = 12196494833634779273;
-                            }
-                            _ => {}
-                        }
-                        match current_block {
-                            12196494833634779273 => {
-                                let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
-                                if frame_hdr.size.width[0] != frame_hdr.size.width[1] {
-                                    if ::core::intrinsics::atomic_load_seqcst(
-                                        &mut (*f).task_thread.error as *mut atomic_int,
-                                    ) == 0
-                                    {
-                                        ((*f).bd_fn.filter_sbrow_resize)(&mut *f, sby);
-                                    }
-                                }
-                                current_block = 563177965161376451;
-                            }
-                            _ => {}
-                        }
-                        match current_block {
-                            563177965161376451 => {
-                                if ::core::intrinsics::atomic_load_seqcst(
-                                    &mut (*f).task_thread.error as *mut atomic_int,
-                                ) == 0
-                                    && (*f).lf.restore_planes != 0
-                                {
-                                    ((*f).bd_fn.filter_sbrow_lr)(&mut *f, sby);
-                                }
-                                current_block = 18238912670629178022;
-                            }
-                            _ => {}
-                        }
-                        match current_block {
-                            18238912670629178022 => {}
-                            _ => {}
-                        }
-                        let uses_2pass_0 = ((*c).n_fc > 1 as c_uint) as c_int;
-                        let sbh = (*f).sbh;
-                        let sbsz = (*f).sb_step * 4;
-                        if (*t).type_0 as c_uint
-                            == RAV1D_TASK_TYPE_ENTROPY_PROGRESS as c_int as c_uint
-                        {
-                            error_0 =
-                                ::core::intrinsics::atomic_load_seqcst(&mut (*f).task_thread.error);
-                            let y: c_uint = if sby + 1 == sbh {
-                                u32::MAX
-                            } else {
-                                ((sby + 1) as c_uint).wrapping_mul(sbsz as c_uint)
-                            };
-                            // Note that `progress.is_some() == (*c).n_fc > 1`.
-                            let progress = &**(*f).sr_cur.progress.as_ref().unwrap();
-                            if !((*f).sr_cur.p.data[0]).is_null() {
-                                progress[0].store(
-                                    if error_0 != 0 { FRAME_ERROR } else { y },
-                                    Ordering::SeqCst,
-                                );
-                            }
-                            (*f).frame_thread.entropy_progress.store(
-                                if error_0 != 0 { TILE_ERROR } else { sby + 1 },
-                                Ordering::SeqCst,
-                            );
-                            if sby + 1 == sbh {
-                                ::core::intrinsics::atomic_store_seqcst(
-                                    &mut *((*f).task_thread.done).as_mut_ptr().offset(1)
-                                        as *mut atomic_int,
-                                    1 as c_int,
-                                );
-                            }
-                            pthread_mutex_lock(&mut (*ttd).lock);
-                            let num_tasks = ::core::intrinsics::atomic_xsub_seqcst(
-                                &mut (*f).task_thread.task_counter,
-                                1 as c_int,
-                            ) - 1;
-                            if (sby + 1) < sbh && num_tasks != 0 {
-                                reset_task_cur(c, ttd, (*t).frame_idx);
-                                continue;
-                            } else {
-                                if num_tasks == 0
-                                    && ::core::intrinsics::atomic_load_seqcst(
-                                        &mut *((*f).task_thread.done).as_mut_ptr().offset(0)
-                                            as *mut atomic_int,
-                                    ) != 0
-                                    && ::core::intrinsics::atomic_load_seqcst(
-                                        &mut *((*f).task_thread.done).as_mut_ptr().offset(1)
-                                            as *mut atomic_int,
-                                    ) != 0
-                                {
-                                    error_0 = ::core::intrinsics::atomic_load_seqcst(
-                                        &mut (*f).task_thread.error,
-                                    );
-                                    rav1d_decode_frame_exit(
-                                        &mut *f,
-                                        if error_0 == 1 {
-                                            Err(EINVAL)
-                                        } else if error_0 != 0 {
-                                            Err(ENOMEM)
-                                        } else {
-                                            Ok(())
-                                        },
-                                    );
-                                    pthread_cond_signal(&mut (*f).task_thread.cond);
-                                }
-                                reset_task_cur(c, ttd, (*t).frame_idx);
-                                continue;
-                            }
-                        } else {
-                            (*f).frame_thread.frame_progress[(sby >> 5) as usize]
-                                .fetch_or((1 as c_uint) << (sby & 31), Ordering::SeqCst);
-                            pthread_mutex_lock(&mut (*f).task_thread.lock);
-                            sby = get_frame_progress(f);
-                            error_0 =
-                                ::core::intrinsics::atomic_load_seqcst(&mut (*f).task_thread.error);
-                            let y_0: c_uint = if sby + 1 == sbh {
-                                u32::MAX
-                            } else {
-                                ((sby + 1) as c_uint).wrapping_mul(sbsz as c_uint)
-                            };
-                            // Note that `progress.is_some() == (*c).n_fc > 1`.
-                            if let Some(progress) = &(*f).sr_cur.progress {
-                                if !((*f).sr_cur.p.data[0]).is_null() {
-                                    progress[1].store(
-                                        if error_0 != 0 { FRAME_ERROR } else { y_0 },
-                                        Ordering::SeqCst,
-                                    );
-                                }
-                            }
-                            pthread_mutex_unlock(&mut (*f).task_thread.lock);
-                            if sby + 1 == sbh {
-                                ::core::intrinsics::atomic_store_seqcst(
-                                    &mut *((*f).task_thread.done).as_mut_ptr().offset(0)
-                                        as *mut atomic_int,
-                                    1 as c_int,
-                                );
-                            }
-                            pthread_mutex_lock(&mut (*ttd).lock);
-                            let num_tasks_0 = ::core::intrinsics::atomic_xsub_seqcst(
-                                &mut (*f).task_thread.task_counter,
-                                1 as c_int,
-                            ) - 1;
-                            if (sby + 1) < sbh && num_tasks_0 != 0 {
-                                reset_task_cur(c, ttd, (*t).frame_idx);
-                                continue;
-                            } else {
-                                if num_tasks_0 == 0
-                                    && ::core::intrinsics::atomic_load_seqcst(
-                                        &mut *((*f).task_thread.done).as_mut_ptr().offset(0)
-                                            as *mut atomic_int,
-                                    ) != 0
-                                    && (uses_2pass_0 == 0
-                                        || ::core::intrinsics::atomic_load_seqcst(
-                                            &mut *((*f).task_thread.done).as_mut_ptr().offset(1)
-                                                as *mut atomic_int,
-                                        ) != 0)
-                                {
-                                    error_0 = ::core::intrinsics::atomic_load_seqcst(
-                                        &mut (*f).task_thread.error,
-                                    );
-                                    rav1d_decode_frame_exit(
-                                        &mut *f,
-                                        if error_0 == 1 {
-                                            Err(EINVAL)
-                                        } else if error_0 != 0 {
-                                            Err(ENOMEM)
-                                        } else {
-                                            Ok(())
-                                        },
-                                    );
-                                    pthread_cond_signal(&mut (*f).task_thread.cond);
-                                }
-                                reset_task_cur(c, ttd, (*t).frame_idx);
-                                continue;
-                            }
-                        }
-                    }
-                }
-            }
-        }
+
+    let park = |tc: *mut Rav1dTaskContext, ttd: *mut TaskThreadData| {
         (*tc).task_thread.flushed = true;
         pthread_cond_signal(&mut (*tc).task_thread.td.cond);
+        // we want to be woken up next time progress is signaled
         ::core::intrinsics::atomic_store_seqcst(&mut (*ttd).cond_signaled, 0 as c_int);
         pthread_cond_wait(&mut (*ttd).cond, &mut (*ttd).lock);
         (*tc).task_thread.flushed = false;
         reset_task_cur(c, ttd, u32::MAX);
+    };
+
+    pthread_mutex_lock(&mut (*ttd).lock);
+    'outer: while !(*tc).task_thread.die {
+        if ::core::intrinsics::atomic_load_seqcst((*c).flush) != 0 {
+            park(tc, ttd);
+            continue 'outer;
+        }
+
+        merge_pending(c);
+        if (*ttd).delayed_fg.exec != 0 {
+            // run delayed film grain first
+            delayed_fg_task(c, ttd);
+            continue 'outer;
+        }
+
+        let mut found = false;
+        let mut f = 0 as *mut Rav1dFrameContext;
+        let mut t = 0 as *mut Rav1dTask;
+        let mut prev_t = 0 as *mut Rav1dTask;
+        if (*c).n_fc > 1 as c_uint {
+            // run init tasks second
+            'init_tasks: for i in 0..(*c).n_fc {
+                let first: c_uint = ::core::intrinsics::atomic_load_seqcst(&mut (*ttd).first);
+                f = &mut *((*c).fc).offset(first.wrapping_add(i).wrapping_rem((*c).n_fc) as isize)
+                    as *mut Rav1dFrameContext;
+                if ::core::intrinsics::atomic_load_seqcst(
+                    &mut (*f).task_thread.init_done as *mut atomic_int,
+                ) != 0
+                {
+                    continue 'init_tasks;
+                }
+                t = (*f).task_thread.task_head;
+                if t.is_null() {
+                    continue 'init_tasks;
+                }
+                if (*t).type_0 as c_uint == RAV1D_TASK_TYPE_INIT as c_int as c_uint {
+                    found = true;
+                    break 'init_tasks;
+                }
+                if (*t).type_0 as c_uint == RAV1D_TASK_TYPE_INIT_CDF as c_int as c_uint {
+                    // XXX This can be a simple else, if adding tasks of both
+                    // passes at once (in dav1d_task_create_tile_sbrow).
+                    // Adding the tasks to the pending Q can result in a
+                    // thread merging them before setting init_done.
+                    // We will need to set init_done before adding to the
+                    // pending Q, so maybe return the tasks, set init_done,
+                    // and add to pending Q only then.
+                    let p1 = (if !((*f).in_cdf.progress).is_null() {
+                        ::core::intrinsics::atomic_load_seqcst((*f).in_cdf.progress)
+                    } else {
+                        1 as c_int as c_uint
+                    }) as c_int;
+                    if p1 != 0 {
+                        ::core::intrinsics::atomic_or_seqcst(
+                            &mut (*f).task_thread.error,
+                            (p1 == TILE_ERROR) as c_int,
+                        );
+                        found = true;
+                        break 'init_tasks;
+                    }
+                }
+            }
+        }
+        if !found {
+            // run decoding tasks last
+            'decoding: while (*ttd).cur < (*c).n_fc {
+                let first_0: c_uint = ::core::intrinsics::atomic_load_seqcst(&mut (*ttd).first);
+                f = &mut *((*c).fc)
+                    .offset(first_0.wrapping_add((*ttd).cur).wrapping_rem((*c).n_fc) as isize)
+                    as *mut Rav1dFrameContext;
+                merge_pending_frame(f);
+                prev_t = (*f).task_thread.task_cur_prev;
+                t = if !prev_t.is_null() {
+                    (*prev_t).next
+                } else {
+                    (*f).task_thread.task_head
+                };
+                while !t.is_null() {
+                    'next: {
+                        if (*t).type_0 as c_uint == RAV1D_TASK_TYPE_INIT_CDF as c_int as c_uint {
+                            break 'next;
+                        }
+                        if (*t).type_0 as c_uint == RAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint
+                            || (*t).type_0 as c_uint
+                                == RAV1D_TASK_TYPE_TILE_RECONSTRUCTION as c_int as c_uint
+                        {
+                            // if not bottom sbrow of tile, this task will be re-added
+                            // after it's finished
+                            if check_tile(t, f, ((*c).n_fc > 1 as c_uint) as c_int) == 0 {
+                                found = true;
+                                break 'decoding;
+                            }
+                        } else if (*t).recon_progress != 0 {
+                            let p = ((*t).type_0 as c_uint
+                                == RAV1D_TASK_TYPE_ENTROPY_PROGRESS as c_int as c_uint)
+                                as c_int;
+                            let error =
+                                ::core::intrinsics::atomic_load_seqcst(&mut (*f).task_thread.error);
+                            if !(::core::intrinsics::atomic_load_seqcst(
+                                &mut *((*f).task_thread.done).as_mut_ptr().offset(p as isize)
+                                    as *mut atomic_int,
+                            ) == 0
+                                || error != 0)
+                            {
+                                unreachable!();
+                            }
+                            let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+                            let tile_row_base =
+                                frame_hdr.tiling.cols * (*f).frame_thread.next_tile_row[p as usize];
+                            if p != 0 {
+                                let p1_0 =
+                                    (*f).frame_thread.entropy_progress.load(Ordering::SeqCst);
+                                if p1_0 < (*t).sby {
+                                    break 'next;
+                                }
+                                ::core::intrinsics::atomic_or_seqcst(
+                                    &mut (*f).task_thread.error,
+                                    (p1_0 == TILE_ERROR) as c_int,
+                                );
+                            }
+                            let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+                            for tc_0 in 0..frame_hdr.tiling.cols {
+                                let ts: *mut Rav1dTileState = &mut *((*f).ts)
+                                    .offset((tile_row_base + tc_0) as isize)
+                                    as *mut Rav1dTileState;
+                                let p2 = ::core::intrinsics::atomic_load_seqcst(
+                                    &mut *((*ts).progress).as_mut_ptr().offset(p as isize)
+                                        as *mut atomic_int,
+                                );
+                                if p2 < (*t).recon_progress {
+                                    break 'next;
+                                }
+                                ::core::intrinsics::atomic_or_seqcst(
+                                    &mut (*f).task_thread.error,
+                                    (p2 == TILE_ERROR) as c_int,
+                                );
+                            }
+                            if ((*t).sby + 1) < (*f).sbh {
+                                // add sby+1 to list to replace this one
+                                let next_t: *mut Rav1dTask = &mut *t.offset(1) as *mut Rav1dTask;
+                                *next_t = (*t).clone();
+                                (*next_t).sby += 1;
+                                let ntr = (*f).frame_thread.next_tile_row[p as usize] + 1;
+                                let start = frame_hdr.tiling.row_start_sb[ntr as usize] as c_int;
+                                if (*next_t).sby == start {
+                                    (*f).frame_thread.next_tile_row[p as usize] = ntr;
+                                }
+                                (*next_t).recon_progress = (*next_t).sby + 1;
+                                insert_task(f, next_t, 0 as c_int);
+                            }
+                            found = true;
+                            break 'decoding;
+                        } else if (*t).type_0 as c_uint == RAV1D_TASK_TYPE_CDEF as c_int as c_uint {
+                            let p1_1 = (*f).frame_thread.copy_lpf_progress
+                                [((*t).sby - 1 >> 5) as usize]
+                                .load(Ordering::SeqCst);
+                            if p1_1 as c_uint & (1 as c_uint) << ((*t).sby - 1 & 31) != 0 {
+                                found = true;
+                                break 'decoding;
+                            }
+                        } else {
+                            if (*t).deblock_progress == 0 {
+                                unreachable!();
+                            }
+                            let p1_2 = (*f).frame_thread.deblock_progress.load(Ordering::SeqCst);
+                            if p1_2 >= (*t).deblock_progress {
+                                ::core::intrinsics::atomic_or_seqcst(
+                                    &mut (*f).task_thread.error,
+                                    (p1_2 == TILE_ERROR) as c_int,
+                                );
+                                found = true;
+                                break 'decoding;
+                            }
+                        }
+                    }
+                    // next:
+                    prev_t = t;
+                    t = (*t).next;
+                    (*f).task_thread.task_cur_prev = prev_t;
+                }
+                (*ttd).cur = ((*ttd).cur).wrapping_add(1);
+            }
+        }
+        if !found {
+            if reset_task_cur(c, ttd, u32::MAX) != 0 {
+                continue 'outer;
+            }
+            if merge_pending(c) != 0 {
+                continue 'outer;
+            }
+            park(tc, ttd);
+            continue 'outer;
+        }
+
+        // found:
+        // remove t from list
+        if !prev_t.is_null() {
+            (*prev_t).next = (*t).next;
+        } else {
+            (*f).task_thread.task_head = (*t).next;
+        }
+        if ((*t).next).is_null() {
+            (*f).task_thread.task_tail = prev_t;
+        }
+        if (*t).type_0 as c_uint > RAV1D_TASK_TYPE_INIT_CDF as c_int as c_uint
+            && ((*f).task_thread.task_head).is_null()
+        {
+            (*ttd).cur = ((*ttd).cur).wrapping_add(1);
+        }
+        (*t).next = 0 as *mut Rav1dTask;
+        // we don't need to check cond_signaled here, since we found a task
+        // after the last signal so we want to re-signal the next waiting thread
+        // and again won't need to signal after that
+        ::core::intrinsics::atomic_store_seqcst(&mut (*ttd).cond_signaled, 1 as c_int);
+        pthread_cond_signal(&mut (*ttd).cond);
+        pthread_mutex_unlock(&mut (*ttd).lock);
+
+        'found_unlocked: loop {
+            let flush = ::core::intrinsics::atomic_load_seqcst((*c).flush);
+            let mut error_0 =
+                ::core::intrinsics::atomic_or_seqcst(&mut (*f).task_thread.error, flush) | flush;
+
+            // run it
+            (*tc).f = f;
+            let mut sby = (*t).sby;
+            let mut task_type = (*t).type_0 as c_uint;
+            'fallthrough: loop {
+                match task_type {
+                    RAV1D_TASK_TYPE_INIT => {
+                        if !((*c).n_fc > 1 as c_uint) {
+                            unreachable!();
+                        }
+                        let res = rav1d_decode_frame_init(&mut *f);
+                        let p1_3 = (if !((*f).in_cdf.progress).is_null() {
+                            ::core::intrinsics::atomic_load_seqcst((*f).in_cdf.progress)
+                        } else {
+                            1 as c_int as c_uint
+                        }) as c_int;
+                        if res.is_err() || p1_3 == TILE_ERROR {
+                            pthread_mutex_lock(&mut (*ttd).lock);
+                            abort_frame(f, if res.is_err() { res } else { Err(EINVAL) });
+                            reset_task_cur(c, ttd, (*t).frame_idx);
+                        } else {
+                            (*t).type_0 = RAV1D_TASK_TYPE_INIT_CDF;
+                            if p1_3 != 0 {
+                                continue 'found_unlocked;
+                            }
+                            add_pending(f, t);
+                            pthread_mutex_lock(&mut (*ttd).lock);
+                        }
+                        continue 'outer;
+                    }
+                    RAV1D_TASK_TYPE_INIT_CDF => {
+                        if !((*c).n_fc > 1 as c_uint) {
+                            unreachable!();
+                        }
+                        let mut res_0 = Err(EINVAL);
+                        if ::core::intrinsics::atomic_load_seqcst(
+                            &mut (*f).task_thread.error as *mut atomic_int,
+                        ) == 0
+                        {
+                            res_0 = rav1d_decode_frame_init_cdf(&mut *f);
+                        }
+                        let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+                        if frame_hdr.refresh_context != 0 && !(*f).task_thread.update_set {
+                            ::core::intrinsics::atomic_store_seqcst(
+                                (*f).out_cdf.progress,
+                                (if res_0.is_err() {
+                                    TILE_ERROR
+                                } else {
+                                    1 as c_int
+                                }) as c_uint,
+                            );
+                        }
+                        if res_0.is_ok() {
+                            // Note that `progress.is_some() == (*c).n_fc > 1`.
+                            let progress = &**(*f).sr_cur.progress.as_ref().unwrap();
+
+                            if !((*c).n_fc > 1 as c_uint) {
+                                unreachable!();
+                            }
+                            let mut p_0 = 1;
+                            while p_0 <= 2 {
+                                let res_1 = rav1d_task_create_tile_sbrow(f, p_0, 0 as c_int);
+                                if res_1.is_err() {
+                                    pthread_mutex_lock(&mut (*ttd).lock);
+                                    // memory allocation failed
+                                    ::core::intrinsics::atomic_store_seqcst(
+                                        &mut *((*f).task_thread.done)
+                                            .as_mut_ptr()
+                                            .offset((2 - p_0) as isize)
+                                            as *mut atomic_int,
+                                        1 as c_int,
+                                    );
+                                    ::core::intrinsics::atomic_store_seqcst(
+                                        &mut (*f).task_thread.error,
+                                        -(1 as c_int),
+                                    );
+                                    ::core::intrinsics::atomic_xsub_seqcst(
+                                        &mut (*f).task_thread.task_counter,
+                                        frame_hdr.tiling.cols * frame_hdr.tiling.rows + (*f).sbh,
+                                    );
+                                    progress[(p_0 - 1) as usize]
+                                        .store(FRAME_ERROR, Ordering::SeqCst);
+                                    if p_0 == 2
+                                        && ::core::intrinsics::atomic_load_seqcst(
+                                            &mut *((*f).task_thread.done).as_mut_ptr().offset(1)
+                                                as *mut atomic_int,
+                                        ) != 0
+                                    {
+                                        if ::core::intrinsics::atomic_load_seqcst(
+                                            &mut (*f).task_thread.task_counter as *mut atomic_int,
+                                        ) != 0
+                                        {
+                                            unreachable!();
+                                        }
+                                        rav1d_decode_frame_exit(&mut *f, Err(ENOMEM));
+                                        pthread_cond_signal(&mut (*f).task_thread.cond);
+                                    } else {
+                                        pthread_mutex_unlock(&mut (*ttd).lock);
+                                    }
+                                }
+                                p_0 += 1;
+                            }
+                            pthread_mutex_lock(&mut (*ttd).lock);
+                        } else {
+                            pthread_mutex_lock(&mut (*ttd).lock);
+                            abort_frame(f, res_0);
+                            reset_task_cur(c, ttd, (*t).frame_idx);
+                            ::core::intrinsics::atomic_store_seqcst(
+                                &mut (*f).task_thread.init_done,
+                                1 as c_int,
+                            );
+                        }
+                        continue 'outer;
+                    }
+                    RAV1D_TASK_TYPE_TILE_ENTROPY | RAV1D_TASK_TYPE_TILE_RECONSTRUCTION => {
+                        let p_1 = ((*t).type_0 as c_uint
+                            == RAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint)
+                            as c_int;
+                        let tile_idx = t.offset_from((*f).task_thread.tile_tasks[p_1 as usize])
+                            as c_long as c_int;
+                        let ts_0: *mut Rav1dTileState =
+                            &mut *((*f).ts).offset(tile_idx as isize) as *mut Rav1dTileState;
+                        (*tc).ts = ts_0;
+                        (*tc).by = sby << (*f).sb_shift;
+                        let uses_2pass = ((*c).n_fc > 1 as c_uint) as c_int;
+                        (*tc).frame_thread.pass = if uses_2pass == 0 {
+                            0 as c_int
+                        } else {
+                            1 as c_int
+                                + ((*t).type_0 as c_uint
+                                    == RAV1D_TASK_TYPE_TILE_RECONSTRUCTION as c_int as c_uint)
+                                    as c_int
+                        };
+                        if error_0 == 0 {
+                            error_0 = match rav1d_decode_tile_sbrow(&mut *tc) {
+                                Ok(()) => 0,
+                                Err(()) => 1,
+                            };
+                        }
+                        let progress = if error_0 != 0 { TILE_ERROR } else { 1 + sby };
+
+                        // signal progress
+                        ::core::intrinsics::atomic_or_seqcst(&mut (*f).task_thread.error, error_0);
+                        if (sby + 1) << (*f).sb_shift < (*ts_0).tiling.row_end {
+                            (*t).sby += 1;
+                            (*t).deps_skip = 0 as c_int;
+                            if check_tile(t, f, uses_2pass) == 0 {
+                                ::core::intrinsics::atomic_store_seqcst(
+                                    &mut *((*ts_0).progress).as_mut_ptr().offset(p_1 as isize)
+                                        as *mut atomic_int,
+                                    progress,
+                                );
+                                reset_task_cur_async(ttd, (*t).frame_idx, (*c).n_fc);
+                                if ::core::intrinsics::atomic_or_seqcst(
+                                    &mut (*ttd).cond_signaled as *mut atomic_int,
+                                    1 as c_int,
+                                ) == 0
+                                {
+                                    pthread_cond_signal(&mut (*ttd).cond);
+                                }
+                                continue 'found_unlocked;
+                            }
+                            ::core::intrinsics::atomic_store_seqcst(
+                                &mut *((*ts_0).progress).as_mut_ptr().offset(p_1 as isize)
+                                    as *mut atomic_int,
+                                progress,
+                            );
+                            add_pending(f, t);
+                            pthread_mutex_lock(&mut (*ttd).lock);
+                        } else {
+                            pthread_mutex_lock(&mut (*ttd).lock);
+                            ::core::intrinsics::atomic_store_seqcst(
+                                &mut *((*ts_0).progress).as_mut_ptr().offset(p_1 as isize)
+                                    as *mut atomic_int,
+                                progress,
+                            );
+                            reset_task_cur(c, ttd, (*t).frame_idx);
+                            error_0 =
+                                ::core::intrinsics::atomic_load_seqcst(&mut (*f).task_thread.error);
+                            let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+                            if frame_hdr.refresh_context != 0
+                                && (*tc).frame_thread.pass <= 1
+                                && (*f).task_thread.update_set
+                                && frame_hdr.tiling.update == tile_idx
+                            {
+                                if error_0 == 0 {
+                                    rav1d_cdf_thread_update(
+                                        frame_hdr,
+                                        (*f).out_cdf.data.cdf,
+                                        &mut (*((*f).ts).offset(frame_hdr.tiling.update as isize))
+                                            .cdf,
+                                    );
+                                }
+                                if (*c).n_fc > 1 as c_uint {
+                                    ::core::intrinsics::atomic_store_seqcst(
+                                        (*f).out_cdf.progress,
+                                        (if error_0 != 0 { TILE_ERROR } else { 1 as c_int })
+                                            as c_uint,
+                                    );
+                                }
+                            }
+                            if ::core::intrinsics::atomic_xsub_seqcst(
+                                &mut (*f).task_thread.task_counter as *mut atomic_int,
+                                1 as c_int,
+                            ) - 1
+                                == 0
+                                && ::core::intrinsics::atomic_load_seqcst(
+                                    &mut *((*f).task_thread.done).as_mut_ptr().offset(0)
+                                        as *mut atomic_int,
+                                ) != 0
+                                && (uses_2pass == 0
+                                    || ::core::intrinsics::atomic_load_seqcst(
+                                        &mut *((*f).task_thread.done).as_mut_ptr().offset(1)
+                                            as *mut atomic_int,
+                                    ) != 0)
+                            {
+                                error_0 = ::core::intrinsics::atomic_load_seqcst(
+                                    &mut (*f).task_thread.error,
+                                );
+                                rav1d_decode_frame_exit(
+                                    &mut *f,
+                                    if error_0 == 1 {
+                                        Err(EINVAL)
+                                    } else if error_0 != 0 {
+                                        Err(ENOMEM)
+                                    } else {
+                                        Ok(())
+                                    },
+                                );
+                                pthread_cond_signal(&mut (*f).task_thread.cond);
+                            }
+                            if !(::core::intrinsics::atomic_load_seqcst(
+                                &mut (*f).task_thread.task_counter as *mut atomic_int,
+                            ) >= 0)
+                            {
+                                unreachable!();
+                            }
+                            if ::core::intrinsics::atomic_or_seqcst(
+                                &mut (*ttd).cond_signaled as *mut atomic_int,
+                                1 as c_int,
+                            ) == 0
+                            {
+                                pthread_cond_signal(&mut (*ttd).cond);
+                            }
+                        }
+                        continue 'outer;
+                    }
+                    RAV1D_TASK_TYPE_DEBLOCK_COLS => {
+                        if ::core::intrinsics::atomic_load_seqcst(
+                            &mut (*f).task_thread.error as *mut atomic_int,
+                        ) == 0
+                        {
+                            ((*f).bd_fn.filter_sbrow_deblock_cols)(&mut *f, sby);
+                        }
+                        if ensure_progress(
+                            ttd,
+                            f,
+                            t,
+                            RAV1D_TASK_TYPE_DEBLOCK_ROWS,
+                            &(*f).frame_thread.deblock_progress,
+                            &mut (*t).deblock_progress,
+                        ) != 0
+                        {
+                            continue 'outer;
+                        }
+                        task_type = RAV1D_TASK_TYPE_DEBLOCK_ROWS;
+                        continue 'fallthrough;
+                    }
+                    RAV1D_TASK_TYPE_DEBLOCK_ROWS => {
+                        if ::core::intrinsics::atomic_load_seqcst(
+                            &mut (*f).task_thread.error as *mut atomic_int,
+                        ) == 0
+                        {
+                            ((*f).bd_fn.filter_sbrow_deblock_rows)(&mut *f, sby);
+                        }
+                        // signal deblock progress
+                        let seq_hdr = &***(*f).seq_hdr.as_ref().unwrap();
+                        let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+                        if frame_hdr.loopfilter.level_y[0] != 0
+                            || frame_hdr.loopfilter.level_y[1] != 0
+                        {
+                            error_0 =
+                                ::core::intrinsics::atomic_load_seqcst(&mut (*f).task_thread.error);
+                            (*f).frame_thread.deblock_progress.store(
+                                if error_0 != 0 { TILE_ERROR } else { sby + 1 },
+                                Ordering::SeqCst,
+                            );
+                            reset_task_cur_async(ttd, (*t).frame_idx, (*c).n_fc);
+                            if ::core::intrinsics::atomic_or_seqcst(
+                                &mut (*ttd).cond_signaled as *mut atomic_int,
+                                1 as c_int,
+                            ) == 0
+                            {
+                                pthread_cond_signal(&mut (*ttd).cond);
+                            }
+                        } else if seq_hdr.cdef != 0 || (*f).lf.restore_planes != 0 {
+                            (*f).frame_thread.copy_lpf_progress[(sby >> 5) as usize]
+                                .fetch_or((1 as c_uint) << (sby & 31), Ordering::SeqCst);
+                            // CDEF needs the top buffer to be saved by lr_copy_lpf of the
+                            // previous sbrow
+                            if sby != 0 {
+                                let prog_1 = (*f).frame_thread.copy_lpf_progress
+                                    [(sby - 1 >> 5) as usize]
+                                    .load(Ordering::SeqCst);
+                                if !prog_1 as c_uint & (1 as c_uint) << (sby - 1 & 31) != 0 {
+                                    (*t).type_0 = RAV1D_TASK_TYPE_CDEF;
+                                    (*t).deblock_progress = 0 as c_int;
+                                    (*t).recon_progress = (*t).deblock_progress;
+                                    add_pending(f, t);
+                                    pthread_mutex_lock(&mut (*ttd).lock);
+                                    continue 'outer;
+                                }
+                            }
+                        }
+                        task_type = RAV1D_TASK_TYPE_CDEF;
+                        continue 'fallthrough;
+                    }
+                    RAV1D_TASK_TYPE_CDEF => {
+                        let seq_hdr = &***(*f).seq_hdr.as_ref().unwrap();
+                        if seq_hdr.cdef != 0 {
+                            if ::core::intrinsics::atomic_load_seqcst(
+                                &mut (*f).task_thread.error as *mut atomic_int,
+                            ) == 0
+                            {
+                                ((*f).bd_fn.filter_sbrow_cdef)(&mut *tc, sby);
+                            }
+                            reset_task_cur_async(ttd, (*t).frame_idx, (*c).n_fc);
+                            if ::core::intrinsics::atomic_or_seqcst(
+                                &mut (*ttd).cond_signaled as *mut atomic_int,
+                                1 as c_int,
+                            ) == 0
+                            {
+                                pthread_cond_signal(&mut (*ttd).cond);
+                            }
+                        }
+                        task_type = RAV1D_TASK_TYPE_SUPER_RESOLUTION;
+                        continue 'fallthrough;
+                    }
+                    RAV1D_TASK_TYPE_SUPER_RESOLUTION => {
+                        let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+                        if frame_hdr.size.width[0] != frame_hdr.size.width[1] {
+                            if ::core::intrinsics::atomic_load_seqcst(
+                                &mut (*f).task_thread.error as *mut atomic_int,
+                            ) == 0
+                            {
+                                ((*f).bd_fn.filter_sbrow_resize)(&mut *f, sby);
+                            }
+                        }
+                        task_type = RAV1D_TASK_TYPE_LOOP_RESTORATION;
+                        continue 'fallthrough;
+                    }
+                    RAV1D_TASK_TYPE_LOOP_RESTORATION => {
+                        if ::core::intrinsics::atomic_load_seqcst(
+                            &mut (*f).task_thread.error as *mut atomic_int,
+                        ) == 0
+                            && (*f).lf.restore_planes != 0
+                        {
+                            ((*f).bd_fn.filter_sbrow_lr)(&mut *f, sby);
+                        }
+                        task_type = RAV1D_TASK_TYPE_RECONSTRUCTION_PROGRESS;
+                        continue 'fallthrough;
+                    }
+                    RAV1D_TASK_TYPE_RECONSTRUCTION_PROGRESS => {
+                        // dummy to cover for no post-filters
+                    }
+                    RAV1D_TASK_TYPE_ENTROPY_PROGRESS => {
+                        // dummy to convert tile progress to frame
+                    }
+                    _ => {
+                        abort();
+                    }
+                }
+                break 'fallthrough;
+            }
+            // if task completed [typically LR], signal picture progress as per below
+            let uses_2pass_0 = ((*c).n_fc > 1 as c_uint) as c_int;
+            let sbh = (*f).sbh;
+            let sbsz = (*f).sb_step * 4;
+            if (*t).type_0 as c_uint == RAV1D_TASK_TYPE_ENTROPY_PROGRESS as c_int as c_uint {
+                error_0 = ::core::intrinsics::atomic_load_seqcst(&mut (*f).task_thread.error);
+                let y: c_uint = if sby + 1 == sbh {
+                    u32::MAX
+                } else {
+                    ((sby + 1) as c_uint).wrapping_mul(sbsz as c_uint)
+                };
+                // Note that `progress.is_some() == (*c).n_fc > 1`.
+                let progress = &**(*f).sr_cur.progress.as_ref().unwrap();
+                if !((*f).sr_cur.p.data[0]).is_null() {
+                    progress[0].store(if error_0 != 0 { FRAME_ERROR } else { y }, Ordering::SeqCst);
+                }
+                (*f).frame_thread.entropy_progress.store(
+                    if error_0 != 0 { TILE_ERROR } else { sby + 1 },
+                    Ordering::SeqCst,
+                );
+                if sby + 1 == sbh {
+                    ::core::intrinsics::atomic_store_seqcst(
+                        &mut *((*f).task_thread.done).as_mut_ptr().offset(1) as *mut atomic_int,
+                        1 as c_int,
+                    );
+                }
+                pthread_mutex_lock(&mut (*ttd).lock);
+                let num_tasks = ::core::intrinsics::atomic_xsub_seqcst(
+                    &mut (*f).task_thread.task_counter,
+                    1 as c_int,
+                ) - 1;
+                if (sby + 1) < sbh && num_tasks != 0 {
+                    reset_task_cur(c, ttd, (*t).frame_idx);
+                    continue 'outer;
+                }
+                if num_tasks == 0
+                    && ::core::intrinsics::atomic_load_seqcst(
+                        &mut *((*f).task_thread.done).as_mut_ptr().offset(0) as *mut atomic_int,
+                    ) != 0
+                    && ::core::intrinsics::atomic_load_seqcst(
+                        &mut *((*f).task_thread.done).as_mut_ptr().offset(1) as *mut atomic_int,
+                    ) != 0
+                {
+                    error_0 = ::core::intrinsics::atomic_load_seqcst(&mut (*f).task_thread.error);
+                    rav1d_decode_frame_exit(
+                        &mut *f,
+                        if error_0 == 1 {
+                            Err(EINVAL)
+                        } else if error_0 != 0 {
+                            Err(ENOMEM)
+                        } else {
+                            Ok(())
+                        },
+                    );
+                    pthread_cond_signal(&mut (*f).task_thread.cond);
+                }
+                reset_task_cur(c, ttd, (*t).frame_idx);
+                continue 'outer;
+            }
+            // t->type != DAV1D_TASK_TYPE_ENTROPY_PROGRESS
+            (*f).frame_thread.frame_progress[(sby >> 5) as usize]
+                .fetch_or((1 as c_uint) << (sby & 31), Ordering::SeqCst);
+            pthread_mutex_lock(&mut (*f).task_thread.lock);
+            sby = get_frame_progress(f);
+            error_0 = ::core::intrinsics::atomic_load_seqcst(&mut (*f).task_thread.error);
+            let y_0: c_uint = if sby + 1 == sbh {
+                u32::MAX
+            } else {
+                ((sby + 1) as c_uint).wrapping_mul(sbsz as c_uint)
+            };
+            // Note that `progress.is_some() == (*c).n_fc > 1`.
+            if let Some(progress) = &(*f).sr_cur.progress {
+                progress[1].store(
+                    if error_0 != 0 { FRAME_ERROR } else { y_0 },
+                    Ordering::SeqCst,
+                );
+            }
+            pthread_mutex_unlock(&mut (*f).task_thread.lock);
+            if sby + 1 == sbh {
+                ::core::intrinsics::atomic_store_seqcst(
+                    &mut *((*f).task_thread.done).as_mut_ptr().offset(0) as *mut atomic_int,
+                    1 as c_int,
+                );
+            }
+            pthread_mutex_lock(&mut (*ttd).lock);
+            let num_tasks_0 = ::core::intrinsics::atomic_xsub_seqcst(
+                &mut (*f).task_thread.task_counter,
+                1 as c_int,
+            ) - 1;
+            if (sby + 1) < sbh && num_tasks_0 != 0 {
+                reset_task_cur(c, ttd, (*t).frame_idx);
+                continue 'outer;
+            }
+            if num_tasks_0 == 0
+                && ::core::intrinsics::atomic_load_seqcst(
+                    &mut *((*f).task_thread.done).as_mut_ptr().offset(0) as *mut atomic_int,
+                ) != 0
+                && (uses_2pass_0 == 0
+                    || ::core::intrinsics::atomic_load_seqcst(
+                        &mut *((*f).task_thread.done).as_mut_ptr().offset(1) as *mut atomic_int,
+                    ) != 0)
+            {
+                error_0 = ::core::intrinsics::atomic_load_seqcst(&mut (*f).task_thread.error);
+                rav1d_decode_frame_exit(
+                    &mut *f,
+                    if error_0 == 1 {
+                        Err(EINVAL)
+                    } else if error_0 != 0 {
+                        Err(ENOMEM)
+                    } else {
+                        Ok(())
+                    },
+                );
+                pthread_cond_signal(&mut (*f).task_thread.cond);
+            }
+            reset_task_cur(c, ttd, (*t).frame_idx);
+
+            break 'found_unlocked;
+        }
     }
     pthread_mutex_unlock(&mut (*ttd).lock);
+
     return 0 as *mut c_void;
 }


### PR DESCRIPTION
`rav1d_worker_task` involves complex control flow with gotos, and therefore was transpiled into a state machine. This refactoring restores the original structure with minimal additional structured control flow to emulate gotos.