### PR TITLE
`struct Av1BlockIntraInter`: Initialize directly

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -76,6 +76,9 @@ use crate::src::intra_edge::EdgeIndex;
 use crate::src::intra_edge::IntraEdges;
 use crate::src::levels::mv;
 use crate::src::levels::Av1Block;
+use crate::src::levels::Av1BlockInter;
+use crate::src::levels::Av1BlockInter1d;
+use crate::src::levels::Av1BlockInterNd;
 use crate::src::levels::Av1BlockIntra;
 use crate::src::levels::Av1BlockIntraInter;
 use crate::src::levels::BlockLevel;
@@ -2125,11 +2128,27 @@ unsafe fn decode_b(
             tx_split1,
         } = read_vartx_tree(t, f, b, bs, bx4, by4);
 
-        b.ii.inter_mut().nd.one_d.mv[0] = r#ref;
         b.uvtx = uvtx;
-        b.ii.inter_mut().max_ytx = max_ytx;
-        b.ii.inter_mut().tx_split0 = tx_split0;
-        b.ii.inter_mut().tx_split1 = tx_split1;
+        b.ii = Av1BlockIntraInter::Inter(Av1BlockInter {
+            nd: Av1BlockInterNd {
+                one_d: Av1BlockInter1d {
+                    mv: [r#ref, Default::default()],
+                    wedge_idx: Default::default(),
+                    mask_sign: Default::default(),
+                    interintra_mode: InterIntraPredMode::Dc, // 0
+                },
+            },
+            comp_type: Default::default(),
+            inter_mode: Default::default(),
+            motion_mode: Default::default(),
+            drl_idx: Default::default(),
+            r#ref: Default::default(),
+            max_ytx,
+            filter2d: Default::default(),
+            interintra_type: Default::default(),
+            tx_split0,
+            tx_split1,
+        });
 
         // reconstruction
         if t.frame_thread.pass == 1 {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2128,6 +2128,12 @@ unsafe fn decode_b(
             tx_split1,
         } = read_vartx_tree(t, f, b, bs, bx4, by4);
 
+        let filter2d = if t.frame_thread.pass == 1 {
+            Filter2d::Bilinear
+        } else {
+            Filter2d::Regular8Tap // 0
+        };
+
         b.uvtx = uvtx;
         b.ii = Av1BlockIntraInter::Inter(Av1BlockInter {
             nd: Av1BlockInterNd {
@@ -2144,7 +2150,7 @@ unsafe fn decode_b(
             drl_idx: Default::default(),
             r#ref: Default::default(),
             max_ytx,
-            filter2d: Default::default(),
+            filter2d,
             interintra_type: Default::default(),
             tx_split0,
             tx_split1,
@@ -2153,7 +2159,6 @@ unsafe fn decode_b(
         // reconstruction
         if t.frame_thread.pass == 1 {
             bd_fn.read_coef_blocks(f, t, bs, b);
-            b.ii.inter_mut().filter2d = Filter2d::Bilinear;
         } else {
             bd_fn.recon_b_inter(f, t, bs, b)?;
         }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -897,13 +897,13 @@ unsafe fn splat_intrabc_mv(
     t: &Rav1dTaskContext,
     rf: &RefMvsFrame,
     bs: BlockSize,
-    b: &Av1Block,
+    r#ref: mv,
     bw4: usize,
     bh4: usize,
 ) {
     let tmpl = Align16(refmvs_block {
         mv: refmvs_mvpair {
-            mv: [b.ii.inter().nd.one_d.mv[0], mv::ZERO],
+            mv: [r#ref, mv::ZERO],
         },
         r#ref: refmvs_refpair { r#ref: [0, -1] },
         bs,
@@ -2124,7 +2124,7 @@ unsafe fn decode_b(
             bd_fn.recon_b_inter(f, t, bs, b)?;
         }
 
-        splat_intrabc_mv(c, t, &f.rf, bs, b, bw4 as usize, bh4 as usize);
+        splat_intrabc_mv(c, t, &f.rf, bs, r#ref, bw4 as usize, bh4 as usize);
 
         CaseSet::<32, false>::many(
             [(&t.l, 1), (&f.a[t.a], 0)],

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1627,11 +1627,6 @@ unsafe fn decode_b(
         true
     };
     b.intra = intra as u8;
-    b.ii = if intra {
-        Av1BlockIntraInter::Intra(Default::default())
-    } else {
-        Av1BlockIntraInter::Inter(Default::default())
-    };
 
     // intra/inter-specific stuff
     if b.intra != 0 {

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -376,13 +376,6 @@ impl Av1BlockIntraInter {
         }
     }
 
-    pub fn intra_mut(&mut self) -> &mut Av1BlockIntra {
-        match self {
-            Self::Intra(intra) => intra,
-            _ => panic!(),
-        }
-    }
-
     pub const fn inter(&self) -> &Av1BlockInter {
         match self {
             Self::Inter(inter) => inter,

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -115,8 +115,9 @@ pub const HOR_PRED: IntraPredMode = 2;
 pub const VERT_PRED: IntraPredMode = 1;
 pub const DC_PRED: IntraPredMode = 0;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, FromRepr, EnumCount)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromRepr, EnumCount, Default)]
 pub enum InterIntraPredMode {
+    #[default]
     Dc = 0,
     Vert = 1,
     Hor = 2,
@@ -377,13 +378,6 @@ impl Av1BlockIntraInter {
     }
 
     pub const fn inter(&self) -> &Av1BlockInter {
-        match self {
-            Self::Inter(inter) => inter,
-            _ => panic!(),
-        }
-    }
-
-    pub fn inter_mut(&mut self) -> &mut Av1BlockInter {
         match self {
             Self::Inter(inter) => inter,
             _ => panic!(),

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -221,7 +221,7 @@ pub const NEARESTMV: InterPredMode = 0;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum DrlProximity {
-    #[default] // TODO(kkysen) Maybe temporary.
+    #[default]
     Nearest,
     Nearer,
     Near,
@@ -298,7 +298,7 @@ impl Neg for mv {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, FromRepr, Default)]
 pub enum MotionMode {
-    #[default] // TODO(kkysen) Maybe temporary.
+    #[default]
     Translation = 0,
     Obmc = 1,
     Warp = 2,
@@ -325,7 +325,7 @@ pub struct Av1BlockInter1d {
     pub interintra_mode: InterIntraPredMode,
 }
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct Av1BlockInter2d {
     pub mv2d: mv,
@@ -339,15 +339,7 @@ pub union Av1BlockInterNd {
     pub two_d: Av1BlockInter2d,
 }
 
-impl Default for Av1BlockInterNd {
-    fn default() -> Self {
-        Self {
-            two_d: Default::default(),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct Av1BlockInter {
     pub nd: Av1BlockInterNd,


### PR DESCRIPTION
Now we can get rid of the `.{inter,intra}_mut()` methods, avoid their overhead, avoid extra default initialization, and now the shape of `union Av1BlockInterNd` is very clear.