### PR TITLE
`struct Rav1dFrameContext_lf::cdef_line`: Convert pointers to offsets

### DIFF
--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -12,6 +12,7 @@ use std::ops::Div;
 use std::ops::Mul;
 use std::ops::Rem;
 use std::ops::Shr;
+use std::slice;
 
 pub trait FromPrimitive<T> {
     fn from_prim(t: T) -> Self;
@@ -206,6 +207,34 @@ pub trait BitDepth: Clone + Copy {
     fn bitdepth_max(&self) -> Self::Pixel;
 
     fn get_intermediate_bits(&self) -> u8;
+
+    fn cast_pixel_slice(bytes: &[u8]) -> &[Self::Pixel] {
+        let size = mem::size_of::<Self::Pixel>();
+
+        // Check that the number of elements is a multiple of the new element
+        // size and that the alignment is correct for the new element type.
+        debug_assert!(bytes.len() % size == 0);
+        assert!(bytes.as_ptr() as usize % mem::align_of::<Self::Pixel>() == 0);
+
+        let len = bytes.len() / size;
+
+        // SAFETY: We've checked that alignment and the number of elements is correct.
+        unsafe { slice::from_raw_parts(bytes.as_ptr().cast(), len) }
+    }
+
+    fn cast_pixel_slice_mut(bytes: &mut [u8]) -> &mut [Self::Pixel] {
+        let size = mem::size_of::<Self::Pixel>();
+
+        // Check that the number of elements is a multiple of the new element
+        // size and that the alignment is correct for the new element type.
+        debug_assert!(bytes.len() % size == 0);
+        assert!(bytes.as_ptr() as usize % mem::align_of::<Self::Pixel>() == 0);
+
+        let len = bytes.len() / size;
+
+        // SAFETY: We've checked that alignment and the number of elements is correct.
+        unsafe { slice::from_raw_parts_mut(bytes.as_mut_ptr().cast(), len) }
+    }
 
     const PREP_BIAS: i16;
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -323,7 +323,7 @@ pub(crate) struct Rav1dFrameContext_bd_fn {
     pub filter_sbrow_deblock_cols: filter_sbrow_fn,
     pub filter_sbrow_deblock_rows: filter_sbrow_fn,
     pub filter_sbrow_cdef:
-        unsafe fn(&Rav1dContext, &Rav1dFrameData, &mut Rav1dTaskContext, c_int) -> (),
+        unsafe fn(&Rav1dContext, &mut Rav1dFrameData, &mut Rav1dTaskContext, c_int) -> (),
     pub filter_sbrow_resize: filter_sbrow_fn,
     pub filter_sbrow_lr: filter_sbrow_fn,
     pub backup_ipred_edge: backup_ipred_edge_fn,
@@ -462,9 +462,9 @@ pub struct Rav1dFrameContext_lf {
     pub tx_lpf_right_edge: TxLpfRightEdge,
     pub cdef_line_buf: AlignedVec32<u8>, /* AlignedVec32<DynPixel> */
     pub lr_line_buf: *mut u8,
-    pub cdef_line: [[*mut DynPixel; 3]; 2], /* [2 pre/post][3 plane] */
-    pub cdef_lpf_line: [*mut DynPixel; 3],  /* plane */
-    pub lr_lpf_line: [*mut DynPixel; 3],    /* plane */
+    pub cdef_line: [[usize; 3]; 2],        /* [2 pre/post][3 plane] */
+    pub cdef_lpf_line: [*mut DynPixel; 3], /* plane */
+    pub lr_lpf_line: [*mut DynPixel; 3],   /* plane */
 
     // in-loop filter per-frame state keeping
     pub start_of_tile_row: *mut u8,

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -4568,7 +4568,7 @@ pub(crate) unsafe fn rav1d_filter_sbrow_deblock_rows<BD: BitDepth>(
 
 pub(crate) unsafe fn rav1d_filter_sbrow_cdef<BD: BitDepth>(
     c: &Rav1dContext,
-    f: &Rav1dFrameData,
+    f: &mut Rav1dFrameData,
     tc: &mut Rav1dTaskContext,
     sby: c_int,
 ) {
@@ -4721,10 +4721,10 @@ pub(crate) unsafe fn rav1d_filter_sbrow<BD: BitDepth>(
     rav1d_filter_sbrow_deblock_cols::<BD>(c, f, t, sby);
     rav1d_filter_sbrow_deblock_rows::<BD>(c, f, t, sby);
     let seq_hdr = &***f.seq_hdr.as_ref().unwrap();
-    let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
     if seq_hdr.cdef != 0 {
         rav1d_filter_sbrow_cdef::<BD>(c, f, t, sby);
     }
+    let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
     if frame_hdr.size.width[0] != frame_hdr.size.width[1] {
         rav1d_filter_sbrow_resize::<BD>(c, f, t, sby);
     }


### PR DESCRIPTION
The pointers in `cdef_line` were pointing into the buffer owned by `cdef_line_buf`. In converting them to offsets, I had to make sure that that offsets were consistently in terms of pixels (rather than bytes). The original code was inconsistent here, with the logic working with `u8` pointers (and so was using byte offsets), but the code that uses `cdef_line` treats the pointers as `BD::Pixel` pointers, so the offset logic is calculated in terms of pixels. In converting to offsets I normalized on pixel offsets. To do so I had to add a couple of helpers:

* `BPC::pxstride` - Does the same thing as `BitDepth::pxstride`, but works in non generic code. This was needed to calculate pixel offsets during the initialization logic.
* `BitDepth::cast_pixel_slice{_mut}` - Converts a `&[u8]` to a `&[Pixel]`. This was needed so that we could index into the buffer using pixel indices within our bidepth-dependent code.

In practice most of the usages of `cdef_line` is to calculate pointers to be passed into asm functions, so the cleaned up code is still doing some pointer arithmetic, though we never dereference those pointers from Rust code.