### PR TITLE
`struct Rav1dFrameContext`: Remove excess mutability and pointers from uses

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1106,7 +1106,7 @@ unsafe fn read_vartx_tree(
             t.by += h as c_int;
         }
         t.by -= bh4 as c_int;
-        if debug_block_info!(&*f, &*t) {
+        if debug_block_info!(f, &*t) {
             println!(
                 "Post-vartxtree[{}/{}]: r={}",
                 tx_split[0],

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3520,7 +3520,7 @@ unsafe fn decode_sb(
                 );
             }
         } else {
-            let b = &mut f.frame_thread.b[(t.by as isize * f.b4_stride + t.bx as isize) as usize];
+            let b = &f.frame_thread.b[(t.by as isize * f.b4_stride + t.bx as isize) as usize];
             bp = if b.bl == bl { b.bp } else { PARTITION_SPLIT };
         }
         let b = &dav1d_block_sizes[bl as usize][bp as usize];
@@ -3671,7 +3671,7 @@ unsafe fn decode_sb(
                 );
             }
         } else {
-            let b = &mut f.frame_thread.b[(t.by as isize * f.b4_stride + t.bx as isize) as usize];
+            let b = &f.frame_thread.b[(t.by as isize * f.b4_stride + t.bx as isize) as usize];
             is_split = b.bl != bl;
         }
 
