### PR TITLE
`struct Rav1dFrameData`: `impl Default` instead of unsafely zeroing and partial initialization

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1237,6 +1237,7 @@ impl TaskContextScratch {
     }
 }
 
+#[derive(Default)]
 #[repr(C)]
 pub struct Rav1dTaskContext_frame_thread {
     pub pass: c_int,
@@ -1295,21 +1296,21 @@ pub(crate) struct Rav1dTaskContext {
 impl Rav1dTaskContext {
     pub(crate) fn new(task_thread: Arc<Rav1dTaskContext_task_thread>) -> Self {
         Self {
-            ts: 0,
+            ts: Default::default(),
             b: Default::default(),
             l: Default::default(),
-            a: 0,
+            a: Default::default(),
             rt: Default::default(),
             cf: Default::default(),
             al_pal: Default::default(),
             pal_sz_uv: Default::default(),
             scratch: FromZeroes::new_zeroed(),
             warpmv: Default::default(),
-            lf_mask: None,
-            top_pre_cdef_toggle: 0,
-            cur_sb_cdef_idx: 0,
+            lf_mask: Default::default(),
+            top_pre_cdef_toggle: Default::default(),
+            cur_sb_cdef_idx: Default::default(),
             tl_4x4_filter: Default::default(),
-            frame_thread: Rav1dTaskContext_frame_thread { pass: 0 },
+            frame_thread: Default::default(),
             task_thread,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,7 +256,7 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
         fc.task_thread.finished = AtomicBool::new(true);
         fc.task_thread.ttd = Arc::clone(&(*c).task_thread);
         let f = fc.data.get_mut().unwrap();
-        f.lf.last_sharpness = 255;
+        f.lf.last_sharpness = u8::MAX;
     }
     (*c).tc = (0..n_tc)
         .map(|n| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@ pub(crate) unsafe fn rav1d_open(c_out: &mut *mut Rav1dContext, s: &Rav1dSettings
 
     let NumThreads { n_tc, n_fc } = get_num_threads(s);
     // TODO fallible allocation
-    (*c).fc = (0..n_fc).map(|i| Rav1dFrameContext::zeroed(i)).collect();
+    (*c).fc = (0..n_fc).map(|i| Rav1dFrameContext::default(i)).collect();
     let ttd = TaskThreadData {
         lock: Mutex::new(()),
         cond: Condvar::new(),


### PR DESCRIPTION
* Fixes `Rav1dFrameData` of #862.
* Fixes `Rav1dFrameContext_lf` of #862.