### PR TITLE
`rust-toolchain.toml`: Upgrade to `nightly-2024-04-01`

### DIFF
--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -239,7 +239,7 @@ pub trait BitDepth: Clone + Copy {
         Self::Pixel::mut_slice_from(bytes).unwrap()
     }
 
-    fn cast_coef_slice(bytes: &[u8]) -> &[Self::Coef] {
+    fn _cast_coef_slice(bytes: &[u8]) -> &[Self::Coef] {
         Self::Coef::slice_from(bytes).unwrap()
     }
 
@@ -261,7 +261,7 @@ pub trait BitDepth: Clone + Copy {
         T::T<BitDepth8>: Copy,
         T::T<BitDepth16>: Copy;
 
-    unsafe fn select_into<T>(bd: BitDepthUnion<T>) -> T::T<Self>
+    unsafe fn _select_into<T>(bd: BitDepthUnion<T>) -> T::T<Self>
     where
         T: BitDepthDependentType,
         T::T<BitDepth8>: Copy,
@@ -337,7 +337,7 @@ impl BitDepth for BitDepth8 {
         &mut bd.bpc8
     }
 
-    unsafe fn select_into<T>(bd: BitDepthUnion<T>) -> T::T<Self>
+    unsafe fn _select_into<T>(bd: BitDepthUnion<T>) -> T::T<Self>
     where
         T: BitDepthDependentType,
         T::T<BitDepth8>: Copy,
@@ -418,7 +418,7 @@ impl BitDepth for BitDepth16 {
         &mut bd.bpc16
     }
 
-    unsafe fn select_into<T>(bd: BitDepthUnion<T>) -> T::T<Self>
+    unsafe fn _select_into<T>(bd: BitDepthUnion<T>) -> T::T<Self>
     where
         T: BitDepthDependentType,
         T::T<BitDepth8>: Copy,

--- a/lib.rs
+++ b/lib.rs
@@ -2,7 +2,7 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![feature(c_variadic)]
-#![cfg_attr(target_arch = "arm", feature(stdsimd))]
+#![cfg_attr(target_arch = "arm", feature(stdarch_arm_feature_detection))]
 #![allow(clippy::all)]
 
 #[cfg(not(any(feature = "bitdepth_8", feature = "bitdepth_16")))]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-11-16"
+channel = "nightly-2024-04-01"
 targets = [
     "x86_64-unknown-linux-gnu",
     "i686-unknown-linux-gnu",

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,7 +1,6 @@
 use std::ffi::c_char;
 use std::ffi::c_uint;
 use std::ffi::c_void;
-use std::ffi::CStr;
 use std::fmt;
 use std::fmt::Write as _;
 use std::io::stderr;
@@ -47,8 +46,7 @@ impl fmt::Write for Dav1dLogger {
         // so it's easiest just to print one byte at a time.
         // This may be slow, but logging can be disabled if it's slow,
         // or the Rust API can be used instead.
-        // TODO(kkysen) Replace with `c"%c"` once its stabilization reaches stable.
-        let fmt = CStr::from_bytes_with_nul(b"%c\0").unwrap();
+        let fmt = c"%c";
         for &byte in s.as_bytes() {
             // # Safety
             //


### PR DESCRIPTION
`rust-analyzer` has been showing me a ton of warnings lately, things like `non_camel_case_types`, which we allow for `rustc`, and which I realized is due to the `rust-analyzer` version being new, and our `rustc` toolchain being old.  Upgrading it to the latest nightly fixes this.  These warnings are especially annoying as they slow down my edit and compile cycle, and we are due for an upgrade anyways, though hopefully we can go to `stable` next (once #620 is merged, though it hasn't been enough of a priority).

We can also replace the `target_arch = "arm"`-dependent `#![feature(stdsimd)]` with the much more specific and more likely to stabilize soon `#![feature(stdarch_arm_feature_detection)]`.

* Fixes #623.