### PR TITLE
`fn dav1d_default_picture_alloc`: Zero initialize pic data with `fn MemPool::pop_init`

### DIFF
--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -371,7 +371,7 @@ pub(crate) struct Rav1dPicAllocator {
     /// # Safety
     ///
     /// If [`Self::is_default`]`()`, then this cookie is a reference to
-    /// [`Rav1dContext::picture_pool`], a `&Arc<MemPool<MaybeUninit<u8>>`.
+    /// [`Rav1dContext::picture_pool`], a `&Arc<MemPool<u8>`.
     /// Thus, its lifetime is that of `&c.picture_pool`,
     /// so the lifetime of the `&`[`Rav1dContext`].
     /// This is used from `dav1d_default_picture_alloc`
@@ -380,7 +380,7 @@ pub(crate) struct Rav1dPicAllocator {
     /// which is called further up on the call stack with a `&`[`Rav1dContext`].
     /// Thus, the lifetime will always be valid where used.
     ///
-    /// Note that this is an `&Arc<MemPool<MaybeUninit<u8>>` turned into a raw pointer,
+    /// Note that this is an `&Arc<MemPool<u8>` turned into a raw pointer,
     /// not an [`Arc::into_raw`] of that [`Arc`].
     /// This is because storing the [`Arc`] would require C to
     /// free data owned by a [`Dav1dPicAllocator`] potentially,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -92,7 +92,6 @@ use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::mem;
-use std::mem::MaybeUninit;
 use std::ops::Add;
 use std::ops::AddAssign;
 use std::ops::Deref;
@@ -427,7 +426,7 @@ pub struct Rav1dContext {
 
     pub(crate) logger: Option<Rav1dLogger>,
 
-    pub(crate) picture_pool: Arc<MemPool<MaybeUninit<u8>>>,
+    pub(crate) picture_pool: Arc<MemPool<u8>>,
 }
 
 // TODO(SJC): Remove when Rav1dContext is thread-safe

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -11,7 +11,7 @@ impl<T> MemPool<T> {
         }
     }
 
-    pub fn pop(&self, size: usize) -> Vec<T> {
+    pub fn _pop(&self, size: usize) -> Vec<T> {
         if let Some(mut buf) = self.bufs.lock().unwrap().pop() {
             if size > buf.capacity() {
                 // TODO fallible allocation
@@ -21,6 +21,24 @@ impl<T> MemPool<T> {
         }
         // TODO fallible allocation
         Vec::with_capacity(size)
+    }
+
+    /// A version of [`Self::pop`] that initializes the [`Vec`].
+    /// This allows it to use [`vec!`], which, if used with `0`,
+    /// calls [`alloc_zeroed`], and thus can leave zero initialization to the OS.
+    ///
+    /// [`alloc_zeroed`]: std::alloc::alloc_zeroed
+    pub fn pop_init(&self, size: usize, init_value: T) -> Vec<T>
+    where
+        T: Copy,
+    {
+        if let Some(mut buf) = self.bufs.lock().unwrap().pop() {
+            // TODO fallible allocation
+            buf.resize(size, init_value);
+            return buf;
+        }
+        // TODO fallible allocation
+        vec![init_value; size]
     }
 
     pub fn push(&self, buf: Vec<T>) {

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -34,7 +34,9 @@ impl<T> MemPool<T> {
     {
         if let Some(mut buf) = self.bufs.lock().unwrap().pop() {
             // TODO fallible allocation
-            buf.resize(size, init_value);
+            if buf.len() < size {
+                buf.resize(size, init_value);
+            }
             return buf;
         }
         // TODO fallible allocation

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -32,12 +32,10 @@ impl<T> MemPool<T> {
     where
         T: Copy,
     {
-        if let Some(mut buf) = self.bufs.lock().unwrap().pop() {
-            // TODO fallible allocation
-            if buf.len() < size {
-                buf.resize(size, init_value);
+        if let Some(buf) = self.bufs.lock().unwrap().pop() {
+            if size <= buf.len() {
+                return buf;
             }
-            return buf;
         }
         // TODO fallible allocation
         vec![init_value; size]

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -131,7 +131,7 @@ unsafe extern "C" fn dav1d_default_picture_alloc(
     let buf = pool.pop_init(pic_cap, 0);
     // We have to `Box` this because `Dav1dPicture::allocator_data` is only 8 bytes.
     let mut buf = Box::new(MemPoolBuf { pool, buf });
-    let data = &mut buf.buf[..];
+    let data = &mut buf.buf[..pic_cap];
     // SAFETY: `Rav1dPicAllocator::alloc_picture_callback` requires that these are `RAV1D_PICTURE_ALIGNMENT`-aligned.
     let align_offset = data.as_ptr().align_offset(RAV1D_PICTURE_ALIGNMENT);
     let data = &mut data[align_offset..][..pic_size];


### PR DESCRIPTION
`fn MemPool::pop_init` uses `vec![]` and thus can optimize to `alloc_zeroed`, which lets the OS handle zeroing out pages, which is far faster.  Thus, we can now safely initialize picture data without significant perf overhead, at least for the default pic allocator.

From my basic benchmarking, it appears this eliminates the perf overhead of initialization that I previously saw with `buf.resize(pic_cap, 0)`.  @fbossen and/or @rinon, could you check this more carefully?