### PR TITLE
Backport compliance check from dav1d 1.4.0

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -2594,6 +2594,25 @@ static void read_restoration_info(Dav1dTaskContext *const t,
     }
 }
 
+// modeled after the equivalent function in aomdec:decodeframe.c
+static int check_trailing_bits_after_symbol_coder(const MsacContext *const msac) {
+    // check marker bit (single 1), followed by zeroes
+    const int n_bits = -(msac->cnt + 14);
+    assert(n_bits <= 0); // this assumes we errored out when cnt <= -15 in caller
+    const int n_bytes = (n_bits + 7) >> 3;
+    const uint8_t *p = &msac->buf_pos[n_bytes];
+    const int pattern = 128 >> ((n_bits - 1) & 7);
+    if ((p[-1] & (2 * pattern - 1)) != pattern)
+        return 1;
+
+    // check remainder zero bytes
+    for (; p < msac->buf_end; p++)
+        if (*p)
+            return 1;
+
+    return 0;
+}
+
 int dav1d_decode_tile_sbrow(Dav1dTaskContext *const t) {
     const Dav1dFrameContext *const f = t->f;
     const enum BlockLevel root_bl = f->seq_hdr->sb128 ? BL_128X128 : BL_64X64;
@@ -2636,9 +2655,6 @@ int dav1d_decode_tile_sbrow(Dav1dTaskContext *const t) {
         f->bd_fn.backup_ipred_edge(t);
         return 0;
     }
-
-    // error out on symbol decoder overread
-    if (ts->msac.cnt < -15) return 1;
 
     if (f->c->n_tc > 1 && f->frame_hdr->use_ref_frame_mvs) {
         f->c->refmvs_dsp.load_tmvs(&f->rf, ts->tiling.row,
@@ -2745,7 +2761,12 @@ int dav1d_decode_tile_sbrow(Dav1dTaskContext *const t) {
     memcpy(&f->lf.tx_lpf_right_edge[1][align_h * tile_col + (t->by >> ss_ver)],
            &t->l.tx_lpf_uv[(t->by & 16) >> ss_ver], sb_step >> ss_ver);
 
-    return 0;
+    // error out on symbol decoder overread
+    if (ts->msac.cnt <= -15) return 1;
+
+    return c->strict_std_compliance &&
+           (t->by >> f->sb_shift) + 1 >= f->frame_hdr->tiling.row_start_sb[tile_row + 1] &&
+           check_trailing_bits_after_symbol_coder(&ts->msac);
 }
 
 int dav1d_decode_frame_init(Dav1dFrameContext *const f) {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4085,6 +4085,28 @@ fn read_restoration_info(
     }
 }
 
+// modeled after the equivalent function in aomdec:decodeframe.c
+fn check_trailing_bits_after_symbol_coder(msac: &MsacContext) -> Result<(), ()> {
+    // check marker bit (single 1), followed by zeroes
+    let n_bits = -(msac.cnt + 14);
+    assert!(n_bits <= 0); // this assumes we errored out when cnt <= -15 in caller
+    let n_bytes = (n_bits + 7) >> 3;
+    let trailing_bytes_offset = msac.buf_index().wrapping_add_signed(n_bytes as isize - 1);
+    let trailing_bytes = &msac.data()[trailing_bytes_offset..];
+    let pattern = 128 >> ((n_bits - 1) & 7);
+    // use x + (x - 1) instead of 2x - 1 to avoid overflow
+    if (trailing_bytes[0] & (pattern + (pattern - 1))) != pattern {
+        return Err(());
+    }
+
+    // check remainder zero bytes
+    if trailing_bytes[1..].iter().any(|&x| x != 0) {
+        return Err(());
+    }
+
+    return Ok(());
+}
+
 pub(crate) fn rav1d_decode_tile_sbrow(
     c: &Rav1dContext,
     t: &mut Rav1dTaskContext,
@@ -4153,11 +4175,6 @@ pub(crate) fn rav1d_decode_tile_sbrow(
         }
         (f.bd_fn().backup_ipred_edge)(f, t);
         return Ok(());
-    }
-
-    // error out on symbol decoder overread
-    if ts.context.try_lock().unwrap().msac.cnt < -15 {
-        return Err(());
     }
 
     if c.tc.len() > 1 && frame_hdr.use_ref_frame_mvs != 0 {
@@ -4313,6 +4330,17 @@ pub(crate) fn rav1d_decode_tile_sbrow(
         &t.l.tx_lpf_uv.index(lpf_uv_start..lpf_uv_start + len_uv),
     );
 
+    // error out on symbol decoder overread
+    if ts.context.try_lock().unwrap().msac.cnt <= -15 {
+        return Err(());
+    }
+
+    if c.strict_std_compliance
+        && (t.b.y >> f.sb_shift) + 1
+            >= f.frame_hdr().tiling.row_start_sb[tile_row as usize + 1].into()
+    {
+        return check_trailing_bits_after_symbol_coder(&ts.context.try_lock().unwrap().msac);
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Check for trailing marker/zero bits in tile data