### PR TITLE
`mod thread_task`: Replace raw pointer with references

### DIFF
--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -5653,12 +5653,12 @@ pub unsafe fn rav1d_cdf_thread_copy(dst: *mut CdfContext, src: *const CdfThreadC
 }
 
 pub unsafe fn rav1d_cdf_thread_alloc(
-    c: *mut Rav1dContext,
+    c: &Rav1dContext,
     cdf: *mut CdfThreadContext,
     have_frame_mt: c_int,
 ) -> Rav1dResult {
     (*cdf).r#ref = rav1d_ref_create_using_pool(
-        (*c).cdf_pool,
+        c.cdf_pool,
         (::core::mem::size_of::<CdfContext>()).wrapping_add(::core::mem::size_of::<AtomicU32>()),
     );
     if ((*cdf).r#ref).is_null() {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -173,37 +173,37 @@ unsafe fn reset_task_cur_async(ttd: &mut TaskThreadData, mut frame_idx: c_uint, 
 }
 
 unsafe fn insert_tasks_between(
-    f: *mut Rav1dFrameContext,
+    f: &mut Rav1dFrameContext,
     first: *mut Rav1dTask,
     last: *mut Rav1dTask,
     a: *mut Rav1dTask,
     b: *mut Rav1dTask,
     cond_signal: c_int,
 ) {
-    let ttd: &mut TaskThreadData = &mut *(*f).task_thread.ttd;
-    if (*(*f).c).flush.load(Ordering::SeqCst) != 0 {
+    let ttd: &mut TaskThreadData = &mut *f.task_thread.ttd;
+    if (*f.c).flush.load(Ordering::SeqCst) != 0 {
         return;
     }
     if !(a.is_null() || (*a).next == b) {
         unreachable!();
     }
     if a.is_null() {
-        (*f).task_thread.task_head = first;
+        f.task_thread.task_head = first;
     } else {
         (*a).next = first;
     }
     if b.is_null() {
-        (*f).task_thread.task_tail = last;
+        f.task_thread.task_tail = last;
     }
     (*last).next = b;
-    reset_task_cur(&*(*f).c, ttd, (*first).frame_idx);
+    reset_task_cur(&*f.c, ttd, (*first).frame_idx);
     if cond_signal != 0 && ttd.cond_signaled.fetch_or(1, Ordering::SeqCst) == 0 {
         pthread_cond_signal(&mut ttd.cond);
     }
 }
 
 unsafe fn insert_tasks(
-    f: *mut Rav1dFrameContext,
+    f: &mut Rav1dFrameContext,
     first: *mut Rav1dTask,
     last: *mut Rav1dTask,
     cond_signal: c_int,
@@ -211,7 +211,7 @@ unsafe fn insert_tasks(
     let mut t_ptr: *mut Rav1dTask;
     let mut prev_t: *mut Rav1dTask = 0 as *mut Rav1dTask;
     let mut current_block_34: u64;
-    t_ptr = (*f).task_thread.task_head;
+    t_ptr = f.task_thread.task_head;
     while !t_ptr.is_null() {
         if (*t_ptr).type_0 as c_uint == RAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint {
             if (*first).type_0 as c_uint > RAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint {
@@ -266,9 +266,9 @@ unsafe fn insert_tasks(
                     == RAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint)
                     as c_int;
                 let t_tile_idx =
-                    first.offset_from((*f).task_thread.tile_tasks[p as usize]) as c_long as c_int;
+                    first.offset_from(f.task_thread.tile_tasks[p as usize]) as c_long as c_int;
                 let p_tile_idx =
-                    t_ptr.offset_from((*f).task_thread.tile_tasks[p as usize]) as c_long as c_int;
+                    t_ptr.offset_from(f.task_thread.tile_tasks[p as usize]) as c_long as c_int;
                 if !(t_tile_idx != p_tile_idx) {
                     unreachable!();
                 }
@@ -286,38 +286,34 @@ unsafe fn insert_tasks(
 }
 
 #[inline]
-unsafe fn insert_task(f: *mut Rav1dFrameContext, t: *mut Rav1dTask, cond_signal: c_int) {
+unsafe fn insert_task(f: &mut Rav1dFrameContext, t: *mut Rav1dTask, cond_signal: c_int) {
     insert_tasks(f, t, t, cond_signal);
 }
 
 #[inline]
-unsafe fn add_pending(f: *mut Rav1dFrameContext, t: *mut Rav1dTask) {
-    pthread_mutex_lock(&mut (*f).task_thread.pending_tasks.lock);
+unsafe fn add_pending(f: &mut Rav1dFrameContext, t: *mut Rav1dTask) {
+    pthread_mutex_lock(&mut f.task_thread.pending_tasks.lock);
     (*t).next = 0 as *mut Rav1dTask;
-    if ((*f).task_thread.pending_tasks.head).is_null() {
-        (*f).task_thread.pending_tasks.head = t;
+    if (f.task_thread.pending_tasks.head).is_null() {
+        f.task_thread.pending_tasks.head = t;
     } else {
-        (*(*f).task_thread.pending_tasks.tail).next = t;
+        (*f.task_thread.pending_tasks.tail).next = t;
     }
-    (*f).task_thread.pending_tasks.tail = t;
-    (*f).task_thread
-        .pending_tasks_merge
-        .store(1, Ordering::SeqCst);
-    pthread_mutex_unlock(&mut (*f).task_thread.pending_tasks.lock);
+    f.task_thread.pending_tasks.tail = t;
+    f.task_thread.pending_tasks_merge.store(1, Ordering::SeqCst);
+    pthread_mutex_unlock(&mut f.task_thread.pending_tasks.lock);
 }
 
 #[inline]
-unsafe fn merge_pending_frame(f: *mut Rav1dFrameContext) -> c_int {
-    let merge = (*f).task_thread.pending_tasks_merge.load(Ordering::SeqCst);
+unsafe fn merge_pending_frame(f: &mut Rav1dFrameContext) -> c_int {
+    let merge = f.task_thread.pending_tasks_merge.load(Ordering::SeqCst);
     if merge != 0 {
-        pthread_mutex_lock(&mut (*f).task_thread.pending_tasks.lock);
-        let mut t: *mut Rav1dTask = (*f).task_thread.pending_tasks.head;
-        (*f).task_thread.pending_tasks.head = 0 as *mut Rav1dTask;
-        (*f).task_thread.pending_tasks.tail = 0 as *mut Rav1dTask;
-        (*f).task_thread
-            .pending_tasks_merge
-            .store(0, Ordering::SeqCst);
-        pthread_mutex_unlock(&mut (*f).task_thread.pending_tasks.lock);
+        pthread_mutex_lock(&mut f.task_thread.pending_tasks.lock);
+        let mut t: *mut Rav1dTask = f.task_thread.pending_tasks.head;
+        f.task_thread.pending_tasks.head = 0 as *mut Rav1dTask;
+        f.task_thread.pending_tasks.tail = 0 as *mut Rav1dTask;
+        f.task_thread.pending_tasks_merge.store(0, Ordering::SeqCst);
+        pthread_mutex_unlock(&mut f.task_thread.pending_tasks.lock);
         while !t.is_null() {
             let tmp: *mut Rav1dTask = (*t).next;
             insert_task(f, t, 0 as c_int);
@@ -339,48 +335,46 @@ unsafe fn merge_pending(c: &Rav1dContext) -> c_int {
 }
 
 unsafe fn create_filter_sbrow(
-    f: *mut Rav1dFrameContext,
+    f: &mut Rav1dFrameContext,
     pass: c_int,
     res_t: *mut *mut Rav1dTask,
 ) -> c_int {
-    let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+    let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
     let has_deblock =
         (frame_hdr.loopfilter.level_y[0] != 0 || frame_hdr.loopfilter.level_y[1] != 0) as c_int;
-    let seq_hdr = &***(*f).seq_hdr.as_ref().unwrap();
+    let seq_hdr = &***f.seq_hdr.as_ref().unwrap();
     let has_cdef = seq_hdr.cdef;
     let has_resize = (frame_hdr.size.width[0] != frame_hdr.size.width[1]) as c_int;
-    let has_lr = (*f).lf.restore_planes;
-    let mut tasks: *mut Rav1dTask = (*f).task_thread.tasks;
-    let uses_2pass = ((*(*f).c).n_fc > 1 as c_uint) as c_int;
-    let num_tasks = (*f).sbh * (1 + uses_2pass);
-    if num_tasks > (*f).task_thread.num_tasks {
+    let has_lr = f.lf.restore_planes;
+    let mut tasks: *mut Rav1dTask = f.task_thread.tasks;
+    let uses_2pass = ((*f.c).n_fc > 1 as c_uint) as c_int;
+    let num_tasks = f.sbh * (1 + uses_2pass);
+    if num_tasks > f.task_thread.num_tasks {
         let size: usize = (::core::mem::size_of::<Rav1dTask>()).wrapping_mul(num_tasks as usize);
-        tasks = realloc((*f).task_thread.tasks as *mut c_void, size) as *mut Rav1dTask;
+        tasks = realloc(f.task_thread.tasks as *mut c_void, size) as *mut Rav1dTask;
         if tasks.is_null() {
             return -(1 as c_int);
         }
         memset(tasks as *mut c_void, 0 as c_int, size);
-        (*f).task_thread.tasks = tasks;
-        (*f).task_thread.num_tasks = num_tasks;
+        f.task_thread.tasks = tasks;
+        f.task_thread.num_tasks = num_tasks;
     }
-    tasks = tasks.offset(((*f).sbh * (pass & 1)) as isize);
+    tasks = tasks.offset((f.sbh * (pass & 1)) as isize);
     if pass & 1 != 0 {
-        (*f).frame_thread.entropy_progress = AtomicI32::new(0);
+        f.frame_thread.entropy_progress = AtomicI32::new(0);
     } else {
-        let prog_sz = (((*f).sbh + 31 & !(31 as c_int)) >> 5) as usize;
-        (*f).frame_thread.frame_progress.clear();
-        (*f).frame_thread
+        let prog_sz = ((f.sbh + 31 & !(31 as c_int)) >> 5) as usize;
+        f.frame_thread.frame_progress.clear();
+        f.frame_thread
             .frame_progress
             .resize_with(prog_sz, || AtomicU32::new(0));
-        (*f).frame_thread.copy_lpf_progress.clear();
-        (*f).frame_thread
+        f.frame_thread.copy_lpf_progress.clear();
+        f.frame_thread
             .copy_lpf_progress
             .resize_with(prog_sz, || AtomicU32::new(0));
-        (*f).frame_thread
-            .deblock_progress
-            .store(0, Ordering::SeqCst);
+        f.frame_thread.deblock_progress.store(0, Ordering::SeqCst);
     }
-    (*f).frame_thread.next_tile_row[(pass & 1) as usize] = 0 as c_int;
+    f.frame_thread.next_tile_row[(pass & 1) as usize] = 0 as c_int;
     let t: *mut Rav1dTask = &mut *tasks.offset(0) as *mut Rav1dTask;
     (*t).sby = 0 as c_int;
     (*t).recon_progress = 1 as c_int;
@@ -396,34 +390,35 @@ unsafe fn create_filter_sbrow(
     } else {
         RAV1D_TASK_TYPE_RECONSTRUCTION_PROGRESS as c_int
     }) as TaskType;
-    (*t).frame_idx = f.offset_from((*(*f).c).fc) as c_long as c_int as c_uint;
+    (*t).frame_idx =
+        (f as *mut Rav1dFrameContext).offset_from((*f.c).fc) as c_long as c_int as c_uint;
     *res_t = t;
     return 0 as c_int;
 }
 
 pub(crate) unsafe fn rav1d_task_create_tile_sbrow(
-    f: *mut Rav1dFrameContext,
+    f: &mut Rav1dFrameContext,
     pass: c_int,
     _cond_signal: c_int,
 ) -> Rav1dResult {
-    let mut tasks: *mut Rav1dTask = (*f).task_thread.tile_tasks[0];
-    let uses_2pass = ((*(*f).c).n_fc > 1 as c_uint) as c_int;
-    let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+    let mut tasks: *mut Rav1dTask = f.task_thread.tile_tasks[0];
+    let uses_2pass = ((*f.c).n_fc > 1 as c_uint) as c_int;
+    let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
     let num_tasks = frame_hdr.tiling.cols * frame_hdr.tiling.rows;
     if pass < 2 {
         let alloc_num_tasks = num_tasks * (1 + uses_2pass);
-        if alloc_num_tasks > (*f).task_thread.num_tile_tasks {
+        if alloc_num_tasks > f.task_thread.num_tile_tasks {
             let size: usize =
                 (::core::mem::size_of::<Rav1dTask>()).wrapping_mul(alloc_num_tasks as usize);
-            tasks = realloc((*f).task_thread.tile_tasks[0] as *mut c_void, size) as *mut Rav1dTask;
+            tasks = realloc(f.task_thread.tile_tasks[0] as *mut c_void, size) as *mut Rav1dTask;
             if tasks.is_null() {
                 return Err(EGeneric);
             }
             memset(tasks as *mut c_void, 0 as c_int, size);
-            (*f).task_thread.tile_tasks[0] = tasks;
-            (*f).task_thread.num_tile_tasks = alloc_num_tasks;
+            f.task_thread.tile_tasks[0] = tasks;
+            f.task_thread.num_tile_tasks = alloc_num_tasks;
         }
-        (*f).task_thread.tile_tasks[1] = tasks.offset(num_tasks as isize);
+        f.task_thread.tile_tasks[1] = tasks.offset(num_tasks as isize);
     }
     tasks = tasks.offset((num_tasks * (pass & 1)) as isize);
     let mut pf_t: *mut Rav1dTask = 0 as *mut Rav1dTask;
@@ -433,10 +428,9 @@ pub(crate) unsafe fn rav1d_task_create_tile_sbrow(
     let mut prev_t: *mut Rav1dTask = 0 as *mut Rav1dTask;
     let mut tile_idx = 0;
     while tile_idx < num_tasks {
-        let ts: *mut Rav1dTileState =
-            &mut *((*f).ts).offset(tile_idx as isize) as *mut Rav1dTileState;
+        let ts: *mut Rav1dTileState = &mut *(f.ts).offset(tile_idx as isize) as *mut Rav1dTileState;
         let t: *mut Rav1dTask = &mut *tasks.offset(tile_idx as isize) as *mut Rav1dTask;
-        (*t).sby = (*ts).tiling.row_start >> (*f).sb_shift;
+        (*t).sby = (*ts).tiling.row_start >> f.sb_shift;
         if !pf_t.is_null() && (*t).sby != 0 {
             (*prev_t).next = pf_t;
             prev_t = pf_t;
@@ -450,7 +444,8 @@ pub(crate) unsafe fn rav1d_task_create_tile_sbrow(
         } else {
             RAV1D_TASK_TYPE_TILE_ENTROPY as c_int
         }) as TaskType;
-        (*t).frame_idx = f.offset_from((*(*f).c).fc) as c_long as c_int as c_uint;
+        (*t).frame_idx =
+            (f as *mut Rav1dFrameContext).offset_from((*f.c).fc) as c_long as c_int as c_uint;
         if !prev_t.is_null() {
             (*prev_t).next = t;
         }
@@ -462,31 +457,30 @@ pub(crate) unsafe fn rav1d_task_create_tile_sbrow(
         prev_t = pf_t;
     }
     (*prev_t).next = 0 as *mut Rav1dTask;
-    (*f).task_thread.done[(pass & 1) as usize].store(0, Ordering::SeqCst);
-    pthread_mutex_lock(&mut (*f).task_thread.pending_tasks.lock);
-    if !(((*f).task_thread.pending_tasks.head).is_null() || pass == 2) {
+    f.task_thread.done[(pass & 1) as usize].store(0, Ordering::SeqCst);
+    pthread_mutex_lock(&mut f.task_thread.pending_tasks.lock);
+    if !((f.task_thread.pending_tasks.head).is_null() || pass == 2) {
         unreachable!();
     }
-    if ((*f).task_thread.pending_tasks.head).is_null() {
-        (*f).task_thread.pending_tasks.head = &mut *tasks.offset(0) as *mut Rav1dTask;
+    if (f.task_thread.pending_tasks.head).is_null() {
+        f.task_thread.pending_tasks.head = &mut *tasks.offset(0) as *mut Rav1dTask;
     } else {
-        (*(*f).task_thread.pending_tasks.tail).next = &mut *tasks.offset(0) as *mut Rav1dTask;
+        (*f.task_thread.pending_tasks.tail).next = &mut *tasks.offset(0) as *mut Rav1dTask;
     }
-    (*f).task_thread.pending_tasks.tail = prev_t;
-    (*f).task_thread
-        .pending_tasks_merge
-        .store(1, Ordering::SeqCst);
-    (*f).task_thread.init_done.store(1, Ordering::SeqCst);
-    pthread_mutex_unlock(&mut (*f).task_thread.pending_tasks.lock);
+    f.task_thread.pending_tasks.tail = prev_t;
+    f.task_thread.pending_tasks_merge.store(1, Ordering::SeqCst);
+    f.task_thread.init_done.store(1, Ordering::SeqCst);
+    pthread_mutex_unlock(&mut f.task_thread.pending_tasks.lock);
     Ok(())
 }
 
-pub(crate) unsafe fn rav1d_task_frame_init(f: *mut Rav1dFrameContext) {
-    let c: &Rav1dContext = &*(*f).c;
-    (*f).task_thread.init_done.store(0, Ordering::SeqCst);
-    let t: *mut Rav1dTask = &mut (*f).task_thread.init_task;
+pub(crate) unsafe fn rav1d_task_frame_init(f: &mut Rav1dFrameContext) {
+    let c: &Rav1dContext = &*f.c;
+    f.task_thread.init_done.store(0, Ordering::SeqCst);
+    let t: *mut Rav1dTask = &mut f.task_thread.init_task;
     (*t).type_0 = RAV1D_TASK_TYPE_INIT;
-    (*t).frame_idx = f.offset_from(c.fc) as c_long as c_int as c_uint;
+    // TODO(SJC): add a frame context index so we don't have to rely on linear offsets
+    (*t).frame_idx = (f as *mut Rav1dFrameContext).offset_from(c.fc) as c_long as c_int as c_uint;
     (*t).sby = 0 as c_int;
     (*t).deblock_progress = 0 as c_int;
     (*t).recon_progress = (*t).deblock_progress;
@@ -526,7 +520,7 @@ unsafe fn ensure_progress(
         (*t).deblock_progress = 0 as c_int;
         (*t).recon_progress = (*t).deblock_progress;
         *target = (*t).sby;
-        add_pending(f, t);
+        add_pending(&mut *f, t);
         pthread_mutex_lock(&mut ttd.lock);
         return 1 as c_int;
     }
@@ -534,31 +528,31 @@ unsafe fn ensure_progress(
 }
 
 #[inline]
-unsafe fn check_tile(t: *mut Rav1dTask, f: *mut Rav1dFrameContext, frame_mt: c_int) -> c_int {
+unsafe fn check_tile(t: *mut Rav1dTask, f: &mut Rav1dFrameContext, frame_mt: c_int) -> c_int {
     let tp = ((*t).type_0 as c_uint == RAV1D_TASK_TYPE_TILE_ENTROPY as c_int as c_uint) as c_int;
-    let tile_idx = t.offset_from((*f).task_thread.tile_tasks[tp as usize]) as c_long as c_int;
-    let ts: *mut Rav1dTileState = &mut *((*f).ts).offset(tile_idx as isize) as *mut Rav1dTileState;
+    let tile_idx = t.offset_from(f.task_thread.tile_tasks[tp as usize]) as c_long as c_int;
+    let ts: *mut Rav1dTileState = &mut *(f.ts).offset(tile_idx as isize) as *mut Rav1dTileState;
     let p1 = (*ts).progress[tp as usize].load(Ordering::SeqCst);
     if p1 < (*t).sby {
         return 1 as c_int;
     }
     let mut error = (p1 == TILE_ERROR) as c_int;
-    error |= (*f).task_thread.error.fetch_or(error, Ordering::SeqCst);
+    error |= f.task_thread.error.fetch_or(error, Ordering::SeqCst);
     if error == 0 && frame_mt != 0 && tp == 0 {
         let p2 = (*ts).progress[1].load(Ordering::SeqCst);
         if p2 <= (*t).sby {
             return 1 as c_int;
         }
         error = (p2 == TILE_ERROR) as c_int;
-        error |= (*f).task_thread.error.fetch_or(error, Ordering::SeqCst);
+        error |= f.task_thread.error.fetch_or(error, Ordering::SeqCst);
     }
-    let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+    let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
     if error == 0 && frame_mt != 0 && !frame_hdr.frame_type.is_key_or_intra() {
-        let p: *const Rav1dThreadPicture = &mut (*f).sr_cur;
+        let p: *const Rav1dThreadPicture = &mut f.sr_cur;
         let ss_ver =
             ((*p).p.p.layout as c_uint == Rav1dPixelLayout::I420 as c_int as c_uint) as c_int;
-        let p_b: c_uint = (((*t).sby + 1) << (*f).sb_shift + 2) as c_uint;
-        let tile_sby = (*t).sby - ((*ts).tiling.row_start >> (*f).sb_shift);
+        let p_b: c_uint = (((*t).sby + 1) << f.sb_shift + 2) as c_uint;
+        let tile_sby = (*t).sby - ((*ts).tiling.row_start >> f.sb_shift);
         let lowest_px: *const [c_int; 2] =
             (*((*ts).lowest_pixel).offset(tile_sby as isize)).as_mut_ptr() as *const [c_int; 2];
         let mut current_block_14: u64;
@@ -583,18 +577,18 @@ unsafe fn check_tile(t: *mut Rav1dTask, f: *mut Rav1dFrameContext, frame_mt: c_i
                 if max == i32::MIN {
                     current_block_14 = 7651349459974463963;
                 } else {
-                    lowest = iclip(max, 1 as c_int, (*f).refp[n as usize].p.p.h) as c_uint;
+                    lowest = iclip(max, 1 as c_int, f.refp[n as usize].p.p.h) as c_uint;
                     current_block_14 = 2370887241019905314;
                 }
             }
             match current_block_14 {
                 2370887241019905314 => {
-                    let p3 = (*f).refp[n as usize].progress.as_ref().unwrap()[(tp == 0) as usize]
+                    let p3 = f.refp[n as usize].progress.as_ref().unwrap()[(tp == 0) as usize]
                         .load(Ordering::SeqCst);
                     if p3 < lowest {
                         return 1 as c_int;
                     }
-                    (*f).task_thread
+                    f.task_thread
                         .error
                         .fetch_or((p3 == FRAME_ERROR) as c_int, Ordering::SeqCst);
                 }
@@ -608,28 +602,28 @@ unsafe fn check_tile(t: *mut Rav1dTask, f: *mut Rav1dFrameContext, frame_mt: c_i
 }
 
 #[inline]
-unsafe fn get_frame_progress(f: *const Rav1dFrameContext) -> c_int {
+unsafe fn get_frame_progress(f: &Rav1dFrameContext) -> c_int {
     // Note that `progress.is_some() == c.n_fc > 1`.
-    let frame_prog = (*f)
+    let frame_prog = f
         .sr_cur
         .progress
         .as_ref()
         .map(|progress| progress[1].load(Ordering::SeqCst))
         .unwrap_or(0);
     if frame_prog >= FRAME_ERROR {
-        return (*f).sbh - 1;
+        return f.sbh - 1;
     }
-    let mut idx = (frame_prog >> (*f).sb_shift + 7) as c_int;
+    let mut idx = (frame_prog >> f.sb_shift + 7) as c_int;
     let mut prog;
     loop {
-        let val: c_uint = !((*f).frame_thread.frame_progress)[idx as usize].load(Ordering::SeqCst);
+        let val: c_uint = !(f.frame_thread.frame_progress)[idx as usize].load(Ordering::SeqCst);
         prog = if val != 0 { ctz(val) } else { 32 as c_int };
         if prog != 32 as c_int {
             break;
         }
         prog = 0 as c_int;
         idx += 1;
-        if !((idx as usize) < (*f).frame_thread.frame_progress.len()) {
+        if !((idx as usize) < f.frame_thread.frame_progress.len()) {
             break;
         }
     }
@@ -637,8 +631,8 @@ unsafe fn get_frame_progress(f: *const Rav1dFrameContext) -> c_int {
 }
 
 #[inline]
-unsafe fn abort_frame(f: *mut Rav1dFrameContext, error: Rav1dResult) {
-    (*f).task_thread.error.store(
+unsafe fn abort_frame(f: &mut Rav1dFrameContext, error: Rav1dResult) {
+    f.task_thread.error.store(
         if error == Err(EINVAL) {
             1 as c_int
         } else {
@@ -646,14 +640,14 @@ unsafe fn abort_frame(f: *mut Rav1dFrameContext, error: Rav1dResult) {
         },
         Ordering::SeqCst,
     );
-    (*f).task_thread.task_counter.store(0, Ordering::SeqCst);
-    (*f).task_thread.done[0].store(1, Ordering::SeqCst);
-    (*f).task_thread.done[1].store(1, Ordering::SeqCst);
-    let progress = &**(*f).sr_cur.progress.as_ref().unwrap();
+    f.task_thread.task_counter.store(0, Ordering::SeqCst);
+    f.task_thread.done[0].store(1, Ordering::SeqCst);
+    f.task_thread.done[1].store(1, Ordering::SeqCst);
+    let progress = &**f.sr_cur.progress.as_ref().unwrap();
     progress[0].store(FRAME_ERROR, Ordering::SeqCst);
     progress[1].store(FRAME_ERROR, Ordering::SeqCst);
-    rav1d_decode_frame_exit(&mut *f, error);
-    pthread_cond_signal(&mut (*f).task_thread.cond);
+    rav1d_decode_frame_exit(f, error);
+    pthread_cond_signal(&mut f.task_thread.cond);
 }
 
 #[inline]

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -79,7 +79,7 @@ unsafe fn rav1d_set_thread_name(name: *const c_char) {
 
 #[inline]
 unsafe fn reset_task_cur(
-    c: *const Rav1dContext,
+    c: &Rav1dContext,
     ttd: *mut TaskThreadData,
     mut frame_idx: c_uint,
 ) -> c_int {
@@ -94,12 +94,7 @@ unsafe fn reset_task_cur(
         }
         reset_frame_idx = u32::MAX;
     }
-    if (*ttd).cur == 0
-        && ((*((*c).fc).offset(first as isize))
-            .task_thread
-            .task_cur_prev)
-            .is_null()
-    {
+    if (*ttd).cur == 0 && ((*(c.fc).offset(first as isize)).task_thread.task_cur_prev).is_null() {
         return 0 as c_int;
     }
     if reset_frame_idx != u32::MAX {
@@ -121,19 +116,18 @@ unsafe fn reset_task_cur(
     match current_block {
         5399440093318478209 => {
             if frame_idx < first {
-                frame_idx = frame_idx.wrapping_add((*c).n_fc);
+                frame_idx = frame_idx.wrapping_add(c.n_fc);
             }
             min_frame_idx = cmp::min(reset_frame_idx, frame_idx);
             cur_frame_idx = first.wrapping_add((*ttd).cur);
-            if (*ttd).cur < (*c).n_fc && cur_frame_idx < min_frame_idx {
+            if (*ttd).cur < c.n_fc && cur_frame_idx < min_frame_idx {
                 return 0 as c_int;
             }
             (*ttd).cur = min_frame_idx.wrapping_sub(first);
-            while (*ttd).cur < (*c).n_fc {
-                if !((*((*c).fc)
-                    .offset(first.wrapping_add((*ttd).cur).wrapping_rem((*c).n_fc) as isize))
-                .task_thread
-                .task_head)
+            while (*ttd).cur < c.n_fc {
+                if !((*(c.fc).offset(first.wrapping_add((*ttd).cur).wrapping_rem(c.n_fc) as isize))
+                    .task_thread
+                    .task_head)
                     .is_null()
                 {
                     break;
@@ -144,11 +138,10 @@ unsafe fn reset_task_cur(
         _ => {}
     }
     let mut i: c_uint = (*ttd).cur;
-    while i < (*c).n_fc {
-        let ref mut fresh0 = (*((*c).fc)
-            .offset(first.wrapping_add(i).wrapping_rem((*c).n_fc) as isize))
-        .task_thread
-        .task_cur_prev;
+    while i < c.n_fc {
+        let ref mut fresh0 = (*(c.fc).offset(first.wrapping_add(i).wrapping_rem(c.n_fc) as isize))
+            .task_thread
+            .task_cur_prev;
         *fresh0 = 0 as *mut Rav1dTask;
         i = i.wrapping_add(1);
     }
@@ -203,7 +196,7 @@ unsafe fn insert_tasks_between(
         (*f).task_thread.task_tail = last;
     }
     (*last).next = b;
-    reset_task_cur((*f).c, ttd, (*first).frame_idx);
+    reset_task_cur(&*(*f).c, ttd, (*first).frame_idx);
     if cond_signal != 0 && (*ttd).cond_signaled.fetch_or(1, Ordering::SeqCst) == 0 {
         pthread_cond_signal(&mut (*ttd).cond);
     }
@@ -335,11 +328,11 @@ unsafe fn merge_pending_frame(f: *mut Rav1dFrameContext) -> c_int {
 }
 
 #[inline]
-unsafe fn merge_pending(c: *const Rav1dContext) -> c_int {
+unsafe fn merge_pending(c: &Rav1dContext) -> c_int {
     let mut res = 0;
     let mut i: c_uint = 0 as c_int as c_uint;
-    while i < (*c).n_fc {
-        res |= merge_pending_frame(&mut *((*c).fc).offset(i as isize));
+    while i < c.n_fc {
+        res |= merge_pending_frame(&mut *(c.fc).offset(i as isize));
         i = i.wrapping_add(1);
     }
     return res;
@@ -489,11 +482,11 @@ pub(crate) unsafe fn rav1d_task_create_tile_sbrow(
 }
 
 pub(crate) unsafe fn rav1d_task_frame_init(f: *mut Rav1dFrameContext) {
-    let c: *const Rav1dContext = (*f).c;
+    let c: &Rav1dContext = &*(*f).c;
     (*f).task_thread.init_done.store(0, Ordering::SeqCst);
     let t: *mut Rav1dTask = &mut (*f).task_thread.init_task;
     (*t).type_0 = RAV1D_TASK_TYPE_INIT;
-    (*t).frame_idx = f.offset_from((*c).fc) as c_long as c_int as c_uint;
+    (*t).frame_idx = f.offset_from(c.fc) as c_long as c_int as c_uint;
     (*t).sby = 0 as c_int;
     (*t).deblock_progress = 0 as c_int;
     (*t).recon_progress = (*t).deblock_progress;
@@ -501,11 +494,11 @@ pub(crate) unsafe fn rav1d_task_frame_init(f: *mut Rav1dFrameContext) {
 }
 
 pub(crate) unsafe fn rav1d_task_delayed_fg(
-    c: *mut Rav1dContext,
-    out: *mut Rav1dPicture,
-    in_0: *const Rav1dPicture,
+    c: &mut Rav1dContext,
+    out: &mut Rav1dPicture,
+    in_0: &Rav1dPicture,
 ) {
-    let ttd: *mut TaskThreadData = &mut (*c).task_thread;
+    let ttd: &mut TaskThreadData = &mut c.task_thread;
     (*ttd).delayed_fg.in_0 = in_0;
     (*ttd).delayed_fg.out = out;
     (*ttd).delayed_fg.type_0 = RAV1D_TASK_TYPE_FG_PREP;
@@ -664,7 +657,7 @@ unsafe fn abort_frame(f: *mut Rav1dFrameContext, error: Rav1dResult) {
 }
 
 #[inline]
-unsafe fn delayed_fg_task(c: *const Rav1dContext, ttd: *mut TaskThreadData) {
+unsafe fn delayed_fg_task(c: &Rav1dContext, ttd: *mut TaskThreadData) {
     let in_0 = (*ttd).delayed_fg.in_0;
     let out = (*ttd).delayed_fg.out;
     let mut off = 0;
@@ -685,7 +678,7 @@ unsafe fn delayed_fg_task(c: *const Rav1dContext, ttd: *mut TaskThreadData) {
                 #[cfg(feature = "bitdepth_8")]
                 8 => {
                     rav1d_prep_grain::<BitDepth8>(
-                        &(*((*c).dsp).as_ptr().offset(0)).fg,
+                        &(*(c.dsp).as_ptr().offset(0)).fg,
                         &mut *out,
                         &*in_0,
                         BitDepth8::select_mut(&mut (*ttd).delayed_fg.grain),
@@ -694,7 +687,7 @@ unsafe fn delayed_fg_task(c: *const Rav1dContext, ttd: *mut TaskThreadData) {
                 #[cfg(feature = "bitdepth_16")]
                 10 | 12 => {
                     rav1d_prep_grain::<BitDepth16>(
-                        &(*((*c).dsp).as_ptr().offset(off as isize)).fg,
+                        &(*(c.dsp).as_ptr().offset(off as isize)).fg,
                         &mut *out,
                         &*in_0,
                         BitDepth16::select_mut(&mut (*ttd).delayed_fg.grain),
@@ -731,7 +724,7 @@ unsafe fn delayed_fg_task(c: *const Rav1dContext, ttd: *mut TaskThreadData) {
             #[cfg(feature = "bitdepth_8")]
             8 => {
                 rav1d_apply_grain_row::<BitDepth8>(
-                    &(*((*c).dsp).as_ptr().offset(0)).fg,
+                    &(*(c.dsp).as_ptr().offset(0)).fg,
                     &mut *out,
                     &*in_0,
                     BitDepth8::select_mut(&mut (*ttd).delayed_fg.grain),
@@ -741,7 +734,7 @@ unsafe fn delayed_fg_task(c: *const Rav1dContext, ttd: *mut TaskThreadData) {
             #[cfg(feature = "bitdepth_16")]
             10 | 12 => {
                 rav1d_apply_grain_row::<BitDepth16>(
-                    &(*((*c).dsp).as_ptr().offset(off as isize)).fg,
+                    &(*(c.dsp).as_ptr().offset(off as isize)).fg,
                     &mut *out,
                     &*in_0,
                     BitDepth16::select_mut(&mut (*ttd).delayed_fg.grain),
@@ -774,7 +767,7 @@ unsafe fn delayed_fg_task(c: *const Rav1dContext, ttd: *mut TaskThreadData) {
 
 pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
     let tc: *mut Rav1dTaskContext = data as *mut Rav1dTaskContext;
-    let c: *const Rav1dContext = (*tc).c;
+    let c: &Rav1dContext = &*(*tc).c;
     let ttd: *mut TaskThreadData = (*tc).task_thread.ttd;
 
     rav1d_set_thread_name(b"dav1d-worker\0" as *const u8 as *const c_char);
@@ -791,7 +784,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
 
     pthread_mutex_lock(&mut (*ttd).lock);
     'outer: while !(*tc).task_thread.die {
-        if (*c).flush.load(Ordering::SeqCst) != 0 {
+        if c.flush.load(Ordering::SeqCst) != 0 {
             park(tc, ttd);
             continue 'outer;
         }
@@ -804,12 +797,12 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
         }
 
         let (f, t, mut prev_t) = 'found: {
-            if (*c).n_fc > 1 as c_uint {
+            if c.n_fc > 1 as c_uint {
                 // run init tasks second
-                'init_tasks: for i in 0..(*c).n_fc {
+                'init_tasks: for i in 0..c.n_fc {
                     let first = (*ttd).first.load(Ordering::SeqCst);
-                    let f = &mut *((*c).fc)
-                        .offset(first.wrapping_add(i).wrapping_rem((*c).n_fc) as isize);
+                    let f =
+                        &mut *(c.fc).offset(first.wrapping_add(i).wrapping_rem(c.n_fc) as isize);
                     if f.task_thread.init_done.load(Ordering::SeqCst) != 0 {
                         continue 'init_tasks;
                     }
@@ -842,10 +835,10 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                 }
             }
             // run decoding tasks last
-            while (*ttd).cur < (*c).n_fc {
+            while (*ttd).cur < c.n_fc {
                 let first_0 = (*ttd).first.load(Ordering::SeqCst);
-                let f = &mut *((*c).fc)
-                    .offset(first_0.wrapping_add((*ttd).cur).wrapping_rem((*c).n_fc) as isize);
+                let f = &mut *(c.fc)
+                    .offset(first_0.wrapping_add((*ttd).cur).wrapping_rem(c.n_fc) as isize);
                 merge_pending_frame(f);
                 let mut prev_t = f.task_thread.task_cur_prev.as_mut();
                 let mut next_t = if let Some(prev_t) = prev_t.as_deref_mut() {
@@ -864,7 +857,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                         {
                             // if not bottom sbrow of tile, this task will be re-added
                             // after it's finished
-                            if check_tile(t, f, ((*c).n_fc > 1 as c_uint) as c_int) == 0 {
+                            if check_tile(t, f, (c.n_fc > 1 as c_uint) as c_int) == 0 {
                                 break 'found (f, t, prev_t);
                             }
                         } else if t.recon_progress != 0 {
@@ -980,7 +973,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
         pthread_mutex_unlock(&mut (*ttd).lock);
 
         'found_unlocked: loop {
-            let flush = (*c).flush.load(Ordering::SeqCst);
+            let flush = c.flush.load(Ordering::SeqCst);
             let mut error_0 = f.task_thread.error.fetch_or(flush, Ordering::SeqCst) | flush;
 
             // run it
@@ -990,7 +983,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
             'fallthrough: loop {
                 match task_type {
                     RAV1D_TASK_TYPE_INIT => {
-                        if !((*c).n_fc > 1 as c_uint) {
+                        if !(c.n_fc > 1 as c_uint) {
                             unreachable!();
                         }
                         let res = rav1d_decode_frame_init(f);
@@ -1014,7 +1007,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                         continue 'outer;
                     }
                     RAV1D_TASK_TYPE_INIT_CDF => {
-                        if !((*c).n_fc > 1 as c_uint) {
+                        if !(c.n_fc > 1 as c_uint) {
                             unreachable!();
                         }
                         let mut res_0 = Err(EINVAL);
@@ -1033,7 +1026,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                             );
                         }
                         if res_0.is_ok() {
-                            if !((*c).n_fc > 1 as c_uint) {
+                            if !(c.n_fc > 1 as c_uint) {
                                 unreachable!();
                             }
                             let mut p_0 = 1;
@@ -1051,7 +1044,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                         Ordering::SeqCst,
                                     );
 
-                                    // Note that `progress.is_some() == (*c).n_fc > 1`.
+                                    // Note that `progress.is_some() == c.n_fc > 1`.
                                     let progress = &**f.sr_cur.progress.as_ref().unwrap();
                                     progress[(p_0 - 1) as usize]
                                         .store(FRAME_ERROR, Ordering::SeqCst);
@@ -1091,7 +1084,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                             &mut *(f.ts).offset(tile_idx as isize) as *mut Rav1dTileState;
                         (*tc).ts = ts_0;
                         (*tc).by = sby << f.sb_shift;
-                        let uses_2pass = ((*c).n_fc > 1 as c_uint) as c_int;
+                        let uses_2pass = (c.n_fc > 1 as c_uint) as c_int;
                         (*tc).frame_thread.pass = if uses_2pass == 0 {
                             0 as c_int
                         } else {
@@ -1115,7 +1108,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                             t.deps_skip = 0 as c_int;
                             if check_tile(t, f, uses_2pass) == 0 {
                                 (*ts_0).progress[p_1 as usize].store(progress, Ordering::SeqCst);
-                                reset_task_cur_async(ttd, t.frame_idx, (*c).n_fc);
+                                reset_task_cur_async(ttd, t.frame_idx, c.n_fc);
                                 if (*ttd).cond_signaled.fetch_or(1, Ordering::SeqCst) == 0 {
                                     pthread_cond_signal(&mut (*ttd).cond);
                                 }
@@ -1142,7 +1135,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                         &mut (*(f.ts).offset(frame_hdr.tiling.update as isize)).cdf,
                                     );
                                 }
-                                if (*c).n_fc > 1 as c_uint {
+                                if c.n_fc > 1 as c_uint {
                                     (*f.out_cdf.progress).store(
                                         (if error_0 != 0 { TILE_ERROR } else { 1 as c_int })
                                             as c_uint,
@@ -1210,7 +1203,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                 if error_0 != 0 { TILE_ERROR } else { sby + 1 },
                                 Ordering::SeqCst,
                             );
-                            reset_task_cur_async(ttd, t.frame_idx, (*c).n_fc);
+                            reset_task_cur_async(ttd, t.frame_idx, c.n_fc);
                             if (*ttd).cond_signaled.fetch_or(1, Ordering::SeqCst) == 0 {
                                 pthread_cond_signal(&mut (*ttd).cond);
                             }
@@ -1242,7 +1235,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                             if f.task_thread.error.load(Ordering::SeqCst) == 0 {
                                 (f.bd_fn.filter_sbrow_cdef)(&mut *tc, sby);
                             }
-                            reset_task_cur_async(ttd, t.frame_idx, (*c).n_fc);
+                            reset_task_cur_async(ttd, t.frame_idx, c.n_fc);
                             if (*ttd).cond_signaled.fetch_or(1, Ordering::SeqCst) == 0 {
                                 pthread_cond_signal(&mut (*ttd).cond);
                             }
@@ -1282,7 +1275,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                 break 'fallthrough;
             }
             // if task completed [typically LR], signal picture progress as per below
-            let uses_2pass_0 = ((*c).n_fc > 1 as c_uint) as c_int;
+            let uses_2pass_0 = (c.n_fc > 1 as c_uint) as c_int;
             let sbh = f.sbh;
             let sbsz = f.sb_step * 4;
             if t.type_0 as c_uint == RAV1D_TASK_TYPE_ENTROPY_PROGRESS as c_int as c_uint {
@@ -1292,7 +1285,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                 } else {
                     ((sby + 1) as c_uint).wrapping_mul(sbsz as c_uint)
                 };
-                // Note that `progress.is_some() == (*c).n_fc > 1`.
+                // Note that `progress.is_some() == c.n_fc > 1`.
                 let progress = &**f.sr_cur.progress.as_ref().unwrap();
                 if !(f.sr_cur.p.data[0]).is_null() {
                     progress[0].store(if error_0 != 0 { FRAME_ERROR } else { y }, Ordering::SeqCst);
@@ -1341,7 +1334,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
             } else {
                 ((sby + 1) as c_uint).wrapping_mul(sbsz as c_uint)
             };
-            // Note that `progress.is_some() == (*c).n_fc > 1`.
+            // Note that `progress.is_some() == c.n_fc > 1`.
             if let Some(progress) = &f.sr_cur.progress {
                 // upon flush, this can be free'ed already
                 if !(f.sr_cur.p.data[0]).is_null() {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -760,24 +760,24 @@ unsafe fn delayed_fg_task(c: &Rav1dContext, ttd: &mut TaskThreadData) {
 }
 
 pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
-    let tc: *mut Rav1dTaskContext = data as *mut Rav1dTaskContext;
-    let c: &Rav1dContext = &*(*tc).c;
-    let ttd: &mut TaskThreadData = &mut *(*tc).task_thread.ttd;
+    let tc: &mut Rav1dTaskContext = &mut *(data as *mut Rav1dTaskContext);
+    let c: &Rav1dContext = &*tc.c;
+    let ttd: &mut TaskThreadData = &mut *tc.task_thread.ttd;
 
     rav1d_set_thread_name(b"dav1d-worker\0" as *const u8 as *const c_char);
 
-    let park = |tc: *mut Rav1dTaskContext, ttd: &mut TaskThreadData| {
-        (*tc).task_thread.flushed = true;
-        pthread_cond_signal(&mut (*tc).task_thread.td.cond);
+    let park = |tc: &mut Rav1dTaskContext, ttd: &mut TaskThreadData| {
+        tc.task_thread.flushed = true;
+        pthread_cond_signal(&mut tc.task_thread.td.cond);
         // we want to be woken up next time progress is signaled
         ttd.cond_signaled.store(0, Ordering::SeqCst);
         pthread_cond_wait(&mut ttd.cond, &mut ttd.lock);
-        (*tc).task_thread.flushed = false;
+        tc.task_thread.flushed = false;
         reset_task_cur(c, ttd, u32::MAX);
     };
 
     pthread_mutex_lock(&mut ttd.lock);
-    'outer: while !(*tc).task_thread.die {
+    'outer: while !tc.task_thread.die {
         if c.flush.load(Ordering::SeqCst) != 0 {
             park(tc, ttd);
             continue 'outer;
@@ -971,7 +971,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
             let mut error_0 = f.task_thread.error.fetch_or(flush, Ordering::SeqCst) | flush;
 
             // run it
-            (*tc).f = f;
+            tc.f = f;
             let mut sby = t.sby;
             let mut task_type = t.type_0 as c_uint;
             'fallthrough: loop {
@@ -1076,10 +1076,10 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                             as c_long as c_int;
                         let ts_0: *mut Rav1dTileState =
                             &mut *(f.ts).offset(tile_idx as isize) as *mut Rav1dTileState;
-                        (*tc).ts = ts_0;
-                        (*tc).by = sby << f.sb_shift;
+                        tc.ts = ts_0;
+                        tc.by = sby << f.sb_shift;
                         let uses_2pass = (c.n_fc > 1 as c_uint) as c_int;
-                        (*tc).frame_thread.pass = if uses_2pass == 0 {
+                        tc.frame_thread.pass = if uses_2pass == 0 {
                             0 as c_int
                         } else {
                             1 as c_int
@@ -1088,7 +1088,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                                     as c_int
                         };
                         if error_0 == 0 {
-                            error_0 = match rav1d_decode_tile_sbrow(&mut *tc) {
+                            error_0 = match rav1d_decode_tile_sbrow(tc) {
                                 Ok(()) => 0,
                                 Err(()) => 1,
                             };
@@ -1118,7 +1118,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                             error_0 = f.task_thread.error.load(Ordering::SeqCst);
                             let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
                             if frame_hdr.refresh_context != 0
-                                && (*tc).frame_thread.pass <= 1
+                                && tc.frame_thread.pass <= 1
                                 && f.task_thread.update_set
                                 && frame_hdr.tiling.update == tile_idx
                             {
@@ -1227,7 +1227,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                         let seq_hdr = &***f.seq_hdr.as_ref().unwrap();
                         if seq_hdr.cdef != 0 {
                             if f.task_thread.error.load(Ordering::SeqCst) == 0 {
-                                (f.bd_fn.filter_sbrow_cdef)(&mut *tc, sby);
+                                (f.bd_fn.filter_sbrow_cdef)(tc, sby);
                             }
                             reset_task_cur_async(ttd, t.frame_idx, c.n_fc);
                             if ttd.cond_signaled.fetch_or(1, Ordering::SeqCst) == 0 {


### PR DESCRIPTION
Replaces raw pointers to the following types with references where possible in `thread_task.rs`:

- `Rav1dContext`
- `TaskThreadData`
- `Rav1dFrameContext`
- `Rav1dTaskContext`

