### PR TITLE
`fn padding`: Fix out-of-bounds bug w/ negative strides from #1163 

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -197,7 +197,7 @@ unsafe fn padding<BD: BitDepth>(
     for y in 0..h {
         let tmp = &mut tmp[(y + 2) * TMP_STRIDE..];
         let src = src + (y as isize * stride);
-        let src = &*src.data.slice::<BD, _>((src.offset.., ..x_end));
+        let src = &*src.data.slice::<BD, _>((src.offset.., ..x_end - 2));
         for x in 2..x_end {
             tmp[x] = src[x - 2].as_::<i16>();
         }


### PR DESCRIPTION
This fixes the out-of-bounds bug from #1163 ([CI](https://github.com/memorysafety/rav1d/actions/runs/9378749875/job/25822460121#step:7:3685)).

I guess the CI PR that enabled `--negstride` testing in CI hadn't been rebased into #1163 when it merged, so CI only failed after merging.