### PR TITLE
Build and test for RISC-V

### DIFF
--- a/.github/workflows/build-and-test-qemu.yml
+++ b/.github/workflows/build-and-test-qemu.yml
@@ -22,6 +22,13 @@ jobs:
             linker: "cc"
             wrapper: "qemu-x86_64-static -cpu max" # enable AVX512
             packages: ""
+            # NOTE: This appears to work for Ubuntu 22.04 and other systems
+            # with a recent version of GNU ld (e.g. 2.38) whereas Ubuntu 20.04
+            # fails with the following linker error: unsupported ISA subset `z'
+          - target: "riscv64gc-unknown-linux-gnu"
+            linker: "riscv64-linux-gnu-gcc"
+            wrapper: "qemu-riscv64-static"
+            packages: "g++-riscv64-linux-gnu libc6-dev-riscv64-cross"
     runs-on: ubuntu-latest
     name: test on ${{ matrix.target }}
     steps:

--- a/build.rs
+++ b/build.rs
@@ -13,8 +13,6 @@ mod asm {
     enum Arch {
         X86(ArchX86),
         Arm(ArchArm),
-        #[allow(dead_code)]
-        Unknown,
     }
 
     #[derive(Clone, Copy, PartialEq, Eq)]
@@ -128,7 +126,6 @@ mod asm {
         let use_nasm = match arch {
             Arch::X86(..) => true,
             Arch::Arm(..) => false,
-            _ => unimplemented!("should not get here"),
         };
 
         let define_prefix = if use_nasm { "%" } else { " #" };
@@ -251,13 +248,11 @@ mod asm {
             Arch::X86(ArchX86::X86_32) => x86_all,
             Arch::X86(ArchX86::X86_64) => x86_64_all,
             Arch::Arm(..) => arm_all,
-            _ => unimplemented!("should not get here"),
         };
 
         let asm_file_dir = match arch {
             Arch::X86(..) => ["x86", "."],
             Arch::Arm(..) => ["arm", pointer_width],
-            _ => unimplemented!("should not get here"),
         };
         let asm_extension = if use_nasm { "asm" } else { "S" };
 

--- a/include/common/attributes.h
+++ b/include/common/attributes.h
@@ -56,7 +56,7 @@
 #define ALIGN_64_VAL 64
 #define ALIGN_32_VAL 32
 #define ALIGN_16_VAL 16
-#elif ARCH_X86_32 || ARCH_ARM || ARCH_AARCH64 || ARCH_PPC64LE
+#elif ARCH_X86_32 || ARCH_ARM || ARCH_AARCH64 || ARCH_PPC64LE || ARCH_LOONGARCH
 /* ARM doesn't benefit from anything more than 16-byte alignment. */
 #define ALIGN_64_VAL 16
 #define ALIGN_32_VAL 16

--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -546,7 +546,10 @@ where
 /// [`avx2`]: crate::src::cpu::CpuFlags::AVX2
 /// [`avx512icl`]: crate::src::cpu::CpuFlags::AVX512ICL
 /// [`neon`]: crate::src::cpu::CpuFlags::NEON
-#[cfg(feature = "asm")]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 macro_rules! bd_fn {
     ($decl_fn:path, $BD:ty, $name:ident, $asm:ident) => {{
         use paste::paste;
@@ -588,18 +591,27 @@ macro_rules! bpc_fn {
     }};
 }
 
-#[cfg(feature = "asm")]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 macro_rules! fn_identity {
     (fn $name:ident) => {
         $name
     };
 }
 
-#[cfg(feature = "asm")]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 pub(crate) use bd_fn;
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 pub(crate) use bpc_fn;
 
-#[cfg(feature = "asm")]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 pub(crate) use fn_identity;

--- a/lib.rs
+++ b/lib.rs
@@ -3,6 +3,10 @@
 #![allow(non_upper_case_globals)]
 #![feature(c_variadic)]
 #![cfg_attr(target_arch = "arm", feature(stdarch_arm_feature_detection))]
+#![cfg_attr(
+    any(target_arch = "riscv32", target_arch = "riscv64"),
+    feature(stdarch_riscv_feature_detection)
+)]
 #![allow(clippy::all)]
 
 #[cfg(not(any(feature = "bitdepth_8", feature = "bitdepth_16")))]

