### PR TITLE
`struct Rav1dFrameContext_task_thread:` Give fields inner mutability

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -702,6 +702,7 @@ pub(crate) struct Rav1dFrameContext_task_thread {
     pub init_done: AtomicI32,
     pub done: [AtomicI32; 2],
     pub retval: Mutex<Rav1dResult>,
+    pub finished: AtomicBool,   // true when FrameData.tiles is cleared
     pub update_set: AtomicBool, // whether we need to update CDF reference
     pub error: AtomicI32,
     pub task_counter: AtomicI32,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -701,8 +701,8 @@ pub(crate) struct Rav1dFrameContext_task_thread {
     pub tasks: UnsafeCell<Rav1dTasks>,
     pub init_done: AtomicI32,
     pub done: [AtomicI32; 2],
-    pub retval: Rav1dResult,
-    pub update_set: bool, // whether we need to update CDF reference
+    pub retval: Mutex<Rav1dResult>,
+    pub update_set: AtomicBool, // whether we need to update CDF reference
     pub error: AtomicI32,
     pub task_counter: AtomicI32,
     // async task insertion

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ use std::ptr;
 use std::ptr::addr_of_mut;
 use std::ptr::NonNull;
 use std::slice;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI32;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
@@ -288,6 +289,8 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
         f.index = n;
         addr_of_mut!(f.tiles).write(Default::default());
         addr_of_mut!(f.task_thread.tasks).write(UnsafeCell::new(Default::default()));
+        addr_of_mut!(f.task_thread.retval).write(Mutex::new(Ok(())));
+        addr_of_mut!(f.task_thread.update_set).write(AtomicBool::new(false));
         addr_of_mut!(f.frame_thread).write(Default::default());
         addr_of_mut!(f.frame_thread_progress).write(Default::default());
         if n_tc > 1 {
@@ -473,9 +476,8 @@ unsafe fn drain_picture(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRe
             c.frame_thread.next = 0 as c_int as c_uint;
         }
         drop(task_thread_lock);
-        let error = f.task_thread.retval;
+        let error = mem::replace(&mut *f.task_thread.retval.try_lock().unwrap(), Ok(()));
         if error.is_err() {
-            f.task_thread.retval = Ok(());
             *c.cached_error_props.get_mut().unwrap() = out_delayed.p.m.clone();
             rav1d_thread_picture_unref(out_delayed);
             return error;
@@ -735,7 +737,7 @@ pub(crate) unsafe fn rav1d_flush(c: *mut Rav1dContext) {
             }
             let f: &mut Rav1dFrameData = &mut *((*c).fc).offset(next as isize);
             rav1d_decode_frame_exit(&*c, f, Err(EGeneric));
-            f.task_thread.retval = Ok(());
+            *f.task_thread.retval.try_lock().unwrap() = Ok(());
             let out_delayed = &mut (*c).frame_thread.out_delayed[next as usize];
             if out_delayed.p.frame_hdr.is_some() {
                 rav1d_thread_picture_unref(out_delayed);

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2545,7 +2545,7 @@ unsafe fn parse_obus(
                 }
 
                 let f = &mut *c.fc.offset(next as isize);
-                while !f.tiles.is_empty() {
+                while !f.task_thread.finished.load(Ordering::SeqCst) {
                     task_thread_lock = f.task_thread.cond.wait(task_thread_lock).unwrap();
                 }
                 let out_delayed = &mut c.frame_thread.out_delayed[next as usize];

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2570,10 +2570,9 @@ unsafe fn parse_obus(
                         c.task_thread.cur.fetch_sub(1, Ordering::Relaxed);
                     }
                 }
-                let error = f.task_thread.retval;
+                let mut error = f.task_thread.retval.try_lock().unwrap();
                 if error.is_err() {
-                    c.cached_error = error;
-                    f.task_thread.retval = Ok(());
+                    c.cached_error = mem::replace(&mut *error, Ok(()));
                     *c.cached_error_props.get_mut().unwrap() = out_delayed.p.m.clone();
                     rav1d_thread_picture_unref(out_delayed);
                 } else if !(out_delayed.p.data.data[0]).is_null() {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -976,7 +976,9 @@ pub unsafe fn rav1d_worker_task(c: &Rav1dContext, task_thread: Arc<Rav1dTaskCont
                             res_0 = rav1d_decode_frame_init_cdf(c, f);
                         }
                         let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
-                        if frame_hdr.refresh_context != 0 && !f.task_thread.update_set {
+                        if frame_hdr.refresh_context != 0
+                            && !f.task_thread.update_set.load(Ordering::Relaxed)
+                        {
                             f.out_cdf.progress().unwrap().store(
                                 (if res_0.is_err() {
                                     TILE_ERROR
@@ -1090,7 +1092,7 @@ pub unsafe fn rav1d_worker_task(c: &Rav1dContext, task_thread: Arc<Rav1dTaskCont
                             let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
                             if frame_hdr.refresh_context != 0
                                 && tc.frame_thread.pass <= 1
-                                && f.task_thread.update_set
+                                && f.task_thread.update_set.load(Ordering::Relaxed)
                                 && frame_hdr.tiling.update as usize == tile_idx
                             {
                                 if error_0 == 0 {


### PR DESCRIPTION
Adds inner mutability to the `retval` and `update_set` fields of `Rav1dFrameContext_task_thread`.

Also adds a finished flag so we don't have to inspect the `tiles` field.