### PR TITLE
`Rav1dFrameContext_frame_thread::b`: Convert to `Vec`

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4529,7 +4529,6 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
         }
         if c.n_fc > 1 {
             freep(&mut f.frame_thread.cbi as *mut *mut CodedBlockInfo as *mut c_void);
-            f.frame_thread.b.clear();
             f.frame_thread
                 .b
                 .resize_with(num_sb128 as usize * 32 * 32, Default::default);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1453,7 +1453,7 @@ unsafe fn decode_b(
 
     let ts = &mut *t.ts;
     let f = &mut *t.f;
-    let decode_block_info = DEBUG_BLOCK_INFO(f, t);
+    let dbg = DEBUG_BLOCK_INFO(f, t);
     let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
     let mut b_mem = Default::default();
     let b = if t.frame_thread.pass != 0 {
@@ -1539,7 +1539,7 @@ unsafe fn decode_b(
                     t.warpmv.matrix[5] = b.matrix()[3] as i32 + 0x10000;
                     rav1d_set_affine_mv2d(bw4, bh4, *b.mv2d(), &mut t.warpmv, t.bx, t.by);
                     rav1d_get_shear_params(&mut t.warpmv);
-                    if decode_block_info {
+                    if dbg {
                         println!(
                             "[ {} {} {}\n  {} {} {} ]\n\
                             alpha={}, beta={}, gamma={}, deta={}, mv=y:{},x:{}",
@@ -1683,7 +1683,7 @@ unsafe fn decode_b(
                 }
             }
 
-            if decode_block_info {
+            if dbg {
                 println!("Post-segid[preskip;{}]: r={}", b.seg_id, ts.msac.rng);
             }
 
@@ -1704,7 +1704,7 @@ unsafe fn decode_b(
         b.skip_mode =
             rav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.skip_mode.0[smctx as usize])
                 as u8;
-        if decode_block_info {
+        if dbg {
             println!("Post-skipmode[{}]: r={}", b.skip_mode, ts.msac.rng);
         }
     } else {
@@ -1718,7 +1718,7 @@ unsafe fn decode_b(
         let sctx = (*t.a).skip[bx4 as usize] + t.l.skip[by4 as usize];
         b.skip =
             rav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.skip[sctx as usize]) as u8;
-        if decode_block_info {
+        if dbg {
             println!("Post-skip[{}]: r={}", b.skip, ts.msac.rng);
         }
     }
@@ -1780,7 +1780,7 @@ unsafe fn decode_b(
 
         seg = Some(&frame_hdr.segmentation.seg_data.d[b.seg_id as usize]);
 
-        if decode_block_info {
+        if dbg {
             println!("Post-segid[postskip;{}]: r={}", b.seg_id, ts.msac.rng);
         }
     }
@@ -1806,7 +1806,7 @@ unsafe fn decode_b(
                 *(t.cur_sb_cdef_idx_ptr).offset(idx + 3) = v;
             }
 
-            if decode_block_info {
+            if dbg {
                 println!(
                     "Post-cdef_idx[{}]: r={}",
                     *t.cur_sb_cdef_idx_ptr, ts.msac.rng
@@ -1845,7 +1845,7 @@ unsafe fn decode_b(
                 delta_q *= 1 << frame_hdr.delta.q.res_log2;
             }
             ts.last_qidx = iclip(ts.last_qidx + delta_q, 1, 255);
-            if have_delta_q && decode_block_info {
+            if have_delta_q && dbg {
                 println!(
                     "Post-delta_q[{}->{}]: r={}",
                     delta_q, ts.last_qidx, ts.msac.rng
@@ -1884,7 +1884,7 @@ unsafe fn decode_b(
                     }
                     ts.last_delta_lf[i] =
                         iclip(ts.last_delta_lf[i] as c_int + delta_lf, -63, 63) as i8;
-                    if have_delta_q && decode_block_info {
+                    if have_delta_q && dbg {
                         println!("Post-delta_lf[{}:{}]: r={}", i, delta_lf, ts.msac.rng);
                     }
                 }
@@ -1918,13 +1918,13 @@ unsafe fn decode_b(
             b.intra =
                 (!rav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.intra[ictx.into()]))
                     as u8;
-            if decode_block_info {
+            if dbg {
                 println!("Post-intra[{}]: r={}", b.intra, ts.msac.rng);
             }
         }
     } else if frame_hdr.allow_intrabc != 0 {
         b.intra = (!rav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.intrabc.0)) as u8;
-        if decode_block_info {
+        if dbg {
             println!("Post-intrabcflag[{}]: r={}", b.intra, ts.msac.rng);
         }
     } else {
@@ -1945,7 +1945,7 @@ unsafe fn decode_b(
             ymode_cdf,
             (N_INTRA_PRED_MODES - 1) as usize,
         ) as u8;
-        if decode_block_info {
+        if dbg {
             println!("Post-ymode[{}]: r={}", b.y_mode(), ts.msac.rng);
         }
 
@@ -1970,7 +1970,7 @@ unsafe fn decode_b(
                 uvmode_cdf,
                 (N_UV_INTRA_PRED_MODES as usize) - 1 - (!cfl_allowed as usize),
             ) as u8;
-            if decode_block_info {
+            if dbg {
                 println!("Post-uvmode[{}]: r={}", b.uv_mode(), ts.msac.rng);
             }
 
@@ -2009,7 +2009,7 @@ unsafe fn decode_b(
                 } else {
                     b.cfl_alpha_mut()[1] = 0;
                 }
-                if decode_block_info {
+                if dbg {
                     println!(
                         "Post-uvalphas[{}/{}]: r={}",
                         b.cfl_alpha()[0],
@@ -2037,7 +2037,7 @@ unsafe fn decode_b(
                     &mut ts.msac,
                     &mut ts.cdf.m.pal_y[sz_ctx as usize][pal_ctx],
                 );
-                if decode_block_info {
+                if dbg {
                     println!("Post-y_pal[{}]: r={}", use_y_pal, ts.msac.rng);
                 }
                 if use_y_pal {
@@ -2051,7 +2051,7 @@ unsafe fn decode_b(
                     &mut ts.msac,
                     &mut ts.cdf.m.pal_uv[pal_ctx as usize],
                 );
-                if decode_block_info {
+                if dbg {
                     println!("Post-uv_pal[{}]: r={}", use_uv_pal, ts.msac.rng);
                 }
                 if use_uv_pal {
@@ -2076,7 +2076,7 @@ unsafe fn decode_b(
                     rav1d_msac_decode_symbol_adapt4(&mut ts.msac, &mut ts.cdf.m.filter_intra.0, 4)
                         as i8;
             }
-            if decode_block_info {
+            if dbg {
                 println!(
                     "Post-filterintramode[{}/{}]: r={}",
                     b.y_mode(),
@@ -2109,7 +2109,7 @@ unsafe fn decode_b(
                 bw4,
                 bh4,
             );
-            if decode_block_info {
+            if dbg {
                 println!("Post-y-pal-indices: r={}", ts.msac.rng);
             }
         }
@@ -2137,7 +2137,7 @@ unsafe fn decode_b(
                 cbw4,
                 cbh4,
             );
-            if decode_block_info {
+            if dbg {
                 println!("Post-uv-pal-indices: r={}", ts.msac.rng);
             }
         }
@@ -2164,7 +2164,7 @@ unsafe fn decode_b(
                     t_dim = &dav1d_txfm_dimensions[b.tx() as usize];
                 }
             }
-            if decode_block_info {
+            if dbg {
                 println!("Post-tx[{}]: r={}", b.tx(), ts.msac.rng);
             }
             t_dim
@@ -2374,7 +2374,7 @@ unsafe fn decode_b(
         b.mv_mut()[0].x = ((src_left - t.bx * 4) * 8) as i16;
         b.mv_mut()[0].y = ((src_top - t.by * 4) * 8) as i16;
 
-        if decode_block_info {
+        if dbg {
             println!(
                 "Post-dmv[{}/{},ref={}/{}|{}/{}]: r={}",
                 b.mv()[0].y,
@@ -2439,7 +2439,7 @@ unsafe fn decode_b(
             let ctx = get_comp_ctx(&*t.a, &t.l, by4, bx4, have_top, have_left);
             let is_comp =
                 rav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.comp[ctx as usize]);
-            if decode_block_info {
+            if dbg {
                 println!("Post-compflag[{}]: r={}", is_comp, ts.msac.rng);
             }
             is_comp
@@ -2475,7 +2475,7 @@ unsafe fn decode_b(
             *b.mv_mut() = mvstack[0].mv.mv;
             fix_mv_precision(frame_hdr, &mut b.mv_mut()[0]);
             fix_mv_precision(frame_hdr, &mut b.mv_mut()[1]);
-            if decode_block_info {
+            if dbg {
                 println!(
                     "Post-skipmodeblock[mv=1:y={},x={},2:y={},x={},refs={}+{}",
                     b.mv()[0].y,
@@ -2551,7 +2551,7 @@ unsafe fn decode_b(
                     }
                 }
             }
-            if decode_block_info {
+            if dbg {
                 println!(
                     "Post-refs[{}/{}]: r={}",
                     b.r#ref()[0],
@@ -2580,7 +2580,7 @@ unsafe fn decode_b(
                 &mut ts.cdf.m.comp_inter_mode[ctx as usize],
                 N_COMP_INTER_PRED_MODES as usize - 1,
             ) as u8;
-            if decode_block_info {
+            if dbg {
                 println!(
                     "Post-compintermode[{},ctx={},n_mvs={}]: r={}",
                     b.inter_mode(),
@@ -2607,7 +2607,7 @@ unsafe fn decode_b(
                             &mut ts.cdf.m.drl_bit[drl_ctx_v2 as usize],
                         ) as u8;
                     }
-                    if decode_block_info {
+                    if dbg {
                         println!(
                             "Post-drlidx[{},n_mvs={}]: r={}",
                             b.drl_idx(),
@@ -2632,7 +2632,7 @@ unsafe fn decode_b(
                             &mut ts.cdf.m.drl_bit[drl_ctx_v3 as usize],
                         ) as u8;
                     }
-                    if decode_block_info {
+                    if dbg {
                         println!(
                             "Post-drlidx[{},n_mvs={}]: r={}",
                             b.drl_idx(),
@@ -2675,7 +2675,7 @@ unsafe fn decode_b(
             };
             assign_comp_mv(0);
             assign_comp_mv(1);
-            if decode_block_info {
+            if dbg {
                 println!(
                     "Post-residual_mv[1:y={},x={},2:y={},x={}]: r={}",
                     b.mv()[0].y,
@@ -2694,7 +2694,7 @@ unsafe fn decode_b(
                     &mut ts.msac,
                     &mut ts.cdf.m.mask_comp[mask_ctx as usize],
                 );
-                if decode_block_info {
+                if dbg {
                     println!(
                         "Post-segwedge_vs_jntavg[{},ctx={}]: r={}",
                         is_segwedge, mask_ctx, ts.msac.rng,
@@ -2727,7 +2727,7 @@ unsafe fn decode_b(
                             &mut ts.msac,
                             &mut ts.cdf.m.jnt_comp[jnt_ctx as usize],
                         ) as u8;
-                    if decode_block_info {
+                    if dbg {
                         println!(
                             "Post-jnt_comp[{},ctx={}[ac:{},ar:{},lc:{},lr:{}]]: r={}",
                             b.comp_type() == COMP_INTER_AVG,
@@ -2759,7 +2759,7 @@ unsafe fn decode_b(
                     *b.comp_type_mut() = COMP_INTER_SEG;
                 }
                 *b.mask_sign_mut() = rav1d_msac_decode_bool_equi(&mut ts.msac) as u8;
-                if decode_block_info {
+                if dbg {
                     println!(
                         "Post-seg/wedge[{},wedge_idx={},sign={}]: r={}",
                         b.comp_type() == COMP_INTER_WEDGE,
@@ -2816,7 +2816,7 @@ unsafe fn decode_b(
                         ) as i8;
                     }
                 }
-                if decode_block_info {
+                if dbg {
                     println!("Post-ref[{}]: r={}", b.r#ref()[0], ts.msac.rng);
                 }
             }
@@ -2905,7 +2905,7 @@ unsafe fn decode_b(
                     }
                 }
 
-                if decode_block_info {
+                if dbg {
                     println!(
                         "Post-intermode[{},drl={},mv=y:{},x:{},n_mvs={}]: r={}",
                         b.inter_mode(),
@@ -2946,7 +2946,7 @@ unsafe fn decode_b(
                     b.mv_mut()[0] = mvstack[0].mv.mv[0];
                     fix_mv_precision(frame_hdr, &mut b.mv_mut()[0]);
                 }
-                if decode_block_info {
+                if dbg {
                     println!(
                         "Post-intermode[{},drl={}]: r={}",
                         b.inter_mode(),
@@ -2960,7 +2960,7 @@ unsafe fn decode_b(
                     &mut ts.cdf.mv,
                     frame_hdr.force_integer_mv == 0,
                 );
-                if decode_block_info {
+                if dbg {
                     println!(
                         "Post-residualmv[mv=y:{},x:{}]: r={}",
                         b.mv()[0].y,
@@ -3000,7 +3000,7 @@ unsafe fn decode_b(
             } else {
                 *b.interintra_type_mut() = INTER_INTRA_NONE;
             }
-            if decode_block_info
+            if dbg
                 && seq_hdr.inter_intra != 0
                 && interintra_allowed_mask & (1 << bs) != 0
             {
@@ -3058,7 +3058,7 @@ unsafe fn decode_b(
                 if b.motion_mode() == MM_WARP as u8 {
                     has_subpel_filter = false;
                     t.warpmv = derive_warpmv(t, bw4, bh4, &mask, b.mv()[0], t.warpmv.clone());
-                    if decode_block_info {
+                    if dbg {
                         println!(
                             "[ {} {} {}\n  {} {} {} ]\n\
                             alpha={}, beta={}, gamma={}, deta={}, mv=y:{},x:{}",
@@ -3088,7 +3088,7 @@ unsafe fn decode_b(
                     }
                 }
 
-                if decode_block_info {
+                if dbg {
                     println!(
                         "Post-motionmode[{}]: r={} [mask: 0x{:x}/0x{:x}]",
                         b.motion_mode(),
@@ -3114,7 +3114,7 @@ unsafe fn decode_b(
                 ) as Dav1dFilterMode;
                 if seq_hdr.dual_filter != 0 {
                     let ctx2 = get_filter_ctx(&*t.a, &t.l, comp, true, b.r#ref()[0], by4, bx4);
-                    if decode_block_info {
+                    if dbg {
                         println!(
                             "Post-subpel_filter1[{},ctx={}]: r={}",
                             filter0, ctx1, ts.msac.rng,
@@ -3125,7 +3125,7 @@ unsafe fn decode_b(
                         &mut ts.cdf.m.filter.0[1][ctx2 as usize],
                         RAV1D_N_SWITCHABLE_FILTERS as usize - 1,
                     ) as Dav1dFilterMode;
-                    if decode_block_info {
+                    if dbg {
                         println!(
                             "Post-subpel_filter2[{},ctx={}]: r={}",
                             filter1, ctx2, ts.msac.rng,
@@ -3133,7 +3133,7 @@ unsafe fn decode_b(
                     }
                     [filter0, filter1]
                 } else {
-                    if decode_block_info {
+                    if dbg {
                         println!(
                             "Post-subpel_filter[{},ctx={}]: r={}",
                             filter0, ctx1, ts.msac.rng

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1620,7 +1620,7 @@ unsafe fn decode_b(
         if frame_hdr.segmentation.update_map == 0 {
             if !(f.prev_segmap).is_null() {
                 let seg_id = get_prev_frame_segid(
-                    f.frame_hdr.as_ref().unwrap(),
+                    frame_hdr,
                     t.by,
                     t.bx,
                     w4,
@@ -1648,7 +1648,7 @@ unsafe fn decode_b(
                 // temporal predicted seg_id
                 if !(f.prev_segmap).is_null() {
                     let seg_id = get_prev_frame_segid(
-                        f.frame_hdr.as_ref().unwrap(),
+                        frame_hdr,
                         t.by,
                         t.bx,
                         w4,
@@ -1739,7 +1739,7 @@ unsafe fn decode_b(
             // temporal predicted seg_id
             if !(f.prev_segmap).is_null() {
                 let seg_id = get_prev_frame_segid(
-                    f.frame_hdr.as_ref().unwrap(),
+                    frame_hdr,
                     t.by,
                     t.bx,
                     w4,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1619,15 +1619,8 @@ unsafe fn decode_b(
     if frame_hdr.segmentation.enabled != 0 {
         if frame_hdr.segmentation.update_map == 0 {
             if !(f.prev_segmap).is_null() {
-                let seg_id = get_prev_frame_segid(
-                    frame_hdr,
-                    t.by,
-                    t.bx,
-                    w4,
-                    h4,
-                    f.prev_segmap,
-                    f.b4_stride,
-                );
+                let seg_id =
+                    get_prev_frame_segid(frame_hdr, t.by, t.bx, w4, h4, f.prev_segmap, f.b4_stride);
                 if seg_id >= RAV1D_MAX_SEGMENTS.into() {
                     return Err(());
                 }
@@ -1738,15 +1731,8 @@ unsafe fn decode_b(
         } {
             // temporal predicted seg_id
             if !(f.prev_segmap).is_null() {
-                let seg_id = get_prev_frame_segid(
-                    frame_hdr,
-                    t.by,
-                    t.bx,
-                    w4,
-                    h4,
-                    f.prev_segmap,
-                    f.b4_stride,
-                );
+                let seg_id =
+                    get_prev_frame_segid(frame_hdr, t.by, t.bx, w4, h4, f.prev_segmap, f.b4_stride);
                 if seg_id >= RAV1D_MAX_SEGMENTS.into() {
                     return Err(());
                 }
@@ -3000,10 +2986,7 @@ unsafe fn decode_b(
             } else {
                 *b.interintra_type_mut() = INTER_INTRA_NONE;
             }
-            if dbg
-                && seq_hdr.inter_intra != 0
-                && interintra_allowed_mask & (1 << bs) != 0
-            {
+            if dbg && seq_hdr.inter_intra != 0 && interintra_allowed_mask & (1 << bs) != 0 {
                 println!(
                     "Post-interintra[t={},m={},w={}]: r={}",
                     b.interintra_type(),
@@ -4546,7 +4529,10 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
         }
         if c.n_fc > 1 {
             freep(&mut f.frame_thread.cbi as *mut *mut CodedBlockInfo as *mut c_void);
-            f.frame_thread.b = vec![Default::default(); num_sb128 as usize * 32 * 32].into(); // TODO: fallible allocation
+            f.frame_thread.b.clear();
+            f.frame_thread
+                .b
+                .resize_with(num_sb128 as usize * 32 * 32, Default::default);
             f.frame_thread.cbi =
                 malloc(::core::mem::size_of::<CodedBlockInfo>() * num_sb128 as usize * 32 * 32)
                     as *mut CodedBlockInfo;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4529,6 +4529,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
         }
         if c.n_fc > 1 {
             freep(&mut f.frame_thread.cbi as *mut *mut CodedBlockInfo as *mut c_void);
+            // TODO: Fallible allocation
             f.frame_thread
                 .b
                 .resize_with(num_sb128 as usize * 32 * 32, Default::default);

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -365,7 +365,7 @@ pub struct Rav1dFrameContext_frame_thread {
     pub frame_progress: Vec<AtomicU32>,
     pub copy_lpf_progress: Vec<AtomicU32>,
     // indexed using t->by * f->b4_stride + t->bx
-    pub b: *mut Av1Block,
+    pub b: Box<[Av1Block]>,
     pub cbi: *mut CodedBlockInfo,
     // indexed using (t->by >> 1) * (f->b4_stride >> 1) + (t->bx >> 1)
     pub pal: *mut [[u16; 8]; 3], /* [3 plane][8 idx] */

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -365,7 +365,7 @@ pub struct Rav1dFrameContext_frame_thread {
     pub frame_progress: Vec<AtomicU32>,
     pub copy_lpf_progress: Vec<AtomicU32>,
     // indexed using t->by * f->b4_stride + t->bx
-    pub b: Box<[Av1Block]>,
+    pub b: Vec<Av1Block>,
     pub cbi: *mut CodedBlockInfo,
     // indexed using (t->by >> 1) * (f->b4_stride >> 1) + (t->bx >> 1)
     pub pal: *mut [[u16; 8]; 3], /* [3 plane][8 idx] */

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -294,7 +294,6 @@ pub struct Av1Block_inter {
     pub tx_split1: u16,
 }
 
-#[derive(Clone, Copy)]
 #[repr(C)]
 pub union Av1Block_intra_inter {
     pub c2rust_unnamed: Av1Block_intra,

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -294,6 +294,7 @@ pub struct Av1Block_inter {
     pub tx_split1: u16,
 }
 
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub union Av1Block_intra_inter {
     pub c2rust_unnamed: Av1Block_intra,
@@ -308,7 +309,7 @@ impl Default for Av1Block_intra_inter {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 #[repr(C)]
 pub struct Av1Block {
     pub bl: u8,

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -309,7 +309,7 @@ impl Default for Av1Block_intra_inter {
     }
 }
 
-#[derive(Default, Clone)]
+#[derive(Default)]
 #[repr(C)]
 pub struct Av1Block {
     pub bl: u8,

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -309,7 +309,7 @@ impl Default for Av1Block_intra_inter {
     }
 }
 
-#[derive(Default, Clone, Copy)]
+#[derive(Default, Clone)]
 #[repr(C)]
 pub struct Av1Block {
     pub bl: u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,6 @@ use crate::src::internal::Rav1dTaskContext;
 use crate::src::internal::Rav1dTaskContext_borrow;
 use crate::src::internal::TaskThreadData;
 use crate::src::intra_edge::rav1d_init_mode_tree;
-use crate::src::levels::Av1Block;
 use crate::src::levels::BL_128X128;
 use crate::src::levels::BL_64X64;
 use crate::src::log::Rav1dLog as _;
@@ -952,7 +951,7 @@ impl Drop for Rav1dContext {
                         &mut (*f).tile_thread.lowest_pixel_mem as *mut *mut [[c_int; 2]; 7]
                             as *mut c_void,
                     );
-                    freep(&mut (*f).frame_thread.b as *mut *mut Av1Block as *mut c_void);
+                    mem::take(&mut (*f).frame_thread.b); // TODO: remove when context is owned
                     rav1d_freep_aligned(
                         &mut (*f).frame_thread.pal_idx as *mut *mut u8 as *mut c_void,
                     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -951,7 +951,7 @@ impl Drop for Rav1dContext {
                         &mut (*f).tile_thread.lowest_pixel_mem as *mut *mut [[c_int; 2]; 7]
                             as *mut c_void,
                     );
-                    mem::take(&mut (*f).frame_thread.b); // TODO: remove when context is owned
+                    let _ = mem::take(&mut (*f).frame_thread.b); // TODO: remove when context is owned
                     rav1d_freep_aligned(
                         &mut (*f).frame_thread.pal_idx as *mut *mut u8 as *mut c_void,
                     );

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -3577,13 +3577,13 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             (if t.frame_thread.pass != 2 as c_int {
                                 t.tl_4x4_filter as c_uint
                             } else {
-                                (*((*f).frame_thread.b).offset(
-                                    ((t.by - 1) as isize * (*f).b4_stride + t.bx as isize - 1)
-                                        as isize,
-                                ))
-                                .c2rust_unnamed
-                                .c2rust_unnamed_0
-                                .filter2d as c_uint
+                                (*f).frame_thread.b[((t.by - 1) as isize * (*f).b4_stride
+                                    + t.bx as isize
+                                    - 1)
+                                    as usize]
+                                    .c2rust_unnamed
+                                    .c2rust_unnamed_0
+                                    .filter2d as c_uint
                             }) as Filter2d,
                         );
                         if res != 0 {
@@ -3625,12 +3625,11 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             (if t.frame_thread.pass != 2 as c_int {
                                 left_filter_2d as c_uint
                             } else {
-                                (*((*f).frame_thread.b).offset(
-                                    (t.by as isize * (*f).b4_stride + t.bx as isize - 1) as isize,
-                                ))
-                                .c2rust_unnamed
-                                .c2rust_unnamed_0
-                                .filter2d as c_uint
+                                (*f).frame_thread.b
+                                    [(t.by as isize * (*f).b4_stride + t.bx as isize - 1) as usize]
+                                    .c2rust_unnamed
+                                    .c2rust_unnamed_0
+                                    .filter2d as c_uint
                             }) as Filter2d,
                         );
                         if res != 0 {
@@ -3680,12 +3679,12 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             (if t.frame_thread.pass != 2 as c_int {
                                 top_filter_2d as c_uint
                             } else {
-                                (*((*f).frame_thread.b).offset(
-                                    ((t.by - 1) as isize * (*f).b4_stride + t.bx as isize) as isize,
-                                ))
-                                .c2rust_unnamed
-                                .c2rust_unnamed_0
-                                .filter2d as c_uint
+                                (*f).frame_thread.b[((t.by - 1) as isize * (*f).b4_stride
+                                    + t.bx as isize)
+                                    as usize]
+                                    .c2rust_unnamed
+                                    .c2rust_unnamed_0
+                                    .filter2d as c_uint
                             }) as Filter2d,
                         );
                         if res != 0 {


### PR DESCRIPTION
Converting `b` to a `Box<[]>` means that in `decode_b` we now have a proper borrow of `f.frame_thread.b`, whereas before we had a raw pointer to the borrowed element. This triggered a number of borrowcheck errors since throughout the function we also pass a reference to `f` to different functions, causing a conflict with the mutable borrow of `f.frame_thread.b`. I was able to make some relatively minor changes to `decode_b` to resolve the borrow conflicts, but I'm not sure if the change to how `DEBUG_BLOCK_INFO` is called (i.e. calling it once at the beginning of the function and caching the result) preserves the original behavior. Since `DEBUG_BLOCK_INFO` is currently hard-coded to return false I figured it was more important to fix the borrow issue than to preserve how debug logging was being done, but let me know if there's a better solution.