### PR TITLE
`struct Rav1dTileState_frame_thread::cf`: Make into offset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +129,7 @@ dependencies = [
  "raw-cpuid",
  "strum",
  "to_method",
+ "zerocopy",
 ]
 
 [[package]]
@@ -195,3 +202,24 @@ name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ paste = "1.0.14"
 raw-cpuid = "11.0.1"
 strum = { version = "0.25.0", features = ["derive"] }
 to_method = "1.1.0"
+zerocopy = "0.7.32"
 
 [build-dependencies]
 cc = "1.0.79"

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,7 +1,6 @@
 use crate::include::common::attributes::ctz;
 use crate::include::common::bitdepth::BitDepth16;
 use crate::include::common::bitdepth::BitDepth8;
-use crate::include::common::bitdepth::DynCoef;
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::bitdepth::BPC;
 use crate::include::common::intops::apply_sign64;
@@ -185,7 +184,6 @@ use crate::src::warpmv::rav1d_get_shear_params;
 use crate::src::warpmv::rav1d_set_affine_mv2d;
 use libc::malloc;
 use libc::ptrdiff_t;
-use libc::uintptr_t;
 use std::array;
 use std::cmp;
 use std::ffi::c_int;
@@ -3622,9 +3620,11 @@ unsafe fn decode_sb(
                             // In 8-bit mode with 2-pass decoding the coefficient buffer
                             // can end up misaligned due to skips here.
                             // Work around the issue by explicitly realigning the buffer.
+                            //
+                            // In 8-bit mode coef is 2 bytes wide, so we align to 32
+                            // elements to get 64 byte alignment.
                             let p = (t.frame_thread.pass & 1) as usize;
-                            ts.frame_thread[p].cf =
-                                (((ts.frame_thread[p].cf as uintptr_t) + 63) & !63) as *mut DynCoef;
+                            ts.frame_thread[p].cf = (ts.frame_thread[p].cf + 31) & !31;
                         }
                     }
                     Some(next_bl) => {
@@ -3907,12 +3907,10 @@ unsafe fn setup_tile(
             0
         };
         ts.frame_thread[p].cf = if !f.frame_thread.cf.is_empty() {
-            f.frame_thread.cf
-                [(tile_start_off * size_mul[0] as usize >> (seq_hdr.hbd == 0) as c_int) as usize..]
-                .as_ptr()
-                .cast::<DynCoef>() as *mut _
+            let bpc = BPC::from_bitdepth_max(f.bitdepth_max);
+            bpc.coef_stride(tile_start_off * size_mul[0] as usize >> (seq_hdr.hbd == 0) as c_int)
         } else {
-            ptr::null_mut()
+            0
         };
     }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -3,7 +3,6 @@ use crate::include::common::bitdepth::BitDepth16;
 use crate::include::common::bitdepth::BitDepth8;
 use crate::include::common::bitdepth::BitDepthDependentType;
 use crate::include::common::bitdepth::BitDepthUnion;
-use crate::include::common::bitdepth::DynCoef;
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::bitdepth::BPC;
 use crate::include::dav1d::common::Rav1dDataProps;
@@ -376,7 +375,7 @@ impl Rav1dFrameContext_bd_fn {
 
     pub unsafe fn recon_b_intra(
         &self,
-        f: &Rav1dFrameData,
+        f: &mut Rav1dFrameData,
         context: &mut Rav1dTaskContext,
         block_size: BlockSize,
         flags: EdgeFlags,
@@ -747,7 +746,7 @@ pub struct Rav1dTileState_tiling {
 #[repr(C)]
 pub struct Rav1dTileState_frame_thread {
     pub pal_idx: usize, // Offset into `f.frame_thread.pal_idx`
-    pub cf: *mut DynCoef,
+    pub cf: usize,      // Offset into `f.frame_thread.cf`
 }
 
 #[repr(C)]


### PR DESCRIPTION
To avoid borrow checker issues I modified `decode_coefs` to use a new `CfSelect` enum to determine which of the two possible coef bufs to use. I also added coef versions of `pxstride` and `cast_pixel_slice` so that I could correctly convert between byte offsets and coef offsets.

I also had to make a couple of functions take a `&mut Rav1dFrameData` (previously they were taking a shared reference) in order to get mutable access to the coef buffers. @rinon does this conflict with your current work? 