### PR TITLE
`struct Rav1dFrameContext_task_thread::lock`: Make a Rust `Mutex`

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -73,7 +73,6 @@ use crate::src::refmvs::refmvs_tile;
 use crate::src::refmvs::Rav1dRefmvsDSPContext;
 use crate::src::thread_data::thread_data;
 use atomig::Atomic;
-use libc::pthread_mutex_t;
 use libc::ptrdiff_t;
 use std::ffi::c_int;
 use std::ffi::c_uint;
@@ -430,7 +429,7 @@ impl Default for Rav1dFrameContext_task_thread_pending_tasks {
 
 #[repr(C)]
 pub(crate) struct Rav1dFrameContext_task_thread {
-    pub lock: pthread_mutex_t,
+    pub lock: Mutex<()>,
     pub cond: Condvar,
     pub ttd: *mut TaskThreadData,
     pub tasks: *mut Rav1dTask,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,10 +359,7 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
         let f: *mut Rav1dFrameContext =
             &mut *((*c).fc).offset(n as isize) as *mut Rav1dFrameContext;
         if (*c).n_tc > 1 as c_uint {
-            if pthread_mutex_init(&mut (*f).task_thread.lock, 0 as *const pthread_mutexattr_t) != 0
-            {
-                return error(c, c_out, &mut thread_attr);
-            }
+            (*f).task_thread.lock = Mutex::new(());
             (*f).task_thread.cond = Condvar::new();
             (*f).task_thread.pending_tasks = Default::default();
         }
@@ -965,7 +962,6 @@ unsafe fn close_internal(c_out: &mut *mut Rav1dContext, flush: c_int) {
         }
         if (*c).n_tc > 1 as c_uint {
             let _ = mem::take(&mut (*f).task_thread.pending_tasks); // TODO: remove when context is owned
-            pthread_mutex_destroy(&mut (*f).task_thread.lock);
         }
         mem::take(&mut (*f).frame_thread.frame_progress); // TODO: remove when context is owned
         mem::take(&mut (*f).frame_thread.copy_lpf_progress); // TODO: remove when context is owned


### PR DESCRIPTION
Replaces `Rav1dFrameContext_task_thread.lock` with a Rust instead of pthreads mutex. This lock does not cover any data but appears to be an alternative lock to the lock in TaskThreadData to reduce unnecessary contention.