### PR TITLE
Backport `cbi` buffer optimization from dav1d 1.3.0

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -2484,6 +2484,9 @@ static void setup_tile(Dav1dTileState *const ts,
         ts->frame_thread[p].pal_idx = f->frame_thread.pal_idx ?
             &f->frame_thread.pal_idx[(size_t)tile_start_off * size_mul[1] / 8] :
             NULL;
+        ts->frame_thread[p].cbi = f->frame_thread.cbi ?
+            &f->frame_thread.cbi[(size_t)tile_start_off * size_mul[0] / 64] :
+            NULL;
         ts->frame_thread[p].cf = f->frame_thread.cf ?
             (uint8_t*)f->frame_thread.cf +
                 (((size_t)tile_start_off * size_mul[0]) >> !f->seq_hdr->hbd) :
@@ -2855,6 +2858,19 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
             }
         }
 
+        const int cbi_sz = num_sb128 * size_mul[0];
+        if (cbi_sz != f->frame_thread.cbi_sz) {
+            dav1d_free_aligned(f->frame_thread.cbi);
+            f->frame_thread.cbi =
+                dav1d_alloc_aligned(ALLOC_BLOCK, sizeof(*f->frame_thread.cbi) *
+                                    cbi_sz * 32 * 32 / 4, 64);
+            if (!f->frame_thread.cbi) {
+                f->frame_thread.cbi_sz = 0;
+                return retval;
+            }
+            f->frame_thread.cbi_sz = cbi_sz;
+        }
+
         const int cf_sz = (num_sb128 * size_mul[0]) << hbd;
         if (cf_sz != f->frame_thread.cf_sz) {
             dav1d_freep_aligned(&f->frame_thread.cf);
@@ -3012,12 +3028,9 @@ int dav1d_decode_frame_init(Dav1dFrameContext *const f) {
         }
         if (c->n_fc > 1) {
             freep(&f->frame_thread.b);
-            freep(&f->frame_thread.cbi);
             f->frame_thread.b = malloc(sizeof(*f->frame_thread.b) *
                                        num_sb128 * 32 * 32);
-            f->frame_thread.cbi = malloc(sizeof(*f->frame_thread.cbi) *
-                                         num_sb128 * 32 * 32);
-            if (!f->frame_thread.b || !f->frame_thread.cbi) {
+            if (!f->frame_thread.b) {
                 f->lf.mask_sz = 0;
                 return retval;
             }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -3991,6 +3991,14 @@ fn setup_tile(
             },
             Ordering::Relaxed,
         );
+        ts.frame_thread[p].cbi_idx.store(
+            if !frame_thread.cbi.is_empty() {
+                tile_start_off * size_mul[0] as usize / 64
+            } else {
+                0
+            },
+            Ordering::Relaxed,
+        );
         ts.frame_thread[p].cf.store(
             if !frame_thread.cf.is_empty() {
                 let bpc = BPC::from_bitdepth_max(bitdepth_max);
@@ -4478,6 +4486,12 @@ pub(crate) fn rav1d_decode_frame_init(c: &Rav1dContext, fc: &Rav1dFrameContext) 
             }
         }
 
+        let cbi_sz = num_sb128 * size_mul[0] as c_int;
+        // TODO: Fallible allocation
+        f.frame_thread
+            .cbi
+            .resize_with(cbi_sz as usize * 32 * 32 / 4, Default::default);
+
         let cf_sz = (num_sb128 * size_mul[0] as c_int) << hbd;
         // TODO: Fallible allocation
         f.frame_thread
@@ -4613,11 +4627,6 @@ pub(crate) fn rav1d_decode_frame_init(c: &Rav1dContext, fc: &Rav1dFrameContext) 
         // TODO: Fallible allocation
         f.frame_thread
             .b
-            .resize_with(num_sb128 as usize * 32 * 32, Default::default);
-
-        // TODO: fallible allocation
-        f.frame_thread
-            .cbi
             .resize_with(num_sb128 as usize * 32 * 32, Default::default);
     }
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -279,14 +279,14 @@ struct Dav1dFrameContext {
         atomic_uint *frame_progress, *copy_lpf_progress;
         // indexed using t->by * f->b4_stride + t->bx
         Av1Block *b;
-        int16_t (*cbi)[3 /* plane */]; /* bits 0-4: txtp, bits 5-15: eob */
+        int16_t *cbi; /* bits 0-4: txtp, bits 5-15: eob */
         // indexed using (t->by >> 1) * (f->b4_stride >> 1) + (t->bx >> 1)
         pixel (*pal)[3 /* plane */][8 /* idx */];
         // iterated over inside tile state
         uint8_t *pal_idx;
         coef *cf;
         int prog_sz;
-        int pal_sz, pal_idx_sz, cf_sz;
+        int cbi_sz, pal_sz, pal_idx_sz, cf_sz;
         // start offsets per tile
         unsigned *tile_start_off;
     } frame_thread;
@@ -364,6 +364,7 @@ struct Dav1dTileState {
     atomic_int progress[2 /* 0: reconstruction, 1: entropy */];
     struct Dav1dTileState_frame_thread {
         uint8_t *pal_idx;
+        int16_t *cbi;
         coef *cf;
     } frame_thread[2 /* 0: reconstruction, 1: entropy */];
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -618,7 +618,7 @@ pub struct Rav1dFrameContext_frame_thread {
     /// Indexed using `t.b.y * f.b4_stride + t.b.x`.
     pub b: DisjointMut<Vec<Av1Block>>,
 
-    pub cbi: Vec<[Atomic<CodedBlockInfo>; 3]>,
+    pub cbi: Vec<Atomic<CodedBlockInfo>>,
 
     /// Indexed using `(t.b.y >> 1) * (f.b4_stride >> 1) + (t.b.x >> 1)`.
     /// Inner indices are `[3 plane][8 idx]`.
@@ -990,6 +990,7 @@ pub struct Rav1dTileState_tiling {
 #[repr(C)]
 pub struct Rav1dTileState_frame_thread {
     pub pal_idx: AtomicUsize, // Offset into `f.frame_thread.pal_idx`
+    pub cbi_idx: AtomicUsize, // Offset into `f.frame_thread.cbi`
     pub cf: AtomicUsize,      // Offset into `f.frame_thread.cf`
 }
 

--- a/src/lib.c
+++ b/src/lib.c
@@ -635,11 +635,11 @@ static COLD void close_internal(Dav1dContext **const c_out, int flush) {
         if (c->n_fc > 1) {
             freep(&f->tile_thread.lowest_pixel_mem);
             freep(&f->frame_thread.b);
+            dav1d_freep_aligned(&f->frame_thread.cbi);
             dav1d_freep_aligned(&f->frame_thread.pal_idx);
             dav1d_freep_aligned(&f->frame_thread.cf);
             freep(&f->frame_thread.tile_start_off);
             dav1d_freep_aligned(&f->frame_thread.pal);
-            freep(&f->frame_thread.cbi);
         }
         if (c->n_tc > 1) {
             pthread_mutex_destroy(&f->task_thread.pending_tasks.lock);

--- a/src/recon_tmpl.c
+++ b/src/recon_tmpl.c
@@ -770,14 +770,12 @@ static void read_coef_tree(Dav1dTaskContext *const t,
         uint8_t cf_ctx;
         int eob;
         coef *cf;
-        int16_t *cbi;
 
         if (t->frame_thread.pass) {
             const int p = t->frame_thread.pass & 1;
             assert(ts->frame_thread[p].cf);
             cf = ts->frame_thread[p].cf;
             ts->frame_thread[p].cf += imin(t_dim->w, 8) * imin(t_dim->h, 8) * 16;
-            cbi = f->frame_thread.cbi[t->by * f->b4_stride + t->bx];
         } else {
             cf = bitfn(t->cf);
         }
@@ -804,10 +802,11 @@ static void read_coef_tree(Dav1dTaskContext *const t,
             case_set_upto16(txw,,,);
 #undef set_ctx
             if (t->frame_thread.pass == 1)
-                cbi[0] = eob * (1 << 5) + txtp;
+                *ts->frame_thread[1].cbi++ = eob * (1 << 5) + txtp;
         } else {
-            eob  = cbi[0] >> 5;
-            txtp = cbi[0] & 0x1f;
+            const int cbi = *ts->frame_thread[0].cbi++;
+            eob  = cbi >> 5;
+            txtp = cbi & 0x1f;
         }
         if (!(t->frame_thread.pass & 1)) {
             assert(dst);
@@ -872,8 +871,6 @@ void bytefn(dav1d_read_coef_blocks)(Dav1dTaskContext *const t,
             for (y = init_y, t->by += init_y; y < sub_h4;
                  y += t_dim->h, t->by += t_dim->h, y_off++)
             {
-                int16_t (*const cbi)[3] =
-                    &f->frame_thread.cbi[t->by * f->b4_stride];
                 int x_off = !!init_x;
                 for (x = init_x, t->bx += init_x; x < sub_w4;
                      x += t_dim->w, t->bx += t_dim->w, x_off++)
@@ -891,7 +888,7 @@ void bytefn(dav1d_read_coef_blocks)(Dav1dTaskContext *const t,
                         if (DEBUG_BLOCK_INFO)
                             printf("Post-y-cf-blk[tx=%d,txtp=%d,eob=%d]: r=%d\n",
                                    b->tx, txtp, eob, ts->msac.rng);
-                        cbi[t->bx][0] = eob * (1 << 5) + txtp;
+                        *ts->frame_thread[1].cbi++ = eob * (1 << 5) + txtp;
                         ts->frame_thread[1].cf += imin(t_dim->w, 8) * imin(t_dim->h, 8) * 16;
 #define set_ctx(type, dir, diridx, off, mul, rep_macro) \
                         rep_macro(type, t->dir lcoef, off, mul * cf_ctx)
@@ -917,8 +914,6 @@ void bytefn(dav1d_read_coef_blocks)(Dav1dTaskContext *const t,
                 for (y = init_y >> ss_ver, t->by += init_y; y < sub_ch4;
                      y += uv_t_dim->h, t->by += uv_t_dim->h << ss_ver)
                 {
-                    int16_t (*const cbi)[3] =
-                        &f->frame_thread.cbi[t->by * f->b4_stride];
                     for (x = init_x >> ss_hor, t->bx += init_x; x < sub_cw4;
                          x += uv_t_dim->w, t->bx += uv_t_dim->w << ss_hor)
                     {
@@ -936,7 +931,7 @@ void bytefn(dav1d_read_coef_blocks)(Dav1dTaskContext *const t,
                             printf("Post-uv-cf-blk[pl=%d,tx=%d,"
                                    "txtp=%d,eob=%d]: r=%d\n",
                                    pl, b->uvtx, txtp, eob, ts->msac.rng);
-                        cbi[t->bx][pl + 1] = eob * (1 << 5) + txtp;
+                        *ts->frame_thread[1].cbi++ = eob * (1 << 5) + txtp;
                         ts->frame_thread[1].cf += uv_t_dim->w * uv_t_dim->h * 16;
 #define set_ctx(type, dir, diridx, off, mul, rep_macro) \
                         rep_macro(type, t->dir ccoef[pl], off, mul * cf_ctx)
@@ -1320,10 +1315,9 @@ void bytefn(dav1d_recon_b_intra)(Dav1dTaskContext *const t, const enum BlockSize
                         enum TxfmType txtp;
                         if (t->frame_thread.pass) {
                             const int p = t->frame_thread.pass & 1;
+                            const int cbi = *ts->frame_thread[p].cbi++;
                             cf = ts->frame_thread[p].cf;
                             ts->frame_thread[p].cf += imin(t_dim->w, 8) * imin(t_dim->h, 8) * 16;
-                            const int cbi =
-                                f->frame_thread.cbi[t->by * f->b4_stride + t->bx][0];
                             eob  = cbi >> 5;
                             txtp = cbi & 0x1f;
                         } else {
@@ -1544,10 +1538,9 @@ void bytefn(dav1d_recon_b_intra)(Dav1dTaskContext *const t, const enum BlockSize
                             coef *cf;
                             if (t->frame_thread.pass) {
                                 const int p = t->frame_thread.pass & 1;
+                                const int cbi = *ts->frame_thread[p].cbi++;
                                 cf = ts->frame_thread[p].cf;
                                 ts->frame_thread[p].cf += uv_t_dim->w * uv_t_dim->h * 16;
-                                const int cbi =
-                                    f->frame_thread.cbi[t->by * f->b4_stride + t->bx][pl + 1];
                                 eob  = cbi >> 5;
                                 txtp = cbi & 0x1f;
                             } else {
@@ -1994,10 +1987,9 @@ int bytefn(dav1d_recon_b_inter)(Dav1dTaskContext *const t, const enum BlockSize 
                         enum TxfmType txtp;
                         if (t->frame_thread.pass) {
                             const int p = t->frame_thread.pass & 1;
+                            const int cbi = *ts->frame_thread[p].cbi++;
                             cf = ts->frame_thread[p].cf;
                             ts->frame_thread[p].cf += uvtx->w * uvtx->h * 16;
-                            const int cbi =
-                                f->frame_thread.cbi[t->by * f->b4_stride + t->bx][pl + 1];
                             eob  = cbi >> 5;
                             txtp = cbi & 0x1f;
                         } else {


### PR DESCRIPTION
Account for chroma subsampling when allocating cbi buffers.

Reduces memory usage (by 3 kB per sb128 for 4:2:0) when decoding streams with subsampled chroma when frame threading is enabled.
