### PR TITLE
`fn ipred_filter_rust`: Cleanup and make safer

### DIFF
--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -1187,8 +1187,8 @@ unsafe extern "C" fn ipred_z_c_erased<BD: BitDepth, const Z: usize>(
     )
 }
 
-unsafe fn filter_fn(
-    flt_ptr: *const i8,
+fn filter_fn(
+    flt_ptr: &[i8],
     p0: c_int,
     p1: c_int,
     p2: c_int,
@@ -1198,21 +1198,21 @@ unsafe fn filter_fn(
     p6: c_int,
 ) -> c_int {
     if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
-        *flt_ptr.offset(0) as c_int * p0
-            + *flt_ptr.offset(1) as c_int * p1
-            + *flt_ptr.offset(16) as c_int * p2
-            + *flt_ptr.offset(17) as c_int * p3
-            + *flt_ptr.offset(32) as c_int * p4
-            + *flt_ptr.offset(33) as c_int * p5
-            + *flt_ptr.offset(48) as c_int * p6
+        flt_ptr[0] as c_int * p0
+            + flt_ptr[1] as c_int * p1
+            + flt_ptr[16] as c_int * p2
+            + flt_ptr[17] as c_int * p3
+            + flt_ptr[32] as c_int * p4
+            + flt_ptr[33] as c_int * p5
+            + flt_ptr[48] as c_int * p6
     } else {
-        *flt_ptr.offset(0) as c_int * p0
-            + *flt_ptr.offset(8) as c_int * p1
-            + *flt_ptr.offset(16) as c_int * p2
-            + *flt_ptr.offset(24) as c_int * p3
-            + *flt_ptr.offset(32) as c_int * p4
-            + *flt_ptr.offset(40) as c_int * p5
-            + *flt_ptr.offset(48) as c_int * p6
+        flt_ptr[0] as c_int * p0
+            + flt_ptr[8] as c_int * p1
+            + flt_ptr[16] as c_int * p2
+            + flt_ptr[24] as c_int * p3
+            + flt_ptr[32] as c_int * p4
+            + flt_ptr[40] as c_int * p5
+            + flt_ptr[48] as c_int * p6
     }
 }
 
@@ -1262,7 +1262,7 @@ unsafe fn ipred_filter_rust<BD: BitDepth>(
             while yy < 2 {
                 let mut xx = 0;
                 while xx < 4 {
-                    let acc = filter_fn(flt_ptr.as_ptr(), p0, p1, p2, p3, p4, p5, p6);
+                    let acc = filter_fn(flt_ptr, p0, p1, p2, p3, p4, p5, p6);
                     *ptr.offset(xx as isize) = bd.iclip_pixel(acc + 8 >> 4);
                     xx += 1;
                     flt_ptr = &flt_ptr[FLT_INCR..];

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -1231,14 +1231,14 @@ unsafe fn ipred_filter_rust<BD: BitDepth>(
     topleft_off: usize,
     width: c_int,
     height: c_int,
-    mut filt_idx: c_int,
+    filt_idx: c_int,
     _max_width: c_int,
     _max_height: c_int,
     bd: BD,
 ) {
     let width = width as usize;
     let height = height as usize;
-    filt_idx &= 511;
+    let filt_idx = filt_idx & 511;
     assert!(filt_idx < 5);
 
     let filter = &dav1d_filter_intra_taps[filt_idx as usize];

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -1236,9 +1236,8 @@ unsafe fn ipred_filter_rust<BD: BitDepth>(
     bd: BD,
 ) {
     filt_idx &= 511 as c_int;
-    if !(filt_idx < 5) {
-        unreachable!();
-    }
+    assert!(filt_idx < 5);
+
     let filter = &dav1d_filter_intra_taps[filt_idx as usize];
     let mut top: *const BD::Pixel = &*topleft_in.offset(1) as *const BD::Pixel;
     let mut y = 0;
@@ -1258,6 +1257,7 @@ unsafe fn ipred_filter_rust<BD: BitDepth>(
             let p6 = (*left.offset((1 * left_stride) as isize)).as_::<c_int>();
             let mut ptr: *mut BD::Pixel = &mut *dst.offset(x as isize) as *mut BD::Pixel;
             let mut flt_ptr = filter.as_slice();
+
             let mut yy = 0;
             while yy < 2 {
                 let mut xx = 0;

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -1238,6 +1238,7 @@ unsafe fn ipred_filter_rust<BD: BitDepth>(
 ) {
     let width = width as usize;
     let height = height as usize;
+    let stride = BD::pxstride(stride);
     let filt_idx = filt_idx & 511;
     assert!(filt_idx < 5);
 
@@ -1264,15 +1265,15 @@ unsafe fn ipred_filter_rust<BD: BitDepth>(
                     *ptr.add(xx) = bd.iclip_pixel(acc + 8 >> 4);
                     flt_ptr = &flt_ptr[FLT_INCR..];
                 }
-                ptr = ptr.offset(BD::pxstride(stride));
+                ptr = ptr.offset(stride);
             }
             left = dst.add(x + 4 - 1);
-            left_stride = BD::pxstride(stride);
+            left_stride = stride;
             top = top.offset(4);
             topleft = top.sub(1);
         }
-        top = dst.offset(BD::pxstride(stride));
-        dst = dst.offset(BD::pxstride(stride) * 2);
+        top = dst.offset(stride);
+        dst = dst.offset(stride * 2);
     }
 }
 

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -1236,13 +1236,15 @@ unsafe fn ipred_filter_rust<BD: BitDepth>(
     _max_height: c_int,
     bd: BD,
 ) {
+    let width = width as usize;
+    let height = height as usize;
     filt_idx &= 511;
     assert!(filt_idx < 5);
 
     let filter = &dav1d_filter_intra_taps[filt_idx as usize];
     let mut top = topleft_in.as_ptr().add(topleft_off + 1);
     for y in (0..height).step_by(2) {
-        let mut topleft = topleft_in.as_ptr().add(topleft_off - y as usize);
+        let mut topleft = topleft_in.as_ptr().add(topleft_off - y);
         let mut left = topleft.sub(1);
         let mut left_stride = -1;
         for x in (0..width).step_by(4) {
@@ -1253,7 +1255,7 @@ unsafe fn ipred_filter_rust<BD: BitDepth>(
             let p4 = (*top.offset(3)).as_::<c_int>();
             let p5 = (*left.offset(0 * left_stride)).as_::<c_int>();
             let p6 = (*left.offset(1 * left_stride)).as_::<c_int>();
-            let mut ptr = dst.offset(x as isize);
+            let mut ptr = dst.add(x);
             let mut flt_ptr = filter.as_slice();
 
             for _yy in 0..2 {
@@ -1264,7 +1266,7 @@ unsafe fn ipred_filter_rust<BD: BitDepth>(
                 }
                 ptr = ptr.offset(BD::pxstride(stride));
             }
-            left = dst.offset((x + 4 - 1) as isize);
+            left = dst.add(x + 4 - 1);
             left_stride = BD::pxstride(stride);
             top = top.offset(4);
             topleft = top.sub(1);

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -1236,7 +1236,7 @@ unsafe fn ipred_filter_rust<BD: BitDepth>(
     _max_height: c_int,
     bd: BD,
 ) {
-    filt_idx &= 511 as c_int;
+    filt_idx &= 511;
     assert!(filt_idx < 5);
 
     let filter = &dav1d_filter_intra_taps[filt_idx as usize];
@@ -1245,7 +1245,7 @@ unsafe fn ipred_filter_rust<BD: BitDepth>(
     while y < height {
         let mut topleft = topleft_in.as_ptr().add(topleft_off - y as usize);
         let mut left = topleft.sub(1);
-        let mut left_stride: ptrdiff_t = -(1 as c_int) as ptrdiff_t;
+        let mut left_stride = -1;
         let mut x = 0;
         while x < width {
             let p0 = (*topleft).as_::<c_int>();
@@ -1273,12 +1273,12 @@ unsafe fn ipred_filter_rust<BD: BitDepth>(
             left = &mut *dst.offset((x + 4 - 1) as isize) as *mut BD::Pixel;
             left_stride = BD::pxstride(stride);
             top = top.offset(4);
-            topleft = &*top.offset(-(1 as c_int) as isize) as *const BD::Pixel;
-            x += 4 as c_int;
+            topleft = &*top.offset(-1) as *const BD::Pixel;
+            x += 4;
         }
         top = &mut *dst.offset(BD::pxstride(stride)) as *mut BD::Pixel;
         dst = &mut *dst.offset(BD::pxstride(stride) * 2) as *mut BD::Pixel;
-        y += 2 as c_int;
+        y += 2;
     }
 }
 

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -1251,26 +1251,26 @@ unsafe fn ipred_filter_rust<BD: BitDepth>(
             let p2 = (*top.offset(1)).as_::<c_int>();
             let p3 = (*top.offset(2)).as_::<c_int>();
             let p4 = (*top.offset(3)).as_::<c_int>();
-            let p5 = (*left.offset((0 * left_stride) as isize)).as_::<c_int>();
-            let p6 = (*left.offset((1 * left_stride) as isize)).as_::<c_int>();
-            let mut ptr: *mut BD::Pixel = &mut *dst.offset(x as isize) as *mut BD::Pixel;
+            let p5 = (*left.offset(0 * left_stride)).as_::<c_int>();
+            let p6 = (*left.offset(1 * left_stride)).as_::<c_int>();
+            let mut ptr = dst.offset(x as isize);
             let mut flt_ptr = filter.as_slice();
 
             for _yy in 0..2 {
                 for xx in 0..4 {
                     let acc = filter_fn(flt_ptr, p0, p1, p2, p3, p4, p5, p6);
-                    *ptr.offset(xx as isize) = bd.iclip_pixel(acc + 8 >> 4);
+                    *ptr.add(xx) = bd.iclip_pixel(acc + 8 >> 4);
                     flt_ptr = &flt_ptr[FLT_INCR..];
                 }
                 ptr = ptr.offset(BD::pxstride(stride));
             }
-            left = &mut *dst.offset((x + 4 - 1) as isize) as *mut BD::Pixel;
+            left = dst.offset((x + 4 - 1) as isize);
             left_stride = BD::pxstride(stride);
             top = top.offset(4);
-            topleft = &*top.offset(-1) as *const BD::Pixel;
+            topleft = top.sub(1);
         }
-        top = &mut *dst.offset(BD::pxstride(stride)) as *mut BD::Pixel;
-        dst = &mut *dst.offset(BD::pxstride(stride) * 2) as *mut BD::Pixel;
+        top = dst.offset(BD::pxstride(stride));
+        dst = dst.offset(BD::pxstride(stride) * 2);
     }
 }
 


### PR DESCRIPTION
This cleans up `ipred_filter_rust` and makes the helper function `filter_fn` safe. I left most of the pointers within the function as pointers because they will point into `dst` at some point (e.g. it's initialized to `topleft_in`, but in a later loop iteration is changed to point to `dst`), so they couldn't be trivially made safe. It may be possible to make this fully safe once `dst` has been made into a `Rav1dPictureDataComponent` ref.