### PR TITLE
`Rav1dFrameContext_lf::level`: Make into a `Vec` and fix padding size

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4524,9 +4524,10 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
         let _ = mem::take(&mut f.lf.level);
         f.lf.mask =
             malloc(::core::mem::size_of::<Av1Filter>() * num_sb128 as usize) as *mut Av1Filter;
-        // over-allocate by 3 bytes since some of the SIMD implementations
-        // index this from the level type and can thus over-read by up to 3
-        f.lf.level = vec![[0u8; 4]; num_sb128 as usize * 32 * 32 + 3].into(); // TODO fallible allocation
+        // over-allocate one element (4 bytes) since some of the SIMD implementations
+        // index this from the level type and can thus over-read by up to 3 bytes.
+        f.lf.level
+            .resize(num_sb128 as usize * 32 * 32 + 1, [0u8; 4]); // TODO: Fallible allocation
         if f.lf.mask.is_null() {
             f.lf.mask_sz = 0;
             return Err(ENOMEM);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4521,7 +4521,6 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
     // update allocation for loopfilter masks
     if num_sb128 != f.lf.mask_sz {
         freep(&mut f.lf.mask as *mut *mut Av1Filter as *mut c_void);
-        let _ = mem::take(&mut f.lf.level);
         f.lf.mask =
             malloc(::core::mem::size_of::<Av1Filter>() * num_sb128 as usize) as *mut Av1Filter;
         // over-allocate one element (4 bytes) since some of the SIMD implementations

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -422,7 +422,7 @@ pub struct Rav1dFrameContext_frame_thread {
 /// loopfilter
 #[repr(C)]
 pub struct Rav1dFrameContext_lf {
-    pub level: Box<[[u8; 4]]>,
+    pub level: Vec<[u8; 4]>,
     pub mask: *mut Av1Filter,
     pub lr_mask: *mut Av1Restoration,
     pub mask_sz: c_int, /* w*h */


### PR DESCRIPTION
Change `level` into a `Vec` (instead of a `Box<[]>`) and use `resize` to reallocate. This makes the field more consistent with how we've been translating similar fields.

I also fixed a minor error in how the array was being over-allocated, i.e. the original C over-allocated 3 **bytes**, whereas we were allocating an extra 3 **elements** (12 bytes). We now over-allocate a single element (4 bytes).