### PR TITLE
`enum CompInterType`: make a real enum

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2428,7 +2428,7 @@ unsafe fn decode_b_inner(
                 frame_hdr.skip_mode.refs[0] as i8,
                 frame_hdr.skip_mode.refs[1] as i8,
             ];
-            *b.comp_type_mut() = Some(CompInterType::COMP_INTER_AVG);
+            *b.comp_type_mut() = Some(CompInterType::Avg);
             *b.inter_mode_mut() = NEARESTMV_NEARESTMV;
             *b.drl_idx_mut() = NEAREST_DRL;
             has_subpel_filter = false;
@@ -2703,15 +2703,15 @@ unsafe fn decode_b_inner(
                         &mut ts.msac,
                         &mut ts.cdf.m.jnt_comp[jnt_ctx as usize],
                     ) {
-                        CompInterType::COMP_INTER_AVG
+                        CompInterType::Avg
                     } else {
-                        CompInterType::COMP_INTER_WEIGHTED_AVG
+                        CompInterType::WeightedAvg
                     };
                     *b.comp_type_mut() = Some(comp_type);
                     if debug_block_info!(f, t) {
                         println!(
                             "Post-jnt_comp[{},ctx={}[ac:{:?},ar:{},lc:{:?},lr:{}]]: r={}",
-                            comp_type == CompInterType::COMP_INTER_AVG,
+                            comp_type == CompInterType::Avg,
                             jnt_ctx,
                             (*t.a).comp_type[bx4 as usize],
                             (*t.a).r#ref[0][bx4 as usize],
@@ -2721,7 +2721,7 @@ unsafe fn decode_b_inner(
                         );
                     }
                 } else {
-                    *b.comp_type_mut() = Some(CompInterType::COMP_INTER_AVG);
+                    *b.comp_type_mut() = Some(CompInterType::Avg);
                 }
             } else {
                 if wedge_allowed_mask & (1 << bs) != 0 {
@@ -2730,12 +2730,12 @@ unsafe fn decode_b_inner(
                         &mut ts.msac,
                         &mut ts.cdf.m.wedge_comp[ctx],
                     ) {
-                        CompInterType::COMP_INTER_SEG
+                        CompInterType::Seg
                     } else {
-                        CompInterType::COMP_INTER_WEDGE
+                        CompInterType::Wedge
                     };
                     *b.comp_type_mut() = Some(comp_type);
-                    if comp_type == CompInterType::COMP_INTER_WEDGE {
+                    if comp_type == CompInterType::Wedge {
                         *b.wedge_idx_mut() = rav1d_msac_decode_symbol_adapt16(
                             &mut ts.msac,
                             &mut ts.cdf.m.wedge_idx[ctx],
@@ -2743,13 +2743,13 @@ unsafe fn decode_b_inner(
                         ) as u8;
                     }
                 } else {
-                    *b.comp_type_mut() = Some(CompInterType::COMP_INTER_SEG);
+                    *b.comp_type_mut() = Some(CompInterType::Seg);
                 }
                 *b.mask_sign_mut() = rav1d_msac_decode_bool_equi(&mut ts.msac) as u8;
                 if debug_block_info!(f, t) {
                     println!(
                         "Post-seg/wedge[{},wedge_idx={},sign={}]: r={}",
-                        b.comp_type() == Some(CompInterType::COMP_INTER_WEDGE),
+                        b.comp_type() == Some(CompInterType::Wedge),
                         b.wedge_idx(),
                         b.mask_sign(),
                         ts.msac.rng,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -82,16 +82,12 @@ use crate::src::levels::BS_64x64;
 use crate::src::levels::BlockLevel;
 use crate::src::levels::BlockPartition;
 use crate::src::levels::BlockSize;
+use crate::src::levels::CompInterType;
 use crate::src::levels::InterIntraType;
 use crate::src::levels::MotionMode;
 use crate::src::levels::RectTxfmSize;
 use crate::src::levels::TxfmSize;
 use crate::src::levels::CFL_PRED;
-use crate::src::levels::COMP_INTER_AVG;
-use crate::src::levels::COMP_INTER_NONE;
-use crate::src::levels::COMP_INTER_SEG;
-use crate::src::levels::COMP_INTER_WEDGE;
-use crate::src::levels::COMP_INTER_WEIGHTED_AVG;
 use crate::src::levels::DC_PRED;
 use crate::src::levels::FILTER_2D_BILINEAR;
 use crate::src::levels::FILTER_PRED;
@@ -1518,7 +1514,7 @@ unsafe fn decode_b_inner(
             }
         } else {
             if f.frame_hdr().frame_type.is_inter_or_switch() /* not intrabc */
-                && b.comp_type() == COMP_INTER_NONE
+                && b.comp_type().is_none()
                 && b.motion_mode() as MotionMode == MM_WARP
             {
                 if b.matrix()[0] == i16::MIN {
@@ -2209,7 +2205,7 @@ unsafe fn decode_b_inner(
                     if has_chroma { b.pal_sz()[1] } else { 0 },
                 );
                 if f.frame_hdr().frame_type.is_inter_or_switch() {
-                    case.set(&mut dir.comp_type.0, COMP_INTER_NONE);
+                    case.set(&mut dir.comp_type.0, None);
                     case.set(&mut dir.r#ref[0], -1);
                     case.set(&mut dir.r#ref[1], -1);
                     case.set(&mut dir.filter.0[0], Rav1dFilterMode::N_SWITCHABLE_FILTERS);
@@ -2432,7 +2428,7 @@ unsafe fn decode_b_inner(
                 frame_hdr.skip_mode.refs[0] as i8,
                 frame_hdr.skip_mode.refs[1] as i8,
             ];
-            *b.comp_type_mut() = COMP_INTER_AVG;
+            *b.comp_type_mut() = Some(CompInterType::COMP_INTER_AVG);
             *b.inter_mode_mut() = NEARESTMV_NEARESTMV;
             *b.drl_idx_mut() = NEAREST_DRL;
             has_subpel_filter = false;
@@ -2703,15 +2699,19 @@ unsafe fn decode_b_inner(
                         by4,
                         bx4,
                     );
-                    *b.comp_type_mut() = COMP_INTER_WEIGHTED_AVG
-                        + rav1d_msac_decode_bool_adapt(
-                            &mut ts.msac,
-                            &mut ts.cdf.m.jnt_comp[jnt_ctx as usize],
-                        ) as u8;
+                    let comp_type = if rav1d_msac_decode_bool_adapt(
+                        &mut ts.msac,
+                        &mut ts.cdf.m.jnt_comp[jnt_ctx as usize],
+                    ) {
+                        CompInterType::COMP_INTER_AVG
+                    } else {
+                        CompInterType::COMP_INTER_WEIGHTED_AVG
+                    };
+                    *b.comp_type_mut() = Some(comp_type);
                     if debug_block_info!(f, t) {
                         println!(
-                            "Post-jnt_comp[{},ctx={}[ac:{},ar:{},lc:{},lr:{}]]: r={}",
-                            b.comp_type() == COMP_INTER_AVG,
+                            "Post-jnt_comp[{},ctx={}[ac:{:?},ar:{},lc:{:?},lr:{}]]: r={}",
+                            comp_type == CompInterType::COMP_INTER_AVG,
                             jnt_ctx,
                             (*t.a).comp_type[bx4 as usize],
                             (*t.a).r#ref[0][bx4 as usize],
@@ -2721,15 +2721,21 @@ unsafe fn decode_b_inner(
                         );
                     }
                 } else {
-                    *b.comp_type_mut() = COMP_INTER_AVG;
+                    *b.comp_type_mut() = Some(CompInterType::COMP_INTER_AVG);
                 }
             } else {
                 if wedge_allowed_mask & (1 << bs) != 0 {
                     let ctx = dav1d_wedge_ctx_lut[bs as usize] as usize;
-                    *b.comp_type_mut() = COMP_INTER_WEDGE
-                        - rav1d_msac_decode_bool_adapt(&mut ts.msac, &mut ts.cdf.m.wedge_comp[ctx])
-                            as u8;
-                    if b.comp_type() == COMP_INTER_WEDGE {
+                    let comp_type = if rav1d_msac_decode_bool_adapt(
+                        &mut ts.msac,
+                        &mut ts.cdf.m.wedge_comp[ctx],
+                    ) {
+                        CompInterType::COMP_INTER_SEG
+                    } else {
+                        CompInterType::COMP_INTER_WEDGE
+                    };
+                    *b.comp_type_mut() = Some(comp_type);
+                    if comp_type == CompInterType::COMP_INTER_WEDGE {
                         *b.wedge_idx_mut() = rav1d_msac_decode_symbol_adapt16(
                             &mut ts.msac,
                             &mut ts.cdf.m.wedge_idx[ctx],
@@ -2737,13 +2743,13 @@ unsafe fn decode_b_inner(
                         ) as u8;
                     }
                 } else {
-                    *b.comp_type_mut() = COMP_INTER_SEG;
+                    *b.comp_type_mut() = Some(CompInterType::COMP_INTER_SEG);
                 }
                 *b.mask_sign_mut() = rav1d_msac_decode_bool_equi(&mut ts.msac) as u8;
                 if debug_block_info!(f, t) {
                     println!(
                         "Post-seg/wedge[{},wedge_idx={},sign={}]: r={}",
-                        b.comp_type() == COMP_INTER_WEDGE,
+                        b.comp_type() == Some(CompInterType::COMP_INTER_WEDGE),
                         b.wedge_idx(),
                         b.mask_sign(),
                         ts.msac.rng,
@@ -2751,7 +2757,7 @@ unsafe fn decode_b_inner(
                 }
             }
         } else {
-            *b.comp_type_mut() = COMP_INTER_NONE;
+            *b.comp_type_mut() = None;
 
             // ref
             if let Some(seg) = seg.filter(|seg| seg.r#ref > 0) {
@@ -3092,7 +3098,7 @@ unsafe fn decode_b_inner(
         // subpel filter
         let filter = if frame_hdr.subpel_filter_mode == Rav1dFilterMode::Switchable {
             if has_subpel_filter {
-                let comp = b.comp_type() != COMP_INTER_NONE;
+                let comp = b.comp_type().is_some();
                 let ctx1 = get_filter_ctx(&*t.a, &t.l, comp, false, b.r#ref()[0], by4, bx4);
                 let filter0 = rav1d_msac_decode_symbol_adapt4(
                     &mut ts.msac,
@@ -3271,7 +3277,7 @@ unsafe fn decode_b_inner(
         let sby = t.by - ts.tiling.row_start >> f.sb_shift;
         let lowest_px = &mut *ts.lowest_pixel.offset(sby as isize);
         // keep track of motion vectors for each reference
-        if b.comp_type() == COMP_INTER_NONE {
+        if b.comp_type().is_none() {
             // y
             if cmp::min(bw4, bh4) > 1
                 && (b.inter_mode() == GLOBALMV && f.gmv_warp_allowed[b.r#ref()[0] as usize] != 0
@@ -3826,7 +3832,7 @@ fn reset_context(ctx: &mut BlockContext, keyframe: bool, pass: c_int) {
         for r#ref in &mut ctx.r#ref.0 {
             r#ref.fill(-1);
         }
-        ctx.comp_type.0.fill(0);
+        ctx.comp_type.0.fill(None);
         ctx.mode.0.fill(NEARESTMV);
     }
     ctx.lcoef.0.fill(0x40);

--- a/src/env.rs
+++ b/src/env.rs
@@ -322,8 +322,8 @@ pub fn get_jnt_comp_ctx(
     let d1 = get_poc_diff(order_hint_n_bits, poc as c_int, ref1poc as c_int).abs();
     let offset = (d0 == d1) as u8;
     let [a_ctx, l_ctx] = [(a, xb4), (l, yb4)].map(|(al, b4)| {
-        (al.comp_type[b4 as usize] >= Some(CompInterType::COMP_INTER_AVG)
-            || al.r#ref[0][b4 as usize] == 6) as u8
+        (al.comp_type[b4 as usize] >= Some(CompInterType::Avg) || al.r#ref[0][b4 as usize] == 6)
+            as u8
     });
 
     3 * offset + a_ctx + l_ctx
@@ -332,7 +332,7 @@ pub fn get_jnt_comp_ctx(
 #[inline]
 pub fn get_mask_comp_ctx(a: &BlockContext, l: &BlockContext, yb4: c_int, xb4: c_int) -> u8 {
     let [a_ctx, l_ctx] = [(a, xb4), (l, yb4)].map(|(al, b4)| {
-        if al.comp_type[b4 as usize] >= Some(CompInterType::COMP_INTER_SEG) {
+        if al.comp_type[b4 as usize] >= Some(CompInterType::Seg) {
             1
         } else if al.r#ref[0][b4 as usize] == 6 {
             3

--- a/src/env.rs
+++ b/src/env.rs
@@ -6,11 +6,9 @@ use crate::include::dav1d::headers::Rav1dWarpedMotionType;
 use crate::src::align::Align8;
 use crate::src::levels::mv;
 use crate::src::levels::BlockLevel;
+use crate::src::levels::CompInterType;
 use crate::src::levels::TxfmSize;
 use crate::src::levels::TxfmType;
-use crate::src::levels::COMP_INTER_AVG;
-use crate::src::levels::COMP_INTER_NONE;
-use crate::src::levels::COMP_INTER_SEG;
 use crate::src::levels::DCT_DCT;
 use crate::src::levels::H_ADST;
 use crate::src::levels::H_FLIPADST;
@@ -44,7 +42,7 @@ pub struct BlockContext {
     pub skip: Align8<[u8; 32]>,
     pub skip_mode: Align8<[u8; 32]>,
     pub intra: Align8<[u8; 32]>,
-    pub comp_type: Align8<[u8; 32]>,
+    pub comp_type: Align8<[Option<CompInterType>; 32]>,
     pub r#ref: Align8<[[i8; 32]; 2]>,
     pub filter: Align8<[[u8; 32]; 2]>,
     pub tx_intra: Align8<[i8; 32]>,
@@ -195,28 +193,28 @@ pub fn get_comp_ctx(
 ) -> u8 {
     if have_top {
         if have_left {
-            if a.comp_type[xb4 as usize] != 0 {
-                if l.comp_type[yb4 as usize] != 0 {
+            if a.comp_type[xb4 as usize].is_some() {
+                if l.comp_type[yb4 as usize].is_some() {
                     4
                 } else {
                     // 4U means intra (-1) or bwd (>= 4)
                     2 + (l.r#ref[0][yb4 as usize] as c_uint >= 4) as u8
                 }
-            } else if l.comp_type[yb4 as usize] != 0 {
+            } else if l.comp_type[yb4 as usize].is_some() {
                 // 4U means intra (-1) or bwd (>= 4)
                 2 + (a.r#ref[0][xb4 as usize] as c_uint >= 4) as u8
             } else {
                 ((l.r#ref[0][yb4 as usize] >= 4) ^ (a.r#ref[0][xb4 as usize] >= 4)) as u8
             }
         } else {
-            if a.comp_type[xb4 as usize] != 0 {
+            if a.comp_type[xb4 as usize].is_some() {
                 3
             } else {
                 (a.r#ref[0][xb4 as usize] >= 4) as u8
             }
         }
     } else if have_left {
-        if l.comp_type[yb4 as usize] != 0 {
+        if l.comp_type[yb4 as usize].is_some() {
             3
         } else {
             (l.r#ref[0][yb4 as usize] >= 4) as u8
@@ -250,14 +248,14 @@ pub fn get_comp_dir_ctx(
             let edge = if a_intra { l } else { a };
             let off = if a_intra { yb4 } else { xb4 };
 
-            if edge.comp_type[off as usize] == COMP_INTER_NONE {
+            if edge.comp_type[off as usize].is_none() {
                 return 2;
             }
             return 1 + 2 * has_uni_comp(edge, off) as u8;
         }
 
-        let a_comp = a.comp_type[xb4 as usize] != COMP_INTER_NONE;
-        let l_comp = l.comp_type[yb4 as usize] != COMP_INTER_NONE;
+        let a_comp = a.comp_type[xb4 as usize].is_some();
+        let l_comp = l.comp_type[yb4 as usize].is_some();
         let a_ref0 = a.r#ref[0][xb4 as usize];
         let l_ref0 = l.r#ref[0][yb4 as usize];
 
@@ -290,7 +288,7 @@ pub fn get_comp_dir_ctx(
         if edge.intra[off as usize] != 0 {
             return 2;
         }
-        if edge.comp_type[off as usize] == COMP_INTER_NONE {
+        if edge.comp_type[off as usize].is_none() {
             return 2;
         }
         return 4 * has_uni_comp(edge, off) as u8;
@@ -324,7 +322,8 @@ pub fn get_jnt_comp_ctx(
     let d1 = get_poc_diff(order_hint_n_bits, poc as c_int, ref1poc as c_int).abs();
     let offset = (d0 == d1) as u8;
     let [a_ctx, l_ctx] = [(a, xb4), (l, yb4)].map(|(al, b4)| {
-        (al.comp_type[b4 as usize] >= COMP_INTER_AVG || al.r#ref[0][b4 as usize] == 6) as u8
+        (al.comp_type[b4 as usize] >= Some(CompInterType::COMP_INTER_AVG)
+            || al.r#ref[0][b4 as usize] == 6) as u8
     });
 
     3 * offset + a_ctx + l_ctx
@@ -333,7 +332,7 @@ pub fn get_jnt_comp_ctx(
 #[inline]
 pub fn get_mask_comp_ctx(a: &BlockContext, l: &BlockContext, yb4: c_int, xb4: c_int) -> u8 {
     let [a_ctx, l_ctx] = [(a, xb4), (l, yb4)].map(|(al, b4)| {
-        if al.comp_type[b4 as usize] >= COMP_INTER_SEG {
+        if al.comp_type[b4 as usize] >= Some(CompInterType::COMP_INTER_SEG) {
             1
         } else if al.r#ref[0][b4 as usize] == 6 {
             3
@@ -367,14 +366,14 @@ pub fn av1_get_ref_ctx(
 
     if have_top && a.intra[xb4 as usize] == 0 {
         cnt[(a.r#ref[0][xb4 as usize] >= 4) as usize] += 1;
-        if a.comp_type[xb4 as usize] != 0 {
+        if a.comp_type[xb4 as usize].is_some() {
             cnt[(a.r#ref[1][xb4 as usize] >= 4) as usize] += 1;
         }
     }
 
     if have_left && l.intra[yb4 as usize] == 0 {
         cnt[(l.r#ref[0][yb4 as usize] >= 4) as usize] += 1;
-        if l.comp_type[yb4 as usize] != 0 {
+        if l.comp_type[yb4 as usize].is_some() {
             cnt[(l.r#ref[1][yb4 as usize] >= 4) as usize] += 1;
         }
     }
@@ -397,7 +396,7 @@ pub fn av1_get_fwd_ref_ctx(
         if a.r#ref[0][xb4 as usize] < 4 {
             cnt[a.r#ref[0][xb4 as usize] as usize] += 1;
         }
-        if a.comp_type[xb4 as usize] != 0 && a.r#ref[1][xb4 as usize] < 4 {
+        if a.comp_type[xb4 as usize].is_some() && a.r#ref[1][xb4 as usize] < 4 {
             cnt[a.r#ref[1][xb4 as usize] as usize] += 1;
         }
     }
@@ -406,7 +405,7 @@ pub fn av1_get_fwd_ref_ctx(
         if l.r#ref[0][yb4 as usize] < 4 {
             cnt[l.r#ref[0][yb4 as usize] as usize] += 1;
         }
-        if l.comp_type[yb4 as usize] != 0 && l.r#ref[1][yb4 as usize] < 4 {
+        if l.comp_type[yb4 as usize].is_some() && l.r#ref[1][yb4 as usize] < 4 {
             cnt[l.r#ref[1][yb4 as usize] as usize] += 1;
         }
     }
@@ -432,7 +431,7 @@ pub fn av1_get_fwd_ref_1_ctx(
         if a.r#ref[0][xb4 as usize] < 2 {
             cnt[a.r#ref[0][xb4 as usize] as usize] += 1;
         }
-        if a.comp_type[xb4 as usize] != 0 && a.r#ref[1][xb4 as usize] < 2 {
+        if a.comp_type[xb4 as usize].is_some() && a.r#ref[1][xb4 as usize] < 2 {
             cnt[a.r#ref[1][xb4 as usize] as usize] += 1;
         }
     }
@@ -441,7 +440,7 @@ pub fn av1_get_fwd_ref_1_ctx(
         if l.r#ref[0][yb4 as usize] < 2 {
             cnt[l.r#ref[0][yb4 as usize] as usize] += 1;
         }
-        if l.comp_type[yb4 as usize] != 0 && l.r#ref[1][yb4 as usize] < 2 {
+        if l.comp_type[yb4 as usize].is_some() && l.r#ref[1][yb4 as usize] < 2 {
             cnt[l.r#ref[1][yb4 as usize] as usize] += 1;
         }
     }
@@ -464,7 +463,7 @@ pub fn av1_get_fwd_ref_2_ctx(
         if (a.r#ref[0][xb4 as usize] ^ 2) < 2 {
             cnt[(a.r#ref[0][xb4 as usize] - 2) as usize] += 1;
         }
-        if a.comp_type[xb4 as usize] != 0 && (a.r#ref[1][xb4 as usize] ^ 2) < 2 {
+        if a.comp_type[xb4 as usize].is_some() && (a.r#ref[1][xb4 as usize] ^ 2) < 2 {
             cnt[(a.r#ref[1][xb4 as usize] - 2) as usize] += 1;
         }
     }
@@ -473,7 +472,7 @@ pub fn av1_get_fwd_ref_2_ctx(
         if (l.r#ref[0][yb4 as usize] ^ 2) < 2 {
             cnt[(l.r#ref[0][yb4 as usize] - 2) as usize] += 1;
         }
-        if l.comp_type[yb4 as usize] != 0 && (l.r#ref[1][yb4 as usize] ^ 2) < 2 {
+        if l.comp_type[yb4 as usize].is_some() && (l.r#ref[1][yb4 as usize] ^ 2) < 2 {
             cnt[(l.r#ref[1][yb4 as usize] - 2) as usize] += 1;
         }
     }
@@ -496,7 +495,7 @@ pub fn av1_get_bwd_ref_ctx(
         if a.r#ref[0][xb4 as usize] >= 4 {
             cnt[(a.r#ref[0][xb4 as usize] - 4) as usize] += 1;
         }
-        if a.comp_type[xb4 as usize] != 0 && a.r#ref[1][xb4 as usize] >= 4 {
+        if a.comp_type[xb4 as usize].is_some() && a.r#ref[1][xb4 as usize] >= 4 {
             cnt[(a.r#ref[1][xb4 as usize] - 4) as usize] += 1;
         }
     }
@@ -505,7 +504,7 @@ pub fn av1_get_bwd_ref_ctx(
         if l.r#ref[0][yb4 as usize] >= 4 {
             cnt[(l.r#ref[0][yb4 as usize] - 4) as usize] += 1;
         }
-        if l.comp_type[yb4 as usize] != 0 && l.r#ref[1][yb4 as usize] >= 4 {
+        if l.comp_type[yb4 as usize].is_some() && l.r#ref[1][yb4 as usize] >= 4 {
             cnt[(l.r#ref[1][yb4 as usize] - 4) as usize] += 1;
         }
     }
@@ -530,7 +529,7 @@ pub fn av1_get_bwd_ref_1_ctx(
         if a.r#ref[0][xb4 as usize] >= 4 {
             cnt[(a.r#ref[0][xb4 as usize] - 4) as usize] += 1;
         }
-        if a.comp_type[xb4 as usize] != 0 && a.r#ref[1][xb4 as usize] >= 4 {
+        if a.comp_type[xb4 as usize].is_some() && a.r#ref[1][xb4 as usize] >= 4 {
             cnt[(a.r#ref[1][xb4 as usize] - 4) as usize] += 1;
         }
     }
@@ -539,7 +538,7 @@ pub fn av1_get_bwd_ref_1_ctx(
         if l.r#ref[0][yb4 as usize] >= 4 {
             cnt[(l.r#ref[0][yb4 as usize] - 4) as usize] += 1;
         }
-        if l.comp_type[yb4 as usize] != 0 && l.r#ref[1][yb4 as usize] >= 4 {
+        if l.comp_type[yb4 as usize].is_some() && l.r#ref[1][yb4 as usize] >= 4 {
             cnt[(l.r#ref[1][yb4 as usize] - 4) as usize] += 1;
         }
     }
@@ -562,7 +561,7 @@ pub fn av1_get_uni_p1_ctx(
         if let Some(cnt) = cnt.get_mut((a.r#ref[0][xb4 as usize] - 1) as usize) {
             *cnt += 1;
         }
-        if a.comp_type[xb4 as usize] != 0 {
+        if a.comp_type[xb4 as usize].is_some() {
             if let Some(cnt) = cnt.get_mut((a.r#ref[1][xb4 as usize] - 1) as usize) {
                 *cnt += 1;
             }
@@ -573,7 +572,7 @@ pub fn av1_get_uni_p1_ctx(
         if let Some(cnt) = cnt.get_mut((l.r#ref[0][yb4 as usize] - 1) as usize) {
             *cnt += 1;
         }
-        if l.comp_type[yb4 as usize] != 0 {
+        if l.comp_type[yb4 as usize].is_some() {
             if let Some(cnt) = cnt.get_mut((l.r#ref[1][yb4 as usize] - 1) as usize) {
                 *cnt += 1;
             }

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -204,10 +204,10 @@ pub const NEARESTMV_NEARESTMV: CompInterPredMode = 0;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CompInterType {
-    COMP_INTER_WEIGHTED_AVG = 1,
-    COMP_INTER_AVG = 2,
-    COMP_INTER_SEG = 3,
-    COMP_INTER_WEDGE = 4,
+    WeightedAvg = 1,
+    Avg = 2,
+    Seg = 3,
+    Wedge = 4,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -202,12 +202,13 @@ pub const NEARESTMV_NEWMV: CompInterPredMode = 2;
 pub const NEARMV_NEARMV: CompInterPredMode = 1;
 pub const NEARESTMV_NEARESTMV: CompInterPredMode = 0;
 
-pub type CompInterType = u8;
-pub const COMP_INTER_WEDGE: CompInterType = 4;
-pub const COMP_INTER_SEG: CompInterType = 3;
-pub const COMP_INTER_AVG: CompInterType = 2;
-pub const COMP_INTER_WEIGHTED_AVG: CompInterType = 1;
-pub const COMP_INTER_NONE: CompInterType = 0;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CompInterType {
+    COMP_INTER_WEIGHTED_AVG = 1,
+    COMP_INTER_AVG = 2,
+    COMP_INTER_SEG = 3,
+    COMP_INTER_WEDGE = 4,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InterIntraType {
@@ -302,7 +303,7 @@ pub union Av1Block_inter_nd {
 #[repr(C)]
 pub struct Av1Block_inter {
     pub c2rust_unnamed: Av1Block_inter_nd,
-    pub comp_type: u8,
+    pub comp_type: Option<CompInterType>,
     pub inter_mode: u8,
     pub motion_mode: u8,
     pub drl_idx: u8,
@@ -351,11 +352,11 @@ impl Av1Block {
         &mut self.c2rust_unnamed.c2rust_unnamed.cfl_alpha
     }
 
-    pub unsafe fn comp_type(&self) -> u8 {
+    pub unsafe fn comp_type(&self) -> Option<CompInterType> {
         self.c2rust_unnamed.c2rust_unnamed_0.comp_type
     }
 
-    pub unsafe fn comp_type_mut(&mut self) -> &mut u8 {
+    pub unsafe fn comp_type_mut(&mut self) -> &mut Option<CompInterType> {
         &mut self.c2rust_unnamed.c2rust_unnamed_0.comp_type
     }
 

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -3364,7 +3364,309 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 pl += 1;
             }
         }
-    } else if b.c2rust_unnamed.c2rust_unnamed_0.comp_type.is_none() {
+    } else if let Some(comp_inter_type) = b.c2rust_unnamed.c2rust_unnamed_0.comp_type {
+        let filter_2d: Filter2d = b.c2rust_unnamed.c2rust_unnamed_0.filter2d as Filter2d;
+        let tmp: *mut [i16; 16384] = (t
+            .scratch
+            .c2rust_unnamed
+            .c2rust_unnamed
+            .c2rust_unnamed
+            .compinter)
+            .as_mut_ptr();
+        let mut jnt_weight = 0;
+        let seg_mask: *mut u8 = (t
+            .scratch
+            .c2rust_unnamed
+            .c2rust_unnamed
+            .c2rust_unnamed
+            .seg_mask)
+            .as_mut_ptr();
+        let mut mask: *const u8 = 0 as *const u8;
+        let mut i = 0;
+        while i < 2 {
+            let refp: *const Rav1dThreadPicture = &*(f.refp).as_ptr().offset(
+                *(b.c2rust_unnamed.c2rust_unnamed_0.r#ref)
+                    .as_ptr()
+                    .offset(i as isize) as isize,
+            ) as *const Rav1dThreadPicture;
+            if b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as c_int == GLOBALMV_GLOBALMV as c_int
+                && f.gmv_warp_allowed[b.c2rust_unnamed.c2rust_unnamed_0.r#ref[i as usize] as usize]
+                    as c_int
+                    != 0
+            {
+                res = warp_affine::<BD>(
+                    f,
+                    t,
+                    0 as *mut BD::Pixel,
+                    (*tmp.offset(i as isize)).as_mut_ptr(),
+                    (bw4 * 4) as ptrdiff_t,
+                    b_dim,
+                    0 as c_int,
+                    refp,
+                    &frame_hdr.gmv[b.c2rust_unnamed.c2rust_unnamed_0.r#ref[i as usize] as usize],
+                );
+                if res != 0 {
+                    return res;
+                }
+            } else {
+                res = mc::<BD>(
+                    f,
+                    t,
+                    0 as *mut BD::Pixel,
+                    (*tmp.offset(i as isize)).as_mut_ptr(),
+                    0 as c_int as ptrdiff_t,
+                    bw4,
+                    bh4,
+                    t.bx,
+                    t.by,
+                    0 as c_int,
+                    b.c2rust_unnamed
+                        .c2rust_unnamed_0
+                        .c2rust_unnamed
+                        .c2rust_unnamed
+                        .mv[i as usize],
+                    refp,
+                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[i as usize] as c_int,
+                    filter_2d,
+                );
+                if res != 0 {
+                    return res;
+                }
+            }
+            i += 1;
+        }
+
+        match comp_inter_type {
+            CompInterType::COMP_INTER_AVG => {
+                ((*dsp).mc.avg)(
+                    dst.cast(),
+                    f.cur.stride[0],
+                    (*tmp.offset(0)).as_mut_ptr(),
+                    (*tmp.offset(1)).as_mut_ptr(),
+                    bw4 * 4,
+                    bh4 * 4,
+                    f.bitdepth_max,
+                );
+            }
+            CompInterType::COMP_INTER_WEIGHTED_AVG => {
+                jnt_weight = f.jnt_weights[b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as usize]
+                    [b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] as usize]
+                    as c_int;
+                ((*dsp).mc.w_avg)(
+                    dst.cast(),
+                    f.cur.stride[0],
+                    (*tmp.offset(0)).as_mut_ptr(),
+                    (*tmp.offset(1)).as_mut_ptr(),
+                    bw4 * 4,
+                    bh4 * 4,
+                    jnt_weight,
+                    f.bitdepth_max,
+                );
+            }
+            CompInterType::COMP_INTER_SEG => {
+                (*dsp).mc.w_mask[chr_layout_idx as usize](
+                    dst.cast(),
+                    f.cur.stride[0],
+                    (*tmp.offset(
+                        b.c2rust_unnamed
+                            .c2rust_unnamed_0
+                            .c2rust_unnamed
+                            .c2rust_unnamed
+                            .mask_sign as isize,
+                    ))
+                    .as_mut_ptr(),
+                    (*tmp.offset(
+                        (b.c2rust_unnamed
+                            .c2rust_unnamed_0
+                            .c2rust_unnamed
+                            .c2rust_unnamed
+                            .mask_sign
+                            == 0) as c_int as isize,
+                    ))
+                    .as_mut_ptr(),
+                    bw4 * 4,
+                    bh4 * 4,
+                    seg_mask,
+                    b.c2rust_unnamed
+                        .c2rust_unnamed_0
+                        .c2rust_unnamed
+                        .c2rust_unnamed
+                        .mask_sign as c_int,
+                    f.bitdepth_max,
+                );
+                mask = seg_mask;
+            }
+            CompInterType::COMP_INTER_WEDGE => {
+                mask = dav1d_wedge_masks[bs as usize][0][0][b
+                    .c2rust_unnamed
+                    .c2rust_unnamed_0
+                    .c2rust_unnamed
+                    .c2rust_unnamed
+                    .wedge_idx
+                    as usize]
+                    .as_ptr();
+                ((*dsp).mc.mask)(
+                    dst.cast(),
+                    f.cur.stride[0],
+                    (*tmp.offset(
+                        b.c2rust_unnamed
+                            .c2rust_unnamed_0
+                            .c2rust_unnamed
+                            .c2rust_unnamed
+                            .mask_sign as isize,
+                    ))
+                    .as_mut_ptr(),
+                    (*tmp.offset(
+                        (b.c2rust_unnamed
+                            .c2rust_unnamed_0
+                            .c2rust_unnamed
+                            .c2rust_unnamed
+                            .mask_sign
+                            == 0) as c_int as isize,
+                    ))
+                    .as_mut_ptr(),
+                    bw4 * 4,
+                    bh4 * 4,
+                    mask,
+                    f.bitdepth_max,
+                );
+                if has_chroma != 0 {
+                    mask = dav1d_wedge_masks[bs as usize][chr_layout_idx as usize][b
+                        .c2rust_unnamed
+                        .c2rust_unnamed_0
+                        .c2rust_unnamed
+                        .c2rust_unnamed
+                        .mask_sign
+                        as usize][b
+                        .c2rust_unnamed
+                        .c2rust_unnamed_0
+                        .c2rust_unnamed
+                        .c2rust_unnamed
+                        .wedge_idx as usize]
+                        .as_ptr();
+                }
+            }
+        }
+        if has_chroma != 0 {
+            let mut pl = 0;
+            while pl < 2 {
+                let mut i = 0;
+                while i < 2 {
+                    let refp: *const Rav1dThreadPicture = &*(f.refp).as_ptr().offset(
+                        *(b.c2rust_unnamed.c2rust_unnamed_0.r#ref)
+                            .as_ptr()
+                            .offset(i as isize) as isize,
+                    )
+                        as *const Rav1dThreadPicture;
+                    if b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as c_int
+                        == GLOBALMV_GLOBALMV as c_int
+                        && cmp::min(cbw4, cbh4) > 1
+                        && f.gmv_warp_allowed
+                            [b.c2rust_unnamed.c2rust_unnamed_0.r#ref[i as usize] as usize]
+                            as c_int
+                            != 0
+                    {
+                        res = warp_affine::<BD>(
+                            f,
+                            t,
+                            0 as *mut BD::Pixel,
+                            (*tmp.offset(i as isize)).as_mut_ptr(),
+                            (bw4 * 4 >> ss_hor) as ptrdiff_t,
+                            b_dim,
+                            1 + pl,
+                            refp,
+                            &frame_hdr.gmv
+                                [b.c2rust_unnamed.c2rust_unnamed_0.r#ref[i as usize] as usize],
+                        );
+                        if res != 0 {
+                            return res;
+                        }
+                    } else {
+                        res = mc::<BD>(
+                            f,
+                            t,
+                            0 as *mut BD::Pixel,
+                            (*tmp.offset(i as isize)).as_mut_ptr(),
+                            0 as c_int as ptrdiff_t,
+                            bw4,
+                            bh4,
+                            t.bx,
+                            t.by,
+                            1 + pl,
+                            b.c2rust_unnamed
+                                .c2rust_unnamed_0
+                                .c2rust_unnamed
+                                .c2rust_unnamed
+                                .mv[i as usize],
+                            refp,
+                            b.c2rust_unnamed.c2rust_unnamed_0.r#ref[i as usize] as c_int,
+                            filter_2d,
+                        );
+                        if res != 0 {
+                            return res;
+                        }
+                    }
+                    i += 1;
+                }
+
+                let uvdst: *mut BD::Pixel = (f.cur.data.data[(1 + pl) as usize] as *mut BD::Pixel)
+                    .offset(uvdstoff as isize);
+                match comp_inter_type {
+                    CompInterType::COMP_INTER_AVG => {
+                        ((*dsp).mc.avg)(
+                            uvdst.cast(),
+                            f.cur.stride[1],
+                            (*tmp.offset(0)).as_mut_ptr(),
+                            (*tmp.offset(1)).as_mut_ptr(),
+                            bw4 * 4 >> ss_hor,
+                            bh4 * 4 >> ss_ver,
+                            f.bitdepth_max,
+                        );
+                    }
+                    CompInterType::COMP_INTER_WEIGHTED_AVG => {
+                        ((*dsp).mc.w_avg)(
+                            uvdst.cast(),
+                            f.cur.stride[1],
+                            (*tmp.offset(0)).as_mut_ptr(),
+                            (*tmp.offset(1)).as_mut_ptr(),
+                            bw4 * 4 >> ss_hor,
+                            bh4 * 4 >> ss_ver,
+                            jnt_weight,
+                            f.bitdepth_max,
+                        );
+                    }
+                    CompInterType::COMP_INTER_SEG | CompInterType::COMP_INTER_WEDGE => {
+                        ((*dsp).mc.mask)(
+                            uvdst.cast(),
+                            f.cur.stride[1],
+                            (*tmp.offset(
+                                b.c2rust_unnamed
+                                    .c2rust_unnamed_0
+                                    .c2rust_unnamed
+                                    .c2rust_unnamed
+                                    .mask_sign as isize,
+                            ))
+                            .as_mut_ptr(),
+                            (*tmp.offset(
+                                (b.c2rust_unnamed
+                                    .c2rust_unnamed_0
+                                    .c2rust_unnamed
+                                    .c2rust_unnamed
+                                    .mask_sign
+                                    == 0) as c_int as isize,
+                            ))
+                            .as_mut_ptr(),
+                            bw4 * 4 >> ss_hor,
+                            bh4 * 4 >> ss_ver,
+                            mask,
+                            f.bitdepth_max,
+                        );
+                    }
+                }
+                pl += 1;
+            }
+        }
+    } else {
         let mut is_sub8x8;
         let mut r: *const *mut refmvs_block;
         let refp: *const Rav1dThreadPicture = &*(f.refp)
@@ -3957,314 +4259,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
             }
         }
         t.tl_4x4_filter = filter_2d;
-    } else {
-        let filter_2d: Filter2d = b.c2rust_unnamed.c2rust_unnamed_0.filter2d as Filter2d;
-        let tmp: *mut [i16; 16384] = (t
-            .scratch
-            .c2rust_unnamed
-            .c2rust_unnamed
-            .c2rust_unnamed
-            .compinter)
-            .as_mut_ptr();
-        let mut jnt_weight = 0;
-        let seg_mask: *mut u8 = (t
-            .scratch
-            .c2rust_unnamed
-            .c2rust_unnamed
-            .c2rust_unnamed
-            .seg_mask)
-            .as_mut_ptr();
-        let mut mask: *const u8 = 0 as *const u8;
-        let mut i = 0;
-        while i < 2 {
-            let refp: *const Rav1dThreadPicture = &*(f.refp).as_ptr().offset(
-                *(b.c2rust_unnamed.c2rust_unnamed_0.r#ref)
-                    .as_ptr()
-                    .offset(i as isize) as isize,
-            ) as *const Rav1dThreadPicture;
-            if b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as c_int == GLOBALMV_GLOBALMV as c_int
-                && f.gmv_warp_allowed[b.c2rust_unnamed.c2rust_unnamed_0.r#ref[i as usize] as usize]
-                    as c_int
-                    != 0
-            {
-                res = warp_affine::<BD>(
-                    f,
-                    t,
-                    0 as *mut BD::Pixel,
-                    (*tmp.offset(i as isize)).as_mut_ptr(),
-                    (bw4 * 4) as ptrdiff_t,
-                    b_dim,
-                    0 as c_int,
-                    refp,
-                    &frame_hdr.gmv[b.c2rust_unnamed.c2rust_unnamed_0.r#ref[i as usize] as usize],
-                );
-                if res != 0 {
-                    return res;
-                }
-            } else {
-                res = mc::<BD>(
-                    f,
-                    t,
-                    0 as *mut BD::Pixel,
-                    (*tmp.offset(i as isize)).as_mut_ptr(),
-                    0 as c_int as ptrdiff_t,
-                    bw4,
-                    bh4,
-                    t.bx,
-                    t.by,
-                    0 as c_int,
-                    b.c2rust_unnamed
-                        .c2rust_unnamed_0
-                        .c2rust_unnamed
-                        .c2rust_unnamed
-                        .mv[i as usize],
-                    refp,
-                    b.c2rust_unnamed.c2rust_unnamed_0.r#ref[i as usize] as c_int,
-                    filter_2d,
-                );
-                if res != 0 {
-                    return res;
-                }
-            }
-            i += 1;
-        }
-
-        // TODO use if let in the surrounding if structure
-        let comp_inter_type = b.c2rust_unnamed.c2rust_unnamed_0.comp_type.unwrap();
-        match comp_inter_type {
-            CompInterType::COMP_INTER_AVG => {
-                ((*dsp).mc.avg)(
-                    dst.cast(),
-                    f.cur.stride[0],
-                    (*tmp.offset(0)).as_mut_ptr(),
-                    (*tmp.offset(1)).as_mut_ptr(),
-                    bw4 * 4,
-                    bh4 * 4,
-                    f.bitdepth_max,
-                );
-            }
-            CompInterType::COMP_INTER_WEIGHTED_AVG => {
-                jnt_weight = f.jnt_weights[b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as usize]
-                    [b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] as usize]
-                    as c_int;
-                ((*dsp).mc.w_avg)(
-                    dst.cast(),
-                    f.cur.stride[0],
-                    (*tmp.offset(0)).as_mut_ptr(),
-                    (*tmp.offset(1)).as_mut_ptr(),
-                    bw4 * 4,
-                    bh4 * 4,
-                    jnt_weight,
-                    f.bitdepth_max,
-                );
-            }
-            CompInterType::COMP_INTER_SEG => {
-                (*dsp).mc.w_mask[chr_layout_idx as usize](
-                    dst.cast(),
-                    f.cur.stride[0],
-                    (*tmp.offset(
-                        b.c2rust_unnamed
-                            .c2rust_unnamed_0
-                            .c2rust_unnamed
-                            .c2rust_unnamed
-                            .mask_sign as isize,
-                    ))
-                    .as_mut_ptr(),
-                    (*tmp.offset(
-                        (b.c2rust_unnamed
-                            .c2rust_unnamed_0
-                            .c2rust_unnamed
-                            .c2rust_unnamed
-                            .mask_sign
-                            == 0) as c_int as isize,
-                    ))
-                    .as_mut_ptr(),
-                    bw4 * 4,
-                    bh4 * 4,
-                    seg_mask,
-                    b.c2rust_unnamed
-                        .c2rust_unnamed_0
-                        .c2rust_unnamed
-                        .c2rust_unnamed
-                        .mask_sign as c_int,
-                    f.bitdepth_max,
-                );
-                mask = seg_mask;
-            }
-            CompInterType::COMP_INTER_WEDGE => {
-                mask = dav1d_wedge_masks[bs as usize][0][0][b
-                    .c2rust_unnamed
-                    .c2rust_unnamed_0
-                    .c2rust_unnamed
-                    .c2rust_unnamed
-                    .wedge_idx
-                    as usize]
-                    .as_ptr();
-                ((*dsp).mc.mask)(
-                    dst.cast(),
-                    f.cur.stride[0],
-                    (*tmp.offset(
-                        b.c2rust_unnamed
-                            .c2rust_unnamed_0
-                            .c2rust_unnamed
-                            .c2rust_unnamed
-                            .mask_sign as isize,
-                    ))
-                    .as_mut_ptr(),
-                    (*tmp.offset(
-                        (b.c2rust_unnamed
-                            .c2rust_unnamed_0
-                            .c2rust_unnamed
-                            .c2rust_unnamed
-                            .mask_sign
-                            == 0) as c_int as isize,
-                    ))
-                    .as_mut_ptr(),
-                    bw4 * 4,
-                    bh4 * 4,
-                    mask,
-                    f.bitdepth_max,
-                );
-                if has_chroma != 0 {
-                    mask = dav1d_wedge_masks[bs as usize][chr_layout_idx as usize][b
-                        .c2rust_unnamed
-                        .c2rust_unnamed_0
-                        .c2rust_unnamed
-                        .c2rust_unnamed
-                        .mask_sign
-                        as usize][b
-                        .c2rust_unnamed
-                        .c2rust_unnamed_0
-                        .c2rust_unnamed
-                        .c2rust_unnamed
-                        .wedge_idx as usize]
-                        .as_ptr();
-                }
-            }
-        }
-        if has_chroma != 0 {
-            let mut pl = 0;
-            while pl < 2 {
-                let mut i = 0;
-                while i < 2 {
-                    let refp: *const Rav1dThreadPicture = &*(f.refp).as_ptr().offset(
-                        *(b.c2rust_unnamed.c2rust_unnamed_0.r#ref)
-                            .as_ptr()
-                            .offset(i as isize) as isize,
-                    )
-                        as *const Rav1dThreadPicture;
-                    if b.c2rust_unnamed.c2rust_unnamed_0.inter_mode as c_int
-                        == GLOBALMV_GLOBALMV as c_int
-                        && cmp::min(cbw4, cbh4) > 1
-                        && f.gmv_warp_allowed
-                            [b.c2rust_unnamed.c2rust_unnamed_0.r#ref[i as usize] as usize]
-                            as c_int
-                            != 0
-                    {
-                        res = warp_affine::<BD>(
-                            f,
-                            t,
-                            0 as *mut BD::Pixel,
-                            (*tmp.offset(i as isize)).as_mut_ptr(),
-                            (bw4 * 4 >> ss_hor) as ptrdiff_t,
-                            b_dim,
-                            1 + pl,
-                            refp,
-                            &frame_hdr.gmv
-                                [b.c2rust_unnamed.c2rust_unnamed_0.r#ref[i as usize] as usize],
-                        );
-                        if res != 0 {
-                            return res;
-                        }
-                    } else {
-                        res = mc::<BD>(
-                            f,
-                            t,
-                            0 as *mut BD::Pixel,
-                            (*tmp.offset(i as isize)).as_mut_ptr(),
-                            0 as c_int as ptrdiff_t,
-                            bw4,
-                            bh4,
-                            t.bx,
-                            t.by,
-                            1 + pl,
-                            b.c2rust_unnamed
-                                .c2rust_unnamed_0
-                                .c2rust_unnamed
-                                .c2rust_unnamed
-                                .mv[i as usize],
-                            refp,
-                            b.c2rust_unnamed.c2rust_unnamed_0.r#ref[i as usize] as c_int,
-                            filter_2d,
-                        );
-                        if res != 0 {
-                            return res;
-                        }
-                    }
-                    i += 1;
-                }
-
-                // TODO use if let in the surrounding if structure
-                let comp_inter_type = b.c2rust_unnamed.c2rust_unnamed_0.comp_type.unwrap();
-
-                let uvdst: *mut BD::Pixel = (f.cur.data.data[(1 + pl) as usize] as *mut BD::Pixel)
-                    .offset(uvdstoff as isize);
-                match comp_inter_type {
-                    CompInterType::COMP_INTER_AVG => {
-                        ((*dsp).mc.avg)(
-                            uvdst.cast(),
-                            f.cur.stride[1],
-                            (*tmp.offset(0)).as_mut_ptr(),
-                            (*tmp.offset(1)).as_mut_ptr(),
-                            bw4 * 4 >> ss_hor,
-                            bh4 * 4 >> ss_ver,
-                            f.bitdepth_max,
-                        );
-                    }
-                    CompInterType::COMP_INTER_WEIGHTED_AVG => {
-                        ((*dsp).mc.w_avg)(
-                            uvdst.cast(),
-                            f.cur.stride[1],
-                            (*tmp.offset(0)).as_mut_ptr(),
-                            (*tmp.offset(1)).as_mut_ptr(),
-                            bw4 * 4 >> ss_hor,
-                            bh4 * 4 >> ss_ver,
-                            jnt_weight,
-                            f.bitdepth_max,
-                        );
-                    }
-                    CompInterType::COMP_INTER_SEG | CompInterType::COMP_INTER_WEDGE => {
-                        ((*dsp).mc.mask)(
-                            uvdst.cast(),
-                            f.cur.stride[1],
-                            (*tmp.offset(
-                                b.c2rust_unnamed
-                                    .c2rust_unnamed_0
-                                    .c2rust_unnamed
-                                    .c2rust_unnamed
-                                    .mask_sign as isize,
-                            ))
-                            .as_mut_ptr(),
-                            (*tmp.offset(
-                                (b.c2rust_unnamed
-                                    .c2rust_unnamed_0
-                                    .c2rust_unnamed
-                                    .c2rust_unnamed
-                                    .mask_sign
-                                    == 0) as c_int as isize,
-                            ))
-                            .as_mut_ptr(),
-                            bw4 * 4 >> ss_hor,
-                            bh4 * 4 >> ss_ver,
-                            mask,
-                            f.bitdepth_max,
-                        );
-                    }
-                }
-                pl += 1;
-            }
-        }
     }
+
     if debug_block_info!(f, t) && 0 != 0 {
         hex_dump::<BD>(
             dst,

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -3437,7 +3437,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
         }
 
         match comp_inter_type {
-            CompInterType::COMP_INTER_AVG => {
+            CompInterType::Avg => {
                 ((*dsp).mc.avg)(
                     dst.cast(),
                     f.cur.stride[0],
@@ -3448,7 +3448,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     f.bitdepth_max,
                 );
             }
-            CompInterType::COMP_INTER_WEIGHTED_AVG => {
+            CompInterType::WeightedAvg => {
                 jnt_weight = f.jnt_weights[b.c2rust_unnamed.c2rust_unnamed_0.r#ref[0] as usize]
                     [b.c2rust_unnamed.c2rust_unnamed_0.r#ref[1] as usize]
                     as c_int;
@@ -3463,7 +3463,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     f.bitdepth_max,
                 );
             }
-            CompInterType::COMP_INTER_SEG => {
+            CompInterType::Seg => {
                 (*dsp).mc.w_mask[chr_layout_idx as usize](
                     dst.cast(),
                     f.cur.stride[0],
@@ -3496,7 +3496,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 );
                 mask = seg_mask;
             }
-            CompInterType::COMP_INTER_WEDGE => {
+            CompInterType::Wedge => {
                 mask = dav1d_wedge_masks[bs as usize][0][0][b
                     .c2rust_unnamed
                     .c2rust_unnamed_0
@@ -3612,7 +3612,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 let uvdst: *mut BD::Pixel = (f.cur.data.data[(1 + pl) as usize] as *mut BD::Pixel)
                     .offset(uvdstoff as isize);
                 match comp_inter_type {
-                    CompInterType::COMP_INTER_AVG => {
+                    CompInterType::Avg => {
                         ((*dsp).mc.avg)(
                             uvdst.cast(),
                             f.cur.stride[1],
@@ -3623,7 +3623,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             f.bitdepth_max,
                         );
                     }
-                    CompInterType::COMP_INTER_WEIGHTED_AVG => {
+                    CompInterType::WeightedAvg => {
                         ((*dsp).mc.w_avg)(
                             uvdst.cast(),
                             f.cur.stride[1],
@@ -3635,7 +3635,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             f.bitdepth_max,
                         );
                     }
-                    CompInterType::COMP_INTER_SEG | CompInterType::COMP_INTER_WEDGE => {
+                    CompInterType::Seg | CompInterType::Wedge => {
                         ((*dsp).mc.mask)(
                             uvdst.cast(),
                             f.cur.stride[1],


### PR DESCRIPTION
this PR looks big but most lines are because I needed to reverse two branches so that 

```rust
if comp_type.is_none() { ... } else { ... }
```

can turn into

```rust
if let Some(comp_type) = comp_type { ... }  else { ... }
```

the first commit is most changes, the second one just the switching of branches and using the variable bound by the if-let