### PR TITLE
`fn loop_restoration_filter`: Take safe `lpf` arg for Rust fallbacks

### DIFF
--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -176,9 +176,9 @@ impl loop_restoration_filter::Fn {
         let left = left[..h as usize].as_ptr().cast();
         // NOTE: The calculated pointer may point to before the beginning of
         // `lpf`, so we must use `.wrapping_offset` here. `.wrapping_offset` is
-        // needed since `.offset` requires the pointer is in bounds, which
+        // needed since `.offset` requires the pointer to be in bounds, which
         // `.wrapping_offset` does not, and delays that requirement to when the
-        // pointer is dereferenced
+        // pointer is dereferenced.
         let lpf_ptr = lpf
             .as_mut_ptr()
             .cast::<BD::Pixel>()

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -372,6 +372,7 @@ fn reconstruct_lpf_offset<BD: BitDepth>(
 /// # Safety
 ///
 /// Must be called by [`loop_restoration_filter::Fn::call`].
+#[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn wiener_c_erased<BD: BitDepth>(
     _p_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
@@ -785,6 +786,7 @@ fn selfguided_filter<BD: BitDepth>(
 /// # Safety
 ///
 /// Must be called by [`loop_restoration_filter::Fn::call`].
+#[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn sgr_5x5_c_erased<BD: BitDepth>(
     _p_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
@@ -859,6 +861,7 @@ fn sgr_5x5_rust<BD: BitDepth>(
 /// # Safety
 ///
 /// Must be called by [`loop_restoration_filter::Fn::call`].
+#[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn sgr_3x3_c_erased<BD: BitDepth>(
     _p_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
@@ -928,6 +931,7 @@ fn sgr_3x3_rust<BD: BitDepth>(
 /// # Safety
 ///
 /// Must be called by [`loop_restoration_filter::Fn::call`].
+#[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn sgr_mix_c_erased<BD: BitDepth>(
     _p_ptr: *mut DynPixel,
     _stride: ptrdiff_t,

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -404,7 +404,7 @@ unsafe extern "C" fn wiener_c_erased<BD: BitDepth>(
 // (since first and last tops are always 0 for chroma)
 // FIXME Could implement a version that requires less temporary memory
 // (should be possible to implement with only 6 rows of temp storage)
-unsafe fn wiener_rust<BD: BitDepth>(
+fn wiener_rust<BD: BitDepth>(
     p: Rav1dPictureDataComponentOffset,
     left: &[LeftPixelRow<BD::Pixel>],
     lpf: &DisjointMut<AlignedVec64<u8>>,
@@ -813,7 +813,7 @@ unsafe extern "C" fn sgr_5x5_c_erased<BD: BitDepth>(
     sgr_5x5_rust(p, left, lpf, lpf_off, w, h, params, edges, bd)
 }
 
-unsafe fn sgr_5x5_rust<BD: BitDepth>(
+fn sgr_5x5_rust<BD: BitDepth>(
     p: Rav1dPictureDataComponentOffset,
     left: &[LeftPixelRow<BD::Pixel>],
     lpf: &DisjointMut<AlignedVec64<u8>>,
@@ -887,7 +887,7 @@ unsafe extern "C" fn sgr_3x3_c_erased<BD: BitDepth>(
     sgr_3x3_rust(p, left, lpf, lpf_off, w, h, params, edges, bd)
 }
 
-unsafe fn sgr_3x3_rust<BD: BitDepth>(
+fn sgr_3x3_rust<BD: BitDepth>(
     p: Rav1dPictureDataComponentOffset,
     left: &[LeftPixelRow<BD::Pixel>],
     lpf: &DisjointMut<AlignedVec64<u8>>,
@@ -956,7 +956,7 @@ unsafe extern "C" fn sgr_mix_c_erased<BD: BitDepth>(
     sgr_mix_rust(p, left, lpf, lpf_off, w, h, params, edges, bd)
 }
 
-unsafe fn sgr_mix_rust<BD: BitDepth>(
+fn sgr_mix_rust<BD: BitDepth>(
     p: Rav1dPictureDataComponentOffset,
     left: &[LeftPixelRow<BD::Pixel>],
     lpf: &DisjointMut<AlignedVec64<u8>>,

--- a/src/lr_apply.rs
+++ b/src/lr_apply.rs
@@ -95,17 +95,11 @@ unsafe fn lr_stripe<BD: BitDepth>(
         // Change the HAVE_BOTTOM bit in edges to (sby + 1 != f->sbh || y + stripe_h != row_h)
         edges ^= (-((sby + 1 != f.sbh || y + stripe_h != row_h) as c_int) as LrEdgeFlags ^ edges)
             & LR_HAVE_BOTTOM;
-        // SAFETY: Access to lr_line_buf here is unchecked, as we may need to
-        // pass an out-of-bounds pointer to this function which is then indexed
-        // back into bounds.
         lr_fn.call::<BD>(
             p,
             left,
-            // NOTE: The calculated pointer may point to before the beginning of
-            // `lr_line_buf`, so we must use `.wrapping_offset` here.
-            // `.wrapping_offset` is needed since `.offset` requires the pointer is in bounds,
-            // which `.wrapping_offset` does not, and delays that requirement to when the pointer is dereferenced
-            (f.lf.lr_line_buf.as_mut_ptr() as *const BD::Pixel).wrapping_offset(lpf_offset),
+            &f.lf.lr_line_buf,
+            lpf_offset,
             unit_w,
             stripe_h,
             &params,


### PR DESCRIPTION
Pass the full `DisjointMut` buffer and an `isize` offset into the `loop_restoration_filter` function, then reconstruct the offset in the Rust fallback functions. This makes the Rust fallbacks fully safe.

* Closes #852