### PR TITLE
`struct Rav1dFrameContext::frame_thread_progress`: Initialize

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -692,6 +692,7 @@ impl Rav1dFrameContext_task_thread {
     }
 }
 
+#[derive(Default)]
 pub(crate) struct Rav1dFrameContext_frame_thread_progress {
     pub entropy: AtomicI32,
     pub deblock: AtomicI32, // in sby units

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,6 +291,7 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
         addr_of_mut!(f.tiles).write(Default::default());
         addr_of_mut!(f.task_thread.tasks).write(UnsafeCell::new(Default::default()));
         addr_of_mut!(f.frame_thread).write(Default::default());
+        addr_of_mut!(f.frame_thread_progress).write(Default::default());
         if n_tc > 1 {
             f.task_thread.lock = Mutex::new(());
             f.task_thread.cond = Condvar::new();


### PR DESCRIPTION
Found another field we forgot to initialize through an assert in a debug build.