### PR TITLE
`fn itxfm`: `wrap_fn_ptr!` it and make call safer

### DIFF
--- a/src/itx.rs
+++ b/src/itx.rs
@@ -159,8 +159,15 @@ pub unsafe fn inv_txfm_add_rust<
     }
 }
 
-pub type itxfm_fn =
-    Option<unsafe extern "C" fn(*mut DynPixel, ptrdiff_t, *mut DynCoef, c_int, c_int) -> ()>;
+pub type itxfm_fn = Option<
+    unsafe extern "C" fn(
+        dst: *mut DynPixel,
+        dst_stride: ptrdiff_t,
+        coeff: *mut DynCoef,
+        eob: c_int,
+        bitdepth_max: c_int,
+    ) -> (),
+>;
 
 pub struct Rav1dInvTxfmDSPContext {
     pub itxfm_add: [[itxfm_fn; N_TX_TYPES_PLUS_LL]; N_RECT_TX_SIZES],

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -174,12 +174,12 @@ impl itxfm::Fn {
         &self,
         dst: *mut BD::Pixel,
         dst_stride: ptrdiff_t,
-        coeff: *mut BD::Coef,
+        coeff: &mut [BD::Coef],
         eob: c_int,
         bd: BD,
     ) {
         let dst = dst.cast();
-        let coeff = coeff.cast();
+        let coeff = coeff.as_mut_ptr().cast();
         let bd = bd.into_c();
         self.get()(dst, dst_stride, coeff, eob, bd)
     }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -1609,6 +1609,8 @@ unsafe fn read_coef_tree<BD: BitDepth>(
     y_off: c_int,
     mut dst: Option<*mut BD::Pixel>,
 ) {
+    let bd = BD::from_c(f.bitdepth_max);
+
     let ts = &f.ts[t.ts];
     let t_dim = &dav1d_txfm_dimensions[ytx as usize];
     let txw = t_dim.w;
@@ -1783,13 +1785,12 @@ unsafe fn read_coef_tree<BD: BitDepth>(
                         "dq",
                     );
                 }
-                (f.dsp.itx.itxfm_add[ytx as usize][txtp as usize])
-                    .expect("non-null function pointer")(
-                    dst.cast(),
+                f.dsp.itx.itxfm_add[ytx as usize][txtp as usize].call::<BD>(
+                    dst,
                     f.cur.stride[0],
-                    cf.as_mut_ptr().cast(),
+                    cf.as_mut_ptr(),
                     eob,
-                    f.bitdepth_max,
+                    bd,
                 );
                 if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                     hex_dump::<BD>(
@@ -2750,13 +2751,12 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                     "dq",
                                 );
                             }
-                            (f.dsp.itx.itxfm_add[intra.tx as usize][txtp as usize])
-                                .expect("non-null function pointer")(
-                                dst.cast(),
+                            f.dsp.itx.itxfm_add[intra.tx as usize][txtp as usize].call::<BD>(
+                                dst,
                                 f.cur.stride[0],
-                                cf.as_mut_ptr().cast(),
+                                cf.as_mut_ptr(),
                                 eob,
-                                f.bitdepth_max,
+                                bd,
                             );
                             if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                                 hex_dump::<BD>(
@@ -3190,13 +3190,12 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                         "dq",
                                     );
                                 }
-                                (f.dsp.itx.itxfm_add[b.uvtx as usize][txtp as usize])
-                                    .expect("non-null function pointer")(
-                                    dst.cast(),
+                                f.dsp.itx.itxfm_add[b.uvtx as usize][txtp as usize].call::<BD>(
+                                    dst,
                                     stride,
-                                    cf.as_mut_ptr().cast(),
+                                    cf.as_mut_ptr(),
                                     eob,
-                                    f.bitdepth_max,
+                                    bd,
                                 );
                                 if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                                     hex_dump::<BD>(
@@ -4145,13 +4144,12 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                                         "dq",
                                     );
                                 }
-                                (f.dsp.itx.itxfm_add[b.uvtx as usize][txtp as usize])
-                                    .expect("non-null function pointer")(
-                                    uvdst.add(4 * x as usize).cast(),
+                                f.dsp.itx.itxfm_add[b.uvtx as usize][txtp as usize].call::<BD>(
+                                    uvdst.add(4 * x as usize),
                                     f.cur.stride[1],
-                                    cf.as_mut_ptr().cast(),
+                                    cf.as_mut_ptr(),
                                     eob,
-                                    f.bitdepth_max,
+                                    bd,
                                 );
                                 if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                                     hex_dump::<BD>(

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -1771,7 +1771,7 @@ unsafe fn read_coef_tree<BD: BitDepth>(
                     CfSelect::Frame(offset) => {
                         let len =
                             cmp::min(t_dim.h as usize, 8) * 4 * cmp::min(t_dim.w as usize, 8) * 4;
-                        cf_guard = f.frame_thread.cf.mut_slice_as(offset..offset + len);
+                        cf_guard = f.frame_thread.cf.mut_slice_as((offset.., ..len));
                         &mut *cf_guard
                     }
                     CfSelect::Task => t.cf.select_mut::<BD>(),
@@ -1788,7 +1788,7 @@ unsafe fn read_coef_tree<BD: BitDepth>(
                 f.dsp.itx.itxfm_add[ytx as usize][txtp as usize].call::<BD>(
                     dst,
                     f.cur.stride[0],
-                    cf.as_mut_ptr(),
+                    cf,
                     eob,
                     bd,
                 );
@@ -2754,7 +2754,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             f.dsp.itx.itxfm_add[intra.tx as usize][txtp as usize].call::<BD>(
                                 dst,
                                 f.cur.stride[0],
-                                cf.as_mut_ptr(),
+                                cf,
                                 eob,
                                 bd,
                             );
@@ -3190,13 +3190,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                         "dq",
                                     );
                                 }
-                                f.dsp.itx.itxfm_add[b.uvtx as usize][txtp as usize].call::<BD>(
-                                    dst,
-                                    stride,
-                                    cf.as_mut_ptr(),
-                                    eob,
-                                    bd,
-                                );
+                                f.dsp.itx.itxfm_add[b.uvtx as usize][txtp as usize]
+                                    .call::<BD>(dst, stride, cf, eob, bd);
                                 if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                                     hex_dump::<BD>(
                                         dst,
@@ -4147,7 +4142,7 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                                 f.dsp.itx.itxfm_add[b.uvtx as usize][txtp as usize].call::<BD>(
                                     uvdst.add(4 * x as usize),
                                     f.cur.stride[1],
-                                    cf.as_mut_ptr(),
+                                    cf,
                                     eob,
                                     bd,
                                 );


### PR DESCRIPTION
This is used with picture data, so I wanted to make this safer first.

It also removes the `Option`, deduplicates the asm `fn`s declarations vs. assignments, and makes `coeff` a slice.