### PR TITLE
`mod mc`: Use `wrap_fn_ptr!` on all remaining `fn` ptrs

### DIFF
--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -467,10 +467,7 @@ macro_rules! bpc_fn {
     }};
 }
 
-#[cfg(all(
-    feature = "asm",
-    not(any(target_arch = "riscv64", target_arch = "riscv32"))
-))]
+#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 macro_rules! fn_identity {
     (fn $name:ident) => {
         $name
@@ -486,8 +483,5 @@ pub(crate) use bd_fn;
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 pub(crate) use bpc_fn;
 
-#[cfg(all(
-    feature = "asm",
-    not(any(target_arch = "riscv64", target_arch = "riscv32"))
-))]
+#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 pub(crate) use fn_identity;

--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -467,7 +467,7 @@ macro_rules! bpc_fn {
     }};
 }
 
-#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
+#[allow(unused)]
 macro_rules! fn_identity {
     (fn $name:ident) => {
         $name
@@ -483,5 +483,5 @@ pub(crate) use bd_fn;
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 pub(crate) use bpc_fn;
 
-#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
+#[allow(unused)]
 pub(crate) use fn_identity;

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -1338,7 +1338,7 @@ impl avg::Fn {
     }
 }
 
-pub type w_avg_fn = unsafe extern "C" fn(
+wrap_fn_ptr!(pub unsafe extern "C" fn w_avg(
     dst: *mut DynPixel,
     dst_stride: isize,
     tmp1: &[i16; COMPINTER_LEN],
@@ -1347,7 +1347,25 @@ pub type w_avg_fn = unsafe extern "C" fn(
     h: i32,
     weight: i32,
     bitdepth_max: i32,
-) -> ();
+) -> ());
+
+impl w_avg::Fn {
+    pub unsafe fn call<BD: BitDepth>(
+        &self,
+        dst: *mut BD::Pixel,
+        dst_stride: isize,
+        tmp1: &[i16; COMPINTER_LEN],
+        tmp2: &[i16; COMPINTER_LEN],
+        w: i32,
+        h: i32,
+        weight: i32,
+        bd: BD,
+    ) {
+        let dst = dst.cast();
+        let bd = bd.into_c();
+        self.get()(dst, dst_stride, tmp1, tmp2, w, h, weight, bd)
+    }
+}
 
 pub type mask_fn = unsafe extern "C" fn(
     dst: *mut DynPixel,
@@ -1468,7 +1486,7 @@ pub struct Rav1dMCDSPContext {
     pub mct: enum_map_ty!(Filter2d, mct::Fn),
     pub mct_scaled: enum_map_ty!(Filter2d, mct_scaled::Fn),
     pub avg: avg::Fn,
-    pub w_avg: w_avg_fn,
+    pub w_avg: w_avg::Fn,
     pub mask: mask_fn,
     pub w_mask: enum_map_ty!(Rav1dPixelLayoutSubSampled, w_mask::Fn),
     pub blend: blend_fn,
@@ -2021,19 +2039,6 @@ unsafe extern "C" fn resize_c_erased<BD: BitDepth>(
     not(any(target_arch = "riscv64", target_arch = "riscv32"))
 ))]
 macro_rules! decl_fn {
-    (w_avg, $name:ident) => {
-        fn $name(
-            dst: *mut DynPixel,
-            dst_stride: isize,
-            tmp1: &[i16; COMPINTER_LEN],
-            tmp2: &[i16; COMPINTER_LEN],
-            w: i32,
-            h: i32,
-            weight: i32,
-            bitdepth_max: i32,
-        );
-    };
-
     (mask, $name:ident) => {
         fn $name(
             dst: *mut DynPixel,
@@ -2113,7 +2118,6 @@ macro_rules! decl_fns {
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 #[allow(dead_code)] // Macro invocations generate more fn declarations than are actually used.
 extern "C" {
-    decl_fns!(w_avg, dav1d_w_avg);
     decl_fns!(mask, dav1d_mask);
     decl_fns!(blend, dav1d_blend);
     decl_fns!(blend_dir, dav1d_blend_v);
@@ -2124,7 +2128,6 @@ extern "C" {
 
 #[cfg(all(feature = "asm", any(target_arch = "arm", target_arch = "aarch64")))]
 extern "C" {
-    decl_fns!(w_avg, dav1d_w_avg, neon);
     decl_fns!(mask, dav1d_mask, neon);
     decl_fns!(blend, dav1d_blend, neon);
     decl_fns!(blend_dir, dav1d_blend_v, neon);
@@ -2183,7 +2186,7 @@ impl Rav1dMCDSPContext {
                 Bilinear => mct_scaled::Fn::new(prep_bilin_scaled_c_erased::<BD>),
             }),
             avg: avg::Fn::new(avg_c_erased::<BD>),
-            w_avg: w_avg_c_erased::<BD>,
+            w_avg: w_avg::Fn::new(w_avg_c_erased::<BD>),
             mask: mask_c_erased::<BD>,
             w_mask: enum_map!(Rav1dPixelLayoutSubSampled => w_mask::Fn; match key {
                 I420 => w_mask::Fn::new(w_mask_420_c_erased::<BD>),
@@ -2279,7 +2282,7 @@ impl Rav1dMCDSPContext {
         });
 
         self.avg = bd_fn!(avg::decl_fn, BD, avg, ssse3);
-        self.w_avg = bd_fn!(BD, w_avg, ssse3);
+        self.w_avg = bd_fn!(w_avg::decl_fn, BD, w_avg, ssse3);
         self.mask = bd_fn!(BD, mask, ssse3);
 
         self.w_mask = enum_map!(Rav1dPixelLayoutSubSampled => w_mask::Fn; match key {
@@ -2361,7 +2364,7 @@ impl Rav1dMCDSPContext {
             });
 
             self.avg = bd_fn!(avg::decl_fn, BD, avg, avx2);
-            self.w_avg = bd_fn!(BD, w_avg, avx2);
+            self.w_avg = bd_fn!(w_avg::decl_fn, BD, w_avg, avx2);
             self.mask = bd_fn!(BD, mask, avx2);
 
             self.w_mask = enum_map!(Rav1dPixelLayoutSubSampled => w_mask::Fn; match key {
@@ -2408,7 +2411,7 @@ impl Rav1dMCDSPContext {
             });
 
             self.avg = bd_fn!(avg::decl_fn, BD, avg, avx512icl);
-            self.w_avg = bd_fn!(BD, w_avg, avx512icl);
+            self.w_avg = bd_fn!(w_avg::decl_fn, BD, w_avg, avx512icl);
             self.mask = bd_fn!(BD, mask, avx512icl);
 
             self.w_mask = enum_map!(Rav1dPixelLayoutSubSampled => w_mask::Fn; match key {
@@ -2464,7 +2467,7 @@ impl Rav1dMCDSPContext {
         });
 
         self.avg = bd_fn!(avg::decl_fn, BD, avg, neon);
-        self.w_avg = bd_fn!(BD, w_avg, neon);
+        self.w_avg = bd_fn!(w_avg::decl_fn, BD, w_avg, neon);
         self.mask = bd_fn!(BD, mask, neon);
         self.blend = bd_fn!(BD, blend, neon);
         self.blend_h = bd_fn!(BD, blend_h, neon);

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -1312,35 +1312,35 @@ impl warp8x8t::Fn {
 }
 
 pub type avg_fn = unsafe extern "C" fn(
-    *mut DynPixel,
-    isize,
-    &[i16; COMPINTER_LEN],
-    &[i16; COMPINTER_LEN],
-    i32,
-    i32,
-    i32,
+    dst: *mut DynPixel,
+    dst_stride: isize,
+    tmp1: &[i16; COMPINTER_LEN],
+    tmp2: &[i16; COMPINTER_LEN],
+    w: i32,
+    h: i32,
+    bitdepth_max: i32,
 ) -> ();
 
 pub type w_avg_fn = unsafe extern "C" fn(
-    *mut DynPixel,
-    isize,
-    &[i16; COMPINTER_LEN],
-    &[i16; COMPINTER_LEN],
-    i32,
-    i32,
-    i32,
-    i32,
+    dst: *mut DynPixel,
+    dst_stride: isize,
+    tmp1: &[i16; COMPINTER_LEN],
+    tmp2: &[i16; COMPINTER_LEN],
+    w: i32,
+    h: i32,
+    weight: i32,
+    bitdepth_max: i32,
 ) -> ();
 
 pub type mask_fn = unsafe extern "C" fn(
-    *mut DynPixel,
-    isize,
-    &[i16; COMPINTER_LEN],
-    &[i16; COMPINTER_LEN],
-    i32,
-    i32,
-    *const u8,
-    i32,
+    dst: *mut DynPixel,
+    dst_stride: isize,
+    tmp1: &[i16; COMPINTER_LEN],
+    tmp2: &[i16; COMPINTER_LEN],
+    w: i32,
+    h: i32,
+    mask: *const u8,
+    bitdepth_max: i32,
 ) -> ();
 
 wrap_fn_ptr!(pub unsafe extern "C" fn w_mask(
@@ -1374,11 +1374,22 @@ impl w_mask::Fn {
     }
 }
 
-pub type blend_fn =
-    unsafe extern "C" fn(*mut DynPixel, isize, *const DynPixel, i32, i32, *const u8) -> ();
+pub type blend_fn = unsafe extern "C" fn(
+    dst: *mut DynPixel,
+    dst_stride: isize,
+    tmp: *const DynPixel,
+    w: i32,
+    h: i32,
+    mask: *const u8,
+) -> ();
 
-pub type blend_dir_fn =
-    unsafe extern "C" fn(*mut DynPixel, isize, *const [DynPixel; SCRATCH_LAP_LEN], i32, i32) -> ();
+pub type blend_dir_fn = unsafe extern "C" fn(
+    dst: *mut DynPixel,
+    dst_stride: isize,
+    tmp: *const [DynPixel; SCRATCH_LAP_LEN],
+    w: i32,
+    h: i32,
+) -> ();
 
 wrap_fn_ptr!(pub unsafe extern "C" fn emu_edge(
     bw: isize,
@@ -1422,16 +1433,16 @@ impl emu_edge::Fn {
 }
 
 pub type resize_fn = unsafe extern "C" fn(
-    *mut DynPixel,
-    isize,
-    *const DynPixel,
-    isize,
-    i32,
-    i32,
-    i32,
-    i32,
-    i32,
-    i32,
+    dst: *mut DynPixel,
+    dst_stride: isize,
+    src: *const DynPixel,
+    src_stride: isize,
+    dst_w: i32,
+    h: i32,
+    src_w: i32,
+    dx: i32,
+    mx: i32,
+    bitdepth_max: i32,
 ) -> ();
 
 pub struct Rav1dMCDSPContext {

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -3418,15 +3418,15 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
             }
             CompInterType::Wedge => {
                 mask = dav1d_wedge_masks[bs as usize][0][0][inter.nd.one_d.wedge_idx as usize];
-                (f.dsp.mc.mask)(
-                    dst.cast(),
+                f.dsp.mc.mask.call::<BD>(
+                    dst,
                     f.cur.stride[0],
                     &tmp[inter.nd.one_d.mask_sign() as usize],
                     &tmp[!inter.nd.one_d.mask_sign() as usize],
                     bw4 * 4,
                     bh4 * 4,
                     mask.as_ptr(),
-                    f.bitdepth_max,
+                    bd,
                 );
                 if has_chroma {
                     mask = dav1d_wedge_masks[bs as usize][chr_layout_idx]
@@ -3506,15 +3506,15 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                         );
                     }
                     CompInterType::Seg | CompInterType::Wedge => {
-                        (f.dsp.mc.mask)(
-                            uvdst.cast(),
+                        f.dsp.mc.mask.call::<BD>(
+                            uvdst,
                             f.cur.stride[1],
                             &tmp[inter.nd.one_d.mask_sign() as usize],
                             &tmp[!inter.nd.one_d.mask_sign() as usize],
                             bw4 * 4 >> ss_hor,
                             bh4 * 4 >> ss_ver,
                             mask.as_ptr(),
-                            f.bitdepth_max,
+                            bd,
                         );
                     }
                 }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -4366,6 +4366,7 @@ pub(crate) unsafe fn rav1d_filter_sbrow_resize<BD: BitDepth>(
     _t: &mut Rav1dTaskContext,
     sby: c_int,
 ) {
+    let bd = BD::from_c(f.bitdepth_max);
     let cur_data = &f.cur.data.as_ref().unwrap().data;
     let sr_cur_data = &f.sr_cur.p.data.as_ref().unwrap().data;
 
@@ -4408,17 +4409,17 @@ pub(crate) unsafe fn rav1d_filter_sbrow_resize<BD: BitDepth>(
         let src_w = 4 * f.bw + ss_hor >> ss_hor;
         let img_h = f.cur.p.h - sbsz * 4 * sby + ss_ver >> ss_ver;
 
-        (f.dsp.mc.resize)(
-            dst.cast(),
+        f.dsp.mc.resize.call::<BD>(
+            dst,
             dst_stride,
-            src.cast(),
+            src,
             src_stride,
             dst_w,
             cmp::min(img_h, h_end) + h_start,
             src_w,
             f.resize_step[(pl != 0) as usize],
             f.resize_start[(pl != 0) as usize],
-            f.bitdepth_max,
+            bd,
         );
     }
 }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -3627,10 +3627,10 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                     dav1d_wedge_masks[bs as usize][0][0][inter.nd.one_d.wedge_idx as usize]
                 }
             };
-            (f.dsp.mc.blend)(
-                dst.cast(),
+            f.dsp.mc.blend.call::<BD>(
+                dst,
                 f.cur.stride[0],
-                tmp.as_mut_ptr().cast(),
+                tmp.as_mut_ptr(),
                 bw4 * 4,
                 bh4 * 4,
                 ii_mask.as_ptr(),
@@ -3934,10 +3934,10 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                             0,
                             bd,
                         );
-                        (f.dsp.mc.blend)(
-                            uvdst.cast(),
+                        f.dsp.mc.blend.call::<BD>(
+                            uvdst,
                             f.cur.stride[1],
-                            tmp.as_mut_ptr().cast(),
+                            tmp.as_mut_ptr(),
                             cbw4 * 4,
                             cbh4 * 4,
                             ii_mask.as_ptr(),

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -3378,14 +3378,14 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
         let mut mask = &[][..];
         match comp_inter_type {
             CompInterType::Avg => {
-                (f.dsp.mc.avg)(
-                    dst.cast(),
+                f.dsp.mc.avg.call::<BD>(
+                    dst,
                     f.cur.stride[0],
                     &tmp[0],
                     &tmp[1],
                     bw4 * 4,
                     bh4 * 4,
-                    f.bitdepth_max,
+                    bd,
                 );
             }
             CompInterType::WeightedAvg => {
@@ -3483,14 +3483,14 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                 let uvdst = cur_data[1 + pl].as_strided_mut_ptr::<BD>().offset(uvdstoff);
                 match comp_inter_type {
                     CompInterType::Avg => {
-                        (f.dsp.mc.avg)(
-                            uvdst.cast(),
+                        f.dsp.mc.avg.call::<BD>(
+                            uvdst,
                             f.cur.stride[1],
                             &tmp[0],
                             &tmp[1],
                             bw4 * 4 >> ss_hor,
                             bh4 * 4 >> ss_ver,
-                            f.bitdepth_max,
+                            bd,
                         );
                     }
                     CompInterType::WeightedAvg => {

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2291,11 +2291,10 @@ unsafe fn obmc<BD: BitDepth>(
                     dav1d_filter_2d[*f.a[t.a].filter[1].index((bx4 + x + 1) as usize) as usize]
                         [*f.a[t.a].filter[0].index((bx4 + x + 1) as usize) as usize],
                 )?;
-                (f.dsp.mc.blend_h)(
-                    dst.as_mut_ptr_at::<BD>(dst_offset + (x * h_mul) as usize)
-                        .cast(),
+                f.dsp.mc.blend_h.call::<BD>(
+                    dst.as_mut_ptr_at::<BD>(dst_offset + (x * h_mul) as usize),
                     dst.stride(),
-                    lap.as_ptr().cast(),
+                    lap,
                     h_mul * ow4 as c_int,
                     v_mul * oh4 as c_int,
                 );
@@ -2338,14 +2337,13 @@ unsafe fn obmc<BD: BitDepth>(
                     dav1d_filter_2d[*t.l.filter[1].index((by4 + y + 1) as usize) as usize]
                         [*t.l.filter[0].index((by4 + y + 1) as usize) as usize],
                 )?;
-                (f.dsp.mc.blend_v)(
+                f.dsp.mc.blend_v.call::<BD>(
                     dst.as_mut_ptr_at::<BD>(
                         dst_offset
                             .wrapping_add_signed((y * v_mul) as isize * dst.pixel_stride::<BD>()),
-                    )
-                    .cast(),
+                    ),
                     dst.stride(),
-                    lap.as_ptr().cast(),
+                    lap,
                     h_mul * ow4 as c_int,
                     v_mul * oh4 as c_int,
                 );

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -3391,15 +3391,15 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
             CompInterType::WeightedAvg => {
                 jnt_weight =
                     f.jnt_weights[inter.r#ref[0] as usize][inter.r#ref[1] as usize] as c_int;
-                (f.dsp.mc.w_avg)(
-                    dst.cast(),
+                f.dsp.mc.w_avg.call::<BD>(
+                    dst,
                     f.cur.stride[0],
                     &tmp[0],
                     &tmp[1],
                     bw4 * 4,
                     bh4 * 4,
                     jnt_weight,
-                    f.bitdepth_max,
+                    bd,
                 );
             }
             CompInterType::Seg => {
@@ -3494,15 +3494,15 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                         );
                     }
                     CompInterType::WeightedAvg => {
-                        (f.dsp.mc.w_avg)(
-                            uvdst.cast(),
+                        f.dsp.mc.w_avg.call::<BD>(
+                            uvdst,
                             f.cur.stride[1],
                             &tmp[0],
                             &tmp[1],
                             bw4 * 4 >> ss_hor,
                             bh4 * 4 >> ss_ver,
                             jnt_weight,
-                            f.bitdepth_max,
+                            bd,
                         );
                     }
                     CompInterType::Seg | CompInterType::Wedge => {


### PR DESCRIPTION
We need this abstraction to add the adapter code in the `fn call`s.