### PR TITLE
`fn Rav1dDSPContext::get`: Lazily initialize with `OnceLock` and store `&'static`s

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -1032,7 +1032,7 @@ unsafe fn cdef_find_dir_rust<BD: BitDepth>(
 
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"),))]
-unsafe fn cdef_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dCdefDSPContext) {
+fn cdef_dsp_init_x86<BD: BitDepth>(c: &mut Rav1dCdefDSPContext) {
     let flags = rav1d_get_cpu_flags();
 
     match BD::BPC {
@@ -1041,27 +1041,27 @@ unsafe fn cdef_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dCdefDSPContext) {
                 return;
             }
 
-            (*c).fb[0] = dav1d_cdef_filter_8x8_8bpc_sse2;
-            (*c).fb[1] = dav1d_cdef_filter_4x8_8bpc_sse2;
-            (*c).fb[2] = dav1d_cdef_filter_4x4_8bpc_sse2;
+            c.fb[0] = dav1d_cdef_filter_8x8_8bpc_sse2;
+            c.fb[1] = dav1d_cdef_filter_4x8_8bpc_sse2;
+            c.fb[2] = dav1d_cdef_filter_4x4_8bpc_sse2;
 
             if !flags.contains(CpuFlags::SSSE3) {
                 return;
             }
 
-            (*c).dir = dav1d_cdef_dir_8bpc_ssse3;
-            (*c).fb[0] = dav1d_cdef_filter_8x8_8bpc_ssse3;
-            (*c).fb[1] = dav1d_cdef_filter_4x8_8bpc_ssse3;
-            (*c).fb[2] = dav1d_cdef_filter_4x4_8bpc_ssse3;
+            c.dir = dav1d_cdef_dir_8bpc_ssse3;
+            c.fb[0] = dav1d_cdef_filter_8x8_8bpc_ssse3;
+            c.fb[1] = dav1d_cdef_filter_4x8_8bpc_ssse3;
+            c.fb[2] = dav1d_cdef_filter_4x4_8bpc_ssse3;
 
             if !flags.contains(CpuFlags::SSE41) {
                 return;
             }
 
-            (*c).dir = dav1d_cdef_dir_8bpc_sse4;
-            (*c).fb[0] = dav1d_cdef_filter_8x8_8bpc_sse4;
-            (*c).fb[1] = dav1d_cdef_filter_4x8_8bpc_sse4;
-            (*c).fb[2] = dav1d_cdef_filter_4x4_8bpc_sse4;
+            c.dir = dav1d_cdef_dir_8bpc_sse4;
+            c.fb[0] = dav1d_cdef_filter_8x8_8bpc_sse4;
+            c.fb[1] = dav1d_cdef_filter_4x8_8bpc_sse4;
+            c.fb[2] = dav1d_cdef_filter_4x4_8bpc_sse4;
 
             #[cfg(target_arch = "x86_64")]
             {
@@ -1069,18 +1069,18 @@ unsafe fn cdef_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dCdefDSPContext) {
                     return;
                 }
 
-                (*c).dir = dav1d_cdef_dir_8bpc_avx2;
-                (*c).fb[0] = dav1d_cdef_filter_8x8_8bpc_avx2;
-                (*c).fb[1] = dav1d_cdef_filter_4x8_8bpc_avx2;
-                (*c).fb[2] = dav1d_cdef_filter_4x4_8bpc_avx2;
+                c.dir = dav1d_cdef_dir_8bpc_avx2;
+                c.fb[0] = dav1d_cdef_filter_8x8_8bpc_avx2;
+                c.fb[1] = dav1d_cdef_filter_4x8_8bpc_avx2;
+                c.fb[2] = dav1d_cdef_filter_4x4_8bpc_avx2;
 
                 if !flags.contains(CpuFlags::AVX512ICL) {
                     return;
                 }
 
-                (*c).fb[0] = dav1d_cdef_filter_8x8_8bpc_avx512icl;
-                (*c).fb[1] = dav1d_cdef_filter_4x8_8bpc_avx512icl;
-                (*c).fb[2] = dav1d_cdef_filter_4x4_8bpc_avx512icl;
+                c.fb[0] = dav1d_cdef_filter_8x8_8bpc_avx512icl;
+                c.fb[1] = dav1d_cdef_filter_4x8_8bpc_avx512icl;
+                c.fb[2] = dav1d_cdef_filter_4x4_8bpc_avx512icl;
             }
         }
         BPC::BPC16 => {
@@ -1088,16 +1088,16 @@ unsafe fn cdef_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dCdefDSPContext) {
                 return;
             }
 
-            (*c).dir = dav1d_cdef_dir_16bpc_ssse3;
-            (*c).fb[0] = dav1d_cdef_filter_8x8_16bpc_ssse3;
-            (*c).fb[1] = dav1d_cdef_filter_4x8_16bpc_ssse3;
-            (*c).fb[2] = dav1d_cdef_filter_4x4_16bpc_ssse3;
+            c.dir = dav1d_cdef_dir_16bpc_ssse3;
+            c.fb[0] = dav1d_cdef_filter_8x8_16bpc_ssse3;
+            c.fb[1] = dav1d_cdef_filter_4x8_16bpc_ssse3;
+            c.fb[2] = dav1d_cdef_filter_4x4_16bpc_ssse3;
 
             if !flags.contains(CpuFlags::SSE41) {
                 return;
             }
 
-            (*c).dir = dav1d_cdef_dir_16bpc_sse4;
+            c.dir = dav1d_cdef_dir_16bpc_sse4;
 
             #[cfg(target_arch = "x86_64")]
             {
@@ -1105,18 +1105,18 @@ unsafe fn cdef_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dCdefDSPContext) {
                     return;
                 }
 
-                (*c).dir = dav1d_cdef_dir_16bpc_avx2;
-                (*c).fb[0] = dav1d_cdef_filter_8x8_16bpc_avx2;
-                (*c).fb[1] = dav1d_cdef_filter_4x8_16bpc_avx2;
-                (*c).fb[2] = dav1d_cdef_filter_4x4_16bpc_avx2;
+                c.dir = dav1d_cdef_dir_16bpc_avx2;
+                c.fb[0] = dav1d_cdef_filter_8x8_16bpc_avx2;
+                c.fb[1] = dav1d_cdef_filter_4x8_16bpc_avx2;
+                c.fb[2] = dav1d_cdef_filter_4x4_16bpc_avx2;
 
                 if !flags.contains(CpuFlags::AVX512ICL) {
                     return;
                 }
 
-                (*c).fb[0] = dav1d_cdef_filter_8x8_16bpc_avx512icl;
-                (*c).fb[1] = dav1d_cdef_filter_4x8_16bpc_avx512icl;
-                (*c).fb[2] = dav1d_cdef_filter_4x4_16bpc_avx512icl;
+                c.fb[0] = dav1d_cdef_filter_8x8_16bpc_avx512icl;
+                c.fb[1] = dav1d_cdef_filter_4x8_16bpc_avx512icl;
+                c.fb[2] = dav1d_cdef_filter_4x4_16bpc_avx512icl;
             }
         }
     };
