### PR TITLE
`struct TaskThreadData_delayed_fg`: Make raw pointers owned references

### DIFF
--- a/src/fg_apply.rs
+++ b/src/fg_apply.rs
@@ -185,7 +185,7 @@ pub(crate) unsafe fn rav1d_prep_grain<BD: BitDepth>(
 
 pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
     dsp: &Rav1dFilmGrainDSPContext,
-    out: &mut Rav1dPicture,
+    out: &Rav1dPicture,
     r#in: &Rav1dPicture,
     grain: &GrainBD<BD>,
     row: usize,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -290,23 +290,13 @@ impl BitDepthDependentType for Grain {
     type T<BD: BitDepth> = GrainBD<BD>;
 }
 
+#[derive(Default)]
 #[repr(C)]
 pub(crate) struct TaskThreadData_delayed_fg {
-    pub in_0: *const Rav1dPicture,
-    pub out: *mut Rav1dPicture,
+    pub in_0: Rav1dPicture,
+    pub out: Rav1dPicture,
     pub type_0: TaskType,
     pub grain: BitDepthUnion<Grain>,
-}
-
-impl Default for TaskThreadData_delayed_fg {
-    fn default() -> Self {
-        Self {
-            in_0: std::ptr::null(),
-            out: std::ptr::null_mut(),
-            type_0: Default::default(),
-            grain: Default::default(),
-        }
-    }
 }
 
 // TODO(SJC): Remove when TaskThreadData_delayed_fg is thread-safe

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,6 @@ use std::sync::Arc;
 use std::sync::Condvar;
 use std::sync::Mutex;
 use std::sync::Once;
-use std::sync::RwLock;
 use std::thread;
 use to_method::To as _;
 
@@ -244,7 +243,7 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
         delayed_fg_exec: AtomicI32::new(0),
         delayed_fg_cond: Condvar::new(),
         delayed_fg_progress: [AtomicI32::new(0), AtomicI32::new(0)],
-        delayed_fg: RwLock::new(mem::zeroed()),
+        delayed_fg: Default::default(),
     };
     (*c).task_thread = Arc::new(ttd);
     (*c).frame_thread.out_delayed = if n_fc > 1 {


### PR DESCRIPTION
Make raw picture pointers in `delayed_fg` into ref-counted references. `Rav1dPicture` needs inner mutability, which is still currently unsafe.

* Fixes #833.
* Fixes `TaskThreadData_delayed_fg` of #862.