### PR TITLE
`struct TaskThreadData`: Replace pthread mutexes with Rust equivalents

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4975,7 +4975,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
         if error.is_err() {
             f.task_thread.retval = Ok(());
             c.cached_error = error;
-            c.cached_error_props = out_delayed.p.m.clone();
+            *c.cached_error_props.get_mut().unwrap() = out_delayed.p.m.clone();
             rav1d_thread_picture_unref(out_delayed);
         } else if !out_delayed.p.data.data[0].is_null() {
             let progress = out_delayed.progress.as_ref().unwrap()[1].load(Ordering::Relaxed);
@@ -5023,7 +5023,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
         rav1d_ref_dec(&mut f.mvs_ref);
         let _ = mem::take(&mut f.seq_hdr);
         let _ = mem::take(&mut f.frame_hdr);
-        c.cached_error_props = c.in_0.m.clone();
+        *c.cached_error_props.get_mut().unwrap() = c.in_0.m.clone();
 
         f.tiles.clear();
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -253,7 +253,7 @@ pub struct Rav1dContext {
     pub(crate) drain: c_int,
     pub(crate) frame_flags: Atomic<PictureFlags>,
     pub(crate) event_flags: Rav1dEventFlags,
-    pub(crate) cached_error_props: Rav1dDataProps,
+    pub(crate) cached_error_props: Mutex<Rav1dDataProps>,
     pub(crate) cached_error: Rav1dResult,
 
     pub(crate) logger: Option<Rav1dLogger>,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -78,9 +78,11 @@ use libc::pthread_mutex_t;
 use libc::ptrdiff_t;
 use std::ffi::c_int;
 use std::ffi::c_uint;
+use std::ptr;
 use std::sync::atomic::AtomicI32;
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
+use std::sync::Mutex;
 
 #[repr(C)]
 pub(crate) struct Rav1dDSPContext {
@@ -408,9 +410,17 @@ pub struct Rav1dFrameContext_lf {
 
 #[repr(C)]
 pub struct Rav1dFrameContext_task_thread_pending_tasks {
-    pub lock: pthread_mutex_t,
     pub head: *mut Rav1dTask,
     pub tail: *mut Rav1dTask,
+}
+
+impl Default for Rav1dFrameContext_task_thread_pending_tasks {
+    fn default() -> Self {
+        Self {
+            head: ptr::null_mut(),
+            tail: ptr::null_mut(),
+        }
+    }
 }
 
 #[repr(C)]
@@ -438,7 +448,7 @@ pub(crate) struct Rav1dFrameContext_task_thread {
     pub task_cur_prev: *mut Rav1dTask,
     // async task insertion
     pub pending_tasks_merge: AtomicI32,
-    pub pending_tasks: Rav1dFrameContext_task_thread_pending_tasks,
+    pub pending_tasks: Mutex<Rav1dFrameContext_task_thread_pending_tasks>,
 }
 
 // threading (refer to tc[] for per-thread things)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -641,7 +641,7 @@ unsafe fn drain_picture(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRe
         let error = (*f).task_thread.retval;
         if error.is_err() {
             (*f).task_thread.retval = Ok(());
-            c.cached_error_props = (*out_delayed).p.m.clone();
+            *c.cached_error_props.get_mut().unwrap() = (*out_delayed).p.m.clone();
             rav1d_thread_picture_unref(out_delayed);
             return error;
         }
@@ -1087,7 +1087,7 @@ pub unsafe extern "C" fn dav1d_get_decode_error_data_props(
     (|| {
         validate_input!((!c.is_null(), EINVAL))?;
         validate_input!((!out.is_null(), EINVAL))?;
-        out.write(mem::take(&mut (*c).cached_error_props).into());
+        out.write(mem::take(&mut *((*c).cached_error_props).get_mut().unwrap()).into());
         Ok(())
     })()
     .into()

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2556,7 +2556,7 @@ unsafe fn parse_obus(
                 if error.is_err() {
                     c.cached_error = error;
                     (*f).task_thread.retval = Ok(());
-                    c.cached_error_props = (*out_delayed).p.m.clone();
+                    *c.cached_error_props.get_mut().unwrap() = (*out_delayed).p.m.clone();
                     rav1d_thread_picture_unref(out_delayed);
                 } else if !((*out_delayed).p.data.data[0]).is_null() {
                     let progress =
@@ -2657,7 +2657,7 @@ pub(crate) unsafe fn rav1d_parse_obus(
     global: bool,
 ) -> Rav1dResult<usize> {
     parse_obus(c, r#in, props, global).inspect_err(|_| {
-        c.cached_error_props = props.clone();
+        *c.cached_error_props.get_mut().unwrap() = props.clone();
         writeln!(c.logger, "Error parsing OBU data");
     })
 }

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -263,10 +263,13 @@ pub fn rav1d_picture_copy_props(
     p.itut_t35 = itut_t35;
 }
 
+// itut_t35 was taken out of the c.itut_t35 originally, but that violates Rust
+// borrowing rules so we need to pass it to this function explicitly.
 pub(crate) unsafe fn rav1d_thread_picture_alloc(
-    c: &mut Rav1dContext,
+    c: &Rav1dContext,
     f: &mut Rav1dFrameContext,
     bpc: c_int,
+    itut_t35: Option<Arc<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>>,
 ) -> Rav1dResult {
     let p = &mut f.sr_cur;
     let have_frame_mt = c.n_fc > 1;
@@ -280,10 +283,10 @@ pub(crate) unsafe fn rav1d_thread_picture_alloc(
         f.frame_hdr.clone(),
         c.content_light.clone(),
         c.mastering_display.clone(),
-        c.itut_t35.take(),
+        itut_t35,
         bpc,
         f.tiles[0].data.m.clone(),
-        &mut c.allocator,
+        &c.allocator,
     )?;
     let flags_mask = if frame_hdr.show_frame != 0 || c.output_invisible_frames {
         PictureFlags::empty()
@@ -302,7 +305,7 @@ pub(crate) unsafe fn rav1d_thread_picture_alloc(
 }
 
 pub(crate) unsafe fn rav1d_picture_alloc_copy(
-    c: &mut Rav1dContext,
+    c: &Rav1dContext,
     dst: &mut Rav1dPicture,
     w: c_int,
     src: &Rav1dPicture,

--- a/src/thread_data.rs
+++ b/src/thread_data.rs
@@ -1,12 +1,12 @@
-use libc::pthread_cond_t;
 use libc::pthread_mutex_t;
 use libc::pthread_t;
 use std::ffi::c_int;
+use std::sync::Condvar;
 
 #[repr(C)]
 pub struct thread_data {
     pub thread: pthread_t,
-    pub cond: pthread_cond_t,
+    pub cond: Condvar,
     pub lock: pthread_mutex_t,
     pub inited: c_int,
 }


### PR DESCRIPTION
Replaces the locking in `Rav1dFrameContext_task_thread.pending_tasks` and `TaskThreadData` with Rust equivalents. `TaskThreadData` can now be accessed as read-only with interior mutability as needed.