### PR TITLE
`mc.rs`: Restore support for negative strides in Rust fallback fns

### DIFF
--- a/src/mc.rs
+++ b/src/mc.rs
@@ -58,7 +58,7 @@ unsafe fn put_rust<BD: BitDepth>(
 #[inline(never)]
 unsafe fn prep_rust<BD: BitDepth>(
     tmp: &mut [i16],
-    mut src: *const BD::Pixel,
+    mut src_ptr: *const BD::Pixel,
     src_stride: isize,
     w: usize,
     h: usize,
@@ -66,11 +66,11 @@ unsafe fn prep_rust<BD: BitDepth>(
 ) {
     let intermediate_bits = bd.get_intermediate_bits();
     for tmp in tmp.chunks_exact_mut(w).take(h) {
+        let src = slice::from_raw_parts(src_ptr, w);
         for x in 0..w {
-            tmp[x] =
-                (((*src.add(x)).as_::<i32>() << intermediate_bits) - (BD::PREP_BIAS as i32)) as i16
+            tmp[x] = ((src[x].as_::<i32>() << intermediate_bits) - (BD::PREP_BIAS as i32)) as i16
         }
-        src = src.offset(src_stride);
+        src_ptr = src_ptr.offset(src_stride);
     }
 }
 

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -1838,13 +1838,7 @@ unsafe extern "C" fn blend_v_c_erased<BD: BitDepth>(
     w: c_int,
     h: c_int,
 ) {
-    blend_v_rust::<BD>(
-        dst.cast(),
-        dst_stride,
-        tmp.cast(),
-        w as usize,
-        h as usize,
-    )
+    blend_v_rust::<BD>(dst.cast(), dst_stride, tmp.cast(), w as usize, h as usize)
 }
 
 unsafe extern "C" fn blend_h_c_erased<BD: BitDepth>(
@@ -1854,13 +1848,7 @@ unsafe extern "C" fn blend_h_c_erased<BD: BitDepth>(
     w: c_int,
     h: c_int,
 ) {
-    blend_h_rust::<BD>(
-        dst.cast(),
-        dst_stride,
-        tmp.cast(),
-        w as usize,
-        h as usize,
-    )
+    blend_h_rust::<BD>(dst.cast(), dst_stride, tmp.cast(), w as usize, h as usize)
 }
 
 unsafe extern "C" fn warp_affine_8x8_c_erased<BD: BitDepth>(

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -681,7 +681,7 @@ unsafe fn avg_rust<BD: BitDepth>(
 
 unsafe fn w_avg_rust<BD: BitDepth>(
     mut dst: *mut BD::Pixel,
-    dst_stride: usize,
+    dst_stride: isize,
     tmp1: &[i16; COMPINTER_LEN],
     tmp2: &[i16; COMPINTER_LEN],
     w: usize,
@@ -704,7 +704,7 @@ unsafe fn w_avg_rust<BD: BitDepth>(
 
         tmp1 = &tmp1[w..];
         tmp2 = &tmp2[w..];
-        dst = dst.offset(dst_stride as isize);
+        dst = dst.offset(dst_stride);
     }
 }
 
@@ -1700,7 +1700,7 @@ unsafe extern "C" fn w_avg_c_erased<BD: BitDepth>(
 ) {
     w_avg_rust(
         dst.cast(),
-        dst_stride as usize,
+        dst_stride,
         tmp1,
         tmp2,
         w as usize,

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -791,7 +791,7 @@ unsafe fn blend_v_rust<BD: BitDepth>(
 
 unsafe fn blend_h_rust<BD: BitDepth>(
     mut dst: *mut BD::Pixel,
-    dst_stride: usize,
+    dst_stride: isize,
     mut tmp: *const BD::Pixel,
     w: usize,
     h: usize,
@@ -805,7 +805,7 @@ unsafe fn blend_h_rust<BD: BitDepth>(
                 blend_px::<BD>(*dst.offset(x as isize), *tmp.offset(x as isize), mask[y]);
         }
 
-        dst = dst.offset(dst_stride as isize);
+        dst = dst.offset(dst_stride);
         tmp = tmp.offset(w as isize);
     }
 }
@@ -1856,7 +1856,7 @@ unsafe extern "C" fn blend_h_c_erased<BD: BitDepth>(
 ) {
     blend_h_rust::<BD>(
         dst.cast(),
-        dst_stride as usize,
+        dst_stride,
         tmp.cast(),
         w as usize,
         h as usize,

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -654,7 +654,7 @@ unsafe fn prep_bilin_scaled_rust<BD: BitDepth>(
 
 unsafe fn avg_rust<BD: BitDepth>(
     mut dst: *mut BD::Pixel,
-    dst_stride: usize,
+    dst_stride: isize,
     tmp1: &[i16; COMPINTER_LEN],
     tmp2: &[i16; COMPINTER_LEN],
     w: usize,
@@ -675,7 +675,7 @@ unsafe fn avg_rust<BD: BitDepth>(
 
         tmp1 = &tmp1[w..];
         tmp2 = &tmp2[w..];
-        dst = dst.offset(dst_stride as isize);
+        dst = dst.offset(dst_stride);
     }
 }
 
@@ -1679,7 +1679,7 @@ unsafe extern "C" fn avg_c_erased<BD: BitDepth>(
 ) {
     avg_rust(
         dst.cast(),
-        dst_stride as usize,
+        dst_stride,
         tmp1,
         tmp2,
         w as usize,

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -354,7 +354,7 @@ unsafe fn prep_8tap_rust<BD: BitDepth>(
 unsafe fn prep_8tap_scaled_rust<BD: BitDepth>(
     mut tmp: *mut i16,
     mut src: *const BD::Pixel,
-    src_stride: usize,
+    src_stride: isize,
     w: usize,
     h: usize,
     mx: usize,
@@ -370,7 +370,7 @@ unsafe fn prep_8tap_scaled_rust<BD: BitDepth>(
     let mut mid_ptr = &mut mid[..];
     let src_stride = BD::pxstride(src_stride);
 
-    src = src.offset(-((src_stride * 3) as isize));
+    src = src.offset(-src_stride * 3);
     for _ in 0..tmp_h {
         let mut imx = mx;
         let mut ioff = 0;
@@ -386,7 +386,7 @@ unsafe fn prep_8tap_scaled_rust<BD: BitDepth>(
         }
 
         mid_ptr = &mut mid_ptr[128..];
-        src = src.offset(src_stride as isize);
+        src = src.offset(src_stride);
     }
 
     mid_ptr = &mut mid[128 * 3..];
@@ -1506,7 +1506,7 @@ macro_rules! filter_fns {
                 prep_8tap_scaled_rust(
                     tmp,
                     src.cast(),
-                    src_stride as usize,
+                    src_stride,
                     w as usize,
                     h as usize,
                     mx as usize,

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -771,7 +771,7 @@ unsafe fn blend_rust<BD: BitDepth>(
 
 unsafe fn blend_v_rust<BD: BitDepth>(
     mut dst: *mut BD::Pixel,
-    dst_stride: usize,
+    dst_stride: isize,
     mut tmp: *const BD::Pixel,
     w: usize,
     h: usize,
@@ -784,7 +784,7 @@ unsafe fn blend_v_rust<BD: BitDepth>(
                 blend_px::<BD>(*dst.offset(x as isize), *tmp.offset(x as isize), mask[x])
         }
 
-        dst = dst.offset(dst_stride as isize);
+        dst = dst.offset(dst_stride);
         tmp = tmp.offset(w as isize);
     }
 }
@@ -1840,7 +1840,7 @@ unsafe extern "C" fn blend_v_c_erased<BD: BitDepth>(
 ) {
     blend_v_rust::<BD>(
         dst.cast(),
-        dst_stride as usize,
+        dst_stride,
         tmp.cast(),
         w as usize,
         h as usize,

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -21,7 +21,6 @@ use libc::intptr_t;
 use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_int;
-use std::iter;
 use std::slice;
 use to_method::To;
 
@@ -748,7 +747,7 @@ fn blend_px<BD: BitDepth>(a: BD::Pixel, b: BD::Pixel, m: u8) -> BD::Pixel {
 
 unsafe fn blend_rust<BD: BitDepth>(
     mut dst: *mut BD::Pixel,
-    dst_stride: usize,
+    dst_stride: isize,
     mut tmp: *const BD::Pixel,
     w: usize,
     h: usize,
@@ -764,7 +763,7 @@ unsafe fn blend_rust<BD: BitDepth>(
             )
         }
 
-        dst = dst.offset(dst_stride as isize);
+        dst = dst.offset(dst_stride);
         tmp = tmp.offset(w as isize);
         mask = mask.offset(w as isize);
     }
@@ -1824,7 +1823,7 @@ unsafe extern "C" fn blend_c_erased<BD: BitDepth>(
 ) {
     blend_rust::<BD>(
         dst.cast(),
-        dst_stride as usize,
+        dst_stride,
         tmp.cast(),
         w as usize,
         h as usize,

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -710,7 +710,7 @@ unsafe fn w_avg_rust<BD: BitDepth>(
 
 unsafe fn mask_rust<BD: BitDepth>(
     mut dst: *mut BD::Pixel,
-    dst_stride: usize,
+    dst_stride: isize,
     tmp1: &[i16; COMPINTER_LEN],
     tmp2: &[i16; COMPINTER_LEN],
     w: usize,
@@ -737,7 +737,7 @@ unsafe fn mask_rust<BD: BitDepth>(
         tmp1 = &tmp1[w..];
         tmp2 = &tmp2[w..];
         mask = mask.offset(w as isize);
-        dst = dst.offset(dst_stride as isize);
+        dst = dst.offset(dst_stride);
     }
 }
 
@@ -1722,7 +1722,7 @@ unsafe extern "C" fn mask_c_erased<BD: BitDepth>(
 ) {
     mask_rust(
         dst.cast(),
-        dst_stride as usize,
+        dst_stride,
         tmp1,
         tmp2,
         w as usize,


### PR DESCRIPTION
Fixes the places where we were incorrectly converting potentially-negative stride values to `usize`. In a few places this meant reverting slices and iterator operations back to raw pointer operations.

* Part of #636.