### PR TITLE
`struct Rav1dTileState`: Make into `Vec` and give interior mutability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "atomig"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcecf20a3720c354e7648983ee8046436dea13caf0fe8f84a791c7fba456cf0f"
+checksum = "0eaf2a17b11f7923d0abe0e07377c7f0f1255a8267f05c8a9cba8dc039acc821"
 dependencies = [
  "atomig-macro",
 ]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3917,7 +3917,7 @@ unsafe fn setup_tile(
     frame_hdr: &Rav1dFrameHeader,
     bitdepth_max: i32,
     sb_shift: i32,
-    f_cur: &Rav1dPicture,
+    cur: &Rav1dPicture,
     bw: i32,
     bh: i32,
     frame_thread: &Rav1dFrameContext_frame_thread,
@@ -3936,7 +3936,7 @@ unsafe fn setup_tile(
     let row_sb_start = frame_hdr.tiling.row_start_sb[tile_row] as c_int;
     let row_sb_end = frame_hdr.tiling.row_start_sb[tile_row + 1] as c_int;
 
-    let size_mul = &ss_size_mul[f_cur.p.layout];
+    let size_mul = &ss_size_mul[cur.p.layout];
     for p in 0..2 {
         ts.frame_thread[p].pal_idx.store(
             if !frame_thread.pal_idx.is_empty() {
@@ -3993,7 +3993,7 @@ unsafe fn setup_tile(
         }
 
         let lr_ref = if diff_width {
-            let ss_hor = (p != 0 && f_cur.p.layout != Rav1dPixelLayout::I444) as u8;
+            let ss_hor = (p != 0 && cur.p.layout != Rav1dPixelLayout::I444) as u8;
             let d = frame_hdr.size.super_res.width_scale_denominator as c_int;
             let unit_size_log2 = frame_hdr.restoration.unit_size[(p != 0) as usize];
             let rnd = (8 << unit_size_log2) - 1;
@@ -4010,7 +4010,7 @@ unsafe fn setup_tile(
             &mut lf.lr_mask[sb_idx as usize].lr[p][unit_idx as usize]
         };
 
-        let mut lr = lr_ref.try_write().unwrap();
+        let lr = lr_ref.get_mut().unwrap();
         *lr = Av1RestorationUnit {
             filter_v: [3, -7, 15],
             filter_h: [3, -7, 15],

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -939,8 +939,8 @@ pub(crate) struct Rav1dFrameData {
     pub sb_step: c_int,
     pub sr_sb128w: c_int,
     pub dq: [[[AtomicU16; 2]; 3]; RAV1D_MAX_SEGMENTS as usize], /* [RAV1D_MAX_SEGMENTS][3 plane][2 dc/ac] */
-    pub qm: [[Option<&'static [u8]>; 3]; 19],             /* [3 plane][19] */
-    pub a: Vec<BlockContext>,                             /* len = w*tile_rows */
+    pub qm: [[Option<&'static [u8]>; 3]; 19],                   /* [3 plane][19] */
+    pub a: Vec<BlockContext>,                                   /* len = w*tile_rows */
     pub rf: RefMvsFrame,
     pub jnt_weights: [[u8; 7]; 7],
     pub bitdepth_max: c_int,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -892,6 +892,7 @@ impl Rav1dFrameContext {
     }
 }
 
+#[derive(Default)]
 #[repr(C)]
 pub(crate) struct Rav1dFrameData {
     pub seq_hdr: Option<Arc<DRav1d<Rav1dSequenceHeader, Dav1dSequenceHeader>>>,
@@ -947,54 +948,6 @@ pub(crate) struct Rav1dFrameData {
     pub frame_thread: Rav1dFrameContext_frame_thread,
     pub lf: Rav1dFrameContext_lf,
     pub lowest_pixel_mem: DisjointMut<Vec<[[c_int; 2]; 7]>>,
-}
-
-impl Default for Rav1dFrameData {
-    fn default() -> Self {
-        Self {
-            seq_hdr: Default::default(),
-            frame_hdr: Default::default(),
-            refp: Default::default(),
-            cur: Default::default(),
-            sr_cur: Default::default(),
-            mvs: Default::default(),
-            ref_mvs: Default::default(),
-            cur_segmap: Default::default(),
-            prev_segmap: Default::default(),
-            refpoc: Default::default(),
-            refrefpoc: Default::default(),
-            gmv_warp_allowed: Default::default(),
-            out_cdf: Default::default(),
-            tiles: Default::default(),
-            svc: Default::default(),
-            resize_step: Default::default(),
-            resize_start: Default::default(),
-            ts: Default::default(),
-            dsp: Default::default(),
-            ipred_edge: Default::default(),
-            ipred_edge_off: Default::default(),
-            b4_stride: Default::default(),
-            w4: Default::default(),
-            h4: Default::default(),
-            bw: Default::default(),
-            bh: Default::default(),
-            sb128w: Default::default(),
-            sb128h: Default::default(),
-            sbh: Default::default(),
-            sb_shift: Default::default(),
-            sb_step: Default::default(),
-            sr_sb128w: Default::default(),
-            dq: Default::default(),
-            qm: Default::default(),
-            a: Default::default(),
-            rf: Default::default(),
-            jnt_weights: Default::default(),
-            bitdepth_max: Default::default(),
-            frame_thread: Default::default(),
-            lf: Default::default(),
-            lowest_pixel_mem: Default::default(),
-        }
-    }
 }
 
 impl Rav1dFrameData {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -102,7 +102,6 @@ use std::ops::Index;
 use std::ops::IndexMut;
 use std::ops::Range;
 use std::ops::Sub;
-use std::ptr;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI32;
 use std::sync::atomic::AtomicI8;

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -104,7 +104,6 @@ use std::ops::Range;
 use std::ops::Sub;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI32;
-use std::sync::atomic::AtomicI8;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::AtomicUsize;
@@ -1011,22 +1010,11 @@ pub struct Rav1dTileState {
     pub dqmem: RwLock<[[[u16; 2]; 3]; RAV1D_MAX_SEGMENTS as usize]>, /* [RAV1D_MAX_SEGMENTS][3 plane][2 dc/ac] */
     pub dq: Atomic<TileStateRef>,
     pub last_qidx: AtomicU8,
-    pub last_delta_lf: [AtomicI8; 4],
+    pub last_delta_lf: Atomic<[i8; 4]>,
     pub lflvlmem: RwLock<[[[[u8; 2]; 8]; 4]; 8]>, /* [8 seg_id][4 dir][8 ref][2 is_gmv] */
     pub lflvl: Atomic<TileStateRef>,
 
     pub lr_ref: RwLock<[Av1RestorationUnit; 3]>,
-}
-
-impl Rav1dTileState {
-    pub fn last_delta_lf(&self) -> [i8; 4] {
-        [
-            self.last_delta_lf[0].load(Ordering::Relaxed),
-            self.last_delta_lf[1].load(Ordering::Relaxed),
-            self.last_delta_lf[2].load(Ordering::Relaxed),
-            self.last_delta_lf[3].load(Ordering::Relaxed),
-        ]
-    }
 }
 
 #[derive(Clone, Copy, Default, Atom)]

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1017,40 +1017,14 @@ impl Rav1dFrameData {
 #[repr(C)]
 pub struct Rav1dTileState_tiling {
     // in 4px units
-    pub col_start: AtomicI32,
-    pub col_end: AtomicI32,
-    pub row_start: AtomicI32,
-    pub row_end: AtomicI32,
+    pub col_start: i32,
+    pub col_end: i32,
+    pub row_start: i32,
+    pub row_end: i32,
 
     // in tile units
-    pub col: AtomicI32,
-    pub row: AtomicI32,
-}
-
-impl Rav1dTileState_tiling {
-    pub fn col_start(&self) -> i32 {
-        self.col_start.load(Ordering::Relaxed)
-    }
-
-    pub fn col_end(&self) -> i32 {
-        self.col_end.load(Ordering::Relaxed)
-    }
-
-    pub fn row_start(&self) -> i32 {
-        self.row_start.load(Ordering::Relaxed)
-    }
-
-    pub fn row_end(&self) -> i32 {
-        self.row_end.load(Ordering::Relaxed)
-    }
-
-    pub fn col(&self) -> i32 {
-        self.col.load(Ordering::Relaxed)
-    }
-
-    pub fn row(&self) -> i32 {
-        self.row.load(Ordering::Relaxed)
-    }
+    pub col: i32,
+    pub row: i32,
 }
 
 #[derive(Default)]

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -104,6 +104,7 @@ use std::ops::Range;
 use std::ops::Sub;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI32;
+use std::sync::atomic::AtomicU16;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::AtomicUsize;
@@ -937,7 +938,7 @@ pub(crate) struct Rav1dFrameData {
     pub sb_shift: c_int,
     pub sb_step: c_int,
     pub sr_sb128w: c_int,
-    pub dq: [[[u16; 2]; 3]; RAV1D_MAX_SEGMENTS as usize], /* [RAV1D_MAX_SEGMENTS][3 plane][2 dc/ac] */
+    pub dq: [[[AtomicU16; 2]; 3]; RAV1D_MAX_SEGMENTS as usize], /* [RAV1D_MAX_SEGMENTS][3 plane][2 dc/ac] */
     pub qm: [[Option<&'static [u8]>; 3]; 19],             /* [3 plane][19] */
     pub a: Vec<BlockContext>,                             /* len = w*tile_rows */
     pub rf: RefMvsFrame,
@@ -1007,7 +1008,7 @@ pub struct Rav1dTileState {
     // each entry is one tile-sbrow; middle index is refidx
     pub lowest_pixel: usize,
 
-    pub dqmem: RwLock<[[[u16; 2]; 3]; RAV1D_MAX_SEGMENTS as usize]>, /* [RAV1D_MAX_SEGMENTS][3 plane][2 dc/ac] */
+    pub dqmem: [[[AtomicU16; 2]; 3]; RAV1D_MAX_SEGMENTS as usize], /* [RAV1D_MAX_SEGMENTS][3 plane][2 dc/ac] */
     pub dq: Atomic<TileStateRef>,
     pub last_qidx: AtomicU8,
     pub last_delta_lf: Atomic<[i8; 4]>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -725,7 +725,7 @@ impl Drop for Rav1dContext {
                 mem::take(fc.frame_thread_progress.copy_lpf.get_mut().unwrap()); // TODO: remove when context is owned
                 let _ = mem::take(&mut f.frame_thread); // TODO: remove when context is owned
                 mem::take(&mut fc.task_thread.tasks); // TODO: remove when context is owned
-                rav1d_free_aligned(f.ts as *mut c_void);
+                let _ = mem::take(&mut f.ts); // TODO: remove when context is owned
                 let _ = mem::take(&mut f.ipred_edge); // TODO: remove when context is owned
                 let _ = mem::take(&mut f.a); // TODO: remove when context is owned
                 let _ = mem::take(&mut f.out_cdf); // TODO: remove when context is owned

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@ use crate::src::internal::Rav1dTaskContext_task_thread;
 use crate::src::internal::TaskThreadData;
 use crate::src::iter::wrapping_iter;
 use crate::src::log::Rav1dLog as _;
-use crate::src::mem::rav1d_free_aligned;
 use crate::src::obu::rav1d_parse_obus;
 use crate::src::obu::rav1d_parse_sequence_header;
 use crate::src::picture::rav1d_picture_alloc_copy;

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -1,6 +1,3 @@
-use libc::free;
-use libc::posix_memalign;
-use std::ffi::c_void;
 use std::sync::Mutex;
 
 pub struct MemPool<T> {
@@ -35,21 +32,4 @@ impl<T> Default for MemPool<T> {
     fn default() -> Self {
         Self::new()
     }
-}
-
-#[inline]
-pub unsafe fn rav1d_alloc_aligned(sz: usize, align: usize) -> *mut c_void {
-    if align & align.wrapping_sub(1) != 0 {
-        unreachable!();
-    }
-    let mut ptr: *mut c_void = 0 as *mut c_void;
-    if posix_memalign(&mut ptr, align, sz) != 0 {
-        return 0 as *mut c_void;
-    }
-    return ptr;
-}
-
-#[inline]
-pub unsafe fn rav1d_free_aligned(ptr: *mut c_void) {
-    free(ptr);
 }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2353,7 +2353,7 @@ unsafe fn obmc<BD: BitDepth>(
     let h_mul = 4 >> ss_hor;
     let v_mul = 4 >> ss_ver;
     let ts = &f.ts[t.ts];
-    if t.b.y > ts.tiling.row_start()
+    if t.b.y > ts.tiling.row_start
         && (pl == 0 || b_dim[0] as c_int * h_mul + b_dim[1] as c_int * v_mul >= 16)
     {
         let mut i = 0;
@@ -2395,7 +2395,7 @@ unsafe fn obmc<BD: BitDepth>(
             x += step4 as c_int;
         }
     }
-    if t.b.x > ts.tiling.col_start() {
+    if t.b.x > ts.tiling.col_start {
         let mut i = 0;
         let mut y = 0;
         while y < h4 && i < cmp::min(b_dim[3], 4) {
@@ -2680,8 +2680,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             .buf_mut::<BD>();
                         let edge_offset = 128;
                         let data_stride = BD::pxstride(f.cur.stride[0]);
-                        let data_width = 4 * ts.tiling.col_end();
-                        let data_height = 4 * ts.tiling.row_end();
+                        let data_width = 4 * ts.tiling.col_end;
+                        let data_height = 4 * ts.tiling.row_end;
                         let data_diff = (data_height - 1) as isize * data_stride;
                         let dst_slice = slice::from_raw_parts(
                             (f.cur.data.as_ref().unwrap().data[0] as *const BD::Pixel)
@@ -2690,11 +2690,11 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         );
                         m = rav1d_prepare_intra_edges(
                             t.b.x,
-                            t.b.x > ts.tiling.col_start(),
+                            t.b.x > ts.tiling.col_start,
                             t.b.y,
-                            t.b.y > ts.tiling.row_start(),
-                            ts.tiling.col_end(),
-                            ts.tiling.row_end(),
+                            t.b.y > ts.tiling.row_start,
+                            ts.tiling.col_end,
+                            ts.tiling.row_end,
                             edge_flags,
                             dst_slice,
                             f.cur.stride[0],
@@ -2909,13 +2909,13 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             };
                             let xpos = t.b.x >> ss_hor;
                             let ypos = t.b.y >> ss_ver;
-                            let xstart = ts.tiling.col_start() >> ss_hor;
-                            let ystart = ts.tiling.row_start() >> ss_ver;
+                            let xstart = ts.tiling.col_start >> ss_hor;
+                            let ystart = ts.tiling.row_start >> ss_ver;
                             let edge_array = scratch.interintra_edge_pal.edge.buf_mut::<BD>();
                             let edge_offset = 128;
                             let data_stride = BD::pxstride(f.cur.stride[1]);
-                            let data_width = 4 * ts.tiling.col_end() >> ss_hor;
-                            let data_height = 4 * ts.tiling.row_end() >> ss_ver;
+                            let data_width = 4 * ts.tiling.col_end >> ss_hor;
+                            let data_height = 4 * ts.tiling.row_end >> ss_ver;
                             let data_diff = (data_height - 1) as isize * data_stride;
                             let uvdst_slice = slice::from_raw_parts(
                                 (f.cur.data.as_ref().unwrap().data[1 + pl as usize]
@@ -2928,8 +2928,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                 xpos > xstart,
                                 ypos,
                                 ypos > ystart,
-                                ts.tiling.col_end() >> ss_hor,
-                                ts.tiling.row_end() >> ss_ver,
+                                ts.tiling.col_end >> ss_hor,
+                                ts.tiling.row_end >> ss_ver,
                                 EdgeFlags::empty(),
                                 uvdst_slice,
                                 stride,
@@ -3115,8 +3115,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                 }) as IntraPredMode;
                                 xpos = t.b.x >> ss_hor;
                                 ypos = t.b.y >> ss_ver;
-                                xstart = (*ts).tiling.col_start() >> ss_hor;
-                                ystart = (*ts).tiling.row_start() >> ss_ver;
+                                xstart = (*ts).tiling.col_start >> ss_hor;
+                                ystart = (*ts).tiling.row_start >> ss_ver;
                                 let edge_array = t
                                     .scratch
                                     .inter_intra_mut()
@@ -3125,8 +3125,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                     .buf_mut::<BD>();
                                 let edge_offset = 128;
                                 let data_stride = BD::pxstride(f.cur.stride[1]);
-                                let data_width = 4 * ts.tiling.col_end() >> ss_hor;
-                                let data_height = 4 * ts.tiling.row_end() >> ss_ver;
+                                let data_width = 4 * ts.tiling.col_end >> ss_hor;
+                                let data_height = 4 * ts.tiling.row_end >> ss_ver;
                                 let data_diff = (data_height - 1) as isize * data_stride;
                                 let dstuv_slice = slice::from_raw_parts(
                                     (f.cur.data.as_ref().unwrap().data[1 + pl as usize]
@@ -3139,8 +3139,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                     xpos > xstart,
                                     ypos,
                                     ypos > ystart,
-                                    ts.tiling.col_end() >> ss_hor,
-                                    ts.tiling.row_end() >> ss_ver,
+                                    ts.tiling.col_end >> ss_hor,
+                                    ts.tiling.row_end >> ss_ver,
                                     edge_flags,
                                     dstuv_slice,
                                     stride,
@@ -3665,8 +3665,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 None
             };
             let data_stride = BD::pxstride(f.cur.stride[0]);
-            let data_width = 4 * ts.tiling.col_end();
-            let data_height = 4 * ts.tiling.row_end();
+            let data_width = 4 * ts.tiling.col_end;
+            let data_height = 4 * ts.tiling.row_end;
             let data_diff = (data_height - 1) as isize * data_stride;
             let dst_slice = slice::from_raw_parts(
                 (f.cur.data.as_ref().unwrap().data[0] as *const BD::Pixel)
@@ -3675,11 +3675,11 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
             );
             m = rav1d_prepare_intra_edges(
                 t.b.x,
-                t.b.x > ts.tiling.col_start(),
+                t.b.x > ts.tiling.col_start,
                 t.b.y,
-                t.b.y > ts.tiling.row_start(),
-                ts.tiling.col_end(),
-                ts.tiling.row_end(),
+                t.b.y > ts.tiling.row_start,
+                ts.tiling.col_end,
+                ts.tiling.row_end,
                 EdgeFlags::empty(),
                 dst_slice,
                 f.cur.stride[0],
@@ -3984,8 +3984,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             None
                         };
                         let data_stride = BD::pxstride(f.cur.stride[1]);
-                        let data_width = 4 * ts.tiling.col_end() >> ss_hor;
-                        let data_height = 4 * ts.tiling.row_end() >> ss_ver;
+                        let data_width = 4 * ts.tiling.col_end >> ss_hor;
+                        let data_height = 4 * ts.tiling.row_end >> ss_ver;
                         let data_diff = (data_height - 1) as isize * data_stride;
                         let dstuv_slice = slice::from_raw_parts(
                             (f.cur.data.as_ref().unwrap().data[1 + pl as usize]
@@ -3995,11 +3995,11 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                         );
                         m = rav1d_prepare_intra_edges(
                             t.b.x >> ss_hor,
-                            t.b.x >> ss_hor > ts.tiling.col_start() >> ss_hor,
+                            t.b.x >> ss_hor > ts.tiling.col_start >> ss_hor,
                             t.b.y >> ss_ver,
-                            t.b.y >> ss_ver > ts.tiling.row_start() >> ss_ver,
-                            ts.tiling.col_end() >> ss_hor,
-                            ts.tiling.row_end() >> ss_ver,
+                            t.b.y >> ss_ver > ts.tiling.row_start >> ss_ver,
+                            ts.tiling.col_end >> ss_hor,
+                            ts.tiling.row_end >> ss_ver,
                             EdgeFlags::empty(),
                             dstuv_slice,
                             f.cur.stride[1],
@@ -4560,12 +4560,12 @@ pub(crate) unsafe fn rav1d_backup_ipred_edge<BD: BitDepth>(
     let ts = &f.ts[t.ts];
     let sby = t.b.y >> f.sb_shift;
     let sby_off = f.sb128w * 128 * sby;
-    let x_off = ts.tiling.col_start();
+    let x_off = ts.tiling.col_start;
     let y: *const BD::Pixel = (f.cur.data.as_ref().unwrap().data[0] as *const BD::Pixel)
         .offset((x_off * 4) as isize)
         .offset((((t.b.y + f.sb_step) * 4 - 1) as isize * BD::pxstride(f.cur.stride[0])) as isize);
     let ipred_edge_off = (f.ipred_edge_off * 0) + (sby_off + x_off * 4) as usize;
-    let n = 4 * (ts.tiling.col_end() - x_off) as usize;
+    let n = 4 * (ts.tiling.col_end - x_off) as usize;
     BD::pixel_copy(
         &mut f
             .ipred_edge
@@ -4584,7 +4584,7 @@ pub(crate) unsafe fn rav1d_backup_ipred_edge<BD: BitDepth>(
         while pl <= 2 {
             let ipred_edge_off =
                 (f.ipred_edge_off * pl) + (sby_off + (x_off * 4 >> ss_hor)) as usize;
-            let n = 4 * (ts.tiling.col_end() - x_off) as usize >> ss_hor;
+            let n = 4 * (ts.tiling.col_end - x_off) as usize >> ss_hor;
             BD::pixel_copy(
                 &mut f
                     .ipred_edge


### PR DESCRIPTION
* Fixes the `ts` field of #713.
* Closes #713.