### PR TITLE
`struct DisjointMut`: Fix missing initializations of `DisjointMut` fields

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -553,6 +553,7 @@ impl TxLpfRightEdge {
 }
 
 /// loopfilter
+#[derive(Default)]
 #[repr(C)]
 pub struct Rav1dFrameContext_lf {
     pub level: DisjointMut<Vec<[u8; 4]>>,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -4,6 +4,7 @@ use crate::include::dav1d::headers::Rav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Rav1dPixelLayout;
 use crate::include::dav1d::headers::Rav1dRestorationType;
 use crate::src::align::Align16;
+use crate::src::align::ArrayDefault;
 use crate::src::ctx::CaseSet;
 use crate::src::disjoint_mut::DisjointMut;
 use crate::src::internal::Bxy;
@@ -25,6 +26,22 @@ pub struct Av1FilterLUT {
     pub e: [u8; 64],
     pub i: [u8; 64],
     pub sharp: [u64; 2],
+}
+
+impl Default for Av1FilterLUT {
+    fn default() -> Self {
+        Self {
+            e: [0; 64],
+            i: [0; 64],
+            sharp: Default::default(),
+        }
+    }
+}
+
+impl ArrayDefault for Av1FilterLUT {
+    fn default() -> Self {
+        Default::default()
+    }
 }
 
 #[derive(Clone, Copy, Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,19 +293,14 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
         addr_of_mut!(f.task_thread.finished).write(AtomicBool::new(true));
         addr_of_mut!(f.frame_thread).write(Default::default());
         addr_of_mut!(f.frame_thread_progress).write(Default::default());
+        addr_of_mut!(f.lowest_pixel_mem).write(Default::default());
+        addr_of_mut!(f.lf).write(Default::default());
         if n_tc > 1 {
             f.task_thread.lock = Mutex::new(());
             f.task_thread.cond = Condvar::new();
             f.task_thread.pending_tasks = Default::default();
         }
         (&mut f.task_thread.ttd as *mut Arc<TaskThreadData>).write(Arc::clone(&(*c).task_thread));
-        addr_of_mut!(f.lf.level).write(Default::default());
-        addr_of_mut!(f.lf.mask).write(Default::default());
-        addr_of_mut!(f.lf.lr_mask).write(Default::default());
-        addr_of_mut!(f.lf.tx_lpf_right_edge).write(Default::default());
-        addr_of_mut!(f.lf.cdef_line_buf).write(Default::default());
-        addr_of_mut!(f.lf.lr_line_buf).write(Default::default());
-        addr_of_mut!(f.lf.start_of_tile_row).write(Default::default());
         f.lf.last_sharpness = -(1 as c_int);
         rav1d_refmvs_init(&mut f.rf);
     }


### PR DESCRIPTION
I found these by running the argon tests in debug mode (not just `debug_assertions`), as these `libstd` assertions are only run in actual debug mode.