### PR TITLE
`struct Rav1dFrameContext_lf::mask`: Make into `Vec`

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -152,7 +152,6 @@ use crate::src::lf_mask::rav1d_calc_eih;
 use crate::src::lf_mask::rav1d_calc_lf_values;
 use crate::src::lf_mask::rav1d_create_lf_mask_inter;
 use crate::src::lf_mask::rav1d_create_lf_mask_intra;
-use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 use crate::src::log::Rav1dLog as _;
@@ -4130,9 +4129,7 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
     t.pal_sz_uv[1] = Default::default();
     let sb128y = t.by >> 5;
     t.a = f.a.offset((col_sb128_start + tile_row * f.sb128w) as isize);
-    t.lf_mask =
-        f.lf.mask
-            .offset((sb128y * f.sb128w + col_sb128_start) as isize);
+    t.lf_mask = f.lf.mask[(sb128y * f.sb128w + col_sb128_start) as usize..].as_mut_ptr();
     for bx in (ts.tiling.col_start..ts.tiling.col_end).step_by(sb_step as usize) {
         t.bx = bx;
         if c.flush.load(Ordering::Acquire) != 0 {
@@ -4519,30 +4516,24 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
     }
 
     // update allocation for loopfilter masks
-    if num_sb128 != f.lf.mask_sz {
-        freep(&mut f.lf.mask as *mut *mut Av1Filter as *mut c_void);
-        f.lf.mask =
-            malloc(::core::mem::size_of::<Av1Filter>() * num_sb128 as usize) as *mut Av1Filter;
-        // over-allocate one element (4 bytes) since some of the SIMD implementations
-        // index this from the level type and can thus over-read by up to 3 bytes.
-        f.lf.level
-            .resize(num_sb128 as usize * 32 * 32 + 1, [0u8; 4]); // TODO: Fallible allocation
-        if f.lf.mask.is_null() {
-            f.lf.mask_sz = 0;
-            return Err(ENOMEM);
-        }
-        if c.n_fc > 1 {
-            // TODO: Fallible allocation
-            f.frame_thread
-                .b
-                .resize_with(num_sb128 as usize * 32 * 32, Default::default);
 
-            // TODO: fallible allocation
-            f.frame_thread
-                .cbi
-                .resize_with(num_sb128 as usize * 32 * 32, Default::default);
-        }
-        f.lf.mask_sz = num_sb128;
+    f.lf.mask.clear();
+    // TODO: Fallible allocation.
+    f.lf.mask.resize_with(num_sb128 as usize, Default::default);
+    // over-allocate one element (4 bytes) since some of the SIMD implementations
+    // index this from the level type and can thus over-read by up to 3 bytes.
+    f.lf.level
+        .resize(num_sb128 as usize * 32 * 32 + 1, [0u8; 4]); // TODO: Fallible allocation
+    if c.n_fc > 1 {
+        // TODO: Fallible allocation
+        f.frame_thread
+            .b
+            .resize_with(num_sb128 as usize * 32 * 32, Default::default);
+
+        // TODO: fallible allocation
+        f.frame_thread
+            .cbi
+            .resize_with(num_sb128 as usize * 32 * 32, Default::default);
     }
 
     f.sr_sb128w = f.sr_cur.p.p.w + 127 >> 7;
@@ -4570,7 +4561,6 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
         f.lf.last_sharpness = frame_hdr.loopfilter.sharpness;
     }
     rav1d_calc_lf_values(&mut f.lf.lvl, &frame_hdr, &[0, 0, 0, 0]);
-    slice::from_raw_parts_mut(f.lf.mask, num_sb128.try_into().unwrap()).fill_with(Default::default);
 
     let ipred_edge_sz = f.sbh * f.sb128w << hbd;
     if ipred_edge_sz != f.ipred_edge_sz {
@@ -4676,7 +4666,6 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
     // We never dereference those pointers, so it doesn't really matter
     // what they point at, as long as the pointers are valid.
     let has_chroma = (f.cur.p.layout != Rav1dPixelLayout::I400) as usize;
-    f.lf.mask_ptr = f.lf.mask;
     f.lf.p = array::from_fn(|i| f.cur.data.data[has_chroma * i].cast());
     f.lf.sr_p = array::from_fn(|i| f.sr_cur.p.data.data[has_chroma * i].cast());
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -444,9 +444,8 @@ pub struct Rav1dFrameContext_frame_thread {
 #[repr(C)]
 pub struct Rav1dFrameContext_lf {
     pub level: Vec<[u8; 4]>,
-    pub mask: *mut Av1Filter,
+    pub mask: Vec<Av1Filter>, /* len = w*h */
     pub lr_mask: *mut Av1Restoration,
-    pub mask_sz: c_int, /* w*h */
     pub lr_mask_sz: c_int,
     pub cdef_buf_plane_sz: [c_int; 2], /* stride*sbh*4 */
     pub cdef_buf_sbh: c_int,
@@ -468,8 +467,6 @@ pub struct Rav1dFrameContext_lf {
     pub need_cdef_lpf_copy: c_int,
     pub p: [*mut DynPixel; 3],
     pub sr_p: [*mut DynPixel; 3],
-    pub mask_ptr: *mut Av1Filter,
-    pub prev_mask_ptr: *mut Av1Filter,
     pub restore_planes: c_int, // enum LrRestorePlanes
 }
 

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -4,7 +4,6 @@ use crate::src::env::BlockContext;
 use crate::src::internal::Rav1dContext;
 use crate::src::internal::Rav1dDSPContext;
 use crate::src::internal::Rav1dFrameData;
-use crate::src::lf_mask::Av1Filter;
 use crate::src::lr_apply::LR_RESTORE_U;
 use crate::src::lr_apply::LR_RESTORE_V;
 use crate::src::lr_apply::LR_RESTORE_Y;
@@ -539,12 +538,13 @@ unsafe fn filter_plane_rows_uv<BD: BitDepth>(
 }
 
 pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
-    f: &Rav1dFrameData,
+    f: &mut Rav1dFrameData,
     p: &[*mut BD::Pixel; 3],
-    lflvl: *mut Av1Filter,
+    lflvl_offset: usize,
     sby: c_int,
     start_of_tile_row: c_int,
 ) {
+    let lflvl = f.lf.mask[lflvl_offset..].as_mut_ptr();
     let mut have_left;
     let seq_hdr = &***f.seq_hdr.as_ref().unwrap();
     let is_sb64 = (seq_hdr.sb128 == 0) as c_int;
@@ -730,11 +730,13 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
 }
 
 pub(crate) unsafe fn rav1d_loopfilter_sbrow_rows<BD: BitDepth>(
-    f: &Rav1dFrameData,
+    f: &mut Rav1dFrameData,
     p: &[*mut BD::Pixel; 3],
-    lflvl: *mut Av1Filter,
+    lflvl_offset: usize,
     sby: c_int,
 ) {
+    let lflvl = f.lf.mask[lflvl_offset..].as_mut_ptr();
+
     // Don't filter outside the frame
     let have_top = sby > 0;
     let seq_hdr = &***f.seq_hdr.as_ref().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -918,7 +918,7 @@ impl Drop for Rav1dContext {
                 rav1d_free_aligned(f.ipred_edge[0] as *mut c_void);
                 free(f.a as *mut c_void);
                 let _ = mem::take(&mut f.tiles);
-                free(f.lf.mask as *mut c_void);
+                let _ = mem::take(&mut f.lf.mask); // TODO: remove when context is owned
                 free(f.lf.lr_mask as *mut c_void);
                 let _ = mem::take(&mut f.lf.level);
                 free(f.lf.tx_lpf_right_edge[0] as *mut c_void);


### PR DESCRIPTION
In a number of cases both `f` and `f.lf.mask` were being passed into the same function, which caused borrow conflicts once the code was changed to use safe slice operations. In these cases I changed the logic to instead pass an offset into the function. In some of these cases the initial offset is actually negative, and another positive offset is added to get a non-negative offset before indexing into the slice. In these cases the offset is passed as an `i32`, otherwise the offset is passed as a `usize`.

There are still some cases where we're taking a raw pointer to `mask` within a function, and a pointer to `mask` is stored in `Rav1dTaskContext::lf_mask`. I've opted to not make all of these fully safe in this PR to keep the changes simple. Looking at how `mask` is used, I noticed that even functions that we've refactored to take all safe arguments are still sometimes using raw pointer operations within the function. Once we've cleaned up pointers in struct fields we'll also need to hunt for usages of `as_ptr`/`as_mut_ptr` and convert those to safe operations as well.

The `mask_ptr` and `prev_mask_ptr` fields were being initialized to point into `mask`, but were never used so I removed them.