### PR TITLE
`struct Rav1dFrameData`: Add `index` field

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -533,6 +533,9 @@ pub(crate) struct Rav1dFrameContext_frame_thread_progress {
 
 #[repr(C)]
 pub(crate) struct Rav1dFrameData {
+    /// Index in [`Rav1dContext::fc`]
+    pub index: usize,
+
     pub seq_hdr: Option<Arc<DRav1d<Rav1dSequenceHeader, Dav1dSequenceHeader>>>,
     pub frame_hdr: Option<Arc<DRav1d<Rav1dFrameHeader, Dav1dFrameHeader>>>,
     pub refp: [Rav1dThreadPicture; 7],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,9 +334,9 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
     } else {
         Box::new([])
     });
-    let mut n: c_uint = 0 as c_int as c_uint;
-    while n < (*c).n_fc {
+    for n in 0..n_fc {
         let f: &mut Rav1dFrameData = &mut *((*c).fc).offset(n as isize);
+        f.index = n;
         addr_of_mut!(f.frame_thread).write(Default::default());
         if n_tc > 1 {
             f.task_thread.lock = Mutex::new(());
@@ -353,7 +353,6 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
         addr_of_mut!(f.lf.start_of_tile_row).write(Default::default());
         f.lf.last_sharpness = -(1 as c_int);
         rav1d_refmvs_init(&mut f.rf);
-        n = n.wrapping_add(1);
     }
     (*c).tc = (0..n_tc)
         .map(|_| {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -399,7 +399,7 @@ unsafe fn create_filter_sbrow(
     } else {
         TaskType::ReconstructionProgress
     };
-    (*t).frame_idx = (f as *mut Rav1dFrameData).offset_from(c.fc) as c_long as c_int as c_uint;
+    (*t).frame_idx = f.index as c_uint;
     *res_t = t;
     return 0 as c_int;
 }
@@ -453,7 +453,7 @@ pub(crate) unsafe fn rav1d_task_create_tile_sbrow(
         } else {
             TaskType::TileEntropy
         };
-        (*t).frame_idx = (f as *mut Rav1dFrameData).offset_from(c.fc) as c_long as c_int as c_uint;
+        (*t).frame_idx = f.index as c_uint;
         if !prev_t.is_null() {
             (*prev_t).next = t;
         }
@@ -485,8 +485,7 @@ pub(crate) unsafe fn rav1d_task_frame_init(c: &Rav1dContext, f: &mut Rav1dFrameD
     f.task_thread.init_done.store(0, Ordering::SeqCst);
     let t: *mut Rav1dTask = &mut f.task_thread.init_task;
     (*t).type_0 = TaskType::Init;
-    // TODO(SJC): add a frame context index so we don't have to rely on linear offsets
-    (*t).frame_idx = (f as *mut Rav1dFrameData).offset_from(c.fc) as c_long as c_int as c_uint;
+    (*t).frame_idx = f.index as c_uint;
     (*t).sby = 0 as c_int;
     (*t).deblock_progress = 0 as c_int;
     (*t).recon_progress = (*t).deblock_progress;


### PR DESCRIPTION
Store the index of a frame context in the array of frame contexts, rather than doing pointer arithmetic to determine the index.