### PR TITLE
`fn decode_coefs`: Cleanup `current_block` control flow

### DIFF
--- a/src/recon.rs
+++ b/src/recon.rs
@@ -1354,15 +1354,11 @@ fn decode_coefs<BD: BitDepth>(
         NoQm,
     }
 
-    let mut ac = None;
+    let ac;
     if dc_tok == 0 {
         cul_level = 0;
         dc_sign_level = 1 << 6;
-        if qm_tbl.is_some() {
-            ac = Some(Ac::Qm);
-        } else {
-            ac = Some(Ac::NoQm);
-        }
+        ac = Some(if qm_tbl.is_some() { Ac::Qm } else { Ac::NoQm });
     } else {
         dc_sign_ctx = get_dc_sign_ctx(tx, a, l) as c_int;
         let dc_sign_cdf = &mut ts_c.cdf.coef.dc_sign[chroma][dc_sign_ctx as usize];
@@ -1407,9 +1403,7 @@ fn decode_coefs<BD: BitDepth>(
                 (if dc_sign != 0 { -dc_dq } else { dc_dq }).as_::<BD::Coef>(),
             );
 
-            if rc != 0 {
-                ac = Some(Ac::Qm);
-            }
+            ac = if rc != 0 { Some(Ac::Qm) } else { None };
         } else {
             // non-qmatrix is the common case and allows for additional optimizations
             if dc_tok == 15 {
@@ -1439,9 +1433,7 @@ fn decode_coefs<BD: BitDepth>(
                 (if dc_sign != 0 { -dc_dq } else { dc_dq }).as_::<BD::Coef>(),
             );
 
-            if rc != 0 {
-                ac = Some(Ac::NoQm);
-            }
+            ac = if rc != 0 { Some(Ac::NoQm) } else { None };
         }
     }
     match ac {

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -1359,10 +1359,8 @@ fn decode_coefs<BD: BitDepth>(
         cul_level = 0;
         dc_sign_level = 1 << 6;
         if qm_tbl.is_some() {
-            // goto ac_qm;
             ac = Some(Ac::Qm);
         } else {
-            // goto ac_noqm;
             ac = Some(Ac::NoQm);
         }
     } else {
@@ -1447,7 +1445,6 @@ fn decode_coefs<BD: BitDepth>(
         }
     }
     match ac {
-        // ac_qm:
         Some(Ac::Qm) => {
             let ac_dq: c_uint = dq_tbl[1].load(Ordering::Relaxed) as c_uint;
             loop {
@@ -1499,7 +1496,6 @@ fn decode_coefs<BD: BitDepth>(
                 }
             }
         }
-        // ac_noqm:
         Some(Ac::NoQm) => {
             let ac_dq: c_uint = dq_tbl[1].load(Ordering::Relaxed) as c_uint;
             loop {


### PR DESCRIPTION
The `goto` here is a bit more complex than just a cleanup block at the end of the function, so I think the generated state machine control flow is pretty much the most reasonable way to represent the necessary control flow. So I've just replaced the `current_block` variable with a cleaner enum that does the same thing.