### PR TITLE
`fn Dav1dPicAllocator::alloc_picture_callback`: Add safety requirement to initialize memory

### DIFF
--- a/tools/dav1d.c
+++ b/tools/dav1d.c
@@ -164,7 +164,10 @@ static int picture_alloc(Dav1dPicture *const p, void *const _) {
     const size_t uv_sz = uv_stride * (aligned_h >> ss_ver);
     const size_t pic_size = y_sz + 2 * uv_sz;
 
-    uint8_t *const buf = malloc(pic_size + DAV1D_PICTURE_ALIGNMENT * 2);
+    // Change for new `rav1d` safety requirement to initialize picture data.
+    // `calloc` of a large size should be optimized to OS zero pages,
+    // removing the overhead, and guaranteeing initialization safety.
+    uint8_t *const buf = calloc(pic_size + DAV1D_PICTURE_ALIGNMENT * 2, 1);
     if (!buf) return DAV1D_ERR(ENOMEM);
     p->allocator_data = buf;
 


### PR DESCRIPTION
Designing our APIs to lazily initialize `Rav1dPictureData` memory is quite difficult.  It turns out that there is no performance overhead if new (e.x. not pooled, which are already initialized) picture allocations are zeroed, as the OS can zero it.  From what I can tell, basically every OS (and things like wasm) zero new memory, so this should largely be free/delayed until writes occur, which is what we want.  #1097 changes `rav1d`'s default pic allocator to do this, but requiring it for all pic allocators would allow us to store `u8`s instead of `MaybeUninit<u8>`s.  Leaving things as `MaybeUninit<u8>` makes things much more difficult and unsafe.

The upstream changes to zero memory should be pretty simple (e.x. replacing `malloc` with `calloc`).  chromium uses the default pic allocator, so this should not be an issue there.  `libplacebo` and `ffmpeg` use their own.  `libplacebo` looks like it uses `pl_zalloc` already.  `ffmpeg` doesn't, but it looks like it could switch without too much effort.  That said, I'm not really sure how much of an effort that might actually be.

Does this sound like a good idea?