### PR TITLE
`fn Rav1dRefmvsDSPContext::splat_mv`: Optimize

### DIFF
--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -516,10 +516,9 @@ impl Rav1dRefmvsDSPContext {
         let bw4 = bw4 as _;
         let bh4 = bh4 as _;
 
-        // SAFETY: Unsafe asm call. `rr` is at least `bh4` elements long, and
-        // each pointer in `rr` is non-null and points to at least `bx4 + bw4`
-        // elements, which is what will be accessed in `splat_mv`. For the Rust
-        // fallback function we pass the length of `rr` directly.
+        // SAFETY: Unsafe asm call. `rr` is `bh4` elements long,
+        // and each ptr in `rr` points to at least `bx4 + bw4` elements,
+        // which is what will be accessed in `splat_mv`.
         unsafe { (self.splat_mv)(rr, rmv, bx4, bw4, bh4) };
 
         if mem::needs_drop::<Guard>() {

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -490,8 +490,11 @@ impl Rav1dRefmvsDSPContext {
             if ri < rf.r.len() {
                 // This is the range that will actually be accessed,
                 // but `splat_mv` expects a pointer offset `bx4` backwards.
-                r_guards[i].write(rf.r.index_mut((ri + bx4.., ..bw4)));
+                let guard = rf.r.index_mut((ri + bx4.., ..bw4));
+                r_guards[i].write(guard);
+                // SAFETY: We just initialized it directly above.
                 let guard = unsafe { r_guards[i].assume_init_mut() };
+                // SAFETY: The above `index_mut` starts at `ri + bx4`, so we can safely index `bx4` backwards.
                 let ptr = unsafe { guard.as_mut_ptr().offset(-(bx4 as isize)) };
                 r_ptrs[i].write(ptr);
             } else {


### PR DESCRIPTION
* Fixes #1152.

35dd0e9 avoids calculations on `r`s that are not actually passed to the `fn` ptr.  We still create the array of 37 elements, both for the guards and for the raw ptrs, as we can't use `alloca`.  This requires extra zero initialization, but otherwise avoids unneeded calculations.

752ec1d then optimizes this further by making the arrays `MaybeUninit`s.  So now the stack allocation is just a subtraction and no initialization is necessary.  This also means we must call destructors manually, but we can use `mem::needs_drop` to skip this when the guard has no `impl Drop` in release mode (i.e. `!cfg(debug_assertions)`).

In 90a6eb8, I also realized we don't need the extra `rr_len: usize` arg, as `bh4` is the same.

I benchmarked this with `cargo build --release && hyperfine './target/release/dav1d -i ./tests/large/chimera_8b_1080p.ivf -o /dev/null'`, and it looks like we do get a large amount of performance back.  @fbossen, let me know if you can reproduce this and if this eliminates the overhead you were seeing.

| Commit  | Time (s) | Speedup |
| ------- | -------- | ------- |
| 97b3184 | 18.566   | 0.00 %  |
| 35dd0e9 | 17.579   | 5.61 %  |
| 752ec1d | 17.185   | 8.04 %  |