### PR TITLE
`struct Pal`: Add inner mutability to pal buffer

### DIFF
--- a/src/disjoint_mut.rs
+++ b/src/disjoint_mut.rs
@@ -13,6 +13,8 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::marker::PhantomData;
+use std::mem;
+use std::mem::ManuallyDrop;
 use std::ops::Bound;
 use std::ops::Deref;
 use std::ops::DerefMut;
@@ -27,6 +29,8 @@ use std::ops::RangeToInclusive;
 use std::ptr;
 use std::ptr::addr_of_mut;
 use std::sync::Arc;
+use zerocopy::AsBytes;
+use zerocopy::FromBytes;
 
 /// Wraps an indexable collection to allow unchecked concurrent mutable borrows.
 ///
@@ -70,6 +74,23 @@ pub struct DisjointMutGuard<'a, T: ?Sized + AsMutPtr, V: ?Sized> {
     bounds: Bounds,
 }
 
+impl<'a, T: AsMutPtr> DisjointMutGuard<'a, T, [u8]> {
+    fn cast<V: AsBytes + FromBytes>(self) -> DisjointMutGuard<'a, T, V> {
+        // We don't want to drop the old guard, because we aren't changing or
+        // removing the bounds from parent here.
+        let mut old_guard = ManuallyDrop::new(self);
+        let bytes = mem::take(&mut old_guard.slice);
+        DisjointMutGuard {
+            slice: V::mut_from(bytes).unwrap(),
+            phantom: old_guard.phantom,
+            #[cfg(debug_assertions)]
+            parent: old_guard.parent,
+            #[cfg(debug_assertions)]
+            bounds: old_guard.bounds.clone(),
+        }
+    }
+}
+
 impl<'a, T: ?Sized + AsMutPtr, V: ?Sized> Deref for DisjointMutGuard<'a, T, V> {
     type Target = V;
 
@@ -94,6 +115,23 @@ pub struct DisjointImmutGuard<'a, T: ?Sized + AsMutPtr, V: ?Sized> {
     parent: &'a DisjointMut<T>,
     #[cfg(debug_assertions)]
     bounds: Bounds,
+}
+
+impl<'a, T: AsMutPtr> DisjointImmutGuard<'a, T, [u8]> {
+    fn cast<V: FromBytes>(self) -> DisjointImmutGuard<'a, T, V> {
+        // We don't want to drop the old guard, because we aren't changing or
+        // removing the bounds from parent here.
+        let mut old_guard = ManuallyDrop::new(self);
+        let bytes = mem::take(&mut old_guard.slice);
+        DisjointImmutGuard {
+            slice: V::ref_from(bytes).unwrap(),
+            phantom: old_guard.phantom,
+            #[cfg(debug_assertions)]
+            parent: old_guard.parent,
+            #[cfg(debug_assertions)]
+            bounds: old_guard.bounds.clone(),
+        }
+    }
 }
 
 impl<'a, T: ?Sized + AsMutPtr, V: ?Sized> Deref for DisjointImmutGuard<'a, T, V> {
@@ -258,6 +296,70 @@ impl<T: ?Sized + AsMutPtr> DisjointMut<T> {
     }
 }
 
