### PR TITLE
Reset debug to defaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,13 +45,6 @@ asm = []
 bitdepth_8 = []
 bitdepth_16 = []
 
-[profile.dev]
-# FIXME: The unoptimized build is currently broken since macros generate references
-# to 16bpc variants of assembly routines although only 8bpc versions exist. Until then
-# debugging will not work correctly. Remove once problem described here is resolved
-# https://github.com/memorysafety/rav1d/pull/613#issuecomment-1846949481
-opt-level = 1
-
 [profile.opt-dev]
 # The debug builds run tests very slowly so this profile keeps debug assertions
 # while enabling basic optimizations. The profile is not suitable for debugging.

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -40,7 +40,11 @@ use std::slice;
 use strum::FromRepr;
 
 #[cfg(feature = "asm")]
-use crate::{include::common::bitdepth::bd_fn, src::cpu::rav1d_get_cpu_flags, src::cpu::CpuFlags};
+use crate::{
+    include::common::bitdepth::{bd_fn, bpc_fn},
+    src::cpu::rav1d_get_cpu_flags,
+    src::cpu::CpuFlags,
+};
 
 wrap_fn_ptr!(pub unsafe extern "C" fn angular_ipred(
     dst: *mut DynPixel,
@@ -2125,17 +2129,17 @@ fn intra_pred_dsp_init_x86<BD: BitDepth>(c: &mut Rav1dIntraPredDSPContext) {
 
         if BD::BPC == BPC::BPC8 {
             c.intra_pred[DC_PRED as usize] =
-                bd_fn!(angular_ipred::decl_fn, BD, ipred_dc, avx512icl);
+                bpc_fn!(angular_ipred::decl_fn, 8 bpc, ipred_dc, avx512icl);
             c.intra_pred[DC_128_PRED as usize] =
-                bd_fn!(angular_ipred::decl_fn, BD, ipred_dc_128, avx512icl);
+                bpc_fn!(angular_ipred::decl_fn, 8 bpc, ipred_dc_128, avx512icl);
             c.intra_pred[TOP_DC_PRED as usize] =
-                bd_fn!(angular_ipred::decl_fn, BD, ipred_dc_top, avx512icl);
+                bpc_fn!(angular_ipred::decl_fn, 8 bpc, ipred_dc_top, avx512icl);
             c.intra_pred[LEFT_DC_PRED as usize] =
-                bd_fn!(angular_ipred::decl_fn, BD, ipred_dc_left, avx512icl);
+                bpc_fn!(angular_ipred::decl_fn, 8 bpc, ipred_dc_left, avx512icl);
             c.intra_pred[HOR_PRED as usize] =
-                bd_fn!(angular_ipred::decl_fn, BD, ipred_h, avx512icl);
+                bpc_fn!(angular_ipred::decl_fn, 8 bpc, ipred_h, avx512icl);
             c.intra_pred[VERT_PRED as usize] =
-                bd_fn!(angular_ipred::decl_fn, BD, ipred_v, avx512icl);
+                bpc_fn!(angular_ipred::decl_fn, 8 bpc, ipred_v, avx512icl);
         }
 
         c.intra_pred[PAETH_PRED as usize] =


### PR DESCRIPTION
Fixes situations where debug builds wouldn't link without dead code elimination and resets debug builds to the defaults.