### PR TITLE
`struct AlignedVec`: Make generic over alignment

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -424,9 +424,6 @@ pub struct CodedBlockInfo {
     pub txtp: [u8; 3], /* plane */
 }
 
-// TODO: Temporary `Default` impl to support using `mem::take` to manually drop
-// this field. Remove once the context is fully owned and can be dropped
-// normally.
 #[derive(Default)]
 #[repr(C)]
 pub struct Rav1dFrameContext_frame_thread {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -427,16 +427,25 @@ pub struct CodedBlockInfo {
 #[derive(Default)]
 #[repr(C)]
 pub struct Rav1dFrameContext_frame_thread {
-    pub next_tile_row: [c_int; 2], /* 0: reconstruction, 1: entropy */
-    // indexed using t->by * f->b4_stride + t->bx
+    /// Indices: 0: reconstruction, 1: entropy.
+    pub next_tile_row: [c_int; 2],
+
+    /// Indexed using `t.by * f.b4_stride + t.bx`.
     pub b: Vec<Av1Block>,
+
     pub cbi: Vec<CodedBlockInfo>,
-    // indexed using (t->by >> 1) * (f->b4_stride >> 1) + (t->bx >> 1)
-    pub pal: AlignedVec64<[[u16; 8]; 3]>, /* [3 plane][8 idx] */
-    // iterated over inside tile state
+
+    /// Indexed using `(t.by >> 1) * (f.b4_stride >> 1) + (t.bx >> 1)`.
+    /// Inner indices are `[3 plane][8 idx]`.
+    pub pal: AlignedVec64<[[u16; 8]; 3]>,
+
+    /// Iterated over inside tile state.
     pub pal_idx: AlignedVec64<u8>,
-    pub cf: AlignedVec64<u8>, // AlignedVec64<DynCoef>
-    // start offsets per tile
+
+    /// [`AlignedVec64`]`<`[`DynCoef`]`>`
+    pub cf: AlignedVec64<u8>,
+
+    /// Start offsets per tile
     pub tile_start_off: Vec<u32>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ use crate::src::fg_apply;
 use crate::src::internal::Rav1dContext;
 use crate::src::internal::Rav1dContextTaskThread;
 use crate::src::internal::Rav1dContextTaskType;
+use crate::src::internal::Rav1dFrameContext_frame_thread;
 use crate::src::internal::Rav1dFrameData;
 use crate::src::internal::Rav1dTask;
 use crate::src::internal::Rav1dTaskContext;
@@ -82,6 +83,7 @@ use std::mem;
 use std::mem::MaybeUninit;
 use std::process::abort;
 use std::ptr;
+use std::ptr::addr_of_mut;
 use std::ptr::NonNull;
 use std::slice;
 use std::sync::atomic::AtomicI32;
@@ -324,6 +326,7 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
     let mut n: c_uint = 0 as c_int as c_uint;
     while n < (*c).n_fc {
         let f: &mut Rav1dFrameData = &mut *((*c).fc).offset(n as isize);
+        addr_of_mut!(f.frame_thread).write(Default::default());
         if n_tc > 1 {
             f.task_thread.lock = Mutex::new(());
             f.task_thread.cond = Condvar::new();


### PR DESCRIPTION
This makes `AlignedVec` generic over alignments by using a marker `trait AlignedByteChunk` `impl`ed for types with the same alignment and size (e.x. `Align64<[u8; 64]>`.  Since `#[repr(align(N))]` is not a const generic, const generics couldn't be used for this, but this works nicely.  We check that `mem::size_of::<C>() == mem::align_of::<C>()` in `AlignedVec`'s constructors to ensure `AlignedByteChunk` is `impl`ed on valid types.  Thus, I also ensured that the `AlignedVec`s were actually constructed, not transmuted through `unsafe { mem::zeroed() }`.