### PR TITLE
`struct Rav1dFrameContext_frame_thread`: backport memory optimization from dav1d 1.3.0

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -272,10 +272,7 @@ struct Dav1dFrameContext {
         atomic_uint *frame_progress, *copy_lpf_progress;
         // indexed using t->by * f->b4_stride + t->bx
         Av1Block *b;
-        struct CodedBlockInfo {
-            int16_t eob[3 /* plane */];
-            uint8_t txtp[3 /* plane */];
-        } *cbi;
+        int16_t (*cbi)[3 /* plane */]; /* bits 0-4: txtp, bits 5-15: eob */
         // indexed using (t->by >> 1) * (f->b4_stride >> 1) + (t->bx >> 1)
         uint16_t (*pal)[3 /* plane */][8 /* idx */];
         // iterated over inside tile state

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -394,13 +394,6 @@ impl Rav1dFrameContext_bd_fn {
 
 #[derive(Default)]
 #[repr(C)]
-pub struct CodedBlockInfo {
-    pub eob: [i16; 3], /* plane */
-    pub txtp: [u8; 3], /* plane */
-}
-
-#[derive(Default)]
-#[repr(C)]
 pub struct Rav1dFrameContext_frame_thread {
     /// Indices: 0: reconstruction, 1: entropy.
     pub next_tile_row: [c_int; 2],
@@ -408,7 +401,7 @@ pub struct Rav1dFrameContext_frame_thread {
     /// Indexed using `t.by * f.b4_stride + t.bx`.
     pub b: Vec<Av1Block>,
 
-    pub cbi: Vec<CodedBlockInfo>,
+    pub cbi: Vec<[i16; 3]>, /* bits 0-4: txtp, bits 5-15: eob */
 
     /// Indexed using `(t.by >> 1) * (f.b4_stride >> 1) + (t.bx >> 1)`.
     /// Inner indices are `[3 plane][8 idx]`.

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -39,6 +39,8 @@ use crate::src::itx::Rav1dInvTxfmDSPContext;
 use crate::src::levels::Av1Block;
 use crate::src::levels::BlockSize;
 use crate::src::levels::Filter2d;
+use crate::src::levels::TxfmType;
+use crate::src::levels::WHT_WHT;
 use crate::src::lf_mask::Av1Filter;
 use crate::src::lf_mask::Av1FilterLUT;
 use crate::src::lf_mask::Av1Restoration;
@@ -392,6 +394,26 @@ impl Rav1dFrameContext_bd_fn {
     }
 }
 
+#[derive(Clone, Copy, Default)]
+pub struct CodedBlockInfo(i16);
+
+impl CodedBlockInfo {
+    const TXTP_BITS: u8 = (TxfmType::BITS - WHT_WHT.leading_zeros()) as u8;
+
+    pub const fn eob(&self) -> i16 {
+        self.0 >> Self::TXTP_BITS
+    }
+
+    pub const fn txtp(&self) -> TxfmType {
+        (self.0 & ((1 << Self::TXTP_BITS) - 1)) as TxfmType
+    }
+
+    pub const fn new(eob: i16, txtp: TxfmType) -> Self {
+        debug_assert!(eob << Self::TXTP_BITS >> Self::TXTP_BITS == eob);
+        Self((eob << Self::TXTP_BITS) | (txtp as i16))
+    }
+}
+
 #[derive(Default)]
 #[repr(C)]
 pub struct Rav1dFrameContext_frame_thread {
@@ -401,7 +423,7 @@ pub struct Rav1dFrameContext_frame_thread {
     /// Indexed using `t.by * f.b4_stride + t.bx`.
     pub b: Vec<Av1Block>,
 
-    pub cbi: Vec<[i16; 3]>, /* bits 0-4: txtp, bits 5-15: eob */
+    pub cbi: Vec<[CodedBlockInfo; 3]>,
 
     /// Indexed using `(t.by >> 1) * (f.b4_stride >> 1) + (t.bx >> 1)`.
     /// Inner indices are `[3 plane][8 idx]`.

--- a/src/recon_tmpl.c
+++ b/src/recon_tmpl.c
@@ -770,14 +770,14 @@ static void read_coef_tree(Dav1dTaskContext *const t,
         uint8_t cf_ctx;
         int eob;
         coef *cf;
-        struct CodedBlockInfo *cbi;
+        int16_t *cbi;
 
         if (t->frame_thread.pass) {
             const int p = t->frame_thread.pass & 1;
             assert(ts->frame_thread[p].cf);
             cf = ts->frame_thread[p].cf;
             ts->frame_thread[p].cf += imin(t_dim->w, 8) * imin(t_dim->h, 8) * 16;
-            cbi = &f->frame_thread.cbi[t->by * f->b4_stride + t->bx];
+            cbi = f->frame_thread.cbi[t->by * f->b4_stride + t->bx];
         } else {
             cf = bitfn(t->cf);
         }
@@ -803,13 +803,11 @@ static void read_coef_tree(Dav1dTaskContext *const t,
             uint8_t *txtp_map = &t->scratch.txtp_map[by4 * 32 + bx4];
             case_set_upto16(txw,,,);
 #undef set_ctx
-            if (t->frame_thread.pass == 1) {
-                cbi->eob[0] = eob;
-                cbi->txtp[0] = txtp;
-            }
+            if (t->frame_thread.pass == 1)
+                cbi[0] = eob * (1 << 5) + txtp;
         } else {
-            eob = cbi->eob[0];
-            txtp = cbi->txtp[0];
+            eob  = cbi[0] >> 5;
+            txtp = cbi[0] & 0x1f;
         }
         if (!(t->frame_thread.pass & 1)) {
             assert(dst);
@@ -874,7 +872,7 @@ void bytefn(dav1d_read_coef_blocks)(Dav1dTaskContext *const t,
             for (y = init_y, t->by += init_y; y < sub_h4;
                  y += t_dim->h, t->by += t_dim->h, y_off++)
             {
-                struct CodedBlockInfo *const cbi =
+                int16_t (*const cbi)[3] =
                     &f->frame_thread.cbi[t->by * f->b4_stride];
                 int x_off = !!init_x;
                 for (x = init_x, t->bx += init_x; x < sub_w4;
@@ -886,14 +884,14 @@ void bytefn(dav1d_read_coef_blocks)(Dav1dTaskContext *const t,
                     } else {
                         uint8_t cf_ctx = 0x40;
                         enum TxfmType txtp;
-                        const int eob = cbi[t->bx].eob[0] =
+                        const int eob =
                             decode_coefs(t, &t->a->lcoef[bx4 + x],
                                          &t->l.lcoef[by4 + y], b->tx, bs, b, 1,
                                          0, ts->frame_thread[1].cf, &txtp, &cf_ctx);
                         if (DEBUG_BLOCK_INFO)
                             printf("Post-y-cf-blk[tx=%d,txtp=%d,eob=%d]: r=%d\n",
                                    b->tx, txtp, eob, ts->msac.rng);
-                        cbi[t->bx].txtp[0] = txtp;
+                        cbi[t->bx][0] = eob * (1 << 5) + txtp;
                         ts->frame_thread[1].cf += imin(t_dim->w, 8) * imin(t_dim->h, 8) * 16;
 #define set_ctx(type, dir, diridx, off, mul, rep_macro) \
                         rep_macro(type, t->dir lcoef, off, mul * cf_ctx)
@@ -919,7 +917,7 @@ void bytefn(dav1d_read_coef_blocks)(Dav1dTaskContext *const t,
                 for (y = init_y >> ss_ver, t->by += init_y; y < sub_ch4;
                      y += uv_t_dim->h, t->by += uv_t_dim->h << ss_ver)
                 {
-                    struct CodedBlockInfo *const cbi =
+                    int16_t (*const cbi)[3] =
                         &f->frame_thread.cbi[t->by * f->b4_stride];
                     for (x = init_x >> ss_hor, t->bx += init_x; x < sub_cw4;
                          x += uv_t_dim->w, t->bx += uv_t_dim->w << ss_hor)
@@ -929,7 +927,7 @@ void bytefn(dav1d_read_coef_blocks)(Dav1dTaskContext *const t,
                         if (!b->intra)
                             txtp = t->scratch.txtp_map[(by4 + (y << ss_ver)) * 32 +
                                                         bx4 + (x << ss_hor)];
-                        const int eob = cbi[t->bx].eob[1 + pl] =
+                        const int eob =
                             decode_coefs(t, &t->a->ccoef[pl][cbx4 + x],
                                          &t->l.ccoef[pl][cby4 + y], b->uvtx, bs,
                                          b, b->intra, 1 + pl, ts->frame_thread[1].cf,
@@ -938,7 +936,7 @@ void bytefn(dav1d_read_coef_blocks)(Dav1dTaskContext *const t,
                             printf("Post-uv-cf-blk[pl=%d,tx=%d,"
                                    "txtp=%d,eob=%d]: r=%d\n",
                                    pl, b->uvtx, txtp, eob, ts->msac.rng);
-                        cbi[t->bx].txtp[1 + pl] = txtp;
+                        cbi[t->bx][pl + 1] = eob * (1 << 5) + txtp;
                         ts->frame_thread[1].cf += uv_t_dim->w * uv_t_dim->h * 16;
 #define set_ctx(type, dir, diridx, off, mul, rep_macro) \
                         rep_macro(type, t->dir ccoef[pl], off, mul * cf_ctx)
@@ -1323,10 +1321,10 @@ void bytefn(dav1d_recon_b_intra)(Dav1dTaskContext *const t, const enum BlockSize
                             const int p = t->frame_thread.pass & 1;
                             cf = ts->frame_thread[p].cf;
                             ts->frame_thread[p].cf += imin(t_dim->w, 8) * imin(t_dim->h, 8) * 16;
-                            const struct CodedBlockInfo *const cbi =
-                                &f->frame_thread.cbi[t->by * f->b4_stride + t->bx];
-                            eob = cbi->eob[0];
-                            txtp = cbi->txtp[0];
+                            const int cbi =
+                                f->frame_thread.cbi[t->by * f->b4_stride + t->bx][0];
+                            eob  = cbi >> 5;
+                            txtp = cbi & 0x1f;
                         } else {
                             uint8_t cf_ctx;
                             cf = bitfn(t->cf);
@@ -1547,10 +1545,10 @@ void bytefn(dav1d_recon_b_intra)(Dav1dTaskContext *const t, const enum BlockSize
                                 const int p = t->frame_thread.pass & 1;
                                 cf = ts->frame_thread[p].cf;
                                 ts->frame_thread[p].cf += uv_t_dim->w * uv_t_dim->h * 16;
-                                const struct CodedBlockInfo *const cbi =
-                                    &f->frame_thread.cbi[t->by * f->b4_stride + t->bx];
-                                eob = cbi->eob[pl + 1];
-                                txtp = cbi->txtp[pl + 1];
+                                const int cbi =
+                                    f->frame_thread.cbi[t->by * f->b4_stride + t->bx][pl + 1];
+                                eob  = cbi >> 5;
+                                txtp = cbi & 0x1f;
                             } else {
                                 uint8_t cf_ctx;
                                 cf = bitfn(t->cf);
@@ -1997,10 +1995,10 @@ int bytefn(dav1d_recon_b_inter)(Dav1dTaskContext *const t, const enum BlockSize 
                             const int p = t->frame_thread.pass & 1;
                             cf = ts->frame_thread[p].cf;
                             ts->frame_thread[p].cf += uvtx->w * uvtx->h * 16;
-                            const struct CodedBlockInfo *const cbi =
-                                &f->frame_thread.cbi[t->by * f->b4_stride + t->bx];
-                            eob = cbi->eob[1 + pl];
-                            txtp = cbi->txtp[1 + pl];
+                            const int cbi =
+                                f->frame_thread.cbi[t->by * f->b4_stride + t->bx][pl + 1];
+                            eob  = cbi >> 5;
+                            txtp = cbi & 0x1f;
                         } else {
                             uint8_t cf_ctx;
                             cf = bitfn(t->cf);


### PR DESCRIPTION
Combine `eob` and `txtp` into single value.