### PR TITLE
`struct Rav1dFrameData::ipred_edge`: Make into `DisjointMut<AlignedVec<u8>>`

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -3,7 +3,6 @@ use crate::include::common::bitdepth::BitDepth16;
 use crate::include::common::bitdepth::BitDepth8;
 use crate::include::common::bitdepth::BitDepthDependentType;
 use crate::include::common::bitdepth::BitDepthUnion;
-use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::bitdepth::BPC;
 use crate::include::dav1d::common::Rav1dDataProps;
 use crate::include::dav1d::data::Rav1dData;
@@ -907,8 +906,13 @@ pub(crate) struct Rav1dFrameData {
     pub n_ts: c_int,
     pub dsp: &'static Rav1dDSPContext,
 
-    pub ipred_edge_sz: c_int,
-    pub ipred_edge: [*mut DynPixel; 3],
+    // `ipred_edge` contains 3 arrays of size `ipred_edge_off`. Use `index *
+    // ipred_edge_off` to access one of the sub-arrays. Note that `ipred_edge_off`
+    // is in pixel units (not bytes), so use `slice_as`/`mut_slice_as` and an offset
+    // in pixel units when slicing.
+    pub ipred_edge: DisjointMut<AlignedVec64<u8>>, // DynPixel
+    pub ipred_edge_off: usize,
+
     pub b4_stride: ptrdiff_t,
     pub w4: c_int,
     pub h4: c_int,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -944,6 +944,7 @@ impl Rav1dFrameData {
         addr_of_mut!((*data.as_mut_ptr()).sr_cur).write(Default::default());
         addr_of_mut!((*data.as_mut_ptr()).out_cdf).write(Default::default());
         addr_of_mut!((*data.as_mut_ptr()).tiles).write(vec![]);
+        addr_of_mut!((*data.as_mut_ptr()).ipred_edge).write(Default::default());
         addr_of_mut!((*data.as_mut_ptr()).a).write(vec![]);
         addr_of_mut!((*data.as_mut_ptr()).rf).write(Default::default());
         addr_of_mut!((*data.as_mut_ptr()).lowest_pixel_mem).write(Default::default());

--- a/src/ipred_prepare.rs
+++ b/src/ipred_prepare.rs
@@ -127,6 +127,8 @@ pub fn rav1d_prepare_intra_edges<BD: BitDepth>(
     edge_flags: EdgeFlags,
     dst: &[BD::Pixel], // contains 4*h first rows of picture, last row in slice contains 4*w samples
     stride: ptrdiff_t,
+    // Buffer and offset pair. `isize` value is the base offset that should be used
+    // when indexing into the buffer.
     prefilter_toplevel_sb_edge: Option<(&DisjointMut<AlignedVec64<u8>>, isize)>,
     mut mode: IntraPredMode,
     angle: &mut c_int,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -766,7 +766,7 @@ impl Drop for Rav1dContext {
                 let _ = mem::take(&mut f.frame_thread); // TODO: remove when context is owned
                 mem::take(&mut fc.task_thread.tasks); // TODO: remove when context is owned
                 rav1d_free_aligned(f.ts as *mut c_void);
-                rav1d_free_aligned(f.ipred_edge[0] as *mut c_void);
+                let _ = mem::take(&mut f.ipred_edge); // TODO: remove when context is owned
                 let _ = mem::take(&mut f.a); // TODO: remove when context is owned
                 let _ = mem::take(&mut f.out_cdf); // TODO: remove when context is owned
                 let _ = mem::take(&mut f.tiles);

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -4521,12 +4521,12 @@ pub(crate) unsafe fn rav1d_backup_ipred_edge<BD: BitDepth>(
         .offset((x_off * 4) as isize)
         .offset((((t.b.y + f.sb_step) * 4 - 1) as isize * BD::pxstride(f.cur.stride[0])) as isize);
     let ipred_edge_off = (f.ipred_edge_off * 0) + (sby_off + x_off * 4) as usize;
-    let n = (4 * (ts.tiling.col_end - x_off)).try_into().unwrap();
+    let n = 4 * (ts.tiling.col_end - x_off) as usize;
     BD::pixel_copy(
         &mut f
             .ipred_edge
             .mut_slice_as(ipred_edge_off..ipred_edge_off + n),
-        slice::from_raw_parts(y, (4 * (ts.tiling.col_end - x_off)).try_into().unwrap()),
+        slice::from_raw_parts(y, n),
         n,
     );
     if f.cur.p.layout as c_uint != Rav1dPixelLayout::I400 as c_int as c_uint {
@@ -4540,19 +4540,17 @@ pub(crate) unsafe fn rav1d_backup_ipred_edge<BD: BitDepth>(
         while pl <= 2 {
             let ipred_edge_off =
                 (f.ipred_edge_off * pl) + (sby_off + (x_off * 4 >> ss_hor)) as usize;
-            let n = (4 * (ts.tiling.col_end - x_off) >> ss_hor)
-                .try_into()
-                .unwrap();
+            let n = 4 * (ts.tiling.col_end - x_off) as usize >> ss_hor;
             BD::pixel_copy(
                 &mut f
                     .ipred_edge
                     .mut_slice_as(ipred_edge_off..ipred_edge_off + n),
                 &slice::from_raw_parts(
-                    f.cur.data.as_ref().unwrap().data[pl].cast(),
-                    (uv_off + (4 * (ts.tiling.col_end - x_off) >> ss_hor) as isize)
-                        .try_into()
-                        .unwrap(),
-                )[uv_off.try_into().unwrap()..],
+                    f.cur.data.as_ref().unwrap().data[pl]
+                        .cast::<BD::Pixel>()
+                        .offset(uv_off),
+                    n,
+                ),
                 n,
             );
             pl += 1;


### PR DESCRIPTION
Part of https://github.com/memorysafety/rav1d/issues/713