### PR TITLE
`struct Rav1dPictureDataComponent`: Refactor out accesses in each `fn`

### DIFF
--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -689,7 +689,7 @@ pub(crate) fn rav1d_calc_lf_values(
         1
     };
 
-    if hdr.loopfilter.level_y[0] == 0 && hdr.loopfilter.level_y[1] == 0 {
+    if hdr.loopfilter.level_y == [0; 2] {
         lflvl_values[..n_seg].fill_with(Default::default);
         return;
     }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -4186,11 +4186,12 @@ pub(crate) unsafe fn rav1d_filter_sbrow_deblock_cols<BD: BitDepth>(
     _t: &mut Rav1dTaskContext,
     sby: c_int,
 ) {
-    let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
+    if !c.inloop_filters.contains(Rav1dInloopFilterType::DEBLOCK) {
+        return;
+    }
 
-    if !c.inloop_filters.contains(Rav1dInloopFilterType::DEBLOCK)
-        || frame_hdr.loopfilter.level_y == [0; 2]
-    {
+    let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
+    if frame_hdr.loopfilter.level_y == [0; 2] {
         return;
     }
 

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -4189,7 +4189,7 @@ pub(crate) unsafe fn rav1d_filter_sbrow_deblock_cols<BD: BitDepth>(
     let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
 
     if !c.inloop_filters.contains(Rav1dInloopFilterType::DEBLOCK)
-        || frame_hdr.loopfilter.level_y[0] == 0 && frame_hdr.loopfilter.level_y[1] == 0
+        || frame_hdr.loopfilter.level_y == [0; 2]
     {
         return;
     }
@@ -4302,7 +4302,7 @@ pub(crate) unsafe fn rav1d_filter_sbrow_deblock_rows<BD: BitDepth>(
     let mask_offset = (sby >> (sb128 == 0) as c_int) * f.sb128w;
     let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
     if c.inloop_filters.contains(Rav1dInloopFilterType::DEBLOCK)
-        && (frame_hdr.loopfilter.level_y[0] != 0 || frame_hdr.loopfilter.level_y[1] != 0)
+        && (frame_hdr.loopfilter.level_y != [0; 2])
     {
         rav1d_loopfilter_sbrow_rows::<BD>(f, &mut p, &p_offset, mask_offset as usize, sby);
     }

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -305,8 +305,7 @@ unsafe fn create_filter_sbrow(
     pass: c_int,
 ) -> Rav1dResult<Rav1dTaskIndex> {
     let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
-    let has_deblock =
-        (frame_hdr.loopfilter.level_y[0] != 0 || frame_hdr.loopfilter.level_y[1] != 0) as c_int;
+    let has_deblock = (frame_hdr.loopfilter.level_y != [0; 2]) as c_int;
     let seq_hdr = &***f.seq_hdr.as_ref().unwrap();
     let has_cdef = seq_hdr.cdef;
     let has_resize = (frame_hdr.size.width[0] != frame_hdr.size.width[1]) as c_int;
@@ -1208,9 +1207,7 @@ pub unsafe fn rav1d_worker_task(c: &Rav1dContext, task_thread: Arc<Rav1dTaskCont
                         // signal deblock progress
                         let seq_hdr = &***f.seq_hdr.as_ref().unwrap();
                         let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
-                        if frame_hdr.loopfilter.level_y[0] != 0
-                            || frame_hdr.loopfilter.level_y[1] != 0
-                        {
+                        if frame_hdr.loopfilter.level_y != [0; 2] {
                             drop(f);
                             error_0 = fc.task_thread.error.load(Ordering::SeqCst);
                             fc.frame_thread_progress.deblock.store(


### PR DESCRIPTION
Quite simple; just want to split this out before more important changes.