### PR TITLE
`fn BitDepth::pxstride`: Make generic over `stride` type and `BitDepth`

### DIFF
--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -174,7 +174,11 @@ pub trait BitDepth: Clone + Copy {
         clip(pixel, 0.into(), self.bitdepth_max())
     }
 
-    fn pxstride(n: usize) -> usize;
+    fn pxstride(n: usize) -> usize {
+        let scale = mem::size_of::<Self::Pixel>();
+        debug_assert!(n % scale == 0);
+        n / scale
+    }
 
     fn bitdepth(&self) -> u8;
 
@@ -236,10 +240,6 @@ impl BitDepth for BitDepth8 {
 
     fn display(pixel: Self::Pixel) -> Self::DisplayPixel {
         DisplayPixel8(pixel)
-    }
-
-    fn pxstride(n: usize) -> usize {
-        n
     }
 
     fn bitdepth(&self) -> u8 {
@@ -317,11 +317,6 @@ impl BitDepth for BitDepth16 {
 
     fn display(pixel: Self::Pixel) -> Self::DisplayPixel {
         DisplayPixel16(pixel)
-    }
-
-    fn pxstride(n: usize) -> usize {
-        debug_assert!(n & 1 == 0);
-        n >> 1
     }
 
     fn bitdepth(&self) -> u8 {

--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -8,8 +8,11 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::mem;
 use std::ops::Add;
+use std::ops::Div;
 use std::ops::Mul;
+use std::ops::Rem;
 use std::ops::Shr;
+use to_method::To as _;
 
 pub trait FromPrimitive<T> {
     fn from_prim(t: T) -> Self;
@@ -174,9 +177,13 @@ pub trait BitDepth: Clone + Copy {
         clip(pixel, 0.into(), self.bitdepth_max())
     }
 
-    fn pxstride(n: usize) -> usize {
-        let scale = mem::size_of::<Self::Pixel>();
-        debug_assert!(n % scale == 0);
+    /// `T` is generally meant to be `usize` or `isize`.
+    fn pxstride<T>(n: T) -> T
+    where
+        T: Copy + Eq + TryFrom<usize> + From<u8> + Div<Output = T> + Rem<Output = T>,
+    {
+        let scale = mem::size_of::<Self::Pixel>().try_to::<T>().ok().unwrap();
+        debug_assert!(n % scale == 0.into());
         n / scale
     }
 


### PR DESCRIPTION
This way we don't have to do `BD::pxstride(stride as usize) as isize`, which is verbose and wrong for negative strides.  There may still be some places where strides are always positive, though, so it's kept generic.  This also lets us fix #636 gradually; this is the first major step in fixing #636.  We'll fully fix that later.

@fbossen, hopefully this'll help you in your PRs not have to write the hundreds of extra `as usize) as isize` casts.