### PR TITLE
`fn rav1d_refmvs_init_frame`: Cleanup

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4585,7 +4585,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
             &f.refpoc,
             f.mvs,
             &f.refrefpoc,
-            f.ref_mvs.as_ptr(),
+            &f.ref_mvs,
             c.tc.len() as c_int,
             c.n_fc as c_int,
         );

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4584,7 +4584,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
             frame_hdr,
             &f.refpoc,
             f.mvs,
-            f.refrefpoc.as_ptr(),
+            &f.refrefpoc,
             f.ref_mvs.as_ptr(),
             c.tc.len() as c_int,
             c.n_fc as c_int,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4586,8 +4586,8 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
             f.mvs,
             &f.refrefpoc,
             &f.ref_mvs,
-            c.tc.len() as c_int,
-            c.n_fc as c_int,
+            c.tc.len(),
+            c.n_fc as usize,
         )?;
     }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4582,7 +4582,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
             &mut f.rf,
             seq_hdr,
             frame_hdr,
-            f.refpoc.as_ptr(),
+            &f.refpoc,
             f.mvs,
             f.refrefpoc.as_ptr(),
             f.ref_mvs.as_ptr(),

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4578,7 +4578,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
 
     // init ref mvs
     if frame_hdr.frame_type.is_inter_or_switch() || frame_hdr.allow_intrabc {
-        let ret = rav1d_refmvs_init_frame(
+        rav1d_refmvs_init_frame(
             &mut f.rf,
             seq_hdr,
             frame_hdr,
@@ -4588,10 +4588,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
             &f.ref_mvs,
             c.tc.len() as c_int,
             c.n_fc as c_int,
-        );
-        if ret.is_err() {
-            return Err(ENOMEM);
-        }
+        )?;
     }
 
     // setup dequant tables

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1430,7 +1430,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
     rf.ih8 = frm_hdr.size.height + 7 >> 3;
     rf.iw4 = rf.iw8 << 1;
     rf.ih4 = rf.ih8 << 1;
-    let r_stride: ptrdiff_t = ((frm_hdr.size.width[0] + 127 & !(127 as c_int)) >> 2) as ptrdiff_t;
+    let r_stride = ((frm_hdr.size.width[0] + 127 & !(127 as c_int)) >> 2) as ptrdiff_t;
     let n_tile_rows = if n_tile_threads > 1 {
         frm_hdr.tiling.rows
     } else {
@@ -1454,7 +1454,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
         }
         rf.r_stride = r_stride;
     }
