### PR TITLE
`decode.rs`: Mark functions safe and document unsafe operations

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4418,7 +4418,9 @@ pub(crate) fn rav1d_decode_tile_sbrow(
     // backup pre-loopfilter pixels for intra prediction of the next sbrow
     if t.frame_thread.pass != 1 {
         // Function call with all safe args, will be marked safe.
-        unsafe { (f.bd_fn().backup_ipred_edge)(f, t); }
+        unsafe {
+            (f.bd_fn().backup_ipred_edge)(f, t);
+        }
     }
 
     // backup t->a/l.tx_lpf_y/uv at tile boundaries to use them to "fix"

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4877,7 +4877,7 @@ pub(crate) fn rav1d_decode_frame_init_cdf(
     Ok(())
 }
 
-unsafe fn rav1d_decode_frame_main(c: &Rav1dContext, f: &mut Rav1dFrameData) -> Rav1dResult {
+fn rav1d_decode_frame_main(c: &Rav1dContext, f: &mut Rav1dFrameData) -> Rav1dResult {
     assert!(c.tc.len() == 1);
 
     let Rav1dContextTaskType::Single(t) = &c.tc[0].task else {
@@ -4931,7 +4931,9 @@ unsafe fn rav1d_decode_frame_main(c: &Rav1dContext, f: &mut Rav1dFrameData) -> R
             }
 
             // loopfilter + cdef + restoration
-            (f.bd_fn().filter_sbrow)(c, f, &mut t, sby);
+            //
+            // SAFETY: Function call with all safe args, will be marked safe.
+            unsafe { (f.bd_fn().filter_sbrow)(c, f, &mut t, sby) };
         }
     }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3585,7 +3585,7 @@ fn decode_b(
     Ok(())
 }
 
-unsafe fn decode_sb(
+fn decode_sb(
     c: &Rav1dContext,
     t: &mut Rav1dTaskContext,
     f: &Rav1dFrameData,
@@ -3927,7 +3927,8 @@ unsafe fn decode_sb(
             [(&f.a[t.a], 0), (&t.l, 1)],
             [hsz as usize; 2],
             [bx8 as usize, by8 as usize],
-            |case, (dir, dir_index)| {
+            // SAFETY: No other thread is accessing the written portion of the buffer.
+            |case, (dir, dir_index)| unsafe {
                 case.set_disjoint(
                     &dir.partition,
                     dav1d_al_part_ctx[dir_index][bl as usize][bp as usize],


### PR DESCRIPTION
Mark `decode_b`, `decode_sb`, `rav1d_decode_tile_sbrow`, and `rav1d_decode_frame_main` as safe, putting any unsafe operations in `unsafe` blocks and documenting their safety invariants. For the `bd_fn` calls those should be safe since they're pure Rust calls and just haven't been marked safe. Once they're made safe we can clean up the unnecessary `unsafe` blocks. I also marked `load_tmvs` and `save_tmvs` safe since those wrap the unsafe asm call and handle converting the safe Rust args to the raw pointers that asm needs.

Part of #843.