### PR TITLE
`struct Rav1dTileState_frame_thread::pal_idx`: Make into offset

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2063,9 +2063,8 @@ unsafe fn decode_b_inner(
                 let p = t.frame_thread.pass & 1;
                 let frame_thread = &mut ts.frame_thread[p as usize];
                 let len = usize::try_from(bw4 * bh4 * 16).unwrap();
-                let pal_idx_offset = frame_thread.pal_idx.as_mut().unwrap();
-                let pal_idx = &mut f.frame_thread.pal_idx[*pal_idx_offset..];
-                *pal_idx_offset += len;
+                let pal_idx = &mut f.frame_thread.pal_idx[frame_thread.pal_idx..][..len];
+                frame_thread.pal_idx += len;
                 pal_idx
             } else {
                 &mut t.scratch.c2rust_unnamed_0.pal_idx
@@ -2091,9 +2090,8 @@ unsafe fn decode_b_inner(
                 let p = t.frame_thread.pass & 1;
                 let frame_thread = &mut ts.frame_thread[p as usize];
                 let len = usize::try_from(cbw4 * cbh4 * 16).unwrap();
-                let pal_idx_offset = frame_thread.pal_idx.as_mut().unwrap();
-                let pal_idx = &mut f.frame_thread.pal_idx[*pal_idx_offset..];
-                *pal_idx_offset += len;
+                let pal_idx = &mut f.frame_thread.pal_idx[frame_thread.pal_idx..];
+                frame_thread.pal_idx += len;
                 pal_idx
             } else {
                 &mut t.scratch.c2rust_unnamed_0.pal_idx[(bw4 * bh4 * 16) as usize..]
@@ -3905,10 +3903,10 @@ unsafe fn setup_tile(
 
     let size_mul = &ss_size_mul[f.cur.p.layout];
     for p in 0..2 {
-        ts.frame_thread[p].pal_idx = if !(f.frame_thread.pal_idx).is_empty() {
-            Some(tile_start_off * size_mul[1] as usize / 4)
+        ts.frame_thread[p].pal_idx = if !f.frame_thread.pal_idx.is_empty() {
+            tile_start_off * size_mul[1] as usize / 4
         } else {
-            None
+            0
         };
         ts.frame_thread[p].cf = if !f.frame_thread.cf.is_empty() {
             f.frame_thread.cf

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2059,17 +2059,17 @@ unsafe fn decode_b_inner(
         }
 
         if b.pal_sz()[0] != 0 {
-            let pal_idx;
-            if t.frame_thread.pass != 0 {
+            let pal_idx = if t.frame_thread.pass != 0 {
                 let p = t.frame_thread.pass & 1;
                 let frame_thread = &mut ts.frame_thread[p as usize];
-                assert!(!frame_thread.pal_idx.is_null());
                 let len = usize::try_from(bw4 * bh4 * 16).unwrap();
-                pal_idx = std::slice::from_raw_parts_mut(frame_thread.pal_idx, len);
-                frame_thread.pal_idx = frame_thread.pal_idx.offset(len as isize);
+                let pal_idx_offset = frame_thread.pal_idx.as_mut().unwrap();
+                let pal_idx = &mut f.frame_thread.pal_idx[*pal_idx_offset..];
+                *pal_idx_offset += len;
+                pal_idx
             } else {
-                pal_idx = &mut t.scratch.c2rust_unnamed_0.pal_idx;
-            }
+                &mut t.scratch.c2rust_unnamed_0.pal_idx
+            };
             read_pal_indices(
                 &mut *t.ts,
                 &mut t.scratch.c2rust_unnamed_0.c2rust_unnamed.c2rust_unnamed,
@@ -2087,17 +2087,17 @@ unsafe fn decode_b_inner(
         }
 
         if has_chroma && b.pal_sz()[1] != 0 {
-            let pal_idx;
-            if t.frame_thread.pass != 0 {
+            let pal_idx = if t.frame_thread.pass != 0 {
                 let p = t.frame_thread.pass & 1;
                 let frame_thread = &mut ts.frame_thread[p as usize];
-                assert!(!(frame_thread.pal_idx).is_null());
                 let len = usize::try_from(cbw4 * cbh4 * 16).unwrap();
-                pal_idx = std::slice::from_raw_parts_mut(frame_thread.pal_idx, len);
-                frame_thread.pal_idx = frame_thread.pal_idx.offset(len as isize);
+                let pal_idx_offset = frame_thread.pal_idx.as_mut().unwrap();
+                let pal_idx = &mut f.frame_thread.pal_idx[*pal_idx_offset..];
+                *pal_idx_offset += len;
+                pal_idx
             } else {
-                pal_idx = &mut t.scratch.c2rust_unnamed_0.pal_idx[(bw4 * bh4 * 16) as usize..];
-            }
+                &mut t.scratch.c2rust_unnamed_0.pal_idx[(bw4 * bh4 * 16) as usize..]
+            };
             read_pal_indices(
                 &mut *t.ts,
                 &mut t.scratch.c2rust_unnamed_0.c2rust_unnamed.c2rust_unnamed,
@@ -3906,9 +3906,9 @@ unsafe fn setup_tile(
     let size_mul = &ss_size_mul[f.cur.p.layout];
     for p in 0..2 {
         ts.frame_thread[p].pal_idx = if !(f.frame_thread.pal_idx).is_empty() {
-            f.frame_thread.pal_idx[tile_start_off * size_mul[1] as usize / 4..].as_ptr() as *mut u8
+            Some(tile_start_off * size_mul[1] as usize / 4)
         } else {
-            ptr::null_mut()
+            None
         };
         ts.frame_thread[p].cf = if !f.frame_thread.cf.is_empty() {
             f.frame_thread.cf

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -618,7 +618,7 @@ pub struct Rav1dTileState_tiling {
 
 #[repr(C)]
 pub struct Rav1dTileState_frame_thread {
-    pub pal_idx: Option<usize>,
+    pub pal_idx: usize, // Offset into `f.frame_thread.pal_idx`
     pub cf: *mut DynCoef,
 }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -618,7 +618,7 @@ pub struct Rav1dTileState_tiling {
 
 #[repr(C)]
 pub struct Rav1dTileState_frame_thread {
-    pub pal_idx: *mut u8,
+    pub pal_idx: Option<usize>,
     pub cf: *mut DynCoef,
 }
 

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2524,9 +2524,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                 let pal_idx = if t.frame_thread.pass != 0 {
                     let p = t.frame_thread.pass & 1;
                     let frame_thread = &mut (*ts).frame_thread[p as usize];
-                    let pal_idx_offset = frame_thread.pal_idx.as_mut().unwrap();
-                    let pal_idx = &f.frame_thread.pal_idx[*pal_idx_offset..];
-                    *pal_idx_offset += (bw4 * bh4 * 16) as usize;
+                    let pal_idx = &f.frame_thread.pal_idx[frame_thread.pal_idx..];
+                    frame_thread.pal_idx += (bw4 * bh4 * 16) as usize;
                     pal_idx
                 } else {
                     &t.scratch.c2rust_unnamed_0.pal_idx
@@ -2907,8 +2906,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         let index = (((t.by >> 1) + (t.bx & 1)) as isize * (f.b4_stride >> 1)
                             + ((t.bx as isize >> 1) as isize + (t.by as isize & 1)) as isize)
                             as isize;
-                        let pal_idx_offset =
-                            (*ts).frame_thread[p as usize].pal_idx.as_mut().unwrap();
+                        let pal_idx_offset = &mut (*ts).frame_thread[p as usize].pal_idx;
                         let pal_idx = &f.frame_thread.pal_idx[*pal_idx_offset..];
                         *pal_idx_offset += (cbw4 * cbh4 * 16) as usize;
                         (&f.frame_thread.pal[index as usize], pal_idx)

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2521,18 +2521,16 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                 let dst: *mut BD::Pixel = (f.cur.data.data[0] as *mut BD::Pixel).offset(
                     (4 * (t.by as isize * BD::pxstride(f.cur.stride[0]) + t.bx as isize)) as isize,
                 );
-                let pal_idx: *const u8;
-                if t.frame_thread.pass != 0 {
+                let pal_idx = if t.frame_thread.pass != 0 {
                     let p = t.frame_thread.pass & 1;
-                    if ((*ts).frame_thread[p as usize].pal_idx).is_null() {
-                        unreachable!();
-                    }
-                    pal_idx = (*ts).frame_thread[p as usize].pal_idx;
-                    (*ts).frame_thread[p as usize].pal_idx =
-                        ((*ts).frame_thread[p as usize].pal_idx).offset((bw4 * bh4 * 16) as isize);
+                    let frame_thread = &mut (*ts).frame_thread[p as usize];
+                    let pal_idx_offset = frame_thread.pal_idx.as_mut().unwrap();
+                    let pal_idx = &f.frame_thread.pal_idx[*pal_idx_offset..];
+                    *pal_idx_offset += (bw4 * bh4 * 16) as usize;
+                    pal_idx
                 } else {
-                    pal_idx = (t.scratch.c2rust_unnamed_0.pal_idx).as_mut_ptr();
-                }
+                    &t.scratch.c2rust_unnamed_0.pal_idx
+                };
                 let pal: *const u16 = if t.frame_thread.pass != 0 {
                     let index = (((t.by as isize >> 1) + (t.bx as isize & 1)) * (f.b4_stride >> 1)
                         + ((t.bx >> 1) + (t.by & 1)) as isize)
@@ -2545,7 +2543,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     dst,
                     f.cur.stride[0],
                     pal,
-                    pal_idx,
+                    pal_idx.as_ptr(),
                     bw4 * 4,
                     bh4 * 4,
                 );
@@ -2904,41 +2902,35 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     let uv_dstoff: ptrdiff_t = 4
                         * ((t.bx >> ss_hor) as isize
                             + (t.by >> ss_ver) as isize * BD::pxstride(f.cur.stride[1]));
-                    let pal: *const [u16; 8];
-                    let pal_idx: *const u8;
-                    if t.frame_thread.pass != 0 {
+                    let (pal, pal_idx) = if t.frame_thread.pass != 0 {
                         let p = t.frame_thread.pass & 1;
-                        if ((*ts).frame_thread[p as usize].pal_idx).is_null() {
-                            unreachable!();
-                        }
                         let index = (((t.by >> 1) + (t.bx & 1)) as isize * (f.b4_stride >> 1)
                             + ((t.bx as isize >> 1) as isize + (t.by as isize & 1)) as isize)
                             as isize;
-                        pal = &f.frame_thread.pal[index as usize][0] as *const [u16; 8];
-                        pal_idx = (*ts).frame_thread[p as usize].pal_idx;
-                        (*ts).frame_thread[p as usize].pal_idx = ((*ts).frame_thread[p as usize]
-                            .pal_idx)
-                            .offset((cbw4 * cbh4 * 16) as isize);
+                        let pal_idx_offset =
+                            (*ts).frame_thread[p as usize].pal_idx.as_mut().unwrap();
+                        let pal_idx = &f.frame_thread.pal_idx[*pal_idx_offset..];
+                        *pal_idx_offset += (cbw4 * cbh4 * 16) as usize;
+                        (&f.frame_thread.pal[index as usize], pal_idx)
                     } else {
-                        pal = (t.scratch.c2rust_unnamed_0.pal).as_mut_ptr() as *const [u16; 8];
-                        pal_idx = &mut *(t.scratch.c2rust_unnamed_0.pal_idx)
-                            .as_mut_ptr()
-                            .offset((bw4 * bh4 * 16) as isize)
-                            as *mut u8;
-                    }
+                        (
+                            &t.scratch.c2rust_unnamed_0.pal,
+                            &t.scratch.c2rust_unnamed_0.pal_idx[(bw4 * bh4 * 16) as usize..],
+                        )
+                    };
                     (*f.dsp).ipred.pal_pred.call::<BD>(
                         (f.cur.data.data[1] as *mut BD::Pixel).offset(uv_dstoff as isize),
                         f.cur.stride[1],
-                        (*pal.offset(1)).as_ptr(),
-                        pal_idx,
+                        pal[1].as_ptr(),
+                        pal_idx.as_ptr(),
                         cbw4 * 4,
                         cbh4 * 4,
                     );
                     (*f.dsp).ipred.pal_pred.call::<BD>(
                         (f.cur.data.data[2] as *mut BD::Pixel).offset(uv_dstoff as isize),
                         f.cur.stride[1],
-                        (*pal.offset(2)).as_ptr(),
-                        pal_idx,
+                        pal[2].as_ptr(),
+                        pal_idx.as_ptr(),
                         cbw4 * 4,
                         cbh4 * 4,
                     );


### PR DESCRIPTION
The first commit converts the field to an `Option<usize>` because the pointer was being set to null in one case. However all usages of `pal_idx` were asserting that it's not null before using, so I don't think making this an `Option` is actually necessary. The second commit removes the `Option`, but I left it as a separate commit in case it's problematic for some reason I'm missing.