### PR TITLE
`struct refmvs_tile::rf`: Remove field and pass through the callstack instead

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2265,6 +2265,7 @@ unsafe fn decode_b_inner(
         let mut ctx = 0;
         rav1d_refmvs_find(
             &t.rt,
+            &f.rf,
             &mut mvstack,
             &mut n_mvs,
             &mut ctx,
@@ -2438,6 +2439,7 @@ unsafe fn decode_b_inner(
             let mut ctx = 0;
             rav1d_refmvs_find(
                 &t.rt,
+                &f.rf,
                 &mut mvstack,
                 &mut n_mvs,
                 &mut ctx,
@@ -2542,6 +2544,7 @@ unsafe fn decode_b_inner(
             let mut ctx = 0;
             rav1d_refmvs_find(
                 &t.rt,
+                &f.rf,
                 &mut mvstack,
                 &mut n_mvs,
                 &mut ctx,
@@ -2816,6 +2819,7 @@ unsafe fn decode_b_inner(
             let mut ctx = 0;
             rav1d_refmvs_find(
                 &t.rt,
+                &f.rf,
                 &mut mvstack,
                 &mut n_mvs,
                 &mut ctx,
@@ -4282,6 +4286,7 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
         rav1d_refmvs_save_tmvs(
             &c.refmvs_dsp,
             &t.rt,
+            &f.rf,
             ts.tiling.col_start >> 1,
             ts.tiling.col_end >> 1,
             t.by >> 1,
@@ -4802,7 +4807,15 @@ unsafe fn rav1d_decode_frame_main(c: &Rav1dContext, f: &mut Rav1dFrameData) -> R
                 rav1d_decode_tile_sbrow(c, &mut t, f).map_err(|()| EINVAL)?;
             }
             if f.frame_hdr().frame_type.is_inter_or_switch() {
-                rav1d_refmvs_save_tmvs(&c.refmvs_dsp, &t.rt, 0, f.bw >> 1, t.by >> 1, by_end);
+                rav1d_refmvs_save_tmvs(
+                    &c.refmvs_dsp,
+                    &t.rt,
+                    &f.rf,
+                    0,
+                    f.bw >> 1,
+                    t.by >> 1,
+                    by_end,
+                );
             }
 
             // loopfilter + cdef + restoration

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -190,7 +190,6 @@ pub struct refmvs_tile_range {
 }
 
 pub(crate) struct refmvs_tile {
-    pub rf: *const refmvs_frame,
     pub r: [*mut refmvs_block; 37],
     pub rp_proj: *mut refmvs_temporal_block,
     pub tile_col: refmvs_tile_range,
@@ -695,6 +694,7 @@ fn add_single_extended_candidate(
 /// their respective position in the current frame.
 pub(crate) unsafe fn rav1d_refmvs_find(
     rt: &refmvs_tile,
+    rf: &refmvs_frame,
     mvstack: &mut [refmvs_candidate; 8],
     cnt: &mut usize,
     ctx: &mut c_int,
@@ -705,7 +705,6 @@ pub(crate) unsafe fn rav1d_refmvs_find(
     bx4: c_int,
     frame_hdr: &Rav1dFrameHeader,
 ) {
-    let rf = &*rt.rf;
     let b_dim = &dav1d_block_dimensions[bs as usize];
     let bw4 = b_dim[0] as c_int;
     let w4 = cmp::min(cmp::min(bw4, 16), rt.tile_col.end - bx4);
@@ -1135,12 +1134,12 @@ pub(crate) unsafe fn rav1d_refmvs_find(
 pub(crate) unsafe fn rav1d_refmvs_save_tmvs(
     dsp: &Rav1dRefmvsDSPContext,
     rt: &refmvs_tile,
+    rf: &refmvs_frame,
     col_start8: c_int,
     col_end8: c_int,
     row_start8: c_int,
     row_end8: c_int,
 ) {
-    let rf = &*rt.rf;
     assert!(row_start8 >= 0);
     assert!((row_end8 - row_start8) as c_uint <= 16);
     let row_end8 = cmp::min(row_end8, rf.ih8);
@@ -1204,7 +1203,6 @@ pub(crate) unsafe fn rav1d_refmvs_tile_sbrow_init(
     }
 
     refmvs_tile {
-        rf,
         r: rs,
         rp_proj,
         tile_col: refmvs_tile_range {

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -189,7 +189,6 @@ pub struct refmvs_tile_range {
     pub end: c_int,
 }
 
-#[repr(C)]
 pub(crate) struct refmvs_tile {
     pub rf: *const refmvs_frame,
     pub r: [*mut refmvs_block; 37],


### PR DESCRIPTION
* Fixes `rf` field of #823.