### PR TITLE
`enum Rav1dRestorationType`: backport optimization from dav1d 1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "atomig"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +111,7 @@ dependencies = [
 name = "rav1d"
 version = "0.2.0"
 dependencies = [
+ "assert_matches",
  "atomig",
  "bitflags",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ path = "tests/seek_stress.rs"
 name = "seek_stress"
 
 [dependencies]
+assert_matches = "1.5.0"
 atomig = { version = "0.4.0", features = ["derive"] }
 bitflags = "2.4.0"
 cfg-if = "1.0.0"

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -1,6 +1,10 @@
 use crate::src::enum_map::EnumKey;
 use std::ffi::c_int;
 use std::ffi::c_uint;
+use std::fmt;
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::fmt::Formatter;
 use std::ops::BitAnd;
 use std::ops::Deref;
 use std::sync::atomic::AtomicU64;
@@ -184,37 +188,73 @@ impl TryFrom<Dav1dAdaptiveBoolean> for Rav1dAdaptiveBoolean {
 }
 
 pub type Dav1dRestorationType = u8;
-pub const DAV1D_RESTORATION_NONE: Dav1dRestorationType =
-    Rav1dRestorationType::None as Dav1dRestorationType;
+pub const DAV1D_RESTORATION_NONE: Dav1dRestorationType = Rav1dRestorationType::None.to_repr();
 pub const DAV1D_RESTORATION_SWITCHABLE: Dav1dRestorationType =
-    Rav1dRestorationType::Switchable as Dav1dRestorationType;
-pub const DAV1D_RESTORATION_WIENER: Dav1dRestorationType =
-    Rav1dRestorationType::Wiener as Dav1dRestorationType;
+    Rav1dRestorationType::Switchable.to_repr();
+pub const DAV1D_RESTORATION_WIENER: Dav1dRestorationType = Rav1dRestorationType::Wiener.to_repr();
 pub const DAV1D_RESTORATION_SGRPROJ: Dav1dRestorationType =
-    Rav1dRestorationType::SgrProj as Dav1dRestorationType;
+    Rav1dRestorationType::SgrProj(SgrIdx::I0).to_repr();
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, FromRepr, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, FromRepr)]
+pub enum SgrIdx {
+    I0 = 0,
+    I1 = 1,
+    I2 = 2,
+    I3 = 3,
+    I4 = 4,
+    I5 = 5,
+    I6 = 6,
+    I7 = 7,
+    I8 = 8,
+    I9 = 9,
+    I10 = 10,
+    I11 = 11,
+    I12 = 12,
+    I13 = 13,
+    I14 = 14,
+    I15 = 15,
+}
+
+impl Display for SgrIdx {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", *self as u8)
+    }
+}
+
+impl Debug for SgrIdx {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Rav1dRestorationType {
     #[default]
-    None = 0,
-    Switchable = 1,
-    Wiener = 2,
-    SgrProj = 3,
-    SgrProj1,
-    SgrProj2,
-    SgrProj3,
-    SgrProj4,
-    SgrProj5,
-    SgrProj6,
-    SgrProj7,
-    SgrProj8,
-    SgrProj9,
-    SgrProj10,
-    SgrProj11,
-    SgrProj12,
-    SgrProj13,
-    SgrProj14,
-    SgrProj15,
+    None,
+    Switchable,
+    Wiener,
+    SgrProj(SgrIdx),
+}
+
+impl Rav1dRestorationType {
+    pub const fn to_repr(&self) -> Dav1dRestorationType {
+        match *self {
+            Self::None => 0,
+            Self::Switchable => 1,
+            Self::Wiener => 2,
+            Self::SgrProj(idx) => 3 + idx as Dav1dRestorationType,
+        }
+    }
+
+    pub const fn from_repr(repr: usize) -> Option<Self> {
+        Some(match repr {
+            0 => Self::None,
+            1 => Self::Switchable,
+            2 => Self::Wiener,
+            3 => Self::SgrProj(SgrIdx::I0),
+            _ => return None,
+        })
+    }
 }
 
 pub type Dav1dWarpedMotionType = c_uint;
@@ -2249,7 +2289,7 @@ impl From<Rav1dFrameHeader_restoration> for Dav1dFrameHeader_restoration {
     fn from(value: Rav1dFrameHeader_restoration) -> Self {
         let Rav1dFrameHeader_restoration { r#type, unit_size } = value;
         Self {
-            r#type: r#type.map(|e| e as u8),
+            r#type: r#type.map(|e| e.to_repr()),
             unit_size,
         }
     }

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -193,13 +193,28 @@ pub const DAV1D_RESTORATION_WIENER: Dav1dRestorationType =
 pub const DAV1D_RESTORATION_SGRPROJ: Dav1dRestorationType =
     Rav1dRestorationType::SgrProj as Dav1dRestorationType;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, FromRepr, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, FromRepr, Default)]
 pub enum Rav1dRestorationType {
     #[default]
     None = 0,
     Switchable = 1,
     Wiener = 2,
     SgrProj = 3,
+    SgrProj1,
+    SgrProj2,
+    SgrProj3,
+    SgrProj4,
+    SgrProj5,
+    SgrProj6,
+    SgrProj7,
+    SgrProj8,
+    SgrProj9,
+    SgrProj10,
+    SgrProj11,
+    SgrProj12,
+    SgrProj13,
+    SgrProj14,
+    SgrProj15,
 }
 
 pub type Dav1dWarpedMotionType = c_uint;

--- a/src/decode.c
+++ b/src/decode.c
@@ -2722,9 +2722,7 @@ static void read_restoration_info(Dav1dTaskContext *const t,
     if (frame_type == DAV1D_RESTORATION_SWITCHABLE) {
         const int filter = dav1d_msac_decode_symbol_adapt4(&ts->msac,
                                ts->cdf.m.restore_switchable, 2);
-        lr->type = filter ? filter == 2 ? DAV1D_RESTORATION_SGRPROJ :
-                                          DAV1D_RESTORATION_WIENER :
-                                          DAV1D_RESTORATION_NONE;
+        lr->type = filter + !!filter; /* NONE/WIENER/SGRPROJ */
     } else {
         const unsigned type =
             dav1d_msac_decode_bool_adapt(&ts->msac,
@@ -2763,7 +2761,7 @@ static void read_restoration_info(Dav1dTaskContext *const t,
     } else if (lr->type == DAV1D_RESTORATION_SGRPROJ) {
         const unsigned idx = dav1d_msac_decode_bools(&ts->msac, 4);
         const uint16_t *const sgr_params = dav1d_sgr_params[idx];
-        lr->sgr_idx = idx;
+        lr->type += idx;
         lr->sgr_weights[0] = sgr_params[0] ? dav1d_msac_decode_subexp(&ts->msac,
             ts->lr_ref[p]->sgr_weights[0] + 96, 128, 4) - 96 : 0;
         lr->sgr_weights[1] = sgr_params[1] ? dav1d_msac_decode_subexp(&ts->msac,
@@ -2773,7 +2771,7 @@ static void read_restoration_info(Dav1dTaskContext *const t,
         ts->lr_ref[p] = lr;
         if (DEBUG_BLOCK_INFO)
             printf("Post-lr_sgrproj[pl=%d,idx=%d,w[%d,%d]]: r=%d\n",
-                   p, lr->sgr_idx, lr->sgr_weights[0],
+                   p, idx, lr->sgr_weights[0],
                    lr->sgr_weights[1], ts->msac.rng);
     }
 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4033,9 +4033,11 @@ unsafe fn read_restoration_info(
             );
         }
     } else if lr.r#type == Rav1dRestorationType::SgrProj {
-        let idx = rav1d_msac_decode_bools(&mut ts.msac, 4) as u8;
-        let sgr_params = &dav1d_sgr_params[idx.into()];
-        lr.sgr_idx = idx;
+        let sgr_idx = rav1d_msac_decode_bools(&mut ts.msac, 4) as usize;
+        let sgr_params = &dav1d_sgr_params[sgr_idx];
+        lr.r#type =
+            Rav1dRestorationType::from_repr(Rav1dRestorationType::SgrProj as usize + sgr_idx)
+                .unwrap();
         lr.sgr_weights[0] = if sgr_params[0] != 0 {
             msac_decode_lr_subexp(ts, lr_ref.sgr_weights[0], 4, 96)
         } else {
@@ -4052,7 +4054,7 @@ unsafe fn read_restoration_info(
         if debug_block_info {
             println!(
                 "Post-lr_sgrproj[pl={},idx={},w[{},{}]]: r={}",
-                p, lr.sgr_idx, lr.sgr_weights[0], lr.sgr_weights[1], ts.msac.rng,
+                p, sgr_idx, lr.sgr_weights[0], lr.sgr_weights[1], ts.msac.rng,
             );
         }
     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -18,6 +18,7 @@ use crate::include::dav1d::headers::Rav1dSequenceHeader;
 use crate::include::dav1d::headers::Rav1dTxfmMode;
 use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
 use crate::include::dav1d::headers::Rav1dWarpedMotionType;
+use crate::include::dav1d::headers::SgrIdx;
 use crate::include::dav1d::headers::RAV1D_MAX_SEGMENTS;
 use crate::include::dav1d::headers::RAV1D_PRIMARY_REF_NONE;
 use crate::src::align::Align16;
@@ -3973,7 +3974,7 @@ unsafe fn read_restoration_info(
             rav1d_msac_decode_symbol_adapt4(&mut ts.msac, &mut ts.cdf.m.restore_switchable.0, 2);
         lr.r#type = if filter != 0 {
             if filter == 2 {
-                Rav1dRestorationType::SgrProj
+                Rav1dRestorationType::SgrProj(SgrIdx::I0)
             } else {
                 Rav1dRestorationType::Wiener
             }
@@ -4001,62 +4002,65 @@ unsafe fn read_restoration_info(
             - adjustment as c_int) as i8
     }
 
-    if lr.r#type == Rav1dRestorationType::Wiener {
-        lr.filter_v[0] = if p != 0 {
-            0
-        } else {
-            msac_decode_lr_subexp(ts, lr_ref.filter_v[0], 1, 5)
-        };
-        lr.filter_v[1] = msac_decode_lr_subexp(ts, lr_ref.filter_v[1], 2, 23);
-        lr.filter_v[2] = msac_decode_lr_subexp(ts, lr_ref.filter_v[2], 3, 17);
+    match lr.r#type {
+        Rav1dRestorationType::Wiener => {
+            lr.filter_v[0] = if p != 0 {
+                0
+            } else {
+                msac_decode_lr_subexp(ts, lr_ref.filter_v[0], 1, 5)
+            };
+            lr.filter_v[1] = msac_decode_lr_subexp(ts, lr_ref.filter_v[1], 2, 23);
+            lr.filter_v[2] = msac_decode_lr_subexp(ts, lr_ref.filter_v[2], 3, 17);
 
-        lr.filter_h[0] = if p != 0 {
-            0
-        } else {
-            msac_decode_lr_subexp(ts, lr_ref.filter_h[0], 1, 5)
-        };
-        lr.filter_h[1] = msac_decode_lr_subexp(ts, lr_ref.filter_h[1], 2, 23);
-        lr.filter_h[2] = msac_decode_lr_subexp(ts, lr_ref.filter_h[2], 3, 17);
-        lr.sgr_weights = lr_ref.sgr_weights;
-        ts.lr_ref[p] = *lr;
-        if debug_block_info {
-            println!(
-                "Post-lr_wiener[pl={},v[{},{},{}],h[{},{},{}]]: r={}",
-                p,
-                lr.filter_v[0],
-                lr.filter_v[1],
-                lr.filter_v[2],
-                lr.filter_h[0],
-                lr.filter_h[1],
-                lr.filter_h[2],
-                ts.msac.rng,
-            );
+            lr.filter_h[0] = if p != 0 {
+                0
+            } else {
+                msac_decode_lr_subexp(ts, lr_ref.filter_h[0], 1, 5)
+            };
+            lr.filter_h[1] = msac_decode_lr_subexp(ts, lr_ref.filter_h[1], 2, 23);
+            lr.filter_h[2] = msac_decode_lr_subexp(ts, lr_ref.filter_h[2], 3, 17);
+            lr.sgr_weights = lr_ref.sgr_weights;
+            ts.lr_ref[p] = *lr;
+            if debug_block_info {
+                println!(
+                    "Post-lr_wiener[pl={},v[{},{},{}],h[{},{},{}]]: r={}",
+                    p,
+                    lr.filter_v[0],
+                    lr.filter_v[1],
+                    lr.filter_v[2],
+                    lr.filter_h[0],
+                    lr.filter_h[1],
+                    lr.filter_h[2],
+                    ts.msac.rng,
+                );
+            }
         }
-    } else if lr.r#type == Rav1dRestorationType::SgrProj {
-        let sgr_idx = rav1d_msac_decode_bools(&mut ts.msac, 4) as usize;
-        let sgr_params = &dav1d_sgr_params[sgr_idx];
-        lr.r#type =
-            Rav1dRestorationType::from_repr(Rav1dRestorationType::SgrProj as usize + sgr_idx)
-                .unwrap();
-        lr.sgr_weights[0] = if sgr_params[0] != 0 {
-            msac_decode_lr_subexp(ts, lr_ref.sgr_weights[0], 4, 96)
-        } else {
-            0
-        };
-        lr.sgr_weights[1] = if sgr_params[1] != 0 {
-            msac_decode_lr_subexp(ts, lr_ref.sgr_weights[1], 4, 32)
-        } else {
-            95
-        };
-        lr.filter_v = lr_ref.filter_v;
-        lr.filter_h = lr_ref.filter_h;
-        ts.lr_ref[p] = *lr;
-        if debug_block_info {
-            println!(
-                "Post-lr_sgrproj[pl={},idx={},w[{},{}]]: r={}",
-                p, sgr_idx, lr.sgr_weights[0], lr.sgr_weights[1], ts.msac.rng,
-            );
+        Rav1dRestorationType::SgrProj(_) => {
+            let sgr_idx =
+                SgrIdx::from_repr(rav1d_msac_decode_bools(&mut ts.msac, 4) as usize).unwrap();
+            let sgr_params = &dav1d_sgr_params[sgr_idx as usize];
+            lr.r#type = Rav1dRestorationType::SgrProj(sgr_idx);
+            lr.sgr_weights[0] = if sgr_params[0] != 0 {
+                msac_decode_lr_subexp(ts, lr_ref.sgr_weights[0], 4, 96)
+            } else {
+                0
+            };
+            lr.sgr_weights[1] = if sgr_params[1] != 0 {
+                msac_decode_lr_subexp(ts, lr_ref.sgr_weights[1], 4, 32)
+            } else {
+                95
+            };
+            lr.filter_v = lr_ref.filter_v;
+            lr.filter_h = lr_ref.filter_h;
+            ts.lr_ref[p] = *lr;
+            if debug_block_info {
+                println!(
+                    "Post-lr_sgrproj[pl={},idx={},w[{},{}]]: r={}",
+                    p, sgr_idx, lr.sgr_weights[0], lr.sgr_weights[1], ts.msac.rng,
+                );
+            }
         }
+        _ => {}
     }
 }
 

--- a/src/lf_mask.h
+++ b/src/lf_mask.h
@@ -40,10 +40,10 @@ typedef struct Av1FilterLUT {
 } Av1FilterLUT;
 
 typedef struct Av1RestorationUnit {
+    /* SGR: type = DAV1D_RESTORATION_SGRPROJ + sgr_idx */
     uint8_t /* enum Dav1dRestorationType */ type;
     int8_t filter_h[3];
     int8_t filter_v[3];
-    uint8_t sgr_idx;
     int8_t sgr_weights[2];
 } Av1RestorationUnit;
 

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -28,7 +28,6 @@ pub struct Av1RestorationUnit {
     pub r#type: Rav1dRestorationType,
     pub filter_h: [i8; 3],
     pub filter_v: [i8; 3],
-    pub sgr_idx: u8,
     pub sgr_weights: [i8; 2],
 }
 

--- a/src/lr_apply.rs
+++ b/src/lr_apply.rs
@@ -14,6 +14,7 @@ use crate::src::looprestoration::LR_HAVE_LEFT;
 use crate::src::looprestoration::LR_HAVE_RIGHT;
 use crate::src::looprestoration::LR_HAVE_TOP;
 use crate::src::tables::dav1d_sgr_params;
+use assert_matches::assert_matches;
 use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_int;
@@ -80,9 +81,8 @@ unsafe fn lr_stripe<BD: BitDepth>(
 
         lr_fn = dsp.lr.wiener[((filter[0][0] | filter[1][0]) == 0) as usize];
     } else {
-        assert!(lr.r#type >= Rav1dRestorationType::SgrProj);
-        let sgr_idx = lr.r#type as usize - Rav1dRestorationType::SgrProj as usize;
-        let sgr_params = &dav1d_sgr_params[sgr_idx];
+        let sgr_idx = assert_matches!(lr.r#type, Rav1dRestorationType::SgrProj(idx) => idx);
+        let sgr_params = &dav1d_sgr_params[sgr_idx as usize];
         params.sgr.s0 = sgr_params[0] as u32;
         params.sgr.s1 = sgr_params[1] as u32;
         params.sgr.w0 = lr.sgr_weights[0] as i16;

--- a/src/lr_apply.rs
+++ b/src/lr_apply.rs
@@ -80,8 +80,9 @@ unsafe fn lr_stripe<BD: BitDepth>(
 
         lr_fn = dsp.lr.wiener[((filter[0][0] | filter[1][0]) == 0) as usize];
     } else {
-        assert_eq!(lr.r#type, Rav1dRestorationType::SgrProj);
-        let sgr_params = &dav1d_sgr_params[lr.sgr_idx as usize];
+        assert!(lr.r#type >= Rav1dRestorationType::SgrProj);
+        let sgr_idx = lr.r#type as usize - Rav1dRestorationType::SgrProj as usize;
+        let sgr_params = &dav1d_sgr_params[sgr_idx];
         params.sgr.s0 = sgr_params[0] as u32;
         params.sgr.s1 = sgr_params[1] as u32;
         params.sgr.w0 = lr.sgr_weights[0] as i16;

--- a/src/lr_apply_tmpl.c
+++ b/src/lr_apply_tmpl.c
@@ -71,8 +71,9 @@ static void lr_stripe(const Dav1dFrameContext *const f, pixel *p,
 
         lr_fn = dsp->lr.wiener[!(filter[0][0] | filter[1][0])];
     } else {
-        assert(lr->type == DAV1D_RESTORATION_SGRPROJ);
-        const uint16_t *const sgr_params = dav1d_sgr_params[lr->sgr_idx];
+        assert(lr->type >= DAV1D_RESTORATION_SGRPROJ);
+        const int sgr_idx = lr->type - DAV1D_RESTORATION_SGRPROJ;
+        const uint16_t *const sgr_params = dav1d_sgr_params[sgr_idx];
         params.sgr.s0 = sgr_params[0];
         params.sgr.s1 = sgr_params[1];
         params.sgr.w0 = lr->sgr_weights[0];


### PR DESCRIPTION
Embed `sgr_idx` into `enum Rav1dRestorationType` to avoid storing it separately. Define `enum Rav1dRestorationType` as `repr(u8)` to match C code and save some memory.