### PR TITLE
`struct Dav1dFrameHeader`: backport memory size reduction from dav1d 1.3.0

### DIFF
--- a/include/dav1d/headers.h
+++ b/include/dav1d/headers.h
@@ -294,22 +294,22 @@ typedef struct Dav1dSequenceHeader {
 } Dav1dSequenceHeader;
 
 typedef struct Dav1dSegmentationData {
-    int delta_q;
-    int delta_lf_y_v, delta_lf_y_h, delta_lf_u, delta_lf_v;
-    int ref;
-    int skip;
-    int globalmv;
+    int16_t delta_q;
+    int8_t delta_lf_y_v, delta_lf_y_h, delta_lf_u, delta_lf_v;
+    int8_t ref;
+    uint8_t skip;
+    uint8_t globalmv;
 } Dav1dSegmentationData;
 
 typedef struct Dav1dSegmentationDataSet {
     Dav1dSegmentationData d[DAV1D_MAX_SEGMENTS];
-    int preskip;
-    int last_active_segid;
+    uint8_t preskip;
+    int8_t last_active_segid;
 } Dav1dSegmentationDataSet;
 
 typedef struct Dav1dLoopfilterModeRefDeltas {
-    int mode_delta[2 /* is_zeromv */];
-    int ref_delta[DAV1D_TOTAL_REFS_PER_FRAME];
+    int8_t mode_delta[2 /* is_zeromv */];
+    int8_t ref_delta[DAV1D_TOTAL_REFS_PER_FRAME];
 } Dav1dLoopfilterModeRefDeltas;
 
 typedef struct Dav1dFilmGrainData {
@@ -335,100 +335,101 @@ typedef struct Dav1dFilmGrainData {
 typedef struct Dav1dFrameHeader {
     struct Dav1dFrameHeader_film_grain {
         Dav1dFilmGrainData data;
-        int present, update;
+        uint8_t present, update;
     } film_grain; ///< film grain parameters
     enum Dav1dFrameType frame_type; ///< type of the picture
     int width[2 /* { coded_width, superresolution_upscaled_width } */], height;
-    int frame_offset; ///< frame number
-    int temporal_id; ///< temporal id of the frame for SVC
-    int spatial_id; ///< spatial id of the frame for SVC
+    uint8_t frame_offset; ///< frame number
+    uint8_t temporal_id; ///< temporal id of the frame for SVC
+    uint8_t spatial_id; ///< spatial id of the frame for SVC
 
-    int show_existing_frame;
-    int existing_frame_idx;
-    int frame_id;
-    int frame_presentation_delay;
-    int show_frame;
-    int showable_frame;
-    int error_resilient_mode;
-    int disable_cdf_update;
-    int allow_screen_content_tools;
-    int force_integer_mv;
-    int frame_size_override;
-    int primary_ref_frame;
-    int buffer_removal_time_present;
+    uint8_t show_existing_frame;
+    uint8_t existing_frame_idx;
+    uint32_t frame_id;
+    uint32_t frame_presentation_delay;
+    uint8_t show_frame;
+    uint8_t showable_frame;
+    uint8_t error_resilient_mode;
+    uint8_t disable_cdf_update;
+    uint8_t allow_screen_content_tools;
+    uint8_t force_integer_mv;
+    uint8_t frame_size_override;
+    uint8_t primary_ref_frame;
+    uint8_t buffer_removal_time_present;
     struct Dav1dFrameHeaderOperatingPoint {
-        int buffer_removal_time;
+        uint32_t buffer_removal_time;
     } operating_points[DAV1D_MAX_OPERATING_POINTS];
-    int refresh_frame_flags;
+    uint8_t refresh_frame_flags;
     int render_width, render_height;
     struct Dav1dFrameHeader_super_res {
-        int width_scale_denominator;
-        int enabled;
+        uint8_t width_scale_denominator;
+        uint8_t enabled;
     } super_res;
-    int have_render_size;
-    int allow_intrabc;
-    int frame_ref_short_signaling;
-    int refidx[DAV1D_REFS_PER_FRAME];
-    int hp;
+    uint8_t have_render_size;
+    uint8_t allow_intrabc;
+    uint8_t frame_ref_short_signaling;
+    int8_t refidx[DAV1D_REFS_PER_FRAME];
+    uint8_t hp;
     enum Dav1dFilterMode subpel_filter_mode;
-    int switchable_motion_mode;
-    int use_ref_frame_mvs;
-    int refresh_context;
+    uint8_t switchable_motion_mode;
+    uint8_t use_ref_frame_mvs;
+    uint8_t refresh_context;
     struct Dav1dFrameHeader_tiling {
-        int uniform;
-        unsigned n_bytes;
-        int min_log2_cols, max_log2_cols, log2_cols, cols;
-        int min_log2_rows, max_log2_rows, log2_rows, rows;
+        uint8_t uniform;
+        uint8_t n_bytes;
+        uint8_t min_log2_cols, max_log2_cols, log2_cols, cols;
+        uint8_t min_log2_rows, max_log2_rows, log2_rows, rows;
         uint16_t col_start_sb[DAV1D_MAX_TILE_COLS + 1];
         uint16_t row_start_sb[DAV1D_MAX_TILE_ROWS + 1];
-        int update;
+        uint16_t update;
     } tiling;
     struct Dav1dFrameHeader_quant {
-        int yac;
-        int ydc_delta;
-        int udc_delta, uac_delta, vdc_delta, vac_delta;
-        int qm, qm_y, qm_u, qm_v;
+        uint8_t yac;
+        int8_t ydc_delta;
+        int8_t udc_delta, uac_delta, vdc_delta, vac_delta;
+        uint8_t qm, qm_y, qm_u, qm_v;
     } quant;
     struct Dav1dFrameHeader_segmentation {
-        int enabled, update_map, temporal, update_data;
+        uint8_t enabled, update_map, temporal, update_data;
         Dav1dSegmentationDataSet seg_data;
-        int lossless[DAV1D_MAX_SEGMENTS], qidx[DAV1D_MAX_SEGMENTS];
+        uint8_t lossless[DAV1D_MAX_SEGMENTS], qidx[DAV1D_MAX_SEGMENTS];
     } segmentation;
     struct Dav1dFrameHeader_delta {
         struct Dav1dFrameHeader_delta_q {
-            int present;
-            int res_log2;
+            uint8_t present;
+            uint8_t res_log2;
         } q;
         struct Dav1dFrameHeader_delta_lf {
-            int present;
-            int res_log2;
-            int multi;
+            uint8_t present;
+            uint8_t res_log2;
+            uint8_t multi;
         } lf;
     } delta;
-    int all_lossless;
+    uint8_t all_lossless;
     struct Dav1dFrameHeader_loopfilter {
-        int level_y[2 /* dir */];
-        int level_u, level_v;
-        int mode_ref_delta_enabled;
-        int mode_ref_delta_update;
+        uint8_t level_y[2 /* dir */];
+        uint8_t level_u, level_v;
+        uint8_t mode_ref_delta_enabled;
+        uint8_t mode_ref_delta_update;
         Dav1dLoopfilterModeRefDeltas mode_ref_deltas;
-        int sharpness;
+        uint8_t sharpness;
     } loopfilter;
     struct Dav1dFrameHeader_cdef {
-        int damping;
-        int n_bits;
-        int y_strength[DAV1D_MAX_CDEF_STRENGTHS];
-        int uv_strength[DAV1D_MAX_CDEF_STRENGTHS];
+        uint8_t damping;
+        uint8_t n_bits;
+        uint8_t y_strength[DAV1D_MAX_CDEF_STRENGTHS];
+        uint8_t uv_strength[DAV1D_MAX_CDEF_STRENGTHS];
     } cdef;
     struct Dav1dFrameHeader_restoration {
         enum Dav1dRestorationType type[3 /* plane */];
-        int unit_size[2 /* y, uv */];
+        uint8_t unit_size[2 /* y, uv */];
     } restoration;
     enum Dav1dTxfmMode txfm_mode;
-    int switchable_comp_refs;
-    int skip_mode_allowed, skip_mode_enabled, skip_mode_refs[2];
-    int warp_motion;
-    int reduced_txtp_set;
+    uint8_t switchable_comp_refs;
+    uint8_t skip_mode_allowed, skip_mode_enabled;
+    int8_t skip_mode_refs[2];
+    uint8_t warp_motion;
+    uint8_t reduced_txtp_set;
     Dav1dWarpedMotionParams gmv[DAV1D_REFS_PER_FRAME];
 } Dav1dFrameHeader;
 

--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -64,7 +64,7 @@ pub const DAV1D_MAX_TILE_COLS: usize = 64;
 pub const DAV1D_MAX_TILE_ROWS: usize = 64;
 pub const DAV1D_MAX_SEGMENTS: u8 = 8;
 pub const DAV1D_NUM_REF_FRAMES: usize = 8;
-pub const DAV1D_PRIMARY_REF_NONE: c_int = 7;
+pub const DAV1D_PRIMARY_REF_NONE: u8 = 7;
 pub const DAV1D_REFS_PER_FRAME: usize = 7;
 pub const DAV1D_TOTAL_REFS_PER_FRAME: usize = DAV1D_REFS_PER_FRAME + 1;
 
@@ -74,7 +74,7 @@ pub(crate) const RAV1D_MAX_TILE_COLS: usize = DAV1D_MAX_TILE_COLS;
 pub(crate) const RAV1D_MAX_TILE_ROWS: usize = DAV1D_MAX_TILE_ROWS;
 pub(crate) const RAV1D_MAX_SEGMENTS: u8 = DAV1D_MAX_SEGMENTS;
 pub(crate) const _RAV1D_NUM_REF_FRAMES: usize = DAV1D_NUM_REF_FRAMES;
-pub(crate) const RAV1D_PRIMARY_REF_NONE: c_int = DAV1D_PRIMARY_REF_NONE;
+pub(crate) const RAV1D_PRIMARY_REF_NONE: u8 = DAV1D_PRIMARY_REF_NONE;
 pub(crate) const RAV1D_REFS_PER_FRAME: usize = DAV1D_REFS_PER_FRAME;
 pub(crate) const RAV1D_TOTAL_REFS_PER_FRAME: usize = DAV1D_TOTAL_REFS_PER_FRAME;
 
@@ -1455,27 +1455,27 @@ impl From<Rav1dSequenceHeader> for Dav1dSequenceHeader {
 #[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dSegmentationData {
-    pub delta_q: c_int,
-    pub delta_lf_y_v: c_int,
-    pub delta_lf_y_h: c_int,
-    pub delta_lf_u: c_int,
-    pub delta_lf_v: c_int,
-    pub r#ref: c_int,
-    pub skip: c_int,
-    pub globalmv: c_int,
+    pub delta_q: i16,
+    pub delta_lf_y_v: i8,
+    pub delta_lf_y_h: i8,
+    pub delta_lf_u: i8,
+    pub delta_lf_v: i8,
+    pub r#ref: i8,
+    pub skip: u8,
+    pub globalmv: u8,
 }
 
 #[derive(Clone, Default)]
 #[repr(C)]
 pub struct Rav1dSegmentationData {
-    pub delta_q: c_int,
-    pub delta_lf_y_v: c_int,
-    pub delta_lf_y_h: c_int,
-    pub delta_lf_u: c_int,
-    pub delta_lf_v: c_int,
-    pub r#ref: c_int,
-    pub skip: c_int,
-    pub globalmv: c_int,
+    pub delta_q: i16,
+    pub delta_lf_y_v: i8,
+    pub delta_lf_y_h: i8,
+    pub delta_lf_u: i8,
+    pub delta_lf_v: i8,
+    pub r#ref: i8,
+    pub skip: u8,
+    pub globalmv: u8,
 }
 
 impl From<Dav1dSegmentationData> for Rav1dSegmentationData {
@@ -1532,16 +1532,16 @@ impl From<Rav1dSegmentationData> for Dav1dSegmentationData {
 #[repr(C)]
 pub struct Dav1dSegmentationDataSet {
     pub d: [Dav1dSegmentationData; DAV1D_MAX_SEGMENTS as usize],
-    pub preskip: c_int,
-    pub last_active_segid: c_int,
+    pub preskip: u8,
+    pub last_active_segid: i8,
 }
 
 #[derive(Clone, Default)]
 #[repr(C)]
 pub struct Rav1dSegmentationDataSet {
     pub d: [Rav1dSegmentationData; RAV1D_MAX_SEGMENTS as usize],
-    pub preskip: c_int,
-    pub last_active_segid: c_int,
+    pub preskip: u8,
+    pub last_active_segid: i8,
 }
 
 impl From<Dav1dSegmentationDataSet> for Rav1dSegmentationDataSet {
@@ -1577,15 +1577,15 @@ impl From<Rav1dSegmentationDataSet> for Dav1dSegmentationDataSet {
 #[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dLoopfilterModeRefDeltas {
-    pub mode_delta: [c_int; 2],
-    pub ref_delta: [c_int; DAV1D_TOTAL_REFS_PER_FRAME],
+    pub mode_delta: [i8; 2],
+    pub ref_delta: [i8; DAV1D_TOTAL_REFS_PER_FRAME],
 }
 
 #[derive(Clone)]
 #[repr(C)]
 pub struct Rav1dLoopfilterModeRefDeltas {
-    pub mode_delta: [c_int; 2],
-    pub ref_delta: [c_int; RAV1D_TOTAL_REFS_PER_FRAME],
+    pub mode_delta: [i8; 2],
+    pub ref_delta: [i8; RAV1D_TOTAL_REFS_PER_FRAME],
 }
 
 impl From<Dav1dLoopfilterModeRefDeltas> for Rav1dLoopfilterModeRefDeltas {
@@ -1785,16 +1785,16 @@ impl From<Rav1dFilmGrainData> for Dav1dFilmGrainData {
 #[repr(C)]
 pub struct Dav1dFrameHeader_film_grain {
     pub data: Dav1dFilmGrainData,
-    pub present: c_int,
-    pub update: c_int,
+    pub present: u8,
+    pub update: u8,
 }
 
 #[derive(Clone)]
 #[repr(C)]
 pub struct Rav1dFrameHeader_film_grain {
     pub data: Rav1dFilmGrainData,
-    pub present: c_int,
-    pub update: c_int,
+    pub present: u8,
+    pub update: u8,
 }
 
 impl From<Dav1dFrameHeader_film_grain> for Rav1dFrameHeader_film_grain {
@@ -1830,13 +1830,13 @@ impl From<Rav1dFrameHeader_film_grain> for Dav1dFrameHeader_film_grain {
 #[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeaderOperatingPoint {
-    pub buffer_removal_time: c_int,
+    pub buffer_removal_time: u32,
 }
 
 #[derive(Clone, Copy, Default)]
 #[repr(C)]
 pub struct Rav1dFrameHeaderOperatingPoint {
-    pub buffer_removal_time: c_int,
+    pub buffer_removal_time: u32,
 }
 
 impl From<Dav1dFrameHeaderOperatingPoint> for Rav1dFrameHeaderOperatingPoint {
@@ -1864,14 +1864,14 @@ impl From<Rav1dFrameHeaderOperatingPoint> for Dav1dFrameHeaderOperatingPoint {
 #[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_super_res {
-    pub width_scale_denominator: c_int,
-    pub enabled: c_int,
+    pub width_scale_denominator: u8,
+    pub enabled: u8,
 }
 
 #[derive(Clone)]
 #[repr(C)]
 pub struct Rav1dFrameHeader_super_res {
-    pub width_scale_denominator: c_int,
+    pub width_scale_denominator: u8,
     pub enabled: bool,
 }
 
@@ -1896,7 +1896,7 @@ impl From<Rav1dFrameHeader_super_res> for Dav1dFrameHeader_super_res {
         } = value;
         Self {
             width_scale_denominator,
-            enabled: enabled as c_int,
+            enabled: enabled as u8,
         }
     }
 }
@@ -1904,37 +1904,37 @@ impl From<Rav1dFrameHeader_super_res> for Dav1dFrameHeader_super_res {
 #[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_tiling {
-    pub uniform: c_int,
-    pub n_bytes: c_uint,
-    pub min_log2_cols: c_int,
-    pub max_log2_cols: c_int,
-    pub log2_cols: c_int,
-    pub cols: c_int,
-    pub min_log2_rows: c_int,
-    pub max_log2_rows: c_int,
-    pub log2_rows: c_int,
-    pub rows: c_int,
+    pub uniform: u8,
+    pub n_bytes: u8,
+    pub min_log2_cols: u8,
+    pub max_log2_cols: u8,
+    pub log2_cols: u8,
+    pub cols: u8,
+    pub min_log2_rows: u8,
+    pub max_log2_rows: u8,
+    pub log2_rows: u8,
+    pub rows: u8,
     pub col_start_sb: [u16; DAV1D_MAX_TILE_COLS + 1],
     pub row_start_sb: [u16; DAV1D_MAX_TILE_ROWS + 1],
-    pub update: c_int,
+    pub update: u16,
 }
 
 #[derive(Clone)]
 #[repr(C)]
 pub struct Rav1dFrameHeader_tiling {
-    pub uniform: c_int,
-    pub n_bytes: c_uint,
-    pub min_log2_cols: c_int,
-    pub max_log2_cols: c_int,
-    pub log2_cols: c_int,
-    pub cols: c_int,
-    pub min_log2_rows: c_int,
-    pub max_log2_rows: c_int,
-    pub log2_rows: c_int,
-    pub rows: c_int,
+    pub uniform: u8,
+    pub n_bytes: u8,
+    pub min_log2_cols: u8,
+    pub max_log2_cols: u8,
+    pub log2_cols: u8,
+    pub cols: u8,
+    pub min_log2_rows: u8,
+    pub max_log2_rows: u8,
+    pub log2_rows: u8,
+    pub rows: u8,
     pub col_start_sb: [u16; RAV1D_MAX_TILE_COLS + 1],
     pub row_start_sb: [u16; RAV1D_MAX_TILE_ROWS + 1],
-    pub update: c_int,
+    pub update: u16,
 }
 
 impl From<Dav1dFrameHeader_tiling> for Rav1dFrameHeader_tiling {
@@ -2010,31 +2010,31 @@ impl From<Rav1dFrameHeader_tiling> for Dav1dFrameHeader_tiling {
 #[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_quant {
-    pub yac: c_int,
-    pub ydc_delta: c_int,
-    pub udc_delta: c_int,
-    pub uac_delta: c_int,
-    pub vdc_delta: c_int,
-    pub vac_delta: c_int,
-    pub qm: c_int,
-    pub qm_y: c_int,
-    pub qm_u: c_int,
-    pub qm_v: c_int,
+    pub yac: u8,
+    pub ydc_delta: i8,
+    pub udc_delta: i8,
+    pub uac_delta: i8,
+    pub vdc_delta: i8,
+    pub vac_delta: i8,
+    pub qm: u8,
+    pub qm_y: u8,
+    pub qm_u: u8,
+    pub qm_v: u8,
 }
 
 #[derive(Clone)]
 #[repr(C)]
 pub struct Rav1dFrameHeader_quant {
-    pub yac: c_int,
-    pub ydc_delta: c_int,
-    pub udc_delta: c_int,
-    pub uac_delta: c_int,
-    pub vdc_delta: c_int,
-    pub vac_delta: c_int,
-    pub qm: c_int,
-    pub qm_y: c_int,
-    pub qm_u: c_int,
-    pub qm_v: c_int,
+    pub yac: u8,
+    pub ydc_delta: i8,
+    pub udc_delta: i8,
+    pub uac_delta: i8,
+    pub vdc_delta: i8,
+    pub vac_delta: i8,
+    pub qm: u8,
+    pub qm_y: u8,
+    pub qm_u: u8,
+    pub qm_v: u8,
 }
 
 impl From<Dav1dFrameHeader_quant> for Rav1dFrameHeader_quant {
@@ -2098,25 +2098,25 @@ impl From<Rav1dFrameHeader_quant> for Dav1dFrameHeader_quant {
 #[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_segmentation {
-    pub enabled: c_int,
-    pub update_map: c_int,
-    pub temporal: c_int,
-    pub update_data: c_int,
+    pub enabled: u8,
+    pub update_map: u8,
+    pub temporal: u8,
+    pub update_data: u8,
     pub seg_data: Dav1dSegmentationDataSet,
-    pub lossless: [c_int; DAV1D_MAX_SEGMENTS as usize],
-    pub qidx: [c_int; DAV1D_MAX_SEGMENTS as usize],
+    pub lossless: [u8; DAV1D_MAX_SEGMENTS as usize],
+    pub qidx: [u8; DAV1D_MAX_SEGMENTS as usize],
 }
 
 #[derive(Clone)]
 #[repr(C)]
 pub struct Rav1dFrameHeader_segmentation {
-    pub enabled: c_int,
-    pub update_map: c_int,
-    pub temporal: c_int,
-    pub update_data: c_int,
+    pub enabled: u8,
+    pub update_map: u8,
+    pub temporal: u8,
+    pub update_data: u8,
     pub seg_data: Rav1dSegmentationDataSet,
-    pub lossless: [c_int; RAV1D_MAX_SEGMENTS as usize],
-    pub qidx: [c_int; RAV1D_MAX_SEGMENTS as usize],
+    pub lossless: [u8; RAV1D_MAX_SEGMENTS as usize],
+    pub qidx: [u8; RAV1D_MAX_SEGMENTS as usize],
 }
 
 impl From<Dav1dFrameHeader_segmentation> for Rav1dFrameHeader_segmentation {
@@ -2168,15 +2168,15 @@ impl From<Rav1dFrameHeader_segmentation> for Dav1dFrameHeader_segmentation {
 #[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_delta_q {
-    pub present: c_int,
-    pub res_log2: c_int,
+    pub present: u8,
+    pub res_log2: u8,
 }
 
 #[derive(Clone)]
 #[repr(C)]
 pub struct Rav1dFrameHeader_delta_q {
-    pub present: c_int,
-    pub res_log2: c_int,
+    pub present: u8,
+    pub res_log2: u8,
 }
 
 impl From<Dav1dFrameHeader_delta_q> for Rav1dFrameHeader_delta_q {
@@ -2196,17 +2196,17 @@ impl From<Rav1dFrameHeader_delta_q> for Dav1dFrameHeader_delta_q {
 #[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_delta_lf {
-    pub present: c_int,
-    pub res_log2: c_int,
-    pub multi: c_int,
+    pub present: u8,
+    pub res_log2: u8,
+    pub multi: u8,
 }
 
 #[derive(Clone)]
 #[repr(C)]
 pub struct Rav1dFrameHeader_delta_lf {
-    pub present: c_int,
-    pub res_log2: c_int,
-    pub multi: c_int,
+    pub present: u8,
+    pub res_log2: u8,
+    pub multi: u8,
 }
 
 impl From<Dav1dFrameHeader_delta_lf> for Rav1dFrameHeader_delta_lf {
@@ -2276,25 +2276,25 @@ impl From<Rav1dFrameHeader_delta> for Dav1dFrameHeader_delta {
 #[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_loopfilter {
-    pub level_y: [c_int; 2],
-    pub level_u: c_int,
-    pub level_v: c_int,
-    pub mode_ref_delta_enabled: c_int,
-    pub mode_ref_delta_update: c_int,
+    pub level_y: [u8; 2],
+    pub level_u: u8,
+    pub level_v: u8,
+    pub mode_ref_delta_enabled: u8,
+    pub mode_ref_delta_update: u8,
     pub mode_ref_deltas: Dav1dLoopfilterModeRefDeltas,
-    pub sharpness: c_int,
+    pub sharpness: u8,
 }
 
 #[derive(Clone)]
 #[repr(C)]
 pub struct Rav1dFrameHeader_loopfilter {
-    pub level_y: [c_int; 2],
-    pub level_u: c_int,
-    pub level_v: c_int,
-    pub mode_ref_delta_enabled: c_int,
-    pub mode_ref_delta_update: c_int,
+    pub level_y: [u8; 2],
+    pub level_u: u8,
+    pub level_v: u8,
+    pub mode_ref_delta_enabled: u8,
+    pub mode_ref_delta_update: u8,
     pub mode_ref_deltas: Rav1dLoopfilterModeRefDeltas,
-    pub sharpness: c_int,
+    pub sharpness: u8,
 }
 
 impl From<Dav1dFrameHeader_loopfilter> for Rav1dFrameHeader_loopfilter {
@@ -2346,19 +2346,19 @@ impl From<Rav1dFrameHeader_loopfilter> for Dav1dFrameHeader_loopfilter {
 #[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader_cdef {
-    pub damping: c_int,
-    pub n_bits: c_int,
-    pub y_strength: [c_int; DAV1D_MAX_CDEF_STRENGTHS],
-    pub uv_strength: [c_int; DAV1D_MAX_CDEF_STRENGTHS],
+    pub damping: u8,
+    pub n_bits: u8,
+    pub y_strength: [u8; DAV1D_MAX_CDEF_STRENGTHS],
+    pub uv_strength: [u8; DAV1D_MAX_CDEF_STRENGTHS],
 }
 
 #[derive(Clone)]
 #[repr(C)]
 pub struct Rav1dFrameHeader_cdef {
-    pub damping: c_int,
-    pub n_bits: c_int,
-    pub y_strength: [c_int; RAV1D_MAX_CDEF_STRENGTHS],
-    pub uv_strength: [c_int; RAV1D_MAX_CDEF_STRENGTHS],
+    pub damping: u8,
+    pub n_bits: u8,
+    pub y_strength: [u8; RAV1D_MAX_CDEF_STRENGTHS],
+    pub uv_strength: [u8; RAV1D_MAX_CDEF_STRENGTHS],
 }
 
 impl From<Dav1dFrameHeader_cdef> for Rav1dFrameHeader_cdef {
@@ -2399,7 +2399,7 @@ impl From<Rav1dFrameHeader_cdef> for Dav1dFrameHeader_cdef {
 #[repr(C)]
 pub struct Dav1dFrameHeader_restoration {
     pub r#type: [Dav1dRestorationType; 3],
-    pub unit_size: [c_int; 2],
+    pub unit_size: [u8; 2],
 }
 
 #[derive(Clone)]
@@ -2414,7 +2414,7 @@ impl From<Dav1dFrameHeader_restoration> for Rav1dFrameHeader_restoration {
         let Dav1dFrameHeader_restoration { r#type, unit_size } = value;
         Self {
             r#type: r#type.map(|e| Rav1dRestorationType::from_repr(e as usize).unwrap()),
-            unit_size: unit_size.map(|e| e.try_into().unwrap()),
+            unit_size,
         }
     }
 }
@@ -2424,7 +2424,7 @@ impl From<Rav1dFrameHeader_restoration> for Dav1dFrameHeader_restoration {
         let Rav1dFrameHeader_restoration { r#type, unit_size } = value;
         Self {
             r#type: r#type.map(|e| e.to_repr()),
-            unit_size: unit_size.map(|e| e.into()),
+            unit_size,
         }
     }
 }
@@ -2436,51 +2436,51 @@ pub struct Dav1dFrameHeader {
     pub frame_type: Dav1dFrameType,
     pub width: [c_int; 2],
     pub height: c_int,
-    pub frame_offset: c_int,
-    pub temporal_id: c_int,
-    pub spatial_id: c_int,
-    pub show_existing_frame: c_int,
-    pub existing_frame_idx: c_int,
-    pub frame_id: c_int,
-    pub frame_presentation_delay: c_int,
-    pub show_frame: c_int,
-    pub showable_frame: c_int,
-    pub error_resilient_mode: c_int,
-    pub disable_cdf_update: c_int,
-    pub allow_screen_content_tools: c_int,
-    pub force_integer_mv: c_int,
-    pub frame_size_override: c_int,
-    pub primary_ref_frame: c_int,
-    pub buffer_removal_time_present: c_int,
+    pub frame_offset: u8,
+    pub temporal_id: u8,
+    pub spatial_id: u8,
+    pub show_existing_frame: u8,
+    pub existing_frame_idx: u8,
+    pub frame_id: u32,
+    pub frame_presentation_delay: u32,
+    pub show_frame: u8,
+    pub showable_frame: u8,
+    pub error_resilient_mode: u8,
+    pub disable_cdf_update: u8,
+    pub allow_screen_content_tools: u8,
+    pub force_integer_mv: u8,
+    pub frame_size_override: u8,
+    pub primary_ref_frame: u8,
+    pub buffer_removal_time_present: u8,
     pub operating_points: [Dav1dFrameHeaderOperatingPoint; DAV1D_MAX_OPERATING_POINTS],
-    pub refresh_frame_flags: c_int,
+    pub refresh_frame_flags: u8,
     pub render_width: c_int,
     pub render_height: c_int,
     pub super_res: Dav1dFrameHeader_super_res,
-    pub have_render_size: c_int,
-    pub allow_intrabc: c_int,
-    pub frame_ref_short_signaling: c_int,
-    pub refidx: [c_int; DAV1D_REFS_PER_FRAME],
-    pub hp: c_int,
+    pub have_render_size: u8,
+    pub allow_intrabc: u8,
+    pub frame_ref_short_signaling: u8,
+    pub refidx: [i8; DAV1D_REFS_PER_FRAME],
+    pub hp: u8,
     pub subpel_filter_mode: Dav1dFilterMode,
-    pub switchable_motion_mode: c_int,
-    pub use_ref_frame_mvs: c_int,
-    pub refresh_context: c_int,
+    pub switchable_motion_mode: u8,
+    pub use_ref_frame_mvs: u8,
+    pub refresh_context: u8,
     pub tiling: Dav1dFrameHeader_tiling,
     pub quant: Dav1dFrameHeader_quant,
     pub segmentation: Dav1dFrameHeader_segmentation,
     pub delta: Dav1dFrameHeader_delta,
-    pub all_lossless: c_int,
+    pub all_lossless: u8,
     pub loopfilter: Dav1dFrameHeader_loopfilter,
     pub cdef: Dav1dFrameHeader_cdef,
     pub restoration: Dav1dFrameHeader_restoration,
     pub txfm_mode: Dav1dTxfmMode,
-    pub switchable_comp_refs: c_int,
-    pub skip_mode_allowed: c_int,
-    pub skip_mode_enabled: c_int,
-    pub skip_mode_refs: [c_int; 2],
-    pub warp_motion: c_int,
-    pub reduced_txtp_set: c_int,
+    pub switchable_comp_refs: u8,
+    pub skip_mode_allowed: u8,
+    pub skip_mode_enabled: u8,
+    pub skip_mode_refs: [i8; 2],
+    pub warp_motion: u8,
+    pub reduced_txtp_set: u8,
     pub gmv: [Dav1dWarpedMotionParams; DAV1D_REFS_PER_FRAME],
 }
 
@@ -2492,15 +2492,15 @@ pub struct Rav1dFrameSize {
     pub render_width: c_int,
     pub render_height: c_int,
     pub super_res: Rav1dFrameHeader_super_res,
-    pub have_render_size: c_int,
+    pub have_render_size: u8,
 }
 
 #[derive(Clone)]
 #[repr(C)]
 pub struct Rav1dFrameSkipMode {
-    pub allowed: c_int,
-    pub enabled: c_int,
-    pub refs: [c_int; 2],
+    pub allowed: u8,
+    pub enabled: u8,
+    pub refs: [i8; 2],
 }
 
 #[derive(Clone)]
@@ -2509,32 +2509,32 @@ pub struct Rav1dFrameHeader {
     pub size: Rav1dFrameSize,
     pub film_grain: Rav1dFrameHeader_film_grain,
     pub frame_type: Rav1dFrameType,
-    pub frame_offset: c_int,
-    pub temporal_id: c_int,
-    pub spatial_id: c_int,
-    pub show_existing_frame: c_int,
-    pub existing_frame_idx: c_int,
-    pub frame_id: c_int,
-    pub frame_presentation_delay: c_int,
-    pub show_frame: c_int,
-    pub showable_frame: c_int,
-    pub error_resilient_mode: c_int,
-    pub disable_cdf_update: c_int,
+    pub frame_offset: u8,
+    pub temporal_id: u8,
+    pub spatial_id: u8,
+    pub show_existing_frame: u8,
+    pub existing_frame_idx: u8,
+    pub frame_id: u32,
+    pub frame_presentation_delay: u32,
+    pub show_frame: u8,
+    pub showable_frame: u8,
+    pub error_resilient_mode: u8,
+    pub disable_cdf_update: u8,
     pub allow_screen_content_tools: bool,
     pub force_integer_mv: bool,
     pub frame_size_override: bool,
-    pub primary_ref_frame: c_int,
-    pub buffer_removal_time_present: c_int,
+    pub primary_ref_frame: u8,
+    pub buffer_removal_time_present: u8,
     pub operating_points: [Rav1dFrameHeaderOperatingPoint; RAV1D_MAX_OPERATING_POINTS],
-    pub refresh_frame_flags: c_int,
+    pub refresh_frame_flags: u8,
     pub allow_intrabc: bool,
-    pub frame_ref_short_signaling: c_int,
-    pub refidx: [c_int; RAV1D_REFS_PER_FRAME],
+    pub frame_ref_short_signaling: u8,
+    pub refidx: [i8; RAV1D_REFS_PER_FRAME],
     pub hp: bool,
     pub subpel_filter_mode: Rav1dFilterMode,
-    pub switchable_motion_mode: c_int,
-    pub use_ref_frame_mvs: c_int,
-    pub refresh_context: c_int,
+    pub switchable_motion_mode: u8,
+    pub use_ref_frame_mvs: u8,
+    pub refresh_context: u8,
     pub tiling: Rav1dFrameHeader_tiling,
     pub quant: Rav1dFrameHeader_quant,
     pub segmentation: Rav1dFrameHeader_segmentation,
@@ -2544,10 +2544,10 @@ pub struct Rav1dFrameHeader {
     pub cdef: Rav1dFrameHeader_cdef,
     pub restoration: Rav1dFrameHeader_restoration,
     pub txfm_mode: Rav1dTxfmMode,
-    pub switchable_comp_refs: c_int,
+    pub switchable_comp_refs: u8,
     pub skip_mode: Rav1dFrameSkipMode,
-    pub warp_motion: c_int,
-    pub reduced_txtp_set: c_int,
+    pub warp_motion: u8,
+    pub reduced_txtp_set: u8,
     pub gmv: [Rav1dWarpedMotionParams; RAV1D_REFS_PER_FRAME],
 }
 

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -148,7 +148,7 @@ unsafe fn backup2x8<BD: BitDepth>(
     }
 }
 
-fn adjust_strength(strength: c_int, var: c_uint) -> c_int {
+fn adjust_strength(strength: u8, var: c_uint) -> c_int {
     if var == 0 {
         return 0;
     }
@@ -159,7 +159,7 @@ fn adjust_strength(strength: c_int, var: c_uint) -> c_int {
         0
     };
 
-    strength * (4 + i) + 8 >> 4
+    strength as c_int * (4 + i) + 8 >> 4
 }
 
 pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
@@ -186,7 +186,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
     let sbsz = 16;
     let sb64w = f.sb128w << 1;
     let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
-    let damping = frame_hdr.cdef.damping + bitdepth_min_8 as c_int;
+    let damping = frame_hdr.cdef.damping + bitdepth_min_8;
     let layout: Rav1dPixelLayout = f.cur.p.layout;
     let uv_idx = (Rav1dPixelLayout::I444 as c_uint).wrapping_sub(layout as c_uint) as c_int;
     let ss_ver = (layout == Rav1dPixelLayout::I420) as c_int;
@@ -261,12 +261,12 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
 
                 let y_pri_lvl = (y_lvl >> 2) << bitdepth_min_8;
                 let mut y_sec_lvl = y_lvl & 3;
-                y_sec_lvl += (y_sec_lvl == 3) as c_int;
+                y_sec_lvl += (y_sec_lvl == 3) as u8;
                 y_sec_lvl <<= bitdepth_min_8;
 
                 let uv_pri_lvl = (uv_lvl >> 2) << bitdepth_min_8;
                 let mut uv_sec_lvl = uv_lvl & 3;
-                uv_sec_lvl += (uv_sec_lvl == 3) as c_int;
+                uv_sec_lvl += (uv_sec_lvl == 3) as u8;
                 uv_sec_lvl <<= bitdepth_min_8;
 
                 let mut bptrs = iptrs;
@@ -389,9 +389,9 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                                     top.cast(),
                                     bot.cast(),
                                     adj_y_pri_lvl,
-                                    y_sec_lvl,
+                                    y_sec_lvl.into(),
                                     dir,
-                                    damping,
+                                    damping.into(),
                                     edges,
                                     f.bitdepth_max,
                                 );
@@ -404,9 +404,9 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                                 top.cast(),
                                 bot.cast(),
                                 0 as c_int,
-                                y_sec_lvl,
+                                y_sec_lvl.into(),
                                 0 as c_int,
-                                damping,
+                                damping.into(),
                                 edges,
                                 f.bitdepth_max,
                             );
@@ -484,10 +484,10 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                                     lr_bak[bit as usize][pl].as_mut_ptr().cast(),
                                     top.cast(),
                                     bot.cast(),
-                                    uv_pri_lvl,
-                                    uv_sec_lvl,
+                                    uv_pri_lvl.into(),
+                                    uv_sec_lvl.into(),
                                     uvdir,
-                                    damping - 1,
+                                    (damping - 1).into(),
                                     edges,
                                     f.bitdepth_max,
                                 );

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -5080,7 +5080,7 @@ pub(crate) fn rav1d_cdf_thread_update(
 }
 
 #[inline]
-unsafe fn get_qcat_idx(q: c_int) -> c_int {
+unsafe fn get_qcat_idx(q: u8) -> c_int {
     if q <= 20 {
         return 0 as c_int;
     }
@@ -5093,7 +5093,7 @@ unsafe fn get_qcat_idx(q: c_int) -> c_int {
     return 3 as c_int;
 }
 
-pub unsafe fn rav1d_cdf_thread_init_static(qidx: c_int) -> CdfThreadContext {
+pub unsafe fn rav1d_cdf_thread_init_static(qidx: u8) -> CdfThreadContext {
     CdfThreadContext::QCat(get_qcat_idx(qidx) as c_uint)
 }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -653,7 +653,7 @@ pub struct Rav1dFrameContext_lf {
     pub mask: Vec<Av1Filter>, /* len = w*h */
     pub lr_mask: Vec<Av1Restoration>,
     pub lim_lut: Align16<Av1FilterLUT>,
-    pub last_sharpness: c_int,
+    pub last_sharpness: u8,
     pub lvl: [[[[u8; 2]; 8]; 4]; 8], /* [8 seg_id][4 dir][8 ref][2 is_gmv] */
     pub tx_lpf_right_edge: TxLpfRightEdge,
     // cdef_line_buf was originally aligned to 32 bytes, but we need to pass
@@ -1002,7 +1002,7 @@ pub struct Rav1dTileState {
 
     pub dqmem: [[[u16; 2]; 3]; RAV1D_MAX_SEGMENTS as usize], /* [RAV1D_MAX_SEGMENTS][3 plane][2 dc/ac] */
     pub dq: TileStateRef,
-    pub last_qidx: c_int,
+    pub last_qidx: u8,
     pub last_delta_lf: [i8; 4],
     pub lflvlmem: [[[[u8; 2]; 8]; 4]; 8], /* [8 seg_id][4 dir][8 ref][2 is_gmv] */
     pub lflvl: TileStateRef,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,7 +269,7 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
         fc.task_thread.finished = AtomicBool::new(true);
         fc.task_thread.ttd = Arc::clone(&(*c).task_thread);
         let f = fc.data.get_mut().unwrap();
-        f.lf.last_sharpness = -(1 as c_int);
+        f.lf.last_sharpness = 255;
     }
     (*c).tc = (0..n_tc)
         .map(|n| {

--- a/src/obu.c
+++ b/src/obu.c
@@ -593,8 +593,8 @@ static int parse_frame_hdr(Dav1dContext *const c, GetBits *const gb) {
             if (!hdr->frame_ref_short_signaling)
                 hdr->refidx[i] = dav1d_get_bits(gb, 3);
             if (seqhdr->frame_id_numbers_present) {
-                const int delta_ref_frame_id_minus_1 = dav1d_get_bits(gb, seqhdr->delta_frame_id_n_bits);
-                const int ref_frame_id = (hdr->frame_id + (1 << seqhdr->frame_id_n_bits) - delta_ref_frame_id_minus_1 - 1) & ((1 << seqhdr->frame_id_n_bits) - 1);
+                const unsigned delta_ref_frame_id = dav1d_get_bits(gb, seqhdr->delta_frame_id_n_bits) + 1;
+                const unsigned ref_frame_id = (hdr->frame_id + (1 << seqhdr->frame_id_n_bits) - delta_ref_frame_id) & ((1 << seqhdr->frame_id_n_bits) - 1);
                 Dav1dFrameHeader *const ref_frame_hdr = c->refs[hdr->refidx[i]].p.p.frame_hdr;
                 if (!ref_frame_hdr || ref_frame_hdr->frame_id != ref_frame_id) return parse_frame_hdr_error(c);
             }
@@ -723,7 +723,7 @@ static int parse_frame_hdr(Dav1dContext *const c, GetBits *const gb) {
         hdr->quant.qm_y = dav1d_get_bits(gb, 4);
         hdr->quant.qm_u = dav1d_get_bits(gb, 4);
         hdr->quant.qm_v =
-            seqhdr->separate_uv_delta_q ? (int)dav1d_get_bits(gb, 4) :
+            seqhdr->separate_uv_delta_q ? dav1d_get_bits(gb, 4) :
                                           hdr->quant.qm_u;
     }
 #if DEBUG_FRAME_HDR

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1,4 +1,4 @@
-use crate::include::common::intops::iclip_u8;
+use crate::include::common::intops::clip_u8;
 use crate::include::common::intops::ulog2;
 use crate::include::dav1d::common::Rav1dDataProps;
 use crate::include::dav1d::data::Rav1dData;
@@ -580,7 +580,7 @@ pub(crate) unsafe fn rav1d_parse_sequence_header(
 unsafe fn parse_frame_size(
     c: &Rav1dContext,
     seqhdr: &Rav1dSequenceHeader,
-    refidx: Option<&[c_int; RAV1D_REFS_PER_FRAME]>,
+    refidx: Option<&[i8; RAV1D_REFS_PER_FRAME]>,
     frame_size_override: bool,
     gb: &mut GetBits,
 ) -> Rav1dResult<Rav1dFrameSize> {
@@ -597,8 +597,8 @@ unsafe fn parse_frame_size(
                 let width_scale_denominator;
                 let width0;
                 if enabled {
-                    width_scale_denominator = 9 + gb.get_bits(3) as c_int;
-                    let d = width_scale_denominator;
+                    width_scale_denominator = 9 + gb.get_bits(3) as u8;
+                    let d = width_scale_denominator as c_int;
                     width0 = cmp::max((width1 * 8 + (d >> 1)) / d, cmp::min(16, width1));
                 } else {
                     width_scale_denominator = 8;
@@ -633,14 +633,14 @@ unsafe fn parse_frame_size(
     let width_scale_denominator;
     let width0;
     if enabled {
-        width_scale_denominator = 9 + gb.get_bits(3) as c_int;
-        let d = width_scale_denominator;
+        width_scale_denominator = 9 + gb.get_bits(3) as u8;
+        let d = width_scale_denominator as c_int;
         width0 = cmp::max((width1 * 8 + (d >> 1)) / d, cmp::min(16, width1));
     } else {
         width_scale_denominator = 8;
         width0 = width1;
     }
-    let have_render_size = gb.get_bit() as c_int;
+    let have_render_size = gb.get_bit() as u8;
     let render_width;
     let render_height;
     if have_render_size != 0 {
@@ -665,7 +665,7 @@ unsafe fn parse_frame_size(
 }
 
 #[inline]
-fn tile_log2(sz: c_int, tgt: c_int) -> c_int {
+fn tile_log2(sz: c_int, tgt: c_int) -> u8 {
     let mut k = 0;
     while sz << k < tgt {
         k += 1;
@@ -681,16 +681,16 @@ static default_mode_ref_deltas: Rav1dLoopfilterModeRefDeltas = Rav1dLoopfilterMo
 unsafe fn parse_refidx(
     c: &Rav1dContext,
     seqhdr: &Rav1dSequenceHeader,
-    frame_ref_short_signaling: c_int,
-    frame_offset: c_int,
-    frame_id: c_int,
+    frame_ref_short_signaling: u8,
+    frame_offset: u8,
+    frame_id: u32,
     gb: &mut GetBits,
-) -> Rav1dResult<[c_int; RAV1D_REFS_PER_FRAME]> {
+) -> Rav1dResult<[i8; RAV1D_REFS_PER_FRAME]> {
     let mut refidx = [-1; RAV1D_REFS_PER_FRAME];
     if frame_ref_short_signaling != 0 {
         // FIXME: Nearly verbatim copy from section 7.8
-        refidx[0] = gb.get_bits(3) as c_int;
-        refidx[3] = gb.get_bits(3) as c_int;
+        refidx[0] = gb.get_bits(3) as i8;
+        refidx[3] = gb.get_bits(3) as i8;
 
         let mut shifted_frame_offset = [0; 8];
         let current_frame_offset = 1 << seqhdr.order_hint_n_bits - 1;
@@ -704,8 +704,8 @@ unsafe fn parse_refidx(
                         .frame_hdr
                         .as_ref()
                         .ok_or(EINVAL)?
-                        .frame_offset,
-                    frame_offset,
+                        .frame_offset as c_int,
+                    frame_offset as c_int,
                 );
         }
 
@@ -794,14 +794,12 @@ unsafe fn parse_refidx(
     }
     for i in 0..7 {
         if frame_ref_short_signaling == 0 {
-            refidx[i as usize] = gb.get_bits(3) as c_int;
+            refidx[i as usize] = gb.get_bits(3) as i8;
         }
         if seqhdr.frame_id_numbers_present != 0 {
-            let delta_ref_frame_id_minus_1 =
-                gb.get_bits(seqhdr.delta_frame_id_n_bits.into()) as c_int;
-            let ref_frame_id =
-                frame_id + (1 << seqhdr.frame_id_n_bits) - delta_ref_frame_id_minus_1 - 1
-                    & (1 << seqhdr.frame_id_n_bits) - 1;
+            let delta_ref_frame_id = gb.get_bits(seqhdr.delta_frame_id_n_bits.into()) as u32 + 1;
+            let ref_frame_id = frame_id + (1 << seqhdr.frame_id_n_bits) - delta_ref_frame_id
+                & (1 << seqhdr.frame_id_n_bits) - 1;
             c.refs[refidx[i as usize] as usize]
                 .p
                 .p
@@ -820,7 +818,7 @@ fn parse_tiling(
     debug: &Debug,
     gb: &mut GetBits,
 ) -> Rav1dResult<Rav1dFrameHeader_tiling> {
-    let uniform = gb.get_bit() as c_int;
+    let uniform = gb.get_bit() as u8;
     let sbsz_min1 = ((64) << seqhdr.sb128) - 1;
     let sbsz_log2 = 6 + seqhdr.sb128;
     let sbw = size.width[0] + sbsz_min1 >> sbsz_log2;
@@ -850,7 +848,7 @@ fn parse_tiling(
             sbx += tile_w;
             cols += 1;
         }
-        let min_log2_rows = cmp::max(min_log2_tiles - log2_cols, 0);
+        let min_log2_rows = min_log2_tiles.saturating_sub(log2_cols);
 
         log2_rows = min_log2_rows;
         while log2_rows < max_log2_rows && gb.get_bit() {
@@ -869,7 +867,7 @@ fn parse_tiling(
         let mut widest_tile = 0;
         let mut max_tile_area_sb = sbw * sbh;
         let mut sbx = 0;
-        while sbx < sbw && cols < RAV1D_MAX_TILE_COLS as c_int {
+        while sbx < sbw && cols < RAV1D_MAX_TILE_COLS as u8 {
             let tile_width_sb = cmp::min(sbw - sbx, max_tile_width_sb);
             let tile_w = if tile_width_sb > 1 {
                 1 + gb.get_uniform(tile_width_sb as c_uint) as c_int
@@ -881,7 +879,7 @@ fn parse_tiling(
             widest_tile = cmp::max(widest_tile, tile_w);
             cols += 1;
         }
-        log2_cols = tile_log2(1, cols);
+        log2_cols = tile_log2(1, cols.into());
         if min_log2_tiles != 0 {
             max_tile_area_sb >>= min_log2_tiles + 1;
         }
@@ -889,7 +887,7 @@ fn parse_tiling(
 
         rows = 0;
         let mut sby = 0;
-        while sby < sbh && rows < RAV1D_MAX_TILE_ROWS as c_int {
+        while sby < sbh && rows < RAV1D_MAX_TILE_ROWS as u8 {
             let tile_height_sb = cmp::min(sbh - sby, max_tile_height_sb);
             let tile_h = if tile_height_sb > 1 {
                 1 + gb.get_uniform(tile_height_sb as c_uint) as c_int
@@ -900,21 +898,21 @@ fn parse_tiling(
             sby += tile_h;
             rows += 1;
         }
-        log2_rows = tile_log2(1, rows);
+        log2_rows = tile_log2(1, rows.into());
     }
     col_start_sb[cols as usize] = sbw as u16;
     row_start_sb[rows as usize] = sbh as u16;
     let update;
     let n_bytes;
     if log2_cols != 0 || log2_rows != 0 {
-        update = gb.get_bits(log2_cols + log2_rows) as c_int;
-        if update >= cols * rows {
+        update = gb.get_bits((log2_cols + log2_rows).into()) as u16;
+        if update >= cols as u16 * rows as u16 {
             return Err(EINVAL);
         }
-        n_bytes = gb.get_bits(2) + 1;
+        n_bytes = gb.get_bits(2) as u8 + 1;
     } else {
         update = 0;
-        n_bytes = update as c_uint;
+        n_bytes = update as u8;
     }
     debug.post(gb, "tiling");
     Ok(Rav1dFrameHeader_tiling {
@@ -940,8 +938,12 @@ fn parse_quant(
     debug: &Debug,
     gb: &mut GetBits,
 ) -> Rav1dFrameHeader_quant {
-    let yac = gb.get_bits(8) as c_int;
-    let ydc_delta = if gb.get_bit() { gb.get_sbits(7) } else { 0 };
+    let yac = gb.get_bits(8) as u8;
+    let ydc_delta = if gb.get_bit() {
+        gb.get_sbits(7) as i8
+    } else {
+        0
+    };
     let udc_delta;
     let uac_delta;
     let vdc_delta;
@@ -955,11 +957,27 @@ fn parse_quant(
         } else {
             0
         };
-        udc_delta = if gb.get_bit() { gb.get_sbits(7) } else { 0 };
-        uac_delta = if gb.get_bit() { gb.get_sbits(7) } else { 0 };
+        udc_delta = if gb.get_bit() {
+            gb.get_sbits(7) as i8
+        } else {
+            0
+        };
+        uac_delta = if gb.get_bit() {
+            gb.get_sbits(7) as i8
+        } else {
+            0
+        };
         if diff_uv_delta != 0 {
-            vdc_delta = if gb.get_bit() { gb.get_sbits(7) } else { 0 };
-            vac_delta = if gb.get_bit() { gb.get_sbits(7) } else { 0 };
+            vdc_delta = if gb.get_bit() {
+                gb.get_sbits(7) as i8
+            } else {
+                0
+            };
+            vac_delta = if gb.get_bit() {
+                gb.get_sbits(7) as i8
+            } else {
+                0
+            };
         } else {
             vdc_delta = udc_delta;
             vac_delta = uac_delta;
@@ -972,15 +990,15 @@ fn parse_quant(
         vac_delta = Default::default();
     }
     debug.post(gb, "quant");
-    let qm = gb.get_bit() as c_int;
+    let qm = gb.get_bit() as u8;
     let qm_y;
     let qm_u;
     let qm_v;
     if qm != 0 {
-        qm_y = gb.get_bits(4) as c_int;
-        qm_u = gb.get_bits(4) as c_int;
+        qm_y = gb.get_bits(4) as u8;
+        qm_u = gb.get_bits(4) as u8;
         qm_v = if seqhdr.separate_uv_delta_q != 0 {
-            gb.get_bits(4) as c_int
+            gb.get_bits(4) as u8
         } else {
             qm_u
         };
@@ -1007,58 +1025,58 @@ fn parse_quant(
 
 fn parse_seg_data(gb: &mut GetBits) -> Rav1dSegmentationDataSet {
     let mut preskip = 0;
-    let mut last_active_segid = -1;
+    let mut last_active_segid = -1 as i8;
     let d = array::from_fn(|i| {
-        let i = i as c_int;
+        let i = i as i8;
         let delta_q;
         if gb.get_bit() {
-            delta_q = gb.get_sbits(9);
+            delta_q = gb.get_sbits(9) as i16;
             last_active_segid = i;
         } else {
             delta_q = 0;
         }
         let delta_lf_y_v;
         if gb.get_bit() {
-            delta_lf_y_v = gb.get_sbits(7);
+            delta_lf_y_v = gb.get_sbits(7) as i8;
             last_active_segid = i;
         } else {
             delta_lf_y_v = 0;
         }
         let delta_lf_y_h;
         if gb.get_bit() {
-            delta_lf_y_h = gb.get_sbits(7);
+            delta_lf_y_h = gb.get_sbits(7) as i8;
             last_active_segid = i;
         } else {
             delta_lf_y_h = 0;
         }
         let delta_lf_u;
         if gb.get_bit() {
-            delta_lf_u = gb.get_sbits(7);
+            delta_lf_u = gb.get_sbits(7) as i8;
             last_active_segid = i;
         } else {
             delta_lf_u = 0;
         }
         let delta_lf_v;
         if gb.get_bit() {
-            delta_lf_v = gb.get_sbits(7);
+            delta_lf_v = gb.get_sbits(7) as i8;
             last_active_segid = i;
         } else {
             delta_lf_v = 0;
         }
         let r#ref;
         if gb.get_bit() {
-            r#ref = gb.get_bits(3) as c_int;
+            r#ref = gb.get_bits(3) as i8;
             last_active_segid = i;
             preskip = 1;
         } else {
             r#ref = -1;
         }
-        let skip = gb.get_bit() as c_int;
+        let skip = gb.get_bit() as u8;
         if skip != 0 {
             last_active_segid = i;
             preskip = 1;
         }
-        let globalmv = gb.get_bit() as c_int;
+        let globalmv = gb.get_bit() as u8;
         if globalmv != 0 {
             last_active_segid = i;
             preskip = 1;
@@ -1083,13 +1101,13 @@ fn parse_seg_data(gb: &mut GetBits) -> Rav1dSegmentationDataSet {
 
 unsafe fn parse_segmentation(
     c: &Rav1dContext,
-    primary_ref_frame: c_int,
-    refidx: &[c_int; RAV1D_REFS_PER_FRAME],
+    primary_ref_frame: u8,
+    refidx: &[i8; RAV1D_REFS_PER_FRAME],
     quant: &Rav1dFrameHeader_quant,
     debug: &Debug,
     gb: &mut GetBits,
 ) -> Rav1dResult<Rav1dFrameHeader_segmentation> {
-    let enabled = gb.get_bit() as c_int;
+    let enabled = gb.get_bit() as u8;
     let update_map;
     let temporal;
     let update_data;
@@ -1099,13 +1117,13 @@ unsafe fn parse_segmentation(
             temporal = 0;
             update_data = 1;
         } else {
-            update_map = gb.get_bit() as c_int;
+            update_map = gb.get_bit() as u8;
             temporal = if update_map != 0 {
-                gb.get_bit() as c_int
+                gb.get_bit() as u8
             } else {
                 0
             };
-            update_data = gb.get_bit() as c_int;
+            update_data = gb.get_bit() as u8;
         }
 
         if update_data != 0 {
@@ -1147,12 +1165,12 @@ unsafe fn parse_segmentation(
         && quant.vac_delta == 0) as c_int;
     let qidx = array::from_fn(|i| {
         if enabled != 0 {
-            iclip_u8(quant.yac + seg_data.d[i].delta_q)
+            clip_u8(quant.yac as c_int + seg_data.d[i].delta_q as c_int)
         } else {
             quant.yac
         }
     });
-    let lossless = array::from_fn(|i| (qidx[i] == 0 && delta_lossless != 0) as c_int);
+    let lossless = array::from_fn(|i| (qidx[i] == 0 && delta_lossless != 0) as u8);
     Ok(Rav1dFrameHeader_segmentation {
         enabled,
         update_map,
@@ -1172,29 +1190,25 @@ fn parse_delta(
 ) -> Rav1dFrameHeader_delta {
     let q = {
         let present = if quant.yac != 0 {
-            gb.get_bit() as c_int
+            gb.get_bit() as u8
         } else {
             0
         };
         let res_log2 = if present != 0 {
-            gb.get_bits(2) as c_int
+            gb.get_bits(2) as u8
         } else {
             0
         };
         Rav1dFrameHeader_delta_q { present, res_log2 }
     };
     let lf = {
-        let present = (q.present != 0 && !allow_intrabc && gb.get_bit()) as c_int;
+        let present = (q.present != 0 && !allow_intrabc && gb.get_bit()) as u8;
         let res_log2 = if present != 0 {
-            gb.get_bits(2) as c_int
+            gb.get_bits(2) as u8
         } else {
             0
         };
-        let multi = if present != 0 {
-            gb.get_bit() as c_int
-        } else {
-            0
-        };
+        let multi = if present != 0 { gb.get_bit() as u8 } else { 0 };
         Rav1dFrameHeader_delta_lf {
             present,
             res_log2,
@@ -1210,8 +1224,8 @@ unsafe fn parse_loopfilter(
     seqhdr: &Rav1dSequenceHeader,
     all_lossless: bool,
     allow_intrabc: bool,
-    primary_ref_frame: c_int,
-    refidx: &[c_int; RAV1D_REFS_PER_FRAME],
+    primary_ref_frame: u8,
+    refidx: &[i8; RAV1D_REFS_PER_FRAME],
     debug: &Debug,
     gb: &mut GetBits,
 ) -> Rav1dResult<Rav1dFrameHeader_loopfilter> {
@@ -1231,16 +1245,16 @@ unsafe fn parse_loopfilter(
         mode_ref_delta_update = 1;
         mode_ref_deltas = default_mode_ref_deltas.clone();
     } else {
-        level_y = [gb.get_bits(6) as c_int, gb.get_bits(6) as c_int];
+        level_y = [gb.get_bits(6) as u8, gb.get_bits(6) as u8];
         if seqhdr.monochrome == 0 && (level_y[0] != 0 || level_y[1] != 0) {
-            level_u = gb.get_bits(6) as c_int;
-            level_v = gb.get_bits(6) as c_int;
+            level_u = gb.get_bits(6) as u8;
+            level_v = gb.get_bits(6) as u8;
         } else {
             // Default initialization.
             level_u = Default::default();
             level_v = Default::default();
         }
-        sharpness = gb.get_bits(3) as c_int;
+        sharpness = gb.get_bits(3) as u8;
 
         if primary_ref_frame == RAV1D_PRIMARY_REF_NONE {
             mode_ref_deltas = default_mode_ref_deltas.clone();
@@ -1256,18 +1270,18 @@ unsafe fn parse_loopfilter(
                 .mode_ref_deltas
                 .clone();
         }
-        mode_ref_delta_enabled = gb.get_bit() as c_int;
+        mode_ref_delta_enabled = gb.get_bit() as u8;
         if mode_ref_delta_enabled != 0 {
-            mode_ref_delta_update = gb.get_bit() as c_int;
+            mode_ref_delta_update = gb.get_bit() as u8;
             if mode_ref_delta_update != 0 {
                 for i in 0..8 {
                     if gb.get_bit() {
-                        mode_ref_deltas.ref_delta[i as usize] = gb.get_sbits(7);
+                        mode_ref_deltas.ref_delta[i as usize] = gb.get_sbits(7) as i8;
                     }
                 }
                 for i in 0..2 {
                     if gb.get_bit() {
-                        mode_ref_deltas.mode_delta[i as usize] = gb.get_sbits(7);
+                        mode_ref_deltas.mode_delta[i as usize] = gb.get_sbits(7) as i8;
                     }
                 }
             }
@@ -1300,12 +1314,12 @@ fn parse_cdef(
     let mut y_strength = [0; RAV1D_MAX_CDEF_STRENGTHS];
     let mut uv_strength = [0; RAV1D_MAX_CDEF_STRENGTHS];
     if !all_lossless && seqhdr.cdef != 0 && !allow_intrabc {
-        damping = gb.get_bits(2) as c_int + 3;
-        n_bits = gb.get_bits(2) as c_int;
+        damping = gb.get_bits(2) as u8 + 3;
+        n_bits = gb.get_bits(2) as u8;
         for i in 0..1 << n_bits {
-            y_strength[i as usize] = gb.get_bits(6) as c_int;
+            y_strength[i as usize] = gb.get_bits(6) as u8;
             if seqhdr.monochrome == 0 {
-                uv_strength[i as usize] = gb.get_bits(6) as c_int;
+                uv_strength[i as usize] = gb.get_bits(6) as u8;
             }
         }
     } else {
@@ -1391,10 +1405,10 @@ fn parse_restoration(
 unsafe fn parse_skip_mode(
     c: &Rav1dContext,
     seqhdr: &Rav1dSequenceHeader,
-    switchable_comp_refs: c_int,
+    switchable_comp_refs: u8,
     frame_type: Rav1dFrameType,
-    frame_offset: c_int,
-    refidx: &[c_int; RAV1D_REFS_PER_FRAME],
+    frame_offset: u8,
+    refidx: &[i8; RAV1D_REFS_PER_FRAME],
     debug: &Debug,
     gb: &mut GetBits,
 ) -> Rav1dResult<Rav1dFrameSkipMode> {
@@ -1481,11 +1495,7 @@ unsafe fn parse_skip_mode(
             }
         }
     }
-    let enabled = if allowed != 0 {
-        gb.get_bit() as c_int
-    } else {
-        0
-    };
+    let enabled = if allowed != 0 { gb.get_bit() as u8 } else { 0 };
     debug.post(gb, "extskip");
     Ok(Rav1dFrameSkipMode {
         allowed,
@@ -1497,8 +1507,8 @@ unsafe fn parse_skip_mode(
 unsafe fn parse_gmv(
     c: &Rav1dContext,
     frame_type: Rav1dFrameType,
-    primary_ref_frame: c_int,
-    refidx: &[c_int; RAV1D_REFS_PER_FRAME],
+    primary_ref_frame: u8,
+    refidx: &[i8; RAV1D_REFS_PER_FRAME],
     hp: bool,
     debug: &Debug,
     gb: &mut GetBits,
@@ -1677,22 +1687,22 @@ fn parse_film_grain_data(
 unsafe fn parse_film_grain(
     c: &Rav1dContext,
     seqhdr: &Rav1dSequenceHeader,
-    show_frame: c_int,
-    showable_frame: c_int,
+    show_frame: u8,
+    showable_frame: u8,
     frame_type: Rav1dFrameType,
-    ref_indices: &[c_int; RAV1D_REFS_PER_FRAME],
+    ref_indices: &[i8; RAV1D_REFS_PER_FRAME],
     debug: &Debug,
     gb: &mut GetBits,
 ) -> Rav1dResult<Rav1dFrameHeader_film_grain> {
     let present = (seqhdr.film_grain_present != 0
         && (show_frame != 0 || showable_frame != 0)
-        && gb.get_bit()) as c_int;
+        && gb.get_bit()) as u8;
     let update;
     let data = if present != 0 {
         let seed = gb.get_bits(16);
-        update = (frame_type != Rav1dFrameType::Inter || gb.get_bit()) as c_int;
+        update = (frame_type != Rav1dFrameType::Inter || gb.get_bit()) as u8;
         if update == 0 {
-            let refidx = gb.get_bits(3) as c_int;
+            let refidx = gb.get_bits(3) as i8;
             let mut found = false;
             for i in 0..7 {
                 if ref_indices[i as usize] == refidx {
@@ -1735,28 +1745,28 @@ unsafe fn parse_film_grain(
 unsafe fn parse_frame_hdr(
     c: &Rav1dContext,
     seqhdr: &Rav1dSequenceHeader,
-    temporal_id: c_int,
-    spatial_id: c_int,
+    temporal_id: u8,
+    spatial_id: u8,
     gb: &mut GetBits,
 ) -> Rav1dResult<Rav1dFrameHeader> {
     let debug = Debug::new(false, "HDR", gb);
 
     debug.post(gb, "show_existing_frame");
-    let show_existing_frame = (seqhdr.reduced_still_picture_header == 0 && gb.get_bit()) as c_int;
+    let show_existing_frame = (seqhdr.reduced_still_picture_header == 0 && gb.get_bit()) as u8;
     let existing_frame_idx;
     let mut frame_presentation_delay;
     if show_existing_frame != 0 {
-        existing_frame_idx = gb.get_bits(3) as c_int;
+        existing_frame_idx = gb.get_bits(3) as u8;
         if seqhdr.decoder_model_info_present != 0 && seqhdr.equal_picture_interval == 0 {
             frame_presentation_delay =
-                gb.get_bits(seqhdr.frame_presentation_delay_length.into()) as c_int;
+                gb.get_bits(seqhdr.frame_presentation_delay_length.into()) as u32;
         } else {
             // Default initialization.
             frame_presentation_delay = Default::default();
         }
         let frame_id;
         if seqhdr.frame_id_numbers_present != 0 {
-            frame_id = gb.get_bits(seqhdr.frame_id_n_bits.into()) as c_int;
+            frame_id = gb.get_bits(seqhdr.frame_id_n_bits.into()) as u32;
             c.refs[existing_frame_idx as usize]
                 .p
                 .p
@@ -1792,23 +1802,23 @@ unsafe fn parse_frame_hdr(
     } else {
         Rav1dFrameType::from_repr(gb.get_bits(2) as usize).unwrap()
     };
-    let show_frame = (seqhdr.reduced_still_picture_header != 0 || gb.get_bit()) as c_int;
+    let show_frame = (seqhdr.reduced_still_picture_header != 0 || gb.get_bit()) as u8;
     let showable_frame;
     if show_frame != 0 {
         if seqhdr.decoder_model_info_present != 0 && seqhdr.equal_picture_interval == 0 {
             frame_presentation_delay =
-                gb.get_bits(seqhdr.frame_presentation_delay_length.into()) as c_int;
+                gb.get_bits(seqhdr.frame_presentation_delay_length.into()) as u32;
         }
-        showable_frame = (frame_type != Rav1dFrameType::Key) as c_int;
+        showable_frame = (frame_type != Rav1dFrameType::Key) as u8;
     } else {
-        showable_frame = gb.get_bit() as c_int;
+        showable_frame = gb.get_bit() as u8;
     }
     let error_resilient_mode = (frame_type == Rav1dFrameType::Key && show_frame != 0
         || frame_type == Rav1dFrameType::Switch
         || seqhdr.reduced_still_picture_header != 0
-        || gb.get_bit()) as c_int;
+        || gb.get_bit()) as u8;
     debug.post(gb, "frametype_bits");
-    let disable_cdf_update = gb.get_bit() as c_int;
+    let disable_cdf_update = gb.get_bit() as u8;
     let allow_screen_content_tools = match seqhdr.screen_content_tools {
         Rav1dAdaptiveBoolean::Adaptive => gb.get_bit(),
         Rav1dAdaptiveBoolean::On => true,
@@ -1830,7 +1840,7 @@ unsafe fn parse_frame_hdr(
 
     let frame_id;
     if seqhdr.frame_id_numbers_present != 0 {
-        frame_id = gb.get_bits(seqhdr.frame_id_n_bits.into()) as c_int;
+        frame_id = gb.get_bits(seqhdr.frame_id_n_bits.into()) as u32;
     } else {
         // Default initialization.
         frame_id = Default::default();
@@ -1845,12 +1855,12 @@ unsafe fn parse_frame_hdr(
     };
     debug.post(gb, "frame_size_override_flag");
     let frame_offset = if seqhdr.order_hint != 0 {
-        gb.get_bits(seqhdr.order_hint_n_bits.into()) as c_int
+        gb.get_bits(seqhdr.order_hint_n_bits.into()) as u8
     } else {
         0
     };
     let primary_ref_frame = if error_resilient_mode == 0 && frame_type.is_inter_or_switch() {
-        gb.get_bits(3) as c_int
+        gb.get_bits(3) as u8
     } else {
         RAV1D_PRIMARY_REF_NONE
     };
@@ -1859,7 +1869,7 @@ unsafe fn parse_frame_hdr(
     let mut operating_points =
         [Rav1dFrameHeaderOperatingPoint::default(); RAV1D_MAX_OPERATING_POINTS];
     if seqhdr.decoder_model_info_present != 0 {
-        buffer_removal_time_present = gb.get_bit() as c_int;
+        buffer_removal_time_present = gb.get_bit() as u8;
         if buffer_removal_time_present != 0 {
             for i in 0..seqhdr.num_operating_points {
                 let seqop = &seqhdr.operating_points[i as usize];
@@ -1869,7 +1879,7 @@ unsafe fn parse_frame_hdr(
                     let in_spatial_layer = seqop.idc >> spatial_id + 8 & 1;
                     if seqop.idc == 0 || in_temporal_layer != 0 && in_spatial_layer != 0 {
                         op.buffer_removal_time =
-                            gb.get_bits(seqhdr.buffer_removal_delay_length.into()) as c_int;
+                            gb.get_bits(seqhdr.buffer_removal_delay_length.into()) as u32;
                     }
                 }
             }
@@ -1892,7 +1902,7 @@ unsafe fn parse_frame_hdr(
         refresh_frame_flags = if frame_type == Rav1dFrameType::Key && show_frame != 0 {
             0xff
         } else {
-            gb.get_bits(8) as c_int
+            gb.get_bits(8) as u8
         };
         if refresh_frame_flags != 0xff && error_resilient_mode != 0 && seqhdr.order_hint != 0 {
             for _ in 0..8 {
@@ -1920,14 +1930,14 @@ unsafe fn parse_frame_hdr(
         refresh_frame_flags = if frame_type == Rav1dFrameType::Switch {
             0xff
         } else {
-            gb.get_bits(8) as c_int
+            gb.get_bits(8) as u8
         };
         if error_resilient_mode != 0 && seqhdr.order_hint != 0 {
             for _ in 0..8 {
                 gb.get_bits(seqhdr.order_hint_n_bits.into());
             }
         }
-        frame_ref_short_signaling = (seqhdr.order_hint != 0 && gb.get_bit()) as c_int;
+        frame_ref_short_signaling = (seqhdr.order_hint != 0 && gb.get_bit()) as u8;
         refidx = parse_refidx(
             c,
             seqhdr,
@@ -1950,18 +1960,18 @@ unsafe fn parse_frame_hdr(
         } else {
             Rav1dFilterMode::from_repr(gb.get_bits(2) as usize).unwrap()
         };
-        switchable_motion_mode = gb.get_bit() as c_int;
+        switchable_motion_mode = gb.get_bit() as u8;
         use_ref_frame_mvs = (error_resilient_mode == 0
             && seqhdr.ref_frame_mvs != 0
             && seqhdr.order_hint != 0
             && frame_type.is_inter_or_switch()
-            && gb.get_bit()) as c_int;
+            && gb.get_bit()) as u8;
     }
     debug.post(gb, "frametype-specific-bits");
 
     let refresh_context = (seqhdr.reduced_still_picture_header == 0
         && disable_cdf_update == 0
-        && !gb.get_bit()) as c_int;
+        && !gb.get_bit()) as u8;
     debug.post(gb, "refresh_context");
 
     let tiling = parse_tiling(seqhdr, &size, &debug, gb)?;
@@ -1998,7 +2008,7 @@ unsafe fn parse_frame_hdr(
     };
     debug.post(gb, "txfmmode");
     let switchable_comp_refs = if frame_type.is_inter_or_switch() {
-        gb.get_bit() as c_int
+        gb.get_bit() as u8
     } else {
         0
     };
@@ -2016,9 +2026,9 @@ unsafe fn parse_frame_hdr(
     let warp_motion = (error_resilient_mode == 0
         && frame_type.is_inter_or_switch()
         && seqhdr.warped_motion != 0
-        && gb.get_bit()) as c_int;
+        && gb.get_bit()) as u8;
     debug.post(gb, "warpmotionbit");
-    let reduced_txtp_set = gb.get_bit() as c_int;
+    let reduced_txtp_set = gb.get_bit() as u8;
     debug.post(gb, "reducedtxtpset");
 
     let gmv = parse_gmv(c, frame_type, primary_ref_frame, &refidx, hp, &debug, gb)?;
@@ -2081,7 +2091,7 @@ unsafe fn parse_frame_hdr(
 }
 
 fn parse_tile_hdr(tiling: &Rav1dFrameHeader_tiling, gb: &mut GetBits) -> Rav1dTileGroupHeader {
-    let n_tiles = tiling.cols * tiling.rows;
+    let n_tiles = tiling.cols as c_int * tiling.rows as c_int;
     let have_tile_pos = if n_tiles > 1 {
         gb.get_bit() as c_int
     } else {
@@ -2090,8 +2100,8 @@ fn parse_tile_hdr(tiling: &Rav1dFrameHeader_tiling, gb: &mut GetBits) -> Rav1dTi
 
     if have_tile_pos != 0 {
         let n_bits = tiling.log2_cols + tiling.log2_rows;
-        let start = gb.get_bits(n_bits) as c_int;
-        let end = gb.get_bits(n_bits) as c_int;
+        let start = gb.get_bits(n_bits.into()) as c_int;
+        let end = gb.get_bits(n_bits.into()) as c_int;
         Rav1dTileGroupHeader { start, end }
     } else {
         Rav1dTileGroupHeader {
@@ -2163,8 +2173,8 @@ unsafe fn parse_obus(
     let mut temporal_id = 0;
     let mut spatial_id = 0;
     if has_extension {
-        temporal_id = gb.get_bits(3) as c_int;
-        spatial_id = gb.get_bits(2) as c_int;
+        temporal_id = gb.get_bits(3) as u8;
+        spatial_id = gb.get_bits(2) as u8;
         gb.get_bits(3); // reserved
     }
 
@@ -2621,7 +2631,7 @@ unsafe fn parse_obus(
                 }
             }
             c.frame_hdr = None;
-        } else if c.n_tiles == frame_hdr.tiling.cols * frame_hdr.tiling.rows {
+        } else if c.n_tiles == frame_hdr.tiling.cols as c_int * frame_hdr.tiling.rows as c_int {
             match frame_hdr.frame_type {
                 Rav1dFrameType::Inter | Rav1dFrameType::Switch => {
                     if c.decode_frame_type > Rav1dDecodeFrameType::Reference

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -524,7 +524,7 @@ unsafe fn decode_coefs<BD: BitDepth>(
     }
     if all_skip != 0 {
         *res_ctx = 0x40 as c_int as u8;
-        *txtp = (lossless * WHT_WHT as c_int) as TxfmType;
+        *txtp = (lossless * WHT_WHT) as TxfmType;
         return -(1 as c_int);
     }
     if lossless != 0 {

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1085,7 +1085,7 @@ pub(crate) fn rav1d_refmvs_find(
     }
 
     // temporal
-    let mut globalmv_ctx = frame_hdr.use_ref_frame_mvs;
+    let mut globalmv_ctx = frame_hdr.use_ref_frame_mvs as c_int;
     if rf.use_ref_frame_mvs != 0 {
         let stride = rf.rp_stride as usize;
         let by8 = by4 >> 1;
@@ -1651,7 +1651,7 @@ pub(crate) fn rav1d_refmvs_init_frame(
             && get_poc_diff(
                 seq_hdr.order_hint_n_bits,
                 ref_poc[4] as c_int,
-                frm_hdr.frame_offset,
+                frm_hdr.frame_offset as c_int,
             ) > 0
         {
             rf.mfmv_ref[rf.n_mfmvs as usize] = 4; // bwd
@@ -1661,7 +1661,7 @@ pub(crate) fn rav1d_refmvs_init_frame(
             && get_poc_diff(
                 seq_hdr.order_hint_n_bits,
                 ref_poc[5] as c_int,
-                frm_hdr.frame_offset,
+                frm_hdr.frame_offset as c_int,
             ) > 0
         {
             rf.mfmv_ref[rf.n_mfmvs as usize] = 5; // altref2
@@ -1672,7 +1672,7 @@ pub(crate) fn rav1d_refmvs_init_frame(
             && get_poc_diff(
                 seq_hdr.order_hint_n_bits,
                 ref_poc[6] as c_int,
-                frm_hdr.frame_offset,
+                frm_hdr.frame_offset as c_int,
             ) > 0
         {
             rf.mfmv_ref[rf.n_mfmvs as usize] = 6; // altref
@@ -1688,7 +1688,7 @@ pub(crate) fn rav1d_refmvs_init_frame(
             let diff1 = get_poc_diff(
                 seq_hdr.order_hint_n_bits,
                 rpoc as c_int,
-                frm_hdr.frame_offset,
+                frm_hdr.frame_offset as c_int,
             );
             if diff1.abs() > 31 {
                 rf.mfmv_ref2cur[n] = i32::MIN;


### PR DESCRIPTION
* Fixes `Dav1dFrameHeader` of #505.

Shrinks `Rav1dFrameHeader` from 1664 to 1120 bytes.