### PR TITLE
`struct Rav1dTaskContext`: Remove `*const Rav1dContext` field

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -665,7 +665,6 @@ pub(crate) struct Rav1dTaskContext_task_thread {
 
 #[repr(C)]
 pub(crate) struct Rav1dTaskContext {
-    pub c: *const Rav1dContext,
     pub f: *const Rav1dFrameContext,
     pub ts: *mut Rav1dTileState,
     pub bx: c_int,
@@ -691,4 +690,13 @@ pub(crate) struct Rav1dTaskContext {
     pub tl_4x4_filter: Filter2d,
     pub frame_thread: Rav1dTaskContext_frame_thread,
     pub task_thread: Rav1dTaskContext_task_thread,
+}
+
+// TODO(SJC): This is a temporary struct to pass a single pointer that holds
+// both a Rav1dContext and Rav1dTaskContext to the start routine in
+// pthread_create. We need to pass the Rav1dTaskContext into the thread by value
+// and remove it from the context structure.
+pub(crate) struct Rav1dTaskContext_borrow<'c> {
+    pub c: &'c Rav1dContext,
+    pub tc: &'c mut Rav1dTaskContext,
 }

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -20,6 +20,7 @@ use crate::src::internal::Rav1dContext;
 use crate::src::internal::Rav1dFrameContext;
 use crate::src::internal::Rav1dTask;
 use crate::src::internal::Rav1dTaskContext;
+use crate::src::internal::Rav1dTaskContext_borrow;
 use crate::src::internal::Rav1dTileState;
 use crate::src::internal::TaskThreadData;
 use crate::src::internal::TaskThreadData_delayed_fg;
@@ -790,8 +791,7 @@ unsafe fn delayed_fg_task<'l, 'ttd: 'l>(
 }
 
 pub unsafe extern "C" fn rav1d_worker_task(data: *mut c_void) -> *mut c_void {
-    let tc: &mut Rav1dTaskContext = &mut *(data as *mut Rav1dTaskContext);
-    let c: &Rav1dContext = &*tc.c;
+    let Rav1dTaskContext_borrow { c, tc } = *Box::from_raw(data as *mut Rav1dTaskContext_borrow);
 
     // We clone the Arc here for the lifetime of this function to avoid an
     // immutable borrow of tc across the call to park


### PR DESCRIPTION
`Rav1dTaskContext` doesn't need to hold a pointer to its parent if we pass this borrow into the thread start function explicitly.