### PR TITLE
`struct CodedBlockInfo`: Make cbi elements atomic

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -82,6 +82,7 @@ use crate::src::refmvs::Rav1dRefmvsDSPContext;
 use crate::src::refmvs::RefMvsFrame;
 use crate::src::unstable_extensions::as_chunks;
 use crate::src::unstable_extensions::as_chunks_mut;
+use atomig::Atom;
 use atomig::Atomic;
 use libc::ptrdiff_t;
 use std::cell::UnsafeCell;
@@ -423,7 +424,7 @@ impl Rav1dFrameContext_bd_fn {
     }
 }
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, Atom)]
 pub struct CodedBlockInfo(i16);
 
 impl CodedBlockInfo {
@@ -482,7 +483,7 @@ pub struct Rav1dFrameContext_frame_thread {
     /// Indexed using `t.b.y * f.b4_stride + t.b.x`.
     pub b: Vec<Av1Block>,
 
-    pub cbi: Vec<[CodedBlockInfo; 3]>,
+    pub cbi: Vec<[Atomic<CodedBlockInfo>; 3]>,
 
     /// Indexed using `(t.b.y >> 1) * (f.b4_stride >> 1) + (t.b.x >> 1)`.
     /// Inner indices are `[3 plane][8 idx]`.


### PR DESCRIPTION
Elements in the `cbi` field are actually `i16`s, so we can make them atomic for inner mutability rather than having to use a lock.