### PR TITLE
Abort on panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ asm = []
 bitdepth_8 = []
 bitdepth_16 = []
 
+[profile.dev]
+panic = "abort"
+
 [profile.opt-dev]
 # The debug builds run tests very slowly so this profile keeps debug assertions
 # while enabling basic optimizations. The profile is not suitable for debugging.
@@ -53,3 +56,4 @@ opt-level = 1
 
 [profile.release]
 codegen-units = 1
+panic = "abort"


### PR DESCRIPTION
Currently tests hang if a thread panics, meaning that if a lot of tests panic CI can hang for a long time. For testing purposes we just want to abort on panic to ensure we get quick test output in those cases.