### PR TITLE
`struct RefMvsFrame`: Create a `Rav1d` version of the `Dav1d` `refmvs_frame`, which is passed to asm

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -119,7 +119,6 @@ use crate::src::log::Rav1dLog as _;
 use crate::src::loopfilter::rav1d_loop_filter_dsp_init;
 use crate::src::looprestoration::rav1d_loop_restoration_dsp_init;
 use crate::src::mc::rav1d_mc_dsp_init;
-use crate::src::mem::freep;
 use crate::src::mem::rav1d_alloc_aligned;
 use crate::src::mem::rav1d_free_aligned;
 use crate::src::mem::rav1d_freep_aligned;
@@ -177,7 +176,6 @@ use crate::src::thread_task::TILE_ERROR;
 use crate::src::warpmv::rav1d_find_affine_int;
 use crate::src::warpmv::rav1d_get_shear_params;
 use crate::src::warpmv::rav1d_set_affine_mv2d;
-use libc::malloc;
 use libc::ptrdiff_t;
 use std::array;
 use std::cmp;
@@ -4184,8 +4182,9 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
     }
 
     if c.tc.len() > 1 && frame_hdr.use_ref_frame_mvs != 0 {
+        let rf = f.rf.as_dav1d();
         (c.refmvs_dsp.load_tmvs)(
-            &f.rf,
+            &rf,
             ts.tiling.row,
             ts.tiling.col_start >> 1,
             ts.tiling.col_end >> 1,
@@ -4783,7 +4782,8 @@ unsafe fn rav1d_decode_frame_main(c: &Rav1dContext, f: &mut Rav1dFrameData) -> R
             t.by = sby << 4 + seq_hdr.sb128;
             let by_end = t.by + f.sb_step >> 1;
             if frame_hdr.use_ref_frame_mvs != 0 {
-                (c.refmvs_dsp.load_tmvs)(&f.rf, tile_row as c_int, 0, f.bw >> 1, t.by >> 1, by_end);
+                let rf = f.rf.as_dav1d();
+                (c.refmvs_dsp.load_tmvs)(&rf, tile_row as c_int, 0, f.bw >> 1, t.by >> 1, by_end);
             }
             for col in 0..cols {
                 t.ts = tile_row * cols + col;

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -68,10 +68,10 @@ use crate::src::recon::rav1d_recon_b_intra;
 use crate::src::recon::read_coef_blocks_fn;
 use crate::src::recon::recon_b_inter_fn;
 use crate::src::recon::recon_b_intra_fn;
-use crate::src::refmvs::refmvs_frame;
 use crate::src::refmvs::refmvs_temporal_block;
 use crate::src::refmvs::refmvs_tile;
 use crate::src::refmvs::Rav1dRefmvsDSPContext;
+use crate::src::refmvs::RefMvsFrame;
 use atomig::Atomic;
 use libc::ptrdiff_t;
 use std::cell::UnsafeCell;
@@ -703,7 +703,7 @@ pub(crate) struct Rav1dFrameData {
     pub dq: [[[u16; 2]; 3]; RAV1D_MAX_SEGMENTS as usize], /* [RAV1D_MAX_SEGMENTS][3 plane][2 dc/ac] */
     pub qm: [[*const u8; 3]; 19],                         /* [3 plane][19] */
     pub a: Vec<BlockContext>,                             /* len = w*tile_rows */
-    pub rf: refmvs_frame,
+    pub rf: RefMvsFrame,
     pub jnt_weights: [[u8; 7]; 7],
     pub bitdepth_max: c_int,
 

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -1,7 +1,6 @@
 use crate::include::common::bitdepth::BitDepth;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
 use crate::include::dav1d::headers::Rav1dPixelLayout;
-use crate::src::env::BlockContext;
 use crate::src::internal::Rav1dContext;
 use crate::src::internal::Rav1dDSPContext;
 use crate::src::internal::Rav1dFrameData;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,6 @@ use crate::src::refmvs::rav1d_refmvs_init;
 use crate::src::thread_task::rav1d_task_delayed_fg;
 use crate::src::thread_task::rav1d_worker_task;
 use crate::src::thread_task::FRAME_ERROR;
-use libc::free;
 use libc::memset;
 use std::cell::UnsafeCell;
 use std::cmp;

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -53,15 +53,6 @@ pub unsafe fn rav1d_freep_aligned(ptr: *mut c_void) {
     }
 }
 
-#[inline]
-pub unsafe fn freep(ptr: *mut c_void) {
-    let mem: *mut *mut c_void = ptr as *mut *mut c_void;
-    if !(*mem).is_null() {
-        free(*mem);
-        *mem = 0 as *mut c_void;
-    }
-}
-
 #[cold]
 unsafe fn mem_pool_destroy(pool: *mut Rav1dMemPool) {
     pthread_mutex_destroy(&mut (*pool).lock);


### PR DESCRIPTION
This lets us change `RefMvsFrame` to be safe, as it's no longer `#[repr(C)]` and we can change its layout. Since the asm functions only take `*const refmvs_frame`, the one-way conversion is easy and should stay simple.  There are only 2 of these conversions needed, and they're only 224 bytes (for `refmvs_frame`) `memcpy`s pretty much.