### PR TITLE
`struct FrameTileThreadData::lowest_pixel_mem`: Make into `Vec`

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -517,13 +517,6 @@ pub(crate) struct Rav1dFrameContext_task_thread {
     pub pending_tasks: Mutex<Rav1dFrameContext_task_thread_pending_tasks>,
 }
 
-// threading (refer to tc[] for per-thread things)
-#[repr(C)]
-pub struct FrameTileThreadData {
-    pub lowest_pixel_mem: *mut [[c_int; 2]; 7],
-    pub lowest_pixel_mem_sz: c_int,
-}
-
 pub(crate) struct Rav1dFrameContext_frame_thread_progress {
     pub entropy: AtomicI32,
     pub deblock: AtomicI32, // in sby units
@@ -592,7 +585,7 @@ pub(crate) struct Rav1dFrameData {
     pub frame_thread_progress: Rav1dFrameContext_frame_thread_progress,
     pub lf: Rav1dFrameContext_lf,
     pub task_thread: Rav1dFrameContext_task_thread,
-    pub tile_thread: FrameTileThreadData,
+    pub lowest_pixel_mem: Vec<[[c_int; 2]; 7]>,
 }
 
 impl Rav1dFrameData {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -902,10 +902,7 @@ impl Drop for Rav1dContext {
             while !(self.fc).is_null() && n_1 < self.n_fc {
                 let f: &mut Rav1dFrameData = &mut *(self.fc).offset(n_1 as isize);
                 if self.n_fc > 1 as c_uint {
-                    freep(
-                        &mut f.tile_thread.lowest_pixel_mem as *mut *mut [[c_int; 2]; 7]
-                            as *mut c_void,
-                    );
+                    let _ = mem::take(&mut f.lowest_pixel_mem); // TODO: remove when context is owned
                 }
                 if self.tc.len() > 1 {
                     let _ = mem::take(&mut f.task_thread.pending_tasks); // TODO: remove when context is owned


### PR DESCRIPTION
Also remove `FrameTileThreadData` because it only had a single field and was only used in one place. `lowest_pixel_mem` is now a direct field of `Rav1dFrameData`.

@rinon let me know if this looks like it'll conflict with your changes. From what I saw it doesn't look like you changed `FrameTileThreadData` so I'm not expecting it to conflict, but we can wait to merge this until after your changes are merged if that'll help.

* Closes #712