-    let rp_stride: ptrdiff_t = r_stride >> 1;
+    let rp_stride = r_stride >> 1;
     if rp_stride != rf.rp_stride || n_tile_rows != rf.n_tile_rows {
         if !(rf.rp_proj).is_null() {
             rav1d_freep_aligned(&mut rf.rp_proj as *mut *mut refmvs_temporal_block as *mut c_void);
@@ -1476,7 +1476,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
     rf.n_frame_threads = n_frame_threads;
     rf.rp = rp;
     rf.rp_ref = rp_ref.as_ptr();
-    let poc: c_uint = frm_hdr.frame_offset as c_uint;
+    let poc = frm_hdr.frame_offset as c_uint;
     let mut i = 0;
     while i < 7 {
         let poc_diff = get_poc_diff(
@@ -1547,7 +1547,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
         }
         let mut n = 0;
         while n < rf.n_mfmvs {
-            let rpoc: c_uint = ref_poc[rf.mfmv_ref[n as usize] as usize];
+            let rpoc = ref_poc[rf.mfmv_ref[n as usize] as usize];
             let diff1 = get_poc_diff(
                 seq_hdr.order_hint_n_bits,
                 rpoc as c_int,
@@ -1563,7 +1563,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
                 };
                 let mut m = 0;
                 while m < 7 {
-                    let rrpoc: c_uint = ref_ref_poc[rf.mfmv_ref[n as usize] as usize][m as usize];
+                    let rrpoc = ref_ref_poc[rf.mfmv_ref[n as usize] as usize][m as usize];
                     let diff2 =
                         get_poc_diff(seq_hdr.order_hint_n_bits, rpoc as c_int, rrpoc as c_int);
                     rf.mfmv_ref2ref[n as usize][m as usize] = if diff2 as c_uint > 31 as c_uint {

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1437,7 +1437,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
         1
     };
     if r_stride != rf.r_stride || n_tile_rows != rf.n_tile_rows {
-        if !(rf.r).is_null() {
+        if !rf.r.is_null() {
             rav1d_freep_aligned(&mut rf.r as *mut *mut refmvs_block as *mut c_void);
         }
         let uses_2pass = (n_tile_threads > 1 && n_frame_threads > 1) as c_int;
@@ -1449,14 +1449,14 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
                 .wrapping_mul((1 + uses_2pass) as usize),
             64,
         ) as *mut refmvs_block;
-        if (rf.r).is_null() {
+        if rf.r.is_null() {
             return Err(ENOMEM);
         }
         rf.r_stride = r_stride;
     }
     let rp_stride = r_stride >> 1;
     if rp_stride != rf.rp_stride || n_tile_rows != rf.n_tile_rows {
-        if !(rf.rp_proj).is_null() {
+        if !rf.rp_proj.is_null() {
             rav1d_freep_aligned(&mut rf.rp_proj as *mut *mut refmvs_temporal_block as *mut c_void);
         }
         rf.rp_proj = rav1d_alloc_aligned(
@@ -1466,7 +1466,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
                 .wrapping_mul(n_tile_rows as usize),
             64,
         ) as *mut refmvs_temporal_block;
-        if (rf.rp_proj).is_null() {
+        if rf.rp_proj.is_null() {
             return Err(ENOMEM);
         }
         rf.rp_stride = rp_stride;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1419,7 +1419,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
     frm_hdr: &Rav1dFrameHeader,
     ref_poc: &[c_uint; 7],
     rp: *mut refmvs_temporal_block,
-    ref_ref_poc: *const [c_uint; 7],
+    ref_ref_poc: &[[c_uint; 7]; 7],
     rp_ref: *const *mut refmvs_temporal_block,
     n_tile_threads: c_int,
     n_frame_threads: c_int,
@@ -1500,7 +1500,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
     rf.n_mfmvs = 0 as c_int;
     if frm_hdr.use_ref_frame_mvs != 0 && seq_hdr.order_hint_n_bits != 0 {
         let mut total = 2;
-        if !(*rp_ref.offset(0)).is_null() && (*ref_ref_poc.offset(0))[6] != ref_poc[3] {
+        if !(*rp_ref.offset(0)).is_null() && ref_ref_poc[0][6] != ref_poc[3] {
             let fresh12 = rf.n_mfmvs;
             rf.n_mfmvs = rf.n_mfmvs + 1;
             rf.mfmv_ref[fresh12 as usize] = 0 as c_int as u8;
@@ -1563,8 +1563,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
                 };
                 let mut m = 0;
                 while m < 7 {
-                    let rrpoc: c_uint =
-                        (*ref_ref_poc.offset(rf.mfmv_ref[n as usize] as isize))[m as usize];
+                    let rrpoc: c_uint = ref_ref_poc[rf.mfmv_ref[n as usize] as usize][m as usize];
                     let diff2 =
                         get_poc_diff(seq_hdr.order_hint_n_bits, rpoc as c_int, rrpoc as c_int);
                     rf.mfmv_ref2ref[n as usize][m as usize] = if diff2 as c_uint > 31 as c_uint {

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1417,7 +1417,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
     rf: &mut refmvs_frame,
     seq_hdr: &Rav1dSequenceHeader,
     frm_hdr: &Rav1dFrameHeader,
-    ref_poc: *const c_uint,
+    ref_poc: &[c_uint; 7],
     rp: *mut refmvs_temporal_block,
     ref_ref_poc: *const [c_uint; 7],
     rp_ref: *const *mut refmvs_temporal_block,
@@ -1481,7 +1481,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
     while i < 7 {
         let poc_diff = get_poc_diff(
             seq_hdr.order_hint_n_bits,
-            *ref_poc.offset(i as isize) as c_int,
+            ref_poc[i as usize] as c_int,
             poc as c_int,
         );
         rf.sign_bias[i as usize] = (poc_diff > 0) as c_int as u8;
@@ -1490,7 +1490,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
             get_poc_diff(
                 seq_hdr.order_hint_n_bits,
                 poc as c_int,
-                *ref_poc.offset(i as isize) as c_int,
+                ref_poc[i as usize] as c_int,
             ),
             -(31 as c_int),
             31 as c_int,
@@ -1500,7 +1500,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
     rf.n_mfmvs = 0 as c_int;
     if frm_hdr.use_ref_frame_mvs != 0 && seq_hdr.order_hint_n_bits != 0 {
         let mut total = 2;
-        if !(*rp_ref.offset(0)).is_null() && (*ref_ref_poc.offset(0))[6] != *ref_poc.offset(3) {
+        if !(*rp_ref.offset(0)).is_null() && (*ref_ref_poc.offset(0))[6] != ref_poc[3] {
             let fresh12 = rf.n_mfmvs;
             rf.n_mfmvs = rf.n_mfmvs + 1;
             rf.mfmv_ref[fresh12 as usize] = 0 as c_int as u8;
@@ -1509,7 +1509,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
         if !(*rp_ref.offset(4)).is_null()
             && get_poc_diff(
                 seq_hdr.order_hint_n_bits,
-                *ref_poc.offset(4) as c_int,
+                ref_poc[4] as c_int,
                 frm_hdr.frame_offset,
             ) > 0
         {
@@ -1520,7 +1520,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
         if !(*rp_ref.offset(5)).is_null()
             && get_poc_diff(
                 seq_hdr.order_hint_n_bits,
-                *ref_poc.offset(5) as c_int,
+                ref_poc[5] as c_int,
                 frm_hdr.frame_offset,
             ) > 0
         {
@@ -1532,7 +1532,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
             && !(*rp_ref.offset(6)).is_null()
             && get_poc_diff(
                 seq_hdr.order_hint_n_bits,
-                *ref_poc.offset(6) as c_int,
+                ref_poc[6] as c_int,
                 frm_hdr.frame_offset,
             ) > 0
         {
@@ -1547,7 +1547,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
         }
         let mut n = 0;
         while n < rf.n_mfmvs {
-            let rpoc: c_uint = *ref_poc.offset(rf.mfmv_ref[n as usize] as isize);
+            let rpoc: c_uint = ref_poc[rf.mfmv_ref[n as usize] as usize];
             let diff1 = get_poc_diff(
                 seq_hdr.order_hint_n_bits,
                 rpoc as c_int,

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1421,8 +1421,8 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
     rp: *mut refmvs_temporal_block,
     ref_ref_poc: &[[c_uint; 7]; 7],
     rp_ref: &[*mut refmvs_temporal_block; 7],
-    n_tile_threads: c_int,
-    n_frame_threads: c_int,
+    n_tile_threads: usize,
+    n_frame_threads: usize,
 ) -> Rav1dResult {
     rf.sbsz = 16 << seq_hdr.sb128;
     rf.frm_hdr = ptr::null();
@@ -1474,8 +1474,8 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
         rf.rp_stride = rp_stride;
     }
     rf.n_tile_rows = n_tile_rows;
-    rf.n_tile_threads = n_tile_threads;
-    rf.n_frame_threads = n_frame_threads;
+    rf.n_tile_threads = n_tile_threads as c_int;
+    rf.n_frame_threads = n_frame_threads as c_int;
     rf.rp = rp;
     rf.rp_ref = rp_ref.as_ptr();
     let poc = frm_hdr.frame_offset as c_uint;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1442,11 +1442,11 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
         }
         let uses_2pass = (n_tile_threads > 1 && n_frame_threads > 1) as c_int;
         rf.r = rav1d_alloc_aligned(
-            (::core::mem::size_of::<refmvs_block>())
-                .wrapping_mul(35)
-                .wrapping_mul(r_stride as usize)
-                .wrapping_mul(n_tile_rows as usize)
-                .wrapping_mul((1 + uses_2pass) as usize),
+            ::core::mem::size_of::<refmvs_block>()
+                * 35
+                * r_stride as usize
+                * n_tile_rows as usize
+                * (1 + uses_2pass) as usize,
             64,
         ) as *mut refmvs_block;
         if rf.r.is_null() {
@@ -1460,10 +1460,10 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
             rav1d_freep_aligned(&mut rf.rp_proj as *mut *mut refmvs_temporal_block as *mut c_void);
         }
         rf.rp_proj = rav1d_alloc_aligned(
-            (::core::mem::size_of::<refmvs_temporal_block>())
-                .wrapping_mul(16)
-                .wrapping_mul(rp_stride as usize)
-                .wrapping_mul(n_tile_rows as usize),
+            ::core::mem::size_of::<refmvs_temporal_block>()
+                * 16
+                * rp_stride as usize
+                * n_tile_rows as usize,
             64,
         ) as *mut refmvs_temporal_block;
         if rf.rp_proj.is_null() {

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1415,7 +1415,7 @@ unsafe extern "C" fn save_tmvs_c(
 
 pub(crate) unsafe fn rav1d_refmvs_init_frame(
     rf: &mut refmvs_frame,
-    seq_hdr: *const Rav1dSequenceHeader,
+    seq_hdr: &Rav1dSequenceHeader,
     frm_hdr: *const Rav1dFrameHeader,
     ref_poc: *const c_uint,
     rp: *mut refmvs_temporal_block,
@@ -1424,7 +1424,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
     n_tile_threads: c_int,
     n_frame_threads: c_int,
 ) -> Rav1dResult {
-    rf.sbsz = (16 as c_int) << (*seq_hdr).sb128;
+    rf.sbsz = (16 as c_int) << seq_hdr.sb128;
     rf.frm_hdr = ptr::null();
     rf.iw8 = (*frm_hdr).size.width[0] + 7 >> 3;
     rf.ih8 = (*frm_hdr).size.height + 7 >> 3;
@@ -1481,7 +1481,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
     let mut i = 0;
     while i < 7 {
         let poc_diff = get_poc_diff(
-            (*seq_hdr).order_hint_n_bits,
+            seq_hdr.order_hint_n_bits,
             *ref_poc.offset(i as isize) as c_int,
             poc as c_int,
         );
@@ -1489,7 +1489,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
         rf.mfmv_sign[i as usize] = (poc_diff < 0) as c_int as u8;
         rf.pocdiff[i as usize] = iclip(
             get_poc_diff(
-                (*seq_hdr).order_hint_n_bits,
+                seq_hdr.order_hint_n_bits,
                 poc as c_int,
                 *ref_poc.offset(i as isize) as c_int,
             ),
@@ -1499,7 +1499,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
         i += 1;
     }
     rf.n_mfmvs = 0 as c_int;
-    if (*frm_hdr).use_ref_frame_mvs != 0 && (*seq_hdr).order_hint_n_bits != 0 {
+    if (*frm_hdr).use_ref_frame_mvs != 0 && seq_hdr.order_hint_n_bits != 0 {
         let mut total = 2;
         if !(*rp_ref.offset(0)).is_null() && (*ref_ref_poc.offset(0))[6] != *ref_poc.offset(3) {
             let fresh12 = rf.n_mfmvs;
@@ -1509,7 +1509,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
         }
         if !(*rp_ref.offset(4)).is_null()
             && get_poc_diff(
-                (*seq_hdr).order_hint_n_bits,
+                seq_hdr.order_hint_n_bits,
                 *ref_poc.offset(4) as c_int,
                 (*frm_hdr).frame_offset,
             ) > 0
@@ -1520,7 +1520,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
         }
         if !(*rp_ref.offset(5)).is_null()
             && get_poc_diff(
-                (*seq_hdr).order_hint_n_bits,
+                seq_hdr.order_hint_n_bits,
                 *ref_poc.offset(5) as c_int,
                 (*frm_hdr).frame_offset,
             ) > 0
@@ -1532,7 +1532,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
         if rf.n_mfmvs < total
             && !(*rp_ref.offset(6)).is_null()
             && get_poc_diff(
-                (*seq_hdr).order_hint_n_bits,
+                seq_hdr.order_hint_n_bits,
                 *ref_poc.offset(6) as c_int,
                 (*frm_hdr).frame_offset,
             ) > 0
@@ -1550,7 +1550,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
         while n < rf.n_mfmvs {
             let rpoc: c_uint = *ref_poc.offset(rf.mfmv_ref[n as usize] as isize);
             let diff1 = get_poc_diff(
-                (*seq_hdr).order_hint_n_bits,
+                seq_hdr.order_hint_n_bits,
                 rpoc as c_int,
                 (*frm_hdr).frame_offset,
             );
@@ -1567,7 +1567,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
                     let rrpoc: c_uint =
                         (*ref_ref_poc.offset(rf.mfmv_ref[n as usize] as isize))[m as usize];
                     let diff2 =
-                        get_poc_diff((*seq_hdr).order_hint_n_bits, rpoc as c_int, rrpoc as c_int);
+                        get_poc_diff(seq_hdr.order_hint_n_bits, rpoc as c_int, rrpoc as c_int);
                     rf.mfmv_ref2ref[n as usize][m as usize] = if diff2 as c_uint > 31 as c_uint {
                         0 as c_int
                     } else {

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1477,8 +1477,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
     rf.rp = rp;
     rf.rp_ref = rp_ref.as_ptr();
     let poc = frm_hdr.frame_offset as c_uint;
-    let mut i = 0;
-    while i < 7 {
+    for i in 0..7 {
         let poc_diff = get_poc_diff(seq_hdr.order_hint_n_bits, ref_poc[i] as c_int, poc as c_int);
         rf.sign_bias[i] = (poc_diff > 0) as u8;
         rf.mfmv_sign[i] = (poc_diff < 0) as u8;
@@ -1487,7 +1486,6 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
             -31,
             31,
         ) as i8;
-        i += 1;
     }
     rf.n_mfmvs = 0;
     if frm_hdr.use_ref_frame_mvs != 0 && seq_hdr.order_hint_n_bits != 0 {
@@ -1532,8 +1530,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
             rf.mfmv_ref[rf.n_mfmvs as usize] = 1;
             rf.n_mfmvs += 1;
         }
-        let mut n = 0;
-        while n < rf.n_mfmvs as usize {
+        for n in 0..rf.n_mfmvs as usize {
             let rpoc = ref_poc[rf.mfmv_ref[n] as usize];
             let diff1 = get_poc_diff(
                 seq_hdr.order_hint_n_bits,
@@ -1544,17 +1541,14 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
                 rf.mfmv_ref2cur[n] = i32::MIN;
             } else {
                 rf.mfmv_ref2cur[n] = if rf.mfmv_ref[n] < 4 { -diff1 } else { diff1 };
-                let mut m = 0;
-                while m < 7 {
+                for m in 0..7 {
                     let rrpoc = ref_ref_poc[rf.mfmv_ref[n] as usize][m];
                     let diff2 =
                         get_poc_diff(seq_hdr.order_hint_n_bits, rpoc as c_int, rrpoc as c_int);
                     // unsigned comparison also catches the < 0 case
                     rf.mfmv_ref2ref[n][m] = if diff2 as c_uint > 31 { 0 } else { diff2 };
-                    m += 1;
                 }
             }
-            n += 1;
         }
     }
     rf.use_ref_frame_mvs = (rf.n_mfmvs > 0) as c_int;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1416,7 +1416,7 @@ unsafe extern "C" fn save_tmvs_c(
 pub(crate) unsafe fn rav1d_refmvs_init_frame(
     rf: &mut refmvs_frame,
     seq_hdr: &Rav1dSequenceHeader,
-    frm_hdr: *const Rav1dFrameHeader,
+    frm_hdr: &Rav1dFrameHeader,
     ref_poc: *const c_uint,
     rp: *mut refmvs_temporal_block,
     ref_ref_poc: *const [c_uint; 7],
@@ -1426,14 +1426,13 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
 ) -> Rav1dResult {
     rf.sbsz = (16 as c_int) << seq_hdr.sb128;
     rf.frm_hdr = ptr::null();
-    rf.iw8 = (*frm_hdr).size.width[0] + 7 >> 3;
-    rf.ih8 = (*frm_hdr).size.height + 7 >> 3;
+    rf.iw8 = frm_hdr.size.width[0] + 7 >> 3;
+    rf.ih8 = frm_hdr.size.height + 7 >> 3;
     rf.iw4 = rf.iw8 << 1;
     rf.ih4 = rf.ih8 << 1;
-    let r_stride: ptrdiff_t =
-        (((*frm_hdr).size.width[0] + 127 & !(127 as c_int)) >> 2) as ptrdiff_t;
+    let r_stride: ptrdiff_t = ((frm_hdr.size.width[0] + 127 & !(127 as c_int)) >> 2) as ptrdiff_t;
     let n_tile_rows = if n_tile_threads > 1 {
-        (*frm_hdr).tiling.rows
+        frm_hdr.tiling.rows
     } else {
         1 as c_int
     };
@@ -1477,7 +1476,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
     rf.n_frame_threads = n_frame_threads;
     rf.rp = rp;
     rf.rp_ref = rp_ref;
-    let poc: c_uint = (*frm_hdr).frame_offset as c_uint;
+    let poc: c_uint = frm_hdr.frame_offset as c_uint;
     let mut i = 0;
     while i < 7 {
         let poc_diff = get_poc_diff(
@@ -1499,7 +1498,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
         i += 1;
     }
     rf.n_mfmvs = 0 as c_int;
-    if (*frm_hdr).use_ref_frame_mvs != 0 && seq_hdr.order_hint_n_bits != 0 {
+    if frm_hdr.use_ref_frame_mvs != 0 && seq_hdr.order_hint_n_bits != 0 {
         let mut total = 2;
         if !(*rp_ref.offset(0)).is_null() && (*ref_ref_poc.offset(0))[6] != *ref_poc.offset(3) {
             let fresh12 = rf.n_mfmvs;
@@ -1511,7 +1510,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
             && get_poc_diff(
                 seq_hdr.order_hint_n_bits,
                 *ref_poc.offset(4) as c_int,
-                (*frm_hdr).frame_offset,
+                frm_hdr.frame_offset,
             ) > 0
         {
             let fresh13 = rf.n_mfmvs;
@@ -1522,7 +1521,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
             && get_poc_diff(
                 seq_hdr.order_hint_n_bits,
                 *ref_poc.offset(5) as c_int,
-                (*frm_hdr).frame_offset,
+                frm_hdr.frame_offset,
             ) > 0
         {
             let fresh14 = rf.n_mfmvs;
@@ -1534,7 +1533,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
             && get_poc_diff(
                 seq_hdr.order_hint_n_bits,
                 *ref_poc.offset(6) as c_int,
-                (*frm_hdr).frame_offset,
+                frm_hdr.frame_offset,
             ) > 0
         {
             let fresh15 = rf.n_mfmvs;
@@ -1552,7 +1551,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
             let diff1 = get_poc_diff(
                 seq_hdr.order_hint_n_bits,
                 rpoc as c_int,
-                (*frm_hdr).frame_offset,
+                frm_hdr.frame_offset,
             );
             if diff1.abs() > 31 {
                 rf.mfmv_ref2cur[n as usize] = i32::MIN;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1441,13 +1441,13 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
         if !rf.r.is_null() {
             rav1d_freep_aligned(&mut rf.r as *mut *mut refmvs_block as *mut c_void);
         }
-        let uses_2pass = (n_tile_threads > 1 && n_frame_threads > 1) as c_int;
+        let uses_2pass = (n_tile_threads > 1 && n_frame_threads > 1) as usize;
         rf.r = rav1d_alloc_aligned(
             ::core::mem::size_of::<refmvs_block>()
                 * 35
                 * r_stride as usize
                 * n_tile_rows as usize
-                * (1 + uses_2pass) as usize,
+                * (1 + uses_2pass),
             64,
         ) as *mut refmvs_block;
         if rf.r.is_null() {

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1420,7 +1420,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
     ref_poc: &[c_uint; 7],
     rp: *mut refmvs_temporal_block,
     ref_ref_poc: &[[c_uint; 7]; 7],
-    rp_ref: *const *mut refmvs_temporal_block,
+    rp_ref: &[*mut refmvs_temporal_block; 7],
     n_tile_threads: c_int,
     n_frame_threads: c_int,
 ) -> Rav1dResult {
@@ -1475,7 +1475,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
     rf.n_tile_threads = n_tile_threads;
     rf.n_frame_threads = n_frame_threads;
     rf.rp = rp;
-    rf.rp_ref = rp_ref;
+    rf.rp_ref = rp_ref.as_ptr();
     let poc: c_uint = frm_hdr.frame_offset as c_uint;
     let mut i = 0;
     while i < 7 {
@@ -1500,13 +1500,13 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
     rf.n_mfmvs = 0 as c_int;
     if frm_hdr.use_ref_frame_mvs != 0 && seq_hdr.order_hint_n_bits != 0 {
         let mut total = 2;
-        if !(*rp_ref.offset(0)).is_null() && ref_ref_poc[0][6] != ref_poc[3] {
+        if !rp_ref[0].is_null() && ref_ref_poc[0][6] != ref_poc[3] {
             let fresh12 = rf.n_mfmvs;
             rf.n_mfmvs = rf.n_mfmvs + 1;
             rf.mfmv_ref[fresh12 as usize] = 0 as c_int as u8;
             total = 3 as c_int;
         }
-        if !(*rp_ref.offset(4)).is_null()
+        if !rp_ref[4].is_null()
             && get_poc_diff(
                 seq_hdr.order_hint_n_bits,
                 ref_poc[4] as c_int,
@@ -1517,7 +1517,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
             rf.n_mfmvs = rf.n_mfmvs + 1;
             rf.mfmv_ref[fresh13 as usize] = 4 as c_int as u8;
         }
-        if !(*rp_ref.offset(5)).is_null()
+        if !rp_ref[5].is_null()
             && get_poc_diff(
                 seq_hdr.order_hint_n_bits,
                 ref_poc[5] as c_int,
@@ -1529,7 +1529,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
             rf.mfmv_ref[fresh14 as usize] = 5 as c_int as u8;
         }
         if rf.n_mfmvs < total
-            && !(*rp_ref.offset(6)).is_null()
+            && !rp_ref[6].is_null()
             && get_poc_diff(
                 seq_hdr.order_hint_n_bits,
                 ref_poc[6] as c_int,
@@ -1540,7 +1540,7 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
             rf.n_mfmvs = rf.n_mfmvs + 1;
             rf.mfmv_ref[fresh15 as usize] = 6 as c_int as u8;
         }
-        if rf.n_mfmvs < total && !(*rp_ref.offset(1)).is_null() {
+        if rf.n_mfmvs < total && !rp_ref[1].is_null() {
             let fresh16 = rf.n_mfmvs;
             rf.n_mfmvs = rf.n_mfmvs + 1;
             rf.mfmv_ref[fresh16 as usize] = 1 as c_int as u8;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1493,9 +1493,8 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
     if frm_hdr.use_ref_frame_mvs != 0 && seq_hdr.order_hint_n_bits != 0 {
         let mut total = 2;
         if !rp_ref[0].is_null() && ref_ref_poc[0][6] != ref_poc[3] {
-            let fresh12 = rf.n_mfmvs;
-            rf.n_mfmvs = rf.n_mfmvs + 1;
-            rf.mfmv_ref[fresh12 as usize] = 0;
+            rf.mfmv_ref[rf.n_mfmvs as usize] = 0;
+            rf.n_mfmvs += 1;
             total = 3;
         }
         if !rp_ref[4].is_null()
@@ -1505,9 +1504,8 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
                 frm_hdr.frame_offset,
             ) > 0
         {
-            let fresh13 = rf.n_mfmvs;
-            rf.n_mfmvs = rf.n_mfmvs + 1;
-            rf.mfmv_ref[fresh13 as usize] = 4;
+            rf.mfmv_ref[rf.n_mfmvs as usize] = 4;
+            rf.n_mfmvs += 1;
         }
         if !rp_ref[5].is_null()
             && get_poc_diff(
@@ -1516,9 +1514,8 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
                 frm_hdr.frame_offset,
             ) > 0
         {
-            let fresh14 = rf.n_mfmvs;
-            rf.n_mfmvs = rf.n_mfmvs + 1;
-            rf.mfmv_ref[fresh14 as usize] = 5;
+            rf.mfmv_ref[rf.n_mfmvs as usize] = 5;
+            rf.n_mfmvs += 1;
         }
         if rf.n_mfmvs < total
             && !rp_ref[6].is_null()
@@ -1528,14 +1525,12 @@ pub(crate) unsafe fn rav1d_refmvs_init_frame(
                 frm_hdr.frame_offset,
             ) > 0
         {
-            let fresh15 = rf.n_mfmvs;
-            rf.n_mfmvs = rf.n_mfmvs + 1;
-            rf.mfmv_ref[fresh15 as usize] = 6;
+            rf.mfmv_ref[rf.n_mfmvs as usize] = 6;
+            rf.n_mfmvs += 1;
         }
         if rf.n_mfmvs < total && !rp_ref[1].is_null() {
-            let fresh16 = rf.n_mfmvs;
-            rf.n_mfmvs = rf.n_mfmvs + 1;
-            rf.mfmv_ref[fresh16 as usize] = 1;
+            rf.mfmv_ref[rf.n_mfmvs as usize] = 1;
+            rf.n_mfmvs += 1;
         }
         let mut n = 0;
         while n < rf.n_mfmvs as usize {


### PR DESCRIPTION
* Fixes part of #820.
* Fixes part of #845.

I'm working on `mvs`, `refmvs`'s `Rav1dRef`, so it's easier to have this cleaned up first.