### PR TITLE
`enum Rav1dProfile`: make a real enum

### DIFF
--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -798,10 +798,31 @@ pub struct Dav1dSequenceHeader {
         [Dav1dSequenceHeaderOperatingParameterInfo; DAV1D_MAX_OPERATING_POINTS],
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, FromRepr)]
+pub enum Rav1dProfile {
+    Main = 0,
+    High = 1,
+    Professional = 2,
+}
+
+impl From<Rav1dProfile> for c_int {
+    fn from(value: Rav1dProfile) -> Self {
+        value as c_int
+    }
+}
+
+impl TryFrom<c_int> for Rav1dProfile {
+    type Error = ();
+
+    fn try_from(value: c_int) -> Result<Self, Self::Error> {
+        Self::from_repr(value as usize).ok_or(())
+    }
+}
+
 #[derive(Clone)]
 #[repr(C)]
 pub struct Rav1dSequenceHeader {
-    pub profile: c_int,
+    pub profile: Rav1dProfile,
     pub max_width: c_int,
     pub max_height: c_int,
     pub layout: Rav1dPixelLayout,
@@ -1032,7 +1053,7 @@ impl From<Dav1dSequenceHeader> for Rav1dSequenceHeader {
             operating_parameter_info,
         } = value;
         Self {
-            profile,
+            profile: profile.try_into().unwrap(),
             max_width,
             max_height,
             layout: layout.try_into().unwrap(),
@@ -1147,7 +1168,7 @@ impl From<Rav1dSequenceHeader> for Dav1dSequenceHeader {
             operating_parameter_info,
         } = value;
         Self {
-            profile,
+            profile: profile.into(),
             max_width,
             max_height,
             layout: layout.into(),

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -32,6 +32,7 @@ use crate::include::dav1d::headers::Rav1dMasteringDisplay;
 use crate::include::dav1d::headers::Rav1dMatrixCoefficients;
 use crate::include::dav1d::headers::Rav1dObuType;
 use crate::include::dav1d::headers::Rav1dPixelLayout;
+use crate::include::dav1d::headers::Rav1dProfile;
 use crate::include::dav1d::headers::Rav1dRestorationType;
 use crate::include::dav1d::headers::Rav1dSegmentationData;
 use crate::include::dav1d::headers::Rav1dSegmentationDataSet;
@@ -139,10 +140,7 @@ impl Debug {
 fn parse_seq_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult<Rav1dSequenceHeader> {
     let debug = Debug::new(false, "SEQHDR", gb);
 
-    let profile = gb.get_bits(3) as c_int;
-    if profile > 2 {
-        return Err(EINVAL);
-    }
+    let profile = Rav1dProfile::from_repr(gb.get_bits(3) as usize).ok_or(EINVAL)?;
     debug.post(gb, "post-profile");
 
     let still_picture = gb.get_bit() as c_int;
@@ -380,13 +378,13 @@ fn parse_seq_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult<Rav1dSeq
 
     let hbd = {
         let mut hbd = gb.get_bit() as c_int;
-        if profile == 2 && hbd != 0 {
+        if profile == Rav1dProfile::Professional && hbd != 0 {
             hbd += gb.get_bit() as c_int;
         }
         hbd
     };
     let monochrome;
-    if profile != 1 {
+    if profile != Rav1dProfile::High {
         monochrome = gb.get_bit() as c_int;
     } else {
         // Default initialization.
@@ -419,7 +417,7 @@ fn parse_seq_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult<Rav1dSeq
     } else if pri == RAV1D_COLOR_PRI_BT709 && trc == RAV1D_TRC_SRGB && mtrx == RAV1D_MC_IDENTITY {
         layout = Rav1dPixelLayout::I444;
         color_range = 1;
-        if profile != 1 && !(profile == 2 && hbd == 2) {
+        if profile != Rav1dProfile::High && !(profile == Rav1dProfile::Professional && hbd == 2) {
             return Err(EINVAL);
         }
 
@@ -430,19 +428,19 @@ fn parse_seq_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult<Rav1dSeq
     } else {
         color_range = gb.get_bit() as c_int;
         match profile {
-            0 => {
+            Rav1dProfile::Main => {
                 layout = Rav1dPixelLayout::I420;
                 ss_ver = 1;
                 ss_hor = ss_ver;
             }
-            1 => {
+            Rav1dProfile::High => {
                 layout = Rav1dPixelLayout::I444;
 
                 // Default initialization.
                 ss_hor = Default::default();
                 ss_ver = Default::default();
             }
-            2 => {
+            Rav1dProfile::Professional => {
                 if hbd == 2 {
                     ss_hor = gb.get_bit() as c_int;
                     if ss_hor != 0 {
@@ -467,7 +465,6 @@ fn parse_seq_hdr(c: &mut Rav1dContext, gb: &mut GetBits) -> Rav1dResult<Rav1dSeq
                     Rav1dPixelLayout::I444
                 };
             }
-            _ => unreachable!(), // TODO(kkysen) Make `profile` an `enum` so this isn't needed.
         }
         chr = if ss_hor & ss_ver != 0 {
             gb.get_bits(2) as Rav1dChromaSamplePosition


### PR DESCRIPTION
This one does not have a `Dav1d` counterpart. The variant names are a based on the spec (https://aomediacodec.github.io/av1-spec/av1-spec.pdf, A.2, page 638)