### PR TITLE
`fn load_tmvs_c`: Cleanup

### DIFF
--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1418,34 +1418,32 @@ unsafe extern "C" fn load_tmvs_c(
             let mut r = (*rf.rp_ref.offset(r#ref as isize))
                 .offset(row_start8 as isize * stride)
                 .cast_const();
-            let mut y_0 = row_start8;
-            while y_0 < row_end8 {
-                let y_sb_align = y_0 & !7;
+            let mut y = row_start8;
+            while y < row_end8 {
+                let y_sb_align = y & !7;
                 let y_proj_start = cmp::max(y_sb_align, row_start8);
                 let y_proj_end = cmp::min(y_sb_align + 8, row_end8);
-                let mut x_0 = col_start8i;
-                while x_0 < col_end8i {
-                    let mut rb = r.offset(x_0 as isize);
+                let mut x = col_start8i;
+                while x < col_end8i {
+                    let mut rb = r.offset(x as isize);
                     let b_ref = (*rb).r#ref as c_int;
                     if !(b_ref == 0) {
                         let ref2ref = rf.mfmv_ref2ref[n as usize][(b_ref - 1) as usize];
                         if !(ref2ref == 0) {
                             let b_mv = (*rb).mv;
                             let offset = mv_projection(b_mv, ref2cur, ref2ref);
-                            let mut pos_x = x_0
-                                + apply_sign(
-                                    (offset.x as c_int).abs() >> 6,
-                                    offset.x as c_int ^ ref_sign,
-                                );
-                            let pos_y = y_0
-                                + apply_sign(
-                                    (offset.y as c_int).abs() >> 6,
-                                    offset.y as c_int ^ ref_sign,
-                                );
+                            let mut pos_x = x + apply_sign(
+                                (offset.x as c_int).abs() >> 6,
+                                offset.x as c_int ^ ref_sign,
+                            );
+                            let pos_y = y + apply_sign(
+                                (offset.y as c_int).abs() >> 6,
+                                offset.y as c_int ^ ref_sign,
+                            );
                             if pos_y >= y_proj_start && pos_y < y_proj_end {
                                 let pos = (pos_y & 15) as isize * stride;
                                 loop {
-                                    let x_sb_align = x_0 & !(7 as c_int);
+                                    let x_sb_align = x & !(7 as c_int);
                                     if pos_x >= cmp::max(x_sb_align - 8, col_start8)
                                         && pos_x < cmp::min(x_sb_align + 16, col_end8)
                                     {
@@ -1453,8 +1451,8 @@ unsafe extern "C" fn load_tmvs_c(
                                         (*rp_proj.offset(pos + pos_x as isize)).r#ref =
                                             ref2ref as i8;
                                     }
-                                    x_0 += 1;
-                                    if x_0 >= col_end8i {
+                                    x += 1;
+                                    if x >= col_end8i {
                                         break;
                                     }
                                     rb = rb.offset(1);
@@ -1466,8 +1464,8 @@ unsafe extern "C" fn load_tmvs_c(
                                 }
                             } else {
                                 loop {
-                                    x_0 += 1;
-                                    if x_0 >= col_end8i {
+                                    x += 1;
+                                    if x >= col_end8i {
                                         break;
                                     }
                                     rb = rb.offset(1);
@@ -1477,13 +1475,13 @@ unsafe extern "C" fn load_tmvs_c(
                                     }
                                 }
                             }
-                            x_0 -= 1;
+                            x -= 1;
                         }
                     }
-                    x_0 += 1;
+                    x += 1;
                 }
                 r = r.offset(stride as isize);
-                y_0 += 1;
+                y += 1;
             }
         }
         n += 1;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1423,57 +1423,55 @@ unsafe extern "C" fn load_tmvs_c(
             while x < col_end8i {
                 let mut rb = r.offset(x as isize);
                 let b_ref = (*rb).r#ref;
-                if !(b_ref == 0) {
-                    let ref2ref = rf.mfmv_ref2ref[n as usize][(b_ref - 1) as usize];
-                    if !(ref2ref == 0) {
-                        let b_mv = (*rb).mv;
-                        let offset = mv_projection(b_mv, ref2cur, ref2ref);
-                        let mut pos_x = x + apply_sign(
-                            (offset.x as c_int).abs() >> 6,
-                            offset.x as c_int ^ ref_sign,
-                        );
-                        let pos_y = y + apply_sign(
-                            (offset.y as c_int).abs() >> 6,
-                            offset.y as c_int ^ ref_sign,
-                        );
-                        if pos_y >= y_proj_start && pos_y < y_proj_end {
-                            let pos = (pos_y & 15) as isize * stride;
-                            loop {
-                                let x_sb_align = x & !(7 as c_int);
-                                if pos_x >= cmp::max(x_sb_align - 8, col_start8)
-                                    && pos_x < cmp::min(x_sb_align + 16, col_end8)
-                                {
-                                    (*rp_proj.offset(pos + pos_x as isize)).mv = (*rb).mv;
-                                    (*rp_proj.offset(pos + pos_x as isize)).r#ref = ref2ref as i8;
-                                }
-                                x += 1;
-                                if x >= col_end8i {
-                                    break;
-                                }
-                                rb = rb.offset(1);
-                                let rb_mv = (*rb).mv;
-                                if (*rb).r#ref != b_ref || rb_mv != b_mv {
-                                    break;
-                                }
-                                pos_x += 1;
-                            }
-                        } else {
-                            loop {
-                                x += 1;
-                                if x >= col_end8i {
-                                    break;
-                                }
-                                rb = rb.offset(1);
-                                let rb_mv = (*rb).mv;
-                                if (*rb).r#ref != b_ref || rb_mv != b_mv {
-                                    break;
-                                }
-                            }
+                if b_ref == 0 {
+                    x += 1;
+                    continue;
+                }
+                let ref2ref = rf.mfmv_ref2ref[n as usize][(b_ref - 1) as usize];
+                if ref2ref == 0 {
+                    x += 1;
+                    continue;
+                }
+                let b_mv = (*rb).mv;
+                let offset = mv_projection(b_mv, ref2cur, ref2ref);
+                let mut pos_x =
+                    x + apply_sign((offset.x as c_int).abs() >> 6, offset.x as c_int ^ ref_sign);
+                let pos_y =
+                    y + apply_sign((offset.y as c_int).abs() >> 6, offset.y as c_int ^ ref_sign);
+                if pos_y >= y_proj_start && pos_y < y_proj_end {
+                    let pos = (pos_y & 15) as isize * stride;
+                    loop {
+                        let x_sb_align = x & !7;
+                        if pos_x >= cmp::max(x_sb_align - 8, col_start8)
+                            && pos_x < cmp::min(x_sb_align + 16, col_end8)
+                        {
+                            (*rp_proj.offset(pos + pos_x as isize)).mv = (*rb).mv;
+                            (*rp_proj.offset(pos + pos_x as isize)).r#ref = ref2ref as i8;
                         }
-                        x -= 1;
+                        x += 1;
+                        if x >= col_end8i {
+                            break;
+                        }
+                        rb = rb.offset(1);
+                        let rb_mv = (*rb).mv;
+                        if (*rb).r#ref != b_ref || rb_mv != b_mv {
+                            break;
+                        }
+                        pos_x += 1;
+                    }
+                } else {
+                    loop {
+                        x += 1;
+                        if x >= col_end8i {
+                            break;
+                        }
+                        rb = rb.offset(1);
+                        let rb_mv = (*rb).mv;
+                        if (*rb).r#ref != b_ref || rb_mv != b_mv {
+                            break;
+                        }
                     }
                 }
-                x += 1;
             }
             r = r.offset(stride as isize);
         }

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1389,12 +1389,8 @@ unsafe extern "C" fn load_tmvs_c(
     if rf.n_tile_threads == 1 {
         tile_row_idx = 0 as c_int;
     }
-    if !(row_start8 >= 0) {
-        unreachable!();
-    }
-    if !((row_end8 - row_start8) as c_uint <= 16 as c_uint) {
-        unreachable!();
-    }
+    assert!(row_start8 >= 0);
+    assert!((row_end8 - row_start8) as c_uint <= 16);
     row_end8 = cmp::min(row_end8, rf.ih8);
     let col_start8i = cmp::max(col_start8 - 8, 0 as c_int);
     let col_end8i = cmp::min(col_end8 + 8, rf.iw8);

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1384,7 +1384,9 @@ unsafe extern "C" fn load_tmvs_c(
     row_start8: c_int,
     mut row_end8: c_int,
 ) {
-    if (*rf).n_tile_threads == 1 {
+    let rf = &*rf;
+
+    if rf.n_tile_threads == 1 {
         tile_row_idx = 0 as c_int;
     }
     if !(row_start8 >= 0) {
@@ -1393,11 +1395,11 @@ unsafe extern "C" fn load_tmvs_c(
     if !((row_end8 - row_start8) as c_uint <= 16 as c_uint) {
         unreachable!();
     }
-    row_end8 = cmp::min(row_end8, (*rf).ih8);
+    row_end8 = cmp::min(row_end8, rf.ih8);
     let col_start8i = cmp::max(col_start8 - 8, 0 as c_int);
-    let col_end8i = cmp::min(col_end8 + 8, (*rf).iw8);
-    let stride: ptrdiff_t = (*rf).rp_stride;
-    let mut rp_proj: *mut refmvs_temporal_block = &mut *((*rf).rp_proj)
+    let col_end8i = cmp::min(col_end8 + 8, rf.iw8);
+    let stride: ptrdiff_t = rf.rp_stride;
+    let mut rp_proj: *mut refmvs_temporal_block = &mut *(rf.rp_proj)
         .offset(16 * stride * tile_row_idx as isize + (row_start8 & 15) as isize * stride)
         as *mut refmvs_temporal_block;
     let mut y = row_start8;
@@ -1410,15 +1412,15 @@ unsafe extern "C" fn load_tmvs_c(
         rp_proj = rp_proj.offset(stride as isize);
         y += 1;
     }
-    rp_proj = &mut *((*rf).rp_proj).offset(16 * stride * tile_row_idx as isize)
+    rp_proj = &mut *(rf.rp_proj).offset(16 * stride * tile_row_idx as isize)
         as *mut refmvs_temporal_block;
     let mut n = 0;
-    while n < (*rf).n_mfmvs {
-        let ref2cur = (*rf).mfmv_ref2cur[n as usize];
+    while n < rf.n_mfmvs {
+        let ref2cur = rf.mfmv_ref2cur[n as usize];
         if !(ref2cur == i32::MIN) {
-            let r#ref = (*rf).mfmv_ref[n as usize] as c_int;
+            let r#ref = rf.mfmv_ref[n as usize] as c_int;
             let ref_sign = r#ref - 4;
-            let mut r: *const refmvs_temporal_block = &mut *(*((*rf).rp_ref).offset(r#ref as isize))
+            let mut r: *const refmvs_temporal_block = &mut *(*(rf.rp_ref).offset(r#ref as isize))
                 .offset(row_start8 as isize * stride)
                 as *mut refmvs_temporal_block;
             let mut y_0 = row_start8;
@@ -1432,7 +1434,7 @@ unsafe extern "C" fn load_tmvs_c(
                         &*r.offset(x_0 as isize) as *const refmvs_temporal_block;
                     let b_ref = (*rb).r#ref as c_int;
                     if !(b_ref == 0) {
-                        let ref2ref = (*rf).mfmv_ref2ref[n as usize][(b_ref - 1) as usize];
+                        let ref2ref = rf.mfmv_ref2ref[n as usize][(b_ref - 1) as usize];
                         if !(ref2ref == 0) {
                             let b_mv: mv = (*rb).mv;
                             let offset: mv = mv_projection(b_mv, ref2cur, ref2ref);

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1420,7 +1420,7 @@ unsafe extern "C" fn load_tmvs_c(
                 let mut x = col_start8i;
                 while x < col_end8i {
                     let mut rb = r.offset(x as isize);
-                    let b_ref = (*rb).r#ref as c_int;
+                    let b_ref = (*rb).r#ref;
                     if !(b_ref == 0) {
                         let ref2ref = rf.mfmv_ref2ref[n as usize][(b_ref - 1) as usize];
                         if !(ref2ref == 0) {
@@ -1451,7 +1451,7 @@ unsafe extern "C" fn load_tmvs_c(
                                     }
                                     rb = rb.offset(1);
                                     let rb_mv = (*rb).mv;
-                                    if (*rb).r#ref as c_int != b_ref || rb_mv != b_mv {
+                                    if (*rb).r#ref != b_ref || rb_mv != b_mv {
                                         break;
                                     }
                                     pos_x += 1;
@@ -1464,7 +1464,7 @@ unsafe extern "C" fn load_tmvs_c(
                                     }
                                     rb = rb.offset(1);
                                     let rb_mv = (*rb).mv;
-                                    if (*rb).r#ref as c_int != b_ref || rb_mv != b_mv {
+                                    if (*rb).r#ref != b_ref || rb_mv != b_mv {
                                         break;
                                     }
                                 }

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1398,19 +1398,14 @@ unsafe extern "C" fn load_tmvs_c(
     let mut rp_proj = rf
         .rp_proj
         .offset(16 * stride * tile_row_idx as isize + (row_start8 & 15) as isize * stride);
-    let mut y = row_start8;
-    while y < row_end8 {
-        let mut x = col_start8;
-        while x < col_end8 {
+    for _ in row_start8..row_end8 {
+        for x in col_start8..col_end8 {
             (*rp_proj.offset(x as isize)).mv = mv::INVALID;
-            x += 1;
         }
         rp_proj = rp_proj.offset(stride as isize);
-        y += 1;
     }
     rp_proj = rf.rp_proj.offset(16 * stride * tile_row_idx as isize);
-    let mut n = 0;
-    while n < rf.n_mfmvs {
+    for n in 0..rf.n_mfmvs {
         let ref2cur = rf.mfmv_ref2cur[n as usize];
         if !(ref2cur == i32::MIN) {
             let r#ref = rf.mfmv_ref[n as usize] as c_int;
@@ -1418,8 +1413,7 @@ unsafe extern "C" fn load_tmvs_c(
             let mut r = (*rf.rp_ref.offset(r#ref as isize))
                 .offset(row_start8 as isize * stride)
                 .cast_const();
-            let mut y = row_start8;
-            while y < row_end8 {
+            for y in row_start8..row_end8 {
                 let y_sb_align = y & !7;
                 let y_proj_start = cmp::max(y_sb_align, row_start8);
                 let y_proj_end = cmp::min(y_sb_align + 8, row_end8);
@@ -1481,10 +1475,8 @@ unsafe extern "C" fn load_tmvs_c(
                     x += 1;
                 }
                 r = r.offset(stride as isize);
-                y += 1;
             }
         }
-        n += 1;
     }
 }
 


### PR DESCRIPTION
This is just basic cleanup.  I'll make it safer next (the fields that I've already made safe on the other side of the `fn` ptr boundary).  Then I'll be able to `Arc`ify the `mvs` fields, as those are accessed here through raw pointers on this side of the `fn` ptr boundary.