### PR TITLE
`struct Rav1dFrameContext_lf::lr_mask`: Make into a `Vec`

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -152,7 +152,6 @@ use crate::src::lf_mask::rav1d_calc_eih;
 use crate::src::lf_mask::rav1d_calc_lf_values;
 use crate::src::lf_mask::rav1d_create_lf_mask_inter;
 use crate::src::lf_mask::rav1d_create_lf_mask_intra;
-use crate::src::lf_mask::Av1Restoration;
 use crate::src::lf_mask::Av1RestorationUnit;
 use crate::src::log::Rav1dLog as _;
 use crate::src::loopfilter::rav1d_loop_filter_dsp_init;
@@ -3924,9 +3923,9 @@ unsafe fn setup_tile(
             if sb128x >= f.sr_sb128w {
                 continue;
             }
-            &(*f.lf.lr_mask.offset((sb_idx + sb128x) as isize)).lr[p][u_idx as usize]
+            &f.lf.lr_mask[(sb_idx + sb128x) as usize].lr[p][u_idx as usize]
         } else {
-            &(*f.lf.lr_mask.offset(sb_idx as isize)).lr[p][unit_idx as usize]
+            &f.lf.lr_mask[sb_idx as usize].lr[p][unit_idx as usize]
         };
 
         let lr = lr_ref.get();
