### PR TITLE
`struct Rav1dPicAllocator`: Make methods `&self` and require callbacks to access `cookie` thread-safely

### DIFF
--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -297,10 +297,8 @@ pub(crate) struct Rav1dPicAllocator {
     ///
     /// # Safety
     ///
-    /// If frame threading is used, accesses to [`Self::cookie`] must be thread-safe.
-    /// If [`Self::cookie`] is accessed in Rust and has interior mutability, it must go through [`UnsafeCell`].
-    ///
-    /// [`UnsafeCell`]: std::cell::UnsafeCell
+    /// If frame threading is used, accesses to [`Self::cookie`] must be thread-safe,
+    /// i.e. [`Self::cookie`] must be [`Send`]` + `[`Sync`].
     pub alloc_picture_callback:
         unsafe extern "C" fn(pic: *mut Dav1dPicture, cookie: *mut c_void) -> Dav1dResult,
 
@@ -308,10 +306,8 @@ pub(crate) struct Rav1dPicAllocator {
     ///
     /// # Safety
     ///
-    /// If frame threading is used, accesses to [`Self::cookie`] must be thread-safe.
-    /// If [`Self::cookie`] is accessed in Rust and has interior mutability, it must go through [`UnsafeCell`].
-    ///
-    /// [`UnsafeCell`]: std::cell::UnsafeCell
+    /// If frame threading is used, accesses to [`Self::cookie`] must be thread-safe,
+    /// i.e. [`Self::cookie`] must be [`Send`]` + `[`Sync`].
     pub release_picture_callback:
         unsafe extern "C" fn(pic: *mut Dav1dPicture, cookie: *mut c_void) -> (),
 }

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -169,7 +169,7 @@ unsafe fn picture_alloc_with_edges(
     itut_t35: Option<Arc<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>>,
     bpc: c_int,
     props: Rav1dDataProps,
-    p_allocator: &mut Rav1dPicAllocator,
+    p_allocator: &Rav1dPicAllocator,
 ) -> Rav1dResult {
     if !p.data[0].is_null() {
         writeln!(logger, "Picture already allocated!",);


### PR DESCRIPTION
Note that this adds to the requirements of `Dav1dPicAllocator::alloc_picture_callback`, part of the `DAV1D_API`.  It requires all accesses to `cookie` to be thread-safe (if threading is enabled), whereas previously it said it will always be called on the main thread.

In practice, I've found 3 implementations of `alloc_picture_callback` (which account for all of the uses in chromium and its dependencies) and they are all unconditionally thread-safe:
* `rav1d`'s default `fn dav1d_default_picture_alloc`: `cookie` is a `Rav1dMemPool`, which is protected by a mutex and thus thread-safe
* `dav1d`'s `fn picture_alloc` (for negative strides): the `cookie` is not uses
* [`ffmpeg`'s `fn libdav1d_picture_allocator`](https://source.chromium.org/chromium/chromium/src/+/main:third_party/ffmpeg/libavcodec/libdav1d.c;l=76?q=libdav1d_picture_allocator&ss=chromium%2Fchromium%2Fsrc): `cookie`'s internal mutability is through [`AVBufferPool`](https://ffmpeg.org/doxygen/4.0/structAVBufferPool.html), which is thread-safe