### PR TITLE
`fn {w_}{avg,mask}_*`: Pass array reference for `tmp` args

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1060,10 +1060,12 @@ impl AlPal {
     }
 }
 
+pub const COMPINTER_LEN: usize = 128 * 128;
+
 #[derive(FromZeroes, FromBytes, AsBytes)]
 #[repr(C, align(64))]
 pub struct ScratchCompinter {
-    pub compinter: [[i16; 128 * 128]; 2],
+    pub compinter: [[i16; COMPINTER_LEN]; 2],
     pub seg_mask: [u8; 128 * 128],
 }
 

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -3398,8 +3398,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 f.dsp.mc.w_mask[chr_layout_idx_w_mask].call(
                     dst,
                     f.cur.stride[0],
-                    tmp[inter.nd.one_d.mask_sign as usize].as_mut_ptr(),
-                    tmp[(inter.nd.one_d.mask_sign == 0) as usize].as_mut_ptr(),
+                    &tmp[inter.nd.one_d.mask_sign as usize],
+                    &tmp[(inter.nd.one_d.mask_sign == 0) as usize],
                     bw4 * 4,
                     bh4 * 4,
                     seg_mask.as_mut_ptr(),
@@ -3413,8 +3413,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 (f.dsp.mc.mask)(
                     dst.cast(),
                     f.cur.stride[0],
-                    tmp[inter.nd.one_d.mask_sign as usize].as_mut_ptr(),
-                    tmp[(inter.nd.one_d.mask_sign == 0) as usize].as_mut_ptr(),
+                    &tmp[inter.nd.one_d.mask_sign as usize],
+                    &tmp[(inter.nd.one_d.mask_sign == 0) as usize],
                     bw4 * 4,
                     bh4 * 4,
                     mask.as_ptr(),
@@ -3502,8 +3502,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                         (f.dsp.mc.mask)(
                             uvdst.cast(),
                             f.cur.stride[1],
-                            tmp[inter.nd.one_d.mask_sign as usize].as_mut_ptr(),
-                            tmp[(inter.nd.one_d.mask_sign == 0) as usize].as_mut_ptr(),
+                            &tmp[inter.nd.one_d.mask_sign as usize],
+                            &tmp[(inter.nd.one_d.mask_sign == 0) as usize],
                             bw4 * 4 >> ss_hor,
                             bh4 * 4 >> ss_ver,
                             mask.as_ptr(),

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -3373,8 +3373,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 (f.dsp.mc.avg)(
                     dst.cast(),
                     f.cur.stride[0],
-                    tmp[0].as_mut_ptr(),
-                    tmp[1].as_mut_ptr(),
+                    &tmp[0],
+                    &tmp[1],
                     bw4 * 4,
                     bh4 * 4,
                     f.bitdepth_max,
@@ -3386,8 +3386,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 (f.dsp.mc.w_avg)(
                     dst.cast(),
                     f.cur.stride[0],
-                    tmp[0].as_mut_ptr(),
-                    tmp[1].as_mut_ptr(),
+                    &tmp[0],
+                    &tmp[1],
                     bw4 * 4,
                     bh4 * 4,
                     jnt_weight,
@@ -3479,8 +3479,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                         (f.dsp.mc.avg)(
                             uvdst.cast(),
                             f.cur.stride[1],
-                            tmp[0].as_mut_ptr(),
-                            tmp[1].as_mut_ptr(),
+                            &tmp[0],
+                            &tmp[1],
                             bw4 * 4 >> ss_hor,
                             bh4 * 4 >> ss_ver,
                             f.bitdepth_max,
@@ -3490,8 +3490,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                         (f.dsp.mc.w_avg)(
                             uvdst.cast(),
                             f.cur.stride[1],
-                            tmp[0].as_mut_ptr(),
-                            tmp[1].as_mut_ptr(),
+                            &tmp[0],
+                            &tmp[1],
                             bw4 * 4 >> ss_hor,
                             bh4 * 4 >> ss_ver,
                             jnt_weight,


### PR DESCRIPTION
The `tmp1` and `tmp2` args to these fns are always pointers to fixed-size arrays, so I've changed the signatures to pass them as array references, allowing us to use safe slice operations in the Rust fallback fns.

Part of https://github.com/memorysafety/rav1d/issues/842.