### PR TITLE
Increase timeout multiplier from 2 to 3

### DIFF
--- a/.github/workflows/build-and-test-x86.yml
+++ b/.github/workflows/build-and-test-x86.yml
@@ -16,7 +16,7 @@ jobs:
           # release build without optimized assembly routines
           {name: "release", flags: "--release --no-default-features --features=bitdepth_8,bitdepth_16", timeout_multiplier: 1},
           # debug build with optimizations to catch overflows with optimized assembly routines
-          {name: "opt-dev", flags: "--profile opt-dev", timeout_multiplier: 2}
+          {name: "opt-dev", flags: "--profile opt-dev", timeout_multiplier: 3}
         ]
         # Test with threads and framedelay
         framedelay: [


### PR DESCRIPTION
With disjoint mut debug checks, we are seeing enough slowdown in CI that we need to increase the timeout.

(merging this to main this time)