### PR TITLE
`struct TaskThreadData`: Split `delayed_fg` lock from thread lock

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4629,7 +4629,7 @@ pub(crate) unsafe fn rav1d_decode_frame(c: &Rav1dContext, fc: &Rav1dFrameContext
             if c.tc.len() > 1 {
                 res = rav1d_task_create_tile_sbrow(c, fc, &f, 0, 1);
                 drop(f); // release the frame data before waiting for the other threads
-                let mut task_thread_lock = (*fc.task_thread.ttd).delayed_fg.lock().unwrap();
+                let mut task_thread_lock = (*fc.task_thread.ttd).lock.lock().unwrap();
                 (*fc.task_thread.ttd).cond.notify_one();
                 if res.is_ok() {
                     while fc.task_thread.done[0].load(Ordering::Relaxed) == 0
@@ -4669,7 +4669,7 @@ fn get_upscale_x0(in_w: c_int, out_w: c_int, step: c_int) -> c_int {
 pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
     // wait for c->out_delayed[next] and move into c->out if visible
     let (fc, out, _task_thread_lock) = if c.fc.len() > 1 {
-        let mut task_thread_lock = c.task_thread.delayed_fg.lock().unwrap();
+        let mut task_thread_lock = c.task_thread.lock.lock().unwrap();
         let next = c.frame_thread.next;
         c.frame_thread.next = (c.frame_thread.next + 1) % c.fc.len() as u32;
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -245,7 +245,6 @@ impl BitDepthDependentType for Grain {
 
 #[repr(C)]
 pub(crate) struct TaskThreadData_delayed_fg {
-    pub exec: c_int,
     pub in_0: *const Rav1dPicture,
     pub out: *mut Rav1dPicture,
     pub type_0: TaskType,
@@ -255,7 +254,6 @@ pub(crate) struct TaskThreadData_delayed_fg {
 impl Default for TaskThreadData_delayed_fg {
     fn default() -> Self {
         Self {
-            exec: 0,
             in_0: std::ptr::null(),
             out: std::ptr::null_mut(),
             type_0: Default::default(),
@@ -279,6 +277,7 @@ pub(crate) struct TaskThreadData {
     /// See [`crate::src::thread_task::reset_task_cur`].
     pub reset_task_cur: AtomicU32,
     pub cond_signaled: AtomicI32,
+    pub delayed_fg_exec: AtomicI32,
     pub delayed_fg_progress: [AtomicI32; 2], /* [0]=started, [1]=completed */
     pub delayed_fg_cond: Condvar,
     /// This lock has a dual purpose - protecting the delayed_fg structure, as

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ use std::sync::Arc;
 use std::sync::Condvar;
 use std::sync::Mutex;
 use std::sync::Once;
+use std::sync::RwLock;
 use std::thread;
 use to_method::To as _;
 
@@ -245,15 +246,16 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
     // TODO fallible allocation
     (*c).fc = (0..n_fc).map(|i| Rav1dFrameContext::zeroed(i)).collect();
     let ttd = TaskThreadData {
+        lock: Mutex::new(()),
         cond: Condvar::new(),
         first: AtomicU32::new(0),
         cur: AtomicU32::new(n_fc as u32),
         reset_task_cur: AtomicU32::new(u32::MAX),
         cond_signaled: AtomicI32::new(0),
         delayed_fg_exec: AtomicI32::new(0),
-        delayed_fg_progress: [AtomicI32::new(0), AtomicI32::new(0)],
         delayed_fg_cond: Condvar::new(),
-        delayed_fg: Mutex::new(mem::zeroed()),
+        delayed_fg_progress: [AtomicI32::new(0), AtomicI32::new(0)],
+        delayed_fg: RwLock::new(mem::zeroed()),
     };
     (&mut (*c).task_thread as *mut Arc<TaskThreadData>).write(Arc::new(ttd));
     addr_of_mut!((*c).tiles).write(Default::default());
@@ -407,7 +409,7 @@ unsafe fn drain_picture(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRe
     loop {
         let next: c_uint = c.frame_thread.next;
         let fc = &c.fc[next as usize];
-        let mut task_thread_lock = c.task_thread.delayed_fg.lock().unwrap();
+        let mut task_thread_lock = c.task_thread.lock.lock().unwrap();
         while !fc.task_thread.finished.load(Ordering::SeqCst) {
             task_thread_lock = fc.task_thread.cond.wait(task_thread_lock).unwrap();
         }
@@ -662,7 +664,7 @@ pub(crate) unsafe fn rav1d_flush(c: *mut Rav1dContext) {
     }
     (*c).flush.store(1, Ordering::SeqCst);
     if (*c).tc.len() > 1 {
-        let mut task_thread_lock = (*c).task_thread.delayed_fg.lock().unwrap();
+        let mut task_thread_lock = (*c).task_thread.lock.lock().unwrap();
         for tc in (*c).tc.iter() {
             while !tc.flushed() {
                 task_thread_lock = tc.thread_data.cond.wait(task_thread_lock).unwrap();
@@ -739,7 +741,7 @@ impl Drop for Rav1dContext {
         unsafe {
             if self.tc.len() > 1 {
                 let ttd: &TaskThreadData = &*self.task_thread;
-                let task_thread_lock = ttd.delayed_fg.lock().unwrap();
+                let task_thread_lock = ttd.lock.lock().unwrap();
                 for tc in self.tc.iter() {
                     tc.thread_data.die.store(true, Ordering::Relaxed);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,7 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
         cur: AtomicU32::new(n_fc as u32),
         reset_task_cur: AtomicU32::new(u32::MAX),
         cond_signaled: AtomicI32::new(0),
+        delayed_fg_exec: AtomicI32::new(0),
         delayed_fg_progress: [AtomicI32::new(0), AtomicI32::new(0)],
         delayed_fg_cond: Condvar::new(),
         delayed_fg: Mutex::new(mem::zeroed()),

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2484,7 +2484,7 @@ unsafe fn parse_obus(
                 );
                 c.event_flags |= c.refs[frame_hdr.existing_frame_idx as usize].p.flags.into();
             } else {
-                let mut task_thread_lock = c.task_thread.delayed_fg.lock().unwrap();
+                let mut task_thread_lock = c.task_thread.lock.lock().unwrap();
                 // Need to append this to the frame output queue.
                 let next = c.frame_thread.next;
                 c.frame_thread.next = (c.frame_thread.next + 1) % c.fc.len() as u32;


### PR DESCRIPTION
The `delayed_fg` mutex was contended because multiple threads need to read from it concurrently. This change splits the mutex back into a lock field, with the same usage as the original pthreads lock, and an `RwLock` for `delayed_fg`.

This change also splits out `delayed_fg.exec` so we don't need to lock the inner struct for writing to write this boolean.

* Fixes #763 