### PR TITLE
`struct Rav1d{,BitDepth}DSPContext`: Consolidate, make safe, and fix some `#[cfg]`s for asm

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -47,7 +47,6 @@ pub type cdef_fn = unsafe extern "C" fn(
 pub type cdef_dir_fn =
     unsafe extern "C" fn(*const DynPixel, ptrdiff_t, *mut c_uint, c_int) -> c_int;
 
-#[repr(C)]
 pub struct Rav1dCdefDSPContext {
     pub dir: cdef_dir_fn,
     pub fb: [cdef_fn; 3],

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -194,8 +194,7 @@ impl fguv_32x32xn::Fn {
     }
 }
 
-#[repr(C)]
-pub(crate) struct Rav1dFilmGrainDSPContext {
+pub struct Rav1dFilmGrainDSPContext {
     pub generate_grain_y: generate_grain_y::Fn,
     pub generate_grain_uv: enum_map_ty!(Rav1dPixelLayoutSubSampled, generate_grain_uv::Fn),
     pub fgy_32x32xn: fgy_32x32xn::Fn,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -126,7 +126,6 @@ pub(crate) struct Rav1dDSPContext {
     pub lf: Rav1dLoopFilterDSPContext,
     pub cdef: Rav1dCdefDSPContext,
     pub lr: Rav1dLoopRestorationDSPContext,
-    pub initialized: bool,
 }
 
 impl Rav1dDSPContext {
@@ -139,7 +138,6 @@ impl Rav1dDSPContext {
             lf: Rav1dLoopFilterDSPContext::default::<BD>(),
             cdef: Rav1dCdefDSPContext::default::<BD>(),
             lr: Rav1dLoopRestorationDSPContext::default::<BD>(),
-            initialized: true,
         }
     }
 
@@ -152,7 +150,6 @@ impl Rav1dDSPContext {
             lf: Rav1dLoopFilterDSPContext::new::<BD>(flags),
             cdef: Rav1dCdefDSPContext::new::<BD>(flags),
             lr: Rav1dLoopRestorationDSPContext::new::<BD>(flags, bpc),
-            initialized: true,
         }
     }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -117,8 +117,7 @@ use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 use zerocopy::FromZeroes;
 
-#[repr(C)]
-pub(crate) struct Rav1dDSPContext {
+pub struct Rav1dDSPContext {
     pub fg: Rav1dFilmGrainDSPContext,
     pub ipred: Rav1dIntraPredDSPContext,
     pub mc: Rav1dMCDSPContext,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -56,6 +56,7 @@ use crate::src::looprestoration::Rav1dLoopRestorationDSPContext;
 use crate::src::mc::Rav1dMCDSPContext;
 use crate::src::mem::MemPool;
 use crate::src::msac::MsacContext;
+use crate::src::msac::Rav1dMsacDSPContext;
 use crate::src::pal::Rav1dPalDSPContext;
 use crate::src::picture::PictureFlags;
 use crate::src::picture::Rav1dThreadPicture;
@@ -117,7 +118,40 @@ use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 use zerocopy::FromZeroes;
 
+#[derive(Default)]
 pub struct Rav1dDSPContext {
+    pub pal: Rav1dPalDSPContext,
+    pub refmvs: Rav1dRefmvsDSPContext,
+    pub msac: Rav1dMsacDSPContext,
+}
+
+impl Rav1dDSPContext {
+    pub const fn default() -> Self {
+        Self {
+            pal: Rav1dPalDSPContext::default(),
+            refmvs: Rav1dRefmvsDSPContext::default(),
+            msac: Rav1dMsacDSPContext::default(),
+        }
+    }
+
+    pub const fn new(flags: CpuFlags) -> Self {
+        Self {
+            pal: Rav1dPalDSPContext::new(flags),
+            refmvs: Rav1dRefmvsDSPContext::new(flags),
+            msac: Rav1dMsacDSPContext::new(flags),
+        }
+    }
+
+    pub fn get() -> &'static Self {
+        static DSP: OnceLock<Rav1dDSPContext> = OnceLock::new();
+        DSP.get_or_init(|| {
+            let flags = rav1d_get_cpu_flags();
+            Self::new(flags)
+        })
+    }
+}
+
+pub struct Rav1dBitDepthDSPContext {
     pub fg: Rav1dFilmGrainDSPContext,
     pub ipred: Rav1dIntraPredDSPContext,
     pub mc: Rav1dMCDSPContext,
@@ -127,7 +161,7 @@ pub struct Rav1dDSPContext {
     pub lr: Rav1dLoopRestorationDSPContext,
 }
 
-impl Rav1dDSPContext {
+impl Rav1dBitDepthDSPContext {
     pub const fn _default<BD: BitDepth>() -> Self {
         Self {
             fg: Rav1dFilmGrainDSPContext::default::<BD>(),
@@ -153,9 +187,9 @@ impl Rav1dDSPContext {
     }
 
     pub fn get(bpc: u8) -> Option<&'static Self> {
-        static BPC8: OnceLock<Rav1dDSPContext> = OnceLock::new();
-        static BPC10: OnceLock<Rav1dDSPContext> = OnceLock::new();
-        static BPC12: OnceLock<Rav1dDSPContext> = OnceLock::new();
+        static BPC8: OnceLock<Rav1dBitDepthDSPContext> = OnceLock::new();
+        static BPC10: OnceLock<Rav1dBitDepthDSPContext> = OnceLock::new();
+        static BPC12: OnceLock<Rav1dBitDepthDSPContext> = OnceLock::new();
         Some(match bpc {
             8 => BPC8.get_or_init(|| {
                 let flags = rav1d_get_cpu_flags();
@@ -352,8 +386,7 @@ pub struct Rav1dContext {
     pub(crate) refs: [Rav1dContext_refs; 8],
     pub(crate) cdf: [CdfThreadContext; 8], // Previously pooled
 
-    pub(crate) pal_dsp: Rav1dPalDSPContext,
-    pub(crate) refmvs_dsp: Rav1dRefmvsDSPContext,
+    pub dsp: &'static Rav1dDSPContext,
 
     pub(crate) allocator: Rav1dPicAllocator,
     pub(crate) apply_grain: bool,
@@ -891,7 +924,7 @@ pub(crate) struct Rav1dFrameData {
 
     pub ts: *mut Rav1dTileState,
     pub n_ts: c_int,
-    pub dsp: &'static Rav1dDSPContext,
+    pub dsp: &'static Rav1dBitDepthDSPContext,
 
     // `ipred_edge` contains 3 arrays of size `ipred_edge_off`. Use `index *
     // ipred_edge_off` to access one of the sub-arrays. Note that `ipred_edge_off`
@@ -1197,7 +1230,7 @@ impl Rav1dTaskContext_task_thread {
 }
 
 #[derive(Clone, Copy, Default)]
-pub(crate) struct Bxy {
+pub struct Bxy {
     pub x: c_int,
     pub y: c_int,
 }

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -165,8 +165,7 @@ impl pal_pred::Fn {
     }
 }
 
-#[repr(C)]
-pub(crate) struct Rav1dIntraPredDSPContext {
+pub struct Rav1dIntraPredDSPContext {
     pub intra_pred: [angular_ipred::Fn; 14],
     pub cfl_ac: enum_map_ty!(Rav1dPixelLayoutSubSampled, cfl_ac::Fn),
     pub cfl_pred: [cfl_pred::Fn; 6],

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -188,7 +188,6 @@ pub unsafe fn inv_txfm_add_rust<BD: BitDepth>(
 pub type itxfm_fn =
     Option<unsafe extern "C" fn(*mut DynPixel, ptrdiff_t, *mut DynCoef, c_int, c_int) -> ()>;
 
-#[repr(C)]
 pub struct Rav1dInvTxfmDSPContext {
     pub itxfm_add: [[itxfm_fn; N_TX_TYPES_PLUS_LL]; N_RECT_TX_SIZES],
 }

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -4,8 +4,8 @@ use crate::include::dav1d::headers::Rav1dFrameHeader;
 use crate::include::dav1d::headers::Rav1dPixelLayout;
 use crate::src::align::AlignedVec64;
 use crate::src::disjoint_mut::DisjointMut;
+use crate::src::internal::Rav1dBitDepthDSPContext;
 use crate::src::internal::Rav1dContext;
-use crate::src::internal::Rav1dDSPContext;
 use crate::src::internal::Rav1dFrameData;
 use crate::src::lr_apply::LR_RESTORE_U;
 use crate::src::lr_apply::LR_RESTORE_V;
@@ -40,7 +40,7 @@ unsafe fn backup_lpf<BD: BitDepth>(
     ss_hor: c_int,
     lr_backup: c_int,
     frame_hdr: &Rav1dFrameHeader,
-    dsp: &Rav1dDSPContext,
+    dsp: &Rav1dBitDepthDSPContext,
     resize_step: [c_int; 2],
     resize_start: [c_int; 2],
     bitdepth_max: c_int,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,6 @@ use crate::src::pal::rav1d_pal_dsp_init;
 use crate::src::picture::rav1d_picture_alloc_copy;
 use crate::src::picture::PictureFlags;
 use crate::src::picture::Rav1dThreadPicture;
-use crate::src::refmvs::rav1d_refmvs_clear;
 use crate::src::refmvs::rav1d_refmvs_dsp_init;
 use crate::src::thread_task::rav1d_task_delayed_fg;
 use crate::src::thread_task::rav1d_worker_task;
@@ -762,7 +761,7 @@ impl Drop for Rav1dContext {
                 let _ = mem::take(&mut f.lf.level);
                 let _ = mem::take(&mut f.lf.tx_lpf_right_edge); // TODO: remove when context is owned
                 let _ = mem::take(&mut f.lf.start_of_tile_row); // TODO: remove when context is owned
-                rav1d_refmvs_clear(&mut f.rf);
+                let _ = mem::take(&mut f.rf);
                 let _ = mem::take(&mut f.lf.cdef_line_buf); // TODO: remove when context is owned
                 let _ = mem::take(&mut f.lf.lr_line_buf); // TODO: remove when context is owned
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ use crate::include::dav1d::headers::Dav1dSequenceHeader;
 use crate::include::dav1d::headers::Rav1dFilmGrainData;
 use crate::include::dav1d::picture::Dav1dPicture;
 use crate::include::dav1d::picture::Rav1dPicture;
+use crate::src::cpu::rav1d_get_cpu_flags;
 use crate::src::cpu::rav1d_init_cpu;
 use crate::src::cpu::rav1d_num_logical_processors;
 use crate::src::decode::rav1d_decode_frame_exit;
@@ -42,11 +43,11 @@ use crate::src::mem::rav1d_free_aligned;
 use crate::src::mem::rav1d_freep_aligned;
 use crate::src::obu::rav1d_parse_obus;
 use crate::src::obu::rav1d_parse_sequence_header;
-use crate::src::pal::rav1d_pal_dsp_init;
+use crate::src::pal::Rav1dPalDSPContext;
 use crate::src::picture::rav1d_picture_alloc_copy;
 use crate::src::picture::PictureFlags;
 use crate::src::picture::Rav1dThreadPicture;
-use crate::src::refmvs::rav1d_refmvs_dsp_init;
+use crate::src::refmvs::Rav1dRefmvsDSPContext;
 use crate::src::thread_task::rav1d_task_delayed_fg;
 use crate::src::thread_task::rav1d_worker_task;
 use crate::src::thread_task::FRAME_ERROR;
@@ -301,8 +302,9 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
             }
         })
         .collect();
-    rav1d_pal_dsp_init(&mut (*c).pal_dsp);
-    rav1d_refmvs_dsp_init(&mut (*c).refmvs_dsp);
+    let flags = rav1d_get_cpu_flags();
+    (*c).pal_dsp = Rav1dPalDSPContext::new(flags);
+    (*c).refmvs_dsp = Rav1dRefmvsDSPContext::new(flags);
     Ok(())
 }
 

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -26,7 +26,6 @@ pub type loopfilter_sb_fn = unsafe extern "C" fn(
     c_int,
 ) -> ();
 
-#[repr(C)]
 pub struct Rav1dLoopFilterDSPContext {
     pub loop_filter_sb: [[loopfilter_sb_fn; 2]; 2],
 }

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -137,7 +137,6 @@ pub type looprestorationfilter_fn = unsafe extern "C" fn(
     c_int,
 ) -> ();
 
-#[repr(C)]
 pub struct Rav1dLoopRestorationDSPContext {
     pub wiener: [looprestorationfilter_fn; 2],
     pub sgr: [looprestorationfilter_fn; 3],

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -1423,7 +1423,7 @@ pub type resize_fn = unsafe extern "C" fn(
     c_int,
     c_int,
 ) -> ();
-#[repr(C)]
+
 pub struct Rav1dMCDSPContext {
     pub mc: enum_map_ty!(Filter2d, mc::Fn),
     pub mc_scaled: enum_map_ty!(Filter2d, mc_scaled::Fn),

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -8,18 +8,12 @@ use std::ffi::c_uint;
 use std::mem;
 use std::ops::Range;
 
-#[cfg(all(feature = "asm", target_arch = "x86_64"))]
+#[cfg(all(feature = "asm", target_feature = "sse2"))]
 extern "C" {
     fn dav1d_msac_decode_hi_tok_sse2(s: *mut MsacContext, cdf: *mut u16) -> c_uint;
     fn dav1d_msac_decode_bool_sse2(s: *mut MsacContext, f: c_uint) -> c_uint;
     fn dav1d_msac_decode_bool_equi_sse2(s: *mut MsacContext) -> c_uint;
     fn dav1d_msac_decode_bool_adapt_sse2(s: *mut MsacContext, cdf: *mut u16) -> c_uint;
-    fn dav1d_msac_decode_symbol_adapt16_avx2(
-        s: &mut MsacContext,
-        cdf: *mut u16,
-        n_symbols: usize,
-        _cdf_len: usize,
-    ) -> c_uint;
     fn dav1d_msac_decode_symbol_adapt16_sse2(
         s: &mut MsacContext,
         cdf: *mut u16,
@@ -38,7 +32,17 @@ extern "C" {
     ) -> c_uint;
 }
 
-#[cfg(all(feature = "asm", target_arch = "aarch64"))]
+#[cfg(all(feature = "asm", target_arch = "x86_64"))]
+extern "C" {
+    fn dav1d_msac_decode_symbol_adapt16_avx2(
+        s: &mut MsacContext,
+        cdf: *mut u16,
+        n_symbols: usize,
+        _cdf_len: usize,
+    ) -> c_uint;
+}
+
+#[cfg(all(feature = "asm", target_feature = "neon"))]
 extern "C" {
     fn dav1d_msac_decode_hi_tok_neon(s: *mut MsacContext, cdf: *mut u16) -> c_uint;
     fn dav1d_msac_decode_bool_neon(s: *mut MsacContext, f: c_uint) -> c_uint;
@@ -77,20 +81,23 @@ impl Rav1dMsacDSPContext {
         }
     }
 
-    #[cfg(all(feature = "asm", target_arch = "x86_64"))]
+    #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
     #[inline(always)]
-    const fn init_x86_64(mut self, flags: CpuFlags) -> Self {
+    const fn init_x86(mut self, flags: CpuFlags) -> Self {
         if !flags.contains(CpuFlags::SSE2) {
             return self;
         }
 
         self.symbol_adapt16 = dav1d_msac_decode_symbol_adapt16_sse2;
 
-        if !flags.contains(CpuFlags::AVX2) {
-            return self;
-        }
+        #[cfg(target_arch = "x86_64")]
+        {
+            if !flags.contains(CpuFlags::AVX2) {
+                return self;
+            }
 
-        self.symbol_adapt16 = dav1d_msac_decode_symbol_adapt16_avx2;
+            self.symbol_adapt16 = dav1d_msac_decode_symbol_adapt16_avx2;
+        }
 
         self
     }
@@ -105,9 +112,9 @@ impl Rav1dMsacDSPContext {
     const fn init(self, flags: CpuFlags) -> Self {
         #[cfg(feature = "asm")]
         {
-            #[cfg(target_arch = "x86_64")]
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             {
-                return self.init_x86_64(flags);
+                return self.init_x86(flags);
             }
             #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
             {
@@ -237,7 +244,7 @@ fn ctx_norm(s: &mut MsacContext, dif: ec_win, rng: c_uint) {
 }
 
 #[cfg_attr(
-    all(feature = "asm", any(target_arch = "x86_64", target_arch = "aarch64")),
+    all(feature = "asm", any(target_feature = "sse2", target_feature = "neon")),
     allow(dead_code)
 )]
 fn rav1d_msac_decode_bool_equi_rust(s: &mut MsacContext) -> bool {
@@ -254,7 +261,7 @@ fn rav1d_msac_decode_bool_equi_rust(s: &mut MsacContext) -> bool {
 }
 
 #[cfg_attr(
-    all(feature = "asm", any(target_arch = "x86_64", target_arch = "aarch64")),
+    all(feature = "asm", any(target_feature = "sse2", target_feature = "neon")),
     allow(dead_code)
 )]
 fn rav1d_msac_decode_bool_rust(s: &mut MsacContext, f: c_uint) -> bool {
@@ -353,7 +360,7 @@ unsafe extern "C" fn rav1d_msac_decode_symbol_adapt_c(
 }
 
 #[cfg_attr(
-    all(feature = "asm", any(target_arch = "x86_64", target_arch = "aarch64")),
+    all(feature = "asm", any(target_feature = "sse2", target_feature = "neon")),
     allow(dead_code)
 )]
 fn rav1d_msac_decode_bool_adapt_rust(s: &mut MsacContext, cdf: &mut [u16; 2]) -> bool {
@@ -372,7 +379,7 @@ fn rav1d_msac_decode_bool_adapt_rust(s: &mut MsacContext, cdf: &mut [u16; 2]) ->
 }
 
 #[cfg_attr(
-    all(feature = "asm", any(target_arch = "x86_64", target_arch = "aarch64")),
+    all(feature = "asm", any(target_feature = "sse2", target_feature = "neon")),
     allow(dead_code)
 )]
 fn rav1d_msac_decode_hi_tok_rust(s: &mut MsacContext, cdf: &mut [u16; 4]) -> c_uint {
@@ -429,12 +436,12 @@ pub fn rav1d_msac_decode_symbol_adapt4(
     n_symbols: usize,
 ) -> c_uint {
     cfg_if! {
-        if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
+        if #[cfg(all(feature = "asm", target_feature = "sse2"))] {
             // Safety: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_symbol_adapt_rust`].
             unsafe {
                 dav1d_msac_decode_symbol_adapt4_sse2(s, cdf.as_mut_ptr(), n_symbols)
             }
-        } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
+        } else if #[cfg(all(feature = "asm", target_feature = "neon"))] {
             // Safety: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_symbol_adapt_rust`].
             unsafe {
                 dav1d_msac_decode_symbol_adapt4_neon(s, cdf.as_mut_ptr(), n_symbols)
@@ -451,12 +458,12 @@ pub fn rav1d_msac_decode_symbol_adapt8(
     n_symbols: usize,
 ) -> c_uint {
     cfg_if! {
-        if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
+        if #[cfg(all(feature = "asm", target_feature = "sse2"))] {
             // Safety: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_symbol_adapt_rust`].
             unsafe {
                 dav1d_msac_decode_symbol_adapt8_sse2(s, cdf.as_mut_ptr(), n_symbols)
             }
-        } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
+        } else if #[cfg(all(feature = "asm", target_feature = "neon"))] {
             // Safety: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_symbol_adapt_rust`].
             unsafe {
                 dav1d_msac_decode_symbol_adapt8_neon(s, cdf.as_mut_ptr(), n_symbols)
@@ -478,7 +485,12 @@ pub fn rav1d_msac_decode_symbol_adapt16(
             unsafe {
                 (s.symbol_adapt16)(s, cdf.as_mut_ptr(), n_symbols, cdf.len())
             }
-        } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
+        } else if #[cfg(all(feature = "asm", target_feature = "sse2"))] {
+            // Safety: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_symbol_adapt_rust`].
+            unsafe {
+                dav1d_msac_decode_symbol_adapt16_sse2(s, cdf.as_mut_ptr(), n_symbols, cdf.len())
+            }
+        } else if #[cfg(all(feature = "asm", target_feature = "neon"))] {
             // Safety: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_symbol_adapt_rust`].
             unsafe {
                 dav1d_msac_decode_symbol_adapt16_neon(s, cdf.as_mut_ptr(), n_symbols)
@@ -491,12 +503,12 @@ pub fn rav1d_msac_decode_symbol_adapt16(
 
 pub fn rav1d_msac_decode_bool_adapt(s: &mut MsacContext, cdf: &mut [u16; 2]) -> bool {
     cfg_if! {
-        if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
+        if #[cfg(all(feature = "asm", target_feature = "sse2"))] {
             // Safety: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_bool_adapt_rust`].
             unsafe {
                 dav1d_msac_decode_bool_adapt_sse2(s, cdf.as_mut_ptr()) != 0
             }
-        } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
+        } else if #[cfg(all(feature = "asm", target_feature = "neon"))] {
             // Safety: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_bool_adapt_rust`].
             unsafe {
                 dav1d_msac_decode_bool_adapt_neon(s, cdf.as_mut_ptr()) != 0
@@ -509,12 +521,12 @@ pub fn rav1d_msac_decode_bool_adapt(s: &mut MsacContext, cdf: &mut [u16; 2]) -> 
 
 pub fn rav1d_msac_decode_bool_equi(s: &mut MsacContext) -> bool {
     cfg_if! {
-        if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
+        if #[cfg(all(feature = "asm", target_feature = "sse2"))] {
             // Safety: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_bool_equi_rust`].
             unsafe {
                 dav1d_msac_decode_bool_equi_sse2(s) != 0
             }
-        } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
+        } else if #[cfg(all(feature = "asm", target_feature = "neon"))] {
             // Safety: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_bool_equi_rust`].
             unsafe {
                 dav1d_msac_decode_bool_equi_neon(s) != 0
@@ -527,12 +539,12 @@ pub fn rav1d_msac_decode_bool_equi(s: &mut MsacContext) -> bool {
 
 pub fn rav1d_msac_decode_bool(s: &mut MsacContext, f: c_uint) -> bool {
     cfg_if! {
-        if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
+        if #[cfg(all(feature = "asm", target_feature = "sse2"))] {
             // Safety: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_bool_rust`].
             unsafe {
                 dav1d_msac_decode_bool_sse2(s, f) != 0
             }
-        } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
+        } else if #[cfg(all(feature = "asm", target_feature = "neon"))] {
             // Safety: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_bool_rust`].
             unsafe {
                 dav1d_msac_decode_bool_neon(s, f) != 0
@@ -545,12 +557,12 @@ pub fn rav1d_msac_decode_bool(s: &mut MsacContext, f: c_uint) -> bool {
 
 pub fn rav1d_msac_decode_hi_tok(s: &mut MsacContext, cdf: &mut [u16; 4]) -> c_uint {
     cfg_if! {
-        if #[cfg(all(feature = "asm", target_arch = "x86_64"))] {
+        if #[cfg(all(feature = "asm", target_feature = "sse2"))] {
             // Safety: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_hi_tok_rust`].
             unsafe {
                 dav1d_msac_decode_hi_tok_sse2(s, cdf.as_mut_ptr())
             }
-        } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
+        } else if #[cfg(all(feature = "asm", target_feature = "neon"))] {
             // Safety: `checkasm` has verified that it is equivalent to [`dav1d_msac_decode_hi_tok_rust`].
             unsafe {
                 dav1d_msac_decode_hi_tok_neon(s, cdf.as_mut_ptr())

--- a/src/pal.rs
+++ b/src/pal.rs
@@ -159,3 +159,9 @@ impl Rav1dPalDSPContext {
         Self::default().init(flags)
     }
 }
+
+impl Default for Rav1dPalDSPContext {
+    fn default() -> Self {
+        Self::default()
+    }
+}

--- a/src/pal.rs
+++ b/src/pal.rs
@@ -11,8 +11,7 @@ pub type pal_idx_finish_fn = unsafe extern "C" fn(
     h: c_int,
 ) -> ();
 
-#[repr(C)]
-pub(crate) struct Rav1dPalDSPContext {
+pub struct Rav1dPalDSPContext {
     pub pal_idx_finish: pal_idx_finish_fn,
 }
 

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -20,8 +20,8 @@ use crate::src::env::get_uv_inter_txtp;
 use crate::src::internal::Bxy;
 use crate::src::internal::Cf;
 use crate::src::internal::CodedBlockInfo;
+use crate::src::internal::Rav1dBitDepthDSPContext;
 use crate::src::internal::Rav1dContext;
-use crate::src::internal::Rav1dDSPContext;
 use crate::src::internal::Rav1dFrameData;
 use crate::src::internal::Rav1dTaskContext;
 use crate::src::internal::ScratchEmuEdge;
@@ -2497,7 +2497,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
 ) {
     let ts = &mut *f.ts.offset(t.ts as isize);
 
-    let dsp: *const Rav1dDSPContext = f.dsp;
+    let dsp: *const Rav1dBitDepthDSPContext = f.dsp;
     let bx4 = t.b.x & 31;
     let by4 = t.b.y & 31;
     let ss_ver = (f.cur.p.layout as c_uint == Rav1dPixelLayout::I420 as c_int as c_uint) as c_int;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -315,8 +315,7 @@ pub type splat_mv_fn = unsafe extern "C" fn(
     rr_len: usize,
 ) -> ();
 
-#[repr(C)]
-pub(crate) struct Rav1dRefmvsDSPContext {
+pub struct Rav1dRefmvsDSPContext {
     load_tmvs: load_tmvs_fn,
     save_tmvs: save_tmvs_fn,
     splat_mv: splat_mv_fn,

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1709,11 +1709,6 @@ pub(crate) fn rav1d_refmvs_init_frame(
     Ok(())
 }
 
-pub(crate) fn rav1d_refmvs_clear(rf: &mut RefMvsFrame) {
-    let _ = mem::take(&mut rf.r);
-    let _ = mem::take(&mut rf.rp_proj);
-}
-
 unsafe extern "C" fn splat_mv_rust(
     rr: *mut *mut refmvs_block,
     rmv: *const Align16<refmvs_block>,

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -199,7 +199,7 @@ pub(crate) struct refmvs_frame<'a> {
 }
 
 #[derive(Default)]
-pub(crate) struct RefMvsFrame {
+pub struct RefMvsFrame {
     pub iw4: c_int,
     pub ih4: c_int,
     pub iw8: c_int,
@@ -229,7 +229,7 @@ pub struct refmvs_tile_range {
     pub end: c_int,
 }
 
-pub(crate) struct refmvs_tile {
+pub struct refmvs_tile {
     /// Unique indices into [`RefMvsFrame::r`].
     /// Out of bounds indices correspond to null pointers.
     ///
@@ -1808,5 +1808,11 @@ impl Rav1dRefmvsDSPContext {
 
     pub const fn new(flags: CpuFlags) -> Self {
         Self::default().init(flags)
+    }
+}
+
+impl Default for Rav1dRefmvsDSPContext {
+    fn default() -> Self {
+        Self::default()
     }
 }

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -5,6 +5,7 @@ use crate::include::dav1d::headers::Rav1dSequenceHeader;
 use crate::include::dav1d::headers::Rav1dWarpedMotionType;
 use crate::src::align::Align16;
 use crate::src::align::AlignedVec64;
+use crate::src::cpu::CpuFlags;
 use crate::src::disjoint_mut::DisjointMut;
 use crate::src::disjoint_mut::DisjointMutArcSlice;
 use crate::src::env::fix_mv_precision;
@@ -17,7 +18,6 @@ use crate::src::intra_edge::EdgeFlags;
 use crate::src::levels::mv;
 use crate::src::levels::BlockSize;
 use crate::src::tables::dav1d_block_dimensions;
-use cfg_if::cfg_if;
 use libc::ptrdiff_t;
 use std::array;
 use std::cmp;
@@ -27,12 +27,6 @@ use std::marker::PhantomData;
 use std::mem;
 use std::ptr;
 use zerocopy::FromZeroes;
-
-#[cfg(all(
-    feature = "asm",
-    not(any(target_arch = "riscv64", target_arch = "riscv32"))
-))]
-use crate::src::cpu::{rav1d_get_cpu_flags, CpuFlags};
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 extern "C" {
@@ -1729,67 +1723,91 @@ unsafe extern "C" fn splat_mv_rust(
     }
 }
 
-#[inline(always)]
-#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "asm"))]
-fn refmvs_dsp_init_x86(c: &mut Rav1dRefmvsDSPContext) {
-    let flags = rav1d_get_cpu_flags();
-
-    if !flags.contains(CpuFlags::SSE2) {
-        return;
+impl Rav1dRefmvsDSPContext {
+    pub const fn default() -> Self {
+        Self {
+            load_tmvs: load_tmvs_c,
+            save_tmvs: save_tmvs_c,
+            splat_mv: splat_mv_rust,
+        }
     }
 
-    c.splat_mv = dav1d_splat_mv_sse2;
-
-    if !flags.contains(CpuFlags::SSSE3) {
-        return;
-    }
-
-    c.save_tmvs = dav1d_save_tmvs_ssse3;
-
-    if !flags.contains(CpuFlags::SSE41) {
-        return;
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    {
-        c.load_tmvs = dav1d_load_tmvs_sse4;
-
-        if !flags.contains(CpuFlags::AVX2) {
-            return;
+    #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
+    #[inline(always)]
+    const fn init_x86(mut self, flags: CpuFlags) -> Self {
+        if !flags.contains(CpuFlags::SSE2) {
+            return self;
         }
 
-        c.save_tmvs = dav1d_save_tmvs_avx2;
-        c.splat_mv = dav1d_splat_mv_avx2;
+        self.splat_mv = dav1d_splat_mv_sse2;
 
-        if !flags.contains(CpuFlags::AVX512ICL) {
-            return;
+        if !flags.contains(CpuFlags::SSSE3) {
+            return self;
         }
 
-        c.save_tmvs = dav1d_save_tmvs_avx512icl;
-        c.splat_mv = dav1d_splat_mv_avx512icl;
-    }
-}
+        self.save_tmvs = dav1d_save_tmvs_ssse3;
 
-#[inline(always)]
-#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), feature = "asm"))]
-fn refmvs_dsp_init_arm(c: &mut Rav1dRefmvsDSPContext) {
-    let flags = rav1d_get_cpu_flags();
-    if flags.contains(CpuFlags::NEON) {
-        c.save_tmvs = dav1d_save_tmvs_neon;
-        c.splat_mv = dav1d_splat_mv_neon;
-    }
-}
-
-#[cold]
-pub(crate) fn rav1d_refmvs_dsp_init(c: &mut Rav1dRefmvsDSPContext) {
-    c.load_tmvs = load_tmvs_c;
-    c.save_tmvs = save_tmvs_c;
-    c.splat_mv = splat_mv_rust;
-    cfg_if! {
-        if #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "asm"))] {
-            refmvs_dsp_init_x86(c);
-        } else if #[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), feature = "asm"))] {
-            refmvs_dsp_init_arm(c);
+        if !flags.contains(CpuFlags::SSE41) {
+            return self;
         }
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            self.load_tmvs = dav1d_load_tmvs_sse4;
+
+            if !flags.contains(CpuFlags::AVX2) {
+                return self;
+            }
+
+            self.save_tmvs = dav1d_save_tmvs_avx2;
+            self.splat_mv = dav1d_splat_mv_avx2;
+
+            if !flags.contains(CpuFlags::AVX512ICL) {
+                return self;
+            }
+
+            self.save_tmvs = dav1d_save_tmvs_avx512icl;
+            self.splat_mv = dav1d_splat_mv_avx512icl;
+        }
+
+        self
+    }
+
+    #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
+    #[inline(always)]
+    const fn init_arm(mut self, flags: CpuFlags) -> Self {
+        if !flags.contains(CpuFlags::NEON) {
+            return self;
+        }
+
+        self.save_tmvs = dav1d_save_tmvs_neon;
+        self.splat_mv = dav1d_splat_mv_neon;
+
+        self
+    }
+
+    #[inline(always)]
+    const fn init(self, flags: CpuFlags) -> Self {
+        #[cfg(feature = "asm")]
+        {
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            {
+                return self.init_x86(flags);
+            }
+            #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+            {
+                return self.init_arm(flags);
+            }
+        }
+
+        #[allow(unreachable_code)] // Reachable on some #[cfg]s.
+        {
+            let _ = flags;
+            self
+        }
+    }
+
+    pub const fn new(flags: CpuFlags) -> Self {
+        Self::default().init(flags)
     }
 }

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -17,8 +17,8 @@ use crate::src::error::Rav1dError::ENOMEM;
 use crate::src::error::Rav1dResult;
 use crate::src::fg_apply::rav1d_apply_grain_row;
 use crate::src::fg_apply::rav1d_prep_grain;
+use crate::src::internal::Rav1dBitDepthDSPContext;
 use crate::src::internal::Rav1dContext;
-use crate::src::internal::Rav1dDSPContext;
 use crate::src::internal::Rav1dFrameContext;
 use crate::src::internal::Rav1dFrameContext_task_thread;
 use crate::src::internal::Rav1dFrameData;
@@ -635,7 +635,7 @@ unsafe fn delayed_fg_task<'l, 'ttd: 'l>(
                 #[cfg(feature = "bitdepth_8")]
                 bpc @ 8 => {
                     rav1d_prep_grain::<BitDepth8>(
-                        &Rav1dDSPContext::get(bpc).as_ref().unwrap().fg,
+                        &Rav1dBitDepthDSPContext::get(bpc).as_ref().unwrap().fg,
                         &mut *out,
                         &*in_0,
                         BitDepth8::select_mut(&mut delayed_fg.grain),
@@ -644,7 +644,7 @@ unsafe fn delayed_fg_task<'l, 'ttd: 'l>(
                 #[cfg(feature = "bitdepth_16")]
                 bpc @ 10 | bpc @ 12 => {
                     rav1d_prep_grain::<BitDepth16>(
-                        &Rav1dDSPContext::get(bpc).as_ref().unwrap().fg,
+                        &Rav1dBitDepthDSPContext::get(bpc).as_ref().unwrap().fg,
                         &mut *out,
                         &*in_0,
                         BitDepth16::select_mut(&mut delayed_fg.grain),
@@ -682,7 +682,7 @@ unsafe fn delayed_fg_task<'l, 'ttd: 'l>(
                 #[cfg(feature = "bitdepth_8")]
                 bpc @ 8 => {
                     rav1d_apply_grain_row::<BitDepth8>(
-                        &Rav1dDSPContext::get(bpc).as_ref().unwrap().fg,
+                        &Rav1dBitDepthDSPContext::get(bpc).as_ref().unwrap().fg,
                         &mut *out,
                         &*in_0,
                         BitDepth8::select(&delayed_fg.grain),
@@ -692,7 +692,7 @@ unsafe fn delayed_fg_task<'l, 'ttd: 'l>(
                 #[cfg(feature = "bitdepth_16")]
                 bpc @ 10 | bpc @ 12 => {
                     rav1d_apply_grain_row::<BitDepth16>(
-                        &Rav1dDSPContext::get(bpc).as_ref().unwrap().fg,
+                        &Rav1dBitDepthDSPContext::get(bpc).as_ref().unwrap().fg,
                         &mut *out,
                         &*in_0,
                         BitDepth16::select(&delayed_fg.grain),


### PR DESCRIPTION
Sorry that this PR is a little all over the place, but essentially what it does is:
* Make `*DSPContext` initialization safe, all `const fn`, and return the DSPs directly.
* Consolidate the non-`BitDepth` dependent DSPs into `Rav1dDSPContext`, with the former `Rav1dDSPContext` renamed to `Rav1dBitDepthDSPContext`.
* Add `Rav1dMsacDSPContext` to use the same approach there instead of a one-off different one.
* Fix incorrectly translated `#[cfg]`s for asm enabling in `mod msac`.
* This would also set us up to easily turn on CPU feature detection for asm `fn`s in `mod msac` as is does everywhere else.  Only compile-time CPU detection is done correctly, so for example, `sse2` asm `fn`s are not used on `x86` unless specifically compiled with `sse2`.