### PR TITLE
`filter_sbrow_fn`: Add `&mut Rav1dTaskContext` arg

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4834,7 +4834,7 @@ unsafe fn rav1d_decode_frame_main(c: &Rav1dContext, f: &mut Rav1dFrameContext) -
             }
 
             // loopfilter + cdef + restoration
-            (f.bd_fn.filter_sbrow)(c, f, sby);
+            (f.bd_fn.filter_sbrow)(c, f, t, sby);
         }
     }
 

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1224,7 +1224,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                     }
                     RAV1D_TASK_TYPE_DEBLOCK_COLS => {
                         if f.task_thread.error.load(Ordering::SeqCst) == 0 {
-                            (f.bd_fn.filter_sbrow_deblock_cols)(c, f, sby);
+                            (f.bd_fn.filter_sbrow_deblock_cols)(c, f, tc, sby);
                         }
                         if ensure_progress(
                             ttd,
@@ -1243,7 +1243,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                     }
                     RAV1D_TASK_TYPE_DEBLOCK_ROWS => {
                         if f.task_thread.error.load(Ordering::SeqCst) == 0 {
-                            (f.bd_fn.filter_sbrow_deblock_rows)(c, f, sby);
+                            (f.bd_fn.filter_sbrow_deblock_rows)(c, f, tc, sby);
                         }
                         // signal deblock progress
                         let seq_hdr = &***f.seq_hdr.as_ref().unwrap();
@@ -1304,7 +1304,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                         let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
                         if frame_hdr.size.width[0] != frame_hdr.size.width[1] {
                             if f.task_thread.error.load(Ordering::SeqCst) == 0 {
-                                (f.bd_fn.filter_sbrow_resize)(c, f, sby);
+                                (f.bd_fn.filter_sbrow_resize)(c, f, tc, sby);
                             }
                         }
                         task_type = RAV1D_TASK_TYPE_LOOP_RESTORATION;
@@ -1314,7 +1314,7 @@ pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
                         if f.task_thread.error.load(Ordering::SeqCst) == 0
                             && f.lf.restore_planes != 0
                         {
-                            (f.bd_fn.filter_sbrow_lr)(c, f, sby);
+                            (f.bd_fn.filter_sbrow_lr)(c, f, tc, sby);
                         }
                         task_type = RAV1D_TASK_TYPE_RECONSTRUCTION_PROGRESS;
                         continue 'fallthrough;


### PR DESCRIPTION
We want to remove the `Rav1dTaskContext` borrow from `Rav1dFrameContext`, so we need to pass both context structures to filters.