### PR TITLE
`fn ipred_smooth{,_v,_h}_rust`: Cleanup and make safer

### DIFF
--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -620,12 +620,13 @@ unsafe fn ipred_smooth_rust<BD: BitDepth>(
     let bottom = topleft[topleft_off - height].as_::<c_int>();
 
     for y in 0..height {
-        for x in 0..width {
+        let dst_slice = slice::from_raw_parts_mut(dst, width);
+        for (x, dst) in dst_slice.iter_mut().enumerate() {
             let pred = weights_ver[y] as c_int * topleft[topleft_off + 1 + x].as_::<c_int>()
                 + (256 - weights_ver[y] as c_int) * bottom
                 + weights_hor[x] as c_int * topleft[topleft_off - (1 + y)].as_::<c_int>()
                 + (256 - weights_hor[x] as c_int) * right;
-            *dst.offset(x as isize) = (pred + 256 >> 9).as_::<BD::Pixel>();
+            *dst = (pred + 256 >> 9).as_::<BD::Pixel>();
         }
         dst = dst.offset(BD::pxstride(stride));
     }

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -619,10 +619,8 @@ unsafe fn ipred_smooth_rust<BD: BitDepth>(
     let weights_ver: *const u8 = &*dav1d_sm_weights.0.as_ptr().offset(height as isize) as *const u8;
     let right = (*topleft.offset(width as isize)).as_::<c_int>();
     let bottom = (*topleft.offset(-height as isize)).as_::<c_int>();
-    let mut y = 0;
-    while y < height {
-        let mut x = 0;
-        while x < width {
+    for y in 0..height {
+        for x in 0..width {
             let pred = *weights_ver.offset(y as isize) as c_int
                 * (*topleft.offset((1 + x) as isize)).as_::<c_int>()
                 + (256 - *weights_ver.offset(y as isize) as c_int) * bottom
@@ -630,10 +628,8 @@ unsafe fn ipred_smooth_rust<BD: BitDepth>(
                     * (*topleft.offset(-(1 + y) as isize)).as_::<c_int>()
                 + (256 - *weights_hor.offset(x as isize) as c_int) * right;
             *dst.offset(x as isize) = (pred + 256 >> 9).as_::<BD::Pixel>();
-            x += 1;
         }
         dst = dst.offset(BD::pxstride(stride));
-        y += 1;
     }
 }
 

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -661,18 +661,14 @@ unsafe fn ipred_smooth_v_rust<BD: BitDepth>(
 ) {
     let weights_ver: *const u8 = &*dav1d_sm_weights.0.as_ptr().offset(height as isize) as *const u8;
     let bottom = (*topleft.offset(-height as isize)).as_::<c_int>();
-    let mut y = 0;
-    while y < height {
-        let mut x = 0;
-        while x < width {
+    for y in 0..height {
+        for x in 0..width {
             let pred = *weights_ver.offset(y as isize) as c_int
                 * (*topleft.offset((1 + x) as isize)).as_::<c_int>()
                 + (256 - *weights_ver.offset(y as isize) as c_int) * bottom;
             *dst.offset(x as isize) = (pred + 128 >> 8).as_::<BD::Pixel>();
-            x += 1;
         }
         dst = dst.offset(BD::pxstride(stride));
-        y += 1;
     }
 }
 

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -702,10 +702,11 @@ unsafe fn ipred_smooth_h_rust<BD: BitDepth>(
     let right = topleft[topleft_off + width].as_::<c_int>();
 
     for y in 0..height {
-        for x in 0..width {
+        let dst_slice = slice::from_raw_parts_mut(dst, width);
+        for (x, dst) in dst_slice.iter_mut().enumerate() {
             let pred = weights_hor[x] as c_int * topleft[topleft_off - (y + 1)].as_::<c_int>()
                 + (256 - weights_hor[x] as c_int) * right;
-            *dst.offset(x as isize) = (pred + 128 >> 8).as_::<BD::Pixel>();
+            *dst = (pred + 128 >> 8).as_::<BD::Pixel>();
         }
         dst = dst.offset(BD::pxstride(stride));
     }

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -614,8 +614,8 @@ unsafe fn ipred_smooth_rust<BD: BitDepth>(
 ) {
     let [width, height] = [width, height].map(|it| it as usize);
 
-    let weights_hor = &dav1d_sm_weights.0[width..];
-    let weights_ver = &dav1d_sm_weights.0[height..];
+    let weights_hor = &dav1d_sm_weights.0[width..][..width];
+    let weights_ver = &dav1d_sm_weights.0[height..][..height];
     let right = topleft[topleft_off + width].as_::<c_int>();
     let bottom = topleft[topleft_off - height].as_::<c_int>();
 
@@ -658,7 +658,7 @@ unsafe fn ipred_smooth_v_rust<BD: BitDepth>(
 ) {
     let [width, height] = [width, height].map(|it| it as usize);
 
-    let weights_ver = &dav1d_sm_weights.0[height..];
+    let weights_ver = &dav1d_sm_weights.0[height..][..height];
     let bottom = topleft[topleft_off - height].as_::<c_int>();
 
     for y in 0..height {
@@ -698,7 +698,7 @@ unsafe fn ipred_smooth_h_rust<BD: BitDepth>(
 ) {
     let [width, height] = [width, height].map(|it| it as usize);
 
-    let weights_hor = &dav1d_sm_weights.0[width..];
+    let weights_hor = &dav1d_sm_weights.0[width..][..width];
     let right = topleft[topleft_off + width].as_::<c_int>();
 
     for y in 0..height {

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -610,10 +610,6 @@ unsafe fn ipred_smooth_rust<BD: BitDepth>(
     topleft: *const BD::Pixel,
     width: c_int,
     height: c_int,
-    _a: c_int,
-    _max_width: c_int,
-    _max_height: c_int,
-    _bd: BD,
 ) {
     let [width, height] = [width, height].map(|it| it as usize);
 
@@ -639,23 +635,13 @@ unsafe extern "C" fn ipred_smooth_c_erased<BD: BitDepth>(
     topleft: *const DynPixel,
     width: c_int,
     height: c_int,
-    a: c_int,
-    max_width: c_int,
-    max_height: c_int,
-    bitdepth_max: c_int,
+    _a: c_int,
+    _max_width: c_int,
+    _max_height: c_int,
+    _bitdepth_max: c_int,
     _topleft_off: usize,
 ) {
-    ipred_smooth_rust(
-        dst.cast(),
-        stride,
-        topleft.cast(),
-        width,
-        height,
-        a,
-        max_width,
-        max_height,
-        BD::from_c(bitdepth_max),
-    );
+    ipred_smooth_rust::<BD>(dst.cast(), stride, topleft.cast(), width, height);
 }
 
 unsafe fn ipred_smooth_v_rust<BD: BitDepth>(

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -659,13 +659,15 @@ unsafe fn ipred_smooth_v_rust<BD: BitDepth>(
     _max_height: c_int,
     _bd: BD,
 ) {
-    let weights_ver: *const u8 = &*dav1d_sm_weights.0.as_ptr().offset(height as isize) as *const u8;
-    let bottom = (*topleft.offset(-height as isize)).as_::<c_int>();
+    let [width, height] = [width, height].map(|it| it as usize);
+
+    let weights_ver = &dav1d_sm_weights.0[height..];
+    let bottom = (*topleft.offset(-(height as isize))).as_::<c_int>();
+
     for y in 0..height {
         for x in 0..width {
-            let pred = *weights_ver.offset(y as isize) as c_int
-                * (*topleft.offset((1 + x) as isize)).as_::<c_int>()
-                + (256 - *weights_ver.offset(y as isize) as c_int) * bottom;
+            let pred = weights_ver[y] as c_int * (*topleft.offset((1 + x) as isize)).as_::<c_int>()
+                + (256 - weights_ver[y] as c_int) * bottom;
             *dst.offset(x as isize) = (pred + 128 >> 8).as_::<BD::Pixel>();
         }
         dst = dst.offset(BD::pxstride(stride));

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -701,18 +701,14 @@ unsafe fn ipred_smooth_h_rust<BD: BitDepth>(
 ) {
     let weights_hor: *const u8 = &*dav1d_sm_weights.0.as_ptr().offset(width as isize) as *const u8;
     let right = (*topleft.offset(width as isize)).as_::<c_int>();
-    let mut y = 0;
-    while y < height {
-        let mut x = 0;
-        while x < width {
+    for y in 0..height {
+        for x in 0..width {
             let pred = *weights_hor.offset(x as isize) as c_int
                 * (*topleft.offset(-(y + 1) as isize)).as_::<c_int>()
                 + (256 - *weights_hor.offset(x as isize) as c_int) * right;
             *dst.offset(x as isize) = (pred + 128 >> 8).as_::<BD::Pixel>();
-            x += 1;
         }
         dst = dst.offset(BD::pxstride(stride));
-        y += 1;
     }
 }
 

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -615,18 +615,18 @@ unsafe fn ipred_smooth_rust<BD: BitDepth>(
     _max_height: c_int,
     _bd: BD,
 ) {
-    let weights_hor: *const u8 = &*dav1d_sm_weights.0.as_ptr().offset(width as isize) as *const u8;
-    let weights_ver: *const u8 = &*dav1d_sm_weights.0.as_ptr().offset(height as isize) as *const u8;
+    let [width, height] = [width, height].map(|it| it as usize);
+
+    let weights_hor = &dav1d_sm_weights.0[width..];
+    let weights_ver = &dav1d_sm_weights.0[height..];
     let right = (*topleft.offset(width as isize)).as_::<c_int>();
-    let bottom = (*topleft.offset(-height as isize)).as_::<c_int>();
+    let bottom = (*topleft.offset(-(height as isize))).as_::<c_int>();
     for y in 0..height {
         for x in 0..width {
-            let pred = *weights_ver.offset(y as isize) as c_int
-                * (*topleft.offset((1 + x) as isize)).as_::<c_int>()
-                + (256 - *weights_ver.offset(y as isize) as c_int) * bottom
-                + *weights_hor.offset(x as isize) as c_int
-                    * (*topleft.offset(-(1 + y) as isize)).as_::<c_int>()
-                + (256 - *weights_hor.offset(x as isize) as c_int) * right;
+            let pred = weights_ver[y] as c_int * (*topleft.offset((1 + x) as isize)).as_::<c_int>()
+                + (256 - weights_ver[y] as c_int) * bottom
+                + weights_hor[x] as c_int * (*topleft.offset(-(1 + y as isize))).as_::<c_int>()
+                + (256 - weights_hor[x] as c_int) * right;
             *dst.offset(x as isize) = (pred + 256 >> 9).as_::<BD::Pixel>();
         }
         dst = dst.offset(BD::pxstride(stride));

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -654,10 +654,6 @@ unsafe fn ipred_smooth_v_rust<BD: BitDepth>(
     topleft: *const BD::Pixel,
     width: c_int,
     height: c_int,
-    _a: c_int,
-    _max_width: c_int,
-    _max_height: c_int,
-    _bd: BD,
 ) {
     let [width, height] = [width, height].map(|it| it as usize);
 
@@ -680,23 +676,13 @@ unsafe extern "C" fn ipred_smooth_v_c_erased<BD: BitDepth>(
     topleft: *const DynPixel,
     width: c_int,
     height: c_int,
-    a: c_int,
-    max_width: c_int,
-    max_height: c_int,
-    bitdepth_max: c_int,
+    _a: c_int,
+    _max_width: c_int,
+    _max_height: c_int,
+    _bitdepth_max: c_int,
     _topleft_off: usize,
 ) {
-    ipred_smooth_v_rust(
-        dst.cast(),
-        stride,
-        topleft.cast(),
-        width,
-        height,
-        a,
-        max_width,
-        max_height,
-        BD::from_c(bitdepth_max),
-    );
+    ipred_smooth_v_rust::<BD>(dst.cast(), stride, topleft.cast(), width, height);
 }
 
 unsafe fn ipred_smooth_h_rust<BD: BitDepth>(

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -699,13 +699,16 @@ unsafe fn ipred_smooth_h_rust<BD: BitDepth>(
     _max_height: c_int,
     _bd: BD,
 ) {
-    let weights_hor: *const u8 = &*dav1d_sm_weights.0.as_ptr().offset(width as isize) as *const u8;
+    let [width, height] = [width, height].map(|it| it as usize);
+
+    let weights_hor = &dav1d_sm_weights.0[width..];
     let right = (*topleft.offset(width as isize)).as_::<c_int>();
+
     for y in 0..height {
         for x in 0..width {
-            let pred = *weights_hor.offset(x as isize) as c_int
-                * (*topleft.offset(-(y + 1) as isize)).as_::<c_int>()
-                + (256 - *weights_hor.offset(x as isize) as c_int) * right;
+            let pred = weights_hor[x] as c_int
+                * (*topleft.offset(-(y as isize + 1))).as_::<c_int>()
+                + (256 - weights_hor[x] as c_int) * right;
             *dst.offset(x as isize) = (pred + 128 >> 8).as_::<BD::Pixel>();
         }
         dst = dst.offset(BD::pxstride(stride));

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -662,10 +662,11 @@ unsafe fn ipred_smooth_v_rust<BD: BitDepth>(
     let bottom = topleft[topleft_off - height].as_::<c_int>();
 
     for y in 0..height {
-        for x in 0..width {
+        let dst_slice = slice::from_raw_parts_mut(dst, width);
+        for (x, dst) in dst_slice.iter_mut().enumerate() {
             let pred = weights_ver[y] as c_int * topleft[topleft_off + 1 + x].as_::<c_int>()
                 + (256 - weights_ver[y] as c_int) * bottom;
-            *dst.offset(x as isize) = (pred + 128 >> 8).as_::<BD::Pixel>();
+            *dst = (pred + 128 >> 8).as_::<BD::Pixel>();
         }
         dst = dst.offset(BD::pxstride(stride));
     }

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -694,10 +694,6 @@ unsafe fn ipred_smooth_h_rust<BD: BitDepth>(
     topleft: *const BD::Pixel,
     width: c_int,
     height: c_int,
-    _a: c_int,
-    _max_width: c_int,
-    _max_height: c_int,
-    _bd: BD,
 ) {
     let [width, height] = [width, height].map(|it| it as usize);
 
@@ -721,23 +717,13 @@ unsafe extern "C" fn ipred_smooth_h_c_erased<BD: BitDepth>(
     topleft: *const DynPixel,
     width: c_int,
     height: c_int,
-    a: c_int,
-    max_width: c_int,
-    max_height: c_int,
-    bitdepth_max: c_int,
+    _a: c_int,
+    _max_width: c_int,
+    _max_height: c_int,
+    _bitdepth_max: c_int,
     _topleft_off: usize,
 ) {
-    ipred_smooth_h_rust(
-        dst.cast(),
-        stride,
-        topleft.cast(),
-        width,
-        height,
-        a,
-        max_width,
-        max_height,
-        BD::from_c(bitdepth_max),
-    );
+    ipred_smooth_h_rust::<BD>(dst.cast(), stride, topleft.cast(), width, height);
 }
 
 #[inline(never)]


### PR DESCRIPTION
* Part of #815.
* Part of #846.