### PR TITLE
`fn ipred_{v,h}_rust`: Cleanup and make safe

### DIFF
--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -478,7 +478,7 @@ unsafe fn ipred_v_rust<BD: BitDepth>(
     width: c_int,
     height: c_int,
 ) {
-    let width = width.try_into().unwrap();
+    let width = width as usize;
 
     for _ in 0..height {
         BD::pixel_copy(

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -459,10 +459,6 @@ unsafe fn ipred_v_rust<BD: BitDepth>(
     topleft: *const BD::Pixel,
     width: c_int,
     height: c_int,
-    _a: c_int,
-    _max_width: c_int,
-    _max_height: c_int,
-    _bd: BD,
 ) {
     let width = width.try_into().unwrap();
 
@@ -482,22 +478,18 @@ unsafe extern "C" fn ipred_v_c_erased<BD: BitDepth>(
     topleft: *const DynPixel,
     width: c_int,
     height: c_int,
-    a: c_int,
-    max_width: c_int,
-    max_height: c_int,
-    bitdepth_max: c_int,
+    _a: c_int,
+    _max_width: c_int,
+    _max_height: c_int,
+    _bitdepth_max: c_int,
     _topleft_off: usize,
 ) {
-    ipred_v_rust(
+    ipred_v_rust::<BD>(
         dst.cast(),
         stride,
         topleft.cast(),
         width,
         height,
-        a,
-        max_width,
-        max_height,
-        BD::from_c(bitdepth_max),
     );
 }
 

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -519,15 +519,13 @@ unsafe fn ipred_h_rust<BD: BitDepth>(
 ) {
     let width = width.try_into().unwrap();
 
-    let mut y = 0;
-    while y < height {
+    for y in 0..height {
         BD::pixel_set(
             slice::from_raw_parts_mut(dst, width),
             *topleft.offset(-(1 + y) as isize),
             width,
         );
         dst = dst.offset(BD::pxstride(stride));
-        y += 1;
     }
 }
 

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -512,10 +512,6 @@ unsafe fn ipred_h_rust<BD: BitDepth>(
     topleft: *const BD::Pixel,
     width: c_int,
     height: c_int,
-    _a: c_int,
-    _max_width: c_int,
-    _max_height: c_int,
-    _bd: BD,
 ) {
     let width = width.try_into().unwrap();
 
@@ -535,22 +531,18 @@ unsafe extern "C" fn ipred_h_c_erased<BD: BitDepth>(
     topleft: *const DynPixel,
     width: c_int,
     height: c_int,
-    a: c_int,
-    max_width: c_int,
-    max_height: c_int,
-    bitdepth_max: c_int,
+    _a: c_int,
+    _max_width: c_int,
+    _max_height: c_int,
+    _bitdepth_max: c_int,
     _topleft_off: usize,
 ) {
-    ipred_h_rust(
+    ipred_h_rust::<BD>(
         dst.cast(),
         stride,
         topleft.cast(),
         width,
         height,
-        a,
-        max_width,
-        max_height,
-        BD::from_c(bitdepth_max),
     );
 }
 

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -466,15 +466,13 @@ unsafe fn ipred_v_rust<BD: BitDepth>(
 ) {
     let width = width.try_into().unwrap();
 
-    let mut y = 0;
-    while y < height {
+    for _ in 0..height {
         BD::pixel_copy(
             slice::from_raw_parts_mut(dst, width),
             &slice::from_raw_parts(topleft, width + 1)[1..],
             width,
         );
         dst = dst.offset(BD::pxstride(stride));
-        y += 1;
     }
 }
 

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -514,7 +514,7 @@ unsafe fn ipred_h_rust<BD: BitDepth>(
     width: c_int,
     height: c_int,
 ) {
-    let width = width.try_into().unwrap();
+    let width = width as usize;
 
     for y in 0..height as usize {
         BD::pixel_set(


### PR DESCRIPTION
* Part of #815.
* Part of #846.