### PR TITLE
`struct RefMvsFrame::rp_proj`: Add `DisjointMut`

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3921,7 +3921,7 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
     }
 
     if c.tc.len() > 1 && frame_hdr.use_ref_frame_mvs != 0 {
-        let rf = f.rf.as_dav1d();
+        let rf = f.rf.as_mut_dav1d();
         (c.refmvs_dsp.load_tmvs)(
             &rf,
             ts.tiling.row,
@@ -4526,7 +4526,7 @@ unsafe fn rav1d_decode_frame_main(c: &Rav1dContext, f: &mut Rav1dFrameData) -> R
             t.b.y = sby << 4 + seq_hdr.sb128;
             let by_end = t.b.y + f.sb_step >> 1;
             if frame_hdr.use_ref_frame_mvs != 0 {
-                let rf = f.rf.as_dav1d();
+                let rf = f.rf.as_mut_dav1d();
                 (c.refmvs_dsp.load_tmvs)(&rf, tile_row as c_int, 0, f.bw >> 1, t.b.y >> 1, by_end);
             }
             for col in 0..cols {

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -222,7 +222,7 @@ pub(crate) struct RefMvsFrame {
 }
 
 impl RefMvsFrame {
-    pub fn as_dav1d<'a>(&'a mut self) -> refmvs_frame<'a> {
+    pub fn as_mut_dav1d<'a>(&'a self) -> refmvs_frame<'a> {
         let Self {
             iw4,
             ih4,
@@ -239,9 +239,9 @@ impl RefMvsFrame {
             n_mfmvs,
             rp,
             rp_ref,
-            ref mut rp_proj,
+            ref rp_proj,
             rp_stride,
-            ref mut r,
+            ref r,
             r_stride,
             n_tile_rows,
             n_tile_threads,


### PR DESCRIPTION
This also makes `fn RefMvsFrame::as_mut_dav1d` take `&self` and use `DisjointMut`'s inner mutability when calling `load_tmvs`.  This way the uses of `f.rf` are `&`s and won't prevent making `f` `&` in #952.

This then sets the stage for passing `DisjointMut`s directly to `fn load_tmvs_c` and using it safely there.  The asm `fn` ptrs will continue to things completely unsafe, as we can't really get around that.