@@ -3719,7 +3719,7 @@ unsafe fn decode_sb(
                 );
             }
         } else {
-            let b = &mut f.frame_thread.b[(t.by as isize * f.b4_stride + t.bx as isize) as usize];
+            let b = &f.frame_thread.b[(t.by as isize * f.b4_stride + t.bx as isize) as usize];
             is_split = b.bl != bl;
         }
 

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -37,7 +37,7 @@ unsafe fn backup_lpf<BD: BitDepth>(
     lr_backup: c_int,
 ) {
     let cdef_backup = (lr_backup == 0) as c_int;
-    let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+    let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
     let dst_w = if frame_hdr.size.super_res.enabled != 0 {
         frame_hdr.size.width[1] + ss_hor >> ss_hor
     } else {
@@ -109,11 +109,11 @@ unsafe fn backup_lpf<BD: BitDepth>(
         }
         dst = dst.offset(4 * BD::pxstride(dst_stride as usize) as isize);
     }
-    let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+    let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
     if lr_backup != 0 && frame_hdr.size.width[0] != frame_hdr.size.width[1] {
         while row + stripe_h <= row_h {
             let n_lines = 4 - (row + stripe_h + 1 == h) as c_int;
-            ((*(*f).dsp).mc.resize)(
+            ((*f.dsp).mc.resize)(
                 dst.cast(),
                 dst_stride,
                 src.cast(),
@@ -121,9 +121,9 @@ unsafe fn backup_lpf<BD: BitDepth>(
                 dst_w,
                 n_lines,
                 src_w,
-                (*f).resize_step[ss_hor as usize],
-                (*f).resize_start[ss_hor as usize],
-                (*f).bitdepth_max,
+                f.resize_step[ss_hor as usize],
+                f.resize_start[ss_hor as usize],
+                f.bitdepth_max,
             );
             row += stripe_h; // unmodified stripe_h for the 1st stripe
             stripe_h = 64 >> ss_ver;
@@ -176,25 +176,25 @@ pub(crate) unsafe fn rav1d_copy_lpf<BD: BitDepth>(
     sby: c_int,
 ) {
     let have_tt = (c.tc.len() > 1) as c_int;
-    let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+    let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
     let resize = (frame_hdr.size.width[0] != frame_hdr.size.width[1]) as c_int;
     let offset = 8 * (sby != 0) as c_int;
-    let src_stride: *const ptrdiff_t = ((*f).cur.stride).as_mut_ptr();
-    let lr_stride: *const ptrdiff_t = ((*f).sr_cur.p.stride).as_mut_ptr();
-    let seq_hdr = &***(*f).seq_hdr.as_ref().unwrap();
+    let src_stride: *const ptrdiff_t = (f.cur.stride).as_mut_ptr();
+    let lr_stride: *const ptrdiff_t = (f.sr_cur.p.stride).as_mut_ptr();
+    let seq_hdr = &***f.seq_hdr.as_ref().unwrap();
     let tt_off = have_tt * sby * ((4 as c_int) << seq_hdr.sb128);
     let dst: [*mut BD::Pixel; 3] = [
-        ((*f).lf.lr_lpf_line[0] as *mut BD::Pixel)
+        (f.lf.lr_lpf_line[0] as *mut BD::Pixel)
             .offset(tt_off as isize * BD::pxstride(*lr_stride.offset(0) as usize) as isize),
-        ((*f).lf.lr_lpf_line[1] as *mut BD::Pixel)
+        (f.lf.lr_lpf_line[1] as *mut BD::Pixel)
             .offset(tt_off as isize * BD::pxstride(*lr_stride.offset(1) as usize) as isize),
-        ((*f).lf.lr_lpf_line[2] as *mut BD::Pixel)
+        (f.lf.lr_lpf_line[2] as *mut BD::Pixel)
             .offset(tt_off as isize * BD::pxstride(*lr_stride.offset(1) as usize) as isize),
     ];
-    let restore_planes = (*f).lf.restore_planes;
+    let restore_planes = f.lf.restore_planes;
     if seq_hdr.cdef != 0 || restore_planes & LR_RESTORE_Y as c_int != 0 {
-        let h = (*f).cur.p.h;
-        let w = (*f).bw << 2;
+        let h = f.cur.p.h;
+        let w = f.bw << 2;
         let row_h = cmp::min((sby + 1) << 6 + seq_hdr.sb128, h - 1);
         let y_stripe = (sby << 6 + seq_hdr.sb128) - offset;
         if restore_planes & LR_RESTORE_Y as c_int != 0 || resize == 0 {
@@ -223,7 +223,7 @@ pub(crate) unsafe fn rav1d_copy_lpf<BD: BitDepth>(
             backup_lpf::<BD>(
                 c,
                 f,
-                ((*f).lf.cdef_lpf_line[0] as *mut BD::Pixel).offset(cdef_off_y as isize),
+                (f.lf.cdef_lpf_line[0] as *mut BD::Pixel).offset(cdef_off_y as isize),
                 *src_stride.offset(0),
                 (*src.offset(0)).offset(
                     -offset as isize * BD::pxstride(*src_stride.offset(0) as usize) as isize,
@@ -241,12 +241,12 @@ pub(crate) unsafe fn rav1d_copy_lpf<BD: BitDepth>(
         }
     }
     if (seq_hdr.cdef != 0 || restore_planes & (LR_RESTORE_U as c_int | LR_RESTORE_V as c_int) != 0)
-        && (*f).cur.p.layout != Rav1dPixelLayout::I400
+        && f.cur.p.layout != Rav1dPixelLayout::I400
     {
-        let ss_ver = ((*f).sr_cur.p.p.layout == Rav1dPixelLayout::I420) as c_int;
-        let ss_hor = ((*f).sr_cur.p.p.layout != Rav1dPixelLayout::I444) as c_int;
-        let h_0 = (*f).cur.p.h + ss_ver >> ss_ver;
-        let w_0 = (*f).bw << 2 - ss_hor;
+        let ss_ver = (f.sr_cur.p.p.layout == Rav1dPixelLayout::I420) as c_int;
+        let ss_hor = (f.sr_cur.p.p.layout != Rav1dPixelLayout::I444) as c_int;
+        let h_0 = f.cur.p.h + ss_ver >> ss_ver;
+        let w_0 = f.bw << 2 - ss_hor;
         let row_h_0 = cmp::min((sby + 1) << 6 - ss_ver + seq_hdr.sb128, h_0 - 1);
         let offset_uv = offset >> ss_ver;
         let y_stripe_0 = (sby << 6 - ss_ver + seq_hdr.sb128) - offset_uv;
@@ -277,7 +277,7 @@ pub(crate) unsafe fn rav1d_copy_lpf<BD: BitDepth>(
                 backup_lpf::<BD>(
                     c,
                     f,
-                    ((*f).lf.cdef_lpf_line[1] as *mut BD::Pixel).offset(cdef_off_uv as isize),
+                    (f.lf.cdef_lpf_line[1] as *mut BD::Pixel).offset(cdef_off_uv as isize),
                     *src_stride.offset(1),
                     (*src.offset(1)).offset(
                         -offset_uv as isize * BD::pxstride(*src_stride.offset(1) as usize) as isize,
@@ -298,7 +298,7 @@ pub(crate) unsafe fn rav1d_copy_lpf<BD: BitDepth>(
             if restore_planes & LR_RESTORE_V as c_int != 0 || resize == 0 {
                 backup_lpf::<BD>(
                     c,
-                    &*f,
+                    f,
                     dst[2],
                     *lr_stride.offset(1),
                     (*src.offset(2)).offset(
@@ -319,7 +319,7 @@ pub(crate) unsafe fn rav1d_copy_lpf<BD: BitDepth>(
                 backup_lpf::<BD>(
                     c,
                     f,
-                    ((*f).lf.cdef_lpf_line[2] as *mut BD::Pixel).offset(cdef_off_uv as isize),
+                    (f.lf.cdef_lpf_line[2] as *mut BD::Pixel).offset(cdef_off_uv as isize),
                     *src_stride.offset(1),
                     (*src.offset(2)).offset(
                         -offset_uv as isize * BD::pxstride(*src_stride.offset(1) as usize) as isize,
@@ -353,7 +353,7 @@ fn unaligned_lvl_slice(lvl: &[[u8; 4]], y: usize) -> &[[u8; 4]] {
 
 #[inline]
 unsafe fn filter_plane_cols_y<BD: BitDepth>(
-    f: *const Rav1dFrameContext,
+    f: &Rav1dFrameContext,
     have_left: bool,
     lvl: &[[u8; 4]],
     b4_stride: ptrdiff_t,
@@ -364,7 +364,7 @@ unsafe fn filter_plane_cols_y<BD: BitDepth>(
     starty4: c_int,
     endy4: c_int,
 ) {
-    let dsp: *const Rav1dDSPContext = (*f).dsp;
+    let dsp: *const Rav1dDSPContext = f.dsp;
     for x in 0..w as usize {
         if !(!have_left && x == 0) {
             let mut hmask: [u32; 4] = [0; 4];
@@ -389,9 +389,9 @@ unsafe fn filter_plane_cols_y<BD: BitDepth>(
                 hmask.as_mut_ptr(),
                 &lvl[x as usize],
                 b4_stride,
-                &(*f).lf.lim_lut.0,
+                &f.lf.lim_lut.0,
                 endy4 - starty4,
-                (*f).bitdepth_max,
+                f.bitdepth_max,
             );
         }
     }
@@ -399,7 +399,7 @@ unsafe fn filter_plane_cols_y<BD: BitDepth>(
 
 #[inline]
 unsafe fn filter_plane_rows_y<BD: BitDepth>(
-    f: *const Rav1dFrameContext,
+    f: &Rav1dFrameContext,
     have_top: bool,
     lvl: &[[u8; 4]],
     b4_stride: ptrdiff_t,
@@ -410,7 +410,7 @@ unsafe fn filter_plane_rows_y<BD: BitDepth>(
     starty4: c_int,
     endy4: c_int,
 ) {
-    let dsp: *const Rav1dDSPContext = (*f).dsp;
+    let dsp: *const Rav1dDSPContext = f.dsp;
     for (y, lvl) in (starty4..endy4).zip(lvl.chunks(b4_stride as usize)) {
         if !(!have_top && y == 0) {
             let vmask: [u32; 4] = [
@@ -425,9 +425,9 @@ unsafe fn filter_plane_rows_y<BD: BitDepth>(
                 vmask.as_ptr(),
                 unaligned_lvl_slice(&lvl[0..], 1).as_ptr(),
                 b4_stride,
-                &(*f).lf.lim_lut.0,
+                &f.lf.lim_lut.0,
                 w,
-                (*f).bitdepth_max,
+                f.bitdepth_max,
             );
         }
         dst = dst.offset(4 * BD::pxstride(ls as usize) as isize);
@@ -436,7 +436,7 @@ unsafe fn filter_plane_rows_y<BD: BitDepth>(
 
 #[inline]
 unsafe fn filter_plane_cols_uv<BD: BitDepth>(
-    f: *const Rav1dFrameContext,
+    f: &Rav1dFrameContext,
     have_left: bool,
     lvl: &[[u8; 4]],
     b4_stride: ptrdiff_t,
@@ -449,7 +449,7 @@ unsafe fn filter_plane_cols_uv<BD: BitDepth>(
     endy4: c_int,
     ss_ver: c_int,
 ) {
-    let dsp: *const Rav1dDSPContext = (*f).dsp;
+    let dsp: *const Rav1dDSPContext = f.dsp;
     for x in 0..w {
         if !(!have_left && x == 0) {
             let mut hmask: [u32; 3] = [0; 3];
@@ -471,9 +471,9 @@ unsafe fn filter_plane_cols_uv<BD: BitDepth>(
                 hmask.as_mut_ptr(),
                 unaligned_lvl_slice(&lvl[x as usize..], 2).as_ptr(),
                 b4_stride,
-                &(*f).lf.lim_lut.0,
+                &f.lf.lim_lut.0,
                 endy4 - starty4,
-                (*f).bitdepth_max,
+                f.bitdepth_max,
             );
             (*dsp).lf.loop_filter_sb[1][0](
                 v.offset((x * 4) as isize).cast(),
@@ -481,9 +481,9 @@ unsafe fn filter_plane_cols_uv<BD: BitDepth>(
                 hmask.as_mut_ptr(),
                 unaligned_lvl_slice(&lvl[x as usize..], 3).as_ptr(),
                 b4_stride,
-                &(*f).lf.lim_lut.0,
+                &f.lf.lim_lut.0,
                 endy4 - starty4,
-                (*f).bitdepth_max,
+                f.bitdepth_max,
             );
         }
     }
@@ -491,7 +491,7 @@ unsafe fn filter_plane_cols_uv<BD: BitDepth>(
 
 #[inline]
 unsafe fn filter_plane_rows_uv<BD: BitDepth>(
-    f: *const Rav1dFrameContext,
+    f: &Rav1dFrameContext,
     have_top: bool,
     lvl: &[[u8; 4]],
     b4_stride: ptrdiff_t,
@@ -504,7 +504,7 @@ unsafe fn filter_plane_rows_uv<BD: BitDepth>(
     endy4: c_int,
     ss_hor: c_int,
 ) {
-    let dsp: *const Rav1dDSPContext = (*f).dsp;
+    let dsp: *const Rav1dDSPContext = f.dsp;
     let mut off_l: ptrdiff_t = 0;
     for (y, lvl) in (starty4..endy4).zip(lvl.chunks(b4_stride as usize)) {
         if !(!have_top && y == 0) {
@@ -519,9 +519,9 @@ unsafe fn filter_plane_rows_uv<BD: BitDepth>(
                 vmask.as_ptr(),
                 unaligned_lvl_slice(&lvl[0..], 2).as_ptr(),
                 b4_stride,
-                &(*f).lf.lim_lut.0,
+                &f.lf.lim_lut.0,
                 w,
-                (*f).bitdepth_max,
+                f.bitdepth_max,
             );
             (*dsp).lf.loop_filter_sb[1][1](
                 v.offset(off_l as isize).cast(),
@@ -529,9 +529,9 @@ unsafe fn filter_plane_rows_uv<BD: BitDepth>(
                 vmask.as_ptr(),
                 unaligned_lvl_slice(&lvl[0..], 3).as_ptr(),
                 b4_stride,
-                &(*f).lf.lim_lut.0,
+                &f.lf.lim_lut.0,
                 w,
-                (*f).bitdepth_max,
+                f.bitdepth_max,
             );
         }
         off_l += 4 * BD::pxstride(ls as usize) as isize;
@@ -539,36 +539,36 @@ unsafe fn filter_plane_rows_uv<BD: BitDepth>(
 }
 
 pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
-    f: *const Rav1dFrameContext,
+    f: &Rav1dFrameContext,
     p: &[*mut BD::Pixel; 3],
     lflvl: *mut Av1Filter,
     sby: c_int,
     start_of_tile_row: c_int,
 ) {
     let mut have_left;
-    let seq_hdr = &***(*f).seq_hdr.as_ref().unwrap();
+    let seq_hdr = &***f.seq_hdr.as_ref().unwrap();
     let is_sb64 = (seq_hdr.sb128 == 0) as c_int;
     let starty4 = (sby & is_sb64) << 4;
     let sbsz = 32 >> is_sb64;
     let sbl2 = 5 - is_sb64;
-    let halign = (*f).bh + 31 & !(31 as c_int);
-    let ss_ver = ((*f).cur.p.layout == Rav1dPixelLayout::I420) as c_int;
-    let ss_hor = ((*f).cur.p.layout != Rav1dPixelLayout::I444) as c_int;
+    let halign = f.bh + 31 & !(31 as c_int);
+    let ss_ver = (f.cur.p.layout == Rav1dPixelLayout::I420) as c_int;
+    let ss_hor = (f.cur.p.layout != Rav1dPixelLayout::I444) as c_int;
     let vmask = 16 >> ss_ver;
     let hmask = 16 >> ss_hor;
     let vmax = (1 as c_uint) << vmask;
     let hmax = (1 as c_uint) << hmask;
-    let endy4 = (starty4 + cmp::min((*f).h4 - sby * sbsz, sbsz)) as c_uint;
+    let endy4 = (starty4 + cmp::min(f.h4 - sby * sbsz, sbsz)) as c_uint;
     let uv_endy4: c_uint = endy4.wrapping_add(ss_ver as c_uint) >> ss_ver;
-    let mut lpf_y: *const u8 = &mut *(*((*f).lf.tx_lpf_right_edge).as_ptr().offset(0))
+    let mut lpf_y: *const u8 = &mut *(*(f.lf.tx_lpf_right_edge).as_ptr().offset(0))
         .offset((sby << sbl2) as isize) as *mut u8;
-    let mut lpf_uv: *const u8 = &mut *(*((*f).lf.tx_lpf_right_edge).as_ptr().offset(1))
+    let mut lpf_uv: *const u8 = &mut *(*(f.lf.tx_lpf_right_edge).as_ptr().offset(1))
         .offset((sby << sbl2 - ss_ver) as isize) as *mut u8;
-    let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+    let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
     let mut tile_col = 1;
     loop {
         let mut x = frame_hdr.tiling.col_start_sb[tile_col as usize] as c_int;
-        if x << sbl2 >= (*f).bw {
+        if x << sbl2 >= f.bw {
             break;
         }
         let bx4: c_int = if x & is_sb64 != 0 { 16 } else { 0 };
@@ -598,7 +598,7 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
             y = y.wrapping_add(1);
             mask <<= 1;
         }
-        if (*f).cur.p.layout != Rav1dPixelLayout::I400 {
+        if f.cur.p.layout != Rav1dPixelLayout::I400 {
             let uv_hmask: *mut [u16; 2] =
                 ((*lflvl.offset(x as isize)).filter_uv[0][cbx4 as usize]).as_mut_ptr();
             let mut y_0: c_uint = (starty4 >> ss_ver) as c_uint;
@@ -628,12 +628,11 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
     }
     if start_of_tile_row != 0 {
         let mut a: *const BlockContext;
-        a = &mut *((*f).a).offset(((*f).sb128w * (start_of_tile_row - 1)) as isize)
-            as *mut BlockContext;
-        for x in 0..(*f).sb128w {
+        a = &mut *(f.a).offset((f.sb128w * (start_of_tile_row - 1)) as isize) as *mut BlockContext;
+        for x in 0..f.sb128w {
             let y_vmask: *mut [u16; 2] =
                 ((*lflvl.offset(x as isize)).filter_y[1][starty4 as usize]).as_mut_ptr();
-            let w: c_uint = cmp::min(32 as c_int, (*f).w4 - (x << 5)) as c_uint;
+            let w: c_uint = cmp::min(32 as c_int, f.w4 - (x << 5)) as c_uint;
             let mut mask_0: c_uint = 1;
             let mut i: c_uint = 0;
             while i < w {
@@ -655,7 +654,7 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
                 mask_0 <<= 1;
                 i = i.wrapping_add(1);
             }
-            if (*f).cur.p.layout != Rav1dPixelLayout::I400 {
+            if f.cur.p.layout != Rav1dPixelLayout::I400 {
                 let cw: c_uint = w.wrapping_add(ss_hor as c_uint) >> ss_hor;
                 let uv_vmask: *mut [u16; 2] = ((*lflvl.offset(x as isize)).filter_uv[1]
                     [(starty4 >> ss_ver) as usize])
@@ -683,19 +682,19 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
         }
     }
     let mut ptr: *mut BD::Pixel;
-    let mut level_ptr = &(*f).lf.level[((*f).b4_stride * sby as isize * sbsz as isize) as usize..];
+    let mut level_ptr = &f.lf.level[(f.b4_stride * sby as isize * sbsz as isize) as usize..];
     ptr = p[0];
     have_left = false;
-    for x in 0..(*f).sb128w {
+    for x in 0..f.sb128w {
         filter_plane_cols_y::<BD>(
             f,
             have_left,
             level_ptr,
-            (*f).b4_stride,
+            f.b4_stride,
             &(*lflvl.offset(x as isize)).filter_y[0],
             ptr,
-            (*f).cur.stride[0],
-            cmp::min(32 as c_int, (*f).w4 - x * 32),
+            f.cur.stride[0],
+            cmp::min(32 as c_int, f.w4 - x * 32),
             starty4,
             endy4 as c_int,
         );
@@ -707,20 +706,19 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
         return;
     }
     let mut uv_off: ptrdiff_t = 0;
-    let mut level_ptr =
-        &(*f).lf.level[((*f).b4_stride * (sby * sbsz >> ss_ver) as isize) as usize..];
+    let mut level_ptr = &f.lf.level[(f.b4_stride * (sby * sbsz >> ss_ver) as isize) as usize..];
     have_left = false;
-    for x in 0..(*f).sb128w {
+    for x in 0..f.sb128w {
         filter_plane_cols_uv::<BD>(
             f,
             have_left,
             level_ptr,
-            (*f).b4_stride,
+            f.b4_stride,
             &(*lflvl.offset(x as isize)).filter_uv[0],
             &mut *p[1].offset(uv_off as isize),
             &mut *p[2].offset(uv_off as isize),
-            (*f).cur.stride[1],
-            cmp::min(32 as c_int, (*f).w4 - x * 32) + ss_hor >> ss_hor,
+            f.cur.stride[1],
+            cmp::min(32 as c_int, f.w4 - x * 32) + ss_hor >> ss_hor,
             starty4 >> ss_ver,
             uv_endy4 as c_int,
             ss_ver,
@@ -732,35 +730,35 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
 }
 
 pub(crate) unsafe fn rav1d_loopfilter_sbrow_rows<BD: BitDepth>(
-    f: *const Rav1dFrameContext,
+    f: &Rav1dFrameContext,
     p: &[*mut BD::Pixel; 3],
     lflvl: *mut Av1Filter,
     sby: c_int,
 ) {
     // Don't filter outside the frame
     let have_top = sby > 0;
-    let seq_hdr = &***(*f).seq_hdr.as_ref().unwrap();
+    let seq_hdr = &***f.seq_hdr.as_ref().unwrap();
     let is_sb64 = (seq_hdr.sb128 == 0) as c_int;
     let starty4 = (sby & is_sb64) << 4;
     let sbsz = 32 >> is_sb64;
-    let ss_ver = ((*f).cur.p.layout == Rav1dPixelLayout::I420) as c_int;
-    let ss_hor = ((*f).cur.p.layout != Rav1dPixelLayout::I444) as c_int;
-    let endy4: c_uint = (starty4 + cmp::min((*f).h4 - sby * sbsz, sbsz)) as c_uint;
+    let ss_ver = (f.cur.p.layout == Rav1dPixelLayout::I420) as c_int;
+    let ss_hor = (f.cur.p.layout != Rav1dPixelLayout::I444) as c_int;
+    let endy4: c_uint = (starty4 + cmp::min(f.h4 - sby * sbsz, sbsz)) as c_uint;
     let uv_endy4: c_uint = endy4.wrapping_add(ss_ver as c_uint) >> ss_ver;
 
     let mut ptr: *mut BD::Pixel;
-    let mut level_ptr = &(*f).lf.level[((*f).b4_stride * sby as isize * sbsz as isize) as usize..];
+    let mut level_ptr = &f.lf.level[(f.b4_stride * sby as isize * sbsz as isize) as usize..];
     ptr = p[0];
-    for x in 0..(*f).sb128w {
+    for x in 0..f.sb128w {
         filter_plane_rows_y::<BD>(
             f,
             have_top,
             level_ptr,
-            (*f).b4_stride,
+            f.b4_stride,
             &(*lflvl.offset(x as isize)).filter_y[1],
             ptr,
-            (*f).cur.stride[0],
-            cmp::min(32, (*f).w4 - x * 32),
+            f.cur.stride[0],
+            cmp::min(32, f.w4 - x * 32),
             starty4,
             endy4 as c_int,
         );
@@ -768,25 +766,24 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_rows<BD: BitDepth>(
         level_ptr = &level_ptr[32..];
     }
 
-    let frame_hdr = &***(*f).frame_hdr.as_ref().unwrap();
+    let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
     if frame_hdr.loopfilter.level_u == 0 && frame_hdr.loopfilter.level_v == 0 {
         return;
     }
 
     let mut uv_off: ptrdiff_t = 0;
-    let mut level_ptr =
-        &(*f).lf.level[((*f).b4_stride * (sby * sbsz >> ss_ver) as isize) as usize..];
-    for x in 0..(*f).sb128w {
+    let mut level_ptr = &f.lf.level[(f.b4_stride * (sby * sbsz >> ss_ver) as isize) as usize..];
+    for x in 0..f.sb128w {
         filter_plane_rows_uv::<BD>(
             f,
             have_top,
             level_ptr,
-            (*f).b4_stride,
+            f.b4_stride,
             &(*lflvl.offset(x as isize)).filter_uv[1],
             &mut *p[1].offset(uv_off as isize),
             &mut *p[2].offset(uv_off as isize),
-            (*f).cur.stride[1],
-            cmp::min(32 as c_int, (*f).w4 - x * 32) + ss_hor >> ss_hor,
+            f.cur.stride[1],
+            cmp::min(32 as c_int, f.w4 - x * 32) + ss_hor >> ss_hor,
             starty4 >> ss_ver,
             uv_endy4 as c_int,
             ss_hor,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2523,12 +2523,12 @@ unsafe fn parse_obus(
                 }
 
                 let f = &mut *c.fc.offset(next as isize);
-                while !(*f).tiles.is_empty() {
-                    task_thread_lock = (*f).task_thread.cond.wait(task_thread_lock).unwrap();
+                while !f.tiles.is_empty() {
+                    task_thread_lock = f.task_thread.cond.wait(task_thread_lock).unwrap();
                 }
                 let out_delayed = &mut c.frame_thread.out_delayed[next as usize];
                 if !out_delayed.p.data.data[0].is_null()
-                    || (*f).task_thread.error.load(Ordering::SeqCst) != 0
+                    || f.task_thread.error.load(Ordering::SeqCst) != 0
                 {
                     let first = c.task_thread.first.load(Ordering::SeqCst);
                     if first + 1 < c.n_fc {
@@ -2548,10 +2548,10 @@ unsafe fn parse_obus(
                         c.task_thread.cur.fetch_sub(1, Ordering::Relaxed);
                     }
                 }
-                let error = (*f).task_thread.retval;
+                let error = f.task_thread.retval;
                 if error.is_err() {
                     c.cached_error = error;
-                    (*f).task_thread.retval = Ok(());
+                    f.task_thread.retval = Ok(());
                     *c.cached_error_props.get_mut().unwrap() = out_delayed.p.m.clone();
                     rav1d_thread_picture_unref(out_delayed);
                 } else if !(out_delayed.p.data.data[0]).is_null() {

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -3196,7 +3196,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                                 as isize,
                                         )
                                         as *mut DynCoef;
-                                    let cbi = &mut (*f).frame_thread.cbi
+                                    let cbi = &(*f).frame_thread.cbi
                                         [(t.by as isize * (*f).b4_stride + t.bx as isize) as usize];
                                     eob = cbi.eob[(pl + 1) as usize] as c_int;
                                     txtp = cbi.txtp[(pl + 1) as usize] as TxfmType;
@@ -4426,7 +4426,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                                     ((*ts).frame_thread[p as usize].cf as *mut BD::Coef).offset(
                                         ((*uvtx).w as c_int * (*uvtx).h as c_int * 16) as isize,
                                     ) as *mut DynCoef;
-                                let cbi = &mut (*f).frame_thread.cbi
+                                let cbi = &(*f).frame_thread.cbi
                                     [(t.by as isize * (*f).b4_stride + t.bx as isize) as usize];
                                 eob = cbi.eob[(1 + pl) as usize] as c_int;
                                 txtp = cbi.txtp[(1 + pl) as usize] as TxfmType;

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -1,6 +1,7 @@
 use crate::include::common::bitdepth::AsPrimitive;
 use crate::include::common::bitdepth::BitDepth;
 use crate::include::common::bitdepth::DynCoef;
+use crate::include::common::bitdepth::BPC;
 use crate::include::common::dump::ac_dump;
 use crate::include::common::dump::coef_dump;
 use crate::include::common::dump::hex_dump;
@@ -1425,7 +1426,11 @@ unsafe fn decode_coefs<BD: BitDepth>(
         0 as *const u8
     };
     let dq_shift = cmp::max(0 as c_int, (*t_dim).ctx as c_int - 2);
-    let cf_max = !(!(127 as c_uint) << (if 16 == 8 { 8 as c_int } else { f.cur.p.bpc })) as c_int;
+    let cf_max = !(!(127 as c_uint)
+        << (match BD::BPC {
+            BPC::BPC8 => 8,
+            BPC::BPC16 => f.cur.p.bpc,
+        })) as c_int;
     let mut cul_level: c_uint;
     let dc_sign_level: c_uint;
     if dc_tok == 0 {


### PR DESCRIPTION
Removes excess mutability and replaces pointers to `struct Rav1dFrameContext` with references wherever possible, i.e. function arguments.