### PR TITLE
Backport `lvl` buffer alignment from dav1d 1.4.2

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1684,7 +1684,7 @@ fn decode_b(
         } else if last_delta_lf != prev_delta_lf {
             // find sb-specific lf lvl parameters
             rav1d_calc_lf_values(
-                &mut *ts.lflvlmem.try_write().unwrap(),
+                &mut (*ts.lflvlmem.try_write().unwrap()),
                 frame_hdr,
                 &last_delta_lf,
             );

--- a/src/internal.h
+++ b/src/internal.h
@@ -302,8 +302,8 @@ struct Dav1dFrameContext {
         int lr_buf_plane_sz[2]; /* (stride*sbh*4) << sb128 if n_tc > 1, else stride*4 */
         int re_sz /* h */;
         ALIGN(Av1FilterLUT lim_lut, 16);
+        ALIGN(uint8_t lvl[8 /* seg_id */][4 /* dir */][8 /* ref */][2 /* is_gmv */], 16);
         int last_sharpness;
-        uint8_t lvl[8 /* seg_id */][4 /* dir */][8 /* ref */][2 /* is_gmv */];
         uint8_t *tx_lpf_right_edge[2];
         uint8_t *cdef_line_buf, *lr_line_buf;
         pixel *cdef_line[2 /* pre, post */][3 /* plane */];
@@ -377,7 +377,7 @@ struct Dav1dTileState {
     int last_qidx;
 
     int8_t last_delta_lf[4];
-    uint8_t lflvlmem[8 /* seg_id */][4 /* dir */][8 /* ref */][2 /* is_gmv */];
+    ALIGN(uint8_t lflvlmem[8 /* seg_id */][4 /* dir */][8 /* ref */][2 /* is_gmv */], 16);
     const uint8_t (*lflvl)[4][8][2];
 
     Av1RestorationUnit *lr_ref[3];

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -724,8 +724,8 @@ pub struct Rav1dFrameContext_lf {
     pub mask: Vec<Av1Filter>, /* len = w*h */
     pub lr_mask: Vec<Av1Restoration>,
     pub lim_lut: Align16<Av1FilterLUT>,
+    pub lvl: [Align16<[[[u8; 2]; 8]; 4]>; 8], /* [8 seg_id][4 dir][8 ref][2 is_gmv] */
     pub last_sharpness: u8,
-    pub lvl: [[[[u8; 2]; 8]; 4]; 8], /* [8 seg_id][4 dir][8 ref][2 is_gmv] */
     pub tx_lpf_right_edge: TxLpfRightEdge,
     // cdef_line_buf was originally aligned to 32 bytes, but we need to pass
     // both cdef_line_buf and lr_line_buf as the same parameter type to
@@ -929,7 +929,7 @@ pub struct Rav1dTileState {
     pub dq: Atomic<TileStateRef>,
     pub last_qidx: AtomicU8,
     pub last_delta_lf: Atomic<[i8; 4]>,
-    pub lflvlmem: RwLock<[[[[u8; 2]; 8]; 4]; 8]>, /* [8 seg_id][4 dir][8 ref][2 is_gmv] */
+    pub lflvlmem: RwLock<[Align16<[[[u8; 2]; 8]; 4]>; 8]>, /* [8 seg_id][4 dir][8 ref][2 is_gmv] */
     pub lflvl: Atomic<TileStateRef>,
 
     pub lr_ref: RwLock<[Av1RestorationUnit; 3]>,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -400,7 +400,7 @@ pub(crate) fn rav1d_create_lf_mask_intra(
     lflvl: &Av1Filter,
     level_cache: &DisjointMut<Vec<[u8; 4]>>,
     b4_stride: ptrdiff_t,
-    filter_level: &[[[u8; 2]; 8]; 4],
+    filter_level: &Align16<[[[u8; 2]; 8]; 4]>,
     b: Bxy,
     iw: c_int,
     ih: c_int,
@@ -502,7 +502,7 @@ pub(crate) fn rav1d_create_lf_mask_inter(
     lflvl: &Av1Filter,
     level_cache: &DisjointMut<Vec<[u8; 4]>>,
     b4_stride: ptrdiff_t,
-    filter_level: &[[[u8; 2]; 8]; 4],
+    filter_level: &Align16<[[[u8; 2]; 8]; 4]>,
     r#ref: usize,
     is_gmv: bool,
     b: Bxy,
@@ -679,7 +679,7 @@ fn calc_lf_value_chroma(
 }
 
 pub(crate) fn rav1d_calc_lf_values(
-    lflvl_values: &mut [[[[u8; 2]; 8]; 4]; RAV1D_MAX_SEGMENTS as usize],
+    lflvl_values: &mut [Align16<[[[u8; 2]; 8]; 4]>; RAV1D_MAX_SEGMENTS as usize],
     hdr: &Rav1dFrameHeader,
     lf_delta: &[i8; 4],
 ) {


### PR DESCRIPTION
Ensures that SIMD stores performed by memset() are aligned.