### PR TITLE
Backport `cdf` optimization from dav1d 1.4.2

### DIFF
--- a/src/cdf.c
+++ b/src/cdf.c
@@ -4069,16 +4069,9 @@ void dav1d_cdf_thread_update(const Dav1dFrameHeader *const hdr,
 /*
  * CDF threading wrappers.
  */
-static inline int get_qcat_idx(const int q) {
-    if (q <= 20) return 0;
-    if (q <= 60) return 1;
-    if (q <= 120) return 2;
-    return 3;
-}
-
-void dav1d_cdf_thread_init_static(CdfThreadContext *const cdf, const int qidx) {
+void dav1d_cdf_thread_init_static(CdfThreadContext *const cdf, const unsigned qidx) {
     cdf->ref = NULL;
-    cdf->data.qcat = get_qcat_idx(qidx);
+    cdf->data.qcat = (qidx > 20) + (qidx > 60) + (qidx > 120);
 }
 
 void dav1d_cdf_thread_copy(CdfContext *const dst, const CdfThreadContext *const src) {

--- a/src/cdf.h
+++ b/src/cdf.h
@@ -138,7 +138,7 @@ typedef struct CdfThreadContext {
     atomic_uint *progress;
 } CdfThreadContext;
 
-void dav1d_cdf_thread_init_static(CdfThreadContext *cdf, int qidx);
+void dav1d_cdf_thread_init_static(CdfThreadContext *cdf, unsigned qidx);
 int dav1d_cdf_thread_alloc(Dav1dContext *c, CdfThreadContext *cdf,
                            const int have_frame_mt);
 void dav1d_cdf_thread_copy(CdfContext *dst, const CdfThreadContext *src);

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -5100,18 +5100,8 @@ pub(crate) fn rav1d_cdf_thread_update(
     }
 }
 
-#[inline]
-const fn get_qcat_idx(q: u8) -> u32 {
-    match q {
-        ..=20 => 0,
-        ..=60 => 1,
-        ..=120 => 2,
-        _ => 3,
-    }
-}
-
 pub fn rav1d_cdf_thread_init_static(qidx: u8) -> CdfThreadContext {
-    CdfThreadContext::QCat(get_qcat_idx(qidx))
+    CdfThreadContext::QCat((qidx > 20) as u32 + (qidx > 60) as u32 + (qidx > 120) as u32)
 }
 
 pub fn rav1d_cdf_thread_copy(src: &CdfThreadContext) -> CdfContext {


### PR DESCRIPTION
`cdf`: Make `qcat` calculation branchless