### PR TITLE
`fn Av1BlockInter1d::mask_sign`: Access as a `bool` to elide bounds checks

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2659,7 +2659,7 @@ unsafe fn decode_b(
                     CompInterType::Seg
                 };
 
-                mask_sign = rav1d_msac_decode_bool_equi(&mut ts_c.msac) as u8;
+                mask_sign = rav1d_msac_decode_bool_equi(&mut ts_c.msac);
                 if debug_block_info!(f, t.b) {
                     println!(
                         "Post-seg/wedge[{},wedge_idx={},sign={}]: r={}",
@@ -2676,7 +2676,7 @@ unsafe fn decode_b(
                 nd: Av1BlockInter1d {
                     mv: mv1d,
                     wedge_idx,
-                    mask_sign,
+                    mask_sign: mask_sign as u8,
                     ..Default::default()
                 }
                 .into(),

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -364,11 +364,20 @@ impl From<MaskedInterIntraPredMode> for InterIntraPredMode {
 pub struct Av1BlockInter1d {
     pub mv: [mv; 2],
     pub wedge_idx: u8,
+
+    /// Stored as a [`u8`] since [`bool`] is not [`FromBytes`].
     pub mask_sign: u8,
+
     pub interintra_mode: MaskedInterIntraPredMode,
 
     /// For `impl `[`AsBytes`].
     pub _padding: u8,
+}
+
+impl Av1BlockInter1d {
+    pub fn mask_sign(&self) -> bool {
+        self.mask_sign != 0
+    }
 }
 
 #[derive(Clone, FromZeroes, FromBytes, AsBytes)]

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -3457,12 +3457,12 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 f.dsp.mc.w_mask[chr_layout_idx_w_mask].call(
                     dst,
                     f.cur.stride[0],
-                    &tmp[inter.nd.one_d.mask_sign as usize],
-                    &tmp[(inter.nd.one_d.mask_sign == 0) as usize],
+                    &tmp[inter.nd.one_d.mask_sign() as usize],
+                    &tmp[!inter.nd.one_d.mask_sign() as usize],
                     bw4 * 4,
                     bh4 * 4,
                     seg_mask.as_mut_ptr(),
-                    inter.nd.one_d.mask_sign as c_int,
+                    inter.nd.one_d.mask_sign() as c_int,
                     bd,
                 );
                 mask = &seg_mask[..];
@@ -3472,8 +3472,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 (f.dsp.mc.mask)(
                     dst.cast(),
                     f.cur.stride[0],
-                    &tmp[inter.nd.one_d.mask_sign as usize],
-                    &tmp[(inter.nd.one_d.mask_sign == 0) as usize],
+                    &tmp[inter.nd.one_d.mask_sign() as usize],
+                    &tmp[!inter.nd.one_d.mask_sign() as usize],
                     bw4 * 4,
                     bh4 * 4,
                     mask.as_ptr(),
@@ -3481,7 +3481,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 );
                 if has_chroma {
                     mask = dav1d_wedge_masks[bs as usize][chr_layout_idx]
-                        [inter.nd.one_d.mask_sign as usize]
+                        [inter.nd.one_d.mask_sign() as usize]
                         [inter.nd.one_d.wedge_idx as usize];
                 }
             }
@@ -3563,8 +3563,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                         (f.dsp.mc.mask)(
                             uvdst.cast(),
                             f.cur.stride[1],
-                            &tmp[inter.nd.one_d.mask_sign as usize],
-                            &tmp[(inter.nd.one_d.mask_sign == 0) as usize],
+                            &tmp[inter.nd.one_d.mask_sign() as usize],
+                            &tmp[!inter.nd.one_d.mask_sign() as usize],
                             bw4 * 4 >> ss_hor,
                             bh4 * 4 >> ss_ver,
                             mask.as_ptr(),


### PR DESCRIPTION
We can't just store this as a `bool` directly since it doesn't `impl FromBytes`, so we just provide a getter.

I noticed this in #1084.