### PR TITLE
`src/cdef_apply.rs`: cleanup

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -25,10 +25,10 @@ bitflags! {
     #[repr(transparent)]
     #[derive(Clone, Copy)]
     pub struct CdefEdgeFlags: u32 {
-        const CDEF_HAVE_BOTTOM = 1 << 3;
-        const CDEF_HAVE_TOP = 1 << 2;
-        const CDEF_HAVE_RIGHT = 1 << 1;
         const CDEF_HAVE_LEFT = 1 << 0;
+        const CDEF_HAVE_RIGHT = 1 << 1;
+        const CDEF_HAVE_TOP = 1 << 2;
+        const CDEF_HAVE_BOTTOM = 1 << 3;
     }
 }
 

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -25,10 +25,10 @@ bitflags! {
     #[repr(transparent)]
     #[derive(Clone, Copy)]
     pub struct CdefEdgeFlags: u32 {
-        const CDEF_HAVE_LEFT = 1 << 0;
-        const CDEF_HAVE_RIGHT = 1 << 1;
-        const CDEF_HAVE_TOP = 1 << 2;
-        const CDEF_HAVE_BOTTOM = 1 << 3;
+        const HAVE_LEFT = 1 << 0;
+        const HAVE_RIGHT = 1 << 1;
+        const HAVE_TOP = 1 << 2;
+        const HAVE_BOTTOM = 1 << 3;
     }
 }
 
