### PR TITLE
Link `librav1d` against C `dav1d` and `seek_stress` instead of Rust versions

### DIFF
--- a/.github/workflows/build-and-test-aarch64-darwin.yml
+++ b/.github/workflows/build-and-test-aarch64-darwin.yml
@@ -24,6 +24,10 @@ jobs:
           key: arm-darwin-cargo-and-target-${{ hashFiles('**/Cargo.lock') }}
       - name: cargo build for aarch64-apple-darwin
         run:  cargo build --release
+        # not quite sure why we need this on the runner, not needed locally
+      - run: |
+            meson build --buildtype release
+            ninja -C build tools/dav1d
       - name: test without frame delay
         run: .github/workflows/test.sh \
             -r ./target/release/dav1d \
@@ -39,6 +43,9 @@ jobs:
             -r ./target/release/dav1d \
             -s ./target/release/seek_stress
             -f 2
+      - run: .github/workflows/test.sh \
+          -r ./target/release/dav1d \
+          -s ./target/release/seek_stress
       - name: upload build artifacts
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v3

--- a/meson.build
+++ b/meson.build
@@ -472,7 +472,27 @@ endif
 # Generate config.h
 config_h_target = configure_file(output: 'config.h', configuration: cdata)
 
+# Use --out-dir instead of --target-dir to fully control where librav1d.a goes.
+# Using --target-dir would put it in a subdirectory. The --out-dir option is
+# currently unstable so we need to tell cargo to enable those.
+# FIXME: this will only work if the host matches the build target.
+cargo_command = [
+    'cargo', 'build', '--lib',
+    '-Z', 'unstable-options',
+    '--out-dir', meson.current_build_dir()
+]
+if get_option('buildtype') == 'release'
+    cargo_command += ['--release']
+endif
 
+librav1d = custom_target(
+    'librav1d',
+    output: 'librav1d.a',
+    input: ['lib.rs'],
+    command: cargo_command,
+    install: true,
+    install_dir: get_option('libdir')
+)
 
 #
 # Include subdir meson.build files

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -135,7 +135,7 @@ if get_option('enable_tools')
             dav1d_input_objs.extract_objects('input/input.c', 'input/ivf.c'),
         ],
         include_directories: [dav1d_inc_dirs, include_directories('../tools')],
-        link_with: libdav1d,
+        link_with: get_option('test_rust') ? librav1d : libdav1d,
         dependencies: [
             thread_dependency,
             rt_dependency,
@@ -149,22 +149,9 @@ if get_option('test_rust')
     test_rust_path = get_option('test_rust_path')
     seek_stress_test_rust_path = get_option('seek_stress_test_rust_path')
 
-    # HACK: If we're trying to test the Rust build, override the `dav1d` and
-    # `seek_stress` executables to point to the versions produced by Cargo.
-    # This will test the Rust executables instead of the C versions.
-    if test_rust_path == ''
-        if get_option('debug')
-            profile = 'debug'
-        else
-            profile = 'release'
-        endif
-        test_rust_path = '../target/' + profile + '/dav1d'
-        test_rust_path = join_paths(meson.current_source_dir(), test_rust_path)
-        dav1d = find_program(test_rust_path, required: true)
-        seek_stress_test_rust_path = '../target/' + profile + '/seek_stress'
-        seek_stress_test_rust_path = join_paths(meson.current_source_dir(), seek_stress_test_rust_path)
-        seek_stress = find_program(seek_stress_test_rust_path, required: true)
-    else
+    # We're trying to test the Rust build, override the `dav1d` and
+    # `seek_stress` executables to point to the versions given during setup.
+    if test_rust_path != ''
         # Adjust relative paths so one can use binary paths relative to project
         # top dir rather than relative to the location of the test subdirectory.
         dav1d = files(join_paths('../', get_option('test_rust_path')))

--- a/tests/seek_stress.c
+++ b/tests/seek_stress.c
@@ -159,12 +159,14 @@ static int main_end(Dav1dContext *c, DemuxerContext *const in) {
 }
 
 int main(const int argc, char *const *const argv) {
+    /* disabled so we can link this code against either librav1d or libdav1d.
     const char *version = dav1d_version();
     if (strcmp(version, DAV1D_VERSION)) {
         fprintf(stderr, "Version mismatch (library: %s, executable: %s)\n",
                 version, DAV1D_VERSION);
         return EXIT_FAILURE;
     }
+    */
 
     CLISettings cli_settings;
     Dav1dSettings lib_settings;

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -111,7 +111,11 @@ dav1d = executable('dav1d',
     dav1d_rc_obj,
     rev_target, cli_config_h_target,
 
-    link_with : [libdav1d, dav1d_input_objs, dav1d_output_objs],
+    link_with : [
+        get_option('test_rust') ? librav1d : libdav1d,
+        dav1d_input_objs,
+        dav1d_output_objs
+        ],
     include_directories : [dav1d_inc_dirs],
     dependencies : [
         getopt_dependency,


### PR DESCRIPTION
Closes #807 and #803.

When the `test_rust` meson option (on by default) is set, use a custom meson command to build `librav1d.a` and link `dav1d` and `seek_stress` with it instead of `libdav1d`. 

Notes:
- Using the subprojects feature of meson doesn't seem to be an option since it requires a specific directory layout.
- Cross-compiling isn't supported.
- The macOS build behaves differently than local macOS, possibly due to meson version differences. Didn't root cause.