### PR TITLE
`struct Rav1dFrameContext_frame_thread_progress`: Block write to `copy_lpf`

### DIFF
--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -323,7 +323,9 @@ unsafe fn create_filter_sbrow(
         let mut frame = fc.frame_thread_progress.frame.try_write().unwrap();
         frame.clear();
         frame.resize_with(prog_sz, || AtomicU32::new(0));
-        let mut copy_lpf = fc.frame_thread_progress.copy_lpf.try_write().unwrap();
+        // copy_lpf is read during task selection, so we are seeing contention
+        // here. This seems rare enough that it is not worth optimizing.
+        let mut copy_lpf = fc.frame_thread_progress.copy_lpf.write().unwrap();
         copy_lpf.clear();
         copy_lpf.resize_with(prog_sz, || AtomicU32::new(0));
         fc.frame_thread_progress.deblock.store(0, Ordering::SeqCst);

--- a/tests/dav1d_argon.bash
+++ b/tests/dav1d_argon.bash
@@ -151,13 +151,13 @@ for i in "${!files[@]}"; do
     printf "\033[1K\r[%3d%% %d/%d] Verifying %s" "$(((i+1)*100/${#files[@]}))" "$((i+1))" "${#files[@]}" "$f"
     cmd=("$DAV1D" -i "$f" --filmgrain "$FILMGRAIN" --verify "$md5" --cpumask "$CPUMASK" --threads "$THREADS" -q)
     if [ "$JOBS" -gt 1 ]; then
-        "${cmd[@]}" 2>/dev/null &
+        "${cmd[@]}"  &
         p=$!
         pids+=("$p")
         declare "file$p=$f"
         block_pids
     else
-        if ! "${cmd[@]}" 2>/dev/null; then
+        if ! "${cmd[@]}" ; then
             fail "$f"
         fi
     fi


### PR DESCRIPTION
Writes to `copy_lpf` were hitting contention with reads during task selection in the argon tests. This seem rare enough that we should just block.

Fixes argon test failures on main.