### PR TITLE
Replace remaining C atomic intrinsics with native Rust atomics

### DIFF
--- a/include/stdatomic.rs
+++ b/include/stdatomic.rs
@@ -1,5 +1,0 @@
-use std::ffi::c_int;
-use std::ffi::c_uint;
-
-pub type atomic_int = c_int;
-pub type atomic_uint = c_uint;

--- a/lib.rs
+++ b/lib.rs
@@ -24,7 +24,6 @@ pub mod include {
         pub mod headers;
         pub mod picture;
     } // mod dav1d
-    pub(crate) mod stdatomic;
 } // mod include
 pub mod src {
     pub mod align;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3921,7 +3921,7 @@ unsafe fn setup_tile(
     }
 
     if (*f.c).n_tc > 1 {
-        ts.progress.fill(row_sb_start as atomic_int);
+        ts.progress.fill_with(|| AtomicI32::new(row_sb_start));
     }
 }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4076,7 +4076,7 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(t: &mut Rav1dTaskContext) -> Result
             f.a.offset((off_2pass + col_sb128_start + tile_row * f.sb128w) as isize);
         for bx in (ts.tiling.col_start..ts.tiling.col_end).step_by(sb_step as usize) {
             t.bx = bx;
-            if ::core::intrinsics::atomic_load_acquire(c.flush) != 0 {
+            if c.flush.load(Ordering::Acquire) != 0 {
                 return Err(());
             }
             decode_sb(t, root_bl, c.intra_edge.root[root_bl as usize])?;
@@ -4114,7 +4114,7 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(t: &mut Rav1dTaskContext) -> Result
             .offset((sb128y * f.sb128w + col_sb128_start) as isize);
     for bx in (ts.tiling.col_start..ts.tiling.col_end).step_by(sb_step as usize) {
         t.bx = bx;
-        if ::core::intrinsics::atomic_load_acquire(c.flush) != 0 {
+        if c.flush.load(Ordering::Acquire) != 0 {
             return Err(());
         }
         let cdef_idx = &mut (*t.lf_mask).cdef_idx;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4873,9 +4873,9 @@ pub(crate) unsafe fn rav1d_decode_frame_exit(f: &mut Rav1dFrameContext, retval: 
     if let Some(frame_hdr) = &f.frame_hdr {
         if frame_hdr.refresh_context != 0 {
             if !f.out_cdf.progress.is_null() {
-                ::core::intrinsics::atomic_store_seqcst(
-                    f.out_cdf.progress,
+                (*f.out_cdf.progress).store(
                     if retval.is_ok() { 1 } else { TILE_ERROR as u32 },
+                    Ordering::SeqCst,
                 );
             }
             rav1d_cdf_thread_unref(&mut f.out_cdf);

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -21,8 +21,6 @@ use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
 use crate::include::dav1d::headers::RAV1D_MAX_SEGMENTS;
 use crate::include::dav1d::picture::Rav1dPicAllocator;
 use crate::include::dav1d::picture::Rav1dPicture;
-use crate::include::stdatomic::atomic_int;
-use crate::include::stdatomic::atomic_uint;
 use crate::src::align::*;
 use crate::src::cdef::Rav1dCdefDSPContext;
 use crate::src::cdf::CdfContext;
@@ -169,14 +167,14 @@ pub(crate) struct TaskThreadData_delayed_fg {
 pub(crate) struct TaskThreadData {
     pub lock: pthread_mutex_t,
     pub cond: pthread_cond_t,
-    pub first: atomic_uint,
+    pub first: AtomicU32,
     pub cur: c_uint,
     /// This is used for delayed reset of the task cur pointer when
     /// such operation is needed but the thread doesn't enter a critical
     /// section (typically when executing the next sbrow task locklessly).
     /// See [`crate::src::thread_task::reset_task_cur`].
-    pub reset_task_cur: atomic_uint,
-    pub cond_signaled: atomic_int,
+    pub reset_task_cur: AtomicU32,
+    pub cond_signaled: AtomicI32,
     pub delayed_fg: TaskThreadData_delayed_fg,
     pub inited: c_int,
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -161,7 +161,7 @@ pub(crate) struct TaskThreadData_delayed_fg {
     pub in_0: *const Rav1dPicture,
     pub out: *mut Rav1dPicture,
     pub type_0: TaskType,
-    pub progress: [atomic_int; 2], /* [0]=started, [1]=completed */
+    pub progress: [AtomicI32; 2], /* [0]=started, [1]=completed */
     pub grain: BitDepthUnion<Grain>,
 }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -540,7 +540,7 @@ pub struct Rav1dTileState {
     pub tiling: Rav1dTileState_tiling,
 
     // in sby units, TILE_ERROR after a decoding error
-    pub progress: [atomic_int; 2], /* 0: reconstruction, 1: entropy */
+    pub progress: [AtomicI32; 2], /* 0: reconstruction, 1: entropy */
     pub frame_thread: [Rav1dTileState_frame_thread; 2], /* 0: reconstruction, 1: entropy */
 
     // in fullpel units, [0] = Y, [1] = UV, used for progress requirements

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -219,10 +219,7 @@ pub struct Rav1dContext {
     pub(crate) in_0: Rav1dData,
     pub(crate) out: Rav1dThreadPicture,
     pub(crate) cache: Rav1dThreadPicture,
-    // flush is a pointer to prevent compiler errors about atomic_load()
-    // not taking const arguments
-    pub(crate) flush_mem: atomic_int,
-    pub(crate) flush: *mut atomic_int,
+    pub(crate) flush: AtomicI32,
     pub(crate) frame_thread: Rav1dContext_frame_thread,
 
     // task threading (refer to tc[] for per_thread thingies)

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2541,16 +2541,17 @@ unsafe fn parse_obus(
                 if !(*out_delayed).p.data[0].is_null()
                     || (*f).task_thread.error.load(Ordering::SeqCst) != 0
                 {
-                    let first = ::core::intrinsics::atomic_load_seqcst(&mut c.task_thread.first);
+                    let first = c.task_thread.first.load(Ordering::SeqCst);
                     if first + 1 < c.n_fc {
-                        ::core::intrinsics::atomic_xadd_seqcst(&mut c.task_thread.first, 1);
+                        c.task_thread.first.fetch_add(1, Ordering::SeqCst);
                     } else {
-                        ::core::intrinsics::atomic_store_seqcst(&mut c.task_thread.first, 0);
+                        c.task_thread.first.store(0, Ordering::SeqCst);
                     }
-                    ::core::intrinsics::atomic_cxchg_seqcst_seqcst(
-                        &mut c.task_thread.reset_task_cur,
+                    let _ = c.task_thread.reset_task_cur.compare_exchange(
                         first,
                         u32::MAX,
+                        Ordering::SeqCst,
+                        Ordering::SeqCst,
                     );
                     if c.task_thread.cur != 0 && c.task_thread.cur < c.n_fc {
                         c.task_thread.cur -= 1;

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -194,7 +194,7 @@ unsafe fn insert_tasks_between(
     cond_signal: c_int,
 ) {
     let ttd: *mut TaskThreadData = (*f).task_thread.ttd;
-    if ::core::intrinsics::atomic_load_seqcst((*(*f).c).flush) != 0 {
+    if (*(*f).c).flush.load(Ordering::SeqCst) != 0 {
         return;
     }
     if !(a.is_null() || (*a).next == b) {
@@ -804,7 +804,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
 
     pthread_mutex_lock(&mut (*ttd).lock);
     'outer: while !(*tc).task_thread.die {
-        if ::core::intrinsics::atomic_load_seqcst((*c).flush) != 0 {
+        if (*c).flush.load(Ordering::SeqCst) != 0 {
             park(tc, ttd);
             continue 'outer;
         }
@@ -1004,7 +1004,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
         pthread_mutex_unlock(&mut (*ttd).lock);
 
         'found_unlocked: loop {
-            let flush = ::core::intrinsics::atomic_load_seqcst((*c).flush);
+            let flush = (*c).flush.load(Ordering::SeqCst);
             let mut error_0 = (*f).task_thread.error.fetch_or(flush, Ordering::SeqCst) | flush;
 
             // run it

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -864,7 +864,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                     // pending Q, so maybe return the tasks, set init_done,
                     // and add to pending Q only then.
                     let p1 = (if !((*f).in_cdf.progress).is_null() {
-                        ::core::intrinsics::atomic_load_seqcst((*f).in_cdf.progress)
+                        (*(*f).in_cdf.progress).load(Ordering::SeqCst)
                     } else {
                         1 as c_int as c_uint
                     }) as c_int;
@@ -1040,7 +1040,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                         }
                         let res = rav1d_decode_frame_init(&mut *f);
                         let p1_3 = (if !((*f).in_cdf.progress).is_null() {
-                            ::core::intrinsics::atomic_load_seqcst((*f).in_cdf.progress)
+                            (*(*f).in_cdf.progress).load(Ordering::SeqCst)
                         } else {
                             1 as c_int as c_uint
                         }) as c_int;
@@ -1068,13 +1068,13 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                         }
                         let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
                         if frame_hdr.refresh_context != 0 && !(*f).task_thread.update_set {
-                            ::core::intrinsics::atomic_store_seqcst(
-                                (*f).out_cdf.progress,
+                            (*(*f).out_cdf.progress).store(
                                 (if res_0.is_err() {
                                     TILE_ERROR
                                 } else {
                                     1 as c_int
                                 }) as c_uint,
+                                Ordering::SeqCst,
                             );
                         }
                         if res_0.is_ok() {
@@ -1204,10 +1204,10 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                     );
                                 }
                                 if (*c).n_fc > 1 as c_uint {
-                                    ::core::intrinsics::atomic_store_seqcst(
-                                        (*f).out_cdf.progress,
+                                    (*(*f).out_cdf.progress).store(
                                         (if error_0 != 0 { TILE_ERROR } else { 1 as c_int })
                                             as c_uint,
+                                        Ordering::SeqCst,
                                     );
                                 }
                             }


### PR DESCRIPTION
Each commit in this PR replaces the atomic field(s) in an individual struct.

Closes #638.