### PR TITLE
`struct TxLpfRightEdge`: New-type wrap the `Vec` in `Rav1dFrameContext_lf::tx_lpf_right_edge`

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4251,7 +4251,7 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
     // backup t->a/l.tx_lpf_y/uv at tile boundaries to use them to "fix"
     // up the initial value in neighbour tiles when running the loopfilter
     let mut align_h = f.bh + 31 & !31;
-    let (tx_lpf_right_edge_y, tx_lpf_right_edge_uv) = f.lf.tx_lpf_right_edge_mut();
+    let (tx_lpf_right_edge_y, tx_lpf_right_edge_uv) = f.lf.tx_lpf_right_edge.get_mut();
     tx_lpf_right_edge_y[(align_h * tile_col + t.by) as usize..][..sb_step as usize]
         .copy_from_slice(&t.l.tx_lpf_y.0[(t.by & 16) as usize..][..sb_step as usize]);
     let ss_ver = (f.cur.p.layout == Rav1dPixelLayout::I420) as c_int;
@@ -4540,7 +4540,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
 
     let re_sz = f.sb128h * frame_hdr.tiling.cols;
     // TODO: Fallible allocation
-    f.lf.tx_lpf_right_edge.resize(re_sz as usize * 32 * 2, 0);
+    f.lf.tx_lpf_right_edge.resize(re_sz as usize, 0);
 
     // init ref mvs
     if frame_hdr.frame_type.is_inter_or_switch() || frame_hdr.allow_intrabc != 0 {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -422,6 +422,33 @@ pub struct Rav1dFrameContext_frame_thread {
     pub tile_start_off: Vec<u32>,
 }
 
+#[derive(Default)]
+pub(crate) struct TxLpfRightEdge {
+    /// `.len() = h * 2`
+    inner: Vec<u8>,
+}
+
+impl TxLpfRightEdge {
+    #[allow(dead_code)]
+    pub const fn new() -> Self {
+        Self { inner: Vec::new() }
+    }
+
+    pub fn resize(&mut self, right_edge_size: usize, value: u8) {
+        self.inner.resize(right_edge_size * 32 * 2, value)
+    }
+
+    pub fn get(&self) -> (&[u8], &[u8]) {
+        let mid = self.inner.len() / 2;
+        self.inner.split_at(mid)
+    }
+
+    pub fn get_mut(&mut self) -> (&mut [u8], &mut [u8]) {
+        let mid = self.inner.len() / 2;
+        self.inner.split_at_mut(mid)
+    }
+}
+
 /// loopfilter
 #[repr(C)]
 pub struct Rav1dFrameContext_lf {
@@ -432,7 +459,7 @@ pub struct Rav1dFrameContext_lf {
     pub lim_lut: Align16<Av1FilterLUT>,
     pub last_sharpness: c_int,
     pub lvl: [[[[u8; 2]; 8]; 4]; 8], /* [8 seg_id][4 dir][8 ref][2 is_gmv] */
-    pub tx_lpf_right_edge: Vec<u8>,  /* len = h*2 */
+    pub tx_lpf_right_edge: TxLpfRightEdge,
     pub cdef_line_buf: AlignedVec32<u8>, /* AlignedVec32<DynPixel> */
     pub lr_line_buf: *mut u8,
     pub cdef_line: [[*mut DynPixel; 3]; 2], /* [2 pre/post][3 plane] */
@@ -445,18 +472,6 @@ pub struct Rav1dFrameContext_lf {
     pub p: [*mut DynPixel; 3],
     pub sr_p: [*mut DynPixel; 3],
     pub restore_planes: c_int, // enum LrRestorePlanes
-}
-
-impl Rav1dFrameContext_lf {
-    pub fn tx_lpf_right_edge(&self) -> (&[u8], &[u8]) {
-        let mid = self.tx_lpf_right_edge.len() / 2;
-        self.tx_lpf_right_edge.split_at(mid)
-    }
-
-    pub fn tx_lpf_right_edge_mut(&mut self) -> (&mut [u8], &mut [u8]) {
-        let mid = self.tx_lpf_right_edge.len() / 2;
-        self.tx_lpf_right_edge.split_at_mut(mid)
-    }
 }
 
 #[repr(C)]

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -560,7 +560,7 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
     let hmax = (1 as c_uint) << hmask;
     let endy4 = (starty4 + cmp::min(f.h4 - sby * sbsz, sbsz)) as c_uint;
     let uv_endy4: c_uint = endy4.wrapping_add(ss_ver as c_uint) >> ss_ver;
-    let (lpf_y, lpf_uv) = f.lf.tx_lpf_right_edge();
+    let (lpf_y, lpf_uv) = f.lf.tx_lpf_right_edge.get();
     let mut lpf_y = &lpf_y[(sby << sbl2) as usize..];
     let mut lpf_uv = &lpf_uv[(sby << sbl2 - ss_ver) as usize..];
     let frame_hdr = &***f.frame_hdr.as_ref().unwrap();


### PR DESCRIPTION
 This way, borrows are made of the field, not the whole `Rav1dFrameContext_lf`.

Fixes the borrowck issue encountered in https://github.com/memorysafety/rav1d/pull/728#issuecomment-1972300089.