### PR TITLE
`struct MsacContext`: Make data safe

### DIFF
--- a/src/c_arc.rs
+++ b/src/c_arc.rs
@@ -229,6 +229,14 @@ impl<T> CArc<[T]> {
     {
         self.stable_ref = self.as_ref()[range].into();
     }
+
+    pub fn split_at(this: Self, mid: usize) -> (Self, Self) {
+        let mut first = this.clone();
+        let mut second = this;
+        first.slice_in_place(..mid);
+        second.slice_in_place(mid..);
+        (first, second)
+    }
 }
 
 impl<T> CArc<[T]>

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -186,12 +186,6 @@ impl MsacAsmContext {
     fn allow_update_cdf(&self) -> bool {
         self.allow_update_cdf != 0
     }
-
-    fn set_buf(&mut self, buf: &[u8]) {
-        let Range { start, end } = buf.as_ptr_range();
-        self.buf_pos = start;
-        self.buf_end = end;
-    }
 }
 
 #[derive(Default)]
@@ -230,7 +224,8 @@ impl MsacContext {
         let data = &**self.data.as_ref().unwrap();
         let buf = &data[self.buf_index()..];
         let buf = f(buf);
-        self.asm.set_buf(buf);
+        self.buf_pos = buf.as_ptr();
+        // We don't actually need to set `self.buf_end` since it has not changed.
     }
 }
 

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -255,7 +255,8 @@ pub fn rav1d_msac_decode_uniform(s: &mut MsacContext, n: c_uint) -> c_int {
 }
 
 const EC_PROB_SHIFT: c_uint = 6;
-const EC_MIN_PROB: c_uint = 4; // must be <= (1 << EC_PROB_SHIFT) / 16
+const EC_MIN_PROB: c_uint = 4;
+const _: () = assert!(EC_MIN_PROB <= (1 << EC_PROB_SHIFT) / 16);
 
 const EC_WIN_SIZE: usize = mem::size_of::<ec_win>() << 3;
 

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -408,7 +408,7 @@ unsafe extern "C" fn rav1d_msac_decode_symbol_adapt_c(
     //
     // This is only called from [`dav1d_msac_decode_symbol_adapt16`],
     // where it comes from `cdf.len()`.
-    let cdf = unsafe { std::slice::from_raw_parts_mut(cdf, cdf_len) };
+    let cdf = unsafe { slice::from_raw_parts_mut(cdf, cdf_len) };
 
     rav1d_msac_decode_symbol_adapt_rust(s, cdf, n_symbols as u8) as c_uint
 }


### PR DESCRIPTION
This stores a `CArc<[u8]>` in `MsacContext` to safely store the `buf_{pos,end}` lifetime.  The lifetime is tricky to do otherwise since it comes from a `Rav1dData` is passed to multiple threads, and the `Rav1dData` already has a `CArc<[u8]>`.  Thus, we pay `Arc::clone`s on the `CArc::split_at`s introduced here, but hopefully that shouldn't be too expensive.  Furthermore, this lets us keep the data origin in `MsacContext`, which allows us to make #1071 safe, which does negative indexing.  To make that simple, `fn data` and `fn buf_index` can be used.

Since `MsacContext` was passed to asm, it needed to be FFI-safe, but `CArc` and the `Arc` inside of it are not.  To get around this, I renamed it to `MsacAsmContext` and created a new wrapper non-FFI-safe `MsacContext` storing the `CArc`.

`fn MsacContext::{buf,buf_index,with_buf}` are now all safe with no `unsafe` at all.