### PR TITLE
`fn get_cur_frame_segid`: Remove negative offsets

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1630,8 +1630,14 @@ unsafe fn decode_b_inner(
                     b.seg_id = 0;
                 }
             } else {
-                let (pred_seg_id, seg_ctx) =
-                    get_cur_frame_segid(t.by, t.bx, have_top, have_left, f.cur_segmap, f.b4_stride);
+                let (pred_seg_id, seg_ctx) = get_cur_frame_segid(
+                    t.by,
+                    t.bx,
+                    have_top,
+                    have_left,
+                    f.cur_segmap,
+                    f.b4_stride as usize,
+                );
                 let diff = rav1d_msac_decode_symbol_adapt8(
                     &mut ts.msac,
                     &mut ts.cdf.m.seg_id[seg_ctx as usize],
@@ -1714,8 +1720,14 @@ unsafe fn decode_b_inner(
                 b.seg_id = 0;
             }
         } else {
-            let (pred_seg_id, seg_ctx) =
-                get_cur_frame_segid(t.by, t.bx, have_top, have_left, f.cur_segmap, f.b4_stride);
+            let (pred_seg_id, seg_ctx) = get_cur_frame_segid(
+                t.by,
+                t.bx,
+                have_top,
+                have_left,
+                f.cur_segmap,
+                f.b4_stride as usize,
+            );
             if b.skip != 0 {
                 b.seg_id = pred_seg_id as u8;
             } else {

--- a/src/env.rs
+++ b/src/env.rs
@@ -607,29 +607,23 @@ pub unsafe fn get_cur_frame_segid(
     let negative_adjustment = have_left as usize + have_top as usize * stride.unsigned_abs();
     cur_seg_map = cur_seg_map
         .add((bx as isize + by as isize * stride - negative_adjustment as isize) as usize);
-    if have_left && have_top {
-        let l = *cur_seg_map.add(stride.unsigned_abs());
-        let a = *cur_seg_map.add(1);
-        let al = *cur_seg_map.add(0);
-        let seg_ctx = if l == a && al == l {
-            2
-        } else if l == a || al == l || a == al {
-            1
-        } else {
-            0
-        };
-        let seg_id = if a == al { a } else { l };
-        (seg_id, seg_ctx)
-    } else {
-        let seg_ctx = 0;
-        let seg_id = if have_left {
-            *cur_seg_map.add(0)
-        } else if have_top {
-            *cur_seg_map.add(0)
-        } else {
-            0
-        };
-        (seg_id, seg_ctx)
+    match (have_left, have_top) {
+        (true, true) => {
+            let l = *cur_seg_map.add(stride.unsigned_abs());
+            let a = *cur_seg_map.add(1);
+            let al = *cur_seg_map.add(0);
+            let seg_ctx = if l == a && al == l {
+                2
+            } else if l == a || al == l || a == al {
+                1
+            } else {
+                0
+            };
+            let seg_id = if a == al { a } else { l };
+            (seg_id, seg_ctx)
+        }
+        (true, false) | (false, true) => (*cur_seg_map.add(0), 0),
+        (false, false) => (0, 0),
     }
 }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -20,7 +20,6 @@ use crate::src::levels::V_ADST;
 use crate::src::levels::V_FLIPADST;
 use crate::src::refmvs::refmvs_candidate;
 use crate::src::tables::TxfmInfo;
-use libc::ptrdiff_t;
 use std::cmp;
 use std::cmp::Ordering;
 use std::ffi::c_int;
@@ -601,15 +600,14 @@ pub unsafe fn get_cur_frame_segid(
     // and it comes from [`Dav1dFrameContext::cur_segmap`],
     // which is set to [`Dav1dFrameContext::cur_segmap_ref`] and [`Dav1dFrameContext::prev_segmap_ref`],
     // which are [`Dav1dRef`]s, which have no size and are refcounted.
-    mut cur_seg_map: *const u8,
-    stride: ptrdiff_t,
+    cur_seg_map: *const u8,
+    stride: usize,
 ) -> (u8, u8) {
-    let negative_adjustment = have_left as usize + have_top as usize * stride.unsigned_abs();
-    cur_seg_map = cur_seg_map
-        .add((bx as isize + by as isize * stride - negative_adjustment as isize) as usize);
+    let negative_adjustment = have_left as usize + have_top as usize * stride;
+    let cur_seg_map = cur_seg_map.add(bx as usize + by as usize * stride - negative_adjustment);
     match (have_left, have_top) {
         (true, true) => {
-            let l = *cur_seg_map.add(stride.unsigned_abs());
+            let l = *cur_seg_map.add(stride);
             let a = *cur_seg_map.add(1);
             let al = *cur_seg_map.add(0);
             let seg_ctx = if l == a && al == l {

--- a/src/env.rs
+++ b/src/env.rs
@@ -604,11 +604,13 @@ pub unsafe fn get_cur_frame_segid(
     mut cur_seg_map: *const u8,
     stride: ptrdiff_t,
 ) -> (u8, u8) {
-    cur_seg_map = cur_seg_map.offset(bx as isize + by as isize * stride);
+    let negative_adjustment = have_left as usize + have_top as usize * stride.unsigned_abs();
+    cur_seg_map = cur_seg_map
+        .add((bx as isize + by as isize * stride - negative_adjustment as isize) as usize);
     if have_left && have_top {
-        let l = *cur_seg_map.offset(-1);
-        let a = *cur_seg_map.offset(-stride as isize);
-        let al = *cur_seg_map.offset(-(stride + 1) as isize);
+        let l = *cur_seg_map.add(stride.unsigned_abs());
+        let a = *cur_seg_map.add(1);
+        let al = *cur_seg_map.add(0);
         let seg_ctx = if l == a && al == l {
             2
         } else if l == a || al == l || a == al {
@@ -621,9 +623,9 @@ pub unsafe fn get_cur_frame_segid(
     } else {
         let seg_ctx = 0;
         let seg_id = if have_left {
-            *cur_seg_map.offset(-1)
+            *cur_seg_map.add(0)
         } else if have_top {
-            *cur_seg_map.offset(-stride as isize)
+            *cur_seg_map.add(0)
         } else {
             0
         };


### PR DESCRIPTION
`fn get_cur_frame_segid` is always called with a whole slice (or will be once segmaps are `Arc`anized), so we only have to worry about negative offsets within this `fn`.  I think this should work for negative strides?

Actually `stride` can't be negative here.