### PR TITLE
`fn rav1d_open`: Make safe by sending an `Arc<Rav1dContext>` to worker threads

### DIFF
--- a/include/dav1d/dav1d.rs
+++ b/include/dav1d/dav1d.rs
@@ -1,5 +1,6 @@
 use crate::include::dav1d::picture::Dav1dPicAllocator;
 use crate::include::dav1d::picture::Rav1dPicAllocator;
+use crate::src::c_arc::RawArc;
 use crate::src::error::Rav1dError;
 use crate::src::internal::Rav1dContext;
 pub use crate::src::log::Dav1dLogger;
@@ -9,7 +10,8 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 use strum::FromRepr;
 
-pub type Dav1dContext = Rav1dContext;
+pub type Dav1dContext = RawArc<Rav1dContext>;
+
 pub type Dav1dRef = ();
 
 pub type Dav1dInloopFilterType = c_uint;

--- a/src/c_arc.rs
+++ b/src/c_arc.rs
@@ -149,10 +149,28 @@ impl<T> RawArc<T> {
 
     /// # Safety
     ///
-    /// The [`RawArc`] must be originally from [`Self::from_arc`].F
+    /// The [`RawArc`] must be originally from [`Self::from_arc`].
+    pub unsafe fn as_ref(&self) -> &T {
+        // SAFETY: `self` must be from `Self::from_arc`,
+        // which calls `Arc::into_raw`,
+        // which returns a ptr to its `T`.
+        // `Arc` allows us to get a `&T` from it,
+        // so this is allowed (unlike `&mut T`).
+        // We don't call `Self::into_arc` since that's consuming,
+        // so we'd have to `mem::forget` the `Arc`
+        // and also do a redundant dereference.
+        unsafe { self.0.cast().as_ref() }
+    }
+
+    /// # Safety
+    ///
+    /// The [`RawArc`] must be originally from [`Self::from_arc`].
     pub unsafe fn into_arc(self) -> Arc<T> {
         let raw = self.0.cast().as_ptr();
-        Arc::from_raw(raw)
+        // SAFETY: `self` must be from `Self::from_arc`,
+        // which calls `Arc::into_raw`.
+        // Thus, it is safe to call the inverse `Arc::from_raw` on it.
+        unsafe { Arc::from_raw(raw) }
     }
 }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1163,15 +1163,17 @@ pub(crate) struct Rav1dTaskContext_task_thread {
     pub ttd: Arc<TaskThreadData>,
     pub flushed: AtomicBool,
     pub die: AtomicBool,
+    pub c: Mutex<Option<Arc<Rav1dContext>>>,
 }
 
 impl Rav1dTaskContext_task_thread {
-    pub(crate) fn new(ttd: Arc<TaskThreadData>) -> Self {
+    pub(crate) const fn new(ttd: Arc<TaskThreadData>) -> Self {
         Self {
             cond: Condvar::new(),
             ttd,
             flushed: AtomicBool::new(false),
             die: AtomicBool::new(false),
+            c: Mutex::new(None),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,6 @@ use crate::src::picture::Rav1dThreadPicture;
 use crate::src::thread_task::rav1d_task_delayed_fg;
 use crate::src::thread_task::rav1d_worker_task;
 use crate::src::thread_task::FRAME_ERROR;
-use parking_lot::Condvar;
 use parking_lot::Mutex;
 use std::cmp;
 use std::ffi::c_char;
@@ -62,7 +61,6 @@ use std::ptr;
 use std::ptr::NonNull;
 use std::slice;
 use std::sync::atomic::AtomicBool;
-use std::sync::atomic::AtomicI32;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -217,16 +215,9 @@ pub(crate) fn rav1d_open(s: &Rav1dSettings) -> Rav1dResult<Arc<Rav1dContext>> {
     // TODO fallible allocation
     c.fc = (0..n_fc).map(|i| Rav1dFrameContext::default(i)).collect();
     let ttd = TaskThreadData {
-        lock: Mutex::new(()),
-        cond: Condvar::new(),
-        first: AtomicU32::new(0),
         cur: AtomicU32::new(n_fc as u32),
         reset_task_cur: AtomicU32::new(u32::MAX),
-        cond_signaled: AtomicI32::new(0),
-        delayed_fg_exec: AtomicI32::new(0),
-        delayed_fg_cond: Condvar::new(),
-        delayed_fg_progress: [AtomicI32::new(0), AtomicI32::new(0)],
-        delayed_fg: Default::default(),
+        ..Default::default()
     };
     c.task_thread = Arc::new(ttd);
     c.state = Mutex::new(Rav1dState {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -47,6 +47,7 @@ use std::sync::atomic::AtomicI32;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::thread;
 
 pub const FRAME_ERROR: u32 = u32::MAX - 1;
 pub const TILE_ERROR: i32 = i32::MAX - 1;
@@ -781,7 +782,10 @@ fn delayed_fg_task<'l, 'ttd: 'l>(
     }
 }
 
-pub fn rav1d_worker_task(c: &Rav1dContext, task_thread: Arc<Rav1dTaskContext_task_thread>) {
+pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContext_task_thread>) {
+    // The main thread will unpark us once `task_thread.c` is set.
+    thread::park();
+    let c = &*task_thread.c.lock().take().unwrap();
     let mut tc = Rav1dTaskContext::new(task_thread);
 
     // We clone the Arc here for the lifetime of this function to avoid an

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -107,7 +107,7 @@ unsafe fn xor128_rand() -> c_int {
 #[inline]
 unsafe fn decode_frame(
     p: *mut Dav1dPicture,
-    c: *const Dav1dContext,
+    c: Option<Dav1dContext>,
     data: *mut Dav1dData,
 ) -> c_int {
     let mut res: c_int;
@@ -141,7 +141,7 @@ unsafe fn decode_frame(
 
 unsafe fn decode_rand(
     in_0: *mut DemuxerContext,
-    c: *const Dav1dContext,
+    c: Option<Dav1dContext>,
     data: *mut Dav1dData,
     fps: c_double,
 ) -> c_int {
@@ -164,7 +164,7 @@ unsafe fn decode_rand(
 
 unsafe fn decode_all(
     in_0: *mut DemuxerContext,
-    c: *const Dav1dContext,
+    c: Option<Dav1dContext>,
     data: *mut Dav1dData,
 ) -> c_int {
     let mut res: c_int;
@@ -183,7 +183,7 @@ unsafe fn decode_all(
 
 unsafe fn seek(
     in_0: *mut DemuxerContext,
-    c: *const Dav1dContext,
+    c: Option<Dav1dContext>,
     pts: u64,
     data: *mut Dav1dData,
 ) -> c_int {
@@ -270,7 +270,7 @@ unsafe fn seek(
             break;
         }
     }
-    dav1d_flush(c);
+    dav1d_flush(c.unwrap());
     return res;
 }
 
@@ -322,7 +322,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
         reserved: [0; 16],
     };
     let mut in_0: *mut DemuxerContext = 0 as *mut DemuxerContext;
-    let mut c: *const Dav1dContext = 0 as *const Dav1dContext;
+    let mut c: Option<Dav1dContext> = None;
     let mut data: Dav1dData = Dav1dData {
         data: None,
         sz: 0,
@@ -488,7 +488,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
                                 if num_flush == 0 {
                                     break;
                                 }
-                                dav1d_flush(c);
+                                dav1d_flush(c.unwrap());
                             }
                             i_1 += 1;
                         }

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -315,7 +315,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
     let mut in_0: *mut DemuxerContext = 0 as *mut DemuxerContext;
     let mut out: *mut MuxerContext = 0 as *mut MuxerContext;
     let mut p = Default::default();
-    let mut c: *const Dav1dContext = 0 as *const Dav1dContext;
+    let mut c: Option<Dav1dContext> = None;
     let mut data: Dav1dData = Dav1dData {
         data: None,
         sz: 0,


### PR DESCRIPTION
* Fixes #862 (`Rav1dContext` initialization, which is the last one).
* Fixes #705.

This does a few things to make `fn rav1d_open`, the construction of `Rav1dContext`, and its usage from the main and worker threads, and its `unsafe` conversion from `Dav1dContext`s all safe or as safe as possible (full `// SAFETY` comments for the latter incoming shortly).

Specifically, this first makes the initialization of `Rav1dContext` in `fn rav1d_open` safe (not through a raw ptr).  This necessitates sending a `&Rav1dContext` to the worker threads (as we `unsafe`ly used to do through a raw ptr).  Since the worker threads may outlive both `fn rav1d_open` and `fn rav1d_close`, we change the `Box<Rav1dContext>` to `Arc<Rav1dContext>`.

Since we still need to set `c.tc` after spawning the worker threads, but we also need to send the `Arc<Rav1dContext>` to the worker threads, we have to do this indirectly and after `Rav1dContext` is fully constructed (otherwise we can't set `c.tc` unless we add a `Mutex` to it, which we don't want to do, since it's used often).  This is done by having the worker threads immediately `thread::park()`.  Then the main thread (in `fn rav1d_open`) set a field (with a `Mutex`) to contain an `Arc<Rav1dContext>`.  Then finally all of the worker threads are `unpark`ed, whereupon they `.take()` that `Arc<Rav1dContext>`, owning it now, and are able to use it as a `&Rav1dContext`.

Now that each thread owns an `Arc<Rav1dContext>`, `fn Rav1dContext::drop` won't be called until the main thread calls `fn rav1d_close` and all of the worker threads exit.  But `drop` is where we notify the worker threads that they should die and then joins them.  So we move that notification logic to `fn Rav1dContext::tell_worker_threads_to_die`, which is now explicitly called in `fn rav1d_close`.  Actually joining the worker threads isn't necessary anymore since `drop` will already be called once the last worker thread is exiting.

Then we update all of the `DAV1D_API`s that use `Dav1dContext` to be safer.  `Dav1dContext`, an opaque type, is changed from an alias of `Rav1dContext` to a ptr to it, specifically an `RawArc<Rav1dContext>`.  Thus, this changes usages of `*const Dav1dContext` to `Dav1dContext`, and `Option` can be used where `None` may be accepted/checked for.  And `RawArc` provides safer (still `unsafe`, but much safer) APIs for getting a `&Rav1dContext` or consuming the `Arc<Rav1dContext>`.  I'm going to add `// SAFETY` and `# Safety` comments to all of these `DAV1D_API`s next, but wanted to do it at the same time that I make all of the other arguments safe, too.

Finally, I cleaned up `fn rav1d_open` some more to directly initialize the `Rav1dContext` instead of first default initializing it.