### PR TITLE
Backport memory optimization for palette mode from dav1d 1.3.0

### DIFF
--- a/include/common/bitdepth.h
+++ b/include/common/bitdepth.h
@@ -34,7 +34,7 @@
 #include "common/attributes.h"
 
 #if !defined(BITDEPTH)
-typedef void pixel;
+typedef uint8_t pixel; /* can't be void due to pointer-to-array usage */
 typedef void coef;
 #define HIGHBD_DECL_SUFFIX /* nothing */
 #define HIGHBD_CALL_SUFFIX /* nothing */

--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -1,4 +1,6 @@
 use crate::include::common::intops::clip;
+use crate::src::align::Align16;
+use crate::src::align::Align8;
 use crate::src::align::ArrayDefault;
 use std::ffi::c_int;
 use std::ffi::c_uint;
@@ -153,6 +155,8 @@ pub trait BitDepth: Clone + Copy {
         + FromBytes
         + AsBytes;
 
+    type AlignPixelX8: Copy;
+
     type Coef: Copy
         + FromPrimitive<c_int>
         + FromPrimitive<c_uint>
@@ -275,6 +279,8 @@ impl BitDepth for BitDepth8 {
 
     type Pixel = u8;
 
+    type AlignPixelX8 = Align8<[Self::Pixel; 0]>;
+
     type Coef = i16;
 
     type Entry = i8;
@@ -350,6 +356,8 @@ impl BitDepth for BitDepth16 {
     const BPC: BPC = BPC::BPC16;
 
     type Pixel = u16;
+
+    type AlignPixelX8 = Align16<[Self::Pixel; 0]>;
 
     type Coef = i32;
 

--- a/src/arm/32/ipred.S
+++ b/src/arm/32/ipred.S
@@ -1576,17 +1576,16 @@ L(ipred_filter_tbl):
 endfunc
 
 // void pal_pred_8bpc_neon(pixel *dst, const ptrdiff_t stride,
-//                         const uint16_t *const pal, const uint8_t *idx,
+//                         const pixel *const pal, const uint8_t *idx,
 //                         const int w, const int h);
 function pal_pred_8bpc_neon, export=1
         push            {r4-r5, lr}
         ldrd            r4,  r5,  [sp, #12]
-        vld1.16         {q0}, [r2, :128]
+        vld1.8          {d0}, [r2, :64]
         clz             lr,  r4
         adr             r12, L(pal_pred_tbl)
         sub             lr,  lr,  #25
         ldr             lr,  [r12, lr, lsl #2]
-        vmovn.i16       d0,  q0
         add             r12, r12, lr
         add             r2,  r0,  r1
         bx              r12

--- a/src/arm/32/ipred16.S
+++ b/src/arm/32/ipred16.S
@@ -1732,7 +1732,7 @@ function ipred_filter_16bpc_neon, export=1
 endfunc
 
 // void pal_pred_16bpc_neon(pixel *dst, const ptrdiff_t stride,
-//                          const uint16_t *const pal, const uint8_t *idx,
+//                          const pixel *const pal, const uint8_t *idx,
 //                          const int w, const int h);
 function pal_pred_16bpc_neon, export=1
         push            {r4-r5, lr}

--- a/src/arm/64/ipred.S
+++ b/src/arm/64/ipred.S
@@ -3921,15 +3921,14 @@ L(ipred_filter_tbl):
 endfunc
 
 // void pal_pred_8bpc_neon(pixel *dst, const ptrdiff_t stride,
-//                         const uint16_t *const pal, const uint8_t *idx,
+//                         const pixel *const pal, const uint8_t *idx,
 //                         const int w, const int h);
 function pal_pred_8bpc_neon, export=1
-        ld1             {v0.8h}, [x2]
+        ld1             {v0.8b}, [x2]
         clz             w9,  w4
         adr             x6,  L(pal_pred_tbl)
         sub             w9,  w9,  #25
         ldrh            w9,  [x6, w9, uxtw #1]
-        xtn             v0.8b,  v0.8h
         sub             x6,  x6,  w9, uxtw
         add             x2,  x0,  x1
         lsl             x1,  x1,  #1

--- a/src/arm/64/ipred16.S
+++ b/src/arm/64/ipred16.S
@@ -4179,7 +4179,7 @@ function ipred_filter_16bpc_neon, export=1
 endfunc
 
 // void pal_pred_16bpc_neon(pixel *dst, const ptrdiff_t stride,
-//                          const uint16_t *const pal, const uint8_t *idx,
+//                          const pixel *const pal, const uint8_t *idx,
 //                          const int w, const int h);
 function pal_pred_16bpc_neon, export=1
         ld1             {v30.8h}, [x2]

--- a/src/decode.c
+++ b/src/decode.c
@@ -370,142 +370,6 @@ static inline int findoddzero(const uint8_t *buf, int len) {
     return 0;
 }
 
-static void read_pal_plane(Dav1dTaskContext *const t, Av1Block *const b,
-                           const int pl, const int sz_ctx,
-                           const int bx4, const int by4)
-{
-    Dav1dTileState *const ts = t->ts;
-    const Dav1dFrameContext *const f = t->f;
-    const int pal_sz = b->pal_sz[pl] = dav1d_msac_decode_symbol_adapt8(&ts->msac,
-                                           ts->cdf.m.pal_sz[pl][sz_ctx], 6) + 2;
-    uint16_t cache[16], used_cache[8];
-    int l_cache = pl ? t->pal_sz_uv[1][by4] : t->l.pal_sz[by4];
-    int n_cache = 0;
-    // don't reuse above palette outside SB64 boundaries
-    int a_cache = by4 & 15 ? pl ? t->pal_sz_uv[0][bx4] : t->a->pal_sz[bx4] : 0;
-    const uint16_t *l = t->al_pal[1][by4][pl], *a = t->al_pal[0][bx4][pl];
-
-    // fill/sort cache
-    while (l_cache && a_cache) {
-        if (*l < *a) {
-            if (!n_cache || cache[n_cache - 1] != *l)
-                cache[n_cache++] = *l;
-            l++;
-            l_cache--;
-        } else {
-            if (*a == *l) {
-                l++;
-                l_cache--;
-            }
-            if (!n_cache || cache[n_cache - 1] != *a)
-                cache[n_cache++] = *a;
-            a++;
-            a_cache--;
-        }
-    }
-    if (l_cache) {
-        do {
-            if (!n_cache || cache[n_cache - 1] != *l)
-                cache[n_cache++] = *l;
-            l++;
-        } while (--l_cache > 0);
-    } else if (a_cache) {
-        do {
-            if (!n_cache || cache[n_cache - 1] != *a)
-                cache[n_cache++] = *a;
-            a++;
-        } while (--a_cache > 0);
-    }
-
-    // find reused cache entries
-    int i = 0;
-    for (int n = 0; n < n_cache && i < pal_sz; n++)
-        if (dav1d_msac_decode_bool_equi(&ts->msac))
-            used_cache[i++] = cache[n];
-    const int n_used_cache = i;
-
-    // parse new entries
-    uint16_t *const pal = t->frame_thread.pass ?
-        f->frame_thread.pal[((t->by >> 1) + (t->bx & 1)) * (f->b4_stride >> 1) +
-                            ((t->bx >> 1) + (t->by & 1))][pl] : t->scratch.pal[pl];
-    if (i < pal_sz) {
-        int prev = pal[i++] = dav1d_msac_decode_bools(&ts->msac, f->cur.p.bpc);
-
-        if (i < pal_sz) {
-            int bits = f->cur.p.bpc - 3 + dav1d_msac_decode_bools(&ts->msac, 2);
-            const int max = (1 << f->cur.p.bpc) - 1;
-
-            do {
-                const int delta = dav1d_msac_decode_bools(&ts->msac, bits);
-                prev = pal[i++] = imin(prev + delta + !pl, max);
-                if (prev + !pl >= max) {
-                    for (; i < pal_sz; i++)
-                        pal[i] = max;
-                    break;
-                }
-                bits = imin(bits, 1 + ulog2(max - prev - !pl));
-            } while (i < pal_sz);
-        }
-
-        // merge cache+new entries
-        int n = 0, m = n_used_cache;
-        for (i = 0; i < pal_sz; i++) {
-            if (n < n_used_cache && (m >= pal_sz || used_cache[n] <= pal[m])) {
-                pal[i] = used_cache[n++];
-            } else {
-                assert(m < pal_sz);
-                pal[i] = pal[m++];
-            }
-        }
-    } else {
-        memcpy(pal, used_cache, n_used_cache * sizeof(*used_cache));
-    }
-
-    if (DEBUG_BLOCK_INFO) {
-        printf("Post-pal[pl=%d,sz=%d,cache_size=%d,used_cache=%d]: r=%d, cache=",
-               pl, pal_sz, n_cache, n_used_cache, ts->msac.rng);
-        for (int n = 0; n < n_cache; n++)
-            printf("%c%02x", n ? ' ' : '[', cache[n]);
-        printf("%s, pal=", n_cache ? "]" : "[]");
-        for (int n = 0; n < pal_sz; n++)
-            printf("%c%02x", n ? ' ' : '[', pal[n]);
-        printf("]\n");
-    }
-}
-
-static void read_pal_uv(Dav1dTaskContext *const t, Av1Block *const b,
-                        const int sz_ctx, const int bx4, const int by4)
-{
-    read_pal_plane(t, b, 1, sz_ctx, bx4, by4);
-
-    // V pal coding
-    Dav1dTileState *const ts = t->ts;
-    const Dav1dFrameContext *const f = t->f;
-    uint16_t *const pal = t->frame_thread.pass ?
-        f->frame_thread.pal[((t->by >> 1) + (t->bx & 1)) * (f->b4_stride >> 1) +
-                            ((t->bx >> 1) + (t->by & 1))][2] : t->scratch.pal[2];
-    if (dav1d_msac_decode_bool_equi(&ts->msac)) {
-        const int bits = f->cur.p.bpc - 4 +
-                         dav1d_msac_decode_bools(&ts->msac, 2);
-        int prev = pal[0] = dav1d_msac_decode_bools(&ts->msac, f->cur.p.bpc);
-        const int max = (1 << f->cur.p.bpc) - 1;
-        for (int i = 1; i < b->pal_sz[1]; i++) {
-            int delta = dav1d_msac_decode_bools(&ts->msac, bits);
-            if (delta && dav1d_msac_decode_bool_equi(&ts->msac)) delta = -delta;
-            prev = pal[i] = (prev + delta) & max;
-        }
-    } else {
-        for (int i = 0; i < b->pal_sz[1]; i++)
-            pal[i] = dav1d_msac_decode_bools(&ts->msac, f->cur.p.bpc);
-    }
-    if (DEBUG_BLOCK_INFO) {
-        printf("Post-pal[pl=2]: r=%d ", ts->msac.rng);
-        for (int n = 0; n < b->pal_sz[1]; n++)
-            printf("%c%02x", n ? ' ' : '[', pal[n]);
-        printf("]\n");
-    }
-}
-
 // meant to be SIMD'able, so that theoretical complexity of this function
 // times block size goes from w4*h4 to w4+h4-1
 // a and b are previous two lines containing (a) top/left entries or (b)
@@ -1306,7 +1170,7 @@ static int decode_b(Dav1dTaskContext *const t,
                 if (DEBUG_BLOCK_INFO)
                     printf("Post-y_pal[%d]: r=%d\n", use_y_pal, ts->msac.rng);
                 if (use_y_pal)
-                    read_pal_plane(t, b, 0, sz_ctx, bx4, by4);
+                    f->bd_fn.read_pal_plane(t, b, 0, sz_ctx, bx4, by4);
             }
 
             if (has_chroma && b->uv_mode == DC_PRED) {
@@ -1316,7 +1180,7 @@ static int decode_b(Dav1dTaskContext *const t,
                 if (DEBUG_BLOCK_INFO)
                     printf("Post-uv_pal[%d]: r=%d\n", use_uv_pal, ts->msac.rng);
                 if (use_uv_pal) // see aomedia bug 2183 for why we use luma coordinates
-                    read_pal_uv(t, b, sz_ctx, bx4, by4);
+                    f->bd_fn.read_pal_uv(t, b, sz_ctx, bx4, by4);
             }
         }
 
@@ -1430,34 +1294,16 @@ static int decode_b(Dav1dTaskContext *const t,
         case_set(bh4, l., 1, by4);
         case_set(bw4, a->, 0, bx4);
 #undef set_ctx
-        if (b->pal_sz[0]) {
-            uint16_t *const pal = t->frame_thread.pass ?
-                f->frame_thread.pal[((t->by >> 1) + (t->bx & 1)) * (f->b4_stride >> 1) +
-                                    ((t->bx >> 1) + (t->by & 1))][0] : t->scratch.pal[0];
-            for (int x = 0; x < bw4; x++)
-                memcpy(t->al_pal[0][bx4 + x][0], pal, 16);
-            for (int y = 0; y < bh4; y++)
-                memcpy(t->al_pal[1][by4 + y][0], pal, 16);
-        }
+        if (b->pal_sz[0])
+            f->bd_fn.copy_pal_block_y(t, bx4, by4, bw4, bh4);
         if (has_chroma) {
 #define set_ctx(type, dir, diridx, off, mul, rep_macro) \
                 rep_macro(type, t->dir uvmode, off, mul * b->uv_mode)
                 case_set(cbh4, l., 1, cby4);
                 case_set(cbw4, a->, 0, cbx4);
 #undef set_ctx
-            if (b->pal_sz[1]) {
-                const uint16_t (*const pal)[8] = t->frame_thread.pass ?
-                    f->frame_thread.pal[((t->by >> 1) + (t->bx & 1)) *
-                    (f->b4_stride >> 1) + ((t->bx >> 1) + (t->by & 1))] :
-                    t->scratch.pal;
-                // see aomedia bug 2183 for why we use luma coordinates here
-                for (int pl = 1; pl <= 2; pl++) {
-                    for (int x = 0; x < bw4; x++)
-                        memcpy(t->al_pal[0][bx4 + x][pl], pal[pl], 16);
-                    for (int y = 0; y < bh4; y++)
-                        memcpy(t->al_pal[1][by4 + y][pl], pal[pl], 16);
-                }
-            }
+            if (b->pal_sz[1])
+                f->bd_fn.copy_pal_block_uv(t, bx4, by4, bw4, bh4);
         }
         if (IS_INTER_OR_SWITCH(f->frame_hdr) || f->frame_hdr->allow_intrabc)
             splat_intraref(f->c, t, bs, bw4, bh4);
@@ -3029,16 +2875,17 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
         }
 
         if (f->frame_hdr->allow_screen_content_tools) {
-            if (num_sb128 != f->frame_thread.pal_sz) {
+            const int pal_sz = num_sb128 << hbd;
+            if (pal_sz != f->frame_thread.pal_sz) {
                 dav1d_freep_aligned(&f->frame_thread.pal);
                 f->frame_thread.pal =
                     dav1d_alloc_aligned(sizeof(*f->frame_thread.pal) *
-                                        num_sb128 * 16 * 16, 64);
+                                        pal_sz * 16 * 16, 64);
                 if (!f->frame_thread.pal) {
                     f->frame_thread.pal_sz = 0;
                     return retval;
                 }
-                f->frame_thread.pal_sz = num_sb128;
+                f->frame_thread.pal_sz = pal_sz;
             }
 
             const int pal_idx_sz = num_sb128 * size_mul[1];
@@ -3614,7 +3461,11 @@ int dav1d_submit_frame(Dav1dContext *const c) {
         f->bd_fn.filter_sbrow_resize = dav1d_filter_sbrow_resize_##bd##bpc; \
         f->bd_fn.filter_sbrow_lr = dav1d_filter_sbrow_lr_##bd##bpc; \
         f->bd_fn.backup_ipred_edge = dav1d_backup_ipred_edge_##bd##bpc; \
-        f->bd_fn.read_coef_blocks = dav1d_read_coef_blocks_##bd##bpc
+        f->bd_fn.read_coef_blocks = dav1d_read_coef_blocks_##bd##bpc; \
+        f->bd_fn.copy_pal_block_y = dav1d_copy_pal_block_y_##bd##bpc; \
+        f->bd_fn.copy_pal_block_uv = dav1d_copy_pal_block_uv_##bd##bpc; \
+        f->bd_fn.read_pal_plane = dav1d_read_pal_plane_##bd##bpc; \
+        f->bd_fn.read_pal_uv = dav1d_read_pal_uv_##bd##bpc
     if (!f->seq_hdr->hbd) {
 #if CONFIG_8BPC
         assign_bitdepth_case(8);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1969,7 +1969,7 @@ unsafe fn decode_b_inner(
             },
         );
         if b.pal_sz()[0] != 0 {
-            (bd_fn.copy_pal_block_y)(t, f, bx4, by4, bw4, bh4);
+            (bd_fn.copy_pal_block_y)(t, f, bx4 as usize, by4 as usize, bw4 as usize, bh4 as usize);
         }
         if has_chroma {
             CaseSet::<32, false>::many(
@@ -1981,7 +1981,14 @@ unsafe fn decode_b_inner(
                 },
             );
             if b.pal_sz()[1] != 0 {
-                (bd_fn.copy_pal_block_uv)(t, f, bx4, by4, bw4, bh4);
+                (bd_fn.copy_pal_block_uv)(
+                    t,
+                    f,
+                    bx4 as usize,
+                    by4 as usize,
+                    bw4 as usize,
+                    bh4 as usize,
+                );
             }
         }
         let frame_hdr = f.frame_hdr();
@@ -4139,10 +4146,9 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
 
         if frame_hdr.allow_screen_content_tools {
             // TODO: Fallible allocation
-            f.frame_thread.pal.resize(
-                num_sb128 as usize * 16 * 16 * 8 * 3 << hbd,
-                Default::default(),
-            );
+            f.frame_thread
+                .pal
+                .resize(num_sb128 as usize * 16 * 16 << hbd);
 
             let pal_idx_sz = num_sb128 * size_mul[1] as c_int;
             // TODO: Fallible allocation

--- a/src/internal.h
+++ b/src/internal.h
@@ -251,6 +251,10 @@ struct Dav1dFrameContext {
         filter_sbrow_fn filter_sbrow_lr;
         backup_ipred_edge_fn backup_ipred_edge;
         read_coef_blocks_fn read_coef_blocks;
+        copy_pal_block_fn copy_pal_block_y;
+        copy_pal_block_fn copy_pal_block_uv;
+        read_pal_plane_fn read_pal_plane;
+        read_pal_uv_fn read_pal_uv;
     } bd_fn;
 
     int ipred_edge_sz;
@@ -274,7 +278,7 @@ struct Dav1dFrameContext {
         Av1Block *b;
         int16_t (*cbi)[3 /* plane */]; /* bits 0-4: txtp, bits 5-15: eob */
         // indexed using (t->by >> 1) * (f->b4_stride >> 1) + (t->bx >> 1)
-        uint16_t (*pal)[3 /* plane */][8 /* idx */];
+        pixel (*pal)[3 /* plane */][8 /* idx */];
         // iterated over inside tile state
         uint8_t *pal_idx;
         coef *cf;
@@ -386,9 +390,10 @@ struct Dav1dTaskContext {
         int16_t cf_8bpc [32 * 32];
         int32_t cf_16bpc[32 * 32];
     };
-    // FIXME types can be changed to pixel (and dynamically allocated)
-    // which would make copy/assign operations slightly faster?
-    uint16_t al_pal[2 /* a/l */][32 /* bx/y4 */][3 /* plane */][8 /* palette_idx */];
+    union {
+        uint8_t  al_pal_8bpc [2 /* a/l */][32 /* bx/y4 */][3 /* plane */][8 /* palette_idx */];
+        uint16_t al_pal_16bpc[2 /* a/l */][32 /* bx/y4 */][3 /* plane */][8 /* palette_idx */];
+    };
     uint8_t pal_sz_uv[2 /* a/l */][32 /* bx4/by4 */];
     ALIGN(union, 64) Dav1dTaskContext_scratch {
         struct {
@@ -419,15 +424,16 @@ struct Dav1dTaskContext {
                 uint8_t txtp_map[32 * 32]; // inter-only
             };
             uint8_t pal_idx[2 * 64 * 64];
-            uint16_t pal[3 /* plane */][8 /* palette_idx */];
-            ALIGN(union, 64) {
+            union {
                 struct {
                     uint8_t interintra_8bpc[64 * 64];
                     uint8_t edge_8bpc[257];
+                    ALIGN(uint8_t pal_8bpc[3 /* plane */][8 /* palette_idx */], 8);
                 };
                 struct {
                     uint16_t interintra_16bpc[64 * 64];
                     uint16_t edge_16bpc[257];
+                    ALIGN(uint16_t pal_16bpc[3 /* plane */][8 /* palette_idx */], 16);
                 };
             };
         };

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -444,11 +444,11 @@ impl CodedBlockInfo {
 
 #[derive(Default)]
 #[repr(C)]
-pub struct AlignedVec64Pal {
+pub struct Pal {
     data: AlignedVec64<u8>,
 }
 
-impl AlignedVec64Pal {
+impl Pal {
     pub fn resize(&mut self, n: usize) {
         self.data.resize(n * 8 * 3, Default::default());
     }
@@ -487,7 +487,7 @@ pub struct Rav1dFrameContext_frame_thread {
     /// Inner indices are `[3 plane][8 idx]`.
     /// Allocated as a flat array. `pal.as_slice` and `pal.as_slice_mut` should be
     /// used to access elements of type `[[BitDepth::Pixel; 8]; 3]`
-    pub pal: AlignedVec64Pal,
+    pub pal: Pal,
 
     /// Iterated over inside tile state.
     pub pal_idx: AlignedVec64<u8>,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -889,6 +889,7 @@ pub union Rav1dTaskContext_scratch_levels_pal {
 pub struct InterIntraEdgePalBD<BD: BitDepth> {
     pub interintra: [BD::Pixel; 64 * 64],
     pub edge: [BD::Pixel; 257],
+    _align: [BD::Pixel; 7],       // Align pal to 8 times BD::Pixel
     pub pal: [[BD::Pixel; 8]; 3], /* [3 plane][8 palette_idx] */
 }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -896,7 +896,7 @@ pub struct InterIntraEdgePalBD<BD: BitDepth> {
 pub struct InterIntraEdgePal;
 
 impl BitDepthDependentType for InterIntraEdgePal {
-    type T<BD: BitDepth> = Align64<InterIntraEdgePalBD<BD>>;
+    type T<BD: BitDepth> = InterIntraEdgePalBD<BD>;
 }
 
 #[derive(Clone, Copy)]

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -889,7 +889,7 @@ pub union Rav1dTaskContext_scratch_levels_pal {
 pub struct InterIntraEdgePalBD<BD: BitDepth> {
     pub interintra: [BD::Pixel; 64 * 64],
     pub edge: [BD::Pixel; 257],
-    _align: [BD::Pixel; 7],       // Align pal to 8 times BD::Pixel
+    _align: [BD::AlignPixelX8; 0],
     pub pal: [[BD::Pixel; 8]; 3], /* [3 plane][8 palette_idx] */
 }
 

--- a/src/ipred.h
+++ b/src/ipred.h
@@ -74,7 +74,7 @@ typedef decl_cfl_pred_fn(*cfl_pred_fn);
  * - only 16-byte alignment is guaranteed for idx.
  */
 #define decl_pal_pred_fn(name) \
-void (name)(pixel *dst, ptrdiff_t stride, const uint16_t *pal, \
+void (name)(pixel *dst, ptrdiff_t stride, const pixel *pal, \
             const uint8_t *idx, int w, int h)
 typedef decl_pal_pred_fn(*pal_pred_fn);
 

--- a/src/ipred_tmpl.c
+++ b/src/ipred_tmpl.c
@@ -715,12 +715,12 @@ cfl_ac_fn(422, 1, 0)
 cfl_ac_fn(444, 0, 0)
 
 static void pal_pred_c(pixel *dst, const ptrdiff_t stride,
-                       const uint16_t *const pal, const uint8_t *idx,
+                       const pixel *const pal, const uint8_t *idx,
                        const int w, const int h)
 {
     for (int y = 0; y < h; y++) {
         for (int x = 0; x < w; x++)
-            dst[x] = (pixel) pal[idx[x]];
+            dst[x] = pal[idx[x]];
         idx += w;
         dst += PXSTRIDE(stride);
     }

--- a/src/recon.h
+++ b/src/recon.h
@@ -57,6 +57,18 @@ typedef decl_backup_ipred_edge_fn(*backup_ipred_edge_fn);
 void (name)(Dav1dTaskContext *t, enum BlockSize bs, const Av1Block *b)
 typedef decl_read_coef_blocks_fn(*read_coef_blocks_fn);
 
+#define decl_copy_pal_block_fn(name) \
+void (name)(Dav1dTaskContext *t, int bx4, int by4, int bw4, int bh4)
+typedef decl_copy_pal_block_fn(*copy_pal_block_fn);
+
+#define decl_read_pal_plane_fn(name) \
+void (name)(Dav1dTaskContext *t, Av1Block *b, int pl, int sz_ctx, int bx4, int by4)
+typedef decl_read_pal_plane_fn(*read_pal_plane_fn);
+
+#define decl_read_pal_uv_fn(name) \
+void (name)(Dav1dTaskContext *t, Av1Block *b, int sz_ctx, int bx4, int by4)
+typedef decl_read_pal_uv_fn(*read_pal_uv_fn);
+
 decl_recon_b_intra_fn(dav1d_recon_b_intra_8bpc);
 decl_recon_b_intra_fn(dav1d_recon_b_intra_16bpc);
 
@@ -81,5 +93,14 @@ decl_backup_ipred_edge_fn(dav1d_backup_ipred_edge_16bpc);
 
 decl_read_coef_blocks_fn(dav1d_read_coef_blocks_8bpc);
 decl_read_coef_blocks_fn(dav1d_read_coef_blocks_16bpc);
+
+decl_copy_pal_block_fn(dav1d_copy_pal_block_y_8bpc);
+decl_copy_pal_block_fn(dav1d_copy_pal_block_y_16bpc);
+decl_copy_pal_block_fn(dav1d_copy_pal_block_uv_8bpc);
+decl_copy_pal_block_fn(dav1d_copy_pal_block_uv_16bpc);
+decl_read_pal_plane_fn(dav1d_read_pal_plane_8bpc);
+decl_read_pal_plane_fn(dav1d_read_pal_plane_16bpc);
+decl_read_pal_uv_fn(dav1d_read_pal_uv_8bpc);
+decl_read_pal_uv_fn(dav1d_read_pal_uv_16bpc);
 
 #endif /* DAV1D_SRC_RECON_H */

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -7,6 +7,7 @@ use crate::include::common::dump::coef_dump;
 use crate::include::common::dump::hex_dump;
 use crate::include::common::intops::apply_sign64;
 use crate::include::common::intops::clip;
+use crate::include::common::intops::ulog2;
 use crate::include::dav1d::dav1d::Rav1dInloopFilterType;
 use crate::include::dav1d::headers::Rav1dPixelLayout;
 use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
@@ -141,6 +142,28 @@ pub(crate) type backup_ipred_edge_fn = unsafe fn(&Rav1dFrameData, &mut Rav1dTask
 
 pub(crate) type read_coef_blocks_fn =
     unsafe fn(&mut Rav1dFrameData, &mut Rav1dTaskContext, BlockSize, &Av1Block) -> ();
+
+pub(crate) type copy_pal_block_fn =
+    unsafe fn(&mut Rav1dTaskContext, &mut Rav1dFrameData, c_int, c_int, c_int, c_int) -> ();
+
+pub(crate) type read_pal_plane_fn = unsafe fn(
+    &mut Rav1dTaskContext,
+    &mut Rav1dFrameData,
+    &mut Av1Block,
+    bool,
+    u8,
+    usize,
+    usize,
+) -> ();
+
+pub(crate) type read_pal_uv_fn = unsafe fn(
+    t: &mut Rav1dTaskContext,
+    f: &mut Rav1dFrameData,
+    b: &mut Av1Block,
+    sz_ctx: u8,
+    bx4: usize,
+    by4: usize,
+) -> ();
 
 #[inline]
 fn read_golomb(msac: &mut MsacContext) -> c_uint {
@@ -2417,14 +2440,16 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                 } else {
                     &t.scratch.c2rust_unnamed_0.pal_idx
                 };
-                let pal: *const u16 = if t.frame_thread.pass != 0 {
+                let pal: *const BD::Pixel = if t.frame_thread.pass != 0 {
                     let index = (((t.b.y as isize >> 1) + (t.b.x as isize & 1))
                         * (f.b4_stride >> 1)
                         + ((t.b.x >> 1) + (t.b.y & 1)) as isize)
                         as isize;
-                    f.frame_thread.pal[index as usize][0].as_ptr()
+                    f.frame_thread.pal_as_slice::<BD>()[index as usize][0].as_ptr()
                 } else {
-                    (t.scratch.c2rust_unnamed_0.pal[0]).as_ptr()
+                    let interintra_edge_pal =
+                        BD::select(&mut t.scratch.c2rust_unnamed_0.interintra_edge_pal);
+                    interintra_edge_pal.0.pal[0].as_ptr()
                 };
                 (*f.dsp).ipred.pal_pred.call::<BD>(
                     dst,
@@ -2497,9 +2522,9 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         } else {
                             None
                         };
-                        let interintra_edge =
-                            BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge);
-                        let edge_array = &mut interintra_edge.0.edge;
+                        let interintra_edge_pal =
+                            BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge_pal);
+                        let edge_array = &mut interintra_edge_pal.0.edge;
                         let edge_offset = 128;
                         let data_stride = BD::pxstride(f.cur.stride[0]);
                         let data_width = 4 * ts.tiling.col_end;
@@ -2715,11 +2740,11 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             };
                             let xpos = t.b.x >> ss_hor;
                             let ypos = t.b.y >> ss_ver;
-                            let xstart = ts.tiling.col_start >> ss_hor;
-                            let ystart = ts.tiling.row_start >> ss_ver;
-                            let interintra_edge =
-                                BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge);
-                            let edge_array = &mut interintra_edge.0.edge;
+                            let xstart = (*ts).tiling.col_start >> ss_hor;
+                            let ystart = (*ts).tiling.row_start >> ss_ver;
+                            let interintra_edge_pal =
+                                BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge_pal);
+                            let edge_array = &mut interintra_edge_pal.0.edge;
                             let edge_offset = 128;
                             let data_stride = BD::pxstride(f.cur.stride[1]);
                             let data_width = 4 * ts.tiling.col_end >> ss_hor;
@@ -2794,10 +2819,15 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         let len = (cbw4 * cbh4 * 16) as usize;
                         let pal_idx = &f.frame_thread.pal_idx[*pal_idx_offset..][..len];
                         *pal_idx_offset += len;
-                        (&f.frame_thread.pal[index as usize], pal_idx)
-                    } else {
                         (
-                            &t.scratch.c2rust_unnamed_0.pal,
+                            &f.frame_thread.pal_as_slice::<BD>()[index as usize],
+                            pal_idx,
+                        )
+                    } else {
+                        let interintra_edge_pal =
+                            BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge_pal);
+                        (
+                            &interintra_edge_pal.0.pal,
                             &t.scratch.c2rust_unnamed_0.pal_idx[(bw4 * bh4 * 16) as usize..],
                         )
                     };
@@ -2915,11 +2945,12 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                 }) as IntraPredMode;
                                 xpos = t.b.x >> ss_hor;
                                 ypos = t.b.y >> ss_ver;
-                                xstart = ts.tiling.col_start >> ss_hor;
-                                ystart = ts.tiling.row_start >> ss_ver;
-                                let interintra_edge =
-                                    BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge);
-                                let edge_array = &mut interintra_edge.0.edge;
+                                xstart = (*ts).tiling.col_start >> ss_hor;
+                                ystart = (*ts).tiling.row_start >> ss_ver;
+                                let interintra_edge_pal = BD::select_mut(
+                                    &mut t.scratch.c2rust_unnamed_0.interintra_edge_pal,
+                                );
+                                let edge_array = &mut interintra_edge_pal.0.edge;
                                 let edge_offset = 128;
                                 let data_stride = BD::pxstride(f.cur.stride[1]);
                                 let data_width = 4 * ts.tiling.col_end >> ss_hor;
@@ -3424,8 +3455,9 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
             }
         }
         if let Some(interintra_type) = b.interintra_type() {
-            let interintra_edge = BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge);
-            let tl_edge_array = &mut interintra_edge.0.edge;
+            let interintra_edge_pal =
+                BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge_pal);
+            let tl_edge_array = &mut interintra_edge_pal.0.edge;
             let tl_edge_offset = 32;
             let mut m = if b.interintra_mode() == InterIntraPredMode::Smooth {
                 SMOOTH_PRED
@@ -3470,8 +3502,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 BD::from_c(f.bitdepth_max),
             );
             let tl_edge = &tl_edge_array[tl_edge_offset..];
-            let tmp = &mut interintra_edge.0.interintra;
-            dsp.ipred.intra_pred[m as usize].call(
+            let tmp = &mut interintra_edge_pal.0.interintra;
+            (*dsp).ipred.intra_pred[m as usize].call(
                 tmp.as_mut_ptr(),
                 4 * bw4 as isize * ::core::mem::size_of::<BD::Pixel>() as isize,
                 tl_edge.as_ptr(),
@@ -3716,9 +3748,9 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                         }
                     };
                     for pl in 0..2 {
-                        let interintra_edge =
-                            BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge);
-                        let tl_edge_array = &mut interintra_edge.0.edge;
+                        let interintra_edge_pal =
+                            BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge_pal);
+                        let tl_edge_array = &mut interintra_edge_pal.0.edge;
                         let tl_edge_offset = 32;
                         let mut m = if b.interintra_mode() == InterIntraPredMode::Smooth {
                             SMOOTH_PRED
@@ -3767,8 +3799,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             BD::from_c(f.bitdepth_max),
                         );
                         let tl_edge = &tl_edge_array[tl_edge_offset..];
-                        let tmp = &mut interintra_edge.0.interintra;
-                        dsp.ipred.intra_pred[m as usize].call(
+                        let tmp = &mut interintra_edge_pal.0.interintra;
+                        (*dsp).ipred.intra_pred[m as usize].call(
                             tmp.as_mut_ptr(),
                             cbw4 as isize * 4 * ::core::mem::size_of::<BD::Pixel>() as isize,
                             tl_edge.as_ptr(),
@@ -4334,5 +4366,303 @@ pub(crate) unsafe fn rav1d_backup_ipred_edge<BD: BitDepth>(
             );
             pl += 1;
         }
+    }
+}
+
+pub(crate) unsafe fn rav1d_copy_pal_block_y<BD: BitDepth>(
+    t: &mut Rav1dTaskContext,
+    f: &mut Rav1dFrameData,
+    bx4: c_int,
+    by4: c_int,
+    bw4: c_int,
+    bh4: c_int,
+) {
+    let pal = if t.frame_thread.pass != 0 {
+        let index = ((t.b.y >> 1) + (t.b.x & 1)) as isize * (f.b4_stride >> 1)
+            + ((t.b.x >> 1) + (t.b.y & 1)) as isize;
+        &f.frame_thread.pal_as_slice::<BD>()[index as usize][0]
+    } else {
+        let interintra_edge_pal =
+            BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge_pal);
+        &interintra_edge_pal.0.pal[0]
+    };
+    for al_pal in &mut BD::select_mut(&mut t.al_pal)[0][bx4 as usize..][..bw4 as usize] {
+        al_pal[0] = *pal;
+    }
+    for al_pal in &mut BD::select_mut(&mut t.al_pal)[1][by4 as usize..][..bh4 as usize] {
+        al_pal[0] = *pal;
+    }
+}
+
+pub(crate) unsafe fn rav1d_copy_pal_block_uv<BD: BitDepth>(
+    t: &mut Rav1dTaskContext,
+    f: &mut Rav1dFrameData,
+    bx4: c_int,
+    by4: c_int,
+    bw4: c_int,
+    bh4: c_int,
+) {
+    let pal = if t.frame_thread.pass != 0 {
+        let index = ((t.b.y >> 1) + (t.b.x & 1)) as isize * (f.b4_stride >> 1)
+            + ((t.b.x >> 1) + (t.b.y & 1)) as isize;
+        &f.frame_thread.pal_as_slice_mut::<BD>()[index as usize]
+    } else {
+        let interintra_edge_pal =
+            BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge_pal);
+        &interintra_edge_pal.0.pal
+    };
+    // see aomedia bug 2183 for why we use luma coordinates here
+    for pl in 1..=2 {
+        for x in 0..bw4 {
+            BD::select_mut(&mut t.al_pal)[0][(bx4 + x) as usize][pl] = pal[pl];
+        }
+        for y in 0..bh4 {
+            BD::select_mut(&mut t.al_pal)[1][(by4 + y) as usize][pl] = pal[pl];
+        }
+    }
+}
+
+pub(crate) unsafe fn rav1d_read_pal_plane<BD: BitDepth>(
+    t: &mut Rav1dTaskContext,
+    f: &mut Rav1dFrameData,
+    b: &mut Av1Block,
+    pl: bool,
+    sz_ctx: u8,
+    bx4: usize,
+    by4: usize,
+) {
+    let pli = pl as usize;
+    let not_pl = !pl as u16;
+
+    let ts = &mut *f.ts.offset(t.ts as isize);
+
+    let pal_sz = rav1d_msac_decode_symbol_adapt8(
+        &mut ts.msac,
+        &mut ts.cdf.m.pal_sz[pli][sz_ctx as usize],
+        6,
+    ) as u8
+        + 2;
+    b.pal_sz_mut()[pli] = pal_sz;
+    let pal_sz = pal_sz as usize;
+    let mut cache = [0.as_::<BD::Pixel>(); 16];
+    let mut used_cache = [0.as_::<BD::Pixel>(); 8];
+    let mut l_cache = if pl {
+        t.pal_sz_uv[1][by4]
+    } else {
+        t.l.pal_sz.0[by4]
+    };
+    let mut n_cache = 0;
+    // don't reuse above palette outside SB64 boundaries
+    let mut a_cache = if by4 & 15 != 0 {
+        if pl {
+            t.pal_sz_uv[0][bx4]
+        } else {
+            (*t.a).pal_sz.0[bx4]
+        }
+    } else {
+        0
+    };
+    let [a, l] = BD::select_mut(&mut t.al_pal);
+    let mut l = &l[by4][pli][..];
+    let mut a = &a[bx4][pli][..];
+
+    // fill/sort cache
+    // TODO: This logic could be replaced with `itertools`' `.merge` and `.dedup`, which would elide bounds checks.
+    while l_cache != 0 && a_cache != 0 {
+        if l[0] < a[0] {
+            if n_cache == 0 || cache[n_cache - 1] != l[0] {
+                cache[n_cache] = l[0];
+                n_cache += 1;
+            }
+            l = &l[1..];
+            l_cache -= 1;
+        } else {
+            if a[0] == l[0] {
+                l = &l[1..];
+                l_cache -= 1;
+            }
+            if n_cache == 0 || cache[n_cache - 1] != a[0] {
+                cache[n_cache] = a[0];
+                n_cache += 1;
+            }
+            a = &a[1..];
+            a_cache -= 1;
+        }
+    }
+    if l_cache != 0 {
+        loop {
+            if n_cache == 0 || cache[n_cache - 1] != l[0] {
+                cache[n_cache] = l[0];
+                n_cache += 1;
+            }
+            l = &l[1..];
+            l_cache -= 1;
+            if !(l_cache > 0) {
+                break;
+            }
+        }
+    } else if a_cache != 0 {
+        loop {
+            if n_cache == 0 || cache[n_cache - 1] != a[0] {
+                cache[n_cache] = a[0];
+                n_cache += 1;
+            }
+            a = &a[1..];
+            a_cache -= 1;
+            if !(a_cache > 0) {
+                break;
+            }
+        }
+    }
+    let cache = &cache[..n_cache];
+
+    // find reused cache entries
+    // TODO: Bounds checks could be elided with more complex iterators.
+    let mut i = 0;
+    for cache in cache {
+        if !(i < pal_sz) {
+            break;
+        }
+        if rav1d_msac_decode_bool_equi(&mut ts.msac) {
+            used_cache[i] = *cache;
+            i += 1;
+        }
+    }
+    let used_cache = &used_cache[..i];
+
+    // parse new entries
+    let pal = if t.frame_thread.pass != 0 {
+        &mut f.frame_thread.pal_as_slice_mut::<BD>()[(((t.b.y >> 1) + (t.b.x & 1)) as isize
+            * (f.b4_stride >> 1)
+            + ((t.b.x >> 1) + (t.b.y & 1)) as isize)
+            as usize][pli]
+    } else {
+        let interintra_edge_pal =
+            BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge_pal);
+        &mut interintra_edge_pal.0.pal[pli]
+    };
+    let pal = &mut pal[..pal_sz];
+    if i < pal.len() {
+        let mut prev = rav1d_msac_decode_bools(&mut ts.msac, f.cur.p.bpc as u32) as u16;
+        pal[i] = prev.as_::<BD::Pixel>();
+        i += 1;
+
+        if i < pal.len() {
+            let mut bits = f.cur.p.bpc as u32 + rav1d_msac_decode_bools(&mut ts.msac, 2) - 3;
+            let max = (1 << f.cur.p.bpc) - 1;
+
+            loop {
+                let delta = rav1d_msac_decode_bools(&mut ts.msac, bits) as u16;
+                prev = cmp::min(prev + delta + not_pl, max);
+                pal[i] = prev.as_::<BD::Pixel>();
+                i += 1;
+                if prev + not_pl >= max {
+                    pal[i..].fill(max.as_::<BD::Pixel>());
+                    break;
+                } else {
+                    bits = cmp::min(bits, 1 + ulog2((max - prev - not_pl) as u32) as u32);
+                    if !(i < pal.len()) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        // merge cache+new entries
+        let mut n = 0;
+        let mut m = used_cache.len();
+        for i in 0..pal.len() {
+            if n < used_cache.len() && (m >= pal.len() || used_cache[n] <= pal[m]) {
+                pal[i] = used_cache[n];
+                n += 1;
+            } else {
+                pal[i] = pal[m];
+                m += 1;
+            }
+        }
+    } else {
+        pal[..used_cache.len()].copy_from_slice(&used_cache);
+    }
+
+    if debug_block_info!(f, t.b) {
+        print!(
+            "Post-pal[pl={},sz={},cache_size={},used_cache={}]: r={}, cache=",
+            pli,
+            pal_sz,
+            cache.len(),
+            used_cache.len(),
+            ts.msac.rng
+        );
+        for (n, cache) in cache.iter().enumerate() {
+            print!(
+                "{}{:02x}",
+                if n != 0 { ' ' } else { '[' },
+                (*cache).as_::<c_int>()
+            );
+        }
+        print!("{}, pal=", if cache.len() != 0 { "]" } else { "[]" });
+        for (n, pal) in pal.iter().enumerate() {
+            print!(
+                "{}{:02x}",
+                if n != 0 { ' ' } else { '[' },
+                (*pal).as_::<c_int>()
+            );
+        }
+        println!("]");
+    }
+}
+
+pub(crate) unsafe fn rav1d_read_pal_uv<BD: BitDepth>(
+    t: &mut Rav1dTaskContext,
+    f: &mut Rav1dFrameData,
+    b: &mut Av1Block,
+    sz_ctx: u8,
+    bx4: usize,
+    by4: usize,
+) {
+    rav1d_read_pal_plane::<BD>(t, f, b, true, sz_ctx, bx4, by4);
+
+    // V pal coding
+    let ts = &mut *f.ts.offset(t.ts as isize);
+
+    let pal = if t.frame_thread.pass != 0 {
+        &mut f.frame_thread.pal_as_slice_mut::<BD>()[(((t.b.y >> 1) + (t.b.x & 1)) as isize
+            * (f.b4_stride >> 1)
+            + ((t.b.x >> 1) + (t.b.y & 1)) as isize)
+            as usize][2]
+    } else {
+        let interintra_edge_pal =
+            BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge_pal);
+        &mut interintra_edge_pal.0.pal[2]
+    };
+    let pal = &mut pal[..b.pal_sz()[1] as usize];
+    if rav1d_msac_decode_bool_equi(&mut ts.msac) {
+        let bits = f.cur.p.bpc as u32 + rav1d_msac_decode_bools(&mut ts.msac, 2) - 4;
+        let mut prev = rav1d_msac_decode_bools(&mut ts.msac, f.cur.p.bpc as c_uint) as u16;
+        pal[0] = prev.as_::<BD::Pixel>();
+        let max = (1 << f.cur.p.bpc) - 1;
+        for pal in &mut pal[1..] {
+            let mut delta = rav1d_msac_decode_bools(&mut ts.msac, bits) as i16;
+            if delta != 0 && rav1d_msac_decode_bool_equi(&mut ts.msac) {
+                delta = -delta;
+            }
+            prev = (prev as i16 + delta) as u16 & max;
+            *pal = prev.as_::<BD::Pixel>();
+        }
+    } else {
+        pal.fill_with(|| {
+            rav1d_msac_decode_bools(&mut ts.msac, f.cur.p.bpc as c_uint).as_::<BD::Pixel>()
+        });
+    }
+    if debug_block_info!(f, t.b) {
+        print!("Post-pal[pl=2]: r={} ", ts.msac.rng);
+        for (n, pal) in pal.iter().enumerate() {
+            print!(
+                "{}{:02x}",
+                if n != 0 { ' ' } else { '[' },
+                (*pal).as_::<c_int>()
+            );
+        }
+        println!("]");
     }
 }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2455,7 +2455,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                 } else {
                     let interintra_edge_pal =
                         BD::select(&t.scratch.c2rust_unnamed_0.interintra_edge_pal);
-                    interintra_edge_pal.0.pal[0].as_ptr()
+                    interintra_edge_pal.pal[0].as_ptr()
                 };
                 (*f.dsp).ipred.pal_pred.call::<BD>(
                     dst,
@@ -2530,7 +2530,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         };
                         let interintra_edge_pal =
                             BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge_pal);
-                        let edge_array = &mut interintra_edge_pal.0.edge;
+                        let edge_array = &mut interintra_edge_pal.edge;
                         let edge_offset = 128;
                         let data_stride = BD::pxstride(f.cur.stride[0]);
                         let data_width = 4 * ts.tiling.col_end;
@@ -2750,7 +2750,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             let ystart = (*ts).tiling.row_start >> ss_ver;
                             let interintra_edge_pal =
                                 BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge_pal);
-                            let edge_array = &mut interintra_edge_pal.0.edge;
+                            let edge_array = &mut interintra_edge_pal.edge;
                             let edge_offset = 128;
                             let data_stride = BD::pxstride(f.cur.stride[1]);
                             let data_width = 4 * ts.tiling.col_end >> ss_hor;
@@ -2833,7 +2833,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         let interintra_edge_pal =
                             BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge_pal);
                         (
-                            &interintra_edge_pal.0.pal,
+                            &interintra_edge_pal.pal,
                             &t.scratch.c2rust_unnamed_0.pal_idx[(bw4 * bh4 * 16) as usize..],
                         )
                     };
@@ -2956,7 +2956,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                 let interintra_edge_pal = BD::select_mut(
                                     &mut t.scratch.c2rust_unnamed_0.interintra_edge_pal,
                                 );
-                                let edge_array = &mut interintra_edge_pal.0.edge;
+                                let edge_array = &mut interintra_edge_pal.edge;
                                 let edge_offset = 128;
                                 let data_stride = BD::pxstride(f.cur.stride[1]);
                                 let data_width = 4 * ts.tiling.col_end >> ss_hor;
@@ -3463,7 +3463,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
         if let Some(interintra_type) = b.interintra_type() {
             let interintra_edge_pal =
                 BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge_pal);
-            let tl_edge_array = &mut interintra_edge_pal.0.edge;
+            let tl_edge_array = &mut interintra_edge_pal.edge;
             let tl_edge_offset = 32;
             let mut m = if b.interintra_mode() == InterIntraPredMode::Smooth {
                 SMOOTH_PRED
@@ -3508,7 +3508,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 BD::from_c(f.bitdepth_max),
             );
             let tl_edge = &tl_edge_array[tl_edge_offset..];
-            let tmp = &mut interintra_edge_pal.0.interintra;
+            let tmp = &mut interintra_edge_pal.interintra;
             (*dsp).ipred.intra_pred[m as usize].call(
                 tmp.as_mut_ptr(),
                 4 * bw4 as isize * ::core::mem::size_of::<BD::Pixel>() as isize,
@@ -3756,7 +3756,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     for pl in 0..2 {
                         let interintra_edge_pal =
                             BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge_pal);
-                        let tl_edge_array = &mut interintra_edge_pal.0.edge;
+                        let tl_edge_array = &mut interintra_edge_pal.edge;
                         let tl_edge_offset = 32;
                         let mut m = if b.interintra_mode() == InterIntraPredMode::Smooth {
                             SMOOTH_PRED
@@ -3805,7 +3805,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             BD::from_c(f.bitdepth_max),
                         );
                         let tl_edge = &tl_edge_array[tl_edge_offset..];
-                        let tmp = &mut interintra_edge_pal.0.interintra;
+                        let tmp = &mut interintra_edge_pal.interintra;
                         (*dsp).ipred.intra_pred[m as usize].call(
                             tmp.as_mut_ptr(),
                             cbw4 as isize * 4 * ::core::mem::size_of::<BD::Pixel>() as isize,
@@ -4389,7 +4389,7 @@ pub(crate) unsafe fn rav1d_copy_pal_block_y<BD: BitDepth>(
         &f.frame_thread.pal.as_slice::<BD>()[index as usize][0]
     } else {
         let interintra_edge_pal = BD::select(&t.scratch.c2rust_unnamed_0.interintra_edge_pal);
-        &interintra_edge_pal.0.pal[0]
+        &interintra_edge_pal.pal[0]
     };
     for al_pal in &mut BD::select_mut(&mut t.al_pal)[0][bx4..][..bw4] {
         al_pal[0] = *pal;
@@ -4413,7 +4413,7 @@ pub(crate) unsafe fn rav1d_copy_pal_block_uv<BD: BitDepth>(
         &f.frame_thread.pal.as_slice_mut::<BD>()[index as usize]
     } else {
         let interintra_edge_pal = BD::select(&t.scratch.c2rust_unnamed_0.interintra_edge_pal);
-        &interintra_edge_pal.0.pal
+        &interintra_edge_pal.pal
     };
     // see aomedia bug 2183 for why we use luma coordinates here
     for pl in 1..=2 {
@@ -4543,7 +4543,7 @@ pub(crate) unsafe fn rav1d_read_pal_plane<BD: BitDepth>(
     } else {
         let interintra_edge_pal =
             BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge_pal);
-        &mut interintra_edge_pal.0.pal[pli]
+        &mut interintra_edge_pal.pal[pli]
     };
     let pal = &mut pal[..pal_sz];
     if i < pal.len() {
@@ -4637,7 +4637,7 @@ pub(crate) unsafe fn rav1d_read_pal_uv<BD: BitDepth>(
     } else {
         let interintra_edge_pal =
             BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge_pal);
-        &mut interintra_edge_pal.0.pal[2]
+        &mut interintra_edge_pal.pal[2]
     };
     let pal = &mut pal[..b.pal_sz()[1] as usize];
     if rav1d_msac_decode_bool_equi(&mut ts.msac) {

--- a/src/recon_tmpl.c
+++ b/src/recon_tmpl.c
@@ -1240,9 +1240,10 @@ void bytefn(dav1d_recon_b_intra)(Dav1dTaskContext *const t, const enum BlockSize
                 } else {
                     pal_idx = t->scratch.pal_idx;
                 }
-                const uint16_t *const pal = t->frame_thread.pass ?
+                const pixel *const pal = t->frame_thread.pass ?
                     f->frame_thread.pal[((t->by >> 1) + (t->bx & 1)) * (f->b4_stride >> 1) +
-                                        ((t->bx >> 1) + (t->by & 1))][0] : t->scratch.pal[0];
+                                        ((t->bx >> 1) + (t->by & 1))][0] :
+                    bytefn(t->scratch.pal)[0];
                 f->dsp->ipred.pal_pred(dst, f->cur.stride[0], pal,
                                        pal_idx, bw4 * 4, bh4 * 4);
                 if (DEBUG_BLOCK_INFO && DEBUG_B_PIXELS)
@@ -1428,7 +1429,7 @@ void bytefn(dav1d_recon_b_intra)(Dav1dTaskContext *const t, const enum BlockSize
             } else if (b->pal_sz[1]) {
                 const ptrdiff_t uv_dstoff = 4 * ((t->bx >> ss_hor) +
                                               (t->by >> ss_ver) * PXSTRIDE(f->cur.stride[1]));
-                const uint16_t (*pal)[8];
+                const pixel (*pal)[8];
                 const uint8_t *pal_idx;
                 if (t->frame_thread.pass) {
                     const int p = t->frame_thread.pass & 1;
@@ -1438,7 +1439,7 @@ void bytefn(dav1d_recon_b_intra)(Dav1dTaskContext *const t, const enum BlockSize
                     pal_idx = ts->frame_thread[p].pal_idx;
                     ts->frame_thread[p].pal_idx += cbw4 * cbh4 * 16;
                 } else {
-                    pal = t->scratch.pal;
+                    pal = bytefn(t->scratch.pal);
                     pal_idx = &t->scratch.pal_idx[bw4 * bh4 * 16];
                 }
 
@@ -2196,5 +2197,180 @@ void bytefn(dav1d_backup_ipred_edge)(Dav1dTaskContext *const t) {
             pixel_copy(&f->ipred_edge[pl][sby_off + (x_off * 4 >> ss_hor)],
                        &((const pixel *) f->cur.data[pl])[uv_off],
                        4 * (ts->tiling.col_end - x_off) >> ss_hor);
+    }
+}
+
+void bytefn(dav1d_copy_pal_block_y)(Dav1dTaskContext *const t,
+                                    const int bx4, const int by4,
+                                    const int bw4, const int bh4)
+
+{
+    const Dav1dFrameContext *const f = t->f;
+    pixel *const pal = t->frame_thread.pass ?
+        f->frame_thread.pal[((t->by >> 1) + (t->bx & 1)) * (f->b4_stride >> 1) +
+                            ((t->bx >> 1) + (t->by & 1))][0] :
+        bytefn(t->scratch.pal)[0];
+    for (int x = 0; x < bw4; x++)
+        memcpy(bytefn(t->al_pal)[0][bx4 + x][0], pal, 8 * sizeof(pixel));
+    for (int y = 0; y < bh4; y++)
+        memcpy(bytefn(t->al_pal)[1][by4 + y][0], pal, 8 * sizeof(pixel));
+}
+
+void bytefn(dav1d_copy_pal_block_uv)(Dav1dTaskContext *const t,
+                                     const int bx4, const int by4,
+                                     const int bw4, const int bh4)
+
+{
+    const Dav1dFrameContext *const f = t->f;
+    const pixel (*const pal)[8] = t->frame_thread.pass ?
+        f->frame_thread.pal[((t->by >> 1) + (t->bx & 1)) * (f->b4_stride >> 1) +
+                            ((t->bx >> 1) + (t->by & 1))] :
+        bytefn(t->scratch.pal);
+    // see aomedia bug 2183 for why we use luma coordinates here
+    for (int pl = 1; pl <= 2; pl++) {
+        for (int x = 0; x < bw4; x++)
+            memcpy(bytefn(t->al_pal)[0][bx4 + x][pl], pal[pl], 8 * sizeof(pixel));
+        for (int y = 0; y < bh4; y++)
+            memcpy(bytefn(t->al_pal)[1][by4 + y][pl], pal[pl], 8 * sizeof(pixel));
+    }
+}
+
+void bytefn(dav1d_read_pal_plane)(Dav1dTaskContext *const t, Av1Block *const b,
+                                  const int pl, const int sz_ctx,
+                                  const int bx4, const int by4)
+{
+    Dav1dTileState *const ts = t->ts;
+    const Dav1dFrameContext *const f = t->f;
+    const int pal_sz = b->pal_sz[pl] = dav1d_msac_decode_symbol_adapt8(&ts->msac,
+                                           ts->cdf.m.pal_sz[pl][sz_ctx], 6) + 2;
+    pixel cache[16], used_cache[8];
+    int l_cache = pl ? t->pal_sz_uv[1][by4] : t->l.pal_sz[by4];
+    int n_cache = 0;
+    // don't reuse above palette outside SB64 boundaries
+    int a_cache = by4 & 15 ? pl ? t->pal_sz_uv[0][bx4] : t->a->pal_sz[bx4] : 0;
+    const pixel *l = bytefn(t->al_pal)[1][by4][pl];
+    const pixel *a = bytefn(t->al_pal)[0][bx4][pl];
+
+    // fill/sort cache
+    while (l_cache && a_cache) {
+        if (*l < *a) {
+            if (!n_cache || cache[n_cache - 1] != *l)
+                cache[n_cache++] = *l;
+            l++;
+            l_cache--;
+        } else {
+            if (*a == *l) {
+                l++;
+                l_cache--;
+            }
+            if (!n_cache || cache[n_cache - 1] != *a)
+                cache[n_cache++] = *a;
+            a++;
+            a_cache--;
+        }
+    }
+    if (l_cache) {
+        do {
+            if (!n_cache || cache[n_cache - 1] != *l)
+                cache[n_cache++] = *l;
+            l++;
+        } while (--l_cache > 0);
+    } else if (a_cache) {
+        do {
+            if (!n_cache || cache[n_cache - 1] != *a)
+                cache[n_cache++] = *a;
+            a++;
+        } while (--a_cache > 0);
+    }
+
+    // find reused cache entries
+    int i = 0;
+    for (int n = 0; n < n_cache && i < pal_sz; n++)
+        if (dav1d_msac_decode_bool_equi(&ts->msac))
+            used_cache[i++] = cache[n];
+    const int n_used_cache = i;
+
+    // parse new entries
+    pixel *const pal = t->frame_thread.pass ?
+        f->frame_thread.pal[((t->by >> 1) + (t->bx & 1)) * (f->b4_stride >> 1) +
+                            ((t->bx >> 1) + (t->by & 1))][pl] :
+        bytefn(t->scratch.pal)[pl];
+    if (i < pal_sz) {
+        const int bpc = BITDEPTH == 8 ? 8 : f->cur.p.bpc;
+        int prev = pal[i++] = dav1d_msac_decode_bools(&ts->msac, bpc);
+
+        if (i < pal_sz) {
+            int bits = bpc - 3 + dav1d_msac_decode_bools(&ts->msac, 2);
+            const int max = (1 << bpc) - 1;
+
+            do {
+                const int delta = dav1d_msac_decode_bools(&ts->msac, bits);
+                prev = pal[i++] = imin(prev + delta + !pl, max);
+                if (prev + !pl >= max) {
+                    for (; i < pal_sz; i++)
+                        pal[i] = max;
+                    break;
+                }
+                bits = imin(bits, 1 + ulog2(max - prev - !pl));
+            } while (i < pal_sz);
+        }
+
+        // merge cache+new entries
+        int n = 0, m = n_used_cache;
+        for (i = 0; i < pal_sz; i++) {
+            if (n < n_used_cache && (m >= pal_sz || used_cache[n] <= pal[m])) {
+                pal[i] = used_cache[n++];
+            } else {
+                assert(m < pal_sz);
+                pal[i] = pal[m++];
+            }
+        }
+    } else {
+        memcpy(pal, used_cache, n_used_cache * sizeof(*used_cache));
+    }
+
+    if (DEBUG_BLOCK_INFO) {
+        printf("Post-pal[pl=%d,sz=%d,cache_size=%d,used_cache=%d]: r=%d, cache=",
+               pl, pal_sz, n_cache, n_used_cache, ts->msac.rng);
+        for (int n = 0; n < n_cache; n++)
+            printf("%c%02x", n ? ' ' : '[', cache[n]);
+        printf("%s, pal=", n_cache ? "]" : "[]");
+        for (int n = 0; n < pal_sz; n++)
+            printf("%c%02x", n ? ' ' : '[', pal[n]);
+        printf("]\n");
+    }
+}
+
+void bytefn(dav1d_read_pal_uv)(Dav1dTaskContext *const t, Av1Block *const b,
+                               const int sz_ctx, const int bx4, const int by4)
+{
+    bytefn(dav1d_read_pal_plane)(t, b, 1, sz_ctx, bx4, by4);
+
+    // V pal coding
+    Dav1dTileState *const ts = t->ts;
+    const Dav1dFrameContext *const f = t->f;
+    pixel *const pal = t->frame_thread.pass ?
+        f->frame_thread.pal[((t->by >> 1) + (t->bx & 1)) * (f->b4_stride >> 1) +
+                            ((t->bx >> 1) + (t->by & 1))][2] :
+        bytefn(t->scratch.pal)[2];
+    const int bpc = BITDEPTH == 8 ? 8 : f->cur.p.bpc;
+    if (dav1d_msac_decode_bool_equi(&ts->msac)) {
+        const int bits = bpc - 4 + dav1d_msac_decode_bools(&ts->msac, 2);
+        int prev = pal[0] = dav1d_msac_decode_bools(&ts->msac, bpc);
+        const int max = (1 << bpc) - 1;
+        for (int i = 1; i < b->pal_sz[1]; i++) {
+            int delta = dav1d_msac_decode_bools(&ts->msac, bits);
+            if (delta && dav1d_msac_decode_bool_equi(&ts->msac)) delta = -delta;
+            prev = pal[i] = (prev + delta) & max;
+        }
+    } else {
+        for (int i = 0; i < b->pal_sz[1]; i++)
+            pal[i] = dav1d_msac_decode_bools(&ts->msac, bpc);
+    }
+    if (DEBUG_BLOCK_INFO) {
+        printf("Post-pal[pl=2]: r=%d ", ts->msac.rng);
+        for (int n = 0; n < b->pal_sz[1]; n++)
+            printf("%c%02x", n ? ' ' : '[', pal[n]);
+        printf("]\n");
     }
 }

--- a/src/x86/ipred_avx2.asm
+++ b/src/x86/ipred_avx2.asm
@@ -5307,12 +5307,11 @@ cglobal ipred_cfl_ac_444_8bpc, 4, 9, 6, ac, y, stride, wpad, hpad, w, h, sz, ac_
     RET
 
 cglobal pal_pred_8bpc, 4, 6, 5, dst, stride, pal, idx, w, h
-    vbroadcasti128       m4, [palq]
+    vpbroadcastq         m4, [palq]
     lea                  r2, [pal_pred_avx2_table]
     tzcnt                wd, wm
     movifnidn            hd, hm
     movsxd               wq, [r2+wq*4]
-    packuswb             m4, m4
     add                  wq, r2
     lea                  r2, [strideq*3]
     jmp                  wq

--- a/src/x86/ipred_avx512.asm
+++ b/src/x86/ipred_avx512.asm
@@ -1114,10 +1114,9 @@ cglobal ipred_smooth_8bpc, 4, 7, 16, dst, stride, tl, w, h, v_weights, stride3
 cglobal pal_pred_8bpc, 4, 7, 5, dst, stride, pal, idx, w, h, stride3
     lea                  r6, [pal_pred_8bpc_avx512icl_table]
     tzcnt                wd, wm
-    vbroadcasti32x4      m4, [palq]
+    vpbroadcastq         m4, [palq]
     movifnidn            hd, hm
     movsxd               wq, [r6+wq*4]
-    packuswb             m4, m4
     add                  wq, r6
     lea            stride3q, [strideq*3]
     jmp                  wq

--- a/src/x86/ipred_sse.asm
+++ b/src/x86/ipred_sse.asm
@@ -3479,17 +3479,16 @@ cglobal ipred_z3_8bpc, 4, 7, 8, -16*10, dst, stride, tl, w, h, angle, dy
     jg .end_transpose_loop
     RET
 
-;---------------------------------------------------------------------------------------
-;int dav1d_pal_pred_ssse3(pixel *dst, const ptrdiff_t stride, const uint16_t *const pal,
-;                                         const uint8_t *idx, const int w, const int h);
-;---------------------------------------------------------------------------------------
+;-------------------------------------------------------------------------------
+;int dav1d_pal_pred_ssse3(pixel *dst, ptrdiff_t stride, const pixel *pal,
+;                         const uint8_t *idx, int w, int h);
+;-------------------------------------------------------------------------------
 cglobal pal_pred_8bpc, 4, 6, 5, dst, stride, pal, idx, w, h
-    mova                 m4, [palq]
+    movq                 m4, [palq]
     LEA                  r2, pal_pred_ssse3_table
     tzcnt                wd, wm
     movifnidn            hd, hm
     movsxd               wq, [r2+wq*4]
-    packuswb             m4, m4
     add                  wq, r2
     lea                  r2, [strideq*3]
     jmp                  wq

--- a/tests/checkasm/ipred.c
+++ b/tests/checkasm/ipred.c
@@ -252,9 +252,9 @@ static void check_pal_pred(Dav1dIntraPredDSPContext *const c) {
     PIXEL_RECT(c_dst, 64, 64);
     PIXEL_RECT(a_dst, 64, 64);
     ALIGN_STK_64(uint8_t, idx, 64 * 64,);
-    ALIGN_STK_16(uint16_t, pal, 8,);
+    ALIGN_STK_16(pixel, pal, 8,);
 
-    declare_func(void, pixel *dst, ptrdiff_t stride, const uint16_t *pal,
+    declare_func(void, pixel *dst, ptrdiff_t stride, const pixel *pal,
                  const uint8_t *idx, int w, int h);
 
     for (int w = 4; w <= 64; w <<= 1)


### PR DESCRIPTION
Allocate memory for palette mode according to bit depth of pixel instead of fixed `u16` size.