### PR TITLE
CI: Test with negative strides

### DIFF
--- a/.github/workflows/build-and-test-aarch64-darwin.yml
+++ b/.github/workflows/build-and-test-aarch64-darwin.yml
@@ -40,7 +40,15 @@ jobs:
             -r ./target/${{ matrix.build.name }}/dav1d \
             -s ./target/${{ matrix.build.name }}/seek_stress \
             -t ${{ matrix.build.timeout_multiplier }}
-        # release tests run quickly so also cover the frame delay cases
+        # release tests run quickly so we test negative strides and frame delays
+      - name: test release build with negative stride
+        if: ${{ matrix.build.name == 'release' }}
+        run: |
+          .github/workflows/test.sh \
+            -r ./target/release/dav1d \
+            -s ./target/release/seek_stress \
+            -t ${{ matrix.build.timeout_multiplier }} \
+            -n
       - name: test release build with frame delay of 1
         if: ${{ matrix.build.name == 'release' }}
         run: |

--- a/.github/workflows/build-and-test-aarch64-darwin.yml
+++ b/.github/workflows/build-and-test-aarch64-darwin.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         build: [
           {name: "release", cargo_flags: "--release",  timeout_multiplier: 1},
+          {name: "release-no-asm", cargo_flags: "--release --no-default-features --features=bitdepth_8,bitdepth_16", timeout_multiplier: 1},
           {name: "debug", cargo_flags: "", timeout_multiplier: 3},
         ]
     runs-on: macos-14
@@ -37,12 +38,12 @@ jobs:
       - name: test ${{ matrix.build.name }} build without frame delay
         run: |
           .github/workflows/test.sh \
-            -r ./target/${{ matrix.build.name }}/dav1d \
-            -s ./target/${{ matrix.build.name }}/seek_stress \
+            -r ./target/${{ startsWith(matrix.build.name, 'release') && 'release' || matrix.build.name }}/dav1d \
+            -s ./target/${{ startsWith(matrix.build.name, 'release') && 'release' || matrix.build.name }}/seek_stress \
             -t ${{ matrix.build.timeout_multiplier }}
         # release tests run quickly so we test negative strides and frame delays
       - name: test release build with negative stride
-        if: ${{ matrix.build.name == 'release' }}
+        if: ${{ startsWith(matrix.build.name, 'release') }}
         run: |
           .github/workflows/test.sh \
             -r ./target/release/dav1d \
@@ -50,7 +51,7 @@ jobs:
             -t ${{ matrix.build.timeout_multiplier }} \
             -n
       - name: test release build with frame delay of 1
-        if: ${{ matrix.build.name == 'release' }}
+        if: ${{ startsWith(matrix.build.name, 'release') }}
         run: |
           .github/workflows/test.sh \
             -r ./target/release/dav1d \
@@ -58,7 +59,7 @@ jobs:
             -t ${{ matrix.build.timeout_multiplier }} \
             -f 1
       - name: test release build with frame delay of 2
-        if: ${{ matrix.build.name == 'release' }}
+        if: ${{ startsWith(matrix.build.name, 'release') }}
         run: |
           .github/workflows/test.sh \
             -r ./target/release/dav1d \

--- a/.github/workflows/build-and-test-x86.yml
+++ b/.github/workflows/build-and-test-x86.yml
@@ -18,9 +18,10 @@ jobs:
           # debug build with optimizations to catch overflows with optimized assembly routines
           {name: "opt-dev", flags: "--profile opt-dev", timeout_multiplier: 3}
         ]
-        # Test with threads and framedelay
-        framedelay: [
+        # Test with negative strides, threads and framedelay
+        variant: [
           "",
+          "-n",
           "-f 1",
           "-f 2"
         ]
@@ -64,15 +65,15 @@ jobs:
               -r target/${{ matrix.target }}/${{ matrix.build.name }}/dav1d \
               -s target/${{ matrix.target }}/${{ matrix.build.name }}/seek_stress \
               -t ${{ matrix.build.timeout_multiplier }} \
-              ${{ matrix.framedelay }}
+              ${{ matrix.variant }}
       - name: copy log files
         if: ${{ !cancelled() }}
         run: |
           cp ${{ github.workspace }}/build/meson-logs/testlog.txt \
              ${{ github.workspace }}/build/meson-logs/testlog-${{ matrix.target }}-${{ matrix.build.name }}.txt
       - name: upload build artifacts
-        # don't upload artifacts for tests w/framedelay to keep names unique
-        if: ${{ !cancelled() && matrix.framedelay == '' }}
+        # don't upload artifacts for all the test variants to keep names unique
+        if: ${{ !cancelled() && matrix.variant == '' }}
         uses: actions/upload-artifact@v4
         with:
           name: meson-test-logs-${{ matrix.target }}-${{ matrix.build.name }}

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -689,13 +689,11 @@ fn fgy_32x32xn_rust<BD: BitDepth>(
         static W: [[c_int; 2]; 2] = [[27, 17], [17, 27]];
 
         let src_row_y = |y| {
-            let row = (src.pixel_offset::<BD>() + src_row_offset)
-                .wrapping_add_signed(y as isize * src.pixel_stride::<BD>());
+            let row = src_row_offset.wrapping_add_signed(y as isize * src.pixel_stride::<BD>());
             src.slice::<BD, _>((row + bx.., ..bw))
         };
         let dst_row_y = |y| {
-            let row = (dst.pixel_offset::<BD>() + dst_row_offset)
-                .wrapping_add_signed(y as isize * dst.pixel_stride::<BD>());
+            let row = dst_row_offset.wrapping_add_signed(y as isize * dst.pixel_stride::<BD>());
             dst.slice_mut::<BD, _>((row + bx.., ..bw))
         };
 
@@ -835,18 +833,16 @@ fn fguv_32x32xn_rust<BD: BitDepth>(
         static W: [[[c_int; 2]; 2 /* off */]; 2 /* sub */] = [[[27, 17], [17, 27]], [[23, 22], [0; 2]]];
 
         let luma_row_uv = |y| {
-            let row = (luma.pixel_offset::<BD>() + luma_row_offset)
-                .wrapping_add_signed((y << sy) as isize * luma.pixel_stride::<BD>());
+            let row =
+                luma_row_offset.wrapping_add_signed((y << sy) as isize * luma.pixel_stride::<BD>());
             luma.slice::<BD, _>((row + (bx << sx).., ..bw << sx))
         };
         let src_row_uv = |y| {
-            let row = (src.pixel_offset::<BD>() + src_row_offset)
-                .wrapping_add_signed(y as isize * src.pixel_stride::<BD>());
+            let row = src_row_offset.wrapping_add_signed(y as isize * src.pixel_stride::<BD>());
             src.slice::<BD, _>((row + bx.., ..bw))
         };
         let dst_row_uv = |y| {
-            let row = (dst.pixel_offset::<BD>() + dst_row_offset)
-                .wrapping_add_signed(y as isize * dst.pixel_stride::<BD>());
+            let row = dst_row_offset.wrapping_add_signed(y as isize * dst.pixel_stride::<BD>());
             dst.slice_mut::<BD, _>((row + bx.., ..bw))
         };
 


### PR DESCRIPTION
Add option (`-n`) to test with negative strides similar to dav1d's test configuration. See issue #636 for details.

We test negative strides with the native and optimized x86 and arm64 builds as they take the least time to complete.