### PR TITLE
`mod itx_1d`: Make fully safe

### DIFF
--- a/src/itx.rs
+++ b/src/itx.rs
@@ -57,7 +57,7 @@ use crate::include::common::bitdepth::bd_fn;
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 use crate::include::common::bitdepth::bpc_fn;
 
-pub type itx_1d_fn = unsafe fn(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int);
+pub type itx_1d_fn = fn(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int);
 
 pub unsafe fn inv_txfm_add_rust<
     const W: usize,

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -57,8 +57,7 @@ use crate::include::common::bitdepth::bd_fn;
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 use crate::include::common::bitdepth::bpc_fn;
 
-pub type itx_1d_fn =
-    unsafe extern "C" fn(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int);
+pub type itx_1d_fn = unsafe fn(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int);
 
 pub unsafe fn inv_txfm_add_rust<
     const W: usize,

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -57,7 +57,7 @@ use crate::include::common::bitdepth::bd_fn;
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 use crate::include::common::bitdepth::bpc_fn;
 
-pub type itx_1d_fn = unsafe fn(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int);
+pub type itx_1d_fn = unsafe fn(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int);
 
 pub unsafe fn inv_txfm_add_rust<
     const W: usize,
@@ -132,12 +132,7 @@ pub unsafe fn inv_txfm_add_rust<
                 c[x] = coeff[y + x * sh].as_();
             }
         }
-        first_1d_fn(
-            c.as_mut_ptr(),
-            1.try_into().unwrap(),
-            row_clip_min,
-            row_clip_max,
-        );
+        first_1d_fn(c, 1.try_into().unwrap(), row_clip_min, row_clip_max);
         c = &mut c[W..];
     }
 
