### PR TITLE
`fn Rav1dPicAllocator::alloc_picture_data`: Allow null and replace with `NonNull::dangling`

### DIFF
--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -479,7 +479,10 @@ impl Rav1dPicAllocator {
         pic.data = Some(Arc::new(Rav1dPictureData {
             // SAFETY: `MaybeUninit<u8>` should be safe for anything.
             data: array::from_fn(|i| {
-                let ptr = data[i].unwrap().cast::<AlignedPixelChunk>();
+                let ptr = data[i]
+                    // Need to cast before `NonNull::dangling` to get the right alignment.
+                    .map(|ptr| ptr.cast::<AlignedPixelChunk>())
+                    .unwrap_or_else(NonNull::dangling);
                 let len = len[(i != 0) as usize];
                 DisjointMut::new(Rav1dPictureDataComponent::new(ptr, len))
             }),


### PR DESCRIPTION
@fbossen pointed out that the pic allocator can return null for the chroma data, but I had added an `Option<NonNull<_>>::unwrap`.  This changes that to use `NonNull::dangling()` instead, which is valid to use to construct 0-length slices.