### PR TITLE
`fn filter_plane_{cols,rows}_{y,uv}`: Refactor, cleanup, and optimize

### DIFF
--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -418,10 +418,11 @@ unsafe fn filter_plane_rows_y<BD: BitDepth>(
     //                                 block2
     for (y, lvl) in (starty4..endy4).zip(lvl.chunks(b4_stride)) {
         if !(!have_top && y == 0) {
+            let mask = &mask[y];
             let vmask = [
-                mask[y][0][0].get() as u32 | (mask[y][0][1].get() as u32) << 16,
-                mask[y][1][0].get() as u32 | (mask[y][1][1].get() as u32) << 16,
-                mask[y][2][0].get() as u32 | (mask[y][2][1].get() as u32) << 16,
+                mask[0][0].get() as u32 | (mask[0][1].get() as u32) << 16,
+                mask[1][0].get() as u32 | (mask[1][1].get() as u32) << 16,
+                mask[2][0].get() as u32 | (mask[2][1].get() as u32) << 16,
             ];
             f.dsp.lf.loop_filter_sb.y.v.call::<BD>(
                 f,

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -372,21 +372,25 @@ unsafe fn filter_plane_cols_y<BD: BitDepth>(
             continue;
         }
         let mask = &mask[x];
-        let mut hmask: [u32; 3] = [0; 3];
-        if starty4 == 0 {
-            hmask[0] = mask[0][0].get() as u32;
-            hmask[1] = mask[1][0].get() as u32;
-            hmask[2] = mask[2][0].get() as u32;
+        let hmask = if starty4 == 0 {
+            let mut hmask = [
+                mask[0][0].get() as u32,
+                mask[1][0].get() as u32,
+                mask[2][0].get() as u32,
+            ];
             if endy4 > 16 {
                 hmask[0] |= (mask[0][1].get() as u32) << 16;
                 hmask[1] |= (mask[1][1].get() as u32) << 16;
                 hmask[2] |= (mask[2][1].get() as u32) << 16;
             }
+            hmask
         } else {
-            hmask[0] = mask[0][1].get() as u32;
-            hmask[1] = mask[1][1].get() as u32;
-            hmask[2] = mask[2][1].get() as u32;
-        }
+            [
+                mask[0][1].get() as u32,
+                mask[1][1].get() as u32,
+                mask[2][1].get() as u32,
+            ]
+        };
         f.dsp.lf.loop_filter_sb.y.h.call::<BD>(
             f,
             y_dst + x * 4,

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -410,18 +410,18 @@ unsafe fn filter_plane_rows_y<BD: BitDepth>(
     mask: &[[[RelaxedAtomic<u16>; 2]; 3]; 32],
     mut y_dst: Rav1dPictureDataComponentOffset,
     w: c_int,
-    starty4: c_int,
-    endy4: c_int,
+    starty4: usize,
+    endy4: usize,
 ) {
     //                                 block1
     // filter edges between rows (e.g. ------)
     //                                 block2
-    for (y, lvl) in (starty4..endy4).zip(lvl.chunks(b4_stride as usize)) {
+    for (y, lvl) in (starty4..endy4).zip(lvl.chunks(b4_stride)) {
         if !(!have_top && y == 0) {
             let vmask = [
-                mask[y as usize][0][0].get() as u32 | (mask[y as usize][0][1].get() as u32) << 16,
-                mask[y as usize][1][0].get() as u32 | (mask[y as usize][1][1].get() as u32) << 16,
-                mask[y as usize][2][0].get() as u32 | (mask[y as usize][2][1].get() as u32) << 16,
+                mask[y][0][0].get() as u32 | (mask[y][0][1].get() as u32) << 16,
+                mask[y][1][0].get() as u32 | (mask[y][1][1].get() as u32) << 16,
+                mask[y][2][0].get() as u32 | (mask[y][2][1].get() as u32) << 16,
             ];
             f.dsp.lf.loop_filter_sb.y.v.call::<BD>(
                 f,
@@ -714,8 +714,8 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_rows<BD: BitDepth>(
             &lflvl[x].filter_y[1],
             p[0] + 128 * x,
             cmp::min(32, f.w4 - x as c_int * 32),
-            starty4,
-            endy4 as c_int,
+            starty4 as usize,
+            endy4 as usize,
         );
         level_ptr = &level_ptr[32..];
     }

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -383,7 +383,7 @@ unsafe fn filter_plane_cols_y<BD: BitDepth>(
                 hmask[1] = mask[x][1][1].get() as u32;
                 hmask[2] = mask[x][2][1].get() as u32;
             }
-            f.dsp.lf.loop_filter_sb[0][0].call::<BD>(
+            f.dsp.lf.loop_filter_sb.y.h.call::<BD>(
                 f,
                 y_dst + x * 4,
                 &hmask,
@@ -416,7 +416,7 @@ unsafe fn filter_plane_rows_y<BD: BitDepth>(
                 mask[y as usize][1][0].get() as u32 | (mask[y as usize][1][1].get() as u32) << 16,
                 mask[y as usize][2][0].get() as u32 | (mask[y as usize][2][1].get() as u32) << 16,
             ];
-            f.dsp.lf.loop_filter_sb[0][1].call::<BD>(
+            f.dsp.lf.loop_filter_sb.y.v.call::<BD>(
                 f,
                 y_dst,
                 &vmask,
@@ -457,14 +457,14 @@ unsafe fn filter_plane_cols_uv<BD: BitDepth>(
                 hmask[1] = mask[x as usize][1][1].get() as u32;
             }
             // hmask[2] = 0; Already initialized to 0 above
-            f.dsp.lf.loop_filter_sb[1][0].call::<BD>(
+            f.dsp.lf.loop_filter_sb.uv.h.call::<BD>(
                 f,
                 u_dst + x * 4,
                 &hmask,
                 unaligned_lvl_slice(&lvl[x as usize..], 2),
                 endy4 - starty4,
             );
-            f.dsp.lf.loop_filter_sb[1][0].call::<BD>(
+            f.dsp.lf.loop_filter_sb.uv.h.call::<BD>(
                 f,
                 v_dst + x * 4,
                 &hmask,
@@ -501,14 +501,14 @@ unsafe fn filter_plane_rows_uv<BD: BitDepth>(
                     | (mask[y as usize][1][1].get() as u32) << (16 >> ss_hor),
                 0,
             ];
-            f.dsp.lf.loop_filter_sb[1][1].call::<BD>(
+            f.dsp.lf.loop_filter_sb.uv.v.call::<BD>(
                 f,
                 u_dst,
                 &vmask,
                 unaligned_lvl_slice(&lvl[0..], 2),
                 w,
             );
-            f.dsp.lf.loop_filter_sb[1][1].call::<BD>(
+            f.dsp.lf.loop_filter_sb.uv.v.call::<BD>(
                 f,
                 v_dst,
                 &vmask,

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -440,6 +440,7 @@ unsafe fn filter_plane_cols_uv<BD: BitDepth>(
 ) {
     // filter edges between columns (e.g. block1 | block2)
     let mask = &mask[..w];
+    let lvl = &lvl[..w];
     for x in 0..w {
         if !have_left && x == 0 {
             continue;
@@ -456,18 +457,19 @@ unsafe fn filter_plane_cols_uv<BD: BitDepth>(
             mask.each_ref().map(|[_, b]| b.get() as u32)
         };
         let hmask = [hmask[0], hmask[1], 0];
+        let lvl = &lvl[x..];
         f.dsp.lf.loop_filter_sb.uv.h.call::<BD>(
             f,
             u_dst + x * 4,
             &hmask,
-            unaligned_lvl_slice(&lvl[x as usize..], 2),
+            unaligned_lvl_slice(lvl, 2),
             endy4 - starty4,
         );
         f.dsp.lf.loop_filter_sb.uv.h.call::<BD>(
             f,
             v_dst + x * 4,
             &hmask,
-            unaligned_lvl_slice(&lvl[x as usize..], 3),
+            unaligned_lvl_slice(lvl, 3),
             endy4 - starty4,
         );
     }

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -367,30 +367,31 @@ unsafe fn filter_plane_cols_y<BD: BitDepth>(
 ) {
     // filter edges between columns (e.g. block1 | block2)
     for x in 0..w {
-        if !(!have_left && x == 0) {
-            let mut hmask: [u32; 3] = [0; 3];
-            if starty4 == 0 {
-                hmask[0] = mask[x][0][0].get() as u32;
-                hmask[1] = mask[x][1][0].get() as u32;
-                hmask[2] = mask[x][2][0].get() as u32;
-                if endy4 > 16 {
-                    hmask[0] |= (mask[x][0][1].get() as u32) << 16;
-                    hmask[1] |= (mask[x][1][1].get() as u32) << 16;
-                    hmask[2] |= (mask[x][2][1].get() as u32) << 16;
-                }
-            } else {
-                hmask[0] = mask[x][0][1].get() as u32;
-                hmask[1] = mask[x][1][1].get() as u32;
-                hmask[2] = mask[x][2][1].get() as u32;
-            }
-            f.dsp.lf.loop_filter_sb.y.h.call::<BD>(
-                f,
-                y_dst + x * 4,
-                &hmask,
-                &lvl[x..],
-                endy4 - starty4,
-            );
+        if !have_left && x == 0 {
+            continue;
         }
+        let mut hmask: [u32; 3] = [0; 3];
+        if starty4 == 0 {
+            hmask[0] = mask[x][0][0].get() as u32;
+            hmask[1] = mask[x][1][0].get() as u32;
+            hmask[2] = mask[x][2][0].get() as u32;
+            if endy4 > 16 {
+                hmask[0] |= (mask[x][0][1].get() as u32) << 16;
+                hmask[1] |= (mask[x][1][1].get() as u32) << 16;
+                hmask[2] |= (mask[x][2][1].get() as u32) << 16;
+            }
+        } else {
+            hmask[0] = mask[x][0][1].get() as u32;
+            hmask[1] = mask[x][1][1].get() as u32;
+            hmask[2] = mask[x][2][1].get() as u32;
+        }
+        f.dsp.lf.loop_filter_sb.y.h.call::<BD>(
+            f,
+            y_dst + x * 4,
+            &hmask,
+            &lvl[x..],
+            endy4 - starty4,
+        );
     }
 }
 

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -441,17 +441,18 @@ unsafe fn filter_plane_cols_uv<BD: BitDepth>(
     // filter edges between columns (e.g. block1 | block2)
     for x in 0..w {
         if !(!have_left && x == 0) {
+            let mask = &mask[x];
             let mut hmask: [u32; 3] = [0; 3];
             if starty4 == 0 {
-                hmask[0] = mask[x as usize][0][0].get() as u32;
-                hmask[1] = mask[x as usize][1][0].get() as u32;
+                hmask[0] = mask[0][0].get() as u32;
+                hmask[1] = mask[1][0].get() as u32;
                 if endy4 > 16 >> ss_ver {
-                    hmask[0] |= (mask[x as usize][0][1].get() as u32) << (16 >> ss_ver);
-                    hmask[1] |= (mask[x as usize][1][1].get() as u32) << (16 >> ss_ver);
+                    hmask[0] |= (mask[0][1].get() as u32) << (16 >> ss_ver);
+                    hmask[1] |= (mask[1][1].get() as u32) << (16 >> ss_ver);
                 }
             } else {
-                hmask[0] = mask[x as usize][0][1].get() as u32;
-                hmask[1] = mask[x as usize][1][1].get() as u32;
+                hmask[0] = mask[0][1].get() as u32;
+                hmask[1] = mask[1][1].get() as u32;
             }
             // hmask[2] = 0; Already initialized to 0 above
             f.dsp.lf.loop_filter_sb.uv.h.call::<BD>(

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -393,6 +393,7 @@ unsafe fn filter_plane_rows_y<BD: BitDepth>(
     //                                 block2
     let lf_sb = &f.dsp.lf.loop_filter_sb;
     let len = endy4 - starty4;
+    let lvl = &lvl[..1 + (len - 1) * b4_stride];
     for i in 0..len {
         let y = i + starty4;
         let y_dst = y_dst + (i as isize * 4 * y_dst.data.pixel_stride::<BD>());
@@ -469,6 +470,7 @@ unsafe fn filter_plane_rows_uv<BD: BitDepth>(
     //                                 block2
     let lf_sb = &f.dsp.lf.loop_filter_sb;
     let len = endy4 - starty4;
+    let lvl = &lvl[..1 + (len - 1) * b4_stride];
     for i in 0..len {
         let y = i + starty4;
         let u_dst = u_dst + (i as isize * 4 * u_dst.data.pixel_stride::<BD>());

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -366,6 +366,7 @@ unsafe fn filter_plane_cols_y<BD: BitDepth>(
     endy4: c_int,
 ) {
     // filter edges between columns (e.g. block1 | block2)
+    let mask = &mask[..w];
     for x in 0..w {
         if !have_left && x == 0 {
             continue;

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -433,13 +433,13 @@ unsafe fn filter_plane_cols_uv<BD: BitDepth>(
     mask: &[[[RelaxedAtomic<u16>; 2]; 2]; 32],
     u_dst: Rav1dPictureDataComponentOffset,
     v_dst: Rav1dPictureDataComponentOffset,
-    w: c_int,
+    w: usize,
     starty4: c_int,
     endy4: c_int,
     ss_ver: c_int,
 ) {
     // filter edges between columns (e.g. block1 | block2)
-    for x in 0..w as usize {
+    for x in 0..w {
         if !(!have_left && x == 0) {
             let mut hmask: [u32; 3] = [0; 3];
             if starty4 == 0 {
@@ -662,7 +662,7 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
             &lflvl[x].filter_uv[0],
             pu + x * (128 >> ss_hor),
             pv + x * (128 >> ss_hor),
-            cmp::min(32, f.w4 - x as c_int * 32) + ss_hor >> ss_hor,
+            (cmp::min(32, f.w4 - x as c_int * 32) + ss_hor >> ss_hor) as usize,
             starty4 as c_int >> ss_ver,
             uv_endy4 as c_int,
             ss_ver,

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -485,8 +485,8 @@ unsafe fn filter_plane_rows_uv<BD: BitDepth>(
     mut u_dst: Rav1dPictureDataComponentOffset,
     mut v_dst: Rav1dPictureDataComponentOffset,
     w: c_int,
-    starty4: c_int,
-    endy4: c_int,
+    starty4: usize,
+    endy4: usize,
     ss_hor: c_int,
 ) {
     //                                 block1
@@ -495,10 +495,8 @@ unsafe fn filter_plane_rows_uv<BD: BitDepth>(
     for (y, lvl) in (starty4..endy4).zip(lvl.chunks(b4_stride as usize)) {
         if !(!have_top && y == 0) {
             let vmask: [u32; 3] = [
-                mask[y as usize][0][0].get() as u32
-                    | (mask[y as usize][0][1].get() as u32) << (16 >> ss_hor),
-                mask[y as usize][1][0].get() as u32
-                    | (mask[y as usize][1][1].get() as u32) << (16 >> ss_hor),
+                mask[y][0][0].get() as u32 | (mask[y][0][1].get() as u32) << (16 >> ss_hor),
+                mask[y][1][0].get() as u32 | (mask[y][1][1].get() as u32) << (16 >> ss_hor),
                 0,
             ];
             f.dsp.lf.loop_filter_sb.uv.v.call::<BD>(
@@ -733,8 +731,8 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_rows<BD: BitDepth>(
             pu + (x * 128 >> ss_hor),
             pv + (x * 128 >> ss_hor),
             cmp::min(32 as c_int, f.w4 - x as c_int * 32) + ss_hor >> ss_hor,
-            starty4 >> ss_ver,
-            uv_endy4 as c_int,
+            starty4 as usize >> ss_ver,
+            uv_endy4 as usize,
             ss_hor,
         );
         level_ptr = &level_ptr[32 >> ss_hor..];

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -361,12 +361,12 @@ unsafe fn filter_plane_cols_y<BD: BitDepth>(
     lvl: &[[u8; 4]],
     mask: &[[[RelaxedAtomic<u16>; 2]; 3]; 32],
     y_dst: Rav1dPictureDataComponentOffset,
-    w: c_int,
+    w: usize,
     starty4: c_int,
     endy4: c_int,
 ) {
     // filter edges between columns (e.g. block1 | block2)
-    for x in 0..w as usize {
+    for x in 0..w {
         if !(!have_left && x == 0) {
             let mut hmask: [u32; 3] = [0; 3];
             if starty4 == 0 {
@@ -642,7 +642,7 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
             level_ptr,
             &lflvl[x].filter_y[0],
             py + x * 128,
-            cmp::min(32, f.w4 - x as c_int * 32),
+            cmp::min(32, f.w4 - x as c_int * 32) as usize,
             starty4 as c_int,
             endy4 as c_int,
         );

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -419,11 +419,9 @@ unsafe fn filter_plane_rows_y<BD: BitDepth>(
     for (y, lvl) in (starty4..endy4).zip(lvl.chunks(b4_stride)) {
         if !(!have_top && y == 0) {
             let mask = &mask[y];
-            let vmask = [
-                mask[0][0].get() as u32 | (mask[0][1].get() as u32) << 16,
-                mask[1][0].get() as u32 | (mask[1][1].get() as u32) << 16,
-                mask[2][0].get() as u32 | (mask[2][1].get() as u32) << 16,
-            ];
+            let vmask = mask
+                .each_ref()
+                .map(|[a, b]| a.get() as u32 | ((b.get() as u32) << 16));
             f.dsp.lf.loop_filter_sb.y.v.call::<BD>(
                 f,
                 y_dst,

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -373,23 +373,14 @@ unsafe fn filter_plane_cols_y<BD: BitDepth>(
         }
         let mask = &mask[x];
         let hmask = if starty4 == 0 {
-            let mut hmask = [
-                mask[0][0].get() as u32,
-                mask[1][0].get() as u32,
-                mask[2][0].get() as u32,
-            ];
             if endy4 > 16 {
-                hmask[0] |= (mask[0][1].get() as u32) << 16;
-                hmask[1] |= (mask[1][1].get() as u32) << 16;
-                hmask[2] |= (mask[2][1].get() as u32) << 16;
+                mask.each_ref()
+                    .map(|[a, b]| a.get() as u32 | ((b.get() as u32) << 16))
+            } else {
+                mask.each_ref().map(|[a, _]| a.get() as u32)
             }
-            hmask
         } else {
-            [
-                mask[0][1].get() as u32,
-                mask[1][1].get() as u32,
-                mask[2][1].get() as u32,
-            ]
+            mask.each_ref().map(|[_, b]| b.get() as u32)
         };
         f.dsp.lf.loop_filter_sb.y.h.call::<BD>(
             f,

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -441,36 +441,37 @@ unsafe fn filter_plane_cols_uv<BD: BitDepth>(
     // filter edges between columns (e.g. block1 | block2)
     let mask = &mask[..w];
     for x in 0..w {
-        if !(!have_left && x == 0) {
-            let mask = &mask[x];
-            let mut hmask: [u32; 3] = [0; 3];
-            if starty4 == 0 {
-                hmask[0] = mask[0][0].get() as u32;
-                hmask[1] = mask[1][0].get() as u32;
-                if endy4 > 16 >> ss_ver {
-                    hmask[0] |= (mask[0][1].get() as u32) << (16 >> ss_ver);
-                    hmask[1] |= (mask[1][1].get() as u32) << (16 >> ss_ver);
-                }
-            } else {
-                hmask[0] = mask[0][1].get() as u32;
-                hmask[1] = mask[1][1].get() as u32;
-            }
-            // hmask[2] = 0; Already initialized to 0 above
-            f.dsp.lf.loop_filter_sb.uv.h.call::<BD>(
-                f,
-                u_dst + x * 4,
-                &hmask,
-                unaligned_lvl_slice(&lvl[x as usize..], 2),
-                endy4 - starty4,
-            );
-            f.dsp.lf.loop_filter_sb.uv.h.call::<BD>(
-                f,
-                v_dst + x * 4,
-                &hmask,
-                unaligned_lvl_slice(&lvl[x as usize..], 3),
-                endy4 - starty4,
-            );
+        if !have_left && x == 0 {
+            continue;
         }
+        let mask = &mask[x];
+        let mut hmask: [u32; 3] = [0; 3];
+        if starty4 == 0 {
+            hmask[0] = mask[0][0].get() as u32;
+            hmask[1] = mask[1][0].get() as u32;
+            if endy4 > 16 >> ss_ver {
+                hmask[0] |= (mask[0][1].get() as u32) << (16 >> ss_ver);
+                hmask[1] |= (mask[1][1].get() as u32) << (16 >> ss_ver);
+            }
+        } else {
+            hmask[0] = mask[0][1].get() as u32;
+            hmask[1] = mask[1][1].get() as u32;
+        }
+        // hmask[2] = 0; Already initialized to 0 above
+        f.dsp.lf.loop_filter_sb.uv.h.call::<BD>(
+            f,
+            u_dst + x * 4,
+            &hmask,
+            unaligned_lvl_slice(&lvl[x as usize..], 2),
+            endy4 - starty4,
+        );
+        f.dsp.lf.loop_filter_sb.uv.h.call::<BD>(
+            f,
+            v_dst + x * 4,
+            &hmask,
+            unaligned_lvl_slice(&lvl[x as usize..], 3),
+            endy4 - starty4,
+        );
     }
 }
 

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -371,20 +371,21 @@ unsafe fn filter_plane_cols_y<BD: BitDepth>(
         if !have_left && x == 0 {
             continue;
         }
+        let mask = &mask[x];
         let mut hmask: [u32; 3] = [0; 3];
         if starty4 == 0 {
-            hmask[0] = mask[x][0][0].get() as u32;
-            hmask[1] = mask[x][1][0].get() as u32;
-            hmask[2] = mask[x][2][0].get() as u32;
+            hmask[0] = mask[0][0].get() as u32;
+            hmask[1] = mask[1][0].get() as u32;
+            hmask[2] = mask[2][0].get() as u32;
             if endy4 > 16 {
-                hmask[0] |= (mask[x][0][1].get() as u32) << 16;
-                hmask[1] |= (mask[x][1][1].get() as u32) << 16;
-                hmask[2] |= (mask[x][2][1].get() as u32) << 16;
+                hmask[0] |= (mask[0][1].get() as u32) << 16;
+                hmask[1] |= (mask[1][1].get() as u32) << 16;
+                hmask[2] |= (mask[2][1].get() as u32) << 16;
             }
         } else {
-            hmask[0] = mask[x][0][1].get() as u32;
-            hmask[1] = mask[x][1][1].get() as u32;
-            hmask[2] = mask[x][2][1].get() as u32;
+            hmask[0] = mask[0][1].get() as u32;
+            hmask[1] = mask[1][1].get() as u32;
+            hmask[2] = mask[2][1].get() as u32;
         }
         f.dsp.lf.loop_filter_sb.y.h.call::<BD>(
             f,

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -439,6 +439,7 @@ unsafe fn filter_plane_cols_uv<BD: BitDepth>(
     ss_ver: c_int,
 ) {
     // filter edges between columns (e.g. block1 | block2)
+    let mask = &mask[..w];
     for x in 0..w {
         if !(!have_left && x == 0) {
             let mask = &mask[x];

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -362,8 +362,8 @@ unsafe fn filter_plane_cols_y<BD: BitDepth>(
     mask: &[[[RelaxedAtomic<u16>; 2]; 3]; 32],
     y_dst: Rav1dPictureDataComponentOffset,
     w: usize,
-    starty4: c_int,
-    endy4: c_int,
+    starty4: usize,
+    endy4: usize,
 ) {
     // filter edges between columns (e.g. block1 | block2)
     let mask = &mask[..w];
@@ -400,7 +400,7 @@ unsafe fn filter_plane_rows_y<BD: BitDepth>(
     b4_stride: usize,
     mask: &[[[RelaxedAtomic<u16>; 2]; 3]; 32],
     mut y_dst: Rav1dPictureDataComponentOffset,
-    w: c_int,
+    w: usize,
     starty4: usize,
     endy4: usize,
 ) {
@@ -434,8 +434,8 @@ unsafe fn filter_plane_cols_uv<BD: BitDepth>(
     u_dst: Rav1dPictureDataComponentOffset,
     v_dst: Rav1dPictureDataComponentOffset,
     w: usize,
-    starty4: c_int,
-    endy4: c_int,
+    starty4: usize,
+    endy4: usize,
     ss_ver: c_int,
 ) {
     // filter edges between columns (e.g. block1 | block2)
@@ -484,7 +484,7 @@ unsafe fn filter_plane_rows_uv<BD: BitDepth>(
     mask: &[[[RelaxedAtomic<u16>; 2]; 2]; 32],
     mut u_dst: Rav1dPictureDataComponentOffset,
     mut v_dst: Rav1dPictureDataComponentOffset,
-    w: c_int,
+    w: usize,
     starty4: usize,
     endy4: usize,
     ss_hor: c_int,
@@ -640,8 +640,8 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
             &lflvl[x].filter_y[0],
             py + x * 128,
             cmp::min(32, f.w4 - x as c_int * 32) as usize,
-            starty4 as c_int,
-            endy4 as c_int,
+            starty4 as usize,
+            endy4 as usize,
         );
         have_left = true;
         level_ptr = &level_ptr[32..];
@@ -663,8 +663,8 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
             pu + x * (128 >> ss_hor),
             pv + x * (128 >> ss_hor),
             (cmp::min(32, f.w4 - x as c_int * 32) + ss_hor >> ss_hor) as usize,
-            starty4 as c_int >> ss_ver,
-            uv_endy4 as c_int,
+            starty4 as usize >> ss_ver,
+            uv_endy4 as usize,
             ss_ver,
         );
         have_left = true;
@@ -703,7 +703,7 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_rows<BD: BitDepth>(
             f.b4_stride as usize,
             &lflvl[x].filter_y[1],
             p[0] + 128 * x,
-            cmp::min(32, f.w4 - x as c_int * 32),
+            cmp::min(32, f.w4 - x as c_int * 32) as usize,
             starty4 as usize,
             endy4 as usize,
         );
@@ -729,7 +729,7 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_rows<BD: BitDepth>(
             &lflvl[x].filter_uv[1],
             pu + (x * 128 >> ss_hor),
             pv + (x * 128 >> ss_hor),
-            cmp::min(32 as c_int, f.w4 - x as c_int * 32) + ss_hor >> ss_hor,
+            (cmp::min(32 as c_int, f.w4 - x as c_int * 32) + ss_hor >> ss_hor) as usize,
             starty4 as usize >> ss_ver,
             uv_endy4 as usize,
             ss_hor,

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -494,11 +494,10 @@ unsafe fn filter_plane_rows_uv<BD: BitDepth>(
     //                                 block2
     for (y, lvl) in (starty4..endy4).zip(lvl.chunks(b4_stride as usize)) {
         if !(!have_top && y == 0) {
-            let vmask: [u32; 3] = [
-                mask[y][0][0].get() as u32 | (mask[y][0][1].get() as u32) << (16 >> ss_hor),
-                mask[y][1][0].get() as u32 | (mask[y][1][1].get() as u32) << (16 >> ss_hor),
-                0,
-            ];
+            let vmask = mask[y]
+                .each_ref()
+                .map(|[a, b]| a.get() as u32 | ((b.get() as u32) << (16 >> ss_hor)));
+            let vmask = [vmask[0], vmask[1], 0];
             f.dsp.lf.loop_filter_sb.uv.v.call::<BD>(
                 f,
                 u_dst,

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -50,10 +50,24 @@ impl loopfilter_sb::Fn {
         let dst = FFISafe::new(&dst);
         self.get()(dst_ptr, stride, mask, lvl, b4_stride, lut, w, bd, dst)
     }
+
+    const fn default<BD: BitDepth, const HV: usize, const YUV: usize>() -> Self {
+        Self::new(loop_filter_sb128_c_erased::<BD, { HV }, { YUV }>)
+    }
+}
+
+pub struct LoopFilterHVDSPContext {
+    pub h: loopfilter_sb::Fn,
+    pub v: loopfilter_sb::Fn,
+}
+
+pub struct LoopFilterYUVDSPContext {
+    pub y: LoopFilterHVDSPContext,
+    pub uv: LoopFilterHVDSPContext,
 }
 
 pub struct Rav1dLoopFilterDSPContext {
-    pub loop_filter_sb: [[loopfilter_sb::Fn; 2]; 2],
+    pub loop_filter_sb: LoopFilterYUVDSPContext,
 }
 
 #[inline(never)]
@@ -351,24 +365,16 @@ impl Rav1dLoopFilterDSPContext {
         use HV::*;
         use YUV::*;
         Self {
-            loop_filter_sb: [
-                [
-                    loopfilter_sb::Fn::new(
-                        loop_filter_sb128_c_erased::<BD, { H as _ }, { Y as _ }>,
-                    ),
-                    loopfilter_sb::Fn::new(
-                        loop_filter_sb128_c_erased::<BD, { V as _ }, { Y as _ }>,
-                    ),
-                ],
-                [
-                    loopfilter_sb::Fn::new(
-                        loop_filter_sb128_c_erased::<BD, { H as _ }, { UV as _ }>,
-                    ),
-                    loopfilter_sb::Fn::new(
-                        loop_filter_sb128_c_erased::<BD, { V as _ }, { UV as _ }>,
-                    ),
-                ],
-            ],
+            loop_filter_sb: LoopFilterYUVDSPContext {
+                y: LoopFilterHVDSPContext {
+                    h: loopfilter_sb::Fn::default::<BD, { H as _ }, { Y as _ }>(),
+                    v: loopfilter_sb::Fn::default::<BD, { V as _ }, { Y as _ }>(),
+                },
+                uv: LoopFilterHVDSPContext {
+                    h: loopfilter_sb::Fn::default::<BD, { H as _ }, { UV as _ }>(),
+                    v: loopfilter_sb::Fn::default::<BD, { V as _ }, { UV as _ }>(),
+                },
+            },
         }
     }
 
@@ -379,10 +385,10 @@ impl Rav1dLoopFilterDSPContext {
             return self;
         }
 
-        self.loop_filter_sb[0][0] = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_h_sb_y, ssse3);
-        self.loop_filter_sb[0][1] = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_v_sb_y, ssse3);
-        self.loop_filter_sb[1][0] = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_h_sb_uv, ssse3);
-        self.loop_filter_sb[1][1] = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_v_sb_uv, ssse3);
+        self.loop_filter_sb.y.h = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_h_sb_y, ssse3);
+        self.loop_filter_sb.y.v = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_v_sb_y, ssse3);
+        self.loop_filter_sb.uv.h = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_h_sb_uv, ssse3);
+        self.loop_filter_sb.uv.v = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_v_sb_uv, ssse3);
 
         #[cfg(target_arch = "x86_64")]
         {
@@ -390,22 +396,21 @@ impl Rav1dLoopFilterDSPContext {
                 return self;
             }
 
-            self.loop_filter_sb[0][0] = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_h_sb_y, avx2);
-            self.loop_filter_sb[0][1] = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_v_sb_y, avx2);
-            self.loop_filter_sb[1][0] = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_h_sb_uv, avx2);
-            self.loop_filter_sb[1][1] = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_v_sb_uv, avx2);
+            self.loop_filter_sb.y.h = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_h_sb_y, avx2);
+            self.loop_filter_sb.y.v = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_v_sb_y, avx2);
+            self.loop_filter_sb.uv.h = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_h_sb_uv, avx2);
+            self.loop_filter_sb.uv.v = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_v_sb_uv, avx2);
 
             if !flags.contains(CpuFlags::AVX512ICL) {
                 return self;
             }
 
-            self.loop_filter_sb[0][1] = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_v_sb_y, avx512icl);
-            self.loop_filter_sb[1][1] = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_v_sb_uv, avx512icl);
+            self.loop_filter_sb.y.v = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_v_sb_y, avx512icl);
+            self.loop_filter_sb.uv.v = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_v_sb_uv, avx512icl);
 
             if !flags.contains(CpuFlags::SLOW_GATHER) {
-                self.loop_filter_sb[0][0] =
-                    bd_fn!(loopfilter_sb::decl_fn, BD, lpf_h_sb_y, avx512icl);
-                self.loop_filter_sb[1][0] =
+                self.loop_filter_sb.y.h = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_h_sb_y, avx512icl);
+                self.loop_filter_sb.uv.h =
                     bd_fn!(loopfilter_sb::decl_fn, BD, lpf_h_sb_uv, avx512icl);
             }
         }
@@ -420,10 +425,10 @@ impl Rav1dLoopFilterDSPContext {
             return self;
         }
 
-        self.loop_filter_sb[0][0] = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_h_sb_y, neon);
-        self.loop_filter_sb[0][1] = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_v_sb_y, neon);
-        self.loop_filter_sb[1][0] = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_h_sb_uv, neon);
-        self.loop_filter_sb[1][1] = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_v_sb_uv, neon);
+        self.loop_filter_sb.y.h = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_h_sb_y, neon);
+        self.loop_filter_sb.y.v = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_v_sb_y, neon);
+        self.loop_filter_sb.uv.h = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_h_sb_uv, neon);
+        self.loop_filter_sb.uv.v = bd_fn!(loopfilter_sb::decl_fn, BD, lpf_v_sb_uv, neon);
 
         self
     }

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -39,13 +39,14 @@ impl loopfilter_sb::Fn {
         dst: Rav1dPictureDataComponentOffset,
         mask: &[u32; 3],
         lvl: &[[u8; 4]],
-        w: c_int,
+        w: usize,
     ) {
         let dst_ptr = dst.data.as_mut_ptr_at::<BD>(dst.offset).cast();
         let stride = dst.data.stride();
         let lvl = lvl.as_ptr();
         let b4_stride = f.b4_stride;
         let lut = &f.lf.lim_lut;
+        let w = w as c_int;
         let bd = f.bitdepth_max;
         let dst = FFISafe::new(&dst);
         self.get()(dst_ptr, stride, mask, lvl, b4_stride, lut, w, bd, dst)

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -8,6 +8,8 @@ use crate::src::cpu::CpuFlags;
 use crate::src::ffi_safe::FFISafe;
 use crate::src::internal::Rav1dFrameData;
 use crate::src::lf_mask::Av1FilterLUT;
+use crate::src::unstable_extensions::as_chunks;
+use crate::src::unstable_extensions::flatten;
 use crate::src::wrap_fn_ptr::wrap_fn_ptr;
 use libc::ptrdiff_t;
 use std::cmp;
@@ -32,6 +34,18 @@ wrap_fn_ptr!(pub unsafe extern "C" fn loopfilter_sb(
     _dst: *const FFISafe<Rav1dPictureDataComponentOffset>,
 ) -> ());
 
+/// Slice `[u8; 4]`s from `lvl`, but "unaligned",
+/// meaning the `[u8; 4]`s can straddle
+/// adjacent `[u8; 4]`s in the `lvl` slice.
+///
+/// Note that this does not result in actual unaligned reads,
+/// since `[u8; 4]` has an alignment of 1.
+/// This optimizes to a single slice with a bounds check.
+#[inline(always)]
+fn unaligned_lvl_slice(lvl: &[[u8; 4]], y: usize) -> &[[u8; 4]] {
+    as_chunks(&flatten(lvl)[y..]).0
+}
+
 impl loopfilter_sb::Fn {
     pub unsafe fn call<BD: BitDepth>(
         &self,
@@ -39,11 +53,12 @@ impl loopfilter_sb::Fn {
         dst: Rav1dPictureDataComponentOffset,
         mask: &[u32; 3],
         lvl: &[[u8; 4]],
+        lvl_y_offset: usize,
         w: usize,
     ) {
         let dst_ptr = dst.data.as_mut_ptr_at::<BD>(dst.offset).cast();
         let stride = dst.data.stride();
-        let lvl = lvl.as_ptr();
+        let lvl = unaligned_lvl_slice(lvl, lvl_y_offset).as_ptr();
         let b4_stride = f.b4_stride;
         let lut = &f.lf.lim_lut;
         let w = w as c_int;


### PR DESCRIPTION
This also helps prepare for making `fn loopfilter_sb`'s `lvl` slice safe.