--- a/meson.build
+++ b/meson.build
@@ -66,7 +66,8 @@ is_asm_enabled = (get_option('enable_asm') == true and
      (host_machine.cpu_family() == 'x86_64' and cc.get_define('__ILP32__').strip() == '') or
      host_machine.cpu_family() == 'aarch64'      or
      host_machine.cpu_family().startswith('arm') or
-     host_machine.cpu() == 'ppc64le'))
+     host_machine.cpu() == 'ppc64le' or
+     host_machine.cpu_family().startswith('loongarch')))
 cdata.set10('HAVE_ASM', is_asm_enabled)
 
 if is_asm_enabled and get_option('b_sanitize') == 'memory'
@@ -236,7 +237,8 @@ endif
 
 if (host_machine.cpu_family() == 'aarch64' or
     host_machine.cpu_family().startswith('arm') or
-    host_machine.cpu() == 'ppc64le')
+    host_machine.cpu() == 'ppc64le' or
+    host_machine.cpu_family().startswith('loongarch'))
     if cc.has_function('getauxval', prefix : '#include <sys/auxv.h>', args : test_args)
         cdata.set('HAVE_GETAUXVAL', 1)
     endif
@@ -382,6 +384,10 @@ if host_machine.cpu_family().startswith('x86')
 endif
 
 cdata.set10('ARCH_PPC64LE', host_machine.cpu() == 'ppc64le')
+
+cdata.set10('ARCH_LOONGARCH', host_machine.cpu_family().startswith('loongarch'))
+cdata.set10('ARCH_LOONGARCH32', host_machine.cpu_family() == 'loongarch32')
+cdata.set10('ARCH_LOONGARCH64', host_machine.cpu_family() == 'loongarch64')
 
 # meson's cc.symbols_have_underscore_prefix() is unfortunately unrelieably
 # when additional flags like '-fprofile-instr-generate' are passed via CFLAGS

--- a/meson.build
+++ b/meson.build
@@ -67,6 +67,7 @@ is_asm_enabled = (get_option('enable_asm') == true and
      host_machine.cpu_family() == 'aarch64'      or
      host_machine.cpu_family().startswith('arm') or
      host_machine.cpu() == 'ppc64le' or
+     host_machine.cpu_family().startswith('riscv') or
      host_machine.cpu_family().startswith('loongarch')))
 cdata.set10('HAVE_ASM', is_asm_enabled)
 
@@ -238,6 +239,7 @@ endif
 if (host_machine.cpu_family() == 'aarch64' or
     host_machine.cpu_family().startswith('arm') or
     host_machine.cpu() == 'ppc64le' or
+    host_machine.cpu_family().startswith('riscv') or
     host_machine.cpu_family().startswith('loongarch'))
     if cc.has_function('getauxval', prefix : '#include <sys/auxv.h>', args : test_args)
         cdata.set('HAVE_GETAUXVAL', 1)
@@ -384,6 +386,10 @@ if host_machine.cpu_family().startswith('x86')
 endif
 
 cdata.set10('ARCH_PPC64LE', host_machine.cpu() == 'ppc64le')
+
+cdata.set10('ARCH_RISCV', host_machine.cpu_family().startswith('riscv'))
+cdata.set10('ARCH_RV32', host_machine.cpu_family() == 'riscv32')
+cdata.set10('ARCH_RV64', host_machine.cpu_family() == 'riscv64')
 
 cdata.set10('ARCH_LOONGARCH', host_machine.cpu_family().startswith('loongarch'))
 cdata.set10('ARCH_LOONGARCH32', host_machine.cpu_family() == 'loongarch32')

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -13,7 +13,10 @@ use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
 
