### PR TITLE
`struct Rav1dFrameContext`: rename to `Rav1dFrameData`

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -237,7 +237,7 @@ impl Rav1dContextTaskThread {
 
 #[repr(C)]
 pub struct Rav1dContext {
-    pub(crate) fc: *mut Rav1dFrameContext,
+    pub(crate) fc: *mut Rav1dFrameData,
     pub(crate) n_fc: c_uint,
 
     /// Worker thread join handles and communication, or main thread task
@@ -503,7 +503,7 @@ pub struct FrameTileThreadData {
 }
 
 #[repr(C)]
-pub(crate) struct Rav1dFrameContext {
+pub(crate) struct Rav1dFrameData {
     pub seq_hdr: Option<Arc<DRav1d<Rav1dSequenceHeader, Dav1dSequenceHeader>>>,
     pub frame_hdr: Option<Arc<DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>>>,
     pub refp: [Rav1dThreadPicture; 7],
@@ -715,7 +715,7 @@ impl Rav1dTaskContext_task_thread {
 
 #[repr(C)]
 pub(crate) struct Rav1dTaskContext {
-    pub f: *mut Rav1dFrameContext,
+    pub f: *mut Rav1dFrameData,
     pub ts: *mut Rav1dTileState,
     pub bx: c_int,
     pub by: c_int,
@@ -744,7 +744,7 @@ pub(crate) struct Rav1dTaskContext {
 
 impl Rav1dTaskContext {
     pub(crate) unsafe fn new(
-        f: *mut Rav1dFrameContext,
+        f: *mut Rav1dFrameData,
         task_thread: Arc<Rav1dTaskContext_task_thread>,
     ) -> Self {
         Self {

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -3,7 +3,7 @@ use crate::include::dav1d::headers::Rav1dPixelLayout;
 use crate::src::env::BlockContext;
 use crate::src::internal::Rav1dContext;
 use crate::src::internal::Rav1dDSPContext;
-use crate::src::internal::Rav1dFrameContext;
+use crate::src::internal::Rav1dFrameData;
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lr_apply::LR_RESTORE_U;
 use crate::src::lr_apply::LR_RESTORE_V;
@@ -22,7 +22,7 @@ use std::slice;
 // stripe with the top of the next super block row.
 unsafe fn backup_lpf<BD: BitDepth>(
     c: &Rav1dContext,
-    f: &Rav1dFrameContext,
+    f: &Rav1dFrameData,
     mut dst: *mut BD::Pixel,
     dst_stride: ptrdiff_t,
     mut src: *const BD::Pixel,
@@ -171,7 +171,7 @@ unsafe fn backup_lpf<BD: BitDepth>(
 
 pub(crate) unsafe fn rav1d_copy_lpf<BD: BitDepth>(
     c: &Rav1dContext,
-    f: &mut Rav1dFrameContext,
+    f: &mut Rav1dFrameData,
     src: *const *mut BD::Pixel,
     sby: c_int,
 ) {
@@ -353,7 +353,7 @@ fn unaligned_lvl_slice(lvl: &[[u8; 4]], y: usize) -> &[[u8; 4]] {
 
 #[inline]
 unsafe fn filter_plane_cols_y<BD: BitDepth>(
-    f: &Rav1dFrameContext,
+    f: &Rav1dFrameData,
     have_left: bool,
     lvl: &[[u8; 4]],
     b4_stride: ptrdiff_t,
@@ -399,7 +399,7 @@ unsafe fn filter_plane_cols_y<BD: BitDepth>(
 
 #[inline]
 unsafe fn filter_plane_rows_y<BD: BitDepth>(
-    f: &Rav1dFrameContext,
+    f: &Rav1dFrameData,
     have_top: bool,
     lvl: &[[u8; 4]],
     b4_stride: ptrdiff_t,
@@ -436,7 +436,7 @@ unsafe fn filter_plane_rows_y<BD: BitDepth>(
 
 #[inline]
 unsafe fn filter_plane_cols_uv<BD: BitDepth>(
-    f: &Rav1dFrameContext,
+    f: &Rav1dFrameData,
     have_left: bool,
     lvl: &[[u8; 4]],
     b4_stride: ptrdiff_t,
@@ -491,7 +491,7 @@ unsafe fn filter_plane_cols_uv<BD: BitDepth>(
 
 #[inline]
 unsafe fn filter_plane_rows_uv<BD: BitDepth>(
-    f: &Rav1dFrameContext,
+    f: &Rav1dFrameData,
     have_top: bool,
     lvl: &[[u8; 4]],
     b4_stride: ptrdiff_t,
@@ -539,7 +539,7 @@ unsafe fn filter_plane_rows_uv<BD: BitDepth>(
 }
 
 pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
-    f: &Rav1dFrameContext,
+    f: &Rav1dFrameData,
     p: &[*mut BD::Pixel; 3],
     lflvl: *mut Av1Filter,
     sby: c_int,
@@ -730,7 +730,7 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
 }
 
 pub(crate) unsafe fn rav1d_loopfilter_sbrow_rows<BD: BitDepth>(
-    f: &Rav1dFrameContext,
+    f: &Rav1dFrameData,
     p: &[*mut BD::Pixel; 3],
     lflvl: *mut Av1Filter,
     sby: c_int,

--- a/src/lr_apply.rs
+++ b/src/lr_apply.rs
@@ -6,7 +6,7 @@ use crate::include::dav1d::headers::RAV1D_RESTORATION_WIENER;
 use crate::src::align::Align16;
 use crate::src::internal::Rav1dContext;
 use crate::src::internal::Rav1dDSPContext;
-use crate::src::internal::Rav1dFrameContext;
+use crate::src::internal::Rav1dFrameData;
 use crate::src::lf_mask::Av1RestorationUnit;
 use crate::src::looprestoration::looprestorationfilter_fn;
 use crate::src::looprestoration::LooprestorationParams;
@@ -29,7 +29,7 @@ pub const LR_RESTORE_Y: LrRestorePlanes = 1;
 
 unsafe fn lr_stripe<BD: BitDepth>(
     c: &Rav1dContext,
-    f: &Rav1dFrameContext,
+    f: &Rav1dFrameData,
     mut p: *mut BD::Pixel,
     mut left: *const [BD::Pixel; 4],
     x: c_int,
@@ -169,7 +169,7 @@ unsafe fn backup4xU<BD: BitDepth>(
 
 unsafe fn lr_sbrow<BD: BitDepth>(
     c: &Rav1dContext,
-    f: &Rav1dFrameContext,
+    f: &Rav1dFrameData,
     mut p: *mut BD::Pixel,
     y: c_int,
     w: c_int,
@@ -270,7 +270,7 @@ unsafe fn lr_sbrow<BD: BitDepth>(
 
 pub(crate) unsafe fn rav1d_lr_sbrow<BD: BitDepth>(
     c: &Rav1dContext,
-    f: &mut Rav1dFrameContext,
+    f: &mut Rav1dFrameData,
     dst: *const *mut BD::Pixel,
     sby: c_int,
 ) {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -22,7 +22,7 @@ use crate::src::error::Rav1dError::EGeneric;
 use crate::src::error::Rav1dError::ENOMEM;
 use crate::src::error::Rav1dResult;
 use crate::src::internal::Rav1dContext;
-use crate::src::internal::Rav1dFrameContext;
+use crate::src::internal::Rav1dFrameData;
 use crate::src::log::Rav1dLog as _;
 use crate::src::log::Rav1dLogger;
 use crate::src::mem::rav1d_mem_pool_pop;
@@ -267,7 +267,7 @@ pub fn rav1d_picture_copy_props(
 // borrowing rules so we need to pass it to this function explicitly.
 pub(crate) unsafe fn rav1d_thread_picture_alloc(
     c: &Rav1dContext,
-    f: &mut Rav1dFrameContext,
+    f: &mut Rav1dFrameData,
     bpc: c_int,
     itut_t35: Option<Arc<DRav1d<Rav1dITUTT35, Dav1dITUTT35>>>,
 ) -> Rav1dResult {


### PR DESCRIPTION
We want to replace `Rav1dFrameContext` with a wrapper struct that holds the atomic and locked fields accessed concurrently and put the rest of the struct inside a Mutex. This automatic refactoring rename is in preparation for this refactoring.