### PR TITLE
CI: Test debug build on aarch64-darwin

### DIFF
--- a/.github/workflows/build-and-benchmark-x86.yml
+++ b/.github/workflows/build-and-benchmark-x86.yml
@@ -45,7 +45,7 @@ jobs:
                 REMOTE_URL: http://download.opencontent.netflix.com.s3.amazonaws.com/AV1/Chimera/Old/Chimera-AV1-10bit-1920x1080-6191kbps.ivf
                 LOCAL_FILE: /tmp/rav1d/Chimera-AV1-10bit-1920x1080-6191kbps.ivf
             - name: upload benchmark data
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                 name: perf-data
                 path:  ${{ github.workspace }}/perf.data.*

--- a/.github/workflows/build-and-test-aarch64-darwin.yml
+++ b/.github/workflows/build-and-test-aarch64-darwin.yml
@@ -34,26 +34,25 @@ jobs:
           key: arm-darwin-cargo-and-target-${{ hashFiles('**/Cargo.lock') }}
       - name: cargo ${{ matrix.build.name }} build for aarch64-apple-darwin
         run:  cargo build ${{ matrix.build.cargo_flags }}
-        # not quite sure why we need this on the runner, not needed locally
-      - run: |
-            meson build --buildtype ${{ matrix.build.name }}
-            ninja -C build tools/dav1d
       - name: test ${{ matrix.build.name }} build without frame delay
-        run: .github/workflows/test.sh \
+        run: |
+          .github/workflows/test.sh \
             -r ./target/${{ matrix.build.name }}/dav1d \
             -s ./target/${{ matrix.build.name }}/seek_stress
         # release tests run quickly so also cover the frame delay cases
       - name: test release build with frame delay of 1
         if: ${{ matrix.build.name == 'release' }}
-        run: .github/workflows/test.sh \
+        run: |
+          .github/workflows/test.sh \
             -r ./target/release/dav1d \
-            -s ./target/release/seek_stress
+            -s ./target/release/seek_stress \
             -f 1
       - name: test release build with frame delay of 2
         if: ${{ matrix.build.name == 'release' }}
-        run: .github/workflows/test.sh \
+        run: |
+          .github/workflows/test.sh \
             -r ./target/release/dav1d \
-            -s ./target/release/seek_stress
+            -s ./target/release/seek_stress \
             -f 2
       - name: copy log files
         if: ${{ !cancelled() }}

--- a/.github/workflows/build-and-test-aarch64-darwin.yml
+++ b/.github/workflows/build-and-test-aarch64-darwin.yml
@@ -64,7 +64,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: meson-test-logs
+          name: meson-test-logs-aarch64-apple-darwin-${{ matrix.build.name }}
           path: |
             ${{ github.workspace }}/build/meson-logs/testlog-*.txt
 

--- a/.github/workflows/build-and-test-aarch64-darwin.yml
+++ b/.github/workflows/build-and-test-aarch64-darwin.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
 jobs:
   test-on-macos-aarch64:
+    strategy:
+      matrix:
+        build: [
+          {name: "release", cargo_flags: "--release",  timeout_multiplier: 1},
+          {name: "debug", cargo_flags: "", timeout_multiplier: 3},
+        ]
     runs-on: macos-14
     name: test on macos-14-aarch64
     steps:
@@ -13,11 +19,11 @@ jobs:
         run: |
           brew install meson
       - name: git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: cache rust dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -26,35 +32,39 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: arm-darwin-cargo-and-target-${{ hashFiles('**/Cargo.lock') }}
-      - name: cargo build for aarch64-apple-darwin
-        run:  cargo build --release
+      - name: cargo ${{ matrix.build.name }} build for aarch64-apple-darwin
+        run:  cargo build ${{ matrix.build.cargo_flags }}
         # not quite sure why we need this on the runner, not needed locally
       - run: |
-            meson build --buildtype release
+            meson build --buildtype ${{ matrix.build.name }}
             ninja -C build tools/dav1d
-      - name: test without frame delay
+      - name: test ${{ matrix.build.name }} build without frame delay
         run: .github/workflows/test.sh \
-            -r ./target/release/dav1d \
-            -s ./target/release/seek_stress
-        # tests run quickly so also cover the frame delay cases
-      - name: test with frame delay of 1
+            -r ./target/${{ matrix.build.name }}/dav1d \
+            -s ./target/${{ matrix.build.name }}/seek_stress
+        # release tests run quickly so also cover the frame delay cases
+      - name: test release build with frame delay of 1
+        if: ${{ matrix.build.name == 'release' }}
         run: .github/workflows/test.sh \
             -r ./target/release/dav1d \
             -s ./target/release/seek_stress
             -f 1
