### PR TITLE
Fix underflow introduced in #1007

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -420,7 +420,7 @@ fn read_tx_tree(
 fn neg_deinterleave(diff: u8, r#ref: u8, max: u8) -> u8 {
     if r#ref == 0 {
         diff
-    } else if r#ref >= max - 1 {
+    } else if r#ref + 1 >= max {
         max - diff - 1
     } else if 2 * r#ref < max {
         if diff <= 2 * r#ref {


### PR DESCRIPTION
`max` can be 0 and subtracting 1 causes underflow