### PR TITLE
`fn DisjointMut::index{,_mut}`: Optimize

### DIFF
--- a/src/disjoint_mut.rs
+++ b/src/disjoint_mut.rs
@@ -669,7 +669,7 @@ where
         // requires that we can immutably dereference `slice`.
         let len = unsafe { (*slice).len() };
         let Range { start, end } = self.to_range(len);
-        if start <= end && start < len && end <= len {
+        if start <= end && end <= len {
             // SAFETY: We have checked that `start` is less than the
             // allocation length therefore cannot overflow. `slice` is a
             // valid pointer into an allocation of sufficient length.
@@ -684,9 +684,6 @@ where
                 }
                 if end > len {
                     panic!("range end index {end} out of range for slice of length {len}");
-                }
-                if start >= len {
-                    panic!("range start index {start} out of range for slice of length {len}")
                 }
                 unreachable!();
             }


### PR DESCRIPTION
This inlines all of the `fn index`-type methods, allowing the bounds checks to be in the caller so that they can be optimized with knowledge from the caller.  At the same time, the error paths are put in `#[inline(never)]` inner `fn`s so that they don't bloat the code at all.  Then, the `Bounds::from` calls in `fn DisjointMutIndex::get_mut` are replaced with `fn SliceBounds::to_range`, which uses `len` directly instead of `usize::MAX`.  `Bounds::from` first substitutes `usize::MAX` for `len`, and then converts it back, but this conflates a range given as `..usize::MAX`, and thus can't be optimized as well.  Finally, the `start < len` check is redundant when we're already checking that `start <= end` and `end <= len`.  I thought LLVM could optimize this out, but it can't, and `std` does it this way.

This should lead to far better optimization for `DisjointMut` indexing and much less code bloat as well (panicking code is quite bloated).