### PR TITLE
`1.79.0`: Update `nightly` to Rust 1.79

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,12 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
-
-[[package]]
 name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,16 +88,6 @@ name = "nasm-rs"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4d98d0065f4b1daf164b3eafb11974c94662e5e2396cf03f32d0bb5c17da51"
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
 
 [[package]]
 name = "parking_lot"
@@ -163,7 +147,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "nasm-rs",
- "num_cpus",
  "parking_lot",
  "paste",
  "raw-cpuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ atomig = { version = "0.4.0", features = ["derive"] }
 bitflags = "2.4.0"
 cfg-if = "1.0.0"
 libc = "0.2"
-num_cpus = "1.0"
 parking_lot = "0.12.2"
 paste = "1.0.14"
 raw-cpuid = "11.0.1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2024-04-01"
+channel = "nightly-2024-06-13"
 targets = [
     "x86_64-unknown-linux-gnu",
     "i686-unknown-linux-gnu",

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,8 +1,10 @@
 use crate::src::const_fn::const_for;
 use bitflags::bitflags;
 use std::ffi::c_uint;
+use std::num::NonZero;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
+use std::thread::available_parallelism;
 
 #[cfg(not(any(
     target_arch = "x86",
@@ -219,6 +221,6 @@ pub extern "C" fn dav1d_set_cpu_flags_mask(mask: c_uint) {
 }
 
 #[cold]
-pub(crate) fn rav1d_num_logical_processors() -> usize {
-    num_cpus::get()
+pub(crate) fn rav1d_num_logical_processors() -> NonZero<usize> {
+    available_parallelism().unwrap_or(NonZero::new(1).unwrap())
 }

--- a/src/disjoint_mut.rs
+++ b/src/disjoint_mut.rs
@@ -671,10 +671,8 @@ impl<T> DisjointMutIndex<[T]> for usize {
     #[inline] // Inline to see bounds checks in order to potentially elide them.
     #[cfg_attr(debug_assertions, track_caller)]
     unsafe fn get_mut(self, slice: *mut [T]) -> *mut Self::Output {
-        // SAFETY: The safety precondition for this trait method requires that
-        // we can immutably dereference `slice`.
         let index = self;
-        let len = unsafe { (*slice).len() };
+        let len = slice.len();
         if index < len {
             // SAFETY: We have checked that `self` is less than the allocation
             // length therefore cannot overflow. `slice` is a valid pointer into
@@ -700,9 +698,7 @@ where
     #[inline] // Inline to see bounds checks in order to potentially elide them.
     #[cfg_attr(debug_assertions, track_caller)]
     unsafe fn get_mut(self, slice: *mut [T]) -> *mut Self::Output {
-        // SAFETY: The safety precondition for this trait method
-        // requires that we can immutably dereference `slice`.
-        let len = unsafe { (*slice).len() };
+        let len = slice.len();
         let Range { start, end } = self.to_range(len);
         if start <= end && end <= len {
             // SAFETY: We have checked that `start` is less than the

--- a/src/ipred_prepare.rs
+++ b/src/ipred_prepare.rs
@@ -213,8 +213,6 @@ pub fn rav1d_prepare_intra_edges<BD: BitDepth>(
     }
 
     // `dst_top` starts with either the top or top-left sample depending on whether have_left is true
-    let edge_buf_guard;
-    let dst_guard;
     let dst_top = if have_top
         && (av1_intra_prediction_edges[mode as usize]
             .needs
@@ -231,12 +229,10 @@ pub fn rav1d_prepare_intra_edges<BD: BitDepth>(
         let n = px_have + have_left as usize;
         if let Some((edge_buf, base)) = prefilter_toplevel_sb_edge {
             let offset = ((x * 4) as usize - have_left as usize).wrapping_add_signed(base);
-            edge_buf_guard = edge_buf.slice_as((offset.., ..n));
-            &*edge_buf_guard
+            &*edge_buf.slice_as((offset.., ..n))
         } else {
             let offset = dst_offset.wrapping_add_signed(-stride) - have_left as usize;
-            dst_guard = dst.slice::<BD, _>((offset.., ..n));
-            &*dst_guard
+            &*dst.slice::<BD, _>((offset.., ..n))
         }
     } else {
         &[]

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -81,9 +81,8 @@ unsafe fn backup_lpf<BD: BitDepth>(
     if lr_backup != 0 && frame_hdr.size.width[0] != frame_hdr.size.width[1] {
         while row + stripe_h <= row_h {
             let n_lines = 4 - (row + stripe_h + 1 == h) as c_int;
-            let mut dst_guard = dst.mut_slice_as((dst_offset.., ..dst_w));
             dsp.mc.resize.call::<BD>(
-                dst_guard.as_mut_ptr(),
+                dst.mut_slice_as((dst_offset.., ..dst_w)).as_mut_ptr(),
                 dst_stride,
                 src,
                 dst_w,
@@ -597,10 +596,10 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
         }
     }
     let lflvl = &f.lf.mask[lflvl_offset..];
-    let level_ptr_guard =
-        f.lf.level
-            .index((f.b4_stride * sby as isize * sbsz as isize) as usize..);
-    let mut level_ptr = &*level_ptr_guard;
+    let mut level_ptr = &*f
+        .lf
+        .level
+        .index((f.b4_stride * sby as isize * sbsz as isize) as usize..);
     have_left = false;
     for x in 0..f.sb128w as usize {
         filter_plane_cols_y::<BD>(
@@ -619,10 +618,10 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
     if frame_hdr.loopfilter.level_u == 0 && frame_hdr.loopfilter.level_v == 0 {
         return;
     }
-    let level_ptr_guard =
-        f.lf.level
-            .index((f.b4_stride * (sby * sbsz >> ss_ver) as isize) as usize..);
-    let mut level_ptr = &*level_ptr_guard;
+    let mut level_ptr = &*f
+        .lf
+        .level
+        .index((f.b4_stride * (sby * sbsz >> ss_ver) as isize) as usize..);
     have_left = false;
     for x in 0..f.sb128w as usize {
         filter_plane_cols_uv::<BD>(
@@ -661,10 +660,10 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_rows<BD: BitDepth>(
     let endy4: c_uint = (starty4 + cmp::min(f.h4 - sby * sbsz, sbsz)) as c_uint;
     let uv_endy4: c_uint = endy4.wrapping_add(ss_ver as c_uint) >> ss_ver;
 
-    let level_ptr_guard =
-        f.lf.level
-            .index((f.b4_stride * sby as isize * sbsz as isize) as usize..);
-    let mut level_ptr = &*level_ptr_guard;
+    let mut level_ptr = &*f
+        .lf
+        .level
+        .index((f.b4_stride * sby as isize * sbsz as isize) as usize..);
     for x in 0..f.sb128w as usize {
         filter_plane_rows_y::<BD>(
             f,
@@ -685,10 +684,10 @@ pub(crate) unsafe fn rav1d_loopfilter_sbrow_rows<BD: BitDepth>(
         return;
     }
 
-    let level_ptr_guard =
-        f.lf.level
-            .index((f.b4_stride * (sby * sbsz >> ss_ver) as isize) as usize..);
-    let mut level_ptr = &*level_ptr_guard;
+    let mut level_ptr = &*f
+        .lf
+        .level
+        .index((f.b4_stride * (sby * sbsz >> ss_ver) as isize) as usize..);
     let [_, pu, pv] = p;
     for x in 0..f.sb128w as usize {
         filter_plane_rows_uv::<BD>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ fn get_num_threads(s: &Rav1dSettings) -> NumThreads {
     let n_tc = if s.n_threads != 0 {
         s.n_threads as usize
     } else {
-        rav1d_num_logical_processors().clamp(1, 256)
+        rav1d_num_logical_processors().get().clamp(1, 256)
     };
     let n_fc = if s.max_frame_delay != 0 {
         cmp::min(s.max_frame_delay as usize, n_tc)

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -483,11 +483,9 @@ impl Rav1dRefmvsDSPContext {
         let bx4 = b4.x as usize;
 
         type Guard<'a> = DisjointMutGuard<'a, AlignedVec64<refmvs_block>, [refmvs_block]>;
-        const UNINIT_GUARD: MaybeUninit<Guard> = MaybeUninit::uninit();
-        const UNINIT_PTR: MaybeUninit<*mut refmvs_block> = MaybeUninit::uninit();
 
-        let mut r_guards = [UNINIT_GUARD; 37];
-        let mut r_ptrs = [UNINIT_PTR; 37];
+        let mut r_guards = [const { MaybeUninit::uninit() }; 37];
+        let mut r_ptrs = [MaybeUninit::uninit(); 37];
 
         let r_indices = &rt.r[offset..][..len];
         // SAFETY: `r_guards[i]` will be initialized if `r_ptrs[i]` is non-null.

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -674,9 +674,8 @@ fn delayed_fg_task<'l, 'ttd: 'l>(
             if ttd.cond_signaled.load(Ordering::SeqCst) != 0 {
                 ttd.cond.notify_one();
             }
-            let mut delayed_fg_guard = ttd.delayed_fg.try_write().unwrap();
             // re-borrow to allow independent field borrows
-            let delayed_fg = &mut *delayed_fg_guard;
+            let delayed_fg = &mut *ttd.delayed_fg.try_write().unwrap();
             let dsp = &Rav1dBitDepthDSPContext::get(delayed_fg.out.p.bpc)
                 .as_ref()
                 .unwrap()


### PR DESCRIPTION
This lets us make a couple of things safe (`fn <* [T]>::len`), as well as simplify a lot of guard stuff due to lifetime extension.