### PR TITLE
`struct Rav1dPic{tureData,Allocator}`: Refactor in preparation for `Arc`ification

### DIFF
--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -17,7 +17,6 @@ use crate::src::c_arc::RawArc;
 use crate::src::error::Dav1dResult;
 use crate::src::error::Rav1dError;
 use crate::src::error::Rav1dError::EINVAL;
-use crate::src::error::Rav1dResult;
 use crate::src::r#ref::Rav1dRef;
 use libc::ptrdiff_t;
 use libc::uintptr_t;
@@ -344,20 +343,5 @@ impl From<Rav1dPicAllocator> for Dav1dPicAllocator {
             alloc_picture_callback: Some(alloc_picture_callback),
             release_picture_callback: Some(release_picture_callback),
         }
-    }
-}
-
-impl Rav1dPicAllocator {
-    pub unsafe fn alloc_picture(&self, p: *mut Rav1dPicture) -> Rav1dResult {
-        let mut p_c = p.read().into();
-        let result = (self.alloc_picture_callback)(&mut p_c, self.cookie);
-        p.write(p_c.into());
-        result.try_into().unwrap()
-    }
-
-    pub unsafe fn release_picture(&self, p: *mut Rav1dPicture) {
-        let mut p_c = p.read().into();
-        (self.release_picture_callback)(&mut p_c, self.cookie);
-        p.write(p_c.into());
     }
 }

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -250,6 +250,14 @@ pub struct Dav1dPicAllocator {
     ///     with a custom pointer that will be passed to
     ///     [`release_picture_callback`].
     ///
+    ///     The only fields of `pic` that will be already set are:
+    ///     * [`Dav1dPicture::p`]
+    ///     * [`Dav1dPicture::seq_hdr`]
+    ///     * [`Dav1dPicture::frame_hdr`]
+    ///     
+    ///     This is not a change from the original `DAV1D_API`,
+    ///     just a clarification of it.
+    ///
     /// * `cookie`: Custom pointer passed to all calls.
     ///
     /// *Note*: No fields other than [`data`], [`stride`] and [`allocator_data`]
@@ -281,6 +289,23 @@ pub struct Dav1dPicAllocator {
     /// # Args
     ///
     /// * `pic`: The picture that was filled by [`alloc_picture_callback`].
+    ///     
+    ///     The only fields of `pic` that will be set are
+    ///     the ones allocated by [`Self::alloc_picture_callback`]:
+    ///     * [`Dav1dPicture::data`]
+    ///     * [`Dav1dPicture::allocator_data`]
+    ///     
+    ///     NOTE: This is a slight change from the original `DAV1D_API`, which was underspecified.
+    ///     However, all known uses of this API follow this already:
+    ///     * `libdav1d`: [`dav1d_default_picture_release`](https://code.videolan.org/videolan/dav1d/-/blob/16ed8e8b99f2fcfffe016e929d3626e15267ad3e/src/picture.c#L85-87)
+    ///     * `dav1d`: [`picture_release`](https://code.videolan.org/videolan/dav1d/-/blob/16ed8e8b99f2fcfffe016e929d3626e15267ad3e/tools/dav1d.c#L180-182)
+    ///     * `dav1dplay`: [`placebo_release_pic`](https://code.videolan.org/videolan/dav1d/-/blob/16ed8e8b99f2fcfffe016e929d3626e15267ad3e/examples/dp_renderer_placebo.c#L375-383)
+    ///     * `libplacebo`: [`pl_release_dav1dpicture`](https://github.com/haasn/libplacebo/blob/34e019bfedaa5a64f268d8f9263db352c0a8f67f/src/include/libplacebo/utils/dav1d_internal.h#L594-L607)
+    ///     * `ffmpeg`: [`libdav1d_picture_release`](https://github.com/FFmpeg/FFmpeg/blob/00b288da73f45acb78b74bcc40f73c7ba1fff7cb/libavcodec/libdav1d.c#L124-L129)
+    ///
+    ///     Making this API safe without this slight tightening of the API
+    ///     [is very difficult](https://github.com/memorysafety/rav1d/pull/685#discussion_r1458171639).
+    ///
     /// * `cookie`: Custom pointer passed to all calls.
     ///
     /// [`dav1d_get_picture`]: crate::src::lib::dav1d_get_picture

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -109,7 +109,12 @@ impl Default for Rav1dPictureData {
     }
 }
 
-#[derive(Clone)]
+// TODO(kkysen) Eventually the [`impl Default`] might not be needed.
+// It's needed currently for a [`mem::take`] that simulates a move,
+// but once everything is Rusty, we may not need to clear the `dst` anymore.
+// This also applies to the `#[derive(Default)]`
+// on [`Rav1dPictureParameters`] and [`Rav1dPixelLayout`].
+#[derive(Clone, Default)]
 #[repr(C)]
 pub(crate) struct Rav1dPicture {
     pub seq_hdr: Option<Arc<DRav1d<Rav1dSequenceHeader, Dav1dSequenceHeader>>>,
@@ -212,28 +217,6 @@ impl From<Rav1dPicture> for Dav1dPicture {
             reserved_ref: Default::default(),
             r#ref,
             allocator_data,
-        }
-    }
-}
-
-// TODO(kkysen) Eventually the [`impl Default`] might not be needed.
-// It's needed currently for a [`mem::take`] that simulates a move,
-// but once everything is Rusty, we may not need to clear the `dst` anymore.
-// This also applies to the `#[derive(Default)]`
-// on [`Rav1dPictureParameters`] and [`Rav1dPixelLayout`].
-impl Default for Rav1dPicture {
-    fn default() -> Self {
-        Self {
-            seq_hdr: None,
-            frame_hdr: None,
-            data: Default::default(),
-            stride: Default::default(),
-            p: Default::default(),
-            m: Default::default(),
-            content_light: None,
-            mastering_display: None,
-            itut_t35: None,
-            r#ref: None,
         }
     }
 }

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -30,6 +30,7 @@ use std::sync::Arc;
 pub(crate) const RAV1D_PICTURE_ALIGNMENT: usize = 64;
 pub const DAV1D_PICTURE_ALIGNMENT: usize = RAV1D_PICTURE_ALIGNMENT;
 
