### PR TITLE
`{struct,union} Av1Block*`: Rename fields and types

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -830,8 +830,8 @@ unsafe fn read_vartx_tree(
         b.uvtx = dav1d_max_txfm_size_for_bs[bs as usize][f.cur.p.layout as usize];
     }
     assert!(tx_split[0] & !0x33 == 0);
-    b.ii.c2rust_unnamed_0.tx_split0 = tx_split[0] as u8;
-    b.ii.c2rust_unnamed_0.tx_split1 = tx_split[1];
+    b.ii.inter.tx_split0 = tx_split[0] as u8;
+    b.ii.inter.tx_split1 = tx_split[1];
 }
 
 #[inline]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -830,8 +830,8 @@ unsafe fn read_vartx_tree(
         b.uvtx = dav1d_max_txfm_size_for_bs[bs as usize][f.cur.p.layout as usize];
     }
     assert!(tx_split[0] & !0x33 == 0);
-    b.c2rust_unnamed.c2rust_unnamed_0.tx_split0 = tx_split[0] as u8;
-    b.c2rust_unnamed.c2rust_unnamed_0.tx_split1 = tx_split[1];
+    b.ii.c2rust_unnamed_0.tx_split0 = tx_split[0] as u8;
+    b.ii.c2rust_unnamed_0.tx_split1 = tx_split[1];
 }
 
 #[inline]

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -376,44 +376,44 @@ pub struct Av1Block {
     pub skip_mode: u8,
     pub skip: u8,
     pub uvtx: RectTxfmSize,
-    pub c2rust_unnamed: Av1Block_intra_inter,
+    pub ii: Av1Block_intra_inter,
 }
 
 impl Av1Block {
     pub unsafe fn cfl_alpha(&self) -> &[i8; 2] {
-        &self.c2rust_unnamed.c2rust_unnamed.cfl_alpha
+        &self.ii.c2rust_unnamed.cfl_alpha
     }
 
     pub unsafe fn cfl_alpha_mut(&mut self) -> &mut [i8; 2] {
-        &mut self.c2rust_unnamed.c2rust_unnamed.cfl_alpha
+        &mut self.ii.c2rust_unnamed.cfl_alpha
     }
 
     pub unsafe fn comp_type(&self) -> Option<CompInterType> {
-        self.c2rust_unnamed.c2rust_unnamed_0.comp_type
+        self.ii.c2rust_unnamed_0.comp_type
     }
 
     pub unsafe fn comp_type_mut(&mut self) -> &mut Option<CompInterType> {
-        &mut self.c2rust_unnamed.c2rust_unnamed_0.comp_type
+        &mut self.ii.c2rust_unnamed_0.comp_type
     }
 
     pub unsafe fn drl_idx(&self) -> DrlProximity {
-        self.c2rust_unnamed.c2rust_unnamed_0.drl_idx
+        self.ii.c2rust_unnamed_0.drl_idx
     }
 
     pub unsafe fn drl_idx_mut(&mut self) -> &mut DrlProximity {
-        &mut self.c2rust_unnamed.c2rust_unnamed_0.drl_idx
+        &mut self.ii.c2rust_unnamed_0.drl_idx
     }
 
     pub unsafe fn inter_mode(&self) -> u8 {
-        self.c2rust_unnamed.c2rust_unnamed_0.inter_mode
+        self.ii.c2rust_unnamed_0.inter_mode
     }
 
     pub unsafe fn inter_mode_mut(&mut self) -> &mut u8 {
-        &mut self.c2rust_unnamed.c2rust_unnamed_0.inter_mode
+        &mut self.ii.c2rust_unnamed_0.inter_mode
     }
 
     pub unsafe fn mask_sign(&self) -> u8 {
-        self.c2rust_unnamed
+        self.ii
             .c2rust_unnamed_0
             .c2rust_unnamed
             .c2rust_unnamed
@@ -422,7 +422,7 @@ impl Av1Block {
 
     pub unsafe fn mask_sign_mut(&mut self) -> &mut u8 {
         &mut self
-            .c2rust_unnamed
+            .ii
             .c2rust_unnamed_0
             .c2rust_unnamed
             .c2rust_unnamed
@@ -430,56 +430,56 @@ impl Av1Block {
     }
 
     pub unsafe fn pal_sz(&self) -> &[u8; 2] {
-        &self.c2rust_unnamed.c2rust_unnamed.pal_sz
+        &self.ii.c2rust_unnamed.pal_sz
     }
 
     pub unsafe fn pal_sz_mut(&mut self) -> &mut [u8; 2] {
-        &mut self.c2rust_unnamed.c2rust_unnamed.pal_sz
+        &mut self.ii.c2rust_unnamed.pal_sz
     }
 
     pub unsafe fn tx(&self) -> u8 {
-        self.c2rust_unnamed.c2rust_unnamed.tx
+        self.ii.c2rust_unnamed.tx
     }
 
     pub unsafe fn tx_mut(&mut self) -> &mut u8 {
-        &mut self.c2rust_unnamed.c2rust_unnamed.tx
+        &mut self.ii.c2rust_unnamed.tx
     }
 
     pub unsafe fn y_mode(&self) -> u8 {
-        self.c2rust_unnamed.c2rust_unnamed.y_mode
+        self.ii.c2rust_unnamed.y_mode
     }
 
     pub unsafe fn y_mode_mut(&mut self) -> &mut u8 {
-        &mut self.c2rust_unnamed.c2rust_unnamed.y_mode
+        &mut self.ii.c2rust_unnamed.y_mode
     }
 
     pub unsafe fn y_angle(&self) -> i8 {
-        self.c2rust_unnamed.c2rust_unnamed.y_angle
+        self.ii.c2rust_unnamed.y_angle
     }
 
     pub unsafe fn y_angle_mut(&mut self) -> &mut i8 {
-        &mut self.c2rust_unnamed.c2rust_unnamed.y_angle
+        &mut self.ii.c2rust_unnamed.y_angle
     }
 
     #[allow(dead_code)]
     pub unsafe fn uv_angle(&self) -> i8 {
-        self.c2rust_unnamed.c2rust_unnamed.uv_angle
+        self.ii.c2rust_unnamed.uv_angle
     }
 
     pub unsafe fn uv_angle_mut(&mut self) -> &mut i8 {
-        &mut self.c2rust_unnamed.c2rust_unnamed.uv_angle
+        &mut self.ii.c2rust_unnamed.uv_angle
     }
 
     pub unsafe fn uv_mode(&self) -> u8 {
-        self.c2rust_unnamed.c2rust_unnamed.uv_mode
+        self.ii.c2rust_unnamed.uv_mode
     }
 
     pub unsafe fn uv_mode_mut(&mut self) -> &mut u8 {
-        &mut self.c2rust_unnamed.c2rust_unnamed.uv_mode
+        &mut self.ii.c2rust_unnamed.uv_mode
     }
 
     pub unsafe fn wedge_idx(&self) -> u8 {
-        self.c2rust_unnamed
+        self.ii
             .c2rust_unnamed_0
             .c2rust_unnamed
             .c2rust_unnamed
@@ -488,7 +488,7 @@ impl Av1Block {
 
     pub unsafe fn wedge_idx_mut(&mut self) -> &mut u8 {
         &mut self
-            .c2rust_unnamed
+            .ii
             .c2rust_unnamed_0
             .c2rust_unnamed
             .c2rust_unnamed
@@ -497,7 +497,7 @@ impl Av1Block {
 
     pub unsafe fn matrix(&self) -> &[i16; 4] {
         &self
-            .c2rust_unnamed
+            .ii
             .c2rust_unnamed_0
             .c2rust_unnamed
             .c2rust_unnamed_0
@@ -506,7 +506,7 @@ impl Av1Block {
 
     pub unsafe fn matrix_mut(&mut self) -> &mut [i16; 4] {
         &mut self
-            .c2rust_unnamed
+            .ii
             .c2rust_unnamed_0
             .c2rust_unnamed
             .c2rust_unnamed_0
@@ -514,26 +514,16 @@ impl Av1Block {
     }
 
     pub unsafe fn mv(&self) -> &[mv; 2] {
-        &self
-            .c2rust_unnamed
-            .c2rust_unnamed_0
-            .c2rust_unnamed
-            .c2rust_unnamed
-            .mv
+        &self.ii.c2rust_unnamed_0.c2rust_unnamed.c2rust_unnamed.mv
     }
 
     pub unsafe fn mv_mut(&mut self) -> &mut [mv; 2] {
-        &mut self
-            .c2rust_unnamed
-            .c2rust_unnamed_0
-            .c2rust_unnamed
-            .c2rust_unnamed
-            .mv
+        &mut self.ii.c2rust_unnamed_0.c2rust_unnamed.c2rust_unnamed.mv
     }
 
     pub unsafe fn mv2d(&self) -> &mv {
         &self
-            .c2rust_unnamed
+            .ii
             .c2rust_unnamed_0
             .c2rust_unnamed
             .c2rust_unnamed_0
@@ -541,39 +531,39 @@ impl Av1Block {
     }
 
     pub unsafe fn filter2d(&self) -> Filter2d {
-        self.c2rust_unnamed.c2rust_unnamed_0.filter2d
+        self.ii.c2rust_unnamed_0.filter2d
     }
 
     pub unsafe fn filter2d_mut(&mut self) -> &mut Filter2d {
-        &mut self.c2rust_unnamed.c2rust_unnamed_0.filter2d
+        &mut self.ii.c2rust_unnamed_0.filter2d
     }
 
     pub unsafe fn r#ref(&self) -> [i8; 2] {
-        self.c2rust_unnamed.c2rust_unnamed_0.r#ref
+        self.ii.c2rust_unnamed_0.r#ref
     }
 
     pub unsafe fn ref_mut(&mut self) -> &mut [i8; 2] {
-        &mut self.c2rust_unnamed.c2rust_unnamed_0.r#ref
+        &mut self.ii.c2rust_unnamed_0.r#ref
     }
 
     pub unsafe fn max_ytx(&self) -> u8 {
-        self.c2rust_unnamed.c2rust_unnamed_0.max_ytx
+        self.ii.c2rust_unnamed_0.max_ytx
     }
 
     pub unsafe fn max_ytx_mut(&mut self) -> &mut u8 {
-        &mut self.c2rust_unnamed.c2rust_unnamed_0.max_ytx
+        &mut self.ii.c2rust_unnamed_0.max_ytx
     }
 
     pub unsafe fn interintra_type(&self) -> Option<InterIntraType> {
-        self.c2rust_unnamed.c2rust_unnamed_0.interintra_type
+        self.ii.c2rust_unnamed_0.interintra_type
     }
 
     pub unsafe fn interintra_type_mut(&mut self) -> &mut Option<InterIntraType> {
-        &mut self.c2rust_unnamed.c2rust_unnamed_0.interintra_type
+        &mut self.ii.c2rust_unnamed_0.interintra_type
     }
 
     pub unsafe fn interintra_mode(&self) -> InterIntraPredMode {
-        self.c2rust_unnamed
+        self.ii
             .c2rust_unnamed_0
             .c2rust_unnamed
             .c2rust_unnamed
@@ -582,7 +572,7 @@ impl Av1Block {
 
     pub unsafe fn interintra_mode_mut(&mut self) -> &mut InterIntraPredMode {
         &mut self
-            .c2rust_unnamed
+            .ii
             .c2rust_unnamed_0
             .c2rust_unnamed
             .c2rust_unnamed
@@ -590,18 +580,18 @@ impl Av1Block {
     }
 
     pub unsafe fn motion_mode(&self) -> MotionMode {
-        self.c2rust_unnamed.c2rust_unnamed_0.motion_mode
+        self.ii.c2rust_unnamed_0.motion_mode
     }
 
     pub unsafe fn motion_mode_mut(&mut self) -> &mut MotionMode {
-        &mut self.c2rust_unnamed.c2rust_unnamed_0.motion_mode
+        &mut self.ii.c2rust_unnamed_0.motion_mode
     }
 
     pub unsafe fn tx_split0(&self) -> u8 {
-        self.c2rust_unnamed.c2rust_unnamed_0.tx_split0
+        self.ii.c2rust_unnamed_0.tx_split0
     }
 
     pub unsafe fn tx_split1(&self) -> u16 {
-        self.c2rust_unnamed.c2rust_unnamed_0.tx_split1
+        self.ii.c2rust_unnamed_0.tx_split1
     }
 }

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -302,7 +302,7 @@ pub enum MotionMode {
 
 #[derive(Copy, Clone, Default)]
 #[repr(C)]
-pub struct Av1Block_intra {
+pub struct Av1BlockIntra {
     pub y_mode: u8,
     pub uv_mode: u8,
     pub tx: u8,
@@ -314,7 +314,7 @@ pub struct Av1Block_intra {
 
 #[derive(Clone, Copy)]
 #[repr(C)]
-pub struct Av1Block_inter_1d {
+pub struct Av1BlockInter1d {
     pub mv: [mv; 2],
     pub wedge_idx: u8,
     pub mask_sign: u8,
@@ -323,22 +323,22 @@ pub struct Av1Block_inter_1d {
 
 #[derive(Clone, Copy)]
 #[repr(C)]
-pub struct Av1Block_inter_2d {
+pub struct Av1BlockInter2d {
     pub mv2d: mv,
     pub matrix: [i16; 4],
 }
 
 #[derive(Clone, Copy)]
 #[repr(C)]
-pub union Av1Block_inter_nd {
-    pub one_d: Av1Block_inter_1d,
-    pub two_d: Av1Block_inter_2d,
+pub union Av1BlockInterNd {
+    pub one_d: Av1BlockInter1d,
+    pub two_d: Av1BlockInter2d,
 }
 
 #[derive(Clone, Copy)]
 #[repr(C)]
-pub struct Av1Block_inter {
-    pub nd: Av1Block_inter_nd,
+pub struct Av1BlockInter {
+    pub nd: Av1BlockInterNd,
     pub comp_type: Option<CompInterType>,
     pub inter_mode: u8,
     pub motion_mode: MotionMode,
@@ -352,14 +352,14 @@ pub struct Av1Block_inter {
 }
 
 #[repr(C)]
-pub union Av1Block_intra_inter {
-    pub intra: Av1Block_intra,
-    pub inter: Av1Block_inter,
+pub union Av1BlockIntraInter {
+    pub intra: Av1BlockIntra,
+    pub inter: Av1BlockInter,
 }
 
-impl Default for Av1Block_intra_inter {
+impl Default for Av1BlockIntraInter {
     fn default() -> Self {
-        Av1Block_intra_inter {
+        Av1BlockIntraInter {
             intra: Default::default(),
         }
     }
@@ -376,7 +376,7 @@ pub struct Av1Block {
     pub skip_mode: u8,
     pub skip: u8,
     pub uvtx: RectTxfmSize,
-    pub ii: Av1Block_intra_inter,
+    pub ii: Av1BlockIntraInter,
 }
 
 impl Av1Block {

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -331,8 +331,8 @@ pub struct Av1Block_inter_2d {
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub union Av1Block_inter_nd {
-    pub c2rust_unnamed: Av1Block_inter_1d,
-    pub c2rust_unnamed_0: Av1Block_inter_2d,
+    pub one_d: Av1Block_inter_1d,
+    pub two_d: Av1Block_inter_2d,
 }
 
 #[derive(Clone, Copy)]
@@ -413,11 +413,11 @@ impl Av1Block {
     }
 
     pub unsafe fn mask_sign(&self) -> u8 {
-        self.ii.inter.nd.c2rust_unnamed.mask_sign
+        self.ii.inter.nd.one_d.mask_sign
     }
 
     pub unsafe fn mask_sign_mut(&mut self) -> &mut u8 {
-        &mut self.ii.inter.nd.c2rust_unnamed.mask_sign
+        &mut self.ii.inter.nd.one_d.mask_sign
     }
 
     pub unsafe fn pal_sz(&self) -> &[u8; 2] {
@@ -470,31 +470,31 @@ impl Av1Block {
     }
 
     pub unsafe fn wedge_idx(&self) -> u8 {
-        self.ii.inter.nd.c2rust_unnamed.wedge_idx
+        self.ii.inter.nd.one_d.wedge_idx
     }
 
     pub unsafe fn wedge_idx_mut(&mut self) -> &mut u8 {
-        &mut self.ii.inter.nd.c2rust_unnamed.wedge_idx
+        &mut self.ii.inter.nd.one_d.wedge_idx
     }
 
     pub unsafe fn matrix(&self) -> &[i16; 4] {
-        &self.ii.inter.nd.c2rust_unnamed_0.matrix
+        &self.ii.inter.nd.two_d.matrix
     }
 
     pub unsafe fn matrix_mut(&mut self) -> &mut [i16; 4] {
-        &mut self.ii.inter.nd.c2rust_unnamed_0.matrix
+        &mut self.ii.inter.nd.two_d.matrix
     }
 
     pub unsafe fn mv(&self) -> &[mv; 2] {
-        &self.ii.inter.nd.c2rust_unnamed.mv
+        &self.ii.inter.nd.one_d.mv
     }
 
     pub unsafe fn mv_mut(&mut self) -> &mut [mv; 2] {
-        &mut self.ii.inter.nd.c2rust_unnamed.mv
+        &mut self.ii.inter.nd.one_d.mv
     }
 
     pub unsafe fn mv2d(&self) -> &mv {
-        &self.ii.inter.nd.c2rust_unnamed_0.mv2d
+        &self.ii.inter.nd.two_d.mv2d
     }
 
     pub unsafe fn filter2d(&self) -> Filter2d {
@@ -530,11 +530,11 @@ impl Av1Block {
     }
 
     pub unsafe fn interintra_mode(&self) -> InterIntraPredMode {
-        self.ii.inter.nd.c2rust_unnamed.interintra_mode
+        self.ii.inter.nd.one_d.interintra_mode
     }
 
     pub unsafe fn interintra_mode_mut(&mut self) -> &mut InterIntraPredMode {
-        &mut self.ii.inter.nd.c2rust_unnamed.interintra_mode
+        &mut self.ii.inter.nd.one_d.interintra_mode
     }
 
     pub unsafe fn motion_mode(&self) -> MotionMode {

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -338,7 +338,7 @@ pub union Av1Block_inter_nd {
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct Av1Block_inter {
-    pub c2rust_unnamed: Av1Block_inter_nd,
+    pub nd: Av1Block_inter_nd,
     pub comp_type: Option<CompInterType>,
     pub inter_mode: u8,
     pub motion_mode: MotionMode,
@@ -413,11 +413,11 @@ impl Av1Block {
     }
 
     pub unsafe fn mask_sign(&self) -> u8 {
-        self.ii.inter.c2rust_unnamed.c2rust_unnamed.mask_sign
+        self.ii.inter.nd.c2rust_unnamed.mask_sign
     }
 
     pub unsafe fn mask_sign_mut(&mut self) -> &mut u8 {
-        &mut self.ii.inter.c2rust_unnamed.c2rust_unnamed.mask_sign
+        &mut self.ii.inter.nd.c2rust_unnamed.mask_sign
     }
 
     pub unsafe fn pal_sz(&self) -> &[u8; 2] {
@@ -470,31 +470,31 @@ impl Av1Block {
     }
 
     pub unsafe fn wedge_idx(&self) -> u8 {
-        self.ii.inter.c2rust_unnamed.c2rust_unnamed.wedge_idx
+        self.ii.inter.nd.c2rust_unnamed.wedge_idx
     }
 
     pub unsafe fn wedge_idx_mut(&mut self) -> &mut u8 {
-        &mut self.ii.inter.c2rust_unnamed.c2rust_unnamed.wedge_idx
+        &mut self.ii.inter.nd.c2rust_unnamed.wedge_idx
     }
 
     pub unsafe fn matrix(&self) -> &[i16; 4] {
-        &self.ii.inter.c2rust_unnamed.c2rust_unnamed_0.matrix
+        &self.ii.inter.nd.c2rust_unnamed_0.matrix
     }
 
     pub unsafe fn matrix_mut(&mut self) -> &mut [i16; 4] {
-        &mut self.ii.inter.c2rust_unnamed.c2rust_unnamed_0.matrix
+        &mut self.ii.inter.nd.c2rust_unnamed_0.matrix
     }
 
     pub unsafe fn mv(&self) -> &[mv; 2] {
-        &self.ii.inter.c2rust_unnamed.c2rust_unnamed.mv
+        &self.ii.inter.nd.c2rust_unnamed.mv
     }
 
     pub unsafe fn mv_mut(&mut self) -> &mut [mv; 2] {
-        &mut self.ii.inter.c2rust_unnamed.c2rust_unnamed.mv
+        &mut self.ii.inter.nd.c2rust_unnamed.mv
     }
 
     pub unsafe fn mv2d(&self) -> &mv {
-        &self.ii.inter.c2rust_unnamed.c2rust_unnamed_0.mv2d
+        &self.ii.inter.nd.c2rust_unnamed_0.mv2d
     }
 
     pub unsafe fn filter2d(&self) -> Filter2d {
@@ -530,11 +530,11 @@ impl Av1Block {
     }
 
     pub unsafe fn interintra_mode(&self) -> InterIntraPredMode {
-        self.ii.inter.c2rust_unnamed.c2rust_unnamed.interintra_mode
+        self.ii.inter.nd.c2rust_unnamed.interintra_mode
     }
 
     pub unsafe fn interintra_mode_mut(&mut self) -> &mut InterIntraPredMode {
-        &mut self.ii.inter.c2rust_unnamed.c2rust_unnamed.interintra_mode
+        &mut self.ii.inter.nd.c2rust_unnamed.interintra_mode
     }
 
     pub unsafe fn motion_mode(&self) -> MotionMode {

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -353,14 +353,14 @@ pub struct Av1Block_inter {
 
 #[repr(C)]
 pub union Av1Block_intra_inter {
-    pub c2rust_unnamed: Av1Block_intra,
-    pub c2rust_unnamed_0: Av1Block_inter,
+    pub intra: Av1Block_intra,
+    pub inter: Av1Block_inter,
 }
 
 impl Default for Av1Block_intra_inter {
     fn default() -> Self {
         Av1Block_intra_inter {
-            c2rust_unnamed: Default::default(),
+            intra: Default::default(),
         }
     }
 }
@@ -381,217 +381,175 @@ pub struct Av1Block {
 
 impl Av1Block {
     pub unsafe fn cfl_alpha(&self) -> &[i8; 2] {
-        &self.ii.c2rust_unnamed.cfl_alpha
+        &self.ii.intra.cfl_alpha
     }
 
     pub unsafe fn cfl_alpha_mut(&mut self) -> &mut [i8; 2] {
-        &mut self.ii.c2rust_unnamed.cfl_alpha
+        &mut self.ii.intra.cfl_alpha
     }
 
     pub unsafe fn comp_type(&self) -> Option<CompInterType> {
-        self.ii.c2rust_unnamed_0.comp_type
+        self.ii.inter.comp_type
     }
 
     pub unsafe fn comp_type_mut(&mut self) -> &mut Option<CompInterType> {
-        &mut self.ii.c2rust_unnamed_0.comp_type
+        &mut self.ii.inter.comp_type
     }
 
     pub unsafe fn drl_idx(&self) -> DrlProximity {
-        self.ii.c2rust_unnamed_0.drl_idx
+        self.ii.inter.drl_idx
     }
 
     pub unsafe fn drl_idx_mut(&mut self) -> &mut DrlProximity {
-        &mut self.ii.c2rust_unnamed_0.drl_idx
+        &mut self.ii.inter.drl_idx
     }
 
     pub unsafe fn inter_mode(&self) -> u8 {
-        self.ii.c2rust_unnamed_0.inter_mode
+        self.ii.inter.inter_mode
     }
 
     pub unsafe fn inter_mode_mut(&mut self) -> &mut u8 {
-        &mut self.ii.c2rust_unnamed_0.inter_mode
+        &mut self.ii.inter.inter_mode
     }
 
     pub unsafe fn mask_sign(&self) -> u8 {
-        self.ii
-            .c2rust_unnamed_0
-            .c2rust_unnamed
-            .c2rust_unnamed
-            .mask_sign
+        self.ii.inter.c2rust_unnamed.c2rust_unnamed.mask_sign
     }
 
     pub unsafe fn mask_sign_mut(&mut self) -> &mut u8 {
-        &mut self
-            .ii
-            .c2rust_unnamed_0
-            .c2rust_unnamed
-            .c2rust_unnamed
-            .mask_sign
+        &mut self.ii.inter.c2rust_unnamed.c2rust_unnamed.mask_sign
     }
 
     pub unsafe fn pal_sz(&self) -> &[u8; 2] {
-        &self.ii.c2rust_unnamed.pal_sz
+        &self.ii.intra.pal_sz
     }
 
     pub unsafe fn pal_sz_mut(&mut self) -> &mut [u8; 2] {
-        &mut self.ii.c2rust_unnamed.pal_sz
+        &mut self.ii.intra.pal_sz
     }
 
     pub unsafe fn tx(&self) -> u8 {
-        self.ii.c2rust_unnamed.tx
+        self.ii.intra.tx
     }
 
     pub unsafe fn tx_mut(&mut self) -> &mut u8 {
-        &mut self.ii.c2rust_unnamed.tx
+        &mut self.ii.intra.tx
     }
 
     pub unsafe fn y_mode(&self) -> u8 {
-        self.ii.c2rust_unnamed.y_mode
+        self.ii.intra.y_mode
     }
 
     pub unsafe fn y_mode_mut(&mut self) -> &mut u8 {
-        &mut self.ii.c2rust_unnamed.y_mode
+        &mut self.ii.intra.y_mode
     }
 
     pub unsafe fn y_angle(&self) -> i8 {
-        self.ii.c2rust_unnamed.y_angle
+        self.ii.intra.y_angle
     }
 
     pub unsafe fn y_angle_mut(&mut self) -> &mut i8 {
-        &mut self.ii.c2rust_unnamed.y_angle
+        &mut self.ii.intra.y_angle
     }
 
     #[allow(dead_code)]
     pub unsafe fn uv_angle(&self) -> i8 {
-        self.ii.c2rust_unnamed.uv_angle
+        self.ii.intra.uv_angle
     }
 
     pub unsafe fn uv_angle_mut(&mut self) -> &mut i8 {
-        &mut self.ii.c2rust_unnamed.uv_angle
+        &mut self.ii.intra.uv_angle
     }
 
     pub unsafe fn uv_mode(&self) -> u8 {
-        self.ii.c2rust_unnamed.uv_mode
+        self.ii.intra.uv_mode
     }
 
     pub unsafe fn uv_mode_mut(&mut self) -> &mut u8 {
-        &mut self.ii.c2rust_unnamed.uv_mode
+        &mut self.ii.intra.uv_mode
     }
 
     pub unsafe fn wedge_idx(&self) -> u8 {
-        self.ii
-            .c2rust_unnamed_0
-            .c2rust_unnamed
-            .c2rust_unnamed
-            .wedge_idx
+        self.ii.inter.c2rust_unnamed.c2rust_unnamed.wedge_idx
     }
 
     pub unsafe fn wedge_idx_mut(&mut self) -> &mut u8 {
-        &mut self
-            .ii
-            .c2rust_unnamed_0
-            .c2rust_unnamed
-            .c2rust_unnamed
-            .wedge_idx
+        &mut self.ii.inter.c2rust_unnamed.c2rust_unnamed.wedge_idx
     }
 
     pub unsafe fn matrix(&self) -> &[i16; 4] {
-        &self
-            .ii
-            .c2rust_unnamed_0
-            .c2rust_unnamed
-            .c2rust_unnamed_0
-            .matrix
+        &self.ii.inter.c2rust_unnamed.c2rust_unnamed_0.matrix
     }
 
     pub unsafe fn matrix_mut(&mut self) -> &mut [i16; 4] {
-        &mut self
-            .ii
-            .c2rust_unnamed_0
-            .c2rust_unnamed
-            .c2rust_unnamed_0
-            .matrix
+        &mut self.ii.inter.c2rust_unnamed.c2rust_unnamed_0.matrix
     }
 
     pub unsafe fn mv(&self) -> &[mv; 2] {
-        &self.ii.c2rust_unnamed_0.c2rust_unnamed.c2rust_unnamed.mv
+        &self.ii.inter.c2rust_unnamed.c2rust_unnamed.mv
     }
 
     pub unsafe fn mv_mut(&mut self) -> &mut [mv; 2] {
-        &mut self.ii.c2rust_unnamed_0.c2rust_unnamed.c2rust_unnamed.mv
+        &mut self.ii.inter.c2rust_unnamed.c2rust_unnamed.mv
     }
 
     pub unsafe fn mv2d(&self) -> &mv {
-        &self
-            .ii
-            .c2rust_unnamed_0
-            .c2rust_unnamed
-            .c2rust_unnamed_0
-            .mv2d
+        &self.ii.inter.c2rust_unnamed.c2rust_unnamed_0.mv2d
     }
 
     pub unsafe fn filter2d(&self) -> Filter2d {
-        self.ii.c2rust_unnamed_0.filter2d
+        self.ii.inter.filter2d
     }
 
     pub unsafe fn filter2d_mut(&mut self) -> &mut Filter2d {
-        &mut self.ii.c2rust_unnamed_0.filter2d
+        &mut self.ii.inter.filter2d
     }
 
     pub unsafe fn r#ref(&self) -> [i8; 2] {
-        self.ii.c2rust_unnamed_0.r#ref
+        self.ii.inter.r#ref
     }
 
     pub unsafe fn ref_mut(&mut self) -> &mut [i8; 2] {
-        &mut self.ii.c2rust_unnamed_0.r#ref
+        &mut self.ii.inter.r#ref
     }
 
     pub unsafe fn max_ytx(&self) -> u8 {
-        self.ii.c2rust_unnamed_0.max_ytx
+        self.ii.inter.max_ytx
     }
 
     pub unsafe fn max_ytx_mut(&mut self) -> &mut u8 {
-        &mut self.ii.c2rust_unnamed_0.max_ytx
+        &mut self.ii.inter.max_ytx
     }
 
     pub unsafe fn interintra_type(&self) -> Option<InterIntraType> {
-        self.ii.c2rust_unnamed_0.interintra_type
+        self.ii.inter.interintra_type
     }
 
     pub unsafe fn interintra_type_mut(&mut self) -> &mut Option<InterIntraType> {
-        &mut self.ii.c2rust_unnamed_0.interintra_type
+        &mut self.ii.inter.interintra_type
     }
 
     pub unsafe fn interintra_mode(&self) -> InterIntraPredMode {
-        self.ii
-            .c2rust_unnamed_0
-            .c2rust_unnamed
-            .c2rust_unnamed
-            .interintra_mode
+        self.ii.inter.c2rust_unnamed.c2rust_unnamed.interintra_mode
     }
 
     pub unsafe fn interintra_mode_mut(&mut self) -> &mut InterIntraPredMode {
-        &mut self
-            .ii
-            .c2rust_unnamed_0
-            .c2rust_unnamed
-            .c2rust_unnamed
-            .interintra_mode
+        &mut self.ii.inter.c2rust_unnamed.c2rust_unnamed.interintra_mode
     }
 
     pub unsafe fn motion_mode(&self) -> MotionMode {
-        self.ii.c2rust_unnamed_0.motion_mode
+        self.ii.inter.motion_mode
     }
 
     pub unsafe fn motion_mode_mut(&mut self) -> &mut MotionMode {
-        &mut self.ii.c2rust_unnamed_0.motion_mode
+        &mut self.ii.inter.motion_mode
     }
 
     pub unsafe fn tx_split0(&self) -> u8 {
-        self.ii.c2rust_unnamed_0.tx_split0
+        self.ii.inter.tx_split0
     }
 
     pub unsafe fn tx_split1(&self) -> u16 {
-        self.ii.c2rust_unnamed_0.tx_split1
+        self.ii.inter.tx_split1
     }
 }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -534,7 +534,7 @@ unsafe fn decode_coefs<BD: BitDepth>(
         *txtp = DCT_DCT;
     } else if chroma != 0 {
         *txtp = (if intra != 0 {
-            dav1d_txtp_from_uvmode[b.c2rust_unnamed.c2rust_unnamed.uv_mode as usize] as c_uint
+            dav1d_txtp_from_uvmode[b.ii.c2rust_unnamed.uv_mode as usize] as c_uint
         } else {
             get_uv_inter_txtp(&*t_dim, *txtp) as c_uint
         }) as TxfmType;
@@ -544,11 +544,10 @@ unsafe fn decode_coefs<BD: BitDepth>(
         let idx: c_uint;
         if intra != 0 {
             let y_mode_nofilt: IntraPredMode =
-                (if b.c2rust_unnamed.c2rust_unnamed.y_mode as c_int == FILTER_PRED as c_int {
-                    dav1d_filter_mode_to_y_mode[b.c2rust_unnamed.c2rust_unnamed.y_angle as usize]
-                        as c_int
+                (if b.ii.c2rust_unnamed.y_mode as c_int == FILTER_PRED as c_int {
+                    dav1d_filter_mode_to_y_mode[b.ii.c2rust_unnamed.y_angle as usize] as c_int
                 } else {
-                    b.c2rust_unnamed.c2rust_unnamed.y_mode as c_int
+                    b.ii.c2rust_unnamed.y_mode as c_int
                 }) as IntraPredMode;
             if frame_hdr.reduced_txtp_set != 0 || (*t_dim).min as c_int == TX_16X16 as c_int {
                 idx = rav1d_msac_decode_symbol_adapt4(
@@ -1930,14 +1929,14 @@ pub(crate) unsafe fn rav1d_read_coef_blocks<BD: BitDepth>(
         &*dav1d_txfm_dimensions.as_ptr().offset(b.uvtx as isize) as *const TxfmInfo;
     let t_dim: *const TxfmInfo = &*dav1d_txfm_dimensions.as_ptr().offset(
         (if b.intra as c_int != 0 {
-            b.c2rust_unnamed.c2rust_unnamed.tx as c_int
+            b.ii.c2rust_unnamed.tx as c_int
         } else {
-            b.c2rust_unnamed.c2rust_unnamed_0.max_ytx as c_int
+            b.ii.c2rust_unnamed_0.max_ytx as c_int
         }) as isize,
     ) as *const TxfmInfo;
     let tx_split: [u16; 2] = [
-        b.c2rust_unnamed.c2rust_unnamed_0.tx_split0 as u16,
-        b.c2rust_unnamed.c2rust_unnamed_0.tx_split1,
+        b.ii.c2rust_unnamed_0.tx_split0 as u16,
+        b.ii.c2rust_unnamed_0.tx_split1,
     ];
     let mut init_y = 0;
     while init_y < h4 {
@@ -1962,7 +1961,7 @@ pub(crate) unsafe fn rav1d_read_coef_blocks<BD: BitDepth>(
                             t,
                             bs,
                             b,
-                            b.c2rust_unnamed.c2rust_unnamed_0.max_ytx as RectTxfmSize,
+                            b.ii.c2rust_unnamed_0.max_ytx as RectTxfmSize,
                             0 as c_int,
                             tx_split,
                             x_off,
@@ -1984,7 +1983,7 @@ pub(crate) unsafe fn rav1d_read_coef_blocks<BD: BitDepth>(
                             &mut t.cf,
                             &mut f.a[t.a].lcoef.index_mut(a_start..a_start + a_len),
                             &mut t.l.lcoef.index_mut(l_start..l_start + l_len),
-                            b.c2rust_unnamed.c2rust_unnamed.tx as RectTxfmSize,
+                            b.ii.c2rust_unnamed.tx as RectTxfmSize,
                             bs,
                             b,
                             1 as c_int,
@@ -1996,10 +1995,7 @@ pub(crate) unsafe fn rav1d_read_coef_blocks<BD: BitDepth>(
                         if debug_block_info!(f, t.b) {
                             println!(
                                 "Post-y-cf-blk[tx={},txtp={},eob={}]: r={}",
-                                b.c2rust_unnamed.c2rust_unnamed.tx as c_int,
-                                txtp as c_uint,
-                                eob,
-                                ts.msac.rng,
+                                b.ii.c2rust_unnamed.tx as c_int, txtp as c_uint, eob, ts.msac.rng,
                             );
                         }
                         f.frame_thread.cbi[cbi_idx..][t.b.x as usize][0].store(
@@ -2520,7 +2516,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
         && (bh4 > ss_ver || t.b.y & 1 != 0)) as c_int;
     let t_dim: *const TxfmInfo = &*dav1d_txfm_dimensions
         .as_ptr()
-        .offset(b.c2rust_unnamed.c2rust_unnamed.tx as isize)
+        .offset(b.ii.c2rust_unnamed.tx as isize)
         as *const TxfmInfo;
     let uv_t_dim: *const TxfmInfo =
         &*dav1d_txfm_dimensions.as_ptr().offset(b.uvtx as isize) as *const TxfmInfo;
@@ -2534,7 +2530,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
         let sub_ch4 = cmp::min(ch4, init_y + 16 >> ss_ver);
         let mut init_x = 0;
         while init_x < w4 {
-            if b.c2rust_unnamed.c2rust_unnamed.pal_sz[0] != 0 {
+            if b.ii.c2rust_unnamed.pal_sz[0] != 0 {
                 let dst: *mut BD::Pixel = (f.cur.data.as_ref().unwrap().data[0] as *mut BD::Pixel)
                     .offset(
                         (4 * (t.b.y as isize * BD::pxstride(f.cur.stride[0]) + t.b.x as isize))
@@ -2619,8 +2615,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     let mut angle;
                     let edge_flags: EdgeFlags;
                     let m: IntraPredMode;
-                    if !(b.c2rust_unnamed.c2rust_unnamed.pal_sz[0] != 0) {
-                        angle = b.c2rust_unnamed.c2rust_unnamed.y_angle as c_int;
+                    if !(b.ii.c2rust_unnamed.pal_sz[0] != 0) {
+                        angle = b.ii.c2rust_unnamed.y_angle as c_int;
                         edge_flags = EdgeFlags::union_all([
                             EdgeFlags::I444_TOP_HAS_RIGHT.select(
                                 !((y > init_y || !sb_has_tr) && x + (*t_dim).w as c_int >= sub_w4),
@@ -2664,7 +2660,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             dst_slice,
                             f.cur.stride[0],
                             top_sb_edge_slice,
-                            b.c2rust_unnamed.c2rust_unnamed.y_mode as IntraPredMode,
+                            b.ii.c2rust_unnamed.y_mode as IntraPredMode,
                             &mut angle,
                             (*t_dim).w as c_int,
                             (*t_dim).h as c_int,
@@ -2746,7 +2742,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                     .lcoef
                                     .index_mut(a_start..a_start + (*t_dim).w as usize),
                                 &mut t.l.lcoef.index_mut(l_start..l_start + (*t_dim).h as usize),
-                                b.c2rust_unnamed.c2rust_unnamed.tx as RectTxfmSize,
+                                b.ii.c2rust_unnamed.tx as RectTxfmSize,
                                 bs,
                                 b,
                                 1 as c_int,
@@ -2759,7 +2755,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             if debug_block_info!(f, t.b) {
                                 println!(
                                     "Post-y-cf-blk[tx={},txtp={},eob={}]: r={}",
-                                    b.c2rust_unnamed.c2rust_unnamed.tx as c_int,
+                                    b.ii.c2rust_unnamed.tx as c_int,
                                     txtp as c_uint,
                                     eob,
                                     ts.msac.rng,
@@ -2787,8 +2783,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                     "dq",
                                 );
                             }
-                            ((*dsp).itx.itxfm_add[b.c2rust_unnamed.c2rust_unnamed.tx as usize]
-                                [txtp as usize])
+                            ((*dsp).itx.itxfm_add[b.ii.c2rust_unnamed.tx as usize][txtp as usize])
                                 .expect("non-null function pointer")(
                                 dst.cast(),
                                 f.cur.stride[0],
@@ -2827,7 +2822,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
             t.b.y -= y;
             if !(has_chroma == 0) {
                 let stride: ptrdiff_t = f.cur.stride[1];
-                if b.c2rust_unnamed.c2rust_unnamed.uv_mode as c_int == CFL_PRED as c_int {
+                if b.ii.c2rust_unnamed.uv_mode as c_int == CFL_PRED as c_int {
                     assert!(init_x == 0 && init_y == 0);
                     let scratch = t.scratch.inter_intra_mut();
                     let ac = scratch.ac_txtp_map.ac_mut();
@@ -2863,7 +2858,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     );
                     let mut pl = 0;
                     while pl < 2 {
-                        if !(b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[pl as usize] == 0) {
+                        if !(b.ii.c2rust_unnamed.cfl_alpha[pl as usize] == 0) {
                             let mut angle = 0;
                             let top_sb_edge_slice = if t.b.y & !ss_ver & f.sb_step - 1 == 0 {
                                 let sby = t.b.y >> f.sb_shift;
@@ -2917,7 +2912,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                 (*uv_t_dim).w as c_int * 4,
                                 (*uv_t_dim).h as c_int * 4,
                                 ac.as_mut_ptr(),
-                                b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[pl as usize] as c_int,
+                                b.ii.c2rust_unnamed.cfl_alpha[pl as usize] as c_int,
                                 BD::from_c(f.bitdepth_max),
                             );
                         }
@@ -2940,7 +2935,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             "v-cfl-pred",
                         );
                     }
-                } else if b.c2rust_unnamed.c2rust_unnamed.pal_sz[1] != 0 {
+                } else if b.ii.c2rust_unnamed.pal_sz[1] != 0 {
                     let uv_dstoff: ptrdiff_t = 4
                         * ((t.b.x >> ss_hor) as isize
                             + (t.b.y >> ss_ver) as isize * BD::pxstride(f.cur.stride[1]));
@@ -3045,13 +3040,11 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             let xstart;
                             let ystart;
                             let m: IntraPredMode;
-                            if !(b.c2rust_unnamed.c2rust_unnamed.uv_mode as c_int
-                                == CFL_PRED as c_int
-                                && b.c2rust_unnamed.c2rust_unnamed.cfl_alpha[pl as usize] as c_int
-                                    != 0
-                                || b.c2rust_unnamed.c2rust_unnamed.pal_sz[1] as c_int != 0)
+                            if !(b.ii.c2rust_unnamed.uv_mode as c_int == CFL_PRED as c_int
+                                && b.ii.c2rust_unnamed.cfl_alpha[pl as usize] as c_int != 0
+                                || b.ii.c2rust_unnamed.pal_sz[1] as c_int != 0)
                             {
-                                angle = b.c2rust_unnamed.c2rust_unnamed.uv_angle as c_int;
+                                angle = b.ii.c2rust_unnamed.uv_angle as c_int;
                                 edge_flags = (if (y > init_y >> ss_ver || !uv_sb_has_tr)
                                     && x + (*uv_t_dim).w as c_int >= sub_cw4
                                 {
@@ -3073,13 +3066,12 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                 } else {
                                     None
                                 };
-                                uv_mode = (if b.c2rust_unnamed.c2rust_unnamed.uv_mode as c_int
-                                    == CFL_PRED as c_int
-                                {
-                                    DC_PRED as c_int
-                                } else {
-                                    b.c2rust_unnamed.c2rust_unnamed.uv_mode as c_int
-                                }) as IntraPredMode;
+                                uv_mode =
+                                    (if b.ii.c2rust_unnamed.uv_mode as c_int == CFL_PRED as c_int {
+                                        DC_PRED as c_int
+                                    } else {
+                                        b.ii.c2rust_unnamed.uv_mode as c_int
+                                    }) as IntraPredMode;
                                 xpos = t.b.x >> ss_hor;
                                 ypos = t.b.y >> ss_ver;
                                 xstart = (*ts).tiling.col_start >> ss_hor;
@@ -3377,8 +3369,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 )?;
             }
         }
-    } else if let Some(comp_inter_type) = b.c2rust_unnamed.c2rust_unnamed_0.comp_type {
-        let filter_2d = b.c2rust_unnamed.c2rust_unnamed_0.filter2d;
+    } else if let Some(comp_inter_type) = b.ii.c2rust_unnamed_0.comp_type {
+        let filter_2d = b.ii.c2rust_unnamed_0.filter2d;
         let scratch = t.scratch.inter_mut();
         let scratch_inter = scratch.lap_inter.inter_mut();
         let tmp = &mut scratch_inter.compinter;
@@ -3386,7 +3378,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
         let seg_mask = &mut scratch_inter.seg_mask;
         for i in 0..2 {
             let refp = &f.refp[b.r#ref()[i] as usize];
-            if b.c2rust_unnamed.c2rust_unnamed_0.inter_mode == GLOBALMV_GLOBALMV
+            if b.ii.c2rust_unnamed_0.inter_mode == GLOBALMV_GLOBALMV
                 && f.gmv_warp_allowed[b.r#ref()[i] as usize] != 0
             {
                 warp_affine::<BD>(


### PR DESCRIPTION
In preparation for making the `union`s into `enum`s/other safe constructs, this renames all of the `c2rust_unnamed*` fields into real names.  This is a very simple but noisy change, so I wanted to put this in its own PR first.