### PR TITLE
`fn mct{,_scaled}::Fn::call: Slice tmp[..w * h] to ensure `slice::from_raw_parts(tmp, w * h)` is correct`

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1163,7 +1163,7 @@ impl ScratchPalBuf {
 
 #[derive(Clone, Copy, FromZeroes, FromBytes, AsBytes)]
 #[repr(C)]
-pub struct ScratchInterintraEdgePal {
+pub struct ScratchInterIntraEdgePal {
     pub interintra: ScratchInterintraBuf,
     pub edge: ScratchEdgeBuf,
     pub pal: ScratchPalBuf,
@@ -1197,7 +1197,7 @@ pub struct ScratchInterIntra {
     pub ac_txtp_map: ScratchAcTxtpMap,
     pub pal_idx_y: [u8; 32 * 64],
     pub pal_idx_uv: [u8; 64 * 64], // also used as pre-pack scratch buffer
-    pub interintra_edge_pal: ScratchInterintraEdgePal,
+    pub interintra_edge_pal: ScratchInterIntraEdgePal,
 }
 
 // Larger of the two between `ScratchInter` and `ScratchInterIntra`.

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -1235,7 +1235,7 @@ impl mct::Fn {
         my: i32,
         bd: BD,
     ) {
-        let tmp = tmp.as_mut_ptr();
+        let tmp = tmp[..(w * h) as usize].as_mut_ptr();
         let src = src.cast();
         let bd = bd.into_c();
         self.get()(tmp, src, src_stride, w, h, mx, my, bd)
@@ -1269,7 +1269,7 @@ impl mct_scaled::Fn {
         dy: i32,
         bd: BD,
     ) {
-        let tmp = tmp.as_mut_ptr();
+        let tmp = tmp[..(w * h) as usize].as_mut_ptr();
         let src = src.cast();
         let bd = bd.into_c();
         self.get()(tmp, src, src_stride, w, h, mx, my, dx, dy, bd)


### PR DESCRIPTION
I think we forgot to do this in https://github.com/memorysafety/rav1d/pull/1083#pullrequestreview-2059205550.