### PR TITLE
Backport `struct CdfContext` size reduction from dav1d 1.4.2

### DIFF
--- a/src/cdf.c
+++ b/src/cdf.c
@@ -4072,9 +4072,7 @@ void dav1d_cdf_thread_copy(CdfContext *const dst, const CdfThreadContext *const 
         memcpy(dst->kfym, default_kf_y_mode_cdf, sizeof(default_kf_y_mode_cdf));
         dst->coef = av1_default_coef_cdf[src->data.qcat];
         memcpy(dst->mv.joint, default_mv_joint_cdf, sizeof(default_mv_joint_cdf));
-        memcpy(dst->dmv.joint, default_mv_joint_cdf, sizeof(default_mv_joint_cdf));
-        dst->mv.comp[0] = dst->mv.comp[1] = dst->dmv.comp[0] = dst->dmv.comp[1] =
-            default_mv_component_cdf;
+        dst->mv.comp[0] = dst->mv.comp[1] = default_mv_component_cdf;
     }
 }
 

--- a/src/cdf.h
+++ b/src/cdf.h
@@ -108,13 +108,13 @@ typedef struct CdfCoefContext {
 
 typedef struct CdfMvComponent {
     ALIGN(uint16_t classes[11 + 5], 32);
-    ALIGN(uint16_t class0_fp[2][4], 8);
-    ALIGN(uint16_t classN_fp[4], 8);
-    ALIGN(uint16_t class0_hp[2], 4);
-    ALIGN(uint16_t classN_hp[2], 4);
-    ALIGN(uint16_t class0[2], 4);
-    ALIGN(uint16_t classN[10][2], 4);
     ALIGN(uint16_t sign[2], 4);
+    ALIGN(uint16_t class0[2], 4);
+    ALIGN(uint16_t class0_fp[2][4], 8);
+    ALIGN(uint16_t class0_hp[2], 4);
+    ALIGN(uint16_t classN[10][2], 4);
+    ALIGN(uint16_t classN_fp[4], 8);
+    ALIGN(uint16_t classN_hp[2], 4);
 } CdfMvComponent;
 
 typedef struct CdfMvContext {
@@ -126,7 +126,7 @@ typedef struct CdfContext {
     CdfModeContext m;
     ALIGN(uint16_t kfym[5][5][N_INTRA_PRED_MODES + 3], 32);
     CdfCoefContext coef;
-    CdfMvContext mv, dmv;
+    CdfMvContext mv;
 } CdfContext;
 
 typedef struct CdfThreadContext {

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -32,7 +32,6 @@ pub struct CdfContext {
     pub kfym: Align32<[[[u16; N_INTRA_PRED_MODES + 3]; 5]; 5]>,
     pub coef: CdfCoefContext,
     pub mv: CdfMvContext,
-    pub dmv: CdfMvContext,
 }
 
 #[derive(Clone)]
@@ -55,13 +54,13 @@ impl Default for CdfMvContext {
 #[repr(C)]
 pub struct CdfMvComponent {
     pub classes: Align32<[u16; 16]>,
-    pub class0_fp: Align8<[[u16; 4]; 2]>,
-    pub classN_fp: Align8<[u16; 4]>,
-    pub class0_hp: Align4<[u16; 2]>,
-    pub classN_hp: Align4<[u16; 2]>,
-    pub class0: Align4<[u16; 2]>,
-    pub classN: Align4<[[u16; 2]; 10]>,
     pub sign: Align4<[u16; 2]>,
+    pub class0: Align4<[u16; 2]>,
+    pub class0_fp: Align8<[[u16; 4]; 2]>,
+    pub class0_hp: Align4<[u16; 2]>,
+    pub classN_fp: Align8<[u16; 4]>,
+    pub classN_hp: Align4<[u16; 2]>,
+    pub classN: Align4<[[u16; 2]; 10]>,
 }
 
 impl Default for CdfMvComponent {
@@ -5103,7 +5102,6 @@ pub fn rav1d_cdf_thread_copy(src: &CdfThreadContext) -> CdfContext {
             kfym: default_kf_y_mode_cdf,
             coef: av1_default_coef_cdf[*i as usize].clone(),
             mv: Default::default(),
-            dmv: Default::default(),
         },
     }
 }

--- a/src/decode.c
+++ b/src/decode.c
@@ -1324,7 +1324,7 @@ static int decode_b(Dav1dTaskContext *const t,
         }
 
         const union mv ref = b->mv[0];
-        read_mv_residual(t, &b->mv[0], &ts->cdf.dmv, 0);
+        read_mv_residual(t, &b->mv[0], &ts->cdf.mv, 0);
 
         // clip intrabc motion vector to decoded parts of current tile
         int border_left = ts->tiling.col_start * 4;


### PR DESCRIPTION
Remove separate intra-only `dmv` contexts in `struct CdfContext` and use the regular `mv` contexts for intra frames.

They are mutually exclusive, and the `dmv` contexts were already discarded and replaced with default contexts on frame completion.