### PR TITLE
`struct Rav1dContext`: Remove `n_tc` field

### DIFF
--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -219,7 +219,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
     let uv_dir: *const u8 = (uv_dirs
         [(layout as c_uint == Rav1dPixelLayout::I422 as c_int as c_uint) as c_int as usize])
         .as_ptr();
-    let have_tt = (c.n_tc > 1 as c_uint) as c_int;
+    let have_tt = (c.tc.len() > 1) as c_int;
     let sb128 = (*f).seq_hdr.as_ref().unwrap().sb128;
     let resize = (frame_hdr.size.width[0] != frame_hdr.size.width[1]) as c_int;
     let y_stride: ptrdiff_t = BD::pxstride((*f).cur.stride[0] as usize) as isize;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3921,7 +3921,7 @@ unsafe fn setup_tile(
         ts.lr_ref[p] = *lr_ref;
     }
 
-    if c.n_tc > 1 {
+    if c.tc.len() > 1 {
         ts.progress.fill_with(|| AtomicI32::new(row_sb_start));
     }
 }
@@ -4070,7 +4070,7 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
         t.frame_thread.pass,
     );
     if t.frame_thread.pass == 2 {
-        let off_2pass = if c.n_tc > 1 {
+        let off_2pass = if c.tc.len() > 1 {
             f.sb128w * frame_hdr.tiling.rows
         } else {
             0
@@ -4096,7 +4096,7 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
         return Err(());
     }
 
-    if c.n_tc > 1 && frame_hdr.use_ref_frame_mvs != 0 {
+    if c.tc.len() > 1 && frame_hdr.use_ref_frame_mvs != 0 {
         c.refmvs_dsp.load_tmvs.expect("non-null function pointer")(
             &f.rf,
             ts.tiling.row,
@@ -4196,7 +4196,7 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
         }
     }
 
-    if seq_hdr.ref_frame_mvs != 0 && c.n_tc > 1 && frame_hdr.frame_type.is_inter_or_switch() {
+    if seq_hdr.ref_frame_mvs != 0 && c.tc.len() > 1 && frame_hdr.frame_type.is_inter_or_switch() {
         rav1d_refmvs_save_tmvs(
             &c.refmvs_dsp,
             &mut t.rt,
@@ -4281,7 +4281,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
         f.n_ts = n_ts;
     }
 
-    let a_sz = f.sb128w * frame_hdr.tiling.rows * (1 + (c.n_fc > 1 && c.n_tc > 1) as c_int);
+    let a_sz = f.sb128w * frame_hdr.tiling.rows * (1 + (c.n_fc > 1 && c.tc.len() > 1) as c_int);
     if a_sz != f.a_sz {
         freep(&mut f.a as *mut *mut BlockContext as *mut c_void);
         f.a = malloc(::core::mem::size_of::<BlockContext>() * a_sz as usize) as *mut BlockContext;
@@ -4400,7 +4400,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
     let mut y_stride = f.cur.stride[0];
     let mut uv_stride = f.cur.stride[1];
     let has_resize = (frame_hdr.size.width[0] != frame_hdr.size.width[1]) as c_int;
-    let need_cdef_lpf_copy = (c.n_tc > 1 && has_resize != 0) as c_int;
+    let need_cdef_lpf_copy = (c.tc.len() > 1 && has_resize != 0) as c_int;
     if y_stride * f.sbh as isize * 4 != f.lf.cdef_buf_plane_sz[0] as isize
         || uv_stride * f.sbh as isize * 8 != f.lf.cdef_buf_plane_sz[1] as isize
         || need_cdef_lpf_copy != f.lf.need_cdef_lpf_copy
@@ -4472,7 +4472,11 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
     }
 
     let sb128 = seq_hdr.sb128;
-    let num_lines = if c.n_tc > 1 { (f.sbh * 4) << sb128 } else { 12 };
+    let num_lines = if c.tc.len() > 1 {
+        (f.sbh * 4) << sb128
+    } else {
+        12
+    };
     y_stride = f.sr_cur.p.stride[0];
     uv_stride = f.sr_cur.p.stride[1];
     if y_stride * num_lines as isize != f.lf.lr_buf_plane_sz[0] as isize
@@ -4609,7 +4613,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
             f.mvs,
             f.refrefpoc.as_ptr(),
             f.ref_mvs.as_ptr(),
-            c.n_tc as c_int,
+            c.tc.len() as c_int,
             c.n_fc as c_int,
         );
         if ret.is_err() {
@@ -4758,7 +4762,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init_cdf(
         }
     }
 
-    if c.n_tc > 1 {
+    if c.tc.len() > 1 {
         for (n, ctx) in slice::from_raw_parts_mut(f.a, sb128w * rows * (1 + uses_2pass as usize))
             .iter_mut()
             .enumerate()
@@ -4779,7 +4783,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init_cdf(
 }
 
 unsafe fn rav1d_decode_frame_main(c: &Rav1dContext, f: &mut Rav1dFrameContext) -> Rav1dResult {
-    assert!(c.n_tc == 1);
+    assert!(c.tc.len() == 1);
 
     let Rav1dContextTaskType::Single(t) = &c.tc[0].task else {
         panic!("Expected a single-threaded context");
@@ -4893,7 +4897,7 @@ pub(crate) unsafe fn rav1d_decode_frame(
     f: &mut Rav1dFrameContext,
 ) -> Rav1dResult {
     assert!(c.n_fc == 1);
-    // if n_tc > 1 (but n_fc == 1), we could run init/exit in the task
+    // if.tc.len() > 1 (but n_fc == 1), we could run init/exit in the task
     // threads also. Not sure it makes a measurable difference.
     let mut res = rav1d_decode_frame_init(c, f);
     if res.is_ok() {
@@ -4901,7 +4905,7 @@ pub(crate) unsafe fn rav1d_decode_frame(
     }
     // wait until all threads have completed
     if res.is_ok() {
-        if c.n_tc > 1 {
+        if c.tc.len() > 1 {
             res = rav1d_task_create_tile_sbrow(c, f, 0, 1);
             let mut task_thread_lock = (*f.task_thread.ttd).delayed_fg.lock().unwrap();
             (*f.task_thread.ttd).cond.notify_one();

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -240,11 +240,9 @@ pub struct Rav1dContext {
     pub(crate) fc: *mut Rav1dFrameContext,
     pub(crate) n_fc: c_uint,
 
-    /// Worker thread join handles and communication, or single thread task
-    /// context if n_tc == 1
+    /// Worker thread join handles and communication, or main thread task
+    /// context if single-threaded
     pub(crate) tc: Box<[Rav1dContextTaskThread]>,
-    /// Number of worker threads
-    pub(crate) n_tc: c_uint,
 
     /// Cache of OBUs that make up a single frame before we submit them
     /// to a frame worker to be decoded.

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -44,7 +44,7 @@ unsafe fn backup_lpf<BD: BitDepth>(
     // The first stripe of the frame is shorter by 8 luma pixel rows.
     let mut stripe_h = ((64 as c_int) << (cdef_backup & sb128)) - 8 * (row == 0) as c_int >> ss_ver;
     src = src.offset((stripe_h - 2) as isize * BD::pxstride(src_stride as usize) as isize);
-    if c.n_tc == 1 as c_uint {
+    if c.tc.len() == 1 {
         if row != 0 {
             let top = (4 as c_int) << sb128;
             // Copy the top part of the stored loop filtered pixels from the
@@ -175,7 +175,7 @@ pub(crate) unsafe fn rav1d_copy_lpf<BD: BitDepth>(
     src: *const *mut BD::Pixel,
     sby: c_int,
 ) {
-    let have_tt = (c.n_tc > 1 as c_uint) as c_int;
+    let have_tt = (c.tc.len() > 1) as c_int;
     let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
     let resize = (frame_hdr.size.width[0] != frame_hdr.size.width[1]) as c_int;
     let offset = 8 * (sby != 0) as c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,7 +297,6 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
     }
     (*c).flush = AtomicI32::new(0);
     let NumThreads { n_tc, n_fc } = get_num_threads(s);
-    (*c).n_tc = n_tc as c_uint;
     (*c).n_fc = n_fc as c_uint;
     (*c).fc = rav1d_alloc_aligned(
         ::core::mem::size_of::<Rav1dFrameContext>().wrapping_mul((*c).n_fc as usize),
@@ -331,7 +330,7 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
     while n < (*c).n_fc {
         let f: *mut Rav1dFrameContext =
             &mut *((*c).fc).offset(n as isize) as *mut Rav1dFrameContext;
-        if (*c).n_tc > 1 as c_uint {
+        if n_tc > 1 {
             (*f).task_thread.lock = Mutex::new(());
             (*f).task_thread.cond = Condvar::new();
             (*f).task_thread.pending_tasks = Default::default();
@@ -342,12 +341,12 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
         rav1d_refmvs_init(&mut (*f).rf);
         n = n.wrapping_add(1);
     }
-    (*c).tc = (0..(*c).n_tc)
+    (*c).tc = (0..n_tc)
         .map(|_| {
             let thread_data = Arc::new(Rav1dTaskContext_task_thread::new(Arc::clone(
                 &(*c).task_thread,
             )));
-            if (*c).n_tc > 1 {
+            if n_tc > 1 {
                 // TODO(SJC): can be removed when c is not a raw pointer
                 let context_borrow = &*c;
                 let thread_data_copy = Arc::clone(&thread_data);
@@ -712,7 +711,7 @@ pub(crate) unsafe fn rav1d_apply_grain(
         rav1d_picture_unref_internal(out);
         return res;
     } else {
-        if c.n_tc > 1 as c_uint {
+        if c.tc.len() > 1 {
             rav1d_task_delayed_fg(c, out, in_0);
         } else {
             match out.p.bpc {
@@ -791,11 +790,11 @@ pub(crate) unsafe fn rav1d_flush(c: *mut Rav1dContext) {
     let _ = mem::take(&mut (*c).mastering_display);
     let _ = mem::take(&mut (*c).itut_t35);
     let _ = mem::take(&mut (*c).cached_error_props);
-    if (*c).n_fc == 1 as c_uint && (*c).n_tc == 1 as c_uint {
+    if (*c).n_fc == 1 as c_uint && (*c).tc.len() == 1 {
         return;
     }
     (*c).flush.store(1, Ordering::SeqCst);
-    if (*c).n_tc > 1 as c_uint {
+    if (*c).tc.len() > 1 {
         let mut task_thread_lock = (*c).task_thread.delayed_fg.lock().unwrap();
         for tc in (*c).tc.iter() {
             while !tc.flushed() {
@@ -888,7 +887,7 @@ impl Drop for Rav1dContext {
         // remove all pointers from the structure. We can't make the drop
         // function unsafe because the Drop trait requires a safe function.
         unsafe {
-            if self.n_tc > 1 {
+            if self.tc.len() > 1 {
                 let ttd: &TaskThreadData = &*self.task_thread;
                 let task_thread_lock = ttd.delayed_fg.lock().unwrap();
                 for tc in self.tc.iter() {
@@ -925,7 +924,7 @@ impl Drop for Rav1dContext {
                     );
                     freep(&mut (*f).frame_thread.cbi as *mut *mut CodedBlockInfo as *mut c_void);
                 }
-                if self.n_tc > 1 as c_uint {
+                if self.tc.len() > 1 {
                     let _ = mem::take(&mut (*f).task_thread.pending_tasks); // TODO: remove when context is owned
                 }
                 mem::take(&mut (*f).frame_thread.frame_progress); // TODO: remove when context is owned

--- a/src/lr_apply.rs
+++ b/src/lr_apply.rs
@@ -52,7 +52,7 @@ unsafe fn lr_stripe<BD: BitDepth>(
         } else {
             0 as c_int
         }) >> 6 - ss_ver + seq_hdr.sb128;
-    let have_tt = (c.n_tc > 1 as c_uint) as c_int;
+    let have_tt = (c.tc.len() > 1) as c_int;
     let mut lpf: *const BD::Pixel = ((*f).lf.lr_lpf_line[plane as usize] as *mut BD::Pixel)
         .offset(
             (have_tt * (sby * ((4 as c_int) << seq_hdr.sb128) - 4)) as isize


### PR DESCRIPTION
Removes `n_tc` and replaces it with tc.len() now that tc is a slice.