### PR TITLE
`struct Rav1dPictureDataComponent`: Store pic data in a `DisjointMut`, but still unsafely use `.as_mut_ptr()` for now

### DIFF
--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -1,5 +1,6 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
+use crate::include::common::bitdepth::BitDepth;
 use crate::include::common::validate::validate_input;
 use crate::include::dav1d::common::Dav1dDataProps;
 use crate::include::dav1d::common::Rav1dDataProps;
@@ -98,7 +99,7 @@ pub struct Dav1dPicture {
 }
 
 pub struct Rav1dPictureData {
-    pub(crate) data: [*mut c_void; 3],
+    data: [*mut c_void; 3],
     pub(crate) allocator_data: Option<NonNull<c_void>>,
     pub(crate) allocator: Rav1dPicAllocator,
 }
@@ -111,6 +112,13 @@ impl Drop for Rav1dPictureData {
             ref allocator,
         } = *self;
         allocator.dealloc_picture_data(data, allocator_data);
+    }
+}
+
+impl Rav1dPictureData {
+    #[inline(always)]
+    pub fn data<BD: BitDepth>(&self) -> [*mut BD::Pixel; 3] {
+        self.data.map(|data| data.cast())
     }
 }
 

--- a/lib.rs
+++ b/lib.rs
@@ -43,7 +43,7 @@ pub mod src {
     mod data;
     mod decode;
     mod dequant_tables;
-    mod disjoint_mut;
+    pub(crate) mod disjoint_mut;
     pub(crate) mod enum_map;
     mod env;
     pub(crate) mod error;

--- a/src/disjoint_mut.rs
+++ b/src/disjoint_mut.rs
@@ -61,6 +61,10 @@ impl<T: AsMutPtr> DisjointMut<T> {
             bounds: debug::DisjointMutAllBounds::new(),
         }
     }
+
+    pub fn into_inner(self) -> T {
+        self.inner.into_inner()
+    }
 }
 
 #[cfg_attr(not(debug_assertions), repr(transparent))]

