### PR TITLE
`mod lr_apply`: clean up code

### DIFF
--- a/src/lr_apply.rs
+++ b/src/lr_apply.rs
@@ -139,19 +139,19 @@ unsafe fn lr_stripe<BD: BitDepth>(
 }
 
 unsafe fn backup4xU<BD: BitDepth>(
-    mut dst: *mut [BD::Pixel; 4],
+    mut dst: &mut [[BD::Pixel; 4]],
     mut src: *const BD::Pixel,
     src_stride: ptrdiff_t,
     mut u: c_int,
 ) {
     while u > 0 {
         BD::pixel_copy(
-            slice::from_raw_parts_mut(&mut *dst as *mut BD::Pixel, 4),
+            &mut dst[0],
             slice::from_raw_parts(&*src as *const BD::Pixel, 4),
             4,
         );
         u -= 1;
-        dst = dst.offset(1);
+        dst = &mut dst[1..];
         src = src.offset(BD::pxstride(src_stride as usize) as isize);
     }
 }
@@ -214,7 +214,7 @@ unsafe fn lr_sbrow<BD: BitDepth>(
             != RAV1D_RESTORATION_NONE as c_int) as c_int;
         if restore_next != 0 {
             backup4xU::<BD>(
-                (pre_lr_border[bit as usize]).as_mut_ptr(),
+                &mut pre_lr_border[bit as usize],
                 p.offset(unit_size as isize).offset(-4),
                 p_stride,
                 row_h - y,

--- a/src/lr_apply.rs
+++ b/src/lr_apply.rs
@@ -31,7 +31,7 @@ unsafe fn lr_stripe<BD: BitDepth>(
     c: &Rav1dContext,
     f: &Rav1dFrameData,
     mut p: *mut BD::Pixel,
-    mut left: *const [BD::Pixel; 4],
+    mut left: &[[BD::Pixel; 4]],
     x: c_int,
     mut y: c_int,
     plane: c_int,
@@ -100,7 +100,7 @@ unsafe fn lr_stripe<BD: BitDepth>(
         lr_fn(
             p.cast(),
             stride,
-            left.cast(),
+            left.as_ptr().cast(),
             lpf.cast(),
             unit_w,
             stripe_h,
@@ -108,7 +108,7 @@ unsafe fn lr_stripe<BD: BitDepth>(
             edges,
             f.bitdepth_max,
         );
-        left = left.offset(stripe_h as isize);
+        left = &left[stripe_h as usize..];
         y += stripe_h;
         p = p.offset(stripe_h as isize * BD::pxstride(stride as usize) as isize);
         edges = edges | LR_HAVE_TOP;
@@ -205,7 +205,7 @@ unsafe fn lr_sbrow<BD: BitDepth>(
                 c,
                 f,
                 p,
-                (pre_lr_border[!bit as usize]).as_mut_ptr() as *const [BD::Pixel; 4],
+                &pre_lr_border[!bit as usize],
                 x,
                 y,
                 plane,
@@ -228,7 +228,7 @@ unsafe fn lr_sbrow<BD: BitDepth>(
             c,
             f,
             p,
-            (pre_lr_border[!bit as usize]).as_mut_ptr() as *const [BD::Pixel; 4],
+            &pre_lr_border[!bit as usize],
             x,
             y,
             plane,

--- a/src/lr_apply.rs
+++ b/src/lr_apply.rs
@@ -135,14 +135,17 @@ unsafe fn lr_stripe<BD: BitDepth>(
 }
 
 unsafe fn backup4xU<BD: BitDepth>(
-    mut dst: &mut [[BD::Pixel; 4]],
+    dst: &mut [[BD::Pixel; 4]],
     src: &[BD::Pixel],
     src_stride: ptrdiff_t,
     u: c_int,
 ) {
-    for (_, src) in (0..u).zip(src.chunks(BD::pxstride(src_stride as usize))) {
-        BD::pixel_copy(&mut dst[0], src, 4);
-        dst = &mut dst[1..];
+    for (src, dst) in src
+        .chunks(BD::pxstride(src_stride as usize))
+        .zip(dst)
+        .take(u as usize)
+    {
+        BD::pixel_copy(dst, src, 4);
     }
 }
 

--- a/src/lr_apply.rs
+++ b/src/lr_apply.rs
@@ -41,7 +41,7 @@ unsafe fn lr_stripe<BD: BitDepth>(
     mut edges: LrEdgeFlags,
 ) {
     let seq_hdr = &***f.seq_hdr.as_ref().unwrap();
-    let dsp: *const Rav1dDSPContext = f.dsp;
+    let dsp: &Rav1dDSPContext = &*f.dsp;
     let chroma = (plane != 0) as c_int;
     let ss_ver = chroma & (f.sr_cur.p.p.layout == Rav1dPixelLayout::I420) as c_int;
     let stride: ptrdiff_t = f.sr_cur.p.stride[chroma as usize];
@@ -82,7 +82,7 @@ unsafe fn lr_stripe<BD: BitDepth>(
         filter[1][4] = filter[1][2];
         filter[1][3] = 128 - (filter[1][0] + filter[1][1] + filter[1][2]) * 2;
 
-        lr_fn = (*dsp).lr.wiener[((filter[0][0] | filter[1][0]) == 0) as usize];
+        lr_fn = dsp.lr.wiener[((filter[0][0] | filter[1][0]) == 0) as usize];
     } else {
         assert_eq!(lr.r#type, RAV1D_RESTORATION_SGRPROJ);
         let sgr_params: &[u16] = &dav1d_sgr_params[lr.sgr_idx as usize];
@@ -90,8 +90,7 @@ unsafe fn lr_stripe<BD: BitDepth>(
         params.sgr.s1 = sgr_params[1] as u32;
         params.sgr.w0 = lr.sgr_weights[0] as i16;
         params.sgr.w1 = 128 - (lr.sgr_weights[0] as i16 + lr.sgr_weights[1] as i16);
-        lr_fn =
-            (*dsp).lr.sgr[(sgr_params[0] != 0) as usize + (sgr_params[1] != 0) as usize * 2 - 1];
+        lr_fn = dsp.lr.sgr[(sgr_params[0] != 0) as usize + (sgr_params[1] != 0) as usize * 2 - 1];
     }
     while y + stripe_h <= row_h {
         // Change the HAVE_BOTTOM bit in edges to (sby + 1 != f->sbh || y + stripe_h != row_h)

--- a/src/lr_apply.rs
+++ b/src/lr_apply.rs
@@ -47,22 +47,14 @@ unsafe fn lr_stripe<BD: BitDepth>(
     let stride: ptrdiff_t = f.sr_cur.p.stride[chroma as usize];
     let sby = y + (if y != 0 { 8 << ss_ver } else { 0 }) >> 6 - ss_ver + seq_hdr.sb128;
     let have_tt = (c.tc.len() > 1) as c_int;
-    // `lpf_offset` can be negative when `have_tt` is 1 and `sby` is 0.
-    // To avoid defining a slice with elements outside the allocated memory area, a
-    // variable `lpf_ptr_offset` is added to keep track of a negative offset that
-    // has to be added when casting the slice to a raw pointer.
-    let lpf_offset = (have_tt * (sby * (4 << seq_hdr.sb128) - 4)) as isize
-        * BD::pxstride(stride as usize) as isize
-        + x as isize;
-    let mut lpf_ptr_offset = if lpf_offset < 0 {
-        -4 * BD::pxstride(stride as usize) as isize
-    } else {
-        0
-    };
-    let mut lpf = &slice::from_raw_parts(
-        f.lf.lr_lpf_line[plane as usize] as *const BD::Pixel,
-        BD::pxstride(f.lf.lr_buf_plane_sz[(plane != 0) as usize] as usize),
-    )[(lpf_offset - lpf_ptr_offset) as usize..];
+    let lpf_stride = BD::pxstride(stride as usize) as isize;
+    let lpf_plane_sz = BD::pxstride(f.lf.lr_buf_plane_sz[(plane != 0) as usize] as usize) as isize;
+    let mut lpf_offset = cmp::max(lpf_stride - lpf_plane_sz, 0);
+    let lpf = &slice::from_raw_parts(
+        (f.lf.lr_lpf_line[plane as usize] as *const BD::Pixel).offset(-lpf_offset),
+        lpf_plane_sz.unsigned_abs(),
+    );
+    lpf_offset += (have_tt * (sby * (4 << seq_hdr.sb128) - 4)) as isize * lpf_stride + x as isize;
     // The first stripe of the frame is shorter by 8 luma pixel rows.
     let mut stripe_h = cmp::min(64 - 8 * (y == 0) as c_int >> ss_ver, row_h - y);
     let lr_fn: looprestorationfilter_fn;
@@ -111,7 +103,7 @@ unsafe fn lr_stripe<BD: BitDepth>(
             p.as_mut_ptr().cast(),
             stride,
             left.as_ptr().cast(),
-            lpf.as_ptr().offset(lpf_ptr_offset).cast(),
+            lpf.as_ptr().offset(lpf_offset).cast(),
             unit_w,
             stripe_h,
             &mut params,
@@ -128,8 +120,7 @@ unsafe fn lr_stripe<BD: BitDepth>(
         }
         p = &mut p[p_offset as usize..];
 
-        lpf = &lpf[(4 * BD::pxstride(stride as usize) as isize + lpf_ptr_offset) as usize..];
-        lpf_ptr_offset = 0;
+        lpf_offset += 4 * lpf_stride;
     }
 }
 

--- a/src/lr_apply.rs
+++ b/src/lr_apply.rs
@@ -273,12 +273,12 @@ pub(crate) unsafe fn rav1d_lr_sbrow<BD: BitDepth>(
     if restore_planes & (LR_RESTORE_U | LR_RESTORE_V) as c_int != 0 {
         let ss_ver = (f.sr_cur.p.p.layout == Rav1dPixelLayout::I420) as c_int;
         let ss_hor = (f.sr_cur.p.p.layout != Rav1dPixelLayout::I444) as c_int;
-        let h_0 = f.sr_cur.p.p.h + ss_ver >> ss_ver;
-        let w_0 = f.sr_cur.p.p.w + ss_hor >> ss_hor;
-        let next_row_y_0 = (sby + 1) << 6 - ss_ver + seq_hdr.sb128;
-        let row_h_0 = cmp::min(next_row_y_0 - (8 >> ss_ver) * not_last, h_0);
+        let h = f.sr_cur.p.p.h + ss_ver >> ss_ver;
+        let w = f.sr_cur.p.p.w + ss_hor >> ss_hor;
+        let next_row_y = (sby + 1) << 6 - ss_ver + seq_hdr.sb128;
+        let row_h = cmp::min(next_row_y - (8 >> ss_ver) * not_last, h);
         let offset_uv = offset_y >> ss_ver;
-        let y_stripe_0 = (sby << 6 - ss_ver + seq_hdr.sb128) - offset_uv;
+        let y_stripe = (sby << 6 - ss_ver + seq_hdr.sb128) - offset_uv;
         if restore_planes & LR_RESTORE_U as c_int != 0 {
             lr_sbrow::<BD>(
                 c,
@@ -286,10 +286,10 @@ pub(crate) unsafe fn rav1d_lr_sbrow<BD: BitDepth>(
                 dst[1].offset(
                     -(offset_uv as isize * BD::pxstride(*dst_stride.offset(1) as usize) as isize),
                 ),
-                y_stripe_0,
-                w_0,
-                h_0,
-                row_h_0,
+                y_stripe,
+                w,
+                h,
+                row_h,
                 1,
             );
         }
@@ -300,10 +300,10 @@ pub(crate) unsafe fn rav1d_lr_sbrow<BD: BitDepth>(
                 dst[2].offset(
                     -(offset_uv as isize * BD::pxstride(*dst_stride.offset(1) as usize) as isize),
                 ),
-                y_stripe_0,
-                w_0,
-                h_0,
-                row_h_0,
+                y_stripe,
+                w,
+                h,
+                row_h,
                 2,
             );
         }

--- a/src/lr_apply.rs
+++ b/src/lr_apply.rs
@@ -243,7 +243,7 @@ unsafe fn lr_sbrow<BD: BitDepth>(
 pub(crate) unsafe fn rav1d_lr_sbrow<BD: BitDepth>(
     c: &Rav1dContext,
     f: &mut Rav1dFrameData,
-    dst: *const *mut BD::Pixel,
+    dst: &[*mut BD::Pixel; 3],
     sby: c_int,
 ) {
     let offset_y = 8 * (sby != 0) as c_int;
@@ -260,7 +260,7 @@ pub(crate) unsafe fn rav1d_lr_sbrow<BD: BitDepth>(
         lr_sbrow::<BD>(
             c,
             f,
-            (*dst.offset(0)).offset(
+            dst[0].offset(
                 -(offset_y as isize * BD::pxstride(*dst_stride.offset(0) as usize) as isize),
             ),
             y_stripe,
@@ -283,7 +283,7 @@ pub(crate) unsafe fn rav1d_lr_sbrow<BD: BitDepth>(
             lr_sbrow::<BD>(
                 c,
                 f,
-                (*dst.offset(1)).offset(
+                dst[1].offset(
                     -(offset_uv as isize * BD::pxstride(*dst_stride.offset(1) as usize) as isize),
                 ),
                 y_stripe_0,
@@ -297,7 +297,7 @@ pub(crate) unsafe fn rav1d_lr_sbrow<BD: BitDepth>(
             lr_sbrow::<BD>(
                 c,
                 f,
-                (*dst.offset(2)).offset(
+                dst[2].offset(
                     -(offset_uv as isize * BD::pxstride(*dst_stride.offset(1) as usize) as isize),
                 ),
                 y_stripe_0,

--- a/src/lr_apply.rs
+++ b/src/lr_apply.rs
@@ -242,7 +242,7 @@ pub(crate) unsafe fn rav1d_lr_sbrow<BD: BitDepth>(
     sby: c_int,
 ) {
     let offset_y = 8 * (sby != 0) as c_int;
-    let dst_stride: *const ptrdiff_t = (f.sr_cur.p.stride).as_mut_ptr();
+    let dst_stride = &f.sr_cur.p.stride;
     let restore_planes = f.lf.restore_planes;
     let not_last = ((sby + 1) < f.sbh) as c_int;
     let seq_hdr = &***f.seq_hdr.as_ref().unwrap();
@@ -256,8 +256,7 @@ pub(crate) unsafe fn rav1d_lr_sbrow<BD: BitDepth>(
             c,
             f,
             &mut dst[0][dst_offset[0]
-                - (offset_y as isize * BD::pxstride(*dst_stride.offset(0) as usize) as isize)
-                    as usize..],
+                - (offset_y as isize * BD::pxstride(dst_stride[0] as usize) as isize) as usize..],
             y_stripe,
             w,
             h,
@@ -279,7 +278,7 @@ pub(crate) unsafe fn rav1d_lr_sbrow<BD: BitDepth>(
                 c,
                 f,
                 &mut dst[1][dst_offset[1]
-                    - (offset_uv as isize * BD::pxstride(*dst_stride.offset(1) as usize) as isize)
+                    - (offset_uv as isize * BD::pxstride(dst_stride[1] as usize) as isize)
                         as usize..],
                 y_stripe,
                 w,
@@ -293,7 +292,7 @@ pub(crate) unsafe fn rav1d_lr_sbrow<BD: BitDepth>(
                 c,
                 f,
                 &mut dst[2][dst_offset[1]
-                    - (offset_uv as isize * BD::pxstride(*dst_stride.offset(1) as usize) as isize)
+                    - (offset_uv as isize * BD::pxstride(dst_stride[1] as usize) as isize)
                         as usize..],
                 y_stripe,
                 w,

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -4715,7 +4715,7 @@ pub(crate) unsafe fn rav1d_filter_sbrow_lr<BD: BitDepth>(
         (f.lf.sr_p[2] as *mut BD::Pixel)
             .offset(y as isize * BD::pxstride(f.sr_cur.p.stride[1] as usize) as isize >> ss_ver),
     ];
-    rav1d_lr_sbrow::<BD>(c, f, sr_p.as_ptr(), sby);
+    rav1d_lr_sbrow::<BD>(c, f, &sr_p, sby);
 }
 
 pub(crate) unsafe fn rav1d_filter_sbrow<BD: BitDepth>(


### PR DESCRIPTION
Fixes #704 :
- restore comments from C code 
- use of slices instead of raw pointers where possible
- general cleanup including removal of unnecessary casts, loop cleanup, and use of `bool` type where appropriate