### PR TITLE
`fn rav1d_decode_frame_init_cdf`: `cargo careful`: Don't call `slice::from_raw_parts(null(), 0)`

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4709,10 +4709,11 @@ pub(crate) unsafe fn rav1d_decode_frame_init_cdf(f: &mut Rav1dFrameContext) -> R
         let mut data = tile.data.as_ref();
         for (j, (ts, tile_start_off)) in iter::zip(
             slice::from_raw_parts_mut(f.ts, end + 1),
-            slice::from_raw_parts(
-                f.frame_thread.tile_start_off,
-                if uses_2pass { end + 1 } else { 0 },
-            )
+            if uses_2pass {
+                slice::from_raw_parts(f.frame_thread.tile_start_off, end + 1)
+            } else {
+                &[]
+            }
             .into_iter()
             .map(|&it| it as usize)
             .chain(iter::repeat(0)),


### PR DESCRIPTION
In debugging another bug, I tried using [`cargo careful`](https://github.com/RalfJung/cargo-careful) (it tries to detect some UB with extra checks, so not as thorough as `miri`, but can run on any code), and it found this one UB where we in effect call `slice::from_raw_parts(ptr::null(), 0)`, which is not allowed.  This just changes that code path to use `&[]` instead.

Also, it might be a good idea to run `cargo careful` in CI for the debug/`opt-dev` builds.