### PR TITLE
`struct Rav1dPicture::data`: Make private and access through `fn data{,_mut,_mut_unchecked}` to guarantee aliased XOR mutable

### DIFF
--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -27,6 +27,9 @@ use std::ptr;
 use std::ptr::NonNull;
 use std::sync::Arc;
 
+pub(crate) const RAV1D_PICTURE_ALIGNMENT: usize = 64;
+pub const DAV1D_PICTURE_ALIGNMENT: usize = RAV1D_PICTURE_ALIGNMENT;
+
 #[repr(C)]
 pub struct Dav1dPictureParameters {
     pub w: c_int,

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -225,17 +225,19 @@ impl Default for Rav1dPicture {
 pub struct Dav1dPicAllocator {
     pub cookie: *mut c_void,
     pub alloc_picture_callback:
-        Option<unsafe extern "C" fn(*mut Dav1dPicture, *mut c_void) -> Dav1dResult>,
+        Option<unsafe extern "C" fn(pic: *mut Dav1dPicture, cookie: *mut c_void) -> Dav1dResult>,
     pub release_picture_callback:
-        Option<unsafe extern "C" fn(*mut Dav1dPicture, *mut c_void) -> ()>,
+        Option<unsafe extern "C" fn(pic: *mut Dav1dPicture, cookie: *mut c_void) -> ()>,
 }
 
 #[derive(Clone)]
 #[repr(C)]
 pub(crate) struct Rav1dPicAllocator {
     pub cookie: *mut c_void,
-    pub alloc_picture_callback: unsafe extern "C" fn(*mut Dav1dPicture, *mut c_void) -> Dav1dResult,
-    pub release_picture_callback: unsafe extern "C" fn(*mut Dav1dPicture, *mut c_void) -> (),
+    pub alloc_picture_callback:
+        unsafe extern "C" fn(pic: *mut Dav1dPicture, cookie: *mut c_void) -> Dav1dResult,
+    pub release_picture_callback:
+        unsafe extern "C" fn(pic: *mut Dav1dPicture, cookie: *mut c_void) -> (),
 }
 
 impl TryFrom<Dav1dPicAllocator> for Rav1dPicAllocator {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -28,6 +28,7 @@ use crate::include::dav1d::headers::RAV1D_TX_SWITCHABLE;
 use crate::include::dav1d::headers::RAV1D_WM_TYPE_AFFINE;
 use crate::include::dav1d::headers::RAV1D_WM_TYPE_IDENTITY;
 use crate::include::dav1d::headers::RAV1D_WM_TYPE_TRANSLATION;
+use crate::include::dav1d::picture::rav1d_picture_unref_internal;
 use crate::include::stdatomic::atomic_int;
 use crate::src::align::Align16;
 use crate::src::cdef::rav1d_cdef_dsp_init;
@@ -178,7 +179,6 @@ use crate::src::msac::rav1d_msac_decode_uniform;
 use crate::src::msac::rav1d_msac_init;
 use crate::src::picture::rav1d_picture_alloc_copy;
 use crate::src::picture::rav1d_picture_ref;
-use crate::src::picture::rav1d_picture_unref_internal;
 use crate::src::picture::rav1d_thread_picture_alloc;
 use crate::src::picture::rav1d_thread_picture_ref;
 use crate::src::picture::rav1d_thread_picture_unref;
@@ -4676,8 +4676,8 @@ pub(crate) unsafe fn rav1d_decode_frame_init(f: &mut Rav1dFrameContext) -> Rav1d
     // what they point at, as long as the pointers are valid.
     let has_chroma = (f.cur.p.layout != Rav1dPixelLayout::I400) as usize;
     f.lf.mask_ptr = f.lf.mask;
-    f.lf.p = array::from_fn(|i| f.cur.data[has_chroma * i].cast());
-    f.lf.sr_p = array::from_fn(|i| f.sr_cur.p.data[has_chroma * i].cast());
+    f.lf.p = array::from_fn(|i| f.cur.data_mut_unchecked()[has_chroma * i].cast());
+    f.lf.sr_p = array::from_fn(|i| f.sr_cur.p.data_mut_unchecked()[has_chroma * i].cast());
 
     Ok(())
 }
@@ -4851,7 +4851,7 @@ unsafe fn rav1d_decode_frame_main(f: &mut Rav1dFrameContext) -> Rav1dResult {
 
 pub(crate) unsafe fn rav1d_decode_frame_exit(f: &mut Rav1dFrameContext, retval: Rav1dResult) {
     let c = &*f.c;
-    if !f.sr_cur.p.data[0].is_null() {
+    if !f.sr_cur.p.data_is_null() {
         f.task_thread.error = 0;
     }
     if c.n_fc > 1 && retval.is_err() && !f.frame_thread.cf.is_null() {
@@ -4958,7 +4958,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
             pthread_cond_wait(&mut f.task_thread.cond, &mut c.task_thread.lock);
         }
         let out_delayed = &mut *c.frame_thread.out_delayed.offset(next as isize);
-        if !out_delayed.p.data[0].is_null()
+        if !out_delayed.p.data_is_null()
             || ::core::intrinsics::atomic_load_seqcst(&mut f.task_thread.error as *mut atomic_int)
                 != 0
         {
@@ -4983,7 +4983,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
             c.cached_error = error;
             c.cached_error_props = out_delayed.p.m.clone();
             rav1d_thread_picture_unref(out_delayed);
-        } else if !out_delayed.p.data[0].is_null() {
+        } else if !out_delayed.p.data_is_null() {
             let progress = out_delayed.progress.as_ref().unwrap()[1].load(Ordering::Relaxed);
             if (out_delayed.visible || c.output_invisible_frames) && progress != FRAME_ERROR {
                 rav1d_thread_picture_ref(&mut c.out, out_delayed);
@@ -5100,14 +5100,14 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
     if frame_hdr.frame_type.is_inter_or_switch() {
         if frame_hdr.primary_ref_frame != RAV1D_PRIMARY_REF_NONE {
             let pri_ref = frame_hdr.refidx[frame_hdr.primary_ref_frame as usize] as usize;
-            if c.refs[pri_ref].p.p.data[0].is_null() {
+            if c.refs[pri_ref].p.p.data_is_null() {
                 on_error(f, c, out_delayed);
                 return Err(EINVAL);
             }
         }
         for i in 0..7 {
             let refidx = frame_hdr.refidx[i] as usize;
-            if c.refs[refidx].p.p.data[0].is_null()
+            if c.refs[refidx].p.p.data_is_null()
                 || (frame_hdr.size.width[0] * 2) < c.refs[refidx].p.p.p.w
                 || (frame_hdr.size.height * 2) < c.refs[refidx].p.p.p.h
                 || frame_hdr.size.width[0] > c.refs[refidx].p.p.p.w * 16

--- a/src/fg_apply.rs
+++ b/src/fg_apply.rs
@@ -77,6 +77,8 @@ pub(crate) unsafe fn rav1d_prep_grain<BD: BitDepth>(
     r#in: &Rav1dPicture,
     grain: &mut GrainBD<BD>,
 ) {
+    assert_eq!((*out.r#ref).ref_cnt, 1);
+
     let GrainBD { grain_lut, scaling } = grain;
     let frame_hdr = &***out.frame_hdr.as_ref().unwrap();
     let data = &frame_hdr.film_grain.data;
@@ -119,16 +121,16 @@ pub(crate) unsafe fn rav1d_prep_grain<BD: BitDepth>(
         let sz = out.p.h as isize * stride;
         if sz < 0 {
             memcpy(
-                (out.data[0] as *mut u8)
+                (out.data_mut()[0] as *mut u8)
                     .offset(sz as isize)
                     .offset(-(stride as isize)) as *mut c_void,
-                (r#in.data[0] as *mut u8)
+                (r#in.data()[0] as *mut u8)
                     .offset(sz as isize)
                     .offset(-(stride as isize)) as *const c_void,
                 -sz as usize,
             );
         } else {
-            memcpy(out.data[0], r#in.data[0], sz as usize);
+            memcpy(out.data_mut()[0], r#in.data()[0], sz as usize);
         }
     }
 
@@ -140,10 +142,10 @@ pub(crate) unsafe fn rav1d_prep_grain<BD: BitDepth>(
         if sz < 0 {
             if data.num_uv_points[0] == 0 {
                 memcpy(
-                    (out.data[1] as *mut u8)
+                    (out.data_mut()[1] as *mut u8)
                         .offset(sz as isize)
                         .offset(-(stride as isize)) as *mut c_void,
-                    (r#in.data[1] as *mut u8)
+                    (r#in.data()[1] as *mut u8)
                         .offset(sz as isize)
                         .offset(-(stride as isize)) as *const c_void,
                     -sz as usize,
@@ -151,10 +153,10 @@ pub(crate) unsafe fn rav1d_prep_grain<BD: BitDepth>(
             }
             if data.num_uv_points[1] == 0 {
                 memcpy(
-                    (out.data[2] as *mut u8)
+                    (out.data_mut()[2] as *mut u8)
                         .offset(sz as isize)
                         .offset(-(stride as isize)) as *mut c_void,
-                    (r#in.data[2] as *mut u8)
+                    (r#in.data()[2] as *mut u8)
                         .offset(sz as isize)
                         .offset(-(stride as isize)) as *const c_void,
                     -sz as usize,
@@ -162,10 +164,10 @@ pub(crate) unsafe fn rav1d_prep_grain<BD: BitDepth>(
             }
         } else {
             if data.num_uv_points[0] == 0 {
-                memcpy(out.data[1], r#in.data[1], sz as usize);
+                memcpy(out.data_mut()[1], r#in.data()[1], sz as usize);
             }
             if data.num_uv_points[1] == 0 {
-                memcpy(out.data[2], r#in.data[2], sz as usize);
+                memcpy(out.data_mut()[2], r#in.data()[2], sz as usize);
             }
         }
     }
@@ -178,6 +180,8 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
     grain: &GrainBD<BD>,
     row: usize,
 ) {
+    assert_eq!((*out.r#ref).ref_cnt, 1);
+
     // Synthesize grain for the affected planes
     let GrainBD { grain_lut, scaling } = grain;
     let seq_hdr = &***out.seq_hdr.as_ref().unwrap();
@@ -188,7 +192,7 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
     let ss_x = (r#in.p.layout != Rav1dPixelLayout::I444) as usize;
     let cpw = out.p.w as usize + ss_x >> ss_x;
     let is_id = seq_hdr.mtrx == RAV1D_MC_IDENTITY;
-    let luma_src = (r#in.data[0] as *mut BD::Pixel)
+    let luma_src = (r#in.data()[0] as *mut BD::Pixel)
         .offset(((row * 32) as isize * BD::pxstride(r#in.stride[0] as usize) as isize) as isize);
     let bitdepth_max = (1 << out.p.bpc) - 1;
     let bd = BD::from_c(bitdepth_max);
@@ -196,7 +200,7 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
     if data.num_y_points != 0 {
         let bh = cmp::min(out.p.h as usize - row * 32, 32);
         dsp.fgy_32x32xn.call(
-            (out.data[0] as *mut BD::Pixel).offset(
+            (out.data_mut()[0] as *mut BD::Pixel).offset(
                 ((row * 32) as isize * BD::pxstride(out.stride[0] as usize) as isize) as isize,
             ),
             luma_src.cast(),
@@ -230,8 +234,8 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
     if data.chroma_scaling_from_luma {
         for pl in 0..2 {
             dsp.fguv_32x32xn[r#in.p.layout.try_into().unwrap()].call(
-                (out.data[1 + pl] as *mut BD::Pixel).offset(uv_off as isize),
-                (r#in.data[1 + pl] as *const BD::Pixel).offset(uv_off as isize),
+                (out.data_mut()[1 + pl] as *mut BD::Pixel).offset(uv_off as isize),
+                (r#in.data()[1 + pl] as *const BD::Pixel).offset(uv_off as isize),
                 r#in.stride[1],
                 data,
                 cpw,
@@ -250,8 +254,8 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
         for pl in 0..2 {
             if data.num_uv_points[pl] != 0 {
                 dsp.fguv_32x32xn[r#in.p.layout.try_into().unwrap()].call(
-                    (out.data[1 + pl] as *mut BD::Pixel).offset(uv_off as isize),
-                    (r#in.data[1 + pl] as *const BD::Pixel).offset(uv_off as isize),
+                    (out.data_mut()[1 + pl] as *mut BD::Pixel).offset(uv_off as isize),
+                    (r#in.data()[1 + pl] as *const BD::Pixel).offset(uv_off as isize),
                     r#in.stride[1],
                     data_c,
                     cpw,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2512,13 +2512,12 @@ unsafe fn parse_obus(c: &mut Rav1dContext, r#in: &Rav1dData, global: bool) -> Ra
                 );
                 rav1d_picture_copy_props(
                     &mut (*c).out.p,
-                    &c.content_light,
-                    &c.mastering_display,
-                    &c.itut_t35,
-                    &r#in.m,
+                    c.content_light.clone(),
+                    c.mastering_display.clone(),
+                    // Must be moved from the context to the frame.
+                    c.itut_t35.take(),
+                    r#in.m.clone(),
                 );
-                // Must be removed from the context after being attached to the frame
-                let _ = mem::take(&mut c.itut_t35);
                 c.event_flags |= c.refs[frame_hdr.existing_frame_idx as usize].p.flags.into();
             } else {
                 pthread_mutex_lock(&mut c.task_thread.lock);
@@ -2581,13 +2580,12 @@ unsafe fn parse_obus(c: &mut Rav1dContext, r#in: &Rav1dData, global: bool) -> Ra
                 (*out_delayed).visible = true;
                 rav1d_picture_copy_props(
                     &mut (*out_delayed).p,
-                    &c.content_light,
-                    &c.mastering_display,
-                    &c.itut_t35,
-                    &r#in.m,
+                    c.content_light.clone(),
+                    c.mastering_display.clone(),
+                    // Must be moved from the context to the frame.
+                    c.itut_t35.take(),
+                    r#in.m.clone(),
                 );
-                // Must be removed from the context after being attached to the frame
-                let _ = mem::take(&mut c.itut_t35);
                 pthread_mutex_unlock(&mut c.task_thread.lock);
             }
             if c.refs[frame_hdr.existing_frame_idx as usize]

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2498,7 +2498,11 @@ unsafe fn parse_obus(c: &mut Rav1dContext, r#in: &Rav1dData, global: bool) -> Ra
                 }
                 _ => {}
             }
-            if c.refs[frame_hdr.existing_frame_idx as usize].p.p.data[0].is_null() {
+            if c.refs[frame_hdr.existing_frame_idx as usize]
+                .p
+                .p
+                .data_is_null()
+            {
                 return Err(EINVAL);
             }
             if c.strict_std_compliance && !c.refs[frame_hdr.existing_frame_idx as usize].p.showable
@@ -2536,7 +2540,7 @@ unsafe fn parse_obus(c: &mut Rav1dContext, r#in: &Rav1dData, global: bool) -> Ra
                     );
                 }
                 let out_delayed = &mut *c.frame_thread.out_delayed.offset(next as isize);
-                if !(*out_delayed).p.data[0].is_null()
+                if !(*out_delayed).p.data_is_null()
                     || ::core::intrinsics::atomic_load_seqcst(
                         &mut (*f).task_thread.error as *mut atomic_int,
                     ) != 0
@@ -2562,7 +2566,7 @@ unsafe fn parse_obus(c: &mut Rav1dContext, r#in: &Rav1dData, global: bool) -> Ra
                     (*f).task_thread.retval = Ok(());
                     c.cached_error_props = (*out_delayed).p.m.clone();
                     rav1d_thread_picture_unref(out_delayed);
-                } else if !((*out_delayed).p.data[0]).is_null() {
+                } else if !(*out_delayed).p.data_is_null() {
                     let progress =
                         (*out_delayed).progress.as_ref().unwrap()[1].load(Ordering::Relaxed);
                     if ((*out_delayed).visible || c.output_invisible_frames)

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -39,7 +39,6 @@ use std::ffi::c_void;
 use std::io;
 use std::mem;
 use std::ptr;
-use std::ptr::addr_of_mut;
 use std::slice;
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
@@ -190,11 +189,10 @@ unsafe fn picture_alloc_with_edges(
         free(pic_ctx as *mut c_void);
         return res;
     }
-    (*pic_ctx).allocator = p_allocator.clone();
-    // TODO(kkysen) A normal assignment here as it used to be
-    // calls `fn drop` on `(*pic_ctx).pic`, which segfaults as it is uninitialized.
-    // We need to figure out the right thing to do here.
-    addr_of_mut!((*pic_ctx).pic).write(p.clone());
+    pic_ctx.write(pic_ctx_context {
+        allocator: p_allocator.clone(),
+        pic: p.clone(),
+    });
     p.r#ref = rav1d_ref_wrap(
         p.data[0] as *const u8,
         Some(free_buffer),

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -164,7 +164,7 @@ unsafe fn picture_alloc_with_edges(
     itut_t35: Option<Arc<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>>,
     bpc: c_int,
     props: Rav1dDataProps,
-    p_allocator: &mut Rav1dPicAllocator,
+    p_allocator: &Rav1dPicAllocator,
 ) -> Rav1dResult {
     if !p.data[0].is_null() {
         writeln!(logger, "Picture already allocated!",);

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -156,13 +156,13 @@ unsafe fn picture_alloc_with_edges(
     p: &mut Rav1dPicture,
     w: c_int,
     h: c_int,
-    seq_hdr: &Option<Arc<DRav1d<Rav1dSequenceHeader, Dav1dSequenceHeader>>>,
-    frame_hdr: &Option<Arc<DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>>>,
-    content_light: &Option<Arc<Rav1dContentLightLevel>>,
-    mastering_display: &Option<Arc<Rav1dMasteringDisplay>>,
-    itut_t35: &Option<Arc<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>>,
+    seq_hdr: Option<Arc<DRav1d<Rav1dSequenceHeader, Dav1dSequenceHeader>>>,
+    frame_hdr: Option<Arc<DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>>>,
+    content_light: Option<Arc<Rav1dContentLightLevel>>,
+    mastering_display: Option<Arc<Rav1dMasteringDisplay>>,
+    itut_t35: Option<Arc<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>>,
     bpc: c_int,
-    props: &Rav1dDataProps,
+    props: Rav1dDataProps,
     p_allocator: &mut Rav1dPicAllocator,
 ) -> Rav1dResult {
     if !p.data[0].is_null() {
@@ -181,8 +181,8 @@ unsafe fn picture_alloc_with_edges(
         layout: seq_hdr.as_ref().unwrap().layout,
         bpc,
     };
-    p.seq_hdr = seq_hdr.clone();
-    p.frame_hdr = frame_hdr.clone();
+    p.seq_hdr = seq_hdr;
+    p.frame_hdr = frame_hdr;
     p.m = Default::default();
     let res = p_allocator.alloc_picture(p);
     if res.is_err() {
@@ -215,15 +215,15 @@ unsafe fn picture_alloc_with_edges(
 
 pub fn rav1d_picture_copy_props(
     p: &mut Rav1dPicture,
-    content_light: &Option<Arc<Rav1dContentLightLevel>>,
-    mastering_display: &Option<Arc<Rav1dMasteringDisplay>>,
-    itut_t35: &Option<Arc<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>>,
-    props: &Rav1dDataProps,
+    content_light: Option<Arc<Rav1dContentLightLevel>>,
+    mastering_display: Option<Arc<Rav1dMasteringDisplay>>,
+    itut_t35: Option<Arc<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>>,
+    props: Rav1dDataProps,
 ) {
-    p.m = props.clone();
-    p.content_light = content_light.clone();
-    p.mastering_display = mastering_display.clone();
-    p.itut_t35 = itut_t35.clone();
+    p.m = props;
+    p.content_light = content_light;
+    p.mastering_display = mastering_display;
+    p.itut_t35 = itut_t35;
 }
 
 pub(crate) unsafe fn rav1d_thread_picture_alloc(
@@ -239,16 +239,15 @@ pub(crate) unsafe fn rav1d_thread_picture_alloc(
         &mut p.p,
         frame_hdr.size.width[1],
         frame_hdr.size.height,
-        &f.seq_hdr,
-        &f.frame_hdr,
-        &c.content_light,
-        &c.mastering_display,
-        &c.itut_t35,
+        f.seq_hdr.clone(),
+        f.frame_hdr.clone(),
+        c.content_light.clone(),
+        c.mastering_display.clone(),
+        c.itut_t35.take(),
         bpc,
-        &mut f.tiles[0].data.m,
+        f.tiles[0].data.m.clone(),
         &mut c.allocator,
     )?;
-    let _ = mem::take(&mut c.itut_t35);
     let flags_mask = if frame_hdr.show_frame != 0 || c.output_invisible_frames {
         PictureFlags::empty()
     } else {
@@ -278,13 +277,13 @@ pub(crate) unsafe fn rav1d_picture_alloc_copy(
         dst,
         w,
         src.p.h,
-        &src.seq_hdr,
-        &src.frame_hdr,
-        &src.content_light,
-        &src.mastering_display,
-        &src.itut_t35,
+        src.seq_hdr.clone(),
+        src.frame_hdr.clone(),
+        src.content_light.clone(),
+        src.mastering_display.clone(),
+        src.itut_t35.clone(),
         src.p.bpc,
-        &src.m,
+        src.m.clone(),
         &mut (*pic_ctx).allocator,
     )
 }

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -14,6 +14,7 @@ use crate::include::dav1d::headers::Rav1dSequenceHeader;
 use crate::include::dav1d::picture::Dav1dPicture;
 use crate::include::dav1d::picture::Rav1dPicAllocator;
 use crate::include::dav1d::picture::Rav1dPicture;
+use crate::include::dav1d::picture::Rav1dPictureParameters;
 use crate::src::error::Dav1dResult;
 use crate::src::error::Rav1dError::EGeneric;
 use crate::src::error::Rav1dError::ENOMEM;
@@ -175,12 +176,14 @@ unsafe fn picture_alloc_with_edges(
     if pic_ctx.is_null() {
         return Err(ENOMEM);
     }
-    p.p.w = w;
-    p.p.h = h;
+    p.p = Rav1dPictureParameters {
+        w,
+        h,
+        layout: seq_hdr.as_ref().unwrap().layout,
+        bpc,
+    };
     p.seq_hdr = seq_hdr.clone();
     p.frame_hdr = frame_hdr.clone();
-    p.p.layout = seq_hdr.as_ref().unwrap().layout;
-    p.p.bpc = bpc;
     p.m = Default::default();
     let res = p_allocator.alloc_picture(p);
     if res.is_err() {

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2094,7 +2094,7 @@ unsafe fn mc<BD: BitDepth>(
         let dy = by * v_mul + (mvy >> 3 + ss_ver);
         let w;
         let h;
-        if (*refp).p.data[0] != (*f).cur.data[0] {
+        if (*refp).p.data()[0] != (*f).cur.data()[0] {
             w = (*f).cur.p.w + ss_hor >> ss_hor;
             h = (*f).cur.p.h + ss_ver >> ss_ver;
         } else {
@@ -2119,7 +2119,7 @@ unsafe fn mc<BD: BitDepth>(
                 (192 as c_int as c_ulong)
                     .wrapping_mul(::core::mem::size_of::<BD::Pixel>() as c_ulong)
                     as ptrdiff_t,
-                (*refp).p.data[pl as usize].cast(),
+                (*refp).p.data()[pl as usize].cast(),
                 ref_stride,
             );
             r#ref = &mut *emu_edge_buf
@@ -2129,7 +2129,7 @@ unsafe fn mc<BD: BitDepth>(
                 .wrapping_mul(::core::mem::size_of::<BD::Pixel>() as c_ulong)
                 as ptrdiff_t;
         } else {
-            r#ref = ((*refp).p.data[pl as usize] as *mut BD::Pixel)
+            r#ref = ((*refp).p.data()[pl as usize] as *mut BD::Pixel)
                 .offset(BD::pxstride(ref_stride as usize) as isize * dy as isize)
                 .offset(dx as isize);
         }
@@ -2211,7 +2211,7 @@ unsafe fn mc<BD: BitDepth>(
                 (320 as c_int as c_ulong)
                     .wrapping_mul(::core::mem::size_of::<BD::Pixel>() as c_ulong)
                     as ptrdiff_t,
-                (*refp).p.data[pl as usize].cast(),
+                (*refp).p.data()[pl as usize].cast(),
                 ref_stride,
             );
             r#ref = &mut *emu_edge_buf.offset((320 * 3 + 3) as isize) as *mut BD::Pixel;
@@ -2222,7 +2222,7 @@ unsafe fn mc<BD: BitDepth>(
                 printf(b"Emu\n\0" as *const u8 as *const c_char);
             }
         } else {
-            r#ref = ((*refp).p.data[pl as usize] as *mut BD::Pixel)
+            r#ref = ((*refp).p.data()[pl as usize] as *mut BD::Pixel)
                 .offset(BD::pxstride(ref_stride as usize) as isize * top as isize)
                 .offset(left as isize);
         }
@@ -2457,7 +2457,7 @@ unsafe fn warp_affine<BD: BitDepth>(
                     (32 as c_int as c_ulong)
                         .wrapping_mul(::core::mem::size_of::<BD::Pixel>() as c_ulong)
                         as ptrdiff_t,
-                    (*refp).p.data[pl as usize].cast(),
+                    (*refp).p.data()[pl as usize].cast(),
                     ref_stride,
                 );
                 ref_ptr = &mut *emu_edge_buf.offset((32 * 3 + 3) as isize) as *mut BD::Pixel;
@@ -2465,7 +2465,7 @@ unsafe fn warp_affine<BD: BitDepth>(
                     .wrapping_mul(::core::mem::size_of::<BD::Pixel>() as c_ulong)
                     as ptrdiff_t;
             } else {
-                ref_ptr = ((*refp).p.data[pl as usize] as *mut BD::Pixel)
+                ref_ptr = ((*refp).p.data()[pl as usize] as *mut BD::Pixel)
                     .offset((BD::pxstride(ref_stride as usize) as isize * dy as isize) as isize)
                     .offset(dx as isize);
             }
@@ -2555,10 +2555,11 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
         let mut init_x = 0;
         while init_x < w4 {
             if b.c2rust_unnamed.c2rust_unnamed.pal_sz[0] != 0 {
-                let dst: *mut BD::Pixel = ((*f).cur.data[0] as *mut BD::Pixel).offset(
-                    (4 * (t.by as isize * BD::pxstride((*f).cur.stride[0] as usize) as isize
-                        + t.bx as isize)) as isize,
-                );
+                let dst: *mut BD::Pixel = ((*f).cur.data_mut_unchecked()[0] as *mut BD::Pixel)
+                    .offset(
+                        (4 * (t.by as isize * BD::pxstride((*f).cur.stride[0] as usize) as isize
+                            + t.bx as isize)) as isize,
+                    );
                 let pal_idx: *const u8;
                 if t.frame_thread.pass != 0 {
                     let p = t.frame_thread.pass & 1;
@@ -2621,11 +2622,12 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
             y = init_y;
             t.by += init_y;
             while y < sub_h4 {
-                let mut dst: *mut BD::Pixel = ((*f).cur.data[0] as *mut BD::Pixel).offset(
-                    (4 * (t.by as isize * BD::pxstride((*f).cur.stride[0] as usize) as isize
-                        + t.bx as isize
-                        + init_x as isize)) as isize,
-                );
+                let mut dst: *mut BD::Pixel = ((*f).cur.data_mut_unchecked()[0] as *mut BD::Pixel)
+                    .offset(
+                        (4 * (t.by as isize * BD::pxstride((*f).cur.stride[0] as usize) as isize
+                            + t.bx as isize
+                            + init_x as isize)) as isize,
+                    );
                 x = init_x;
                 t.bx += init_x;
                 while x < sub_w4 {
@@ -2821,7 +2823,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         unreachable!();
                     }
                     let ac = &mut t.scratch.c2rust_unnamed_0.ac;
-                    let y_src: *mut BD::Pixel = ((*f).cur.data[0] as *mut BD::Pixel)
+                    let y_src: *const BD::Pixel = ((*f).cur.data()[0] as *const BD::Pixel)
                         .offset((4 * (t.bx & !ss_hor)) as isize)
                         .offset(
                             ((4 * (t.by & !ss_ver)) as isize
@@ -2832,8 +2834,10 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         * ((t.bx >> ss_hor) as isize
                             + (t.by >> ss_ver) as isize * BD::pxstride(stride as usize) as isize);
                     let uv_dst: [*mut BD::Pixel; 2] = [
-                        ((*f).cur.data[1] as *mut BD::Pixel).offset(uv_off as isize),
-                        ((*f).cur.data[2] as *mut BD::Pixel).offset(uv_off as isize),
+                        ((*f).cur.data_mut_unchecked()[1] as *mut BD::Pixel)
+                            .offset(uv_off as isize),
+                        ((*f).cur.data_mut_unchecked()[2] as *mut BD::Pixel)
+                            .offset(uv_off as isize),
                     ];
                     let furthest_r =
                         (cw4 << ss_hor) + (*t_dim).w as c_int - 1 & !((*t_dim).w as c_int - 1);
@@ -2942,7 +2946,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             as *mut u8;
                     }
                     (*(*f).dsp).ipred.pal_pred.call::<BD>(
-                        ((*f).cur.data[1] as *mut BD::Pixel).offset(uv_dstoff as isize),
+                        ((*f).cur.data_mut_unchecked()[1] as *mut BD::Pixel)
+                            .offset(uv_dstoff as isize),
                         (*f).cur.stride[1],
                         (*pal.offset(1)).as_ptr(),
                         pal_idx,
@@ -2950,7 +2955,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         cbh4 * 4,
                     );
                     (*(*f).dsp).ipred.pal_pred.call::<BD>(
-                        ((*f).cur.data[2] as *mut BD::Pixel).offset(uv_dstoff as isize),
+                        ((*f).cur.data_mut_unchecked()[2] as *mut BD::Pixel)
+                            .offset(uv_dstoff as isize),
                         (*f).cur.stride[1],
                         (*pal.offset(2)).as_ptr(),
                         pal_idx,
@@ -2959,14 +2965,14 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     );
                     if DEBUG_BLOCK_INFO(&*f, t) && 0 != 0 {
                         hex_dump::<BD>(
-                            ((*f).cur.data[1] as *mut BD::Pixel).offset(uv_dstoff as isize),
+                            ((*f).cur.data()[1] as *const BD::Pixel).offset(uv_dstoff as isize),
                             BD::pxstride((*f).cur.stride[1] as usize),
                             cbw4 as usize * 4,
                             cbh4 as usize * 4,
                             "u-pal-pred",
                         );
                         hex_dump::<BD>(
-                            ((*f).cur.data[2] as *mut BD::Pixel).offset(uv_dstoff as isize),
+                            ((*f).cur.data()[2] as *const BD::Pixel).offset(uv_dstoff as isize),
                             BD::pxstride((*f).cur.stride[1] as usize),
                             cbw4 as usize * 4,
                             cbh4 as usize * 4,
@@ -3003,12 +3009,13 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     t.by += init_y;
                     while y < sub_ch4 {
                         let mut dst: *mut BD::Pixel =
-                            ((*f).cur.data[(1 + pl) as usize] as *mut BD::Pixel).offset(
-                                (4 * ((t.by >> ss_ver) as isize
-                                    * BD::pxstride(stride as usize) as isize
-                                    + (t.bx + init_x >> ss_hor) as isize))
-                                    as isize,
-                            );
+                            ((*f).cur.data_mut_unchecked()[(1 + pl) as usize] as *mut BD::Pixel)
+                                .offset(
+                                    (4 * ((t.by >> ss_ver) as isize
+                                        * BD::pxstride(stride as usize) as isize
+                                        + (t.bx + init_x >> ss_hor) as isize))
+                                        as isize,
+                                );
                         x = init_x >> ss_hor;
                         t.bx += init_x;
                         while x < sub_cw4 {
@@ -3280,7 +3287,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
     let mut res;
     let cbh4 = bh4 + ss_ver >> ss_ver;
     let cbw4 = bw4 + ss_hor >> ss_hor;
-    let mut dst: *mut BD::Pixel = ((*f).cur.data[0] as *mut BD::Pixel).offset(
+    let mut dst: *mut BD::Pixel = ((*f).cur.data_mut_unchecked()[0] as *mut BD::Pixel).offset(
         (4 * (t.by as isize * BD::pxstride((*f).cur.stride[0] as usize) as isize + t.bx as isize))
             as isize,
     );
@@ -3319,7 +3326,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
             while pl < 3 {
                 res = mc::<BD>(
                     t,
-                    ((*f).cur.data[pl as usize] as *mut BD::Pixel).offset(uvdstoff as isize),
+                    ((*f).cur.data_mut_unchecked()[pl as usize] as *mut BD::Pixel)
+                        .offset(uvdstoff as isize),
                     0 as *mut i16,
                     (*f).cur.stride[1],
                     bw4 << (bw4 == ss_hor) as c_int,
@@ -3544,7 +3552,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     while pl < 2 {
                         res = mc::<BD>(
                             t,
-                            ((*f).cur.data[(1 + pl) as usize] as *mut BD::Pixel)
+                            ((*f).cur.data_mut_unchecked()[(1 + pl) as usize] as *mut BD::Pixel)
                                 .offset(uvdstoff as isize),
                             0 as *mut i16,
                             (*f).cur.stride[1],
@@ -3601,7 +3609,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     while pl < 2 {
                         res = mc::<BD>(
                             t,
-                            ((*f).cur.data[(1 + pl) as usize] as *mut BD::Pixel)
+                            ((*f).cur.data_mut_unchecked()[(1 + pl) as usize] as *mut BD::Pixel)
                                 .offset(uvdstoff as isize)
                                 .offset(v_off as isize),
                             0 as *mut i16,
@@ -3647,7 +3655,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     while pl < 2 {
                         res = mc::<BD>(
                             t,
-                            ((*f).cur.data[(1 + pl) as usize] as *mut BD::Pixel)
+                            ((*f).cur.data_mut_unchecked()[(1 + pl) as usize] as *mut BD::Pixel)
                                 .offset(uvdstoff as isize)
                                 .offset(h_off as isize),
                             0 as *mut i16,
@@ -3697,7 +3705,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 while pl < 2 {
                     res = mc::<BD>(
                         t,
-                        ((*f).cur.data[(1 + pl) as usize] as *mut BD::Pixel)
+                        ((*f).cur.data_mut_unchecked()[(1 + pl) as usize] as *mut BD::Pixel)
                             .offset(uvdstoff as isize)
                             .offset(h_off as isize)
                             .offset(v_off as isize),
@@ -3738,7 +3746,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     while pl < 2 {
                         res = warp_affine::<BD>(
                             t,
-                            ((*f).cur.data[(1 + pl) as usize] as *mut BD::Pixel)
+                            ((*f).cur.data_mut_unchecked()[(1 + pl) as usize] as *mut BD::Pixel)
                                 .offset(uvdstoff as isize),
                             0 as *mut i16,
                             (*f).cur.stride[1],
@@ -3763,7 +3771,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     while pl < 2 {
                         res = mc::<BD>(
                             t,
-                            ((*f).cur.data[(1 + pl) as usize] as *mut BD::Pixel)
+                            ((*f).cur.data_mut_unchecked()[(1 + pl) as usize] as *mut BD::Pixel)
                                 .offset(uvdstoff as isize),
                             0 as *mut i16,
                             (*f).cur.stride[1],
@@ -3789,7 +3797,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                         {
                             res = obmc::<BD>(
                                 t,
-                                ((*f).cur.data[(1 + pl) as usize] as *mut BD::Pixel)
+                                ((*f).cur.data_mut_unchecked()[(1 + pl) as usize]
+                                    as *mut BD::Pixel)
                                     .offset(uvdstoff as isize),
                                 (*f).cur.stride[1],
                                 b_dim,
@@ -3855,9 +3864,9 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                                 .interintra_mode as c_int
                         }) as IntraPredMode;
                         let mut angle = 0;
-                        let uvdst: *mut BD::Pixel = ((*f).cur.data[(1 + pl) as usize]
-                            as *mut BD::Pixel)
-                            .offset(uvdstoff as isize);
+                        let uvdst: *mut BD::Pixel =
+                            ((*f).cur.data_mut_unchecked()[(1 + pl) as usize] as *mut BD::Pixel)
+                                .offset(uvdstoff as isize);
                         let mut top_sb_edge: *const BD::Pixel = 0 as *const BD::Pixel;
                         if t.by & (*f).sb_step - 1 == 0 {
                             top_sb_edge = (*f).ipred_edge[(pl + 1) as usize] as *mut BD::Pixel;
@@ -4152,8 +4161,9 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     }
                     i += 1;
                 }
-                let uvdst: *mut BD::Pixel =
-                    ((*f).cur.data[(1 + pl) as usize] as *mut BD::Pixel).offset(uvdstoff as isize);
+                let uvdst: *mut BD::Pixel = ((*f).cur.data_mut_unchecked()[(1 + pl) as usize]
+                    as *mut BD::Pixel)
+                    .offset(uvdstoff as isize);
                 match b.c2rust_unnamed.c2rust_unnamed_0.comp_type as c_int {
                     2 => {
                         ((*dsp).mc.avg)(
@@ -4221,16 +4231,14 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
         );
         if has_chroma != 0 {
             hex_dump::<BD>(
-                &mut *(*((*f).cur.data).as_ptr().offset(1) as *mut BD::Pixel)
-                    .offset(uvdstoff as isize),
+                ((*f).cur.data()[1] as *mut BD::Pixel).offset(uvdstoff as isize),
                 (*f).cur.stride[1] as usize,
                 cbw4 as usize * 4,
                 cbh4 as usize * 4,
                 "u-pred",
             );
             hex_dump::<BD>(
-                &mut *(*((*f).cur.data).as_ptr().offset(2) as *mut BD::Pixel)
-                    .offset(uvdstoff as isize),
+                ((*f).cur.data()[2] as *mut BD::Pixel).offset(uvdstoff as isize),
                 (*f).cur.stride[1] as usize,
                 cbw4 as usize * 4,
                 cbh4 as usize * 4,
@@ -4320,15 +4328,15 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
             if has_chroma != 0 {
                 let mut pl = 0;
                 while pl < 2 {
-                    let mut uvdst: *mut BD::Pixel = ((*f).cur.data[(1 + pl) as usize]
-                        as *mut BD::Pixel)
-                        .offset(uvdstoff as isize)
-                        .offset(
-                            (BD::pxstride((*f).cur.stride[1] as usize) as isize
-                                * init_y as isize
-                                * 4
-                                >> ss_ver) as isize,
-                        );
+                    let mut uvdst: *mut BD::Pixel =
+                        ((*f).cur.data_mut_unchecked()[(1 + pl) as usize] as *mut BD::Pixel)
+                            .offset(uvdstoff as isize)
+                            .offset(
+                                (BD::pxstride((*f).cur.stride[1] as usize) as isize
+                                    * init_y as isize
+                                    * 4
+                                    >> ss_ver) as isize,
+                            );
                     y = init_y >> ss_ver;
                     t.by += init_y;
                     while y < cmp::min(ch4, init_y + 16 >> ss_ver) {
@@ -4672,7 +4680,7 @@ pub(crate) unsafe fn rav1d_backup_ipred_edge<BD: BitDepth>(t: &mut Rav1dTaskCont
     let sby = t.by >> (*f).sb_shift;
     let sby_off = (*f).sb128w * 128 * sby;
     let x_off = (*ts).tiling.col_start;
-    let y: *const BD::Pixel = ((*f).cur.data[0] as *const BD::Pixel)
+    let y: *const BD::Pixel = ((*f).cur.data()[0] as *const BD::Pixel)
         .offset((x_off * 4) as isize)
         .offset(
             (((t.by + (*f).sb_step) * 4 - 1) as isize
@@ -4708,7 +4716,7 @@ pub(crate) unsafe fn rav1d_backup_ipred_edge<BD: BitDepth>(t: &mut Rav1dTaskCont
                         .unwrap(),
                 )[(sby_off + (x_off * 4 >> ss_hor)).try_into().unwrap()..],
                 &slice::from_raw_parts(
-                    (*f).cur.data[pl as usize].cast(),
+                    (*f).cur.data()[pl as usize].cast(),
                     (uv_off + (4 * ((*ts).tiling.col_end - x_off) >> ss_hor) as isize)
                         .try_into()
                         .unwrap(),

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1543,7 +1543,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                             };
                             // Note that `progress.is_some() == (*c).n_fc > 1`.
                             let progress = &**(*f).sr_cur.progress.as_ref().unwrap();
-                            if !((*f).sr_cur.p.data[0]).is_null() {
+                            if !(*f).sr_cur.p.data_is_null() {
                                 progress[0].store(
                                     if error_0 != 0 { FRAME_ERROR } else { y },
                                     Ordering::SeqCst,
@@ -1611,7 +1611,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                             };
                             // Note that `progress.is_some() == (*c).n_fc > 1`.
                             if let Some(progress) = &(*f).sr_cur.progress {
-                                if !((*f).sr_cur.p.data[0]).is_null() {
+                                if !(*f).sr_cur.p.data_is_null() {
                                     progress[1].store(
                                         if error_0 != 0 { FRAME_ERROR } else { y_0 },
                                         Ordering::SeqCst,


### PR DESCRIPTION
Before more heavily refactoring `Rav1dPicture`, the `.data` self-referential slices, the `.allocator_data` data owner, and `.r#ref` ref count (which is very complex and entangled), this ensures we access `.data` in a safe aliased XOR mutable way.

For immutable access (`fn data`), there are no limits.

For mutable access (`fn data_mut`), we check that the ref count is 1 (similar to `{Arc,Mutex}::get_mut`). This is used for accesses through `out: &mut Rav1dPicture` in `mod fg_apply`.

In `mod recon` in `fn rav1d_recon_b_{intra,inter}`, mutable accesses are through `f.cur`, but the ref count is not 1.  For these, we use `fn data_mut_unchecked`, which will eventually have to be dynamically protected, probably through a `Mutex`.

In `mod decode` in `fn rav1d_decode_frame_init`, mutable accesses are through `f.cur` and `f.sr_cur.p`. The accesses here are more complex since they are stored in `Rav1dFrameContext_lf`, and because the luma pixels are re-used for the chroma pixels when there is no chroma. This mutably aliases the luma pixels, which would be UB, but they are not actually accessed, as they are only there to avoid extra branches.  Thus, we use `fn data_mut_unchecked` for these and will make them safe later.