### PR TITLE
Backport fix for new sequence event flag from dav1d 1.4.0

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5203,6 +5203,7 @@ pub fn rav1d_submit_frame(c: &mut Rav1dContext) -> Rav1dResult {
         c.content_light.clone(),
         c.mastering_display.clone(),
         c.output_invisible_frames,
+        c.max_spatial_id,
         &c.frame_flags,
         &mut f,
         bpc,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -407,7 +407,7 @@ pub struct Rav1dContext {
     pub(crate) operating_point: u8,
     pub(crate) operating_point_idc: c_uint,
     pub(crate) all_layers: bool,
-    pub(crate) max_spatial_id: bool,
+    pub(crate) max_spatial_id: u8,
     pub(crate) frame_size_limit: c_uint,
     pub(crate) strict_std_compliance: bool,
     pub(crate) output_invisible_frames: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,7 +337,7 @@ impl Rav1dPicture {
 unsafe fn output_image(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dResult {
     let mut res = Ok(());
 
-    let r#in: *mut Rav1dThreadPicture = if c.all_layers || !c.max_spatial_id {
+    let r#in: *mut Rav1dThreadPicture = if c.all_layers || c.max_spatial_id == 0 {
         &mut c.out
     } else {
         &mut c.cache
@@ -349,7 +349,7 @@ unsafe fn output_image(c: &mut Rav1dContext, out: &mut Rav1dPicture) -> Rav1dRes
     }
     let _ = mem::take(&mut *r#in);
 
-    if !c.all_layers && c.max_spatial_id && c.out.p.data.is_some() {
+    if !c.all_layers && c.max_spatial_id != 0 && c.out.p.data.is_some() {
         *r#in = mem::take(&mut c.out);
     }
     res
@@ -359,9 +359,9 @@ fn output_picture_ready(c: &mut Rav1dContext, drain: bool) -> bool {
     if c.cached_error.is_some() {
         return true;
     }
-    if !c.all_layers && c.max_spatial_id {
+    if !c.all_layers && c.max_spatial_id != 0 {
         if c.out.p.data.is_some() && c.cache.p.data.is_some() {
-            if c.max_spatial_id == (c.cache.p.frame_hdr.as_ref().unwrap().spatial_id != 0)
+            if c.max_spatial_id == c.cache.p.frame_hdr.as_ref().unwrap().spatial_id
                 || c.out.flags.contains(PictureFlags::NEW_TEMPORAL_UNIT)
             {
                 return true;

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2256,9 +2256,9 @@ unsafe fn parse_obus(
             c.operating_point_idc = seq_hdr.operating_points[op_idx as usize].idc as c_uint;
             let spatial_mask = c.operating_point_idc >> 8;
             c.max_spatial_id = if spatial_mask != 0 {
-                ulog2(spatial_mask) != 0
+                ulog2(spatial_mask) as u8
             } else {
-                false
+                0
             };
 
             // If we have read a sequence header which is different from the old one,

--- a/src/picture.c
+++ b/src/picture.c
@@ -214,9 +214,10 @@ int dav1d_thread_picture_alloc(Dav1dContext *const c, Dav1dFrameContext *const f
     c->itut_t35 = NULL;
     c->n_itut_t35 = 0;
 
-    // Don't clear these flags from c->frame_flags if the frame is not visible.
+    // Don't clear these flags from c->frame_flags if the frame is not going to be output.
     // This way they will be added to the next visible frame too.
-    const int flags_mask = (f->frame_hdr->show_frame || c->output_invisible_frames)
+    const int flags_mask = ((f->frame_hdr->show_frame || c->output_invisible_frames) &&
+                            c->max_spatial_id == f->frame_hdr->spatial_id)
                            ? 0 : (PICTURE_FLAG_NEW_SEQUENCE | PICTURE_FLAG_NEW_OP_PARAMS_INFO);
     p->flags = c->frame_flags;
     c->frame_flags &= flags_mask;


### PR DESCRIPTION
Picture: propagate the new sequence event flag in the next picture if the current one is from a lower layer.

Change type of `max_spatial_id` from `bool` to `u8` to ensure that tests comparing two values of `max_spatial_id` are correct.