### PR TITLE
`struct Rav1dTaskContext::ts`: Make into an offset

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -894,7 +894,7 @@ impl Rav1dTaskContext_task_thread {
 
 #[repr(C)]
 pub(crate) struct Rav1dTaskContext {
-    pub ts: *mut Rav1dTileState,
+    pub ts: usize, // Index into `f.ts`
     pub bx: c_int,
     pub by: c_int,
     pub l: BlockContext,
@@ -922,7 +922,7 @@ pub(crate) struct Rav1dTaskContext {
 impl Rav1dTaskContext {
     pub(crate) unsafe fn new(task_thread: Arc<Rav1dTaskContext_task_thread>) -> Self {
         Self {
-            ts: ptr::null_mut(),
+            ts: 0,
             bx: 0,
             by: 0,
             l: mem::zeroed(),

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1062,7 +1062,7 @@ pub unsafe fn rav1d_worker_task(c: &Rav1dContext, task_thread: Arc<Rav1dTaskCont
                             .unwrap();
                         let ts_0: *mut Rav1dTileState =
                             &mut *(f.ts).offset(tile_idx as isize) as *mut Rav1dTileState;
-                        tc.ts = ts_0;
+                        tc.ts = tile_idx;
                         tc.by = sby << f.sb_shift;
                         let uses_2pass = (c.n_fc > 1 as c_uint) as c_int;
                         tc.frame_thread.pass = if uses_2pass == 0 {


### PR DESCRIPTION
I mildly regret turning all the `(*ts)` into `ts` because it makes the diff very noisy, apologies for that. If I run into a similar situation for future fields I'll break the cleanup into a separate PR.

* Part of #716