### PR TITLE
`union BitDepthUnion`: Remove and replace with safe `enum`

### DIFF
--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -299,10 +299,6 @@ impl BitDepth for BitDepth8 {
     }
 
     fn select_grain_mut(grain: &mut Grain) -> &mut GrainBD<Self> {
-        if !matches!(grain, Grain::Bpc8(..)) {
-            *grain = Grain::Bpc8(Default::default());
-        }
-
         match grain {
             Grain::Bpc8(grain) => grain,
             _ => unreachable!(),
@@ -371,10 +367,6 @@ impl BitDepth for BitDepth16 {
     }
 
     fn select_grain_mut(grain: &mut Grain) -> &mut GrainBD<Self> {
-        if !matches!(grain, Grain::Bpc16(..)) {
-            *grain = Grain::Bpc16(Default::default());
-        }
-
         match grain {
             Grain::Bpc16(grain) => grain,
             _ => unreachable!(),

--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -2,8 +2,6 @@ use crate::include::common::intops::clip;
 use crate::src::align::Align16;
 use crate::src::align::Align8;
 use crate::src::align::ArrayDefault;
-use crate::src::internal::Grain;
-use crate::src::internal::GrainBD;
 use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_void;
@@ -234,10 +232,6 @@ pub trait BitDepth: Clone + Copy {
     fn get_intermediate_bits(&self) -> u8;
 
     const PREP_BIAS: i16;
-
-    fn select_grain(grain: &Grain) -> &GrainBD<Self>;
-
-    fn select_grain_mut(bd: &mut Grain) -> &mut GrainBD<Self>;
 }
 
 #[derive(Clone, Copy)]
@@ -290,20 +284,6 @@ impl BitDepth for BitDepth8 {
 
     /// Output in interval `[-5132, 9212]`; fits in [`i16`] as is.
     const PREP_BIAS: i16 = 0;
-
-    fn select_grain(grain: &Grain) -> &GrainBD<Self> {
-        match grain {
-            Grain::Bpc8(grain) => grain,
-            _ => unreachable!(),
-        }
-    }
-
-    fn select_grain_mut(grain: &mut Grain) -> &mut GrainBD<Self> {
-        match grain {
-            Grain::Bpc8(grain) => grain,
-            _ => unreachable!(),
-        }
-    }
 }
 
 #[derive(Clone, Copy)]
@@ -358,20 +338,6 @@ impl BitDepth for BitDepth16 {
     /// Output in interval `[-20588, 36956]` (10-bit), `[-20602, 36983]` (12-bit)
     /// Subtract a bias to ensure the output fits in [`i16`].
     const PREP_BIAS: i16 = 8192;
-
-    fn select_grain(grain: &Grain) -> &GrainBD<Self> {
-        match grain {
-            Grain::Bpc16(grain) => grain,
-            _ => unreachable!(),
-        }
-    }
-
-    fn select_grain_mut(grain: &mut Grain) -> &mut GrainBD<Self> {
-        match grain {
-            Grain::Bpc16(grain) => grain,
-            _ => unreachable!(),
-        }
-    }
 }
 
 pub struct DisplayPixel8(<BitDepth8 as BitDepth>::Pixel);

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,8 +1,6 @@
 use crate::include::common::bitdepth::BitDepth;
 use crate::include::common::bitdepth::BitDepth16;
 use crate::include::common::bitdepth::BitDepth8;
-use crate::include::common::bitdepth::BitDepthDependentType;
-use crate::include::common::bitdepth::BitDepthUnion;
 use crate::include::common::bitdepth::BPC;
 use crate::include::dav1d::common::Rav1dDataProps;
 use crate::include::dav1d::data::Rav1dData;
@@ -286,10 +284,12 @@ impl<BD: BitDepth> Default for GrainBD<BD> {
     }
 }
 
-pub struct Grain;
-
-impl BitDepthDependentType for Grain {
-    type T<BD: BitDepth> = GrainBD<BD>;
+#[derive(Default)]
+pub enum Grain {
+    #[default]
+    Uninit,
+    Bpc8(GrainBD<BitDepth8>),
+    Bpc16(GrainBD<BitDepth16>),
 }
 
 #[derive(Default)]
@@ -298,7 +298,7 @@ pub(crate) struct TaskThreadData_delayed_fg {
     pub in_0: Rav1dPicture,
     pub out: Rav1dPicture,
     pub type_0: TaskType,
-    pub grain: BitDepthUnion<Grain>,
+    pub grain: Grain,
 }
 
 // TODO(SJC): Remove when TaskThreadData_delayed_fg is thread-safe

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -627,7 +627,7 @@ unsafe fn delayed_fg_task<'l, 'ttd: 'l>(
                         &Rav1dBitDepthDSPContext::get(bpc).as_ref().unwrap().fg,
                         &mut delayed_fg.out,
                         &delayed_fg.in_0,
-                        BitDepth8::select_mut(&mut delayed_fg.grain),
+                        BitDepth8::select_grain_mut(&mut delayed_fg.grain),
                     );
                 }
                 #[cfg(feature = "bitdepth_16")]
@@ -636,7 +636,7 @@ unsafe fn delayed_fg_task<'l, 'ttd: 'l>(
                         &Rav1dBitDepthDSPContext::get(bpc).as_ref().unwrap().fg,
                         &mut delayed_fg.out,
                         &delayed_fg.in_0,
-                        BitDepth16::select_mut(&mut delayed_fg.grain),
+                        BitDepth16::select_grain_mut(&mut delayed_fg.grain),
                     );
                 }
                 _ => {
@@ -674,7 +674,7 @@ unsafe fn delayed_fg_task<'l, 'ttd: 'l>(
                         &Rav1dBitDepthDSPContext::get(bpc).as_ref().unwrap().fg,
                         &delayed_fg.out,
                         &delayed_fg.in_0,
-                        BitDepth8::select(&delayed_fg.grain),
+                        BitDepth8::select_grain(&delayed_fg.grain),
                         row as usize,
                     );
                 }
