### PR TITLE
`struct Rav1dTileStateContext`: Put `cdf` and `msac` in a `Mutex`

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -925,7 +925,6 @@ pub(crate) struct Rav1dFrameData {
     pub resize_start: [c_int; 2],            /* y, uv */
 
     pub ts: *mut Rav1dTileState,
-    pub ts_c: DisjointMut<Vec<Rav1dTileStateContext>>,
     pub n_ts: c_int,
     pub dsp: &'static Rav1dBitDepthDSPContext,
 
@@ -980,7 +979,6 @@ impl Default for Rav1dFrameData {
             resize_step: Default::default(),
             resize_start: Default::default(),
             ts: ptr::null_mut(),
-            ts_c: Default::default(),
             n_ts: Default::default(),
             dsp: Default::default(),
             ipred_edge: Default::default(),
@@ -1043,6 +1041,7 @@ pub struct Rav1dTileState_frame_thread {
     pub cf: usize,      // Offset into `f.frame_thread.cf`
 }
 
+#[derive(Default)]
 #[repr(C, align(32))]
 pub struct Rav1dTileStateContext {
     pub cdf: CdfContext,
@@ -1051,6 +1050,8 @@ pub struct Rav1dTileStateContext {
 
 #[repr(C)]
 pub struct Rav1dTileState {
+    pub context: Mutex<Rav1dTileStateContext>,
+
     pub tiling: Rav1dTileState_tiling,
 
     // in sby units, TILE_ERROR after a decoding error

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -7,6 +7,7 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::mem;
 use std::ops::Range;
+use std::ptr;
 
 #[cfg(all(feature = "asm", target_feature = "sse2"))]
 extern "C" {
@@ -157,6 +158,22 @@ pub struct MsacContext {
         n_symbols: usize,
         _cdf_len: usize,
     ) -> c_uint,
+}
+
+impl Default for MsacContext {
+    fn default() -> Self {
+        Self {
+            buf_pos: ptr::null(),
+            buf_end: ptr::null(),
+            dif: Default::default(),
+            rng: Default::default(),
+            cnt: Default::default(),
+            allow_update_cdf: Default::default(),
+
+            #[cfg(all(feature = "asm", target_arch = "x86_64"))]
+            symbol_adapt16: Rav1dMsacDSPContext::default().symbol_adapt16,
+        }
+    }
 }
 
 impl MsacContext {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1120,7 +1120,11 @@ pub unsafe fn rav1d_worker_task(c: &Rav1dContext, task_thread: Arc<Rav1dTaskCont
                                     rav1d_cdf_thread_update(
                                         frame_hdr,
                                         &mut f.out_cdf.cdf_write(),
-                                        &f.ts_c.index(frame_hdr.tiling.update as usize).cdf,
+                                        &(*(f.ts).offset(frame_hdr.tiling.update as isize))
+                                            .context
+                                            .try_lock()
+                                            .unwrap()
+                                            .cdf,
                                     );
                                 }
                                 if let Some(progress) = f.out_cdf.progress() {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1120,7 +1120,7 @@ pub unsafe fn rav1d_worker_task(c: &Rav1dContext, task_thread: Arc<Rav1dTaskCont
                                     rav1d_cdf_thread_update(
                                         frame_hdr,
                                         &mut f.out_cdf.cdf_write(),
-                                        &(*(f.ts).offset(frame_hdr.tiling.update as isize)).cdf,
+                                        &f.ts_c.index(frame_hdr.tiling.update as usize).cdf,
                                     );
                                 }
                                 if let Some(progress) = f.out_cdf.progress() {


### PR DESCRIPTION
This is the first step in giving `Rav1dTileState` interior mutability, which is necessary to make the `ts` allocation safe.

The context fields of `Rav1dTileState` (`msac` and `cdf`) are accessed exclusively from one thread at a time, so I've put them in a `Mutex` to allow us to still gain mutable access once the tile state is immutably shared between threads. This required reworking how the data is accessed, as the original logic was accessing the fields at multiple points in the callstacks, which would have resulted in lock conflicts when a function further down in the callstack would try to acquire a lock that's already held higher up. I've changed the code to pass down the mutable reference, ensuring that the lock is only held once. For a couple of functions this meant taking an `Option<&mut Rav1dTileStateContext>` in cases where the function only needs access to the context object in some code paths.