### PR TITLE
`fn *`: Make a bunch of already safe `fn`s nominally safe and clean them up

### DIFF
--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -6,7 +6,6 @@ use crate::src::align::Align32;
 use crate::src::align::Align4;
 use crate::src::align::Align8;
 use crate::src::error::Rav1dResult;
-use crate::src::internal::Rav1dContext;
 use crate::src::levels::BlockLevel;
 use crate::src::levels::BlockPartition;
 use crate::src::levels::BlockSize;
@@ -5116,10 +5115,7 @@ pub fn rav1d_cdf_thread_copy(dst: &mut CdfContext, src: &CdfThreadContext) {
     }
 }
 
-pub fn rav1d_cdf_thread_alloc(
-    _c: &Rav1dContext,
-    have_frame_mt: c_int,
-) -> Rav1dResult<CdfThreadContext> {
+pub fn rav1d_cdf_thread_alloc(have_frame_mt: c_int) -> Rav1dResult<CdfThreadContext> {
     let progress = if have_frame_mt != 0 {
         Some(AtomicU32::new(0))
     } else {

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -5116,6 +5116,7 @@ pub fn rav1d_cdf_thread_copy(dst: &mut CdfContext, src: &CdfThreadContext) {
 }
 
 pub fn rav1d_cdf_thread_alloc(have_frame_mt: bool) -> Rav1dResult<CdfThreadContext> {
+    // TODO fallible allocation
     Ok(CdfThreadContext::Cdf(Arc::new(CdfThreadContext_data {
         cdf: Default::default(),
         progress: have_frame_mt.then_some(AtomicU32::new(0)),

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -5116,7 +5116,7 @@ pub fn rav1d_cdf_thread_copy(dst: &mut CdfContext, src: &CdfThreadContext) {
     }
 }
 
-pub unsafe fn rav1d_cdf_thread_alloc(
+pub fn rav1d_cdf_thread_alloc(
     _c: &Rav1dContext,
     have_frame_mt: c_int,
 ) -> Rav1dResult<CdfThreadContext> {

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -5117,6 +5117,7 @@ pub fn rav1d_cdf_thread_copy(dst: &mut CdfContext, src: &CdfThreadContext) {
 
 pub fn rav1d_cdf_thread_alloc(have_frame_mt: bool) -> Rav1dResult<CdfThreadContext> {
     // TODO fallible allocation
+    // Previously pooled.
     Ok(CdfThreadContext::Cdf(Arc::new(CdfThreadContext_data {
         cdf: Default::default(),
         progress: have_frame_mt.then_some(AtomicU32::new(0)),

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_code)]
+
 use crate::include::dav1d::headers::Rav1dFilterMode;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
 use crate::include::dav1d::headers::RAV1D_MAX_SEGMENTS;

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -5087,7 +5087,7 @@ const fn get_qcat_idx(q: u8) -> u32 {
     }
 }
 
-pub unsafe fn rav1d_cdf_thread_init_static(qidx: u8) -> CdfThreadContext {
+pub fn rav1d_cdf_thread_init_static(qidx: u8) -> CdfThreadContext {
     CdfThreadContext::QCat(get_qcat_idx(qidx))
 }
 

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -5079,7 +5079,7 @@ pub(crate) fn rav1d_cdf_thread_update(
 }
 
 #[inline]
-unsafe fn get_qcat_idx(q: u8) -> c_int {
+fn get_qcat_idx(q: u8) -> c_int {
     if q <= 20 {
         return 0 as c_int;
     }

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -5115,14 +5115,9 @@ pub fn rav1d_cdf_thread_copy(dst: &mut CdfContext, src: &CdfThreadContext) {
     }
 }
 
-pub fn rav1d_cdf_thread_alloc(have_frame_mt: c_int) -> Rav1dResult<CdfThreadContext> {
-    let progress = if have_frame_mt != 0 {
-        Some(AtomicU32::new(0))
-    } else {
-        None
-    };
+pub fn rav1d_cdf_thread_alloc(have_frame_mt: bool) -> Rav1dResult<CdfThreadContext> {
     Ok(CdfThreadContext::Cdf(Arc::new(CdfThreadContext_data {
         cdf: Default::default(),
-        progress,
+        progress: have_frame_mt.then_some(AtomicU32::new(0)),
     })))
 }

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -16,7 +16,6 @@ use crate::src::levels::N_TX_SIZES;
 use crate::src::levels::N_UV_INTRA_PRED_MODES;
 use crate::src::tables::dav1d_partition_type_count;
 use std::cmp;
-use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
@@ -5079,21 +5078,17 @@ pub(crate) fn rav1d_cdf_thread_update(
 }
 
 #[inline]
-fn get_qcat_idx(q: u8) -> c_int {
-    if q <= 20 {
-        return 0 as c_int;
+const fn get_qcat_idx(q: u8) -> u32 {
+    match q {
+        ..=20 => 0,
+        ..=60 => 1,
+        ..=120 => 2,
+        _ => 3,
     }
-    if q <= 60 {
-        return 1 as c_int;
-    }
-    if q <= 120 {
-        return 2 as c_int;
-    }
-    return 3 as c_int;
 }
 
 pub unsafe fn rav1d_cdf_thread_init_static(qidx: u8) -> CdfThreadContext {
-    CdfThreadContext::QCat(get_qcat_idx(qidx) as c_uint)
+    CdfThreadContext::QCat(get_qcat_idx(qidx))
 }
 
 pub fn rav1d_cdf_thread_copy(dst: &mut CdfContext, src: &CdfThreadContext) {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3917,7 +3917,7 @@ unsafe fn setup_tile(
     }
 }
 
-unsafe fn read_restoration_info(
+fn read_restoration_info(
     ts: &mut Rav1dTileState,
     lr: &mut Av1RestorationUnit,
     p: usize,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3846,7 +3846,7 @@ unsafe fn setup_tile(
         };
     }
 
-    rav1d_cdf_thread_copy(&mut ts.cdf, in_cdf);
+    ts.cdf = rav1d_cdf_thread_copy(in_cdf);
     ts.last_qidx = frame_hdr.quant.yac;
     ts.last_delta_lf.fill(0);
 
@@ -4572,7 +4572,7 @@ pub(crate) unsafe fn rav1d_decode_frame_init_cdf(
     let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
 
     if frame_hdr.refresh_context != 0 {
-        rav1d_cdf_thread_copy(&mut f.out_cdf.cdf_write(), in_cdf);
+        *f.out_cdf.cdf_write() = rav1d_cdf_thread_copy(in_cdf);
     }
 
     let uses_2pass = c.fc.len() > 1;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4979,7 +4979,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
         *fc.in_cdf.try_write().unwrap() = c.cdf[pri_ref].clone();
     }
     if frame_hdr.refresh_context != 0 {
-        let res = rav1d_cdf_thread_alloc((c.fc.len() > 1) as c_int);
+        let res = rav1d_cdf_thread_alloc(c.fc.len() > 1);
         match res {
             Err(e) => {
                 on_error(fc, &mut f, c, out);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4979,7 +4979,7 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
         *fc.in_cdf.try_write().unwrap() = c.cdf[pri_ref].clone();
     }
     if frame_hdr.refresh_context != 0 {
-        let res = rav1d_cdf_thread_alloc(c, (c.fc.len() > 1) as c_int);
+        let res = rav1d_cdf_thread_alloc((c.fc.len() > 1) as c_int);
         match res {
             Err(e) => {
                 on_error(fc, &mut f, c, out);

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -577,7 +577,7 @@ pub(crate) fn rav1d_parse_sequence_header(
     res.map(DRav1d::from_rav1d)
 }
 
-unsafe fn parse_frame_size(
+fn parse_frame_size(
     c: &Rav1dContext,
     seqhdr: &Rav1dSequenceHeader,
     refidx: Option<&[i8; RAV1D_REFS_PER_FRAME]>,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2601,7 +2601,7 @@ unsafe fn parse_obus(
             if c.tiles.is_empty() {
                 return Err(EINVAL);
             }
-            rav1d_submit_frame(&mut *c)?;
+            rav1d_submit_frame(c)?;
             assert!(c.tiles.is_empty());
             c.frame_hdr = None;
             c.n_tiles = 0;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1219,7 +1219,7 @@ fn parse_delta(
     Rav1dFrameHeader_delta { q, lf }
 }
 
-unsafe fn parse_loopfilter(
+fn parse_loopfilter(
     c: &Rav1dContext,
     seqhdr: &Rav1dSequenceHeader,
     all_lossless: bool,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1402,7 +1402,7 @@ fn parse_restoration(
     Rav1dFrameHeader_restoration { r#type, unit_size }
 }
 
-unsafe fn parse_skip_mode(
+fn parse_skip_mode(
     c: &Rav1dContext,
     seqhdr: &Rav1dSequenceHeader,
     switchable_comp_refs: u8,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -678,7 +678,7 @@ static default_mode_ref_deltas: Rav1dLoopfilterModeRefDeltas = Rav1dLoopfilterMo
     ref_delta: [1, 0, 0, 0, -1, 0, -1, -1],
 };
 
-unsafe fn parse_refidx(
+fn parse_refidx(
     c: &Rav1dContext,
     seqhdr: &Rav1dSequenceHeader,
     frame_ref_short_signaling: u8,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2117,7 +2117,7 @@ unsafe fn parse_obus(
     props: &Rav1dDataProps,
     gb: &mut GetBits,
 ) -> Rav1dResult<()> {
-    unsafe fn skip(c: &mut Rav1dContext) {
+    fn skip(c: &mut Rav1dContext) {
         // update refs with only the headers in case we skip the frame
         for i in 0..8 {
             if c.frame_hdr.as_ref().unwrap().refresh_frame_flags & (1 << i) != 0 {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1684,7 +1684,7 @@ fn parse_film_grain_data(
     })
 }
 
-unsafe fn parse_film_grain(
+fn parse_film_grain(
     c: &Rav1dContext,
     seqhdr: &Rav1dSequenceHeader,
     show_frame: u8,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1099,7 +1099,7 @@ fn parse_seg_data(gb: &mut GetBits) -> Rav1dSegmentationDataSet {
     }
 }
 
-unsafe fn parse_segmentation(
+fn parse_segmentation(
     c: &Rav1dContext,
     primary_ref_frame: u8,
     refidx: &[i8; RAV1D_REFS_PER_FRAME],

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2174,7 +2174,7 @@ unsafe fn parse_obus(
         }
     }
 
-    unsafe fn parse_tile_grp(
+    fn parse_tile_grp(
         c: &mut Rav1dContext,
         r#in: &CArc<[u8]>,
         props: &Rav1dDataProps,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -532,7 +532,7 @@ fn parse_seq_hdr(
     })
 }
 
-pub(crate) unsafe fn rav1d_parse_sequence_header(
+pub(crate) fn rav1d_parse_sequence_header(
     mut data: &[u8],
 ) -> Rav1dResult<DRav1d<Rav1dSequenceHeader, Dav1dSequenceHeader>> {
     let mut res = Err(ENOENT);

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1504,7 +1504,7 @@ fn parse_skip_mode(
     })
 }
 
-unsafe fn parse_gmv(
+fn parse_gmv(
     c: &Rav1dContext,
     frame_type: Rav1dFrameType,
     primary_ref_frame: u8,

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1,4 +1,3 @@
-use crate::include::common::attributes::ctz;
 use crate::include::common::bitdepth::BitDepth;
 #[cfg(feature = "bitdepth_16")]
 use crate::include::common::bitdepth::BitDepth16;
@@ -574,7 +573,7 @@ fn get_frame_progress(fc: &Rav1dFrameContext, f: &Rav1dFrameData) -> c_int {
     let frame = fc.frame_thread_progress.frame.try_read().unwrap();
     loop {
         let val = !frame[idx as usize].load(Ordering::SeqCst);
-        prog = if val != 0 { ctz(val) } else { 32 };
+        prog = val.trailing_zeros();
         if prog != 32 {
             break;
         }
@@ -584,7 +583,7 @@ fn get_frame_progress(fc: &Rav1dFrameContext, f: &Rav1dFrameData) -> c_int {
             break;
         }
     }
-    return (idx << 5 | prog) - 1;
+    return (idx << 5 | prog as c_int) - 1;
 }
 
 #[inline]

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -558,7 +558,7 @@ unsafe fn check_tile(
 }
 
 #[inline]
-unsafe fn get_frame_progress(fc: &Rav1dFrameContext, f: &Rav1dFrameData) -> c_int {
+fn get_frame_progress(fc: &Rav1dFrameContext, f: &Rav1dFrameData) -> c_int {
     // Note that `progress.is_some() == c.fc.len() > 1`.
     let frame_prog = f
         .sr_cur

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -125,9 +125,9 @@ unsafe fn reset_task_cur(c: &Rav1dContext, ttd: &TaskThreadData, mut frame_idx: 
 fn reset_task_cur_async(ttd: &TaskThreadData, mut frame_idx: c_uint, n_frames: c_uint) {
     let first = ttd.first.load(Ordering::SeqCst);
     if frame_idx < first {
-        frame_idx = frame_idx.wrapping_add(n_frames);
+        frame_idx += n_frames;
     }
-    let mut last_idx: c_uint = frame_idx;
+    let mut last_idx = frame_idx;
     loop {
         frame_idx = last_idx;
         last_idx = ttd.reset_task_cur.swap(frame_idx, Ordering::SeqCst);

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -586,14 +586,9 @@ fn get_frame_progress(fc: &Rav1dFrameContext, f: &Rav1dFrameData) -> c_int {
 
 #[inline]
 fn abort_frame(c: &Rav1dContext, fc: &Rav1dFrameContext, error: Rav1dResult) {
-    fc.task_thread.error.store(
-        if error == Err(EINVAL) {
-            1 as c_int
-        } else {
-            -(1 as c_int)
-        },
-        Ordering::SeqCst,
-    );
+    fc.task_thread
+        .error
+        .store(if error == Err(EINVAL) { 1 } else { -1 }, Ordering::SeqCst);
     fc.task_thread.task_counter.store(0, Ordering::SeqCst);
     fc.task_thread.done[0].store(1, Ordering::SeqCst);
     fc.task_thread.done[1].store(1, Ordering::SeqCst);

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -583,7 +583,7 @@ fn get_frame_progress(fc: &Rav1dFrameContext, f: &Rav1dFrameData) -> c_int {
             break;
         }
     }
-    return (idx << 5 | prog as c_int) - 1;
+    (idx << 5 | prog as c_int) - 1
 }
 
 #[inline]

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -568,7 +568,7 @@ fn get_frame_progress(fc: &Rav1dFrameContext, f: &Rav1dFrameData) -> c_int {
     if frame_prog >= FRAME_ERROR {
         return f.sbh - 1;
     }
-    let mut idx = (frame_prog >> f.sb_shift + 7) as c_int;
+    let mut idx = frame_prog >> f.sb_shift + 7;
     let mut prog;
     let frame = fc.frame_thread_progress.frame.try_read().unwrap();
     loop {
@@ -583,7 +583,7 @@ fn get_frame_progress(fc: &Rav1dFrameContext, f: &Rav1dFrameData) -> c_int {
             break;
         }
     }
-    (idx << 5 | prog as c_int) - 1
+    (idx << 5 | prog) as c_int - 1
 }
 
 #[inline]

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -573,7 +573,7 @@ fn get_frame_progress(fc: &Rav1dFrameContext, f: &Rav1dFrameData) -> c_int {
     let mut prog;
     let frame = fc.frame_thread_progress.frame.try_read().unwrap();
     loop {
-        let val: c_uint = !frame[idx as usize].load(Ordering::SeqCst);
+        let val = !frame[idx as usize].load(Ordering::SeqCst);
         prog = if val != 0 { ctz(val) } else { 32 };
         if prog != 32 {
             break;

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -574,11 +574,11 @@ fn get_frame_progress(fc: &Rav1dFrameContext, f: &Rav1dFrameData) -> c_int {
     let frame = fc.frame_thread_progress.frame.try_read().unwrap();
     loop {
         let val: c_uint = !frame[idx as usize].load(Ordering::SeqCst);
-        prog = if val != 0 { ctz(val) } else { 32 as c_int };
-        if prog != 32 as c_int {
+        prog = if val != 0 { ctz(val) } else { 32 };
+        if prog != 32 {
             break;
         }
-        prog = 0 as c_int;
+        prog = 0;
         idx += 1;
         if !((idx as usize) < frame.len()) {
             break;

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -122,7 +122,7 @@ unsafe fn reset_task_cur(c: &Rav1dContext, ttd: &TaskThreadData, mut frame_idx: 
 }
 
 #[inline]
-unsafe fn reset_task_cur_async(ttd: &TaskThreadData, mut frame_idx: c_uint, n_frames: c_uint) {
+fn reset_task_cur_async(ttd: &TaskThreadData, mut frame_idx: c_uint, n_frames: c_uint) {
     let first = ttd.first.load(Ordering::SeqCst);
     if frame_idx < first {
         frame_idx = frame_idx.wrapping_add(n_frames);

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -588,7 +588,7 @@ fn get_frame_progress(fc: &Rav1dFrameContext, f: &Rav1dFrameData) -> c_int {
 }
 
 #[inline]
-unsafe fn abort_frame(c: &Rav1dContext, fc: &Rav1dFrameContext, error: Rav1dResult) {
+fn abort_frame(c: &Rav1dContext, fc: &Rav1dFrameContext, error: Rav1dResult) {
     fc.task_thread.error.store(
         if error == Err(EINVAL) {
             1 as c_int

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -434,7 +434,7 @@ pub(crate) unsafe fn rav1d_task_frame_init(c: &Rav1dContext, fc: &Rav1dFrameCont
     insert_task(c, fc, t_idx, 1 as c_int);
 }
 
-pub(crate) unsafe fn rav1d_task_delayed_fg(
+pub(crate) fn rav1d_task_delayed_fg(
     c: &mut Rav1dContext,
     out: &mut Rav1dPicture,
     in_0: &Rav1dPicture,


### PR DESCRIPTION
This makes a bunch of `fn`s that were already safe or trivially safe nominally safe:
* `fn reset_task_cur_async`
* `fn rav1d_task_delayed_fg`
* `fn get_frame_progress`
* `fn abort_frame`
* `fn read_restoration_info`
* `fn rav1d_cdf_thread_alloc`
* `fn get_qcat_idx`
* `fn rav1d_cdf_thread_init_statci`
* `fn rav1d_cdf_thread_copy`
* `fn parse_obus::skip`
* `fn parse_obus::parse_tile_grp`
* `fn rav1d_parse_sequence_header`
* `fn parse_frame_size`
* `fn parse_refidx`
* `fn parse_segmentation`
* `fn parse_loopfilter`
* `fn parse_skip_mode`
* `fn parse_gmv`
* `fn parse_film_grain`

It also cleans up all of those `fn`s, and `mod cdf` is also now made `#![deny(unsafe_code)]`.