### PR TITLE
`struct RefMvsFrame::r`: Add `DisjointMut`

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -43,6 +43,7 @@ pub mod src {
     pub(crate) mod enum_map;
     mod env;
     pub(crate) mod error;
+    mod ffi_safe;
     mod fg_apply;
     mod filmgrain;
     mod getbits;

--- a/src/ffi_safe.rs
+++ b/src/ffi_safe.rs
@@ -16,7 +16,7 @@ impl<'a, T> FFISafe<'a, T> {
         ptr::from_ref(this).cast()
     }
 
-    pub fn new_mut(this: &'a mut T) -> *mut Self {
+    pub fn _new_mut(this: &'a mut T) -> *mut Self {
         ptr::from_mut(this).cast()
     }
 
@@ -31,7 +31,7 @@ impl<'a, T> FFISafe<'a, T> {
     /// # Safety
     ///
     /// `this` must have been returned from [`Self::new_mut`].
-    pub unsafe fn get_mut(this: *mut Self) -> &'a mut T {
+    pub unsafe fn _get_mut(this: *mut Self) -> &'a mut T {
         // SAFETY: `this` originally was a `&'a mut T` in `Self::new_mut`.
         unsafe { &mut *this.cast() }
     }

--- a/src/ffi_safe.rs
+++ b/src/ffi_safe.rs
@@ -1,0 +1,38 @@
+use std::marker::PhantomData;
+use std::ptr;
+
+/// A type that bypasses `#[warn(improper_ctypes)]` checks of FFI safe types.
+/// This type is meant to roundtrip a reference to a type `T` with lifetime `'a`
+/// through an `extern "C" fn` ptr from a Rust caller to Rust callee.
+/// Non-Rust callees should not access this type.
+#[repr(C)]
+pub struct FFISafe<'a, T> {
+    phantom: PhantomData<&'a T>,
+    non_zst: bool,
+}
+
+impl<'a, T> FFISafe<'a, T> {
+    pub fn new(this: &'a T) -> *const Self {
+        ptr::from_ref(this).cast()
+    }
+
+    pub fn new_mut(this: &'a mut T) -> *mut Self {
+        ptr::from_mut(this).cast()
+    }
+
+    /// # Safety
+    ///
+    /// `this` must have been returned from [`Self::new`].
+    pub unsafe fn get(this: *const Self) -> &'a T {
+        // SAFETY: `this` originally was a `&'a T` in `Self::new`.
+        unsafe { &*this.cast() }
+    }
+
+    /// # Safety
+    ///
+    /// `this` must have been returned from [`Self::new_mut`].
+    pub unsafe fn get_mut(this: *mut Self) -> &'a mut T {
+        // SAFETY: `this` originally was a `&'a mut T` in `Self::new_mut`.
+        unsafe { &mut *this.cast() }
+    }
+}

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2228,7 +2228,7 @@ unsafe fn obmc<BD: BitDepth>(
         let mut i = 0;
         let mut x = 0;
         while x < w4 && i < cmp::min(b_dim[2], 4) {
-            let a_r = f.rf.r[r[0] + t.b.x as usize + x as usize + 1];
+            let a_r = *f.rf.r.index(r[0] + t.b.x as usize + x as usize + 1);
             let a_b_dim = &dav1d_block_dimensions[a_r.bs as usize];
             let step4 = clip(a_b_dim[0], 2, 16);
             if a_r.r#ref.r#ref[0] > 0 {
@@ -2268,7 +2268,7 @@ unsafe fn obmc<BD: BitDepth>(
         let mut i = 0;
         let mut y = 0;
         while y < h4 && i < cmp::min(b_dim[3], 4) {
-            let l_r = f.rf.r[r[y as usize + 1 + 1] + t.b.x as usize - 1];
+            let l_r = *f.rf.r.index(r[y as usize + 1 + 1] + t.b.x as usize - 1);
             let l_b_dim = &dav1d_block_dimensions[l_r.bs as usize];
             let step4 = clip(l_b_dim[1], 2, 16);
             if l_r.r#ref.r#ref[0] > 0 {
@@ -3555,13 +3555,13 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 assert!(ss_hor == 1);
                 let r = &t.rt.r[(t.b.y as usize & 31) + 5 - 1..];
                 if bw4 == 1 {
-                    is_sub8x8 &= f.rf.r[r[1] + t.b.x as usize - 1].r#ref.r#ref[0] > 0;
+                    is_sub8x8 &= f.rf.r.index(r[1] + t.b.x as usize - 1).r#ref.r#ref[0] > 0;
                 }
                 if bh4 == ss_ver {
-                    is_sub8x8 &= f.rf.r[r[0] + t.b.x as usize].r#ref.r#ref[0] > 0;
+                    is_sub8x8 &= f.rf.r.index(r[0] + t.b.x as usize).r#ref.r#ref[0] > 0;
                 }
                 if bw4 == 1 && bh4 == ss_ver {
-                    is_sub8x8 &= f.rf.r[r[0] + t.b.x as usize - 1].r#ref.r#ref[0] > 0;
+                    is_sub8x8 &= f.rf.r.index(r[0] + t.b.x as usize - 1).r#ref.r#ref[0] > 0;
                 }
                 r
             } else {
@@ -3573,7 +3573,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 let mut v_off = 0isize;
                 if bw4 == 1 && bh4 == ss_ver {
                     for pl in 0..2 {
-                        let r = f.rf.r[r[0] + t.b.x as usize - 1];
+                        let r = *f.rf.r.index(r[0] + t.b.x as usize - 1);
                         mc::<BD>(
                             f,
                             &mut t.scratch.c2rust_unnamed.emu_edge,
@@ -3608,7 +3608,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     let left_filter_2d = dav1d_filter_2d[t.l.filter[1][by4 as usize] as usize]
                         [t.l.filter[0][by4 as usize] as usize];
                     for pl in 0..2 {
-                        let r = f.rf.r[r[1] + t.b.x as usize - 1];
+                        let r = *f.rf.r.index(r[1] + t.b.x as usize - 1);
                         mc::<BD>(
                             f,
                             &mut t.scratch.c2rust_unnamed.emu_edge,
@@ -3641,7 +3641,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     let top_filter_2d = dav1d_filter_2d[(*t.a).filter[1][bx4 as usize] as usize]
                         [(*t.a).filter[0][bx4 as usize] as usize];
                     for pl in 0..2 {
-                        let r = f.rf.r[r[0] + t.b.x as usize];
+                        let r = *f.rf.r.index(r[0] + t.b.x as usize);
                         mc::<BD>(
                             f,
                             &mut t.scratch.c2rust_unnamed.emu_edge,


### PR DESCRIPTION
This removes `&mut` accesses of `Rav1dFrameData` added in #942.