### PR TITLE
`fn pal_pred`: Make FFI boundary safer

### DIFF
--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -180,12 +180,13 @@ impl pal_pred::Fn {
         dst: *mut BD::Pixel,
         stride: ptrdiff_t,
         pal: &[BD::Pixel; 8],
-        idx: *const u8,
+        idx: &[u8],
         w: c_int,
         h: c_int,
     ) {
         let dst = dst.cast();
         let pal = pal.as_ptr().cast();
+        let idx = idx.as_ptr();
         self.get()(dst, stride, pal, idx, w, h)
     }
 }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2527,14 +2527,14 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     let index =
                         ((y >> 1) + (x & 1)) * (f.b4_stride as usize >> 1) + (x >> 1) + (y & 1);
                     pal_guard = f.frame_thread.pal.index::<BD>(index);
-                    &pal_guard[0]
+                    &*pal_guard
                 } else {
-                    &scratch.interintra_edge_pal.pal.buf::<BD>()[0]
+                    scratch.interintra_edge_pal.pal.buf::<BD>()
                 };
                 f.dsp.ipred.pal_pred.call::<BD>(
                     dst,
                     f.cur.stride[0],
-                    pal.as_ptr(),
+                    &pal[0],
                     pal_idx.as_ptr(),
                     bw4 * 4,
                     bh4 * 4,
@@ -2934,7 +2934,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                 f.dsp.ipred.pal_pred.call::<BD>(
                     cur_data[1].as_mut_ptr::<BD>().offset(uv_dstoff),
                     f.cur.stride[1],
-                    pal[1].as_ptr(),
+                    &pal[1],
                     pal_idx.as_ptr(),
                     cbw4 * 4,
                     cbh4 * 4,
@@ -2942,7 +2942,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                 f.dsp.ipred.pal_pred.call::<BD>(
                     cur_data[2].as_mut_ptr::<BD>().offset(uv_dstoff),
                     f.cur.stride[1],
-                    pal[2].as_ptr(),
+                    &pal[2],
                     pal_idx.as_ptr(),
                     cbw4 * 4,
                     cbh4 * 4,

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2535,7 +2535,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     dst,
                     f.cur.stride[0],
                     &pal[0],
-                    pal_idx.as_ptr(),
+                    pal_idx,
                     bw4 * 4,
                     bh4 * 4,
                 );
@@ -2935,7 +2935,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     cur_data[1].as_mut_ptr::<BD>().offset(uv_dstoff),
                     f.cur.stride[1],
                     &pal[1],
-                    pal_idx.as_ptr(),
+                    pal_idx,
                     cbw4 * 4,
                     cbh4 * 4,
                 );
@@ -2943,7 +2943,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     cur_data[2].as_mut_ptr::<BD>().offset(uv_dstoff),
                     f.cur.stride[1],
                     &pal[2],
-                    pal_idx.as_ptr(),
+                    pal_idx,
                     cbw4 * 4,
                     cbh4 * 4,
                 );


### PR DESCRIPTION
I'm trying to pass `Rav1dPictureDataComponent` through here, so I want to make the rest as safe as possible first.