### PR TITLE
`fn MsacContext::new`: Make `fn rav1d_msac_init` a method returning `Self` directly and make `data` a slice

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -131,7 +131,7 @@ use crate::src::msac::rav1d_msac_decode_symbol_adapt16;
 use crate::src::msac::rav1d_msac_decode_symbol_adapt4;
 use crate::src::msac::rav1d_msac_decode_symbol_adapt8;
 use crate::src::msac::rav1d_msac_decode_uniform;
-use crate::src::msac::rav1d_msac_init;
+use crate::src::msac::MsacContext;
 use crate::src::pal::Rav1dPalDSPContext;
 use crate::src::picture::rav1d_picture_alloc_copy;
 use crate::src::picture::rav1d_thread_picture_alloc;
@@ -3851,8 +3851,7 @@ unsafe fn setup_tile(
     ts.last_qidx = frame_hdr.quant.yac;
     ts.last_delta_lf.fill(0);
 
-    rav1d_msac_init(
-        &mut ts.msac,
+    ts.msac = MsacContext::new(
         data.as_ptr(),
         data.len(),
         frame_hdr.disable_cdf_update != 0,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3851,12 +3851,7 @@ unsafe fn setup_tile(
     ts.last_qidx = frame_hdr.quant.yac;
     ts.last_delta_lf.fill(0);
 
-    ts.msac = MsacContext::new(
-        data.as_ptr(),
-        data.len(),
-        frame_hdr.disable_cdf_update != 0,
-        &c.dsp.msac,
-    );
+    ts.msac = MsacContext::new(data, frame_hdr.disable_cdf_update != 0, &c.dsp.msac);
 
     ts.tiling.row = tile_row as c_int;
     ts.tiling.col = tile_col as c_int;

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -7,6 +7,7 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::mem;
 use std::ops::Range;
+use std::slice;
 
 #[cfg(all(feature = "asm", target_feature = "sse2"))]
 extern "C" {
@@ -180,10 +181,6 @@ impl MsacContext {
 
     fn allow_update_cdf(&self) -> bool {
         self.allow_update_cdf != 0
-    }
-
-    fn set_allow_update_cdf(&mut self, val: bool) {
-        self.allow_update_cdf = val.into()
     }
 }
 
@@ -399,34 +396,36 @@ fn rav1d_msac_decode_hi_tok_rust(s: &mut MsacContext, cdf: &mut [u16; 4]) -> c_u
     tok
 }
 
-/// # Safety
-///
-/// `data` and `sz` must form a valid slice,
-/// and must live longer than all of the other functions called on [`MsacContext`].
-pub unsafe fn rav1d_msac_init(
-    s: &mut MsacContext,
-    data: *const u8,
-    sz: usize,
-    disable_cdf_update_flag: bool,
-    dsp: &Rav1dMsacDSPContext,
-) {
-    s.set_buf(std::slice::from_raw_parts(data, sz));
-    s.dif = (1 << (EC_WIN_SIZE - 1)) - 1;
-    s.rng = 0x8000;
-    s.cnt = -15;
-    s.set_allow_update_cdf(!disable_cdf_update_flag);
-    ctx_refill(s);
-
-    #[cfg(feature = "asm")]
-    {
-        #[cfg(target_arch = "x86_64")]
-        {
-            s.symbol_adapt16 = dsp.symbol_adapt16;
-        }
-        #[cfg(not(target_arch = "x86_64"))]
-        {
-            let _ = dsp.symbol_adapt16;
-        }
+impl MsacContext {
+    /// # Safety
+    ///
+    /// `data` and `sz` must form a valid slice,
+    /// and must live longer than all of the other functions called on the returned [`Self`].
+    pub unsafe fn new(
+        data: *const u8,
+        sz: usize,
+        disable_cdf_update_flag: bool,
+        dsp: &Rav1dMsacDSPContext,
+    ) -> Self {
+        // SAFETY: Guaranteed by safety preconditions.
+        let data = unsafe { slice::from_raw_parts(data, sz) };
+        let Range {
+            start: buf_pos,
+            end: buf_end,
+        } = data.as_ptr_range();
+        let mut s = Self {
+            buf_pos,
+            buf_end,
+            dif: (1 << (EC_WIN_SIZE - 1)) - 1,
+            rng: 0x8000,
+            cnt: -15,
+            allow_update_cdf: (!disable_cdf_update_flag).into(),
+            #[cfg(all(feature = "asm", target_arch = "x86_64"))]
+            symbol_adapt16: dsp.symbol_adapt16,
+        };
+        let _ = dsp.symbol_adapt16; // Silence unused warnings.
+        ctx_refill(&mut s);
+        s
     }
 }
 

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -7,7 +7,6 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::mem;
 use std::ops::Range;
-use std::slice;
 
 #[cfg(all(feature = "asm", target_feature = "sse2"))]
 extern "C" {
@@ -399,16 +398,12 @@ fn rav1d_msac_decode_hi_tok_rust(s: &mut MsacContext, cdf: &mut [u16; 4]) -> c_u
 impl MsacContext {
     /// # Safety
     ///
-    /// `data` and `sz` must form a valid slice,
-    /// and must live longer than all of the other functions called on the returned [`Self`].
+    /// `data` must live longer than all of the other functions called on the returned [`Self`].
     pub unsafe fn new(
-        data: *const u8,
-        sz: usize,
+        data: &[u8],
         disable_cdf_update_flag: bool,
         dsp: &Rav1dMsacDSPContext,
     ) -> Self {
-        // SAFETY: Guaranteed by safety preconditions.
-        let data = unsafe { slice::from_raw_parts(data, sz) };
         let Range {
             start: buf_pos,
             end: buf_end,


### PR DESCRIPTION
I was trying to make `fn new` totally safe by adding a lifetime to `MsacContext`, but I'm not sure how to do that yet (it is a slice from a `Rav1dData`).  Since @randomPoison is working on making `ts: *mut Rav1dTileState` safe right now and `MsacContext` is a field of `Rav1dTileState`, I'll leave that part for later.