### PR TITLE
`struct Rav1dTaskContext::scratch`: Make into `zerocopy`-based "unions"

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -65,9 +65,9 @@ use crate::src::internal::Rav1dContextTaskType;
 use crate::src::internal::Rav1dDSPContext;
 use crate::src::internal::Rav1dFrameData;
 use crate::src::internal::Rav1dTaskContext;
-use crate::src::internal::Rav1dTaskContext_scratch_pal;
 use crate::src::internal::Rav1dTileState;
 use crate::src::internal::ScalableMotionParams;
+use crate::src::internal::ScratchPal;
 use crate::src::internal::TileStateRef;
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::intra_edge::EdgeIndex;
@@ -701,7 +701,7 @@ fn order_palette(
 unsafe fn read_pal_indices(
     ts: &mut Rav1dTileState,
     pal_dsp: &Rav1dPalDSPContext,
-    scratch_pal: &mut Rav1dTaskContext_scratch_pal,
+    scratch_pal: &mut ScratchPal,
     pal_tmp: &mut [u8],
     pal_idx: Option<&mut [u8]>, // if None, use pal_tmp instead of pal_idx
     b: &Av1Block,
@@ -718,7 +718,7 @@ unsafe fn read_pal_indices(
     let stride = bw4 * 4;
     pal_tmp[0] = rav1d_msac_decode_uniform(&mut ts.msac, pal_sz as c_uint) as u8;
     let color_map_cdf = &mut ts.cdf.m.color_map[pli][pal_sz - 2];
-    let Rav1dTaskContext_scratch_pal {
+    let ScratchPal {
         pal_order: order,
         pal_ctx: ctx,
     } = scratch_pal;
@@ -1771,6 +1771,7 @@ unsafe fn decode_b(
 
         if b.pal_sz()[0] != 0 {
             let mut pal_idx_guard;
+            let scratch = t.scratch.inter_intra_mut();
             let pal_idx = if t.frame_thread.pass != 0 {
                 let p = t.frame_thread.pass & 1;
                 let frame_thread = &mut ts.frame_thread[p as usize];
@@ -1782,13 +1783,13 @@ unsafe fn decode_b(
                 frame_thread.pal_idx += len;
                 &mut *pal_idx_guard
             } else {
-                &mut t.scratch.c2rust_unnamed_0.pal_idx_y
+                &mut scratch.pal_idx_y
             };
             read_pal_indices(
                 ts,
                 &c.pal_dsp,
-                &mut t.scratch.c2rust_unnamed_0.c2rust_unnamed.c2rust_unnamed,
-                &mut t.scratch.c2rust_unnamed_0.pal_idx_uv,
+                scratch.levels_pal.pal_mut(),
+                &mut scratch.pal_idx_uv,
                 Some(pal_idx),
                 b,
                 false,
@@ -1804,6 +1805,7 @@ unsafe fn decode_b(
 
         if has_chroma && b.pal_sz()[1] != 0 {
             let mut pal_idx_guard;
+            let scratch = t.scratch.inter_intra_mut();
             let pal_idx = if t.frame_thread.pass != 0 {
                 let p = t.frame_thread.pass & 1;
                 let frame_thread = &mut ts.frame_thread[p as usize];
@@ -1820,8 +1822,8 @@ unsafe fn decode_b(
             read_pal_indices(
                 ts,
                 &c.pal_dsp,
-                &mut t.scratch.c2rust_unnamed_0.c2rust_unnamed.c2rust_unnamed,
-                &mut t.scratch.c2rust_unnamed_0.pal_idx_uv,
+                scratch.levels_pal.pal_mut(),
+                &mut scratch.pal_idx_uv,
                 pal_idx,
                 b,
                 true,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -960,7 +960,7 @@ impl ScratchLapInter {
 const EMU_EDGE_LEN: usize = 320 * (256 + 7);
 // stride=192 for non-SVC, or 320 for SVC
 #[derive(FromZeroes, FromBytes, AsBytes)]
-#[repr(C, align(32))]
+#[repr(C, align(64))]
 pub struct ScratchEmuEdge([u8; EMU_EDGE_LEN * 2]);
 
 impl ScratchEmuEdge {
@@ -1008,8 +1008,8 @@ impl ScratchInterintraBuf {
 }
 
 #[derive(Clone, Copy, FromZeroes, FromBytes, AsBytes)]
-#[repr(C, align(32))]
-pub struct ScratchEdgeBuf([u8; 257 * 2 + 30]); // 257 Pixel elements + 30 padding bytes
+#[repr(C, align(64))]
+pub struct ScratchEdgeBuf([u8; 257 * 2 + 62]); // 257 Pixel elements + 62 padding bytes
 
 impl ScratchEdgeBuf {
     pub fn buf_mut<BD: BitDepth>(&mut self) -> &mut [BD::Pixel; 257] {
@@ -1039,11 +1039,11 @@ pub struct ScratchInterintraEdgePal {
     pub pal: ScratchPalBuf,
 
     /// For `AsBytes`, so there's no implicit padding.
-    _padding: [u8; 48],
+    _padding: [u8; 16],
 }
 
 #[derive(Clone, Copy, FromZeroes, FromBytes, AsBytes)]
-#[repr(C, align(32))]
+#[repr(C, align(64))]
 pub struct ScratchAcTxtpMap([u8; 1024 * 2]);
 
 impl ScratchAcTxtpMap {


### PR DESCRIPTION
Makes the various scratch `union`s into safe "union"s by using `zerocopy`.