### PR TITLE
`fn emu_edge`: `wrap_fn_ptr!` it and make call safer

### DIFF
--- a/src/mc.rs
+++ b/src/mc.rs
@@ -1378,16 +1378,16 @@ pub type blend_dir_fn =
     unsafe extern "C" fn(*mut DynPixel, isize, *const [DynPixel; SCRATCH_LAP_LEN], i32, i32) -> ();
 
 pub type emu_edge_fn = unsafe extern "C" fn(
-    isize,
-    isize,
-    isize,
-    isize,
-    isize,
-    isize,
-    *mut [DynPixel; EMU_EDGE_LEN],
-    usize,
-    *const DynPixel,
-    isize,
+    bw: isize,
+    bh: isize,
+    iw: isize,
+    ih: isize,
+    x: isize,
+    y: isize,
+    dst: *mut [DynPixel; EMU_EDGE_LEN],
+    dst_stride: usize,
+    src: *const DynPixel,
+    src_stride: isize,
 ) -> ();
 
 pub type resize_fn = unsafe extern "C" fn(

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -1386,7 +1386,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn emu_edge(
     x: isize,
     y: isize,
     dst: *mut [DynPixel; EMU_EDGE_LEN],
-    dst_stride: usize,
+    dst_stride: isize,
     src: *const DynPixel,
     src_stride: isize,
 ) -> ());
@@ -1406,7 +1406,7 @@ impl emu_edge::Fn {
         src_stride: isize,
     ) {
         let dst = dst.as_mut_ptr().cast();
-        let dst_stride = dst_pxstride * mem::size_of::<BD::Pixel>();
+        let dst_stride = (dst_pxstride * mem::size_of::<BD::Pixel>()) as isize;
         let src = src.cast();
         self.get()(bw, bh, iw, ih, x, y, dst, dst_stride, src, src_stride)
     }
