### PR TITLE
Backport memory optimization from dav1d 1.3.0

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -402,7 +402,6 @@ struct Dav1dTaskContext {
     // which would make copy/assign operations slightly faster?
     uint16_t al_pal[2 /* a/l */][32 /* bx/y4 */][3 /* plane */][8 /* palette_idx */];
     uint8_t pal_sz_uv[2 /* a/l */][32 /* bx4/by4 */];
-    uint8_t txtp_map[32 * 32]; // inter-only
     ALIGN(union, 64) Dav1dTaskContext_scratch {
         struct {
             union {
@@ -427,7 +426,10 @@ struct Dav1dTaskContext {
                     uint8_t pal_ctx[64];
                 };
             };
-            int16_t ac[32 * 32];
+            union {
+                int16_t ac[32 * 32]; // intra-only
+                uint8_t txtp_map[32 * 32]; // inter-only
+            };
             uint8_t pal_idx[2 * 64 * 64];
             uint16_t pal[3 /* plane */][8 /* palette_idx */];
             ALIGN(union, 64) {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -719,9 +719,16 @@ impl BitDepthDependentType for InterIntraEdge {
 
 #[derive(Clone, Copy)]
 #[repr(C)]
+pub union Rav1dTaskContext_scratch_ac_txtp_map {
+    pub ac: [i16; 1024],      // intra only
+    pub txtp_map: [u8; 1024], // inter only
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
 pub struct Rav1dTaskContext_scratch_levels_pal_ac_interintra_edge {
     pub c2rust_unnamed: Rav1dTaskContext_scratch_levels_pal,
-    pub ac: [i16; 1024],
+    pub ac_txtp_map: Rav1dTaskContext_scratch_ac_txtp_map,
     pub pal_idx: [u8; 8192],
     pub pal: [[u16; 8]; 3], /* [3 plane][8 palette_idx] */
     pub interintra_edge: BitDepthUnion<InterIntraEdge>,
@@ -770,7 +777,6 @@ pub(crate) struct Rav1dTaskContext {
     // which would make copy/assign operations slightly faster?
     pub al_pal: [[[[u16; 8]; 3]; 32]; 2], /* [2 a/l][32 bx/y4][3 plane][8 palette_idx] */
     pub pal_sz_uv: [[u8; 32]; 2],         /* [2 a/l][32 bx4/by4] */
-    pub txtp_map: [u8; 1024],             // inter-only
     pub scratch: Rav1dTaskContext_scratch,
 
     pub warpmv: Rav1dWarpedMotionParams,
@@ -797,7 +803,6 @@ impl Rav1dTaskContext {
             cf: Default::default(),
             al_pal: Default::default(),
             pal_sz_uv: Default::default(),
-            txtp_map: [0u8; 1024],
             scratch: mem::zeroed(),
             warpmv: mem::zeroed(),
             lf_mask: ptr::null_mut(),

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -1771,7 +1771,8 @@ unsafe fn read_coef_tree<BD: BitDepth>(
                     case.set(&mut dir.lcoef.0, cf_ctx);
                 },
             );
-            let txtp_map = &mut (*t).txtp_map[(by4 * 32 + bx4) as usize..];
+            let txtp_map = &mut (*t).scratch.c2rust_unnamed_0.ac_txtp_map.txtp_map
+                [(by4 * 32 + bx4) as usize..];
             CaseSet::<16, false>::one((), txw as usize, 0, |case, ()| {
                 for txtp_map in txtp_map.chunks_mut(32).take(txh as usize) {
                     case.set(txtp_map, txtp);
@@ -1992,7 +1993,7 @@ pub(crate) unsafe fn rav1d_read_coef_blocks<BD: BitDepth>(
                             let mut cf_ctx: u8 = 0x40 as c_int as u8;
                             let mut txtp: TxfmType = DCT_DCT;
                             if b.intra == 0 {
-                                txtp = t.txtp_map
+                                txtp = t.scratch.c2rust_unnamed_0.ac_txtp_map.txtp_map
                                     [((by4 + (y << ss_ver)) * 32 + bx4 + (x << ss_hor)) as usize]
                                     as TxfmType;
                             }
@@ -2822,7 +2823,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     if !(init_x == 0 && init_y == 0) {
                         unreachable!();
                     }
-                    let ac = &mut t.scratch.c2rust_unnamed_0.ac;
+                    let ac = &mut t.scratch.c2rust_unnamed_0.ac_txtp_map.ac;
                     let y_src: *mut BD::Pixel = (f.cur.data.data[0] as *mut BD::Pixel)
                         .offset((4 * (t.bx & !ss_hor)) as isize)
                         .offset(
@@ -4394,7 +4395,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             } else {
                                 let mut cf_ctx: u8 = 0;
                                 cf = BD::select_mut(&mut (*t).cf).0.as_mut_ptr();
-                                txtp = t.txtp_map
+                                txtp = t.scratch.c2rust_unnamed_0.ac_txtp_map.txtp_map
                                     [((by4 + (y << ss_ver)) * 32 + bx4 + (x << ss_hor)) as usize]
                                     as TxfmType;
                                 eob = decode_coefs::<BD>(

--- a/src/recon_tmpl.c
+++ b/src/recon_tmpl.c
@@ -800,7 +800,7 @@ static void read_coef_tree(Dav1dTaskContext *const t,
                 rep_macro(type, txtp_map, 0, mul * txtp); \
                 txtp_map += 32; \
             }
-            uint8_t *txtp_map = &t->txtp_map[by4 * 32 + bx4];
+            uint8_t *txtp_map = &t->scratch.txtp_map[by4 * 32 + bx4];
             case_set_upto16(txw,,,);
 #undef set_ctx
             if (t->frame_thread.pass == 1) {
@@ -927,8 +927,8 @@ void bytefn(dav1d_read_coef_blocks)(Dav1dTaskContext *const t,
                         uint8_t cf_ctx = 0x40;
                         enum TxfmType txtp;
                         if (!b->intra)
-                            txtp = t->txtp_map[(by4 + (y << ss_ver)) * 32 +
-                                                bx4 + (x << ss_hor)];
+                            txtp = t->scratch.txtp_map[(by4 + (y << ss_ver)) * 32 +
+                                                        bx4 + (x << ss_hor)];
                         const int eob = cbi[t->bx].eob[1 + pl] =
                             decode_coefs(t, &t->a->ccoef[pl][cbx4 + x],
                                          &t->l.ccoef[pl][cby4 + y], b->uvtx, bs,
@@ -2004,8 +2004,8 @@ int bytefn(dav1d_recon_b_inter)(Dav1dTaskContext *const t, const enum BlockSize 
                         } else {
                             uint8_t cf_ctx;
                             cf = bitfn(t->cf);
-                            txtp = t->txtp_map[(by4 + (y << ss_ver)) * 32 +
-                                                bx4 + (x << ss_hor)];
+                            txtp = t->scratch.txtp_map[(by4 + (y << ss_ver)) * 32 +
+                                                        bx4 + (x << ss_hor)];
                             eob = decode_coefs(t, &t->a->ccoef[pl][cbx4 + x],
                                                &t->l.ccoef[pl][cby4 + y],
                                                b->uvtx, bs, b, 0, 1 + pl,


### PR DESCRIPTION
Define union to share memory space for `ac` and `txtp_map`