+impl<T: AsMutPtr<Target = u8>> DisjointMut<T> {
+    /// Mutably borrow a slice or element of a convertible type.
+    ///
+    /// This method accesses an element or slice of elements of a type that
+    /// implements `zerocopy::FromBytes` from a buffer of `u8`.
+    ///
+    /// This mutable borrow may be unchecked and callers must ensure that no
+    /// other borrows from this collection overlap with the mutably borrowed
+    /// region for the lifetime of that mutable borrow.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure that no elements of the resulting borrowed slice or
+    /// element are concurrently borrowed (immutably or mutably) at all during
+    /// the lifetime of the returned mutable borrow. We require that the
+    /// referenced data must be plain data and not contain any pointers or
+    /// references to avoid other potential memory safety issues due to racy
+    /// access.
+    #[cfg_attr(debug_assertions, track_caller)]
+    pub unsafe fn index_mut_as<'a, I, V>(&'a self, index: I) -> DisjointMutGuard<'a, T, V>
+    where
+        I: Into<Bounds> + Clone,
+        V: AsBytes + FromBytes,
+    {
+        let bounds = index.into().multiply(mem::size_of::<V>());
+        // SAFETY: Same safety requirements as this method.
+        let byte_guard = unsafe { self.index_mut(bounds.range) };
+        byte_guard.cast()
+    }
+
+    /// Immutably borrow a slice or element of a convertible type.
+    ///
+    /// This method accesses an element or slice of elements of a type that
+    /// implements `zerocopy::FromBytes` from a buffer of `u8`.
+    ///
+    /// This immutable borrow may be unchecked and callers must ensure that no
+    /// other mutable borrows from this collection overlap with the returned
+    /// immutably borrowed region for the lifetime of that borrow.
+    ///
+    /// # Safety
+    ///
+    /// This method is not marked as unsafe but its safety requires correct
+    /// usage alongside [`index_mut`]. It cannot result in a race
+    /// condition without creating an overlapping mutable range via
+    /// [`index_mut`]. As an internal helper, we ensure that all calls are
+    /// safe and document this when mutating rather than marking each immutable
+    /// reference with virtually identical safety justifications.
+    ///
+    /// Caller must take care that no elements of the resulting borrowed slice
+    /// or element are concurrently mutably borrowed at all by [`index_mut`]
+    /// during the lifetime of the returned borrow.
+    ///
+    /// [`index_mut`]: DisjointMut::index_mut
+    #[cfg_attr(debug_assertions, track_caller)]
+    pub fn index_as<'a, I, V>(&'a self, index: I) -> DisjointImmutGuard<'a, T, V>
+    where
+        I: Into<Bounds> + Clone,
+        V: FromBytes,
+    {
+        let bounds = index.into().multiply(mem::size_of::<V>());
+        self.index(bounds.range).cast()
+    }
+}
+
 /// This trait is a stable implementation of [`std::slice::SliceIndex`] to allow
 /// for indexing into mutable slice raw pointers.
 pub trait DisjointMutIndex<T: ?Sized> {
@@ -308,6 +410,12 @@ impl Bounds {
         let a = &self.range;
         let b = &other.range;
         a.start < b.end && b.start < a.end
+    }
+
+    fn multiply(self, multiple: usize) -> Bounds {
+        let start = self.range.start * multiple;
+        let end = self.range.end * multiple;
+        Self { range: start..end }
     }
 }
 

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -13,7 +13,6 @@ use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
-use std::slice;
 use std::sync::atomic::AtomicU16;
 use std::sync::atomic::Ordering;
 
