### PR TITLE
`struct Av1Restoration`: Replace `Cell` with `RwLock`

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3748,15 +3748,14 @@ unsafe fn setup_tile(
             &f.lf.lr_mask[sb_idx as usize].lr[p][unit_idx as usize]
         };
 
-        let lr = lr_ref.get();
-        let lr = Av1RestorationUnit {
+        let mut lr = lr_ref.try_write().unwrap();
+        *lr = Av1RestorationUnit {
             filter_v: [3, -7, 15],
             filter_h: [3, -7, 15],
             sgr_weights: [-32, 31],
-            ..lr
+            ..*lr
         };
-        lr_ref.set(lr);
-        ts.lr_ref[p] = lr;
+        ts.lr_ref[p] = *lr;
     }
 
     if c.tc.len() > 1 {
@@ -4012,9 +4011,11 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
                     let px_x = x << unit_size_log2 + ss_hor;
                     let sb_idx = (t.b.y >> 5) * f.sr_sb128w + (px_x >> 7);
                     let unit_idx = ((t.b.y & 16) >> 3) + ((px_x & 64) >> 6);
-                    let lr = f.lf.lr_mask[sb_idx as usize].lr[p][unit_idx as usize].get_mut();
+                    let mut lr = f.lf.lr_mask[sb_idx as usize].lr[p][unit_idx as usize]
+                        .try_write()
+                        .unwrap();
 
-                    read_restoration_info(ts, lr, p, frame_type, debug_block_info!(f, t.b));
+                    read_restoration_info(ts, &mut lr, p, frame_type, debug_block_info!(f, t.b));
                 }
             } else {
                 let x = 4 * t.b.x >> ss_hor;
@@ -4029,9 +4030,11 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
                 }
                 let sb_idx = (t.b.y >> 5) * f.sr_sb128w + (t.b.x >> 5);
                 let unit_idx = ((t.b.y & 16) >> 3) + ((t.b.x & 16) >> 4);
-                let lr = f.lf.lr_mask[sb_idx as usize].lr[p][unit_idx as usize].get_mut();
+                let mut lr = f.lf.lr_mask[sb_idx as usize].lr[p][unit_idx as usize]
+                    .try_write()
+                    .unwrap();
 
-                read_restoration_info(ts, lr, p, frame_type, debug_block_info!(f, t.b));
+                read_restoration_info(ts, &mut lr, p, frame_type, debug_block_info!(f, t.b));
             }
         }
         decode_sb(c, t, f, root_bl, EdgeIndex::root())?;

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -13,12 +13,12 @@ use crate::src::levels::TX_4X4;
 use crate::src::tables::dav1d_block_dimensions;
 use crate::src::tables::dav1d_txfm_dimensions;
 use libc::ptrdiff_t;
-use std::cell::Cell;
 use std::cmp;
 use std::ffi::c_int;
 use std::sync::atomic::AtomicI8;
 use std::sync::atomic::AtomicU16;
 use std::sync::atomic::Ordering;
+use std::sync::RwLock;
 
 #[repr(C)]
 pub struct Av1FilterLUT {
@@ -54,7 +54,7 @@ pub struct Av1Filter {
 #[derive(Default)]
 #[repr(C)]
 pub struct Av1Restoration {
-    pub lr: [[Cell<Av1RestorationUnit>; 4]; 3],
+    pub lr: [[RwLock<Av1RestorationUnit>; 4]; 3],
 }
 
 /// In `txa`, the array lengths represent from inner to outer:

--- a/src/lr_apply.rs
+++ b/src/lr_apply.rs
@@ -193,16 +193,19 @@ unsafe fn lr_sbrow<BD: BitDepth>(
     aligned_unit_pos <<= ss_ver;
     let sb_idx = (aligned_unit_pos >> 7) * f.sr_sb128w;
     let unit_idx = (aligned_unit_pos >> 6 & 1) << 1;
-    lr[0] = f.lf.lr_mask[sb_idx as usize].lr[plane as usize][unit_idx as usize].get();
+    lr[0] = *f.lf.lr_mask[sb_idx as usize].lr[plane as usize][unit_idx as usize]
+        .try_read()
+        .unwrap();
     let mut restore = lr[0].r#type != Rav1dRestorationType::None;
     let mut x = 0;
     let mut bit = false;
     while x + max_unit_size <= w {
         let next_x = x + unit_size;
         let next_u_idx = unit_idx + (next_x >> shift_hor - 1 & 1);
-        lr[!bit as usize] = f.lf.lr_mask[(sb_idx + (next_x >> shift_hor)) as usize].lr
+        lr[!bit as usize] = *f.lf.lr_mask[(sb_idx + (next_x >> shift_hor)) as usize].lr
             [plane as usize][next_u_idx as usize]
-            .get();
+            .try_read()
+            .unwrap();
         let restore_next = lr[!bit as usize].r#type != Rav1dRestorationType::None;
         if restore_next {
             backup4xU::<BD>(


### PR DESCRIPTION
`Rav1dFrameContext_lf::lr_mask` is shared across threads, and therefore must be a thread-safe `Sync` type. This changes replaces an existing usage of `Cell` to provide interior mutability with non-blocking usage of `RwLock`.