### PR TITLE
`struct Rav1dContext_intra_edge::root`: Replace with safe getter

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4105,7 +4105,7 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
             if c.flush.load(Ordering::Acquire) != 0 {
                 return Err(());
             }
-            decode_sb(c, t, f, root_bl, c.intra_edge.root[root_bl as usize])?;
+            decode_sb(c, t, f, root_bl, c.intra_edge.root(root_bl))?;
             if t.bx & 16 != 0 || f.seq_hdr().sb128 != 0 {
                 t.a = (t.a).offset(1);
             }
@@ -4213,7 +4213,7 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
                 read_restoration_info(t, f, lr, p, frame_type);
             }
         }
-        decode_sb(c, t, f, root_bl, c.intra_edge.root[root_bl as usize])?;
+        decode_sb(c, t, f, root_bl, c.intra_edge.root(root_bl))?;
         if t.bx & 16 != 0 || f.seq_hdr().sb128 != 0 {
             t.a = (t.a).offset(1);
             t.lf_mask = (t.lf_mask).offset(1);

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -40,8 +40,11 @@ use crate::src::intra_edge::EdgeTip;
 use crate::src::ipred::Rav1dIntraPredDSPContext;
 use crate::src::itx::Rav1dInvTxfmDSPContext;
 use crate::src::levels::Av1Block;
+use crate::src::levels::BlockLevel;
 use crate::src::levels::BlockSize;
 use crate::src::levels::Filter2d;
+use crate::src::levels::BL_128X128;
+use crate::src::levels::BL_64X64;
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
 use crate::src::lf_mask::Av1Restoration;
@@ -204,11 +207,20 @@ pub(crate) struct Rav1dContext_refs {
 
 #[repr(C)]
 pub struct Rav1dContext_intra_edge {
-    pub root: [*mut EdgeNode; 2],
     pub branch_sb128: [EdgeBranch; 85],
     pub branch_sb64: [EdgeBranch; 21],
     pub tip_sb128: [EdgeTip; 256],
     pub tip_sb64: [EdgeTip; 64],
+}
+
+impl Rav1dContext_intra_edge {
+    pub fn root(&self, bl: BlockLevel) -> &EdgeNode {
+        match bl {
+            BL_128X128 => &self.branch_sb128[0].node,
+            BL_64X64 => &self.branch_sb64[0].node,
+            _ => unreachable!(),
+        }
+    }
 }
 
 pub(crate) enum Rav1dContextTaskType {

--- a/src/intra_edge.rs
+++ b/src/intra_edge.rs
@@ -194,12 +194,7 @@ unsafe fn init_mode_node(
     };
 }
 
-pub unsafe fn rav1d_init_mode_tree(
-    root_node: *mut EdgeNode,
-    nt: &mut [EdgeTip],
-    allow_sb128: bool,
-) {
-    let root = root_node as *mut EdgeBranch;
+pub unsafe fn rav1d_init_mode_tree(root: *mut EdgeBranch, nt: &mut [EdgeTip], allow_sb128: bool) {
     let mut mem = ModeSelMem {
         nwc: [ptr::null_mut(); 3],
         nt: nt.as_mut_ptr(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,6 @@ use crate::src::internal::Rav1dTaskContext;
 use crate::src::internal::Rav1dTaskContext_task_thread;
 use crate::src::internal::TaskThreadData;
 use crate::src::intra_edge::rav1d_init_mode_tree;
-use crate::src::levels::BL_128X128;
-use crate::src::levels::BL_64X64;
 use crate::src::log::Rav1dLog as _;
 use crate::src::mem::freep;
 use crate::src::mem::rav1d_alloc_aligned;
@@ -362,17 +360,13 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
         })
         .collect();
     rav1d_refmvs_dsp_init(&mut (*c).refmvs_dsp);
-    (*c).intra_edge.root[BL_128X128 as c_int as usize] =
-        &mut (*((*c).intra_edge.branch_sb128).as_mut_ptr().offset(0)).node;
     rav1d_init_mode_tree(
-        (*c).intra_edge.root[BL_128X128 as c_int as usize],
+        &mut (*c).intra_edge.branch_sb128[0],
         &mut (*c).intra_edge.tip_sb128,
         true,
     );
-    (*c).intra_edge.root[BL_64X64 as c_int as usize] =
-        &mut (*((*c).intra_edge.branch_sb64).as_mut_ptr().offset(0)).node;
     rav1d_init_mode_tree(
-        (*c).intra_edge.root[BL_64X64 as c_int as usize],
+        &mut (*c).intra_edge.branch_sb64[0],
         &mut (*c).intra_edge.tip_sb64,
         false,
     );


### PR DESCRIPTION
`root` contained pointers to `branch_sb128` and `branch_sb64`, so we can replace it with a simple getter.

In investigating this I discovered that most of our logic for working with the mode tree still uses raw pointers to nodes. I've added #756 to track the work to make node access safe.