### PR TITLE
`fn rav1d_flush`: Cleanup and make mostly safe

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -58,6 +58,7 @@ pub mod src {
     mod intra_edge;
     mod ipred;
     mod ipred_prepare;
+    mod iter;
     mod itx;
     mod itx_1d;
     mod levels;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4648,13 +4648,8 @@ pub(crate) fn rav1d_decode_frame_exit(
     if c.fc.len() > 1 && retval.is_err() && !cf.is_empty() {
         cf.fill_with(Default::default);
     }
-    // TODO(kkysen) use array::zip when stable
-    for i in 0..7 {
-        if f.refp[i].p.frame_hdr.is_some() {
-            let _ = mem::take(&mut f.refp[i]);
-        }
-        let _ = mem::take(&mut f.ref_mvs[i]);
-    }
+    let _ = mem::take(&mut f.refp);
+    let _ = mem::take(&mut f.ref_mvs);
     let _ = mem::take(&mut f.cur);
     let _ = mem::take(&mut f.sr_cur);
     let _ = mem::take(&mut *fc.in_cdf.try_write().unwrap());

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3973,7 +3973,7 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
         t.a = (off_2pass + col_sb128_start + tile_row * f.sb128w) as usize;
         for bx in (ts.tiling.col_start..ts.tiling.col_end).step_by(sb_step as usize) {
             t.b.x = bx;
-            if c.flush.load(Ordering::Acquire) != 0 {
+            if c.flush.load(Ordering::Acquire) {
                 return Err(());
             }
             decode_sb(c, t, f, root_bl, EdgeIndex::root())?;
@@ -4008,7 +4008,7 @@ pub(crate) unsafe fn rav1d_decode_tile_sbrow(
     t.lf_mask = Some((sb128y * f.sb128w + col_sb128_start) as usize);
     for bx in (ts.tiling.col_start..ts.tiling.col_end).step_by(sb_step as usize) {
         t.b.x = bx;
-        if c.flush.load(Ordering::Acquire) != 0 {
+        if c.flush.load(Ordering::Acquire) {
             return Err(());
         }
         let cdef_idx = &f.lf.mask[t.lf_mask.unwrap()].cdef_idx;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4645,7 +4645,7 @@ pub(crate) fn rav1d_decode_frame_exit(
         task_thread.error.store(0, Ordering::Relaxed);
     }
     let cf = f.frame_thread.cf.get_mut();
-    if c.fc.len() > 1 && retval.is_err() && !cf.is_empty() {
+    if c.fc.len() > 1 && retval.is_err() {
         cf.fill_with(Default::default);
     }
     let _ = mem::take(&mut f.refp);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4632,7 +4632,7 @@ unsafe fn rav1d_decode_frame_main(c: &Rav1dContext, f: &mut Rav1dFrameData) -> R
     Ok(())
 }
 
-pub(crate) unsafe fn rav1d_decode_frame_exit(
+pub(crate) fn rav1d_decode_frame_exit(
     c: &Rav1dContext,
     fc: &Rav1dFrameContext,
     retval: Rav1dResult,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -379,15 +379,6 @@ pub struct Rav1dContext {
     pub(crate) picture_pool: Arc<MemPool<MaybeUninit<u8>>>,
 }
 
-impl Rav1dContext {
-    /// Iterates over all frame contexts in the `fc` buffer, starting at a given
-    /// index. The iterator wraps around to the start of the buffer. so all
-    /// contexts will be included.
-    pub(crate) fn fc_iter(&self, start: usize) -> impl Iterator<Item = &Rav1dFrameContext> {
-        self.fc.iter().skip(start).chain(self.fc.iter().take(start))
-    }
-}
-
 // TODO(SJC): Remove when Rav1dContext is thread-safe
 unsafe impl Send for Rav1dContext {}
 // TODO(SJC): Remove when Rav1dContext is thread-safe

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -344,7 +344,7 @@ pub struct Rav1dContext {
     pub(crate) in_0: Rav1dData,
     pub(crate) out: Rav1dThreadPicture,
     pub(crate) cache: Rav1dThreadPicture,
-    pub(crate) flush: AtomicI32,
+    pub(crate) flush: AtomicBool,
     pub(crate) frame_thread: Rav1dContext_frame_thread,
 
     // task threading (refer to tc[] for per_thread thingies)

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -368,7 +368,7 @@ pub struct Rav1dContext {
     pub(crate) output_invisible_frames: bool,
     pub(crate) inloop_filters: Rav1dInloopFilterType,
     pub(crate) decode_frame_type: Rav1dDecodeFrameType,
-    pub(crate) drain: c_int,
+    pub(crate) drain: bool,
     pub(crate) frame_flags: Atomic<PictureFlags>,
     pub(crate) event_flags: Rav1dEventFlags,
     pub(crate) cached_error_props: Mutex<Rav1dDataProps>,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -816,7 +816,7 @@ impl Default for Rav1dFrameContext_task_thread {
 }
 
 impl Rav1dFrameContext_task_thread {
-    pub unsafe fn tasks(&self) -> *mut Rav1dTasks {
+    pub fn tasks(&self) -> *mut Rav1dTasks {
         self.tasks.get()
     }
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,8 @@
+/// Iterate through `iter` starting at index `start`
+/// and then wrapping around to `start` again.
+pub fn wrapping_iter<I, T>(iter: I, start: usize) -> impl Iterator<Item = T>
+where
+    I: Iterator<Item = T> + Clone,
+{
+    iter.clone().skip(start).chain(iter.take(start))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -644,7 +644,7 @@ pub(crate) unsafe fn rav1d_flush(c: &mut Rav1dContext) {
     let mut i = 0;
     while i < 8 {
         if c.refs[i as usize].p.p.frame_hdr.is_some() {
-            let _ = mem::take(&mut (*(c.refs).as_mut_ptr().offset(i as isize)).p);
+            let _ = mem::take(&mut c.refs[i as usize].p);
         }
         let _ = mem::take(&mut c.refs[i as usize].segmap);
         let _ = mem::take(&mut c.refs[i as usize].refmvs);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -631,44 +631,44 @@ pub unsafe extern "C" fn dav1d_apply_grain(
     .into()
 }
 
-pub(crate) unsafe fn rav1d_flush(c: *mut Rav1dContext) {
-    let _ = mem::take(&mut (*c).in_0);
-    if (*c).out.p.frame_hdr.is_some() {
-        let _ = mem::take(&mut (*c).out);
+pub(crate) unsafe fn rav1d_flush(c: &mut Rav1dContext) {
+    let _ = mem::take(&mut c.in_0);
+    if c.out.p.frame_hdr.is_some() {
+        let _ = mem::take(&mut c.out);
     }
-    if (*c).cache.p.frame_hdr.is_some() {
-        let _ = mem::take(&mut (*c).cache);
+    if c.cache.p.frame_hdr.is_some() {
+        let _ = mem::take(&mut c.cache);
     }
-    (*c).drain = 0 as c_int;
-    (*c).cached_error = Ok(());
+    c.drain = 0 as c_int;
+    c.cached_error = Ok(());
     let mut i = 0;
     while i < 8 {
-        if (*c).refs[i as usize].p.p.frame_hdr.is_some() {
-            let _ = mem::take(&mut (*((*c).refs).as_mut_ptr().offset(i as isize)).p);
+        if c.refs[i as usize].p.p.frame_hdr.is_some() {
+            let _ = mem::take(&mut (*(c.refs).as_mut_ptr().offset(i as isize)).p);
         }
-        let _ = mem::take(&mut (*c).refs[i as usize].segmap);
-        let _ = mem::take(&mut (*c).refs[i as usize].refmvs);
-        let _ = mem::take(&mut (*c).cdf[i]);
+        let _ = mem::take(&mut c.refs[i as usize].segmap);
+        let _ = mem::take(&mut c.refs[i as usize].refmvs);
+        let _ = mem::take(&mut c.cdf[i]);
         i += 1;
     }
-    let _ = mem::take(&mut (*c).frame_hdr); // TODO(kkysen) Why wasn't [`rav1d_ref_dec`] called on it?
-    let _ = mem::take(&mut (*c).seq_hdr);
-    let _ = mem::take(&mut (*c).content_light);
-    let _ = mem::take(&mut (*c).mastering_display);
-    let _ = mem::take(&mut (*c).itut_t35);
-    let _ = mem::take(&mut (*c).cached_error_props);
-    if (*c).fc.len() == 1 && (*c).tc.len() == 1 {
+    let _ = mem::take(&mut c.frame_hdr); // TODO(kkysen) Why wasn't [`rav1d_ref_dec`] called on it?
+    let _ = mem::take(&mut c.seq_hdr);
+    let _ = mem::take(&mut c.content_light);
+    let _ = mem::take(&mut c.mastering_display);
+    let _ = mem::take(&mut c.itut_t35);
+    let _ = mem::take(&mut c.cached_error_props);
+    if c.fc.len() == 1 && c.tc.len() == 1 {
         return;
     }
-    (*c).flush.store(1, Ordering::SeqCst);
-    if (*c).tc.len() > 1 {
-        let mut task_thread_lock = (*c).task_thread.lock.lock().unwrap();
-        for tc in (*c).tc.iter() {
+    c.flush.store(1, Ordering::SeqCst);
+    if c.tc.len() > 1 {
+        let mut task_thread_lock = c.task_thread.lock.lock().unwrap();
+        for tc in c.tc.iter() {
             while !tc.flushed() {
                 task_thread_lock = tc.thread_data.cond.wait(task_thread_lock).unwrap();
             }
         }
-        for fc in (*c).fc.iter_mut() {
+        for fc in c.fc.iter_mut() {
             let tasks = &mut *fc.task_thread.tasks();
             tasks.head = None;
             tasks.tail = None;
@@ -676,32 +676,30 @@ pub(crate) unsafe fn rav1d_flush(c: *mut Rav1dContext) {
             *fc.task_thread.pending_tasks.get_mut().unwrap() = Default::default();
             fc.task_thread.pending_tasks_merge = AtomicI32::new(0);
         }
-        (*c).task_thread.first.store(0, Ordering::SeqCst);
-        (*c).task_thread
-            .cur
-            .store((*c).fc.len() as u32, Ordering::SeqCst);
-        (*c).task_thread
+        c.task_thread.first.store(0, Ordering::SeqCst);
+        c.task_thread.cur.store(c.fc.len() as u32, Ordering::SeqCst);
+        c.task_thread
             .reset_task_cur
             .store(u32::MAX, Ordering::SeqCst);
-        (*c).task_thread.cond_signaled.store(0, Ordering::SeqCst);
+        c.task_thread.cond_signaled.store(0, Ordering::SeqCst);
     }
-    if (*c).fc.len() > 1 {
-        for fc in wrapping_iter((*c).fc.iter(), (*c).frame_thread.next as usize) {
-            rav1d_decode_frame_exit(&*c, fc, Err(EGeneric));
+    if c.fc.len() > 1 {
+        for fc in wrapping_iter(c.fc.iter(), c.frame_thread.next as usize) {
+            rav1d_decode_frame_exit(c, fc, Err(EGeneric));
             *fc.task_thread.retval.try_lock().unwrap() = Ok(());
-            let out_delayed = &mut (*c).frame_thread.out_delayed[fc.index];
+            let out_delayed = &mut c.frame_thread.out_delayed[fc.index];
             if out_delayed.p.frame_hdr.is_some() {
                 let _ = mem::take(out_delayed);
             }
         }
-        (*c).frame_thread.next = 0 as c_int as c_uint;
+        c.frame_thread.next = 0 as c_int as c_uint;
     }
-    (*c).flush.store(0, Ordering::SeqCst);
+    c.flush.store(0, Ordering::SeqCst);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_flush(c: *mut Dav1dContext) {
-    rav1d_flush(c)
+    rav1d_flush(&mut *c)
 }
 
 #[cold]
@@ -725,7 +723,7 @@ unsafe fn close_internal(c_out: &mut *mut Rav1dContext, flush: c_int) {
         return;
     }
     if flush != 0 {
-        rav1d_flush(c);
+        rav1d_flush(&mut *c);
     }
     c.drop_in_place();
     rav1d_freep_aligned(c_out as *mut _ as *mut c_void);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -502,7 +502,7 @@ pub(crate) unsafe fn rav1d_send_data(c: &mut Rav1dContext, in_0: &mut Rav1dData)
     if in_0.data.is_some() {
         let sz = in_0.data.as_ref().unwrap().len();
         validate_input!((sz > 0 && sz <= usize::MAX / 2, EINVAL))?;
-        c.drain = 0 as c_int;
+        c.drain = false;
     }
     if c.in_0.data.is_some() {
         return Err(EAGAIN);
@@ -535,13 +535,13 @@ pub(crate) unsafe fn rav1d_get_picture(
     c: &mut Rav1dContext,
     out: &mut Rav1dPicture,
 ) -> Rav1dResult {
-    let drain = mem::replace(&mut c.drain, 1);
+    let drain = mem::replace(&mut c.drain, true);
     gen_picture(c)?;
     mem::replace(&mut c.cached_error, Ok(()))?;
     if output_picture_ready(c, c.fc.len() == 1) {
         return output_image(c, out);
     }
-    if c.fc.len() > 1 && drain != 0 {
+    if c.fc.len() > 1 && drain {
         return drain_picture(c, out);
     }
     Err(EAGAIN)
@@ -635,7 +635,7 @@ pub(crate) unsafe fn rav1d_flush(c: &mut Rav1dContext) {
     let _ = mem::take(&mut c.in_0);
     let _ = mem::take(&mut c.out);
     let _ = mem::take(&mut c.cache);
-    c.drain = 0;
+    c.drain = false;
     c.cached_error = Ok(());
     let _ = mem::take(&mut c.refs);
     let _ = mem::take(&mut c.cdf);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -639,7 +639,7 @@ pub(crate) unsafe fn rav1d_flush(c: &mut Rav1dContext) {
     if c.cache.p.frame_hdr.is_some() {
         let _ = mem::take(&mut c.cache);
     }
-    c.drain = 0 as c_int;
+    c.drain = 0;
     c.cached_error = Ok(());
     let mut i = 0;
     while i < 8 {
@@ -692,7 +692,7 @@ pub(crate) unsafe fn rav1d_flush(c: &mut Rav1dContext) {
                 let _ = mem::take(out_delayed);
             }
         }
-        c.frame_thread.next = 0 as c_int as c_uint;
+        c.frame_thread.next = 0;
     }
     c.flush.store(0, Ordering::SeqCst);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -648,9 +648,9 @@ pub(crate) unsafe fn rav1d_flush(c: &mut Rav1dContext) {
         }
         let _ = mem::take(&mut c.refs[i as usize].segmap);
         let _ = mem::take(&mut c.refs[i as usize].refmvs);
-        let _ = mem::take(&mut c.cdf[i]);
         i += 1;
     }
+    let _ = mem::take(&mut c.cdf);
     let _ = mem::take(&mut c.frame_hdr); // TODO(kkysen) Why wasn't [`rav1d_ref_dec`] called on it?
     let _ = mem::take(&mut c.seq_hdr);
     let _ = mem::take(&mut c.content_light);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ use crate::src::internal::Rav1dFrameContext;
 use crate::src::internal::Rav1dTaskContext;
 use crate::src::internal::Rav1dTaskContext_task_thread;
 use crate::src::internal::TaskThreadData;
+use crate::src::iter::wrapping_iter;
 use crate::src::log::Rav1dLog as _;
 use crate::src::mem::rav1d_alloc_aligned;
 use crate::src::mem::rav1d_free_aligned;
@@ -685,7 +686,7 @@ pub(crate) unsafe fn rav1d_flush(c: *mut Rav1dContext) {
         (*c).task_thread.cond_signaled.store(0, Ordering::SeqCst);
     }
     if (*c).fc.len() > 1 {
-        for fc in (*c).fc_iter((*c).frame_thread.next as usize) {
+        for fc in wrapping_iter((*c).fc.iter(), (*c).frame_thread.next as usize) {
             rav1d_decode_frame_exit(&*c, fc, Err(EGeneric));
             *fc.task_thread.retval.try_lock().unwrap() = Ok(());
             let out_delayed = &mut (*c).frame_thread.out_delayed[fc.index];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -633,25 +633,13 @@ pub unsafe extern "C" fn dav1d_apply_grain(
 
 pub(crate) unsafe fn rav1d_flush(c: &mut Rav1dContext) {
     let _ = mem::take(&mut c.in_0);
-    if c.out.p.frame_hdr.is_some() {
-        let _ = mem::take(&mut c.out);
-    }
-    if c.cache.p.frame_hdr.is_some() {
-        let _ = mem::take(&mut c.cache);
-    }
+    let _ = mem::take(&mut c.out);
+    let _ = mem::take(&mut c.cache);
     c.drain = 0;
     c.cached_error = Ok(());
-    let mut i = 0;
-    while i < 8 {
-        if c.refs[i as usize].p.p.frame_hdr.is_some() {
-            let _ = mem::take(&mut c.refs[i as usize].p);
-        }
-        let _ = mem::take(&mut c.refs[i as usize].segmap);
-        let _ = mem::take(&mut c.refs[i as usize].refmvs);
-        i += 1;
-    }
+    let _ = mem::take(&mut c.refs);
     let _ = mem::take(&mut c.cdf);
-    let _ = mem::take(&mut c.frame_hdr); // TODO(kkysen) Why wasn't [`rav1d_ref_dec`] called on it?
+    let _ = mem::take(&mut c.frame_hdr);
     let _ = mem::take(&mut c.seq_hdr);
     let _ = mem::take(&mut c.content_light);
     let _ = mem::take(&mut c.mastering_display);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,7 +240,7 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
             );
         }
     }
-    (*c).flush = AtomicI32::new(0);
+    (*c).flush = AtomicBool::new(false);
     let NumThreads { n_tc, n_fc } = get_num_threads(s);
     // TODO fallible allocation
     (*c).fc = (0..n_fc).map(|i| Rav1dFrameContext::zeroed(i)).collect();
@@ -648,7 +648,7 @@ pub(crate) unsafe fn rav1d_flush(c: &mut Rav1dContext) {
     if c.fc.len() == 1 && c.tc.len() == 1 {
         return;
     }
-    c.flush.store(1, Ordering::SeqCst);
+    c.flush.store(true, Ordering::SeqCst);
     if c.tc.len() > 1 {
         let mut task_thread_lock = c.task_thread.lock.lock().unwrap();
         for tc in c.tc.iter() {
@@ -682,7 +682,7 @@ pub(crate) unsafe fn rav1d_flush(c: &mut Rav1dContext) {
         }
         c.frame_thread.next = 0;
     }
-    c.flush.store(0, Ordering::SeqCst);
+    c.flush.store(false, Ordering::SeqCst);
 }
 
 #[no_mangle]

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -60,8 +60,11 @@ pub const TILE_ERROR: i32 = i32::MAX - 1;
 #[inline]
 unsafe fn reset_task_cur(c: &Rav1dContext, ttd: &TaskThreadData, mut frame_idx: c_uint) -> c_int {
     unsafe fn curr_found(c: &Rav1dContext, ttd: &TaskThreadData, first: usize) -> c_int {
-        for i in ttd.cur.load(Ordering::Relaxed) as usize..c.fc.len() {
-            (*c.fc[(first + i) % c.fc.len()].task_thread.tasks()).cur_prev = None;
+        for fc in wrapping_iter(
+            c.fc.iter(),
+            first + ttd.cur.load(Ordering::Relaxed) as usize,
+        ) {
+            (*fc.task_thread.tasks()).cur_prev = None;
         }
         return 1;
     }

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -29,6 +29,7 @@ use crate::src::internal::Rav1dTileState;
 use crate::src::internal::TaskThreadData;
 use crate::src::internal::TaskThreadData_delayed_fg;
 use crate::src::internal::TaskType;
+use crate::src::iter::wrapping_iter;
 use crate::src::picture::Rav1dThreadPicture;
 use std::cmp;
 use std::ffi::c_int;
@@ -761,7 +762,9 @@ pub unsafe fn rav1d_worker_task(c: &Rav1dContext, task_thread: Arc<Rav1dTaskCont
         let (fc, t_idx, prev_t) = 'found: {
             if c.fc.len() > 1 {
                 // run init tasks second
-                'init_tasks: for fc in c.fc_iter(ttd.first.load(Ordering::SeqCst) as usize) {
+                'init_tasks: for fc in
+                    wrapping_iter(c.fc.iter(), ttd.first.load(Ordering::SeqCst) as usize)
+                {
                     let tasks = &*fc.task_thread.tasks();
                     if fc.task_thread.init_done.load(Ordering::SeqCst) != 0 {
                         continue 'init_tasks;


### PR DESCRIPTION
The remaining `unsafe` is from `Rav1dFrameContext_task_thread::tasks`, which is an `UnsafeCell<Rav1dTasks>`.