### PR TITLE
`struct Dav1dContentLightLevel`: backport size reduction from dav1d 1.3.0

### DIFF
--- a/include/dav1d/headers.h
+++ b/include/dav1d/headers.h
@@ -178,8 +178,8 @@ enum Dav1dChromaSamplePosition {
 };
 
 typedef struct Dav1dContentLightLevel {
-    int max_content_light_level;
-    int max_frame_average_light_level;
+    uint16_t max_content_light_level;
+    uint16_t max_frame_average_light_level;
 } Dav1dContentLightLevel;
 
 typedef struct Dav1dMasteringDisplay {

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -611,8 +611,8 @@ impl TryFrom<Dav1dChromaSamplePosition> for Rav1dChromaSamplePosition {
 
 #[repr(C)]
 pub struct Rav1dContentLightLevel {
-    pub max_content_light_level: c_int,
-    pub max_frame_average_light_level: c_int,
+    pub max_content_light_level: u16,
+    pub max_frame_average_light_level: u16,
 }
 
 pub type Dav1dContentLightLevel = Rav1dContentLightLevel;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2342,12 +2342,12 @@ unsafe fn parse_obus(
             match ObuMetaType::from_repr(meta_type as usize) {
                 Some(ObuMetaType::HdrCll) => {
                     let debug = debug.named("CLLOBU");
-                    let max_content_light_level = gb.get_bits(16) as c_int;
+                    let max_content_light_level = gb.get_bits(16) as u16;
                     debug.log(
                         &gb,
                         format_args!("max-content-light-level: {max_content_light_level}"),
                     );
-                    let max_frame_average_light_level = gb.get_bits(16) as c_int;
+                    let max_frame_average_light_level = gb.get_bits(16) as u16;
                     debug.log(
                         &gb,
                         format_args!(


### PR DESCRIPTION
* Fixes part of #505.