### PR TITLE
`struct DisjointMut`: Simplify bounds and improve error messages

### DIFF
--- a/src/disjoint_mut.rs
+++ b/src/disjoint_mut.rs
@@ -471,6 +471,12 @@ mod debug {
         let current_thread = thread::current().id();
         let [current_mutable, existing_mutable] =
             [current_mutable, existing_mutable].map(|mutable| if mutable { "&mut" } else { "&" });
+        // Example:
+        //
+        // &mut _[0..8] on ThreadId(3) overlaps with existing &mut _[0..8] on ThreadId(2):
+        // stack backtrace:
+        //    0: rav1d::src::disjoint_mut::debug::DisjointMutBounds::new
+        //              at ./src/disjoint_mut.rs:443:28
         panic!("{current_mutable} _[{current_bounds}] on {current_thread:?} overlaps with existing {existing_mutable} _[{existing_bounds}] on {existing_thread:?}:\nstack backtrace:\n{existing_backtrace}");
     }
 

--- a/src/disjoint_mut.rs
+++ b/src/disjoint_mut.rs
@@ -182,6 +182,7 @@ impl<T: AsMutPtr> DisjointMut<T> {
     /// referenced data must be plain data and not contain any pointers or
     /// references to avoid other potential memory safety issues due to racy
     /// access.
+    #[cfg_attr(debug_assertions, track_caller)]
     pub unsafe fn index_mut<'a, I>(
         &'a self,
         index: I,
@@ -223,6 +224,7 @@ impl<T: AsMutPtr> DisjointMut<T> {
     /// during the lifetime of the returned borrow.
     ///
     /// [`index_mut`]: DisjointMut::index_mut
+    #[cfg_attr(debug_assertions, track_caller)]
     pub fn index<'a, I>(
         &'a self,
         index: I,
@@ -454,6 +456,7 @@ mod debug {
         immutable: Mutex<Vec<DisjointMutBounds>>,
     }
 
+    #[track_caller]
     fn check_overlaps(
         current_bounds: &Bounds,
         current_mutable: bool,
@@ -481,6 +484,7 @@ mod debug {
     }
 
     impl<T: AsMutPtr> DisjointMut<T> {
+        #[track_caller]
         fn add_mut_bounds(&self, bounds: Bounds) {
             for b in self.bounds.immutable.lock().unwrap().iter() {
                 check_overlaps(&bounds, true, b, false);
@@ -492,6 +496,7 @@ mod debug {
             mut_bounds.push(DisjointMutBounds::new(bounds));
         }
 
+        #[track_caller]
         fn add_immut_bounds(&self, bounds: Bounds) {
             let mut_bounds = self.bounds.mutable.lock().unwrap();
             for b in mut_bounds.iter() {
@@ -524,6 +529,7 @@ mod debug {
     }
 
     impl<'a, T: AsMutPtr, V: ?Sized> DisjointMutGuard<'a, T, V> {
+        #[track_caller]
         pub fn new(parent: &'a DisjointMut<T>, slice: &'a mut V, bounds: Bounds) -> Self {
             parent.add_mut_bounds(bounds.clone());
             Self {
@@ -542,6 +548,7 @@ mod debug {
     }
 
     impl<'a, T: AsMutPtr, V: ?Sized> DisjointImmutGuard<'a, T, V> {
+        #[track_caller]
         pub fn new(parent: &'a DisjointMut<T>, slice: &'a V, bounds: Bounds) -> Self {
             parent.add_immut_bounds(bounds.clone());
             Self {


### PR DESCRIPTION
When I was first looking into why `DisjointMut` slowed things down so drastically, I first tried simplifying the ranges/bounds.  I then discovered it was mostly the backtraces (fixed in #967), but I had already done this and started building stuff off of it, and I think it makes the logic a lot clearer (I had a hard time understanding the previous overlapping logic), specifically `fn overlap` and `fn get_mut`.  I also improved the error messages, making it more concise, and printing the `Display` version of the `Backtrace` that's normally printed on panics rather than the `Debug` version we'd been printing.