+#[derive(Default)]
 #[repr(C)]
 pub struct Dav1dPictureParameters {
     pub w: c_int,
@@ -72,6 +73,7 @@ impl From<Rav1dPictureParameters> for Dav1dPictureParameters {
     }
 }
 
+#[derive(Default)]
 #[repr(C)]
 pub struct Dav1dPicture {
     pub seq_hdr: Option<NonNull<Dav1dSequenceHeader>>,

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -90,7 +90,7 @@ pub struct Dav1dPicture {
     pub mastering_display_ref: Option<RawArc<Rav1dMasteringDisplay>>, // opaque, so we can change this
     pub itut_t35_ref: Option<RawArc<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>>, // opaque, so we can change this
     pub reserved_ref: [uintptr_t; 4],
-    pub r#ref: *mut Dav1dRef,
+    pub r#ref: Option<NonNull<Dav1dRef>>,
     pub allocator_data: Option<NonNull<c_void>>,
 }
 
@@ -121,7 +121,7 @@ pub(crate) struct Rav1dPicture {
     pub content_light: Option<Arc<Rav1dContentLightLevel>>,
     pub mastering_display: Option<Arc<Rav1dMasteringDisplay>>,
     pub itut_t35: Option<Arc<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>>,
-    pub r#ref: *mut Rav1dRef,
+    pub r#ref: Option<NonNull<Rav1dRef>>,
 }
 
 impl From<Dav1dPicture> for Rav1dPicture {
@@ -233,7 +233,7 @@ impl Default for Rav1dPicture {
             content_light: None,
             mastering_display: None,
             itut_t35: None,
-            r#ref: ptr::null_mut(),
+            r#ref: None,
         }
     }
 }

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -91,20 +91,20 @@ pub struct Dav1dPicture {
     pub itut_t35_ref: Option<RawArc<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>>, // opaque, so we can change this
     pub reserved_ref: [uintptr_t; 4],
     pub r#ref: *mut Dav1dRef,
-    pub allocator_data: *mut c_void,
+    pub allocator_data: Option<NonNull<c_void>>,
 }
 
 #[derive(Clone)]
 pub(crate) struct Rav1dPictureData {
     pub data: [*mut c_void; 3],
-    pub allocator_data: *mut c_void,
+    pub allocator_data: Option<NonNull<c_void>>,
 }
 
 impl Default for Rav1dPictureData {
     fn default() -> Self {
         Self {
             data: [ptr::null_mut(); 3],
-            allocator_data: ptr::null_mut(),
+            allocator_data: Default::default(),
         }
     }
 }

