### PR TITLE
`Rav1dContext_frame_thread::out_delayed`: Make a `Box<[_]>`

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4952,7 +4952,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
         while !f.tiles.is_empty() {
             task_thread_lock = f.task_thread.cond.wait(task_thread_lock).unwrap();
         }
-        let out_delayed = &mut *c.frame_thread.out_delayed.offset(next as isize);
+        let out_delayed = &mut c.frame_thread.out_delayed[next as usize];
         if !out_delayed.p.data.data[0].is_null() || f.task_thread.error.load(Ordering::SeqCst) != 0
         {
             let first = c.task_thread.first.load(Ordering::SeqCst);

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -124,7 +124,7 @@ pub const RAV1D_TASK_TYPE_INIT: TaskType = 0;
 
 #[repr(C)]
 pub(crate) struct Rav1dContext_frame_thread {
-    pub out_delayed: *mut Rav1dThreadPicture,
+    pub out_delayed: Box<[Rav1dThreadPicture]>,
     pub next: c_uint,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,11 +345,11 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
         inited: 1,
     };
     (&mut (*c).task_thread as *mut Arc<TaskThreadData>).write(Arc::new(ttd));
-    if (*c).n_fc > 1 {
-        (*c).frame_thread.out_delayed = std::iter::repeat_with(Rav1dThreadPicture::default)
-            .take((*c).n_fc as usize)
-            .collect();
-    }
+    ptr::addr_of_mut!((*c).frame_thread.out_delayed).write(if (*c).n_fc > 1 {
+        (0..(*c).n_fc).map(|_| Default::default()).collect()
+    } else {
+        Box::new([])
+    });
     let mut n: c_uint = 0 as c_int as c_uint;
     while n < (*c).n_fc {
         let f: *mut Rav1dFrameContext =


### PR DESCRIPTION
* fixes https://github.com/memorysafety/rav1d/issues/707

the issue suggests this could be a `Vec<_>`, but because this allocation cannot grow a boxed slice seems more natural to me.

I tried to take this a bit further, but the code in `lib.rs` runs into serious borrow checker issues.