### PR TITLE
`struct Rav1dContext`: Initialize as `Default::default()`

### DIFF
--- a/include/dav1d/dav1d.rs
+++ b/include/dav1d/dav1d.rs
@@ -55,9 +55,10 @@ pub const DAV1D_DECODEFRAMETYPE_INTRA: Dav1dDecodeFrameType =
 pub const DAV1D_DECODEFRAMETYPE_KEY: Dav1dDecodeFrameType =
     Rav1dDecodeFrameType::Key as Dav1dDecodeFrameType;
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromRepr)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromRepr, Default)]
 pub(crate) enum Rav1dDecodeFrameType {
     /// decode and return all frames
+    #[default]
     All = 0,
     /// decode and return frames referenced by other frames only
     Reference = 1,

--- a/include/dav1d/dav1d.rs
+++ b/include/dav1d/dav1d.rs
@@ -55,7 +55,6 @@ pub const DAV1D_DECODEFRAMETYPE_INTRA: Dav1dDecodeFrameType =
 pub const DAV1D_DECODEFRAMETYPE_KEY: Dav1dDecodeFrameType =
     Rav1dDecodeFrameType::Key as Dav1dDecodeFrameType;
 
-#[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromRepr)]
 pub(crate) enum Rav1dDecodeFrameType {
     /// decode and return all frames
@@ -78,8 +77,7 @@ impl TryFrom<Dav1dDecodeFrameType> for Rav1dDecodeFrameType {
     type Error = Rav1dError;
 
     fn try_from(value: Dav1dDecodeFrameType) -> Result<Self, Self::Error> {
-        let value = u8::try_from(value).map_err(|_| Rav1dError::EINVAL)?;
-        Self::from_repr(value).ok_or(Rav1dError::EINVAL)
+        Self::from_repr(value as usize).ok_or(Rav1dError::EINVAL)
     }
 }
 

--- a/lib.rs
+++ b/lib.rs
@@ -54,6 +54,7 @@ pub mod src {
     mod unstable_extensions;
     pub(crate) mod wrap_fn_ptr;
     // TODO(kkysen) Temporarily `pub(crate)` due to a `pub use` until TAIT.
+    mod extensions;
     pub(super) mod internal;
     mod intra_edge;
     mod ipred;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -60,6 +60,7 @@ use crate::src::error::Rav1dError::EINVAL;
 use crate::src::error::Rav1dError::ENOMEM;
 use crate::src::error::Rav1dError::ENOPROTOOPT;
 use crate::src::error::Rav1dResult;
+use crate::src::extensions::OptionError as _;
 use crate::src::internal::Bxy;
 use crate::src::internal::Rav1dBitDepthDSPContext;
 use crate::src::internal::Rav1dContext;
@@ -4801,10 +4802,7 @@ pub(crate) unsafe fn rav1d_decode_frame(c: &Rav1dContext, fc: &Rav1dFrameContext
                     }
                 }
                 drop(task_thread_lock);
-                res = match *fc.task_thread.retval.try_lock().unwrap() {
-                    Some(e) => Err(e),
-                    None => Ok(()),
-                };
+                res = fc.task_thread.retval.try_lock().unwrap().err_or(());
             } else {
                 res = rav1d_decode_frame_main(c, &mut f);
                 let frame_hdr = &***f.frame_hdr.as_ref().unwrap();

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4772,7 +4772,7 @@ pub(crate) fn rav1d_decode_frame_exit(
     let _ = mem::take(&mut f.frame_hdr);
     f.tiles.clear();
     task_thread.finished.store(true, Ordering::SeqCst);
-    *task_thread.retval.try_lock().unwrap() = retval;
+    *task_thread.retval.try_lock().unwrap() = retval.err();
 }
 
 pub(crate) unsafe fn rav1d_decode_frame(c: &Rav1dContext, fc: &Rav1dFrameContext) -> Rav1dResult {
@@ -4801,7 +4801,10 @@ pub(crate) unsafe fn rav1d_decode_frame(c: &Rav1dContext, fc: &Rav1dFrameContext
                     }
                 }
                 drop(task_thread_lock);
-                res = *fc.task_thread.retval.try_lock().unwrap();
+                res = match *fc.task_thread.retval.try_lock().unwrap() {
+                    Some(e) => Err(e),
+                    None => Ok(()),
+                };
             } else {
                 res = rav1d_decode_frame_main(c, &mut f);
                 let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
@@ -4859,9 +4862,9 @@ pub unsafe fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
                 c.task_thread.cur.fetch_sub(1, Ordering::Relaxed);
             }
         }
-        let mut error = fc.task_thread.retval.try_lock().unwrap();
-        if error.is_err() {
-            c.cached_error = mem::replace(&mut *error, Ok(()));
+        let error = &mut *fc.task_thread.retval.try_lock().unwrap();
+        if error.is_some() {
+            c.cached_error = mem::take(&mut *error);
             *c.cached_error_props.get_mut().unwrap() = out_delayed.p.m.clone();
             let _ = mem::take(out_delayed);
         } else if out_delayed.p.data.is_some() {

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -1,0 +1,13 @@
+pub trait OptionError<E> {
+    fn err_or<T>(self, ok: T) -> Result<T, E>;
+}
+
+impl<E> OptionError<E> for Option<E> {
+    #[inline]
+    fn err_or<T>(self, ok: T) -> Result<T, E> {
+        match self {
+            Some(e) => Err(e),
+            None => Ok(ok),
+        }
+    }
+}

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -151,6 +151,12 @@ impl Rav1dDSPContext {
     }
 }
 
+impl Default for &'static Rav1dDSPContext {
+    fn default() -> Self {
+        Rav1dDSPContext::get()
+    }
+}
+
 pub struct Rav1dBitDepthDSPContext {
     pub fg: Rav1dFilmGrainDSPContext,
     pub ipred: Rav1dIntraPredDSPContext,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -249,6 +249,7 @@ impl Default for TaskType {
     }
 }
 
+#[derive(Default)]
 #[repr(C)]
 pub(crate) struct Rav1dContext_frame_thread {
     pub out_delayed: Box<[Rav1dThreadPicture]>,
@@ -360,6 +361,7 @@ impl Rav1dContextTaskThread {
     }
 }
 
+#[derive(Default)]
 #[repr(C)]
 pub struct Rav1dContext {
     pub(crate) fc: Box<[Rav1dFrameContext]>,

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2524,9 +2524,9 @@ unsafe fn parse_obus(
                         c.task_thread.cur.fetch_sub(1, Ordering::Relaxed);
                     }
                 }
-                let mut error = fc.task_thread.retval.try_lock().unwrap();
-                if error.is_err() {
-                    c.cached_error = mem::replace(&mut *error, Ok(()));
+                let error = &mut *fc.task_thread.retval.try_lock().unwrap();
+                if error.is_some() {
+                    c.cached_error = mem::take(error);
                     *c.cached_error_props.get_mut().unwrap() = out_delayed.p.m.clone();
                     let _ = mem::take(out_delayed);
                 } else if out_delayed.p.data.is_some() {


### PR DESCRIPTION
* Fixes `Rav1dContext` of #862.

This replaces the zero (`memset`) initialization of `Rav1dContext` with `Default::default()` initialization in `fn rav1d_open`.  I haven't yet made initialization fully safe in `fn rav1d_open` due to borrowck errors, but this should ensure everything is safely initialized, and hopefully fixes some heisenbugs?