@@ -684,7 +684,7 @@ unsafe fn delayed_fg_task<'l, 'ttd: 'l>(
                         &Rav1dBitDepthDSPContext::get(bpc).as_ref().unwrap().fg,
                         &delayed_fg.out,
                         &delayed_fg.in_0,
-                        BitDepth16::select(&delayed_fg.grain),
+                        BitDepth16::select_grain(&delayed_fg.grain),
                         row as usize,
                     );
                 }

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -629,20 +629,26 @@ unsafe fn delayed_fg_task<'l, 'ttd: 'l>(
             match delayed_fg.out.p.bpc {
                 #[cfg(feature = "bitdepth_8")]
                 bpc @ 8 => {
+                    let Grain::Bpc8(grain) = &mut delayed_fg.grain else {
+                        unreachable!();
+                    };
                     rav1d_prep_grain::<BitDepth8>(
                         &Rav1dBitDepthDSPContext::get(bpc).as_ref().unwrap().fg,
                         &mut delayed_fg.out,
                         &delayed_fg.in_0,
-                        BitDepth8::select_grain_mut(&mut delayed_fg.grain),
+                        grain,
                     );
                 }
                 #[cfg(feature = "bitdepth_16")]
                 bpc @ 10 | bpc @ 12 => {
+                    let Grain::Bpc16(grain) = &mut delayed_fg.grain else {
+                        unreachable!();
+                    };
                     rav1d_prep_grain::<BitDepth16>(
                         &Rav1dBitDepthDSPContext::get(bpc).as_ref().unwrap().fg,
                         &mut delayed_fg.out,
                         &delayed_fg.in_0,
-                        BitDepth16::select_grain_mut(&mut delayed_fg.grain),
+                        grain,
                     );
                 }
                 _ => {
@@ -676,21 +682,27 @@ unsafe fn delayed_fg_task<'l, 'ttd: 'l>(
             match delayed_fg.out.p.bpc {
                 #[cfg(feature = "bitdepth_8")]
                 bpc @ 8 => {
+                    let Grain::Bpc8(grain) = &delayed_fg.grain else {
+                        unreachable!();
+                    };
                     rav1d_apply_grain_row::<BitDepth8>(
                         &Rav1dBitDepthDSPContext::get(bpc).as_ref().unwrap().fg,
                         &delayed_fg.out,
                         &delayed_fg.in_0,
-                        BitDepth8::select_grain(&delayed_fg.grain),
+                        grain,
                         row as usize,
                     );
                 }
                 #[cfg(feature = "bitdepth_16")]
                 bpc @ 10 | bpc @ 12 => {
+                    let Grain::Bpc16(grain) = &delayed_fg.grain else {
+                        unreachable!();
+                    };
                     rav1d_apply_grain_row::<BitDepth16>(
                         &Rav1dBitDepthDSPContext::get(bpc).as_ref().unwrap().fg,
                         &delayed_fg.out,
                         &delayed_fg.in_0,
-                        BitDepth16::select_grain(&delayed_fg.grain),
+                        grain,
                         row as usize,
                     );
                 }

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -16,6 +16,7 @@ use crate::src::error::Rav1dError::ENOMEM;
 use crate::src::error::Rav1dResult;
 use crate::src::fg_apply::rav1d_apply_grain_row;
 use crate::src::fg_apply::rav1d_prep_grain;
+use crate::src::internal::Grain;
 use crate::src::internal::Rav1dBitDepthDSPContext;
 use crate::src::internal::Rav1dContext;
 use crate::src::internal::Rav1dFrameContext;
@@ -442,6 +443,11 @@ pub(crate) fn rav1d_task_delayed_fg(
         delayed_fg.in_0 = in_0.clone();
         delayed_fg.out = out.clone();
         delayed_fg.type_0 = TaskType::FgPrep;
+        delayed_fg.grain = match out.p.bpc {
+            8 => Grain::Bpc8(Default::default()),
+            10 | 12 => Grain::Bpc16(Default::default()),
+            _ => unreachable!(),
+        }
     }
     let task_thread_lock = ttd.lock.lock().unwrap();
     ttd.delayed_fg_exec.store(1, Ordering::Relaxed);


### PR DESCRIPTION
Removes `BitDepthUnion` and replaces the last usage of it with an enum. Split off from #1073 due to questions around lazy initialization. I've reworked this to eagerly initialize the `Grain` enum in `rav1d_task_delayed_fg` where we setup the rest of the delayed fg task.