### PR TITLE
`fn rav1d_apply_grain_row`: Fix argon failure caused by 735033346

### DIFF
--- a/src/fg_apply.rs
+++ b/src/fg_apply.rs
@@ -149,7 +149,6 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
 
     let ss_y = (r#in.p.layout == Rav1dPixelLayout::I420) as usize;
     let ss_x = (r#in.p.layout != Rav1dPixelLayout::I444) as usize;
-    let layout = r#in.p.layout.try_into().unwrap();
     let cpw = w + ss_x >> ss_x;
     let is_id = seq_hdr.mtrx == Rav1dMatrixCoefficients::IDENTITY;
     let luma_src = in_data[0]
@@ -191,6 +190,7 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
         }
     }
 
+    let layout = r#in.p.layout.try_into().unwrap();
     let uv_off = (row * BLOCK_SIZE) as isize * BD::pxstride(out.stride[1]) >> ss_y;
     if data.chroma_scaling_from_luma {
         for pl in 0..2 {


### PR DESCRIPTION
735033346 caused a failure in the argon tests I didn't catch until I merged #1114.