### PR TITLE
`struct TxLpfRightEdge`: Add inner mutability

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4067,16 +4067,18 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
     // backup t->a/l.tx_lpf_y/uv at tile boundaries to use them to "fix"
     // up the initial value in neighbour tiles when running the loopfilter
     let mut align_h = f.bh + 31 & !31;
-    let (tx_lpf_right_edge_y, tx_lpf_right_edge_uv) = f.lf.tx_lpf_right_edge.get_mut();
-    tx_lpf_right_edge_y[(align_h * tile_col + t.b.y) as usize..][..sb_step as usize]
-        .copy_from_slice(&t.l.tx_lpf_y.0[(t.b.y & 16) as usize..][..sb_step as usize]);
+    let start_y = (align_h * tile_col + t.b.y) as usize;
+    f.lf.tx_lpf_right_edge.copy_from_slice_y(
+        start_y..start_y + sb_step as usize,
+        &t.l.tx_lpf_y.0[(t.b.y & 16) as usize..][..sb_step as usize],
+    );
     let ss_ver = (f.cur.p.layout == Rav1dPixelLayout::I420) as c_int;
     align_h >>= ss_ver;
-    tx_lpf_right_edge_uv[(align_h * tile_col + (t.b.y >> ss_ver)) as usize..]
-        [..(sb_step >> ss_ver) as usize]
-        .copy_from_slice(
-            &t.l.tx_lpf_uv.0[((t.b.y & 16) >> ss_ver) as usize..][..(sb_step >> ss_ver) as usize],
-        );
+    let start_uv = (align_h * tile_col + (t.b.y >> ss_ver)) as usize;
+    f.lf.tx_lpf_right_edge.copy_from_slice_uv(
+        start_uv..start_uv + (sb_step >> ss_ver) as usize,
+        &t.l.tx_lpf_uv.0[((t.b.y & 16) >> ss_ver) as usize..][..(sb_step >> ss_ver) as usize],
+    );
 
     Ok(())
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -92,8 +92,10 @@ use std::ffi::c_uint;
 use std::mem;
 use std::ops::Add;
 use std::ops::AddAssign;
+use std::ops::Deref;
 use std::ops::Index;
 use std::ops::IndexMut;
+use std::ops::Range;
 use std::ops::Sub;
 use std::ptr;
 use std::sync::atomic::AtomicBool;
@@ -504,27 +506,49 @@ pub struct Rav1dFrameContext_frame_thread {
 #[derive(Default)]
 pub(crate) struct TxLpfRightEdge {
     /// `.len() = h * 2`
-    inner: Vec<u8>,
+    inner: DisjointMut<Vec<u8>>,
 }
 
 impl TxLpfRightEdge {
     #[allow(dead_code)]
-    pub const fn new() -> Self {
-        Self { inner: Vec::new() }
+    pub fn new() -> Self {
+        Self {
+            inner: DisjointMut::default(),
+        }
     }
 
     pub fn resize(&mut self, right_edge_size: usize, value: u8) {
         self.inner.resize(right_edge_size * 32 * 2, value)
     }
 
-    pub fn get(&self) -> (&[u8], &[u8]) {
+    pub fn get<'a>(
+        &'a self,
+        index_y: Range<usize>,
+        index_uv: Range<usize>,
+    ) -> (
+        impl 'a + Deref<Target = [u8]>,
+        impl 'a + Deref<Target = [u8]>,
+    ) {
         let mid = self.inner.len() / 2;
-        self.inner.split_at(mid)
+        assert!(index_y.end <= mid);
+        let (uv_start, uv_end) = (index_uv.start + mid, index_uv.end + mid);
+        (
+            self.inner.index(index_y),
+            self.inner.index(uv_start..uv_end),
+        )
     }
 
-    pub fn get_mut(&mut self) -> (&mut [u8], &mut [u8]) {
+    pub fn copy_from_slice_y(&self, index: Range<usize>, src: &[u8]) {
+        #[allow(unused_mut)]
+        let mut slice_mut = unsafe { self.inner.index_mut(index) };
+        slice_mut.copy_from_slice(src);
+    }
+
+    pub fn copy_from_slice_uv(&self, index: Range<usize>, src: &[u8]) {
         let mid = self.inner.len() / 2;
-        self.inner.split_at_mut(mid)
+        #[allow(unused_mut)]
+        let mut slice_mut = unsafe { self.inner.index_mut(index.start + mid..index.end + mid) };
+        slice_mut.copy_from_slice(src);
     }
 }
 

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -618,9 +618,8 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
     let hmax = (1 as c_uint) << hmask;
     let endy4 = starty4 + cmp::min(f.h4 - sby * sbsz, sbsz) as u32;
     let uv_endy4 = (endy4 + ss_ver as u32) >> ss_ver;
-    let (lpf_y, lpf_uv) = f.lf.tx_lpf_right_edge.get();
-    let mut lpf_y = &lpf_y[(sby << sbl2) as usize..];
-    let mut lpf_uv = &lpf_uv[(sby << sbl2 - ss_ver) as usize..];
+    let mut lpf_y_idx = (sby << sbl2) as usize;
+    let mut lpf_uv_idx = (sby << sbl2 - ss_ver) as usize;
     let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
 
     // fix lpf strength at tile col boundaries
@@ -634,6 +633,10 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
         let cbx4 = bx4 >> ss_hor;
         x >>= is_sb64;
         let y_hmask = &lflvl[x as usize].filter_y[0][bx4 as usize];
+        let (lpf_y, lpf_uv) = f.lf.tx_lpf_right_edge.get(
+            lpf_y_idx..lpf_y_idx + (endy4 - starty4) as usize,
+            lpf_uv_idx..lpf_uv_idx + (uv_endy4 - (starty4 >> ss_ver)) as usize,
+        );
         for y in starty4..endy4 {
             let mask: u32 = 1 << y;
             let sidx = (mask >= 0x10000) as usize;
@@ -659,8 +662,8 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
                     .fetch_or(smask, Ordering::Relaxed);
             }
         }
-        lpf_y = &lpf_y[halign..];
-        lpf_uv = &lpf_uv[(halign >> ss_ver)..];
+        lpf_y_idx += halign;
+        lpf_uv_idx += halign >> ss_ver;
         tile_col += 1;
     }
 


### PR DESCRIPTION
Adds inner mutability to the right edge split vector by using DisjointMut and narrower ranges for reading and writing data.