### PR TITLE
`mod lib`: Mark `#![deny(unsafe_op_in_unsafe_fn)]` with safety docs and comments

### DIFF
--- a/src/c_arc.rs
+++ b/src/c_arc.rs
@@ -168,6 +168,9 @@ impl<T> RawArc<T> {
     /// # Safety
     ///
     /// The [`RawArc`] must be originally from [`Self::from_arc`].
+    ///
+    /// This must be called before ever calling [`Self::into_arc`],
+    /// including on [`Clone`]s.
     pub unsafe fn as_ref(&self) -> &T {
         // SAFETY: `self` must be from `Self::from_arc`,
         // which calls `Arc::into_raw`,
@@ -183,6 +186,8 @@ impl<T> RawArc<T> {
     /// # Safety
     ///
     /// The [`RawArc`] must be originally from [`Self::from_arc`].
+    ///
+    /// After calling this, the [`RawArc`] and [`Clone`]s of it may not be used anymore.
     pub unsafe fn into_arc(self) -> Arc<T> {
         let raw = self.0.cast().as_ptr();
         // SAFETY: `self` must be from `Self::from_arc`,

--- a/src/c_arc.rs
+++ b/src/c_arc.rs
@@ -169,7 +169,7 @@ impl<T> RawArc<T> {
     ///
     /// The [`RawArc`] must be originally from [`Self::from_arc`].
     ///
-    /// This must be called before ever calling [`Self::into_arc`],
+    /// This must not be called after [`Self::into_arc`],
     /// including on [`Clone`]s.
     pub unsafe fn as_ref(&self) -> &T {
         // SAFETY: `self` must be from `Self::from_arc`,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 #[cfg(feature = "bitdepth_16")]
 use crate::include::common::bitdepth::BitDepth16;
 #[cfg(feature = "bitdepth_8")]
@@ -127,10 +129,16 @@ impl Default for Rav1dSettings {
     }
 }
 
+/// # Safety
+///
+/// * `s` must be valid to [`ptr::write`] to.
+///   The former contents of `s` are not [`drop`]ped and it may be uninitialized.
 #[no_mangle]
 #[cold]
-pub unsafe extern "C" fn dav1d_default_settings(s: *mut Dav1dSettings) {
-    s.write(Rav1dSettings::default().into());
+pub unsafe extern "C" fn dav1d_default_settings(s: NonNull<Dav1dSettings>) {
+    let settings = Rav1dSettings::default().into();
+    // SAFETY: `s` is safe to `ptr::write` to.
+    unsafe { s.as_ptr().write(settings) };
 }
 
 struct NumThreads {
@@ -161,12 +169,18 @@ pub(crate) fn rav1d_get_frame_delay(s: &Rav1dSettings) -> Rav1dResult<usize> {
     Ok(n_fc)
 }
 
+/// # Safety
+///
+/// * `s`, if [`NonNull`], must valid to [`ptr::read`] from.
 #[no_mangle]
 #[cold]
-pub unsafe extern "C" fn dav1d_get_frame_delay(s: *const Dav1dSettings) -> Dav1dResult {
+pub unsafe extern "C" fn dav1d_get_frame_delay(s: Option<NonNull<Dav1dSettings>>) -> Dav1dResult {
     (|| {
-        validate_input!((!s.is_null(), EINVAL))?;
-        rav1d_get_frame_delay(&s.read().try_into()?).map(|frame_delay| frame_delay as c_uint)
+        let s = validate_input!(s.ok_or(EINVAL))?;
+        // SAFETY: `s` is safe to `ptr::read`.
+        let s = unsafe { s.as_ptr().read() };
+        let s = s.try_into()?;
+        rav1d_get_frame_delay(&s).map(|frame_delay| frame_delay as c_uint)
     })()
     .into()
 }
@@ -300,16 +314,24 @@ pub(crate) fn rav1d_open(s: &Rav1dSettings) -> Rav1dResult<Arc<Rav1dContext>> {
     Ok(c)
 }
 
+/// # Safety
+///
+/// * `c_out`, if [`NonNull`], is valid to [`ptr::write`] to.
+/// * `s`, if [`NonNull`], is valid to [`ptr::read`] from.
 #[no_mangle]
 #[cold]
 pub unsafe extern "C" fn dav1d_open(
-    c_out: *mut Option<Dav1dContext>,
-    s: *const Dav1dSettings,
+    c_out: Option<NonNull<Option<Dav1dContext>>>,
+    s: Option<NonNull<Dav1dSettings>>,
 ) -> Dav1dResult {
     (|| {
-        validate_input!((!c_out.is_null(), EINVAL))?;
-        validate_input!((!s.is_null(), EINVAL))?;
-        let s = s.read().try_into()?;
+        let mut c_out = validate_input!(c_out.ok_or(EINVAL))?;
+        let s = validate_input!(s.ok_or(EINVAL))?;
+        // SAFETY: `c_out` is safe to write to.
+        let c_out = unsafe { c_out.as_mut() };
+        // SAFETY: `s` is safe to read from.
+        let s = unsafe { s.as_ptr().read() };
+        let s = s.try_into()?;
         let c = rav1d_open(&s).inspect_err(|_| {
             *c_out = None;
         })?;
@@ -319,18 +341,25 @@ pub unsafe extern "C" fn dav1d_open(
     .into()
 }
 
+/// # Safety
+///
+/// * `out`, if [`NonNull`], is valid to [`ptr::write`] to.
+/// * `ptr`, if [`NonNull`], is the start of a `&[u8]` slice of length `sz`.
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_parse_sequence_header(
-    out: *mut Dav1dSequenceHeader,
-    ptr: *const u8,
+    out: Option<NonNull<Dav1dSequenceHeader>>,
+    ptr: Option<NonNull<u8>>,
     sz: usize,
 ) -> Dav1dResult {
     (|| {
-        validate_input!((!out.is_null(), EINVAL))?;
-        validate_input!((!ptr.is_null(), EINVAL))?;
+        let out = validate_input!(out.ok_or(EINVAL))?;
+        let ptr = validate_input!(ptr.ok_or(EINVAL))?;
         validate_input!((sz > 0 && sz <= usize::MAX / 2, EINVAL))?;
-        let seq_hdr = rav1d_parse_sequence_header(slice::from_raw_parts(ptr, sz))?;
-        out.write(seq_hdr.dav1d);
+        // SAFETY: `ptr` is the start of a `&[u8]` slice of length `sz`.
+        let data = unsafe { slice::from_raw_parts(ptr.as_ptr(), sz) };
+        let seq_hdr = rav1d_parse_sequence_header(data)?.dav1d;
+        // SAFETY: `out` is safe to write to.
+        unsafe { out.as_ptr().write(seq_hdr) };
         Ok(())
     })()
     .into()
@@ -351,6 +380,7 @@ impl Rav1dPicture {
     }
 }
 
+#[allow(unsafe_op_in_unsafe_fn)]
 unsafe fn output_image(
     c: &Rav1dContext,
     state: &mut Rav1dState,
@@ -403,11 +433,7 @@ fn output_picture_ready(c: &Rav1dContext, state: &mut Rav1dState, drain: bool) -
     state.out.p.data.is_some()
 }
 
-unsafe fn drain_picture(
-    c: &Rav1dContext,
-    state: &mut Rav1dState,
-    out: &mut Rav1dPicture,
-) -> Rav1dResult {
+fn drain_picture(c: &Rav1dContext, state: &mut Rav1dState, out: &mut Rav1dPicture) -> Rav1dResult {
     let mut drained = false;
     for _ in 0..c.fc.len() {
         let next = state.frame_thread.next;
@@ -454,12 +480,14 @@ unsafe fn drain_picture(
             }
             let _ = mem::take(out_delayed);
             if output_picture_ready(c, state, false) {
-                return output_image(c, state, out);
+                // SAFETY: TODO remove when `output_image` is safe.
+                return unsafe { output_image(c, state, out) };
             }
         }
     }
     if output_picture_ready(c, state, true) {
-        return output_image(c, state, out);
+        // SAFETY: TODO remove when `output_image` is safe.
+        return unsafe { output_image(c, state, out) };
     }
     Err(EAGAIN)
 }
@@ -513,30 +541,41 @@ pub(crate) fn rav1d_send_data(c: &Rav1dContext, in_0: &mut Rav1dData) -> Rav1dRe
     res
 }
 
+/// # Safety
+///
+/// * `c`, if [`NonNull`], must be from [`dav1d_open`] and not be passed to [`dav1d_close`] yet.
+/// * `r#in`, if [`NonNull`], must be valid to [`ptr::read`] from and [`ptr::write`] to.
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_send_data(
     c: Option<Dav1dContext>,
-    in_0: *mut Dav1dData,
+    r#in: Option<NonNull<Dav1dData>>,
 ) -> Dav1dResult {
     (|| {
         let c = validate_input!(c.ok_or(EINVAL))?;
-        validate_input!((!in_0.is_null(), EINVAL))?;
-        let c = c.as_ref();
-        let mut in_rust = in_0.read().into();
+        let r#in = validate_input!(r#in.ok_or(EINVAL))?;
+        // SAFETY: `c` is from `dav1d_open` and thus from `RawArc::from_arc`.
+        // It has not yet been passed to `dav1d_close` and thus not to `RawArc::into_arc` yet.
+        let c = unsafe { c.as_ref() };
+        // SAFETY: `r#in` is safe to read from.
+        let in_c = unsafe { r#in.as_ptr().read() };
+        let mut in_rust = in_c.into();
         let result = rav1d_send_data(c, &mut in_rust);
-        in_0.write(in_rust.into());
+        let in_c = in_rust.into();
+        // SAFETY: `r#in` is safe to write to.
+        unsafe { r#in.as_ptr().write(in_c) };
         result
     })()
     .into()
 }
 
-pub(crate) unsafe fn rav1d_get_picture(c: &Rav1dContext, out: &mut Rav1dPicture) -> Rav1dResult {
+pub(crate) fn rav1d_get_picture(c: &Rav1dContext, out: &mut Rav1dPicture) -> Rav1dResult {
     let state = &mut *c.state.try_lock().unwrap();
     let drain = mem::replace(&mut state.drain, true);
     gen_picture(c, state)?;
     mem::take(&mut state.cached_error).err_or(())?;
     if output_picture_ready(c, state, c.fc.len() == 1) {
-        return output_image(c, state, out);
+        // SAFETY: TODO remove when `output_image` is safe.
+        return unsafe { output_image(c, state, out) };
     }
     if c.fc.len() > 1 && drain {
         return drain_picture(c, state, out);
@@ -544,18 +583,26 @@ pub(crate) unsafe fn rav1d_get_picture(c: &Rav1dContext, out: &mut Rav1dPicture)
     Err(EAGAIN)
 }
 
+/// # Safety
+///
+/// * `c`, if [`NonNull`], must be from [`dav1d_open`] and not be passed to [`dav1d_close`] yet.
+/// * `out`, if [`NonNull`], must be valid to [`ptr::write`] to.
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_get_picture(
     c: Option<Dav1dContext>,
-    out: *mut Dav1dPicture,
+    out: Option<NonNull<Dav1dPicture>>,
 ) -> Dav1dResult {
     (|| {
         let c = validate_input!(c.ok_or(EINVAL))?;
-        validate_input!((!out.is_null(), EINVAL))?;
-        let c = c.as_ref();
+        let out = validate_input!(out.ok_or(EINVAL))?;
+        // SAFETY: `c` is from `dav1d_open` and thus from `RawArc::from_arc`.
+        // It has not yet been passed to `dav1d_close` and thus not to `RawArc::into_arc` yet.
+        let c = unsafe { c.as_ref() };
         let mut out_rust = Default::default(); // TODO(kkysen) Temporary until we return it directly.
         let result = rav1d_get_picture(c, &mut out_rust);
-        out.write(out_rust.into());
+        let out_c = out_rust.into();
+        // SAFETY: `out` is safe to write to.
+        unsafe { out.as_ptr().write(out_c) };
         result
     })()
     .into()
@@ -604,25 +651,35 @@ pub(crate) fn rav1d_apply_grain(
     };
 }
 
+/// # Safety
+///
+/// * `c`, if [`NonNull`], must be from [`dav1d_open`] and not be passed to [`dav1d_close`] yet.
+/// * `out`, if [`NonNull`], must be valid to [`ptr::write`] to.
+/// * `r#in`, if [`NonNull`], must be valid to [`ptr::read`] from.
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_apply_grain(
     c: Option<Dav1dContext>,
-    out: *mut Dav1dPicture,
-    in_0: *const Dav1dPicture,
+    out: Option<NonNull<Dav1dPicture>>,
+    r#in: Option<NonNull<Dav1dPicture>>,
 ) -> Dav1dResult {
     (|| {
         let c = validate_input!(c.ok_or(EINVAL))?;
-        validate_input!((!out.is_null(), EINVAL))?;
-        validate_input!((!in_0.is_null(), EINVAL))?;
-        let c = c.as_ref();
-        let in_0 = in_0.read();
+        let out = validate_input!(out.ok_or(EINVAL))?;
+        let r#in = validate_input!(r#in.ok_or(EINVAL))?;
+        // SAFETY: `c` is from `dav1d_open` and thus from `RawArc::from_arc`.
+        // It has not yet been passed to `dav1d_close` and thus not to `RawArc::into_arc` yet.
+        let c = unsafe { c.as_ref() };
+        // SAFETY: `r#in` is safe to read from.
+        let in_c = unsafe { r#in.as_ptr().read() };
         // Don't `.update_rav1d()` [`Rav1dSequenceHeader`] because it's meant to be read-only.
         // Don't `.update_rav1d()` [`Rav1dFrameHeader`] because it's meant to be read-only.
         // Don't `.update_rav1d()` [`Rav1dITUTT35`] because we never read it.
         let mut out_rust = Default::default(); // TODO(kkysen) Temporary until we return it directly.
-        let in_rust = in_0.into();
+        let in_rust = in_c.into();
         let result = rav1d_apply_grain(c, &mut out_rust, &in_rust);
-        out.write(out_rust.into());
+        let out_c = out_rust.into();
+        // SAFETY: `out` is safe to write to.
+        unsafe { out.as_ptr().write(out_c) };
         result
     })()
     .into()
@@ -675,9 +732,14 @@ pub(crate) fn rav1d_flush(c: &Rav1dContext) {
     c.flush.store(false, Ordering::SeqCst);
 }
 
+/// # Safety
+///
+/// * `c` must be from [`dav1d_open`] and not be passed to [`dav1d_close`] yet.
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_flush(c: Dav1dContext) {
-    let c = c.as_ref();
+    // SAFETY: `c` is from `dav1d_open` and thus from `RawArc::from_arc`.
+    // It has not yet been passed to `dav1d_close` and thus not to `RawArc::into_arc` yet.
+    let c = unsafe { c.as_ref() };
     rav1d_flush(c)
 }
 
@@ -688,14 +750,23 @@ pub(crate) fn rav1d_close(c: Arc<Rav1dContext>) {
     c.tell_worker_threads_to_die();
 }
 
+/// # Safety
+///
+/// * `c_out`, if [`NonNull`], must be safe to [`ptr::read`] from and [`ptr::write`] to.
+///   The `Dav1dContext` pointed to by `c_out` must be from [`dav1d_open`].
 #[no_mangle]
 #[cold]
-pub unsafe extern "C" fn dav1d_close(c_out: *mut Option<Dav1dContext>) {
-    if validate_input!(!c_out.is_null()).is_err() {
+pub unsafe extern "C" fn dav1d_close(c_out: Option<NonNull<Option<Dav1dContext>>>) {
+    let Ok(mut c_out) = validate_input!(c_out.ok_or(())) else {
         return;
-    }
-    let c_out = &mut *c_out;
-    mem::take(c_out).map(|c| rav1d_close(c.into_arc()));
+    };
+    // SAFETY: `c_out` is safe to read from and write to.
+    let c_out = unsafe { c_out.as_mut() };
+    mem::take(c_out).map(|c| {
+        // SAFETY: `c` is from `dav1d_open` and thus from `RawArc::from_arc`.
+        let c = unsafe { c.into_arc() };
+        rav1d_close(c);
+    });
 }
 
 impl Rav1dContext {
@@ -712,52 +783,81 @@ impl Rav1dContext {
     }
 }
 
+/// # Safety
+///
+/// * `c`, if [`NonNull`], must be from [`dav1d_open`] and not be passed to [`dav1d_close`] yet.
+/// * `flags`, if [`NonNull`], must be valid to [`ptr::write`] to.
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_get_event_flags(
     c: Option<Dav1dContext>,
-    flags: *mut Dav1dEventFlags,
+    flags: Option<NonNull<Dav1dEventFlags>>,
 ) -> Dav1dResult {
     (|| {
         let c = validate_input!(c.ok_or(EINVAL))?;
-        validate_input!((!flags.is_null(), EINVAL))?;
-        let c = c.as_ref();
+        let flags = validate_input!(flags.ok_or(EINVAL))?;
+        // SAFETY: `c` is from `dav1d_open` and thus from `RawArc::from_arc`.
+        // It has not yet been passed to `dav1d_close` and thus not to `RawArc::into_arc` yet.
+        let c = unsafe { c.as_ref() };
         let state = &mut *c.state.try_lock().unwrap();
-        flags.write(mem::take(&mut state.event_flags).into());
+        let flags_rust = mem::take(&mut state.event_flags);
+        let flags_c = flags_rust.into();
+        // SAFETY: `flags` is safe to write to.
+        unsafe { flags.as_ptr().write(flags_c) };
         Ok(())
     })()
     .into()
 }
 
+/// # Safety
+///
+/// * `c`, if [`NonNull`], must be from [`dav1d_open`] and not be passed to [`dav1d_close`] yet.
+/// * `out`, if [`NonNull`], is valid to [`ptr::write`] to.
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_get_decode_error_data_props(
     c: Option<Dav1dContext>,
-    out: *mut Dav1dDataProps,
+    out: Option<NonNull<Dav1dDataProps>>,
 ) -> Dav1dResult {
     (|| {
         let c = validate_input!(c.ok_or(EINVAL))?;
-        validate_input!((!out.is_null(), EINVAL))?;
-        let c = c.as_ref();
+        let out = validate_input!(out.ok_or(EINVAL))?;
+        // SAFETY: `c` is from `dav1d_open` and thus from `RawArc::from_arc`.
+        // It has not yet been passed to `dav1d_close` and thus not to `RawArc::into_arc` yet.
+        let c = unsafe { c.as_ref() };
         let state = &mut *c.state.try_lock().unwrap();
-        out.write(mem::take(&mut state.cached_error_props).into());
+        let props_rust = mem::take(&mut state.cached_error_props);
+        let props_c = props_rust.into();
+        // SAFETY: `out` is safety to write to.
+        unsafe { out.as_ptr().write(props_c) };
         Ok(())
     })()
     .into()
 }
 
+/// # Safety
+///
+/// * `p`, if [`NonNull`], must be valid to [`ptr::read`] from and [`ptr::write`] to.
 #[no_mangle]
-pub unsafe extern "C" fn dav1d_picture_unref(p: *mut Dav1dPicture) {
-    if validate_input!(!p.is_null()).is_err() {
+pub unsafe extern "C" fn dav1d_picture_unref(p: Option<NonNull<Dav1dPicture>>) {
+    let Ok(p) = validate_input!(p.ok_or(())) else {
         return;
-    }
-    let mut p_rust = p.read().to::<Rav1dPicture>();
+    };
+    // SAFETY: `p` is safe to read from.
+    let p_c = unsafe { p.as_ptr().read() };
+    let mut p_rust = p_c.to::<Rav1dPicture>();
     let _ = mem::take(&mut p_rust);
-    p.write(p_rust.into());
+    let p_c = p_rust.into();
+    // SAFETY: `p` is safe to write to.
+    unsafe { p.as_ptr().write(p_c) };
 }
 
+/// # Safety
+///
+/// * `buf`, if [`NonNull`], is valid to [`ptr::write`] to.
+///   After this call, `buf.data` will be an allocated slice of length `sz`.
 #[no_mangle]
-pub unsafe extern "C" fn dav1d_data_create(buf: *mut Dav1dData, sz: usize) -> *mut u8 {
+pub unsafe extern "C" fn dav1d_data_create(buf: Option<NonNull<Dav1dData>>, sz: usize) -> *mut u8 {
     || -> Rav1dResult<*mut u8> {
-        let buf = validate_input!(NonNull::new(buf).ok_or(EINVAL))?;
+        let buf = validate_input!(buf.ok_or(EINVAL))?;
         validate_input!((sz <= usize::MAX / 2, EINVAL))?;
         let data = Rav1dData::create(sz)?;
         let data = data.to::<Dav1dData>();
@@ -765,61 +865,90 @@ pub unsafe extern "C" fn dav1d_data_create(buf: *mut Dav1dData, sz: usize) -> *m
             .data
             .map(|ptr| ptr.as_ptr())
             .unwrap_or_else(ptr::null_mut);
-        buf.as_ptr().write(data);
+        // SAFETY: `buf` is safe to write to.
+        unsafe { buf.as_ptr().write(data) };
         Ok(ptr)
     }()
     .unwrap_or_else(|_| ptr::null_mut())
 }
 
+/// # Safety
+///
+/// * `buf`, if [`NonNull`], is valid to [`ptr::write`] to.
+/// * `ptr`, if [`NonNull`], is the start of a `&[u8]` slice of length `sz`.
+/// * `ptr`'s slice must be valid to dereference until `free_callback` is called on it, which must deallocate it.
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_data_wrap(
-    buf: *mut Dav1dData,
-    ptr: *const u8,
+    buf: Option<NonNull<Dav1dData>>,
+    ptr: Option<NonNull<u8>>,
     sz: usize,
     free_callback: Option<FnFree>,
     user_data: *mut c_void,
 ) -> Dav1dResult {
     || -> Rav1dResult {
-        let buf = validate_input!(NonNull::new(buf).ok_or(EINVAL))?;
-        let ptr = validate_input!(NonNull::new(ptr.cast_mut()).ok_or(EINVAL))?;
+        let buf = validate_input!(buf.ok_or(EINVAL))?;
+        let ptr = validate_input!(ptr.ok_or(EINVAL))?;
         validate_input!((sz <= usize::MAX / 2, EINVAL))?;
-        let data = slice::from_raw_parts(ptr.as_ptr(), sz).into();
-        let data = Rav1dData::wrap(data, free_callback, user_data)?;
-        buf.as_ptr().write(data.into());
+        // SAFETY: `ptr` is the start of a `&[u8]` slice of length `sz`.
+        let data = unsafe { slice::from_raw_parts(ptr.as_ptr(), sz) };
+        // SAFETY: `ptr`, and thus `data`, is valid to dereference until `free_callback` is called on it, which deallocates it.
+        let data = unsafe { Rav1dData::wrap(data.into(), free_callback, user_data) }?;
+        let data_c = data.into();
+        // SAFETY: `buf` is safe to write to.
+        unsafe { buf.as_ptr().write(data_c) };
         Ok(())
     }()
     .into()
 }
 
+/// # Safety
+///
+/// * `buf`, if [`NonNull`], is valid to [`ptr::read`] from and [`ptr::write`] to.
+/// * `user_data`, if [`NonNull`], is valid to dereference until `free_callback` is called on it, which must deallocate it.
 #[no_mangle]
 pub unsafe extern "C" fn dav1d_data_wrap_user_data(
-    buf: *mut Dav1dData,
-    user_data: *const u8,
+    buf: Option<NonNull<Dav1dData>>,
+    user_data: Option<NonNull<u8>>,
     free_callback: Option<FnFree>,
     cookie: *mut c_void,
 ) -> Dav1dResult {
     || -> Rav1dResult {
-        let buf = validate_input!(NonNull::new(buf).ok_or(EINVAL))?;
+        let buf = validate_input!(buf.ok_or(EINVAL))?;
         // Note that `dav1d` doesn't do this check, but they do for the similar [`dav1d_data_wrap`].
-        let user_data = validate_input!(NonNull::new(user_data.cast_mut()).ok_or(EINVAL))?;
-        let mut data = buf.as_ptr().read().to::<Rav1dData>();
-        data.wrap_user_data(user_data, free_callback, cookie)?;
-        buf.as_ptr().write(data.into());
+        let user_data = validate_input!(user_data.ok_or(EINVAL))?;
+        // SAFETY: `buf` is safe to read from.
+        let data_c = unsafe { buf.as_ptr().read() };
+        let mut data = data_c.to::<Rav1dData>();
+        // SAFETY: `user_data` is valid to dereference until `free_callback` is called on it, which deallocates it.
+        unsafe { data.wrap_user_data(user_data, free_callback, cookie) }?;
+        let data_c = data.into();
+        // SAFETY: `buf` is safe to write to.
+        unsafe { buf.as_ptr().write(data_c) };
         Ok(())
     }()
     .into()
 }
 
+/// # Safety
+///
+/// * `buf`, if [`NonNull`], is safe to [`ptr::read`] from and [`ptr::write`] from.
 #[no_mangle]
-pub unsafe extern "C" fn dav1d_data_unref(buf: *mut Dav1dData) {
-    let buf = validate_input!(NonNull::new(buf).ok_or(()));
+pub unsafe extern "C" fn dav1d_data_unref(buf: Option<NonNull<Dav1dData>>) {
+    let buf = validate_input!(buf.ok_or(()));
     let Ok(mut buf) = buf else { return };
-    let _ = mem::take(buf.as_mut()).to::<Rav1dData>();
+    // SAFETY: `buf` is safe to read from and write to.
+    let buf = unsafe { buf.as_mut() };
+    let _ = mem::take(buf).to::<Rav1dData>();
 }
 
+/// # Safety
+///
+/// * `props`, if [`NonNull`], is safe to [`ptr::read`] from and [`ptr::write`] from.
 #[no_mangle]
-pub unsafe extern "C" fn dav1d_data_props_unref(props: *mut Dav1dDataProps) {
-    let props = validate_input!(NonNull::new(props).ok_or(()));
+pub unsafe extern "C" fn dav1d_data_props_unref(props: Option<NonNull<Dav1dDataProps>>) {
+    let props = validate_input!(props.ok_or(()));
     let Ok(mut props) = props else { return };
-    let _ = mem::take(props.as_mut()).to::<Rav1dDataProps>();
+    // SAFETY: `props` is safe to read from and write to.
+    let props = unsafe { props.as_mut() };
+    let _ = mem::take(props).to::<Rav1dDataProps>();
 }

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -379,7 +379,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
             return 1 as c_int;
         }
         if i < cli_settings.skip {
-            dav1d_data_unref(&mut data);
+            dav1d_data_unref(NonNull::new(&mut data));
         }
         i = i.wrapping_add(1);
     }
@@ -459,7 +459,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
             }; 32],
         };
         let mut seq_skip: c_uint = 0 as c_int as c_uint;
-        while dav1d_parse_sequence_header(&mut seq, data.data.unwrap().as_ptr(), data.sz).0 != 0 {
+        while dav1d_parse_sequence_header(NonNull::new(&mut seq), data.data, data.sz).0 != 0 {
             res = input_read(in_0, &mut data);
             if res < 0 {
                 input_close(in_0);
@@ -479,7 +479,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
     if cli_settings.limit != 0 as c_int as c_uint && cli_settings.limit < total {
         total = cli_settings.limit;
     }
-    res = dav1d_open(&mut c, &mut lib_settings).0;
+    res = dav1d_open(NonNull::new(&mut c), NonNull::new(&mut lib_settings)).0;
     if res != 0 {
         return 1 as c_int;
     }
@@ -510,10 +510,10 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
             0 as c_int,
             ::core::mem::size_of::<Dav1dPicture>(),
         );
-        res = dav1d_send_data(c, &mut data).0;
+        res = dav1d_send_data(c, NonNull::new(&mut data)).0;
         if res < 0 {
             if res != -EAGAIN {
-                dav1d_data_unref(&mut data);
+                dav1d_data_unref(NonNull::new(&mut data));
                 fprintf(
                     stderr,
                     b"Error decoding frame: %s\n\0" as *const u8 as *const c_char,
@@ -524,7 +524,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
                 }
             }
         }
-        res = dav1d_get_picture(c, &mut p).0;
+        res = dav1d_get_picture(c, NonNull::new(&mut p)).0;
         if res < 0 {
             if res != -EAGAIN {
                 fprintf(
@@ -581,11 +581,11 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
         }
     }
     if data.sz > 0 {
-        dav1d_data_unref(&mut data);
+        dav1d_data_unref(NonNull::new(&mut data));
     }
     if res == 0 {
         while cli_settings.limit == 0 || n_out < cli_settings.limit {
-            res = dav1d_get_picture(c, &mut p).0;
+            res = dav1d_get_picture(c, NonNull::new(&mut p)).0;
             if res < 0 {
                 if res != -EAGAIN {
                     fprintf(
@@ -655,7 +655,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
         fprintf(stderr, b"No data decoded\n\0" as *const u8 as *const c_char);
         res = 1 as c_int;
     }
-    dav1d_close(&mut c);
+    dav1d_close(NonNull::new(&mut c));
     return if res == 0 { 0 as c_int } else { 1 as c_int };
 }
 

--- a/tools/dav1d_cli_parse.rs
+++ b/tools/dav1d_cli_parse.rs
@@ -39,6 +39,7 @@ use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
 use std::process::exit;
+use std::ptr::NonNull;
 
 use cfg_if::cfg_if;
 
@@ -627,7 +628,7 @@ pub unsafe fn parse(
         0 as c_int,
         ::core::mem::size_of::<CLISettings>(),
     );
-    dav1d_default_settings(lib_settings);
+    dav1d_default_settings(NonNull::new(lib_settings).unwrap());
     (*lib_settings).strict_std_compliance = 1 as c_int;
     let mut grain_specified = 0;
     loop {

--- a/tools/input/annexb.rs
+++ b/tools/input/annexb.rs
@@ -21,6 +21,7 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
+use std::ptr::NonNull;
 
 #[repr(C)]
 pub struct DemuxerPriv {
@@ -281,7 +282,7 @@ unsafe extern "C" fn annexb_read(c: *mut AnnexbInputContext, data: *mut Dav1dDat
     if res < 0 || len.wrapping_add(res as usize) > (*c).frame_unit_size {
         return -1;
     }
-    let ptr: *mut u8 = dav1d_data_create(data, len);
+    let ptr: *mut u8 = dav1d_data_create(NonNull::new(data), len);
     if ptr.is_null() {
         return -1;
     }
@@ -295,7 +296,7 @@ unsafe extern "C" fn annexb_read(c: *mut AnnexbInputContext, data: *mut Dav1dDat
             b"Failed to read frame data: %s\n\0" as *const u8 as *const c_char,
             strerror(*errno_location()),
         );
-        dav1d_data_unref(data);
+        dav1d_data_unref(NonNull::new(data));
         return -1;
     }
     return 0 as c_int;

--- a/tools/input/ivf.rs
+++ b/tools/input/ivf.rs
@@ -18,6 +18,7 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
+use std::ptr::NonNull;
 
 #[repr(C)]
 pub struct DemuxerPriv {
@@ -229,7 +230,7 @@ unsafe extern "C" fn ivf_read(c: *mut IvfInputContext, buf: *mut Dav1dData) -> c
     if ivf_read_header(c, &mut sz, &mut off, &mut ts) != 0 {
         return -1;
     }
-    ptr = dav1d_data_create(buf, sz as usize);
+    ptr = dav1d_data_create(NonNull::new(buf), sz as usize);
     if ptr.is_null() {
         return -1;
     }
@@ -239,7 +240,7 @@ unsafe extern "C" fn ivf_read(c: *mut IvfInputContext, buf: *mut Dav1dData) -> c
             b"Failed to read frame data: %s\n\0" as *const u8 as *const c_char,
             strerror(*errno_location()),
         );
-        dav1d_data_unref(buf);
+        dav1d_data_unref(NonNull::new(buf));
         return -1;
     }
     (*buf).m.offset = off;

--- a/tools/input/section5.rs
+++ b/tools/input/section5.rs
@@ -21,6 +21,7 @@ use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ffi::c_ulong;
 use std::ffi::c_void;
+use std::ptr::NonNull;
 
 #[repr(C)]
 pub struct DemuxerPriv {
@@ -297,7 +298,7 @@ unsafe extern "C" fn section5_read(c: *mut Section5InputContext, data: *mut Dav1
         }
     }
     fseeko((*c).f, -(total_bytes as libc::off_t), 1 as c_int);
-    let ptr: *mut u8 = dav1d_data_create(data, total_bytes);
+    let ptr: *mut u8 = dav1d_data_create(NonNull::new(data), total_bytes);
     if ptr.is_null() {
         return -1;
     }
@@ -307,7 +308,7 @@ unsafe extern "C" fn section5_read(c: *mut Section5InputContext, data: *mut Dav1
             b"Failed to read frame data: %s\n\0" as *const u8 as *const c_char,
             strerror(*errno_location()),
         );
-        dav1d_data_unref(data);
+        dav1d_data_unref(NonNull::new(data));
         return -1;
     }
     return 0 as c_int;

--- a/tools/output/md5.rs
+++ b/tools/output/md5.rs
@@ -569,7 +569,7 @@ unsafe extern "C" fn md5_write(md5: *mut MD5Context, p: *mut Dav1dPicture) -> c_
             pl += 1;
         }
     }
-    dav1d_picture_unref(p);
+    dav1d_picture_unref(NonNull::new(p));
     return 0 as c_int;
 }
 

--- a/tools/output/null.rs
+++ b/tools/output/null.rs
@@ -4,6 +4,7 @@ use rav1d::src::lib::dav1d_picture_unref;
 use std::ffi::c_char;
 use std::ffi::c_int;
 use std::ffi::c_uint;
+use std::ptr::NonNull;
 
 extern "C" {
     pub type MuxerPriv;
@@ -30,7 +31,7 @@ pub struct Muxer {
 pub type NullOutputContext = MuxerPriv;
 
 unsafe extern "C" fn null_write(_c: *mut NullOutputContext, p: *mut Dav1dPicture) -> c_int {
-    dav1d_picture_unref(p);
+    dav1d_picture_unref(NonNull::new(p));
     return 0 as c_int;
 }
 

--- a/tools/output/y4m2.rs
+++ b/tools/output/y4m2.rs
@@ -207,14 +207,14 @@ unsafe extern "C" fn y4m2_write(c: *mut Y4m2OutputContext, p: *mut Dav1dPicture)
             match current_block {
                 11545648641752300099 => {}
                 _ => {
-                    dav1d_picture_unref(p);
+                    dav1d_picture_unref(NonNull::new(p));
                     return 0 as c_int;
                 }
             }
         }
         _ => {}
     }
-    dav1d_picture_unref(p);
+    dav1d_picture_unref(NonNull::new(p));
     fprintf(
         stderr,
         b"Failed to write frame data: %s\n\0" as *const u8 as *const c_char,

--- a/tools/output/yuv.rs
+++ b/tools/output/yuv.rs
@@ -121,14 +121,14 @@ unsafe extern "C" fn yuv_write(c: *mut YuvOutputContext, p: *mut Dav1dPicture) -
             match current_block {
                 11680617278722171943 => {}
                 _ => {
-                    dav1d_picture_unref(p);
+                    dav1d_picture_unref(NonNull::new(p));
                     return 0 as c_int;
                 }
             }
         }
         _ => {}
     }
-    dav1d_picture_unref(p);
+    dav1d_picture_unref(NonNull::new(p));
     fprintf(
         stderr,
         b"Failed to write frame data: %s\n\0" as *const u8 as *const c_char,


### PR DESCRIPTION
* Fixes #847.

This marks `mod lib` as `#![deny(unsafe_op_in_unsafe_fn)]` by adding `# Safety` docs and `// SAFETY` comments on all `DAV1D_API`s.

The few Rust `fn`s that remain `unsafe` I added temporary `unsafe {}` blocks and `!#[allow(unsafe_op_in_unsafe_fn)]`s on.