### PR TITLE
`struct Rav1dFrameData::a`: Make into `Vec`

### DIFF
--- a/src/align.rs
+++ b/src/align.rs
@@ -28,6 +28,12 @@ impl<T: ArrayDefault + Copy, const N: usize> ArrayDefault for [T; N] {
     }
 }
 
+impl<T> ArrayDefault for Option<T> {
+    fn default() -> Self {
+        None
+    }
+}
+
 macro_rules! impl_ArrayDefault {
     ($T:ty) => {
         impl ArrayDefault for $T {

--- a/src/env.rs
+++ b/src/env.rs
@@ -26,6 +26,7 @@ use std::cmp::Ordering;
 use std::ffi::c_int;
 use std::ffi::c_uint;
 
+#[derive(Default)]
 #[repr(C)]
 pub struct BlockContext {
     pub mode: Align8<[u8; 32]>,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -703,8 +703,7 @@ pub(crate) struct Rav1dFrameData {
     pub sr_sb128w: c_int,
     pub dq: [[[u16; 2]; 3]; RAV1D_MAX_SEGMENTS as usize], /* [RAV1D_MAX_SEGMENTS][3 plane][2 dc/ac] */
     pub qm: [[*const u8; 3]; 19],                         /* [3 plane][19] */
-    pub a: *mut BlockContext,
-    pub a_sz: c_int, /* w*tile_rows */
+    pub a: Vec<BlockContext>,                             /* len = w*tile_rows */
     pub rf: refmvs_frame,
     pub jnt_weights: [[u8; 7]; 7],
     pub bitdepth_max: c_int,

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -657,8 +657,7 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
 
     // fix lpf strength at tile row boundaries
     if start_of_tile_row != 0 {
-        let mut a: &[BlockContext] = slice::from_raw_parts(f.a, f.a_sz as usize);
-        a = &a[(f.sb128w * (start_of_tile_row - 1)) as usize..];
+        let mut a = &f.a[(f.sb128w * (start_of_tile_row - 1)) as usize..];
         for x in 0..f.sb128w {
             let y_vmask: &mut [[u16; 2]; 3] = &mut lflvl[x as usize].filter_y[1][starty4 as usize];
             let w = cmp::min(32, f.w4 - (x << 5)) as u32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -912,7 +912,7 @@ impl Drop for Rav1dContext {
                 mem::take(&mut f.task_thread.tasks); // TODO: remove when context is owned
                 rav1d_free_aligned(f.ts as *mut c_void);
                 rav1d_free_aligned(f.ipred_edge[0] as *mut c_void);
-                free(f.a as *mut c_void);
+                let _ = mem::take(&mut f.a); // TODO: remove when context is owned
                 let _ = mem::take(&mut f.tiles);
                 let _ = mem::take(&mut f.lf.mask); // TODO: remove when context is owned
                 let _ = mem::take(&mut f.lf.lr_mask); // TODO: remove when context is owned


### PR DESCRIPTION
This will need to be wrapped in a `DisjointMut` due to being accessed concurrently across threads, but I want to start by making it `Vec` and then add the wrapper in a followup PR.