### PR TITLE
`Rav1dFrameContext_frame_thread::pal`: Make into an aligned `Vec`

### DIFF
--- a/src/align.rs
+++ b/src/align.rs
@@ -38,6 +38,7 @@ impl_ArrayDefault!(u8);
 impl_ArrayDefault!(i8);
 impl_ArrayDefault!(i16);
 impl_ArrayDefault!(i32);
+impl_ArrayDefault!(u16);
 
 macro_rules! def_align {
     ($align:literal, $name:ident) => {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2262,7 +2262,7 @@ unsafe fn decode_b_inner(
                 let pal = if t.frame_thread.pass != 0 {
                     let index = ((t.by >> 1) + (t.bx & 1)) as isize * (f.b4_stride >> 1)
                         + ((t.bx >> 1) + (t.by & 1)) as isize;
-                    &f.frame_thread.pal[index as usize]
+                    &f.frame_thread.pal[index as usize].0
                 } else {
                     &t.scratch.c2rust_unnamed_0.pal
                 };

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2262,7 +2262,7 @@ unsafe fn decode_b_inner(
                 let pal = if t.frame_thread.pass != 0 {
                     let index = ((t.by >> 1) + (t.bx & 1)) as isize * (f.b4_stride >> 1)
                         + ((t.bx >> 1) + (t.by & 1)) as isize;
-                    &f.frame_thread.pal[index as usize].0
+                    &f.frame_thread.pal[index as usize]
                 } else {
                     &t.scratch.c2rust_unnamed_0.pal
                 };
@@ -4383,12 +4383,10 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
         }
 
         if frame_hdr.allow_screen_content_tools != 0 {
-            if num_sb128 as usize != f.frame_thread.pal_sz() {
-                // TODO: Fallible allocation
-                f.frame_thread
-                    .pal
-                    .resize_with(num_sb128 as usize * 16 * 16, Default::default);
-            }
+            // TODO: Fallible allocation
+            f.frame_thread
+                .pal
+                .resize(num_sb128 as usize * 16 * 16, Default::default());
 
             let pal_idx_sz = num_sb128 * size_mul[1] as c_int;
             if pal_idx_sz != f.frame_thread.pal_idx_sz {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4383,12 +4383,11 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
         }
 
         if frame_hdr.allow_screen_content_tools != 0 {
-            if num_sb128 != f.frame_thread.pal_sz {
+            if num_sb128 as usize != f.frame_thread.pal_sz() {
                 // TODO: Fallible allocation
                 f.frame_thread
                     .pal
                     .resize_with(num_sb128 as usize * 16 * 16, Default::default);
-                f.frame_thread.pal_sz = num_sb128;
             }
 
             let pal_idx_sz = num_sb128 * size_mul[1] as c_int;
@@ -4408,7 +4407,6 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
             let _ = mem::take(&mut f.frame_thread.pal);
             rav1d_freep_aligned(&mut f.frame_thread.pal_idx as *mut *mut u8 as *mut c_void);
             f.frame_thread.pal_idx_sz = 0;
-            f.frame_thread.pal_sz = f.frame_thread.pal_idx_sz;
         }
     }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -423,11 +423,16 @@ pub struct Rav1dFrameContext_frame_thread {
     // iterated over inside tile state
     pub pal_idx: *mut u8,
     pub cf: *mut DynCoef,
-    pub pal_sz: c_int,
     pub pal_idx_sz: c_int,
     pub cf_sz: c_int,
     // start offsets per tile
     pub tile_start_off: *mut u32,
+}
+
+impl Rav1dFrameContext_frame_thread {
+    pub fn pal_sz(&self) -> usize {
+        self.pal.len() / (16 * 16)
+    }
 }
 
 /// loopfilter

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -419,7 +419,7 @@ pub struct Rav1dFrameContext_frame_thread {
     pub b: Vec<Av1Block>,
     pub cbi: Vec<CodedBlockInfo>,
     // indexed using (t->by >> 1) * (f->b4_stride >> 1) + (t->bx >> 1)
-    pub pal: *mut [[u16; 8]; 3], /* [3 plane][8 idx] */
+    pub pal: Vec<[[u16; 8]; 3]>, /* [3 plane][8 idx] */
     // iterated over inside tile state
     pub pal_idx: *mut u8,
     pub cf: *mut DynCoef,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -419,7 +419,7 @@ pub struct Rav1dFrameContext_frame_thread {
     pub b: Vec<Av1Block>,
     pub cbi: Vec<CodedBlockInfo>,
     // indexed using (t->by >> 1) * (f->b4_stride >> 1) + (t->bx >> 1)
-    pub pal: Vec<[[u16; 8]; 3]>, /* [3 plane][8 idx] */
+    pub pal: Vec<Align64<[[u16; 8]; 3]>>, /* [3 plane][8 idx] */
     // iterated over inside tile state
     pub pal_idx: *mut u8,
     pub cf: *mut DynCoef,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -419,7 +419,7 @@ pub struct Rav1dFrameContext_frame_thread {
     pub b: Vec<Av1Block>,
     pub cbi: Vec<CodedBlockInfo>,
     // indexed using (t->by >> 1) * (f->b4_stride >> 1) + (t->bx >> 1)
-    pub pal: Vec<Align64<[[u16; 8]; 3]>>, /* [3 plane][8 idx] */
+    pub pal: AlignedVec64<[[u16; 8]; 3]>, /* [3 plane][8 idx] */
     // iterated over inside tile state
     pub pal_idx: *mut u8,
     pub cf: *mut DynCoef,
@@ -427,12 +427,6 @@ pub struct Rav1dFrameContext_frame_thread {
     pub cf_sz: c_int,
     // start offsets per tile
     pub tile_start_off: *mut u32,
-}
-
-impl Rav1dFrameContext_frame_thread {
-    pub fn pal_sz(&self) -> usize {
-        self.pal.len() / (16 * 16)
-    }
 }
 
 /// loopfilter

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -907,9 +907,7 @@ impl Drop for Rav1dContext {
                     rav1d_freep_aligned(&mut f.frame_thread.pal_idx as *mut *mut u8 as *mut c_void);
                     rav1d_freep_aligned(&mut f.frame_thread.cf as *mut *mut DynCoef as *mut c_void);
                     freep(&mut f.frame_thread.tile_start_off as *mut *mut u32 as *mut c_void);
-                    rav1d_freep_aligned(
-                        &mut f.frame_thread.pal as *mut *mut [[u16; 8]; 3] as *mut c_void,
-                    );
+                    let _ = mem::take(&mut f.frame_thread.pal); // TODO: remove when context is owned
                     let _ = mem::take(&mut f.frame_thread.cbi); // TODO: remove when context is owned
                 }
                 if self.tc.len() > 1 {

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2573,13 +2573,12 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     pal_idx = (t.scratch.c2rust_unnamed_0.pal_idx).as_mut_ptr();
                 }
                 let pal: *const u16 = if t.frame_thread.pass != 0 {
-                    ((*(f.frame_thread.pal).offset(
-                        (((t.by as isize >> 1) + (t.bx as isize & 1)) * (f.b4_stride >> 1)
-                            + ((t.bx >> 1) + (t.by & 1)) as isize) as isize,
-                    ))[0])
-                        .as_mut_ptr()
+                    let index = (((t.by as isize >> 1) + (t.bx as isize & 1)) * (f.b4_stride >> 1)
+                        + ((t.bx >> 1) + (t.by & 1)) as isize)
+                        as isize;
+                    f.frame_thread.pal[index as usize][0].as_ptr()
                 } else {
-                    (t.scratch.c2rust_unnamed_0.pal[0]).as_mut_ptr()
+                    (t.scratch.c2rust_unnamed_0.pal[0]).as_ptr()
                 };
                 (*f.dsp).ipred.pal_pred.call::<BD>(
                     dst,
@@ -2958,12 +2957,10 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         if ((*ts).frame_thread[p as usize].pal_idx).is_null() {
                             unreachable!();
                         }
-                        pal = (*(f.frame_thread.pal).offset(
-                            (((t.by >> 1) + (t.bx & 1)) as isize * (f.b4_stride >> 1)
-                                + ((t.bx as isize >> 1) as isize + (t.by as isize & 1)) as isize)
-                                as isize,
-                        ))
-                        .as_mut_ptr() as *const [u16; 8];
+                        let index = (((t.by >> 1) + (t.bx & 1)) as isize * (f.b4_stride >> 1)
+                            + ((t.bx as isize >> 1) as isize + (t.by as isize & 1)) as isize)
+                            as isize;
+                        pal = &f.frame_thread.pal[index as usize][0] as *const [u16; 8];
                         pal_idx = (*ts).frame_thread[p as usize].pal_idx;
                         (*ts).frame_thread[p as usize].pal_idx = ((*ts).frame_thread[p as usize]
                             .pal_idx)


### PR DESCRIPTION
This also adds `AlignedVec64` to have the `Vec` aligned, since a `Vec<Align64<T>>` would add extra padding between each element since it would align each element, and we only want to align the whole `Vec`/slice.