--- a/src/fg_apply.rs
+++ b/src/fg_apply.rs
@@ -119,18 +119,24 @@ pub(crate) unsafe fn rav1d_prep_grain<BD: BitDepth>(
         let sz = out.p.h as isize * stride;
         if sz < 0 {
             memcpy(
-                (out.data.as_ref().unwrap().data::<BD>()[0] as *mut u8)
+                out.data.as_ref().unwrap().data[0]
+                    .as_mut_ptr()
                     .offset(sz as isize)
                     .offset(-(stride as isize)) as *mut c_void,
-                (r#in.data.as_ref().unwrap().data::<BD>()[0] as *mut u8)
+                r#in.data.as_ref().unwrap().data[0]
+                    .as_mut_ptr()
                     .offset(sz as isize)
                     .offset(-(stride as isize)) as *const c_void,
                 -sz as usize,
             );
         } else {
             memcpy(
-                out.data.as_ref().unwrap().data::<BD>()[0].cast::<c_void>(),
-                r#in.data.as_ref().unwrap().data::<BD>()[0].cast::<c_void>(),
+                out.data.as_ref().unwrap().data[0]
+                    .as_mut_ptr()
+                    .cast::<c_void>(),
+                r#in.data.as_ref().unwrap().data[0]
+                    .as_mut_ptr()
+                    .cast::<c_void>(),
                 sz as usize,
             );
         }
@@ -144,10 +150,12 @@ pub(crate) unsafe fn rav1d_prep_grain<BD: BitDepth>(
         if sz < 0 {
             if data.num_uv_points[0] == 0 {
                 memcpy(
-                    (out.data.as_ref().unwrap().data::<BD>()[1] as *mut u8)
+                    out.data.as_ref().unwrap().data[1]
+                        .as_mut_ptr()
                         .offset(sz as isize)
                         .offset(-(stride as isize)) as *mut c_void,
-                    (r#in.data.as_ref().unwrap().data::<BD>()[1] as *mut u8)
+                    r#in.data.as_ref().unwrap().data[1]
+                        .as_mut_ptr()
                         .offset(sz as isize)
                         .offset(-(stride as isize)) as *const c_void,
                     -sz as usize,
@@ -155,10 +163,12 @@ pub(crate) unsafe fn rav1d_prep_grain<BD: BitDepth>(
             }
             if data.num_uv_points[1] == 0 {
                 memcpy(
-                    (out.data.as_ref().unwrap().data::<BD>()[2] as *mut u8)
+                    out.data.as_ref().unwrap().data[2]
+                        .as_mut_ptr()
                         .offset(sz as isize)
                         .offset(-(stride as isize)) as *mut c_void,
-                    (r#in.data.as_ref().unwrap().data::<BD>()[2] as *mut u8)
+                    r#in.data.as_ref().unwrap().data[2]
+                        .as_mut_ptr()
                         .offset(sz as isize)
                         .offset(-(stride as isize)) as *const c_void,
                     -sz as usize,
@@ -167,15 +177,23 @@ pub(crate) unsafe fn rav1d_prep_grain<BD: BitDepth>(
         } else {
             if data.num_uv_points[0] == 0 {
                 memcpy(
-                    out.data.as_ref().unwrap().data::<BD>()[1].cast::<c_void>(),
-                    r#in.data.as_ref().unwrap().data::<BD>()[1].cast::<c_void>(),
+                    out.data.as_ref().unwrap().data[1]
+                        .as_mut_ptr()
+                        .cast::<c_void>(),
+                    r#in.data.as_ref().unwrap().data[1]
+                        .as_mut_ptr()
+                        .cast::<c_void>(),
                     sz as usize,
                 );
             }
             if data.num_uv_points[1] == 0 {
                 memcpy(
-                    out.data.as_ref().unwrap().data::<BD>()[2].cast::<c_void>(),
-                    r#in.data.as_ref().unwrap().data::<BD>()[2].cast::<c_void>(),
+                    out.data.as_ref().unwrap().data[2]
+                        .as_mut_ptr()
+                        .cast::<c_void>(),
+                    r#in.data.as_ref().unwrap().data[2]
+                        .as_mut_ptr()
+                        .cast::<c_void>(),
                     sz as usize,
                 );
             }
@@ -200,7 +218,9 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
     let ss_x = (r#in.p.layout != Rav1dPixelLayout::I444) as usize;
     let cpw = out.p.w as usize + ss_x >> ss_x;
     let is_id = seq_hdr.mtrx == Rav1dMatrixCoefficients::IDENTITY;
-    let luma_src = r#in.data.as_ref().unwrap().data::<BD>()[0]
+    let luma_src = r#in.data.as_ref().unwrap().data[0]
+        .as_mut_ptr()
+        .cast::<BD::Pixel>()
         .offset(((row * 32) as isize * BD::pxstride(r#in.stride[0])) as isize);
     let bitdepth_max = (1 << out.p.bpc) - 1;
     let bd = BD::from_c(bitdepth_max);
@@ -208,7 +228,9 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
     if data.num_y_points != 0 {
         let bh = cmp::min(out.p.h as usize - row * 32, 32);
         dsp.fgy_32x32xn.call(
-            out.data.as_ref().unwrap().data::<BD>()[0]
+            out.data.as_ref().unwrap().data[0]
+                .as_mut_ptr()
+                .cast::<BD::Pixel>()
                 .offset(((row * 32) as isize * BD::pxstride(out.stride[0])) as isize),
             luma_src.cast(),
             out.stride[0],
@@ -241,8 +263,13 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
     if data.chroma_scaling_from_luma {
         for pl in 0..2 {
             dsp.fguv_32x32xn[r#in.p.layout.try_into().unwrap()].call(
-                out.data.as_ref().unwrap().data::<BD>()[1 + pl].offset(uv_off as isize),
-                r#in.data.as_ref().unwrap().data::<BD>()[1 + pl]
+                out.data.as_ref().unwrap().data[1 + pl]
+                    .as_mut_ptr()
+                    .cast::<BD::Pixel>()
+                    .offset(uv_off as isize),
+                r#in.data.as_ref().unwrap().data[1 + pl]
+                    .as_mut_ptr()
+                    .cast::<BD::Pixel>()
                     .cast_const()
                     .offset(uv_off as isize),
                 r#in.stride[1],
@@ -263,8 +290,13 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
         for pl in 0..2 {
             if data.num_uv_points[pl] != 0 {
                 dsp.fguv_32x32xn[r#in.p.layout.try_into().unwrap()].call(
-                    out.data.as_ref().unwrap().data::<BD>()[1 + pl].offset(uv_off as isize),
-                    r#in.data.as_ref().unwrap().data::<BD>()[1 + pl]
+                    out.data.as_ref().unwrap().data[1 + pl]
+                        .as_mut_ptr()
+                        .cast::<BD::Pixel>()
+                        .offset(uv_off as isize),
+                    r#in.data.as_ref().unwrap().data[1 + pl]
+                        .as_mut_ptr()
+                        .cast::<BD::Pixel>()
                         .cast_const()
                         .offset(uv_off as isize),
                     r#in.stride[1],

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2098,7 +2098,9 @@ unsafe fn mc<BD: BitDepth>(
         let w;
         let h;
 
-        if refp.p.data.as_ref().unwrap().data[0] != f.cur.data.as_ref().unwrap().data[0] {
+        if refp.p.data.as_ref().unwrap().data::<BD>()[0]
+            != f.cur.data.as_ref().unwrap().data::<BD>()[0]
+        {
             w = f.cur.p.w + ss_hor >> ss_hor;
             h = f.cur.p.h + ss_ver >> ss_ver;
         } else {
@@ -2120,7 +2122,7 @@ unsafe fn mc<BD: BitDepth>(
                 (dy - (my != 0) as c_int * 3) as intptr_t,
                 emu_edge_buf.as_mut_ptr().cast(),
                 192 * mem::size_of::<BD::Pixel>(),
-                refp.p.data.as_ref().unwrap().data[pl].cast(),
+                refp.p.data.as_ref().unwrap().data::<BD>()[pl].cast(),
                 ref_stride,
             );
             r#ref = emu_edge_buf
@@ -2128,7 +2130,7 @@ unsafe fn mc<BD: BitDepth>(
                 .add((192 * (my != 0) as c_int * 3 + (mx != 0) as c_int * 3) as usize);
             ref_stride = 192 * ::core::mem::size_of::<BD::Pixel>() as isize;
         } else {
-            r#ref = (refp.p.data.as_ref().unwrap().data[pl] as *mut BD::Pixel)
+            r#ref = refp.p.data.as_ref().unwrap().data::<BD>()[pl]
                 .offset(BD::pxstride(ref_stride) * dy as isize)
                 .add(dx as usize);
         }
@@ -2192,7 +2194,7 @@ unsafe fn mc<BD: BitDepth>(
                 (top - 3) as intptr_t,
                 emu_edge_buf.as_mut_ptr().cast(),
                 320 * mem::size_of::<BD::Pixel>(),
-                refp.p.data.as_ref().unwrap().data[pl].cast(),
+                refp.p.data.as_ref().unwrap().data::<BD>()[pl].cast(),
                 ref_stride,
             );
             r#ref = emu_edge_buf.as_mut_ptr().add((320 * 3 + 3) as usize);
@@ -2201,7 +2203,7 @@ unsafe fn mc<BD: BitDepth>(
                 println!("Emu");
             }
         } else {
-            r#ref = (refp.p.data.as_ref().unwrap().data[pl] as *mut BD::Pixel)
+            r#ref = refp.p.data.as_ref().unwrap().data::<BD>()[pl]
                 .offset(BD::pxstride(ref_stride) * top as isize)
                 .offset(left as isize);
         }
@@ -2400,13 +2402,14 @@ unsafe fn warp_affine<BD: BitDepth>(
                     (dy - 3) as intptr_t,
                     emu_edge_buf.as_mut_ptr().cast(),
                     32 * mem::size_of::<BD::Pixel>(),
-                    refp.p.data.as_ref().unwrap().data[pl].cast(),
+                    refp.p.data.as_ref().unwrap().data::<BD>()[pl].cast(),
                     ref_stride,
                 );
                 ref_ptr = emu_edge_buf.as_ptr().add(32 * 3 + 3);
                 ref_stride = 32 * ::core::mem::size_of::<BD::Pixel>() as isize;
             } else {
-                ref_ptr = (refp.p.data.as_ref().unwrap().data[pl] as *const BD::Pixel)
+                ref_ptr = refp.p.data.as_ref().unwrap().data::<BD>()[pl]
+                    .cast_const()
                     .offset(BD::pxstride(ref_stride) * dy as isize)
                     .offset(dx as isize);
             }
@@ -2497,7 +2500,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
         let sub_ch4 = cmp::min(ch4, init_y + 16 >> ss_ver);
         for init_x in (0..w4).step_by(16) {
             if intra.pal_sz[0] != 0 {
-                let dst: *mut BD::Pixel = (f.cur.data.as_ref().unwrap().data[0] as *mut BD::Pixel)
+                let dst: *mut BD::Pixel = f.cur.data.as_ref().unwrap().data::<BD>()[0]
                     .offset(4 * (t.b.y as isize * BD::pxstride(f.cur.stride[0]) + t.b.x as isize));
                 let pal_idx_guard;
                 let scratch = t.scratch.inter_intra_mut();
@@ -2565,12 +2568,11 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
             y = init_y;
             t.b.y += init_y;
             while y < sub_h4 {
-                let mut dst: *mut BD::Pixel =
-                    (f.cur.data.as_ref().unwrap().data[0] as *mut BD::Pixel).offset(
-                        4 * (t.b.y as isize * BD::pxstride(f.cur.stride[0])
-                            + t.b.x as isize
-                            + init_x as isize),
-                    );
+                let mut dst: *mut BD::Pixel = f.cur.data.as_ref().unwrap().data::<BD>()[0].offset(
+                    4 * (t.b.y as isize * BD::pxstride(f.cur.stride[0])
+                        + t.b.x as isize
+                        + init_x as isize),
+                );
                 x = init_x;
                 t.b.x += init_x;
                 while x < sub_w4 {
@@ -2607,7 +2609,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         let data_height = 4 * ts.tiling.row_end;
                         let data_diff = (data_height - 1) as isize * data_stride;
                         let dst_slice = slice::from_raw_parts(
-                            (f.cur.data.as_ref().unwrap().data[0] as *const BD::Pixel)
+                            f.cur.data.as_ref().unwrap().data::<BD>()[0]
+                                .cast_const()
                                 .offset(cmp::min(data_diff, 0)),
                             data_diff.unsigned_abs() + data_width as usize,
                         );
@@ -2794,15 +2797,15 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
 
                 let scratch = t.scratch.inter_intra_mut();
                 let ac = scratch.ac_txtp_map.ac_mut();
-                let y_src = (f.cur.data.as_ref().unwrap().data[0] as *mut BD::Pixel)
+                let y_src = f.cur.data.as_ref().unwrap().data::<BD>()[0]
                     .add((4 * (t.b.x & !ss_hor)) as usize)
                     .offset((4 * (t.b.y & !ss_ver)) as isize * BD::pxstride(f.cur.stride[0]));
                 let uv_off = 4
                     * ((t.b.x >> ss_hor) as isize
                         + (t.b.y >> ss_ver) as isize * BD::pxstride(stride));
                 let uv_dst = [
-                    (f.cur.data.as_ref().unwrap().data[1] as *mut BD::Pixel).offset(uv_off),
-                    (f.cur.data.as_ref().unwrap().data[2] as *mut BD::Pixel).offset(uv_off),
+                    f.cur.data.as_ref().unwrap().data::<BD>()[1].offset(uv_off),
+                    f.cur.data.as_ref().unwrap().data::<BD>()[2].offset(uv_off),
                 ];
 
                 let furthest_r = (cw4 << ss_hor) + t_dim.w as c_int - 1 & !(t_dim.w as c_int - 1);
@@ -2840,7 +2843,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     let data_height = 4 * ts.tiling.row_end >> ss_ver;
                     let data_diff = (data_height - 1) as isize * data_stride;
                     let uvdst_slice = slice::from_raw_parts(
-                        (f.cur.data.as_ref().unwrap().data[1 + pl] as *const BD::Pixel)
+                        f.cur.data.as_ref().unwrap().data::<BD>()[1 + pl]
+                            .cast_const()
                             .offset(cmp::min(data_diff, 0)),
                         data_diff.unsigned_abs() + data_width as usize,
                     );
@@ -2925,7 +2929,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                 };
 
                 f.dsp.ipred.pal_pred.call::<BD>(
-                    (f.cur.data.as_ref().unwrap().data[1] as *mut BD::Pixel).offset(uv_dstoff),
+                    f.cur.data.as_ref().unwrap().data::<BD>()[1].offset(uv_dstoff),
                     f.cur.stride[1],
                     pal[1].as_ptr(),
                     pal_idx.as_ptr(),
@@ -2933,7 +2937,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     cbh4 * 4,
                 );
                 f.dsp.ipred.pal_pred.call::<BD>(
-                    (f.cur.data.as_ref().unwrap().data[2] as *mut BD::Pixel).offset(uv_dstoff),
+                    f.cur.data.as_ref().unwrap().data::<BD>()[2].offset(uv_dstoff),
                     f.cur.stride[1],
                     pal[2].as_ptr(),
                     pal_idx.as_ptr(),
@@ -2942,14 +2946,14 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                 );
                 if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                     hex_dump::<BD>(
-                        (f.cur.data.as_ref().unwrap().data[1] as *mut BD::Pixel).offset(uv_dstoff),
+                        f.cur.data.as_ref().unwrap().data::<BD>()[1].offset(uv_dstoff),
                         BD::pxstride(f.cur.stride[1] as usize),
                         cbw4 as usize * 4,
                         cbh4 as usize * 4,
                         "u-pal-pred",
                     );
                     hex_dump::<BD>(
-                        (f.cur.data.as_ref().unwrap().data[2] as *mut BD::Pixel).offset(uv_dstoff),
+                        f.cur.data.as_ref().unwrap().data::<BD>()[2].offset(uv_dstoff),
                         BD::pxstride(f.cur.stride[1] as usize),
                         cbw4 as usize * 4,
                         cbh4 as usize * 4,
@@ -2979,8 +2983,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                 y = init_y >> ss_ver;
                 t.b.y += init_y;
                 while y < sub_ch4 {
-                    let mut dst = (f.cur.data.as_ref().unwrap().data[(1 + pl) as usize]
-                        as *mut BD::Pixel)
+                    let mut dst = f.cur.data.as_ref().unwrap().data::<BD>()[(1 + pl) as usize]
                         .offset(
                             4 * ((t.b.y >> ss_ver) as isize * BD::pxstride(stride)
                                 + (t.b.x + init_x >> ss_hor) as isize),
@@ -3039,8 +3042,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             let data_height = 4 * ts.tiling.row_end >> ss_ver;
                             let data_diff = (data_height - 1) as isize * data_stride;
                             let dstuv_slice = slice::from_raw_parts(
-                                (f.cur.data.as_ref().unwrap().data[1 + pl as usize]
-                                    as *const BD::Pixel)
+                                f.cur.data.as_ref().unwrap().data::<BD>()[1 + pl as usize]
+                                    .cast_const()
                                     .offset(cmp::min(data_diff, 0)),
                                 data_diff.unsigned_abs() + data_width as usize,
                             );
@@ -3267,7 +3270,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
     // prediction
     let cbh4 = bh4 + ss_ver >> ss_ver;
     let cbw4 = bw4 + ss_hor >> ss_hor;
-    let mut dst = (f.cur.data.as_ref().unwrap().data[0] as *mut BD::Pixel)
+    let mut dst = f.cur.data.as_ref().unwrap().data::<BD>()[0]
         .offset(4 * (t.b.y as isize * BD::pxstride(f.cur.stride[0]) + t.b.x as isize));
     let uvdstoff = 4
         * ((t.b.x >> ss_hor) as isize + (t.b.y >> ss_ver) as isize * BD::pxstride(f.cur.stride[1]));
@@ -3301,8 +3304,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     &mut scratch.emu_edge,
                     t.b,
                     MaybeTempPixels::NonTemp {
-                        dst: (f.cur.data.as_ref().unwrap().data[pl] as *mut BD::Pixel)
-                            .offset(uvdstoff),
+                        dst: f.cur.data.as_ref().unwrap().data::<BD>()[pl].offset(uvdstoff),
                         dst_stride: f.cur.stride[1],
                     },
                     bw4 << (bw4 == ss_hor) as c_int,
@@ -3472,8 +3474,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     }
                 }
 
-                let uvdst =
-                    (f.cur.data.as_ref().unwrap().data[1 + pl] as *mut BD::Pixel).offset(uvdstoff);
+                let uvdst = f.cur.data.as_ref().unwrap().data::<BD>()[1 + pl].offset(uvdstoff);
                 match comp_inter_type {
                     CompInterType::Avg => {
                         (f.dsp.mc.avg)(
@@ -3584,7 +3585,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
             let data_height = 4 * ts.tiling.row_end;
             let data_diff = (data_height - 1) as isize * data_stride;
             let dst_slice = slice::from_raw_parts(
-                (f.cur.data.as_ref().unwrap().data[0] as *const BD::Pixel)
+                f.cur.data.as_ref().unwrap().data::<BD>()[0]
+                    .cast_const()
                     .offset(cmp::min(data_diff, 0)),
                 data_diff.unsigned_abs() + data_width as usize,
             );
@@ -3671,7 +3673,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             &mut t.scratch.inter_mut().emu_edge,
                             t.b,
                             MaybeTempPixels::NonTemp {
-                                dst: (f.cur.data.as_ref().unwrap().data[1 + pl] as *mut BD::Pixel)
+                                dst: f.cur.data.as_ref().unwrap().data::<BD>()[1 + pl]
                                     .offset(uvdstoff),
                                 dst_stride: f.cur.stride[1],
                             },
@@ -3712,7 +3714,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             &mut t.scratch.inter_mut().emu_edge,
                             t.b,
                             MaybeTempPixels::NonTemp {
-                                dst: (f.cur.data.as_ref().unwrap().data[1 + pl] as *mut BD::Pixel)
+                                dst: f.cur.data.as_ref().unwrap().data::<BD>()[1 + pl]
                                     .offset(uvdstoff + v_off),
                                 dst_stride: f.cur.stride[1],
                             },
@@ -3750,7 +3752,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             &mut t.scratch.inter_mut().emu_edge,
                             t.b,
                             MaybeTempPixels::NonTemp {
-                                dst: (f.cur.data.as_ref().unwrap().data[1 + pl] as *mut BD::Pixel)
+                                dst: f.cur.data.as_ref().unwrap().data::<BD>()[1 + pl]
                                     .offset(uvdstoff + h_off),
                                 dst_stride: f.cur.stride[1],
                             },
@@ -3784,7 +3786,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                         &mut t.scratch.inter_mut().emu_edge,
                         t.b,
                         MaybeTempPixels::NonTemp {
-                            dst: (f.cur.data.as_ref().unwrap().data[1 + pl] as *mut BD::Pixel)
+                            dst: f.cur.data.as_ref().unwrap().data::<BD>()[1 + pl]
                                 .offset(uvdstoff + h_off + v_off),
                             dst_stride: f.cur.stride[1],
                         },
@@ -3812,7 +3814,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             &mut t.scratch.inter_mut().emu_edge,
                             t.b,
                             MaybeTempPixels::NonTemp {
-                                dst: (f.cur.data.as_ref().unwrap().data[1 + pl] as *mut BD::Pixel)
+                                dst: f.cur.data.as_ref().unwrap().data::<BD>()[1 + pl]
                                     .offset(uvdstoff),
                                 dst_stride: f.cur.stride[1],
                             },
@@ -3833,7 +3835,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             &mut t.scratch.inter_mut().emu_edge,
                             t.b,
                             MaybeTempPixels::NonTemp {
-                                dst: (f.cur.data.as_ref().unwrap().data[1 + pl] as *mut BD::Pixel)
+                                dst: f.cur.data.as_ref().unwrap().data::<BD>()[1 + pl]
                                     .offset(uvdstoff),
                                 dst_stride: f.cur.stride[1],
                             },
@@ -3851,8 +3853,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             obmc::<BD>(
                                 f,
                                 t,
-                                (f.cur.data.as_ref().unwrap().data[1 + pl] as *mut BD::Pixel)
-                                    .offset(uvdstoff),
+                                f.cur.data.as_ref().unwrap().data::<BD>()[1 + pl].offset(uvdstoff),
                                 f.cur.stride[1],
                                 b_dim,
                                 1 + pl,
@@ -3889,8 +3890,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             mode => mode as IntraPredMode,
                         };
                         let mut angle = 0;
-                        let uvdst = (f.cur.data.as_ref().unwrap().data[1 + pl] as *mut BD::Pixel)
-                            .offset(uvdstoff);
+                        let uvdst =
+                            f.cur.data.as_ref().unwrap().data::<BD>()[1 + pl].offset(uvdstoff);
                         let top_sb_edge_slice = if t.b.y & f.sb_step - 1 == 0 {
                             let sby = t.b.y >> f.sb_shift;
                             let offset = (f.ipred_edge_off * (pl + 1)) as isize
@@ -3904,8 +3905,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                         let data_height = 4 * ts.tiling.row_end >> ss_ver;
                         let data_diff = (data_height - 1) as isize * data_stride;
                         let dstuv_slice = slice::from_raw_parts(
-                            (f.cur.data.as_ref().unwrap().data[1 + pl as usize]
-                                as *const BD::Pixel)
+                            f.cur.data.as_ref().unwrap().data::<BD>()[1 + pl as usize]
+                                .cast_const()
                                 .offset(cmp::min(data_diff, 0)),
                             data_diff.unsigned_abs() + data_width as usize,
                         );
@@ -3967,14 +3968,14 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
         );
         if has_chroma {
             hex_dump::<BD>(
-                (f.cur.data.as_ref().unwrap().data[1] as *mut BD::Pixel).offset(uvdstoff),
+                f.cur.data.as_ref().unwrap().data::<BD>()[1].offset(uvdstoff),
                 f.cur.stride[1] as usize,
                 cbw4 as usize * 4,
                 cbh4 as usize * 4,
                 "u-pred",
             );
             hex_dump::<BD>(
-                (f.cur.data.as_ref().unwrap().data[2] as *mut BD::Pixel).offset(uvdstoff),
+                f.cur.data.as_ref().unwrap().data::<BD>()[2].offset(uvdstoff),
                 f.cur.stride[1] as usize,
                 cbw4 as usize * 4,
                 cbh4 as usize * 4,
@@ -4058,11 +4059,9 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
             // chroma coefs and inverse transform
             if has_chroma {
                 for pl in 0..2 {
-                    let mut uvdst = (f.cur.data.as_ref().unwrap().data[1 + pl] as *mut BD::Pixel)
-                        .offset(
-                            uvdstoff
-                                + (BD::pxstride(f.cur.stride[1]) * init_y as isize * 4 >> ss_ver),
-                        );
+                    let mut uvdst = f.cur.data.as_ref().unwrap().data::<BD>()[1 + pl].offset(
+                        uvdstoff + (BD::pxstride(f.cur.stride[1]) * init_y as isize * 4 >> ss_ver),
+                    );
                     y = init_y >> ss_ver;
                     t.b.y += init_y;
                     while y < cmp::min(ch4, init_y + 16 >> ss_ver) {
@@ -4211,19 +4210,19 @@ pub(crate) unsafe fn rav1d_filter_sbrow_deblock_cols<BD: BitDepth>(
 
         let p = [
             slice::from_raw_parts_mut(
-                f.cur.data.as_ref().unwrap().data[f.lf.p[0]]
+                f.cur.data.as_ref().unwrap().data::<BD>()[f.lf.p[0]]
                     .cast::<BD::Pixel>()
                     .offset(cmp::min(y_span, 0)),
                 y_span.unsigned_abs() + y_width as usize + RAV1D_PICTURE_ALIGNMENT,
             ),
             slice::from_raw_parts_mut(
-                f.cur.data.as_ref().unwrap().data[f.lf.p[1]]
+                f.cur.data.as_ref().unwrap().data::<BD>()[f.lf.p[1]]
                     .cast::<BD::Pixel>()
                     .offset(cmp::min(uv_span, 0)),
                 uv_span.unsigned_abs() + uv_width as usize + RAV1D_PICTURE_ALIGNMENT,
             ),
             slice::from_raw_parts_mut(
-                f.cur.data.as_ref().unwrap().data[f.lf.p[2]]
+                f.cur.data.as_ref().unwrap().data::<BD>()[f.lf.p[2]]
                     .cast::<BD::Pixel>()
                     .offset(cmp::min(uv_span, 0)),
                 uv_span.unsigned_abs() + uv_width as usize + RAV1D_PICTURE_ALIGNMENT,
@@ -4269,19 +4268,19 @@ pub(crate) unsafe fn rav1d_filter_sbrow_deblock_rows<BD: BitDepth>(
 
         let p = [
             slice::from_raw_parts_mut(
-                f.cur.data.as_ref().unwrap().data[f.lf.p[0]]
+                f.cur.data.as_ref().unwrap().data::<BD>()[f.lf.p[0]]
                     .cast::<BD::Pixel>()
                     .offset(cmp::min(y_span, 0)),
                 y_span.unsigned_abs() + y_width as usize + RAV1D_PICTURE_ALIGNMENT,
             ),
             slice::from_raw_parts_mut(
-                f.cur.data.as_ref().unwrap().data[f.lf.p[1]]
+                f.cur.data.as_ref().unwrap().data::<BD>()[f.lf.p[1]]
                     .cast::<BD::Pixel>()
                     .offset(cmp::min(uv_span, 0)),
                 uv_span.unsigned_abs() + uv_width as usize + RAV1D_PICTURE_ALIGNMENT,
             ),
             slice::from_raw_parts_mut(
-                f.cur.data.as_ref().unwrap().data[f.lf.p[2]]
+                f.cur.data.as_ref().unwrap().data::<BD>()[f.lf.p[2]]
                     .cast::<BD::Pixel>()
                     .offset(cmp::min(uv_span, 0)),
                 uv_span.unsigned_abs() + uv_width as usize + RAV1D_PICTURE_ALIGNMENT,
@@ -4322,13 +4321,13 @@ pub(crate) unsafe fn rav1d_filter_sbrow_cdef<BD: BitDepth>(
     let y = sby * sbsz * 4;
     let ss_ver = (f.cur.p.layout == Rav1dPixelLayout::I420) as c_int;
     let p = [
-        f.cur.data.as_ref().unwrap().data[f.lf.p[0]]
+        f.cur.data.as_ref().unwrap().data::<BD>()[f.lf.p[0]]
             .cast::<BD::Pixel>()
             .offset((y as isize * BD::pxstride(f.cur.stride[0])) as isize),
-        f.cur.data.as_ref().unwrap().data[f.lf.p[1]]
+        f.cur.data.as_ref().unwrap().data::<BD>()[f.lf.p[1]]
             .cast::<BD::Pixel>()
             .offset((y as isize * BD::pxstride(f.cur.stride[1]) >> ss_ver) as isize),
-        f.cur.data.as_ref().unwrap().data[f.lf.p[2]]
+        f.cur.data.as_ref().unwrap().data::<BD>()[f.lf.p[2]]
             .cast::<BD::Pixel>()
             .offset((y as isize * BD::pxstride(f.cur.stride[1]) >> ss_ver) as isize),
     ];
@@ -4361,24 +4360,24 @@ pub(crate) unsafe fn rav1d_filter_sbrow_resize<BD: BitDepth>(
     let y = sby * sbsz * 4;
     let ss_ver = (f.cur.p.layout == Rav1dPixelLayout::I420) as c_int;
     let p = [
-        f.cur.data.as_ref().unwrap().data[f.lf.p[0]]
+        f.cur.data.as_ref().unwrap().data::<BD>()[f.lf.p[0]]
             .cast::<BD::Pixel>()
             .offset(y as isize * BD::pxstride(f.cur.stride[0])),
-        f.cur.data.as_ref().unwrap().data[f.lf.p[1]]
+        f.cur.data.as_ref().unwrap().data::<BD>()[f.lf.p[1]]
             .cast::<BD::Pixel>()
             .offset(y as isize * BD::pxstride(f.cur.stride[1]) >> ss_ver),
-        f.cur.data.as_ref().unwrap().data[f.lf.p[2]]
+        f.cur.data.as_ref().unwrap().data::<BD>()[f.lf.p[2]]
             .cast::<BD::Pixel>()
             .offset(y as isize * BD::pxstride(f.cur.stride[1]) >> ss_ver),
     ];
     let sr_p = [
-        f.sr_cur.p.data.as_ref().unwrap().data[f.lf.sr_p[0]]
+        f.sr_cur.p.data.as_ref().unwrap().data::<BD>()[f.lf.sr_p[0]]
             .cast::<BD::Pixel>()
             .offset((y as isize * BD::pxstride(f.sr_cur.p.stride[0])) as isize),
-        f.sr_cur.p.data.as_ref().unwrap().data[f.lf.sr_p[1]]
+        f.sr_cur.p.data.as_ref().unwrap().data::<BD>()[f.lf.sr_p[1]]
             .cast::<BD::Pixel>()
             .offset((y as isize * BD::pxstride(f.sr_cur.p.stride[1]) >> ss_ver) as isize),
-        f.sr_cur.p.data.as_ref().unwrap().data[f.lf.sr_p[2]]
+        f.sr_cur.p.data.as_ref().unwrap().data::<BD>()[f.lf.sr_p[2]]
             .cast::<BD::Pixel>()
             .offset((y as isize * BD::pxstride(f.sr_cur.p.stride[1]) >> ss_ver) as isize),
     ];
@@ -4428,15 +4427,15 @@ pub(crate) unsafe fn rav1d_filter_sbrow_lr<BD: BitDepth>(
     let h = f.sr_cur.p.p.h + 127 & !127;
     let mut sr_p = [
         slice::from_raw_parts_mut(
-            f.sr_cur.p.data.as_ref().unwrap().data[f.lf.sr_p[0]].cast::<BD::Pixel>(),
+            f.sr_cur.p.data.as_ref().unwrap().data::<BD>()[f.lf.sr_p[0]].cast::<BD::Pixel>(),
             (h as isize * BD::pxstride(f.sr_cur.p.stride[0])) as usize,
         ),
         slice::from_raw_parts_mut(
-            f.sr_cur.p.data.as_ref().unwrap().data[f.lf.sr_p[1]].cast::<BD::Pixel>(),
+            f.sr_cur.p.data.as_ref().unwrap().data::<BD>()[f.lf.sr_p[1]].cast::<BD::Pixel>(),
             (h as isize * BD::pxstride(f.sr_cur.p.stride[1])) as usize >> ss_ver,
         ),
         slice::from_raw_parts_mut(
-            f.sr_cur.p.data.as_ref().unwrap().data[f.lf.sr_p[2]].cast::<BD::Pixel>(),
+            f.sr_cur.p.data.as_ref().unwrap().data::<BD>()[f.lf.sr_p[2]].cast::<BD::Pixel>(),
             (h as isize * BD::pxstride(f.sr_cur.p.stride[1])) as usize >> ss_ver,
         ),
     ];
@@ -4477,10 +4476,12 @@ pub(crate) unsafe fn rav1d_backup_ipred_edge<BD: BitDepth>(
     let sby_off = f.sb128w * 128 * sby;
     let x_off = ts.tiling.col_start;
 
-    let y = (f.cur.data.as_ref().unwrap().data[0] as *const BD::Pixel).offset(
-        (x_off * 4) as isize
-            + ((t.b.y + f.sb_step) * 4 - 1) as isize * BD::pxstride(f.cur.stride[0]),
-    );
+    let y = f.cur.data.as_ref().unwrap().data::<BD>()[0]
+        .cast_const()
+        .offset(
+            (x_off * 4) as isize
+                + ((t.b.y + f.sb_step) * 4 - 1) as isize * BD::pxstride(f.cur.stride[0]),
+        );
     let ipred_edge_off = (f.ipred_edge_off * 0) + (sby_off + x_off * 4) as usize;
     let n = 4 * (ts.tiling.col_end - x_off) as usize;
     BD::pixel_copy(
@@ -4506,7 +4507,7 @@ pub(crate) unsafe fn rav1d_backup_ipred_edge<BD: BitDepth>(
                     .ipred_edge
                     .mut_slice_as(ipred_edge_off..ipred_edge_off + n),
                 slice::from_raw_parts(
-                    f.cur.data.as_ref().unwrap().data[pl]
+                    f.cur.data.as_ref().unwrap().data::<BD>()[pl]
                         .cast::<BD::Pixel>()
                         .offset(uv_off),
                     n,


### PR DESCRIPTION
This adds `Rav1dPictureDataComponent`, which stores the ptr and length of each of the YUV components of a `Rav1dPictureData`.  This is wrapped in `DisjointMut` so that it can be safely accessed disjointly mutably, but for now, access is still done unsafely through `.as_mut_ptr()`.  Changing that to safe/checked `.index(_mut)`s can be done, but I'll have to narrow/split up a bunch of the borrows, and there are a lot of uses, so I'm leaving that to my next PR.