@@ -206,15 +205,11 @@ pub(crate) unsafe fn rav1d_copy_lpf<BD: BitDepth>(
             let cdef_off_y: ptrdiff_t = (sby * 4) as isize * BD::pxstride(src_stride[0]);
             let cdef_plane_y_sz = 4 * f.sbh as isize * y_stride;
             let y_span = cdef_plane_y_sz - y_stride;
+            let cdef_line_start = (f.lf.cdef_lpf_line[0] as isize + cmp::min(y_span, 0)) as usize;
             backup_lpf::<BD>(
                 c,
-                slice::from_raw_parts_mut(
-                    cdef_line_buf
-                        .as_mut_ptr()
-                        .add(f.lf.cdef_lpf_line[0])
-                        .offset(cmp::min(y_span, 0)),
-                    cdef_plane_y_sz.unsigned_abs(),
-                ),
+                &mut cdef_line_buf
+                    [cdef_line_start..cdef_line_start + cdef_plane_y_sz.unsigned_abs()],
                 (cdef_off_y - cmp::min(y_span, 0)) as usize,
                 src_stride[0],
                 src[0],
@@ -278,15 +273,12 @@ pub(crate) unsafe fn rav1d_copy_lpf<BD: BitDepth>(
             if have_tt != 0 && resize != 0 {
                 let cdef_plane_uv_sz = 4 * f.sbh as isize * uv_stride;
                 let uv_span = cdef_plane_uv_sz - uv_stride;
+                let cdef_line_start =
+                    (f.lf.cdef_lpf_line[1] as isize + cmp::min(uv_span, 0)) as usize;
                 backup_lpf::<BD>(
                     c,
-                    slice::from_raw_parts_mut(
-                        cdef_line_buf
-                            .as_mut_ptr()
-                            .add(f.lf.cdef_lpf_line[1])
-                            .offset(cmp::min(uv_span, 0)),
-                        cdef_plane_uv_sz.unsigned_abs(),
-                    ),
+                    &mut cdef_line_buf
+                        [cdef_line_start..cdef_line_start + cdef_plane_uv_sz.unsigned_abs()],
                     (cdef_off_uv - cmp::min(uv_span, 0)) as usize,
                     src_stride[1],
                     src[1],
@@ -338,15 +330,12 @@ pub(crate) unsafe fn rav1d_copy_lpf<BD: BitDepth>(
             if have_tt != 0 && resize != 0 {
                 let cdef_plane_uv_sz = 4 * f.sbh as isize * uv_stride;
                 let uv_span = cdef_plane_uv_sz - uv_stride;
+                let cdef_line_start =
+                    (f.lf.cdef_lpf_line[2] as isize + cmp::min(uv_span, 0)) as usize;
                 backup_lpf::<BD>(
                     c,
-                    slice::from_raw_parts_mut(
-                        cdef_line_buf
-                            .as_mut_ptr()
-                            .add(f.lf.cdef_lpf_line[2])
-                            .offset(cmp::min(uv_span, 0)),
-                        cdef_plane_uv_sz.unsigned_abs(),
-                    ),
+                    &mut cdef_line_buf
+                        [cdef_line_start..cdef_line_start + cdef_plane_uv_sz.unsigned_abs()],
                     (cdef_off_uv - cmp::min(uv_span, 0)) as usize,
                     src_stride[1],
                     src[2],

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2455,12 +2455,14 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                 } else {
                     &t.scratch.c2rust_unnamed_0.pal_idx
                 };
+                let pal_guard;
                 let pal: *const BD::Pixel = if t.frame_thread.pass != 0 {
                     let index = (((t.b.y as isize >> 1) + (t.b.x as isize & 1))
                         * (f.b4_stride >> 1)
                         + ((t.b.x >> 1) + (t.b.y & 1)) as isize)
                         as isize;
-                    f.frame_thread.pal.as_slice::<BD>()[index as usize][0].as_ptr()
+                    pal_guard = f.frame_thread.pal.index::<BD>(index as usize);
+                    pal_guard[0].as_ptr()
                 } else {
                     let interintra_edge_pal =
                         BD::select(&t.scratch.c2rust_unnamed_0.interintra_edge_pal);
@@ -2826,6 +2828,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     let uv_dstoff: ptrdiff_t = 4
                         * ((t.b.x >> ss_hor) as isize
                             + (t.b.y >> ss_ver) as isize * BD::pxstride(f.cur.stride[1]));
+                    let pal_guard;
                     let (pal, pal_idx) = if t.frame_thread.pass != 0 {
                         let p = t.frame_thread.pass & 1;
                         let index = (((t.b.y >> 1) + (t.b.x & 1)) as isize * (f.b4_stride >> 1)
@@ -2835,10 +2838,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         let len = (cbw4 * cbh4 * 16) as usize;
                         let pal_idx = &f.frame_thread.pal_idx[*pal_idx_offset..][..len];
                         *pal_idx_offset += len;
-                        (
-                            &f.frame_thread.pal.as_slice::<BD>()[index as usize],
-                            pal_idx,
-                        )
+                        pal_guard = f.frame_thread.pal.index::<BD>(index as usize);
+                        (&*pal_guard, pal_idx)
                     } else {
                         let interintra_edge_pal =
                             BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge_pal);
@@ -4401,10 +4402,12 @@ pub(crate) unsafe fn rav1d_copy_pal_block_y<BD: BitDepth>(
     bw4: usize,
     bh4: usize,
 ) {
+    let pal_guard;
     let pal = if t.frame_thread.pass != 0 {
         let index = ((t.b.y >> 1) + (t.b.x & 1)) as isize * (f.b4_stride >> 1)
             + ((t.b.x >> 1) + (t.b.y & 1)) as isize;
-        &f.frame_thread.pal.as_slice::<BD>()[index as usize][0]
+        pal_guard = f.frame_thread.pal.index::<BD>(index as usize);
+        &pal_guard[0]
     } else {
         let interintra_edge_pal = BD::select(&t.scratch.c2rust_unnamed_0.interintra_edge_pal);
         &interintra_edge_pal.pal[0]
@@ -4425,10 +4428,12 @@ pub(crate) unsafe fn rav1d_copy_pal_block_uv<BD: BitDepth>(
     bw4: usize,
     bh4: usize,
 ) {
+    let pal_guard;
     let pal = if t.frame_thread.pass != 0 {
         let index = ((t.b.y >> 1) + (t.b.x & 1)) as isize * (f.b4_stride >> 1)
             + ((t.b.x >> 1) + (t.b.y & 1)) as isize;
-        &f.frame_thread.pal.as_slice_mut::<BD>()[index as usize]
+        pal_guard = f.frame_thread.pal.index::<BD>(index as usize);
+        &pal_guard
     } else {
         let interintra_edge_pal = BD::select(&t.scratch.c2rust_unnamed_0.interintra_edge_pal);
         &interintra_edge_pal.pal
@@ -4553,11 +4558,12 @@ pub(crate) unsafe fn rav1d_read_pal_plane<BD: BitDepth>(
     let used_cache = &used_cache[..i];
 
     // parse new entries
+    let mut pal_guard;
     let pal = if t.frame_thread.pass != 0 {
-        &mut f.frame_thread.pal.as_slice_mut::<BD>()[(((t.b.y >> 1) + (t.b.x & 1)) as isize
-            * (f.b4_stride >> 1)
-            + ((t.b.x >> 1) + (t.b.y & 1)) as isize)
-            as usize][pli]
+        let pal_start = (((t.b.y >> 1) + (t.b.x & 1)) as isize * (f.b4_stride >> 1)
+            + ((t.b.x >> 1) + (t.b.y & 1)) as isize) as usize;
+        pal_guard = f.frame_thread.pal.index_mut::<BD>(pal_start);
+        &mut pal_guard[pli]
     } else {
         let interintra_edge_pal =
             BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge_pal);
@@ -4647,11 +4653,13 @@ pub(crate) unsafe fn rav1d_read_pal_uv<BD: BitDepth>(
     // V pal coding
     let ts = &mut *f.ts.offset(t.ts as isize);
 
+    let mut pal_guard;
     let pal = if t.frame_thread.pass != 0 {
-        &mut f.frame_thread.pal.as_slice_mut::<BD>()[(((t.b.y >> 1) + (t.b.x & 1)) as isize
-            * (f.b4_stride >> 1)
-            + ((t.b.x >> 1) + (t.b.y & 1)) as isize)
-            as usize][2]
+        pal_guard = f.frame_thread.pal.index_mut::<BD>(
+            (((t.b.y >> 1) + (t.b.x & 1)) as isize * (f.b4_stride >> 1)
+                + ((t.b.x >> 1) + (t.b.y & 1)) as isize) as usize,
+        );
+        &mut pal_guard[2]
     } else {
         let interintra_edge_pal =
             BD::select_mut(&mut t.scratch.c2rust_unnamed_0.interintra_edge_pal);

--- a/src/unstable_extensions.rs
+++ b/src/unstable_extensions.rs
@@ -8,7 +8,6 @@
 
 use std::mem;
 use std::slice::from_raw_parts;
-use std::slice::from_raw_parts_mut;
 
 /// From `1.75.0`.
 pub const fn flatten<const N: usize, T>(this: &[[T; N]]) -> &[T] {
@@ -52,31 +51,5 @@ pub const fn as_chunks<const N: usize, T>(this: &[T]) -> (&[[T; N]], &[T]) {
     // SAFETY: We already panicked for zero, and ensured by construction
     // that the length of the subslice is a multiple of N.
     let array_slice = unsafe { as_chunks_unchecked(multiple_of_n) };
-    (array_slice, remainder)
-}
-
-#[inline]
-#[must_use]
-pub unsafe fn as_chunks_unchecked_mut<const N: usize, T>(this: &mut [T]) -> &mut [[T; N]] {
-    // SAFETY: Caller must guarantee that `N` is nonzero and exactly divides the slice length
-    let new_len = /* unsafe */ {
-        assert!(N != 0 && this.len() % N == 0);
-        this.len() / N
-    };
-    // SAFETY: We cast a slice of `new_len * N` elements into
-    // a slice of `new_len` many `N` elements chunks.
-    unsafe { from_raw_parts_mut(this.as_mut_ptr().cast(), new_len) }
-}
-
-#[inline]
-#[track_caller]
-#[must_use]
-pub fn as_chunks_mut<const N: usize, T>(this: &mut [T]) -> (&mut [[T; N]], &mut [T]) {
-    assert!(N != 0, "chunk size must be non-zero");
-    let len = this.len() / N;
-    let (multiple_of_n, remainder) = this.split_at_mut(len * N);
-    // SAFETY: We already panicked for zero, and ensured by construction
-    // that the length of the subslice is a multiple of N.
-    let array_slice = unsafe { as_chunks_unchecked_mut(multiple_of_n) };
     (array_slice, remainder)
 }


### PR DESCRIPTION
The `pal` buffer is a type-erased `Pixel` buffer that needs to be accessed concurrently. This change adds support for casting `DisjointMut` guards from `[u8]` buffers to appropriate bitdepth-dependent types that implement `FromBytes`.