### PR TITLE
`#![feature(core_intrinsics)]`: Remove as it's unused

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -2,7 +2,6 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![feature(c_variadic)]
-#![feature(core_intrinsics)]
 #![cfg_attr(target_arch = "arm", feature(stdsimd))]
 #![allow(clippy::all)]
 


### PR DESCRIPTION
* Fixes part of #592

Feature no longer needed now that we use stable SIMD APIs.