### PR TITLE
`fn pal_pred`: Make safe

### DIFF
--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -214,7 +214,7 @@ impl Rav1dPictureDataComponent {
     }
 
     /// Stride in number of [`u8`] bytes.
-    fn stride(&self) -> isize {
+    pub fn stride(&self) -> isize {
         // SAFETY: We're only accessing the `stride` fields, not `ptr`.
         unsafe { (*self.0.inner()).stride }
     }

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -258,6 +258,22 @@ impl Rav1dPictureDataComponent {
         self.as_mut_ptr::<BD>().cast_const()
     }
 
+    /// Non-strided, absolute ptr to [`BitDepth::Pixel`]s starting at `offset`.
+    ///
+    /// Bounds checked, but not [`DisjointMut`]-checked.
+    pub fn as_mut_ptr_at<BD: BitDepth>(&self, pixel_offset: usize) -> *mut BD::Pixel {
+        assert!(pixel_offset <= self.pixel_len::<BD>());
+        // SAFETY: We just checked that `pixel_offset` is in bounds.
+        unsafe { self.as_mut_ptr::<BD>().add(pixel_offset) }
+    }
+
+    /// Non-strided, absolute ptr to [`BitDepth::Pixel`]s starting at `offset`.
+    ///
+    /// Bounds checked, but not [`DisjointMut`]-checked.
+    pub fn as_ptr_at<BD: BitDepth>(&self, offset: usize) -> *const BD::Pixel {
+        self.as_mut_ptr_at::<BD>(offset).cast_const()
+    }
+
     /// Strided ptr to [`BitDepth::Pixel`]s.
     pub fn as_strided_mut_ptr<BD: BitDepth>(&self) -> *mut BD::Pixel {
         // SAFETY: Transmutation is safe because we verify this with `zerocopy` in `Self::slice`.

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -233,7 +233,7 @@ impl Rav1dPictureDataComponent {
     }
 
     /// Strided ptr to [`u8`] bytes.
-    fn as_byte_mut_ptr(&self) -> *mut u8 {
+    fn as_strided_byte_mut_ptr(&self) -> *mut u8 {
         let ptr = self.0.as_mut_ptr();
         let stride = self.stride();
         if stride < 0 {
@@ -247,21 +247,33 @@ impl Rav1dPictureDataComponent {
         }
     }
 
-    /// Strided ptr to pixels.
+    /// Non-strided, absolute ptr to [`BitDepth::Pixel`]s.
     pub fn as_mut_ptr<BD: BitDepth>(&self) -> *mut BD::Pixel {
-        self.as_byte_mut_ptr().cast()
+        // SAFETY: Transmutation is safe because we verify this with `zerocopy` in `Self::slice`.
+        self.0.as_mut_ptr().cast()
     }
 
-    /// Strided ptr to pixels.
+    /// Non-strided, absolute ptr to [`BitDepth::Pixel`]s.
     pub fn as_ptr<BD: BitDepth>(&self) -> *const BD::Pixel {
         self.as_mut_ptr::<BD>().cast_const()
+    }
+
+    /// Strided ptr to [`BitDepth::Pixel`]s.
+    pub fn as_strided_mut_ptr<BD: BitDepth>(&self) -> *mut BD::Pixel {
+        // SAFETY: Transmutation is safe because we verify this with `zerocopy` in `Self::slice`.
+        self.as_strided_byte_mut_ptr().cast()
+    }
+
+    /// Strided ptr to [`BitDepth::Pixel`]s.
+    pub fn as_strided_ptr<BD: BitDepth>(&self) -> *const BD::Pixel {
+        self.as_strided_mut_ptr::<BD>().cast_const()
     }
 
     fn as_dav1d(&self) -> Option<NonNull<c_void>> {
         if self.len() == 0 {
             None
         } else {
-            NonNull::new(self.as_byte_mut_ptr().cast())
+            NonNull::new(self.as_strided_byte_mut_ptr().cast())
         }
     }
 

--- a/src/fg_apply.rs
+++ b/src/fg_apply.rs
@@ -195,12 +195,8 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
     if data.chroma_scaling_from_luma {
         for pl in 0..2 {
             dsp.fguv_32x32xn[layout].call(
-                out_data[1 + pl]
-                    .as_strided_mut_ptr::<BD>()
-                    .offset(uv_off as isize),
-                in_data[1 + pl]
-                    .as_strided_ptr::<BD>()
-                    .offset(uv_off as isize),
+                out_data[1 + pl].as_strided_mut_ptr::<BD>().offset(uv_off),
+                in_data[1 + pl].as_strided_ptr::<BD>().offset(uv_off),
                 r#in.stride[1],
                 data,
                 cpw,
@@ -219,12 +215,8 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
         for pl in 0..2 {
             if data.num_uv_points[pl] != 0 {
                 dsp.fguv_32x32xn[layout].call(
-                    out_data[1 + pl]
-                        .as_strided_mut_ptr::<BD>()
-                        .offset(uv_off as isize),
-                    in_data[1 + pl]
-                        .as_strided_ptr::<BD>()
-                        .offset(uv_off as isize),
+                    out_data[1 + pl].as_strided_mut_ptr::<BD>().offset(uv_off),
+                    in_data[1 + pl].as_strided_ptr::<BD>().offset(uv_off),
                     r#in.stride[1],
                     data_c,
                     cpw,

--- a/src/fg_apply.rs
+++ b/src/fg_apply.rs
@@ -153,7 +153,7 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
     let cpw = w + ss_x >> ss_x;
     let is_id = seq_hdr.mtrx == Rav1dMatrixCoefficients::IDENTITY;
     let luma_src = in_data[0]
-        .as_mut_ptr::<BD>()
+        .as_strided_mut_ptr::<BD>()
         .offset((row * BLOCK_SIZE) as isize * BD::pxstride(r#in.stride[0]));
     let bitdepth_max = (1 << out.p.bpc) - 1;
     let bd = BD::from_c(bitdepth_max);
@@ -162,7 +162,7 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
         let bh = cmp::min(h - row * BLOCK_SIZE, BLOCK_SIZE);
         dsp.fgy_32x32xn.call(
             out_data[0]
-                .as_mut_ptr::<BD>()
+                .as_strided_mut_ptr::<BD>()
                 .offset((row * BLOCK_SIZE) as isize * BD::pxstride(out.stride[0])),
             luma_src,
             out.stride[0],
@@ -195,8 +195,12 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
     if data.chroma_scaling_from_luma {
         for pl in 0..2 {
             dsp.fguv_32x32xn[layout].call(
-                out_data[1 + pl].as_mut_ptr::<BD>().offset(uv_off as isize),
-                in_data[1 + pl].as_ptr::<BD>().offset(uv_off as isize),
+                out_data[1 + pl]
+                    .as_strided_mut_ptr::<BD>()
+                    .offset(uv_off as isize),
+                in_data[1 + pl]
+                    .as_strided_ptr::<BD>()
+                    .offset(uv_off as isize),
                 r#in.stride[1],
                 data,
                 cpw,
@@ -215,8 +219,12 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
         for pl in 0..2 {
             if data.num_uv_points[pl] != 0 {
                 dsp.fguv_32x32xn[layout].call(
-                    out_data[1 + pl].as_mut_ptr::<BD>().offset(uv_off as isize),
-                    in_data[1 + pl].as_ptr::<BD>().offset(uv_off as isize),
+                    out_data[1 + pl]
+                        .as_strided_mut_ptr::<BD>()
+                        .offset(uv_off as isize),
+                    in_data[1 + pl]
+                        .as_strided_ptr::<BD>()
+                        .offset(uv_off as isize),
                     r#in.stride[1],
                     data_c,
                     cpw,

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -177,7 +177,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn pal_pred(
 ) -> ());
 
 impl pal_pred::Fn {
-    pub unsafe fn call<BD: BitDepth>(
+    pub fn call<BD: BitDepth>(
         &self,
         dst: &Rav1dPictureDataComponent,
         dst_offset: usize,
@@ -188,12 +188,13 @@ impl pal_pred::Fn {
     ) {
         // SAFETY: `DisjointMut` is unchecked for asm `fn`s,
         // but passed through as an extra arg for the fallback `fn`.
-        let dst_ptr = dst.as_mut_ptr::<BD>().add(dst_offset).cast();
+        let dst_ptr = dst.as_mut_ptr_at::<BD>(dst_offset).cast();
         let stride = dst.stride();
         let pal = pal.as_ptr().cast();
         let idx = idx[..(w * h) as usize / 2].as_ptr();
         let dst = FFISafe::new(dst);
-        self.get()(dst_ptr, stride, pal, idx, w, h, dst)
+        // SAFETY: Fallback `fn pal_pred_rust` is safe; asm is supposed to do the same.
+        unsafe { self.get()(dst_ptr, stride, pal, idx, w, h, dst) }
     }
 }
 

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -1410,7 +1410,7 @@ unsafe extern "C" fn cfl_ac_c_erased<BD: BitDepth, const IS_SS_HOR: bool, const 
     );
 }
 
-unsafe fn pal_pred_rust<BD: BitDepth>(
+fn pal_pred_rust<BD: BitDepth>(
     dst: &Rav1dPictureDataComponent,
     mut dst_offset: usize,
     pal: &[BD::Pixel; 8],
@@ -1436,6 +1436,7 @@ unsafe fn pal_pred_rust<BD: BitDepth>(
     }
 }
 
+#[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn pal_pred_c_erased<BD: BitDepth>(
     dst_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
@@ -1453,7 +1454,7 @@ unsafe extern "C" fn pal_pred_c_erased<BD: BitDepth>(
     // SAFETY: Undoing dyn cast in `pal_pred::Fn::call`.
     let pal = unsafe { &*pal.cast() };
     // SAFETY: Length sliced in `pal_pred::Fn::call`.
-    let idx = slice::from_raw_parts(idx, (w * h) as usize / 2);
+    let idx = unsafe { slice::from_raw_parts(idx, (w * h) as usize / 2) };
     pal_pred_rust::<BD>(dst, dst_offset, pal, idx, w, h)
 }
 


### PR DESCRIPTION
This makes the rest of `fn pal_pred` safe.  `dst` is made safe by adding an extra `FFISafe<Rav1dPictureDataComponent>` arg.  `idx` is made safe by recreating the slice, with the length checked in `fn call`.  Thus, the fallback `fn pal_pred_rust` is now safe, so I marked `fn pal_pred::Fn::call` safe, too (just asserting the asm is safe).