### PR TITLE
`mod refmvs`: Backport fix for buffer overread from dav1d 1.4.2

### DIFF
--- a/src/refmvs.c
+++ b/src/refmvs.c
@@ -817,7 +817,9 @@ int dav1d_refmvs_init_frame(refmvs_frame *const rf,
     if (r_stride != rf->r_stride || n_tile_rows != rf->n_tile_rows) {
         if (rf->r) dav1d_freep_aligned(&rf->r);
         const int uses_2pass = n_tile_threads > 1 && n_frame_threads > 1;
-        rf->r = dav1d_alloc_aligned(sizeof(*rf->r) * 35 * r_stride * n_tile_rows * (1 + uses_2pass), 64);
+        /* sizeof(refmvs_block) == 12 but it's accessed using 16-byte loads in asm,
+         * so add 4 bytes of padding to avoid buffer overreads. */
+        rf->r = dav1d_alloc_aligned(sizeof(*rf->r) * 35 * r_stride * n_tile_rows * (1 + uses_2pass) + 4, 64);
         if (!rf->r) return DAV1D_ERR(ENOMEM);
         rf->r_stride = r_stride;
     }

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -434,6 +434,14 @@ impl Rav1dRefmvsDSPContext {
                 return ptr::null();
             }
             // SAFETY: `.add` is in-bounds; checked above.
+            // Also note that asm may read 12-byte `refmvs_block`s in 16-byte chunks.
+            // This is safe because we allocate `rf.r` with an extra `R_PAD` (1) elements.
+            // These ptrs are only read, so these overlapping reads are safe
+            // (only read is only checked in the fallback Rust `fn`).
+            // Furthermore, this is provenance safe because
+            // we derive the ptrs from `rf.r.as_mut_ptr()`,
+            // as opposed to materializing intermediate references.
+            const _: () = assert!(mem::size_of::<refmvs_block>() * (1 + R_PAD) > 16);
             unsafe { rf.r.as_mut_ptr().cast_const().add(ri) }
         });
 


### PR DESCRIPTION
Fix buffer overread in `save_tmvs()` asm
    
The `refmvs_block` struct is only 12 bytes large but it is accessed using 16-byte unaligned loads in asm.
    
In order to avoid reading past the end of the allocated buffer, it is made slightly larger.
