### PR TITLE
`looprestoration.rs`: Cleanup in aarch64 functions

### DIFF
--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -2080,30 +2080,30 @@ unsafe fn sgr_filter_3x3_neon<BD: BitDepth>(
 
     const BUF_STRIDE: usize = 384 + 16;
 
-    let mut sumsq_buf: Align16<[i32; BUF_STRIDE * 3 + 16]> = Align16([0; BUF_STRIDE * 3 + 16]);
-    let mut sum_buf: Align16<[i16; BUF_STRIDE * 3 + 16]> = Align16([0; BUF_STRIDE * 3 + 16]);
+    let mut sumsq_buf = Align16([0; BUF_STRIDE * 3 + 16]);
+    let mut sum_buf = Align16([0; BUF_STRIDE * 3 + 16]);
 
-    let mut sumsq_ptrs: [*mut i32; 3];
-    let mut sum_ptrs: [*mut i16; 3];
-    let mut sumsq_rows: [*mut i32; 3] = [0 as *mut i32; 3];
-    let mut sum_rows: [*mut i16; 3] = [0 as *mut i16; 3];
+    let mut sumsq_ptrs;
+    let mut sum_ptrs;
+    let mut sumsq_rows = [0 as *mut i32; 3];
+    let mut sum_rows = [0 as *mut i16; 3];
     for i in 0..3 {
         sumsq_rows[i] = (sumsq_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
         sum_rows[i] = (sum_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
     }
 
-    let mut A_buf: Align16<[i32; BUF_STRIDE * 3 + 16]> = Align16([0; BUF_STRIDE * 3 + 16]);
-    let mut B_buf: Align16<[i16; BUF_STRIDE * 3 + 16]> = Align16([0; BUF_STRIDE * 3 + 16]);
+    let mut A_buf = Align16([0; BUF_STRIDE * 3 + 16]);
+    let mut B_buf = Align16([0; BUF_STRIDE * 3 + 16]);
 
-    let mut A_ptrs: [*mut i32; 3] = [0 as *mut i32; 3];
-    let mut B_ptrs: [*mut i16; 3] = [0 as *mut i16; 3];
+    let mut A_ptrs = [0 as *mut i32; 3];
+    let mut B_ptrs = [0 as *mut i16; 3];
     for i in 0..3 {
         A_ptrs[i] = (A_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
         B_ptrs[i] = (B_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
     }
 
     let mut src = dst;
-    let mut lpf_bottom: *const BD::Pixel = lpf.offset(6 * stride);
+    let mut lpf_bottom = lpf.offset(6 * stride);
 
     #[derive(PartialEq)]
     enum Track {

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -2741,48 +2741,48 @@ unsafe fn sgr_filter_mix_neon<BD: BitDepth>(
 
     const BUF_STRIDE: usize = 384 + 16;
 
-    let mut sumsq5_buf: Align16<[i32; BUF_STRIDE * 5 + 16]> = Align16([0; BUF_STRIDE * 5 + 16]);
-    let mut sum5_buf: Align16<[i16; BUF_STRIDE * 5 + 16]> = Align16([0; BUF_STRIDE * 5 + 16]);
+    let mut sumsq5_buf = Align16([0; BUF_STRIDE * 5 + 16]);
+    let mut sum5_buf = Align16([0; BUF_STRIDE * 5 + 16]);
 
-    let mut sumsq5_rows: [*mut i32; 5] = [0 as *mut i32; 5];
-    let mut sum5_rows: [*mut i16; 5] = [0 as *mut i16; 5];
+    let mut sumsq5_rows = [0 as *mut i32; 5];
+    let mut sum5_rows = [0 as *mut i16; 5];
     for i in 0..5 {
         sumsq5_rows[i] = (sumsq5_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
         sum5_rows[i] = (sum5_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
     }
 
-    let mut sumsq3_buf: Align16<[i32; BUF_STRIDE * 3 + 16]> = Align16([0; BUF_STRIDE * 3 + 16]);
-    let mut sum3_buf: Align16<[i16; BUF_STRIDE * 3 + 16]> = Align16([0; BUF_STRIDE * 3 + 16]);
+    let mut sumsq3_buf = Align16([0; BUF_STRIDE * 3 + 16]);
+    let mut sum3_buf = Align16([0; BUF_STRIDE * 3 + 16]);
 
-    let mut sumsq3_rows: [*mut i32; 3] = [0 as *mut i32; 3];
-    let mut sum3_rows: [*mut i16; 3] = [0 as *mut i16; 3];
+    let mut sumsq3_rows = [0 as *mut i32; 3];
+    let mut sum3_rows = [0 as *mut i16; 3];
     for i in 0..3 {
         sumsq3_rows[i] = (sumsq3_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
         sum3_rows[i] = (sum3_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
     }
 
-    let mut A5_buf: Align16<[i32; BUF_STRIDE * 2 + 16]> = Align16([0; BUF_STRIDE * 2 + 16]);
-    let mut B5_buf: Align16<[i16; BUF_STRIDE * 2 + 16]> = Align16([0; BUF_STRIDE * 2 + 16]);
+    let mut A5_buf = Align16([0; BUF_STRIDE * 2 + 16]);
+    let mut B5_buf = Align16([0; BUF_STRIDE * 2 + 16]);
 
-    let mut A5_ptrs: [*mut i32; 2] = [0 as *mut i32; 2];
-    let mut B5_ptrs: [*mut i16; 2] = [0 as *mut i16; 2];
+    let mut A5_ptrs = [0 as *mut i32; 2];
+    let mut B5_ptrs = [0 as *mut i16; 2];
     for i in 0..2 {
         A5_ptrs[i] = (A5_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
         B5_ptrs[i] = (B5_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
     }
 
-    let mut A3_buf: Align16<[i32; BUF_STRIDE * 4 + 16]> = Align16([0; BUF_STRIDE * 4 + 16]);
-    let mut B3_buf: Align16<[i16; BUF_STRIDE * 4 + 16]> = Align16([0; BUF_STRIDE * 4 + 16]);
+    let mut A3_buf = Align16([0; BUF_STRIDE * 4 + 16]);
+    let mut B3_buf = Align16([0; BUF_STRIDE * 4 + 16]);
 
-    let mut A3_ptrs: [*mut i32; 4] = [0 as *mut i32; 4];
-    let mut B3_ptrs: [*mut i16; 4] = [0 as *mut i16; 4];
+    let mut A3_ptrs = [0 as *mut i32; 4];
+    let mut B3_ptrs = [0 as *mut i16; 4];
     for i in 0..4 {
         A3_ptrs[i] = (A3_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
         B3_ptrs[i] = (B3_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
     }
 
     let mut src = dst;
-    let mut lpf_bottom: *const BD::Pixel = lpf.offset(6 * stride);
+    let mut lpf_bottom = lpf.offset(6 * stride);
 
     #[derive(PartialEq)]
     enum Track {
@@ -2795,15 +2795,15 @@ unsafe fn sgr_filter_mix_neon<BD: BitDepth>(
 
     let lr_have_top = (edges & LR_HAVE_TOP) != 0;
 
-    let mut sumsq3_ptrs: [*mut i32; 3] = [0 as *mut i32; 3];
-    let mut sum3_ptrs: [*mut i16; 3] = [0 as *mut i16; 3];
+    let mut sumsq3_ptrs = [0 as *mut i32; 3];
+    let mut sum3_ptrs = [0 as *mut i16; 3];
     for i in 0..3 {
         sumsq3_ptrs[i] = sumsq3_rows[if lr_have_top { i } else { 0 }];
         sum3_ptrs[i] = sum3_rows[if lr_have_top { i } else { 0 }];
     }
 
-    let mut sumsq5_ptrs: [*mut i32; 5] = [0 as *mut i32; 5];
-    let mut sum5_ptrs: [*mut i16; 5] = [0 as *mut i16; 5];
+    let mut sumsq5_ptrs = [0 as *mut i32; 5];
+    let mut sum5_ptrs = [0 as *mut i16; 5];
     for i in 0..5 {
         sumsq5_ptrs[i] = sumsq5_rows[if lr_have_top && i > 0 { i - 1 } else { 0 }];
         sum5_ptrs[i] = sum5_rows[if lr_have_top && i > 0 { i - 1 } else { 0 }];

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -2350,30 +2350,30 @@ unsafe fn sgr_filter_5x5_neon<BD: BitDepth>(
 
     const BUF_STRIDE: usize = 384 + 16;
 
-    let mut sumsq_buf: Align16<[i32; BUF_STRIDE * 5 + 16]> = Align16([0; BUF_STRIDE * 5 + 16]);
-    let mut sum_buf: Align16<[i16; BUF_STRIDE * 5 + 16]> = Align16([0; BUF_STRIDE * 5 + 16]);
+    let mut sumsq_buf = Align16([0; BUF_STRIDE * 5 + 16]);
+    let mut sum_buf = Align16([0; BUF_STRIDE * 5 + 16]);
 
-    let mut sumsq_ptrs: [*mut i32; 5] = [0 as *mut i32; 5];
-    let mut sum_ptrs: [*mut i16; 5] = [0 as *mut i16; 5];
-    let mut sumsq_rows: [*mut i32; 5] = [0 as *mut i32; 5];
-    let mut sum_rows: [*mut i16; 5] = [0 as *mut i16; 5];
+    let mut sumsq_ptrs = [ptr::null_mut(); 5];
+    let mut sum_ptrs = [ptr::null_mut(); 5];
+    let mut sumsq_rows = [ptr::null_mut(); 5];
+    let mut sum_rows = [ptr::null_mut(); 5];
     for i in 0..5 {
         sumsq_rows[i] = (sumsq_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
         sum_rows[i] = (sum_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
     }
 
-    let mut A_buf: Align16<[i32; BUF_STRIDE * 2 + 16]> = Align16([0; BUF_STRIDE * 2 + 16]);
-    let mut B_buf: Align16<[i16; BUF_STRIDE * 2 + 16]> = Align16([0; BUF_STRIDE * 2 + 16]);
+    let mut A_buf = Align16([0; BUF_STRIDE * 2 + 16]);
+    let mut B_buf = Align16([0; BUF_STRIDE * 2 + 16]);
 
-    let mut A_ptrs: [*mut i32; 2] = [0 as *mut i32; 2];
-    let mut B_ptrs: [*mut i16; 2] = [0 as *mut i16; 2];
+    let mut A_ptrs = [ptr::null_mut(); 2];
+    let mut B_ptrs = [ptr::null_mut(); 2];
     for i in 0..2 {
         A_ptrs[i] = (A_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
         B_ptrs[i] = (B_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
     }
 
     let mut src = dst;
-    let mut lpf_bottom: *const BD::Pixel = lpf.offset(6 * stride);
+    let mut lpf_bottom = lpf.offset(6 * stride);
 
     #[derive(PartialEq)]
     enum Track {

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -2085,8 +2085,8 @@ unsafe fn sgr_filter_3x3_neon<BD: BitDepth>(
 
     let mut sumsq_ptrs;
     let mut sum_ptrs;
-    let mut sumsq_rows = [0 as *mut i32; 3];
-    let mut sum_rows = [0 as *mut i16; 3];
+    let mut sumsq_rows = [ptr::null_mut(); 3];
+    let mut sum_rows = [ptr::null_mut(); 3];
     for i in 0..3 {
         sumsq_rows[i] = (sumsq_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
         sum_rows[i] = (sum_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
@@ -2095,8 +2095,8 @@ unsafe fn sgr_filter_3x3_neon<BD: BitDepth>(
     let mut A_buf = Align16([0; BUF_STRIDE * 3 + 16]);
     let mut B_buf = Align16([0; BUF_STRIDE * 3 + 16]);
 
-    let mut A_ptrs = [0 as *mut i32; 3];
-    let mut B_ptrs = [0 as *mut i16; 3];
+    let mut A_ptrs = [ptr::null_mut(); 3];
+    let mut B_ptrs = [ptr::null_mut(); 3];
     for i in 0..3 {
         A_ptrs[i] = (A_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
         B_ptrs[i] = (B_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -3419,12 +3419,12 @@ unsafe fn sgr_filter_mix_neon<BD: BitDepth>(
 ) {
     let w = w as c_int;
     let h = h as c_int;
-    let mut tmp1: Align16<[i16; 24576]> = Align16([0; 24576]);
-    let mut tmp2: Align16<[i16; 24576]> = Align16([0; 24576]);
+    let mut tmp1 = Align16([0; 64 * 384]);
+    let mut tmp2 = Align16([0; 64 * 384]);
     let sgr = params.sgr();
     rav1d_sgr_filter2_neon(&mut tmp1.0, dst, left, lpf, w, h, sgr.s0, edges, bd);
     rav1d_sgr_filter1_neon(&mut tmp2.0, dst, left, lpf, w, h, sgr.s1, edges, bd);
-    let wt: [i16; 2] = [sgr.w0, sgr.w1];
+    let wt = [sgr.w0, sgr.w1];
     rav1d_sgr_weighted2_neon(dst, dst, &mut tmp1.0, &mut tmp2.0, w, h, &wt, bd);
 }
 

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -2744,8 +2744,8 @@ unsafe fn sgr_filter_mix_neon<BD: BitDepth>(
     let mut sumsq5_buf = Align16([0; BUF_STRIDE * 5 + 16]);
     let mut sum5_buf = Align16([0; BUF_STRIDE * 5 + 16]);
 
-    let mut sumsq5_rows = [0 as *mut i32; 5];
-    let mut sum5_rows = [0 as *mut i16; 5];
+    let mut sumsq5_rows = [ptr::null_mut(); 5];
+    let mut sum5_rows = [ptr::null_mut(); 5];
     for i in 0..5 {
         sumsq5_rows[i] = (sumsq5_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
         sum5_rows[i] = (sum5_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
@@ -2754,8 +2754,8 @@ unsafe fn sgr_filter_mix_neon<BD: BitDepth>(
     let mut sumsq3_buf = Align16([0; BUF_STRIDE * 3 + 16]);
     let mut sum3_buf = Align16([0; BUF_STRIDE * 3 + 16]);
 
-    let mut sumsq3_rows = [0 as *mut i32; 3];
-    let mut sum3_rows = [0 as *mut i16; 3];
+    let mut sumsq3_rows = [ptr::null_mut(); 3];
+    let mut sum3_rows = [ptr::null_mut(); 3];
     for i in 0..3 {
         sumsq3_rows[i] = (sumsq3_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
         sum3_rows[i] = (sum3_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
@@ -2764,8 +2764,8 @@ unsafe fn sgr_filter_mix_neon<BD: BitDepth>(
     let mut A5_buf = Align16([0; BUF_STRIDE * 2 + 16]);
     let mut B5_buf = Align16([0; BUF_STRIDE * 2 + 16]);
 
-    let mut A5_ptrs = [0 as *mut i32; 2];
-    let mut B5_ptrs = [0 as *mut i16; 2];
+    let mut A5_ptrs = [ptr::null_mut(); 2];
+    let mut B5_ptrs = [ptr::null_mut(); 2];
     for i in 0..2 {
         A5_ptrs[i] = (A5_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
         B5_ptrs[i] = (B5_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
@@ -2774,8 +2774,8 @@ unsafe fn sgr_filter_mix_neon<BD: BitDepth>(
     let mut A3_buf = Align16([0; BUF_STRIDE * 4 + 16]);
     let mut B3_buf = Align16([0; BUF_STRIDE * 4 + 16]);
 
-    let mut A3_ptrs = [0 as *mut i32; 4];
-    let mut B3_ptrs = [0 as *mut i16; 4];
+    let mut A3_ptrs = [ptr::null_mut(); 4];
+    let mut B3_ptrs = [ptr::null_mut(); 4];
     for i in 0..4 {
         A3_ptrs[i] = (A3_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
         B3_ptrs[i] = (B3_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
@@ -2795,15 +2795,15 @@ unsafe fn sgr_filter_mix_neon<BD: BitDepth>(
 
     let lr_have_top = (edges & LR_HAVE_TOP) != 0;
 
-    let mut sumsq3_ptrs = [0 as *mut i32; 3];
-    let mut sum3_ptrs = [0 as *mut i16; 3];
+    let mut sumsq3_ptrs = [ptr::null_mut(); 3];
+    let mut sum3_ptrs = [ptr::null_mut(); 3];
     for i in 0..3 {
         sumsq3_ptrs[i] = sumsq3_rows[if lr_have_top { i } else { 0 }];
         sum3_ptrs[i] = sum3_rows[if lr_have_top { i } else { 0 }];
     }
 
-    let mut sumsq5_ptrs = [0 as *mut i32; 5];
-    let mut sum5_ptrs = [0 as *mut i16; 5];
+    let mut sumsq5_ptrs = [ptr::null_mut(); 5];
+    let mut sum5_ptrs = [ptr::null_mut(); 5];
     for i in 0..5 {
         sumsq5_ptrs[i] = sumsq5_rows[if lr_have_top && i > 0 { i - 1 } else { 0 }];
         sum5_ptrs[i] = sum5_rows[if lr_have_top && i > 0 { i - 1 } else { 0 }];

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -2747,8 +2747,8 @@ unsafe fn sgr_filter_mix_neon<BD: BitDepth>(
     let mut sumsq5_rows = [ptr::null_mut(); 5];
     let mut sum5_rows = [ptr::null_mut(); 5];
     for i in 0..5 {
-        sumsq5_rows[i] = (sumsq5_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
-        sum5_rows[i] = (sum5_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
+        sumsq5_rows[i] = sumsq5_buf.0[i * BUF_STRIDE..][..BUF_STRIDE].as_mut_ptr();
+        sum5_rows[i] = sum5_buf.0[i * BUF_STRIDE..][..BUF_STRIDE].as_mut_ptr();
     }
 
     let mut sumsq3_buf = Align16([0; BUF_STRIDE * 3 + 16]);
@@ -2757,8 +2757,8 @@ unsafe fn sgr_filter_mix_neon<BD: BitDepth>(
     let mut sumsq3_rows = [ptr::null_mut(); 3];
     let mut sum3_rows = [ptr::null_mut(); 3];
     for i in 0..3 {
-        sumsq3_rows[i] = (sumsq3_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
-        sum3_rows[i] = (sum3_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
+        sumsq3_rows[i] = sumsq3_buf.0[i * BUF_STRIDE..][..BUF_STRIDE].as_mut_ptr();
+        sum3_rows[i] = sum3_buf.0[i * BUF_STRIDE..][..BUF_STRIDE].as_mut_ptr();
     }
 
     let mut A5_buf = Align16([0; BUF_STRIDE * 2 + 16]);
@@ -2767,8 +2767,8 @@ unsafe fn sgr_filter_mix_neon<BD: BitDepth>(
     let mut A5_ptrs = [ptr::null_mut(); 2];
     let mut B5_ptrs = [ptr::null_mut(); 2];
     for i in 0..2 {
-        A5_ptrs[i] = (A5_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
-        B5_ptrs[i] = (B5_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
+        A5_ptrs[i] = A5_buf.0[i * BUF_STRIDE..][..BUF_STRIDE].as_mut_ptr();
+        B5_ptrs[i] = B5_buf.0[i * BUF_STRIDE..][..BUF_STRIDE].as_mut_ptr();
     }
 
     let mut A3_buf = Align16([0; BUF_STRIDE * 4 + 16]);
@@ -2777,8 +2777,8 @@ unsafe fn sgr_filter_mix_neon<BD: BitDepth>(
     let mut A3_ptrs = [ptr::null_mut(); 4];
     let mut B3_ptrs = [ptr::null_mut(); 4];
     for i in 0..4 {
-        A3_ptrs[i] = (A3_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
-        B3_ptrs[i] = (B3_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
+        A3_ptrs[i] = A3_buf.0[i * BUF_STRIDE..][..BUF_STRIDE].as_mut_ptr();
+        B3_ptrs[i] = B3_buf.0[i * BUF_STRIDE..][..BUF_STRIDE].as_mut_ptr();
     }
 
     let mut src = dst;

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -2088,8 +2088,8 @@ unsafe fn sgr_filter_3x3_neon<BD: BitDepth>(
     let mut sumsq_rows = [ptr::null_mut(); 3];
     let mut sum_rows = [ptr::null_mut(); 3];
     for i in 0..3 {
-        sumsq_rows[i] = (sumsq_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
-        sum_rows[i] = (sum_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
+        sumsq_rows[i] = sumsq_buf.0[i * BUF_STRIDE..][..BUF_STRIDE].as_mut_ptr();
+        sum_rows[i] = sum_buf.0[i * BUF_STRIDE..][..BUF_STRIDE].as_mut_ptr();
     }
 
     let mut A_buf = Align16([0; BUF_STRIDE * 3 + 16]);
@@ -2098,8 +2098,8 @@ unsafe fn sgr_filter_3x3_neon<BD: BitDepth>(
     let mut A_ptrs = [ptr::null_mut(); 3];
     let mut B_ptrs = [ptr::null_mut(); 3];
     for i in 0..3 {
-        A_ptrs[i] = (A_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
-        B_ptrs[i] = (B_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
+        A_ptrs[i] = A_buf.0[i * BUF_STRIDE..][..BUF_STRIDE].as_mut_ptr();
+        B_ptrs[i] = B_buf.0[i * BUF_STRIDE..][..BUF_STRIDE].as_mut_ptr();
     }
 
     let mut src = dst;

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -2358,8 +2358,8 @@ unsafe fn sgr_filter_5x5_neon<BD: BitDepth>(
     let mut sumsq_rows = [ptr::null_mut(); 5];
     let mut sum_rows = [ptr::null_mut(); 5];
     for i in 0..5 {
-        sumsq_rows[i] = (sumsq_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
-        sum_rows[i] = (sum_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
+        sumsq_rows[i] = sumsq_buf.0[i * BUF_STRIDE..][..BUF_STRIDE].as_mut_ptr();
+        sum_rows[i] = sum_buf.0[i * BUF_STRIDE..][..BUF_STRIDE].as_mut_ptr();
     }
 
     let mut A_buf = Align16([0; BUF_STRIDE * 2 + 16]);
@@ -2368,8 +2368,8 @@ unsafe fn sgr_filter_5x5_neon<BD: BitDepth>(
     let mut A_ptrs = [ptr::null_mut(); 2];
     let mut B_ptrs = [ptr::null_mut(); 2];
     for i in 0..2 {
-        A_ptrs[i] = (A_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
-        B_ptrs[i] = (B_buf.0[i * BUF_STRIDE..i * BUF_STRIDE + BUF_STRIDE]).as_mut_ptr();
+        A_ptrs[i] = A_buf.0[i * BUF_STRIDE..][..BUF_STRIDE].as_mut_ptr();
+        B_ptrs[i] = B_buf.0[i * BUF_STRIDE..][..BUF_STRIDE].as_mut_ptr();
     }
 
     let mut src = dst;

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -2018,8 +2018,8 @@ unsafe fn sgr_finish_mix_neon<BD: BitDepth>(
 ) {
     const FILTER_OUT_STRIDE: usize = 384;
 
-    let mut tmp5: Align16<[i16; 2 * FILTER_OUT_STRIDE]> = Align16([0; 2 * FILTER_OUT_STRIDE]);
-    let mut tmp3: Align16<[i16; 2 * FILTER_OUT_STRIDE]> = Align16([0; 2 * FILTER_OUT_STRIDE]);
+    let mut tmp5 = Align16([0; 2 * FILTER_OUT_STRIDE]);
+    let mut tmp3 = Align16([0; 2 * FILTER_OUT_STRIDE]);
 
     rav1d_sgr_finish_filter2_2rows_neon(tmp5.0.as_mut_ptr(), *dst, A5_ptrs, B5_ptrs, w, h, bd);
     rav1d_sgr_finish_filter1_2rows_neon(tmp3.0.as_mut_ptr(), *dst, A3_ptrs, B3_ptrs, w, h, bd);


### PR DESCRIPTION
The aarch64 functions were already basically clean, minus some redundant type annotations and other minor issues. This PR cleans those up.