@@ -580,7 +580,7 @@ unsafe fn padding<BD: BitDepth>(
     let mut x_end = w + 2;
     let mut y_start = -(2 as c_int);
     let mut y_end = h + 2;
-    if !edges.contains(CdefEdgeFlags::CDEF_HAVE_TOP) {
+    if !edges.contains(CdefEdgeFlags::HAVE_TOP) {
         fill(
             tmp.offset(-2).offset(-((2 * tmp_stride) as isize)),
             tmp_stride,
@@ -589,7 +589,7 @@ unsafe fn padding<BD: BitDepth>(
         );
         y_start = 0 as c_int;
     }
-    if !edges.contains(CdefEdgeFlags::CDEF_HAVE_BOTTOM) {
+    if !edges.contains(CdefEdgeFlags::HAVE_BOTTOM) {
         fill(
             tmp.offset((h as isize * tmp_stride) as isize)
                 .offset(-(2 as c_int as isize)),
@@ -599,7 +599,7 @@ unsafe fn padding<BD: BitDepth>(
         );
         y_end -= 2 as c_int;
     }
-    if !edges.contains(CdefEdgeFlags::CDEF_HAVE_LEFT) {
+    if !edges.contains(CdefEdgeFlags::HAVE_LEFT) {
         fill(
             tmp.offset((y_start as isize * tmp_stride) as isize)
                 .offset(-(2 as c_int as isize)),
@@ -609,7 +609,7 @@ unsafe fn padding<BD: BitDepth>(
         );
         x_start = 0 as c_int;
     }
-    if !edges.contains(CdefEdgeFlags::CDEF_HAVE_RIGHT) {
+    if !edges.contains(CdefEdgeFlags::HAVE_RIGHT) {
         fill(
             tmp.offset((y_start as isize * tmp_stride) as isize)
                 .offset(w as isize),

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -459,26 +459,24 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                         bit ^= 1 as c_int;
                         last_skip = 0 as c_int;
                     }
-                    bptrs[0] = (bptrs[0]).offset(8);
-                    bptrs[1] = (bptrs[1]).offset((8 >> ss_hor) as isize);
-                    bptrs[2] = (bptrs[2]).offset((8 >> ss_hor) as isize);
+                    bptrs[0] = bptrs[0].add(8);
+                    bptrs[1] = bptrs[1].add(8 >> ss_hor);
+                    bptrs[2] = bptrs[2].add(8 >> ss_hor);
                     edges = ::core::mem::transmute::<c_uint, CdefEdgeFlags>(
                         edges as c_uint | CDEF_HAVE_LEFT as c_int as c_uint,
                     );
                 }
             }
-            iptrs[0] = (iptrs[0]).offset((sbsz * 4) as isize);
-            iptrs[1] = (iptrs[1]).offset((sbsz * 4 >> ss_hor) as isize);
-            iptrs[2] = (iptrs[2]).offset((sbsz * 4 >> ss_hor) as isize);
+            iptrs[0] = iptrs[0].add(sbsz as usize * 4);
+            iptrs[1] = iptrs[1].add(sbsz as usize * 4 >> ss_hor);
+            iptrs[2] = iptrs[2].add(sbsz as usize * 4 >> ss_hor);
             edges = ::core::mem::transmute::<c_uint, CdefEdgeFlags>(
                 edges as c_uint | CDEF_HAVE_LEFT as c_int as c_uint,
             );
         }
-        ptrs[0] = (ptrs[0]).offset(8 * BD::pxstride((*f).cur.stride[0] as usize) as isize);
-        ptrs[1] =
-            (ptrs[1]).offset(8 * BD::pxstride((*f).cur.stride[1] as usize) as isize >> ss_ver);
-        ptrs[2] =
-            (ptrs[2]).offset(8 * BD::pxstride((*f).cur.stride[1] as usize) as isize >> ss_ver);
+        ptrs[0] = ptrs[0].offset(8 * BD::pxstride((*f).cur.stride[0] as usize) as isize);
+        ptrs[1] = ptrs[1].offset(8 * BD::pxstride((*f).cur.stride[1] as usize) as isize >> ss_ver);
+        ptrs[2] = ptrs[2].offset(8 * BD::pxstride((*f).cur.stride[1] as usize) as isize >> ss_ver);
         tc.top_pre_cdef_toggle ^= 1 as c_int;
         edges = ::core::mem::transmute::<c_uint, CdefEdgeFlags>(
             edges as c_uint | CDEF_HAVE_TOP as c_int as c_uint,

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -41,15 +41,14 @@ unsafe fn backup2lines<BD: BitDepth>(
     layout: Rav1dPixelLayout,
 ) {
     let y_stride: ptrdiff_t = BD::pxstride(stride[0] as usize) as isize;
+    let len = 2 * y_stride.unsigned_abs();
     if y_stride < 0 {
-        let len = (-2 * y_stride) as usize;
         BD::pixel_copy(
             slice::from_raw_parts_mut(dst[0].offset(y_stride), len),
             slice::from_raw_parts(src[0].offset(7 * y_stride), len),
             len,
         );
     } else {
-        let len = 2 * y_stride as usize;
         BD::pixel_copy(
             slice::from_raw_parts_mut(dst[0], len),
             slice::from_raw_parts(src[0].offset(6 * y_stride), len),
@@ -59,6 +58,7 @@ unsafe fn backup2lines<BD: BitDepth>(
 
     if layout != Rav1dPixelLayout::I400 {
         let uv_stride: ptrdiff_t = BD::pxstride(stride[1] as usize) as isize;
+        let len = 2 * uv_stride.unsigned_abs();
         if uv_stride < 0 {
             let uv_off = if layout == Rav1dPixelLayout::I420 {
                 3
@@ -66,7 +66,6 @@ unsafe fn backup2lines<BD: BitDepth>(
                 7
             };
 
-            let len = (-2 * uv_stride) as usize;
             BD::pixel_copy(
                 slice::from_raw_parts_mut(dst[1].offset(uv_stride), len),
                 slice::from_raw_parts(src[1].offset(uv_off * uv_stride), len),
@@ -84,7 +83,6 @@ unsafe fn backup2lines<BD: BitDepth>(
                 6
             };
 
-            let len = 2 * uv_stride as usize;
             BD::pixel_copy(
                 slice::from_raw_parts_mut(dst[1], len),
                 slice::from_raw_parts(src[1].offset(uv_off * uv_stride), len),

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -211,7 +211,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
             edges as c_uint | CDEF_HAVE_RIGHT as c_int as c_uint,
         );
         let mut prev_flag: Backup2x8Flags = 0 as Backup2x8Flags;
-        let mut last_skip = 1;
+        let mut last_skip = true;
         for sbx in 0..sb64w {
             let noskip_row: *const [u16; 2];
             let noskip_mask: c_uint;
@@ -230,7 +230,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                 || frame_hdr.cdef.y_strength[cdef_idx as usize] == 0
                     && frame_hdr.cdef.uv_strength[cdef_idx as usize] == 0
             {
-                last_skip = 1 as c_int;
+                last_skip = true;
             } else {
                 noskip_row = &*((*lflvl.offset(sb128x as isize)).noskip_mask)
                     .as_ptr()
@@ -265,9 +265,9 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                     }
                     let bx_mask: u32 = (3 as c_uint) << (bx & 30);
                     if noskip_mask & bx_mask == 0 {
-                        last_skip = 1;
+                        last_skip = true;
                     } else {
-                        do_left = (if last_skip != 0 {
+                        do_left = (if last_skip {
                             flag
                         } else {
                             (prev_flag ^ flag) & flag
@@ -457,7 +457,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                             }
                         }
                         bit ^= 1 as c_int;
-                        last_skip = 0 as c_int;
+                        last_skip = false;
                     }
                     bptrs[0] = bptrs[0].add(8);
                     bptrs[1] = bptrs[1].add(8 >> ss_hor);

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -310,37 +310,25 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                         } else if sbrow_start != 0 && by == by_start {
                             if resize != 0 {
                                 offset = ((sby - 1) * 4) as isize * y_stride + (bx * 4) as isize;
-                                top = &mut *((*((*f).lf.cdef_lpf_line).as_mut_ptr().offset(0))
-                                    as *mut BD::Pixel)
-                                    .offset(offset);
+                                top = (*f).lf.cdef_lpf_line[0].cast::<BD::Pixel>().offset(offset);
                             } else {
                                 offset = (sby * ((4 as c_int) << sb128) - 4) as isize * y_stride
                                     + (bx * 4) as isize;
-                                top = &mut *((*((*f).lf.lr_lpf_line).as_mut_ptr().offset(0))
-                                    as *mut BD::Pixel)
-                                    .offset(offset);
+                                top = (*f).lf.lr_lpf_line[0].cast::<BD::Pixel>().offset(offset);
                             }
-                            bot = (bptrs[0]).offset((8 * y_stride) as isize);
+                            bot = bptrs[0].offset(8 * y_stride as isize);
                             st_y = false;
                         } else if sbrow_start == 0 && by + 2 >= by_end {
-                            top = &mut *((*(*((*f).lf.cdef_line).as_mut_ptr().offset(tf as isize))
-                                .as_mut_ptr()
-                                .offset(0))
-                                as *mut BD::Pixel)
-                                .offset(
-                                    ((sby * 4) as isize * y_stride + (bx * 4) as isize) as isize,
-                                );
+                            top = (*f).lf.cdef_line[tf as usize][0]
+                                .cast::<BD::Pixel>()
+                                .offset((sby * 4) as isize * y_stride + (bx * 4) as isize);
                             if resize != 0 {
                                 offset = (sby * 4 + 2) as isize * y_stride + (bx * 4) as isize;
-                                bot = &mut *((*((*f).lf.cdef_lpf_line).as_mut_ptr().offset(0))
-                                    as *mut BD::Pixel)
-                                    .offset(offset);
+                                bot = (*f).lf.cdef_lpf_line[0].cast::<BD::Pixel>().offset(offset);
                             } else {
                                 let line = sby * ((4 as c_int) << sb128) + 4 * sb128 + 2;
                                 offset = line as isize * y_stride + (bx * 4) as isize;
-                                bot = &mut *((*((*f).lf.lr_lpf_line).as_mut_ptr().offset(0))
-                                    as *mut BD::Pixel)
-                                    .offset(offset);
+                                bot = (*f).lf.lr_lpf_line[0].cast::<BD::Pixel>().offset(offset);
                             }
                             st_y = false;
                         } else {
@@ -349,12 +337,10 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
 
                         if st_y {
                             offset = (sby * 4) as isize * y_stride;
-                            top = &mut *((*(*((*f).lf.cdef_line).as_mut_ptr().offset(tf as isize))
-                                .as_mut_ptr()
-                                .offset(0))
-                                as *mut BD::Pixel)
-                                .offset((have_tt as isize * offset + (bx * 4) as isize) as isize);
-                            bot = (bptrs[0]).offset((8 * y_stride) as isize);
+                            top = (*f).lf.cdef_line[tf as usize][0]
+                                .cast::<BD::Pixel>()
+                                .offset(have_tt as isize * offset + (bx * 4) as isize);
+                            bot = bptrs[0].offset(8 * y_stride as isize);
                         }
 
                         if y_pri_lvl != 0 {
@@ -406,45 +392,38 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                                     if resize != 0 {
                                         offset = ((sby - 1) * 4) as isize * uv_stride
                                             + (bx * 4 >> ss_hor) as isize;
-                                        top =
-                                            &mut *((*((*f).lf.cdef_lpf_line).as_mut_ptr().add(pl))
-                                                as *mut BD::Pixel)
-                                                .offset(offset as isize);
+                                        top = (*f).lf.cdef_lpf_line[pl]
+                                            .cast::<BD::Pixel>()
+                                            .offset(offset);
                                     } else {
                                         let line_0 = sby * ((4 as c_int) << sb128) - 4;
                                         offset = line_0 as isize * uv_stride
                                             + (bx * 4 >> ss_hor) as isize;
-                                        top = &mut *((*((*f).lf.lr_lpf_line).as_mut_ptr().add(pl))
-                                            as *mut BD::Pixel)
-                                            .offset(offset as isize);
+                                        top = (*f).lf.lr_lpf_line[pl]
+                                            .cast::<BD::Pixel>()
+                                            .offset(offset);
                                     }
-                                    bot = (bptrs[pl])
-                                        .offset(((8 >> ss_ver) as isize * uv_stride) as isize);
+                                    bot = bptrs[pl].offset(((8 >> ss_ver) * uv_stride) as isize);
                                     st_uv = false;
                                 } else if sbrow_start == 0 && by + 2 >= by_end {
                                     let top_offset: ptrdiff_t = (sby * 8) as isize * uv_stride
                                         + (bx * 4 >> ss_hor) as isize;
-                                    top = &mut *((*(*((*f).lf.cdef_line)
-                                        .as_mut_ptr()
-                                        .offset(tf as isize))
-                                    .as_mut_ptr()
-                                    .add(pl))
-                                        as *mut BD::Pixel)
-                                        .offset(top_offset as isize);
+                                    top = (*f).lf.cdef_line[tf as usize][pl]
+                                        .cast::<BD::Pixel>()
+                                        .offset(top_offset);
                                     if resize != 0 {
                                         offset = (sby * 4 + 2) as isize * uv_stride
                                             + (bx * 4 >> ss_hor) as isize;
-                                        bot =
-                                            &mut *((*((*f).lf.cdef_lpf_line).as_mut_ptr().add(pl))
-                                                as *mut BD::Pixel)
-                                                .offset(offset as isize);
+                                        bot = (*f).lf.cdef_lpf_line[pl]
+                                            .cast::<BD::Pixel>()
+                                            .offset(offset);
                                     } else {
                                         let line_1 = sby * ((4 as c_int) << sb128) + 4 * sb128 + 2;
                                         offset = line_1 as isize * uv_stride
                                             + (bx * 4 >> ss_hor) as isize;
-                                        bot = &mut *((*((*f).lf.lr_lpf_line).as_mut_ptr().add(pl))
-                                            as *mut BD::Pixel)
-                                            .offset(offset as isize);
+                                        bot = (*f).lf.lr_lpf_line[pl]
+                                            .cast::<BD::Pixel>()
+                                            .offset(offset);
                                     }
                                     st_uv = false;
                                 } else {
@@ -452,20 +431,14 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                                 }
 
                                 if st_uv {
-                                    let offset_0: ptrdiff_t = (sby * 8) as isize * uv_stride;
-                                    top = &mut *((*(*((*f).lf.cdef_line)
-                                        .as_mut_ptr()
-                                        .offset(tf as isize))
-                                    .as_mut_ptr()
-                                    .add(pl))
-                                        as *mut BD::Pixel)
+                                    let offset_0 = (sby * 8) as isize * uv_stride;
+                                    top = (*f).lf.cdef_line[tf as usize][pl]
+                                        .cast::<BD::Pixel>()
                                         .offset(
-                                            (have_tt as isize * offset_0
-                                                + (bx * 4 >> ss_hor) as isize)
-                                                as isize,
+                                            have_tt as isize * offset_0
+                                                + (bx * 4 >> ss_hor) as isize,
                                         );
-                                    bot = (bptrs[pl])
-                                        .offset(((8 >> ss_ver) as isize * uv_stride) as isize);
+                                    bot = bptrs[pl].offset((8 >> ss_ver) * uv_stride);
                                 }
 
                                 (*dsp).cdef.fb[uv_idx as usize](

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -192,12 +192,12 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
             && edges as c_uint & CDEF_HAVE_BOTTOM as c_int as c_uint != 0
         {
             let cdef_top_bak: [*mut BD::Pixel; 3] = [
-                ((*f).lf.cdef_line[(tf == 0) as c_int as usize][0] as *mut BD::Pixel)
-                    .offset(((have_tt * sby * 4) as isize * y_stride) as isize),
-                ((*f).lf.cdef_line[(tf == 0) as c_int as usize][1] as *mut BD::Pixel)
-                    .offset(((have_tt * sby * 8) as isize * uv_stride) as isize),
-                ((*f).lf.cdef_line[(tf == 0) as c_int as usize][2] as *mut BD::Pixel)
-                    .offset(((have_tt * sby * 8) as isize * uv_stride) as isize),
+                ((*f).lf.cdef_line[(tf == 0) as usize][0] as *mut BD::Pixel)
+                    .offset((have_tt * sby * 4) as isize * y_stride),
+                ((*f).lf.cdef_line[(tf == 0) as usize][1] as *mut BD::Pixel)
+                    .offset((have_tt * sby * 8) as isize * uv_stride),
+                ((*f).lf.cdef_line[(tf == 0) as usize][2] as *mut BD::Pixel)
+                    .offset((have_tt * sby * 8) as isize * uv_stride),
             ];
             backup2lines::<BD>(&cdef_top_bak, &ptrs, &(*f).cur.stride, layout);
         }
@@ -265,7 +265,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                     }
                     let bx_mask: u32 = (3 as c_uint) << (bx & 30);
                     if noskip_mask & bx_mask == 0 {
-                        last_skip = 1 as c_int;
+                        last_skip = 1;
                     } else {
                         do_left = (if last_skip != 0 {
                             flag

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -144,7 +144,7 @@ unsafe fn adjust_strength(strength: c_int, var: c_uint) -> c_int {
 
 pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
     c: &Rav1dContext,
-    tc: *mut Rav1dTaskContext,
+    tc: &mut Rav1dTaskContext,
     p: &[*mut BD::Pixel; 3],
     lflvl: *const Av1Filter,
     by_start: c_int,
@@ -152,7 +152,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
     sbrow_start: c_int,
     sby: c_int,
 ) {
-    let f: *mut Rav1dFrameContext = (*tc).f as *mut Rav1dFrameContext;
+    let f: *mut Rav1dFrameContext = tc.f as *mut Rav1dFrameContext;
     let bitdepth_min_8 = if 16 == 8 { 0 } else { (*f).cur.p.bpc - 8 };
     let dsp: *const Rav1dDSPContext = (*f).dsp;
     let mut edges: CdefEdgeFlags = (CDEF_HAVE_BOTTOM as c_int
@@ -181,7 +181,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
     let uv_stride: ptrdiff_t = BD::pxstride((*f).cur.stride[1] as usize) as isize;
     let mut bit = 0;
     for by in (by_start..by_end).step_by(2) {
-        let tf = (*tc).top_pre_cdef_toggle;
+        let tf = tc.top_pre_cdef_toggle;
         let by_idx = (by & 30) >> 1;
         if by + 2 >= (*f).bh {
             edges = ::core::mem::transmute::<c_uint, CdefEdgeFlags>(
@@ -518,7 +518,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
             (ptrs[1]).offset(8 * BD::pxstride((*f).cur.stride[1] as usize) as isize >> ss_ver);
         ptrs[2] =
             (ptrs[2]).offset(8 * BD::pxstride((*f).cur.stride[1] as usize) as isize >> ss_ver);
-        (*tc).top_pre_cdef_toggle ^= 1 as c_int;
+        tc.top_pre_cdef_toggle ^= 1 as c_int;
         edges = ::core::mem::transmute::<c_uint, CdefEdgeFlags>(
             edges as c_uint | CDEF_HAVE_TOP as c_int as c_uint,
         );

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -35,7 +35,7 @@ impl Backup2x8Flags {
 }
 
 unsafe fn backup2lines<BD: BitDepth>(
-    dst: &[*mut BD::Pixel],
+    dst: &[*mut BD::Pixel; 3],
     src: &[*mut BD::Pixel; 3],
     stride: &[ptrdiff_t; 2],
     layout: Rav1dPixelLayout,

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -16,11 +16,6 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::slice;
 
-const CDEF_HAVE_BOTTOM: CdefEdgeFlags = CdefEdgeFlags::CDEF_HAVE_BOTTOM;
-const CDEF_HAVE_LEFT: CdefEdgeFlags = CdefEdgeFlags::CDEF_HAVE_LEFT;
-const CDEF_HAVE_RIGHT: CdefEdgeFlags = CdefEdgeFlags::CDEF_HAVE_RIGHT;
-const CDEF_HAVE_TOP: CdefEdgeFlags = CdefEdgeFlags::CDEF_HAVE_TOP;
-
 bitflags! {
     #[derive(Clone, Copy)]
     struct Backup2x8Flags: u8 {
@@ -166,9 +161,9 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
     };
     let dsp: *const Rav1dDSPContext = (*f).dsp;
     let mut edges: CdefEdgeFlags = if by_start > 0 {
-        CDEF_HAVE_BOTTOM | CDEF_HAVE_TOP
+        CdefEdgeFlags::CDEF_HAVE_BOTTOM | CdefEdgeFlags::CDEF_HAVE_TOP
     } else {
-        CDEF_HAVE_BOTTOM
+        CdefEdgeFlags::CDEF_HAVE_BOTTOM
     };
     let mut ptrs: [*mut BD::Pixel; 3] = *p;
     let sbsz = 16;
@@ -193,10 +188,10 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
         let tf = tc.top_pre_cdef_toggle;
         let by_idx = (by & 30) >> 1;
         if by + 2 >= (*f).bh {
-            edges.remove(CDEF_HAVE_BOTTOM);
+            edges.remove(CdefEdgeFlags::CDEF_HAVE_BOTTOM);
         }
         if (have_tt == 0 || sbrow_start != 0 || (by + 2) < by_end)
-            && edges.contains(CDEF_HAVE_BOTTOM)
+            && edges.contains(CdefEdgeFlags::CDEF_HAVE_BOTTOM)
         {
             let cdef_top_bak: [*mut BD::Pixel; 3] = [
                 ((*f).lf.cdef_line[(tf == 0) as usize][0] as *mut BD::Pixel)
@@ -211,8 +206,8 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
         let mut lr_bak: Align16<[[[[BD::Pixel; 2]; 8]; 3]; 2]> =
             Align16([[[[0.into(); 2]; 8]; 3]; 2]);
         let mut iptrs: [*mut BD::Pixel; 3] = ptrs;
-        edges.remove(CDEF_HAVE_LEFT);
-        edges.insert(CDEF_HAVE_RIGHT);
+        edges.remove(CdefEdgeFlags::CDEF_HAVE_LEFT);
+        edges.insert(CdefEdgeFlags::CDEF_HAVE_RIGHT);
         let mut prev_flag: Backup2x8Flags = Backup2x8Flags::empty();
         let mut last_skip = true;
         for sbx in 0..sb64w {
@@ -264,7 +259,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                     let mut offset: ptrdiff_t;
                     let st_y: bool;
                     if bx + 2 >= (*f).bw {
-                        edges.remove(CDEF_HAVE_RIGHT);
+                        edges.remove(CdefEdgeFlags::CDEF_HAVE_RIGHT);
                     }
                     let bx_mask: u32 = (3 as c_uint) << (bx & 30);
                     if noskip_mask & bx_mask == 0 {
@@ -276,7 +271,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                             (prev_flag ^ flag) & flag
                         };
                         prev_flag = flag;
-                        if !do_left.is_empty() && edges.contains(CDEF_HAVE_LEFT) {
+                        if !do_left.is_empty() && edges.contains(CdefEdgeFlags::CDEF_HAVE_LEFT) {
                             backup2x8::<BD>(
                                 &mut lr_bak[bit as usize],
                                 &bptrs,
@@ -286,7 +281,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                                 do_left as Backup2x8Flags,
                             );
                         }
-                        if edges.contains(CDEF_HAVE_RIGHT) {
+                        if edges.contains(CdefEdgeFlags::CDEF_HAVE_RIGHT) {
                             backup2x8::<BD>(
                                 &mut lr_bak[(bit == 0) as usize],
                                 &bptrs,
@@ -465,18 +460,18 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                     bptrs[0] = bptrs[0].add(8);
                     bptrs[1] = bptrs[1].add(8 >> ss_hor);
                     bptrs[2] = bptrs[2].add(8 >> ss_hor);
-                    edges.insert(CDEF_HAVE_LEFT);
+                    edges.insert(CdefEdgeFlags::CDEF_HAVE_LEFT);
                 }
             }
             iptrs[0] = iptrs[0].add(sbsz as usize * 4);
             iptrs[1] = iptrs[1].add(sbsz as usize * 4 >> ss_hor);
             iptrs[2] = iptrs[2].add(sbsz as usize * 4 >> ss_hor);
-            edges.insert(CDEF_HAVE_LEFT);
+            edges.insert(CdefEdgeFlags::CDEF_HAVE_LEFT);
         }
         ptrs[0] = ptrs[0].offset(8 * BD::pxstride((*f).cur.stride[0] as usize) as isize);
         ptrs[1] = ptrs[1].offset(8 * BD::pxstride((*f).cur.stride[1] as usize) as isize >> ss_ver);
         ptrs[2] = ptrs[2].offset(8 * BD::pxstride((*f).cur.stride[1] as usize) as isize >> ss_ver);
         tc.top_pre_cdef_toggle ^= 1 as c_int;
-        edges.insert(CDEF_HAVE_TOP);
+        edges.insert(CdefEdgeFlags::CDEF_HAVE_TOP);
     }
 }

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -145,7 +145,7 @@ unsafe fn adjust_strength(strength: c_int, var: c_uint) -> c_int {
 pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
     c: &Rav1dContext,
     tc: *mut Rav1dTaskContext,
-    p: *const *mut BD::Pixel,
+    p: &[*mut BD::Pixel; 3],
     lflvl: *const Av1Filter,
     by_start: c_int,
     by_end: c_int,
@@ -161,7 +161,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
         } else {
             0
         })) as CdefEdgeFlags;
-    let mut ptrs: [*mut BD::Pixel; 3] = [*p.offset(0), *p.offset(1), *p.offset(2)];
+    let mut ptrs: [*mut BD::Pixel; 3] = *p;
     let sbsz = 16;
     let sb64w = (*f).sb128w << 1;
     let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -268,13 +268,12 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                         last_skip = 1 as c_int;
                     } else {
                         do_left = (if last_skip != 0 {
-                            flag as c_uint
+                            flag
                         } else {
-                            (prev_flag as c_uint ^ flag as c_uint) & flag as c_uint
+                            (prev_flag ^ flag) & flag
                         }) as c_int;
                         prev_flag = flag;
-                        if do_left != 0 && edges as c_uint & CDEF_HAVE_LEFT as c_int as c_uint != 0
-                        {
+                        if do_left != 0 && edges & CDEF_HAVE_LEFT != 0 {
                             backup2x8::<BD>(
                                 &mut lr_bak[bit as usize],
                                 &bptrs,
@@ -313,13 +312,13 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                                 offset = ((sby - 1) * 4) as isize * y_stride + (bx * 4) as isize;
                                 top = &mut *((*((*f).lf.cdef_lpf_line).as_mut_ptr().offset(0))
                                     as *mut BD::Pixel)
-                                    .offset(offset as isize);
+                                    .offset(offset);
                             } else {
                                 offset = (sby * ((4 as c_int) << sb128) - 4) as isize * y_stride
                                     + (bx * 4) as isize;
                                 top = &mut *((*((*f).lf.lr_lpf_line).as_mut_ptr().offset(0))
                                     as *mut BD::Pixel)
-                                    .offset(offset as isize);
+                                    .offset(offset);
                             }
                             bot = (bptrs[0]).offset((8 * y_stride) as isize);
                             st_y = false;
@@ -335,13 +334,13 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                                 offset = (sby * 4 + 2) as isize * y_stride + (bx * 4) as isize;
                                 bot = &mut *((*((*f).lf.cdef_lpf_line).as_mut_ptr().offset(0))
                                     as *mut BD::Pixel)
-                                    .offset(offset as isize);
+                                    .offset(offset);
                             } else {
                                 let line = sby * ((4 as c_int) << sb128) + 4 * sb128 + 2;
                                 offset = line as isize * y_stride + (bx * 4) as isize;
                                 bot = &mut *((*((*f).lf.lr_lpf_line).as_mut_ptr().offset(0))
                                     as *mut BD::Pixel)
-                                    .offset(offset as isize);
+                                    .offset(offset);
                             }
                             st_y = false;
                         } else {

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -171,8 +171,8 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
     let ss_ver = (layout == Rav1dPixelLayout::I420) as c_int;
     let ss_hor = (layout != Rav1dPixelLayout::I444) as c_int;
 
-    static uv_dirs: [[u8; 8]; 2] = [[0, 1, 2, 3, 4, 5, 6, 7], [7, 0, 2, 4, 5, 6, 6, 6]];
-    let uv_dir: &[u8; 8] = &uv_dirs[(layout == Rav1dPixelLayout::I422) as usize];
+    static UV_DIRS: [[u8; 8]; 2] = [[0, 1, 2, 3, 4, 5, 6, 7], [7, 0, 2, 4, 5, 6, 6, 6]];
+    let uv_dir: &[u8; 8] = &UV_DIRS[(layout == Rav1dPixelLayout::I422) as usize];
 
     let have_tt = (c.tc.len() > 1) as c_int;
     let sb128 = (*f).seq_hdr.as_ref().unwrap().sb128;

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -24,6 +24,16 @@ bitflags! {
     }
 }
 
+impl Backup2x8Flags {
+    pub const fn select(&self, select: bool) -> Self {
+        if select {
+            *self
+        } else {
+            Self::empty()
+        }
+    }
+}
+
 unsafe fn backup2lines<BD: BitDepth>(
     dst: &[*mut BD::Pixel],
     src: &[*mut BD::Pixel; 3],
@@ -237,9 +247,8 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                     | (*noskip_row.offset(0))[0] as c_uint;
                 y_lvl = frame_hdr.cdef.y_strength[cdef_idx as usize];
                 uv_lvl = frame_hdr.cdef.uv_strength[cdef_idx as usize];
-                flag = Backup2x8Flags::from_bits_truncate(
-                    (y_lvl != 0) as u8 + (((uv_lvl != 0) as u8) << 1),
-                );
+                flag =
+                    Backup2x8Flags::Y.select(y_lvl != 0) | Backup2x8Flags::UV.select(uv_lvl != 0);
                 y_pri_lvl = (y_lvl >> 2) << bitdepth_min_8;
                 y_sec_lvl = y_lvl & 3;
                 y_sec_lvl += (y_sec_lvl == 3) as c_int;

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -4622,7 +4622,7 @@ pub(crate) unsafe fn rav1d_filter_sbrow_cdef<BD: BitDepth>(
     if sby != 0 {
         let ss_ver =
             ((*f).cur.p.layout as c_uint == Rav1dPixelLayout::I420 as c_int as c_uint) as c_int;
-        let mut p_up: [*mut BD::Pixel; 3] = [
+        let p_up: [*mut BD::Pixel; 3] = [
             (p[0]).offset(-((8 * BD::pxstride((*f).cur.stride[0] as usize) as isize) as isize)),
             (p[1]).offset(
                 -((8 * BD::pxstride((*f).cur.stride[1] as usize) as isize >> ss_ver) as isize),
@@ -4631,20 +4631,11 @@ pub(crate) unsafe fn rav1d_filter_sbrow_cdef<BD: BitDepth>(
                 -((8 * BD::pxstride((*f).cur.stride[1] as usize) as isize >> ss_ver) as isize),
             ),
         ];
-        rav1d_cdef_brow::<BD>(
-            c,
-            tc,
-            p_up.as_mut_ptr(),
-            prev_mask,
-            start - 2,
-            start,
-            1 as c_int,
-            sby,
-        );
+        rav1d_cdef_brow::<BD>(c, tc, &p_up, prev_mask, start - 2, start, 1 as c_int, sby);
     }
     let n_blks = sbsz - 2 * ((sby + 1) < (*f).sbh) as c_int;
     let end = cmp::min(start + n_blks, (*f).bh);
-    rav1d_cdef_brow::<BD>(c, tc, p.as_ptr(), mask, start, end, 0 as c_int, sby);
+    rav1d_cdef_brow::<BD>(c, tc, &p, mask, start, end, 0 as c_int, sby);
 }
 
 pub(crate) unsafe fn rav1d_filter_sbrow_resize<BD: BitDepth>(


### PR DESCRIPTION
Besides cleanup, this also fixes bugs in `slice::from_raw_parts(_mut)` calls in `BD::pixel_copy`s introduced during bitdepth deduplication.

can be reviewed commit-by-commit. 

these PRs get pretty large and have many unrelated changes. Would stacked PRs easier to review?

I'll leave some specific notes/questions in inline comments.