### PR TITLE
`fn inv_txfm_add_wht_wht_4x4_rust`: Cleanup and make mostly safe

### DIFF
--- a/src/itx.rs
+++ b/src/itx.rs
@@ -469,20 +469,22 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust<BD: BitDepth>(
     const H: usize = 4;
     const W: usize = 4;
 
+    let coeff = slice::from_raw_parts_mut(coeff, W * H);
+
     let mut tmp = [0; W * H];
     let mut c = &mut tmp[..];
     let mut y = 0;
     while y < H {
         let mut x = 0;
         while x < W {
-            c[x as usize] = (*coeff.offset((y + x * H) as isize)).as_::<i32>() >> 2;
+            c[x as usize] = coeff[(y + x * H) as usize].as_::<i32>() >> 2;
             x += 1;
         }
         dav1d_inv_wht4_1d_c(c.as_mut_ptr(), 1);
         y += 1;
         c = &mut c[W..];
     }
-    slice::from_raw_parts_mut(coeff, W * H).fill(0.into());
+    coeff.fill(0.into());
     let mut x = 0;
     while x < W {
         dav1d_inv_wht4_1d_c(tmp[x as usize..].as_mut_ptr(), H as isize);

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -149,11 +149,9 @@ pub unsafe fn inv_txfm_add_rust<
         );
     }
 
