### PR TITLE
Backport security fix from dav1d 1.4.0

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -2637,7 +2637,7 @@ static void setup_tile(Dav1dTileState *const ts,
                        const Dav1dFrameContext *const f,
                        const uint8_t *const data, const size_t sz,
                        const int tile_row, const int tile_col,
-                       const int tile_start_off)
+                       const unsigned tile_start_off)
 {
     const int col_sb_start = f->frame_hdr->tiling.col_start_sb[tile_col];
     const int col_sb128_start = col_sb_start >> !f->seq_hdr->sb128;
@@ -2988,15 +2988,16 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
     const uint8_t *const size_mul = ss_size_mul[f->cur.p.layout];
     const int hbd = !!f->seq_hdr->hbd;
     if (c->n_fc > 1) {
+        const unsigned sb_step4 = f->sb_step * 4;
         int tile_idx = 0;
         for (int tile_row = 0; tile_row < f->frame_hdr->tiling.rows; tile_row++) {
-            int row_off = f->frame_hdr->tiling.row_start_sb[tile_row] *
-                          f->sb_step * 4 * f->sb128w * 128;
-            int b_diff = (f->frame_hdr->tiling.row_start_sb[tile_row + 1] -
-                          f->frame_hdr->tiling.row_start_sb[tile_row]) * f->sb_step * 4;
+            const unsigned row_off = f->frame_hdr->tiling.row_start_sb[tile_row] *
+                                     sb_step4 * f->sb128w * 128;
+            const unsigned b_diff = (f->frame_hdr->tiling.row_start_sb[tile_row + 1] -
+                                     f->frame_hdr->tiling.row_start_sb[tile_row]) * sb_step4;
             for (int tile_col = 0; tile_col < f->frame_hdr->tiling.cols; tile_col++) {
                 f->frame_thread.tile_start_off[tile_idx++] = row_off + b_diff *
-                    f->frame_hdr->tiling.col_start_sb[tile_col] * f->sb_step * 4;
+                    f->frame_hdr->tiling.col_start_sb[tile_col] * sb_step4;
             }
         }
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -293,7 +293,7 @@ struct Dav1dFrameContext {
         int prog_sz;
         int pal_sz, pal_idx_sz, cf_sz;
         // start offsets per tile
-        int *tile_start_off;
+        unsigned *tile_start_off;
     } frame_thread;
 
     // loopfilter

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -427,7 +427,7 @@ pub struct Rav1dFrameContext_frame_thread {
     pub pal_idx_sz: c_int,
     pub cf_sz: c_int,
     // start offsets per tile
-    pub tile_start_off: *mut c_int,
+    pub tile_start_off: *mut u32,
 }
 
 /// loopfilter

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -906,7 +906,7 @@ impl Drop for Rav1dContext {
                     let _ = mem::take(&mut f.frame_thread.b); // TODO: remove when context is owned
                     rav1d_freep_aligned(&mut f.frame_thread.pal_idx as *mut *mut u8 as *mut c_void);
                     rav1d_freep_aligned(&mut f.frame_thread.cf as *mut *mut DynCoef as *mut c_void);
-                    freep(&mut f.frame_thread.tile_start_off as *mut *mut c_int as *mut c_void);
+                    freep(&mut f.frame_thread.tile_start_off as *mut *mut u32 as *mut c_void);
                     rav1d_freep_aligned(
                         &mut f.frame_thread.pal as *mut *mut [[u16; 8]; 3] as *mut c_void,
                     );


### PR DESCRIPTION
Addresses #753 by using unsigned integer values for `tile_start_off` instead of signed ones to avoid possible overflow.