@@ -3946,13 +3945,12 @@ unsafe fn setup_tile(
 }
 
 unsafe fn read_restoration_info(
-    t: &mut Rav1dTaskContext,
-    f: &Rav1dFrameData,
+    ts: &mut Rav1dTileState,
     lr: &mut Av1RestorationUnit,
     p: usize,
     frame_type: Rav1dRestorationType,
+    debug_block_info: bool,
 ) {
-    let ts = &mut *t.ts;
     let lr_ref = ts.lr_ref[p];
 
     if frame_type == RAV1D_RESTORATION_SWITCHABLE {
@@ -4006,7 +4004,7 @@ unsafe fn read_restoration_info(
         lr.filter_h[2] = msac_decode_lr_subexp(ts, lr_ref.filter_h[2], 3, 17);
         lr.sgr_weights = lr_ref.sgr_weights;
         ts.lr_ref[p] = *lr;
-        if debug_block_info!(f, t) {
+        if debug_block_info {
             println!(
                 "Post-lr_wiener[pl={},v[{},{},{}],h[{},{},{}]]: r={}",
                 p,
@@ -4036,7 +4034,7 @@ unsafe fn read_restoration_info(
         lr.filter_v = lr_ref.filter_v;
         lr.filter_h = lr_ref.filter_h;
         ts.lr_ref[p] = *lr;
-        if debug_block_info!(f, t) {
+        if debug_block_info {
             println!(
                 "Post-lr_sgrproj[pl={},idx={},w[{},{}]]: r={}",
                 p, lr.sgr_idx, lr.sgr_weights[0], lr.sgr_weights[1], ts.msac.rng,
@@ -4143,7 +4141,7 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
             cdef_idx[0] = -1;
             t.cur_sb_cdef_idx_ptr = cdef_idx.as_mut_ptr();
         }
-        let frame_hdr = f.frame_hdr();
+        let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
         // Restoration filter
         for p in 0..3 {
             if (f.lf.restore_planes >> p) & 1 == 0 {
@@ -4184,10 +4182,9 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
                     let px_x = x << unit_size_log2 + ss_hor;
                     let sb_idx = (t.by >> 5) * f.sr_sb128w + (px_x >> 7);
                     let unit_idx = ((t.by & 16) >> 3) + ((px_x & 64) >> 6);
-                    let lr = (*(f.lf.lr_mask).offset(sb_idx as isize)).lr[p][unit_idx as usize]
-                        .get_mut();
+                    let lr = f.lf.lr_mask[sb_idx as usize].lr[p][unit_idx as usize].get_mut();
 
-                    read_restoration_info(t, f, lr, p, frame_type);
+                    read_restoration_info(&mut *t.ts, lr, p, frame_type, debug_block_info!(f, t));
                 }
             } else {
                 let x = 4 * t.bx >> ss_hor;
@@ -4202,10 +4199,9 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
                 }
                 let sb_idx = (t.by >> 5) * f.sr_sb128w + (t.bx >> 5);
                 let unit_idx = ((t.by & 16) >> 3) + ((t.bx & 16) >> 4);
-                let lr =
-                    (*(f.lf.lr_mask).offset(sb_idx as isize)).lr[p][unit_idx as usize].get_mut();
+                let lr = f.lf.lr_mask[sb_idx as usize].lr[p][unit_idx as usize].get_mut();
 
-                read_restoration_info(t, f, lr, p, frame_type);
+                read_restoration_info(&mut *t.ts, lr, p, frame_type, debug_block_info!(f, t));
             }
         }
         decode_sb(c, t, f, root_bl, c.intra_edge.root(root_bl))?;
@@ -4520,16 +4516,9 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
 
     f.sr_sb128w = f.sr_cur.p.p.w + 127 >> 7;
     let lr_mask_sz = f.sr_sb128w * f.sb128h;
-    if lr_mask_sz != f.lf.lr_mask_sz {
-        freep(&mut f.lf.lr_mask as *mut *mut Av1Restoration as *mut c_void);
-        f.lf.lr_mask = malloc(::core::mem::size_of::<Av1Restoration>() * lr_mask_sz as usize)
-            as *mut Av1Restoration;
-        if f.lf.lr_mask.is_null() {
-            f.lf.lr_mask_sz = 0;
-            return Err(ENOMEM);
-        }
-        f.lf.lr_mask_sz = lr_mask_sz;
-    }
+    // TODO: Fallible allocation
+    f.lf.lr_mask
+        .resize_with(lr_mask_sz as usize, Default::default);
     f.lf.restore_planes = frame_hdr
         .restoration
         .r#type

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -448,8 +448,7 @@ pub struct Rav1dFrameContext_frame_thread {
 pub struct Rav1dFrameContext_lf {
     pub level: Vec<[u8; 4]>,
     pub mask: Vec<Av1Filter>, /* len = w*h */
-    pub lr_mask: *mut Av1Restoration,
-    pub lr_mask_sz: c_int,
+    pub lr_mask: Vec<Av1Restoration>,
     pub cdef_buf_plane_sz: [c_int; 2], /* stride*sbh*4 */
     pub cdef_buf_sbh: c_int,
     pub lr_buf_plane_sz: [c_int; 2], /* (stride*sbh*4) << sb128 if n_tc > 1, else stride*4 */

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -41,6 +41,7 @@ pub struct Av1Filter {
     pub noskip_mask: [[u16; 2]; 16],
 }
 
+#[derive(Default)]
 #[repr(C)]
 pub struct Av1Restoration {
     pub lr: [[Cell<Av1RestorationUnit>; 4]; 3],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -913,7 +913,7 @@ impl Drop for Rav1dContext {
                 free(f.a as *mut c_void);
                 let _ = mem::take(&mut f.tiles);
                 let _ = mem::take(&mut f.lf.mask); // TODO: remove when context is owned
-                free(f.lf.lr_mask as *mut c_void);
+                let _ = mem::take(&mut f.lf.lr_mask); // TODO: remove when context is owned
                 let _ = mem::take(&mut f.lf.level);
                 free(f.lf.tx_lpf_right_edge[0] as *mut c_void);
                 free(f.lf.start_of_tile_row as *mut c_void);

--- a/src/lr_apply.rs
+++ b/src/lr_apply.rs
@@ -182,14 +182,14 @@ unsafe fn lr_sbrow<BD: BitDepth>(
     aligned_unit_pos <<= ss_ver;
     let sb_idx = (aligned_unit_pos >> 7) * f.sr_sb128w;
     let unit_idx = (aligned_unit_pos >> 6 & 1) << 1;
-    lr[0] = (*(f.lf.lr_mask).offset(sb_idx as isize)).lr[plane as usize][unit_idx as usize].get();
+    lr[0] = f.lf.lr_mask[sb_idx as usize].lr[plane as usize][unit_idx as usize].get();
     let mut restore = lr[0].r#type != RAV1D_RESTORATION_NONE;
     let mut x = 0;
     let mut bit = false;
     while x + max_unit_size <= w {
         let next_x = x + unit_size;
         let next_u_idx = unit_idx + (next_x >> shift_hor - 1 & 1);
-        lr[!bit as usize] = (*(f.lf.lr_mask).offset((sb_idx + (next_x >> shift_hor)) as isize)).lr
+        lr[!bit as usize] = f.lf.lr_mask[(sb_idx + (next_x >> shift_hor)) as usize].lr
             [plane as usize][next_u_idx as usize]
             .get();
         let restore_next = lr[!bit as usize].r#type != RAV1D_RESTORATION_NONE;


### PR DESCRIPTION
~~In order to make this work I had to inline `setup_tile` into its one call site in order to address borrow conflicts. Once making `lr_mask` into a `Vec`, it became necessary to pass `f` as a `&mut Rav1dFrameData` in order to get mutable access to `lr_mask`. This caused a large number of borrow conflicts in the calling function because a large amount of immutable borrows are held across the call site. Most notable is that we're calling `setup_tile` within a `for tile in &f.tiles`, which means we can't pass `&mut f` into a function within the loop body.~~

~~I don't like this solution, mostly because I don't see this being a solution we can apply in the general case, but I couldn't think of a cleaner way to address the borrow issue here. The main alternative here I considered was to not pass `f` as a whole into `setup_tile` and instead manually pass in all of the values it needed. That would allow us to only mutably borrow `f.lf`, which would prevent the borrow conflicts. However `setup_tile` accesses several fields of `f`, and it would have been extremely verbose to pass to pass them all manually. Since there was only one callsite and only one field needed to be mutably borrowed, inlining seemed simplest.~~

NOTE: The inlining mentioned above is no longer necessary after #766.

`read_restoration_info` had a different issue where both `&f` and `&mut f.lf` were being passed into the same function, which can't happen. In this case `f` was only being used in calls to `debug_block_info!`, so I opted to hoist the call to `debug_block_info!` to the call site so that the compiler could see that the field borrows were disjoint.