### PR TITLE
Remove unnecessary `unsafe` block

### DIFF
--- a/src/recon.rs
+++ b/src/recon.rs
@@ -1579,7 +1579,7 @@ impl CfSelect {
     ) {
         match self {
             CfSelect::Frame(offset) => {
-                let mut cf = unsafe { f.frame_thread.cf.mut_element_as(offset + index) };
+                let mut cf = f.frame_thread.cf.mut_element_as(offset + index);
                 *cf = value;
             }
             CfSelect::Task => {


### PR DESCRIPTION
This `unsafe` block is no longer necessary after #1082.