### PR TITLE
`fn cdef{,_dir}`: Make `dst` arg safe w/ `Rav1dPictureDataComponentOffset`

### DIFF
--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -362,24 +362,28 @@ pub struct Rav1dPictureDataComponentOffset<'a> {
 }
 
 impl<'a> AddAssign<usize> for Rav1dPictureDataComponentOffset<'a> {
+    #[cfg_attr(debug_assertions, track_caller)]
     fn add_assign(&mut self, rhs: usize) {
         self.offset += rhs;
     }
 }
 
 impl<'a> SubAssign<usize> for Rav1dPictureDataComponentOffset<'a> {
+    #[cfg_attr(debug_assertions, track_caller)]
     fn sub_assign(&mut self, rhs: usize) {
         self.offset -= rhs;
     }
 }
 
 impl<'a> AddAssign<isize> for Rav1dPictureDataComponentOffset<'a> {
+    #[cfg_attr(debug_assertions, track_caller)]
     fn add_assign(&mut self, rhs: isize) {
         self.offset = self.offset.wrapping_add_signed(rhs);
     }
 }
 
 impl<'a> SubAssign<isize> for Rav1dPictureDataComponentOffset<'a> {
+    #[cfg_attr(debug_assertions, track_caller)]
     fn sub_assign(&mut self, rhs: isize) {
         self.offset = self.offset.wrapping_add_signed(-rhs);
     }
@@ -388,6 +392,7 @@ impl<'a> SubAssign<isize> for Rav1dPictureDataComponentOffset<'a> {
 impl<'a> Add<usize> for Rav1dPictureDataComponentOffset<'a> {
     type Output = Self;
 
+    #[cfg_attr(debug_assertions, track_caller)]
     fn add(mut self, rhs: usize) -> Self::Output {
         self += rhs;
         self
@@ -397,6 +402,7 @@ impl<'a> Add<usize> for Rav1dPictureDataComponentOffset<'a> {
 impl<'a> Sub<usize> for Rav1dPictureDataComponentOffset<'a> {
     type Output = Self;
 
+    #[cfg_attr(debug_assertions, track_caller)]
     fn sub(mut self, rhs: usize) -> Self::Output {
         self -= rhs;
         self
@@ -406,6 +412,7 @@ impl<'a> Sub<usize> for Rav1dPictureDataComponentOffset<'a> {
 impl<'a> Add<isize> for Rav1dPictureDataComponentOffset<'a> {
     type Output = Self;
 
+    #[cfg_attr(debug_assertions, track_caller)]
     fn add(mut self, rhs: isize) -> Self::Output {
         self += rhs;
         self
@@ -415,6 +422,7 @@ impl<'a> Add<isize> for Rav1dPictureDataComponentOffset<'a> {
 impl<'a> Sub<isize> for Rav1dPictureDataComponentOffset<'a> {
     type Output = Self;
 
+    #[cfg_attr(debug_assertions, track_caller)]
     fn sub(mut self, rhs: isize) -> Self::Output {
         self -= rhs;
         self

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -221,19 +221,17 @@ unsafe fn cdef_filter_block_rust<BD: BitDepth>(
     sec_strength: c_int,
     dir: c_int,
     damping: c_int,
-    w: c_int,
-    h: c_int,
+    w: usize,
+    h: usize,
     edges: CdefEdgeFlags,
     bd: BD,
 ) {
-    let [dir, w, h] = [dir, w, h].map(|it| it as usize);
+    let dir = dir as usize;
 
     assert!((w == 4 || w == 8) && (h == 4 || h == 8));
     let mut tmp = [0; TMP_STRIDE * TMP_STRIDE]; // `12 * 12` is the maximum value of `TMP_STRIDE * (h + 4)`.
 
-    padding::<BD>(
-        &mut tmp, dst, left, top, bottom, w as usize, h as usize, edges,
-    );
+    padding::<BD>(&mut tmp, dst, left, top, bottom, w, h, edges);
 
     let tmp = tmp;
     let tmp_offset = 2 * TMP_STRIDE + 2;
@@ -378,8 +376,8 @@ unsafe extern "C" fn cdef_filter_block_c_erased<BD: BitDepth, const W: usize, co
         sec_strength,
         dir,
         damping,
-        W as c_int,
-        H as c_int,
+        W,
+        H,
         edges,
         bd,
     )

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -335,8 +335,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                             let adj_y_pri_lvl = adjust_strength(y_pri_lvl, variance);
                             if adj_y_pri_lvl != 0 || y_sec_lvl != 0 {
                                 f.dsp.cdef.fb[0].call::<BD>(
-                                    bptrs[0].data.as_mut_ptr_at::<BD>(bptrs[0].offset),
-                                    bptrs[0].data.stride(),
+                                    bptrs[0],
                                     &lr_bak[bit as usize][0],
                                     top,
                                     bot,
@@ -350,8 +349,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                             }
                         } else if y_sec_lvl != 0 {
                             f.dsp.cdef.fb[0].call::<BD>(
-                                bptrs[0].data.as_mut_ptr_at::<BD>(bptrs[0].offset),
-                                bptrs[0].data.stride(),
+                                bptrs[0],
                                 &lr_bak[bit as usize][0],
                                 top,
                                 bot,
@@ -435,8 +433,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                                 }
 
                                 f.dsp.cdef.fb[uv_idx as usize].call::<BD>(
-                                    bptrs[pl].data.as_mut_ptr_at::<BD>(bptrs[pl].offset),
-                                    bptrs[pl].data.stride(),
+                                    bptrs[pl],
                                     &lr_bak[bit as usize][pl],
                                     top,
                                     bot,

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -265,12 +265,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
 
                         let mut variance = 0;
                         let dir = if y_pri_lvl != 0 || uv_pri_lvl != 0 {
-                            f.dsp.cdef.dir.call::<BD>(
-                                bptrs[0].data.as_ptr_at::<BD>(bptrs[0].offset),
-                                bptrs[0].data.stride(),
-                                &mut variance,
-                                bd,
-                            )
+                            f.dsp.cdef.dir.call::<BD>(bptrs[0], &mut variance, bd)
                         } else {
                             0
                         };


### PR DESCRIPTION
`top` is always from another buffer, and `bottom` is sometimes from another buffer, sometimes from a `Rav1dPicture`, so I'm going to do those separately.