--- a/src/fg_apply.rs
+++ b/src/fg_apply.rs
@@ -119,16 +119,16 @@ pub(crate) unsafe fn rav1d_prep_grain<BD: BitDepth>(
         let sz = out.p.h as isize * stride;
         if sz < 0 {
             memcpy(
-                (out.data[0] as *mut u8)
+                (out.data.data[0] as *mut u8)
                     .offset(sz as isize)
                     .offset(-(stride as isize)) as *mut c_void,
-                (r#in.data[0] as *mut u8)
+                (r#in.data.data[0] as *mut u8)
                     .offset(sz as isize)
                     .offset(-(stride as isize)) as *const c_void,
                 -sz as usize,
             );
         } else {
-            memcpy(out.data[0], r#in.data[0], sz as usize);
+            memcpy(out.data.data[0], r#in.data.data[0], sz as usize);
         }
     }
 
@@ -140,10 +140,10 @@ pub(crate) unsafe fn rav1d_prep_grain<BD: BitDepth>(
         if sz < 0 {
             if data.num_uv_points[0] == 0 {
                 memcpy(
-                    (out.data[1] as *mut u8)
+                    (out.data.data[1] as *mut u8)
                         .offset(sz as isize)
                         .offset(-(stride as isize)) as *mut c_void,
-                    (r#in.data[1] as *mut u8)
+                    (r#in.data.data[1] as *mut u8)
                         .offset(sz as isize)
                         .offset(-(stride as isize)) as *const c_void,
                     -sz as usize,
@@ -151,10 +151,10 @@ pub(crate) unsafe fn rav1d_prep_grain<BD: BitDepth>(
             }
             if data.num_uv_points[1] == 0 {
                 memcpy(
-                    (out.data[2] as *mut u8)
+                    (out.data.data[2] as *mut u8)
                         .offset(sz as isize)
                         .offset(-(stride as isize)) as *mut c_void,
-                    (r#in.data[2] as *mut u8)
+                    (r#in.data.data[2] as *mut u8)
                         .offset(sz as isize)
                         .offset(-(stride as isize)) as *const c_void,
                     -sz as usize,
@@ -162,10 +162,10 @@ pub(crate) unsafe fn rav1d_prep_grain<BD: BitDepth>(
             }
         } else {
             if data.num_uv_points[0] == 0 {
-                memcpy(out.data[1], r#in.data[1], sz as usize);
+                memcpy(out.data.data[1], r#in.data.data[1], sz as usize);
             }
             if data.num_uv_points[1] == 0 {
-                memcpy(out.data[2], r#in.data[2], sz as usize);
+                memcpy(out.data.data[2], r#in.data.data[2], sz as usize);
             }
         }
     }
@@ -188,7 +188,7 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
     let ss_x = (r#in.p.layout != Rav1dPixelLayout::I444) as usize;
     let cpw = out.p.w as usize + ss_x >> ss_x;
     let is_id = seq_hdr.mtrx == RAV1D_MC_IDENTITY;
-    let luma_src = (r#in.data[0] as *mut BD::Pixel)
+    let luma_src = (r#in.data.data[0] as *mut BD::Pixel)
         .offset(((row * 32) as isize * BD::pxstride(r#in.stride[0] as usize) as isize) as isize);
     let bitdepth_max = (1 << out.p.bpc) - 1;
     let bd = BD::from_c(bitdepth_max);
@@ -196,7 +196,7 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
     if data.num_y_points != 0 {
         let bh = cmp::min(out.p.h as usize - row * 32, 32);
         dsp.fgy_32x32xn.call(
-            (out.data[0] as *mut BD::Pixel).offset(
+            (out.data.data[0] as *mut BD::Pixel).offset(
                 ((row * 32) as isize * BD::pxstride(out.stride[0] as usize) as isize) as isize,
             ),
             luma_src.cast(),
@@ -230,8 +230,8 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
     if data.chroma_scaling_from_luma {
         for pl in 0..2 {
             dsp.fguv_32x32xn[r#in.p.layout.try_into().unwrap()].call(
-                (out.data[1 + pl] as *mut BD::Pixel).offset(uv_off as isize),
-                (r#in.data[1 + pl] as *const BD::Pixel).offset(uv_off as isize),
+                (out.data.data[1 + pl] as *mut BD::Pixel).offset(uv_off as isize),
+                (r#in.data.data[1 + pl] as *const BD::Pixel).offset(uv_off as isize),
                 r#in.stride[1],
                 data,
                 cpw,
@@ -250,8 +250,8 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
         for pl in 0..2 {
             if data.num_uv_points[pl] != 0 {
                 dsp.fguv_32x32xn[r#in.p.layout.try_into().unwrap()].call(
-                    (out.data[1 + pl] as *mut BD::Pixel).offset(uv_off as isize),
-                    (r#in.data[1 + pl] as *const BD::Pixel).offset(uv_off as isize),
+                    (out.data.data[1 + pl] as *mut BD::Pixel).offset(uv_off as isize),
+                    (r#in.data.data[1 + pl] as *const BD::Pixel).offset(uv_off as isize),
                     r#in.stride[1],
                     data_c,
                     cpw,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -568,7 +568,7 @@ unsafe fn output_image(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRes
     }
     rav1d_thread_picture_unref(r#in);
 
-    if !c.all_layers && c.max_spatial_id && !(c.out.p.data[0]).is_null() {
+    if !c.all_layers && c.max_spatial_id && !(c.out.p.data.data[0]).is_null() {
         rav1d_thread_picture_move_ref(r#in, &mut c.out);
     }
     res
@@ -579,7 +579,7 @@ unsafe fn output_picture_ready(c: &mut Rav1dContext, drain: bool) -> bool {
         return true;
     }
     if !c.all_layers && c.max_spatial_id {
-        if !c.out.p.data[0].is_null() && !c.cache.p.data[0].is_null() {
+        if !c.out.p.data.data[0].is_null() && !c.cache.p.data.data[0].is_null() {
             if c.max_spatial_id == (c.cache.p.frame_hdr.as_ref().unwrap().spatial_id != 0)
                 || c.out.flags.contains(PictureFlags::NEW_TEMPORAL_UNIT)
             {
@@ -589,17 +589,17 @@ unsafe fn output_picture_ready(c: &mut Rav1dContext, drain: bool) -> bool {
             rav1d_thread_picture_move_ref(&mut c.cache, &mut c.out);
             return false;
         } else {
-            if !c.cache.p.data[0].is_null() && drain {
+            if !c.cache.p.data.data[0].is_null() && drain {
                 return true;
             } else {
-                if !c.out.p.data[0].is_null() {
+                if !c.out.p.data.data[0].is_null() {
                     rav1d_thread_picture_move_ref(&mut c.cache, &mut c.out);
                     return false;
                 }
             }
         }
     }
-    !c.out.p.data[0].is_null()
+    !c.out.p.data.data[0].is_null()
 }
 
 unsafe fn drain_picture(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dResult {
@@ -618,7 +618,7 @@ unsafe fn drain_picture(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRe
         }
         let out_delayed: *mut Rav1dThreadPicture =
             &mut *(c.frame_thread.out_delayed).offset(next as isize) as *mut Rav1dThreadPicture;
-        if !((*out_delayed).p.data[0]).is_null()
+        if !((*out_delayed).p.data.data[0]).is_null()
             || (*f).task_thread.error.load(Ordering::SeqCst) != 0
         {
             let first: c_uint = c.task_thread.first.load(Ordering::SeqCst);
@@ -653,7 +653,7 @@ unsafe fn drain_picture(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRe
             rav1d_thread_picture_unref(out_delayed);
             return error;
         }
-        if !((*out_delayed).p.data[0]).is_null() {
+        if !((*out_delayed).p.data.data[0]).is_null() {
             let progress = (*out_delayed).progress.as_ref().unwrap()[1].load(Ordering::Relaxed);
             if ((*out_delayed).visible || c.output_invisible_frames) && progress != FRAME_ERROR {
                 rav1d_thread_picture_ref(&mut c.out, out_delayed);

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2506,7 +2506,7 @@ unsafe fn parse_obus(
                 }
                 _ => {}
             }
-            if c.refs[frame_hdr.existing_frame_idx as usize].p.p.data[0].is_null() {
+            if c.refs[frame_hdr.existing_frame_idx as usize].p.p.data.data[0].is_null() {
                 return Err(EINVAL);
             }
             if c.strict_std_compliance && !c.refs[frame_hdr.existing_frame_idx as usize].p.showable
@@ -2544,7 +2544,7 @@ unsafe fn parse_obus(
                     );
                 }
                 let out_delayed = &mut *c.frame_thread.out_delayed.offset(next as isize);
-                if !(*out_delayed).p.data[0].is_null()
+                if !(*out_delayed).p.data.data[0].is_null()
                     || (*f).task_thread.error.load(Ordering::SeqCst) != 0
                 {
                     let first = c.task_thread.first.load(Ordering::SeqCst);
@@ -2569,7 +2569,7 @@ unsafe fn parse_obus(
                     (*f).task_thread.retval = Ok(());
                     c.cached_error_props = (*out_delayed).p.m.clone();
                     rav1d_thread_picture_unref(out_delayed);
-                } else if !((*out_delayed).p.data[0]).is_null() {
+                } else if !((*out_delayed).p.data.data[0]).is_null() {
                     let progress =
                         (*out_delayed).progress.as_ref().unwrap()[1].load(Ordering::Relaxed);
                     if ((*out_delayed).visible || c.output_invisible_frames)

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2094,7 +2094,7 @@ unsafe fn mc<BD: BitDepth>(
         let dy = by * v_mul + (mvy >> 3 + ss_ver);
         let w;
         let h;
-        if (*refp).p.data[0] != (*f).cur.data[0] {
+        if (*refp).p.data.data[0] != (*f).cur.data.data[0] {
             w = (*f).cur.p.w + ss_hor >> ss_hor;
             h = (*f).cur.p.h + ss_ver >> ss_ver;
         } else {
@@ -2119,7 +2119,7 @@ unsafe fn mc<BD: BitDepth>(
                 (192 as c_int as c_ulong)
                     .wrapping_mul(::core::mem::size_of::<BD::Pixel>() as c_ulong)
                     as ptrdiff_t,
-                (*refp).p.data[pl as usize].cast(),
+                (*refp).p.data.data[pl as usize].cast(),
                 ref_stride,
             );
             r#ref = &mut *emu_edge_buf
@@ -2129,7 +2129,7 @@ unsafe fn mc<BD: BitDepth>(
                 .wrapping_mul(::core::mem::size_of::<BD::Pixel>() as c_ulong)
                 as ptrdiff_t;
         } else {
-            r#ref = ((*refp).p.data[pl as usize] as *mut BD::Pixel)
+            r#ref = ((*refp).p.data.data[pl as usize] as *mut BD::Pixel)
                 .offset(BD::pxstride(ref_stride as usize) as isize * dy as isize)
                 .offset(dx as isize);
         }
@@ -2211,7 +2211,7 @@ unsafe fn mc<BD: BitDepth>(
                 (320 as c_int as c_ulong)
                     .wrapping_mul(::core::mem::size_of::<BD::Pixel>() as c_ulong)
                     as ptrdiff_t,
-                (*refp).p.data[pl as usize].cast(),
+                (*refp).p.data.data[pl as usize].cast(),
                 ref_stride,
             );
             r#ref = &mut *emu_edge_buf.offset((320 * 3 + 3) as isize) as *mut BD::Pixel;
@@ -2222,7 +2222,7 @@ unsafe fn mc<BD: BitDepth>(
                 printf(b"Emu\n\0" as *const u8 as *const c_char);
             }
         } else {
-            r#ref = ((*refp).p.data[pl as usize] as *mut BD::Pixel)
+            r#ref = ((*refp).p.data.data[pl as usize] as *mut BD::Pixel)
                 .offset(BD::pxstride(ref_stride as usize) as isize * top as isize)
                 .offset(left as isize);
         }
@@ -2457,7 +2457,7 @@ unsafe fn warp_affine<BD: BitDepth>(
                     (32 as c_int as c_ulong)
                         .wrapping_mul(::core::mem::size_of::<BD::Pixel>() as c_ulong)
                         as ptrdiff_t,
-                    (*refp).p.data[pl as usize].cast(),
+                    (*refp).p.data.data[pl as usize].cast(),
                     ref_stride,
                 );
                 ref_ptr = &mut *emu_edge_buf.offset((32 * 3 + 3) as isize) as *mut BD::Pixel;
@@ -2465,7 +2465,7 @@ unsafe fn warp_affine<BD: BitDepth>(
                     .wrapping_mul(::core::mem::size_of::<BD::Pixel>() as c_ulong)
                     as ptrdiff_t;
             } else {
-                ref_ptr = ((*refp).p.data[pl as usize] as *mut BD::Pixel)
+                ref_ptr = ((*refp).p.data.data[pl as usize] as *mut BD::Pixel)
                     .offset((BD::pxstride(ref_stride as usize) as isize * dy as isize) as isize)
                     .offset(dx as isize);
             }
@@ -2555,7 +2555,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
         let mut init_x = 0;
         while init_x < w4 {
             if b.c2rust_unnamed.c2rust_unnamed.pal_sz[0] != 0 {
-                let dst: *mut BD::Pixel = ((*f).cur.data[0] as *mut BD::Pixel).offset(
+                let dst: *mut BD::Pixel = ((*f).cur.data.data[0] as *mut BD::Pixel).offset(
                     (4 * (t.by as isize * BD::pxstride((*f).cur.stride[0] as usize) as isize
                         + t.bx as isize)) as isize,
                 );
@@ -2621,7 +2621,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
             y = init_y;
             t.by += init_y;
             while y < sub_h4 {
-                let mut dst: *mut BD::Pixel = ((*f).cur.data[0] as *mut BD::Pixel).offset(
+                let mut dst: *mut BD::Pixel = ((*f).cur.data.data[0] as *mut BD::Pixel).offset(
                     (4 * (t.by as isize * BD::pxstride((*f).cur.stride[0] as usize) as isize
                         + t.bx as isize
                         + init_x as isize)) as isize,
@@ -2821,7 +2821,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         unreachable!();
                     }
                     let ac = &mut t.scratch.c2rust_unnamed_0.ac;
-                    let y_src: *mut BD::Pixel = ((*f).cur.data[0] as *mut BD::Pixel)
+                    let y_src: *mut BD::Pixel = ((*f).cur.data.data[0] as *mut BD::Pixel)
                         .offset((4 * (t.bx & !ss_hor)) as isize)
                         .offset(
                             ((4 * (t.by & !ss_ver)) as isize
@@ -2832,8 +2832,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         * ((t.bx >> ss_hor) as isize
                             + (t.by >> ss_ver) as isize * BD::pxstride(stride as usize) as isize);
                     let uv_dst: [*mut BD::Pixel; 2] = [
-                        ((*f).cur.data[1] as *mut BD::Pixel).offset(uv_off as isize),
-                        ((*f).cur.data[2] as *mut BD::Pixel).offset(uv_off as isize),
+                        ((*f).cur.data.data[1] as *mut BD::Pixel).offset(uv_off as isize),
+                        ((*f).cur.data.data[2] as *mut BD::Pixel).offset(uv_off as isize),
                     ];
                     let furthest_r =
                         (cw4 << ss_hor) + (*t_dim).w as c_int - 1 & !((*t_dim).w as c_int - 1);
@@ -2942,7 +2942,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             as *mut u8;
                     }
                     (*(*f).dsp).ipred.pal_pred.call::<BD>(
-                        ((*f).cur.data[1] as *mut BD::Pixel).offset(uv_dstoff as isize),
+                        ((*f).cur.data.data[1] as *mut BD::Pixel).offset(uv_dstoff as isize),
                         (*f).cur.stride[1],
                         (*pal.offset(1)).as_ptr(),
                         pal_idx,
@@ -2950,7 +2950,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         cbh4 * 4,
                     );
                     (*(*f).dsp).ipred.pal_pred.call::<BD>(
-                        ((*f).cur.data[2] as *mut BD::Pixel).offset(uv_dstoff as isize),
+                        ((*f).cur.data.data[2] as *mut BD::Pixel).offset(uv_dstoff as isize),
                         (*f).cur.stride[1],
                         (*pal.offset(2)).as_ptr(),
                         pal_idx,
@@ -2959,14 +2959,14 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     );
                     if DEBUG_BLOCK_INFO(&*f, t) && 0 != 0 {
                         hex_dump::<BD>(
-                            ((*f).cur.data[1] as *mut BD::Pixel).offset(uv_dstoff as isize),
+                            ((*f).cur.data.data[1] as *mut BD::Pixel).offset(uv_dstoff as isize),
                             BD::pxstride((*f).cur.stride[1] as usize),
                             cbw4 as usize * 4,
                             cbh4 as usize * 4,
                             "u-pal-pred",
                         );
                         hex_dump::<BD>(
-                            ((*f).cur.data[2] as *mut BD::Pixel).offset(uv_dstoff as isize),
+                            ((*f).cur.data.data[2] as *mut BD::Pixel).offset(uv_dstoff as isize),
                             BD::pxstride((*f).cur.stride[1] as usize),
                             cbw4 as usize * 4,
                             cbh4 as usize * 4,
@@ -3003,7 +3003,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     t.by += init_y;
                     while y < sub_ch4 {
                         let mut dst: *mut BD::Pixel =
-                            ((*f).cur.data[(1 + pl) as usize] as *mut BD::Pixel).offset(
+                            ((*f).cur.data.data[(1 + pl) as usize] as *mut BD::Pixel).offset(
                                 (4 * ((t.by >> ss_ver) as isize
                                     * BD::pxstride(stride as usize) as isize
                                     + (t.bx + init_x >> ss_hor) as isize))
@@ -3280,7 +3280,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
     let mut res;
     let cbh4 = bh4 + ss_ver >> ss_ver;
     let cbw4 = bw4 + ss_hor >> ss_hor;
-    let mut dst: *mut BD::Pixel = ((*f).cur.data[0] as *mut BD::Pixel).offset(
+    let mut dst: *mut BD::Pixel = ((*f).cur.data.data[0] as *mut BD::Pixel).offset(
         (4 * (t.by as isize * BD::pxstride((*f).cur.stride[0] as usize) as isize + t.bx as isize))
             as isize,
     );
@@ -3319,7 +3319,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
             while pl < 3 {
                 res = mc::<BD>(
                     t,
-                    ((*f).cur.data[pl as usize] as *mut BD::Pixel).offset(uvdstoff as isize),
+                    ((*f).cur.data.data[pl as usize] as *mut BD::Pixel).offset(uvdstoff as isize),
                     0 as *mut i16,
                     (*f).cur.stride[1],
                     bw4 << (bw4 == ss_hor) as c_int,
@@ -3544,7 +3544,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     while pl < 2 {
                         res = mc::<BD>(
                             t,
-                            ((*f).cur.data[(1 + pl) as usize] as *mut BD::Pixel)
+                            ((*f).cur.data.data[(1 + pl) as usize] as *mut BD::Pixel)
                                 .offset(uvdstoff as isize),
                             0 as *mut i16,
                             (*f).cur.stride[1],
@@ -3601,7 +3601,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     while pl < 2 {
                         res = mc::<BD>(
                             t,
-                            ((*f).cur.data[(1 + pl) as usize] as *mut BD::Pixel)
+                            ((*f).cur.data.data[(1 + pl) as usize] as *mut BD::Pixel)
                                 .offset(uvdstoff as isize)
                                 .offset(v_off as isize),
                             0 as *mut i16,
@@ -3647,7 +3647,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     while pl < 2 {
                         res = mc::<BD>(
                             t,
-                            ((*f).cur.data[(1 + pl) as usize] as *mut BD::Pixel)
+                            ((*f).cur.data.data[(1 + pl) as usize] as *mut BD::Pixel)
                                 .offset(uvdstoff as isize)
                                 .offset(h_off as isize),
                             0 as *mut i16,
@@ -3697,7 +3697,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 while pl < 2 {
                     res = mc::<BD>(
                         t,
-                        ((*f).cur.data[(1 + pl) as usize] as *mut BD::Pixel)
+                        ((*f).cur.data.data[(1 + pl) as usize] as *mut BD::Pixel)
                             .offset(uvdstoff as isize)
                             .offset(h_off as isize)
                             .offset(v_off as isize),
@@ -3738,7 +3738,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     while pl < 2 {
                         res = warp_affine::<BD>(
                             t,
-                            ((*f).cur.data[(1 + pl) as usize] as *mut BD::Pixel)
+                            ((*f).cur.data.data[(1 + pl) as usize] as *mut BD::Pixel)
                                 .offset(uvdstoff as isize),
                             0 as *mut i16,
                             (*f).cur.stride[1],
@@ -3763,7 +3763,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     while pl < 2 {
                         res = mc::<BD>(
                             t,
-                            ((*f).cur.data[(1 + pl) as usize] as *mut BD::Pixel)
+                            ((*f).cur.data.data[(1 + pl) as usize] as *mut BD::Pixel)
                                 .offset(uvdstoff as isize),
                             0 as *mut i16,
                             (*f).cur.stride[1],
@@ -3789,7 +3789,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                         {
                             res = obmc::<BD>(
                                 t,
-                                ((*f).cur.data[(1 + pl) as usize] as *mut BD::Pixel)
+                                ((*f).cur.data.data[(1 + pl) as usize] as *mut BD::Pixel)
                                     .offset(uvdstoff as isize),
                                 (*f).cur.stride[1],
                                 b_dim,
@@ -3855,7 +3855,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                                 .interintra_mode as c_int
                         }) as IntraPredMode;
                         let mut angle = 0;
-                        let uvdst: *mut BD::Pixel = ((*f).cur.data[(1 + pl) as usize]
+                        let uvdst: *mut BD::Pixel = ((*f).cur.data.data[(1 + pl) as usize]
                             as *mut BD::Pixel)
                             .offset(uvdstoff as isize);
                         let mut top_sb_edge: *const BD::Pixel = 0 as *const BD::Pixel;
@@ -4152,8 +4152,9 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     }
                     i += 1;
                 }
-                let uvdst: *mut BD::Pixel =
-                    ((*f).cur.data[(1 + pl) as usize] as *mut BD::Pixel).offset(uvdstoff as isize);
+                let uvdst: *mut BD::Pixel = ((*f).cur.data.data[(1 + pl) as usize]
+                    as *mut BD::Pixel)
+                    .offset(uvdstoff as isize);
                 match b.c2rust_unnamed.c2rust_unnamed_0.comp_type as c_int {
                     2 => {
                         ((*dsp).mc.avg)(
@@ -4221,7 +4222,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
         );
         if has_chroma != 0 {
             hex_dump::<BD>(
-                &mut *(*((*f).cur.data).as_ptr().offset(1) as *mut BD::Pixel)
+                &mut *(*((*f).cur.data.data).as_ptr().offset(1) as *mut BD::Pixel)
                     .offset(uvdstoff as isize),
                 (*f).cur.stride[1] as usize,
                 cbw4 as usize * 4,
@@ -4229,7 +4230,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 "u-pred",
             );
             hex_dump::<BD>(
-                &mut *(*((*f).cur.data).as_ptr().offset(2) as *mut BD::Pixel)
+                &mut *(*((*f).cur.data.data).as_ptr().offset(2) as *mut BD::Pixel)
                     .offset(uvdstoff as isize),
                 (*f).cur.stride[1] as usize,
                 cbw4 as usize * 4,
@@ -4320,7 +4321,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
             if has_chroma != 0 {
                 let mut pl = 0;
                 while pl < 2 {
-                    let mut uvdst: *mut BD::Pixel = ((*f).cur.data[(1 + pl) as usize]
+                    let mut uvdst: *mut BD::Pixel = ((*f).cur.data.data[(1 + pl) as usize]
                         as *mut BD::Pixel)
                         .offset(uvdstoff as isize)
                         .offset(
@@ -4672,7 +4673,7 @@ pub(crate) unsafe fn rav1d_backup_ipred_edge<BD: BitDepth>(t: &mut Rav1dTaskCont
     let sby = t.by >> (*f).sb_shift;
     let sby_off = (*f).sb128w * 128 * sby;
     let x_off = (*ts).tiling.col_start;
-    let y: *const BD::Pixel = ((*f).cur.data[0] as *const BD::Pixel)
+    let y: *const BD::Pixel = ((*f).cur.data.data[0] as *const BD::Pixel)
         .offset((x_off * 4) as isize)
         .offset(
             (((t.by + (*f).sb_step) * 4 - 1) as isize
@@ -4708,7 +4709,7 @@ pub(crate) unsafe fn rav1d_backup_ipred_edge<BD: BitDepth>(t: &mut Rav1dTaskCont
                         .unwrap(),
                 )[(sby_off + (x_off * 4 >> ss_hor)).try_into().unwrap()..],
                 &slice::from_raw_parts(
-                    (*f).cur.data[pl as usize].cast(),
+                    (*f).cur.data.data[pl as usize].cast(),
                     (uv_off + (4 * ((*ts).tiling.col_end - x_off) >> ss_hor) as isize)
                         .try_into()
                         .unwrap(),

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1281,7 +1281,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                 };
                 // Note that `progress.is_some() == c.n_fc > 1`.
                 let progress = &**f.sr_cur.progress.as_ref().unwrap();
-                if !(f.sr_cur.p.data[0]).is_null() {
+                if !(f.sr_cur.p.data.data[0]).is_null() {
                     progress[0].store(if error_0 != 0 { FRAME_ERROR } else { y }, Ordering::SeqCst);
                 }
                 f.frame_thread.entropy_progress.store(
@@ -1331,7 +1331,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
             // Note that `progress.is_some() == c.n_fc > 1`.
             if let Some(progress) = &f.sr_cur.progress {
                 // upon flush, this can be free'ed already
-                if !(f.sr_cur.p.data[0]).is_null() {
+                if !(f.sr_cur.p.data.data[0]).is_null() {
                     progress[1].store(
                         if error_0 != 0 { FRAME_ERROR } else { y_0 },
                         Ordering::SeqCst,

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -147,7 +147,7 @@ unsafe fn decode_rand(
     let mut p: Dav1dPicture = Dav1dPicture {
         seq_hdr: None,
         frame_hdr: None,
-        data: [0 as *mut c_void; 3],
+        data: Default::default(),
         stride: [0; 2],
         p: Dav1dPictureParameters {
             w: 0,
@@ -202,7 +202,7 @@ unsafe fn decode_all(
     let mut p: Dav1dPicture = Dav1dPicture {
         seq_hdr: None,
         frame_hdr: None,
-        data: [0 as *mut c_void; 3],
+        data: Default::default(),
         stride: [0; 2],
         p: Dav1dPictureParameters {
             w: 0,

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -56,7 +56,6 @@ use rav1d::include::dav1d::headers::DAV1D_OFF;
 use rav1d::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I400;
 use rav1d::include::dav1d::picture::Dav1dPicAllocator;
 use rav1d::include::dav1d::picture::Dav1dPicture;
-use rav1d::include::dav1d::picture::Dav1dPictureParameters;
 use rav1d::src::lib::dav1d_close;
 use rav1d::src::lib::dav1d_flush;
 use rav1d::src::lib::dav1d_get_picture;
@@ -143,40 +142,7 @@ unsafe fn decode_rand(
     fps: c_double,
 ) -> c_int {
     let mut res = 0;
-    let mut p: Dav1dPicture = Dav1dPicture {
-        seq_hdr: None,
-        frame_hdr: None,
-        data: Default::default(),
-        stride: [0; 2],
-        p: Dav1dPictureParameters {
-            w: 0,
-            h: 0,
-            layout: DAV1D_PIXEL_LAYOUT_I400,
-            bpc: 0,
-        },
-        m: Dav1dDataProps {
-            timestamp: 0,
-            duration: 0,
-            offset: 0,
-            size: 0,
-            user_data: Dav1dUserData {
-                data: None,
-                r#ref: None,
-            },
-        },
-        content_light: None,
-        mastering_display: None,
-        itut_t35: None,
-        reserved: [0; 4],
-        frame_hdr_ref: None,
-        seq_hdr_ref: None,
-        content_light_ref: None,
-        mastering_display_ref: None,
-        itut_t35_ref: None,
-        reserved_ref: [0; 4],
-        r#ref: None,
-        allocator_data: None,
-    };
+    let mut p = Default::default();
     let num_frames: c_int = xor128_rand() % (fps * 5 as c_double) as c_int;
     let mut i = 0;
     while i < num_frames {
@@ -198,40 +164,7 @@ unsafe fn decode_all(
     data: *mut Dav1dData,
 ) -> c_int {
     let mut res: c_int;
-    let mut p: Dav1dPicture = Dav1dPicture {
-        seq_hdr: None,
-        frame_hdr: None,
-        data: Default::default(),
-        stride: [0; 2],
-        p: Dav1dPictureParameters {
-            w: 0,
-            h: 0,
-            layout: DAV1D_PIXEL_LAYOUT_I400,
-            bpc: 0,
-        },
-        m: Dav1dDataProps {
-            timestamp: 0,
-            duration: 0,
-            offset: 0,
-            size: 0,
-            user_data: Dav1dUserData {
-                data: None,
-                r#ref: None,
-            },
-        },
-        content_light: None,
-        mastering_display: None,
-        itut_t35: None,
-        reserved: [0; 4],
-        frame_hdr_ref: None,
-        seq_hdr_ref: None,
-        content_light_ref: None,
-        mastering_display_ref: None,
-        itut_t35_ref: None,
-        reserved_ref: [0; 4],
-        r#ref: None,
-        allocator_data: None,
-    };
+    let mut p = Default::default();
     loop {
         res = decode_frame(&mut p, c, data);
         if res != 0 {

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -42,7 +42,6 @@ use rav1d::include::dav1d::common::Dav1dUserData;
 use rav1d::include::dav1d::data::Dav1dData;
 use rav1d::include::dav1d::dav1d::Dav1dContext;
 use rav1d::include::dav1d::dav1d::Dav1dLogger;
-use rav1d::include::dav1d::dav1d::Dav1dRef;
 use rav1d::include::dav1d::dav1d::Dav1dSettings;
 use rav1d::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
 use rav1d::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
@@ -175,7 +174,7 @@ unsafe fn decode_rand(
         mastering_display_ref: None,
         itut_t35_ref: None,
         reserved_ref: [0; 4],
-        r#ref: 0 as *mut Dav1dRef,
+        r#ref: None,
         allocator_data: None,
     };
     let num_frames: c_int = xor128_rand() % (fps * 5 as c_double) as c_int;
@@ -230,7 +229,7 @@ unsafe fn decode_all(
         mastering_display_ref: None,
         itut_t35_ref: None,
         reserved_ref: [0; 4],
-        r#ref: 0 as *mut Dav1dRef,
+        r#ref: None,
         allocator_data: None,
     };
     loop {

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -176,7 +176,7 @@ unsafe fn decode_rand(
         itut_t35_ref: None,
         reserved_ref: [0; 4],
         r#ref: 0 as *mut Dav1dRef,
-        allocator_data: 0 as *mut c_void,
+        allocator_data: None,
     };
     let num_frames: c_int = xor128_rand() % (fps * 5 as c_double) as c_int;
     let mut i = 0;
@@ -231,7 +231,7 @@ unsafe fn decode_all(
         itut_t35_ref: None,
         reserved_ref: [0; 4],
         r#ref: 0 as *mut Dav1dRef,
-        allocator_data: 0 as *mut c_void,
+        allocator_data: None,
     };
     loop {
         res = decode_frame(&mut p, c, data);

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -59,7 +59,6 @@ use rav1d::include::dav1d::common::Dav1dUserData;
 use rav1d::include::dav1d::data::Dav1dData;
 use rav1d::include::dav1d::dav1d::Dav1dContext;
 use rav1d::include::dav1d::dav1d::Dav1dLogger;
-use rav1d::include::dav1d::dav1d::Dav1dRef;
 use rav1d::include::dav1d::dav1d::Dav1dSettings;
 use rav1d::include::dav1d::dav1d::DAV1D_DECODEFRAMETYPE_ALL;
 use rav1d::include::dav1d::dav1d::DAV1D_INLOOPFILTER_NONE;
@@ -341,7 +340,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
         mastering_display_ref: None,
         itut_t35_ref: None,
         reserved_ref: [0; 4],
-        r#ref: 0 as *mut Dav1dRef,
+        r#ref: None,
         allocator_data: None,
     };
     let mut c: *mut Dav1dContext = 0 as *mut Dav1dContext;

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -75,7 +75,6 @@ use rav1d::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I420;
 use rav1d::include::dav1d::headers::DAV1D_PIXEL_LAYOUT_I444;
 use rav1d::include::dav1d::picture::Dav1dPicAllocator;
 use rav1d::include::dav1d::picture::Dav1dPicture;
-use rav1d::include::dav1d::picture::Dav1dPictureParameters;
 use rav1d::include::dav1d::picture::DAV1D_PICTURE_ALIGNMENT;
 use rav1d::src::lib::dav1d_close;
 use rav1d::src::lib::dav1d_data_unref;
@@ -309,40 +308,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
     };
     let mut in_0: *mut DemuxerContext = 0 as *mut DemuxerContext;
     let mut out: *mut MuxerContext = 0 as *mut MuxerContext;
-    let mut p: Dav1dPicture = Dav1dPicture {
-        seq_hdr: None,
-        frame_hdr: None,
-        data: Default::default(),
-        stride: [0; 2],
-        p: Dav1dPictureParameters {
-            w: 0,
-            h: 0,
-            layout: DAV1D_PIXEL_LAYOUT_I400,
-            bpc: 0,
-        },
-        m: Dav1dDataProps {
-            timestamp: 0,
-            duration: 0,
-            offset: 0,
-            size: 0,
-            user_data: Dav1dUserData {
-                data: None,
-                r#ref: None,
-            },
-        },
-        content_light: None,
-        mastering_display: None,
-        itut_t35: None,
-        reserved: [0; 4],
-        frame_hdr_ref: None,
-        seq_hdr_ref: None,
-        content_light_ref: None,
-        mastering_display_ref: None,
-        itut_t35_ref: None,
-        reserved_ref: [0; 4],
-        r#ref: None,
-        allocator_data: None,
-    };
+    let mut p = Default::default();
     let mut c: *mut Dav1dContext = 0 as *mut Dav1dContext;
     let mut data: Dav1dData = Dav1dData {
         data: None,

--- a/tools/output/md5.rs
+++ b/tools/output/md5.rs
@@ -21,6 +21,8 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
+use std::ptr;
+use std::ptr::NonNull;
 
 #[repr(C)]
 pub struct MuxerPriv {
@@ -540,7 +542,7 @@ unsafe extern "C" fn md5_write(md5: *mut MD5Context, p: *mut Dav1dPicture) -> c_
     let hbd = ((*p).p.bpc > 8) as c_int;
     let w = (*p).p.w;
     let h = (*p).p.h;
-    let mut yptr: *mut u8 = (*p).data[0] as *mut u8;
+    let mut yptr: *mut u8 = (*p).data[0].map_or_else(ptr::null_mut, NonNull::as_ptr) as *mut u8;
     let mut y = 0;
     while y < h {
         md5_update(md5, yptr, (w << hbd) as c_uint);
@@ -556,7 +558,8 @@ unsafe extern "C" fn md5_write(md5: *mut MD5Context, p: *mut Dav1dPicture) -> c_
         let ch = h + ss_ver >> ss_ver;
         let mut pl = 1;
         while pl <= 2 {
-            let mut uvptr: *mut u8 = (*p).data[pl as usize] as *mut u8;
+            let mut uvptr: *mut u8 =
+                (*p).data[pl as usize].map_or_else(ptr::null_mut, NonNull::as_ptr) as *mut u8;
             let mut y_0 = 0;
             while y_0 < ch {
                 md5_update(md5, uvptr, (cw << hbd) as c_uint);

--- a/tools/output/y4m2.rs
+++ b/tools/output/y4m2.rs
@@ -19,6 +19,8 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
+use std::ptr;
+use std::ptr::NonNull;
 
 #[repr(C)]
 pub struct MuxerPriv {
@@ -157,7 +159,7 @@ unsafe extern "C" fn y4m2_write(c: *mut Y4m2OutputContext, p: *mut Dav1dPicture)
     fprintf((*c).f, b"FRAME\n\0" as *const u8 as *const c_char);
     let mut ptr: *mut u8;
     let hbd = ((*p).p.bpc > 8) as c_int;
-    ptr = (*p).data[0] as *mut u8;
+    ptr = (*p).data[0].map_or_else(ptr::null_mut, NonNull::as_ptr) as *mut u8;
     let mut y = 0;
     loop {
         if !(y < (*p).p.h) {
@@ -186,7 +188,8 @@ unsafe extern "C" fn y4m2_write(c: *mut Y4m2OutputContext, p: *mut Dav1dPicture)
                         current_block = 13797916685926291137;
                         break;
                     }
-                    ptr = (*p).data[pl as usize] as *mut u8;
+                    ptr = (*p).data[pl as usize].map_or_else(ptr::null_mut, NonNull::as_ptr)
+                        as *mut u8;
                     let mut y_0 = 0;
                     while y_0 < ch {
                         if fwrite(ptr as *const c_void, (cw << hbd) as usize, 1, (*c).f) != 1 {


### PR DESCRIPTION
I've been trying to `Arc`ify this `Rav1dPictureData`, but keep running into a bug with `Rav1dFrameHeader`'s `Arc` getting corrupted and having a ref count `> isize::MAX`.  To narrow down a smaller change, this is a set of changes in preparation for the actual `Arc`ification that don't have any issues.