-#[cfg(feature = "asm")]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 use crate::include::common::bitdepth::BPC;
 
 bitflags! {

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -60,6 +60,8 @@ COLD void dav1d_init_cpu(void) {
     dav1d_cpu_flags = dav1d_get_cpu_flags_loongarch();
 #elif ARCH_PPC64LE
     dav1d_cpu_flags = dav1d_get_cpu_flags_ppc();
+#elif ARCH_RISCV
+    dav1d_cpu_flags = dav1d_get_cpu_flags_riscv();
 #elif ARCH_X86
     dav1d_cpu_flags = dav1d_get_cpu_flags_x86();
 #endif

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -56,6 +56,8 @@ COLD void dav1d_init_cpu(void) {
 // memory sanitizer is inherently incompatible with asm
 #if ARCH_AARCH64 || ARCH_ARM
     dav1d_cpu_flags = dav1d_get_cpu_flags_arm();
+#elif ARCH_LOONGARCH
+    dav1d_cpu_flags = dav1d_get_cpu_flags_loongarch();
 #elif ARCH_PPC64LE
     dav1d_cpu_flags = dav1d_get_cpu_flags_ppc();
 #elif ARCH_X86

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -41,6 +41,8 @@
 #include "src/loongarch/cpu.h"
 #elif ARCH_PPC64LE
 #include "src/ppc/cpu.h"
+#elif ARCH_RISCV
+#include "src/riscv/cpu.h"
 #elif ARCH_X86
 #include "src/x86/cpu.h"
 #endif

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -37,6 +37,8 @@
 
 #if ARCH_AARCH64 || ARCH_ARM
 #include "src/arm/cpu.h"
+#elif ARCH_LOONGARCH
+#include "src/loongarch/cpu.h"
 #elif ARCH_PPC64LE
 #include "src/ppc/cpu.h"
 #elif ARCH_X86

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -28,7 +28,10 @@ use std::ops::Shl;
 use std::ops::Shr;
 use to_method::To;
 
-#[cfg(feature = "asm")]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 use crate::include::common::bitdepth::bd_fn;
 
 pub const GRAIN_WIDTH: usize = 82;

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -41,7 +41,10 @@ use std::ffi::c_void;
 use std::slice;
 use strum::FromRepr;
 
-#[cfg(feature = "asm")]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 use crate::include::common::bitdepth::bd_fn;
 
 #[cfg(all(feature = "asm", target_arch = "x86_64"))]

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -48,7 +48,10 @@ use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_void;
 
-#[cfg(feature = "asm")]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 use crate::include::common::bitdepth::bd_fn;
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
@@ -190,7 +193,10 @@ pub struct Rav1dInvTxfmDSPContext {
     pub itxfm_add: [[itxfm_fn; N_TX_TYPES_PLUS_LL]; N_RECT_TX_SIZES],
 }
 
-#[cfg(feature = "asm")]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 macro_rules! decl_itx_fn {
     ($name:ident) => {
         fn $name(
@@ -216,14 +222,20 @@ macro_rules! decl_itx_fn {
     };
 }
 
-#[cfg(feature = "asm")]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 macro_rules! decl_itx1_fns {
     ($w:literal x $h:literal, $bpc:literal bpc, $asm:ident) => {
         decl_itx_fn!(dct, dct, $w x $h, $bpc bpc, $asm);
     };
 }
 
-#[cfg(feature = "asm")]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 macro_rules! decl_itx2_fns {
     ($w:literal x $h:literal, $bpc:literal bpc, $asm:ident) => {
         decl_itx1_fns!($w x $h, $bpc bpc, $asm);
@@ -231,7 +243,10 @@ macro_rules! decl_itx2_fns {
     };
 }
 
-#[cfg(feature = "asm")]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 macro_rules! decl_itx12_fns {
     ($w:literal x $h:literal, $bpc:literal bpc, $asm:ident) => {
         decl_itx2_fns!($w x $h, $bpc bpc, $asm);
@@ -248,7 +263,10 @@ macro_rules! decl_itx12_fns {
     };
 }
 
-#[cfg(feature = "asm")]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 macro_rules! decl_itx16_fns {
     ($w:literal x $h:literal, $bpc:literal bpc, $asm:ident) => {
         decl_itx12_fns!($w x $h, $bpc bpc, $asm);
@@ -259,7 +277,10 @@ macro_rules! decl_itx16_fns {
     };
 }
 
-#[cfg(feature = "asm")]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 macro_rules! decl_itx_fns {
     ($bpc:literal bpc, $asm:ident) => {
         decl_itx16_fns!( 4 x  4, $bpc bpc, $asm);
@@ -520,7 +541,10 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust<BD: BitDepth>(
     }
 }
 
-#[cfg(feature = "asm")]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 macro_rules! assign_itx_fn {
     ($c:ident, $BD:ty, $w:literal, $h:literal, $type:ident, $type_enum:ident, $ext:ident) => {{
         use paste::paste;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "bitdepth_16")]
 use crate::include::common::bitdepth::BitDepth16;
+#[cfg(feature = "bitdepth_8")]
 use crate::include::common::bitdepth::BitDepth8;
 use crate::include::common::validate::validate_input;
 use crate::include::dav1d::common::Dav1dDataProps;

--- a/src/loongarch/cpu.c
+++ b/src/loongarch/cpu.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2023, VideoLAN and dav1d authors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "common/attributes.h"
+#include "src/loongarch/cpu.h"
+
+#if defined(HAVE_GETAUXVAL)
+#include <sys/auxv.h>
+
+#define LA_HWCAP_LSX    ( 1 << 4 )
+#define LA_HWCAP_LASX   ( 1 << 5 )
+#endif
+
+COLD unsigned dav1d_get_cpu_flags_loongarch(void) {
+    unsigned flags = 0;
+#if defined(HAVE_GETAUXVAL)
+    unsigned long hw_cap = getauxval(AT_HWCAP);
+    flags |= (hw_cap & LA_HWCAP_LSX) ? DAV1D_LOONGARCH_CPU_FLAG_LSX : 0;
+    flags |= (hw_cap & LA_HWCAP_LASX) ? DAV1D_LOONGARCH_CPU_FLAG_LASX : 0;
+#endif
+
+    return flags;
+}

--- a/src/loongarch/cpu.h
+++ b/src/loongarch/cpu.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2023, VideoLAN and dav1d authors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DAV1D_SRC_LOONGARCH_CPU_H
+#define DAV1D_SRC_LOONGARCH_CPU_H
+
+enum CpuFlags {
+    DAV1D_LOONGARCH_CPU_FLAG_LSX  = 1 << 0,
+    DAV1D_LOONGARCH_CPU_FLAG_LASX = 1 << 1,
+};
+
+unsigned dav1d_get_cpu_flags_loongarch(void);
+
+#endif /* DAV1D_SRC_LOONGARCH_CPU_H */

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -9,7 +9,10 @@ use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
 
-#[cfg(feature = "asm")]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 use crate::include::common::bitdepth::BPC;
 
 pub type loopfilter_sb_fn = unsafe extern "C" fn(

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -21,7 +21,10 @@ use std::ffi::c_int;
 use std::iter;
 use to_method::To;
 
-#[cfg(feature = "asm")]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 use crate::include::common::bitdepth::bd_fn;
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
@@ -2008,7 +2011,10 @@ pub(crate) unsafe extern "C" fn resize_c_erased<BD: BitDepth>(
 }
 
 // TODO(legare): Generated fns are temporarily pub until init fns are deduplicated.
-#[cfg(feature = "asm")]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 macro_rules! decl_fn {
     (avg, $name:ident) => {
         pub(crate) fn $name(
@@ -2126,7 +2132,10 @@ macro_rules! decl_fn {
     };
 }
 
-#[cfg(feature = "asm")]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 macro_rules! decl_fns {
     ($fn_kind:ident, $name:ident, $asm:ident) => {
         paste::paste! {

--- a/src/meson.build
+++ b/src/meson.build
@@ -233,6 +233,10 @@ if is_asm_enabled
             'ppc/cdef_tmpl.c',
             'ppc/looprestoration_tmpl.c',
         )
+    elif host_machine.cpu_family().startswith('loongarch')
+        libdav1d_sources += files(
+            'loongarch/cpu.c',
+        )
     endif
 endif
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -233,6 +233,10 @@ if is_asm_enabled
             'ppc/cdef_tmpl.c',
             'ppc/looprestoration_tmpl.c',
         )
+    elif host_machine.cpu_family().startswith('riscv')
+        libdav1d_sources += files(
+            'riscv/cpu.c',
+        )
     elif host_machine.cpu_family().startswith('loongarch')
         libdav1d_sources += files(
             'loongarch/cpu.c',

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -28,7 +28,10 @@ use std::mem;
 use std::ptr;
 use zerocopy::FromZeroes;
 
-#[cfg(feature = "asm")]
+#[cfg(all(
+    feature = "asm",
+    not(any(target_arch = "riscv64", target_arch = "riscv32"))
+))]
 use crate::src::cpu::{rav1d_get_cpu_flags, CpuFlags};
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]

--- a/src/riscv/cpu.c
+++ b/src/riscv/cpu.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2022, VideoLAN and dav1d authors
+ * Copyright © 2022, Nathan Egge
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "common/attributes.h"
+
+#include "src/riscv/cpu.h"
+
+#if defined(HAVE_GETAUXVAL)
+#include <sys/auxv.h>
+
+#define HWCAP_RVV (1 << ('v' - 'a'))
+
+#endif
+
+COLD unsigned dav1d_get_cpu_flags_riscv(void) {
+    unsigned flags = 0;
+#if defined(HAVE_GETAUXVAL)
+    unsigned long hw_cap = getauxval(AT_HWCAP);
+    flags |= (hw_cap & HWCAP_RVV) ? DAV1D_RISCV_CPU_FLAG_V : 0;
+#endif
+
+    return flags;
+}

--- a/src/riscv/cpu.h
+++ b/src/riscv/cpu.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2022, VideoLAN and dav1d authors
+ * Copyright © 2022, Nathan Egge
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DAV1D_SRC_RISCV_CPU_H
+#define DAV1D_SRC_RISCV_CPU_H
+
+enum CpuFlags {
+    DAV1D_RISCV_CPU_FLAG_V = 1 << 0,
+};
+
+unsigned dav1d_get_cpu_flags_riscv(void);
+
+#endif /* DAV1D_SRC_RISCV_CPU_H */

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1,6 +1,8 @@
 use crate::include::common::attributes::ctz;
 use crate::include::common::bitdepth::BitDepth;
+#[cfg(feature = "bitdepth_16")]
 use crate::include::common::bitdepth::BitDepth16;
+#[cfg(feature = "bitdepth_8")]
 use crate::include::common::bitdepth::BitDepth8;
 use crate::include::common::intops::iclip;
 use crate::include::dav1d::headers::Rav1dPixelLayout;

--- a/tests/checkasm/checkasm.c
+++ b/tests/checkasm/checkasm.c
@@ -98,6 +98,9 @@ static const struct cpu {
     { "NEON",               "neon",      DAV1D_ARM_CPU_FLAG_NEON },
 #elif ARCH_PPC64LE
     { "VSX",                "vsx",       DAV1D_PPC_CPU_FLAG_VSX },
+#elif ARCH_LOONGARCH
+    { "LSX",                "lsx",       DAV1D_LOONGARCH_CPU_FLAG_LSX },
+    { "LASX",               "lasx",      DAV1D_LOONGARCH_CPU_FLAG_LASX },
 #endif
     { 0 }
 };

--- a/tests/checkasm/checkasm.h
+++ b/tests/checkasm/checkasm.h
@@ -178,6 +178,23 @@ static inline uint64_t readtime(void) {
     return (((uint64_t)tbu) << 32) | (uint64_t)tbl;
 }
 #define readtime readtime
+#elif ARCH_LOONGARCH
+static inline uint64_t readtime(void) {
+#if ARCH_LOONGARCH64
+    uint64_t a, id;
+    __asm__ __volatile__("rdtime.d  %0, %1"
+                         : "=r"(a), "=r"(id)
+                         :: );
+    return a;
+#else
+    uint32_t a, id;
+    __asm__ __volatile__("rdtimel.w  %0, %1"
+                         : "=r"(a), "=r"(id)
+                         :: );
+    return (uint64_t)a;
+#endif
+}
+#define readtime readtime
 #endif
 
 /* Verifies that clobbered callee-saved registers

--- a/tools/dav1d_cli_parse.c
+++ b/tools/dav1d_cli_parse.c
@@ -101,6 +101,8 @@ static const struct option long_opts[] = {
 
 #if ARCH_AARCH64 || ARCH_ARM
 #define ALLOWED_CPU_MASKS " or 'neon'"
+#elif ARCH_LOONGARCH
+#define ALLOWED_CPU_MASKS ", 'lsx' or 'lasx'"
 #elif ARCH_PPC64LE
 #define ALLOWED_CPU_MASKS " or 'vsx'"
 #elif ARCH_X86
@@ -216,6 +218,9 @@ enum CpuMask {
 static const EnumParseTable cpu_mask_tbl[] = {
 #if ARCH_AARCH64 || ARCH_ARM
     { "neon", DAV1D_ARM_CPU_FLAG_NEON },
+#elif ARCH_LOONGARCH
+    { "lsx", DAV1D_LOONGARCH_CPU_FLAG_LSX },
+    { "lasx", DAV1D_LOONGARCH_CPU_FLAG_LASX },
 #elif ARCH_PPC64LE
     { "vsx", DAV1D_PPC_CPU_FLAG_VSX },
 #elif ARCH_X86

--- a/tools/dav1d_cli_parse.c
+++ b/tools/dav1d_cli_parse.c
@@ -105,6 +105,8 @@ static const struct option long_opts[] = {
 #define ALLOWED_CPU_MASKS ", 'lsx' or 'lasx'"
 #elif ARCH_PPC64LE
 #define ALLOWED_CPU_MASKS " or 'vsx'"
+#elif ARCH_RISCV
+#define ALLOWED_CPU_MASKS " or 'rvv'"
 #elif ARCH_X86
 #define ALLOWED_CPU_MASKS \
     ", 'sse2', 'ssse3', 'sse41', 'avx2' or 'avx512icl'"
@@ -223,6 +225,8 @@ static const EnumParseTable cpu_mask_tbl[] = {
     { "lasx", DAV1D_LOONGARCH_CPU_FLAG_LASX },
 #elif ARCH_PPC64LE
     { "vsx", DAV1D_PPC_CPU_FLAG_VSX },
+#elif ARCH_RISCV
+    { "rvv", DAV1D_RISCV_CPU_FLAG_V },
 #elif ARCH_X86
     { "sse2",      X86_CPU_MASK_SSE2 },
     { "ssse3",     X86_CPU_MASK_SSSE3 },

--- a/tools/dav1d_cli_parse.rs
+++ b/tools/dav1d_cli_parse.rs
@@ -473,6 +473,8 @@ cfg_if! {
                 }
             },
         ];
+    } else {
+        static mut cpu_mask_tbl: [EnumParseTable; 0] = [];
     }
 }
 


### PR DESCRIPTION
* Closes #775.
* Closes #861.

Build for QEMU user with:
```
RUSTFLAGS="-C target-feature=+crt-static,+v -C linker=riscv64-linux-gnu-gcc"  \
    cargo build --target riscv64gc-unknown-linux-gnu
```

(Note to self: remove `,+v` in above command to test RISC-V sans assembly.)

Note: the above command seems to work on Ubuntu 22.04 which comes with ld version 2.38 but fail on Ubuntu 20.04 where ld is version 2.34.