-      - name: test with frame delay of 2
+      - name: test release build with frame delay of 2
+        if: ${{ matrix.build.name == 'release' }}
         run: .github/workflows/test.sh \
             -r ./target/release/dav1d \
             -s ./target/release/seek_stress
             -f 2
-      - run: .github/workflows/test.sh \
-          -r ./target/release/dav1d \
-          -s ./target/release/seek_stress
+      - name: copy log files
+        if: ${{ !cancelled() }}
+        run: |
+          cp ${{ github.workspace }}/build/meson-logs/testlog.txt \
+              ${{ github.workspace }}/build/meson-logs/testlog-aarch64-apple-darwin-${{ matrix.build.name }}.txt
       - name: upload build artifacts
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: meson-test-logs
           path: |
-            ${{ github.workspace }}/build/meson-logs/testlog.txt
+            ${{ github.workspace }}/build/meson-logs/testlog-*.txt
 

--- a/.github/workflows/build-and-test-x86-extra.yml
+++ b/.github/workflows/build-and-test-x86-extra.yml
@@ -28,11 +28,11 @@ jobs:
           packages: meson nasm gcc-multilib
           version: 1.0 # version of cache to load
       - name: git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: cache rust toolchain
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.rustup/toolchains
@@ -40,7 +40,7 @@ jobs:
             ~/.rustup/settings.toml
           key: ${{ runner.os }}-${{ matrix.target }}-rust-toolchain-${{ hashFiles('rust-toolchain', 'rust-toolchain.toml') }}
       - name: cache rust crates
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -51,7 +51,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: cache argon test vectors
         id: cache-argon
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             tests/argon

--- a/.github/workflows/build-and-test-x86.yml
+++ b/.github/workflows/build-and-test-x86.yml
@@ -71,10 +71,11 @@ jobs:
           cp ${{ github.workspace }}/build/meson-logs/testlog.txt \
              ${{ github.workspace }}/build/meson-logs/testlog-${{ matrix.target }}-${{ matrix.build.name }}.txt
       - name: upload build artifacts
-        if: ${{ !cancelled() }}
+        # don't upload artifacts for tests w/framedelay to keep names unique
+        if: ${{ !cancelled() && matrix.framedelay == '' }}
         uses: actions/upload-artifact@v4
         with:
-          name: meson-test-logs
+          name: meson-test-logs-${{ matrix.target }}-${{ matrix.build.name }}
           path: |
              ${{ github.workspace }}/build/meson-logs/testlog-*.txt
   test-on-macos-latest:
@@ -123,6 +124,6 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: meson-test-logs
+          name: meson-test-logs-x86_64-apple-darwin
           path: |
               ${{ github.workspace }}/build/meson-logs/testlog-*.txt

--- a/.github/workflows/build-and-test-x86.yml
+++ b/.github/workflows/build-and-test-x86.yml
@@ -32,11 +32,11 @@ jobs:
           packages: meson nasm gcc-multilib
           version: 1.0 # version of cache to load
       - name: git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: cache rust toolchain
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.rustup/toolchains
@@ -44,7 +44,7 @@ jobs:
             ~/.rustup/settings.toml
           key: ${{ runner.os }}-${{ matrix.target }}-rust-toolchain-${{ hashFiles('rust-toolchain', 'rust-toolchain.toml') }}
       - name: cache rust crates
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -72,7 +72,7 @@ jobs:
              ${{ github.workspace }}/build/meson-logs/testlog-${{ matrix.target }}-${{ matrix.build.name }}.txt
       - name: upload build artifacts
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: meson-test-logs
           path: |
@@ -85,11 +85,11 @@ jobs:
           HOMEBREW_NO_AUTO_UPDATE: 1
         run: brew install meson nasm
       - name: git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: cache rust toolchain
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.rustup/toolchains
@@ -97,7 +97,7 @@ jobs:
             ~/.rustup/settings.toml
           key: ${{ runner.os }}-rust-toolchain-${{ hashFiles('rust-toolchain', 'rust-toolchain.toml') }}
       - name: cache rust crates
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -121,7 +121,7 @@ jobs:
               ${{ github.workspace }}/build/meson-logs/testlog-x86_64-apple-darwin.txt
       - name: upload build artifacts
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: meson-test-logs
           path: |


### PR DESCRIPTION
Sometimes testing without optimizations can surface issues so we add an unoptimized test run for aarch64-darwin since tests run fast on that platform.