### PR TITLE
`mod refmvs`: `fn` ptr cleanup

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4793,14 +4793,7 @@ unsafe fn rav1d_decode_frame_main(c: &Rav1dContext, f: &mut Rav1dFrameData) -> R
             t.by = sby << 4 + seq_hdr.sb128;
             let by_end = t.by + f.sb_step >> 1;
             if frame_hdr.use_ref_frame_mvs != 0 {
-                (c.refmvs_dsp.load_tmvs)(
-                    &mut f.rf,
-                    tile_row as c_int,
-                    0,
-                    f.bw >> 1,
-                    t.by >> 1,
-                    by_end,
-                );
+                (c.refmvs_dsp.load_tmvs)(&f.rf, tile_row as c_int, 0, f.bw >> 1, t.by >> 1, by_end);
             }
             for tile in &mut ts[..] {
                 t.ts = tile;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4182,7 +4182,7 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
     }
 
     if c.tc.len() > 1 && frame_hdr.use_ref_frame_mvs != 0 {
-        c.refmvs_dsp.load_tmvs.expect("non-null function pointer")(
+        (c.refmvs_dsp.load_tmvs)(
             &f.rf,
             ts.tiling.row,
             ts.tiling.col_start >> 1,
@@ -4793,7 +4793,7 @@ unsafe fn rav1d_decode_frame_main(c: &Rav1dContext, f: &mut Rav1dFrameData) -> R
             t.by = sby << 4 + seq_hdr.sb128;
             let by_end = t.by + f.sb_step >> 1;
             if frame_hdr.use_ref_frame_mvs != 0 {
-                (c.refmvs_dsp.load_tmvs).expect("non-null function pointer")(
+                (c.refmvs_dsp.load_tmvs)(
                     &mut f.rf,
                     tile_row as c_int,
                     0,

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -216,14 +216,14 @@ pub(crate) type load_tmvs_fn = Option<
 
 pub type save_tmvs_fn = Option<
     unsafe extern "C" fn(
-        *mut refmvs_temporal_block,
-        ptrdiff_t,
-        *const *const refmvs_block,
-        *const u8,
-        c_int,
-        c_int,
-        c_int,
-        c_int,
+        rp: *mut refmvs_temporal_block,
+        stride: ptrdiff_t,
+        rr: *const *const refmvs_block,
+        ref_sign: *const u8,
+        col_end8: c_int,
+        row_end8: c_int,
+        col_start8: c_int,
+        row_start8: c_int,
     ) -> (),
 >;
 

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -242,7 +242,14 @@ extern "C" {
 }
 
 pub type splat_mv_fn = Option<
-    unsafe extern "C" fn(*mut *mut refmvs_block, usize, &refmvs_block, usize, usize, usize) -> (),
+    unsafe extern "C" fn(
+        rr: *mut *mut refmvs_block,
+        rr_len: usize,
+        rmv: &refmvs_block,
+        bx4: usize,
+        bw4: usize,
+        bh4: usize,
+    ) -> (),
 >;
 
 #[repr(C)]

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -207,29 +207,25 @@ pub struct refmvs_candidate {
     pub weight: c_int,
 }
 
-pub(crate) type load_tmvs_fn = Option<
-    unsafe extern "C" fn(
-        rf: *const refmvs_frame,
-        tile_row_idx: c_int,
-        col_start8: c_int,
-        col_end8: c_int,
-        row_start8: c_int,
-        row_end8: c_int,
-    ) -> (),
->;
+pub(crate) type load_tmvs_fn = unsafe extern "C" fn(
+    rf: *const refmvs_frame,
+    tile_row_idx: c_int,
+    col_start8: c_int,
+    col_end8: c_int,
+    row_start8: c_int,
+    row_end8: c_int,
+) -> ();
 
-pub type save_tmvs_fn = Option<
-    unsafe extern "C" fn(
-        rp: *mut refmvs_temporal_block,
-        stride: ptrdiff_t,
-        rr: *const *const refmvs_block,
-        ref_sign: *const u8,
-        col_end8: c_int,
-        row_end8: c_int,
-        col_start8: c_int,
-        row_start8: c_int,
-    ) -> (),
->;
+pub type save_tmvs_fn = unsafe extern "C" fn(
+    rp: *mut refmvs_temporal_block,
+    stride: ptrdiff_t,
+    rr: *const *const refmvs_block,
+    ref_sign: *const u8,
+    col_end8: c_int,
+    row_end8: c_int,
+    col_start8: c_int,
+    row_start8: c_int,
+) -> ();
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
 extern "C" {
@@ -245,17 +241,15 @@ extern "C" {
     );
 }
 
-pub type splat_mv_fn = Option<
-    unsafe extern "C" fn(
-        rr: *mut *mut refmvs_block,
-        rmv: *const refmvs_block,
-        bx4: c_int,
-        bw4: c_int,
-        bh4: c_int,
-        // Extra args, unused by asm.F
-        rr_len: usize,
-    ) -> (),
->;
+pub type splat_mv_fn = unsafe extern "C" fn(
+    rr: *mut *mut refmvs_block,
+    rmv: *const refmvs_block,
+    bx4: c_int,
+    bw4: c_int,
+    bh4: c_int,
+    // Extra args, unused by asm.F
+    rr_len: usize,
+) -> ();
 
 #[repr(C)]
 pub(crate) struct Rav1dRefmvsDSPContext {
@@ -273,14 +267,7 @@ impl Rav1dRefmvsDSPContext {
         bw4: usize,
         bh4: usize,
     ) {
-        self.splat_mv.expect("non-null function pointer")(
-            rr.as_mut_ptr(),
-            rmv,
-            bx4 as _,
-            bw4 as _,
-            bh4 as _,
-            rr.len(),
-        );
+        (self.splat_mv)(rr.as_mut_ptr(), rmv, bx4 as _, bw4 as _, bh4 as _, rr.len());
     }
 }
 
@@ -1168,7 +1155,7 @@ pub(crate) unsafe fn rav1d_refmvs_save_tmvs(
     let ref_sign = &rf.mfmv_sign;
     let rp = rf.rp.offset(row_start8 as isize * stride);
 
-    dsp.save_tmvs.expect("non-null function pointer")(
+    (dsp.save_tmvs)(
         rp,
         stride,
         rt.r.as_ptr().offset(6) as *const *const refmvs_block,
@@ -1615,13 +1602,13 @@ unsafe fn refmvs_dsp_init_x86(c: *mut Rav1dRefmvsDSPContext) {
         return;
     }
 
-    (*c).splat_mv = Some(dav1d_splat_mv_sse2);
+    (*c).splat_mv = dav1d_splat_mv_sse2;
 
     if !flags.contains(CpuFlags::SSSE3) {
         return;
     }
 
-    (*c).save_tmvs = Some(dav1d_save_tmvs_ssse3);
+    (*c).save_tmvs = dav1d_save_tmvs_ssse3;
 
     if !flags.contains(CpuFlags::SSE41) {
         return;
@@ -1629,21 +1616,21 @@ unsafe fn refmvs_dsp_init_x86(c: *mut Rav1dRefmvsDSPContext) {
 
     #[cfg(target_arch = "x86_64")]
     {
-        (*c).load_tmvs = Some(dav1d_load_tmvs_sse4);
+        (*c).load_tmvs = dav1d_load_tmvs_sse4;
 
         if !flags.contains(CpuFlags::AVX2) {
             return;
         }
 
-        (*c).save_tmvs = Some(dav1d_save_tmvs_avx2);
-        (*c).splat_mv = Some(dav1d_splat_mv_avx2);
+        (*c).save_tmvs = dav1d_save_tmvs_avx2;
+        (*c).splat_mv = dav1d_splat_mv_avx2;
 
         if !flags.contains(CpuFlags::AVX512ICL) {
             return;
         }
 
-        (*c).save_tmvs = Some(dav1d_save_tmvs_avx512icl);
-        (*c).splat_mv = Some(dav1d_splat_mv_avx512icl);
+        (*c).save_tmvs = dav1d_save_tmvs_avx512icl;
+        (*c).splat_mv = dav1d_splat_mv_avx512icl;
     }
 }
 
@@ -1652,16 +1639,16 @@ unsafe fn refmvs_dsp_init_x86(c: *mut Rav1dRefmvsDSPContext) {
 unsafe fn refmvs_dsp_init_arm(c: *mut Rav1dRefmvsDSPContext) {
     let flags = rav1d_get_cpu_flags();
     if flags.contains(CpuFlags::NEON) {
-        (*c).save_tmvs = Some(dav1d_save_tmvs_neon);
-        (*c).splat_mv = Some(dav1d_splat_mv_neon);
+        (*c).save_tmvs = dav1d_save_tmvs_neon;
+        (*c).splat_mv = dav1d_splat_mv_neon;
     }
 }
 
 #[cold]
 pub(crate) unsafe fn rav1d_refmvs_dsp_init(c: *mut Rav1dRefmvsDSPContext) {
-    (*c).load_tmvs = Some(load_tmvs_c);
-    (*c).save_tmvs = Some(save_tmvs_c);
-    (*c).splat_mv = Some(splat_mv_rust);
+    (*c).load_tmvs = load_tmvs_c;
+    (*c).save_tmvs = save_tmvs_c;
+    (*c).splat_mv = splat_mv_rust;
     cfg_if! {
         if #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "asm"))] {
             refmvs_dsp_init_x86(c);

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -203,8 +203,16 @@ pub struct refmvs_candidate {
     pub weight: c_int,
 }
 
-pub(crate) type load_tmvs_fn =
-    Option<unsafe extern "C" fn(*const refmvs_frame, c_int, c_int, c_int, c_int, c_int) -> ()>;
+pub(crate) type load_tmvs_fn = Option<
+    unsafe extern "C" fn(
+        rf: *const refmvs_frame,
+        tile_row_idx: c_int,
+        col_start8: c_int,
+        col_end8: c_int,
+        row_start8: c_int,
+        row_end8: c_int,
+    ) -> (),
+>;
 
 pub type save_tmvs_fn = Option<
     unsafe extern "C" fn(


### PR DESCRIPTION
This also removes the indirection in `mod ffi` that I added a long time ago.  We have long since figured out that indirection is bad for perf, so this removes it.  The extra length args are passed at the end of the args so that asm calls can be done without modification/interception.