### PR TITLE
`struct Rav1dTileState::lflvl`: Make into enum

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -644,17 +644,17 @@ pub struct Rav1dTileState {
     pub lowest_pixel: *mut [[c_int; 2]; 7],
 
     pub dqmem: [[[u16; 2]; 3]; RAV1D_MAX_SEGMENTS as usize], /* [RAV1D_MAX_SEGMENTS][3 plane][2 dc/ac] */
-    pub dq: TileStateDq,
+    pub dq: TileStateRef,
     pub last_qidx: c_int,
     pub last_delta_lf: [i8; 4],
     pub lflvlmem: [[[[u8; 2]; 8]; 4]; 8], /* [8 seg_id][4 dir][8 ref][2 is_gmv] */
-    pub lflvl: *const [[[u8; 2]; 8]; 4],
+    pub lflvl: TileStateRef,
 
     pub lr_ref: [Av1RestorationUnit; 3],
 }
 
 #[derive(Clone, Copy)]
-pub enum TileStateDq {
+pub enum TileStateRef {
     Frame,
     Local,
 }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -20,7 +20,7 @@ use crate::src::internal::Rav1dDSPContext;
 use crate::src::internal::Rav1dFrameData;
 use crate::src::internal::Rav1dTaskContext;
 use crate::src::internal::Rav1dTileState;
-use crate::src::internal::TileStateDq;
+use crate::src::internal::TileStateRef;
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::ipred_prepare::rav1d_prepare_intra_edges;
 use crate::src::ipred_prepare::sm_flag;
@@ -1380,8 +1380,8 @@ unsafe fn decode_coefs<BD: BitDepth>(
         rc = 0 as c_int as c_uint;
     }
     let dq = match (*ts).dq {
-        TileStateDq::Frame => &f.dq,
-        TileStateDq::Local => &(*ts).dqmem,
+        TileStateRef::Frame => &f.dq,
+        TileStateRef::Local => &(*ts).dqmem,
     };
     let dq_tbl = &dq[b.seg_id as usize][plane as usize];
     let qm_tbl: *const u8 = if (*txtp as c_uint) < IDTX as c_int as c_uint {


### PR DESCRIPTION
Rename `TileStateDq` to `TileStateRef` and use it for both fields, since both have the same structure of either referencing a field in the frame data or referencing the local tile state field.

* Closes #715