### PR TITLE
`fn rav1d_refmvs_tile_sbrow_init`: Cleanup

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4128,8 +4128,7 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
     let col_sb128_start = col_sb_start >> (seq_hdr.sb128 == 0) as c_int;
 
     if frame_hdr.frame_type.is_inter_or_switch() || frame_hdr.allow_intrabc {
-        rav1d_refmvs_tile_sbrow_init(
-            &mut t.rt,
+        t.rt = rav1d_refmvs_tile_sbrow_init(
             &f.rf,
             ts.tiling.col_start,
             ts.tiling.col_end,

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1195,10 +1195,8 @@ pub(crate) unsafe fn rav1d_refmvs_tile_sbrow_init(
         as *mut refmvs_block;
     let sbsz = rf.sbsz;
     let off = sbsz * sby & 16;
-    let mut i = 0;
-    while i < sbsz {
+    for i in 0..sbsz {
         rt.r[(off + 5 + i) as usize] = r;
-        i += 1;
         r = r.offset(rf.r_stride as isize);
     }
     rt.r[(off + 0) as usize] = r;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1185,13 +1185,12 @@ pub(crate) unsafe fn rav1d_refmvs_tile_sbrow_init(
     rt.rp_proj = &mut *(rf.rp_proj).offset(16 * rf.rp_stride * tile_row_idx as isize)
         as *mut refmvs_temporal_block;
     let uses_2pass = (rf.n_tile_threads > 1 && rf.n_frame_threads > 1) as c_int;
-    let pass_off: ptrdiff_t = if uses_2pass != 0 && pass == 2 {
+    let pass_off = if uses_2pass != 0 && pass == 2 {
         35 * rf.r_stride * rf.n_tile_rows as isize
     } else {
         0
     };
-    let mut r: *mut refmvs_block = &mut *(rf.r)
-        .offset(35 * rf.r_stride * tile_row_idx as isize + pass_off)
+    let mut r = &mut *(rf.r).offset(35 * rf.r_stride * tile_row_idx as isize + pass_off)
         as *mut refmvs_block;
     let sbsz = rf.sbsz;
     let off = sbsz * sby & 16;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1169,7 +1169,7 @@ pub(crate) unsafe fn rav1d_refmvs_save_tmvs(
 }
 
 pub(crate) unsafe fn rav1d_refmvs_tile_sbrow_init(
-    rt: *mut refmvs_tile,
+    rt: &mut refmvs_tile,
     rf: *const refmvs_frame,
     tile_col_start4: c_int,
     tile_col_end4: c_int,
@@ -1182,7 +1182,7 @@ pub(crate) unsafe fn rav1d_refmvs_tile_sbrow_init(
     if (*rf).n_tile_threads == 1 {
         tile_row_idx = 0 as c_int;
     }
-    (*rt).rp_proj = &mut *((*rf).rp_proj).offset(16 * (*rf).rp_stride * tile_row_idx as isize)
+    rt.rp_proj = &mut *((*rf).rp_proj).offset(16 * (*rf).rp_stride * tile_row_idx as isize)
         as *mut refmvs_temporal_block;
     let uses_2pass = ((*rf).n_tile_threads > 1 && (*rf).n_frame_threads > 1) as c_int;
     let pass_off: ptrdiff_t = if uses_2pass != 0 && pass == 2 {
@@ -1197,33 +1197,33 @@ pub(crate) unsafe fn rav1d_refmvs_tile_sbrow_init(
     let off = sbsz * sby & 16;
     let mut i = 0;
     while i < sbsz {
-        (*rt).r[(off + 5 + i) as usize] = r;
+        rt.r[(off + 5 + i) as usize] = r;
         i += 1;
         r = r.offset((*rf).r_stride as isize);
     }
-    (*rt).r[(off + 0) as usize] = r;
+    rt.r[(off + 0) as usize] = r;
     r = r.offset((*rf).r_stride as isize);
-    (*rt).r[(off + 1) as usize] = 0 as *mut refmvs_block;
-    (*rt).r[(off + 2) as usize] = r;
+    rt.r[(off + 1) as usize] = 0 as *mut refmvs_block;
+    rt.r[(off + 2) as usize] = r;
     r = r.offset((*rf).r_stride as isize);
-    (*rt).r[(off + 3) as usize] = 0 as *mut refmvs_block;
-    (*rt).r[(off + 4) as usize] = r;
+    rt.r[(off + 3) as usize] = 0 as *mut refmvs_block;
+    rt.r[(off + 4) as usize] = r;
     if sby & 1 != 0 {
-        let tmp: *mut c_void = (*rt).r[(off + 0) as usize] as *mut c_void;
-        (*rt).r[(off + 0) as usize] = (*rt).r[(off + sbsz + 0) as usize];
-        (*rt).r[(off + sbsz + 0) as usize] = tmp as *mut refmvs_block;
-        let tmp_0: *mut c_void = (*rt).r[(off + 2) as usize] as *mut c_void;
-        (*rt).r[(off + 2) as usize] = (*rt).r[(off + sbsz + 2) as usize];
-        (*rt).r[(off + sbsz + 2) as usize] = tmp_0 as *mut refmvs_block;
-        let tmp_1: *mut c_void = (*rt).r[(off + 4) as usize] as *mut c_void;
-        (*rt).r[(off + 4) as usize] = (*rt).r[(off + sbsz + 4) as usize];
-        (*rt).r[(off + sbsz + 4) as usize] = tmp_1 as *mut refmvs_block;
+        let tmp: *mut c_void = rt.r[(off + 0) as usize] as *mut c_void;
+        rt.r[(off + 0) as usize] = rt.r[(off + sbsz + 0) as usize];
+        rt.r[(off + sbsz + 0) as usize] = tmp as *mut refmvs_block;
+        let tmp_0: *mut c_void = rt.r[(off + 2) as usize] as *mut c_void;
+        rt.r[(off + 2) as usize] = rt.r[(off + sbsz + 2) as usize];
+        rt.r[(off + sbsz + 2) as usize] = tmp_0 as *mut refmvs_block;
+        let tmp_1: *mut c_void = rt.r[(off + 4) as usize] as *mut c_void;
+        rt.r[(off + 4) as usize] = rt.r[(off + sbsz + 4) as usize];
+        rt.r[(off + sbsz + 4) as usize] = tmp_1 as *mut refmvs_block;
     }
-    (*rt).rf = rf;
-    (*rt).tile_row.start = tile_row_start4;
-    (*rt).tile_row.end = cmp::min(tile_row_end4, (*rf).ih4);
-    (*rt).tile_col.start = tile_col_start4;
-    (*rt).tile_col.end = cmp::min(tile_col_end4, (*rf).iw4);
+    rt.rf = rf;
+    rt.tile_row.start = tile_row_start4;
+    rt.tile_row.end = cmp::min(tile_row_end4, (*rf).ih4);
+    rt.tile_col.start = tile_col_start4;
+    rt.tile_col.end = cmp::min(tile_col_end4, (*rf).iw4);
 }
 
 unsafe extern "C" fn load_tmvs_c(

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1209,9 +1209,9 @@ pub(crate) unsafe fn rav1d_refmvs_tile_sbrow_init(
     rt.r[(off + 3) as usize] = 0 as *mut refmvs_block;
     rt.r[(off + 4) as usize] = r;
     if sby & 1 != 0 {
-        rt.r.swap((off + 0) as usize, (off + sbsz + 0) as usize);
-        rt.r.swap((off + 2) as usize, (off + sbsz + 2) as usize);
-        rt.r.swap((off + 4) as usize, (off + sbsz + 4) as usize);
+        for i in [0, 2, 4] {
+            rt.r.swap((off + i) as usize, (off + sbsz + i) as usize);
+        }
     }
     rt.rf = rf;
     rt.tile_row.start = tile_row_start4;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1183,8 +1183,8 @@ pub(crate) unsafe fn rav1d_refmvs_tile_sbrow_init(
         tile_row_idx = 0;
     }
     rt.rp_proj = rf.rp_proj.offset(16 * rf.rp_stride * tile_row_idx as isize);
-    let uses_2pass = (rf.n_tile_threads > 1 && rf.n_frame_threads > 1) as c_int;
-    let pass_off = if uses_2pass != 0 && pass == 2 {
+    let uses_2pass = rf.n_tile_threads > 1 && rf.n_frame_threads > 1;
+    let pass_off = if uses_2pass && pass == 2 {
         35 * rf.r_stride * rf.n_tile_rows as isize
     } else {
         0

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1170,7 +1170,7 @@ pub(crate) unsafe fn rav1d_refmvs_save_tmvs(
 
 pub(crate) unsafe fn rav1d_refmvs_tile_sbrow_init(
     rt: &mut refmvs_tile,
-    rf: *const refmvs_frame,
+    rf: &refmvs_frame,
     tile_col_start4: c_int,
     tile_col_end4: c_int,
     tile_row_start4: c_int,
@@ -1179,33 +1179,33 @@ pub(crate) unsafe fn rav1d_refmvs_tile_sbrow_init(
     mut tile_row_idx: c_int,
     pass: c_int,
 ) {
-    if (*rf).n_tile_threads == 1 {
+    if rf.n_tile_threads == 1 {
         tile_row_idx = 0 as c_int;
     }
-    rt.rp_proj = &mut *((*rf).rp_proj).offset(16 * (*rf).rp_stride * tile_row_idx as isize)
+    rt.rp_proj = &mut *(rf.rp_proj).offset(16 * rf.rp_stride * tile_row_idx as isize)
         as *mut refmvs_temporal_block;
-    let uses_2pass = ((*rf).n_tile_threads > 1 && (*rf).n_frame_threads > 1) as c_int;
+    let uses_2pass = (rf.n_tile_threads > 1 && rf.n_frame_threads > 1) as c_int;
     let pass_off: ptrdiff_t = if uses_2pass != 0 && pass == 2 {
-        35 * (*rf).r_stride * (*rf).n_tile_rows as isize
+        35 * rf.r_stride * rf.n_tile_rows as isize
     } else {
         0
     };
-    let mut r: *mut refmvs_block = &mut *((*rf).r)
-        .offset(35 * (*rf).r_stride * tile_row_idx as isize + pass_off)
+    let mut r: *mut refmvs_block = &mut *(rf.r)
+        .offset(35 * rf.r_stride * tile_row_idx as isize + pass_off)
         as *mut refmvs_block;
-    let sbsz = (*rf).sbsz;
+    let sbsz = rf.sbsz;
     let off = sbsz * sby & 16;
     let mut i = 0;
     while i < sbsz {
         rt.r[(off + 5 + i) as usize] = r;
         i += 1;
-        r = r.offset((*rf).r_stride as isize);
+        r = r.offset(rf.r_stride as isize);
     }
     rt.r[(off + 0) as usize] = r;
-    r = r.offset((*rf).r_stride as isize);
+    r = r.offset(rf.r_stride as isize);
     rt.r[(off + 1) as usize] = 0 as *mut refmvs_block;
     rt.r[(off + 2) as usize] = r;
-    r = r.offset((*rf).r_stride as isize);
+    r = r.offset(rf.r_stride as isize);
     rt.r[(off + 3) as usize] = 0 as *mut refmvs_block;
     rt.r[(off + 4) as usize] = r;
     if sby & 1 != 0 {
@@ -1221,9 +1221,9 @@ pub(crate) unsafe fn rav1d_refmvs_tile_sbrow_init(
     }
     rt.rf = rf;
     rt.tile_row.start = tile_row_start4;
-    rt.tile_row.end = cmp::min(tile_row_end4, (*rf).ih4);
+    rt.tile_row.end = cmp::min(tile_row_end4, rf.ih4);
     rt.tile_col.start = tile_col_start4;
-    rt.tile_col.end = cmp::min(tile_col_end4, (*rf).iw4);
+    rt.tile_col.end = cmp::min(tile_col_end4, rf.iw4);
 }
 
 unsafe extern "C" fn load_tmvs_c(

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1209,15 +1209,9 @@ pub(crate) unsafe fn rav1d_refmvs_tile_sbrow_init(
     rt.r[(off + 3) as usize] = 0 as *mut refmvs_block;
     rt.r[(off + 4) as usize] = r;
     if sby & 1 != 0 {
-        let tmp: *mut c_void = rt.r[(off + 0) as usize] as *mut c_void;
-        rt.r[(off + 0) as usize] = rt.r[(off + sbsz + 0) as usize];
-        rt.r[(off + sbsz + 0) as usize] = tmp as *mut refmvs_block;
-        let tmp_0: *mut c_void = rt.r[(off + 2) as usize] as *mut c_void;
-        rt.r[(off + 2) as usize] = rt.r[(off + sbsz + 2) as usize];
-        rt.r[(off + sbsz + 2) as usize] = tmp_0 as *mut refmvs_block;
-        let tmp_1: *mut c_void = rt.r[(off + 4) as usize] as *mut c_void;
-        rt.r[(off + 4) as usize] = rt.r[(off + sbsz + 4) as usize];
-        rt.r[(off + sbsz + 4) as usize] = tmp_1 as *mut refmvs_block;
+        rt.r.swap((off + 0) as usize, (off + sbsz + 0) as usize);
+        rt.r.swap((off + 2) as usize, (off + sbsz + 2) as usize);
+        rt.r.swap((off + 4) as usize, (off + sbsz + 4) as usize);
     }
     rt.rf = rf;
     rt.tile_row.start = tile_row_start4;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1180,18 +1180,17 @@ pub(crate) unsafe fn rav1d_refmvs_tile_sbrow_init(
     pass: c_int,
 ) {
     if rf.n_tile_threads == 1 {
-        tile_row_idx = 0 as c_int;
+        tile_row_idx = 0;
     }
-    rt.rp_proj = &mut *(rf.rp_proj).offset(16 * rf.rp_stride * tile_row_idx as isize)
-        as *mut refmvs_temporal_block;
+    rt.rp_proj = rf.rp_proj.offset(16 * rf.rp_stride * tile_row_idx as isize);
     let uses_2pass = (rf.n_tile_threads > 1 && rf.n_frame_threads > 1) as c_int;
     let pass_off = if uses_2pass != 0 && pass == 2 {
         35 * rf.r_stride * rf.n_tile_rows as isize
     } else {
         0
     };
-    let mut r = &mut *(rf.r).offset(35 * rf.r_stride * tile_row_idx as isize + pass_off)
-        as *mut refmvs_block;
+    let mut r =
+        rf.r.offset(35 * rf.r_stride * tile_row_idx as isize + pass_off);
     let sbsz = rf.sbsz;
     let off = sbsz * sby & 16;
     for i in 0..sbsz {


### PR DESCRIPTION
* Fixes part of #820.
* Fixes part of #845.