### PR TITLE
`fn rav1d_recon_b_intra`: Cleanup

### DIFF
--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2468,6 +2468,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
     b: &Av1Block,
     intra: &Av1BlockIntra,
 ) {
+    let bd = BD::from_c(f.bitdepth_max);
     let ts = &f.ts[t.ts];
 
     let bx4 = t.b.x & 31;
@@ -2633,7 +2634,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             intra_edge_filter,
                             edge_array,
                             edge_offset,
-                            BD::from_c(f.bitdepth_max),
+                            bd,
                         );
                         let edge = edge_array.as_ptr().add(edge_offset);
                         f.dsp.ipred.intra_pred[m as usize].call(
@@ -2645,7 +2646,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             angle | intra_flags,
                             4 * f.bw - 4 * t.b.x,
                             4 * f.bh - 4 * t.b.y,
-                            BD::from_c(f.bitdepth_max),
+                            bd,
                         );
 
                         if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
@@ -2866,7 +2867,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         0,
                         edge_array,
                         edge_offset,
-                        BD::from_c(f.bitdepth_max),
+                        bd,
                     );
                     let edge = edge_array.as_ptr().add(edge_offset);
                     f.dsp.ipred.cfl_pred[m as usize].call(
@@ -2877,7 +2878,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         uv_t_dim.h as c_int * 4,
                         ac.as_mut_ptr(),
                         intra.cfl_alpha[pl] as c_int,
-                        BD::from_c(f.bitdepth_max),
+                        bd,
                     );
                 }
                 if debug_block_info!(&*f, t.b) && DEBUG_B_PIXELS {
@@ -3066,7 +3067,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                 intra_edge_filter,
                                 edge_array,
                                 edge_offset,
-                                BD::from_c(f.bitdepth_max),
+                                bd,
                             );
                             angle |= intra_edge_filter_flag;
                             let edge = edge_array.as_ptr().add(edge_offset);
@@ -3079,7 +3080,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                 angle | sm_uv_fl,
                                 4 * f.bw + ss_hor - 4 * (t.b.x & !ss_hor) >> ss_hor,
                                 4 * f.bh + ss_ver - 4 * (t.b.y & !ss_ver) >> ss_ver,