@@ -1938,7 +1938,7 @@ unsafe extern "C" fn emu_edge_c_erased<BD: BitDepth>(
     x: isize,
     y: isize,
     dst: *mut [DynPixel; EMU_EDGE_LEN],
-    dst_stride: usize,
+    dst_stride: isize,
     r#ref: *const DynPixel,
     ref_stride: isize,
 ) {
@@ -1950,7 +1950,8 @@ unsafe extern "C" fn emu_edge_c_erased<BD: BitDepth>(
         x,
         y,
         dst.cast(),
-        dst_stride,
+        // Is `usize` in `fn emu_edge::Fn::call`.
+        dst_stride as usize,
         r#ref.cast(),
         ref_stride,
     )

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -20,6 +20,7 @@ use crate::src::tables::dav1d_resize_filter;
 use crate::src::wrap_fn_ptr::wrap_fn_ptr;
 use std::cmp;
 use std::iter;
+use std::mem;
 use std::slice;
 use to_method::To;
 
@@ -1400,11 +1401,12 @@ impl emu_edge::Fn {
         x: isize,
         y: isize,
         dst: &mut [BD::Pixel; EMU_EDGE_LEN],
-        dst_stride: usize,
+        dst_pxstride: usize,
         src: *const BD::Pixel,
         src_stride: isize,
     ) {
         let dst = dst.as_mut_ptr().cast();
+        let dst_stride = dst_pxstride * mem::size_of::<BD::Pixel>();
         let src = src.cast();
         self.get()(bw, bh, iw, ih, x, y, dst, dst_stride, src, src_stride)
     }

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -1399,12 +1399,12 @@ impl emu_edge::Fn {
         ih: isize,
         x: isize,
         y: isize,
-        dst: *mut [BD::Pixel; EMU_EDGE_LEN],
+        dst: &mut [BD::Pixel; EMU_EDGE_LEN],
         dst_stride: usize,
         src: *const BD::Pixel,
         src_stride: isize,
     ) {
-        let dst = dst.cast();
+        let dst = dst.as_mut_ptr().cast();
         let src = src.cast();
         self.get()(bw, bh, iw, ih, x, y, dst, dst_stride, src, src_stride)
     }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2113,16 +2113,16 @@ unsafe fn mc<BD: BitDepth>(
             || dy + bh4 * v_mul + (my != 0) as c_int * 4 > h
         {
             let emu_edge_buf = emu_edge.buf_mut::<BD>();
-            (f.dsp.mc.emu_edge)(
+            f.dsp.mc.emu_edge.call::<BD>(
                 (bw4 * h_mul + (mx != 0) as c_int * 7) as intptr_t,
                 (bh4 * v_mul + (my != 0) as c_int * 7) as intptr_t,
                 w as intptr_t,
                 h as intptr_t,
                 (dx - (mx != 0) as c_int * 3) as intptr_t,
                 (dy - (my != 0) as c_int * 3) as intptr_t,
-                emu_edge_buf.as_mut_ptr().cast(),
+                emu_edge_buf,
                 192 * mem::size_of::<BD::Pixel>(),
-                ref_data[pl].as_ptr::<BD>().cast(),
+                ref_data[pl].as_ptr::<BD>(),
                 ref_stride,
             );
             r#ref = emu_edge_buf
@@ -2186,16 +2186,16 @@ unsafe fn mc<BD: BitDepth>(
         let h = refp.p.p.h + ss_ver >> ss_ver;
         if left < 3 || top < 3 || right + 4 > w || bottom + 4 > h {
             let emu_edge_buf = emu_edge.buf_mut::<BD>();
-            (f.dsp.mc.emu_edge)(
+            f.dsp.mc.emu_edge.call::<BD>(
                 (right - left + 7) as intptr_t,
                 (bottom - top + 7) as intptr_t,
                 w as intptr_t,
                 h as intptr_t,
                 (left - 3) as intptr_t,
                 (top - 3) as intptr_t,
-                emu_edge_buf.as_mut_ptr().cast(),
+                emu_edge_buf,
                 320 * mem::size_of::<BD::Pixel>(),
-                ref_data[pl].as_ptr::<BD>().cast(),
+                ref_data[pl].as_ptr::<BD>(),
                 ref_stride,
             );
             r#ref = emu_edge_buf.as_mut_ptr().add((320 * 3 + 3) as usize);
@@ -2396,16 +2396,16 @@ unsafe fn warp_affine<BD: BitDepth>(
 
             if dx < 3 || dx + 8 + 4 > width || dy < 3 || dy + 8 + 4 > height {
                 let emu_edge_buf = emu_edge.buf_mut::<BD>();
-                (f.dsp.mc.emu_edge)(
+                f.dsp.mc.emu_edge.call::<BD>(
                     15,
                     15,
                     width as intptr_t,
                     height as intptr_t,
                     (dx - 3) as intptr_t,
                     (dy - 3) as intptr_t,
-                    emu_edge_buf.as_mut_ptr().cast(),
+                    emu_edge_buf,
                     32 * mem::size_of::<BD::Pixel>(),
-                    ref_data[pl].as_ptr::<BD>().cast(),
+                    ref_data[pl].as_ptr::<BD>(),
                     ref_stride,
                 );
                 ref_ptr = emu_edge_buf.as_ptr().add(32 * 3 + 3);

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -105,7 +105,6 @@ use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
-use std::mem;
 use std::ops::BitOr;
 use std::ptr;
 use std::slice;
@@ -2121,7 +2120,7 @@ unsafe fn mc<BD: BitDepth>(
                 (dx - (mx != 0) as c_int * 3) as intptr_t,
                 (dy - (my != 0) as c_int * 3) as intptr_t,
                 emu_edge_buf,
-                192 * mem::size_of::<BD::Pixel>(),
+                192,
                 ref_data[pl].as_ptr::<BD>(),
                 ref_stride,
             );
@@ -2194,7 +2193,7 @@ unsafe fn mc<BD: BitDepth>(
                 (left - 3) as intptr_t,
                 (top - 3) as intptr_t,
                 emu_edge_buf,
-                320 * mem::size_of::<BD::Pixel>(),
+                320,
                 ref_data[pl].as_ptr::<BD>(),
                 ref_stride,
             );
@@ -2404,7 +2403,7 @@ unsafe fn warp_affine<BD: BitDepth>(
                     (dx - 3) as intptr_t,
                     (dy - 3) as intptr_t,
                     emu_edge_buf,
-                    32 * mem::size_of::<BD::Pixel>(),
+                    32,
                     ref_data[pl].as_ptr::<BD>(),
                     ref_stride,
                 );


### PR DESCRIPTION
We had also changed one of the `isize` args to `usize` for some reason.  I changed it back for the `fn` ptr itself.

This is used with picture data, so I wanted to make this safer first.