### PR TITLE
`fn Rav1dFrameContext_bd_fn::get`: Replace field with lookups to static versions

### DIFF
--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -85,6 +85,16 @@ pub enum BPC {
     BPC16,
 }
 
+impl BPC {
+    pub fn from_bitdepth_max(bitdepth_max: c_int) -> Self {
+        if bitdepth_max == BitDepth8::new(()).bitdepth_max().into() {
+            Self::BPC8
+        } else {
+            Self::BPC16
+        }
+    }
+}
+
 pub trait BitDepth: Clone + Copy {
     const BPC: BPC;
     const BITDEPTH: u8;

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -331,8 +331,6 @@ pub struct ScalableMotionParams {
     pub step: c_int,
 }
 
-#[repr(C)]
-#[derive(Clone)]
 pub(crate) struct Rav1dFrameContext_bd_fn {
     pub recon_b_intra: recon_b_intra_fn,
     pub recon_b_inter: recon_b_inter_fn,
@@ -554,7 +552,6 @@ pub(crate) struct Rav1dFrameData {
     pub ts: *mut Rav1dTileState,
     pub n_ts: c_int,
     pub dsp: *const Rav1dDSPContext,
-    pub bd_fn: Rav1dFrameContext_bd_fn,
 
     pub ipred_edge_sz: c_int,
     pub ipred_edge: [*mut DynPixel; 3],
@@ -585,6 +582,11 @@ pub(crate) struct Rav1dFrameData {
 }
 
 impl Rav1dFrameData {
+    pub fn bd_fn(&self) -> &'static Rav1dFrameContext_bd_fn {
+        let bpc = BPC::from_bitdepth_max(self.bitdepth_max);
+        Rav1dFrameContext_bd_fn::get(bpc)
+    }
+
     pub fn frame_hdr(&self) -> &Rav1dFrameHeader {
         self.frame_hdr.as_ref().unwrap()
     }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,8 +1,11 @@
 use crate::include::common::bitdepth::BitDepth;
+use crate::include::common::bitdepth::BitDepth16;
+use crate::include::common::bitdepth::BitDepth8;
 use crate::include::common::bitdepth::BitDepthDependentType;
 use crate::include::common::bitdepth::BitDepthUnion;
 use crate::include::common::bitdepth::DynCoef;
 use crate::include::common::bitdepth::DynPixel;
+use crate::include::common::bitdepth::BPC;
 use crate::include::dav1d::common::Rav1dDataProps;
 use crate::include::dav1d::data::Rav1dData;
 use crate::include::dav1d::dav1d::Rav1dDecodeFrameType;
@@ -345,7 +348,7 @@ pub(crate) struct Rav1dFrameContext_bd_fn {
 }
 
 impl Rav1dFrameContext_bd_fn {
-    pub fn new<BD: BitDepth>() -> Self {
+    pub const fn new<BD: BitDepth>() -> Self {
         Self {
             recon_b_inter: rav1d_recon_b_inter::<BD>,
             recon_b_intra: rav1d_recon_b_intra::<BD>,
@@ -357,6 +360,15 @@ impl Rav1dFrameContext_bd_fn {
             filter_sbrow_lr: rav1d_filter_sbrow_lr::<BD>,
             backup_ipred_edge: rav1d_backup_ipred_edge::<BD>,
             read_coef_blocks: rav1d_read_coef_blocks::<BD>,
+        }
+    }
+
+    pub const fn get(bpc: BPC) -> &'static Self {
+        const BPC8: Rav1dFrameContext_bd_fn = Rav1dFrameContext_bd_fn::new::<BitDepth8>();
+        const BPC16: Rav1dFrameContext_bd_fn = Rav1dFrameContext_bd_fn::new::<BitDepth16>();
+        match bpc {
+            BPC::BPC8 => &BPC8,
+            BPC::BPC16 => &BPC16,
         }
     }
 

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1222,7 +1222,7 @@ pub unsafe fn rav1d_worker_task(c: &Rav1dContext, task_thread: Arc<Rav1dTaskCont
                     }
                     RAV1D_TASK_TYPE_DEBLOCK_COLS => {
                         if f.task_thread.error.load(Ordering::SeqCst) == 0 {
-                            (f.bd_fn.filter_sbrow_deblock_cols)(c, f, &mut tc, sby);
+                            (f.bd_fn().filter_sbrow_deblock_cols)(c, f, &mut tc, sby);
                         }
                         if ensure_progress(
                             ttd,
@@ -1241,7 +1241,7 @@ pub unsafe fn rav1d_worker_task(c: &Rav1dContext, task_thread: Arc<Rav1dTaskCont
                     }
                     RAV1D_TASK_TYPE_DEBLOCK_ROWS => {
                         if f.task_thread.error.load(Ordering::SeqCst) == 0 {
-                            (f.bd_fn.filter_sbrow_deblock_rows)(c, f, &mut tc, sby);
+                            (f.bd_fn().filter_sbrow_deblock_rows)(c, f, &mut tc, sby);
                         }
                         // signal deblock progress
                         let seq_hdr = &***f.seq_hdr.as_ref().unwrap();
@@ -1288,7 +1288,7 @@ pub unsafe fn rav1d_worker_task(c: &Rav1dContext, task_thread: Arc<Rav1dTaskCont
                         let seq_hdr = &***f.seq_hdr.as_ref().unwrap();
                         if seq_hdr.cdef != 0 {
                             if f.task_thread.error.load(Ordering::SeqCst) == 0 {
-                                (f.bd_fn.filter_sbrow_cdef)(c, f, &mut tc, sby);
+                                (f.bd_fn().filter_sbrow_cdef)(c, f, &mut tc, sby);
                             }
                             reset_task_cur_async(ttd, t.frame_idx, c.n_fc);
                             if ttd.cond_signaled.fetch_or(1, Ordering::SeqCst) == 0 {
@@ -1302,7 +1302,7 @@ pub unsafe fn rav1d_worker_task(c: &Rav1dContext, task_thread: Arc<Rav1dTaskCont
                         let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
                         if frame_hdr.size.width[0] != frame_hdr.size.width[1] {
                             if f.task_thread.error.load(Ordering::SeqCst) == 0 {
-                                (f.bd_fn.filter_sbrow_resize)(c, f, &mut tc, sby);
+                                (f.bd_fn().filter_sbrow_resize)(c, f, &mut tc, sby);
                             }
                         }
                         task_type = RAV1D_TASK_TYPE_LOOP_RESTORATION;
@@ -1312,7 +1312,7 @@ pub unsafe fn rav1d_worker_task(c: &Rav1dContext, task_thread: Arc<Rav1dTaskCont
                         if f.task_thread.error.load(Ordering::SeqCst) == 0
                             && f.lf.restore_planes != 0
                         {
-                            (f.bd_fn.filter_sbrow_lr)(c, f, &mut tc, sby);
+                            (f.bd_fn().filter_sbrow_lr)(c, f, &mut tc, sby);
                         }
                         task_type = RAV1D_TASK_TYPE_RECONSTRUCTION_PROGRESS;
                         continue 'fallthrough;


### PR DESCRIPTION
`fn Rav1dFrameContext_bd_fn::new` is `const` and pure, so we can have a pure `bitdepth_max: c_int` => `&'static Rav1dFrameContext_bd_fn` `fn`, thereby avoiding `.clone()`s and saving on memory.

See https://github.com/memorysafety/rav1d/pull/748#discussion_r1491936115 and https://github.com/memorysafety/rav1d/pull/748#discussion_r1491949677.

We can also do a similar thing for `Rav1dDSPContext`, but with it cached based on runtime CPU features. 