-                                BD::from_c(f.bitdepth_max),
+                                bd,
                             );
                             if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                                 hex_dump::<BD>(

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2510,7 +2510,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     let frame_thread = &ts.frame_thread[p];
                     let len = (bw4 * bh4 * 8) as usize;
                     let pal_idx = frame_thread.pal_idx.load(Ordering::Relaxed);
-                    pal_idx_guard = f.frame_thread.pal_idx.index(pal_idx..pal_idx + len);
+                    pal_idx_guard = f.frame_thread.pal_idx.index((pal_idx.., ..len));
                     frame_thread.pal_idx.store(pal_idx + len, Ordering::Relaxed);
                     &*pal_idx_guard
                 } else {
@@ -2523,14 +2523,14 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     let index =
                         ((y >> 1) + (x & 1)) * (f.b4_stride as usize >> 1) + (x >> 1) + (y & 1);
                     pal_guard = f.frame_thread.pal.index::<BD>(index);
-                    pal_guard[0].as_ptr()
+                    &pal_guard[0]
                 } else {
-                    scratch.interintra_edge_pal.pal.buf::<BD>()[0].as_ptr()
+                    &scratch.interintra_edge_pal.pal.buf::<BD>()[0]
                 };
                 f.dsp.ipred.pal_pred.call::<BD>(
                     dst,
                     f.cur.stride[0],
-                    pal,
+                    pal.as_ptr(),
                     pal_idx.as_ptr(),
                     bw4 * 4,
                     bh4 * 4,

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -138,6 +138,8 @@ macro_rules! debug_block_info {
 }
 pub(crate) use debug_block_info;
 
+const DEBUG_B_PIXELS: bool = false;
+
 pub(crate) type recon_b_intra_fn = unsafe fn(
     &Rav1dFrameData,
     &mut Rav1dTaskContext,
@@ -1778,7 +1780,7 @@ unsafe fn read_coef_tree<BD: BitDepth>(
                     }
                     CfSelect::Task => &mut BD::select_mut(&mut t.cf).0,
                 };
-                if debug_block_info!(f, t.b) && false {
+                if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                     coef_dump(
                         cf,
                         cmp::min(t_dim.h as usize, 8) * 4,
@@ -1795,7 +1797,7 @@ unsafe fn read_coef_tree<BD: BitDepth>(
                     eob,
                     f.bitdepth_max,
                 );
-                if debug_block_info!(f, t.b) && false {
+                if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                     hex_dump::<BD>(
                         dst,
                         f.cur.stride[0] as usize,
@@ -2529,7 +2531,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     bw4 * 4,
                     bh4 * 4,
                 );
-                if debug_block_info!(f, t.b) && 0 != 0 {
+                if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                     hex_dump::<BD>(
                         dst,
                         BD::pxstride(f.cur.stride[0]) as usize,
@@ -2640,7 +2642,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             4 * f.bh - 4 * t.b.y,
                             BD::from_c(f.bitdepth_max),
                         );
-                        if debug_block_info!(f, t.b) && 0 != 0 {
+                        if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                             hex_dump::<BD>(
                                 edge.offset(-(t_dim.h as isize * 4)),
                                 t_dim.h as usize * 4,
@@ -2731,7 +2733,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             );
                         }
                         if eob >= 0 {
-                            if debug_block_info!(f, t.b) && 0 != 0 {
+                            if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                                 coef_dump(
                                     cf,
                                     cmp::min(t_dim.h as usize, 8) * 4,
@@ -2748,7 +2750,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                 eob,
                                 f.bitdepth_max,
                             );
-                            if debug_block_info!(f, t.b) && 0 != 0 {
+                            if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                                 hex_dump::<BD>(
                                     dst,
                                     f.cur.stride[0] as usize,
@@ -2866,7 +2868,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         BD::from_c(f.bitdepth_max),
                     );
                 }
-                if debug_block_info!(&*f, t.b) && 0 != 0 {
+                if debug_block_info!(&*f, t.b) && DEBUG_B_PIXELS {
                     ac_dump(ac, 4 * cbw4 as usize, 4 * cbh4 as usize, "ac");
                     hex_dump::<BD>(
                         uv_dst[0],
@@ -2929,7 +2931,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     cbw4 * 4,
                     cbh4 * 4,
                 );
-                if debug_block_info!(f, t.b) && 0 != 0 {
+                if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                     hex_dump::<BD>(
                         (f.cur.data.as_ref().unwrap().data[1] as *mut BD::Pixel).offset(uv_dstoff),
                         BD::pxstride(f.cur.stride[1] as usize),
@@ -3062,7 +3064,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                 4 * f.bh + ss_ver - 4 * (t.b.y & !ss_ver) >> ss_ver,
                                 BD::from_c(f.bitdepth_max),
                             );
-                            if debug_block_info!(f, t.b) && 0 != 0 {
+                            if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                                 hex_dump::<BD>(
                                     edge.offset(-(uv_t_dim.h as isize * 4)),
                                     uv_t_dim.h as usize * 4,
@@ -3160,7 +3162,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                 );
                             }
                             if eob >= 0 {
-                                if debug_block_info!(f, t.b) && 0 != 0 {
+                                if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                                     coef_dump(
                                         cf,
                                         uv_t_dim.h as usize * 4,
@@ -3177,7 +3179,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                     eob,
                                     f.bitdepth_max,
                                 );
-                                if debug_block_info!(f, t.b) && 0 != 0 {
+                                if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                                     hex_dump::<BD>(
                                         dst,
                                         stride as usize,
@@ -3937,7 +3939,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
         t.tl_4x4_filter = filter_2d;
     }
 
-    if debug_block_info!(f, t.b) && 0 != 0 {
+    if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
         hex_dump::<BD>(
             dst,
             f.cur.stride[0] as usize,
@@ -4113,7 +4115,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                                 );
                             }
                             if eob >= 0 {
-                                if debug_block_info!(f, t.b) && 0 != 0 {
+                                if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                                     coef_dump(
                                         cf,
                                         uvtx.h as usize * 4,
@@ -4130,7 +4132,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                                     eob,
                                     f.bitdepth_max,
                                 );
-                                if debug_block_info!(f, t.b) && 0 != 0 {
+                                if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                                     hex_dump::<BD>(
                                         &mut *uvdst.offset((4 * x) as isize),
                                         f.cur.stride[1] as usize,

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2481,9 +2481,9 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
     let h4 = cmp::min(bh4, f.bh - t.b.y);
     let cw4 = w4 + ss_hor >> ss_hor;
     let ch4 = h4 + ss_ver >> ss_ver;
-    let has_chroma = (f.cur.p.layout as c_uint != Rav1dPixelLayout::I400 as c_int as c_uint
+    let has_chroma = f.cur.p.layout as c_uint != Rav1dPixelLayout::I400 as c_int as c_uint
         && (bw4 > ss_hor || t.b.x & 1 != 0)
-        && (bh4 > ss_ver || t.b.y & 1 != 0)) as c_int;
+        && (bh4 > ss_ver || t.b.y & 1 != 0);
     let t_dim = &dav1d_txfm_dimensions[intra.tx as usize];
     let uv_t_dim = &dav1d_txfm_dimensions[b.uvtx as usize];
     let cbw4 = bw4 + ss_hor >> ss_hor;
@@ -2784,7 +2784,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                 t.b.y += t_dim.h as c_int;
             }
             t.b.y -= y;
-            if !(has_chroma == 0) {
+            if !(!has_chroma) {
                 let stride: ptrdiff_t = f.cur.stride[1];
                 if intra.uv_mode as c_int == CFL_PRED as c_int {
                     assert!(init_x == 0 && init_y == 0);

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2511,7 +2511,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     &scratch.pal_idx_y
                 };
                 let pal_guard;
-                let pal: *const BD::Pixel = if t.frame_thread.pass != 0 {
+                let pal = if t.frame_thread.pass != 0 {
                     let x = t.b.x as usize;
                     let y = t.b.y as usize;
                     let index =
@@ -2572,8 +2572,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                 t.b.x += init_x;
                 while x < sub_w4 {
                     let mut angle;
-                    let edge_flags: EdgeFlags;
-                    let m: IntraPredMode;
+                    let edge_flags;
+                    let m;
                     if !(intra.pal_sz[0] != 0) {
                         angle = intra.y_angle as c_int;
                         edge_flags = EdgeFlags::union_all([
@@ -2669,7 +2669,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         let mut cf_guard;
                         let cf;
                         let eob;
-                        let mut txtp: TxfmType = DCT_DCT;
+                        let mut txtp = DCT_DCT;
                         if t.frame_thread.pass != 0 {
                             let p = (t.frame_thread.pass & 1) as usize;
                             let len = cmp::min(t_dim.h as usize, 8)
@@ -2686,7 +2686,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             eob = cbi.eob().into();
                             txtp = cbi.txtp();
                         } else {
-                            let mut cf_ctx: u8 = 0;
+                            let mut cf_ctx = 0;
                             let a_start = (bx4 + x) as usize;
                             let l_start = (by4 + y) as usize;
                             eob = decode_coefs::<BD>(
@@ -2780,19 +2780,18 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
             if !has_chroma {
                 continue;
             }
-            let stride: ptrdiff_t = f.cur.stride[1];
+            let stride = f.cur.stride[1];
             if intra.uv_mode == CFL_PRED {
                 assert!(init_x == 0 && init_y == 0);
                 let scratch = t.scratch.inter_intra_mut();
                 let ac = scratch.ac_txtp_map.ac_mut();
-                let y_src: *mut BD::Pixel = (f.cur.data.as_ref().unwrap().data[0]
-                    as *mut BD::Pixel)
+                let y_src = (f.cur.data.as_ref().unwrap().data[0] as *mut BD::Pixel)
                     .offset((4 * (t.b.x & !ss_hor)) as isize)
                     .offset((4 * (t.b.y & !ss_ver)) as isize * BD::pxstride(f.cur.stride[0]));
-                let uv_off: ptrdiff_t = 4
+                let uv_off = 4
                     * ((t.b.x >> ss_hor) as isize
                         + (t.b.y >> ss_ver) as isize * BD::pxstride(stride));
-                let uv_dst: [*mut BD::Pixel; 2] = [
+                let uv_dst = [
                     (f.cur.data.as_ref().unwrap().data[1] as *mut BD::Pixel).offset(uv_off),
                     (f.cur.data.as_ref().unwrap().data[2] as *mut BD::Pixel).offset(uv_off),
                 ];
@@ -2885,7 +2884,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     );
                 }
             } else if intra.pal_sz[1] != 0 {
-                let uv_dstoff: ptrdiff_t = 4
+                let uv_dstoff = 4
                     * ((t.b.x >> ss_hor) as isize
                         + (t.b.y >> ss_ver) as isize * BD::pxstride(f.cur.stride[1]));
                 let pal_idx_guard;
@@ -2968,23 +2967,23 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                 y = init_y >> ss_ver;
                 t.b.y += init_y;
                 while y < sub_ch4 {
-                    let mut dst: *mut BD::Pixel =
-                        (f.cur.data.as_ref().unwrap().data[(1 + pl) as usize] as *mut BD::Pixel)
-                            .offset(
-                                4 * ((t.b.y >> ss_ver) as isize * BD::pxstride(stride)
-                                    + (t.b.x + init_x >> ss_hor) as isize),
-                            );
+                    let mut dst = (f.cur.data.as_ref().unwrap().data[(1 + pl) as usize]
+                        as *mut BD::Pixel)
+                        .offset(
+                            4 * ((t.b.y >> ss_ver) as isize * BD::pxstride(stride)
+                                + (t.b.x + init_x >> ss_hor) as isize),
+                        );
                     x = init_x >> ss_hor;
                     t.b.x += init_x;
                     while x < sub_cw4 {
                         let mut angle;
-                        let edge_flags: EdgeFlags;
-                        let uv_mode: IntraPredMode;
+                        let edge_flags;
+                        let uv_mode;
                         let xpos;
                         let ypos;
                         let xstart;
                         let ystart;
-                        let m: IntraPredMode;
+                        let m;
                         if !(intra.uv_mode == CFL_PRED && intra.cfl_alpha[pl] != 0
                             || intra.pal_sz[1] != 0)
                         {
@@ -3099,7 +3098,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             }
                         }
                         if b.skip == 0 {
-                            let mut txtp: TxfmType = DCT_DCT;
+                            let mut txtp = DCT_DCT;
                             let eob;
                             let mut cf_guard;
                             let cf;

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2490,12 +2490,10 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
     let cbh4 = bh4 + ss_ver >> ss_ver;
     let intra_edge_filter = f.seq_hdr.as_ref().unwrap().intra_edge_filter;
     let intra_edge_filter_flag = (intra_edge_filter as c_int) << 10;
-    let mut init_y = 0;
-    while init_y < h4 {
+    for init_y in (0..h4).step_by(16) {
         let sub_h4 = cmp::min(h4, 16 + init_y);
         let sub_ch4 = cmp::min(ch4, init_y + 16 >> ss_ver);
-        let mut init_x = 0;
-        while init_x < w4 {
+        for init_x in (0..w4).step_by(16) {
             if intra.pal_sz[0] != 0 {
                 let dst: *mut BD::Pixel = (f.cur.data.as_ref().unwrap().data[0] as *mut BD::Pixel)
                     .offset(
@@ -2820,8 +2818,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         cbw4 * 4,
                         cbh4 * 4,
                     );
-                    let mut pl = 0;
-                    while pl < 2 {
+                    for pl in 0..2 {
                         if !(intra.cfl_alpha[pl as usize] == 0) {
                             let mut angle = 0;
                             let top_sb_edge_slice = if t.b.y & !ss_ver & f.sb_step - 1 == 0 {
@@ -2880,7 +2877,6 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                 BD::from_c(f.bitdepth_max),
                             );
                         }
-                        pl += 1;
                     }
                     if debug_block_info!(&*f, t.b) && 0 != 0 {
                         ac_dump(ac, 4 * cbw4 as usize, 4 * cbh4 as usize, "ac");
@@ -2983,8 +2979,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     intra_edge_flags.contains(EdgeFlags::I420_LEFT_HAS_BOTTOM >> f.cur.p.layout)
                 };
                 let sub_cw4 = cmp::min(cw4, init_x + 16 >> ss_hor);
-                let mut pl = 0;
-                while pl < 2 {
+                for pl in 0..2 {
                     y = init_y >> ss_ver;
                     t.b.y += init_y;
                     while y < sub_ch4 {
@@ -3245,12 +3240,9 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         t.b.y += (uv_t_dim.h as c_int) << ss_ver;
                     }
                     t.b.y -= y << ss_ver;
-                    pl += 1;
                 }
             }
-            init_x += 16 as c_int;
         }
-        init_y += 16 as c_int;
     }
 }
 

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2474,9 +2474,9 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
     let ss_hor = (f.cur.p.layout as c_uint != Rav1dPixelLayout::I444 as c_int as c_uint) as c_int;
     let cbx4 = bx4 >> ss_hor;
     let cby4 = by4 >> ss_ver;
-    let b_dim: *const u8 = (dav1d_block_dimensions[bs as usize]).as_ptr();
-    let bw4 = *b_dim.offset(0) as c_int;
-    let bh4 = *b_dim.offset(1) as c_int;
+    let b_dim = &dav1d_block_dimensions[bs as usize];
+    let bw4 = b_dim[0] as c_int;
+    let bh4 = b_dim[1] as c_int;
     let w4 = cmp::min(bw4, f.bw - t.b.x);
     let h4 = cmp::min(bh4, f.bh - t.b.y);
     let cw4 = w4 + ss_hor >> ss_hor;

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -20,7 +20,6 @@ use crate::src::env::get_uv_inter_txtp;
 use crate::src::internal::Bxy;
 use crate::src::internal::Cf;
 use crate::src::internal::CodedBlockInfo;
-use crate::src::internal::Rav1dBitDepthDSPContext;
 use crate::src::internal::Rav1dContext;
 use crate::src::internal::Rav1dFrameData;
 use crate::src::internal::Rav1dTaskContext;
@@ -2469,7 +2468,6 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
 ) {
     let ts = &f.ts[t.ts];
 
-    let dsp: *const Rav1dBitDepthDSPContext = f.dsp;
     let bx4 = t.b.x & 31;
     let by4 = t.b.y & 31;
     let ss_ver = (f.cur.p.layout as c_uint == Rav1dPixelLayout::I420 as c_int as c_uint) as c_int;
@@ -2638,7 +2636,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             BD::from_c(f.bitdepth_max),
                         );
                         let edge = edge_array.as_ptr().add(edge_offset);
-                        (*dsp).ipred.intra_pred[m as usize].call(
+                        f.dsp.ipred.intra_pred[m as usize].call(
                             dst,
                             f.cur.stride[0],
                             edge,
@@ -2751,7 +2749,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                     "dq",
                                 );
                             }
-                            ((*dsp).itx.itxfm_add[intra.tx as usize][txtp as usize])
+                            (f.dsp.itx.itxfm_add[intra.tx as usize][txtp as usize])
                                 .expect("non-null function pointer")(
                                 dst.cast(),
                                 f.cur.stride[0],
@@ -2815,7 +2813,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         (cw4 << ss_hor) + (*t_dim).w as c_int - 1 & !((*t_dim).w as c_int - 1);
                     let furthest_b =
                         (ch4 << ss_ver) + (*t_dim).h as c_int - 1 & !((*t_dim).h as c_int - 1);
-                    (*dsp).ipred.cfl_ac[f.cur.p.layout.try_into().unwrap()].call::<BD>(
+                    f.dsp.ipred.cfl_ac[f.cur.p.layout.try_into().unwrap()].call::<BD>(
                         ac.as_mut_ptr(),
                         y_src,
                         f.cur.stride[0],
@@ -2873,7 +2871,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                 BD::from_c(f.bitdepth_max),
                             );
                             let edge = edge_array.as_ptr().add(edge_offset);
-                            (*dsp).ipred.cfl_pred[m as usize].call(
+                            f.dsp.ipred.cfl_pred[m as usize].call(
                                 uv_dst[pl as usize],
                                 stride,
                                 edge,
@@ -3085,7 +3083,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                 );
                                 angle |= intra_edge_filter_flag;
                                 let edge = edge_array.as_ptr().add(edge_offset);
-                                (*dsp).ipred.intra_pred[m as usize].call(
+                                f.dsp.ipred.intra_pred[m as usize].call(
                                     dst,
                                     stride,
                                     edge,
@@ -3213,7 +3211,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                             "dq",
                                         );
                                     }
-                                    ((*dsp).itx.itxfm_add[b.uvtx as usize][txtp as usize])
+                                    (f.dsp.itx.itxfm_add[b.uvtx as usize][txtp as usize])
                                         .expect("non-null function pointer")(
                                         dst.cast(),
                                         stride,

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2988,19 +2988,13 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             || intra.pal_sz[1] != 0)
                         {
                             angle = intra.uv_angle as c_int;
-                            edge_flags = (if (y > init_y >> ss_ver || !uv_sb_has_tr)
-                                && x + uv_t_dim.w as c_int >= sub_cw4
-                            {
-                                EdgeFlags::empty()
-                            } else {
-                                EdgeFlags::I444_TOP_HAS_RIGHT
-                            }) | (if x > init_x >> ss_hor
-                                || !uv_sb_has_bl && y + uv_t_dim.h as c_int >= sub_ch4
-                            {
-                                EdgeFlags::empty()
-                            } else {
-                                EdgeFlags::I444_LEFT_HAS_BOTTOM
-                            });
+                            edge_flags = EdgeFlags::I444_TOP_HAS_RIGHT.select(
+                                !((y > init_y >> ss_ver || !uv_sb_has_tr)
+                                    && x + uv_t_dim.w as c_int >= sub_cw4),
+                            ) | EdgeFlags::I444_LEFT_HAS_BOTTOM.select(
+                                !(x > init_x >> ss_hor
+                                    || !uv_sb_has_bl && y + uv_t_dim.h as c_int >= sub_ch4),
+                            );
                             let top_sb_edge_slice = if t.b.y & !ss_ver & f.sb_step - 1 == 0 {
                                 let sby = t.b.y >> f.sb_shift;
                                 let offset = (f.ipred_edge_off * (1 + pl)) as isize
@@ -3016,8 +3010,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             };
                             xpos = t.b.x >> ss_hor;
                             ypos = t.b.y >> ss_ver;
-                            xstart = (*ts).tiling.col_start >> ss_hor;
-                            ystart = (*ts).tiling.row_start >> ss_ver;
+                            xstart = ts.tiling.col_start >> ss_hor;
+                            ystart = ts.tiling.row_start >> ss_ver;
                             let edge_array = t
                                 .scratch
                                 .inter_intra_mut()

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2412,8 +2412,8 @@ unsafe fn warp_affine<BD: BitDepth>(
                 ref_stride = 32 * ::core::mem::size_of::<BD::Pixel>() as isize;
             } else {
                 ref_ptr = (refp.p.data.as_ref().unwrap().data[pl] as *const BD::Pixel)
-                    .offset((BD::pxstride(ref_stride) * dy as isize) as isize)
-                    .add(dx as usize);
+                    .offset(BD::pxstride(ref_stride) * dy as isize)
+                    .offset(dx as isize);
             }
             match dst {
                 MaybeTempPixels::Temp {
@@ -2658,7 +2658,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             );
                             hex_dump::<BD>(edge, 0, 1, 1, "tl");
                             hex_dump::<BD>(
-                                edge.offset(1),
+                                edge.add(1),
                                 t_dim.w as usize * 4,
                                 t_dim.w as usize * 4,
                                 2,
@@ -2777,7 +2777,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             },
                         );
                     }
-                    dst = dst.offset(4 * t_dim.w as isize);
+                    dst = dst.add(4 * t_dim.w as usize);
                     x += t_dim.w as c_int;
                     t.b.x += t_dim.w as c_int;
                 }
@@ -2799,7 +2799,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                 let scratch = t.scratch.inter_intra_mut();
                 let ac = scratch.ac_txtp_map.ac_mut();
                 let y_src = (f.cur.data.as_ref().unwrap().data[0] as *mut BD::Pixel)
-                    .offset((4 * (t.b.x & !ss_hor)) as isize)
+                    .add((4 * (t.b.x & !ss_hor)) as usize)
                     .offset((4 * (t.b.y & !ss_ver)) as isize * BD::pxstride(f.cur.stride[0]));
                 let uv_off = 4
                     * ((t.b.x >> ss_hor) as isize
@@ -3091,7 +3091,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                 );
                                 hex_dump::<BD>(edge, 0, 1, 1, "tl");
                                 hex_dump::<BD>(
-                                    edge.offset(1),
+                                    edge.add(1),
                                     uv_t_dim.w as usize * 4,
                                     uv_t_dim.w as usize * 4,
                                     2,
@@ -3217,7 +3217,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                 },
                             );
                         }
-                        dst = dst.offset(uv_t_dim.w as isize * 4);
+                        dst = dst.add(uv_t_dim.w as usize * 4);
                         x += uv_t_dim.w as c_int;
                         t.b.x += (uv_t_dim.w as c_int) << ss_hor;
                     }


### PR DESCRIPTION
There are some `goto`s in the C, but they are just used for skipping an `if` block, so the existing `c2rust transpile` version is good enough.