### PR TITLE
`struct Rav1dFrameContext_lf`: Add inner mutability

### DIFF
--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -231,14 +231,6 @@ pub trait BitDepth: Clone + Copy {
 
     fn get_intermediate_bits(&self) -> u8;
 
-    fn cast_pixel_slice(bytes: &[u8]) -> &[Self::Pixel] {
-        Self::Pixel::slice_from(bytes).unwrap()
-    }
-
-    fn cast_pixel_slice_mut(bytes: &mut [u8]) -> &mut [Self::Pixel] {
-        Self::Pixel::mut_slice_from(bytes).unwrap()
-    }
-
     fn _cast_coef_slice(bytes: &[u8]) -> &[Self::Coef] {
         Self::Coef::slice_from(bytes).unwrap()
     }

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -3,7 +3,9 @@ use crate::include::common::bitdepth::BPC;
 use crate::include::common::intops::ulog2;
 use crate::include::dav1d::headers::Rav1dPixelLayout;
 use crate::src::align::Align16;
+use crate::src::align::AlignedVec32;
 use crate::src::cdef::CdefEdgeFlags;
+use crate::src::disjoint_mut::DisjointMut;
 use crate::src::internal::Rav1dContext;
 use crate::src::internal::Rav1dFrameData;
 use crate::src::internal::Rav1dTaskContext;
@@ -33,8 +35,9 @@ impl Backup2x8Flags {
     }
 }
 
