### PR TITLE
`fn {init_quant_tables,rav1d_calc_lf_values}`: Cleanup and elide bounds checks

### DIFF
--- a/include/common/intops.rs
+++ b/include/common/intops.rs
@@ -46,11 +46,6 @@ pub fn iclip(v: c_int, min: c_int, max: c_int) -> c_int {
 }
 
 #[inline]
-pub fn iclip_u8(v: c_int) -> c_int {
-    clip_u8(v).into()
-}
-
-#[inline]
 pub fn apply_sign(v: c_int, s: c_int) -> c_int {
     if s < 0 {
         -v

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -4,6 +4,7 @@ use crate::include::dav1d::headers::Rav1dFrameHeader;
 use crate::include::dav1d::headers::Rav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Rav1dPixelLayout;
 use crate::include::dav1d::headers::Rav1dRestorationType;
+use crate::include::dav1d::headers::RAV1D_MAX_SEGMENTS;
 use crate::src::align::Align16;
 use crate::src::align::ArrayDefault;
 use crate::src::ctx::CaseSet;
@@ -686,11 +687,15 @@ fn calc_lf_value_chroma(
 }
 
 pub(crate) fn rav1d_calc_lf_values(
-    lflvl_values: &mut [[[[u8; 2]; 8]; 4]; 8],
+    lflvl_values: &mut [[[[u8; 2]; 8]; 4]; RAV1D_MAX_SEGMENTS as usize],
     hdr: &Rav1dFrameHeader,
     lf_delta: &[i8; 4],
 ) {
-    let n_seg = if hdr.segmentation.enabled != 0 { 8 } else { 1 };
+    let n_seg = if hdr.segmentation.enabled != 0 {
+        RAV1D_MAX_SEGMENTS as usize
+    } else {
+        1
+    };
 
     if hdr.loopfilter.level_y[0] == 0 && hdr.loopfilter.level_y[1] == 0 {
         lflvl_values[..n_seg].fill_with(Default::default);


### PR DESCRIPTION
Came across this when reviewing #1032.  We can pass array refs instead of slices and eliminate the bounds checks.