### PR TITLE
`fn filter_edge`,`fn upsample_edge`: Cleanup and make safe

### DIFF
--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -785,7 +785,7 @@ fn get_upsample(wh: c_int, angle: c_int, is_sm: bool) -> bool {
 
 #[inline(never)]
 unsafe fn upsample_edge<BD: BitDepth>(
-    out: *mut BD::Pixel,
+    out: &mut [BD::Pixel],
     hsz: c_int,
     in_0: *const BD::Pixel,
     from: c_int,
@@ -796,7 +796,7 @@ unsafe fn upsample_edge<BD: BitDepth>(
     let mut i;
     i = 0 as c_int;
     while i < hsz - 1 {
-        *out.offset((i * 2) as isize) = *in_0.offset(iclip(i, from, to - 1) as isize);
+        out[(i * 2) as usize] = *in_0.offset(iclip(i, from, to - 1) as isize);
         let mut s = 0;
         let mut j = 0;
         while j < 4 {
@@ -804,11 +804,11 @@ unsafe fn upsample_edge<BD: BitDepth>(
                 * kernel[j as usize] as c_int;
             j += 1;
         }
-        *out.offset((i * 2 + 1) as isize) =
+        out[(i * 2 + 1) as usize] =
             iclip(s + 8 >> 4, 0 as c_int, bd.bitdepth_max().as_::<c_int>()).as_::<BD::Pixel>();
         i += 1;
     }
-    *out.offset((i * 2) as isize) = *in_0.offset(iclip(i, from, to - 1) as isize);
+    out[(i * 2) as usize] = *in_0.offset(iclip(i, from, to - 1) as isize);
 }
 
 unsafe fn ipred_z1_rust<BD: BitDepth>(
@@ -839,7 +839,7 @@ unsafe fn ipred_z1_rust<BD: BitDepth>(
     };
     if upsample_above {
         upsample_edge::<BD>(
-            top_out.as_mut_ptr(),
+            &mut top_out,
             width + height,
             &*topleft_in.offset(1),
             -(1 as c_int),
@@ -938,7 +938,7 @@ unsafe fn ipred_z2_rust<BD: BitDepth>(
     let topleft = 64;
     if upsample_above {
         upsample_edge::<BD>(
-            edge[topleft..].as_mut_ptr(),
+            &mut edge[topleft..],
             width + 1,
             topleft_in,
             0 as c_int,
@@ -975,7 +975,7 @@ unsafe fn ipred_z2_rust<BD: BitDepth>(
     }
     if upsample_left {
         upsample_edge::<BD>(
-            edge[topleft - height as usize * 2..].as_mut_ptr(),
+            &mut edge[topleft - height as usize * 2..],
             height + 1,
             &*topleft_in.offset(-height as isize),
             0 as c_int,
@@ -1075,7 +1075,7 @@ unsafe fn ipred_z3_rust<BD: BitDepth>(
     };
     if upsample_left {
         upsample_edge::<BD>(
-            left_out.as_mut_ptr(),
+            &mut left_out,
             width + height,
             &*topleft_in.offset(-(width + height) as isize),
             cmp::max(width - height, 0 as c_int),

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -784,7 +784,7 @@ fn get_upsample(wh: c_int, angle: c_int, is_sm: bool) -> bool {
 fn upsample_edge<BD: BitDepth>(
     out: &mut [BD::Pixel],
     hsz: c_int,
-    in_0: &[BD::Pixel; SCRATCH_EDGE_LEN],
+    r#in: &[BD::Pixel; SCRATCH_EDGE_LEN],
     in_off: usize,
     from: c_int,
     to: c_int,
@@ -792,10 +792,10 @@ fn upsample_edge<BD: BitDepth>(
 ) {
     static kernel: [i8; 4] = [-1, 9, 9, -1];
     for i in 0..hsz - 1 {
-        out[(i * 2) as usize] = in_0[in_off + iclip(i, from, to - 1) as usize];
+        out[(i * 2) as usize] = r#in[in_off + iclip(i, from, to - 1) as usize];
         let mut s = 0;
         for j in 0..4 {
-            s += in_0[in_off.wrapping_add_signed(iclip(i + j - 1, from, to - 1) as isize)]
+            s += r#in[in_off.wrapping_add_signed(iclip(i + j - 1, from, to - 1) as isize)]
                 .as_::<c_int>()
                 * kernel[j as usize] as c_int;
         }
@@ -803,7 +803,7 @@ fn upsample_edge<BD: BitDepth>(
             iclip(s + 8 >> 4, 0, bd.bitdepth_max().as_::<c_int>()).as_::<BD::Pixel>();
     }
     let i = hsz - 1;
-    out[(i * 2) as usize] = in_0[in_off + iclip(i, from, to - 1) as usize];
+    out[(i * 2) as usize] = r#in[in_off + iclip(i, from, to - 1) as usize];
 }
 
 unsafe fn ipred_z1_rust<BD: BitDepth>(

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -800,7 +800,7 @@ fn upsample_edge<BD: BitDepth>(
                 * kernel[j as usize] as c_int;
         }
         out[(i * 2 + 1) as usize] =
-            iclip(s + 8 >> 4, 0 as c_int, bd.bitdepth_max().as_::<c_int>()).as_::<BD::Pixel>();
+            iclip(s + 8 >> 4, 0, bd.bitdepth_max().as_::<c_int>()).as_::<BD::Pixel>();
     }
     let i = hsz - 1;
     out[(i * 2) as usize] = in_0[in_off + iclip(i, from, to - 1) as usize];

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -745,7 +745,7 @@ fn filter_edge<BD: BitDepth>(
     sz: c_int,
     lim_from: c_int,
     lim_to: c_int,
-    in_0: &[BD::Pixel; SCRATCH_EDGE_LEN],
+    r#in: &[BD::Pixel; SCRATCH_EDGE_LEN],
     in_off: usize,
     from: c_int,
     to: c_int,
@@ -755,13 +755,13 @@ fn filter_edge<BD: BitDepth>(
     assert!(strength > 0);
     let mut i = 0;
     while i < cmp::min(sz, lim_from) {
-        out[out_off + i as usize] = in_0[in_off + iclip(i, from, to - 1) as usize];
+        out[out_off + i as usize] = r#in[in_off + iclip(i, from, to - 1) as usize];
         i += 1;
     }
     while i < cmp::min(lim_to, sz) {
         let mut s = 0;
         for j in 0..5 {
-            s += in_0[in_off.wrapping_add_signed(iclip(i - 2 + j, from, to - 1) as isize)]
+            s += r#in[in_off.wrapping_add_signed(iclip(i - 2 + j, from, to - 1) as isize)]
                 .as_::<c_int>()
                 * kernel[(strength - 1) as usize][j as usize] as c_int;
         }
@@ -769,7 +769,7 @@ fn filter_edge<BD: BitDepth>(
         i += 1;
     }
     while i < sz {
-        out[out_off + i as usize] = in_0[in_off + iclip(i, from, to - 1) as usize];
+        out[out_off + i as usize] = r#in[in_off + iclip(i, from, to - 1) as usize];
         i += 1;
     }
 }

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -761,12 +761,10 @@ fn filter_edge<BD: BitDepth>(
     }
     while i < cmp::min(lim_to, sz) {
         let mut s = 0;
-        let mut j = 0;
-        while j < 5 {
+        for j in 0..5 {
             s += in_0[in_off.wrapping_add_signed(iclip(i - 2 + j, from, to - 1) as isize)]
                 .as_::<c_int>()
                 * kernel[(strength - 1) as usize][j as usize] as c_int;
-            j += 1;
         }
         out[out_off.wrapping_add_signed(i as isize)] = (s + 8 >> 4).as_::<BD::Pixel>();
         i += 1;

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -739,7 +739,7 @@ fn get_filter_strength(wh: c_int, angle: c_int, is_sm: bool) -> c_int {
 }
 
 #[inline(never)]
-unsafe fn filter_edge<BD: BitDepth>(
+fn filter_edge<BD: BitDepth>(
     out: &mut [BD::Pixel],
     out_off: usize,
     sz: c_int,
@@ -786,7 +786,7 @@ fn get_upsample(wh: c_int, angle: c_int, is_sm: bool) -> bool {
 }
 
 #[inline(never)]
-unsafe fn upsample_edge<BD: BitDepth>(
+fn upsample_edge<BD: BitDepth>(
     out: &mut [BD::Pixel],
     hsz: c_int,
     in_0: &[BD::Pixel; SCRATCH_EDGE_LEN],

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -755,8 +755,7 @@ fn filter_edge<BD: BitDepth>(
     assert!(strength > 0);
     let mut i = 0;
     while i < cmp::min(sz, lim_from) {
-        out[out_off.wrapping_add_signed(i as isize)] =
-            in_0[in_off.wrapping_add_signed(iclip(i, from, to - 1) as isize)];
+        out[out_off + i as usize] = in_0[in_off + iclip(i, from, to - 1) as usize];
         i += 1;
     }
     while i < cmp::min(lim_to, sz) {
@@ -766,12 +765,11 @@ fn filter_edge<BD: BitDepth>(
                 .as_::<c_int>()
                 * kernel[(strength - 1) as usize][j as usize] as c_int;
         }
-        out[out_off.wrapping_add_signed(i as isize)] = (s + 8 >> 4).as_::<BD::Pixel>();
+        out[out_off + i as usize] = (s + 8 >> 4).as_::<BD::Pixel>();
         i += 1;
     }
     while i < sz {
-        out[out_off.wrapping_add_signed(i as isize)] =
-            in_0[in_off.wrapping_add_signed(iclip(i, from, to - 1) as isize)];
+        out[out_off + i as usize] = in_0[in_off + iclip(i, from, to - 1) as usize];
         i += 1;
     }
 }

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -752,6 +752,7 @@ fn filter_edge<BD: BitDepth>(
     strength: c_int,
 ) {
     static kernel: [[u8; 5]; 3] = [[0, 4, 8, 4, 0], [0, 5, 6, 5, 0], [2, 4, 4, 4, 2]];
+
     assert!(strength > 0);
     let mut i = 0;
     while i < cmp::min(sz, lim_from) {

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -752,9 +752,7 @@ fn filter_edge<BD: BitDepth>(
     strength: c_int,
 ) {
     static kernel: [[u8; 5]; 3] = [[0, 4, 8, 4, 0], [0, 5, 6, 5, 0], [2, 4, 4, 4, 2]];
-    if !(strength > 0) {
-        unreachable!();
-    }
+    assert!(strength > 0);
     let mut i = 0;
     while i < cmp::min(sz, lim_from) {
         out[out_off.wrapping_add_signed(i as isize)] =

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -791,22 +791,18 @@ fn upsample_edge<BD: BitDepth>(
     bd: BD,
 ) {
     static kernel: [i8; 4] = [-1, 9, 9, -1];
-    let mut i;
-    i = 0 as c_int;
-    while i < hsz - 1 {
+    for i in 0..hsz - 1 {
         out[(i * 2) as usize] = in_0[in_off.wrapping_add_signed(iclip(i, from, to - 1) as isize)];
         let mut s = 0;
-        let mut j = 0;
-        while j < 4 {
+        for j in 0..4 {
             s += in_0[in_off.wrapping_add_signed(iclip(i + j - 1, from, to - 1) as isize)]
                 .as_::<c_int>()
                 * kernel[j as usize] as c_int;
-            j += 1;
         }
         out[(i * 2 + 1) as usize] =
             iclip(s + 8 >> 4, 0 as c_int, bd.bitdepth_max().as_::<c_int>()).as_::<BD::Pixel>();
-        i += 1;
     }
+    let i = hsz - 1;
     out[(i * 2) as usize] = in_0[in_off.wrapping_add_signed(iclip(i, from, to - 1) as isize)];
 }
 

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -792,7 +792,7 @@ fn upsample_edge<BD: BitDepth>(
 ) {
     static kernel: [i8; 4] = [-1, 9, 9, -1];
     for i in 0..hsz - 1 {
-        out[(i * 2) as usize] = in_0[in_off.wrapping_add_signed(iclip(i, from, to - 1) as isize)];
+        out[(i * 2) as usize] = in_0[in_off + iclip(i, from, to - 1) as usize];
         let mut s = 0;
         for j in 0..4 {
             s += in_0[in_off.wrapping_add_signed(iclip(i + j - 1, from, to - 1) as isize)]
@@ -803,7 +803,7 @@ fn upsample_edge<BD: BitDepth>(
             iclip(s + 8 >> 4, 0 as c_int, bd.bitdepth_max().as_::<c_int>()).as_::<BD::Pixel>();
     }
     let i = hsz - 1;
-    out[(i * 2) as usize] = in_0[in_off.wrapping_add_signed(iclip(i, from, to - 1) as isize)];
+    out[(i * 2) as usize] = in_0[in_off + iclip(i, from, to - 1) as usize];
 }
 
 unsafe fn ipred_z1_rust<BD: BitDepth>(


### PR DESCRIPTION
This PR makes `filter_edge` and `upsample_edge` safe, though doing so also involved threading the safe array refs through `ipred_z*_rust`. The remainder of the cleanup for those functions will come in followup PRs.

Part of https://github.com/memorysafety/rav1d/issues/846 and https://github.com/memorysafety/rav1d/issues/815.