+/// `dst_buf` is a buffer of `BD::Pixel` elements
 unsafe fn backup2lines<BD: BitDepth>(
-    dst_buf: &mut [BD::Pixel],
+    dst_buf: &DisjointMut<AlignedVec32<u8>>,
     dst_off: [usize; 3],
     src: &[*mut BD::Pixel; 3],
     stride: &[ptrdiff_t; 2],
@@ -43,14 +46,15 @@ unsafe fn backup2lines<BD: BitDepth>(
     let y_stride: ptrdiff_t = BD::pxstride(stride[0]);
     let len = 2 * y_stride.unsigned_abs();
     if y_stride < 0 {
+        let start = dst_off[0].wrapping_add_signed(y_stride);
         BD::pixel_copy(
-            &mut dst_buf[dst_off[0].wrapping_add_signed(y_stride)..][..len],
+            &mut dst_buf.mut_slice_as(start..start + len),
             slice::from_raw_parts(src[0].offset(7 * y_stride), len),
             len,
         );
     } else {
         BD::pixel_copy(
-            &mut dst_buf[dst_off[0]..][..len],
+            &mut dst_buf.mut_slice_as(dst_off[0]..dst_off[0] + len),
             slice::from_raw_parts(src[0].offset(6 * y_stride), len),
             len,
         );
@@ -66,13 +70,15 @@ unsafe fn backup2lines<BD: BitDepth>(
                 7
             };
 
+            let start = dst_off[1].wrapping_add_signed(uv_stride);
             BD::pixel_copy(
-                &mut dst_buf[dst_off[1].wrapping_add_signed(uv_stride)..][..len],
+                &mut dst_buf.mut_slice_as(start..start + len),
                 slice::from_raw_parts(src[1].offset(uv_off * uv_stride), len),
                 len,
             );
+            let start = dst_off[2].wrapping_add_signed(uv_stride);
             BD::pixel_copy(
-                &mut dst_buf[dst_off[2].wrapping_add_signed(uv_stride)..][..len],
+                &mut dst_buf.mut_slice_as(start..start + len),
                 slice::from_raw_parts(src[2].offset(uv_off * uv_stride), len),
                 len,
             );
@@ -84,12 +90,12 @@ unsafe fn backup2lines<BD: BitDepth>(
             };
 
             BD::pixel_copy(
-                &mut dst_buf[dst_off[1]..][..len],
+                &mut dst_buf.mut_slice_as(dst_off[1]..dst_off[1] + len),
                 slice::from_raw_parts(src[1].offset(uv_off * uv_stride), len),
                 len,
             );
             BD::pixel_copy(
-                &mut dst_buf[dst_off[2]..][..len],
+                &mut dst_buf.mut_slice_as(dst_off[2]..dst_off[2] + len),
                 slice::from_raw_parts(src[2].offset(uv_off * uv_stride), len),
                 len,
             );
@@ -195,9 +201,6 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
     let y_stride: ptrdiff_t = BD::pxstride(f.cur.stride[0]);
     let uv_stride: ptrdiff_t = BD::pxstride(f.cur.stride[1]);
 
-    let cdef_line_buf = BD::cast_pixel_slice_mut(&mut f.lf.cdef_line_buf);
-    let lr_line_buf = BD::cast_pixel_slice(&f.lf.lr_line_buf);
-
     let mut bit = false;
     for by in (by_start..by_end).step_by(2) {
         let tf = tc.top_pre_cdef_toggle != 0;
@@ -218,7 +221,13 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                 f.lf.cdef_line[!tf as usize][2]
                     .wrapping_add_signed(have_tt as isize * sby as isize * 8 * uv_stride),
             ];
-            backup2lines::<BD>(cdef_line_buf, cdef_top_bak, &ptrs, &f.cur.stride, layout);
+            backup2lines::<BD>(
+                &f.lf.cdef_line_buf,
+                cdef_top_bak,
+                &ptrs,
+                &f.cur.stride,
+                layout,
+            );
         }
 
         let mut lr_bak =
@@ -318,15 +327,17 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                         let mut offset: ptrdiff_t;
                         let st_y: bool;
 
+                        let lr_line_buf_lock = f.lf.lr_line_buf.read().unwrap();
+                        let lr_line_buf = BD::cast_pixel_slice(&lr_line_buf_lock);
                         if !have_tt {
                             st_y = true;
                         } else if sbrow_start && by == by_start {
                             if resize {
                                 offset = ((sby - 1) * 4) as isize * y_stride + (bx * 4) as isize;
-                                top = cdef_line_buf
-                                    .as_mut_ptr()
-                                    .add(f.lf.cdef_lpf_line[0])
-                                    .offset(offset);
+                                top = &*f
+                                    .lf
+                                    .cdef_line_buf
+                                    .element_as((f.lf.cdef_lpf_line[0] as isize + offset) as usize);
                             } else {
                                 offset = (sby * ((4 as c_int) << sb128) - 4) as isize * y_stride
                                     + (bx * 4) as isize;
@@ -336,16 +347,15 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                             st_y = false;
                         } else if !sbrow_start && by + 2 >= by_end {
                             offset = (sby * 4) as isize * y_stride + (bx * 4) as isize;
-                            top = cdef_line_buf
-                                .as_mut_ptr()
-                                .add(f.lf.cdef_line[tf as usize][0])
-                                .offset(offset);
+                            top = &*f.lf.cdef_line_buf.element_as(
+                                (f.lf.cdef_line[tf as usize][0] as isize + offset) as usize,
+                            );
                             if resize {
                                 offset = (sby * 4 + 2) as isize * y_stride + (bx * 4) as isize;
-                                bot = cdef_line_buf
-                                    .as_mut_ptr()
-                                    .add(f.lf.cdef_lpf_line[0])
-                                    .offset(offset);
+                                bot = &*f
+                                    .lf
+                                    .cdef_line_buf
+                                    .element_as((f.lf.cdef_lpf_line[0] as isize + offset) as usize);
                             } else {
                                 let line = sby * ((4 as c_int) << sb128) + 4 * sb128 + 2;
                                 offset = line as isize * y_stride + (bx * 4) as isize;
@@ -359,10 +369,9 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                         if st_y {
                             offset = have_tt as isize * (sby * 4) as isize * y_stride
                                 + (bx * 4) as isize;
-                            top = cdef_line_buf
-                                .as_mut_ptr()
-                                .add(f.lf.cdef_line[tf as usize][0])
-                                .offset(offset);
+                            top = &*f.lf.cdef_line_buf.element_as(
+                                (f.lf.cdef_line[tf as usize][0] as isize + offset) as usize,
+                            );
                             bot = bptrs[0].offset(8 * y_stride as isize);
                         }
 
@@ -415,10 +424,9 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                                     if resize {
                                         offset = ((sby - 1) * 4) as isize * uv_stride
                                             + (bx * 4 >> ss_hor) as isize;
-                                        top = cdef_line_buf
-                                            .as_mut_ptr()
-                                            .add(f.lf.cdef_lpf_line[pl])
-                                            .offset(offset);
+                                        top = &*f.lf.cdef_line_buf.element_as(
+                                            (f.lf.cdef_lpf_line[pl] as isize + offset) as usize,
+                                        );
                                     } else {
                                         let line_0 = sby * ((4 as c_int) << sb128) - 4;
                                         offset = line_0 as isize * uv_stride
@@ -433,17 +441,16 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                                 } else if !sbrow_start && by + 2 >= by_end {
                                     let top_offset: ptrdiff_t = (sby * 8) as isize * uv_stride
                                         + (bx * 4 >> ss_hor) as isize;
-                                    top = cdef_line_buf
-                                        .as_mut_ptr()
-                                        .add(f.lf.cdef_line[tf as usize][pl])
-                                        .offset(top_offset);
+                                    top = &*f.lf.cdef_line_buf.element_as(
+                                        (f.lf.cdef_line[tf as usize][pl] as isize + top_offset)
+                                            as usize,
+                                    );
                                     if resize {
                                         offset = (sby * 4 + 2) as isize * uv_stride
                                             + (bx * 4 >> ss_hor) as isize;
-                                        bot = cdef_line_buf
-                                            .as_mut_ptr()
-                                            .add(f.lf.cdef_lpf_line[pl])
-                                            .offset(offset);
+                                        bot = &*f.lf.cdef_line_buf.element_as(
+                                            (f.lf.cdef_lpf_line[pl] as isize + offset) as usize,
+                                        );
                                     } else {
                                         let line = sby * ((4 as c_int) << sb128) + 4 * sb128 + 2;
                                         offset =
@@ -461,10 +468,10 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                                 if st_uv {
                                     let offset = have_tt as isize * (sby * 8) as isize * uv_stride
                                         + (bx * 4 >> ss_hor) as isize;
-                                    top = cdef_line_buf
-                                        .as_mut_ptr()
-                                        .add(f.lf.cdef_line[tf as usize][pl])
-                                        .offset(offset);
+                                    top = &*f.lf.cdef_line_buf.element_as(
+                                        (f.lf.cdef_line[tf as usize][pl] as isize + offset)
+                                            as usize,
+                                    );
                                     bot = bptrs[pl].offset((8 >> ss_ver) * uv_stride);
                                 }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4218,7 +4218,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
     alloc_sz += y_stride.unsigned_abs() * num_lines as usize;
     alloc_sz += uv_stride.unsigned_abs() * num_lines as usize * 2;
     // TODO: Fallible allocation
-    f.lf.lr_line_buf.try_write().unwrap().resize(alloc_sz, 0);
+    f.lf.lr_line_buf.resize(alloc_sz, 0);
 
     let y_stride_px = bpc.pxstride(y_stride);
     let uv_stride_px = bpc.pxstride(uv_stride);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4218,7 +4218,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init(
     alloc_sz += y_stride.unsigned_abs() * num_lines as usize;
     alloc_sz += uv_stride.unsigned_abs() * num_lines as usize * 2;
     // TODO: Fallible allocation
-    f.lf.lr_line_buf.resize(alloc_sz, 0);
+    f.lf.lr_line_buf.try_write().unwrap().resize(alloc_sz, 0);
 
     let y_stride_px = bpc.pxstride(y_stride);
     let uv_stride_px = bpc.pxstride(uv_stride);

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -108,6 +108,7 @@ use std::sync::Arc;
 use std::sync::Condvar;
 use std::sync::Mutex;
 use std::sync::OnceLock;
+use std::sync::RwLock;
 use std::thread::JoinHandle;
 
 #[repr(C)]
@@ -515,7 +516,7 @@ impl Pal {
         &'a self,
         index: usize,
     ) -> DisjointImmutGuard<'b, AlignedVec64<u8>, PalArray<BD>> {
-        self.data.index_as(index)
+        self.data.element_as(index)
     }
 
     /// Mutably borrow a pal array.
@@ -537,7 +538,7 @@ impl Pal {
         // indexed region we are mutably borrowing is not concurrently borrowed
         // and will not be borrowed during the lifetime of the returned
         // reference.
-        unsafe { self.data.index_mut_as(index) }
+        unsafe { self.data.mut_element_as(index) }
     }
 }
 
@@ -628,8 +629,8 @@ pub struct Rav1dFrameContext_lf {
     pub last_sharpness: c_int,
     pub lvl: [[[[u8; 2]; 8]; 4]; 8], /* [8 seg_id][4 dir][8 ref][2 is_gmv] */
     pub tx_lpf_right_edge: TxLpfRightEdge,
-    pub cdef_line_buf: AlignedVec32<u8>, /* AlignedVec32<DynPixel> */
-    pub lr_line_buf: AlignedVec64<u8>,
+    pub cdef_line_buf: DisjointMut<AlignedVec32<u8>>, /* AlignedVec32<DynPixel> */
+    pub lr_line_buf: RwLock<AlignedVec64<u8>>,
     pub cdef_line: [[usize; 3]; 2], /* [2 pre/post][3 plane] */
     pub cdef_lpf_line: [usize; 3],  /* plane */
     pub lr_lpf_line: [usize; 3],    /* plane */

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -108,7 +108,6 @@ use std::sync::Arc;
 use std::sync::Condvar;
 use std::sync::Mutex;
 use std::sync::OnceLock;
-use std::sync::RwLock;
 use std::thread::JoinHandle;
 
 #[repr(C)]
@@ -629,8 +628,11 @@ pub struct Rav1dFrameContext_lf {
     pub last_sharpness: c_int,
     pub lvl: [[[[u8; 2]; 8]; 4]; 8], /* [8 seg_id][4 dir][8 ref][2 is_gmv] */
     pub tx_lpf_right_edge: TxLpfRightEdge,
-    pub cdef_line_buf: DisjointMut<AlignedVec32<u8>>, /* AlignedVec32<DynPixel> */
-    pub lr_line_buf: RwLock<AlignedVec64<u8>>,
+    // cdef_line_buf was originally aligned to 32 bytes, but we need to pass
+    // both cdef_line_buf and lr_line_buf as the same parameter type to
+    // backup2lines.
+    pub cdef_line_buf: DisjointMut<AlignedVec64<u8>>, /* AlignedVec32<DynPixel> */
+    pub lr_line_buf: DisjointMut<AlignedVec64<u8>>,
     pub cdef_line: [[usize; 3]; 2], /* [2 pre/post][3 plane] */
     pub cdef_lpf_line: [usize; 3],  /* plane */
     pub lr_lpf_line: [usize; 3],    /* plane */

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -1,6 +1,9 @@
 use crate::include::common::bitdepth::BitDepth;
+use crate::include::common::bitdepth::DynPixel;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
 use crate::include::dav1d::headers::Rav1dPixelLayout;
+use crate::src::align::AlignedVec64;
+use crate::src::disjoint_mut::DisjointMut;
 use crate::src::internal::Rav1dContext;
 use crate::src::internal::Rav1dDSPContext;
 use crate::src::internal::Rav1dFrameData;
@@ -22,8 +25,8 @@ use std::sync::atomic::Ordering;
 // stripe with the top of the next super block row.
 unsafe fn backup_lpf<BD: BitDepth>(
     c: &Rav1dContext,
-    dst: &mut [BD::Pixel],
-    mut dst_offset: usize,
+    dst: &DisjointMut<AlignedVec64<u8>>,
+    mut dst_offset: usize, // in pixel units
     dst_stride: ptrdiff_t,
     src: &[BD::Pixel],
     mut src_offset: usize,
@@ -59,19 +62,23 @@ unsafe fn backup_lpf<BD: BitDepth>(
             let top_size = top * px_abs_stride;
             // Copy the top part of the stored loop filtered pixels from the
             // previous sb row needed above the first stripe of this sb row.
-            let (dst, dst_top) = if dst_stride < 0 {
-                let dst = &mut dst[dst_offset - top_size - 3 * px_abs_stride..];
-                let (dst_top, dst) = dst.split_at_mut(top_size);
-                (dst, dst_top)
+            let (dst_idx, src_idx) = if dst_stride < 0 {
+                (
+                    dst_offset - 3 * px_abs_stride,
+                    dst_offset - top_size - 3 * px_abs_stride,
+                )
             } else {
-                let dst = &mut dst[dst_offset..];
-                dst.split_at_mut(top_size)
+                (dst_offset, dst_offset + top_size)
             };
 
             for i in 0..4 {
                 BD::pixel_copy(
-                    &mut dst[i * px_abs_stride..],
-                    &dst_top[i * px_abs_stride..],
+                    &mut dst.mut_slice_as(
+                        dst_idx + i * px_abs_stride..dst_idx + i * px_abs_stride + dst_w as usize,
+                    ),
+                    &dst.slice_as(
+                        src_idx + i * px_abs_stride..src_idx + i * px_abs_stride + dst_w as usize,
+                    ),
                     dst_w as usize,
                 );
             }
@@ -81,8 +88,9 @@ unsafe fn backup_lpf<BD: BitDepth>(
     if lr_backup != 0 && frame_hdr.size.width[0] != frame_hdr.size.width[1] {
         while row + stripe_h <= row_h {
             let n_lines = 4 - (row + stripe_h + 1 == h) as c_int;
+            let mut dst_guard = dst.mut_slice_as(dst_offset..dst_offset + dst_w as usize);
             (dsp.mc.resize)(
-                dst.as_mut_ptr().add(dst_offset).cast(),
+                dst_guard.as_mut_ptr() as *mut BD::Pixel as *mut DynPixel,
                 dst_stride,
                 src.as_ptr().add(src_offset).cast(),
                 src_stride,
@@ -102,13 +110,16 @@ unsafe fn backup_lpf<BD: BitDepth>(
 
             if n_lines == 3 {
                 let dst_abs_px_stride = BD::pxstride(dst_stride.unsigned_abs());
-                let (src_tmp, dst_tmp) = if dst_stride < 0 {
-                    let (dst_tmp, src_tmp) = dst[dst_offset..].split_at_mut(dst_abs_px_stride);
-                    (src_tmp, dst_tmp)
+                let (src_idx, dst_idx) = if dst_stride < 0 {
+                    (dst_offset + dst_abs_px_stride, dst_offset)
                 } else {
-                    dst[dst_offset - dst_abs_px_stride..].split_at_mut(dst_abs_px_stride)
+                    (dst_offset - dst_abs_px_stride, dst_offset)
                 };
-                BD::pixel_copy(dst_tmp, src_tmp, dst_w as usize);
+                BD::pixel_copy(
+                    &mut dst.mut_slice_as(dst_idx..dst_idx + dst_w as usize),
+                    &dst.slice_as(src_idx..src_idx + dst_w as usize),
+                    dst_w as usize,
+                );
                 dst_offset = (dst_offset as isize + BD::pxstride(dst_stride)) as usize;
             }
         }
@@ -117,17 +128,24 @@ unsafe fn backup_lpf<BD: BitDepth>(
             let n_lines = 4 - (row + stripe_h + 1 == h) as c_int;
             for i in 0..4 {
                 let dst_abs_px_stride = BD::pxstride(dst_stride.unsigned_abs());
-                let (src_tmp, dst_tmp) = if i != n_lines {
-                    (&src[src_offset..], &mut dst[dst_offset..])
-                } else if dst_stride < 0 {
-                    let (dst_tmp, src_tmp) = dst[dst_offset..].split_at_mut(dst_abs_px_stride);
-                    (&*src_tmp, dst_tmp)
+                if i != n_lines {
+                    BD::pixel_copy(
+                        &mut dst.mut_slice_as(dst_offset..dst_offset + src_w as usize),
+                        &src[src_offset..],
+                        src_w as usize,
+                    );
                 } else {
-                    let (src_tmp, dst_tmp) =
-                        dst[dst_offset - dst_abs_px_stride..].split_at_mut(dst_abs_px_stride);
-                    (&*src_tmp, dst_tmp)
-                };
-                BD::pixel_copy(dst_tmp, src_tmp, src_w as usize);
+                    let (src_idx, dst_idx) = if dst_stride < 0 {
+                        (dst_offset + dst_abs_px_stride, dst_offset)
+                    } else {
+                        (dst_offset - dst_abs_px_stride, dst_offset)
+                    };
+                    BD::pixel_copy(
+                        &mut dst.mut_slice_as(dst_idx..dst_idx + src_w as usize),
+                        &dst.slice_as(src_idx..src_idx + src_w as usize),
+                        src_w as usize,
+                    )
+                }
                 dst_offset = (dst_offset as isize + BD::pxstride(dst_stride)) as usize;
                 src_offset = (src_offset as isize + BD::pxstride(src_stride)) as usize;
             }
@@ -171,8 +189,6 @@ pub(crate) unsafe fn rav1d_copy_lpf<BD: BitDepth>(
     // TODO Also check block level restore type to reduce copying.
     let restore_planes = f.lf.restore_planes;
 
-    let mut lr_line_buf_lock = f.lf.lr_line_buf.write().unwrap();
-    let lr_line_buf = BD::cast_pixel_slice_mut(&mut lr_line_buf_lock);
     if seq_hdr.cdef != 0 || restore_planes & LR_RESTORE_Y as c_int != 0 {
         let h = f.cur.p.h;
         let w = f.bw << 2;
@@ -181,7 +197,7 @@ pub(crate) unsafe fn rav1d_copy_lpf<BD: BitDepth>(
         if restore_planes & LR_RESTORE_Y as c_int != 0 || resize == 0 {
             backup_lpf::<BD>(
                 c,
-                lr_line_buf,
+                &f.lf.lr_line_buf,
                 dst_offset[0],
                 lr_stride[0],
                 src[0],
@@ -209,10 +225,8 @@ pub(crate) unsafe fn rav1d_copy_lpf<BD: BitDepth>(
             let cdef_line_start = (f.lf.cdef_lpf_line[0] as isize + cmp::min(y_span, 0)) as usize;
             backup_lpf::<BD>(
                 c,
-                &mut f.lf.cdef_line_buf.mut_slice_as(
-                    cdef_line_start..cdef_line_start + cdef_plane_y_sz.unsigned_abs(),
-                ),
-                (cdef_off_y - cmp::min(y_span, 0)) as usize,
+                &f.lf.cdef_line_buf,
+                cdef_line_start + (cdef_off_y - cmp::min(y_span, 0)) as usize,
                 src_stride[0],
                 src[0],
                 (src_offset[0] as isize - offset as isize * src_y_stride as isize) as usize,
@@ -248,7 +262,7 @@ pub(crate) unsafe fn rav1d_copy_lpf<BD: BitDepth>(
             if restore_planes & LR_RESTORE_U as c_int != 0 || resize == 0 {
                 backup_lpf::<BD>(
                     c,
-                    lr_line_buf,
+                    &f.lf.lr_line_buf,
                     dst_offset[1],
                     lr_stride[1],
                     src[1],
@@ -276,10 +290,8 @@ pub(crate) unsafe fn rav1d_copy_lpf<BD: BitDepth>(
                     (f.lf.cdef_lpf_line[1] as isize + cmp::min(uv_span, 0)) as usize;
                 backup_lpf::<BD>(
                     c,
-                    &mut f.lf.cdef_line_buf.mut_slice_as(
-                        cdef_line_start..cdef_line_start + cdef_plane_uv_sz.unsigned_abs(),
-                    ),
-                    (cdef_off_uv - cmp::min(uv_span, 0)) as usize,
+                    &f.lf.cdef_line_buf,
+                    cdef_line_start + (cdef_off_uv - cmp::min(uv_span, 0)) as usize,
                     src_stride[1],
                     src[1],
                     (src_offset[1] as isize - offset_uv as isize * src_uv_stride) as usize,
@@ -304,7 +316,7 @@ pub(crate) unsafe fn rav1d_copy_lpf<BD: BitDepth>(
             if restore_planes & LR_RESTORE_V as c_int != 0 || resize == 0 {
                 backup_lpf::<BD>(
                     c,
-                    lr_line_buf,
+                    &f.lf.lr_line_buf,
                     dst_offset[2],
                     lr_stride[1],
                     src[2],
@@ -332,10 +344,8 @@ pub(crate) unsafe fn rav1d_copy_lpf<BD: BitDepth>(
                     (f.lf.cdef_lpf_line[2] as isize + cmp::min(uv_span, 0)) as usize;
                 backup_lpf::<BD>(
                     c,
-                    &mut f.lf.cdef_line_buf.mut_slice_as(
-                        cdef_line_start..cdef_line_start + cdef_plane_uv_sz.unsigned_abs(),
-                    ),
-                    (cdef_off_uv - cmp::min(uv_span, 0)) as usize,
+                    &f.lf.cdef_line_buf,
+                    cdef_line_start + (cdef_off_uv - cmp::min(uv_span, 0)) as usize,
                     src_stride[1],
                     src[2],
                     (src_offset[1] as isize - offset_uv as isize * src_uv_stride) as usize,

--- a/src/lr_apply.rs
+++ b/src/lr_apply.rs
@@ -45,7 +45,8 @@ unsafe fn lr_stripe<BD: BitDepth>(
     let sby = y + (if y != 0 { 8 << ss_ver } else { 0 }) >> 6 - ss_ver + seq_hdr.sb128;
     let have_tt = (c.tc.len() > 1) as c_int;
     let lpf_stride = BD::pxstride(stride);
-    let lr_line_buf = BD::cast_pixel_slice(&f.lf.lr_line_buf);
+    let lr_line_buf_lock = f.lf.lr_line_buf.read().unwrap();
+    let lr_line_buf = BD::cast_pixel_slice(&lr_line_buf_lock);
     let mut lpf_offset = f.lf.lr_lpf_line[plane as usize] as isize;
     lpf_offset += (have_tt * (sby * (4 << seq_hdr.sb128) - 4)) as isize * lpf_stride + x as isize;
     // The first stripe of the frame is shorter by 8 luma pixel rows.


### PR DESCRIPTION
Adds inner mutability to the `cdef_line_buf`, and `lr_line_buf` fields by using locks taken without blocking. Any blocking indicates contention that we should address in other ways.