@@ -1276,28 +1276,28 @@ unsafe extern "C" fn cdef_filter_4x4_neon_erased<BD: BitDepth>(
 
 #[inline(always)]
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64"),))]
-unsafe fn cdef_dsp_init_arm<BD: BitDepth>(c: *mut Rav1dCdefDSPContext) {
+fn cdef_dsp_init_arm<BD: BitDepth>(c: &mut Rav1dCdefDSPContext) {
     let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::NEON) {
         return;
     }
 
-    (*c).dir = match BD::BPC {
+    c.dir = match BD::BPC {
         BPC::BPC8 => dav1d_cdef_find_dir_8bpc_neon,
         BPC::BPC16 => dav1d_cdef_find_dir_16bpc_neon,
     };
-    (*c).fb[0] = cdef_filter_8x8_neon_erased::<BD>;
-    (*c).fb[1] = cdef_filter_4x8_neon_erased::<BD>;
-    (*c).fb[2] = cdef_filter_4x4_neon_erased::<BD>;
+    c.fb[0] = cdef_filter_8x8_neon_erased::<BD>;
+    c.fb[1] = cdef_filter_4x8_neon_erased::<BD>;
+    c.fb[2] = cdef_filter_4x4_neon_erased::<BD>;
 }
 
 #[cold]
-pub unsafe fn rav1d_cdef_dsp_init<BD: BitDepth>(c: *mut Rav1dCdefDSPContext) {
-    (*c).dir = cdef_find_dir_c_erased::<BD>;
-    (*c).fb[0] = cdef_filter_block_8x8_c_erased::<BD>;
-    (*c).fb[1] = cdef_filter_block_4x8_c_erased::<BD>;
-    (*c).fb[2] = cdef_filter_block_4x4_c_erased::<BD>;
+pub fn rav1d_cdef_dsp_init<BD: BitDepth>(c: &mut Rav1dCdefDSPContext) {
+    c.dir = cdef_find_dir_c_erased::<BD>;
+    c.fb[0] = cdef_filter_block_8x8_c_erased::<BD>;
+    c.fb[1] = cdef_filter_block_4x8_c_erased::<BD>;
+    c.fb[2] = cdef_filter_block_4x4_c_erased::<BD>;
 
     #[cfg(feature = "asm")]
     cfg_if! {

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -1190,6 +1190,7 @@ impl Rav1dCdefDSPContext {
     }
 
     #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
+    #[inline(always)]
     const fn init_x86<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
         match BD::BPC {
             BPC::BPC8 => {
@@ -1281,6 +1282,7 @@ impl Rav1dCdefDSPContext {
     }
 
     #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
+    #[inline(always)]
     const fn init_arm<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::NEON) {
             return self;
@@ -1297,6 +1299,7 @@ impl Rav1dCdefDSPContext {
         self
     }
 
+    #[inline(always)]
     const fn init<BD: BitDepth>(self, flags: CpuFlags) -> Self {
         #[cfg(feature = "asm")]
         {

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -1178,7 +1178,7 @@ unsafe extern "C" fn cdef_filter_4x4_neon_erased<BD: BitDepth>(
 }
 
 impl Rav1dCdefDSPContext {
-    const fn default<BD: BitDepth>() -> Self {
+    pub const fn default<BD: BitDepth>() -> Self {
         Self {
             dir: cdef_find_dir_c_erased::<BD>,
             fb: [
@@ -1297,7 +1297,7 @@ impl Rav1dCdefDSPContext {
         self
     }
 
-    fn init<BD: BitDepth>(self, flags: CpuFlags) -> Self {
+    const fn init<BD: BitDepth>(self, flags: CpuFlags) -> Self {
         #[cfg(feature = "asm")]
         {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -1317,7 +1317,7 @@ impl Rav1dCdefDSPContext {
         }
     }
 
-    pub fn new<BD: BitDepth>(flags: CpuFlags) -> Self {
+    pub const fn new<BD: BitDepth>(flags: CpuFlags) -> Self {
         Self::default::<BD>().init::<BD>(flags)
     }
 }

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -1178,7 +1178,7 @@ unsafe extern "C" fn cdef_filter_4x4_neon_erased<BD: BitDepth>(
 }
 
 impl Rav1dCdefDSPContext {
-    const fn new_c<BD: BitDepth>() -> Self {
+    const fn default<BD: BitDepth>() -> Self {
         Self {
             dir: cdef_find_dir_c_erased::<BD>,
             fb: [
@@ -1318,6 +1318,6 @@ impl Rav1dCdefDSPContext {
     }
 
     pub fn new<BD: BitDepth>(flags: CpuFlags) -> Self {
-        Self::new_c::<BD>().init::<BD>(flags)
+        Self::default::<BD>().init::<BD>(flags)
     }
 }

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -171,7 +171,6 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
         BPC::BPC8 => 0,
         BPC::BPC16 => f.cur.p.bpc - 8,
     };
-    let dsp = &*f.dsp;
     let mut edges: CdefEdgeFlags = if by_start > 0 {
         CdefEdgeFlags::HAVE_BOTTOM | CdefEdgeFlags::HAVE_TOP
     } else {
@@ -304,7 +303,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
 
                         let mut variance = 0;
                         let dir = if y_pri_lvl != 0 || uv_pri_lvl != 0 {
-                            (dsp.cdef.dir)(
+                            (f.dsp.cdef.dir)(
                                 bptrs[0].cast(),
                                 f.cur.stride[0],
                                 &mut variance,
@@ -370,7 +369,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                         if y_pri_lvl != 0 {
                             let adj_y_pri_lvl = adjust_strength(y_pri_lvl, variance);
                             if adj_y_pri_lvl != 0 || y_sec_lvl != 0 {
-                                dsp.cdef.fb[0](
+                                f.dsp.cdef.fb[0](
                                     bptrs[0].cast(),
                                     f.cur.stride[0],
                                     lr_bak[bit as usize][0].as_mut_ptr().cast(),
@@ -385,7 +384,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                                 );
                             }
                         } else if y_sec_lvl != 0 {
-                            dsp.cdef.fb[0](
+                            f.dsp.cdef.fb[0](
                                 bptrs[0].cast(),
                                 f.cur.stride[0],
                                 (lr_bak[bit as usize][0]).as_mut_ptr().cast(),
@@ -469,7 +468,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                                     bot = bptrs[pl].offset((8 >> ss_ver) * uv_stride);
                                 }
 
-                                dsp.cdef.fb[uv_idx as usize](
+                                f.dsp.cdef.fb[uv_idx as usize](
                                     bptrs[pl].cast(),
                                     f.cur.stride[1],
                                     lr_bak[bit as usize][pl].as_mut_ptr().cast(),

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -180,7 +180,6 @@ static rav1d_cpu_flags: AtomicU32 = AtomicU32::new(0);
 /// so it shouldn't be performance sensitive.
 static rav1d_cpu_flags_mask: AtomicU32 = AtomicU32::new(!0);
 
-#[cfg(feature = "asm")]
 #[inline(always)]
 pub(crate) fn rav1d_get_cpu_flags() -> CpuFlags {
     let flags =

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -119,7 +119,7 @@ use crate::src::lf_mask::Av1RestorationUnit;
 use crate::src::log::Rav1dLog as _;
 use crate::src::loopfilter::Rav1dLoopFilterDSPContext;
 use crate::src::looprestoration::Rav1dLoopRestorationDSPContext;
-use crate::src::mc::rav1d_mc_dsp_init;
+use crate::src::mc::Rav1dMCDSPContext;
 use crate::src::mem::rav1d_alloc_aligned;
 use crate::src::mem::rav1d_free_aligned;
 use crate::src::mem::rav1d_freep_aligned;
@@ -4736,7 +4736,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
                 dsp.itx = Rav1dInvTxfmDSPContext::new::<BitDepth8>(flags, bpc);
                 dsp.lf = Rav1dLoopFilterDSPContext::new::<BitDepth8>(flags);
                 dsp.lr = Rav1dLoopRestorationDSPContext::new::<BitDepth8>(flags, bpc);
-                rav1d_mc_dsp_init::<BitDepth8>(&mut dsp.mc);
+                dsp.mc = Rav1dMCDSPContext::new::<BitDepth8>(flags);
                 dsp.fg = Rav1dFilmGrainDSPContext::new::<BitDepth8>(flags);
             }
             #[cfg(feature = "bitdepth_16")]
@@ -4746,7 +4746,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
                 dsp.itx = Rav1dInvTxfmDSPContext::new::<BitDepth16>(flags, bpc);
                 dsp.lf = Rav1dLoopFilterDSPContext::new::<BitDepth16>(flags);
                 dsp.lr = Rav1dLoopRestorationDSPContext::new::<BitDepth16>(flags, bpc);
-                rav1d_mc_dsp_init::<BitDepth16>(&mut dsp.mc);
+                dsp.mc = Rav1dMCDSPContext::new::<BitDepth16>(flags);
                 dsp.fg = Rav1dFilmGrainDSPContext::new::<BitDepth16>(flags);
             }
             _ => {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -76,7 +76,7 @@ use crate::src::internal::TileStateRef;
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::intra_edge::EdgeIndex;
 use crate::src::intra_edge::IntraEdges;
-use crate::src::ipred::rav1d_intra_pred_dsp_init;
+use crate::src::ipred::Rav1dIntraPredDSPContext;
 use crate::src::itx::rav1d_itx_dsp_init;
 use crate::src::levels::mv;
 use crate::src::levels::Av1Block;
@@ -4732,7 +4732,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
             #[cfg(feature = "bitdepth_8")]
             8 => {
                 dsp.cdef = Rav1dCdefDSPContext::new::<BitDepth8>(flags);
-                rav1d_intra_pred_dsp_init::<BitDepth8>(&mut dsp.ipred);
+                dsp.ipred = Rav1dIntraPredDSPContext::new::<BitDepth8>(flags);
                 rav1d_itx_dsp_init::<BitDepth8>(&mut dsp.itx, bpc);
                 rav1d_loop_filter_dsp_init::<BitDepth8>(&mut dsp.lf);
                 rav1d_loop_restoration_dsp_init::<BitDepth8>(&mut dsp.lr, bpc);
@@ -4742,7 +4742,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
             #[cfg(feature = "bitdepth_16")]
             10 | 12 => {
                 dsp.cdef = Rav1dCdefDSPContext::new::<BitDepth16>(flags);
-                rav1d_intra_pred_dsp_init::<BitDepth16>(&mut dsp.ipred);
+                dsp.ipred = Rav1dIntraPredDSPContext::new::<BitDepth16>(flags);
                 rav1d_itx_dsp_init::<BitDepth16>(&mut dsp.itx, bpc);
                 rav1d_loop_filter_dsp_init::<BitDepth16>(&mut dsp.lf);
                 rav1d_loop_restoration_dsp_init::<BitDepth16>(&mut dsp.lr, bpc);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -118,7 +118,7 @@ use crate::src::lf_mask::rav1d_create_lf_mask_intra;
 use crate::src::lf_mask::Av1RestorationUnit;
 use crate::src::log::Rav1dLog as _;
 use crate::src::loopfilter::Rav1dLoopFilterDSPContext;
-use crate::src::looprestoration::rav1d_loop_restoration_dsp_init;
+use crate::src::looprestoration::Rav1dLoopRestorationDSPContext;
 use crate::src::mc::rav1d_mc_dsp_init;
 use crate::src::mem::rav1d_alloc_aligned;
 use crate::src::mem::rav1d_free_aligned;
@@ -4735,7 +4735,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
                 dsp.ipred = Rav1dIntraPredDSPContext::new::<BitDepth8>(flags);
                 dsp.itx = Rav1dInvTxfmDSPContext::new::<BitDepth8>(flags, bpc);
                 dsp.lf = Rav1dLoopFilterDSPContext::new::<BitDepth8>(flags);
-                rav1d_loop_restoration_dsp_init::<BitDepth8>(&mut dsp.lr, bpc);
+                dsp.lr = Rav1dLoopRestorationDSPContext::new::<BitDepth8>(flags, bpc);
                 rav1d_mc_dsp_init::<BitDepth8>(&mut dsp.mc);
                 dsp.fg = Rav1dFilmGrainDSPContext::new::<BitDepth8>(flags);
             }
@@ -4745,7 +4745,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
                 dsp.ipred = Rav1dIntraPredDSPContext::new::<BitDepth16>(flags);
                 dsp.itx = Rav1dInvTxfmDSPContext::new::<BitDepth16>(flags, bpc);
                 dsp.lf = Rav1dLoopFilterDSPContext::new::<BitDepth16>(flags);
-                rav1d_loop_restoration_dsp_init::<BitDepth16>(&mut dsp.lr, bpc);
+                dsp.lr = Rav1dLoopRestorationDSPContext::new::<BitDepth16>(flags, bpc);
                 rav1d_mc_dsp_init::<BitDepth16>(&mut dsp.mc);
                 dsp.fg = Rav1dFilmGrainDSPContext::new::<BitDepth16>(flags);
             }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -28,6 +28,7 @@ use crate::src::cdf::rav1d_cdf_thread_init_static;
 use crate::src::cdf::rav1d_cdf_thread_update;
 use crate::src::cdf::CdfMvComponent;
 use crate::src::cdf::CdfMvContext;
+use crate::src::cpu::rav1d_get_cpu_flags;
 use crate::src::ctx::CaseSet;
 use crate::src::dequant_tables::dav1d_dq_tbl;
 use crate::src::disjoint_mut::DisjointMut;
@@ -4726,6 +4727,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
         let dsp = &mut c.dsp[seq_hdr.hbd as usize];
         dsp.initialized = true;
 
+        let flags = rav1d_get_cpu_flags();
         match bpc {
             #[cfg(feature = "bitdepth_8")]
             8 => {
@@ -4735,7 +4737,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
                 rav1d_loop_filter_dsp_init::<BitDepth8>(&mut dsp.lf);
                 rav1d_loop_restoration_dsp_init::<BitDepth8>(&mut dsp.lr, bpc);
                 rav1d_mc_dsp_init::<BitDepth8>(&mut dsp.mc);
-                dsp.fg = Rav1dFilmGrainDSPContext::new::<BitDepth8>();
+                dsp.fg = Rav1dFilmGrainDSPContext::new::<BitDepth8>(flags);
             }
             #[cfg(feature = "bitdepth_16")]
             10 | 12 => {
@@ -4745,7 +4747,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
                 rav1d_loop_filter_dsp_init::<BitDepth16>(&mut dsp.lf);
                 rav1d_loop_restoration_dsp_init::<BitDepth16>(&mut dsp.lr, bpc);
                 rav1d_mc_dsp_init::<BitDepth16>(&mut dsp.mc);
-                dsp.fg = Rav1dFilmGrainDSPContext::new::<BitDepth16>();
+                dsp.fg = Rav1dFilmGrainDSPContext::new::<BitDepth16>(flags);
             }
             _ => {
                 writeln!(

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -77,7 +77,7 @@ use crate::src::intra_edge::EdgeFlags;
 use crate::src::intra_edge::EdgeIndex;
 use crate::src::intra_edge::IntraEdges;
 use crate::src::ipred::Rav1dIntraPredDSPContext;
-use crate::src::itx::rav1d_itx_dsp_init;
+use crate::src::itx::Rav1dInvTxfmDSPContext;
 use crate::src::levels::mv;
 use crate::src::levels::Av1Block;
 use crate::src::levels::BlockLevel;
@@ -4733,7 +4733,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
             8 => {
                 dsp.cdef = Rav1dCdefDSPContext::new::<BitDepth8>(flags);
                 dsp.ipred = Rav1dIntraPredDSPContext::new::<BitDepth8>(flags);
-                rav1d_itx_dsp_init::<BitDepth8>(&mut dsp.itx, bpc);
+                dsp.itx = Rav1dInvTxfmDSPContext::new::<BitDepth8>(flags, bpc);
                 rav1d_loop_filter_dsp_init::<BitDepth8>(&mut dsp.lf);
                 rav1d_loop_restoration_dsp_init::<BitDepth8>(&mut dsp.lr, bpc);
                 rav1d_mc_dsp_init::<BitDepth8>(&mut dsp.mc);
@@ -4743,7 +4743,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
             10 | 12 => {
                 dsp.cdef = Rav1dCdefDSPContext::new::<BitDepth16>(flags);
                 dsp.ipred = Rav1dIntraPredDSPContext::new::<BitDepth16>(flags);
-                rav1d_itx_dsp_init::<BitDepth16>(&mut dsp.itx, bpc);
+                dsp.itx = Rav1dInvTxfmDSPContext::new::<BitDepth16>(flags, bpc);
                 rav1d_loop_filter_dsp_init::<BitDepth16>(&mut dsp.lf);
                 rav1d_loop_restoration_dsp_init::<BitDepth16>(&mut dsp.lr, bpc);
                 rav1d_mc_dsp_init::<BitDepth16>(&mut dsp.mc);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -21,7 +21,7 @@ use crate::include::dav1d::headers::RAV1D_MAX_SEGMENTS;
 use crate::include::dav1d::headers::RAV1D_PRIMARY_REF_NONE;
 use crate::src::align::Align16;
 use crate::src::align::AlignedVec64;
-use crate::src::cdef::rav1d_cdef_dsp_init;
+use crate::src::cdef::Rav1dCdefDSPContext;
 use crate::src::cdf::rav1d_cdf_thread_alloc;
 use crate::src::cdf::rav1d_cdf_thread_copy;
 use crate::src::cdf::rav1d_cdf_thread_init_static;
@@ -4731,7 +4731,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
         match bpc {
             #[cfg(feature = "bitdepth_8")]
             8 => {
-                rav1d_cdef_dsp_init::<BitDepth8>(&mut dsp.cdef);
+                dsp.cdef = Rav1dCdefDSPContext::new::<BitDepth8>(flags);
                 rav1d_intra_pred_dsp_init::<BitDepth8>(&mut dsp.ipred);
                 rav1d_itx_dsp_init::<BitDepth8>(&mut dsp.itx, bpc);
                 rav1d_loop_filter_dsp_init::<BitDepth8>(&mut dsp.lf);
@@ -4741,7 +4741,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
             }
             #[cfg(feature = "bitdepth_16")]
             10 | 12 => {
-                rav1d_cdef_dsp_init::<BitDepth16>(&mut dsp.cdef);
+                dsp.cdef = Rav1dCdefDSPContext::new::<BitDepth16>(flags);
                 rav1d_intra_pred_dsp_init::<BitDepth16>(&mut dsp.ipred);
                 rav1d_itx_dsp_init::<BitDepth16>(&mut dsp.itx, bpc);
                 rav1d_loop_filter_dsp_init::<BitDepth16>(&mut dsp.lf);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -117,7 +117,7 @@ use crate::src::lf_mask::rav1d_create_lf_mask_inter;
 use crate::src::lf_mask::rav1d_create_lf_mask_intra;
 use crate::src::lf_mask::Av1RestorationUnit;
 use crate::src::log::Rav1dLog as _;
-use crate::src::loopfilter::rav1d_loop_filter_dsp_init;
+use crate::src::loopfilter::Rav1dLoopFilterDSPContext;
 use crate::src::looprestoration::rav1d_loop_restoration_dsp_init;
 use crate::src::mc::rav1d_mc_dsp_init;
 use crate::src::mem::rav1d_alloc_aligned;
@@ -4734,7 +4734,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
                 dsp.cdef = Rav1dCdefDSPContext::new::<BitDepth8>(flags);
                 dsp.ipred = Rav1dIntraPredDSPContext::new::<BitDepth8>(flags);
                 dsp.itx = Rav1dInvTxfmDSPContext::new::<BitDepth8>(flags, bpc);
-                rav1d_loop_filter_dsp_init::<BitDepth8>(&mut dsp.lf);
+                dsp.lf = Rav1dLoopFilterDSPContext::new::<BitDepth8>(flags);
                 rav1d_loop_restoration_dsp_init::<BitDepth8>(&mut dsp.lr, bpc);
                 rav1d_mc_dsp_init::<BitDepth8>(&mut dsp.mc);
                 dsp.fg = Rav1dFilmGrainDSPContext::new::<BitDepth8>(flags);
@@ -4744,7 +4744,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
                 dsp.cdef = Rav1dCdefDSPContext::new::<BitDepth16>(flags);
                 dsp.ipred = Rav1dIntraPredDSPContext::new::<BitDepth16>(flags);
                 dsp.itx = Rav1dInvTxfmDSPContext::new::<BitDepth16>(flags, bpc);
-                rav1d_loop_filter_dsp_init::<BitDepth16>(&mut dsp.lf);
+                dsp.lf = Rav1dLoopFilterDSPContext::new::<BitDepth16>(flags);
                 rav1d_loop_restoration_dsp_init::<BitDepth16>(&mut dsp.lr, bpc);
                 rav1d_mc_dsp_init::<BitDepth16>(&mut dsp.mc);
                 dsp.fg = Rav1dFilmGrainDSPContext::new::<BitDepth16>(flags);

--- a/src/enum_map.rs
+++ b/src/enum_map.rs
@@ -59,7 +59,7 @@ where
 {
     /// Create an [`EnumMap`] with default values when `V: ` [`DefaultValue`].
     #[allow(dead_code)] // TODO(kkysen) remove when used
-    pub const fn default() -> Self {
+    const fn default() -> Self {
         Self {
             array: [V::DEFAULT; N],
             _phantom: PhantomData,

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -1092,7 +1092,7 @@ unsafe fn fguv_32x32xn_neon<BD: BitDepth, const NM: usize, const IS_SX: bool, co
 }
 
 impl Rav1dFilmGrainDSPContext {
-    const fn default<BD: BitDepth>() -> Self {
+    pub const fn default<BD: BitDepth>() -> Self {
         Self {
             generate_grain_y: generate_grain_y::Fn::new(generate_grain_y_c_erased::<BD>),
             generate_grain_uv: enum_map!(Rav1dPixelLayoutSubSampled => generate_grain_uv::Fn; match key {

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -1092,7 +1092,7 @@ unsafe fn fguv_32x32xn_neon<BD: BitDepth, const NM: usize, const IS_SX: bool, co
 }
 
 impl Rav1dFilmGrainDSPContext {
-    const fn new_c<BD: BitDepth>() -> Self {
+    const fn default<BD: BitDepth>() -> Self {
         Self {
             generate_grain_y: generate_grain_y::Fn::new(generate_grain_y_c_erased::<BD>),
             generate_grain_uv: enum_map!(Rav1dPixelLayoutSubSampled => generate_grain_uv::Fn; match key {
@@ -1210,6 +1210,6 @@ impl Rav1dFilmGrainDSPContext {
     }
 
     pub const fn new<BD: BitDepth>(flags: CpuFlags) -> Self {
-        Self::new_c::<BD>().init::<BD>(flags)
+        Self::default::<BD>().init::<BD>(flags)
     }
 }

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -1110,6 +1110,7 @@ impl Rav1dFilmGrainDSPContext {
     }
 
     #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
+    #[inline(always)]
     const fn init_x86<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::SSSE3) {
             return self;
@@ -1167,6 +1168,7 @@ impl Rav1dFilmGrainDSPContext {
     }
 
     #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
+    #[inline(always)]
     const fn init_arm<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::NEON) {
             return self;
@@ -1189,6 +1191,7 @@ impl Rav1dFilmGrainDSPContext {
         self
     }
 
+    #[inline(always)]
     const fn init<BD: BitDepth>(self, flags: CpuFlags) -> Self {
         #[cfg(feature = "asm")]
         {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -27,6 +27,7 @@ use crate::src::align::*;
 use crate::src::cdef::Rav1dCdefDSPContext;
 use crate::src::cdf::CdfContext;
 use crate::src::cdf::CdfThreadContext;
+use crate::src::cpu::CpuFlags;
 use crate::src::disjoint_mut::DisjointMut;
 use crate::src::disjoint_mut::DisjointMutArcSlice;
 use crate::src::env::BlockContext;
@@ -117,6 +118,34 @@ pub(crate) struct Rav1dDSPContext {
     pub cdef: Rav1dCdefDSPContext,
     pub lr: Rav1dLoopRestorationDSPContext,
     pub initialized: bool,
+}
+
+impl Rav1dDSPContext {
+    pub const fn _default<BD: BitDepth>() -> Self {
+        Self {
+            fg: Rav1dFilmGrainDSPContext::default::<BD>(),
+            ipred: Rav1dIntraPredDSPContext::default::<BD>(),
+            mc: Rav1dMCDSPContext::default::<BD>(),
+            itx: Rav1dInvTxfmDSPContext::default::<BD>(),
+            lf: Rav1dLoopFilterDSPContext::default::<BD>(),
+            cdef: Rav1dCdefDSPContext::default::<BD>(),
+            lr: Rav1dLoopRestorationDSPContext::default::<BD>(),
+            initialized: true,
+        }
+    }
+
+    pub const fn new<BD: BitDepth>(flags: CpuFlags, bpc: c_int) -> Self {
+        Self {
+            fg: Rav1dFilmGrainDSPContext::new::<BD>(flags),
+            ipred: Rav1dIntraPredDSPContext::new::<BD>(flags),
+            mc: Rav1dMCDSPContext::new::<BD>(flags),
+            itx: Rav1dInvTxfmDSPContext::new::<BD>(flags, bpc),
+            lf: Rav1dLoopFilterDSPContext::new::<BD>(flags),
+            cdef: Rav1dCdefDSPContext::new::<BD>(flags),
+            lr: Rav1dLoopRestorationDSPContext::new::<BD>(flags, bpc),
+            initialized: true,
+        }
+    }
 }
 
 #[derive(Clone, Default)]

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -27,6 +27,7 @@ use crate::src::align::*;
 use crate::src::cdef::Rav1dCdefDSPContext;
 use crate::src::cdf::CdfContext;
 use crate::src::cdf::CdfThreadContext;
+use crate::src::cpu::rav1d_get_cpu_flags;
 use crate::src::cpu::CpuFlags;
 use crate::src::disjoint_mut::DisjointMut;
 use crate::src::disjoint_mut::DisjointMutArcSlice;
@@ -106,6 +107,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Condvar;
 use std::sync::Mutex;
+use std::sync::OnceLock;
 use std::thread::JoinHandle;
 
 #[repr(C)]
@@ -145,6 +147,27 @@ impl Rav1dDSPContext {
             lr: Rav1dLoopRestorationDSPContext::new::<BD>(flags, bpc),
             initialized: true,
         }
+    }
+
+    pub fn get(bpc: c_int) -> Option<&'static Self> {
+        static BPC8: OnceLock<Rav1dDSPContext> = OnceLock::new();
+        static BPC10: OnceLock<Rav1dDSPContext> = OnceLock::new();
+        static BPC12: OnceLock<Rav1dDSPContext> = OnceLock::new();
+        Some(match bpc {
+            8 => BPC8.get_or_init(|| {
+                let flags = rav1d_get_cpu_flags();
+                Self::new::<BitDepth8>(flags, bpc)
+            }),
+            10 => BPC10.get_or_init(|| {
+                let flags = rav1d_get_cpu_flags();
+                Self::new::<BitDepth16>(flags, bpc)
+            }),
+            12 => BPC12.get_or_init(|| {
+                let flags = rav1d_get_cpu_flags();
+                Self::new::<BitDepth16>(flags, bpc)
+            }),
+            _ => return None,
+        })
     }
 }
 
@@ -317,7 +340,6 @@ pub struct Rav1dContext {
     pub(crate) refs: [Rav1dContext_refs; 8],
     pub(crate) cdf: [CdfThreadContext; 8], // Previously pooled
 
-    pub(crate) dsp: [Rav1dDSPContext; 3], /* 8, 10, 12 bits/component */
     pub(crate) refmvs_dsp: Rav1dRefmvsDSPContext,
 
     pub(crate) allocator: Rav1dPicAllocator,
@@ -782,7 +804,7 @@ pub(crate) struct Rav1dFrameData {
 
     pub ts: *mut Rav1dTileState,
     pub n_ts: c_int,
-    pub dsp: *const Rav1dDSPContext,
+    pub dsp: &'static Rav1dDSPContext,
 
     pub ipred_edge_sz: c_int,
     pub ipred_edge: [*mut DynPixel; 3],

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -2049,7 +2049,7 @@ mod neon {
 }
 
 impl Rav1dIntraPredDSPContext {
-    const fn default<BD: BitDepth>() -> Self {
+    pub const fn default<BD: BitDepth>() -> Self {
         Self {
             intra_pred: {
                 let mut a = [DefaultValue::DEFAULT; N_IMPL_INTRA_PRED_MODES];
@@ -2272,7 +2272,7 @@ impl Rav1dIntraPredDSPContext {
         self
     }
 
-    fn init<BD: BitDepth>(self, flags: CpuFlags) -> Self {
+    const fn init<BD: BitDepth>(self, flags: CpuFlags) -> Self {
         #[cfg(feature = "asm")]
         {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -2292,7 +2292,7 @@ impl Rav1dIntraPredDSPContext {
         }
     }
 
-    pub fn new<BD: BitDepth>(flags: CpuFlags) -> Self {
+    pub const fn new<BD: BitDepth>(flags: CpuFlags) -> Self {
         Self::default::<BD>().init::<BD>(flags)
     }
 }

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -2049,7 +2049,7 @@ mod neon {
 }
 
 impl Rav1dIntraPredDSPContext {
-    const fn new_c<BD: BitDepth>() -> Self {
+    const fn default<BD: BitDepth>() -> Self {
         Self {
             intra_pred: {
                 let mut a = [DefaultValue::DEFAULT; N_IMPL_INTRA_PRED_MODES];
@@ -2293,6 +2293,6 @@ impl Rav1dIntraPredDSPContext {
     }
 
     pub fn new<BD: BitDepth>(flags: CpuFlags) -> Self {
-        Self::new_c::<BD>().init::<BD>(flags)
+        Self::default::<BD>().init::<BD>(flags)
     }
 }

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -2097,6 +2097,7 @@ impl Rav1dIntraPredDSPContext {
     }
 
     #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
+    #[inline(always)]
     const fn init_x86<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::SSSE3) {
             return self;
@@ -2220,6 +2221,7 @@ impl Rav1dIntraPredDSPContext {
     }
 
     #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
+    #[inline(always)]
     const fn init_arm<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::NEON) {
             return self;
@@ -2272,6 +2274,7 @@ impl Rav1dIntraPredDSPContext {
         self
     }
 
+    #[inline(always)]
     const fn init<BD: BitDepth>(self, flags: CpuFlags) -> Self {
         #[cfg(feature = "asm")]
         {

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -891,6 +891,7 @@ impl Rav1dInvTxfmDSPContext {
     }
 
     #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
+    #[inline(always)]
     const fn init_x86<BD: BitDepth>(mut self, flags: CpuFlags, bpc: c_int) -> Self {
         if !flags.contains(CpuFlags::SSE2) {
             return self;
@@ -1067,6 +1068,7 @@ impl Rav1dInvTxfmDSPContext {
     }
 
     #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
+    #[inline(always)]
     const fn init_arm<BD: BitDepth>(mut self, flags: CpuFlags, bpc: c_int) -> Self {
         if !flags.contains(CpuFlags::NEON) {
             return self;
@@ -1106,6 +1108,7 @@ impl Rav1dInvTxfmDSPContext {
         assign::<BD>(self)
     }
 
+    #[inline(always)]
     const fn init<BD: BitDepth>(self, flags: CpuFlags, bpc: c_int) -> Self {
         #[cfg(feature = "asm")]
         {

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -616,7 +616,6 @@ macro_rules! assign_itx2_fn {
 }
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
-#[rustfmt::skip]
 macro_rules! assign_itx12_bpc_fn {
     ($c:ident, $w:literal, $h:literal, $bpc:literal bpc, $ext:ident) => {{
         assign_itx2_bpc_fn!($c, $w, $h, $bpc bpc, $ext);
@@ -630,7 +629,6 @@ macro_rules! assign_itx12_bpc_fn {
         assign_itx_bpc_fn!($c, $w, $h, flipadst_adst, ADST_FLIPADST, $bpc bpc, $ext);
         assign_itx_bpc_fn!($c, $w, $h, flipadst_flipadst, FLIPADST_FLIPADST, $bpc bpc, $ext);
         assign_itx_bpc_fn!($c, $w, $h, identity_dct, V_DCT, $bpc bpc, $ext);
-
     }};
 
     ($c:ident, $pfx:ident, $w:literal, $h:literal, $bpc:literal bpc, $ext:ident) => {{
@@ -649,7 +647,6 @@ macro_rules! assign_itx12_bpc_fn {
 }
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
-#[rustfmt::skip]
 macro_rules! assign_itx12_fn {
     ($c:ident, $BD:ty, $w:literal, $h:literal, $ext:ident) => {{
         assign_itx2_fn!($c, BD, $w, $h, $ext);
@@ -675,7 +672,16 @@ macro_rules! assign_itx12_fn {
         assign_itx_fn!($c, BD, $pfx, $w, $h, adst_flipadst, FLIPADST_ADST, $ext);
         assign_itx_fn!($c, BD, $pfx, $w, $h, flipadst_dct, DCT_FLIPADST, $ext);
         assign_itx_fn!($c, BD, $pfx, $w, $h, flipadst_adst, ADST_FLIPADST, $ext);
-        assign_itx_fn!($c, BD, $pfx, $w, $h, flipadst_flipadst, FLIPADST_FLIPADST, $ext);
+        assign_itx_fn!(
+            $c,
+            BD,
+            $pfx,
+            $w,
+            $h,
+            flipadst_flipadst,
+            FLIPADST_FLIPADST,
+            $ext
+        );
         assign_itx_fn!($c, BD, $pfx, $w, $h, identity_dct, V_DCT, $ext);
     }};
 }
@@ -720,9 +726,7 @@ macro_rules! assign_itx16_fn {
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
-#[rustfmt::skip]
 unsafe fn itx_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dInvTxfmDSPContext, bpc: c_int) {
-
     let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSE2) {
@@ -899,7 +903,6 @@ unsafe fn itx_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dInvTxfmDSPContext, bpc: c_
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]
-#[rustfmt::skip]
 unsafe fn itx_dsp_init_arm<BD: BitDepth>(c: *mut Rav1dInvTxfmDSPContext, bpc: c_int) {
     let flags = rav1d_get_cpu_flags();
 
@@ -911,26 +914,29 @@ unsafe fn itx_dsp_init_arm<BD: BitDepth>(c: *mut Rav1dInvTxfmDSPContext, bpc: c_
         return;
     }
 
-    assign_itx_fn!  (c, BD, 4, 4, wht_wht, WHT_WHT, neon);
-    assign_itx16_fn!(c, BD,     4,  4, neon);
-    assign_itx16_fn!(c, BD, R,  4,  8, neon);
-    assign_itx16_fn!(c, BD, R,  4, 16, neon);
-    assign_itx16_fn!(c, BD, R,  8,  4, neon);
-    assign_itx16_fn!(c, BD,     8,  8, neon);
-    assign_itx16_fn!(c, BD, R,  8, 16, neon);
-    assign_itx16_fn!(c, BD, R, 16,  4, neon);
-    assign_itx16_fn!(c, BD, R, 16,  8, neon);
-    assign_itx12_fn!(c, BD,    16, 16, neon);
-    assign_itx2_fn! (c, BD, R,  8, 32, neon);
-    assign_itx2_fn! (c, BD, R, 16, 32, neon);
-    assign_itx2_fn! (c, BD, R, 32,  8, neon);
-    assign_itx2_fn! (c, BD, R, 32, 16, neon);
-    assign_itx2_fn! (c, BD,    32, 32, neon);
-    assign_itx1_fn! (c, BD, R, 16, 64, neon);
-    assign_itx1_fn! (c, BD, R, 32, 64, neon);
-    assign_itx1_fn! (c, BD, R, 64, 16, neon);
-    assign_itx1_fn! (c, BD, R, 64, 32, neon);
-    assign_itx1_fn! (c, BD,    64, 64, neon);
+    #[rustfmt::skip]
+    (|| {
+        assign_itx_fn!  (c, BD, 4, 4, wht_wht, WHT_WHT, neon);
+        assign_itx16_fn!(c, BD,     4,  4, neon);
+        assign_itx16_fn!(c, BD, R,  4,  8, neon);
+        assign_itx16_fn!(c, BD, R,  4, 16, neon);
+        assign_itx16_fn!(c, BD, R,  8,  4, neon);
+        assign_itx16_fn!(c, BD,     8,  8, neon);
+        assign_itx16_fn!(c, BD, R,  8, 16, neon);
+        assign_itx16_fn!(c, BD, R, 16,  4, neon);
+        assign_itx16_fn!(c, BD, R, 16,  8, neon);
+        assign_itx12_fn!(c, BD,    16, 16, neon);
+        assign_itx2_fn! (c, BD, R,  8, 32, neon);
+        assign_itx2_fn! (c, BD, R, 16, 32, neon);
+        assign_itx2_fn! (c, BD, R, 32,  8, neon);
+        assign_itx2_fn! (c, BD, R, 32, 16, neon);
+        assign_itx2_fn! (c, BD,    32, 32, neon);
+        assign_itx1_fn! (c, BD, R, 16, 64, neon);
+        assign_itx1_fn! (c, BD, R, 32, 64, neon);
+        assign_itx1_fn! (c, BD, R, 64, 16, neon);
+        assign_itx1_fn! (c, BD, R, 64, 32, neon);
+        assign_itx1_fn! (c, BD,    64, 64, neon);
+    })();
 }
 
 macro_rules! assign_itx_all_fn64 {
@@ -1068,31 +1074,32 @@ macro_rules! assign_itx_all_fn84 {
 }
 
 #[cold]
-#[rustfmt::skip]
 pub unsafe fn rav1d_itx_dsp_init<BD: BitDepth>(c: *mut Rav1dInvTxfmDSPContext, mut _bpc: c_int) {
+    (*c).itxfm_add[TX_4X4 as usize][WHT_WHT as usize] =
+        Some(inv_txfm_add_wht_wht_4x4_c_erased::<BD>);
 
-
-    (*c).itxfm_add[TX_4X4 as usize][WHT_WHT as usize]
-        = Some(inv_txfm_add_wht_wht_4x4_c_erased::<BD>);
-    assign_itx_all_fn84!(c, BD,  4,  4   );
-    assign_itx_all_fn84!(c, BD,  4,  8, R);
-    assign_itx_all_fn84!(c, BD,  4, 16, R);
-    assign_itx_all_fn84!(c, BD,  8,  4, R);
-    assign_itx_all_fn84!(c, BD,  8,  8   );
-    assign_itx_all_fn84!(c, BD,  8, 16, R);
-    assign_itx_all_fn32!(c, BD,  8, 32, R);
-    assign_itx_all_fn84!(c, BD, 16,  4, R);
-    assign_itx_all_fn84!(c, BD, 16,  8, R);
-    assign_itx_all_fn16!(c, BD, 16, 16   );
-    assign_itx_all_fn32!(c, BD, 16, 32, R);
-    assign_itx_all_fn64!(c, BD, 16, 64, R);
-    assign_itx_all_fn32!(c, BD, 32,  8, R);
-    assign_itx_all_fn32!(c, BD, 32, 16, R);
-    assign_itx_all_fn32!(c, BD, 32, 32   );
-    assign_itx_all_fn64!(c, BD, 32, 64, R);
-    assign_itx_all_fn64!(c, BD, 64, 16, R);
-    assign_itx_all_fn64!(c, BD, 64, 32, R);
-    assign_itx_all_fn64!(c, BD, 64, 64   );
+    #[rustfmt::skip]
+    (|| {
+        assign_itx_all_fn84!(c, BD,  4,  4   );
+        assign_itx_all_fn84!(c, BD,  4,  8, R);
+        assign_itx_all_fn84!(c, BD,  4, 16, R);
+        assign_itx_all_fn84!(c, BD,  8,  4, R);
+        assign_itx_all_fn84!(c, BD,  8,  8   );
+        assign_itx_all_fn84!(c, BD,  8, 16, R);
+        assign_itx_all_fn32!(c, BD,  8, 32, R);
+        assign_itx_all_fn84!(c, BD, 16,  4, R);
+        assign_itx_all_fn84!(c, BD, 16,  8, R);
+        assign_itx_all_fn16!(c, BD, 16, 16   );
+        assign_itx_all_fn32!(c, BD, 16, 32, R);
+        assign_itx_all_fn64!(c, BD, 16, 64, R);
+        assign_itx_all_fn32!(c, BD, 32,  8, R);
+        assign_itx_all_fn32!(c, BD, 32, 16, R);
+        assign_itx_all_fn32!(c, BD, 32, 32   );
+        assign_itx_all_fn64!(c, BD, 32, 64, R);
+        assign_itx_all_fn64!(c, BD, 64, 16, R);
+        assign_itx_all_fn64!(c, BD, 64, 32, R);
+        assign_itx_all_fn64!(c, BD, 64, 64   );
+    })();
 
     #[cfg(feature = "asm")]
     cfg_if! {

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -531,7 +531,7 @@ macro_rules! assign_itx_fn {
         use paste::paste;
 
         paste! {
-            (*$c).itxfm_add[[<TX_ $w X $h>] as usize][$type_enum as usize]
+            $c.itxfm_add[[<TX_ $w X $h>] as usize][$type_enum as usize]
                 = Some(bd_fn!(BD, [< inv_txfm_add_ $type _ $w x $h >], $ext));
         }
     }};
@@ -540,7 +540,7 @@ macro_rules! assign_itx_fn {
         use paste::paste;
 
         paste! {
-            (*$c).itxfm_add[[<$pfx TX_ $w X $h>] as usize][$type_enum as usize]
+            $c.itxfm_add[[<$pfx TX_ $w X $h>] as usize][$type_enum as usize]
                 = Some(bd_fn!(BD, [< inv_txfm_add_ $type _ $w x $h >], $ext));
         }
     }};
@@ -552,7 +552,7 @@ macro_rules! assign_itx_bpc_fn {
         use paste::paste;
 
         paste! {
-            (*$c).itxfm_add[[<$pfx TX_ $w X $h>] as usize][$type_enum as usize]
+            $c.itxfm_add[[<$pfx TX_ $w X $h>] as usize][$type_enum as usize]
                 = Some(bpc_fn!($bpc bpc, [< inv_txfm_add_ $type _ $w x $h >], $ext));
         }
     }};
@@ -561,7 +561,7 @@ macro_rules! assign_itx_bpc_fn {
         use paste::paste;
 
         paste! {
-            (*$c).itxfm_add[[<TX_ $w X $h>] as usize][$type_enum as usize]
+            $c.itxfm_add[[<TX_ $w X $h>] as usize][$type_enum as usize]
                 = Some(bpc_fn!($bpc bpc, [< inv_txfm_add_ $type _ $w x $h >], $ext));
         }
     }};
@@ -726,7 +726,7 @@ macro_rules! assign_itx16_fn {
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
-unsafe fn itx_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dInvTxfmDSPContext, bpc: c_int) {
+fn itx_dsp_init_x86<BD: BitDepth>(c: &mut Rav1dInvTxfmDSPContext, bpc: c_int) {
     let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSE2) {
@@ -903,7 +903,7 @@ unsafe fn itx_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dInvTxfmDSPContext, bpc: c_
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]
-unsafe fn itx_dsp_init_arm<BD: BitDepth>(c: *mut Rav1dInvTxfmDSPContext, bpc: c_int) {
+fn itx_dsp_init_arm<BD: BitDepth>(c: &mut Rav1dInvTxfmDSPContext, bpc: c_int) {
     let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::NEON) {
@@ -944,7 +944,7 @@ macro_rules! assign_itx_all_fn64 {
         use paste::paste;
 
         paste! {
-            (*$c).itxfm_add[[<TX_ $w X $h>] as usize][DCT_DCT as usize] =
+            $c.itxfm_add[[<TX_ $w X $h>] as usize][DCT_DCT as usize] =
                 Some([< inv_txfm_add_dct_dct_ $w x $h _c_erased >]::<BD>);
         }
     }};
@@ -953,7 +953,7 @@ macro_rules! assign_itx_all_fn64 {
         use paste::paste;
 
         paste! {
-            (*$c).itxfm_add[[<$pfx TX_ $w X $h>] as usize][DCT_DCT as usize]
+            $c.itxfm_add[[<$pfx TX_ $w X $h>] as usize][DCT_DCT as usize]
                 = Some([< inv_txfm_add_dct_dct_ $w x $h _c_erased >]::<BD>);
         }
     }};
@@ -965,7 +965,7 @@ macro_rules! assign_itx_all_fn32 {
 
         assign_itx_all_fn64!($c, BD, $w, $h);
         paste! {
-            (*$c).itxfm_add[[<TX_ $w X $h>] as usize][IDTX as usize]
+            $c.itxfm_add[[<TX_ $w X $h>] as usize][IDTX as usize]
                 = Some([< inv_txfm_add_identity_identity_ $w x $h _c_erased >]::<BD>);
         }
     }};
@@ -975,7 +975,7 @@ macro_rules! assign_itx_all_fn32 {
 
         assign_itx_all_fn64!($c, BD, $w, $h, $pfx);
         paste! {
-            (*$c).itxfm_add[[<$pfx TX_ $w X $h>] as usize][IDTX as usize]
+            $c.itxfm_add[[<$pfx TX_ $w X $h>] as usize][IDTX as usize]
                 = Some([< inv_txfm_add_identity_identity_ $w x $h _c_erased >]::<BD>);
         }
     }};
@@ -987,25 +987,25 @@ macro_rules! assign_itx_all_fn16 {
 
         assign_itx_all_fn32!($c, BD, $w, $h);
         paste! {
-            (*$c).itxfm_add[[<TX_ $w X $h>] as usize][DCT_ADST as usize]
+            $c.itxfm_add[[<TX_ $w X $h>] as usize][DCT_ADST as usize]
                 = Some([< inv_txfm_add_adst_dct_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<TX_ $w X $h>] as usize][ADST_DCT as usize]
+            $c.itxfm_add[[<TX_ $w X $h>] as usize][ADST_DCT as usize]
                 = Some([< inv_txfm_add_dct_adst_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<TX_ $w X $h>] as usize][ADST_ADST as usize]
+            $c.itxfm_add[[<TX_ $w X $h>] as usize][ADST_ADST as usize]
                 = Some([< inv_txfm_add_adst_adst_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<TX_ $w X $h>] as usize][ADST_FLIPADST as usize]
+            $c.itxfm_add[[<TX_ $w X $h>] as usize][ADST_FLIPADST as usize]
                 = Some([< inv_txfm_add_flipadst_adst_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<TX_ $w X $h>] as usize][FLIPADST_ADST as usize]
+            $c.itxfm_add[[<TX_ $w X $h>] as usize][FLIPADST_ADST as usize]
                 = Some([< inv_txfm_add_adst_flipadst_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<TX_ $w X $h>] as usize][DCT_FLIPADST as usize]
+            $c.itxfm_add[[<TX_ $w X $h>] as usize][DCT_FLIPADST as usize]
                 = Some([< inv_txfm_add_flipadst_dct_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<TX_ $w X $h>] as usize][FLIPADST_DCT as usize]
+            $c.itxfm_add[[<TX_ $w X $h>] as usize][FLIPADST_DCT as usize]
                 = Some([< inv_txfm_add_dct_flipadst_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<TX_ $w X $h>] as usize][FLIPADST_FLIPADST as usize]
+            $c.itxfm_add[[<TX_ $w X $h>] as usize][FLIPADST_FLIPADST as usize]
                 = Some([< inv_txfm_add_flipadst_flipadst_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<TX_ $w X $h>] as usize][H_DCT as usize]
+            $c.itxfm_add[[<TX_ $w X $h>] as usize][H_DCT as usize]
                 = Some([< inv_txfm_add_dct_identity_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<TX_ $w X $h>] as usize][V_DCT as usize]
+            $c.itxfm_add[[<TX_ $w X $h>] as usize][V_DCT as usize]
                 = Some([< inv_txfm_add_identity_dct_ $w x $h _c_erased >]::<BD>);
         }
     }};
@@ -1015,25 +1015,25 @@ macro_rules! assign_itx_all_fn16 {
 
         assign_itx_all_fn32!($c, BD, $w, $h, $pfx);
         paste! {
-            (*$c).itxfm_add[[<$pfx TX_ $w X $h>] as usize][DCT_ADST as usize]
+            $c.itxfm_add[[<$pfx TX_ $w X $h>] as usize][DCT_ADST as usize]
                 = Some([< inv_txfm_add_adst_dct_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<$pfx TX_ $w X $h>] as usize][ADST_DCT as usize]
+            $c.itxfm_add[[<$pfx TX_ $w X $h>] as usize][ADST_DCT as usize]
                 = Some([< inv_txfm_add_dct_adst_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<$pfx TX_ $w X $h>] as usize][ADST_ADST as usize]
+            $c.itxfm_add[[<$pfx TX_ $w X $h>] as usize][ADST_ADST as usize]
                 = Some([< inv_txfm_add_adst_adst_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<$pfx TX_ $w X $h>] as usize][ADST_FLIPADST as usize]
+            $c.itxfm_add[[<$pfx TX_ $w X $h>] as usize][ADST_FLIPADST as usize]
                 = Some([< inv_txfm_add_flipadst_adst_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<$pfx TX_ $w X $h>] as usize][FLIPADST_ADST as usize]
+            $c.itxfm_add[[<$pfx TX_ $w X $h>] as usize][FLIPADST_ADST as usize]
                 = Some([< inv_txfm_add_adst_flipadst_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<$pfx TX_ $w X $h>] as usize][DCT_FLIPADST as usize]
+            $c.itxfm_add[[<$pfx TX_ $w X $h>] as usize][DCT_FLIPADST as usize]
                 = Some([< inv_txfm_add_flipadst_dct_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<$pfx TX_ $w X $h>] as usize][FLIPADST_DCT as usize]
+            $c.itxfm_add[[<$pfx TX_ $w X $h>] as usize][FLIPADST_DCT as usize]
                 = Some([< inv_txfm_add_dct_flipadst_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<$pfx TX_ $w X $h>] as usize][FLIPADST_FLIPADST as usize]
+            $c.itxfm_add[[<$pfx TX_ $w X $h>] as usize][FLIPADST_FLIPADST as usize]
                 = Some([< inv_txfm_add_flipadst_flipadst_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<$pfx TX_ $w X $h>] as usize][H_DCT as usize]
+            $c.itxfm_add[[<$pfx TX_ $w X $h>] as usize][H_DCT as usize]
                 = Some([< inv_txfm_add_dct_identity_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<$pfx TX_ $w X $h>] as usize][V_DCT as usize]
+            $c.itxfm_add[[<$pfx TX_ $w X $h>] as usize][V_DCT as usize]
                 = Some([< inv_txfm_add_identity_dct_ $w x $h _c_erased >]::<BD>);
         }
     }};
@@ -1045,13 +1045,13 @@ macro_rules! assign_itx_all_fn84 {
 
         assign_itx_all_fn16!($c, BD, $w, $h);
         paste! {
-            (*$c).itxfm_add[[<TX_ $w X $h>] as usize][H_FLIPADST as usize]
+            $c.itxfm_add[[<TX_ $w X $h>] as usize][H_FLIPADST as usize]
                 = Some([< inv_txfm_add_flipadst_identity_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<TX_ $w X $h>] as usize][V_FLIPADST as usize]
+            $c.itxfm_add[[<TX_ $w X $h>] as usize][V_FLIPADST as usize]
                 = Some([< inv_txfm_add_identity_flipadst_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<TX_ $w X $h>] as usize][H_ADST as usize]
+            $c.itxfm_add[[<TX_ $w X $h>] as usize][H_ADST as usize]
                 = Some([< inv_txfm_add_adst_identity_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<TX_ $w X $h>] as usize][V_ADST as usize]
+            $c.itxfm_add[[<TX_ $w X $h>] as usize][V_ADST as usize]
                 = Some([< inv_txfm_add_identity_adst_ $w x $h _c_erased >]::<BD>);
         }
     }};
@@ -1061,22 +1061,21 @@ macro_rules! assign_itx_all_fn84 {
 
         assign_itx_all_fn16!($c, BD, $w, $h, $pfx);
         paste! {
-            (*$c).itxfm_add[[<$pfx TX_ $w X $h>] as usize][H_FLIPADST as usize]
+            $c.itxfm_add[[<$pfx TX_ $w X $h>] as usize][H_FLIPADST as usize]
                 = Some([< inv_txfm_add_flipadst_identity_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<$pfx TX_ $w X $h>] as usize][V_FLIPADST as usize]
+            $c.itxfm_add[[<$pfx TX_ $w X $h>] as usize][V_FLIPADST as usize]
                 = Some([< inv_txfm_add_identity_flipadst_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<$pfx TX_ $w X $h>] as usize][H_ADST as usize]
+            $c.itxfm_add[[<$pfx TX_ $w X $h>] as usize][H_ADST as usize]
                 = Some([< inv_txfm_add_adst_identity_ $w x $h _c_erased >]::<BD>);
-            (*$c).itxfm_add[[<$pfx TX_ $w X $h>] as usize][V_ADST as usize]
+            $c.itxfm_add[[<$pfx TX_ $w X $h>] as usize][V_ADST as usize]
                 = Some([< inv_txfm_add_identity_adst_ $w x $h _c_erased >]::<BD>);
         }
     }};
 }
 
 #[cold]
-pub unsafe fn rav1d_itx_dsp_init<BD: BitDepth>(c: *mut Rav1dInvTxfmDSPContext, mut _bpc: c_int) {
-    (*c).itxfm_add[TX_4X4 as usize][WHT_WHT as usize] =
-        Some(inv_txfm_add_wht_wht_4x4_c_erased::<BD>);
+pub fn rav1d_itx_dsp_init<BD: BitDepth>(c: &mut Rav1dInvTxfmDSPContext, mut _bpc: c_int) {
+    c.itxfm_add[TX_4X4 as usize][WHT_WHT as usize] = Some(inv_txfm_add_wht_wht_4x4_c_erased::<BD>);
 
     #[rustfmt::skip]
     (|| {

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -854,7 +854,7 @@ macro_rules! assign_itx_all_fn84 {
 }
 
 impl Rav1dInvTxfmDSPContext {
-    const fn new_c<BD: BitDepth>() -> Self {
+    const fn default<BD: BitDepth>() -> Self {
         let mut c = Self {
             itxfm_add: [[None; N_TX_TYPES_PLUS_LL]; N_RECT_TX_SIZES],
         };
@@ -1128,6 +1128,6 @@ impl Rav1dInvTxfmDSPContext {
     }
 
     pub fn new<BD: BitDepth>(flags: CpuFlags, bpc: c_int) -> Self {
-        Self::new_c::<BD>().init::<BD>(flags, bpc)
+        Self::default::<BD>().init::<BD>(flags, bpc)
     }
 }

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -854,7 +854,7 @@ macro_rules! assign_itx_all_fn84 {
 }
 
 impl Rav1dInvTxfmDSPContext {
-    const fn default<BD: BitDepth>() -> Self {
+    pub const fn default<BD: BitDepth>() -> Self {
         let mut c = Self {
             itxfm_add: [[None; N_TX_TYPES_PLUS_LL]; N_RECT_TX_SIZES],
         };
@@ -1106,7 +1106,7 @@ impl Rav1dInvTxfmDSPContext {
         assign::<BD>(self)
     }
 
-    fn init<BD: BitDepth>(self, flags: CpuFlags, bpc: c_int) -> Self {
+    const fn init<BD: BitDepth>(self, flags: CpuFlags, bpc: c_int) -> Self {
         #[cfg(feature = "asm")]
         {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -1127,7 +1127,7 @@ impl Rav1dInvTxfmDSPContext {
         }
     }
 
-    pub fn new<BD: BitDepth>(flags: CpuFlags, bpc: c_int) -> Self {
+    pub const fn new<BD: BitDepth>(flags: CpuFlags, bpc: c_int) -> Self {
         Self::default::<BD>().init::<BD>(flags, bpc)
     }
 }

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -1,3 +1,4 @@
+use crate::src::enum_map::EnumKey;
 use std::ops::Neg;
 use strum::EnumCount;
 use strum::FromRepr;
@@ -180,6 +181,25 @@ pub enum Filter2d {
     Smooth8Tap = 7,
     SmoothSharp8Tap = 8,
     Bilinear = 9,
+}
+
+impl EnumKey<{ Self::COUNT }> for Filter2d {
+    const VALUES: [Self; Self::COUNT] = [
+        Self::Regular8Tap,
+        Self::RegularSmooth8Tap,
+        Self::RegularSharp8Tap,
+        Self::SharpRegular8Tap,
+        Self::SharpSmooth8Tap,
+        Self::Sharp8Tap,
+        Self::SmoothRegular8Tap,
+        Self::Smooth8Tap,
+        Self::SmoothSharp8Tap,
+        Self::Bilinear,
+    ];
+
+    fn as_usize(self) -> usize {
+        self as usize
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, FromRepr, EnumCount)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ use crate::src::fg_apply;
 use crate::src::internal::Rav1dContext;
 use crate::src::internal::Rav1dContextTaskThread;
 use crate::src::internal::Rav1dContextTaskType;
+use crate::src::internal::Rav1dDSPContext;
 use crate::src::internal::Rav1dFrameData;
 use crate::src::internal::Rav1dTaskContext;
 use crate::src::internal::Rav1dTaskContext_task_thread;
@@ -609,17 +610,17 @@ pub(crate) unsafe fn rav1d_apply_grain(
         } else {
             match out.p.bpc {
                 #[cfg(feature = "bitdepth_8")]
-                8 => {
+                bpc @ 8 => {
                     fg_apply::rav1d_apply_grain::<BitDepth8>(
-                        &mut (*(c.dsp).as_mut_ptr().offset(0)).fg,
+                        &Rav1dDSPContext::get(bpc).as_ref().unwrap().fg,
                         out,
                         in_0,
                     );
                 }
                 #[cfg(feature = "bitdepth_16")]
-                10 | 12 => {
+                bpc @ 10 | bpc @ 12 => {
                     fg_apply::rav1d_apply_grain::<BitDepth16>(
-                        &mut (*(c.dsp).as_mut_ptr().offset(((out.p.bpc >> 1) - 4) as isize)).fg,
+                        &Rav1dDSPContext::get(bpc).as_ref().unwrap().fg,
                         out,
                         in_0,
                     );

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -980,7 +980,7 @@ unsafe fn loop_filter_v_sb128uv_rust<BD: BitDepth>(
 }
 
 impl Rav1dLoopFilterDSPContext {
-    const fn new_c<BD: BitDepth>() -> Self {
+    const fn default<BD: BitDepth>() -> Self {
         Self {
             loop_filter_sb: [
                 [
@@ -1106,6 +1106,6 @@ impl Rav1dLoopFilterDSPContext {
     }
 
     pub fn new<BD: BitDepth>(flags: CpuFlags) -> Self {
-        Self::new_c::<BD>().init::<BD>(flags)
+        Self::default::<BD>().init::<BD>(flags)
     }
 }

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -2,17 +2,12 @@ use crate::include::common::bitdepth::AsPrimitive;
 use crate::include::common::bitdepth::BitDepth;
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::intops::iclip;
+use crate::src::cpu::CpuFlags;
 use crate::src::lf_mask::Av1FilterLUT;
 use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
-
-#[cfg(feature = "asm")]
-use crate::src::cpu::{rav1d_get_cpu_flags, CpuFlags};
-
-#[cfg(feature = "asm")]
-use cfg_if::cfg_if;
 
 #[cfg(feature = "asm")]
 use crate::include::common::bitdepth::BPC;
@@ -984,110 +979,133 @@ unsafe fn loop_filter_v_sb128uv_rust<BD: BitDepth>(
     }
 }
 
-#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
-#[inline(always)]
-fn loop_filter_dsp_init_x86<BD: BitDepth>(c: &mut Rav1dLoopFilterDSPContext) {
-    let flags = rav1d_get_cpu_flags();
-
-    if !flags.contains(CpuFlags::SSSE3) {
-        return;
+impl Rav1dLoopFilterDSPContext {
+    const fn new_c<BD: BitDepth>() -> Self {
+        Self {
+            loop_filter_sb: [
+                [
+                    loop_filter_h_sb128y_c_erased::<BD>,
+                    loop_filter_v_sb128y_c_erased::<BD>,
+                ],
+                [
+                    loop_filter_h_sb128uv_c_erased::<BD>,
+                    loop_filter_v_sb128uv_c_erased::<BD>,
+                ],
+            ],
+        }
     }
-    match BD::BPC {
-        BPC::BPC8 => {
-            c.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_8bpc_ssse3;
-            c.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_8bpc_ssse3;
-            c.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_8bpc_ssse3;
-            c.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_8bpc_ssse3;
 
-            #[cfg(target_arch = "x86_64")]
-            {
-                if !flags.contains(CpuFlags::AVX2) {
-                    return;
+    #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
+    const fn init_x86<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
+        if !flags.contains(CpuFlags::SSSE3) {
+            return self;
+        }
+
+        match BD::BPC {
+            BPC::BPC8 => {
+                self.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_8bpc_ssse3;
+                self.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_8bpc_ssse3;
+                self.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_8bpc_ssse3;
+                self.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_8bpc_ssse3;
+
+                #[cfg(target_arch = "x86_64")]
+                {
+                    if !flags.contains(CpuFlags::AVX2) {
+                        return self;
+                    }
+
+                    self.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_8bpc_avx2;
+                    self.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_8bpc_avx2;
+                    self.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_8bpc_avx2;
+                    self.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_8bpc_avx2;
+
+                    if !flags.contains(CpuFlags::AVX512ICL) {
+                        return self;
+                    }
+
+                    self.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_8bpc_avx512icl;
+                    self.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_8bpc_avx512icl;
+                    self.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_8bpc_avx512icl;
+                    self.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_8bpc_avx512icl;
                 }
+            }
+            BPC::BPC16 => {
+                self.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_16bpc_ssse3;
+                self.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_16bpc_ssse3;
+                self.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_16bpc_ssse3;
+                self.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_16bpc_ssse3;
 
-                c.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_8bpc_avx2;
-                c.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_8bpc_avx2;
-                c.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_8bpc_avx2;
-                c.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_8bpc_avx2;
+                #[cfg(target_arch = "x86_64")]
+                {
+                    if !flags.contains(CpuFlags::AVX2) {
+                        return self;
+                    }
 
-                if !flags.contains(CpuFlags::AVX512ICL) {
-                    return;
+                    self.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_16bpc_avx2;
+                    self.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_16bpc_avx2;
+                    self.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_16bpc_avx2;
+                    self.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_16bpc_avx2;
+
+                    if !flags.contains(CpuFlags::AVX512ICL) {
+                        return self;
+                    }
+
+                    self.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_16bpc_avx512icl;
+                    self.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_16bpc_avx512icl;
+                    self.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_16bpc_avx512icl;
+                    self.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_16bpc_avx512icl;
                 }
-
-                c.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_8bpc_avx512icl;
-                c.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_8bpc_avx512icl;
-                c.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_8bpc_avx512icl;
-                c.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_8bpc_avx512icl;
             }
         }
-        BPC::BPC16 => {
-            c.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_16bpc_ssse3;
-            c.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_16bpc_ssse3;
-            c.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_16bpc_ssse3;
-            c.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_16bpc_ssse3;
 
-            #[cfg(target_arch = "x86_64")]
-            {
-                if !flags.contains(CpuFlags::AVX2) {
-                    return;
-                }
+        self
+    }
 
-                c.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_16bpc_avx2;
-                c.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_16bpc_avx2;
-                c.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_16bpc_avx2;
-                c.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_16bpc_avx2;
+    #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
+    const fn init_arm<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
+        if !flags.contains(CpuFlags::NEON) {
+            return self;
+        }
 
-                if !flags.contains(CpuFlags::AVX512ICL) {
-                    return;
-                }
-
-                c.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_16bpc_avx512icl;
-                c.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_16bpc_avx512icl;
-                c.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_16bpc_avx512icl;
-                c.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_16bpc_avx512icl;
+        match BD::BPC {
+            BPC::BPC8 => {
+                self.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_8bpc_neon;
+                self.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_8bpc_neon;
+                self.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_8bpc_neon;
+                self.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_8bpc_neon;
+            }
+            BPC::BPC16 => {
+                self.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_16bpc_neon;
+                self.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_16bpc_neon;
+                self.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_16bpc_neon;
+                self.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_16bpc_neon;
             }
         }
-    }
-}
 
-#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
-#[inline(always)]
-fn loop_filter_dsp_init_arm<BD: BitDepth>(c: &mut Rav1dLoopFilterDSPContext) {
-    let flags = rav1d_get_cpu_flags();
-
-    if !flags.contains(CpuFlags::NEON) {
-        return;
+        self
     }
 
-    match BD::BPC {
-        BPC::BPC8 => {
-            c.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_8bpc_neon;
-            c.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_8bpc_neon;
-            c.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_8bpc_neon;
-            c.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_8bpc_neon;
+    fn init<BD: BitDepth>(self, flags: CpuFlags) -> Self {
+        #[cfg(feature = "asm")]
+        {
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            {
+                return self.init_x86::<BD>(flags);
+            }
+            #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+            {
+                return self.init_arm::<BD>(flags);
+            }
         }
-        BPC::BPC16 => {
-            c.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_16bpc_neon;
-            c.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_16bpc_neon;
-            c.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_16bpc_neon;
-            c.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_16bpc_neon;
+
+        #[allow(unreachable_code)] // Reachable on some #[cfg]s.
+        {
+            let _ = flags;
+            self
         }
     }
-}
 
-#[cold]
-pub fn rav1d_loop_filter_dsp_init<BD: BitDepth>(c: &mut Rav1dLoopFilterDSPContext) {
-    c.loop_filter_sb[0][0] = loop_filter_h_sb128y_c_erased::<BD>;
-    c.loop_filter_sb[0][1] = loop_filter_v_sb128y_c_erased::<BD>;
-    c.loop_filter_sb[1][0] = loop_filter_h_sb128uv_c_erased::<BD>;
-    c.loop_filter_sb[1][1] = loop_filter_v_sb128uv_c_erased::<BD>;
-
-    #[cfg(feature = "asm")]
-    cfg_if! {
-        if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
-            loop_filter_dsp_init_x86::<BD>(c);
-        } else if #[cfg(any(target_arch = "arm", target_arch = "aarch64"))] {
-            loop_filter_dsp_init_arm::<BD>(c);
-        }
+    pub fn new<BD: BitDepth>(flags: CpuFlags) -> Self {
+        Self::new_c::<BD>().init::<BD>(flags)
     }
 }

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -996,6 +996,7 @@ impl Rav1dLoopFilterDSPContext {
     }
 
     #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
+    #[inline(always)]
     const fn init_x86<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::SSSE3) {
             return self;
@@ -1062,6 +1063,7 @@ impl Rav1dLoopFilterDSPContext {
     }
 
     #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
+    #[inline(always)]
     const fn init_arm<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::NEON) {
             return self;
@@ -1085,6 +1087,7 @@ impl Rav1dLoopFilterDSPContext {
         self
     }
 
+    #[inline(always)]
     const fn init<BD: BitDepth>(self, flags: CpuFlags) -> Self {
         #[cfg(feature = "asm")]
         {

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -980,7 +980,7 @@ unsafe fn loop_filter_v_sb128uv_rust<BD: BitDepth>(
 }
 
 impl Rav1dLoopFilterDSPContext {
-    const fn default<BD: BitDepth>() -> Self {
+    pub const fn default<BD: BitDepth>() -> Self {
         Self {
             loop_filter_sb: [
                 [
@@ -1085,7 +1085,7 @@ impl Rav1dLoopFilterDSPContext {
         self
     }
 
-    fn init<BD: BitDepth>(self, flags: CpuFlags) -> Self {
+    const fn init<BD: BitDepth>(self, flags: CpuFlags) -> Self {
         #[cfg(feature = "asm")]
         {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -1105,7 +1105,7 @@ impl Rav1dLoopFilterDSPContext {
         }
     }
 
-    pub fn new<BD: BitDepth>(flags: CpuFlags) -> Self {
+    pub const fn new<BD: BitDepth>(flags: CpuFlags) -> Self {
         Self::default::<BD>().init::<BD>(flags)
     }
 }

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -986,7 +986,7 @@ unsafe fn loop_filter_v_sb128uv_rust<BD: BitDepth>(
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
-unsafe fn loop_filter_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dLoopFilterDSPContext) {
+fn loop_filter_dsp_init_x86<BD: BitDepth>(c: &mut Rav1dLoopFilterDSPContext) {
     let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::SSSE3) {
@@ -994,10 +994,10 @@ unsafe fn loop_filter_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dLoopFilterDSPConte
     }
     match BD::BPC {
         BPC::BPC8 => {
-            (*c).loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_8bpc_ssse3;
-            (*c).loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_8bpc_ssse3;
-            (*c).loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_8bpc_ssse3;
-            (*c).loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_8bpc_ssse3;
+            c.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_8bpc_ssse3;
+            c.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_8bpc_ssse3;
+            c.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_8bpc_ssse3;
+            c.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_8bpc_ssse3;
 
             #[cfg(target_arch = "x86_64")]
             {
@@ -1005,26 +1005,26 @@ unsafe fn loop_filter_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dLoopFilterDSPConte
                     return;
                 }
 
-                (*c).loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_8bpc_avx2;
-                (*c).loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_8bpc_avx2;
-                (*c).loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_8bpc_avx2;
-                (*c).loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_8bpc_avx2;
+                c.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_8bpc_avx2;
+                c.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_8bpc_avx2;
+                c.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_8bpc_avx2;
+                c.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_8bpc_avx2;
 
                 if !flags.contains(CpuFlags::AVX512ICL) {
                     return;
                 }
 
-                (*c).loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_8bpc_avx512icl;
-                (*c).loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_8bpc_avx512icl;
-                (*c).loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_8bpc_avx512icl;
-                (*c).loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_8bpc_avx512icl;
+                c.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_8bpc_avx512icl;
+                c.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_8bpc_avx512icl;
+                c.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_8bpc_avx512icl;
+                c.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_8bpc_avx512icl;
             }
         }
         BPC::BPC16 => {
-            (*c).loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_16bpc_ssse3;
-            (*c).loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_16bpc_ssse3;
-            (*c).loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_16bpc_ssse3;
-            (*c).loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_16bpc_ssse3;
+            c.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_16bpc_ssse3;
+            c.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_16bpc_ssse3;
+            c.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_16bpc_ssse3;
+            c.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_16bpc_ssse3;
 
             #[cfg(target_arch = "x86_64")]
             {
@@ -1032,19 +1032,19 @@ unsafe fn loop_filter_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dLoopFilterDSPConte
                     return;
                 }
 
-                (*c).loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_16bpc_avx2;
-                (*c).loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_16bpc_avx2;
-                (*c).loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_16bpc_avx2;
-                (*c).loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_16bpc_avx2;
+                c.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_16bpc_avx2;
+                c.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_16bpc_avx2;
+                c.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_16bpc_avx2;
+                c.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_16bpc_avx2;
 
                 if !flags.contains(CpuFlags::AVX512ICL) {
                     return;
                 }
 
-                (*c).loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_16bpc_avx512icl;
-                (*c).loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_16bpc_avx512icl;
-                (*c).loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_16bpc_avx512icl;
-                (*c).loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_16bpc_avx512icl;
+                c.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_16bpc_avx512icl;
+                c.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_16bpc_avx512icl;
+                c.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_16bpc_avx512icl;
+                c.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_16bpc_avx512icl;
             }
         }
     }
@@ -1052,7 +1052,7 @@ unsafe fn loop_filter_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dLoopFilterDSPConte
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]
-unsafe fn loop_filter_dsp_init_arm<BD: BitDepth>(c: *mut Rav1dLoopFilterDSPContext) {
+fn loop_filter_dsp_init_arm<BD: BitDepth>(c: &mut Rav1dLoopFilterDSPContext) {
     let flags = rav1d_get_cpu_flags();
 
     if !flags.contains(CpuFlags::NEON) {
@@ -1061,26 +1061,26 @@ unsafe fn loop_filter_dsp_init_arm<BD: BitDepth>(c: *mut Rav1dLoopFilterDSPConte
 
     match BD::BPC {
         BPC::BPC8 => {
-            (*c).loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_8bpc_neon;
-            (*c).loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_8bpc_neon;
-            (*c).loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_8bpc_neon;
-            (*c).loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_8bpc_neon;
+            c.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_8bpc_neon;
+            c.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_8bpc_neon;
+            c.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_8bpc_neon;
+            c.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_8bpc_neon;
         }
         BPC::BPC16 => {
-            (*c).loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_16bpc_neon;
-            (*c).loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_16bpc_neon;
-            (*c).loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_16bpc_neon;
-            (*c).loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_16bpc_neon;
+            c.loop_filter_sb[0][0] = dav1d_lpf_h_sb_y_16bpc_neon;
+            c.loop_filter_sb[0][1] = dav1d_lpf_v_sb_y_16bpc_neon;
+            c.loop_filter_sb[1][0] = dav1d_lpf_h_sb_uv_16bpc_neon;
+            c.loop_filter_sb[1][1] = dav1d_lpf_v_sb_uv_16bpc_neon;
         }
     }
 }
 
 #[cold]
-pub unsafe fn rav1d_loop_filter_dsp_init<BD: BitDepth>(c: *mut Rav1dLoopFilterDSPContext) {
-    (*c).loop_filter_sb[0][0] = loop_filter_h_sb128y_c_erased::<BD>;
-    (*c).loop_filter_sb[0][1] = loop_filter_v_sb128y_c_erased::<BD>;
-    (*c).loop_filter_sb[1][0] = loop_filter_h_sb128uv_c_erased::<BD>;
-    (*c).loop_filter_sb[1][1] = loop_filter_v_sb128uv_c_erased::<BD>;
+pub fn rav1d_loop_filter_dsp_init<BD: BitDepth>(c: &mut Rav1dLoopFilterDSPContext) {
+    c.loop_filter_sb[0][0] = loop_filter_h_sb128y_c_erased::<BD>;
+    c.loop_filter_sb[0][1] = loop_filter_v_sb128y_c_erased::<BD>;
+    c.loop_filter_sb[1][0] = loop_filter_h_sb128uv_c_erased::<BD>;
+    c.loop_filter_sb[1][1] = loop_filter_v_sb128uv_c_erased::<BD>;
 
     #[cfg(feature = "asm")]
     cfg_if! {

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -3453,7 +3453,7 @@ unsafe fn sgr_filter_mix_neon<BD: BitDepth>(
 }
 
 impl Rav1dLoopRestorationDSPContext {
-    const fn default<BD: BitDepth>() -> Self {
+    pub const fn default<BD: BitDepth>() -> Self {
         Self {
             wiener: [wiener_c_erased::<BD>; 2],
             sgr: [
@@ -3553,7 +3553,7 @@ impl Rav1dLoopRestorationDSPContext {
         self
     }
 
-    fn init<BD: BitDepth>(self, flags: CpuFlags, bpc: c_int) -> Self {
+    const fn init<BD: BitDepth>(self, flags: CpuFlags, bpc: c_int) -> Self {
         #[cfg(feature = "asm")]
         {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -3574,7 +3574,7 @@ impl Rav1dLoopRestorationDSPContext {
         }
     }
 
-    pub fn new<BD: BitDepth>(flags: CpuFlags, bpc: c_int) -> Self {
+    pub const fn new<BD: BitDepth>(flags: CpuFlags, bpc: c_int) -> Self {
         Self::default::<BD>().init::<BD>(flags, bpc)
     }
 }

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -3465,6 +3465,7 @@ impl Rav1dLoopRestorationDSPContext {
     }
 
     #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
+    #[inline(always)]
     const fn init_x86<BD: BitDepth>(mut self, flags: CpuFlags, bpc: c_int) -> Self {
         if !flags.contains(CpuFlags::SSE2) {
             return self;
@@ -3527,6 +3528,7 @@ impl Rav1dLoopRestorationDSPContext {
     }
 
     #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
+    #[inline(always)]
     const fn init_arm<BD: BitDepth>(mut self, flags: CpuFlags, bpc: c_int) -> Self {
         if !flags.contains(CpuFlags::NEON) {
             return self;
@@ -3553,6 +3555,7 @@ impl Rav1dLoopRestorationDSPContext {
         self
     }
 
+    #[inline(always)]
     const fn init<BD: BitDepth>(self, flags: CpuFlags, bpc: c_int) -> Self {
         #[cfg(feature = "asm")]
         {

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -6,6 +6,7 @@ use crate::include::common::bitdepth::ToPrimitive;
 use crate::include::common::bitdepth::BPC;
 use crate::include::common::intops::iclip;
 use crate::src::align::Align16;
+use crate::src::cpu::CpuFlags;
 use crate::src::cursor::CursorMut;
 use crate::src::tables::dav1d_sgr_x_by_x;
 use libc::ptrdiff_t;
@@ -26,9 +27,6 @@ use libc::intptr_t;
     any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")
 ))]
 use crate::include::common::bitdepth::bd_fn;
-
-#[cfg(feature = "asm")]
-use crate::src::cpu::{rav1d_get_cpu_flags, CpuFlags};
 
 #[cfg(all(feature = "asm", target_arch = "arm"))]
 extern "C" {
@@ -3454,110 +3452,129 @@ unsafe fn sgr_filter_mix_neon<BD: BitDepth>(
     );
 }
 
-#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
-#[inline(always)]
-fn loop_restoration_dsp_init_x86<BD: BitDepth>(c: &mut Rav1dLoopRestorationDSPContext, bpc: c_int) {
-    let flags = rav1d_get_cpu_flags();
-
-    if !flags.contains(CpuFlags::SSE2) {
-        return;
+impl Rav1dLoopRestorationDSPContext {
+    const fn new_c<BD: BitDepth>() -> Self {
+        Self {
+            wiener: [wiener_c_erased::<BD>; 2],
+            sgr: [
+                sgr_5x5_c_erased::<BD>,
+                sgr_3x3_c_erased::<BD>,
+                sgr_mix_c_erased::<BD>,
+            ],
+        }
     }
 
-    if BD::BPC == BPC::BPC8 {
-        c.wiener[0] = decl_looprestorationfilter_fn!(fn dav1d_wiener_filter7_8bpc_sse2);
-        c.wiener[1] = decl_looprestorationfilter_fn!(fn dav1d_wiener_filter5_8bpc_sse2);
-    }
-
-    if !flags.contains(CpuFlags::SSSE3) {
-        return;
-    }
-
-    c.wiener[0] = bd_fn!(decl_looprestorationfilter_fn, BD, wiener_filter7, ssse3);
-    c.wiener[1] = bd_fn!(decl_looprestorationfilter_fn, BD, wiener_filter5, ssse3);
-
-    if BD::BPC == BPC::BPC8 || bpc == 10 {
-        c.sgr[0] = bd_fn!(decl_looprestorationfilter_fn, BD, sgr_filter_5x5, ssse3);
-        c.sgr[1] = bd_fn!(decl_looprestorationfilter_fn, BD, sgr_filter_3x3, ssse3);
-        c.sgr[2] = bd_fn!(decl_looprestorationfilter_fn, BD, sgr_filter_mix, ssse3);
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    {
-        if !flags.contains(CpuFlags::AVX2) {
-            return;
+    #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
+    const fn init_x86<BD: BitDepth>(mut self, flags: CpuFlags, bpc: c_int) -> Self {
+        if !flags.contains(CpuFlags::SSE2) {
+            return self;
         }
 
-        c.wiener[0] = bd_fn!(decl_looprestorationfilter_fn, BD, wiener_filter7, avx2);
-        c.wiener[1] = bd_fn!(decl_looprestorationfilter_fn, BD, wiener_filter5, avx2);
-
-        if BD::BPC == BPC::BPC8 || bpc == 10 {
-            c.sgr[0] = bd_fn!(decl_looprestorationfilter_fn, BD, sgr_filter_5x5, avx2);
-            c.sgr[1] = bd_fn!(decl_looprestorationfilter_fn, BD, sgr_filter_3x3, avx2);
-            c.sgr[2] = bd_fn!(decl_looprestorationfilter_fn, BD, sgr_filter_mix, avx2);
-        }
-
-        if !flags.contains(CpuFlags::AVX512ICL) {
-            return;
-        }
-
-        c.wiener[0] = bd_fn!(decl_looprestorationfilter_fn, BD, wiener_filter7, avx512icl);
-        c.wiener[1] = match BD::BPC {
-            // With VNNI we don't need a 5-tap version.
-            BPC::BPC8 => c.wiener[0],
-            BPC::BPC16 => decl_looprestorationfilter_fn!(fn dav1d_wiener_filter5_16bpc_avx512icl),
+        if let BPC::BPC8 = BD::BPC {
+            self.wiener[0] = decl_looprestorationfilter_fn!(fn dav1d_wiener_filter7_8bpc_sse2);
+            self.wiener[1] = decl_looprestorationfilter_fn!(fn dav1d_wiener_filter5_8bpc_sse2);
         };
 
-        if BD::BPC == BPC::BPC8 || bpc == 10 {
-            c.sgr[0] = bd_fn!(decl_looprestorationfilter_fn, BD, sgr_filter_5x5, avx512icl);
-            c.sgr[1] = bd_fn!(decl_looprestorationfilter_fn, BD, sgr_filter_3x3, avx512icl);
-            c.sgr[2] = bd_fn!(decl_looprestorationfilter_fn, BD, sgr_filter_mix, avx512icl);
+        if !flags.contains(CpuFlags::SSSE3) {
+            return self;
+        }
+
+        self.wiener[0] = bd_fn!(decl_looprestorationfilter_fn, BD, wiener_filter7, ssse3);
+        self.wiener[1] = bd_fn!(decl_looprestorationfilter_fn, BD, wiener_filter5, ssse3);
+
+        if matches!(BD::BPC, BPC::BPC8) || bpc == 10 {
+            self.sgr[0] = bd_fn!(decl_looprestorationfilter_fn, BD, sgr_filter_5x5, ssse3);
+            self.sgr[1] = bd_fn!(decl_looprestorationfilter_fn, BD, sgr_filter_3x3, ssse3);
+            self.sgr[2] = bd_fn!(decl_looprestorationfilter_fn, BD, sgr_filter_mix, ssse3);
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            if !flags.contains(CpuFlags::AVX2) {
+                return self;
+            }
+
+            self.wiener[0] = bd_fn!(decl_looprestorationfilter_fn, BD, wiener_filter7, avx2);
+            self.wiener[1] = bd_fn!(decl_looprestorationfilter_fn, BD, wiener_filter5, avx2);
+
+            if matches!(BD::BPC, BPC::BPC8) || bpc == 10 {
+                self.sgr[0] = bd_fn!(decl_looprestorationfilter_fn, BD, sgr_filter_5x5, avx2);
+                self.sgr[1] = bd_fn!(decl_looprestorationfilter_fn, BD, sgr_filter_3x3, avx2);
+                self.sgr[2] = bd_fn!(decl_looprestorationfilter_fn, BD, sgr_filter_mix, avx2);
+            }
+
+            if !flags.contains(CpuFlags::AVX512ICL) {
+                return self;
+            }
+
+            self.wiener[0] = bd_fn!(decl_looprestorationfilter_fn, BD, wiener_filter7, avx512icl);
+            self.wiener[1] = match BD::BPC {
+                // With VNNI we don't need a 5-tap version.
+                BPC::BPC8 => self.wiener[0],
+                BPC::BPC16 => {
+                    decl_looprestorationfilter_fn!(fn dav1d_wiener_filter5_16bpc_avx512icl)
+                }
+            };
+
+            if matches!(BD::BPC, BPC::BPC8) || bpc == 10 {
+                self.sgr[0] = bd_fn!(decl_looprestorationfilter_fn, BD, sgr_filter_5x5, avx512icl);
+                self.sgr[1] = bd_fn!(decl_looprestorationfilter_fn, BD, sgr_filter_3x3, avx512icl);
+                self.sgr[2] = bd_fn!(decl_looprestorationfilter_fn, BD, sgr_filter_mix, avx512icl);
+            }
+        }
+
+        self
+    }
+
+    #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
+    const fn init_arm<BD: BitDepth>(mut self, flags: CpuFlags, bpc: c_int) -> Self {
+        if !flags.contains(CpuFlags::NEON) {
+            return self;
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            self.wiener[0] = bd_fn!(decl_looprestorationfilter_fn, BD, wiener_filter7, neon);
+            self.wiener[1] = bd_fn!(decl_looprestorationfilter_fn, BD, wiener_filter5, neon);
+        }
+
+        #[cfg(target_arch = "arm")]
+        {
+            self.wiener[0] = wiener_filter_neon_erased::<BD>;
+            self.wiener[1] = wiener_filter_neon_erased::<BD>;
+        }
+
+        if matches!(BD::BPC, BPC::BPC8) || bpc == 10 {
+            self.sgr[0] = sgr_filter_5x5_neon_erased::<BD>;
+            self.sgr[1] = sgr_filter_3x3_neon_erased::<BD>;
+            self.sgr[2] = sgr_filter_mix_neon_erased::<BD>;
+        }
+
+        self
+    }
+
+    fn init<BD: BitDepth>(self, flags: CpuFlags, bpc: c_int) -> Self {
+        #[cfg(feature = "asm")]
+        {
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            {
+                return self.init_x86::<BD>(flags, bpc);
+            }
+            #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+            {
+                return self.init_arm::<BD>(flags, bpc);
+            }
+        }
+
+        #[allow(unreachable_code)] // Reachable on some #[cfg]s.
+        {
+            let _ = flags;
+            let _ = bpc;
+            self
         }
     }
-}
 
-#[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
-#[inline(always)]
-fn loop_restoration_dsp_init_arm<BD: BitDepth>(c: &mut Rav1dLoopRestorationDSPContext, bpc: c_int) {
-    let flags = rav1d_get_cpu_flags();
-
-    if !flags.contains(CpuFlags::NEON) {
-        return;
-    }
-
-    cfg_if::cfg_if! {
-        if #[cfg(target_arch = "aarch64")] {
-            c.wiener[0] = bd_fn!(decl_looprestorationfilter_fn, BD, wiener_filter7, neon);
-            c.wiener[1] = bd_fn!(decl_looprestorationfilter_fn, BD, wiener_filter5, neon);
-        } else {
-            c.wiener[0] = wiener_filter_neon_erased::<BD>;
-            c.wiener[1] = wiener_filter_neon_erased::<BD>;
-        }
-    }
-
-    if BD::BPC == BPC::BPC8 || bpc == 10 {
-        c.sgr[0] = sgr_filter_5x5_neon_erased::<BD>;
-        c.sgr[1] = sgr_filter_3x3_neon_erased::<BD>;
-        c.sgr[2] = sgr_filter_mix_neon_erased::<BD>;
-    }
-}
-
-#[cold]
-pub fn rav1d_loop_restoration_dsp_init<BD: BitDepth>(
-    c: &mut Rav1dLoopRestorationDSPContext,
-    _bpc: c_int,
-) {
-    c.wiener[1] = wiener_c_erased::<BD>;
-    c.wiener[0] = c.wiener[1];
-    c.sgr[0] = sgr_5x5_c_erased::<BD>;
-    c.sgr[1] = sgr_3x3_c_erased::<BD>;
-    c.sgr[2] = sgr_mix_c_erased::<BD>;
-
-    #[cfg(feature = "asm")]
-    cfg_if::cfg_if! {
-        if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
-            loop_restoration_dsp_init_x86::<BD>(c, _bpc);
-        } else if #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]{
-            loop_restoration_dsp_init_arm::<BD>(c, _bpc);
-        }
+    pub fn new<BD: BitDepth>(flags: CpuFlags, bpc: c_int) -> Self {
+        Self::new_c::<BD>().init::<BD>(flags, bpc)
     }
 }

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -3453,7 +3453,7 @@ unsafe fn sgr_filter_mix_neon<BD: BitDepth>(
 }
 
 impl Rav1dLoopRestorationDSPContext {
-    const fn new_c<BD: BitDepth>() -> Self {
+    const fn default<BD: BitDepth>() -> Self {
         Self {
             wiener: [wiener_c_erased::<BD>; 2],
             sgr: [
@@ -3575,6 +3575,6 @@ impl Rav1dLoopRestorationDSPContext {
     }
 
     pub fn new<BD: BitDepth>(flags: CpuFlags, bpc: c_int) -> Self {
-        Self::new_c::<BD>().init::<BD>(flags, bpc)
+        Self::default::<BD>().init::<BD>(flags, bpc)
     }
 }

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -2184,7 +2184,7 @@ extern "C" {
 }
 
 impl Rav1dMCDSPContext {
-    const fn new_c<BD: BitDepth>() -> Self {
+    const fn default<BD: BitDepth>() -> Self {
         Self {
             mc: enum_map!(Filter2d => mc::Fn; match key {
                 Regular8Tap => mc::Fn::new(put_8tap_regular_c_erased::<BD>),
@@ -2551,6 +2551,6 @@ impl Rav1dMCDSPContext {
     }
 
     pub fn new<BD: BitDepth>(flags: CpuFlags) -> Self {
-        Self::new_c::<BD>().init::<BD>(flags)
+        Self::default::<BD>().init::<BD>(flags)
     }
 }

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -2352,8 +2352,8 @@ impl Rav1dMCDSPContext {
         }
 
         if let BPC::BPC8 = BD::BPC {
-            self.warp8x8 = dav1d_warp_affine_8x8_8bpc_sse4;
-            self.warp8x8t = dav1d_warp_affine_8x8t_8bpc_sse4;
+            self.warp8x8 = bpc_fn!(8 bpc, warp_affine_8x8, sse4);
+            self.warp8x8t = bpc_fn!(8 bpc, warp_affine_8x8t, sse4);
         }
 
         #[cfg(target_arch = "x86_64")]

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -2184,7 +2184,7 @@ extern "C" {
 }
 
 impl Rav1dMCDSPContext {
-    const fn default<BD: BitDepth>() -> Self {
+    pub const fn default<BD: BitDepth>() -> Self {
         Self {
             mc: enum_map!(Filter2d => mc::Fn; match key {
                 Regular8Tap => mc::Fn::new(put_8tap_regular_c_erased::<BD>),
@@ -2530,7 +2530,7 @@ impl Rav1dMCDSPContext {
         self
     }
 
-    fn init<BD: BitDepth>(self, flags: CpuFlags) -> Self {
+    const fn init<BD: BitDepth>(self, flags: CpuFlags) -> Self {
         #[cfg(feature = "asm")]
         {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -2550,7 +2550,7 @@ impl Rav1dMCDSPContext {
         }
     }
 
-    pub fn new<BD: BitDepth>(flags: CpuFlags) -> Self {
+    pub const fn new<BD: BitDepth>(flags: CpuFlags) -> Self {
         Self::default::<BD>().init::<BD>(flags)
     }
 }

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -2253,6 +2253,7 @@ impl Rav1dMCDSPContext {
     }
 
     #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
+    #[inline(always)]
     const fn init_x86<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::SSE2) {
             return self;
@@ -2480,6 +2481,7 @@ impl Rav1dMCDSPContext {
     }
 
     #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
+    #[inline(always)]
     const fn init_arm<BD: BitDepth>(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::NEON) {
             return self;
@@ -2530,6 +2532,7 @@ impl Rav1dMCDSPContext {
         self
     }
 
+    #[inline(always)]
     const fn init<BD: BitDepth>(self, flags: CpuFlags) -> Self {
         #[cfg(feature = "asm")]
         {

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -2227,7 +2227,7 @@ extern "C" {
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
-unsafe fn mc_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dMCDSPContext) {
+fn mc_dsp_init_x86<BD: BitDepth>(c: &mut Rav1dMCDSPContext) {
     use Filter2d::*;
 
     let flags = rav1d_get_cpu_flags();
@@ -2237,94 +2237,92 @@ unsafe fn mc_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dMCDSPContext) {
     }
 
     if BD::BPC == BPC::BPC8 {
-        (*c).mct[Bilinear as usize] = dav1d_prep_bilin_8bpc_sse2;
-        (*c).mct[Regular8Tap as usize] = dav1d_prep_8tap_regular_8bpc_sse2;
-        (*c).mct[RegularSmooth8Tap as usize] = dav1d_prep_8tap_regular_smooth_8bpc_sse2;
-        (*c).mct[RegularSharp8Tap as usize] = dav1d_prep_8tap_regular_sharp_8bpc_sse2;
-        (*c).mct[SmoothRegular8Tap as usize] = dav1d_prep_8tap_smooth_regular_8bpc_sse2;
-        (*c).mct[Smooth8Tap as usize] = dav1d_prep_8tap_smooth_8bpc_sse2;
-        (*c).mct[SmoothSharp8Tap as usize] = dav1d_prep_8tap_smooth_sharp_8bpc_sse2;
-        (*c).mct[SharpRegular8Tap as usize] = dav1d_prep_8tap_sharp_regular_8bpc_sse2;
-        (*c).mct[SharpSmooth8Tap as usize] = dav1d_prep_8tap_sharp_smooth_8bpc_sse2;
-        (*c).mct[Sharp8Tap as usize] = dav1d_prep_8tap_sharp_8bpc_sse2;
+        c.mct[Bilinear as usize] = dav1d_prep_bilin_8bpc_sse2;
+        c.mct[Regular8Tap as usize] = dav1d_prep_8tap_regular_8bpc_sse2;
+        c.mct[RegularSmooth8Tap as usize] = dav1d_prep_8tap_regular_smooth_8bpc_sse2;
+        c.mct[RegularSharp8Tap as usize] = dav1d_prep_8tap_regular_sharp_8bpc_sse2;
+        c.mct[SmoothRegular8Tap as usize] = dav1d_prep_8tap_smooth_regular_8bpc_sse2;
+        c.mct[Smooth8Tap as usize] = dav1d_prep_8tap_smooth_8bpc_sse2;
+        c.mct[SmoothSharp8Tap as usize] = dav1d_prep_8tap_smooth_sharp_8bpc_sse2;
+        c.mct[SharpRegular8Tap as usize] = dav1d_prep_8tap_sharp_regular_8bpc_sse2;
+        c.mct[SharpSmooth8Tap as usize] = dav1d_prep_8tap_sharp_smooth_8bpc_sse2;
+        c.mct[Sharp8Tap as usize] = dav1d_prep_8tap_sharp_8bpc_sse2;
 
-        (*c).warp8x8 = dav1d_warp_affine_8x8_8bpc_sse2;
-        (*c).warp8x8t = dav1d_warp_affine_8x8t_8bpc_sse2;
+        c.warp8x8 = dav1d_warp_affine_8x8_8bpc_sse2;
+        c.warp8x8t = dav1d_warp_affine_8x8t_8bpc_sse2;
     }
 
     if !flags.contains(CpuFlags::SSSE3) {
         return;
     }
 
-    (*c).mc[Regular8Tap as usize] = bd_fn!(BD, put_8tap_regular, ssse3);
-    (*c).mc[RegularSmooth8Tap as usize] = bd_fn!(BD, put_8tap_regular_smooth, ssse3);
-    (*c).mc[RegularSharp8Tap as usize] = bd_fn!(BD, put_8tap_regular_sharp, ssse3);
-    (*c).mc[SmoothRegular8Tap as usize] = bd_fn!(BD, put_8tap_smooth_regular, ssse3);
-    (*c).mc[Smooth8Tap as usize] = bd_fn!(BD, put_8tap_smooth, ssse3);
-    (*c).mc[SmoothSharp8Tap as usize] = bd_fn!(BD, put_8tap_smooth_sharp, ssse3);
-    (*c).mc[SharpRegular8Tap as usize] = bd_fn!(BD, put_8tap_sharp_regular, ssse3);
-    (*c).mc[SharpSmooth8Tap as usize] = bd_fn!(BD, put_8tap_sharp_smooth, ssse3);
-    (*c).mc[Sharp8Tap as usize] = bd_fn!(BD, put_8tap_sharp, ssse3);
-    (*c).mc[Bilinear as usize] = bd_fn!(BD, put_bilin, ssse3);
+    c.mc[Regular8Tap as usize] = bd_fn!(BD, put_8tap_regular, ssse3);
+    c.mc[RegularSmooth8Tap as usize] = bd_fn!(BD, put_8tap_regular_smooth, ssse3);
+    c.mc[RegularSharp8Tap as usize] = bd_fn!(BD, put_8tap_regular_sharp, ssse3);
+    c.mc[SmoothRegular8Tap as usize] = bd_fn!(BD, put_8tap_smooth_regular, ssse3);
+    c.mc[Smooth8Tap as usize] = bd_fn!(BD, put_8tap_smooth, ssse3);
+    c.mc[SmoothSharp8Tap as usize] = bd_fn!(BD, put_8tap_smooth_sharp, ssse3);
+    c.mc[SharpRegular8Tap as usize] = bd_fn!(BD, put_8tap_sharp_regular, ssse3);
+    c.mc[SharpSmooth8Tap as usize] = bd_fn!(BD, put_8tap_sharp_smooth, ssse3);
+    c.mc[Sharp8Tap as usize] = bd_fn!(BD, put_8tap_sharp, ssse3);
+    c.mc[Bilinear as usize] = bd_fn!(BD, put_bilin, ssse3);
 
-    (*c).mct[Regular8Tap as usize] = bd_fn!(BD, prep_8tap_regular, ssse3);
-    (*c).mct[RegularSmooth8Tap as usize] = bd_fn!(BD, prep_8tap_regular_smooth, ssse3);
-    (*c).mct[RegularSharp8Tap as usize] = bd_fn!(BD, prep_8tap_regular_sharp, ssse3);
-    (*c).mct[SmoothRegular8Tap as usize] = bd_fn!(BD, prep_8tap_smooth_regular, ssse3);
-    (*c).mct[Smooth8Tap as usize] = bd_fn!(BD, prep_8tap_smooth, ssse3);
-    (*c).mct[SmoothSharp8Tap as usize] = bd_fn!(BD, prep_8tap_smooth_sharp, ssse3);
-    (*c).mct[SharpRegular8Tap as usize] = bd_fn!(BD, prep_8tap_sharp_regular, ssse3);
-    (*c).mct[SharpSmooth8Tap as usize] = bd_fn!(BD, prep_8tap_sharp_smooth, ssse3);
-    (*c).mct[Sharp8Tap as usize] = bd_fn!(BD, prep_8tap_sharp, ssse3);
-    (*c).mct[Bilinear as usize] = bd_fn!(BD, prep_bilin, ssse3);
+    c.mct[Regular8Tap as usize] = bd_fn!(BD, prep_8tap_regular, ssse3);
+    c.mct[RegularSmooth8Tap as usize] = bd_fn!(BD, prep_8tap_regular_smooth, ssse3);
+    c.mct[RegularSharp8Tap as usize] = bd_fn!(BD, prep_8tap_regular_sharp, ssse3);
+    c.mct[SmoothRegular8Tap as usize] = bd_fn!(BD, prep_8tap_smooth_regular, ssse3);
+    c.mct[Smooth8Tap as usize] = bd_fn!(BD, prep_8tap_smooth, ssse3);
+    c.mct[SmoothSharp8Tap as usize] = bd_fn!(BD, prep_8tap_smooth_sharp, ssse3);
+    c.mct[SharpRegular8Tap as usize] = bd_fn!(BD, prep_8tap_sharp_regular, ssse3);
+    c.mct[SharpSmooth8Tap as usize] = bd_fn!(BD, prep_8tap_sharp_smooth, ssse3);
+    c.mct[Sharp8Tap as usize] = bd_fn!(BD, prep_8tap_sharp, ssse3);
+    c.mct[Bilinear as usize] = bd_fn!(BD, prep_bilin, ssse3);
 
-    (*c).mc_scaled[Regular8Tap as usize] = bd_fn!(BD, put_8tap_scaled_regular, ssse3);
-    (*c).mc_scaled[RegularSmooth8Tap as usize] = bd_fn!(BD, put_8tap_scaled_regular_smooth, ssse3);
-    (*c).mc_scaled[RegularSharp8Tap as usize] = bd_fn!(BD, put_8tap_scaled_regular_sharp, ssse3);
-    (*c).mc_scaled[SmoothRegular8Tap as usize] = bd_fn!(BD, put_8tap_scaled_smooth_regular, ssse3);
-    (*c).mc_scaled[Smooth8Tap as usize] = bd_fn!(BD, put_8tap_scaled_smooth, ssse3);
-    (*c).mc_scaled[SmoothSharp8Tap as usize] = bd_fn!(BD, put_8tap_scaled_smooth_sharp, ssse3);
-    (*c).mc_scaled[SharpRegular8Tap as usize] = bd_fn!(BD, put_8tap_scaled_sharp_regular, ssse3);
-    (*c).mc_scaled[SharpSmooth8Tap as usize] = bd_fn!(BD, put_8tap_scaled_sharp_smooth, ssse3);
-    (*c).mc_scaled[Sharp8Tap as usize] = bd_fn!(BD, put_8tap_scaled_sharp, ssse3);
-    (*c).mc_scaled[Bilinear as usize] = bd_fn!(BD, put_bilin_scaled, ssse3);
+    c.mc_scaled[Regular8Tap as usize] = bd_fn!(BD, put_8tap_scaled_regular, ssse3);
+    c.mc_scaled[RegularSmooth8Tap as usize] = bd_fn!(BD, put_8tap_scaled_regular_smooth, ssse3);
+    c.mc_scaled[RegularSharp8Tap as usize] = bd_fn!(BD, put_8tap_scaled_regular_sharp, ssse3);
+    c.mc_scaled[SmoothRegular8Tap as usize] = bd_fn!(BD, put_8tap_scaled_smooth_regular, ssse3);
+    c.mc_scaled[Smooth8Tap as usize] = bd_fn!(BD, put_8tap_scaled_smooth, ssse3);
+    c.mc_scaled[SmoothSharp8Tap as usize] = bd_fn!(BD, put_8tap_scaled_smooth_sharp, ssse3);
+    c.mc_scaled[SharpRegular8Tap as usize] = bd_fn!(BD, put_8tap_scaled_sharp_regular, ssse3);
+    c.mc_scaled[SharpSmooth8Tap as usize] = bd_fn!(BD, put_8tap_scaled_sharp_smooth, ssse3);
+    c.mc_scaled[Sharp8Tap as usize] = bd_fn!(BD, put_8tap_scaled_sharp, ssse3);
+    c.mc_scaled[Bilinear as usize] = bd_fn!(BD, put_bilin_scaled, ssse3);
 
-    (*c).mct_scaled[Regular8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_regular, ssse3);
-    (*c).mct_scaled[RegularSmooth8Tap as usize] =
-        bd_fn!(BD, prep_8tap_scaled_regular_smooth, ssse3);
-    (*c).mct_scaled[RegularSharp8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_regular_sharp, ssse3);
-    (*c).mct_scaled[SmoothRegular8Tap as usize] =
-        bd_fn!(BD, prep_8tap_scaled_smooth_regular, ssse3);
-    (*c).mct_scaled[Smooth8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_smooth, ssse3);
-    (*c).mct_scaled[SmoothSharp8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_smooth_sharp, ssse3);
-    (*c).mct_scaled[SharpRegular8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_sharp_regular, ssse3);
-    (*c).mct_scaled[SharpSmooth8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_sharp_smooth, ssse3);
-    (*c).mct_scaled[Sharp8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_sharp, ssse3);
-    (*c).mct_scaled[Bilinear as usize] = bd_fn!(BD, prep_bilin_scaled, ssse3);
+    c.mct_scaled[Regular8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_regular, ssse3);
+    c.mct_scaled[RegularSmooth8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_regular_smooth, ssse3);
+    c.mct_scaled[RegularSharp8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_regular_sharp, ssse3);
+    c.mct_scaled[SmoothRegular8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_smooth_regular, ssse3);
+    c.mct_scaled[Smooth8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_smooth, ssse3);
+    c.mct_scaled[SmoothSharp8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_smooth_sharp, ssse3);
+    c.mct_scaled[SharpRegular8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_sharp_regular, ssse3);
+    c.mct_scaled[SharpSmooth8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_sharp_smooth, ssse3);
+    c.mct_scaled[Sharp8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_sharp, ssse3);
+    c.mct_scaled[Bilinear as usize] = bd_fn!(BD, prep_bilin_scaled, ssse3);
 
-    (*c).avg = bd_fn!(BD, avg, ssse3);
-    (*c).w_avg = bd_fn!(BD, w_avg, ssse3);
-    (*c).mask = bd_fn!(BD, mask, ssse3);
+    c.avg = bd_fn!(BD, avg, ssse3);
+    c.w_avg = bd_fn!(BD, w_avg, ssse3);
+    c.mask = bd_fn!(BD, mask, ssse3);
 
-    (*c).w_mask[0] = bd_fn!(BD, w_mask_444, ssse3);
-    (*c).w_mask[1] = bd_fn!(BD, w_mask_422, ssse3);
-    (*c).w_mask[2] = bd_fn!(BD, w_mask_420, ssse3);
+    c.w_mask[0] = bd_fn!(BD, w_mask_444, ssse3);
+    c.w_mask[1] = bd_fn!(BD, w_mask_422, ssse3);
+    c.w_mask[2] = bd_fn!(BD, w_mask_420, ssse3);
 
-    (*c).blend = bd_fn!(BD, blend, ssse3);
-    (*c).blend_v = bd_fn!(BD, blend_v, ssse3);
-    (*c).blend_h = bd_fn!(BD, blend_h, ssse3);
-    (*c).warp8x8 = bd_fn!(BD, warp_affine_8x8, ssse3);
-    (*c).warp8x8t = bd_fn!(BD, warp_affine_8x8t, ssse3);
-    (*c).emu_edge = bd_fn!(BD, emu_edge, ssse3);
-    (*c).resize = bd_fn!(BD, resize, ssse3);
+    c.blend = bd_fn!(BD, blend, ssse3);
+    c.blend_v = bd_fn!(BD, blend_v, ssse3);
+    c.blend_h = bd_fn!(BD, blend_h, ssse3);
+    c.warp8x8 = bd_fn!(BD, warp_affine_8x8, ssse3);
+    c.warp8x8t = bd_fn!(BD, warp_affine_8x8t, ssse3);
+    c.emu_edge = bd_fn!(BD, emu_edge, ssse3);
+    c.resize = bd_fn!(BD, resize, ssse3);
 
     if !flags.contains(CpuFlags::SSE41) {
         return;
     }
 
     if BD::BPC == BPC::BPC8 {
-        (*c).warp8x8 = dav1d_warp_affine_8x8_8bpc_sse4;
-        (*c).warp8x8t = dav1d_warp_affine_8x8t_8bpc_sse4;
+        c.warp8x8 = dav1d_warp_affine_8x8_8bpc_sse4;
+        c.warp8x8t = dav1d_warp_affine_8x8t_8bpc_sse4;
     }
 
     #[cfg(target_arch = "x86_64")]
@@ -2333,118 +2331,114 @@ unsafe fn mc_dsp_init_x86<BD: BitDepth>(c: *mut Rav1dMCDSPContext) {
             return;
         }
 
-        (*c).mc[Regular8Tap as usize] = bd_fn!(BD, put_8tap_regular, avx2);
-        (*c).mc[RegularSmooth8Tap as usize] = bd_fn!(BD, put_8tap_regular_smooth, avx2);
-        (*c).mc[RegularSharp8Tap as usize] = bd_fn!(BD, put_8tap_regular_sharp, avx2);
-        (*c).mc[SmoothRegular8Tap as usize] = bd_fn!(BD, put_8tap_smooth_regular, avx2);
-        (*c).mc[Smooth8Tap as usize] = bd_fn!(BD, put_8tap_smooth, avx2);
-        (*c).mc[SmoothSharp8Tap as usize] = bd_fn!(BD, put_8tap_smooth_sharp, avx2);
-        (*c).mc[SharpRegular8Tap as usize] = bd_fn!(BD, put_8tap_sharp_regular, avx2);
-        (*c).mc[SharpSmooth8Tap as usize] = bd_fn!(BD, put_8tap_sharp_smooth, avx2);
-        (*c).mc[Sharp8Tap as usize] = bd_fn!(BD, put_8tap_sharp, avx2);
-        (*c).mc[Bilinear as usize] = bd_fn!(BD, put_bilin, avx2);
+        c.mc[Regular8Tap as usize] = bd_fn!(BD, put_8tap_regular, avx2);
+        c.mc[RegularSmooth8Tap as usize] = bd_fn!(BD, put_8tap_regular_smooth, avx2);
+        c.mc[RegularSharp8Tap as usize] = bd_fn!(BD, put_8tap_regular_sharp, avx2);
+        c.mc[SmoothRegular8Tap as usize] = bd_fn!(BD, put_8tap_smooth_regular, avx2);
+        c.mc[Smooth8Tap as usize] = bd_fn!(BD, put_8tap_smooth, avx2);
+        c.mc[SmoothSharp8Tap as usize] = bd_fn!(BD, put_8tap_smooth_sharp, avx2);
+        c.mc[SharpRegular8Tap as usize] = bd_fn!(BD, put_8tap_sharp_regular, avx2);
+        c.mc[SharpSmooth8Tap as usize] = bd_fn!(BD, put_8tap_sharp_smooth, avx2);
+        c.mc[Sharp8Tap as usize] = bd_fn!(BD, put_8tap_sharp, avx2);
+        c.mc[Bilinear as usize] = bd_fn!(BD, put_bilin, avx2);
 
-        (*c).mct[Regular8Tap as usize] = bd_fn!(BD, prep_8tap_regular, avx2);
-        (*c).mct[RegularSmooth8Tap as usize] = bd_fn!(BD, prep_8tap_regular_smooth, avx2);
-        (*c).mct[RegularSharp8Tap as usize] = bd_fn!(BD, prep_8tap_regular_sharp, avx2);
-        (*c).mct[SmoothRegular8Tap as usize] = bd_fn!(BD, prep_8tap_smooth_regular, avx2);
-        (*c).mct[Smooth8Tap as usize] = bd_fn!(BD, prep_8tap_smooth, avx2);
-        (*c).mct[SmoothSharp8Tap as usize] = bd_fn!(BD, prep_8tap_smooth_sharp, avx2);
-        (*c).mct[SharpRegular8Tap as usize] = bd_fn!(BD, prep_8tap_sharp_regular, avx2);
-        (*c).mct[SharpSmooth8Tap as usize] = bd_fn!(BD, prep_8tap_sharp_smooth, avx2);
-        (*c).mct[Sharp8Tap as usize] = bd_fn!(BD, prep_8tap_sharp, avx2);
-        (*c).mct[Bilinear as usize] = bd_fn!(BD, prep_bilin, avx2);
+        c.mct[Regular8Tap as usize] = bd_fn!(BD, prep_8tap_regular, avx2);
+        c.mct[RegularSmooth8Tap as usize] = bd_fn!(BD, prep_8tap_regular_smooth, avx2);
+        c.mct[RegularSharp8Tap as usize] = bd_fn!(BD, prep_8tap_regular_sharp, avx2);
+        c.mct[SmoothRegular8Tap as usize] = bd_fn!(BD, prep_8tap_smooth_regular, avx2);
+        c.mct[Smooth8Tap as usize] = bd_fn!(BD, prep_8tap_smooth, avx2);
+        c.mct[SmoothSharp8Tap as usize] = bd_fn!(BD, prep_8tap_smooth_sharp, avx2);
+        c.mct[SharpRegular8Tap as usize] = bd_fn!(BD, prep_8tap_sharp_regular, avx2);
+        c.mct[SharpSmooth8Tap as usize] = bd_fn!(BD, prep_8tap_sharp_smooth, avx2);
+        c.mct[Sharp8Tap as usize] = bd_fn!(BD, prep_8tap_sharp, avx2);
+        c.mct[Bilinear as usize] = bd_fn!(BD, prep_bilin, avx2);
 
-        (*c).mc_scaled[Regular8Tap as usize] = bd_fn!(BD, put_8tap_scaled_regular, avx2);
-        (*c).mc_scaled[RegularSmooth8Tap as usize] =
-            bd_fn!(BD, put_8tap_scaled_regular_smooth, avx2);
-        (*c).mc_scaled[RegularSharp8Tap as usize] = bd_fn!(BD, put_8tap_scaled_regular_sharp, avx2);
-        (*c).mc_scaled[SmoothRegular8Tap as usize] =
-            bd_fn!(BD, put_8tap_scaled_smooth_regular, avx2);
-        (*c).mc_scaled[Smooth8Tap as usize] = bd_fn!(BD, put_8tap_scaled_smooth, avx2);
-        (*c).mc_scaled[SmoothSharp8Tap as usize] = bd_fn!(BD, put_8tap_scaled_smooth_sharp, avx2);
-        (*c).mc_scaled[SharpRegular8Tap as usize] = bd_fn!(BD, put_8tap_scaled_sharp_regular, avx2);
-        (*c).mc_scaled[SharpSmooth8Tap as usize] = bd_fn!(BD, put_8tap_scaled_sharp_smooth, avx2);
-        (*c).mc_scaled[Sharp8Tap as usize] = bd_fn!(BD, put_8tap_scaled_sharp, avx2);
-        (*c).mc_scaled[Bilinear as usize] = bd_fn!(BD, put_bilin_scaled, avx2);
+        c.mc_scaled[Regular8Tap as usize] = bd_fn!(BD, put_8tap_scaled_regular, avx2);
+        c.mc_scaled[RegularSmooth8Tap as usize] = bd_fn!(BD, put_8tap_scaled_regular_smooth, avx2);
+        c.mc_scaled[RegularSharp8Tap as usize] = bd_fn!(BD, put_8tap_scaled_regular_sharp, avx2);
+        c.mc_scaled[SmoothRegular8Tap as usize] = bd_fn!(BD, put_8tap_scaled_smooth_regular, avx2);
+        c.mc_scaled[Smooth8Tap as usize] = bd_fn!(BD, put_8tap_scaled_smooth, avx2);
+        c.mc_scaled[SmoothSharp8Tap as usize] = bd_fn!(BD, put_8tap_scaled_smooth_sharp, avx2);
+        c.mc_scaled[SharpRegular8Tap as usize] = bd_fn!(BD, put_8tap_scaled_sharp_regular, avx2);
+        c.mc_scaled[SharpSmooth8Tap as usize] = bd_fn!(BD, put_8tap_scaled_sharp_smooth, avx2);
+        c.mc_scaled[Sharp8Tap as usize] = bd_fn!(BD, put_8tap_scaled_sharp, avx2);
+        c.mc_scaled[Bilinear as usize] = bd_fn!(BD, put_bilin_scaled, avx2);
 
-        (*c).mct_scaled[Regular8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_regular, avx2);
-        (*c).mct_scaled[RegularSmooth8Tap as usize] =
+        c.mct_scaled[Regular8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_regular, avx2);
+        c.mct_scaled[RegularSmooth8Tap as usize] =
             bd_fn!(BD, prep_8tap_scaled_regular_smooth, avx2);
-        (*c).mct_scaled[RegularSharp8Tap as usize] =
-            bd_fn!(BD, prep_8tap_scaled_regular_sharp, avx2);
-        (*c).mct_scaled[SmoothRegular8Tap as usize] =
+        c.mct_scaled[RegularSharp8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_regular_sharp, avx2);
+        c.mct_scaled[SmoothRegular8Tap as usize] =
             bd_fn!(BD, prep_8tap_scaled_smooth_regular, avx2);
-        (*c).mct_scaled[Smooth8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_smooth, avx2);
-        (*c).mct_scaled[SmoothSharp8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_smooth_sharp, avx2);
-        (*c).mct_scaled[SharpRegular8Tap as usize] =
-            bd_fn!(BD, prep_8tap_scaled_sharp_regular, avx2);
-        (*c).mct_scaled[SharpSmooth8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_sharp_smooth, avx2);
-        (*c).mct_scaled[Sharp8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_sharp, avx2);
-        (*c).mct_scaled[Bilinear as usize] = bd_fn!(BD, prep_bilin_scaled, avx2);
+        c.mct_scaled[Smooth8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_smooth, avx2);
+        c.mct_scaled[SmoothSharp8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_smooth_sharp, avx2);
+        c.mct_scaled[SharpRegular8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_sharp_regular, avx2);
+        c.mct_scaled[SharpSmooth8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_sharp_smooth, avx2);
+        c.mct_scaled[Sharp8Tap as usize] = bd_fn!(BD, prep_8tap_scaled_sharp, avx2);
+        c.mct_scaled[Bilinear as usize] = bd_fn!(BD, prep_bilin_scaled, avx2);
 
-        (*c).avg = bd_fn!(BD, avg, avx2);
-        (*c).w_avg = bd_fn!(BD, w_avg, avx2);
-        (*c).mask = bd_fn!(BD, mask, avx2);
+        c.avg = bd_fn!(BD, avg, avx2);
+        c.w_avg = bd_fn!(BD, w_avg, avx2);
+        c.mask = bd_fn!(BD, mask, avx2);
 
-        (*c).w_mask[0] = bd_fn!(BD, w_mask_444, avx2);
-        (*c).w_mask[1] = bd_fn!(BD, w_mask_422, avx2);
-        (*c).w_mask[2] = bd_fn!(BD, w_mask_420, avx2);
+        c.w_mask[0] = bd_fn!(BD, w_mask_444, avx2);
+        c.w_mask[1] = bd_fn!(BD, w_mask_422, avx2);
+        c.w_mask[2] = bd_fn!(BD, w_mask_420, avx2);
 
-        (*c).blend = bd_fn!(BD, blend, avx2);
-        (*c).blend_v = bd_fn!(BD, blend_v, avx2);
-        (*c).blend_h = bd_fn!(BD, blend_h, avx2);
-        (*c).warp8x8 = bd_fn!(BD, warp_affine_8x8, avx2);
-        (*c).warp8x8t = bd_fn!(BD, warp_affine_8x8t, avx2);
-        (*c).emu_edge = bd_fn!(BD, emu_edge, avx2);
-        (*c).resize = bd_fn!(BD, resize, avx2);
+        c.blend = bd_fn!(BD, blend, avx2);
+        c.blend_v = bd_fn!(BD, blend_v, avx2);
+        c.blend_h = bd_fn!(BD, blend_h, avx2);
+        c.warp8x8 = bd_fn!(BD, warp_affine_8x8, avx2);
+        c.warp8x8t = bd_fn!(BD, warp_affine_8x8t, avx2);
+        c.emu_edge = bd_fn!(BD, emu_edge, avx2);
+        c.resize = bd_fn!(BD, resize, avx2);
 
         if !flags.contains(CpuFlags::AVX512ICL) {
             return;
         }
 
-        (*c).mc[Regular8Tap as usize] = bd_fn!(BD, put_8tap_regular, avx512icl);
-        (*c).mc[RegularSmooth8Tap as usize] = bd_fn!(BD, put_8tap_regular_smooth, avx512icl);
-        (*c).mc[RegularSharp8Tap as usize] = bd_fn!(BD, put_8tap_regular_sharp, avx512icl);
-        (*c).mc[SmoothRegular8Tap as usize] = bd_fn!(BD, put_8tap_smooth_regular, avx512icl);
-        (*c).mc[Smooth8Tap as usize] = bd_fn!(BD, put_8tap_smooth, avx512icl);
-        (*c).mc[SmoothSharp8Tap as usize] = bd_fn!(BD, put_8tap_smooth_sharp, avx512icl);
-        (*c).mc[SharpRegular8Tap as usize] = bd_fn!(BD, put_8tap_sharp_regular, avx512icl);
-        (*c).mc[SharpSmooth8Tap as usize] = bd_fn!(BD, put_8tap_sharp_smooth, avx512icl);
-        (*c).mc[Sharp8Tap as usize] = bd_fn!(BD, put_8tap_sharp, avx512icl);
-        (*c).mc[Bilinear as usize] = bd_fn!(BD, put_bilin, avx512icl);
+        c.mc[Regular8Tap as usize] = bd_fn!(BD, put_8tap_regular, avx512icl);
+        c.mc[RegularSmooth8Tap as usize] = bd_fn!(BD, put_8tap_regular_smooth, avx512icl);
+        c.mc[RegularSharp8Tap as usize] = bd_fn!(BD, put_8tap_regular_sharp, avx512icl);
+        c.mc[SmoothRegular8Tap as usize] = bd_fn!(BD, put_8tap_smooth_regular, avx512icl);
+        c.mc[Smooth8Tap as usize] = bd_fn!(BD, put_8tap_smooth, avx512icl);
+        c.mc[SmoothSharp8Tap as usize] = bd_fn!(BD, put_8tap_smooth_sharp, avx512icl);
+        c.mc[SharpRegular8Tap as usize] = bd_fn!(BD, put_8tap_sharp_regular, avx512icl);
+        c.mc[SharpSmooth8Tap as usize] = bd_fn!(BD, put_8tap_sharp_smooth, avx512icl);
+        c.mc[Sharp8Tap as usize] = bd_fn!(BD, put_8tap_sharp, avx512icl);
+        c.mc[Bilinear as usize] = bd_fn!(BD, put_bilin, avx512icl);
 
-        (*c).mct[Regular8Tap as usize] = bd_fn!(BD, prep_8tap_regular, avx512icl);
-        (*c).mct[RegularSmooth8Tap as usize] = bd_fn!(BD, prep_8tap_regular_smooth, avx512icl);
-        (*c).mct[RegularSharp8Tap as usize] = bd_fn!(BD, prep_8tap_regular_sharp, avx512icl);
-        (*c).mct[SmoothRegular8Tap as usize] = bd_fn!(BD, prep_8tap_smooth_regular, avx512icl);
-        (*c).mct[Smooth8Tap as usize] = bd_fn!(BD, prep_8tap_smooth, avx512icl);
-        (*c).mct[SmoothSharp8Tap as usize] = bd_fn!(BD, prep_8tap_smooth_sharp, avx512icl);
-        (*c).mct[SharpRegular8Tap as usize] = bd_fn!(BD, prep_8tap_sharp_regular, avx512icl);
-        (*c).mct[SharpSmooth8Tap as usize] = bd_fn!(BD, prep_8tap_sharp_smooth, avx512icl);
-        (*c).mct[Sharp8Tap as usize] = bd_fn!(BD, prep_8tap_sharp, avx512icl);
-        (*c).mct[Bilinear as usize] = bd_fn!(BD, prep_bilin, avx512icl);
+        c.mct[Regular8Tap as usize] = bd_fn!(BD, prep_8tap_regular, avx512icl);
+        c.mct[RegularSmooth8Tap as usize] = bd_fn!(BD, prep_8tap_regular_smooth, avx512icl);
+        c.mct[RegularSharp8Tap as usize] = bd_fn!(BD, prep_8tap_regular_sharp, avx512icl);
+        c.mct[SmoothRegular8Tap as usize] = bd_fn!(BD, prep_8tap_smooth_regular, avx512icl);
+        c.mct[Smooth8Tap as usize] = bd_fn!(BD, prep_8tap_smooth, avx512icl);
+        c.mct[SmoothSharp8Tap as usize] = bd_fn!(BD, prep_8tap_smooth_sharp, avx512icl);
+        c.mct[SharpRegular8Tap as usize] = bd_fn!(BD, prep_8tap_sharp_regular, avx512icl);
+        c.mct[SharpSmooth8Tap as usize] = bd_fn!(BD, prep_8tap_sharp_smooth, avx512icl);
+        c.mct[Sharp8Tap as usize] = bd_fn!(BD, prep_8tap_sharp, avx512icl);
+        c.mct[Bilinear as usize] = bd_fn!(BD, prep_bilin, avx512icl);
 
-        (*c).avg = bd_fn!(BD, avg, avx512icl);
-        (*c).w_avg = bd_fn!(BD, w_avg, avx512icl);
-        (*c).mask = bd_fn!(BD, mask, avx512icl);
+        c.avg = bd_fn!(BD, avg, avx512icl);
+        c.w_avg = bd_fn!(BD, w_avg, avx512icl);
+        c.mask = bd_fn!(BD, mask, avx512icl);
 
-        (*c).w_mask[0] = bd_fn!(BD, w_mask_444, avx512icl);
-        (*c).w_mask[1] = bd_fn!(BD, w_mask_422, avx512icl);
-        (*c).w_mask[2] = bd_fn!(BD, w_mask_420, avx512icl);
+        c.w_mask[0] = bd_fn!(BD, w_mask_444, avx512icl);
+        c.w_mask[1] = bd_fn!(BD, w_mask_422, avx512icl);
+        c.w_mask[2] = bd_fn!(BD, w_mask_420, avx512icl);
 
-        (*c).blend = bd_fn!(BD, blend, avx512icl);
-        (*c).blend_v = bd_fn!(BD, blend_v, avx512icl);
-        (*c).blend_h = bd_fn!(BD, blend_h, avx512icl);
-        (*c).warp8x8 = bd_fn!(BD, warp_affine_8x8, avx512icl);
-        (*c).warp8x8t = bd_fn!(BD, warp_affine_8x8t, avx512icl);
-        (*c).resize = bd_fn!(BD, resize, avx512icl);
+        c.blend = bd_fn!(BD, blend, avx512icl);
+        c.blend_v = bd_fn!(BD, blend_v, avx512icl);
+        c.blend_h = bd_fn!(BD, blend_h, avx512icl);
+        c.warp8x8 = bd_fn!(BD, warp_affine_8x8, avx512icl);
+        c.warp8x8t = bd_fn!(BD, warp_affine_8x8t, avx512icl);
+        c.resize = bd_fn!(BD, resize, avx512icl);
     }
 }
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 #[inline(always)]
-unsafe fn mc_dsp_init_arm<BD: BitDepth>(c: *mut Rav1dMCDSPContext) {
+fn mc_dsp_init_arm<BD: BitDepth>(c: &mut Rav1dMCDSPContext) {
     use Filter2d::*;
 
     let flags = rav1d_get_cpu_flags();
@@ -2453,107 +2447,107 @@ unsafe fn mc_dsp_init_arm<BD: BitDepth>(c: *mut Rav1dMCDSPContext) {
         return;
     }
 
-    (*c).mc[Regular8Tap as usize] = bd_fn!(BP, put_8tap_regular, neon);
-    (*c).mc[RegularSmooth8Tap as usize] = bd_fn!(BP, put_8tap_regular_smooth, neon);
-    (*c).mc[RegularSharp8Tap as usize] = bd_fn!(BP, put_8tap_regular_sharp, neon);
-    (*c).mc[SmoothRegular8Tap as usize] = bd_fn!(BP, put_8tap_smooth_regular, neon);
-    (*c).mc[Smooth8Tap as usize] = bd_fn!(BP, put_8tap_smooth, neon);
-    (*c).mc[SmoothSharp8Tap as usize] = bd_fn!(BP, put_8tap_smooth_sharp, neon);
-    (*c).mc[SharpRegular8Tap as usize] = bd_fn!(BP, put_8tap_sharp_regular, neon);
-    (*c).mc[SharpSmooth8Tap as usize] = bd_fn!(BP, put_8tap_sharp_smooth, neon);
-    (*c).mc[Sharp8Tap as usize] = bd_fn!(BP, put_8tap_sharp, neon);
-    (*c).mc[Bilinear as usize] = bd_fn!(BP, put_bilin, neon);
+    c.mc[Regular8Tap as usize] = bd_fn!(BP, put_8tap_regular, neon);
+    c.mc[RegularSmooth8Tap as usize] = bd_fn!(BP, put_8tap_regular_smooth, neon);
+    c.mc[RegularSharp8Tap as usize] = bd_fn!(BP, put_8tap_regular_sharp, neon);
+    c.mc[SmoothRegular8Tap as usize] = bd_fn!(BP, put_8tap_smooth_regular, neon);
+    c.mc[Smooth8Tap as usize] = bd_fn!(BP, put_8tap_smooth, neon);
+    c.mc[SmoothSharp8Tap as usize] = bd_fn!(BP, put_8tap_smooth_sharp, neon);
+    c.mc[SharpRegular8Tap as usize] = bd_fn!(BP, put_8tap_sharp_regular, neon);
+    c.mc[SharpSmooth8Tap as usize] = bd_fn!(BP, put_8tap_sharp_smooth, neon);
+    c.mc[Sharp8Tap as usize] = bd_fn!(BP, put_8tap_sharp, neon);
+    c.mc[Bilinear as usize] = bd_fn!(BP, put_bilin, neon);
 
-    (*c).mct[Regular8Tap as usize] = bd_fn!(BP, prep_8tap_regular, neon);
-    (*c).mct[RegularSmooth8Tap as usize] = bd_fn!(BP, prep_8tap_regular_smooth, neon);
-    (*c).mct[RegularSharp8Tap as usize] = bd_fn!(BP, prep_8tap_regular_sharp, neon);
-    (*c).mct[SmoothRegular8Tap as usize] = bd_fn!(BP, prep_8tap_smooth_regular, neon);
-    (*c).mct[Smooth8Tap as usize] = bd_fn!(BP, prep_8tap_smooth, neon);
-    (*c).mct[SmoothSharp8Tap as usize] = bd_fn!(BP, prep_8tap_smooth_sharp, neon);
-    (*c).mct[SharpRegular8Tap as usize] = bd_fn!(BP, prep_8tap_sharp_regular, neon);
-    (*c).mct[SharpSmooth8Tap as usize] = bd_fn!(BP, prep_8tap_sharp_smooth, neon);
-    (*c).mct[Sharp8Tap as usize] = bd_fn!(BP, prep_8tap_sharp, neon);
-    (*c).mct[Bilinear as usize] = bd_fn!(BP, prep_bilin, neon);
+    c.mct[Regular8Tap as usize] = bd_fn!(BP, prep_8tap_regular, neon);
+    c.mct[RegularSmooth8Tap as usize] = bd_fn!(BP, prep_8tap_regular_smooth, neon);
+    c.mct[RegularSharp8Tap as usize] = bd_fn!(BP, prep_8tap_regular_sharp, neon);
+    c.mct[SmoothRegular8Tap as usize] = bd_fn!(BP, prep_8tap_smooth_regular, neon);
+    c.mct[Smooth8Tap as usize] = bd_fn!(BP, prep_8tap_smooth, neon);
+    c.mct[SmoothSharp8Tap as usize] = bd_fn!(BP, prep_8tap_smooth_sharp, neon);
+    c.mct[SharpRegular8Tap as usize] = bd_fn!(BP, prep_8tap_sharp_regular, neon);
+    c.mct[SharpSmooth8Tap as usize] = bd_fn!(BP, prep_8tap_sharp_smooth, neon);
+    c.mct[Sharp8Tap as usize] = bd_fn!(BP, prep_8tap_sharp, neon);
+    c.mct[Bilinear as usize] = bd_fn!(BP, prep_bilin, neon);
 
-    (*c).avg = bd_fn!(BP, avg, neon);
-    (*c).w_avg = bd_fn!(BP, w_avg, neon);
-    (*c).mask = bd_fn!(BP, mask, neon);
-    (*c).blend = bd_fn!(BP, blend, neon);
-    (*c).blend_h = bd_fn!(BP, blend_h, neon);
-    (*c).blend_v = bd_fn!(BP, blend_v, neon);
+    c.avg = bd_fn!(BP, avg, neon);
+    c.w_avg = bd_fn!(BP, w_avg, neon);
+    c.mask = bd_fn!(BP, mask, neon);
+    c.blend = bd_fn!(BP, blend, neon);
+    c.blend_h = bd_fn!(BP, blend_h, neon);
+    c.blend_v = bd_fn!(BP, blend_v, neon);
 
-    (*c).w_mask[0] = bd_fn!(BP, w_mask_444, neon);
-    (*c).w_mask[1] = bd_fn!(BP, w_mask_422, neon);
-    (*c).w_mask[2] = bd_fn!(BP, w_mask_420, neon);
+    c.w_mask[0] = bd_fn!(BP, w_mask_444, neon);
+    c.w_mask[1] = bd_fn!(BP, w_mask_422, neon);
+    c.w_mask[2] = bd_fn!(BP, w_mask_420, neon);
 
-    (*c).warp8x8 = bd_fn!(BP, warp_affine_8x8, neon);
-    (*c).warp8x8t = bd_fn!(BP, warp_affine_8x8t, neon);
-    (*c).emu_edge = bd_fn!(BP, emu_edge, neon);
+    c.warp8x8 = bd_fn!(BP, warp_affine_8x8, neon);
+    c.warp8x8t = bd_fn!(BP, warp_affine_8x8t, neon);
+    c.emu_edge = bd_fn!(BP, emu_edge, neon);
 }
 
 #[cold]
-pub unsafe fn rav1d_mc_dsp_init<BD: BitDepth>(c: *mut Rav1dMCDSPContext) {
+pub fn rav1d_mc_dsp_init<BD: BitDepth>(c: &mut Rav1dMCDSPContext) {
     use Filter2d::*;
 
-    (*c).mc[Regular8Tap as usize] = put_8tap_regular_c_erased::<BD>;
-    (*c).mc[RegularSmooth8Tap as usize] = put_8tap_regular_smooth_c_erased::<BD>;
-    (*c).mc[RegularSharp8Tap as usize] = put_8tap_regular_sharp_c_erased::<BD>;
-    (*c).mc[SharpRegular8Tap as usize] = put_8tap_sharp_regular_c_erased::<BD>;
-    (*c).mc[SharpSmooth8Tap as usize] = put_8tap_sharp_smooth_c_erased::<BD>;
-    (*c).mc[Sharp8Tap as usize] = put_8tap_sharp_c_erased::<BD>;
-    (*c).mc[SmoothRegular8Tap as usize] = put_8tap_smooth_regular_c_erased::<BD>;
-    (*c).mc[Smooth8Tap as usize] = put_8tap_smooth_c_erased::<BD>;
-    (*c).mc[SmoothSharp8Tap as usize] = put_8tap_smooth_sharp_c_erased::<BD>;
-    (*c).mc[Bilinear as usize] = put_bilin_c_erased::<BD>;
+    c.mc[Regular8Tap as usize] = put_8tap_regular_c_erased::<BD>;
+    c.mc[RegularSmooth8Tap as usize] = put_8tap_regular_smooth_c_erased::<BD>;
+    c.mc[RegularSharp8Tap as usize] = put_8tap_regular_sharp_c_erased::<BD>;
+    c.mc[SharpRegular8Tap as usize] = put_8tap_sharp_regular_c_erased::<BD>;
+    c.mc[SharpSmooth8Tap as usize] = put_8tap_sharp_smooth_c_erased::<BD>;
+    c.mc[Sharp8Tap as usize] = put_8tap_sharp_c_erased::<BD>;
+    c.mc[SmoothRegular8Tap as usize] = put_8tap_smooth_regular_c_erased::<BD>;
+    c.mc[Smooth8Tap as usize] = put_8tap_smooth_c_erased::<BD>;
+    c.mc[SmoothSharp8Tap as usize] = put_8tap_smooth_sharp_c_erased::<BD>;
+    c.mc[Bilinear as usize] = put_bilin_c_erased::<BD>;
 
-    (*c).mct[Regular8Tap as usize] = prep_8tap_regular_c_erased::<BD>;
-    (*c).mct[RegularSmooth8Tap as usize] = prep_8tap_regular_smooth_c_erased::<BD>;
-    (*c).mct[RegularSharp8Tap as usize] = prep_8tap_regular_sharp_c_erased::<BD>;
-    (*c).mct[SharpRegular8Tap as usize] = prep_8tap_sharp_regular_c_erased::<BD>;
-    (*c).mct[SharpSmooth8Tap as usize] = prep_8tap_sharp_smooth_c_erased::<BD>;
-    (*c).mct[Sharp8Tap as usize] = prep_8tap_sharp_c_erased::<BD>;
-    (*c).mct[SmoothRegular8Tap as usize] = prep_8tap_smooth_regular_c_erased::<BD>;
-    (*c).mct[Smooth8Tap as usize] = prep_8tap_smooth_c_erased::<BD>;
-    (*c).mct[SmoothSharp8Tap as usize] = prep_8tap_smooth_sharp_c_erased::<BD>;
-    (*c).mct[Bilinear as usize] = prep_bilin_c_erased::<BD>;
+    c.mct[Regular8Tap as usize] = prep_8tap_regular_c_erased::<BD>;
+    c.mct[RegularSmooth8Tap as usize] = prep_8tap_regular_smooth_c_erased::<BD>;
+    c.mct[RegularSharp8Tap as usize] = prep_8tap_regular_sharp_c_erased::<BD>;
+    c.mct[SharpRegular8Tap as usize] = prep_8tap_sharp_regular_c_erased::<BD>;
+    c.mct[SharpSmooth8Tap as usize] = prep_8tap_sharp_smooth_c_erased::<BD>;
+    c.mct[Sharp8Tap as usize] = prep_8tap_sharp_c_erased::<BD>;
+    c.mct[SmoothRegular8Tap as usize] = prep_8tap_smooth_regular_c_erased::<BD>;
+    c.mct[Smooth8Tap as usize] = prep_8tap_smooth_c_erased::<BD>;
+    c.mct[SmoothSharp8Tap as usize] = prep_8tap_smooth_sharp_c_erased::<BD>;
+    c.mct[Bilinear as usize] = prep_bilin_c_erased::<BD>;
 
-    (*c).mc_scaled[Regular8Tap as usize] = put_8tap_regular_scaled_c_erased::<BD>;
-    (*c).mc_scaled[RegularSmooth8Tap as usize] = put_8tap_regular_smooth_scaled_c_erased::<BD>;
-    (*c).mc_scaled[RegularSharp8Tap as usize] = put_8tap_regular_sharp_scaled_c_erased::<BD>;
-    (*c).mc_scaled[SharpRegular8Tap as usize] = put_8tap_sharp_regular_scaled_c_erased::<BD>;
-    (*c).mc_scaled[SharpSmooth8Tap as usize] = put_8tap_sharp_smooth_scaled_c_erased::<BD>;
-    (*c).mc_scaled[Sharp8Tap as usize] = put_8tap_sharp_scaled_c_erased::<BD>;
-    (*c).mc_scaled[SmoothRegular8Tap as usize] = put_8tap_smooth_regular_scaled_c_erased::<BD>;
-    (*c).mc_scaled[Smooth8Tap as usize] = put_8tap_smooth_scaled_c_erased::<BD>;
-    (*c).mc_scaled[SmoothSharp8Tap as usize] = put_8tap_smooth_sharp_scaled_c_erased::<BD>;
-    (*c).mc_scaled[Bilinear as usize] = put_bilin_scaled_c_erased::<BD>;
+    c.mc_scaled[Regular8Tap as usize] = put_8tap_regular_scaled_c_erased::<BD>;
+    c.mc_scaled[RegularSmooth8Tap as usize] = put_8tap_regular_smooth_scaled_c_erased::<BD>;
+    c.mc_scaled[RegularSharp8Tap as usize] = put_8tap_regular_sharp_scaled_c_erased::<BD>;
+    c.mc_scaled[SharpRegular8Tap as usize] = put_8tap_sharp_regular_scaled_c_erased::<BD>;
+    c.mc_scaled[SharpSmooth8Tap as usize] = put_8tap_sharp_smooth_scaled_c_erased::<BD>;
+    c.mc_scaled[Sharp8Tap as usize] = put_8tap_sharp_scaled_c_erased::<BD>;
+    c.mc_scaled[SmoothRegular8Tap as usize] = put_8tap_smooth_regular_scaled_c_erased::<BD>;
+    c.mc_scaled[Smooth8Tap as usize] = put_8tap_smooth_scaled_c_erased::<BD>;
+    c.mc_scaled[SmoothSharp8Tap as usize] = put_8tap_smooth_sharp_scaled_c_erased::<BD>;
+    c.mc_scaled[Bilinear as usize] = put_bilin_scaled_c_erased::<BD>;
 
-    (*c).mct_scaled[Regular8Tap as usize] = prep_8tap_regular_scaled_c_erased::<BD>;
-    (*c).mct_scaled[RegularSmooth8Tap as usize] = prep_8tap_regular_smooth_scaled_c_erased::<BD>;
-    (*c).mct_scaled[RegularSharp8Tap as usize] = prep_8tap_regular_sharp_scaled_c_erased::<BD>;
-    (*c).mct_scaled[SharpRegular8Tap as usize] = prep_8tap_sharp_regular_scaled_c_erased::<BD>;
-    (*c).mct_scaled[SharpSmooth8Tap as usize] = prep_8tap_sharp_smooth_scaled_c_erased::<BD>;
-    (*c).mct_scaled[Sharp8Tap as usize] = prep_8tap_sharp_scaled_c_erased::<BD>;
-    (*c).mct_scaled[SmoothRegular8Tap as usize] = prep_8tap_smooth_regular_scaled_c_erased::<BD>;
-    (*c).mct_scaled[Smooth8Tap as usize] = prep_8tap_smooth_scaled_c_erased::<BD>;
-    (*c).mct_scaled[SmoothSharp8Tap as usize] = prep_8tap_smooth_sharp_scaled_c_erased::<BD>;
-    (*c).mct_scaled[Bilinear as usize] = prep_bilin_scaled_c_erased::<BD>;
+    c.mct_scaled[Regular8Tap as usize] = prep_8tap_regular_scaled_c_erased::<BD>;
+    c.mct_scaled[RegularSmooth8Tap as usize] = prep_8tap_regular_smooth_scaled_c_erased::<BD>;
+    c.mct_scaled[RegularSharp8Tap as usize] = prep_8tap_regular_sharp_scaled_c_erased::<BD>;
+    c.mct_scaled[SharpRegular8Tap as usize] = prep_8tap_sharp_regular_scaled_c_erased::<BD>;
+    c.mct_scaled[SharpSmooth8Tap as usize] = prep_8tap_sharp_smooth_scaled_c_erased::<BD>;
+    c.mct_scaled[Sharp8Tap as usize] = prep_8tap_sharp_scaled_c_erased::<BD>;
+    c.mct_scaled[SmoothRegular8Tap as usize] = prep_8tap_smooth_regular_scaled_c_erased::<BD>;
+    c.mct_scaled[Smooth8Tap as usize] = prep_8tap_smooth_scaled_c_erased::<BD>;
+    c.mct_scaled[SmoothSharp8Tap as usize] = prep_8tap_smooth_sharp_scaled_c_erased::<BD>;
+    c.mct_scaled[Bilinear as usize] = prep_bilin_scaled_c_erased::<BD>;
 
-    (*c).avg = avg_c_erased::<BD>;
-    (*c).w_avg = w_avg_c_erased::<BD>;
-    (*c).mask = mask_c_erased::<BD>;
+    c.avg = avg_c_erased::<BD>;
+    c.w_avg = w_avg_c_erased::<BD>;
+    c.mask = mask_c_erased::<BD>;
 
-    (*c).w_mask[0] = w_mask_444_c_erased::<BD>;
-    (*c).w_mask[1] = w_mask_422_c_erased::<BD>;
-    (*c).w_mask[2] = w_mask_420_c_erased::<BD>;
+    c.w_mask[0] = w_mask_444_c_erased::<BD>;
+    c.w_mask[1] = w_mask_422_c_erased::<BD>;
+    c.w_mask[2] = w_mask_420_c_erased::<BD>;
 
-    (*c).blend = blend_c_erased::<BD>;
-    (*c).blend_v = blend_v_c_erased::<BD>;
-    (*c).blend_h = blend_h_c_erased::<BD>;
-    (*c).warp8x8 = warp_affine_8x8_c_erased::<BD>;
-    (*c).warp8x8t = warp_affine_8x8t_c_erased::<BD>;
-    (*c).emu_edge = emu_edge_c_erased::<BD>;
-    (*c).resize = resize_c_erased::<BD>;
+    c.blend = blend_c_erased::<BD>;
+    c.blend_v = blend_v_c_erased::<BD>;
+    c.blend_h = blend_h_c_erased::<BD>;
+    c.warp8x8 = warp_affine_8x8_c_erased::<BD>;
+    c.warp8x8t = warp_affine_8x8t_c_erased::<BD>;
+    c.emu_edge = emu_edge_c_erased::<BD>;
+    c.resize = resize_c_erased::<BD>;
 
     #[cfg(feature = "asm")]
     cfg_if::cfg_if! {

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -10,6 +10,7 @@ use crate::include::common::intops::clip;
 use crate::include::common::intops::ulog2;
 use crate::include::dav1d::dav1d::Rav1dInloopFilterType;
 use crate::include::dav1d::headers::Rav1dPixelLayout;
+use crate::include::dav1d::headers::Rav1dPixelLayoutSubSampled;
 use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
 use crate::include::dav1d::headers::Rav1dWarpedMotionType;
 use crate::include::dav1d::picture::RAV1D_PICTURE_ALIGNMENT;
@@ -3186,6 +3187,12 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
     } else {
         Rav1dPixelLayout::I444 - f.cur.p.layout
     } as usize;
+    let chr_layout_idx_w_mask = f
+        .cur
+        .p
+        .layout
+        .try_into()
+        .unwrap_or(Rav1dPixelLayoutSubSampled::I444);
     let cbh4 = bh4 + ss_ver >> ss_ver;
     let cbw4 = bw4 + ss_hor >> ss_hor;
     let mut dst = (f.cur.data.data[0] as *mut BD::Pixel)
@@ -3313,7 +3320,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 );
             }
             CompInterType::Seg => {
-                dsp.mc.w_mask[chr_layout_idx].call(
+                dsp.mc.w_mask[chr_layout_idx_w_mask].call(
                     dst,
                     f.cur.stride[0],
                     tmp[b.mask_sign() as usize].as_mut_ptr(),

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2103,15 +2103,15 @@ unsafe fn mc<BD: BitDepth>(
                 BitDepth::from_c(f.bitdepth_max),
             );
         } else {
-            (*f.dsp).mc.mct[filter_2d as usize](
+            (*f.dsp).mc.mct[filter_2d as usize].call::<BD>(
                 dst16,
-                r#ref.cast(),
+                r#ref,
                 ref_stride,
                 bw4 * h_mul,
                 bh4 * v_mul,
                 mx << (ss_hor == 0) as c_int,
                 my << (ss_ver == 0) as c_int,
-                f.bitdepth_max,
+                BD::from_c(f.bitdepth_max),
             );
         }
     } else {

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2091,7 +2091,7 @@ unsafe fn mc<BD: BitDepth>(
                 .offset(dx as isize);
         }
         if !dst8.is_null() {
-            (*f.dsp).mc.mc[filter_2d as usize].call::<BD>(
+            (*f.dsp).mc.mc[filter_2d].call::<BD>(
                 dst8,
                 dst_stride,
                 r#ref,
@@ -2103,7 +2103,7 @@ unsafe fn mc<BD: BitDepth>(
                 BitDepth::from_c(f.bitdepth_max),
             );
         } else {
-            (*f.dsp).mc.mct[filter_2d as usize].call::<BD>(
+            (*f.dsp).mc.mct[filter_2d].call::<BD>(
                 dst16,
                 r#ref,
                 ref_stride,
@@ -2171,7 +2171,7 @@ unsafe fn mc<BD: BitDepth>(
                 .offset(left as isize);
         }
         if !dst8.is_null() {
-            (*f.dsp).mc.mc_scaled[filter_2d as usize].call::<BD>(
+            (*f.dsp).mc.mc_scaled[filter_2d].call::<BD>(
                 dst8,
                 dst_stride,
                 r#ref,
@@ -2185,7 +2185,7 @@ unsafe fn mc<BD: BitDepth>(
                 BD::from_c(f.bitdepth_max),
             );
         } else {
-            (*f.dsp).mc.mct_scaled[filter_2d as usize].call::<BD>(
+            (*f.dsp).mc.mct_scaled[filter_2d].call::<BD>(
                 dst16,
                 r#ref,
                 ref_stride,

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2091,16 +2091,16 @@ unsafe fn mc<BD: BitDepth>(
                 .offset(dx as isize);
         }
         if !dst8.is_null() {
-            (*f.dsp).mc.mc[filter_2d as usize](
-                dst8.cast(),
+            (*f.dsp).mc.mc[filter_2d as usize].call::<BD>(
+                dst8,
                 dst_stride,
-                r#ref.cast(),
+                r#ref,
                 ref_stride,
                 bw4 * h_mul,
                 bh4 * v_mul,
                 mx << (ss_hor == 0) as c_int,
                 my << (ss_ver == 0) as c_int,
-                f.bitdepth_max,
+                BitDepth::from_c(f.bitdepth_max),
             );
         } else {
             (*f.dsp).mc.mct[filter_2d as usize](

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -3313,8 +3313,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 );
             }
             CompInterType::Seg => {
-                dsp.mc.w_mask[chr_layout_idx](
-                    dst.cast(),
+                dsp.mc.w_mask[chr_layout_idx].call(
+                    dst,
                     f.cur.stride[0],
                     tmp[b.mask_sign() as usize].as_mut_ptr(),
                     tmp[(b.mask_sign() == 0) as usize].as_mut_ptr(),
@@ -3322,7 +3322,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     bh4 * 4,
                     seg_mask.as_mut_ptr(),
                     b.mask_sign() as c_int,
-                    f.bitdepth_max,
+                    BD::from_c(f.bitdepth_max),
                 );
                 mask = &seg_mask[..];
             }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2171,10 +2171,10 @@ unsafe fn mc<BD: BitDepth>(
                 .offset(left as isize);
         }
         if !dst8.is_null() {
-            (*f.dsp).mc.mc_scaled[filter_2d as usize](
-                dst8.cast(),
+            (*f.dsp).mc.mc_scaled[filter_2d as usize].call::<BD>(
+                dst8,
                 dst_stride,
-                r#ref.cast(),
+                r#ref,
                 ref_stride,
                 bw4 * h_mul,
                 bh4 * v_mul,
@@ -2182,7 +2182,7 @@ unsafe fn mc<BD: BitDepth>(
                 pos_y & 0x3ff,
                 f.svc[refidx][0].step,
                 f.svc[refidx][1].step,
-                f.bitdepth_max,
+                BD::from_c(f.bitdepth_max),
             );
         } else {
             (*f.dsp).mc.mct_scaled[filter_2d as usize](

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2185,9 +2185,9 @@ unsafe fn mc<BD: BitDepth>(
                 BD::from_c(f.bitdepth_max),
             );
         } else {
-            (*f.dsp).mc.mct_scaled[filter_2d as usize](
+            (*f.dsp).mc.mct_scaled[filter_2d as usize].call::<BD>(
                 dst16,
-                r#ref.cast(),
+                r#ref,
                 ref_stride,
                 bw4 * h_mul,
                 bh4 * v_mul,
@@ -2195,7 +2195,7 @@ unsafe fn mc<BD: BitDepth>(
                 pos_y & 0x3ff,
                 f.svc[refidx][0].step,
                 f.svc[refidx][1].step,
-                f.bitdepth_max,
+                BD::from_c(f.bitdepth_max),
             );
         }
     }


### PR DESCRIPTION
* Fixes `dsp` field of #713.
* Fixes all `fn *dsp_init`s of #862.
* Improves DSP initialization code size of #809.

This
* Makes all `fn *dsp_init*`s safe.
* Changes all `fn *dsp_init*`s into `fn *DSPContext::new`s that directly initialize the type without `unsafe`ly zero initializing it first.  This is done by directly initializing in `fn default`, which is for the fallback `fn`s, and then updating the `fn` ptrs in the `fn init_{x86,arm}`s.  These `fn`s are also all `const` now, as that was trivial.
* Adds `wrap_fn_ptr!` and `enum_map!`s to the array fields of `Rav1dMCDSPContext`, since I needed a default value to initialize the arrays directly if I want it the indices to be named (rather than a normal array, whose order is easy to mix up).  `wrap_fn_ptr!` provides that default value, which is then optimized out.
* Replaces the `Rav1dContext::dsp` array, which is manually lazily initialized, with `fn Rav1dDSPContext::get`, which uses `OnceLock` for lazy initialization.
* Makes the `Rav1dFrameData::dsp` raw ptr into a `&'static` now that we lazily initialize it with `OnceLock`.

This also dramatically reduces the code size of DSP initialization (in KiB):

| Target                          | Before | After |
| ------------------------------- | ------ | ----- |
|      `x86_64-unknown-linux-gnu` | 192.5  | 95.6  |
|        `i686-unknown-linux-gnu` | 106.5  | 39.6  |
|     `aarch64-unknown-linux-gnu` |  88.2  | 15.3  |
| `armv7-unknown-linux-gnueabihf` | 103.8  | 17.0  |

This is measured before using `cargo bloat --filter 'dsp_init'` and after using `cargo bloat --filter 'DSPContext::new'`.