### PR TITLE
`struct RelaxedAtomic`: Replace `Atomic*`s that use only relaxed ops with `RelaxedAtomic`

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -51,6 +51,7 @@ pub mod src {
     mod fg_apply;
     mod filmgrain;
     mod getbits;
+    pub(crate) mod relaxed_atomic;
     mod unstable_extensions;
     pub(crate) mod wrap_fn_ptr;
     // TODO(kkysen) Temporarily `pub(crate)` due to a `pub use` until TAIT.

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -15,7 +15,6 @@ use libc::ptrdiff_t;
 use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
-use std::sync::atomic::Ordering;
 
 bitflags! {
     #[derive(Clone, Copy)]
@@ -208,7 +207,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
             let sb128x = sbx >> 1;
             let sb64_idx = ((by & sbsz) >> 3) + (sbx & 1);
             let cdef_idx = f.lf.mask[(lflvl_offset + sb128x) as usize].cdef_idx[sb64_idx as usize]
-                .load(atomig::Ordering::Relaxed) as c_int;
+                .get() as c_int;
             if cdef_idx == -1
                 || frame_hdr.cdef.y_strength[cdef_idx as usize] == 0
                     && frame_hdr.cdef.uv_strength[cdef_idx as usize] == 0
@@ -218,8 +217,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                 // Create a complete 32-bit mask for the sb row ahead of time.
                 let noskip_row =
                     &f.lf.mask[(lflvl_offset + sb128x) as usize].noskip_mask[by_idx as usize];
-                let noskip_mask = (noskip_row[1].load(Ordering::Relaxed) as u32) << 16
-                    | noskip_row[0].load(Ordering::Relaxed) as u32;
+                let noskip_mask = (noskip_row[1].get() as u32) << 16 | noskip_row[0].get() as u32;
 
                 let y_lvl = frame_hdr.cdef.y_strength[cdef_idx as usize];
                 let uv_lvl = frame_hdr.cdef.uv_strength[cdef_idx as usize];

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -485,8 +485,8 @@ impl Rav1dTask {
     }
 }
 
-impl Clone for Rav1dTask {
-    fn clone(&self) -> Self {
+impl Rav1dTask {
+    pub fn without_next(&self) -> Self {
         Self {
             frame_idx: self.frame_idx,
             tile_idx: self.tile_idx,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -495,7 +495,7 @@ impl Clone for Rav1dTask {
             recon_progress: self.recon_progress,
             deblock_progress: self.deblock_progress,
             deps_skip: AtomicI32::new(self.deps_skip.load(Ordering::Relaxed)),
-            next: Atomic::new(Rav1dTaskIndex::None),
+            next: Default::default(),
         }
     }
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -86,6 +86,7 @@ use crate::src::refmvs::refmvs_temporal_block;
 use crate::src::refmvs::refmvs_tile;
 use crate::src::refmvs::Rav1dRefmvsDSPContext;
 use crate::src::refmvs::RefMvsFrame;
+use crate::src::relaxed_atomic::RelaxedAtomic;
 use crate::src::thread_task::Rav1dTaskIndex;
 use crate::src::thread_task::Rav1dTasks;
 use atomig::Atom;
@@ -102,10 +103,7 @@ use std::ops::Deref;
 use std::ops::Range;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI32;
-use std::sync::atomic::AtomicU16;
 use std::sync::atomic::AtomicU32;
-use std::sync::atomic::AtomicU8;
-use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -319,14 +317,14 @@ pub(crate) struct TaskThreadData {
     pub lock: Mutex<()>,
     pub cond: Condvar,
     pub first: AtomicU32,
-    pub cur: AtomicU32,
+    pub cur: RelaxedAtomic<u32>,
     /// This is used for delayed reset of the task cur pointer when
     /// such operation is needed but the thread doesn't enter a critical
     /// section (typically when executing the next sbrow task locklessly).
     /// See [`crate::src::thread_task::reset_task_cur`].
     pub reset_task_cur: AtomicU32,
     pub cond_signaled: AtomicI32,
-    pub delayed_fg_exec: AtomicI32,
+    pub delayed_fg_exec: RelaxedAtomic<i32>,
     pub delayed_fg_cond: Condvar,
     pub delayed_fg_progress: [AtomicI32; 2], /* [0]=started, [1]=completed */
     pub delayed_fg: RwLock<TaskThreadData_delayed_fg>,
@@ -364,7 +362,7 @@ pub(crate) struct Rav1dContextTaskThread {
 
 impl Rav1dContextTaskThread {
     pub fn flushed(&self) -> bool {
-        self.thread_data.flushed.load(Ordering::Relaxed)
+        self.thread_data.flushed.get()
     }
 }
 
@@ -459,7 +457,7 @@ pub struct Rav1dTask {
     // task dependencies
     pub recon_progress: c_int,
     pub deblock_progress: c_int,
-    pub deps_skip: AtomicI32,
+    pub deps_skip: RelaxedAtomic<i32>,
     // only used in task queue
     pub next: Atomic<Rav1dTaskIndex>,
 }
@@ -494,7 +492,7 @@ impl Rav1dTask {
             sby: self.sby,
             recon_progress: self.recon_progress,
             deblock_progress: self.deblock_progress,
-            deps_skip: AtomicI32::new(self.deps_skip.load(Ordering::Relaxed)),
+            deps_skip: self.deps_skip.clone(),
             next: Default::default(),
         }
     }
@@ -658,12 +656,12 @@ impl Pal {
 #[repr(C)]
 pub struct Rav1dFrameContext_frame_thread {
     /// Indices: 0: reconstruction, 1: entropy.
-    pub next_tile_row: [AtomicI32; 2],
+    pub next_tile_row: [RelaxedAtomic<i32>; 2],
 
     /// Indexed using `t.b.y * f.b4_stride + t.b.x`.
     pub b: DisjointMut<Vec<Av1Block>>,
 
-    pub cbi: Vec<Atomic<CodedBlockInfo>>,
+    pub cbi: Vec<RelaxedAtomic<CodedBlockInfo>>,
 
     /// Indexed using `(t.b.y >> 1) * (f.b4_stride >> 1) + (t.b.x >> 1)`.
     /// Inner indices are `[3 plane][8 idx]`.
@@ -772,8 +770,8 @@ pub(crate) struct Rav1dFrameContext_task_thread {
     pub init_done: AtomicI32,
     pub done: [AtomicI32; 2],
     pub retval: Mutex<Option<Rav1dError>>,
-    pub finished: AtomicBool,   // true when FrameData.tiles is cleared
-    pub update_set: AtomicBool, // whether we need to update CDF reference
+    pub finished: AtomicBool, // true when FrameData.tiles is cleared
+    pub update_set: RelaxedAtomic<bool>, // whether we need to update CDF reference
     pub error: AtomicI32,
     pub task_counter: AtomicI32,
 }
@@ -868,9 +866,9 @@ pub(crate) struct Rav1dFrameData {
     pub sb_shift: c_int,
     pub sb_step: c_int,
     pub sr_sb128w: c_int,
-    pub dq: [[[AtomicU16; 2]; 3]; RAV1D_MAX_SEGMENTS as usize], /* [RAV1D_MAX_SEGMENTS][3 plane][2 dc/ac] */
-    pub qm: [[Option<&'static [u8]>; 3]; 19],                   /* [3 plane][19] */
-    pub a: Vec<BlockContext>,                                   /* len = w*tile_rows */
+    pub dq: [[[RelaxedAtomic<u16>; 2]; 3]; RAV1D_MAX_SEGMENTS as usize], /* [RAV1D_MAX_SEGMENTS][3 plane][2 dc/ac] */
+    pub qm: [[Option<&'static [u8]>; 3]; 19],                            /* [3 plane][19] */
+    pub a: Vec<BlockContext>,                                            /* len = w*tile_rows */
     pub rf: RefMvsFrame,
     pub jnt_weights: [[u8; 7]; 7],
     pub bitdepth_max: c_int,
@@ -912,9 +910,9 @@ pub struct Rav1dTileState_tiling {
 #[derive(Default)]
 #[repr(C)]
 pub struct Rav1dTileState_frame_thread {
-    pub pal_idx: AtomicUsize, // Offset into `f.frame_thread.pal_idx`
-    pub cbi_idx: AtomicUsize, // Offset into `f.frame_thread.cbi`
-    pub cf: AtomicUsize,      // Offset into `f.frame_thread.cf`
+    pub pal_idx: RelaxedAtomic<usize>, // Offset into `f.frame_thread.pal_idx`
+    pub cbi_idx: RelaxedAtomic<usize>, // Offset into `f.frame_thread.cbi`
+    pub cf: RelaxedAtomic<usize>,      // Offset into `f.frame_thread.cf`
 }
 
 #[derive(Default)]
@@ -939,12 +937,12 @@ pub struct Rav1dTileState {
     // each entry is one tile-sbrow; middle index is refidx
     pub lowest_pixel: usize,
 
-    pub dqmem: [[[AtomicU16; 2]; 3]; RAV1D_MAX_SEGMENTS as usize], /* [RAV1D_MAX_SEGMENTS][3 plane][2 dc/ac] */
-    pub dq: Atomic<TileStateRef>,
-    pub last_qidx: AtomicU8,
-    pub last_delta_lf: Atomic<[i8; 4]>,
+    pub dqmem: [[[RelaxedAtomic<u16>; 2]; 3]; RAV1D_MAX_SEGMENTS as usize], /* [RAV1D_MAX_SEGMENTS][3 plane][2 dc/ac] */
+    pub dq: RelaxedAtomic<TileStateRef>,
+    pub last_qidx: RelaxedAtomic<u8>,
+    pub last_delta_lf: RelaxedAtomic<[i8; 4]>,
     pub lflvlmem: RwLock<[Align16<[[[u8; 2]; 8]; 4]>; 8]>, /* [8 seg_id][4 dir][8 ref][2 is_gmv] */
-    pub lflvl: Atomic<TileStateRef>,
+    pub lflvl: RelaxedAtomic<TileStateRef>,
 
     pub lr_ref: RwLock<[Av1RestorationUnit; 3]>,
 }
@@ -1161,19 +1159,19 @@ pub struct Rav1dTaskContext_frame_thread {
 pub(crate) struct Rav1dTaskContext_task_thread {
     pub cond: Condvar,
     pub ttd: Arc<TaskThreadData>,
-    pub flushed: AtomicBool,
-    pub die: AtomicBool,
+    pub flushed: RelaxedAtomic<bool>,
+    pub die: RelaxedAtomic<bool>,
     pub c: Mutex<Option<Arc<Rav1dContext>>>,
 }
 
 impl Rav1dTaskContext_task_thread {
-    pub(crate) const fn new(ttd: Arc<TaskThreadData>) -> Self {
+    pub(crate) fn new(ttd: Arc<TaskThreadData>) -> Self {
         Self {
             cond: Condvar::new(),
             ttd,
-            flushed: AtomicBool::new(false),
-            die: AtomicBool::new(false),
-            c: Mutex::new(None),
+            flushed: Default::default(),
+            die: Default::default(),
+            c: Default::default(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -701,7 +701,9 @@ pub(crate) fn rav1d_flush(c: &Rav1dContext) {
             fc.task_thread.tasks.clear();
         }
         c.task_thread.first.store(0, Ordering::SeqCst);
-        c.task_thread.cur.store(c.fc.len() as u32, Ordering::SeqCst);
+        c.task_thread
+            .cur
+            .store(c.fc.len() as u32, Ordering::Relaxed);
         c.task_thread
             .reset_task_cur
             .store(u32::MAX, Ordering::SeqCst);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,7 @@ pub(crate) fn rav1d_open(s: &Rav1dSettings) -> Rav1dResult<Arc<Rav1dContext>> {
     let NumThreads { n_tc, n_fc } = get_num_threads(s);
 
     let ttd = TaskThreadData {
-        cur: AtomicU32::new(n_fc as u32),
+        cur: (n_fc as u32).into(),
         reset_task_cur: AtomicU32::new(u32::MAX),
         ..Default::default()
     };
@@ -455,9 +455,9 @@ fn drain_picture(c: &Rav1dContext, state: &mut Rav1dState, out: &mut Rav1dPictur
                 Ordering::SeqCst,
                 Ordering::SeqCst,
             );
-            let cur = c.task_thread.cur.load(Ordering::Relaxed);
+            let cur = c.task_thread.cur.get();
             if cur != 0 && (cur as usize) < c.fc.len() {
-                c.task_thread.cur.store(cur - 1, Ordering::Relaxed);
+                c.task_thread.cur.set(cur - 1);
             }
             drained = true;
         } else if drained {
@@ -701,9 +701,7 @@ pub(crate) fn rav1d_flush(c: &Rav1dContext) {
             fc.task_thread.tasks.clear();
         }
         c.task_thread.first.store(0, Ordering::SeqCst);
-        c.task_thread
-            .cur
-            .store(c.fc.len() as u32, Ordering::Relaxed);
+        c.task_thread.cur.set(c.fc.len() as u32);
         c.task_thread
             .reset_task_cur
             .store(u32::MAX, Ordering::SeqCst);
@@ -768,7 +766,7 @@ impl Rav1dContext {
         let ttd = &*self.task_thread;
         let _task_thread_lock = ttd.lock.lock();
         for tc in self.tc.iter() {
-            tc.thread_data.die.store(true, Ordering::Relaxed);
+            tc.thread_data.die.set(true);
         }
         ttd.cond.notify_all();
     }

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2540,10 +2540,10 @@ fn parse_obus(
                         Ordering::SeqCst,
                         Ordering::SeqCst,
                     );
-                    if c.task_thread.cur.load(Ordering::Relaxed) != 0
-                        && (c.task_thread.cur.load(Ordering::Relaxed) as usize) < c.fc.len()
+                    if c.task_thread.cur.get() != 0
+                        && (c.task_thread.cur.get() as usize) < c.fc.len()
                     {
-                        c.task_thread.cur.fetch_sub(1, Ordering::Relaxed);
+                        c.task_thread.cur.update(|cur| cur - 1);
                     }
                 }
                 let error = &mut *fc.task_thread.retval.try_lock().unwrap();

--- a/src/relaxed_atomic.rs
+++ b/src/relaxed_atomic.rs
@@ -1,0 +1,61 @@
+use atomig::Atom;
+use atomig::Atomic;
+use std::sync::atomic::Ordering;
+
+/// A [`Atomic`] type that can only be accessed
+/// through [`Ordering::Relaxed`] loads and stores,
+/// which are essentially normal loads and stores.
+///
+/// This prevents the usage of methods like [`AtomicU8::fetch_or`]
+/// that compile down to contended `lock *` instructions
+/// even with [`Ordering::Relaxed`].
+///
+/// [`AtomicU8::fetch_or`]: std::sync::atomic::AtomicU8::fetch_or
+#[derive(Default)]
+pub struct RelaxedAtomic<T: Atom> {
+    inner: Atomic<T>,
+}
+
+impl<T: Atom> RelaxedAtomic<T> {
+    pub fn new(value: T) -> Self {
+        Self {
+            inner: Atomic::new(value),
+        }
+    }
+
+    pub fn get(&self) -> T {
+        self.inner.load(Ordering::Relaxed)
+    }
+
+    pub fn set(&self, value: T) {
+        self.inner.store(value, Ordering::Relaxed);
+    }
+
+    pub fn update(&self, f: impl Fn(T) -> T) {
+        self.set(f(self.get()));
+    }
+
+    pub fn inner(&self) -> &Atomic<T> {
+        &self.inner
+    }
+}
+
+impl<T: Atom + Copy> RelaxedAtomic<T> {
+    pub fn get_update(&self, f: impl Fn(T) -> T) -> T {
+        let old = self.get();
+        self.set(f(old));
+        old
+    }
+}
+
+impl<T: Atom> Clone for RelaxedAtomic<T> {
+    fn clone(&self) -> Self {
+        Self::new(self.get())
+    }
+}
+
+impl<T: Atom> From<T> for RelaxedAtomic<T> {
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -537,9 +537,7 @@ fn ensure_progress<'l, 'ttd: 'l>(
             type_0,
             recon_progress: 0,
             deblock_progress: t.sby,
-            deps_skip: AtomicI32::new(t.deps_skip.load(Ordering::Relaxed)),
-            next: Default::default(),
-            ..*t
+            ..t.clone()
         };
         f.task_thread.tasks.add_pending(t);
         *task_thread_lock = Some(ttd.lock.lock());
@@ -928,11 +926,9 @@ pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContext_task_thread>) {
                             if (t.sby + 1) < f.sbh {
                                 // add sby+1 to list to replace this one
                                 let next_t = Rav1dTask {
-                                    next: Default::default(),
                                     sby: t.sby + 1,
                                     recon_progress: t.sby + 2,
-                                    deps_skip: AtomicI32::new(t.deps_skip.load(Ordering::Relaxed)),
-                                    ..*t
+                                    ..t.clone()
                                 };
                                 let ntr = f.frame_thread.next_tile_row[p as usize]
                                     .load(Ordering::Relaxed)

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -27,6 +27,7 @@ use crate::src::internal::Rav1dTaskContext_task_thread;
 use crate::src::internal::TaskThreadData;
 use crate::src::internal::TaskType;
 use crate::src::iter::wrapping_iter;
+use crate::src::relaxed_atomic::RelaxedAtomic;
 use atomig::Atom;
 use atomig::Atomic;
 use parking_lot::Mutex;
@@ -44,7 +45,6 @@ use std::ops::Deref;
 use std::process::abort;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI32;
-use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::thread;
@@ -67,14 +67,8 @@ pub const TILE_ERROR: i32 = i32::MAX - 1;
 #[inline]
 fn reset_task_cur(c: &Rav1dContext, ttd: &TaskThreadData, mut frame_idx: c_uint) -> c_int {
     fn curr_found(c: &Rav1dContext, ttd: &TaskThreadData, first: usize) -> c_int {
-        for fc in wrapping_iter(
-            c.fc.iter(),
-            first + ttd.cur.load(Ordering::Relaxed) as usize,
-        ) {
-            fc.task_thread
-                .tasks
-                .cur_prev
-                .store(Rav1dTaskIndex::None, Ordering::Relaxed);
+        for fc in wrapping_iter(c.fc.iter(), first + ttd.cur.get() as usize) {
+            fc.task_thread.tasks.cur_prev.set(Rav1dTaskIndex::None);
         }
         return 1;
     }
@@ -88,23 +82,22 @@ fn reset_task_cur(c: &Rav1dContext, ttd: &TaskThreadData, mut frame_idx: c_uint)
         }
         reset_frame_idx = u32::MAX;
     }
-    if ttd.cur.load(Ordering::Relaxed) == 0
+    if ttd.cur.get() == 0
         && c.fc[first as usize]
             .task_thread
             .tasks
             .cur_prev
-            .load(Ordering::Relaxed)
+            .get()
             .is_none()
     {
         return 0 as c_int;
     }
     if reset_frame_idx != u32::MAX {
         if frame_idx == u32::MAX {
-            if reset_frame_idx > first.wrapping_add(ttd.cur.load(Ordering::Relaxed)) {
+            if reset_frame_idx > first.wrapping_add(ttd.cur.get()) {
                 return 0 as c_int;
             }
-            ttd.cur
-                .store(reset_frame_idx.wrapping_sub(first), Ordering::Relaxed);
+            ttd.cur.set(reset_frame_idx.wrapping_sub(first));
             return curr_found(c, ttd, first as usize);
         }
     } else {
@@ -116,14 +109,13 @@ fn reset_task_cur(c: &Rav1dContext, ttd: &TaskThreadData, mut frame_idx: c_uint)
         frame_idx += c.fc.len() as c_uint;
     }
     min_frame_idx = cmp::min(reset_frame_idx, frame_idx);
-    cur_frame_idx = first.wrapping_add(ttd.cur.load(Ordering::Relaxed));
-    if (ttd.cur.load(Ordering::Relaxed) as usize) < c.fc.len() && cur_frame_idx < min_frame_idx {
+    cur_frame_idx = first.wrapping_add(ttd.cur.get());
+    if (ttd.cur.get() as usize) < c.fc.len() && cur_frame_idx < min_frame_idx {
         return 0 as c_int;
     }
-    ttd.cur
-        .store(min_frame_idx.wrapping_sub(first), Ordering::Relaxed);
-    while (ttd.cur.load(Ordering::Relaxed) as usize) < c.fc.len() {
-        if c.fc[((first + ttd.cur.load(Ordering::Relaxed)) as usize) % c.fc.len()]
+    ttd.cur.set(min_frame_idx.wrapping_sub(first));
+    while (ttd.cur.get() as usize) < c.fc.len() {
+        if c.fc[((first + ttd.cur.get()) as usize) % c.fc.len()]
             .task_thread
             .tasks
             .head
@@ -132,7 +124,7 @@ fn reset_task_cur(c: &Rav1dContext, ttd: &TaskThreadData, mut frame_idx: c_uint)
         {
             break;
         }
-        ttd.cur.fetch_add(1, Ordering::Relaxed);
+        ttd.cur.update(|cur| cur + 1);
     }
     return curr_found(c, ttd, first as usize);
 }
@@ -173,7 +165,7 @@ pub struct Rav1dTasks {
     // This cur pointer is theoretical here, we actually keep track of the
     // "prev_t" variable. This is needed to not loose the tasks in
     // [head;cur-1] when picking one for execution.
-    pub cur_prev: Atomic<Rav1dTaskIndex>,
+    pub cur_prev: RelaxedAtomic<Rav1dTaskIndex>,
 }
 
 impl Rav1dTasks {
@@ -286,7 +278,7 @@ impl Rav1dTasks {
         self.pending_tasks.try_lock().unwrap().clear();
         self.pending_tasks_merge.store(false, Ordering::SeqCst);
         self.head.store(Default::default(), Ordering::Relaxed);
-        self.cur_prev.store(Default::default(), Ordering::Relaxed);
+        self.cur_prev.set(Default::default());
     }
 
     pub fn remove(&self, t: Rav1dTaskIndex, prev_t: Rav1dTaskIndex) -> Option<Rav1dTask> {
@@ -413,15 +405,15 @@ fn create_filter_sbrow(fc: &Rav1dFrameContext, f: &Rav1dFrameData, pass: c_int) 
         let prog_sz = ((f.sbh + 31 & !(31 as c_int)) >> 5) as usize;
         let mut frame = fc.frame_thread_progress.frame.try_write().unwrap();
         frame.clear();
-        frame.resize_with(prog_sz, || AtomicU32::new(0));
+        frame.resize_with(prog_sz, Default::default);
         // copy_lpf is read during task selection, so we are seeing contention
         // here. This seems rare enough that it is not worth optimizing.
         let mut copy_lpf = fc.frame_thread_progress.copy_lpf.write();
         copy_lpf.clear();
-        copy_lpf.resize_with(prog_sz, || AtomicU32::new(0));
+        copy_lpf.resize_with(prog_sz, Default::default);
         fc.frame_thread_progress.deblock.store(0, Ordering::SeqCst);
     }
-    f.frame_thread.next_tile_row[(pass & 1) as usize].store(0, Ordering::Relaxed);
+    f.frame_thread.next_tile_row[(pass & 1) as usize].set(0);
     let type_0 = if pass == 1 {
         TaskType::EntropyProgress
     } else if has_deblock != 0 {
@@ -465,7 +457,7 @@ pub(crate) fn rav1d_task_create_tile_sbrow(
                 sby: ts.tiling.row_start >> f.sb_shift,
                 recon_progress: 0,
                 deblock_progress: 0,
-                deps_skip: AtomicI32::new(0),
+                deps_skip: 0.into(),
                 type_0: if pass != 1 {
                     TaskType::TileReconstruction
                 } else {
@@ -512,7 +504,7 @@ pub(crate) fn rav1d_task_delayed_fg(c: &Rav1dContext, out: &mut Rav1dPicture, in
         }
     }
     let mut task_thread_lock = ttd.lock.lock();
-    ttd.delayed_fg_exec.store(1, Ordering::Relaxed);
+    ttd.delayed_fg_exec.set(1);
     ttd.cond.notify_one();
     ttd.delayed_fg_cond.wait(&mut task_thread_lock);
     drop(task_thread_lock);
@@ -580,7 +572,7 @@ fn check_tile(
         let lowest_px = f
             .lowest_pixel_mem
             .index(ts.lowest_pixel + tile_sby as usize);
-        for n in t.deps_skip.load(Ordering::Relaxed)..7 {
+        for n in t.deps_skip.get()..7 {
             'next: {
                 let lowest = if tp {
                     // if temporal mv refs are disabled, we only need this
@@ -615,7 +607,7 @@ fn check_tile(
                     .fetch_or((p3 == FRAME_ERROR) as c_int, Ordering::SeqCst);
             }
             // next:
-            t.deps_skip.fetch_add(1, Ordering::Relaxed);
+            t.deps_skip.update(|it| it + 1);
         }
     }
     return 0;
@@ -678,7 +670,7 @@ fn delayed_fg_task<'l, 'ttd: 'l>(
     let mut done;
     match delayed_fg_type {
         TaskType::FgPrep => {
-            ttd.delayed_fg_exec.store(0, Ordering::Relaxed);
+            ttd.delayed_fg_exec.set(0);
             if ttd.cond_signaled.load(Ordering::SeqCst) != 0 {
                 ttd.cond.notify_one();
             }
@@ -710,7 +702,7 @@ fn delayed_fg_task<'l, 'ttd: 'l>(
                 }
             }
             delayed_fg.type_0 = TaskType::FgApply;
-            ttd.delayed_fg_exec.store(1, Ordering::Relaxed);
+            ttd.delayed_fg_exec.set(1);
         }
         TaskType::FgApply => {}
         _ => {
@@ -726,7 +718,7 @@ fn delayed_fg_task<'l, 'ttd: 'l>(
             ttd.cond.notify_one();
         } else if row + 1 >= progmax {
             *task_thread_lock = Some(ttd.lock.lock());
-            ttd.delayed_fg_exec.store(0, Ordering::Relaxed);
+            ttd.delayed_fg_exec.set(0);
             if row >= progmax {
                 break;
             }
@@ -770,7 +762,7 @@ fn delayed_fg_task<'l, 'ttd: 'l>(
             continue;
         }
         *task_thread_lock = Some(ttd.lock.lock());
-        ttd.delayed_fg_exec.store(0, Ordering::Relaxed);
+        ttd.delayed_fg_exec.set(0);
         break;
     }
     done = ttd.delayed_fg_progress[1].fetch_add(1, Ordering::SeqCst) + 1;
@@ -797,24 +789,24 @@ pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContext_task_thread>) {
         ttd: &TaskThreadData,
         task_thread_lock: &mut MutexGuard<'ttd, ()>,
     ) {
-        tc.task_thread.flushed.store(true, Ordering::Relaxed);
+        tc.task_thread.flushed.set(true);
         tc.task_thread.cond.notify_one();
         // we want to be woken up next time progress is signaled
         ttd.cond_signaled.store(0, Ordering::SeqCst);
         ttd.cond.wait(task_thread_lock);
-        tc.task_thread.flushed.store(false, Ordering::Relaxed);
+        tc.task_thread.flushed.set(false);
         reset_task_cur(c, ttd, u32::MAX);
     }
 
     let mut task_thread_lock = Some(ttd.lock.lock());
-    'outer: while !tc.task_thread.die.load(Ordering::Relaxed) {
+    'outer: while !tc.task_thread.die.get() {
         if c.flush.load(Ordering::SeqCst) {
             park(c, &mut tc, ttd, task_thread_lock.as_mut().unwrap());
             continue 'outer;
         }
 
         merge_pending(c);
-        if ttd.delayed_fg_exec.load(Ordering::Relaxed) != 0 {
+        if ttd.delayed_fg_exec.get() != 0 {
             // run delayed film grain first
             delayed_fg_task(ttd, &mut task_thread_lock);
             continue 'outer;
@@ -862,12 +854,12 @@ pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContext_task_thread>) {
                 }
             }
             // run decoding tasks last
-            while (ttd.cur.load(Ordering::Relaxed) as usize) < c.fc.len() {
+            while (ttd.cur.get() as usize) < c.fc.len() {
                 let first = ttd.first.load(Ordering::SeqCst);
-                let fc = &c.fc[(first + ttd.cur.load(Ordering::Relaxed)) as usize % c.fc.len()];
+                let fc = &c.fc[(first + ttd.cur.get()) as usize % c.fc.len()];
                 let tasks = &fc.task_thread.tasks;
                 tasks.merge_pending_frame(c);
-                let mut prev_t = tasks.cur_prev.load(Ordering::Relaxed);
+                let mut prev_t = tasks.cur_prev.get();
                 let mut t_idx = if prev_t.is_some() {
                     tasks.index(prev_t).next()
                 } else {
@@ -903,7 +895,7 @@ pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContext_task_thread>) {
                             assert!(done == 0 || error != 0, "done: {done}, error: {error}");
                             let frame_hdr = fc.frame_hdr();
                             let tile_row_base = frame_hdr.tiling.cols as c_int
-                                * f.frame_thread.next_tile_row[p as usize].load(Ordering::Relaxed);
+                                * f.frame_thread.next_tile_row[p as usize].get();
                             if p {
                                 let p1_0 = fc.frame_thread_progress.entropy.load(Ordering::SeqCst);
                                 if p1_0 < t.sby {
@@ -930,13 +922,10 @@ pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContext_task_thread>) {
                                     recon_progress: t.sby + 2,
                                     ..t.without_next()
                                 };
-                                let ntr = f.frame_thread.next_tile_row[p as usize]
-                                    .load(Ordering::Relaxed)
-                                    + 1;
+                                let ntr = f.frame_thread.next_tile_row[p as usize].get() + 1;
                                 let start = frame_hdr.tiling.row_start_sb[ntr as usize] as c_int;
                                 if next_t.sby == start {
-                                    f.frame_thread.next_tile_row[p as usize]
-                                        .store(ntr, Ordering::Relaxed);
+                                    f.frame_thread.next_tile_row[p as usize].set(ntr);
                                 }
                                 drop(t);
                                 fc.task_thread.insert_task(c, next_t, 0);
@@ -965,9 +954,9 @@ pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContext_task_thread>) {
                     // next:
                     prev_t = t_idx;
                     t_idx = t.next();
-                    tasks.cur_prev.store(prev_t, Ordering::Relaxed);
+                    tasks.cur_prev.set(prev_t);
                 }
-                ttd.cur.fetch_add(1, Ordering::Relaxed);
+                ttd.cur.update(|cur| cur + 1);
             }
             if reset_task_cur(c, ttd, u32::MAX) != 0 {
                 continue 'outer;
@@ -988,7 +977,7 @@ pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContext_task_thread>) {
         if t.type_0 > TaskType::InitCdf
             && fc.task_thread.tasks.head.load(Ordering::SeqCst).is_none()
         {
-            ttd.cur.fetch_add(1, Ordering::Relaxed);
+            ttd.cur.update(|cur| cur + 1);
         }
         // we don't need to check cond_signaled here, since we found a task
         // after the last signal so we want to re-signal the next waiting thread
@@ -1042,9 +1031,7 @@ pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContext_task_thread>) {
                             res_0 = rav1d_decode_frame_init_cdf(c, fc, &mut f, &fc.in_cdf());
                         }
                         let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
-                        if frame_hdr.refresh_context != 0
-                            && !fc.task_thread.update_set.load(Ordering::Relaxed)
-                        {
+                        if frame_hdr.refresh_context != 0 && !fc.task_thread.update_set.get() {
                             f.out_cdf.progress().unwrap().store(
                                 (if res_0.is_err() {
                                     TILE_ERROR
@@ -1140,7 +1127,7 @@ pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContext_task_thread>) {
                         fc.task_thread.error.fetch_or(error_0, Ordering::SeqCst);
                         if (sby + 1) << f.sb_shift < ts.tiling.row_end {
                             t.sby += 1;
-                            t.deps_skip = AtomicI32::new(0);
+                            t.deps_skip = 0.into();
                             if check_tile(&f, &fc.task_thread, &t, uses_2pass) == 0 {
                                 ts.progress[p_1 as usize].store(progress, Ordering::SeqCst);
                                 reset_task_cur_async(ttd, t.frame_idx, c.fc.len() as u32);
@@ -1163,7 +1150,7 @@ pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContext_task_thread>) {
                             let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
                             if frame_hdr.refresh_context != 0
                                 && tc.frame_thread.pass <= 1
-                                && fc.task_thread.update_set.load(Ordering::Relaxed)
+                                && fc.task_thread.update_set.get()
                                 && frame_hdr.tiling.update as usize == tile_idx
                             {
                                 if error_0 == 0 {

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -302,7 +302,7 @@ impl Rav1dTasks {
                 .ok()?;
         }
         self.index(t).set_next(Rav1dTaskIndex::None);
-        Some(self.index(t).clone())
+        Some(self.index(t).without_next())
     }
 
     #[inline]
@@ -537,7 +537,7 @@ fn ensure_progress<'l, 'ttd: 'l>(
             type_0,
             recon_progress: 0,
             deblock_progress: t.sby,
-            ..t.clone()
+            ..t.without_next()
         };
         f.task_thread.tasks.add_pending(t);
         *task_thread_lock = Some(ttd.lock.lock());
@@ -928,7 +928,7 @@ pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContext_task_thread>) {
                                 let next_t = Rav1dTask {
                                     sby: t.sby + 1,
                                     recon_progress: t.sby + 2,
-                                    ..t.clone()
+                                    ..t.without_next()
                                 };
                                 let ntr = f.frame_thread.next_tile_row[p as usize]
                                     .load(Ordering::Relaxed)


### PR DESCRIPTION
* Fixes #1173.

`RelaxedAtomic` requires `Ordering::Relaxed` loads and stores, disallowing other relaxed ops like `.fetch_or`.  The former are always plain loads and stores, while the latter are contended `lock *` instructions, so this ensures `RelaxedAtomic`s have little to no overhead.  It also makes clear which types are meant to be fully relaxed.

This should fix #1173 because it removes all relaxed `.fetch_*`es and replaces them with `.update`s, which do separate relaxed loads and stores, which don't have overhead.  This may replace an `add` with a load, `add`, and store, for example, but it gets rid of the `lock add`, which can cause contention, so it should generally have little to no overhead over no atomics at all.