@@ -148,7 +143,7 @@ pub unsafe fn inv_txfm_add_rust<
 
     for x in 0..W {
         second_1d_fn(
-            tmp[x..].as_mut_ptr(),
+            &mut tmp[x..],
             W.try_into().unwrap(),
             col_clip_min,
             col_clip_max,
@@ -481,13 +476,13 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust<BD: BitDepth>(
         for x in 0..W {
             c[x] = coeff[y + x * H].as_::<i32>() >> 2;
         }
-        dav1d_inv_wht4_1d_c(c.as_mut_ptr(), 1.try_into().unwrap());
+        dav1d_inv_wht4_1d_c(c, 1.try_into().unwrap());
         c = &mut c[W..];
     }
     coeff.fill(0.into());
 
     for x in 0..W {
-        dav1d_inv_wht4_1d_c(tmp[x..].as_mut_ptr(), H.try_into().unwrap());
+        dav1d_inv_wht4_1d_c(&mut tmp[x..], H.try_into().unwrap());
     }
 
     for y in 0..H {

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -4,6 +4,7 @@ use crate::include::common::bitdepth::DynCoef;
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::intops::iclip;
 use crate::src::cpu::CpuFlags;
+use crate::src::itx_1d::rav1d_inv_wht4_1d_c;
 use crate::src::levels::ADST_ADST;
 use crate::src::levels::ADST_DCT;
 use crate::src::levels::ADST_FLIPADST;
@@ -372,8 +373,8 @@ macro_rules! inv_txfm_fn {
                     stride,
                     coeff.cast(),
                     eob,
-                    [<dav1d_inv_ $type1 $w _1d_c>],
-                    [<dav1d_inv_ $type2 $h _1d_c>],
+                    [<rav1d_inv_ $type1 $w _1d_c>],
+                    [<rav1d_inv_ $type2 $h _1d_c>],
                     BD::from_c(bitdepth_max),
                 );
             }
@@ -463,8 +464,6 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust<BD: BitDepth>(
     _eob: c_int,
     bd: BD,
 ) {
-    use crate::src::itx_1d::dav1d_inv_wht4_1d_c;
-
     const H: usize = 4;
     const W: usize = 4;
 
@@ -476,13 +475,13 @@ unsafe fn inv_txfm_add_wht_wht_4x4_rust<BD: BitDepth>(
         for x in 0..W {
             c[x] = coeff[y + x * H].as_::<i32>() >> 2;
         }
-        dav1d_inv_wht4_1d_c(c, 1.try_into().unwrap());
+        rav1d_inv_wht4_1d_c(c, 1.try_into().unwrap());
         c = &mut c[W..];
     }
     coeff.fill(0.into());
 
     for x in 0..W {
-        dav1d_inv_wht4_1d_c(&mut tmp[x..], H.try_into().unwrap());
+        rav1d_inv_wht4_1d_c(&mut tmp[x..], H.try_into().unwrap());
     }
 
     for y in 0..H {

--- a/src/itx_1d.rs
+++ b/src/itx_1d.rs
@@ -1,9 +1,11 @@
+#![deny(unsafe_code)]
+
 use crate::include::common::intops::iclip;
 use std::ffi::c_int;
 use std::num::NonZeroUsize;
 
 #[inline(never)]
-unsafe fn inv_dct4_1d_internal_c(
+fn inv_dct4_1d_internal_c(
     c: &mut [i32],
     stride: NonZeroUsize,
     min: c_int,
@@ -37,12 +39,12 @@ unsafe fn inv_dct4_1d_internal_c(
     c[3 * stride] = iclip(t0 - t3, min, max);
 }
 
-pub unsafe fn dav1d_inv_dct4_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+pub fn dav1d_inv_dct4_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_dct4_1d_internal_c(c, stride, min, max, 0 as c_int);
 }
 
 #[inline(never)]
-unsafe fn inv_dct8_1d_internal_c(
+fn inv_dct8_1d_internal_c(
     c: &mut [i32],
     stride: NonZeroUsize,
     min: c_int,
@@ -91,12 +93,12 @@ unsafe fn inv_dct8_1d_internal_c(
     c[7 * stride] = iclip(t0 - t7, min, max);
 }
 
-pub unsafe fn dav1d_inv_dct8_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+pub fn dav1d_inv_dct8_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_dct8_1d_internal_c(c, stride, min, max, 0 as c_int);
 }
 
 #[inline(never)]
-unsafe fn inv_dct16_1d_internal_c(
+fn inv_dct16_1d_internal_c(
     c: &mut [i32],
     stride: NonZeroUsize,
     min: c_int,
@@ -191,12 +193,12 @@ unsafe fn inv_dct16_1d_internal_c(
     c[15 * stride] = iclip(t0 - t15a, min, max);
 }
 
-pub unsafe fn dav1d_inv_dct16_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+pub fn dav1d_inv_dct16_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_dct16_1d_internal_c(c, stride, min, max, 0 as c_int);
 }
 
 #[inline(never)]
-unsafe fn inv_dct32_1d_internal_c(
+fn inv_dct32_1d_internal_c(
     c: &mut [i32],
     stride: NonZeroUsize,
     min: c_int,
@@ -395,11 +397,11 @@ unsafe fn inv_dct32_1d_internal_c(
     c[31 * stride] = iclip(t0 - t31, min, max);
 }
 
-pub unsafe fn dav1d_inv_dct32_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+pub fn dav1d_inv_dct32_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_dct32_1d_internal_c(c, stride, min, max, 0 as c_int);
 }
 
-pub unsafe fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     let stride = stride.get();
 
     inv_dct32_1d_internal_c(c, (stride << 1).try_into().unwrap(), min, max, 1 as c_int);
@@ -742,7 +744,7 @@ pub unsafe fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_i
 }
 
 #[inline(never)]
-unsafe fn inv_adst4_1d_internal_c(
+fn inv_adst4_1d_internal_c(
     c: &mut [i32],
     stride: NonZeroUsize,
     out_backwards: bool,
@@ -786,7 +788,7 @@ unsafe fn inv_adst4_1d_internal_c(
 }
 
 #[inline(never)]
-unsafe fn inv_adst8_1d_internal_c(
+fn inv_adst8_1d_internal_c(
     c: &mut [i32],
     stride: NonZeroUsize,
     out_backwards: bool,
@@ -850,7 +852,7 @@ unsafe fn inv_adst8_1d_internal_c(
 }
 
 #[inline(never)]
-unsafe fn inv_adst16_1d_internal_c(
+fn inv_adst16_1d_internal_c(
     c: &mut [i32],
     stride: NonZeroUsize,
     out_backwards: bool,
@@ -977,51 +979,31 @@ unsafe fn inv_adst16_1d_internal_c(
     out[(out_off + 10 * out_s) as usize] = (t14a - t15a) * 181 + 128 >> 8;
 }
 
-pub unsafe fn dav1d_inv_flipadst4_1d_c(
-    c: &mut [i32],
-    stride: NonZeroUsize,
-    min: c_int,
-    max: c_int,
-) {
+pub fn dav1d_inv_flipadst4_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_adst4_1d_internal_c(c, stride, true, min, max);
 }
 
-pub unsafe fn dav1d_inv_adst4_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+pub fn dav1d_inv_adst4_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_adst4_1d_internal_c(c, stride, false, min, max);
 }
 
-pub unsafe fn dav1d_inv_adst8_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+pub fn dav1d_inv_adst8_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_adst8_1d_internal_c(c, stride, false, min, max);
 }
 
-pub unsafe fn dav1d_inv_flipadst8_1d_c(
-    c: &mut [i32],
-    stride: NonZeroUsize,
-    min: c_int,
-    max: c_int,
-) {
+pub fn dav1d_inv_flipadst8_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_adst8_1d_internal_c(c, stride, true, min, max);
 }
 
-pub unsafe fn dav1d_inv_flipadst16_1d_c(
-    c: &mut [i32],
-    stride: NonZeroUsize,
-    min: c_int,
-    max: c_int,
-) {
+pub fn dav1d_inv_flipadst16_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_adst16_1d_internal_c(c, stride, true, min, max);
 }
 
-pub unsafe fn dav1d_inv_adst16_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+pub fn dav1d_inv_adst16_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_adst16_1d_internal_c(c, stride, false, min, max);
 }
 
-pub unsafe fn dav1d_inv_identity4_1d_c(
-    c: &mut [i32],
-    stride: NonZeroUsize,
-    _min: c_int,
-    _max: c_int,
-) {
+pub fn dav1d_inv_identity4_1d_c(c: &mut [i32], stride: NonZeroUsize, _min: c_int, _max: c_int) {
     let stride = stride.get();
 
     let mut i = 0;
@@ -1032,12 +1014,7 @@ pub unsafe fn dav1d_inv_identity4_1d_c(
     }
 }
 
-pub unsafe fn dav1d_inv_identity8_1d_c(
-    c: &mut [i32],
-    stride: NonZeroUsize,
-    _min: c_int,
-    _max: c_int,
-) {
+pub fn dav1d_inv_identity8_1d_c(c: &mut [i32], stride: NonZeroUsize, _min: c_int, _max: c_int) {
     let stride = stride.get();
 
     let mut i = 0;
@@ -1047,12 +1024,7 @@ pub unsafe fn dav1d_inv_identity8_1d_c(
     }
 }
 
-pub unsafe fn dav1d_inv_identity16_1d_c(
-    c: &mut [i32],
-    stride: NonZeroUsize,
-    _min: c_int,
-    _max: c_int,
-) {
+pub fn dav1d_inv_identity16_1d_c(c: &mut [i32], stride: NonZeroUsize, _min: c_int, _max: c_int) {
     let stride = stride.get();
 
     let mut i = 0;
@@ -1063,12 +1035,7 @@ pub unsafe fn dav1d_inv_identity16_1d_c(
     }
 }
 
-pub unsafe fn dav1d_inv_identity32_1d_c(
-    c: &mut [i32],
-    stride: NonZeroUsize,
-    _min: c_int,
-    _max: c_int,
-) {
+pub fn dav1d_inv_identity32_1d_c(c: &mut [i32], stride: NonZeroUsize, _min: c_int, _max: c_int) {
     let stride = stride.get();
 
     let mut i = 0;
@@ -1078,7 +1045,7 @@ pub unsafe fn dav1d_inv_identity32_1d_c(
     }
 }
 
-pub unsafe fn dav1d_inv_wht4_1d_c(c: &mut [i32], stride: NonZeroUsize) {
+pub fn dav1d_inv_wht4_1d_c(c: &mut [i32], stride: NonZeroUsize) {
     let stride = stride.get();
 
     let in0 = c[0 * stride];

--- a/src/itx_1d.rs
+++ b/src/itx_1d.rs
@@ -1,11 +1,10 @@
 use crate::include::common::intops::iclip;
 use std::ffi::c_int;
-use std::num::NonZeroIsize;
 use std::num::NonZeroUsize;
 
 #[inline(never)]
 unsafe fn inv_dct4_1d_internal_c(
-    c: *mut i32,
+    c: &mut [i32],
     stride: NonZeroUsize,
     min: c_int,
     max: c_int,
@@ -13,8 +12,8 @@ unsafe fn inv_dct4_1d_internal_c(
 ) {
     let stride = stride.get();
 
-    let in0 = *c.offset((0 * stride) as isize);
-    let in1 = *c.offset((1 * stride) as isize);
+    let in0 = c[0 * stride];
+    let in1 = c[1 * stride];
     let t0;
     let t1;
     let t2;
@@ -25,26 +24,26 @@ unsafe fn inv_dct4_1d_internal_c(
         t2 = in1 * 1567 + 2048 >> 12;
         t3 = in1 * 3784 + 2048 >> 12;
     } else {
-        let in2 = *c.offset((2 * stride) as isize);
-        let in3 = *c.offset((3 * stride) as isize);
+        let in2 = c[2 * stride];
+        let in3 = c[3 * stride];
         t0 = (in0 + in2) * 181 + 128 >> 8;
         t1 = (in0 - in2) * 181 + 128 >> 8;
         t2 = (in1 * 1567 - in3 * (3784 - 4096) + 2048 >> 12) - in3;
         t3 = (in1 * (3784 - 4096) + in3 * 1567 + 2048 >> 12) + in1;
     }
-    *c.offset((0 * stride) as isize) = iclip(t0 + t3, min, max);
-    *c.offset((1 * stride) as isize) = iclip(t1 + t2, min, max);
-    *c.offset((2 * stride) as isize) = iclip(t1 - t2, min, max);
-    *c.offset((3 * stride) as isize) = iclip(t0 - t3, min, max);
+    c[0 * stride] = iclip(t0 + t3, min, max);
+    c[1 * stride] = iclip(t1 + t2, min, max);
+    c[2 * stride] = iclip(t1 - t2, min, max);
+    c[3 * stride] = iclip(t0 - t3, min, max);
 }
 
-pub unsafe fn dav1d_inv_dct4_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
+pub unsafe fn dav1d_inv_dct4_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_dct4_1d_internal_c(c, stride, min, max, 0 as c_int);
 }
 
 #[inline(never)]
 unsafe fn inv_dct8_1d_internal_c(
-    c: *mut i32,
+    c: &mut [i32],
     stride: NonZeroUsize,
     min: c_int,
     max: c_int,
@@ -53,8 +52,8 @@ unsafe fn inv_dct8_1d_internal_c(
     let stride = stride.get();
 
     inv_dct4_1d_internal_c(c, (stride << 1).try_into().unwrap(), min, max, tx64);
-    let in1 = *c.offset((1 * stride) as isize);
-    let in3 = *c.offset((3 * stride) as isize);
+    let in1 = c[1 * stride];
+    let in3 = c[3 * stride];
     let t4a;
     let mut t5a;
     let mut t6a;
@@ -65,8 +64,8 @@ unsafe fn inv_dct8_1d_internal_c(
         t6a = in3 * 3406 + 2048 >> 12;
         t7a = in1 * 4017 + 2048 >> 12;
     } else {
-        let in5 = *c.offset((5 * stride) as isize);
-        let in7 = *c.offset((7 * stride) as isize);
+        let in5 = c[5 * stride];
+        let in7 = c[7 * stride];
         t4a = (in1 * 799 - in7 * (4017 - 4096) + 2048 >> 12) - in7;
         t5a = in5 * 1703 - in3 * 1138 + 1024 >> 11;
         t6a = in5 * 1138 + in3 * 1703 + 1024 >> 11;
@@ -78,27 +77,27 @@ unsafe fn inv_dct8_1d_internal_c(
     t6a = iclip(t7a - t6a, min, max);
     let t5 = (t6a - t5a) * 181 + 128 >> 8;
     let t6 = (t6a + t5a) * 181 + 128 >> 8;
-    let t0 = *c.offset((0 * stride) as isize);
-    let t1 = *c.offset((2 * stride) as isize);
-    let t2 = *c.offset((4 * stride) as isize);
-    let t3 = *c.offset((6 * stride) as isize);
-    *c.offset((0 * stride) as isize) = iclip(t0 + t7, min, max);
-    *c.offset((1 * stride) as isize) = iclip(t1 + t6, min, max);
-    *c.offset((2 * stride) as isize) = iclip(t2 + t5, min, max);
-    *c.offset((3 * stride) as isize) = iclip(t3 + t4, min, max);
-    *c.offset((4 * stride) as isize) = iclip(t3 - t4, min, max);
-    *c.offset((5 * stride) as isize) = iclip(t2 - t5, min, max);
-    *c.offset((6 * stride) as isize) = iclip(t1 - t6, min, max);
-    *c.offset((7 * stride) as isize) = iclip(t0 - t7, min, max);
+    let t0 = c[0 * stride];
+    let t1 = c[2 * stride];
+    let t2 = c[4 * stride];
+    let t3 = c[6 * stride];
+    c[0 * stride] = iclip(t0 + t7, min, max);
+    c[1 * stride] = iclip(t1 + t6, min, max);
+    c[2 * stride] = iclip(t2 + t5, min, max);
+    c[3 * stride] = iclip(t3 + t4, min, max);
+    c[4 * stride] = iclip(t3 - t4, min, max);
+    c[5 * stride] = iclip(t2 - t5, min, max);
+    c[6 * stride] = iclip(t1 - t6, min, max);
+    c[7 * stride] = iclip(t0 - t7, min, max);
 }
 
-pub unsafe fn dav1d_inv_dct8_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
+pub unsafe fn dav1d_inv_dct8_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_dct8_1d_internal_c(c, stride, min, max, 0 as c_int);
 }
 
 #[inline(never)]
 unsafe fn inv_dct16_1d_internal_c(
-    c: *mut i32,
+    c: &mut [i32],
     stride: NonZeroUsize,
     min: c_int,
     max: c_int,
@@ -107,10 +106,10 @@ unsafe fn inv_dct16_1d_internal_c(
     let stride = stride.get();
 
     inv_dct8_1d_internal_c(c, (stride << 1).try_into().unwrap(), min, max, tx64);
-    let in1 = *c.offset((1 * stride) as isize);
-    let in3 = *c.offset((3 * stride) as isize);
-    let in5 = *c.offset((5 * stride) as isize);
-    let in7 = *c.offset((7 * stride) as isize);
+    let in1 = c[1 * stride];
+    let in3 = c[3 * stride];
+    let in5 = c[5 * stride];
+    let in7 = c[7 * stride];
     let mut t8a;
     let mut t9a;
     let mut t10a;
@@ -129,10 +128,10 @@ unsafe fn inv_dct16_1d_internal_c(
         t14a = in7 * 3166 + 2048 >> 12;
         t15a = in1 * 4076 + 2048 >> 12;
     } else {
-        let in9 = *c.offset((9 * stride) as isize);
-        let in11 = *c.offset((11 * stride) as isize);
-        let in13 = *c.offset((13 * stride) as isize);
-        let in15 = *c.offset((15 * stride) as isize);
+        let in9 = c[9 * stride];
+        let in11 = c[11 * stride];
+        let in13 = c[13 * stride];
+        let in15 = c[15 * stride];
         t8a = (in1 * 401 - in15 * (4076 - 4096) + 2048 >> 12) - in15;
         t9a = in9 * 1583 - in7 * 1299 + 1024 >> 11;
         t10a = (in5 * 1931 - in11 * (3612 - 4096) + 2048 >> 12) - in11;
@@ -166,39 +165,39 @@ unsafe fn inv_dct16_1d_internal_c(
     t13a = (t13 + t10) * 181 + 128 >> 8;
     t11 = (t12a - t11a) * 181 + 128 >> 8;
     t12 = (t12a + t11a) * 181 + 128 >> 8;
-    let t0 = *c.offset((0 * stride) as isize);
-    let t1 = *c.offset((2 * stride) as isize);
-    let t2 = *c.offset((4 * stride) as isize);
-    let t3 = *c.offset((6 * stride) as isize);
-    let t4 = *c.offset((8 * stride) as isize);
-    let t5 = *c.offset((10 * stride) as isize);
-    let t6 = *c.offset((12 * stride) as isize);
-    let t7 = *c.offset((14 * stride) as isize);
-    *c.offset((0 * stride) as isize) = iclip(t0 + t15a, min, max);
-    *c.offset((1 * stride) as isize) = iclip(t1 + t14, min, max);
-    *c.offset((2 * stride) as isize) = iclip(t2 + t13a, min, max);
-    *c.offset((3 * stride) as isize) = iclip(t3 + t12, min, max);
-    *c.offset((4 * stride) as isize) = iclip(t4 + t11, min, max);
-    *c.offset((5 * stride) as isize) = iclip(t5 + t10a, min, max);
-    *c.offset((6 * stride) as isize) = iclip(t6 + t9, min, max);
-    *c.offset((7 * stride) as isize) = iclip(t7 + t8a, min, max);
-    *c.offset((8 * stride) as isize) = iclip(t7 - t8a, min, max);
-    *c.offset((9 * stride) as isize) = iclip(t6 - t9, min, max);
-    *c.offset((10 * stride) as isize) = iclip(t5 - t10a, min, max);
-    *c.offset((11 * stride) as isize) = iclip(t4 - t11, min, max);
-    *c.offset((12 * stride) as isize) = iclip(t3 - t12, min, max);
-    *c.offset((13 * stride) as isize) = iclip(t2 - t13a, min, max);
-    *c.offset((14 * stride) as isize) = iclip(t1 - t14, min, max);
-    *c.offset((15 * stride) as isize) = iclip(t0 - t15a, min, max);
+    let t0 = c[0 * stride];
+    let t1 = c[2 * stride];
+    let t2 = c[4 * stride];
+    let t3 = c[6 * stride];
+    let t4 = c[8 * stride];
+    let t5 = c[10 * stride];
+    let t6 = c[12 * stride];
+    let t7 = c[14 * stride];
+    c[0 * stride] = iclip(t0 + t15a, min, max);
+    c[1 * stride] = iclip(t1 + t14, min, max);
+    c[2 * stride] = iclip(t2 + t13a, min, max);
+    c[3 * stride] = iclip(t3 + t12, min, max);
+    c[4 * stride] = iclip(t4 + t11, min, max);
+    c[5 * stride] = iclip(t5 + t10a, min, max);
+    c[6 * stride] = iclip(t6 + t9, min, max);
+    c[7 * stride] = iclip(t7 + t8a, min, max);
+    c[8 * stride] = iclip(t7 - t8a, min, max);
+    c[9 * stride] = iclip(t6 - t9, min, max);
+    c[10 * stride] = iclip(t5 - t10a, min, max);
+    c[11 * stride] = iclip(t4 - t11, min, max);
+    c[12 * stride] = iclip(t3 - t12, min, max);
+    c[13 * stride] = iclip(t2 - t13a, min, max);
+    c[14 * stride] = iclip(t1 - t14, min, max);
+    c[15 * stride] = iclip(t0 - t15a, min, max);
 }
 
-pub unsafe fn dav1d_inv_dct16_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
+pub unsafe fn dav1d_inv_dct16_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_dct16_1d_internal_c(c, stride, min, max, 0 as c_int);
 }
 
 #[inline(never)]
 unsafe fn inv_dct32_1d_internal_c(
-    c: *mut i32,
+    c: &mut [i32],
     stride: NonZeroUsize,
     min: c_int,
     max: c_int,
@@ -207,14 +206,14 @@ unsafe fn inv_dct32_1d_internal_c(
     let stride = stride.get();
 
     inv_dct16_1d_internal_c(c, (stride << 1).try_into().unwrap(), min, max, tx64);
-    let in1 = *c.offset((1 * stride) as isize);
-    let in3 = *c.offset((3 * stride) as isize);
-    let in5 = *c.offset((5 * stride) as isize);
-    let in7 = *c.offset((7 * stride) as isize);
-    let in9 = *c.offset((9 * stride) as isize);
-    let in11 = *c.offset((11 * stride) as isize);
-    let in13 = *c.offset((13 * stride) as isize);
-    let in15 = *c.offset((15 * stride) as isize);
+    let in1 = c[1 * stride];
+    let in3 = c[3 * stride];
+    let in5 = c[5 * stride];
+    let in7 = c[7 * stride];
+    let in9 = c[9 * stride];
+    let in11 = c[11 * stride];
+    let in13 = c[13 * stride];
+    let in15 = c[15 * stride];
     let mut t16a;
     let mut t17a;
     let mut t18a;
@@ -249,14 +248,14 @@ unsafe fn inv_dct32_1d_internal_c(
         t30a = in15 * 3035 + 2048 >> 12;
         t31a = in1 * 4091 + 2048 >> 12;
     } else {
-        let in17 = *c.offset((17 * stride) as isize);
-        let in19 = *c.offset((19 * stride) as isize);
-        let in21 = *c.offset((21 * stride) as isize);
-        let in23 = *c.offset((23 * stride) as isize);
-        let in25 = *c.offset((25 * stride) as isize);
-        let in27 = *c.offset((27 * stride) as isize);
-        let in29 = *c.offset((29 * stride) as isize);
-        let in31 = *c.offset((31 * stride) as isize);
+        let in17 = c[17 * stride];
+        let in19 = c[19 * stride];
+        let in21 = c[21 * stride];
+        let in23 = c[23 * stride];
+        let in25 = c[25 * stride];
+        let in27 = c[27 * stride];
+        let in29 = c[29 * stride];
+        let in31 = c[31 * stride];
         t16a = (in1 * 201 - in31 * (4091 - 4096) + 2048 >> 12) - in31;
         t17a = (in17 * (3035 - 4096) - in15 * 2751 + 2048 >> 12) + in17;
         t18a = (in9 * 1751 - in23 * (3703 - 4096) + 2048 >> 12) - in23;
@@ -346,80 +345,80 @@ unsafe fn inv_dct32_1d_internal_c(
     t25 = (t25a + t22a) * 181 + 128 >> 8;
     t23a = (t24 - t23) * 181 + 128 >> 8;
     t24a = (t24 + t23) * 181 + 128 >> 8;
-    let t0 = *c.offset((0 * stride) as isize);
-    let t1 = *c.offset((2 * stride) as isize);
-    let t2 = *c.offset((4 * stride) as isize);
-    let t3 = *c.offset((6 * stride) as isize);
-    let t4 = *c.offset((8 * stride) as isize);
-    let t5 = *c.offset((10 * stride) as isize);
-    let t6 = *c.offset((12 * stride) as isize);
-    let t7 = *c.offset((14 * stride) as isize);
-    let t8 = *c.offset((16 * stride) as isize);
-    let t9 = *c.offset((18 * stride) as isize);
-    let t10 = *c.offset((20 * stride) as isize);
-    let t11 = *c.offset((22 * stride) as isize);
-    let t12 = *c.offset((24 * stride) as isize);
-    let t13 = *c.offset((26 * stride) as isize);
-    let t14 = *c.offset((28 * stride) as isize);
-    let t15 = *c.offset((30 * stride) as isize);
-    *c.offset((0 * stride) as isize) = iclip(t0 + t31, min, max);
-    *c.offset((1 * stride) as isize) = iclip(t1 + t30a, min, max);
-    *c.offset((2 * stride) as isize) = iclip(t2 + t29, min, max);
-    *c.offset((3 * stride) as isize) = iclip(t3 + t28a, min, max);
-    *c.offset((4 * stride) as isize) = iclip(t4 + t27, min, max);
-    *c.offset((5 * stride) as isize) = iclip(t5 + t26a, min, max);
-    *c.offset((6 * stride) as isize) = iclip(t6 + t25, min, max);
-    *c.offset((7 * stride) as isize) = iclip(t7 + t24a, min, max);
-    *c.offset((8 * stride) as isize) = iclip(t8 + t23a, min, max);
-    *c.offset((9 * stride) as isize) = iclip(t9 + t22, min, max);
-    *c.offset((10 * stride) as isize) = iclip(t10 + t21a, min, max);
-    *c.offset((11 * stride) as isize) = iclip(t11 + t20, min, max);
-    *c.offset((12 * stride) as isize) = iclip(t12 + t19a, min, max);
-    *c.offset((13 * stride) as isize) = iclip(t13 + t18, min, max);
-    *c.offset((14 * stride) as isize) = iclip(t14 + t17a, min, max);
-    *c.offset((15 * stride) as isize) = iclip(t15 + t16, min, max);
-    *c.offset((16 * stride) as isize) = iclip(t15 - t16, min, max);
-    *c.offset((17 * stride) as isize) = iclip(t14 - t17a, min, max);
-    *c.offset((18 * stride) as isize) = iclip(t13 - t18, min, max);
-    *c.offset((19 * stride) as isize) = iclip(t12 - t19a, min, max);
-    *c.offset((20 * stride) as isize) = iclip(t11 - t20, min, max);
-    *c.offset((21 * stride) as isize) = iclip(t10 - t21a, min, max);
-    *c.offset((22 * stride) as isize) = iclip(t9 - t22, min, max);
-    *c.offset((23 * stride) as isize) = iclip(t8 - t23a, min, max);
-    *c.offset((24 * stride) as isize) = iclip(t7 - t24a, min, max);
-    *c.offset((25 * stride) as isize) = iclip(t6 - t25, min, max);
-    *c.offset((26 * stride) as isize) = iclip(t5 - t26a, min, max);
-    *c.offset((27 * stride) as isize) = iclip(t4 - t27, min, max);
-    *c.offset((28 * stride) as isize) = iclip(t3 - t28a, min, max);
-    *c.offset((29 * stride) as isize) = iclip(t2 - t29, min, max);
-    *c.offset((30 * stride) as isize) = iclip(t1 - t30a, min, max);
-    *c.offset((31 * stride) as isize) = iclip(t0 - t31, min, max);
+    let t0 = c[0 * stride];
+    let t1 = c[2 * stride];
+    let t2 = c[4 * stride];
+    let t3 = c[6 * stride];
+    let t4 = c[8 * stride];
+    let t5 = c[10 * stride];
+    let t6 = c[12 * stride];
+    let t7 = c[14 * stride];
+    let t8 = c[16 * stride];
+    let t9 = c[18 * stride];
+    let t10 = c[20 * stride];
+    let t11 = c[22 * stride];
+    let t12 = c[24 * stride];
+    let t13 = c[26 * stride];
+    let t14 = c[28 * stride];
+    let t15 = c[30 * stride];
+    c[0 * stride] = iclip(t0 + t31, min, max);
+    c[1 * stride] = iclip(t1 + t30a, min, max);
+    c[2 * stride] = iclip(t2 + t29, min, max);
+    c[3 * stride] = iclip(t3 + t28a, min, max);
+    c[4 * stride] = iclip(t4 + t27, min, max);
+    c[5 * stride] = iclip(t5 + t26a, min, max);
+    c[6 * stride] = iclip(t6 + t25, min, max);
+    c[7 * stride] = iclip(t7 + t24a, min, max);
+    c[8 * stride] = iclip(t8 + t23a, min, max);
+    c[9 * stride] = iclip(t9 + t22, min, max);
+    c[10 * stride] = iclip(t10 + t21a, min, max);
+    c[11 * stride] = iclip(t11 + t20, min, max);
+    c[12 * stride] = iclip(t12 + t19a, min, max);
+    c[13 * stride] = iclip(t13 + t18, min, max);
+    c[14 * stride] = iclip(t14 + t17a, min, max);
+    c[15 * stride] = iclip(t15 + t16, min, max);
+    c[16 * stride] = iclip(t15 - t16, min, max);
+    c[17 * stride] = iclip(t14 - t17a, min, max);
+    c[18 * stride] = iclip(t13 - t18, min, max);
+    c[19 * stride] = iclip(t12 - t19a, min, max);
+    c[20 * stride] = iclip(t11 - t20, min, max);
+    c[21 * stride] = iclip(t10 - t21a, min, max);
+    c[22 * stride] = iclip(t9 - t22, min, max);
+    c[23 * stride] = iclip(t8 - t23a, min, max);
+    c[24 * stride] = iclip(t7 - t24a, min, max);
+    c[25 * stride] = iclip(t6 - t25, min, max);
+    c[26 * stride] = iclip(t5 - t26a, min, max);
+    c[27 * stride] = iclip(t4 - t27, min, max);
+    c[28 * stride] = iclip(t3 - t28a, min, max);
+    c[29 * stride] = iclip(t2 - t29, min, max);
+    c[30 * stride] = iclip(t1 - t30a, min, max);
+    c[31 * stride] = iclip(t0 - t31, min, max);
 }
 
-pub unsafe fn dav1d_inv_dct32_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
+pub unsafe fn dav1d_inv_dct32_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_dct32_1d_internal_c(c, stride, min, max, 0 as c_int);
 }
 
-pub unsafe fn dav1d_inv_dct64_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
+pub unsafe fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     let stride = stride.get();
 
     inv_dct32_1d_internal_c(c, (stride << 1).try_into().unwrap(), min, max, 1 as c_int);
-    let in1 = *c.offset((1 * stride) as isize);
-    let in3 = *c.offset((3 * stride) as isize);
-    let in5 = *c.offset((5 * stride) as isize);
-    let in7 = *c.offset((7 * stride) as isize);
-    let in9 = *c.offset((9 * stride) as isize);
-    let in11 = *c.offset((11 * stride) as isize);
-    let in13 = *c.offset((13 * stride) as isize);
-    let in15 = *c.offset((15 * stride) as isize);
-    let in17 = *c.offset((17 * stride) as isize);
-    let in19 = *c.offset((19 * stride) as isize);
-    let in21 = *c.offset((21 * stride) as isize);
-    let in23 = *c.offset((23 * stride) as isize);
-    let in25 = *c.offset((25 * stride) as isize);
-    let in27 = *c.offset((27 * stride) as isize);
-    let in29 = *c.offset((29 * stride) as isize);
-    let in31 = *c.offset((31 * stride) as isize);
+    let in1 = c[1 * stride];
+    let in3 = c[3 * stride];
+    let in5 = c[5 * stride];
+    let in7 = c[7 * stride];
+    let in9 = c[9 * stride];
+    let in11 = c[11 * stride];
+    let in13 = c[13 * stride];
+    let in15 = c[15 * stride];
+    let in17 = c[17 * stride];
+    let in19 = c[19 * stride];
+    let in21 = c[21 * stride];
+    let in23 = c[23 * stride];
+    let in25 = c[25 * stride];
+    let in27 = c[27 * stride];
+    let in29 = c[29 * stride];
+    let in31 = c[31 * stride];
     let mut t32a = in1 * 101 + 2048 >> 12;
     let mut t33a = in31 * -(2824 as c_int) + 2048 >> 12;
     let mut t34a = in17 * 1660 + 2048 >> 12;
@@ -644,132 +643,142 @@ pub unsafe fn dav1d_inv_dct64_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int
     t53a = (t42 + t53) * 181 + 128 >> 8;
     t54 = (t41a + t54a) * 181 + 128 >> 8;
     t55a = (t40 + t55) * 181 + 128 >> 8;
-    let t0 = *c.offset((0 * stride) as isize);
-    let t1 = *c.offset((2 * stride) as isize);
-    let t2 = *c.offset((4 * stride) as isize);
-    let t3 = *c.offset((6 * stride) as isize);
-    let t4 = *c.offset((8 * stride) as isize);
-    let t5 = *c.offset((10 * stride) as isize);
-    let t6 = *c.offset((12 * stride) as isize);
-    let t7 = *c.offset((14 * stride) as isize);
-    let t8 = *c.offset((16 * stride) as isize);
-    let t9 = *c.offset((18 * stride) as isize);
-    let t10 = *c.offset((20 * stride) as isize);
-    let t11 = *c.offset((22 * stride) as isize);
-    let t12 = *c.offset((24 * stride) as isize);
-    let t13 = *c.offset((26 * stride) as isize);
-    let t14 = *c.offset((28 * stride) as isize);
-    let t15 = *c.offset((30 * stride) as isize);
-    let t16 = *c.offset((32 * stride) as isize);
-    let t17 = *c.offset((34 * stride) as isize);
-    let t18 = *c.offset((36 * stride) as isize);
-    let t19 = *c.offset((38 * stride) as isize);
-    let t20 = *c.offset((40 * stride) as isize);
-    let t21 = *c.offset((42 * stride) as isize);
-    let t22 = *c.offset((44 * stride) as isize);
-    let t23 = *c.offset((46 * stride) as isize);
-    let t24 = *c.offset((48 * stride) as isize);
-    let t25 = *c.offset((50 * stride) as isize);
-    let t26 = *c.offset((52 * stride) as isize);
-    let t27 = *c.offset((54 * stride) as isize);
-    let t28 = *c.offset((56 * stride) as isize);
-    let t29 = *c.offset((58 * stride) as isize);
-    let t30 = *c.offset((60 * stride) as isize);
-    let t31 = *c.offset((62 * stride) as isize);
-    *c.offset((0 * stride) as isize) = iclip(t0 + t63a, min, max);
-    *c.offset((1 * stride) as isize) = iclip(t1 + t62, min, max);
-    *c.offset((2 * stride) as isize) = iclip(t2 + t61a, min, max);
-    *c.offset((3 * stride) as isize) = iclip(t3 + t60, min, max);
-    *c.offset((4 * stride) as isize) = iclip(t4 + t59a, min, max);
-    *c.offset((5 * stride) as isize) = iclip(t5 + t58, min, max);
-    *c.offset((6 * stride) as isize) = iclip(t6 + t57a, min, max);
-    *c.offset((7 * stride) as isize) = iclip(t7 + t56, min, max);
-    *c.offset((8 * stride) as isize) = iclip(t8 + t55a, min, max);
-    *c.offset((9 * stride) as isize) = iclip(t9 + t54, min, max);
-    *c.offset((10 * stride) as isize) = iclip(t10 + t53a, min, max);
-    *c.offset((11 * stride) as isize) = iclip(t11 + t52, min, max);
-    *c.offset((12 * stride) as isize) = iclip(t12 + t51a, min, max);
-    *c.offset((13 * stride) as isize) = iclip(t13 + t50, min, max);
-    *c.offset((14 * stride) as isize) = iclip(t14 + t49a, min, max);
-    *c.offset((15 * stride) as isize) = iclip(t15 + t48, min, max);
-    *c.offset((16 * stride) as isize) = iclip(t16 + t47, min, max);
-    *c.offset((17 * stride) as isize) = iclip(t17 + t46a, min, max);
-    *c.offset((18 * stride) as isize) = iclip(t18 + t45, min, max);
-    *c.offset((19 * stride) as isize) = iclip(t19 + t44a, min, max);
-    *c.offset((20 * stride) as isize) = iclip(t20 + t43, min, max);
-    *c.offset((21 * stride) as isize) = iclip(t21 + t42a, min, max);
-    *c.offset((22 * stride) as isize) = iclip(t22 + t41, min, max);
-    *c.offset((23 * stride) as isize) = iclip(t23 + t40a, min, max);
-    *c.offset((24 * stride) as isize) = iclip(t24 + t39, min, max);
-    *c.offset((25 * stride) as isize) = iclip(t25 + t38a, min, max);
-    *c.offset((26 * stride) as isize) = iclip(t26 + t37, min, max);
-    *c.offset((27 * stride) as isize) = iclip(t27 + t36a, min, max);
-    *c.offset((28 * stride) as isize) = iclip(t28 + t35, min, max);
-    *c.offset((29 * stride) as isize) = iclip(t29 + t34a, min, max);
-    *c.offset((30 * stride) as isize) = iclip(t30 + t33, min, max);
-    *c.offset((31 * stride) as isize) = iclip(t31 + t32a, min, max);
-    *c.offset((32 * stride) as isize) = iclip(t31 - t32a, min, max);
-    *c.offset((33 * stride) as isize) = iclip(t30 - t33, min, max);
-    *c.offset((34 * stride) as isize) = iclip(t29 - t34a, min, max);
-    *c.offset((35 * stride) as isize) = iclip(t28 - t35, min, max);
-    *c.offset((36 * stride) as isize) = iclip(t27 - t36a, min, max);
-    *c.offset((37 * stride) as isize) = iclip(t26 - t37, min, max);
-    *c.offset((38 * stride) as isize) = iclip(t25 - t38a, min, max);
-    *c.offset((39 * stride) as isize) = iclip(t24 - t39, min, max);
-    *c.offset((40 * stride) as isize) = iclip(t23 - t40a, min, max);
-    *c.offset((41 * stride) as isize) = iclip(t22 - t41, min, max);
-    *c.offset((42 * stride) as isize) = iclip(t21 - t42a, min, max);
-    *c.offset((43 * stride) as isize) = iclip(t20 - t43, min, max);
-    *c.offset((44 * stride) as isize) = iclip(t19 - t44a, min, max);
-    *c.offset((45 * stride) as isize) = iclip(t18 - t45, min, max);
-    *c.offset((46 * stride) as isize) = iclip(t17 - t46a, min, max);
-    *c.offset((47 * stride) as isize) = iclip(t16 - t47, min, max);
-    *c.offset((48 * stride) as isize) = iclip(t15 - t48, min, max);
-    *c.offset((49 * stride) as isize) = iclip(t14 - t49a, min, max);
-    *c.offset((50 * stride) as isize) = iclip(t13 - t50, min, max);
-    *c.offset((51 * stride) as isize) = iclip(t12 - t51a, min, max);
-    *c.offset((52 * stride) as isize) = iclip(t11 - t52, min, max);
-    *c.offset((53 * stride) as isize) = iclip(t10 - t53a, min, max);
-    *c.offset((54 * stride) as isize) = iclip(t9 - t54, min, max);
-    *c.offset((55 * stride) as isize) = iclip(t8 - t55a, min, max);
-    *c.offset((56 * stride) as isize) = iclip(t7 - t56, min, max);
-    *c.offset((57 * stride) as isize) = iclip(t6 - t57a, min, max);
-    *c.offset((58 * stride) as isize) = iclip(t5 - t58, min, max);
-    *c.offset((59 * stride) as isize) = iclip(t4 - t59a, min, max);
-    *c.offset((60 * stride) as isize) = iclip(t3 - t60, min, max);
-    *c.offset((61 * stride) as isize) = iclip(t2 - t61a, min, max);
-    *c.offset((62 * stride) as isize) = iclip(t1 - t62, min, max);
-    *c.offset((63 * stride) as isize) = iclip(t0 - t63a, min, max);
+    let t0 = c[0 * stride];
+    let t1 = c[2 * stride];
+    let t2 = c[4 * stride];
+    let t3 = c[6 * stride];
+    let t4 = c[8 * stride];
+    let t5 = c[10 * stride];
+    let t6 = c[12 * stride];
+    let t7 = c[14 * stride];
+    let t8 = c[16 * stride];
+    let t9 = c[18 * stride];
+    let t10 = c[20 * stride];
+    let t11 = c[22 * stride];
+    let t12 = c[24 * stride];
+    let t13 = c[26 * stride];
+    let t14 = c[28 * stride];
+    let t15 = c[30 * stride];
+    let t16 = c[32 * stride];
+    let t17 = c[34 * stride];
+    let t18 = c[36 * stride];
+    let t19 = c[38 * stride];
+    let t20 = c[40 * stride];
+    let t21 = c[42 * stride];
+    let t22 = c[44 * stride];
+    let t23 = c[46 * stride];
+    let t24 = c[48 * stride];
+    let t25 = c[50 * stride];
+    let t26 = c[52 * stride];
+    let t27 = c[54 * stride];
+    let t28 = c[56 * stride];
+    let t29 = c[58 * stride];
+    let t30 = c[60 * stride];
+    let t31 = c[62 * stride];
+    c[0 * stride] = iclip(t0 + t63a, min, max);
+    c[1 * stride] = iclip(t1 + t62, min, max);
+    c[2 * stride] = iclip(t2 + t61a, min, max);
+    c[3 * stride] = iclip(t3 + t60, min, max);
+    c[4 * stride] = iclip(t4 + t59a, min, max);
+    c[5 * stride] = iclip(t5 + t58, min, max);
+    c[6 * stride] = iclip(t6 + t57a, min, max);
+    c[7 * stride] = iclip(t7 + t56, min, max);
+    c[8 * stride] = iclip(t8 + t55a, min, max);
+    c[9 * stride] = iclip(t9 + t54, min, max);
+    c[10 * stride] = iclip(t10 + t53a, min, max);
+    c[11 * stride] = iclip(t11 + t52, min, max);
+    c[12 * stride] = iclip(t12 + t51a, min, max);
+    c[13 * stride] = iclip(t13 + t50, min, max);
+    c[14 * stride] = iclip(t14 + t49a, min, max);
+    c[15 * stride] = iclip(t15 + t48, min, max);
+    c[16 * stride] = iclip(t16 + t47, min, max);
+    c[17 * stride] = iclip(t17 + t46a, min, max);
+    c[18 * stride] = iclip(t18 + t45, min, max);
+    c[19 * stride] = iclip(t19 + t44a, min, max);
+    c[20 * stride] = iclip(t20 + t43, min, max);
+    c[21 * stride] = iclip(t21 + t42a, min, max);
+    c[22 * stride] = iclip(t22 + t41, min, max);
+    c[23 * stride] = iclip(t23 + t40a, min, max);
+    c[24 * stride] = iclip(t24 + t39, min, max);
+    c[25 * stride] = iclip(t25 + t38a, min, max);
+    c[26 * stride] = iclip(t26 + t37, min, max);
+    c[27 * stride] = iclip(t27 + t36a, min, max);
+    c[28 * stride] = iclip(t28 + t35, min, max);
+    c[29 * stride] = iclip(t29 + t34a, min, max);
+    c[30 * stride] = iclip(t30 + t33, min, max);
+    c[31 * stride] = iclip(t31 + t32a, min, max);
+    c[32 * stride] = iclip(t31 - t32a, min, max);
+    c[33 * stride] = iclip(t30 - t33, min, max);
+    c[34 * stride] = iclip(t29 - t34a, min, max);
+    c[35 * stride] = iclip(t28 - t35, min, max);
+    c[36 * stride] = iclip(t27 - t36a, min, max);
+    c[37 * stride] = iclip(t26 - t37, min, max);
+    c[38 * stride] = iclip(t25 - t38a, min, max);
+    c[39 * stride] = iclip(t24 - t39, min, max);
+    c[40 * stride] = iclip(t23 - t40a, min, max);
+    c[41 * stride] = iclip(t22 - t41, min, max);
+    c[42 * stride] = iclip(t21 - t42a, min, max);
+    c[43 * stride] = iclip(t20 - t43, min, max);
+    c[44 * stride] = iclip(t19 - t44a, min, max);
+    c[45 * stride] = iclip(t18 - t45, min, max);
+    c[46 * stride] = iclip(t17 - t46a, min, max);
+    c[47 * stride] = iclip(t16 - t47, min, max);
+    c[48 * stride] = iclip(t15 - t48, min, max);
+    c[49 * stride] = iclip(t14 - t49a, min, max);
+    c[50 * stride] = iclip(t13 - t50, min, max);
+    c[51 * stride] = iclip(t12 - t51a, min, max);
+    c[52 * stride] = iclip(t11 - t52, min, max);
+    c[53 * stride] = iclip(t10 - t53a, min, max);
+    c[54 * stride] = iclip(t9 - t54, min, max);
+    c[55 * stride] = iclip(t8 - t55a, min, max);
+    c[56 * stride] = iclip(t7 - t56, min, max);
+    c[57 * stride] = iclip(t6 - t57a, min, max);
+    c[58 * stride] = iclip(t5 - t58, min, max);
+    c[59 * stride] = iclip(t4 - t59a, min, max);
+    c[60 * stride] = iclip(t3 - t60, min, max);
+    c[61 * stride] = iclip(t2 - t61a, min, max);
+    c[62 * stride] = iclip(t1 - t62, min, max);
+    c[63 * stride] = iclip(t0 - t63a, min, max);
 }
 
 #[inline(never)]
 unsafe fn inv_adst4_1d_internal_c(
-    in_0: *const i32,
-    in_s: NonZeroUsize,
+    c: &mut [i32],
+    stride: NonZeroUsize,
+    out_backwards: bool,
     _min: c_int,
     _max: c_int,
-    out: *mut i32,
-    out_s: NonZeroIsize,
 ) {
-    let in_s = in_s.get();
-    let out_s = out_s.get();
+    let stride = stride.get();
 
-    let in0 = *in_0.offset((0 * in_s) as isize);
-    let in1 = *in_0.offset((1 * in_s) as isize);
-    let in2 = *in_0.offset((2 * in_s) as isize);
-    let in3 = *in_0.offset((3 * in_s) as isize);
-    *out.offset((0 * out_s) as isize) =
+    let in_0 = &c[..];
+    let in_s = stride;
+
+    let in0 = in_0[0 * in_s];
+    let in1 = in_0[1 * in_s];
+    let in2 = in_0[2 * in_s];
+    let in3 = in_0[3 * in_s];
+
+    let out = &mut c[..];
+    let stride = stride as isize;
+    let (out_off, out_s) = if out_backwards {
+        ((4 - 1) * stride, -stride)
+    } else {
+        (0, stride)
+    };
+
+    out[(out_off + 0 * out_s) as usize] =
         (1321 * in0 + (3803 - 4096) * in2 + (2482 - 4096) * in3 + (3344 - 4096) * in1 + 2048 >> 12)
             + in2
             + in3
             + in1;
-    *out.offset((1 * out_s) as isize) =
+    out[(out_off + 1 * out_s) as usize] =
         ((2482 - 4096) * in0 - 1321 * in2 - (3803 - 4096) * in3 + (3344 - 4096) * in1 + 2048 >> 12)
             + in0
             - in3
             + in1;
-    *out.offset((2 * out_s) as isize) = 209 * (in0 - in2 + in3) + 128 >> 8;
-    *out.offset((3 * out_s) as isize) =
+    out[(out_off + 2 * out_s) as usize] = 209 * (in0 - in2 + in3) + 128 >> 8;
+    out[(out_off + 3 * out_s) as usize] =
         ((3803 - 4096) * in0 + (2482 - 4096) * in2 - 1321 * in3 - (3344 - 4096) * in1 + 2048 >> 12)
             + in0
             + in2
@@ -778,24 +787,25 @@ unsafe fn inv_adst4_1d_internal_c(
 
 #[inline(never)]
 unsafe fn inv_adst8_1d_internal_c(
-    in_0: *const i32,
-    in_s: NonZeroUsize,
+    c: &mut [i32],
+    stride: NonZeroUsize,
+    out_backwards: bool,
     min: c_int,
     max: c_int,
-    out: *mut i32,
-    out_s: NonZeroIsize,
 ) {
-    let in_s = in_s.get();
-    let out_s = out_s.get();
+    let stride = stride.get();
 
-    let in0 = *in_0.offset((0 * in_s) as isize);
-    let in1 = *in_0.offset((1 * in_s) as isize);
-    let in2 = *in_0.offset((2 * in_s) as isize);
-    let in3 = *in_0.offset((3 * in_s) as isize);
-    let in4 = *in_0.offset((4 * in_s) as isize);
-    let in5 = *in_0.offset((5 * in_s) as isize);
-    let in6 = *in_0.offset((6 * in_s) as isize);
-    let in7 = *in_0.offset((7 * in_s) as isize);
+    let in_0 = &c[..];
+    let in_s = stride;
+
+    let in0 = in_0[0 * in_s];
+    let in1 = in_0[1 * in_s];
+    let in2 = in_0[2 * in_s];
+    let in3 = in_0[3 * in_s];
+    let in4 = in_0[4 * in_s];
+    let in5 = in_0[5 * in_s];
+    let in6 = in_0[6 * in_s];
+    let in7 = in_0[7 * in_s];
     let t0a = ((4076 - 4096) * in7 + 401 * in0 + 2048 >> 12) + in7;
     let t1a = (401 * in7 - (4076 - 4096) * in0 + 2048 >> 12) - in0;
     let t2a = ((3612 - 4096) * in5 + 1931 * in2 + 2048 >> 12) + in5;
@@ -816,48 +826,58 @@ unsafe fn inv_adst8_1d_internal_c(
     t5a = (1567 * t4 - (3784 - 4096) * t5 + 2048 >> 12) - t5;
     t6a = ((3784 - 4096) * t7 - 1567 * t6 + 2048 >> 12) + t7;
     t7a = (1567 * t7 + (3784 - 4096) * t6 + 2048 >> 12) + t6;
-    *out.offset((0 * out_s) as isize) = iclip(t0 + t2, min, max);
-    *out.offset((7 * out_s) as isize) = -iclip(t1 + t3, min, max);
+
+    let out = &mut c[..];
+    let stride = stride as isize;
+    let (out_off, out_s) = if out_backwards {
+        ((8 - 1) * stride, -stride)
+    } else {
+        (0, stride)
+    };
+
+    out[(out_off + 0 * out_s) as usize] = iclip(t0 + t2, min, max);
+    out[(out_off + 7 * out_s) as usize] = -iclip(t1 + t3, min, max);
     t2 = iclip(t0 - t2, min, max);
     t3 = iclip(t1 - t3, min, max);
-    *out.offset((1 * out_s) as isize) = -iclip(t4a + t6a, min, max);
-    *out.offset((6 * out_s) as isize) = iclip(t5a + t7a, min, max);
+    out[(out_off + 1 * out_s) as usize] = -iclip(t4a + t6a, min, max);
+    out[(out_off + 6 * out_s) as usize] = iclip(t5a + t7a, min, max);
     t6 = iclip(t4a - t6a, min, max);
     t7 = iclip(t5a - t7a, min, max);
-    *out.offset((3 * out_s) as isize) = -((t2 + t3) * 181 + 128 >> 8);
-    *out.offset((4 * out_s) as isize) = (t2 - t3) * 181 + 128 >> 8;
-    *out.offset((2 * out_s) as isize) = (t6 + t7) * 181 + 128 >> 8;
-    *out.offset((5 * out_s) as isize) = -((t6 - t7) * 181 + 128 >> 8);
+    out[(out_off + 3 * out_s) as usize] = -((t2 + t3) * 181 + 128 >> 8);
+    out[(out_off + 4 * out_s) as usize] = (t2 - t3) * 181 + 128 >> 8;
+    out[(out_off + 2 * out_s) as usize] = (t6 + t7) * 181 + 128 >> 8;
+    out[(out_off + 5 * out_s) as usize] = -((t6 - t7) * 181 + 128 >> 8);
 }
 
 #[inline(never)]
 unsafe fn inv_adst16_1d_internal_c(
-    in_0: *const i32,
-    in_s: NonZeroUsize,
+    c: &mut [i32],
+    stride: NonZeroUsize,
+    out_backwards: bool,
     min: c_int,
     max: c_int,
-    out: *mut i32,
-    out_s: NonZeroIsize,
 ) {
-    let in_s = in_s.get();
-    let out_s = out_s.get();
+    let stride = stride.get();
 
-    let in0 = *in_0.offset((0 * in_s) as isize);
-    let in1 = *in_0.offset((1 * in_s) as isize);
-    let in2 = *in_0.offset((2 * in_s) as isize);
-    let in3 = *in_0.offset((3 * in_s) as isize);
-    let in4 = *in_0.offset((4 * in_s) as isize);
-    let in5 = *in_0.offset((5 * in_s) as isize);
-    let in6 = *in_0.offset((6 * in_s) as isize);
-    let in7 = *in_0.offset((7 * in_s) as isize);
-    let in8 = *in_0.offset((8 * in_s) as isize);
-    let in9 = *in_0.offset((9 * in_s) as isize);
-    let in10 = *in_0.offset((10 * in_s) as isize);
-    let in11 = *in_0.offset((11 * in_s) as isize);
-    let in12 = *in_0.offset((12 * in_s) as isize);
-    let in13 = *in_0.offset((13 * in_s) as isize);
-    let in14 = *in_0.offset((14 * in_s) as isize);
-    let in15 = *in_0.offset((15 * in_s) as isize);
+    let in_0 = &c[..];
+    let in_s = stride;
+
+    let in0 = in_0[0 * in_s];
+    let in1 = in_0[1 * in_s];
+    let in2 = in_0[2 * in_s];
+    let in3 = in_0[3 * in_s];
+    let in4 = in_0[4 * in_s];
+    let in5 = in_0[5 * in_s];
+    let in6 = in_0[6 * in_s];
+    let in7 = in_0[7 * in_s];
+    let in8 = in_0[8 * in_s];
+    let in9 = in_0[9 * in_s];
+    let in10 = in_0[10 * in_s];
+    let in11 = in_0[11 * in_s];
+    let in12 = in_0[12 * in_s];
+    let in13 = in_0[13 * in_s];
+    let in14 = in_0[14 * in_s];
+    let in15 = in_0[15 * in_s];
     let mut t0 = (in15 * (4091 - 4096) + in0 * 201 + 2048 >> 12) + in15;
     let mut t1 = (in15 * 201 - in0 * (4091 - 4096) + 2048 >> 12) - in0;
     let mut t2 = (in13 * (3973 - 4096) + in2 * 995 + 2048 >> 12) + in13;
@@ -922,79 +942,82 @@ unsafe fn inv_adst16_1d_internal_c(
     t13 = (t12a * 1567 - t13a * (3784 - 4096) + 2048 >> 12) - t13a;
     t14 = (t15a * (3784 - 4096) - t14a * 1567 + 2048 >> 12) + t15a;
     t15 = (t15a * 1567 + t14a * (3784 - 4096) + 2048 >> 12) + t14a;
-    *out.offset((0 * out_s) as isize) = iclip(t0 + t2, min, max);
-    *out.offset((15 * out_s) as isize) = -iclip(t1 + t3, min, max);
+
+    let out = &mut c[..];
+    let stride = stride as isize;
+    let (out_off, out_s) = if out_backwards {
+        ((16 - 1) * stride, -stride)
+    } else {
+        (0, stride)
+    };
+
+    out[(out_off + 0 * out_s) as usize] = iclip(t0 + t2, min, max);
+    out[(out_off + 15 * out_s) as usize] = -iclip(t1 + t3, min, max);
     t2a = iclip(t0 - t2, min, max);
     t3a = iclip(t1 - t3, min, max);
-    *out.offset((3 * out_s) as isize) = -iclip(t4a + t6a, min, max);
-    *out.offset((12 * out_s) as isize) = iclip(t5a + t7a, min, max);
+    out[(out_off + 3 * out_s) as usize] = -iclip(t4a + t6a, min, max);
+    out[(out_off + 12 * out_s) as usize] = iclip(t5a + t7a, min, max);
     t6 = iclip(t4a - t6a, min, max);
     t7 = iclip(t5a - t7a, min, max);
-    *out.offset((1 * out_s) as isize) = -iclip(t8a + t10a, min, max);
-    *out.offset((14 * out_s) as isize) = iclip(t9a + t11a, min, max);
+    out[(out_off + 1 * out_s) as usize] = -iclip(t8a + t10a, min, max);
+    out[(out_off + 14 * out_s) as usize] = iclip(t9a + t11a, min, max);
     t10 = iclip(t8a - t10a, min, max);
     t11 = iclip(t9a - t11a, min, max);
-    *out.offset((2 * out_s) as isize) = iclip(t12 + t14, min, max);
-    *out.offset((13 * out_s) as isize) = -iclip(t13 + t15, min, max);
+    out[(out_off + 2 * out_s) as usize] = iclip(t12 + t14, min, max);
+    out[(out_off + 13 * out_s) as usize] = -iclip(t13 + t15, min, max);
     t14a = iclip(t12 - t14, min, max);
     t15a = iclip(t13 - t15, min, max);
-    *out.offset((7 * out_s) as isize) = -((t2a + t3a) * 181 + 128 >> 8);
-    *out.offset((8 * out_s) as isize) = (t2a - t3a) * 181 + 128 >> 8;
-    *out.offset((4 * out_s) as isize) = (t6 + t7) * 181 + 128 >> 8;
-    *out.offset((11 * out_s) as isize) = -((t6 - t7) * 181 + 128 >> 8);
-    *out.offset((6 * out_s) as isize) = (t10 + t11) * 181 + 128 >> 8;
-    *out.offset((9 * out_s) as isize) = -((t10 - t11) * 181 + 128 >> 8);
-    *out.offset((5 * out_s) as isize) = -((t14a + t15a) * 181 + 128 >> 8);
-    *out.offset((10 * out_s) as isize) = (t14a - t15a) * 181 + 128 >> 8;
+    out[(out_off + 7 * out_s) as usize] = -((t2a + t3a) * 181 + 128 >> 8);
+    out[(out_off + 8 * out_s) as usize] = (t2a - t3a) * 181 + 128 >> 8;
+    out[(out_off + 4 * out_s) as usize] = (t6 + t7) * 181 + 128 >> 8;
+    out[(out_off + 11 * out_s) as usize] = -((t6 - t7) * 181 + 128 >> 8);
+    out[(out_off + 6 * out_s) as usize] = (t10 + t11) * 181 + 128 >> 8;
+    out[(out_off + 9 * out_s) as usize] = -((t10 - t11) * 181 + 128 >> 8);
+    out[(out_off + 5 * out_s) as usize] = -((t14a + t15a) * 181 + 128 >> 8);
+    out[(out_off + 10 * out_s) as usize] = (t14a - t15a) * 181 + 128 >> 8;
 }
 
-pub unsafe fn dav1d_inv_flipadst4_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
-    inv_adst4_1d_internal_c(
-        c,
-        stride,
-        min,
-        max,
-        &mut *c.add((4 - 1) * stride.get()),
-        (-(stride.get() as isize)).try_into().unwrap(),
-    );
+pub unsafe fn dav1d_inv_flipadst4_1d_c(
+    c: &mut [i32],
+    stride: NonZeroUsize,
+    min: c_int,
+    max: c_int,
+) {
+    inv_adst4_1d_internal_c(c, stride, true, min, max);
 }
 
-pub unsafe fn dav1d_inv_adst4_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
-    inv_adst4_1d_internal_c(c, stride, min, max, c, stride.try_into().unwrap());
+pub unsafe fn dav1d_inv_adst4_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+    inv_adst4_1d_internal_c(c, stride, false, min, max);
 }
 
-pub unsafe fn dav1d_inv_adst8_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
-    inv_adst8_1d_internal_c(c, stride, min, max, c, stride.try_into().unwrap());
+pub unsafe fn dav1d_inv_adst8_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+    inv_adst8_1d_internal_c(c, stride, false, min, max);
 }
 
-pub unsafe fn dav1d_inv_flipadst8_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
-    inv_adst8_1d_internal_c(
-        c,
-        stride,
-        min,
-        max,
-        &mut *c.add((8 - 1) * stride.get()),
-        (-(stride.get() as isize)).try_into().unwrap(),
-    );
+pub unsafe fn dav1d_inv_flipadst8_1d_c(
+    c: &mut [i32],
+    stride: NonZeroUsize,
+    min: c_int,
+    max: c_int,
+) {
+    inv_adst8_1d_internal_c(c, stride, true, min, max);
 }
 
-pub unsafe fn dav1d_inv_flipadst16_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
-    inv_adst16_1d_internal_c(
-        c,
-        stride,
-        min,
-        max,
-        &mut *c.add((16 - 1) * stride.get()),
-        (-(stride.get() as isize)).try_into().unwrap(),
-    );
+pub unsafe fn dav1d_inv_flipadst16_1d_c(
+    c: &mut [i32],
+    stride: NonZeroUsize,
+    min: c_int,
+    max: c_int,
+) {
+    inv_adst16_1d_internal_c(c, stride, true, min, max);
 }
 
-pub unsafe fn dav1d_inv_adst16_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
-    inv_adst16_1d_internal_c(c, stride, min, max, c, stride.try_into().unwrap());
+pub unsafe fn dav1d_inv_adst16_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+    inv_adst16_1d_internal_c(c, stride, false, min, max);
 }
 
 pub unsafe fn dav1d_inv_identity4_1d_c(
-    c: *mut i32,
+    c: &mut [i32],
     stride: NonZeroUsize,
     _min: c_int,
     _max: c_int,
@@ -1003,14 +1026,14 @@ pub unsafe fn dav1d_inv_identity4_1d_c(
 
     let mut i = 0;
     while i < 4 {
-        let in_0 = *c.offset((stride * i) as isize);
-        *c.offset((stride * i) as isize) = in_0 + (in_0 * 1697 + 2048 >> 12);
+        let in_0 = c[stride * i];
+        c[stride * i] = in_0 + (in_0 * 1697 + 2048 >> 12);
         i += 1;
     }
 }
 
 pub unsafe fn dav1d_inv_identity8_1d_c(
-    c: *mut i32,
+    c: &mut [i32],
     stride: NonZeroUsize,
     _min: c_int,
     _max: c_int,
@@ -1019,14 +1042,13 @@ pub unsafe fn dav1d_inv_identity8_1d_c(
 
     let mut i = 0;
     while i < 8 {
-        let ref mut fresh0 = *c.offset((stride * i) as isize);
-        *fresh0 *= 2 as c_int;
+        c[stride * i] *= 2;
         i += 1;
     }
 }
 
 pub unsafe fn dav1d_inv_identity16_1d_c(
-    c: *mut i32,
+    c: &mut [i32],
     stride: NonZeroUsize,
     _min: c_int,
     _max: c_int,
@@ -1035,14 +1057,14 @@ pub unsafe fn dav1d_inv_identity16_1d_c(
 
     let mut i = 0;
     while i < 16 {
-        let in_0 = *c.offset((stride * i) as isize);
-        *c.offset((stride * i) as isize) = 2 * in_0 + (in_0 * 1697 + 1024 >> 11);
+        let in_0 = c[stride * i];
+        c[stride * i] = 2 * in_0 + (in_0 * 1697 + 1024 >> 11);
         i += 1;
     }
 }
 
 pub unsafe fn dav1d_inv_identity32_1d_c(
-    c: *mut i32,
+    c: &mut [i32],
     stride: NonZeroUsize,
     _min: c_int,
     _max: c_int,
@@ -1051,26 +1073,25 @@ pub unsafe fn dav1d_inv_identity32_1d_c(
 
     let mut i = 0;
     while i < 32 {
-        let ref mut fresh1 = *c.offset((stride * i) as isize);
-        *fresh1 *= 4 as c_int;
+        c[stride * i] *= 4;
         i += 1;
     }
 }
 
-pub unsafe fn dav1d_inv_wht4_1d_c(c: *mut i32, stride: NonZeroUsize) {
+pub unsafe fn dav1d_inv_wht4_1d_c(c: &mut [i32], stride: NonZeroUsize) {
     let stride = stride.get();
 
-    let in0 = *c.offset((0 * stride) as isize);
-    let in1 = *c.offset((1 * stride) as isize);
-    let in2 = *c.offset((2 * stride) as isize);
-    let in3 = *c.offset((3 * stride) as isize);
+    let in0 = c[0 * stride];
+    let in1 = c[1 * stride];
+    let in2 = c[2 * stride];
+    let in3 = c[3 * stride];
     let t0 = in0 + in1;
     let t2 = in2 - in3;
     let t4 = t0 - t2 >> 1;
     let t3 = t4 - in3;
     let t1 = t4 - in1;
-    *c.offset((0 * stride) as isize) = t0 - t3;
-    *c.offset((1 * stride) as isize) = t3;
-    *c.offset((2 * stride) as isize) = t1;
-    *c.offset((3 * stride) as isize) = t2 + t1;
+    c[0 * stride] = t0 - t3;
+    c[1 * stride] = t3;
+    c[2 * stride] = t1;
+    c[3 * stride] = t2 + t1;
 }

--- a/src/itx_1d.rs
+++ b/src/itx_1d.rs
@@ -81,7 +81,7 @@ fn inv_dct4_1d_internal_c(
 }
 
 pub fn dav1d_inv_dct4_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
-    inv_dct4_1d_internal_c(c, stride, min, max, 0 as c_int);
+    inv_dct4_1d_internal_c(c, stride, min, max, 0);
 }
 
 #[inline(never)]
@@ -106,7 +106,7 @@ fn inv_dct8_1d_internal_c(
     let t7a;
     if tx64 != 0 {
         t4a = in1 * 799 + 2048 >> 12;
-        t5a = in3 * -(2276 as c_int) + 2048 >> 12;
+        t5a = in3 * -2276 + 2048 >> 12;
         t6a = in3 * 3406 + 2048 >> 12;
         t7a = in1 * 4017 + 2048 >> 12;
     } else {
@@ -143,7 +143,7 @@ fn inv_dct8_1d_internal_c(
 }
 
 pub fn dav1d_inv_dct8_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
-    inv_dct8_1d_internal_c(c, stride, min, max, 0 as c_int);
+    inv_dct8_1d_internal_c(c, stride, min, max, 0);
 }
 
 #[inline(never)]
@@ -174,9 +174,9 @@ fn inv_dct16_1d_internal_c(
     let mut t15a;
     if tx64 != 0 {
         t8a = in1 * 401 + 2048 >> 12;
-        t9a = in7 * -(2598 as c_int) + 2048 >> 12;
+        t9a = in7 * -2598 + 2048 >> 12;
         t10a = in5 * 1931 + 2048 >> 12;
-        t11a = in3 * -(1189 as c_int) + 2048 >> 12;
+        t11a = in3 * -1189 + 2048 >> 12;
         t12a = in3 * 3920 + 2048 >> 12;
         t13a = in5 * 3612 + 2048 >> 12;
         t14a = in7 * 3166 + 2048 >> 12;
@@ -252,7 +252,7 @@ fn inv_dct16_1d_internal_c(
 }
 
 pub fn dav1d_inv_dct16_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
-    inv_dct16_1d_internal_c(c, stride, min, max, 0 as c_int);
+    inv_dct16_1d_internal_c(c, stride, min, max, 0);
 }
 
 #[inline(never)]
@@ -295,13 +295,13 @@ fn inv_dct32_1d_internal_c(
     let mut t31a;
     if tx64 != 0 {
         t16a = in1 * 201 + 2048 >> 12;
-        t17a = in15 * -(2751 as c_int) + 2048 >> 12;
+        t17a = in15 * -2751 + 2048 >> 12;
         t18a = in9 * 1751 + 2048 >> 12;
-        t19a = in7 * -(1380 as c_int) + 2048 >> 12;
+        t19a = in7 * -1380 + 2048 >> 12;
         t20a = in5 * 995 + 2048 >> 12;
-        t21a = in11 * -(2106 as c_int) + 2048 >> 12;
+        t21a = in11 * -2106 + 2048 >> 12;
         t22a = in13 * 2440 + 2048 >> 12;
-        t23a = in3 * -(601 as c_int) + 2048 >> 12;
+        t23a = in3 * -601 + 2048 >> 12;
         t24a = in3 * 4052 + 2048 >> 12;
         t25a = in13 * 3290 + 2048 >> 12;
         t26a = in11 * 3513 + 2048 >> 12;
@@ -468,14 +468,14 @@ fn inv_dct32_1d_internal_c(
 }
 
 pub fn dav1d_inv_dct32_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
-    inv_dct32_1d_internal_c(c, stride, min, max, 0 as c_int);
+    inv_dct32_1d_internal_c(c, stride, min, max, 0);
 }
 
 pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     let clip = |v| iclip(v, min, max);
     let stride = stride.get();
 
-    inv_dct32_1d_internal_c(c, (stride << 1).try_into().unwrap(), min, max, 1 as c_int);
+    inv_dct32_1d_internal_c(c, (stride << 1).try_into().unwrap(), min, max, 1);
 
     let in1 = c[1 * stride];
     let in3 = c[3 * stride];
@@ -495,21 +495,21 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
     let in31 = c[31 * stride];
 
     let mut t32a = in1 * 101 + 2048 >> 12;
-    let mut t33a = in31 * -(2824 as c_int) + 2048 >> 12;
+    let mut t33a = in31 * -2824 + 2048 >> 12;
     let mut t34a = in17 * 1660 + 2048 >> 12;
-    let mut t35a = in15 * -(1474 as c_int) + 2048 >> 12;
+    let mut t35a = in15 * -1474 + 2048 >> 12;
     let mut t36a = in9 * 897 + 2048 >> 12;
-    let mut t37a = in23 * -(2191 as c_int) + 2048 >> 12;
+    let mut t37a = in23 * -2191 + 2048 >> 12;
     let mut t38a = in25 * 2359 + 2048 >> 12;
-    let mut t39a = in7 * -(700 as c_int) + 2048 >> 12;
+    let mut t39a = in7 * -700 + 2048 >> 12;
     let mut t40a = in5 * 501 + 2048 >> 12;
-    let mut t41a = in27 * -(2520 as c_int) + 2048 >> 12;
+    let mut t41a = in27 * -2520 + 2048 >> 12;
     let mut t42a = in21 * 2019 + 2048 >> 12;
-    let mut t43a = in11 * -(1092 as c_int) + 2048 >> 12;
+    let mut t43a = in11 * -1092 + 2048 >> 12;
     let mut t44a = in13 * 1285 + 2048 >> 12;
-    let mut t45a = in19 * -(1842 as c_int) + 2048 >> 12;
+    let mut t45a = in19 * -1842 + 2048 >> 12;
     let mut t46a = in29 * 2675 + 2048 >> 12;
-    let mut t47a = in3 * -(301 as c_int) + 2048 >> 12;
+    let mut t47a = in3 * -301 + 2048 >> 12;
     let mut t48a = in3 * 4085 + 2048 >> 12;
     let mut t49a = in29 * 3102 + 2048 >> 12;
     let mut t50a = in19 * 3659 + 2048 >> 12;
@@ -561,18 +561,18 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
     let mut t63 = clip(t63a + t62a);
 
     t33a = (t33 * (4096 - 4076) + t62 * 401 + 2048 >> 12) - t33;
-    t34a = (t34 * -(401 as c_int) + t61 * (4096 - 4076) + 2048 >> 12) - t61;
-    t37a = t37 * -(1299 as c_int) + t58 * 1583 + 1024 >> 11;
-    t38a = t38 * -(1583 as c_int) + t57 * -(1299 as c_int) + 1024 >> 11;
+    t34a = (t34 * -401 + t61 * (4096 - 4076) + 2048 >> 12) - t61;
+    t37a = t37 * -1299 + t58 * 1583 + 1024 >> 11;
+    t38a = t38 * -1583 + t57 * -1299 + 1024 >> 11;
     t41a = (t41 * (4096 - 3612) + t54 * 1931 + 2048 >> 12) - t41;
-    t42a = (t42 * -(1931 as c_int) + t53 * (4096 - 3612) + 2048 >> 12) - t53;
-    t45a = (t45 * -(1189 as c_int) + t50 * (3920 - 4096) + 2048 >> 12) + t50;
-    t46a = (t46 * (4096 - 3920) + t49 * -(1189 as c_int) + 2048 >> 12) - t46;
-    t49a = (t46 * -(1189 as c_int) + t49 * (3920 - 4096) + 2048 >> 12) + t49;
+    t42a = (t42 * -1931 + t53 * (4096 - 3612) + 2048 >> 12) - t53;
+    t45a = (t45 * -1189 + t50 * (3920 - 4096) + 2048 >> 12) + t50;
+    t46a = (t46 * (4096 - 3920) + t49 * -1189 + 2048 >> 12) - t46;
+    t49a = (t46 * -1189 + t49 * (3920 - 4096) + 2048 >> 12) + t49;
     t50a = (t45 * (3920 - 4096) + t50 * 1189 + 2048 >> 12) + t45;
     t53a = (t42 * (4096 - 3612) + t53 * 1931 + 2048 >> 12) - t42;
     t54a = (t41 * 1931 + t54 * (3612 - 4096) + 2048 >> 12) + t54;
-    t57a = t38 * -(1299 as c_int) + t57 * 1583 + 1024 >> 11;
+    t57a = t38 * -1299 + t57 * 1583 + 1024 >> 11;
     t58a = t37 * 1583 + t58 * 1299 + 1024 >> 11;
     t61a = (t34 * (4096 - 4076) + t61 * 401 + 2048 >> 12) - t34;
     t62a = (t33 * 401 + t62 * (4076 - 4096) + 2048 >> 12) + t62;
@@ -612,14 +612,14 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
 
     t34a = (t34 * (4096 - 4017) + t61 * 799 + 2048 >> 12) - t34;
     t35 = (t35a * (4096 - 4017) + t60a * 799 + 2048 >> 12) - t35a;
-    t36 = (t36a * -(799 as c_int) + t59a * (4096 - 4017) + 2048 >> 12) - t59a;
-    t37a = (t37 * -(799 as c_int) + t58 * (4096 - 4017) + 2048 >> 12) - t58;
-    t42a = t42 * -(1138 as c_int) + t53 * 1703 + 1024 >> 11;
-    t43 = t43a * -(1138 as c_int) + t52a * 1703 + 1024 >> 11;
-    t44 = t44a * -(1703 as c_int) + t51a * -(1138 as c_int) + 1024 >> 11;
-    t45a = t45 * -(1703 as c_int) + t50 * -(1138 as c_int) + 1024 >> 11;
-    t50a = t45 * -(1138 as c_int) + t50 * 1703 + 1024 >> 11;
-    t51 = t44a * -(1138 as c_int) + t51a * 1703 + 1024 >> 11;
+    t36 = (t36a * -799 + t59a * (4096 - 4017) + 2048 >> 12) - t59a;
+    t37a = (t37 * -799 + t58 * (4096 - 4017) + 2048 >> 12) - t58;
+    t42a = t42 * -1138 + t53 * 1703 + 1024 >> 11;
+    t43 = t43a * -1138 + t52a * 1703 + 1024 >> 11;
+    t44 = t44a * -1703 + t51a * -1138 + 1024 >> 11;
+    t45a = t45 * -1703 + t50 * -1138 + 1024 >> 11;
+    t50a = t45 * -1138 + t50 * 1703 + 1024 >> 11;
+    t51 = t44a * -1138 + t51a * 1703 + 1024 >> 11;
     t52 = t43a * 1703 + t52a * 1138 + 1024 >> 11;
     t53a = t42 * 1703 + t53 * 1138 + 1024 >> 11;
     t58a = (t37 * (4096 - 4017) + t58 * 799 + 2048 >> 12) - t37;
@@ -664,10 +664,10 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
     t37a = (t37 * (4096 - 3784) + t58 * 1567 + 2048 >> 12) - t37;
     t38 = (t38a * (4096 - 3784) + t57a * 1567 + 2048 >> 12) - t38a;
     t39a = (t39 * (4096 - 3784) + t56 * 1567 + 2048 >> 12) - t39;
-    t40a = (t40 * -(1567 as c_int) + t55 * (4096 - 3784) + 2048 >> 12) - t55;
-    t41 = (t41a * -(1567 as c_int) + t54a * (4096 - 3784) + 2048 >> 12) - t54a;
-    t42a = (t42 * -(1567 as c_int) + t53 * (4096 - 3784) + 2048 >> 12) - t53;
-    t43 = (t43a * -(1567 as c_int) + t52a * (4096 - 3784) + 2048 >> 12) - t52a;
+    t40a = (t40 * -1567 + t55 * (4096 - 3784) + 2048 >> 12) - t55;
+    t41 = (t41a * -1567 + t54a * (4096 - 3784) + 2048 >> 12) - t54a;
+    t42a = (t42 * -1567 + t53 * (4096 - 3784) + 2048 >> 12) - t53;
+    t43 = (t43a * -1567 + t52a * (4096 - 3784) + 2048 >> 12) - t52a;
     t52 = (t43a * (4096 - 3784) + t52a * 1567 + 2048 >> 12) - t43a;
     t53a = (t42 * (4096 - 3784) + t53 * 1567 + 2048 >> 12) - t42;
     t54 = (t41a * (4096 - 3784) + t54a * 1567 + 2048 >> 12) - t41a;

--- a/src/itx_1d.rs
+++ b/src/itx_1d.rs
@@ -1006,42 +1006,34 @@ pub fn dav1d_inv_adst16_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, ma
 pub fn dav1d_inv_identity4_1d_c(c: &mut [i32], stride: NonZeroUsize, _min: c_int, _max: c_int) {
     let stride = stride.get();
 
-    let mut i = 0;
-    while i < 4 {
+    for i in 0..4 {
         let in_0 = c[stride * i];
         c[stride * i] = in_0 + (in_0 * 1697 + 2048 >> 12);
-        i += 1;
     }
 }
 
 pub fn dav1d_inv_identity8_1d_c(c: &mut [i32], stride: NonZeroUsize, _min: c_int, _max: c_int) {
     let stride = stride.get();
 
-    let mut i = 0;
-    while i < 8 {
+    for i in 0..8 {
         c[stride * i] *= 2;
-        i += 1;
     }
 }
 
 pub fn dav1d_inv_identity16_1d_c(c: &mut [i32], stride: NonZeroUsize, _min: c_int, _max: c_int) {
     let stride = stride.get();
 
-    let mut i = 0;
-    while i < 16 {
+    for i in 0..16 {
         let in_0 = c[stride * i];
         c[stride * i] = 2 * in_0 + (in_0 * 1697 + 1024 >> 11);
-        i += 1;
     }
 }
 
 pub fn dav1d_inv_identity32_1d_c(c: &mut [i32], stride: NonZeroUsize, _min: c_int, _max: c_int) {
     let stride = stride.get();
 
-    let mut i = 0;
-    while i < 32 {
+    for i in 0..32 {
         c[stride * i] *= 4;
-        i += 1;
     }
 }
 

--- a/src/itx_1d.rs
+++ b/src/itx_1d.rs
@@ -38,12 +38,7 @@ unsafe fn inv_dct4_1d_internal_c(
     *c.offset((3 * stride) as isize) = iclip(t0 - t3, min, max);
 }
 
-pub unsafe extern "C" fn dav1d_inv_dct4_1d_c(
-    c: *mut i32,
-    stride: NonZeroUsize,
-    min: c_int,
-    max: c_int,
-) {
+pub unsafe fn dav1d_inv_dct4_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_dct4_1d_internal_c(c, stride, min, max, 0 as c_int);
 }
 
@@ -97,12 +92,7 @@ unsafe fn inv_dct8_1d_internal_c(
     *c.offset((7 * stride) as isize) = iclip(t0 - t7, min, max);
 }
 
-pub unsafe extern "C" fn dav1d_inv_dct8_1d_c(
-    c: *mut i32,
-    stride: NonZeroUsize,
-    min: c_int,
-    max: c_int,
-) {
+pub unsafe fn dav1d_inv_dct8_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_dct8_1d_internal_c(c, stride, min, max, 0 as c_int);
 }
 
@@ -202,12 +192,7 @@ unsafe fn inv_dct16_1d_internal_c(
     *c.offset((15 * stride) as isize) = iclip(t0 - t15a, min, max);
 }
 
-pub unsafe extern "C" fn dav1d_inv_dct16_1d_c(
-    c: *mut i32,
-    stride: NonZeroUsize,
-    min: c_int,
-    max: c_int,
-) {
+pub unsafe fn dav1d_inv_dct16_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_dct16_1d_internal_c(c, stride, min, max, 0 as c_int);
 }
 
@@ -411,21 +396,11 @@ unsafe fn inv_dct32_1d_internal_c(
     *c.offset((31 * stride) as isize) = iclip(t0 - t31, min, max);
 }
 
-pub unsafe extern "C" fn dav1d_inv_dct32_1d_c(
-    c: *mut i32,
-    stride: NonZeroUsize,
-    min: c_int,
-    max: c_int,
-) {
+pub unsafe fn dav1d_inv_dct32_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_dct32_1d_internal_c(c, stride, min, max, 0 as c_int);
 }
 
-pub unsafe extern "C" fn dav1d_inv_dct64_1d_c(
-    c: *mut i32,
-    stride: NonZeroUsize,
-    min: c_int,
-    max: c_int,
-) {
+pub unsafe fn dav1d_inv_dct64_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
     let stride = stride.get();
 
     inv_dct32_1d_internal_c(c, (stride << 1).try_into().unwrap(), min, max, 1 as c_int);
@@ -973,12 +948,7 @@ unsafe fn inv_adst16_1d_internal_c(
     *out.offset((10 * out_s) as isize) = (t14a - t15a) * 181 + 128 >> 8;
 }
 
-pub unsafe extern "C" fn dav1d_inv_flipadst4_1d_c(
-    c: *mut i32,
-    stride: NonZeroUsize,
-    min: c_int,
-    max: c_int,
-) {
+pub unsafe fn dav1d_inv_flipadst4_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_adst4_1d_internal_c(
         c,
         stride,
@@ -989,30 +959,15 @@ pub unsafe extern "C" fn dav1d_inv_flipadst4_1d_c(
     );
 }
 
-pub unsafe extern "C" fn dav1d_inv_adst4_1d_c(
-    c: *mut i32,
-    stride: NonZeroUsize,
-    min: c_int,
-    max: c_int,
-) {
+pub unsafe fn dav1d_inv_adst4_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_adst4_1d_internal_c(c, stride, min, max, c, stride.try_into().unwrap());
 }
 
-pub unsafe extern "C" fn dav1d_inv_adst8_1d_c(
-    c: *mut i32,
-    stride: NonZeroUsize,
-    min: c_int,
-    max: c_int,
-) {
+pub unsafe fn dav1d_inv_adst8_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_adst8_1d_internal_c(c, stride, min, max, c, stride.try_into().unwrap());
 }
 
-pub unsafe extern "C" fn dav1d_inv_flipadst8_1d_c(
-    c: *mut i32,
-    stride: NonZeroUsize,
-    min: c_int,
-    max: c_int,
-) {
+pub unsafe fn dav1d_inv_flipadst8_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_adst8_1d_internal_c(
         c,
         stride,
@@ -1023,12 +978,7 @@ pub unsafe extern "C" fn dav1d_inv_flipadst8_1d_c(
     );
 }
 
-pub unsafe extern "C" fn dav1d_inv_flipadst16_1d_c(
-    c: *mut i32,
-    stride: NonZeroUsize,
-    min: c_int,
-    max: c_int,
-) {
+pub unsafe fn dav1d_inv_flipadst16_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_adst16_1d_internal_c(
         c,
         stride,
@@ -1039,16 +989,11 @@ pub unsafe extern "C" fn dav1d_inv_flipadst16_1d_c(
     );
 }
 
-pub unsafe extern "C" fn dav1d_inv_adst16_1d_c(
-    c: *mut i32,
-    stride: NonZeroUsize,
-    min: c_int,
-    max: c_int,
-) {
+pub unsafe fn dav1d_inv_adst16_1d_c(c: *mut i32, stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_adst16_1d_internal_c(c, stride, min, max, c, stride.try_into().unwrap());
 }
 
-pub unsafe extern "C" fn dav1d_inv_identity4_1d_c(
+pub unsafe fn dav1d_inv_identity4_1d_c(
     c: *mut i32,
     stride: NonZeroUsize,
     _min: c_int,
@@ -1064,7 +1009,7 @@ pub unsafe extern "C" fn dav1d_inv_identity4_1d_c(
     }
 }
 
-pub unsafe extern "C" fn dav1d_inv_identity8_1d_c(
+pub unsafe fn dav1d_inv_identity8_1d_c(
     c: *mut i32,
     stride: NonZeroUsize,
     _min: c_int,
@@ -1080,7 +1025,7 @@ pub unsafe extern "C" fn dav1d_inv_identity8_1d_c(
     }
 }
 
-pub unsafe extern "C" fn dav1d_inv_identity16_1d_c(
+pub unsafe fn dav1d_inv_identity16_1d_c(
     c: *mut i32,
     stride: NonZeroUsize,
     _min: c_int,
@@ -1096,7 +1041,7 @@ pub unsafe extern "C" fn dav1d_inv_identity16_1d_c(
     }
 }
 
-pub unsafe extern "C" fn dav1d_inv_identity32_1d_c(
+pub unsafe fn dav1d_inv_identity32_1d_c(
     c: *mut i32,
     stride: NonZeroUsize,
     _min: c_int,

--- a/src/itx_1d.rs
+++ b/src/itx_1d.rs
@@ -1,18 +1,18 @@
 use crate::include::common::intops::iclip;
-use libc::ptrdiff_t;
 use std::ffi::c_int;
+use std::num::NonZeroIsize;
+use std::num::NonZeroUsize;
 
 #[inline(never)]
 unsafe fn inv_dct4_1d_internal_c(
     c: *mut i32,
-    stride: ptrdiff_t,
+    stride: NonZeroUsize,
     min: c_int,
     max: c_int,
     tx64: c_int,
 ) {
-    if !(stride > 0) {
-        unreachable!();
-    }
+    let stride = stride.get();
+
     let in0 = *c.offset((0 * stride) as isize);
     let in1 = *c.offset((1 * stride) as isize);
     let t0;
@@ -40,7 +40,7 @@ unsafe fn inv_dct4_1d_internal_c(
 
 pub unsafe extern "C" fn dav1d_inv_dct4_1d_c(
     c: *mut i32,
-    stride: ptrdiff_t,
+    stride: NonZeroUsize,
     min: c_int,
     max: c_int,
 ) {
@@ -50,15 +50,14 @@ pub unsafe extern "C" fn dav1d_inv_dct4_1d_c(
 #[inline(never)]
 unsafe fn inv_dct8_1d_internal_c(
     c: *mut i32,
-    stride: ptrdiff_t,
+    stride: NonZeroUsize,
     min: c_int,
     max: c_int,
     tx64: c_int,
 ) {
-    if !(stride > 0) {
-        unreachable!();
-    }
-    inv_dct4_1d_internal_c(c, stride << 1, min, max, tx64);
+    let stride = stride.get();
+
+    inv_dct4_1d_internal_c(c, (stride << 1).try_into().unwrap(), min, max, tx64);
     let in1 = *c.offset((1 * stride) as isize);
     let in3 = *c.offset((3 * stride) as isize);
     let t4a;
@@ -100,7 +99,7 @@ unsafe fn inv_dct8_1d_internal_c(
 
 pub unsafe extern "C" fn dav1d_inv_dct8_1d_c(
     c: *mut i32,
-    stride: ptrdiff_t,
+    stride: NonZeroUsize,
     min: c_int,
     max: c_int,
 ) {
@@ -110,15 +109,14 @@ pub unsafe extern "C" fn dav1d_inv_dct8_1d_c(
 #[inline(never)]
 unsafe fn inv_dct16_1d_internal_c(
     c: *mut i32,
-    stride: ptrdiff_t,
+    stride: NonZeroUsize,
     min: c_int,
     max: c_int,
     tx64: c_int,
 ) {
-    if !(stride > 0) {
-        unreachable!();
-    }
-    inv_dct8_1d_internal_c(c, stride << 1, min, max, tx64);
+    let stride = stride.get();
+
+    inv_dct8_1d_internal_c(c, (stride << 1).try_into().unwrap(), min, max, tx64);
     let in1 = *c.offset((1 * stride) as isize);
     let in3 = *c.offset((3 * stride) as isize);
     let in5 = *c.offset((5 * stride) as isize);
@@ -206,7 +204,7 @@ unsafe fn inv_dct16_1d_internal_c(
 
 pub unsafe extern "C" fn dav1d_inv_dct16_1d_c(
     c: *mut i32,
-    stride: ptrdiff_t,
+    stride: NonZeroUsize,
     min: c_int,
     max: c_int,
 ) {
@@ -216,15 +214,14 @@ pub unsafe extern "C" fn dav1d_inv_dct16_1d_c(
 #[inline(never)]
 unsafe fn inv_dct32_1d_internal_c(
     c: *mut i32,
-    stride: ptrdiff_t,
+    stride: NonZeroUsize,
     min: c_int,
     max: c_int,
     tx64: c_int,
 ) {
-    if !(stride > 0) {
-        unreachable!();
-    }
-    inv_dct16_1d_internal_c(c, stride << 1, min, max, tx64);
+    let stride = stride.get();
+
+    inv_dct16_1d_internal_c(c, (stride << 1).try_into().unwrap(), min, max, tx64);
     let in1 = *c.offset((1 * stride) as isize);
     let in3 = *c.offset((3 * stride) as isize);
     let in5 = *c.offset((5 * stride) as isize);
@@ -416,7 +413,7 @@ unsafe fn inv_dct32_1d_internal_c(
 
 pub unsafe extern "C" fn dav1d_inv_dct32_1d_c(
     c: *mut i32,
-    stride: ptrdiff_t,
+    stride: NonZeroUsize,
     min: c_int,
     max: c_int,
 ) {
@@ -425,14 +422,13 @@ pub unsafe extern "C" fn dav1d_inv_dct32_1d_c(
 
 pub unsafe extern "C" fn dav1d_inv_dct64_1d_c(
     c: *mut i32,
-    stride: ptrdiff_t,
+    stride: NonZeroUsize,
     min: c_int,
     max: c_int,
 ) {
-    if !(stride > 0) {
-        unreachable!();
-    }
-    inv_dct32_1d_internal_c(c, stride << 1, min, max, 1 as c_int);
+    let stride = stride.get();
+
+    inv_dct32_1d_internal_c(c, (stride << 1).try_into().unwrap(), min, max, 1 as c_int);
     let in1 = *c.offset((1 * stride) as isize);
     let in3 = *c.offset((3 * stride) as isize);
     let in5 = *c.offset((5 * stride) as isize);
@@ -774,15 +770,15 @@ pub unsafe extern "C" fn dav1d_inv_dct64_1d_c(
 #[inline(never)]
 unsafe fn inv_adst4_1d_internal_c(
     in_0: *const i32,
-    in_s: ptrdiff_t,
+    in_s: NonZeroUsize,
     _min: c_int,
     _max: c_int,
     out: *mut i32,
-    out_s: ptrdiff_t,
+    out_s: NonZeroIsize,
 ) {
-    if !(in_s > 0 && out_s != 0) {
-        unreachable!();
-    }
+    let in_s = in_s.get();
+    let out_s = out_s.get();
+
     let in0 = *in_0.offset((0 * in_s) as isize);
     let in1 = *in_0.offset((1 * in_s) as isize);
     let in2 = *in_0.offset((2 * in_s) as isize);
@@ -808,15 +804,15 @@ unsafe fn inv_adst4_1d_internal_c(
 #[inline(never)]
 unsafe fn inv_adst8_1d_internal_c(
     in_0: *const i32,
-    in_s: ptrdiff_t,
+    in_s: NonZeroUsize,
     min: c_int,
     max: c_int,
     out: *mut i32,
-    out_s: ptrdiff_t,
+    out_s: NonZeroIsize,
 ) {
-    if !(in_s > 0 && out_s != 0) {
-        unreachable!();
-    }
+    let in_s = in_s.get();
+    let out_s = out_s.get();
+
     let in0 = *in_0.offset((0 * in_s) as isize);
     let in1 = *in_0.offset((1 * in_s) as isize);
     let in2 = *in_0.offset((2 * in_s) as isize);
@@ -862,15 +858,15 @@ unsafe fn inv_adst8_1d_internal_c(
 #[inline(never)]
 unsafe fn inv_adst16_1d_internal_c(
     in_0: *const i32,
-    in_s: ptrdiff_t,
+    in_s: NonZeroUsize,
     min: c_int,
     max: c_int,
     out: *mut i32,
-    out_s: ptrdiff_t,
+    out_s: NonZeroIsize,
 ) {
-    if !(in_s > 0 && out_s != 0) {
-        unreachable!();
-    }
+    let in_s = in_s.get();
+    let out_s = out_s.get();
+
     let in0 = *in_0.offset((0 * in_s) as isize);
     let in1 = *in_0.offset((1 * in_s) as isize);
     let in2 = *in_0.offset((2 * in_s) as isize);
@@ -979,7 +975,7 @@ unsafe fn inv_adst16_1d_internal_c(
 
 pub unsafe extern "C" fn dav1d_inv_flipadst4_1d_c(
     c: *mut i32,
-    stride: ptrdiff_t,
+    stride: NonZeroUsize,
     min: c_int,
     max: c_int,
 ) {
@@ -988,32 +984,32 @@ pub unsafe extern "C" fn dav1d_inv_flipadst4_1d_c(
         stride,
         min,
         max,
-        &mut *c.offset(((4 - 1) as isize * stride) as isize),
-        -stride,
+        &mut *c.add((4 - 1) * stride.get()),
+        (-(stride.get() as isize)).try_into().unwrap(),
     );
 }
 
 pub unsafe extern "C" fn dav1d_inv_adst4_1d_c(
     c: *mut i32,
-    stride: ptrdiff_t,
+    stride: NonZeroUsize,
     min: c_int,
     max: c_int,
 ) {
-    inv_adst4_1d_internal_c(c, stride, min, max, c, stride);
+    inv_adst4_1d_internal_c(c, stride, min, max, c, stride.try_into().unwrap());
 }
 
 pub unsafe extern "C" fn dav1d_inv_adst8_1d_c(
     c: *mut i32,
-    stride: ptrdiff_t,
+    stride: NonZeroUsize,
     min: c_int,
     max: c_int,
 ) {
-    inv_adst8_1d_internal_c(c, stride, min, max, c, stride);
+    inv_adst8_1d_internal_c(c, stride, min, max, c, stride.try_into().unwrap());
 }
 
 pub unsafe extern "C" fn dav1d_inv_flipadst8_1d_c(
     c: *mut i32,
-    stride: ptrdiff_t,
+    stride: NonZeroUsize,
     min: c_int,
     max: c_int,
 ) {
@@ -1022,14 +1018,14 @@ pub unsafe extern "C" fn dav1d_inv_flipadst8_1d_c(
         stride,
         min,
         max,
-        &mut *c.offset(((8 - 1) as isize * stride) as isize),
-        -stride,
+        &mut *c.add((8 - 1) * stride.get()),
+        (-(stride.get() as isize)).try_into().unwrap(),
     );
 }
 
 pub unsafe extern "C" fn dav1d_inv_flipadst16_1d_c(
     c: *mut i32,
-    stride: ptrdiff_t,
+    stride: NonZeroUsize,
     min: c_int,
     max: c_int,
 ) {
@@ -1038,49 +1034,47 @@ pub unsafe extern "C" fn dav1d_inv_flipadst16_1d_c(
         stride,
         min,
         max,
-        &mut *c.offset((16 - 1) as isize * stride),
-        -stride,
+        &mut *c.add((16 - 1) * stride.get()),
+        (-(stride.get() as isize)).try_into().unwrap(),
     );
 }
 
 pub unsafe extern "C" fn dav1d_inv_adst16_1d_c(
     c: *mut i32,
-    stride: ptrdiff_t,
+    stride: NonZeroUsize,
     min: c_int,
     max: c_int,
 ) {
-    inv_adst16_1d_internal_c(c, stride, min, max, c, stride);
+    inv_adst16_1d_internal_c(c, stride, min, max, c, stride.try_into().unwrap());
 }
 
 pub unsafe extern "C" fn dav1d_inv_identity4_1d_c(
     c: *mut i32,
-    stride: ptrdiff_t,
+    stride: NonZeroUsize,
     _min: c_int,
     _max: c_int,
 ) {
-    if !(stride > 0) {
-        unreachable!();
-    }
+    let stride = stride.get();
+
     let mut i = 0;
     while i < 4 {
-        let in_0 = *c.offset(stride * i as isize);
-        *c.offset(stride * i as isize) = in_0 + (in_0 * 1697 + 2048 >> 12);
+        let in_0 = *c.offset((stride * i) as isize);
+        *c.offset((stride * i) as isize) = in_0 + (in_0 * 1697 + 2048 >> 12);
         i += 1;
     }
 }
 
 pub unsafe extern "C" fn dav1d_inv_identity8_1d_c(
     c: *mut i32,
-    stride: ptrdiff_t,
+    stride: NonZeroUsize,
     _min: c_int,
     _max: c_int,
 ) {
-    if !(stride > 0) {
-        unreachable!();
-    }
+    let stride = stride.get();
+
     let mut i = 0;
     while i < 8 {
-        let ref mut fresh0 = *c.offset((stride * i as isize) as isize);
+        let ref mut fresh0 = *c.offset((stride * i) as isize);
         *fresh0 *= 2 as c_int;
         i += 1;
     }
@@ -1088,42 +1082,39 @@ pub unsafe extern "C" fn dav1d_inv_identity8_1d_c(
 
 pub unsafe extern "C" fn dav1d_inv_identity16_1d_c(
     c: *mut i32,
-    stride: ptrdiff_t,
+    stride: NonZeroUsize,
     _min: c_int,
     _max: c_int,
 ) {
-    if !(stride > 0) {
-        unreachable!();
-    }
+    let stride = stride.get();
+
     let mut i = 0;
     while i < 16 {
-        let in_0 = *c.offset((stride * i as isize) as isize);
-        *c.offset((stride * i as isize) as isize) = 2 * in_0 + (in_0 * 1697 + 1024 >> 11);
+        let in_0 = *c.offset((stride * i) as isize);
+        *c.offset((stride * i) as isize) = 2 * in_0 + (in_0 * 1697 + 1024 >> 11);
         i += 1;
     }
 }
 
 pub unsafe extern "C" fn dav1d_inv_identity32_1d_c(
     c: *mut i32,
-    stride: ptrdiff_t,
+    stride: NonZeroUsize,
     _min: c_int,
     _max: c_int,
 ) {
-    if !(stride > 0) {
-        unreachable!();
-    }
+    let stride = stride.get();
+
     let mut i = 0;
     while i < 32 {
-        let ref mut fresh1 = *c.offset((stride * i as isize) as isize);
+        let ref mut fresh1 = *c.offset((stride * i) as isize);
         *fresh1 *= 4 as c_int;
         i += 1;
     }
 }
 
-pub unsafe fn dav1d_inv_wht4_1d_c(c: *mut i32, stride: ptrdiff_t) {
-    if !(stride > 0) {
-        unreachable!();
-    }
+pub unsafe fn dav1d_inv_wht4_1d_c(c: *mut i32, stride: NonZeroUsize) {
+    let stride = stride.get();
+
     let in0 = *c.offset((0 * stride) as isize);
     let in1 = *c.offset((1 * stride) as isize);
     let in2 = *c.offset((2 * stride) as isize);

--- a/src/itx_1d.rs
+++ b/src/itx_1d.rs
@@ -16,6 +16,7 @@ fn inv_dct4_1d_internal_c(
 
     let in0 = c[0 * stride];
     let in1 = c[1 * stride];
+
     let t0;
     let t1;
     let t2;
@@ -28,11 +29,13 @@ fn inv_dct4_1d_internal_c(
     } else {
         let in2 = c[2 * stride];
         let in3 = c[3 * stride];
+
         t0 = (in0 + in2) * 181 + 128 >> 8;
         t1 = (in0 - in2) * 181 + 128 >> 8;
         t2 = (in1 * 1567 - in3 * (3784 - 4096) + 2048 >> 12) - in3;
         t3 = (in1 * (3784 - 4096) + in3 * 1567 + 2048 >> 12) + in1;
     }
+
     c[0 * stride] = iclip(t0 + t3, min, max);
     c[1 * stride] = iclip(t1 + t2, min, max);
     c[2 * stride] = iclip(t1 - t2, min, max);
@@ -54,8 +57,10 @@ fn inv_dct8_1d_internal_c(
     let stride = stride.get();
 
     inv_dct4_1d_internal_c(c, (stride << 1).try_into().unwrap(), min, max, tx64);
+
     let in1 = c[1 * stride];
     let in3 = c[3 * stride];
+
     let t4a;
     let mut t5a;
     let mut t6a;
@@ -68,21 +73,26 @@ fn inv_dct8_1d_internal_c(
     } else {
         let in5 = c[5 * stride];
         let in7 = c[7 * stride];
+
         t4a = (in1 * 799 - in7 * (4017 - 4096) + 2048 >> 12) - in7;
         t5a = in5 * 1703 - in3 * 1138 + 1024 >> 11;
         t6a = in5 * 1138 + in3 * 1703 + 1024 >> 11;
         t7a = (in1 * (4017 - 4096) + in7 * 799 + 2048 >> 12) + in1;
     }
+
     let t4 = iclip(t4a + t5a, min, max);
     t5a = iclip(t4a - t5a, min, max);
     let t7 = iclip(t7a + t6a, min, max);
     t6a = iclip(t7a - t6a, min, max);
+
     let t5 = (t6a - t5a) * 181 + 128 >> 8;
     let t6 = (t6a + t5a) * 181 + 128 >> 8;
+
     let t0 = c[0 * stride];
     let t1 = c[2 * stride];
     let t2 = c[4 * stride];
     let t3 = c[6 * stride];
+
     c[0 * stride] = iclip(t0 + t7, min, max);
     c[1 * stride] = iclip(t1 + t6, min, max);
     c[2 * stride] = iclip(t2 + t5, min, max);
@@ -108,10 +118,12 @@ fn inv_dct16_1d_internal_c(
     let stride = stride.get();
 
     inv_dct8_1d_internal_c(c, (stride << 1).try_into().unwrap(), min, max, tx64);
+
     let in1 = c[1 * stride];
     let in3 = c[3 * stride];
     let in5 = c[5 * stride];
     let in7 = c[7 * stride];
+
     let mut t8a;
     let mut t9a;
     let mut t10a;
@@ -134,6 +146,7 @@ fn inv_dct16_1d_internal_c(
         let in11 = c[11 * stride];
         let in13 = c[13 * stride];
         let in15 = c[15 * stride];
+
         t8a = (in1 * 401 - in15 * (4076 - 4096) + 2048 >> 12) - in15;
         t9a = in9 * 1583 - in7 * 1299 + 1024 >> 11;
         t10a = (in5 * 1931 - in11 * (3612 - 4096) + 2048 >> 12) - in11;
@@ -143,6 +156,7 @@ fn inv_dct16_1d_internal_c(
         t14a = in9 * 1299 + in7 * 1583 + 1024 >> 11;
         t15a = (in1 * (4076 - 4096) + in15 * 401 + 2048 >> 12) + in1;
     }
+
     let t8 = iclip(t8a + t9a, min, max);
     let mut t9 = iclip(t8a - t9a, min, max);
     let mut t10 = iclip(t11a - t10a, min, max);
@@ -151,6 +165,7 @@ fn inv_dct16_1d_internal_c(
     let mut t13 = iclip(t12a - t13a, min, max);
     let mut t14 = iclip(t15a - t14a, min, max);
     let t15 = iclip(t15a + t14a, min, max);
+
     t9a = (t14 * 1567 - t9 * (3784 - 4096) + 2048 >> 12) - t9;
     t14a = (t14 * (3784 - 4096) + t9 * 1567 + 2048 >> 12) + t14;
     t10a = (-(t13 * (3784 - 4096) + t10 * 1567) + 2048 >> 12) - t13;
@@ -163,10 +178,12 @@ fn inv_dct16_1d_internal_c(
     t13 = iclip(t14a - t13a, min, max);
     t14 = iclip(t14a + t13a, min, max);
     t15a = iclip(t15 + t12, min, max);
+
     t10a = (t13 - t10) * 181 + 128 >> 8;
     t13a = (t13 + t10) * 181 + 128 >> 8;
     t11 = (t12a - t11a) * 181 + 128 >> 8;
     t12 = (t12a + t11a) * 181 + 128 >> 8;
+
     let t0 = c[0 * stride];
     let t1 = c[2 * stride];
     let t2 = c[4 * stride];
@@ -175,6 +192,7 @@ fn inv_dct16_1d_internal_c(
     let t5 = c[10 * stride];
     let t6 = c[12 * stride];
     let t7 = c[14 * stride];
+
     c[0 * stride] = iclip(t0 + t15a, min, max);
     c[1 * stride] = iclip(t1 + t14, min, max);
     c[2 * stride] = iclip(t2 + t13a, min, max);
@@ -208,6 +226,7 @@ fn inv_dct32_1d_internal_c(
     let stride = stride.get();
 
     inv_dct16_1d_internal_c(c, (stride << 1).try_into().unwrap(), min, max, tx64);
+
     let in1 = c[1 * stride];
     let in3 = c[3 * stride];
     let in5 = c[5 * stride];
@@ -216,6 +235,7 @@ fn inv_dct32_1d_internal_c(
     let in11 = c[11 * stride];
     let in13 = c[13 * stride];
     let in15 = c[15 * stride];
+
     let mut t16a;
     let mut t17a;
     let mut t18a;
@@ -258,6 +278,7 @@ fn inv_dct32_1d_internal_c(
         let in27 = c[27 * stride];
         let in29 = c[29 * stride];
         let in31 = c[31 * stride];
+
         t16a = (in1 * 201 - in31 * (4091 - 4096) + 2048 >> 12) - in31;
         t17a = (in17 * (3035 - 4096) - in15 * 2751 + 2048 >> 12) + in17;
         t18a = (in9 * 1751 - in23 * (3703 - 4096) + 2048 >> 12) - in23;
@@ -275,6 +296,7 @@ fn inv_dct32_1d_internal_c(
         t30a = (in17 * 2751 + in15 * (3035 - 4096) + 2048 >> 12) + in15;
         t31a = (in1 * (4091 - 4096) + in31 * 201 + 2048 >> 12) + in1;
     }
+
     let mut t16 = iclip(t16a + t17a, min, max);
     let mut t17 = iclip(t16a - t17a, min, max);
     let mut t18 = iclip(t19a - t18a, min, max);
@@ -291,6 +313,7 @@ fn inv_dct32_1d_internal_c(
     let mut t29 = iclip(t28a - t29a, min, max);
     let mut t30 = iclip(t31a - t30a, min, max);
     let mut t31 = iclip(t31a + t30a, min, max);
+
     t17a = (t30 * 799 - t17 * (4017 - 4096) + 2048 >> 12) - t17;
     t30a = (t30 * (4017 - 4096) + t17 * 799 + 2048 >> 12) + t30;
     t18a = (-(t29 * (4017 - 4096) + t18 * 799) + 2048 >> 12) - t29;
@@ -299,6 +322,7 @@ fn inv_dct32_1d_internal_c(
     t26a = t26 * 1138 + t21 * 1703 + 1024 >> 11;
     t22a = -(t25 * 1138 + t22 * 1703) + 1024 >> 11;
     t25a = t25 * 1703 - t22 * 1138 + 1024 >> 11;
+
     t16a = iclip(t16 + t19, min, max);
     t17 = iclip(t17a + t18a, min, max);
     t18 = iclip(t17a - t18a, min, max);
@@ -315,6 +339,7 @@ fn inv_dct32_1d_internal_c(
     t29 = iclip(t30a - t29a, min, max);
     t30 = iclip(t30a + t29a, min, max);
     t31a = iclip(t31 + t28, min, max);
+
     t18a = (t29 * 1567 - t18 * (3784 - 4096) + 2048 >> 12) - t18;
     t29a = (t29 * (3784 - 4096) + t18 * 1567 + 2048 >> 12) + t29;
     t19 = (t28a * 1567 - t19a * (3784 - 4096) + 2048 >> 12) - t19a;
@@ -323,6 +348,7 @@ fn inv_dct32_1d_internal_c(
     t27 = (t27a * 1567 - t20a * (3784 - 4096) + 2048 >> 12) - t20a;
     t21a = (-(t26 * (3784 - 4096) + t21 * 1567) + 2048 >> 12) - t26;
     t26a = (t26 * 1567 - t21 * (3784 - 4096) + 2048 >> 12) - t21;
+
     t16 = iclip(t16a + t23a, min, max);
     t17a = iclip(t17 + t22, min, max);
     t18 = iclip(t18a + t21a, min, max);
@@ -339,6 +365,7 @@ fn inv_dct32_1d_internal_c(
     t29 = iclip(t29a + t26a, min, max);
     t30a = iclip(t30 + t25, min, max);
     t31 = iclip(t31a + t24a, min, max);
+
     t20 = (t27a - t20a) * 181 + 128 >> 8;
     t27 = (t27a + t20a) * 181 + 128 >> 8;
     t21a = (t26 - t21) * 181 + 128 >> 8;
@@ -347,6 +374,7 @@ fn inv_dct32_1d_internal_c(
     t25 = (t25a + t22a) * 181 + 128 >> 8;
     t23a = (t24 - t23) * 181 + 128 >> 8;
     t24a = (t24 + t23) * 181 + 128 >> 8;
+
     let t0 = c[0 * stride];
     let t1 = c[2 * stride];
     let t2 = c[4 * stride];
@@ -363,6 +391,7 @@ fn inv_dct32_1d_internal_c(
     let t13 = c[26 * stride];
     let t14 = c[28 * stride];
     let t15 = c[30 * stride];
+
     c[0 * stride] = iclip(t0 + t31, min, max);
     c[1 * stride] = iclip(t1 + t30a, min, max);
     c[2 * stride] = iclip(t2 + t29, min, max);
@@ -405,6 +434,7 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
     let stride = stride.get();
 
     inv_dct32_1d_internal_c(c, (stride << 1).try_into().unwrap(), min, max, 1 as c_int);
+
     let in1 = c[1 * stride];
     let in3 = c[3 * stride];
     let in5 = c[5 * stride];
@@ -421,6 +451,7 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
     let in27 = c[27 * stride];
     let in29 = c[29 * stride];
     let in31 = c[31 * stride];
+
     let mut t32a = in1 * 101 + 2048 >> 12;
     let mut t33a = in31 * -(2824 as c_int) + 2048 >> 12;
     let mut t34a = in17 * 1660 + 2048 >> 12;
@@ -453,6 +484,7 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
     let mut t61a = in17 * 3745 + 2048 >> 12;
     let mut t62a = in31 * 2967 + 2048 >> 12;
     let mut t63a = in1 * 4095 + 2048 >> 12;
+
     let mut t32 = iclip(t32a + t33a, min, max);
     let mut t33 = iclip(t32a - t33a, min, max);
     let mut t34 = iclip(t35a - t34a, min, max);
@@ -485,6 +517,7 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
     let mut t61 = iclip(t60a - t61a, min, max);
     let mut t62 = iclip(t63a - t62a, min, max);
     let mut t63 = iclip(t63a + t62a, min, max);
+
     t33a = (t33 * (4096 - 4076) + t62 * 401 + 2048 >> 12) - t33;
     t34a = (t34 * -(401 as c_int) + t61 * (4096 - 4076) + 2048 >> 12) - t61;
     t37a = t37 * -(1299 as c_int) + t58 * 1583 + 1024 >> 11;
@@ -501,6 +534,7 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
     t58a = t37 * 1583 + t58 * 1299 + 1024 >> 11;
     t61a = (t34 * (4096 - 4076) + t61 * 401 + 2048 >> 12) - t34;
     t62a = (t33 * 401 + t62 * (4076 - 4096) + 2048 >> 12) + t62;
+
     t32a = iclip(t32 + t35, min, max);
     t33 = iclip(t33a + t34a, min, max);
     t34 = iclip(t33a - t34a, min, max);
@@ -533,6 +567,7 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
     t61 = iclip(t62a - t61a, min, max);
     t62 = iclip(t62a + t61a, min, max);
     t63a = iclip(t63 + t60, min, max);
+
     t34a = (t34 * (4096 - 4017) + t61 * 799 + 2048 >> 12) - t34;
     t35 = (t35a * (4096 - 4017) + t60a * 799 + 2048 >> 12) - t35a;
     t36 = (t36a * -(799 as c_int) + t59a * (4096 - 4017) + 2048 >> 12) - t59a;
@@ -549,6 +584,7 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
     t59 = (t36a * (4096 - 4017) + t59a * 799 + 2048 >> 12) - t36a;
     t60 = (t35a * 799 + t60a * (4017 - 4096) + 2048 >> 12) + t60a;
     t61a = (t34 * 799 + t61 * (4017 - 4096) + 2048 >> 12) + t61;
+
     t32 = iclip(t32a + t39a, min, max);
     t33a = iclip(t33 + t38, min, max);
     t34 = iclip(t34a + t37a, min, max);
@@ -581,6 +617,7 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
     t61 = iclip(t61a + t58a, min, max);
     t62a = iclip(t62 + t57, min, max);
     t63 = iclip(t63a + t56a, min, max);
+
     t36 = (t36a * (4096 - 3784) + t59a * 1567 + 2048 >> 12) - t36a;
     t37a = (t37 * (4096 - 3784) + t58 * 1567 + 2048 >> 12) - t37;
     t38 = (t38a * (4096 - 3784) + t57a * 1567 + 2048 >> 12) - t38a;
@@ -597,6 +634,7 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
     t57 = (t38a * 1567 + t57a * (3784 - 4096) + 2048 >> 12) + t57a;
     t58a = (t37 * 1567 + t58 * (3784 - 4096) + 2048 >> 12) + t58;
     t59 = (t36a * 1567 + t59a * (3784 - 4096) + 2048 >> 12) + t59a;
+
     t32a = iclip(t32 + t47, min, max);
     t33 = iclip(t33a + t46a, min, max);
     t34a = iclip(t34 + t45, min, max);
@@ -629,6 +667,7 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
     t61a = iclip(t61 + t50, min, max);
     t62 = iclip(t62a + t49a, min, max);
     t63a = iclip(t63 + t48, min, max);
+
     t40a = (t55 - t40) * 181 + 128 >> 8;
     t41 = (t54a - t41a) * 181 + 128 >> 8;
     t42a = (t53 - t42) * 181 + 128 >> 8;
@@ -645,6 +684,7 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
     t53a = (t42 + t53) * 181 + 128 >> 8;
     t54 = (t41a + t54a) * 181 + 128 >> 8;
     t55a = (t40 + t55) * 181 + 128 >> 8;
+
     let t0 = c[0 * stride];
     let t1 = c[2 * stride];
     let t2 = c[4 * stride];
@@ -677,6 +717,7 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
     let t29 = c[58 * stride];
     let t30 = c[60 * stride];
     let t31 = c[62 * stride];
+
     c[0 * stride] = iclip(t0 + t63a, min, max);
     c[1 * stride] = iclip(t1 + t62, min, max);
     c[2 * stride] = iclip(t2 + t61a, min, max);
@@ -808,6 +849,7 @@ fn inv_adst8_1d_internal_c(
     let in5 = in_0[5 * in_s];
     let in6 = in_0[6 * in_s];
     let in7 = in_0[7 * in_s];
+
     let t0a = ((4076 - 4096) * in7 + 401 * in0 + 2048 >> 12) + in7;
     let t1a = (401 * in7 - (4076 - 4096) * in0 + 2048 >> 12) - in0;
     let t2a = ((3612 - 4096) * in5 + 1931 * in2 + 2048 >> 12) + in5;
@@ -816,6 +858,7 @@ fn inv_adst8_1d_internal_c(
     let mut t5a = 1583 * in3 - 1299 * in4 + 1024 >> 11;
     let mut t6a = (1189 * in1 + (3920 - 4096) * in6 + 2048 >> 12) + in6;
     let mut t7a = ((3920 - 4096) * in1 - 1189 * in6 + 2048 >> 12) + in1;
+
     let t0 = iclip(t0a + t4a, min, max);
     let t1 = iclip(t1a + t5a, min, max);
     let mut t2 = iclip(t2a + t6a, min, max);
@@ -824,6 +867,7 @@ fn inv_adst8_1d_internal_c(
     let t5 = iclip(t1a - t5a, min, max);
     let mut t6 = iclip(t2a - t6a, min, max);
     let mut t7 = iclip(t3a - t7a, min, max);
+
     t4a = ((3784 - 4096) * t4 + 1567 * t5 + 2048 >> 12) + t4;
     t5a = (1567 * t4 - (3784 - 4096) * t5 + 2048 >> 12) - t5;
     t6a = ((3784 - 4096) * t7 - 1567 * t6 + 2048 >> 12) + t7;
@@ -845,6 +889,7 @@ fn inv_adst8_1d_internal_c(
     out[(out_off + 6 * out_s) as usize] = iclip(t5a + t7a, min, max);
     t6 = iclip(t4a - t6a, min, max);
     t7 = iclip(t5a - t7a, min, max);
+
     out[(out_off + 3 * out_s) as usize] = -((t2 + t3) * 181 + 128 >> 8);
     out[(out_off + 4 * out_s) as usize] = (t2 - t3) * 181 + 128 >> 8;
     out[(out_off + 2 * out_s) as usize] = (t6 + t7) * 181 + 128 >> 8;
@@ -880,6 +925,7 @@ fn inv_adst16_1d_internal_c(
     let in13 = in_0[13 * in_s];
     let in14 = in_0[14 * in_s];
     let in15 = in_0[15 * in_s];
+
     let mut t0 = (in15 * (4091 - 4096) + in0 * 201 + 2048 >> 12) + in15;
     let mut t1 = (in15 * 201 - in0 * (4091 - 4096) + 2048 >> 12) - in0;
     let mut t2 = (in13 * (3973 - 4096) + in2 * 995 + 2048 >> 12) + in13;
@@ -896,6 +942,7 @@ fn inv_adst16_1d_internal_c(
     let mut t13 = (in3 * (3857 - 4096) - in12 * 1380 + 2048 >> 12) + in3;
     let mut t14 = (in1 * 601 + in14 * (4052 - 4096) + 2048 >> 12) + in14;
     let mut t15 = (in1 * (4052 - 4096) - in14 * 601 + 2048 >> 12) + in1;
+
     let t0a = iclip(t0 + t8, min, max);
     let t1a = iclip(t1 + t9, min, max);
     let mut t2a = iclip(t2 + t10, min, max);
@@ -912,6 +959,7 @@ fn inv_adst16_1d_internal_c(
     let mut t13a = iclip(t5 - t13, min, max);
     let mut t14a = iclip(t6 - t14, min, max);
     let mut t15a = iclip(t7 - t15, min, max);
+
     t8 = (t8a * (4017 - 4096) + t9a * 799 + 2048 >> 12) + t8a;
     t9 = (t8a * 799 - t9a * (4017 - 4096) + 2048 >> 12) - t9a;
     t10 = (t10a * 2276 + t11a * (3406 - 4096) + 2048 >> 12) + t11a;
@@ -920,6 +968,7 @@ fn inv_adst16_1d_internal_c(
     t13 = (t13a * 799 + t12a * (4017 - 4096) + 2048 >> 12) + t12a;
     t14 = (t15a * 2276 - t14a * (3406 - 4096) + 2048 >> 12) - t14a;
     t15 = (t15a * (3406 - 4096) + t14a * 2276 + 2048 >> 12) + t15a;
+
     t0 = iclip(t0a + t4a, min, max);
     t1 = iclip(t1a + t5a, min, max);
     t2 = iclip(t2a + t6a, min, max);
@@ -936,6 +985,7 @@ fn inv_adst16_1d_internal_c(
     t13a = iclip(t9 - t13, min, max);
     t14a = iclip(t10 - t14, min, max);
     t15a = iclip(t11 - t15, min, max);
+
     t4a = (t4 * (3784 - 4096) + t5 * 1567 + 2048 >> 12) + t4;
     t5a = (t4 * 1567 - t5 * (3784 - 4096) + 2048 >> 12) - t5;
     t6a = (t7 * (3784 - 4096) - t6 * 1567 + 2048 >> 12) + t7;
@@ -969,6 +1019,7 @@ fn inv_adst16_1d_internal_c(
     out[(out_off + 13 * out_s) as usize] = -iclip(t13 + t15, min, max);
     t14a = iclip(t12 - t14, min, max);
     t15a = iclip(t13 - t15, min, max);
+
     out[(out_off + 7 * out_s) as usize] = -((t2a + t3a) * 181 + 128 >> 8);
     out[(out_off + 8 * out_s) as usize] = (t2a - t3a) * 181 + 128 >> 8;
     out[(out_off + 4 * out_s) as usize] = (t6 + t7) * 181 + 128 >> 8;
@@ -1044,11 +1095,13 @@ pub fn dav1d_inv_wht4_1d_c(c: &mut [i32], stride: NonZeroUsize) {
     let in1 = c[1 * stride];
     let in2 = c[2 * stride];
     let in3 = c[3 * stride];
+
     let t0 = in0 + in1;
     let t2 = in2 - in3;
     let t4 = t0 - t2 >> 1;
     let t3 = t4 - in3;
     let t1 = t4 - in1;
+
     c[0 * stride] = t0 - t3;
     c[1 * stride] = t3;
     c[2 * stride] = t1;

--- a/src/itx_1d.rs
+++ b/src/itx_1d.rs
@@ -49,6 +49,7 @@ fn inv_dct4_1d_internal_c(
     max: c_int,
     tx64: c_int,
 ) {
+    let clip = |v| iclip(v, min, max);
     let stride = stride.get();
 
     let in0 = c[0 * stride];
@@ -73,10 +74,10 @@ fn inv_dct4_1d_internal_c(
         t3 = (in1 * (3784 - 4096) + in3 * 1567 + 2048 >> 12) + in1;
     }
 
-    c[0 * stride] = iclip(t0 + t3, min, max);
-    c[1 * stride] = iclip(t1 + t2, min, max);
-    c[2 * stride] = iclip(t1 - t2, min, max);
-    c[3 * stride] = iclip(t0 - t3, min, max);
+    c[0 * stride] = clip(t0 + t3);
+    c[1 * stride] = clip(t1 + t2);
+    c[2 * stride] = clip(t1 - t2);
+    c[3 * stride] = clip(t0 - t3);
 }
 
 pub fn dav1d_inv_dct4_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
@@ -91,6 +92,7 @@ fn inv_dct8_1d_internal_c(
     max: c_int,
     tx64: c_int,
 ) {
+    let clip = |v| iclip(v, min, max);
     let stride = stride.get();
 
     inv_dct4_1d_internal_c(c, (stride << 1).try_into().unwrap(), min, max, tx64);
@@ -117,10 +119,10 @@ fn inv_dct8_1d_internal_c(
         t7a = (in1 * (4017 - 4096) + in7 * 799 + 2048 >> 12) + in1;
     }
 
-    let t4 = iclip(t4a + t5a, min, max);
-    t5a = iclip(t4a - t5a, min, max);
-    let t7 = iclip(t7a + t6a, min, max);
-    t6a = iclip(t7a - t6a, min, max);
+    let t4 = clip(t4a + t5a);
+    t5a = clip(t4a - t5a);
+    let t7 = clip(t7a + t6a);
+    t6a = clip(t7a - t6a);
 
     let t5 = (t6a - t5a) * 181 + 128 >> 8;
     let t6 = (t6a + t5a) * 181 + 128 >> 8;
@@ -130,14 +132,14 @@ fn inv_dct8_1d_internal_c(
     let t2 = c[4 * stride];
     let t3 = c[6 * stride];
 
-    c[0 * stride] = iclip(t0 + t7, min, max);
-    c[1 * stride] = iclip(t1 + t6, min, max);
-    c[2 * stride] = iclip(t2 + t5, min, max);
-    c[3 * stride] = iclip(t3 + t4, min, max);
-    c[4 * stride] = iclip(t3 - t4, min, max);
-    c[5 * stride] = iclip(t2 - t5, min, max);
-    c[6 * stride] = iclip(t1 - t6, min, max);
-    c[7 * stride] = iclip(t0 - t7, min, max);
+    c[0 * stride] = clip(t0 + t7);
+    c[1 * stride] = clip(t1 + t6);
+    c[2 * stride] = clip(t2 + t5);
+    c[3 * stride] = clip(t3 + t4);
+    c[4 * stride] = clip(t3 - t4);
+    c[5 * stride] = clip(t2 - t5);
+    c[6 * stride] = clip(t1 - t6);
+    c[7 * stride] = clip(t0 - t7);
 }
 
 pub fn dav1d_inv_dct8_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
@@ -152,6 +154,7 @@ fn inv_dct16_1d_internal_c(
     max: c_int,
     tx64: c_int,
 ) {
+    let clip = |v| iclip(v, min, max);
     let stride = stride.get();
 
     inv_dct8_1d_internal_c(c, (stride << 1).try_into().unwrap(), min, max, tx64);
@@ -194,27 +197,27 @@ fn inv_dct16_1d_internal_c(
         t15a = (in1 * (4076 - 4096) + in15 * 401 + 2048 >> 12) + in1;
     }
 
-    let t8 = iclip(t8a + t9a, min, max);
-    let mut t9 = iclip(t8a - t9a, min, max);
-    let mut t10 = iclip(t11a - t10a, min, max);
-    let mut t11 = iclip(t11a + t10a, min, max);
-    let mut t12 = iclip(t12a + t13a, min, max);
-    let mut t13 = iclip(t12a - t13a, min, max);
-    let mut t14 = iclip(t15a - t14a, min, max);
-    let t15 = iclip(t15a + t14a, min, max);
+    let t8 = clip(t8a + t9a);
+    let mut t9 = clip(t8a - t9a);
+    let mut t10 = clip(t11a - t10a);
+    let mut t11 = clip(t11a + t10a);
+    let mut t12 = clip(t12a + t13a);
+    let mut t13 = clip(t12a - t13a);
+    let mut t14 = clip(t15a - t14a);
+    let t15 = clip(t15a + t14a);
 
     t9a = (t14 * 1567 - t9 * (3784 - 4096) + 2048 >> 12) - t9;
     t14a = (t14 * (3784 - 4096) + t9 * 1567 + 2048 >> 12) + t14;
     t10a = (-(t13 * (3784 - 4096) + t10 * 1567) + 2048 >> 12) - t13;
     t13a = (t13 * 1567 - t10 * (3784 - 4096) + 2048 >> 12) - t10;
-    t8a = iclip(t8 + t11, min, max);
-    t9 = iclip(t9a + t10a, min, max);
-    t10 = iclip(t9a - t10a, min, max);
-    t11a = iclip(t8 - t11, min, max);
-    t12a = iclip(t15 - t12, min, max);
-    t13 = iclip(t14a - t13a, min, max);
-    t14 = iclip(t14a + t13a, min, max);
-    t15a = iclip(t15 + t12, min, max);
+    t8a = clip(t8 + t11);
+    t9 = clip(t9a + t10a);
+    t10 = clip(t9a - t10a);
+    t11a = clip(t8 - t11);
+    t12a = clip(t15 - t12);
+    t13 = clip(t14a - t13a);
+    t14 = clip(t14a + t13a);
+    t15a = clip(t15 + t12);
 
     t10a = (t13 - t10) * 181 + 128 >> 8;
     t13a = (t13 + t10) * 181 + 128 >> 8;
@@ -230,22 +233,22 @@ fn inv_dct16_1d_internal_c(
     let t6 = c[12 * stride];
     let t7 = c[14 * stride];
 
-    c[0 * stride] = iclip(t0 + t15a, min, max);
-    c[1 * stride] = iclip(t1 + t14, min, max);
-    c[2 * stride] = iclip(t2 + t13a, min, max);
-    c[3 * stride] = iclip(t3 + t12, min, max);
-    c[4 * stride] = iclip(t4 + t11, min, max);
-    c[5 * stride] = iclip(t5 + t10a, min, max);
-    c[6 * stride] = iclip(t6 + t9, min, max);
-    c[7 * stride] = iclip(t7 + t8a, min, max);
-    c[8 * stride] = iclip(t7 - t8a, min, max);
-    c[9 * stride] = iclip(t6 - t9, min, max);
-    c[10 * stride] = iclip(t5 - t10a, min, max);
-    c[11 * stride] = iclip(t4 - t11, min, max);
-    c[12 * stride] = iclip(t3 - t12, min, max);
-    c[13 * stride] = iclip(t2 - t13a, min, max);
-    c[14 * stride] = iclip(t1 - t14, min, max);
-    c[15 * stride] = iclip(t0 - t15a, min, max);
+    c[0 * stride] = clip(t0 + t15a);
+    c[1 * stride] = clip(t1 + t14);
+    c[2 * stride] = clip(t2 + t13a);
+    c[3 * stride] = clip(t3 + t12);
+    c[4 * stride] = clip(t4 + t11);
+    c[5 * stride] = clip(t5 + t10a);
+    c[6 * stride] = clip(t6 + t9);
+    c[7 * stride] = clip(t7 + t8a);
+    c[8 * stride] = clip(t7 - t8a);
+    c[9 * stride] = clip(t6 - t9);
+    c[10 * stride] = clip(t5 - t10a);
+    c[11 * stride] = clip(t4 - t11);
+    c[12 * stride] = clip(t3 - t12);
+    c[13 * stride] = clip(t2 - t13a);
+    c[14 * stride] = clip(t1 - t14);
+    c[15 * stride] = clip(t0 - t15a);
 }
 
 pub fn dav1d_inv_dct16_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
@@ -260,6 +263,7 @@ fn inv_dct32_1d_internal_c(
     max: c_int,
     tx64: c_int,
 ) {
+    let clip = |v| iclip(v, min, max);
     let stride = stride.get();
 
     inv_dct16_1d_internal_c(c, (stride << 1).try_into().unwrap(), min, max, tx64);
@@ -334,22 +338,22 @@ fn inv_dct32_1d_internal_c(
         t31a = (in1 * (4091 - 4096) + in31 * 201 + 2048 >> 12) + in1;
     }
 
-    let mut t16 = iclip(t16a + t17a, min, max);
-    let mut t17 = iclip(t16a - t17a, min, max);
-    let mut t18 = iclip(t19a - t18a, min, max);
-    let mut t19 = iclip(t19a + t18a, min, max);
-    let mut t20 = iclip(t20a + t21a, min, max);
-    let mut t21 = iclip(t20a - t21a, min, max);
-    let mut t22 = iclip(t23a - t22a, min, max);
-    let mut t23 = iclip(t23a + t22a, min, max);
-    let mut t24 = iclip(t24a + t25a, min, max);
-    let mut t25 = iclip(t24a - t25a, min, max);
-    let mut t26 = iclip(t27a - t26a, min, max);
-    let mut t27 = iclip(t27a + t26a, min, max);
-    let mut t28 = iclip(t28a + t29a, min, max);
-    let mut t29 = iclip(t28a - t29a, min, max);
-    let mut t30 = iclip(t31a - t30a, min, max);
-    let mut t31 = iclip(t31a + t30a, min, max);
+    let mut t16 = clip(t16a + t17a);
+    let mut t17 = clip(t16a - t17a);
+    let mut t18 = clip(t19a - t18a);
+    let mut t19 = clip(t19a + t18a);
+    let mut t20 = clip(t20a + t21a);
+    let mut t21 = clip(t20a - t21a);
+    let mut t22 = clip(t23a - t22a);
+    let mut t23 = clip(t23a + t22a);
+    let mut t24 = clip(t24a + t25a);
+    let mut t25 = clip(t24a - t25a);
+    let mut t26 = clip(t27a - t26a);
+    let mut t27 = clip(t27a + t26a);
+    let mut t28 = clip(t28a + t29a);
+    let mut t29 = clip(t28a - t29a);
+    let mut t30 = clip(t31a - t30a);
+    let mut t31 = clip(t31a + t30a);
 
     t17a = (t30 * 799 - t17 * (4017 - 4096) + 2048 >> 12) - t17;
     t30a = (t30 * (4017 - 4096) + t17 * 799 + 2048 >> 12) + t30;
@@ -360,22 +364,22 @@ fn inv_dct32_1d_internal_c(
     t22a = -(t25 * 1138 + t22 * 1703) + 1024 >> 11;
     t25a = t25 * 1703 - t22 * 1138 + 1024 >> 11;
 
-    t16a = iclip(t16 + t19, min, max);
-    t17 = iclip(t17a + t18a, min, max);
-    t18 = iclip(t17a - t18a, min, max);
-    t19a = iclip(t16 - t19, min, max);
-    t20a = iclip(t23 - t20, min, max);
-    t21 = iclip(t22a - t21a, min, max);
-    t22 = iclip(t22a + t21a, min, max);
-    t23a = iclip(t23 + t20, min, max);
-    t24a = iclip(t24 + t27, min, max);
-    t25 = iclip(t25a + t26a, min, max);
-    t26 = iclip(t25a - t26a, min, max);
-    t27a = iclip(t24 - t27, min, max);
-    t28a = iclip(t31 - t28, min, max);
-    t29 = iclip(t30a - t29a, min, max);
-    t30 = iclip(t30a + t29a, min, max);
-    t31a = iclip(t31 + t28, min, max);
+    t16a = clip(t16 + t19);
+    t17 = clip(t17a + t18a);
+    t18 = clip(t17a - t18a);
+    t19a = clip(t16 - t19);
+    t20a = clip(t23 - t20);
+    t21 = clip(t22a - t21a);
+    t22 = clip(t22a + t21a);
+    t23a = clip(t23 + t20);
+    t24a = clip(t24 + t27);
+    t25 = clip(t25a + t26a);
+    t26 = clip(t25a - t26a);
+    t27a = clip(t24 - t27);
+    t28a = clip(t31 - t28);
+    t29 = clip(t30a - t29a);
+    t30 = clip(t30a + t29a);
+    t31a = clip(t31 + t28);
 
     t18a = (t29 * 1567 - t18 * (3784 - 4096) + 2048 >> 12) - t18;
     t29a = (t29 * (3784 - 4096) + t18 * 1567 + 2048 >> 12) + t29;
@@ -386,22 +390,22 @@ fn inv_dct32_1d_internal_c(
     t21a = (-(t26 * (3784 - 4096) + t21 * 1567) + 2048 >> 12) - t26;
     t26a = (t26 * 1567 - t21 * (3784 - 4096) + 2048 >> 12) - t21;
 
-    t16 = iclip(t16a + t23a, min, max);
-    t17a = iclip(t17 + t22, min, max);
-    t18 = iclip(t18a + t21a, min, max);
-    t19a = iclip(t19 + t20, min, max);
-    t20a = iclip(t19 - t20, min, max);
-    t21 = iclip(t18a - t21a, min, max);
-    t22a = iclip(t17 - t22, min, max);
-    t23 = iclip(t16a - t23a, min, max);
-    t24 = iclip(t31a - t24a, min, max);
-    t25a = iclip(t30 - t25, min, max);
-    t26 = iclip(t29a - t26a, min, max);
-    t27a = iclip(t28 - t27, min, max);
-    t28a = iclip(t28 + t27, min, max);
-    t29 = iclip(t29a + t26a, min, max);
-    t30a = iclip(t30 + t25, min, max);
-    t31 = iclip(t31a + t24a, min, max);
+    t16 = clip(t16a + t23a);
+    t17a = clip(t17 + t22);
+    t18 = clip(t18a + t21a);
+    t19a = clip(t19 + t20);
+    t20a = clip(t19 - t20);
+    t21 = clip(t18a - t21a);
+    t22a = clip(t17 - t22);
+    t23 = clip(t16a - t23a);
+    t24 = clip(t31a - t24a);
+    t25a = clip(t30 - t25);
+    t26 = clip(t29a - t26a);
+    t27a = clip(t28 - t27);
+    t28a = clip(t28 + t27);
+    t29 = clip(t29a + t26a);
+    t30a = clip(t30 + t25);
+    t31 = clip(t31a + t24a);
 
     t20 = (t27a - t20a) * 181 + 128 >> 8;
     t27 = (t27a + t20a) * 181 + 128 >> 8;
@@ -429,38 +433,38 @@ fn inv_dct32_1d_internal_c(
     let t14 = c[28 * stride];
     let t15 = c[30 * stride];
 
-    c[0 * stride] = iclip(t0 + t31, min, max);
-    c[1 * stride] = iclip(t1 + t30a, min, max);
-    c[2 * stride] = iclip(t2 + t29, min, max);
-    c[3 * stride] = iclip(t3 + t28a, min, max);
-    c[4 * stride] = iclip(t4 + t27, min, max);
-    c[5 * stride] = iclip(t5 + t26a, min, max);
-    c[6 * stride] = iclip(t6 + t25, min, max);
-    c[7 * stride] = iclip(t7 + t24a, min, max);
-    c[8 * stride] = iclip(t8 + t23a, min, max);
-    c[9 * stride] = iclip(t9 + t22, min, max);
-    c[10 * stride] = iclip(t10 + t21a, min, max);
-    c[11 * stride] = iclip(t11 + t20, min, max);
-    c[12 * stride] = iclip(t12 + t19a, min, max);
-    c[13 * stride] = iclip(t13 + t18, min, max);
-    c[14 * stride] = iclip(t14 + t17a, min, max);
-    c[15 * stride] = iclip(t15 + t16, min, max);
-    c[16 * stride] = iclip(t15 - t16, min, max);
-    c[17 * stride] = iclip(t14 - t17a, min, max);
-    c[18 * stride] = iclip(t13 - t18, min, max);
-    c[19 * stride] = iclip(t12 - t19a, min, max);
-    c[20 * stride] = iclip(t11 - t20, min, max);
-    c[21 * stride] = iclip(t10 - t21a, min, max);
-    c[22 * stride] = iclip(t9 - t22, min, max);
-    c[23 * stride] = iclip(t8 - t23a, min, max);
-    c[24 * stride] = iclip(t7 - t24a, min, max);
-    c[25 * stride] = iclip(t6 - t25, min, max);
-    c[26 * stride] = iclip(t5 - t26a, min, max);
-    c[27 * stride] = iclip(t4 - t27, min, max);
-    c[28 * stride] = iclip(t3 - t28a, min, max);
-    c[29 * stride] = iclip(t2 - t29, min, max);
-    c[30 * stride] = iclip(t1 - t30a, min, max);
-    c[31 * stride] = iclip(t0 - t31, min, max);
+    c[0 * stride] = clip(t0 + t31);
+    c[1 * stride] = clip(t1 + t30a);
+    c[2 * stride] = clip(t2 + t29);
+    c[3 * stride] = clip(t3 + t28a);
+    c[4 * stride] = clip(t4 + t27);
+    c[5 * stride] = clip(t5 + t26a);
+    c[6 * stride] = clip(t6 + t25);
+    c[7 * stride] = clip(t7 + t24a);
+    c[8 * stride] = clip(t8 + t23a);
+    c[9 * stride] = clip(t9 + t22);
+    c[10 * stride] = clip(t10 + t21a);
+    c[11 * stride] = clip(t11 + t20);
+    c[12 * stride] = clip(t12 + t19a);
+    c[13 * stride] = clip(t13 + t18);
+    c[14 * stride] = clip(t14 + t17a);
+    c[15 * stride] = clip(t15 + t16);
+    c[16 * stride] = clip(t15 - t16);
+    c[17 * stride] = clip(t14 - t17a);
+    c[18 * stride] = clip(t13 - t18);
+    c[19 * stride] = clip(t12 - t19a);
+    c[20 * stride] = clip(t11 - t20);
+    c[21 * stride] = clip(t10 - t21a);
+    c[22 * stride] = clip(t9 - t22);
+    c[23 * stride] = clip(t8 - t23a);
+    c[24 * stride] = clip(t7 - t24a);
+    c[25 * stride] = clip(t6 - t25);
+    c[26 * stride] = clip(t5 - t26a);
+    c[27 * stride] = clip(t4 - t27);
+    c[28 * stride] = clip(t3 - t28a);
+    c[29 * stride] = clip(t2 - t29);
+    c[30 * stride] = clip(t1 - t30a);
+    c[31 * stride] = clip(t0 - t31);
 }
 
 pub fn dav1d_inv_dct32_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
@@ -468,6 +472,7 @@ pub fn dav1d_inv_dct32_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
 }
 
 pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+    let clip = |v| iclip(v, min, max);
     let stride = stride.get();
 
     inv_dct32_1d_internal_c(c, (stride << 1).try_into().unwrap(), min, max, 1 as c_int);
@@ -522,38 +527,38 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
     let mut t62a = in31 * 2967 + 2048 >> 12;
     let mut t63a = in1 * 4095 + 2048 >> 12;
 
-    let mut t32 = iclip(t32a + t33a, min, max);
-    let mut t33 = iclip(t32a - t33a, min, max);
-    let mut t34 = iclip(t35a - t34a, min, max);
-    let mut t35 = iclip(t35a + t34a, min, max);
-    let mut t36 = iclip(t36a + t37a, min, max);
-    let mut t37 = iclip(t36a - t37a, min, max);
-    let mut t38 = iclip(t39a - t38a, min, max);
-    let mut t39 = iclip(t39a + t38a, min, max);
-    let mut t40 = iclip(t40a + t41a, min, max);
-    let mut t41 = iclip(t40a - t41a, min, max);
-    let mut t42 = iclip(t43a - t42a, min, max);
-    let mut t43 = iclip(t43a + t42a, min, max);
-    let mut t44 = iclip(t44a + t45a, min, max);
-    let mut t45 = iclip(t44a - t45a, min, max);
-    let mut t46 = iclip(t47a - t46a, min, max);
-    let mut t47 = iclip(t47a + t46a, min, max);
-    let mut t48 = iclip(t48a + t49a, min, max);
-    let mut t49 = iclip(t48a - t49a, min, max);
-    let mut t50 = iclip(t51a - t50a, min, max);
-    let mut t51 = iclip(t51a + t50a, min, max);
-    let mut t52 = iclip(t52a + t53a, min, max);
-    let mut t53 = iclip(t52a - t53a, min, max);
-    let mut t54 = iclip(t55a - t54a, min, max);
-    let mut t55 = iclip(t55a + t54a, min, max);
-    let mut t56 = iclip(t56a + t57a, min, max);
-    let mut t57 = iclip(t56a - t57a, min, max);
-    let mut t58 = iclip(t59a - t58a, min, max);
-    let mut t59 = iclip(t59a + t58a, min, max);
-    let mut t60 = iclip(t60a + t61a, min, max);
-    let mut t61 = iclip(t60a - t61a, min, max);
-    let mut t62 = iclip(t63a - t62a, min, max);
-    let mut t63 = iclip(t63a + t62a, min, max);
+    let mut t32 = clip(t32a + t33a);
+    let mut t33 = clip(t32a - t33a);
+    let mut t34 = clip(t35a - t34a);
+    let mut t35 = clip(t35a + t34a);
+    let mut t36 = clip(t36a + t37a);
+    let mut t37 = clip(t36a - t37a);
+    let mut t38 = clip(t39a - t38a);
+    let mut t39 = clip(t39a + t38a);
+    let mut t40 = clip(t40a + t41a);
+    let mut t41 = clip(t40a - t41a);
+    let mut t42 = clip(t43a - t42a);
+    let mut t43 = clip(t43a + t42a);
+    let mut t44 = clip(t44a + t45a);
+    let mut t45 = clip(t44a - t45a);
+    let mut t46 = clip(t47a - t46a);
+    let mut t47 = clip(t47a + t46a);
+    let mut t48 = clip(t48a + t49a);
+    let mut t49 = clip(t48a - t49a);
+    let mut t50 = clip(t51a - t50a);
+    let mut t51 = clip(t51a + t50a);
+    let mut t52 = clip(t52a + t53a);
+    let mut t53 = clip(t52a - t53a);
+    let mut t54 = clip(t55a - t54a);
+    let mut t55 = clip(t55a + t54a);
+    let mut t56 = clip(t56a + t57a);
+    let mut t57 = clip(t56a - t57a);
+    let mut t58 = clip(t59a - t58a);
+    let mut t59 = clip(t59a + t58a);
+    let mut t60 = clip(t60a + t61a);
+    let mut t61 = clip(t60a - t61a);
+    let mut t62 = clip(t63a - t62a);
+    let mut t63 = clip(t63a + t62a);
 
     t33a = (t33 * (4096 - 4076) + t62 * 401 + 2048 >> 12) - t33;
     t34a = (t34 * -(401 as c_int) + t61 * (4096 - 4076) + 2048 >> 12) - t61;
@@ -572,38 +577,38 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
     t61a = (t34 * (4096 - 4076) + t61 * 401 + 2048 >> 12) - t34;
     t62a = (t33 * 401 + t62 * (4076 - 4096) + 2048 >> 12) + t62;
 
-    t32a = iclip(t32 + t35, min, max);
-    t33 = iclip(t33a + t34a, min, max);
-    t34 = iclip(t33a - t34a, min, max);
-    t35a = iclip(t32 - t35, min, max);
-    t36a = iclip(t39 - t36, min, max);
-    t37 = iclip(t38a - t37a, min, max);
-    t38 = iclip(t38a + t37a, min, max);
-    t39a = iclip(t39 + t36, min, max);
-    t40a = iclip(t40 + t43, min, max);
-    t41 = iclip(t41a + t42a, min, max);
-    t42 = iclip(t41a - t42a, min, max);
-    t43a = iclip(t40 - t43, min, max);
-    t44a = iclip(t47 - t44, min, max);
-    t45 = iclip(t46a - t45a, min, max);
-    t46 = iclip(t46a + t45a, min, max);
-    t47a = iclip(t47 + t44, min, max);
-    t48a = iclip(t48 + t51, min, max);
-    t49 = iclip(t49a + t50a, min, max);
-    t50 = iclip(t49a - t50a, min, max);
-    t51a = iclip(t48 - t51, min, max);
-    t52a = iclip(t55 - t52, min, max);
-    t53 = iclip(t54a - t53a, min, max);
-    t54 = iclip(t54a + t53a, min, max);
-    t55a = iclip(t55 + t52, min, max);
-    t56a = iclip(t56 + t59, min, max);
-    t57 = iclip(t57a + t58a, min, max);
-    t58 = iclip(t57a - t58a, min, max);
-    t59a = iclip(t56 - t59, min, max);
-    t60a = iclip(t63 - t60, min, max);
-    t61 = iclip(t62a - t61a, min, max);
-    t62 = iclip(t62a + t61a, min, max);
-    t63a = iclip(t63 + t60, min, max);
+    t32a = clip(t32 + t35);
+    t33 = clip(t33a + t34a);
+    t34 = clip(t33a - t34a);
+    t35a = clip(t32 - t35);
+    t36a = clip(t39 - t36);
+    t37 = clip(t38a - t37a);
+    t38 = clip(t38a + t37a);
+    t39a = clip(t39 + t36);
+    t40a = clip(t40 + t43);
+    t41 = clip(t41a + t42a);
+    t42 = clip(t41a - t42a);
+    t43a = clip(t40 - t43);
+    t44a = clip(t47 - t44);
+    t45 = clip(t46a - t45a);
+    t46 = clip(t46a + t45a);
+    t47a = clip(t47 + t44);
+    t48a = clip(t48 + t51);
+    t49 = clip(t49a + t50a);
+    t50 = clip(t49a - t50a);
+    t51a = clip(t48 - t51);
+    t52a = clip(t55 - t52);
+    t53 = clip(t54a - t53a);
+    t54 = clip(t54a + t53a);
+    t55a = clip(t55 + t52);
+    t56a = clip(t56 + t59);
+    t57 = clip(t57a + t58a);
+    t58 = clip(t57a - t58a);
+    t59a = clip(t56 - t59);
+    t60a = clip(t63 - t60);
+    t61 = clip(t62a - t61a);
+    t62 = clip(t62a + t61a);
+    t63a = clip(t63 + t60);
 
     t34a = (t34 * (4096 - 4017) + t61 * 799 + 2048 >> 12) - t34;
     t35 = (t35a * (4096 - 4017) + t60a * 799 + 2048 >> 12) - t35a;
@@ -622,38 +627,38 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
     t60 = (t35a * 799 + t60a * (4017 - 4096) + 2048 >> 12) + t60a;
     t61a = (t34 * 799 + t61 * (4017 - 4096) + 2048 >> 12) + t61;
 
-    t32 = iclip(t32a + t39a, min, max);
-    t33a = iclip(t33 + t38, min, max);
-    t34 = iclip(t34a + t37a, min, max);
-    t35a = iclip(t35 + t36, min, max);
-    t36a = iclip(t35 - t36, min, max);
-    t37 = iclip(t34a - t37a, min, max);
-    t38a = iclip(t33 - t38, min, max);
-    t39 = iclip(t32a - t39a, min, max);
-    t40 = iclip(t47a - t40a, min, max);
-    t41a = iclip(t46 - t41, min, max);
-    t42 = iclip(t45a - t42a, min, max);
-    t43a = iclip(t44 - t43, min, max);
-    t44a = iclip(t44 + t43, min, max);
-    t45 = iclip(t45a + t42a, min, max);
-    t46a = iclip(t46 + t41, min, max);
-    t47 = iclip(t47a + t40a, min, max);
-    t48 = iclip(t48a + t55a, min, max);
-    t49a = iclip(t49 + t54, min, max);
-    t50 = iclip(t50a + t53a, min, max);
-    t51a = iclip(t51 + t52, min, max);
-    t52a = iclip(t51 - t52, min, max);
-    t53 = iclip(t50a - t53a, min, max);
-    t54a = iclip(t49 - t54, min, max);
-    t55 = iclip(t48a - t55a, min, max);
-    t56 = iclip(t63a - t56a, min, max);
-    t57a = iclip(t62 - t57, min, max);
-    t58 = iclip(t61a - t58a, min, max);
-    t59a = iclip(t60 - t59, min, max);
-    t60a = iclip(t60 + t59, min, max);
-    t61 = iclip(t61a + t58a, min, max);
-    t62a = iclip(t62 + t57, min, max);
-    t63 = iclip(t63a + t56a, min, max);
+    t32 = clip(t32a + t39a);
+    t33a = clip(t33 + t38);
+    t34 = clip(t34a + t37a);
+    t35a = clip(t35 + t36);
+    t36a = clip(t35 - t36);
+    t37 = clip(t34a - t37a);
+    t38a = clip(t33 - t38);
+    t39 = clip(t32a - t39a);
+    t40 = clip(t47a - t40a);
+    t41a = clip(t46 - t41);
+    t42 = clip(t45a - t42a);
+    t43a = clip(t44 - t43);
+    t44a = clip(t44 + t43);
+    t45 = clip(t45a + t42a);
+    t46a = clip(t46 + t41);
+    t47 = clip(t47a + t40a);
+    t48 = clip(t48a + t55a);
+    t49a = clip(t49 + t54);
+    t50 = clip(t50a + t53a);
+    t51a = clip(t51 + t52);
+    t52a = clip(t51 - t52);
+    t53 = clip(t50a - t53a);
+    t54a = clip(t49 - t54);
+    t55 = clip(t48a - t55a);
+    t56 = clip(t63a - t56a);
+    t57a = clip(t62 - t57);
+    t58 = clip(t61a - t58a);
+    t59a = clip(t60 - t59);
+    t60a = clip(t60 + t59);
+    t61 = clip(t61a + t58a);
+    t62a = clip(t62 + t57);
+    t63 = clip(t63a + t56a);
 
     t36 = (t36a * (4096 - 3784) + t59a * 1567 + 2048 >> 12) - t36a;
     t37a = (t37 * (4096 - 3784) + t58 * 1567 + 2048 >> 12) - t37;
@@ -672,38 +677,38 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
     t58a = (t37 * 1567 + t58 * (3784 - 4096) + 2048 >> 12) + t58;
     t59 = (t36a * 1567 + t59a * (3784 - 4096) + 2048 >> 12) + t59a;
 
-    t32a = iclip(t32 + t47, min, max);
-    t33 = iclip(t33a + t46a, min, max);
-    t34a = iclip(t34 + t45, min, max);
-    t35 = iclip(t35a + t44a, min, max);
-    t36a = iclip(t36 + t43, min, max);
-    t37 = iclip(t37a + t42a, min, max);
-    t38a = iclip(t38 + t41, min, max);
-    t39 = iclip(t39a + t40a, min, max);
-    t40 = iclip(t39a - t40a, min, max);
-    t41a = iclip(t38 - t41, min, max);
-    t42 = iclip(t37a - t42a, min, max);
-    t43a = iclip(t36 - t43, min, max);
-    t44 = iclip(t35a - t44a, min, max);
-    t45a = iclip(t34 - t45, min, max);
-    t46 = iclip(t33a - t46a, min, max);
-    t47a = iclip(t32 - t47, min, max);
-    t48a = iclip(t63 - t48, min, max);
-    t49 = iclip(t62a - t49a, min, max);
-    t50a = iclip(t61 - t50, min, max);
-    t51 = iclip(t60a - t51a, min, max);
-    t52a = iclip(t59 - t52, min, max);
-    t53 = iclip(t58a - t53a, min, max);
-    t54a = iclip(t57 - t54, min, max);
-    t55 = iclip(t56a - t55a, min, max);
-    t56 = iclip(t56a + t55a, min, max);
-    t57a = iclip(t57 + t54, min, max);
-    t58 = iclip(t58a + t53a, min, max);
-    t59a = iclip(t59 + t52, min, max);
-    t60 = iclip(t60a + t51a, min, max);
-    t61a = iclip(t61 + t50, min, max);
-    t62 = iclip(t62a + t49a, min, max);
-    t63a = iclip(t63 + t48, min, max);
+    t32a = clip(t32 + t47);
+    t33 = clip(t33a + t46a);
+    t34a = clip(t34 + t45);
+    t35 = clip(t35a + t44a);
+    t36a = clip(t36 + t43);
+    t37 = clip(t37a + t42a);
+    t38a = clip(t38 + t41);
+    t39 = clip(t39a + t40a);
+    t40 = clip(t39a - t40a);
+    t41a = clip(t38 - t41);
+    t42 = clip(t37a - t42a);
+    t43a = clip(t36 - t43);
+    t44 = clip(t35a - t44a);
+    t45a = clip(t34 - t45);
+    t46 = clip(t33a - t46a);
+    t47a = clip(t32 - t47);
+    t48a = clip(t63 - t48);
+    t49 = clip(t62a - t49a);
+    t50a = clip(t61 - t50);
+    t51 = clip(t60a - t51a);
+    t52a = clip(t59 - t52);
+    t53 = clip(t58a - t53a);
+    t54a = clip(t57 - t54);
+    t55 = clip(t56a - t55a);
+    t56 = clip(t56a + t55a);
+    t57a = clip(t57 + t54);
+    t58 = clip(t58a + t53a);
+    t59a = clip(t59 + t52);
+    t60 = clip(t60a + t51a);
+    t61a = clip(t61 + t50);
+    t62 = clip(t62a + t49a);
+    t63a = clip(t63 + t48);
 
     t40a = (t55 - t40) * 181 + 128 >> 8;
     t41 = (t54a - t41a) * 181 + 128 >> 8;
@@ -755,70 +760,70 @@ pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max
     let t30 = c[60 * stride];
     let t31 = c[62 * stride];
 
-    c[0 * stride] = iclip(t0 + t63a, min, max);
-    c[1 * stride] = iclip(t1 + t62, min, max);
-    c[2 * stride] = iclip(t2 + t61a, min, max);
-    c[3 * stride] = iclip(t3 + t60, min, max);
-    c[4 * stride] = iclip(t4 + t59a, min, max);
-    c[5 * stride] = iclip(t5 + t58, min, max);
-    c[6 * stride] = iclip(t6 + t57a, min, max);
-    c[7 * stride] = iclip(t7 + t56, min, max);
-    c[8 * stride] = iclip(t8 + t55a, min, max);
-    c[9 * stride] = iclip(t9 + t54, min, max);
-    c[10 * stride] = iclip(t10 + t53a, min, max);
-    c[11 * stride] = iclip(t11 + t52, min, max);
-    c[12 * stride] = iclip(t12 + t51a, min, max);
-    c[13 * stride] = iclip(t13 + t50, min, max);
-    c[14 * stride] = iclip(t14 + t49a, min, max);
-    c[15 * stride] = iclip(t15 + t48, min, max);
-    c[16 * stride] = iclip(t16 + t47, min, max);
-    c[17 * stride] = iclip(t17 + t46a, min, max);
-    c[18 * stride] = iclip(t18 + t45, min, max);
-    c[19 * stride] = iclip(t19 + t44a, min, max);
-    c[20 * stride] = iclip(t20 + t43, min, max);
-    c[21 * stride] = iclip(t21 + t42a, min, max);
-    c[22 * stride] = iclip(t22 + t41, min, max);
-    c[23 * stride] = iclip(t23 + t40a, min, max);
-    c[24 * stride] = iclip(t24 + t39, min, max);
-    c[25 * stride] = iclip(t25 + t38a, min, max);
-    c[26 * stride] = iclip(t26 + t37, min, max);
-    c[27 * stride] = iclip(t27 + t36a, min, max);
-    c[28 * stride] = iclip(t28 + t35, min, max);
-    c[29 * stride] = iclip(t29 + t34a, min, max);
-    c[30 * stride] = iclip(t30 + t33, min, max);
-    c[31 * stride] = iclip(t31 + t32a, min, max);
-    c[32 * stride] = iclip(t31 - t32a, min, max);
-    c[33 * stride] = iclip(t30 - t33, min, max);
-    c[34 * stride] = iclip(t29 - t34a, min, max);
-    c[35 * stride] = iclip(t28 - t35, min, max);
-    c[36 * stride] = iclip(t27 - t36a, min, max);
-    c[37 * stride] = iclip(t26 - t37, min, max);
-    c[38 * stride] = iclip(t25 - t38a, min, max);
-    c[39 * stride] = iclip(t24 - t39, min, max);
-    c[40 * stride] = iclip(t23 - t40a, min, max);
-    c[41 * stride] = iclip(t22 - t41, min, max);
-    c[42 * stride] = iclip(t21 - t42a, min, max);
-    c[43 * stride] = iclip(t20 - t43, min, max);
-    c[44 * stride] = iclip(t19 - t44a, min, max);
-    c[45 * stride] = iclip(t18 - t45, min, max);
-    c[46 * stride] = iclip(t17 - t46a, min, max);
-    c[47 * stride] = iclip(t16 - t47, min, max);
-    c[48 * stride] = iclip(t15 - t48, min, max);
-    c[49 * stride] = iclip(t14 - t49a, min, max);
-    c[50 * stride] = iclip(t13 - t50, min, max);
-    c[51 * stride] = iclip(t12 - t51a, min, max);
-    c[52 * stride] = iclip(t11 - t52, min, max);
-    c[53 * stride] = iclip(t10 - t53a, min, max);
-    c[54 * stride] = iclip(t9 - t54, min, max);
-    c[55 * stride] = iclip(t8 - t55a, min, max);
-    c[56 * stride] = iclip(t7 - t56, min, max);
-    c[57 * stride] = iclip(t6 - t57a, min, max);
-    c[58 * stride] = iclip(t5 - t58, min, max);
-    c[59 * stride] = iclip(t4 - t59a, min, max);
-    c[60 * stride] = iclip(t3 - t60, min, max);
-    c[61 * stride] = iclip(t2 - t61a, min, max);
-    c[62 * stride] = iclip(t1 - t62, min, max);
-    c[63 * stride] = iclip(t0 - t63a, min, max);
+    c[0 * stride] = clip(t0 + t63a);
+    c[1 * stride] = clip(t1 + t62);
+    c[2 * stride] = clip(t2 + t61a);
+    c[3 * stride] = clip(t3 + t60);
+    c[4 * stride] = clip(t4 + t59a);
+    c[5 * stride] = clip(t5 + t58);
+    c[6 * stride] = clip(t6 + t57a);
+    c[7 * stride] = clip(t7 + t56);
+    c[8 * stride] = clip(t8 + t55a);
+    c[9 * stride] = clip(t9 + t54);
+    c[10 * stride] = clip(t10 + t53a);
+    c[11 * stride] = clip(t11 + t52);
+    c[12 * stride] = clip(t12 + t51a);
+    c[13 * stride] = clip(t13 + t50);
+    c[14 * stride] = clip(t14 + t49a);
+    c[15 * stride] = clip(t15 + t48);
+    c[16 * stride] = clip(t16 + t47);
+    c[17 * stride] = clip(t17 + t46a);
+    c[18 * stride] = clip(t18 + t45);
+    c[19 * stride] = clip(t19 + t44a);
+    c[20 * stride] = clip(t20 + t43);
+    c[21 * stride] = clip(t21 + t42a);
+    c[22 * stride] = clip(t22 + t41);
+    c[23 * stride] = clip(t23 + t40a);
+    c[24 * stride] = clip(t24 + t39);
+    c[25 * stride] = clip(t25 + t38a);
+    c[26 * stride] = clip(t26 + t37);
+    c[27 * stride] = clip(t27 + t36a);
+    c[28 * stride] = clip(t28 + t35);
+    c[29 * stride] = clip(t29 + t34a);
+    c[30 * stride] = clip(t30 + t33);
+    c[31 * stride] = clip(t31 + t32a);
+    c[32 * stride] = clip(t31 - t32a);
+    c[33 * stride] = clip(t30 - t33);
+    c[34 * stride] = clip(t29 - t34a);
+    c[35 * stride] = clip(t28 - t35);
+    c[36 * stride] = clip(t27 - t36a);
+    c[37 * stride] = clip(t26 - t37);
+    c[38 * stride] = clip(t25 - t38a);
+    c[39 * stride] = clip(t24 - t39);
+    c[40 * stride] = clip(t23 - t40a);
+    c[41 * stride] = clip(t22 - t41);
+    c[42 * stride] = clip(t21 - t42a);
+    c[43 * stride] = clip(t20 - t43);
+    c[44 * stride] = clip(t19 - t44a);
+    c[45 * stride] = clip(t18 - t45);
+    c[46 * stride] = clip(t17 - t46a);
+    c[47 * stride] = clip(t16 - t47);
+    c[48 * stride] = clip(t15 - t48);
+    c[49 * stride] = clip(t14 - t49a);
+    c[50 * stride] = clip(t13 - t50);
+    c[51 * stride] = clip(t12 - t51a);
+    c[52 * stride] = clip(t11 - t52);
+    c[53 * stride] = clip(t10 - t53a);
+    c[54 * stride] = clip(t9 - t54);
+    c[55 * stride] = clip(t8 - t55a);
+    c[56 * stride] = clip(t7 - t56);
+    c[57 * stride] = clip(t6 - t57a);
+    c[58 * stride] = clip(t5 - t58);
+    c[59 * stride] = clip(t4 - t59a);
+    c[60 * stride] = clip(t3 - t60);
+    c[61 * stride] = clip(t2 - t61a);
+    c[62 * stride] = clip(t1 - t62);
+    c[63 * stride] = clip(t0 - t63a);
 }
 
 #[inline(never)]
@@ -873,6 +878,7 @@ fn inv_adst8_1d_internal_c(
     min: c_int,
     max: c_int,
 ) {
+    let clip = |v| iclip(v, min, max);
     let stride = stride.get();
 
     let in_0 = &c[..];
@@ -896,14 +902,14 @@ fn inv_adst8_1d_internal_c(
     let mut t6a = (1189 * in1 + (3920 - 4096) * in6 + 2048 >> 12) + in6;
     let mut t7a = ((3920 - 4096) * in1 - 1189 * in6 + 2048 >> 12) + in1;
 
-    let t0 = iclip(t0a + t4a, min, max);
-    let t1 = iclip(t1a + t5a, min, max);
-    let mut t2 = iclip(t2a + t6a, min, max);
-    let mut t3 = iclip(t3a + t7a, min, max);
-    let t4 = iclip(t0a - t4a, min, max);
-    let t5 = iclip(t1a - t5a, min, max);
-    let mut t6 = iclip(t2a - t6a, min, max);
-    let mut t7 = iclip(t3a - t7a, min, max);
+    let t0 = clip(t0a + t4a);
+    let t1 = clip(t1a + t5a);
+    let mut t2 = clip(t2a + t6a);
+    let mut t3 = clip(t3a + t7a);
+    let t4 = clip(t0a - t4a);
+    let t5 = clip(t1a - t5a);
+    let mut t6 = clip(t2a - t6a);
+    let mut t7 = clip(t3a - t7a);
 
     t4a = ((3784 - 4096) * t4 + 1567 * t5 + 2048 >> 12) + t4;
     t5a = (1567 * t4 - (3784 - 4096) * t5 + 2048 >> 12) - t5;
@@ -918,14 +924,14 @@ fn inv_adst8_1d_internal_c(
         (0, stride)
     };
 
-    out[(out_off + 0 * out_s) as usize] = iclip(t0 + t2, min, max);
-    out[(out_off + 7 * out_s) as usize] = -iclip(t1 + t3, min, max);
-    t2 = iclip(t0 - t2, min, max);
-    t3 = iclip(t1 - t3, min, max);
-    out[(out_off + 1 * out_s) as usize] = -iclip(t4a + t6a, min, max);
-    out[(out_off + 6 * out_s) as usize] = iclip(t5a + t7a, min, max);
-    t6 = iclip(t4a - t6a, min, max);
-    t7 = iclip(t5a - t7a, min, max);
+    out[(out_off + 0 * out_s) as usize] = clip(t0 + t2);
+    out[(out_off + 7 * out_s) as usize] = -clip(t1 + t3);
+    t2 = clip(t0 - t2);
+    t3 = clip(t1 - t3);
+    out[(out_off + 1 * out_s) as usize] = -clip(t4a + t6a);
+    out[(out_off + 6 * out_s) as usize] = clip(t5a + t7a);
+    t6 = clip(t4a - t6a);
+    t7 = clip(t5a - t7a);
 
     out[(out_off + 3 * out_s) as usize] = -((t2 + t3) * 181 + 128 >> 8);
     out[(out_off + 4 * out_s) as usize] = (t2 - t3) * 181 + 128 >> 8;
@@ -941,6 +947,7 @@ fn inv_adst16_1d_internal_c(
     min: c_int,
     max: c_int,
 ) {
+    let clip = |v| iclip(v, min, max);
     let stride = stride.get();
 
     let in_0 = &c[..];
@@ -980,22 +987,22 @@ fn inv_adst16_1d_internal_c(
     let mut t14 = (in1 * 601 + in14 * (4052 - 4096) + 2048 >> 12) + in14;
     let mut t15 = (in1 * (4052 - 4096) - in14 * 601 + 2048 >> 12) + in1;
 
-    let t0a = iclip(t0 + t8, min, max);
-    let t1a = iclip(t1 + t9, min, max);
-    let mut t2a = iclip(t2 + t10, min, max);
-    let mut t3a = iclip(t3 + t11, min, max);
-    let mut t4a = iclip(t4 + t12, min, max);
-    let mut t5a = iclip(t5 + t13, min, max);
-    let mut t6a = iclip(t6 + t14, min, max);
-    let mut t7a = iclip(t7 + t15, min, max);
-    let mut t8a = iclip(t0 - t8, min, max);
-    let mut t9a = iclip(t1 - t9, min, max);
-    let mut t10a = iclip(t2 - t10, min, max);
-    let mut t11a = iclip(t3 - t11, min, max);
-    let mut t12a = iclip(t4 - t12, min, max);
-    let mut t13a = iclip(t5 - t13, min, max);
-    let mut t14a = iclip(t6 - t14, min, max);
-    let mut t15a = iclip(t7 - t15, min, max);
+    let t0a = clip(t0 + t8);
+    let t1a = clip(t1 + t9);
+    let mut t2a = clip(t2 + t10);
+    let mut t3a = clip(t3 + t11);
+    let mut t4a = clip(t4 + t12);
+    let mut t5a = clip(t5 + t13);
+    let mut t6a = clip(t6 + t14);
+    let mut t7a = clip(t7 + t15);
+    let mut t8a = clip(t0 - t8);
+    let mut t9a = clip(t1 - t9);
+    let mut t10a = clip(t2 - t10);
+    let mut t11a = clip(t3 - t11);
+    let mut t12a = clip(t4 - t12);
+    let mut t13a = clip(t5 - t13);
+    let mut t14a = clip(t6 - t14);
+    let mut t15a = clip(t7 - t15);
 
     t8 = (t8a * (4017 - 4096) + t9a * 799 + 2048 >> 12) + t8a;
     t9 = (t8a * 799 - t9a * (4017 - 4096) + 2048 >> 12) - t9a;
@@ -1006,22 +1013,22 @@ fn inv_adst16_1d_internal_c(
     t14 = (t15a * 2276 - t14a * (3406 - 4096) + 2048 >> 12) - t14a;
     t15 = (t15a * (3406 - 4096) + t14a * 2276 + 2048 >> 12) + t15a;
 
-    t0 = iclip(t0a + t4a, min, max);
-    t1 = iclip(t1a + t5a, min, max);
-    t2 = iclip(t2a + t6a, min, max);
-    t3 = iclip(t3a + t7a, min, max);
-    t4 = iclip(t0a - t4a, min, max);
-    t5 = iclip(t1a - t5a, min, max);
-    t6 = iclip(t2a - t6a, min, max);
-    t7 = iclip(t3a - t7a, min, max);
-    t8a = iclip(t8 + t12, min, max);
-    t9a = iclip(t9 + t13, min, max);
-    t10a = iclip(t10 + t14, min, max);
-    t11a = iclip(t11 + t15, min, max);
-    t12a = iclip(t8 - t12, min, max);
-    t13a = iclip(t9 - t13, min, max);
-    t14a = iclip(t10 - t14, min, max);
-    t15a = iclip(t11 - t15, min, max);
+    t0 = clip(t0a + t4a);
+    t1 = clip(t1a + t5a);
+    t2 = clip(t2a + t6a);
+    t3 = clip(t3a + t7a);
+    t4 = clip(t0a - t4a);
+    t5 = clip(t1a - t5a);
+    t6 = clip(t2a - t6a);
+    t7 = clip(t3a - t7a);
+    t8a = clip(t8 + t12);
+    t9a = clip(t9 + t13);
+    t10a = clip(t10 + t14);
+    t11a = clip(t11 + t15);
+    t12a = clip(t8 - t12);
+    t13a = clip(t9 - t13);
+    t14a = clip(t10 - t14);
+    t15a = clip(t11 - t15);
 
     t4a = (t4 * (3784 - 4096) + t5 * 1567 + 2048 >> 12) + t4;
     t5a = (t4 * 1567 - t5 * (3784 - 4096) + 2048 >> 12) - t5;
@@ -1040,22 +1047,22 @@ fn inv_adst16_1d_internal_c(
         (0, stride)
     };
 
-    out[(out_off + 0 * out_s) as usize] = iclip(t0 + t2, min, max);
-    out[(out_off + 15 * out_s) as usize] = -iclip(t1 + t3, min, max);
-    t2a = iclip(t0 - t2, min, max);
-    t3a = iclip(t1 - t3, min, max);
-    out[(out_off + 3 * out_s) as usize] = -iclip(t4a + t6a, min, max);
-    out[(out_off + 12 * out_s) as usize] = iclip(t5a + t7a, min, max);
-    t6 = iclip(t4a - t6a, min, max);
-    t7 = iclip(t5a - t7a, min, max);
-    out[(out_off + 1 * out_s) as usize] = -iclip(t8a + t10a, min, max);
-    out[(out_off + 14 * out_s) as usize] = iclip(t9a + t11a, min, max);
-    t10 = iclip(t8a - t10a, min, max);
-    t11 = iclip(t9a - t11a, min, max);
-    out[(out_off + 2 * out_s) as usize] = iclip(t12 + t14, min, max);
-    out[(out_off + 13 * out_s) as usize] = -iclip(t13 + t15, min, max);
-    t14a = iclip(t12 - t14, min, max);
-    t15a = iclip(t13 - t15, min, max);
+    out[(out_off + 0 * out_s) as usize] = clip(t0 + t2);
+    out[(out_off + 15 * out_s) as usize] = -clip(t1 + t3);
+    t2a = clip(t0 - t2);
+    t3a = clip(t1 - t3);
+    out[(out_off + 3 * out_s) as usize] = -clip(t4a + t6a);
+    out[(out_off + 12 * out_s) as usize] = clip(t5a + t7a);
+    t6 = clip(t4a - t6a);
+    t7 = clip(t5a - t7a);
+    out[(out_off + 1 * out_s) as usize] = -clip(t8a + t10a);
+    out[(out_off + 14 * out_s) as usize] = clip(t9a + t11a);
+    t10 = clip(t8a - t10a);
+    t11 = clip(t9a - t11a);
+    out[(out_off + 2 * out_s) as usize] = clip(t12 + t14);
+    out[(out_off + 13 * out_s) as usize] = -clip(t13 + t15);
+    t14a = clip(t12 - t14);
+    t15a = clip(t13 - t15);
 
     out[(out_off + 7 * out_s) as usize] = -((t2a + t3a) * 181 + 128 >> 8);
     out[(out_off + 8 * out_s) as usize] = (t2a - t3a) * 181 + 128 >> 8;

--- a/src/itx_1d.rs
+++ b/src/itx_1d.rs
@@ -80,7 +80,7 @@ fn inv_dct4_1d_internal_c(
     c[3 * stride] = clip(t0 - t3);
 }
 
-pub fn dav1d_inv_dct4_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+pub fn rav1d_inv_dct4_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_dct4_1d_internal_c(c, stride, min, max, 0);
 }
 
@@ -142,7 +142,7 @@ fn inv_dct8_1d_internal_c(
     c[7 * stride] = clip(t0 - t7);
 }
 
-pub fn dav1d_inv_dct8_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+pub fn rav1d_inv_dct8_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_dct8_1d_internal_c(c, stride, min, max, 0);
 }
 
@@ -251,7 +251,7 @@ fn inv_dct16_1d_internal_c(
     c[15 * stride] = clip(t0 - t15a);
 }
 
-pub fn dav1d_inv_dct16_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+pub fn rav1d_inv_dct16_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_dct16_1d_internal_c(c, stride, min, max, 0);
 }
 
@@ -467,11 +467,11 @@ fn inv_dct32_1d_internal_c(
     c[31 * stride] = clip(t0 - t31);
 }
 
-pub fn dav1d_inv_dct32_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+pub fn rav1d_inv_dct32_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_dct32_1d_internal_c(c, stride, min, max, 0);
 }
 
-pub fn dav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+pub fn rav1d_inv_dct64_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     let clip = |v| iclip(v, min, max);
     let stride = stride.get();
 
@@ -1074,31 +1074,31 @@ fn inv_adst16_1d_internal_c(
     out[(out_off + 10 * out_s) as usize] = (t14a - t15a) * 181 + 128 >> 8;
 }
 
-pub fn dav1d_inv_flipadst4_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+pub fn rav1d_inv_flipadst4_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_adst4_1d_internal_c(c, stride, true, min, max);
 }
 
-pub fn dav1d_inv_adst4_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+pub fn rav1d_inv_adst4_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_adst4_1d_internal_c(c, stride, false, min, max);
 }
 
-pub fn dav1d_inv_adst8_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+pub fn rav1d_inv_adst8_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_adst8_1d_internal_c(c, stride, false, min, max);
 }
 
-pub fn dav1d_inv_flipadst8_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+pub fn rav1d_inv_flipadst8_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_adst8_1d_internal_c(c, stride, true, min, max);
 }
 
-pub fn dav1d_inv_flipadst16_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+pub fn rav1d_inv_flipadst16_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_adst16_1d_internal_c(c, stride, true, min, max);
 }
 
-pub fn dav1d_inv_adst16_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
+pub fn rav1d_inv_adst16_1d_c(c: &mut [i32], stride: NonZeroUsize, min: c_int, max: c_int) {
     inv_adst16_1d_internal_c(c, stride, false, min, max);
 }
 
-pub fn dav1d_inv_identity4_1d_c(c: &mut [i32], stride: NonZeroUsize, _min: c_int, _max: c_int) {
+pub fn rav1d_inv_identity4_1d_c(c: &mut [i32], stride: NonZeroUsize, _min: c_int, _max: c_int) {
     let stride = stride.get();
 
     for i in 0..4 {
@@ -1107,7 +1107,7 @@ pub fn dav1d_inv_identity4_1d_c(c: &mut [i32], stride: NonZeroUsize, _min: c_int
     }
 }
 
-pub fn dav1d_inv_identity8_1d_c(c: &mut [i32], stride: NonZeroUsize, _min: c_int, _max: c_int) {
+pub fn rav1d_inv_identity8_1d_c(c: &mut [i32], stride: NonZeroUsize, _min: c_int, _max: c_int) {
     let stride = stride.get();
 
     for i in 0..8 {
@@ -1115,7 +1115,7 @@ pub fn dav1d_inv_identity8_1d_c(c: &mut [i32], stride: NonZeroUsize, _min: c_int
     }
 }
 
-pub fn dav1d_inv_identity16_1d_c(c: &mut [i32], stride: NonZeroUsize, _min: c_int, _max: c_int) {
+pub fn rav1d_inv_identity16_1d_c(c: &mut [i32], stride: NonZeroUsize, _min: c_int, _max: c_int) {
     let stride = stride.get();
 
     for i in 0..16 {
@@ -1124,7 +1124,7 @@ pub fn dav1d_inv_identity16_1d_c(c: &mut [i32], stride: NonZeroUsize, _min: c_in
     }
 }
 
-pub fn dav1d_inv_identity32_1d_c(c: &mut [i32], stride: NonZeroUsize, _min: c_int, _max: c_int) {
+pub fn rav1d_inv_identity32_1d_c(c: &mut [i32], stride: NonZeroUsize, _min: c_int, _max: c_int) {
     let stride = stride.get();
 
     for i in 0..32 {
@@ -1132,7 +1132,7 @@ pub fn dav1d_inv_identity32_1d_c(c: &mut [i32], stride: NonZeroUsize, _min: c_in
     }
 }
 
-pub fn dav1d_inv_wht4_1d_c(c: &mut [i32], stride: NonZeroUsize) {
+pub fn rav1d_inv_wht4_1d_c(c: &mut [i32], stride: NonZeroUsize) {
     let stride = stride.get();
 
     let in0 = c[0 * stride];


### PR DESCRIPTION
* Fixes #816.
* Fixes #844.

All 624 `unsafe` ops in `mod itx_1d` (the largest `mod` remaining in terms of `unsafe` ops) are now gone.  Only 2214 left!

There's a bunch more that could be polished and optimized here (e.x. bounds checks), but these are fallbacks, so it's not really worth it.