### PR TITLE
`struct Av1BlockIntraInter`: Access variants directly, avoiding checks

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -879,19 +879,19 @@ unsafe fn splat_oneref_mv(
     t: &Rav1dTaskContext,
     rf: &RefMvsFrame,
     bs: BlockSize,
-    b: &Av1Block,
+    inter: &Av1BlockInter,
     bw4: usize,
     bh4: usize,
 ) {
-    let mode = b.ii.inter().inter_mode;
+    let mode = inter.inter_mode;
     let tmpl = Align16(refmvs_block {
         mv: refmvs_mvpair {
-            mv: [b.ii.inter().nd.one_d.mv[0], mv::ZERO],
+            mv: [inter.nd.one_d.mv[0], mv::ZERO],
         },
         r#ref: refmvs_refpair {
             r#ref: [
-                b.ii.inter().r#ref[0] + 1,
-                b.ii.inter().interintra_type.map(|_| 0).unwrap_or(-1),
+                inter.r#ref[0] + 1,
+                inter.interintra_type.map(|_| 0).unwrap_or(-1),
             ],
         },
         bs,
@@ -927,18 +927,18 @@ unsafe fn splat_tworef_mv(
     t: &Rav1dTaskContext,
     rf: &RefMvsFrame,
     bs: BlockSize,
-    b: &Av1Block,
+    inter: &Av1BlockInter,
     bw4: usize,
     bh4: usize,
 ) {
     assert!(bw4 >= 2 && bh4 >= 2);
-    let mode = b.ii.inter().inter_mode;
+    let mode = inter.inter_mode;
     let tmpl = Align16(refmvs_block {
         mv: refmvs_mvpair {
-            mv: b.ii.inter().nd.one_d.mv,
+            mv: inter.nd.one_d.mv,
         },
         r#ref: refmvs_refpair {
-            r#ref: [b.ii.inter().r#ref[0] + 1, b.ii.inter().r#ref[1] + 1],
+            r#ref: [inter.r#ref[0] + 1, inter.r#ref[1] + 1],
         },
         bs,
         mf: (mode == GLOBALMV_GLOBALMV) as u8 | (1 << mode & 0xbc != 0) as u8 * 2,
@@ -3115,9 +3115,9 @@ unsafe fn decode_b(
 
         // context updates
         if is_comp {
-            splat_tworef_mv(c, t, &f.rf, bs, b, bw4 as usize, bh4 as usize);
+            splat_tworef_mv(c, t, &f.rf, bs, &inter, bw4 as usize, bh4 as usize);
         } else {
-            splat_oneref_mv(c, t, &f.rf, bs, b, bw4 as usize, bh4 as usize);
+            splat_oneref_mv(c, t, &f.rf, bs, &inter, bw4 as usize, bh4 as usize);
         }
 
         CaseSet::<32, false>::many(

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1171,131 +1171,134 @@ unsafe fn decode_b(
     let frame_type = f.frame_hdr.as_ref().unwrap().frame_type;
 
     if t.frame_thread.pass == 2 {
-        if b.intra != 0 {
-            bd_fn.recon_b_intra(f, t, bs, intra_edge_flags, b);
+        match b.ii {
+            Av1BlockIntraInter::Intra(intra) => {
+                bd_fn.recon_b_intra(f, t, bs, intra_edge_flags, b);
 
-            let y_mode = b.ii.intra().y_mode;
-            let y_mode_nofilt = if y_mode == FILTER_PRED {
-                DC_PRED
-            } else {
-                y_mode
-            };
-            CaseSet::<32, false>::many(
-                [&t.l, &f.a[t.a]],
-                [bh4 as usize, bw4 as usize],
-                [by4 as usize, bx4 as usize],
-                |case, dir| {
-                    case.set_disjoint(&dir.mode, y_mode_nofilt);
-                    case.set_disjoint(&dir.intra, 1);
-                },
-            );
-            if frame_type.is_inter_or_switch() {
-                let ri = t.rt.r[(t.b.y as usize & 31) + 5 + bh4 as usize - 1] + t.b.x as usize;
-                let r = &mut *f.rf.r.index_mut(ri..ri + bw4 as usize);
-                for block in r {
-                    block.r#ref.r#ref[0] = 0;
-                    block.bs = bs;
-                }
-                let rr = &t.rt.r[(t.b.y as usize & 31) + 5..][..bh4 as usize - 1];
-                for r in rr {
-                    let block = &mut f.rf.r.index_mut(r + t.b.x as usize + bw4 as usize - 1);
-                    block.r#ref.r#ref[0] = 0;
-                    block.bs = bs;
-                }
-            }
-
-            if has_chroma {
+                let y_mode = b.ii.intra().y_mode;
+                let y_mode_nofilt = if y_mode == FILTER_PRED {
+                    DC_PRED
+                } else {
+                    y_mode
+                };
                 CaseSet::<32, false>::many(
                     [&t.l, &f.a[t.a]],
-                    [cbh4 as usize, cbw4 as usize],
-                    [cby4 as usize, cbx4 as usize],
+                    [bh4 as usize, bw4 as usize],
+                    [by4 as usize, bx4 as usize],
                     |case, dir| {
-                        case.set_disjoint(&dir.uvmode, b.ii.intra().uv_mode);
+                        case.set_disjoint(&dir.mode, y_mode_nofilt);
+                        case.set_disjoint(&dir.intra, 1);
                     },
                 );
-            }
-        } else {
-            if frame_type.is_inter_or_switch() /* not intrabc */
-                && b.ii.inter().comp_type.is_none()
-                && b.ii.inter().motion_mode == MotionMode::Warp
-            {
-                if b.ii.inter().nd.two_d.matrix[0] == i16::MIN {
-                    t.warpmv.r#type = Rav1dWarpedMotionType::Identity;
-                } else {
-                    t.warpmv.r#type = Rav1dWarpedMotionType::Affine;
-                    t.warpmv.matrix[2] = b.ii.inter().nd.two_d.matrix[0] as i32 + 0x10000;
-                    t.warpmv.matrix[3] = b.ii.inter().nd.two_d.matrix[1] as i32;
-                    t.warpmv.matrix[4] = b.ii.inter().nd.two_d.matrix[2] as i32;
-                    t.warpmv.matrix[5] = b.ii.inter().nd.two_d.matrix[3] as i32 + 0x10000;
-                    rav1d_set_affine_mv2d(
-                        bw4,
-                        bh4,
-                        b.ii.inter().nd.two_d.mv2d,
-                        &mut t.warpmv,
-                        t.b.x,
-                        t.b.y,
-                    );
-                    rav1d_get_shear_params(&mut t.warpmv);
-                    if debug_block_info!(f, t.b) {
-                        println!(
-                            "[ {} {} {}\n  {} {} {} ]\n\
-                            alpha={}, beta={}, gamma={}, deta={}, mv=y:{},x:{}",
-                            SignAbs(t.warpmv.matrix[0]),
-                            SignAbs(t.warpmv.matrix[1]),
-                            SignAbs(t.warpmv.matrix[2]),
-                            SignAbs(t.warpmv.matrix[3]),
-                            SignAbs(t.warpmv.matrix[4]),
-                            SignAbs(t.warpmv.matrix[5]),
-                            SignAbs(t.warpmv.alpha().into()),
-                            SignAbs(t.warpmv.beta().into()),
-                            SignAbs(t.warpmv.gamma().into()),
-                            SignAbs(t.warpmv.delta().into()),
-                            b.ii.inter().nd.two_d.mv2d.y,
-                            b.ii.inter().nd.two_d.mv2d.x,
-                        );
+                if frame_type.is_inter_or_switch() {
+                    let ri = t.rt.r[(t.b.y as usize & 31) + 5 + bh4 as usize - 1] + t.b.x as usize;
+                    let r = &mut *f.rf.r.index_mut(ri..ri + bw4 as usize);
+                    for block in r {
+                        block.r#ref.r#ref[0] = 0;
+                        block.bs = bs;
+                    }
+                    let rr = &t.rt.r[(t.b.y as usize & 31) + 5..][..bh4 as usize - 1];
+                    for r in rr {
+                        let block = &mut f.rf.r.index_mut(r + t.b.x as usize + bw4 as usize - 1);
+                        block.r#ref.r#ref[0] = 0;
+                        block.bs = bs;
                     }
                 }
-            }
-            bd_fn.recon_b_inter(f, t, bs, b)?;
 
-            let filter = &dav1d_filter_dir[b.ii.inter().filter2d as usize];
-            CaseSet::<32, false>::many(
-                [&t.l, &f.a[t.a]],
-                [bh4 as usize, bw4 as usize],
-                [by4 as usize, bx4 as usize],
-                |case, dir| {
-                    case.set_disjoint(&dir.filter[0], filter[0].into());
-                    case.set_disjoint(&dir.filter[1], filter[1].into());
-                    case.set_disjoint(&dir.intra, 0);
-                },
-            );
-
-            if frame_type.is_inter_or_switch() {
-                let ri = t.rt.r[(t.b.y as usize & 31) + 5 + bh4 as usize - 1] + t.b.x as usize;
-                let r = &mut *f.rf.r.index_mut(ri..ri + bw4 as usize);
-                for block in r {
-                    block.r#ref.r#ref[0] = b.ii.inter().r#ref[0] + 1;
-                    block.mv.mv[0] = b.ii.inter().nd.one_d.mv[0];
-                    block.bs = bs;
-                }
-                let rr = &t.rt.r[(t.b.y as usize & 31) + 5..][..bh4 as usize - 1];
-                for r in rr {
-                    let block = &mut f.rf.r.index_mut(r + t.b.x as usize + bw4 as usize - 1);
-                    block.r#ref.r#ref[0] = b.ii.inter().r#ref[0] + 1;
-                    block.mv.mv[0] = b.ii.inter().nd.one_d.mv[0];
-                    block.bs = bs;
+                if has_chroma {
+                    CaseSet::<32, false>::many(
+                        [&t.l, &f.a[t.a]],
+                        [cbh4 as usize, cbw4 as usize],
+                        [cby4 as usize, cbx4 as usize],
+                        |case, dir| {
+                            case.set_disjoint(&dir.uvmode, intra.uv_mode);
+                        },
+                    );
                 }
             }
+            Av1BlockIntraInter::Inter(inter) => {
+                if frame_type.is_inter_or_switch() /* not intrabc */
+                && inter.comp_type.is_none()
+                && inter.motion_mode == MotionMode::Warp
+                {
+                    if inter.nd.two_d.matrix[0] == i16::MIN {
+                        t.warpmv.r#type = Rav1dWarpedMotionType::Identity;
+                    } else {
+                        t.warpmv.r#type = Rav1dWarpedMotionType::Affine;
+                        t.warpmv.matrix[2] = inter.nd.two_d.matrix[0] as i32 + 0x10000;
+                        t.warpmv.matrix[3] = inter.nd.two_d.matrix[1] as i32;
+                        t.warpmv.matrix[4] = inter.nd.two_d.matrix[2] as i32;
+                        t.warpmv.matrix[5] = inter.nd.two_d.matrix[3] as i32 + 0x10000;
+                        rav1d_set_affine_mv2d(
+                            bw4,
+                            bh4,
+                            inter.nd.two_d.mv2d,
+                            &mut t.warpmv,
+                            t.b.x,
+                            t.b.y,
+                        );
+                        rav1d_get_shear_params(&mut t.warpmv);
+                        if debug_block_info!(f, t.b) {
+                            println!(
+                                "[ {} {} {}\n  {} {} {} ]\n\
+                            alpha={}, beta={}, gamma={}, deta={}, mv=y:{},x:{}",
+                                SignAbs(t.warpmv.matrix[0]),
+                                SignAbs(t.warpmv.matrix[1]),
+                                SignAbs(t.warpmv.matrix[2]),
+                                SignAbs(t.warpmv.matrix[3]),
+                                SignAbs(t.warpmv.matrix[4]),
+                                SignAbs(t.warpmv.matrix[5]),
+                                SignAbs(t.warpmv.alpha().into()),
+                                SignAbs(t.warpmv.beta().into()),
+                                SignAbs(t.warpmv.gamma().into()),
+                                SignAbs(t.warpmv.delta().into()),
+                                inter.nd.two_d.mv2d.y,
+                                inter.nd.two_d.mv2d.x,
+                            );
+                        }
+                    }
+                }
+                bd_fn.recon_b_inter(f, t, bs, b)?;
 
-            if has_chroma {
+                let filter = &dav1d_filter_dir[inter.filter2d as usize];
                 CaseSet::<32, false>::many(
                     [&t.l, &f.a[t.a]],
-                    [cbh4 as usize, cbw4 as usize],
-                    [cby4 as usize, cbx4 as usize],
+                    [bh4 as usize, bw4 as usize],
+                    [by4 as usize, bx4 as usize],
                     |case, dir| {
-                        case.set_disjoint(&dir.uvmode, DC_PRED);
+                        case.set_disjoint(&dir.filter[0], filter[0].into());
+                        case.set_disjoint(&dir.filter[1], filter[1].into());
+                        case.set_disjoint(&dir.intra, 0);
                     },
                 );
+
+                if frame_type.is_inter_or_switch() {
+                    let ri = t.rt.r[(t.b.y as usize & 31) + 5 + bh4 as usize - 1] + t.b.x as usize;
+                    let r = &mut *f.rf.r.index_mut(ri..ri + bw4 as usize);
+                    for block in r {
+                        block.r#ref.r#ref[0] = inter.r#ref[0] + 1;
+                        block.mv.mv[0] = inter.nd.one_d.mv[0];
+                        block.bs = bs;
+                    }
+                    let rr = &t.rt.r[(t.b.y as usize & 31) + 5..][..bh4 as usize - 1];
+                    for r in rr {
+                        let block = &mut f.rf.r.index_mut(r + t.b.x as usize + bw4 as usize - 1);
+                        block.r#ref.r#ref[0] = inter.r#ref[0] + 1;
+                        block.mv.mv[0] = inter.nd.one_d.mv[0];
+                        block.bs = bs;
+                    }
+                }
+
+                if has_chroma {
+                    CaseSet::<32, false>::many(
+                        [&t.l, &f.a[t.a]],
+                        [cbh4 as usize, cbw4 as usize],
+                        [cby4 as usize, cbx4 as usize],
+                        |case, dir| {
+                            case.set_disjoint(&dir.uvmode, DC_PRED);
+                        },
+                    );
+                }
             }
         }
 
@@ -1626,10 +1629,9 @@ unsafe fn decode_b(
     } else {
         true
     };
-    b.intra = intra as u8;
 
     // intra/inter-specific stuff
-    if b.intra != 0 {
+    if intra {
         let ymode_cdf = if frame_hdr.frame_type.is_inter_or_switch() {
             &mut ts.cdf.m.y_mode[dav1d_ymode_size_context[bs as usize] as usize]
         } else {
@@ -3182,149 +3184,41 @@ unsafe fn decode_b(
         }
     }
 
-    if t.frame_thread.pass == 1 && b.intra == 0 && frame_hdr.frame_type.is_inter_or_switch() {
-        let sby = t.b.y - ts.tiling.row_start >> f.sb_shift;
-        let mut lowest_px = f.lowest_pixel_mem.index_mut(ts.lowest_pixel + sby as usize);
-        // keep track of motion vectors for each reference
-        if b.ii.inter().comp_type.is_none() {
-            // y
-            if cmp::min(bw4, bh4) > 1
-                && (b.ii.inter().inter_mode == GLOBALMV
-                    && f.gmv_warp_allowed[b.ii.inter().r#ref[0] as usize] != 0
-                    || b.ii.inter().motion_mode == MotionMode::Warp
-                        && t.warpmv.r#type > Rav1dWarpedMotionType::Translation)
-            {
-                affine_lowest_px_luma(
-                    t,
-                    &mut lowest_px[b.ii.inter().r#ref[0] as usize][0],
-                    b_dim,
-                    if b.ii.inter().motion_mode == MotionMode::Warp {
-                        &t.warpmv
-                    } else {
-                        &frame_hdr.gmv[b.ii.inter().r#ref[0] as usize]
-                    },
-                );
-            } else {
-                mc_lowest_px(
-                    &mut lowest_px[b.ii.inter().r#ref[0] as usize][0],
-                    t.b.y,
-                    bh4,
-                    b.ii.inter().nd.one_d.mv[0].y,
-                    0,
-                    &f.svc[b.ii.inter().r#ref[0] as usize][1],
-                );
-                if b.ii.inter().motion_mode == MotionMode::Obmc {
-                    obmc_lowest_px(
-                        &f.rf.r,
-                        t,
-                        &*f.ts.offset(t.ts as isize),
-                        f.cur.p.layout,
-                        &f.svc,
-                        &mut lowest_px,
-                        false,
-                        b_dim,
-                        bx4,
-                        by4,
-                        w4,
-                        h4,
-                    );
-                }
-            }
-
-            // uv
-            if has_chroma {
-                // sub8x8 derivation
-                let mut is_sub8x8 = bw4 == ss_hor || bh4 == ss_ver;
-                let r = if is_sub8x8 {
-                    assert!(ss_hor == 1);
-                    let r =
-                        <[_; 2]>::try_from(&t.rt.r[(t.b.y as usize & 31) + 5 - 1..][..2]).unwrap();
-
-                    if bw4 == 1 {
-                        is_sub8x8 &= f.rf.r.index(r[1] + t.b.x as usize - 1).r#ref.r#ref[0] > 0;
-                    }
-                    if bh4 == ss_ver {
-                        is_sub8x8 &= f.rf.r.index(r[0] + t.b.x as usize).r#ref.r#ref[0] > 0;
-                    }
-                    if bw4 == 1 && bh4 == ss_ver {
-                        is_sub8x8 &= f.rf.r.index(r[0] + t.b.x as usize - 1).r#ref.r#ref[0] > 0;
-                    }
-
-                    r
-                } else {
-                    Default::default() // Never actually used.
-                };
-
-                // chroma prediction
-                if is_sub8x8 {
-                    if bw4 == 1 && bh4 == ss_ver {
-                        let rr = *f.rf.r.index(r[0] + t.b.x as usize - 1);
-                        mc_lowest_px(
-                            &mut lowest_px[rr.r#ref.r#ref[0] as usize - 1][1],
-                            t.b.y - 1,
-                            bh4,
-                            rr.mv.mv[0].y,
-                            ss_ver,
-                            &f.svc[rr.r#ref.r#ref[0] as usize - 1][1],
-                        );
-                    }
-                    if bw4 == 1 {
-                        let rr = *f.rf.r.index(r[1] + t.b.x as usize - 1);
-                        mc_lowest_px(
-                            &mut lowest_px[rr.r#ref.r#ref[0] as usize - 1][1],
-                            t.b.y,
-                            bh4,
-                            rr.mv.mv[0].y,
-                            ss_ver,
-                            &f.svc[rr.r#ref.r#ref[0] as usize - 1][1],
-                        );
-                    }
-                    if bh4 == ss_ver {
-                        let rr = *f.rf.r.index(r[0] + t.b.x as usize);
-                        mc_lowest_px(
-                            &mut lowest_px[rr.r#ref.r#ref[0] as usize - 1][1],
-                            t.b.y - 1,
-                            bh4,
-                            rr.mv.mv[0].y,
-                            ss_ver,
-                            &f.svc[rr.r#ref.r#ref[0] as usize - 1][1],
-                        );
-                    }
-                    mc_lowest_px(
-                        &mut lowest_px[b.ii.inter().r#ref[0] as usize][1],
-                        t.b.y,
-                        bh4,
-                        b.ii.inter().nd.one_d.mv[0].y,
-                        ss_ver,
-                        &f.svc[b.ii.inter().r#ref[0] as usize][1],
-                    );
-                } else if cmp::min(cbw4, cbh4) > 1
-                    && (b.ii.inter().inter_mode == GLOBALMV
-                        && f.gmv_warp_allowed[b.ii.inter().r#ref[0] as usize] != 0
-                        || b.ii.inter().motion_mode == MotionMode::Warp
+    match b.ii {
+        Av1BlockIntraInter::Inter(inter)
+            if t.frame_thread.pass == 1 && frame_hdr.frame_type.is_inter_or_switch() =>
+        {
+            let sby = t.b.y - ts.tiling.row_start >> f.sb_shift;
+            let mut lowest_px = f.lowest_pixel_mem.index_mut(ts.lowest_pixel + sby as usize);
+            // keep track of motion vectors for each reference
+            if inter.comp_type.is_none() {
+                // y
+                if cmp::min(bw4, bh4) > 1
+                    && (inter.inter_mode == GLOBALMV
+                        && f.gmv_warp_allowed[inter.r#ref[0] as usize] != 0
+                        || inter.motion_mode == MotionMode::Warp
                             && t.warpmv.r#type > Rav1dWarpedMotionType::Translation)
                 {
-                    affine_lowest_px_chroma(
+                    affine_lowest_px_luma(
                         t,
-                        f.cur.p.layout,
-                        &mut lowest_px[b.ii.inter().r#ref[0] as usize][1],
+                        &mut lowest_px[inter.r#ref[0] as usize][0],
                         b_dim,
-                        if b.ii.inter().motion_mode == MotionMode::Warp {
+                        if inter.motion_mode == MotionMode::Warp {
                             &t.warpmv
                         } else {
-                            &frame_hdr.gmv[b.ii.inter().r#ref[0] as usize]
+                            &frame_hdr.gmv[inter.r#ref[0] as usize]
                         },
                     );
                 } else {
                     mc_lowest_px(
-                        &mut lowest_px[b.ii.inter().r#ref[0] as usize][1],
-                        t.b.y & !ss_ver,
-                        bh4 << (bh4 == ss_ver) as c_int,
-                        b.ii.inter().nd.one_d.mv[0].y,
-                        ss_ver,
-                        &f.svc[b.ii.inter().r#ref[0] as usize][1],
+                        &mut lowest_px[inter.r#ref[0] as usize][0],
+                        t.b.y,
+                        bh4,
+                        inter.nd.one_d.mv[0].y,
+                        0,
+                        &f.svc[inter.r#ref[0] as usize][1],
                     );
-                    if b.ii.inter().motion_mode == MotionMode::Obmc {
+                    if inter.motion_mode == MotionMode::Obmc {
                         obmc_lowest_px(
                             &f.rf.r,
                             t,
@@ -3332,7 +3226,7 @@ unsafe fn decode_b(
                             f.cur.p.layout,
                             &f.svc,
                             &mut lowest_px,
-                            true,
+                            false,
                             b_dim,
                             bx4,
                             by4,
@@ -3341,79 +3235,192 @@ unsafe fn decode_b(
                         );
                     }
                 }
-            }
-        } else {
-            // y
-            let refmvs = || {
-                std::iter::zip(b.ii.inter().r#ref, b.ii.inter().nd.one_d.mv)
-                    .map(|(r#ref, mv)| (r#ref as usize, mv))
-            };
-            for (r#ref, mv) in refmvs() {
-                if b.ii.inter().inter_mode == GLOBALMV_GLOBALMV && f.gmv_warp_allowed[r#ref] != 0 {
-                    affine_lowest_px_luma(
-                        t,
-                        &mut lowest_px[r#ref][0],
-                        b_dim,
-                        &frame_hdr.gmv[r#ref],
-                    );
-                } else {
-                    mc_lowest_px(
-                        &mut lowest_px[r#ref][0],
-                        t.b.y,
-                        bh4,
-                        mv.y,
-                        0,
-                        &f.svc[r#ref][1],
-                    );
-                }
-            }
-            for (r#ref, mv) in refmvs() {
-                if b.ii.inter().inter_mode == GLOBALMV_GLOBALMV && f.gmv_warp_allowed[r#ref] != 0 {
-                    affine_lowest_px_luma(
-                        t,
-                        &mut lowest_px[r#ref][0],
-                        b_dim,
-                        &frame_hdr.gmv[r#ref],
-                    );
-                } else {
-                    mc_lowest_px(
-                        &mut lowest_px[r#ref][0],
-                        t.b.y,
-                        bh4,
-                        mv.y,
-                        0,
-                        &f.svc[r#ref][1],
-                    );
-                }
-            }
 
-            // uv
-            if has_chroma {
-                for (r#ref, mv) in refmvs() {
-                    if b.ii.inter().inter_mode == GLOBALMV_GLOBALMV
-                        && cmp::min(cbw4, cbh4) > 1
-                        && f.gmv_warp_allowed[r#ref] != 0
+                // uv
+                if has_chroma {
+                    // sub8x8 derivation
+                    let mut is_sub8x8 = bw4 == ss_hor || bh4 == ss_ver;
+                    let r = if is_sub8x8 {
+                        assert!(ss_hor == 1);
+                        let r = <[_; 2]>::try_from(&t.rt.r[(t.b.y as usize & 31) + 5 - 1..][..2])
+                            .unwrap();
+
+                        if bw4 == 1 {
+                            is_sub8x8 &= f.rf.r.index(r[1] + t.b.x as usize - 1).r#ref.r#ref[0] > 0;
+                        }
+                        if bh4 == ss_ver {
+                            is_sub8x8 &= f.rf.r.index(r[0] + t.b.x as usize).r#ref.r#ref[0] > 0;
+                        }
+                        if bw4 == 1 && bh4 == ss_ver {
+                            is_sub8x8 &= f.rf.r.index(r[0] + t.b.x as usize - 1).r#ref.r#ref[0] > 0;
+                        }
+
+                        r
+                    } else {
+                        Default::default() // Never actually used.
+                    };
+
+                    // chroma prediction
+                    if is_sub8x8 {
+                        if bw4 == 1 && bh4 == ss_ver {
+                            let rr = *f.rf.r.index(r[0] + t.b.x as usize - 1);
+                            mc_lowest_px(
+                                &mut lowest_px[rr.r#ref.r#ref[0] as usize - 1][1],
+                                t.b.y - 1,
+                                bh4,
+                                rr.mv.mv[0].y,
+                                ss_ver,
+                                &f.svc[rr.r#ref.r#ref[0] as usize - 1][1],
+                            );
+                        }
+                        if bw4 == 1 {
+                            let rr = *f.rf.r.index(r[1] + t.b.x as usize - 1);
+                            mc_lowest_px(
+                                &mut lowest_px[rr.r#ref.r#ref[0] as usize - 1][1],
+                                t.b.y,
+                                bh4,
+                                rr.mv.mv[0].y,
+                                ss_ver,
+                                &f.svc[rr.r#ref.r#ref[0] as usize - 1][1],
+                            );
+                        }
+                        if bh4 == ss_ver {
+                            let rr = *f.rf.r.index(r[0] + t.b.x as usize);
+                            mc_lowest_px(
+                                &mut lowest_px[rr.r#ref.r#ref[0] as usize - 1][1],
+                                t.b.y - 1,
+                                bh4,
+                                rr.mv.mv[0].y,
+                                ss_ver,
+                                &f.svc[rr.r#ref.r#ref[0] as usize - 1][1],
+                            );
+                        }
+                        mc_lowest_px(
+                            &mut lowest_px[inter.r#ref[0] as usize][1],
+                            t.b.y,
+                            bh4,
+                            inter.nd.one_d.mv[0].y,
+                            ss_ver,
+                            &f.svc[inter.r#ref[0] as usize][1],
+                        );
+                    } else if cmp::min(cbw4, cbh4) > 1
+                        && (inter.inter_mode == GLOBALMV
+                            && f.gmv_warp_allowed[inter.r#ref[0] as usize] != 0
+                            || inter.motion_mode == MotionMode::Warp
+                                && t.warpmv.r#type > Rav1dWarpedMotionType::Translation)
                     {
                         affine_lowest_px_chroma(
                             t,
                             f.cur.p.layout,
-                            &mut lowest_px[r#ref][1],
+                            &mut lowest_px[inter.r#ref[0] as usize][1],
+                            b_dim,
+                            if inter.motion_mode == MotionMode::Warp {
+                                &t.warpmv
+                            } else {
+                                &frame_hdr.gmv[inter.r#ref[0] as usize]
+                            },
+                        );
+                    } else {
+                        mc_lowest_px(
+                            &mut lowest_px[inter.r#ref[0] as usize][1],
+                            t.b.y & !ss_ver,
+                            bh4 << (bh4 == ss_ver) as c_int,
+                            inter.nd.one_d.mv[0].y,
+                            ss_ver,
+                            &f.svc[inter.r#ref[0] as usize][1],
+                        );
+                        if inter.motion_mode == MotionMode::Obmc {
+                            obmc_lowest_px(
+                                &f.rf.r,
+                                t,
+                                &*f.ts.offset(t.ts as isize),
+                                f.cur.p.layout,
+                                &f.svc,
+                                &mut lowest_px,
+                                true,
+                                b_dim,
+                                bx4,
+                                by4,
+                                w4,
+                                h4,
+                            );
+                        }
+                    }
+                }
+            } else {
+                // y
+                let refmvs = || {
+                    std::iter::zip(inter.r#ref, inter.nd.one_d.mv)
+                        .map(|(r#ref, mv)| (r#ref as usize, mv))
+                };
+                for (r#ref, mv) in refmvs() {
+                    if inter.inter_mode == GLOBALMV_GLOBALMV && f.gmv_warp_allowed[r#ref] != 0 {
+                        affine_lowest_px_luma(
+                            t,
+                            &mut lowest_px[r#ref][0],
                             b_dim,
                             &frame_hdr.gmv[r#ref],
                         );
                     } else {
                         mc_lowest_px(
-                            &mut lowest_px[r#ref][1],
+                            &mut lowest_px[r#ref][0],
                             t.b.y,
                             bh4,
                             mv.y,
-                            ss_ver,
+                            0,
                             &f.svc[r#ref][1],
                         );
                     }
                 }
+                for (r#ref, mv) in refmvs() {
+                    if inter.inter_mode == GLOBALMV_GLOBALMV && f.gmv_warp_allowed[r#ref] != 0 {
+                        affine_lowest_px_luma(
+                            t,
+                            &mut lowest_px[r#ref][0],
+                            b_dim,
+                            &frame_hdr.gmv[r#ref],
+                        );
+                    } else {
+                        mc_lowest_px(
+                            &mut lowest_px[r#ref][0],
+                            t.b.y,
+                            bh4,
+                            mv.y,
+                            0,
+                            &f.svc[r#ref][1],
+                        );
+                    }
+                }
+
+                // uv
+                if has_chroma {
+                    for (r#ref, mv) in refmvs() {
+                        if inter.inter_mode == GLOBALMV_GLOBALMV
+                            && cmp::min(cbw4, cbh4) > 1
+                            && f.gmv_warp_allowed[r#ref] != 0
+                        {
+                            affine_lowest_px_chroma(
+                                t,
+                                f.cur.p.layout,
+                                &mut lowest_px[r#ref][1],
+                                b_dim,
+                                &frame_hdr.gmv[r#ref],
+                            );
+                        } else {
+                            mc_lowest_px(
+                                &mut lowest_px[r#ref][1],
+                                t.b.y,
+                                bh4,
+                                mv.y,
+                                ss_ver,
+                                &f.svc[r#ref][1],
+                            );
+                        }
+                    }
+                }
             }
         }
+        _ => {}
     }
 
     Ok(())

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2126,7 +2126,7 @@ unsafe fn decode_b(
         let filter2d = if t.frame_thread.pass == 1 {
             Filter2d::Bilinear
         } else {
-            Filter2d::Regular8Tap // 0
+            Default::default()
         };
 
         b.uvtx = uvtx;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1173,7 +1173,7 @@ unsafe fn decode_b(
     if t.frame_thread.pass == 2 {
         match &b.ii {
             Av1BlockIntraInter::Intra(intra) => {
-                bd_fn.recon_b_intra(f, t, bs, intra_edge_flags, b);
+                bd_fn.recon_b_intra(f, t, bs, intra_edge_flags, b, intra);
 
                 let y_mode = intra.y_mode;
                 let y_mode_nofilt = if y_mode == FILTER_PRED {
@@ -1888,7 +1888,7 @@ unsafe fn decode_b(
         };
         let t_dim = &dav1d_txfm_dimensions[tx as usize];
 
-        b.ii = Av1BlockIntraInter::Intra(Av1BlockIntra {
+        let intra = Av1BlockIntra {
             y_mode,
             uv_mode,
             tx,
@@ -1896,13 +1896,14 @@ unsafe fn decode_b(
             y_angle,
             uv_angle,
             cfl_alpha,
-        });
+        };
+        b.ii = Av1BlockIntraInter::Intra(intra.clone()); // cheap 9-byte clone
 
         // reconstruction
         if t.frame_thread.pass == 1 {
             bd_fn.read_coef_blocks(f, t, bs, b);
         } else {
-            bd_fn.recon_b_intra(f, t, bs, intra_edge_flags, b);
+            bd_fn.recon_b_intra(f, t, bs, intra_edge_flags, b, &intra);
         }
 
         if f.frame_hdr().loopfilter.level_y != [0, 0] {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1171,7 +1171,7 @@ unsafe fn decode_b(
     let frame_type = f.frame_hdr.as_ref().unwrap().frame_type;
 
     if t.frame_thread.pass == 2 {
-        match b.ii {
+        match &b.ii {
             Av1BlockIntraInter::Intra(intra) => {
                 bd_fn.recon_b_intra(f, t, bs, intra_edge_flags, b);
 
@@ -3180,7 +3180,7 @@ unsafe fn decode_b(
         }
     }
 
-    match b.ii {
+    match &b.ii {
         Av1BlockIntraInter::Inter(inter)
             if t.frame_thread.pass == 1 && frame_hdr.frame_type.is_inter_or_switch() =>
         {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1258,7 +1258,7 @@ unsafe fn decode_b(
                         }
                     }
                 }
-                bd_fn.recon_b_inter(f, t, bs, b)?;
+                bd_fn.recon_b_inter(f, t, bs, b, inter)?;
 
                 let filter = &dav1d_filter_dir[inter.filter2d as usize];
                 CaseSet::<32, false>::many(
@@ -2130,7 +2130,7 @@ unsafe fn decode_b(
         };
 
         b.uvtx = uvtx;
-        b.ii = Av1BlockIntraInter::Inter(Av1BlockInter {
+        let inter = Av1BlockInter {
             nd: Av1BlockInterNd {
                 one_d: Av1BlockInter1d {
                     mv: [r#ref, Default::default()],
@@ -2149,13 +2149,14 @@ unsafe fn decode_b(
             interintra_type: Default::default(),
             tx_split0,
             tx_split1,
-        });
+        };
+        b.ii = Av1BlockIntraInter::Inter(inter.clone()); // Cheap 24-byte clone
 
         // reconstruction
         if t.frame_thread.pass == 1 {
             bd_fn.read_coef_blocks(f, t, bs, b);
         } else {
-            bd_fn.recon_b_inter(f, t, bs, b)?;
+            bd_fn.recon_b_inter(f, t, bs, b, &inter)?;
         }
 
         splat_intrabc_mv(c, t, &f.rf, bs, r#ref, bw4 as usize, bh4 as usize);
@@ -3034,7 +3035,7 @@ unsafe fn decode_b(
         } = read_vartx_tree(t, f, b, bs, bx4, by4);
 
         b.uvtx = uvtx;
-        b.ii = Av1BlockIntraInter::Inter(Av1BlockInter {
+        let inter = Av1BlockInter {
             nd,
             comp_type,
             inter_mode,
@@ -3046,13 +3047,14 @@ unsafe fn decode_b(
             interintra_type,
             tx_split0,
             tx_split1,
-        });
+        };
+        b.ii = Av1BlockIntraInter::Inter(inter.clone());
 
         // reconstruction
         if t.frame_thread.pass == 1 {
             bd_fn.read_coef_blocks(f, t, bs, b);
         } else {
-            bd_fn.recon_b_inter(f, t, bs, b)?;
+            bd_fn.recon_b_inter(f, t, bs, b, &inter)?;
         }
 
         let frame_hdr = f.frame_hdr();

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -40,6 +40,7 @@ use crate::src::intra_edge::EdgeFlags;
 use crate::src::ipred::Rav1dIntraPredDSPContext;
 use crate::src::itx::Rav1dInvTxfmDSPContext;
 use crate::src::levels::Av1Block;
+use crate::src::levels::Av1BlockInter;
 use crate::src::levels::Av1BlockIntra;
 use crate::src::levels::BlockSize;
 use crate::src::levels::Filter2d;
@@ -485,8 +486,9 @@ impl Rav1dFrameContext_bd_fn {
         context: &mut Rav1dTaskContext,
         block_size: BlockSize,
         block: &Av1Block,
+        inter: &Av1BlockInter,
     ) -> Result<(), ()> {
-        (self.recon_b_inter)(f, context, block_size, block)
+        (self.recon_b_inter)(f, context, block_size, block, inter)
     }
 
     pub unsafe fn read_coef_blocks(

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -40,6 +40,7 @@ use crate::src::intra_edge::EdgeFlags;
 use crate::src::ipred::Rav1dIntraPredDSPContext;
 use crate::src::itx::Rav1dInvTxfmDSPContext;
 use crate::src::levels::Av1Block;
+use crate::src::levels::Av1BlockIntra;
 use crate::src::levels::BlockSize;
 use crate::src::levels::Filter2d;
 use crate::src::levels::TxfmType;
@@ -473,8 +474,9 @@ impl Rav1dFrameContext_bd_fn {
         block_size: BlockSize,
         flags: EdgeFlags,
         block: &Av1Block,
+        intra: &Av1BlockIntra,
     ) {
-        (self.recon_b_intra)(f, context, block_size, flags, block);
+        (self.recon_b_intra)(f, context, block_size, flags, block, intra);
     }
 
     pub unsafe fn recon_b_inter(

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1256,7 +1256,7 @@ impl Rav1dTaskContext {
             lf_mask: None,
             top_pre_cdef_toggle: 0,
             cur_sb_cdef_idx: 0,
-            tl_4x4_filter: Filter2d::Regular8Tap, // 0
+            tl_4x4_filter: Default::default(),
             frame_thread: Rav1dTaskContext_frame_thread { pass: 0 },
             task_thread,
         }

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -389,7 +389,6 @@ pub struct Av1Block {
     pub bl: BlockLevel,
     pub bs: u8,
     pub bp: BlockPartition,
-    pub intra: u8,
     pub seg_id: u8,
     pub skip_mode: u8,
     pub skip: u8,

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -332,12 +332,14 @@ pub struct Av1BlockInter2d {
     pub matrix: [i16; 4],
 }
 
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub union Av1BlockInterNd {
     pub one_d: Av1BlockInter1d,
     pub two_d: Av1BlockInter2d,
 }
 
+#[derive(Clone)]
 #[repr(C)]
 pub struct Av1BlockInter {
     pub nd: Av1BlockInterNd,

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -304,7 +304,7 @@ pub enum MotionMode {
     Warp = 2,
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 #[repr(C)]
 pub struct Av1BlockIntra {
     pub y_mode: u8,
@@ -360,13 +360,6 @@ pub enum Av1BlockIntraInter {
 }
 
 impl Av1BlockIntraInter {
-    pub const fn intra(&self) -> &Av1BlockIntra {
-        match self {
-            Self::Intra(intra) => intra,
-            _ => panic!(),
-        }
-    }
-
     pub const fn inter(&self) -> &Av1BlockInter {
         match self {
             Self::Inter(inter) => inter,

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -172,7 +172,7 @@ pub enum BlockSize {
 
 #[derive(Clone, Copy, PartialEq, Eq, EnumCount, Default)]
 pub enum Filter2d {
-    #[default] // TODO(kkysen) Maybe temporary.
+    #[default]
     Regular8Tap = 0,
     RegularSmooth8Tap = 1,
     RegularSharp8Tap = 2,
@@ -362,11 +362,14 @@ pub enum Av1BlockIntraInter {
 }
 
 impl Av1BlockIntraInter {
-    pub const fn inter(&self) -> &Av1BlockInter {
+    pub fn filter2d(&self) -> Filter2d {
+        // More optimal code if we use a default instead of just panicking.
         match self {
-            Self::Inter(inter) => inter,
-            _ => panic!(),
+            Self::Inter(inter) => Some(inter),
+            _ => None,
         }
+        .map(|inter| inter.filter2d)
+        .unwrap_or_default()
     }
 }
 

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -304,7 +304,7 @@ pub enum MotionMode {
     Warp = 2,
 }
 
-#[derive(Copy, Clone, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct Av1BlockIntra {
     pub y_mode: u8,
@@ -332,14 +332,12 @@ pub struct Av1BlockInter2d {
     pub matrix: [i16; 4],
 }
 
-#[derive(Clone, Copy)]
 #[repr(C)]
 pub union Av1BlockInterNd {
     pub one_d: Av1BlockInter1d,
     pub two_d: Av1BlockInter2d,
 }
 
-#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct Av1BlockInter {
     pub nd: Av1BlockInterNd,

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -33,6 +33,7 @@ use crate::src::ipred_prepare::sm_flag;
 use crate::src::ipred_prepare::sm_uv_flag;
 use crate::src::levels::mv;
 use crate::src::levels::Av1Block;
+use crate::src::levels::Av1BlockInter;
 use crate::src::levels::Av1BlockIntra;
 use crate::src::levels::Av1BlockIntraInter;
 use crate::src::levels::BlockSize;
@@ -137,11 +138,22 @@ macro_rules! debug_block_info {
 }
 pub(crate) use debug_block_info;
 
-pub(crate) type recon_b_intra_fn =
-    unsafe fn(&Rav1dFrameData, &mut Rav1dTaskContext, BlockSize, EdgeFlags, &Av1Block, &Av1BlockIntra) -> ();
+pub(crate) type recon_b_intra_fn = unsafe fn(
+    &Rav1dFrameData,
+    &mut Rav1dTaskContext,
+    BlockSize,
+    EdgeFlags,
+    &Av1Block,
+    &Av1BlockIntra,
+) -> ();
 
-pub(crate) type recon_b_inter_fn =
-    unsafe fn(&Rav1dFrameData, &mut Rav1dTaskContext, BlockSize, &Av1Block) -> Result<(), ()>;
+pub(crate) type recon_b_inter_fn = unsafe fn(
+    &Rav1dFrameData,
+    &mut Rav1dTaskContext,
+    BlockSize,
+    &Av1Block,
+    &Av1BlockInter,
+) -> Result<(), ()>;
 
 pub(crate) type filter_sbrow_fn =
     unsafe fn(&Rav1dContext, &Rav1dFrameData, &mut Rav1dTaskContext, c_int) -> ();
@@ -2502,9 +2514,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
     let has_chroma = (f.cur.p.layout as c_uint != Rav1dPixelLayout::I400 as c_int as c_uint
         && (bw4 > ss_hor || t.b.x & 1 != 0)
         && (bh4 > ss_ver || t.b.y & 1 != 0)) as c_int;
-    let t_dim: *const TxfmInfo = &*dav1d_txfm_dimensions
-        .as_ptr()
-        .offset(intra.tx as isize) as *const TxfmInfo;
+    let t_dim: *const TxfmInfo =
+        &*dav1d_txfm_dimensions.as_ptr().offset(intra.tx as isize) as *const TxfmInfo;
     let uv_t_dim: *const TxfmInfo =
         &*dav1d_txfm_dimensions.as_ptr().offset(b.uvtx as isize) as *const TxfmInfo;
     let cbw4 = bw4 + ss_hor >> ss_hor;
@@ -2741,10 +2752,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             if debug_block_info!(f, t.b) {
                                 println!(
                                     "Post-y-cf-blk[tx={},txtp={},eob={}]: r={}",
-                                    intra.tx as c_int,
-                                    txtp as c_uint,
-                                    eob,
-                                    ts.msac.rng,
+                                    intra.tx as c_int, txtp as c_uint, eob, ts.msac.rng,
                                 );
                             }
                             CaseSet::<16, true>::many(
@@ -3277,6 +3285,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
     t: &mut Rav1dTaskContext,
     bs: BlockSize,
     b: &Av1Block,
+    inter: &Av1BlockInter,
 ) -> Result<(), ()> {
     let ts: &mut super::internal::Rav1dTileState = &mut *f.ts.offset(t.ts as isize);
     let bx4 = t.b.x & 31;
@@ -3326,7 +3335,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
             t.b.x,
             t.b.y,
             0,
-            b.ii.inter().nd.one_d.mv[0],
+            inter.nd.one_d.mv[0],
             &f.sr_cur,
             0,
             Filter2d::Bilinear,
@@ -3346,24 +3355,24 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     t.b.x & !ss_hor,
                     t.b.y & !ss_ver,
                     pl,
-                    b.ii.inter().nd.one_d.mv[0],
+                    inter.nd.one_d.mv[0],
                     &f.sr_cur,
                     0,
                     Filter2d::Bilinear,
                 )?;
             }
         }
-    } else if let Some(comp_inter_type) = b.ii.inter().comp_type {
-        let filter_2d = b.ii.inter().filter2d;
+    } else if let Some(comp_inter_type) = inter.comp_type {
+        let filter_2d = inter.filter2d;
         let scratch = t.scratch.inter_mut();
         let scratch_inter = scratch.lap_inter.inter_mut();
         let tmp = &mut scratch_inter.compinter;
         let mut jnt_weight = 0;
         let seg_mask = &mut scratch_inter.seg_mask;
         for i in 0..2 {
-            let refp = &f.refp[b.ii.inter().r#ref[i] as usize];
-            if b.ii.inter().inter_mode == GLOBALMV_GLOBALMV
-                && f.gmv_warp_allowed[b.ii.inter().r#ref[i] as usize] != 0
+            let refp = &f.refp[inter.r#ref[i] as usize];
+            if inter.inter_mode == GLOBALMV_GLOBALMV
+                && f.gmv_warp_allowed[inter.r#ref[i] as usize] != 0
             {
                 warp_affine::<BD>(
                     f,
@@ -3375,7 +3384,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     b_dim,
                     0,
                     refp,
-                    &frame_hdr.gmv[b.ii.inter().r#ref[i] as usize],
+                    &frame_hdr.gmv[inter.r#ref[i] as usize],
                 )?;
             } else {
                 mc::<BD>(
@@ -3390,9 +3399,9 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     t.b.x,
                     t.b.y,
                     0,
-                    b.ii.inter().nd.one_d.mv[i],
+                    inter.nd.one_d.mv[i],
                     refp,
-                    b.ii.inter().r#ref[i] as usize,
+                    inter.r#ref[i] as usize,
                     filter_2d,
                 )?;
             }
@@ -3412,8 +3421,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 );
             }
             CompInterType::WeightedAvg => {
-                jnt_weight = f.jnt_weights[b.ii.inter().r#ref[0] as usize]
-                    [b.ii.inter().r#ref[1] as usize] as c_int;
+                jnt_weight =
+                    f.jnt_weights[inter.r#ref[0] as usize][inter.r#ref[1] as usize] as c_int;
                 (f.dsp.mc.w_avg)(
                     dst.cast(),
                     f.cur.stride[0],
@@ -3429,24 +3438,23 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 f.dsp.mc.w_mask[chr_layout_idx_w_mask].call(
                     dst,
                     f.cur.stride[0],
-                    tmp[b.ii.inter().nd.one_d.mask_sign as usize].as_mut_ptr(),
-                    tmp[(b.ii.inter().nd.one_d.mask_sign == 0) as usize].as_mut_ptr(),
+                    tmp[inter.nd.one_d.mask_sign as usize].as_mut_ptr(),
+                    tmp[(inter.nd.one_d.mask_sign == 0) as usize].as_mut_ptr(),
                     bw4 * 4,
                     bh4 * 4,
                     seg_mask.as_mut_ptr(),
-                    b.ii.inter().nd.one_d.mask_sign as c_int,
+                    inter.nd.one_d.mask_sign as c_int,
                     BD::from_c(f.bitdepth_max),
                 );
                 mask = &seg_mask[..];
             }
             CompInterType::Wedge => {
-                mask =
-                    dav1d_wedge_masks[bs as usize][0][0][b.ii.inter().nd.one_d.wedge_idx as usize];
+                mask = dav1d_wedge_masks[bs as usize][0][0][inter.nd.one_d.wedge_idx as usize];
                 (f.dsp.mc.mask)(
                     dst.cast(),
                     f.cur.stride[0],
-                    tmp[b.ii.inter().nd.one_d.mask_sign as usize].as_mut_ptr(),
-                    tmp[(b.ii.inter().nd.one_d.mask_sign == 0) as usize].as_mut_ptr(),
+                    tmp[inter.nd.one_d.mask_sign as usize].as_mut_ptr(),
+                    tmp[(inter.nd.one_d.mask_sign == 0) as usize].as_mut_ptr(),
                     bw4 * 4,
                     bh4 * 4,
                     mask.as_ptr(),
@@ -3454,18 +3462,18 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 );
                 if has_chroma {
                     mask = dav1d_wedge_masks[bs as usize][chr_layout_idx]
-                        [b.ii.inter().nd.one_d.mask_sign as usize]
-                        [b.ii.inter().nd.one_d.wedge_idx as usize];
+                        [inter.nd.one_d.mask_sign as usize]
+                        [inter.nd.one_d.wedge_idx as usize];
                 }
             }
         }
         if has_chroma {
             for pl in 0..2 {
                 for i in 0..2 {
-                    let refp = &f.refp[b.ii.inter().r#ref[i] as usize];
-                    if b.ii.inter().inter_mode == GLOBALMV_GLOBALMV
+                    let refp = &f.refp[inter.r#ref[i] as usize];
+                    if inter.inter_mode == GLOBALMV_GLOBALMV
                         && cmp::min(cbw4, cbh4) > 1
-                        && f.gmv_warp_allowed[b.ii.inter().r#ref[i] as usize] != 0
+                        && f.gmv_warp_allowed[inter.r#ref[i] as usize] != 0
                     {
                         warp_affine::<BD>(
                             f,
@@ -3477,7 +3485,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             b_dim,
                             1 + pl,
                             refp,
-                            &frame_hdr.gmv[b.ii.inter().r#ref[i] as usize],
+                            &frame_hdr.gmv[inter.r#ref[i] as usize],
                         )?;
                     } else {
                         mc::<BD>(
@@ -3492,9 +3500,9 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             t.b.x,
                             t.b.y,
                             1 + pl,
-                            b.ii.inter().nd.one_d.mv[i],
+                            inter.nd.one_d.mv[i],
                             refp,
-                            b.ii.inter().r#ref[i] as usize,
+                            inter.r#ref[i] as usize,
                             filter_2d,
                         )?;
                     }
@@ -3531,8 +3539,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                         (f.dsp.mc.mask)(
                             uvdst.cast(),
                             f.cur.stride[1],
-                            tmp[b.ii.inter().nd.one_d.mask_sign as usize].as_mut_ptr(),
-                            tmp[(b.ii.inter().nd.one_d.mask_sign == 0) as usize].as_mut_ptr(),
+                            tmp[inter.nd.one_d.mask_sign as usize].as_mut_ptr(),
+                            tmp[(inter.nd.one_d.mask_sign == 0) as usize].as_mut_ptr(),
                             bw4 * 4 >> ss_hor,
                             bh4 * 4 >> ss_ver,
                             mask.as_ptr(),
@@ -3543,12 +3551,11 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
             }
         }
     } else {
-        let refp = &f.refp[b.ii.inter().r#ref[0] as usize];
-        let filter_2d = b.ii.inter().filter2d;
+        let refp = &f.refp[inter.r#ref[0] as usize];
+        let filter_2d = inter.filter2d;
         if cmp::min(bw4, bh4) > 1
-            && (b.ii.inter().inter_mode == GLOBALMV
-                && f.gmv_warp_allowed[b.ii.inter().r#ref[0] as usize] != 0
-                || b.ii.inter().motion_mode == MotionMode::Warp
+            && (inter.inter_mode == GLOBALMV && f.gmv_warp_allowed[inter.r#ref[0] as usize] != 0
+                || inter.motion_mode == MotionMode::Warp
                     && t.warpmv.r#type > Rav1dWarpedMotionType::Translation)
         {
             warp_affine::<BD>(
@@ -3561,10 +3568,10 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 b_dim,
                 0,
                 refp,
-                if b.ii.inter().motion_mode == MotionMode::Warp {
+                if inter.motion_mode == MotionMode::Warp {
                     &t.warpmv
                 } else {
-                    &frame_hdr.gmv[b.ii.inter().r#ref[0] as usize]
+                    &frame_hdr.gmv[inter.r#ref[0] as usize]
                 },
             )?;
         } else {
@@ -3580,23 +3587,23 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 t.b.x,
                 t.b.y,
                 0,
-                b.ii.inter().nd.one_d.mv[0],
+                inter.nd.one_d.mv[0],
                 refp,
-                b.ii.inter().r#ref[0] as usize,
+                inter.r#ref[0] as usize,
                 filter_2d,
             )?;
-            if b.ii.inter().motion_mode == MotionMode::Obmc {
+            if inter.motion_mode == MotionMode::Obmc {
                 obmc::<BD>(f, t, dst, (*f).cur.stride[0], b_dim, 0, bx4, by4, w4, h4)?;
             }
         }
-        if let Some(interintra_type) = b.ii.inter().interintra_type {
+        if let Some(interintra_type) = inter.interintra_type {
             let interintra_edge_pal = &mut t.scratch.inter_intra_mut().interintra_edge_pal;
             let tl_edge_array = interintra_edge_pal.edge.buf_mut::<BD>();
             let tl_edge_offset = 32;
-            let mut m = if b.ii.inter().nd.one_d.interintra_mode == InterIntraPredMode::Smooth {
+            let mut m = if inter.nd.one_d.interintra_mode == InterIntraPredMode::Smooth {
                 SMOOTH_PRED
             } else {
-                b.ii.inter().nd.one_d.interintra_mode as IntraPredMode
+                inter.nd.one_d.interintra_mode as IntraPredMode
             };
             let mut angle = 0;
             let top_sb_edge_slice = if t.b.y & f.sb_step - 1 == 0 {
@@ -3651,10 +3658,10 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
             );
             let ii_mask = match interintra_type {
                 InterIntraType::Blend => {
-                    dav1d_ii_masks[bs as usize][0][b.ii.inter().nd.one_d.interintra_mode as usize]
+                    dav1d_ii_masks[bs as usize][0][inter.nd.one_d.interintra_mode as usize]
                 }
                 InterIntraType::Wedge => {
-                    dav1d_wedge_masks[bs as usize][0][0][b.ii.inter().nd.one_d.wedge_idx as usize]
+                    dav1d_wedge_masks[bs as usize][0][0][inter.nd.one_d.wedge_idx as usize]
                 }
             };
             (f.dsp.mc.blend)(
@@ -3825,17 +3832,17 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                         t.b.x,
                         t.b.y,
                         1 + pl,
-                        b.ii.inter().nd.one_d.mv[0],
+                        inter.nd.one_d.mv[0],
                         refp,
-                        b.ii.inter().r#ref[0] as usize,
+                        inter.r#ref[0] as usize,
                         filter_2d,
                     )?;
                 }
             } else {
                 if cmp::min(cbw4, cbh4) > 1
-                    && (b.ii.inter().inter_mode == GLOBALMV
-                        && f.gmv_warp_allowed[b.ii.inter().r#ref[0] as usize] != 0
-                        || b.ii.inter().motion_mode == MotionMode::Warp
+                    && (inter.inter_mode == GLOBALMV
+                        && f.gmv_warp_allowed[inter.r#ref[0] as usize] != 0
+                        || inter.motion_mode == MotionMode::Warp
                             && t.warpmv.r#type > Rav1dWarpedMotionType::Translation)
                 {
                     for pl in 0..2 {
@@ -3851,10 +3858,10 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             b_dim,
                             1 + pl,
                             refp,
-                            if b.ii.inter().motion_mode == MotionMode::Warp {
+                            if inter.motion_mode == MotionMode::Warp {
                                 &t.warpmv
                             } else {
-                                &frame_hdr.gmv[b.ii.inter().r#ref[0] as usize]
+                                &frame_hdr.gmv[inter.r#ref[0] as usize]
                             },
                         )?;
                     }
@@ -3874,12 +3881,12 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             t.b.x & !ss_hor,
                             t.b.y & !ss_ver,
                             1 + pl,
-                            b.ii.inter().nd.one_d.mv[0],
+                            inter.nd.one_d.mv[0],
                             refp,
-                            b.ii.inter().r#ref[0] as usize,
+                            inter.r#ref[0] as usize,
                             filter_2d,
                         )?;
-                        if b.ii.inter().motion_mode == MotionMode::Obmc {
+                        if inter.motion_mode == MotionMode::Obmc {
                             obmc::<BD>(
                                 f,
                                 t,
@@ -3897,15 +3904,15 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                         }
                     }
                 }
-                if let Some(interintra_type) = b.ii.inter().interintra_type {
+                if let Some(interintra_type) = inter.interintra_type {
                     let ii_mask = match interintra_type {
                         InterIntraType::Blend => {
                             dav1d_ii_masks[bs as usize][chr_layout_idx]
-                                [b.ii.inter().nd.one_d.interintra_mode as usize]
+                                [inter.nd.one_d.interintra_mode as usize]
                         }
                         InterIntraType::Wedge => {
                             dav1d_wedge_masks[bs as usize][chr_layout_idx][0]
-                                [b.ii.inter().nd.one_d.wedge_idx as usize]
+                                [inter.nd.one_d.wedge_idx as usize]
                         }
                     };
                     for pl in 0..2 {
@@ -3913,12 +3920,11 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             &mut t.scratch.inter_intra_mut().interintra_edge_pal;
                         let tl_edge_array = interintra_edge_pal.edge.buf_mut::<BD>();
                         let tl_edge_offset = 32;
-                        let mut m = if b.ii.inter().nd.one_d.interintra_mode
-                            == InterIntraPredMode::Smooth
+                        let mut m = if inter.nd.one_d.interintra_mode == InterIntraPredMode::Smooth
                         {
                             SMOOTH_PRED
                         } else {
-                            b.ii.inter().nd.one_d.interintra_mode as IntraPredMode
+                            inter.nd.one_d.interintra_mode as IntraPredMode
                         };
                         let mut angle = 0;
                         let uvdst = (f.cur.data.as_ref().unwrap().data[(1 + pl) as usize]
@@ -4043,8 +4049,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
         return Ok(());
     }
     let uvtx = &dav1d_txfm_dimensions[b.uvtx as usize];
-    let ytx = &dav1d_txfm_dimensions[b.ii.inter().max_ytx as usize];
-    let tx_split = [b.ii.inter().tx_split0 as u16, b.ii.inter().tx_split1];
+    let ytx = &dav1d_txfm_dimensions[inter.max_ytx as usize];
+    let tx_split = [inter.tx_split0 as u16, inter.tx_split1];
     for init_y in (0..bh4).step_by(16) {
         for init_x in (0..bw4).step_by(16) {
             let mut y_off = (init_y != 0) as c_int;
@@ -4063,7 +4069,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                         t,
                         bs,
                         b,
-                        b.ii.inter().max_ytx,
+                        inter.max_ytx,
                         0,
                         tx_split,
                         x_off,

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -527,7 +527,7 @@ unsafe fn decode_coefs<BD: BitDepth>(
         return -(1 as c_int);
     }
     use Av1BlockIntraInter::*;
-    *txtp = match b.ii {
+    *txtp = match &b.ii {
         _ if lossless != 0 => {
             assert!((*t_dim).max == TX_4X4);
             WHT_WHT
@@ -1917,7 +1917,7 @@ pub(crate) unsafe fn rav1d_read_coef_blocks<BD: BitDepth>(
     assert!(b.skip == 0);
     let uv_t_dim: *const TxfmInfo =
         &*dav1d_txfm_dimensions.as_ptr().offset(b.uvtx as isize) as *const TxfmInfo;
-    let t_dim: *const TxfmInfo = &*dav1d_txfm_dimensions.as_ptr().offset(match b.ii {
+    let t_dim: *const TxfmInfo = &*dav1d_txfm_dimensions.as_ptr().offset(match &b.ii {
         Av1BlockIntraInter::Intra(intra) => intra.tx,
         Av1BlockIntraInter::Inter(inter) => inter.max_ytx,
     } as isize) as *const TxfmInfo;
@@ -1938,7 +1938,7 @@ pub(crate) unsafe fn rav1d_read_coef_blocks<BD: BitDepth>(
                 x = init_x;
                 t.b.x += init_x;
                 while x < sub_w4 {
-                    match b.ii {
+                    match &b.ii {
                         Av1BlockIntraInter::Inter(inter) => {
                             let tx_split = [inter.tx_split0 as u16, inter.tx_split1];
                             read_coef_tree::<BD>(

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -3726,8 +3726,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                                             - 1,
                                     )
                                     .ii
-                                    .inter()
-                                    .filter2d
+                                    .filter2d()
                             },
                         )?;
                     }
@@ -3768,8 +3767,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                                             as usize,
                                     )
                                     .ii
-                                    .inter()
-                                    .filter2d
+                                    .filter2d()
                             },
                         )?;
                     }
@@ -3809,8 +3807,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                                             + t.b.x as usize,
                                     )
                                     .ii
-                                    .inter()
-                                    .filter2d
+                                    .filter2d()
                             },
                         )?;
                     }


### PR DESCRIPTION
This removes `Av1Block::intra`, which was the now-redundant discriminant of `Av1BlockIntraInter`.  Now code matches on `Av1BlockIntraInter` directly and avoids checks when accessing `inter` or `intra`.