### PR TITLE
`fn fg{y,uv}_32x32xn::Fn::call`: Make args safe `Rav1dPictureDataComponent`s

### DIFF
--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -261,6 +261,7 @@ impl Rav1dPictureDataComponent {
     /// Non-strided, absolute ptr to [`BitDepth::Pixel`]s starting at `offset`.
     ///
     /// Bounds checked, but not [`DisjointMut`]-checked.
+    #[cfg_attr(debug_assertions, track_caller)]
     pub fn as_mut_ptr_at<BD: BitDepth>(&self, pixel_offset: usize) -> *mut BD::Pixel {
         assert!(pixel_offset <= self.pixel_len::<BD>());
         // SAFETY: We just checked that `pixel_offset` is in bounds.
@@ -270,6 +271,7 @@ impl Rav1dPictureDataComponent {
     /// Non-strided, absolute ptr to [`BitDepth::Pixel`]s starting at `offset`.
     ///
     /// Bounds checked, but not [`DisjointMut`]-checked.
+    #[cfg_attr(debug_assertions, track_caller)]
     pub fn as_ptr_at<BD: BitDepth>(&self, offset: usize) -> *const BD::Pixel {
         self.as_mut_ptr_at::<BD>(offset).cast_const()
     }

--- a/src/fg_apply.rs
+++ b/src/fg_apply.rs
@@ -188,21 +188,19 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
     }
 
     let layout = r#in.p.layout.try_into().unwrap();
-    let uv_off = (row * BLOCK_SIZE) as isize * BD::pxstride(out.stride[1]) >> ss_y;
     if data.chroma_scaling_from_luma {
         for pl in 0..2 {
             dsp.fguv_32x32xn[layout].call(
-                out_data[1 + pl].as_strided_mut_ptr::<BD>().offset(uv_off),
-                in_data[1 + pl].as_strided_ptr::<BD>().offset(uv_off),
-                r#in.stride[1],
+                layout,
+                &out_data[1 + pl],
+                &in_data[1 + pl],
                 data,
                 cpw,
                 &scaling[0],
                 &grain_lut[1 + pl],
                 bh,
                 row,
-                luma_src,
-                r#in.stride[0],
+                &in_data[0],
                 pl != 0,
                 is_id,
                 bd,
@@ -212,17 +210,16 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
         for pl in 0..2 {
             if data.num_uv_points[pl] != 0 {
                 dsp.fguv_32x32xn[layout].call(
-                    out_data[1 + pl].as_strided_mut_ptr::<BD>().offset(uv_off),
-                    in_data[1 + pl].as_strided_ptr::<BD>().offset(uv_off),
-                    r#in.stride[1],
+                    layout,
+                    &out_data[1 + pl],
+                    &in_data[1 + pl],
                     data_c,
                     cpw,
                     &scaling[1 + pl],
                     &grain_lut[1 + pl],
                     bh,
                     row,
-                    luma_src,
-                    r#in.stride[0],
+                    &in_data[0],
                     pl != 0,
                     is_id,
                     bd,

--- a/src/fg_apply.rs
+++ b/src/fg_apply.rs
@@ -160,11 +160,8 @@ pub(crate) unsafe fn rav1d_apply_grain_row<BD: BitDepth>(
     if data.num_y_points != 0 {
         let bh = cmp::min(h - row * BLOCK_SIZE, BLOCK_SIZE);
         dsp.fgy_32x32xn.call(
-            out_data[0]
-                .as_strided_mut_ptr::<BD>()
-                .offset((row * BLOCK_SIZE) as isize * BD::pxstride(out.stride[0])),
-            luma_src,
-            out.stride[0],
+            &out_data[0],
+            &in_data[0],
             data,
             w,
             &scaling[0],

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -26,6 +26,7 @@ use std::ffi::c_uint;
 use std::ops::Add;
 use std::ops::Shl;
 use std::ops::Shr;
+use std::ptr;
 use to_method::To;
 
 #[cfg(all(
@@ -118,8 +119,8 @@ impl fgy_32x32xn::Fn {
         let dst_row = dst_row.cast();
         let src_row = src_row.cast();
         let data = &data.clone().into();
-        let scaling = (scaling as *const BD::Scaling).cast();
-        let grain_lut = (grain_lut as *const GrainLut<BD::Entry>).cast();
+        let scaling = ptr::from_ref(scaling).cast();
+        let grain_lut = ptr::from_ref(grain_lut).cast();
         let bh = bh as c_int;
         let row_num = row_num as c_int;
         let bd = bd.into_c();


### PR DESCRIPTION
This replaces the ptr args of `fn fg{y,uv}_32x32xn::Fn::call` with `&Rav1dPictureDataComponent`s, doing the ptr offset calculations inside the `fn`.  This prepares things for making the `fn` ptr call pass extra `FFISafe<Rav1dPictureDataComponent>` args to make the fallbacks safe.

Note also that the `src` and `dst` strides have already been asserted to be equal before these `fn`s are called.