### PR TITLE
`fn rav1d_refmvs_save_tmvs`: Cleanup

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4281,7 +4281,7 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
     {
         rav1d_refmvs_save_tmvs(
             &c.refmvs_dsp,
-            &mut t.rt,
+            &t.rt,
             ts.tiling.col_start >> 1,
             ts.tiling.col_end >> 1,
             t.by >> 1,
@@ -4802,7 +4802,7 @@ unsafe fn rav1d_decode_frame_main(c: &Rav1dContext, f: &mut Rav1dFrameData) -> R
                 rav1d_decode_tile_sbrow(c, &mut t, f).map_err(|()| EINVAL)?;
             }
             if f.frame_hdr().frame_type.is_inter_or_switch() {
-                rav1d_refmvs_save_tmvs(&c.refmvs_dsp, &mut t.rt, 0, f.bw >> 1, t.by >> 1, by_end);
+                rav1d_refmvs_save_tmvs(&c.refmvs_dsp, &t.rt, 0, f.bw >> 1, t.by >> 1, by_end);
             }
 
             // loopfilter + cdef + restoration

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1137,13 +1137,13 @@ pub(crate) unsafe fn rav1d_refmvs_find(
 // into buffers for use in future frame's temporal MV prediction
 pub(crate) unsafe fn rav1d_refmvs_save_tmvs(
     dsp: &Rav1dRefmvsDSPContext,
-    rt: *const refmvs_tile,
+    rt: &refmvs_tile,
     col_start8: c_int,
     mut col_end8: c_int,
     row_start8: c_int,
     mut row_end8: c_int,
 ) {
-    let rf: *const refmvs_frame = (*rt).rf;
+    let rf: *const refmvs_frame = rt.rf;
     if !(row_start8 >= 0) {
         unreachable!();
     }
@@ -1159,7 +1159,7 @@ pub(crate) unsafe fn rav1d_refmvs_save_tmvs(
     dsp.save_tmvs.expect("non-null function pointer")(
         rp,
         stride,
-        (*rt).r.as_ptr().offset(6) as *const *const refmvs_block,
+        rt.r.as_ptr().offset(6) as *const *const refmvs_block,
         ref_sign,
         col_end8,
         row_end8,

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1139,15 +1139,15 @@ pub(crate) unsafe fn rav1d_refmvs_save_tmvs(
     dsp: &Rav1dRefmvsDSPContext,
     rt: &refmvs_tile,
     col_start8: c_int,
-    mut col_end8: c_int,
+    col_end8: c_int,
     row_start8: c_int,
-    mut row_end8: c_int,
+    row_end8: c_int,
 ) {
     let rf = &*rt.rf;
     assert!(row_start8 >= 0);
     assert!((row_end8 - row_start8) as c_uint <= 16);
-    row_end8 = cmp::min(row_end8, rf.ih8);
-    col_end8 = cmp::min(col_end8, rf.iw8);
+    let row_end8 = cmp::min(row_end8, rf.ih8);
+    let col_end8 = cmp::min(col_end8, rf.iw8);
     let stride = rf.rp_stride;
     let ref_sign = (rf.mfmv_sign).as_ptr();
     let rp = rf.rp.offset(row_start8 as isize * stride);

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1143,18 +1143,18 @@ pub(crate) unsafe fn rav1d_refmvs_save_tmvs(
     row_start8: c_int,
     mut row_end8: c_int,
 ) {
-    let rf: *const refmvs_frame = rt.rf;
+    let rf = &*rt.rf;
     if !(row_start8 >= 0) {
         unreachable!();
     }
     if !((row_end8 - row_start8) as c_uint <= 16 as c_uint) {
         unreachable!();
     }
-    row_end8 = cmp::min(row_end8, (*rf).ih8);
-    col_end8 = cmp::min(col_end8, (*rf).iw8);
-    let stride: ptrdiff_t = (*rf).rp_stride;
-    let ref_sign: *const u8 = ((*rf).mfmv_sign).as_ptr();
-    let rp: *mut refmvs_temporal_block = (*rf).rp.offset(row_start8 as isize * stride);
+    row_end8 = cmp::min(row_end8, rf.ih8);
+    col_end8 = cmp::min(col_end8, rf.iw8);
+    let stride: ptrdiff_t = rf.rp_stride;
+    let ref_sign: *const u8 = (rf.mfmv_sign).as_ptr();
+    let rp: *mut refmvs_temporal_block = rf.rp.offset(row_start8 as isize * stride);
 
     dsp.save_tmvs.expect("non-null function pointer")(
         rp,

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1147,7 +1147,7 @@ pub(crate) unsafe fn rav1d_refmvs_save_tmvs(
     if !(row_start8 >= 0) {
         unreachable!();
     }
-    if !((row_end8 - row_start8) as c_uint <= 16 as c_uint) {
+    if !((row_end8 - row_start8) as c_uint <= 16) {
         unreachable!();
     }
     row_end8 = cmp::min(row_end8, rf.ih8);

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1149,14 +1149,14 @@ pub(crate) unsafe fn rav1d_refmvs_save_tmvs(
     let row_end8 = cmp::min(row_end8, rf.ih8);
     let col_end8 = cmp::min(col_end8, rf.iw8);
     let stride = rf.rp_stride;
-    let ref_sign = (rf.mfmv_sign).as_ptr();
+    let ref_sign = &rf.mfmv_sign;
     let rp = rf.rp.offset(row_start8 as isize * stride);
 
     dsp.save_tmvs.expect("non-null function pointer")(
         rp,
         stride,
         rt.r.as_ptr().offset(6) as *const *const refmvs_block,
-        ref_sign,
+        ref_sign.as_ptr(),
         col_end8,
         row_end8,
         col_start8,

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1144,12 +1144,8 @@ pub(crate) unsafe fn rav1d_refmvs_save_tmvs(
     mut row_end8: c_int,
 ) {
     let rf = &*rt.rf;
-    if !(row_start8 >= 0) {
-        unreachable!();
-    }
-    if !((row_end8 - row_start8) as c_uint <= 16) {
-        unreachable!();
-    }
+    assert!(row_start8 >= 0);
+    assert!((row_end8 - row_start8) as c_uint <= 16);
     row_end8 = cmp::min(row_end8, rf.ih8);
     col_end8 = cmp::min(col_end8, rf.iw8);
     let stride = rf.rp_stride;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1136,7 +1136,7 @@ pub(crate) unsafe fn rav1d_refmvs_find(
 // cache the current tile/sbrow (or frame/sbrow)'s projectable motion vectors
 // into buffers for use in future frame's temporal MV prediction
 pub(crate) unsafe fn rav1d_refmvs_save_tmvs(
-    dsp: *const Rav1dRefmvsDSPContext,
+    dsp: &Rav1dRefmvsDSPContext,
     rt: *const refmvs_tile,
     col_start8: c_int,
     mut col_end8: c_int,
@@ -1156,7 +1156,7 @@ pub(crate) unsafe fn rav1d_refmvs_save_tmvs(
     let ref_sign: *const u8 = ((*rf).mfmv_sign).as_ptr();
     let rp: *mut refmvs_temporal_block = (*rf).rp.offset(row_start8 as isize * stride);
 
-    (*dsp).save_tmvs.expect("non-null function pointer")(
+    dsp.save_tmvs.expect("non-null function pointer")(
         rp,
         stride,
         (*rt).r.as_ptr().offset(6) as *const *const refmvs_block,

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1152,9 +1152,9 @@ pub(crate) unsafe fn rav1d_refmvs_save_tmvs(
     }
     row_end8 = cmp::min(row_end8, rf.ih8);
     col_end8 = cmp::min(col_end8, rf.iw8);
-    let stride: ptrdiff_t = rf.rp_stride;
-    let ref_sign: *const u8 = (rf.mfmv_sign).as_ptr();
-    let rp: *mut refmvs_temporal_block = rf.rp.offset(row_start8 as isize * stride);
+    let stride = rf.rp_stride;
+    let ref_sign = (rf.mfmv_sign).as_ptr();
+    let rp = rf.rp.offset(row_start8 as isize * stride);
 
     dsp.save_tmvs.expect("non-null function pointer")(
         rp,


### PR DESCRIPTION
* Fixes part of #820.
* Fixes part of #845.