### PR TITLE
CI: Pin version of macos to avoid build failure

### DIFF
--- a/.github/workflows/build-and-test-x86.yml
+++ b/.github/workflows/build-and-test-x86.yml
@@ -78,8 +78,8 @@ jobs:
           name: meson-test-logs-${{ matrix.target }}-${{ matrix.build.name }}
           path: |
              ${{ github.workspace }}/build/meson-logs/testlog-*.txt
-  test-on-macos-latest:
-    runs-on: macos-latest
+  test-on-macos-13:
+    runs-on: macos-13 # select an x86_64 image
     steps:
       - name: install prerequisites
         env:


### PR DESCRIPTION
It seems `macos-latest` transitioned (is transitioning) from `x86` to `aarch64`. This may lead to unintended interactions with caching of the Rust toolchain. We've observed runs that failed because `cargo` was not found. My best guess is that we restored a `x86` toolchain onto a `aarch64` host but reproducing to make sure would take too much time. Requesting `macos-13` instead of `macos-latest` should avoid this issue altogether.