### PR TITLE
`decode.rs`: Remove `unsafe` marker from safe functions

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -799,9 +799,17 @@ fn read_pal_indices(
         }
     }
 
-    // SAFETY: Unsafe asm call, checkasm tests have verified that the signature is
-    // correct. `pal_idx` and `pal_tmp` are at least `(bw4 * 4) * (bh4 * 4)`
-    // elements long, which is how many elements `pal_idx_finish` will read/write.
+    if let Some(pal_idx) = &pal_idx {
+        let read_len = bw4 * 2 * bh4 * 4;
+        debug_assert!(pal_idx.len() >= read_len);
+    }
+    let read_len = bw4 * 4 * bh4 * 4;
+    debug_assert!(pal_tmp.len() >= read_len);
+
+    // SAFETY: Unsafe asm call. `pal_idx` is at least `(bw * 2) * (bh * 4)`
+    // elements long and `pal_tmp` is at least `(bw4 * 4)
+    // * (bh4 * 4)` elements long, which is how many elements `pal_idx_finish`
+    // will read/write.
     unsafe {
         (pal_dsp.pal_idx_finish)(
             pal_idx.unwrap_or(pal_tmp).as_mut_ptr(),

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -806,7 +806,7 @@ fn read_pal_indices(
     let read_len = bw4 * 4 * bh4 * 4;
     debug_assert!(pal_tmp.len() >= read_len);
 
-    // SAFETY: Unsafe asm call. `pal_idx` is at least `(bw * 2) * (bh * 4)`
+    // SAFETY: Unsafe asm call. `pal_idx` is at least `(bw4 * 2) * (bh4 * 4)`
     // elements long and `pal_tmp` is at least `(bw4 * 4)
     // * (bh4 * 4)` elements long, which is how many elements `pal_idx_finish`
     // will read/write.

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -494,9 +494,10 @@ impl Rav1dRefmvsDSPContext {
         let bw4 = bw4 as _;
         let bh4 = bh4 as _;
 
-        // SAFETY: Unsafe asm call, checkasm has verified the signature is correct. `rr` is at
-        // least `bh4` elements long, and each pointer in `rr` is non-null and points to at
-        // least `bx4 * bw4` elements, which is what will be accessed in `splat_mv`.
+        // SAFETY: Unsafe asm call. `rr` is at least `bh4` elements long, and
+        // each pointer in `rr` is non-null and points to at least `bx4 + bw4`
+        // elements, which is what will be accessed in `splat_mv`. For the Rust
+        // fallback function we pass the length of `rr` directly.
         unsafe {
             (self.splat_mv)(rr.as_mut_ptr(), rmv, bx4, bw4, bh4, rr.len());
         }


### PR DESCRIPTION
Remove `unsafe` marker from the smaller functions in `decode.rs` that are already safe or mostly safe, and add `unsafe` blocks and safety comments where needed.