-    let mut c = &tmp[..];
-    for _ in 0..H {
+    for y in 0..H {
         for x in 0..W {
-            *dst.add(x) = bd.iclip_pixel((*dst.add(x)).as_::<c_int>() + (c[0] + 8 >> 4));
-            c = &c[1..];
+            *dst.add(x) = bd.iclip_pixel((*dst.add(x)).as_::<c_int>() + (tmp[y * W + x] + 8 >> 4));
         }
         dst = dst.offset(BD::pxstride(stride));
     }
@@ -486,11 +484,9 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust<BD: BitDepth>(
         dav1d_inv_wht4_1d_c(tmp[x..].as_mut_ptr(), H as isize);
     }
 
-    let mut c = &tmp[..];
-    for _ in 0..H {
+    for y in 0..H {
         for x in 0..W {
-            *dst.add(x) = bd.iclip_pixel((*dst.add(x)).as_::<c_int>() + c[0]);
-            c = &c[1..];
+            *dst.add(x) = bd.iclip_pixel((*dst.add(x)).as_::<c_int>() + tmp[y * W + x]);
         }
         dst = dst.offset(BD::pxstride(stride));
     }

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -485,11 +485,13 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust<BD: BitDepth>(
         c = &mut c[W..];
     }
     coeff.fill(0.into());
+
     let mut x = 0;
     while x < W {
         dav1d_inv_wht4_1d_c(tmp[x as usize..].as_mut_ptr(), H as isize);
         x += 1;
     }
+    
     c = &mut tmp[..];
     let mut y = 0;
     while y < H {

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -490,10 +490,8 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust<BD: BitDepth>(
     while y < 4 {
         let mut x = 0;
         while x < 4 {
-            let fresh1 = c;
+            *dst.offset(x as isize) = bd.iclip_pixel((*dst.offset(x as isize)).as_::<c_int>() + *c);
             c = c.offset(1);
-            *dst.offset(x as isize) =
-                bd.iclip_pixel((*dst.offset(x as isize)).as_::<c_int>() + *fresh1);
             x += 1;
         }
         y += 1;

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -491,15 +491,15 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust<BD: BitDepth>(
         dav1d_inv_wht4_1d_c(tmp[x as usize..].as_mut_ptr(), H as isize);
         x += 1;
     }
-    
-    c = &mut tmp[..];
+
+    let mut c = &tmp[..];
     let mut y = 0;
     while y < H {
         let mut x = 0;
         while x < W {
             *dst.offset(x as isize) =
                 bd.iclip_pixel((*dst.offset(x as isize)).as_::<c_int>() + c[0]);
-            c = &mut c[1..];
+            c = &c[1..];
             x += 1;
         }
         y += 1;

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -475,17 +475,14 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust<BD: BitDepth>(
             *c.offset(x as isize) = (*coeff.offset((y + x * 4) as isize)).as_::<i32>() >> 2;
             x += 1;
         }
-        dav1d_inv_wht4_1d_c(c, 1 as c_int as ptrdiff_t);
+        dav1d_inv_wht4_1d_c(c, 1);
         y += 1;
         c = c.offset(4);
     }
     slice::from_raw_parts_mut(coeff, 4 * 4).fill(0.into());
     let mut x_0 = 0;
     while x_0 < 4 {
-        dav1d_inv_wht4_1d_c(
-            &mut *tmp.as_mut_ptr().offset(x_0 as isize),
-            4 as c_int as ptrdiff_t,
-        );
+        dav1d_inv_wht4_1d_c(&mut *tmp.as_mut_ptr().offset(x_0 as isize), 4);
         x_0 += 1;
     }
     c = tmp.as_mut_ptr();

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -467,31 +467,32 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust<BD: BitDepth>(
     use crate::src::itx_1d::dav1d_inv_wht4_1d_c;
 
     let mut tmp = [0; 16];
-    let mut c = tmp.as_mut_ptr();
+    let mut c = &mut tmp[..];
     let mut y = 0;
     while y < 4 {
         let mut x = 0;
         while x < 4 {
-            *c.offset(x as isize) = (*coeff.offset((y + x * 4) as isize)).as_::<i32>() >> 2;
+            c[x as usize] = (*coeff.offset((y + x * 4) as isize)).as_::<i32>() >> 2;
             x += 1;
         }
-        dav1d_inv_wht4_1d_c(c, 1);
+        dav1d_inv_wht4_1d_c(c.as_mut_ptr(), 1);
         y += 1;
-        c = c.offset(4);
+        c = &mut c[4..];
     }
     slice::from_raw_parts_mut(coeff, 4 * 4).fill(0.into());
     let mut x = 0;
     while x < 4 {
-        dav1d_inv_wht4_1d_c(&mut *tmp.as_mut_ptr().offset(x as isize), 4);
+        dav1d_inv_wht4_1d_c(tmp[x as usize..].as_mut_ptr(), 4);
         x += 1;
     }
-    c = tmp.as_mut_ptr();
+    c = &mut tmp[..];
     let mut y = 0;
     while y < 4 {
         let mut x = 0;
         while x < 4 {
-            *dst.offset(x as isize) = bd.iclip_pixel((*dst.offset(x as isize)).as_::<c_int>() + *c);
-            c = c.offset(1);
+            *dst.offset(x as isize) =
+                bd.iclip_pixel((*dst.offset(x as isize)).as_::<c_int>() + c[0]);
+            c = &mut c[1..];
             x += 1;
         }
         y += 1;

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -492,7 +492,7 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust<BD: BitDepth>(
             *dst.add(x) = bd.iclip_pixel((*dst.add(x)).as_::<c_int>() + c[0]);
             c = &c[1..];
         }
-        dst = dst.offset(BD::pxstride(stride as usize) as isize);
+        dst = dst.offset(BD::pxstride(stride));
     }
 }
 

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -466,8 +466,8 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust<BD: BitDepth>(
 ) {
     use crate::src::itx_1d::dav1d_inv_wht4_1d_c;
 
-    let mut tmp: [i32; 16] = [0; 16];
-    let mut c: *mut i32 = tmp.as_mut_ptr();
+    let mut tmp = [0; 16];
+    let mut c = tmp.as_mut_ptr();
     let mut y = 0;
     while y < 4 {
         let mut x = 0;

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -475,7 +475,7 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust<BD: BitDepth>(
     let mut c = &mut tmp[..];
     for y in 0..H {
         for x in 0..W {
-            c[x as usize] = coeff[(y + x * H) as usize].as_::<i32>() >> 2;
+            c[x] = coeff[y + x * H].as_::<i32>() >> 2;
         }
         dav1d_inv_wht4_1d_c(c.as_mut_ptr(), 1);
         c = &mut c[W..];
@@ -483,14 +483,13 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust<BD: BitDepth>(
     coeff.fill(0.into());
 
     for x in 0..W {
-        dav1d_inv_wht4_1d_c(tmp[x as usize..].as_mut_ptr(), H as isize);
+        dav1d_inv_wht4_1d_c(tmp[x..].as_mut_ptr(), H as isize);
     }
 
     let mut c = &tmp[..];
     for _ in 0..H {
         for x in 0..W {
-            *dst.offset(x as isize) =
-                bd.iclip_pixel((*dst.offset(x as isize)).as_::<c_int>() + c[0]);
+            *dst.add(x) = bd.iclip_pixel((*dst.add(x)).as_::<c_int>() + c[0]);
             c = &c[1..];
         }
         dst = dst.offset(BD::pxstride(stride as usize) as isize);

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -480,23 +480,23 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust<BD: BitDepth>(
         c = c.offset(4);
     }
     slice::from_raw_parts_mut(coeff, 4 * 4).fill(0.into());
-    let mut x_0 = 0;
-    while x_0 < 4 {
-        dav1d_inv_wht4_1d_c(&mut *tmp.as_mut_ptr().offset(x_0 as isize), 4);
-        x_0 += 1;
+    let mut x = 0;
+    while x < 4 {
+        dav1d_inv_wht4_1d_c(&mut *tmp.as_mut_ptr().offset(x as isize), 4);
+        x += 1;
     }
     c = tmp.as_mut_ptr();
-    let mut y_0 = 0;
-    while y_0 < 4 {
-        let mut x_1 = 0;
-        while x_1 < 4 {
+    let mut y = 0;
+    while y < 4 {
+        let mut x = 0;
+        while x < 4 {
             let fresh1 = c;
             c = c.offset(1);
-            *dst.offset(x_1 as isize) =
-                bd.iclip_pixel((*dst.offset(x_1 as isize)).as_::<c_int>() + *fresh1);
-            x_1 += 1;
+            *dst.offset(x as isize) =
+                bd.iclip_pixel((*dst.offset(x as isize)).as_::<c_int>() + *fresh1);
+            x += 1;
         }
-        y_0 += 1;
+        y += 1;
         dst = dst.offset(BD::pxstride(stride as usize) as isize);
     }
 }

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -473,36 +473,26 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust<BD: BitDepth>(
 
     let mut tmp = [0; W * H];
     let mut c = &mut tmp[..];
-    let mut y = 0;
-    while y < H {
-        let mut x = 0;
-        while x < W {
+    for y in 0..H {
+        for x in 0..W {
             c[x as usize] = coeff[(y + x * H) as usize].as_::<i32>() >> 2;
-            x += 1;
         }
         dav1d_inv_wht4_1d_c(c.as_mut_ptr(), 1);
-        y += 1;
         c = &mut c[W..];
     }
     coeff.fill(0.into());
 
-    let mut x = 0;
-    while x < W {
+    for x in 0..W {
         dav1d_inv_wht4_1d_c(tmp[x as usize..].as_mut_ptr(), H as isize);
-        x += 1;
     }
 
     let mut c = &tmp[..];
-    let mut y = 0;
-    while y < H {
-        let mut x = 0;
-        while x < W {
+    for _ in 0..H {
+        for x in 0..W {
             *dst.offset(x as isize) =
                 bd.iclip_pixel((*dst.offset(x as isize)).as_::<c_int>() + c[0]);
             c = &c[1..];
-            x += 1;
         }
-        y += 1;
         dst = dst.offset(BD::pxstride(stride as usize) as isize);
     }
 }


### PR DESCRIPTION
* Fixes `fn inv_txfm_add_wht_wht_4x4_rust` of #817.
* Fixes `fn inv_txfm_add_wht_wht_4x4_rust` of #836.

Very similar to #1041.