### PR TITLE
`mod dump`: Make safe

### DIFF
--- a/include/common/dump.rs
+++ b/include/common/dump.rs
@@ -11,7 +11,7 @@ pub unsafe fn hex_fdump<BD: BitDepth>(
     w: usize,
     h: usize,
     what: &str,
-) {
+) -> io::Result<()> {
     let len = if h == 0 {
         0
     } else {
@@ -19,13 +19,14 @@ pub unsafe fn hex_fdump<BD: BitDepth>(
     };
     let buf = std::slice::from_raw_parts(buf, len);
 
-    write!(out, "{}", what).unwrap();
+    write!(out, "{}", what)?;
     for buf in buf.chunks(BD::pxstride(stride)) {
         for &x in &buf[..w] {
-            write!(out, " {}", BD::display(x)).unwrap();
+            write!(out, " {}", BD::display(x))?;
         }
-        writeln!(out).unwrap();
+        writeln!(out)?;
     }
+    Ok(())
 }
 
 #[inline]
@@ -36,7 +37,7 @@ pub unsafe fn hex_dump<BD: BitDepth>(
     h: usize,
     what: &str,
 ) {
-    hex_fdump::<BD>(&mut stdout(), buf, stride, w, h, what);
+    hex_fdump::<BD>(&mut stdout(), buf, stride, w, h, what).unwrap();
 }
 
 #[inline]

--- a/include/common/dump.rs
+++ b/include/common/dump.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_code)]
+
 use crate::include::common::bitdepth::BitDepth;
 use crate::include::dav1d::picture::Rav1dPictureDataComponentOffset;
 use std::fmt::Display;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1205,8 +1205,7 @@ fn decode_b(
     if t.frame_thread.pass == 2 {
         match &b.ii {
             Av1BlockIntraInter::Intra(intra) => {
-                // SAFETY: Function call with all safe args, will be marked safe.
-                unsafe { (bd_fn.recon_b_intra)(f, t, None, bs, intra_edge_flags, b, intra) };
+                (bd_fn.recon_b_intra)(f, t, None, bs, intra_edge_flags, b, intra);
 
                 let y_mode = intra.y_mode;
                 let y_mode_nofilt = if y_mode == FILTER_PRED {
@@ -1943,11 +1942,9 @@ fn decode_b(
 
         // reconstruction
         if t.frame_thread.pass == 1 {
-            // SAFETY: Function call with all safe args, will be marked safe.
-            unsafe { (bd_fn.read_coef_blocks)(f, t, ts_c, bs, b) };
+            (bd_fn.read_coef_blocks)(f, t, ts_c, bs, b);
         } else {
-            // SAFETY: Function call with all safe args, will be marked safe.
-            unsafe { (bd_fn.recon_b_intra)(f, t, Some(ts_c), bs, intra_edge_flags, b, &intra) };
+            (bd_fn.recon_b_intra)(f, t, Some(ts_c), bs, intra_edge_flags, b, &intra);
         }
 
         if f.frame_hdr().loopfilter.level_y != [0, 0] {
@@ -2193,8 +2190,7 @@ fn decode_b(
 
         // reconstruction
         if t.frame_thread.pass == 1 {
-            // SAFETY: Function call with all safe args, will be marked safe.
-            unsafe { (bd_fn.read_coef_blocks)(f, t, ts_c, bs, b) };
+            (bd_fn.read_coef_blocks)(f, t, ts_c, bs, b);
         } else {
             // SAFETY: Function call with all safe args, will be marked safe.
             unsafe { (bd_fn.recon_b_inter)(f, t, Some(ts_c), bs, b, &inter)? };
@@ -3087,8 +3083,7 @@ fn decode_b(
 
         // reconstruction
         if t.frame_thread.pass == 1 {
-            // SAFETY: Function call with all safe args, will be marked safe.
-            unsafe { (bd_fn.read_coef_blocks)(f, t, ts_c, bs, b) };
+            (bd_fn.read_coef_blocks)(f, t, ts_c, bs, b);
         } else {
             // SAFETY: Function call with all safe args, will be marked safe.
             unsafe { (bd_fn.recon_b_inter)(f, t, Some(ts_c), bs, b, &inter)? };

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1206,9 +1206,7 @@ fn decode_b(
         match &b.ii {
             Av1BlockIntraInter::Intra(intra) => {
                 // SAFETY: Function call with all safe args, will be marked safe.
-                unsafe {
-                    bd_fn.recon_b_intra(f, t, None, bs, intra_edge_flags, b, intra);
-                }
+                unsafe { (bd_fn.recon_b_intra)(f, t, None, bs, intra_edge_flags, b, intra) };
 
                 let y_mode = intra.y_mode;
                 let y_mode_nofilt = if y_mode == FILTER_PRED {
@@ -1289,9 +1287,7 @@ fn decode_b(
                 }
 
                 // SAFETY: Function call with all safe args, will be marked safe.
-                unsafe {
-                    bd_fn.recon_b_inter(f, t, None, bs, b, inter)?;
-                }
+                unsafe { (bd_fn.recon_b_inter)(f, t, None, bs, b, inter)? };
 
                 let filter = &dav1d_filter_dir[inter.filter2d as usize];
                 CaseSet::<32, false>::many(
@@ -1948,10 +1944,10 @@ fn decode_b(
         // reconstruction
         if t.frame_thread.pass == 1 {
             // SAFETY: Function call with all safe args, will be marked safe.
-            unsafe { bd_fn.read_coef_blocks(f, t, ts_c, bs, b) };
+            unsafe { (bd_fn.read_coef_blocks)(f, t, ts_c, bs, b) };
         } else {
             // SAFETY: Function call with all safe args, will be marked safe.
-            unsafe { bd_fn.recon_b_intra(f, t, Some(ts_c), bs, intra_edge_flags, b, &intra) };
+            unsafe { (bd_fn.recon_b_intra)(f, t, Some(ts_c), bs, intra_edge_flags, b, &intra) };
         }
 
         if f.frame_hdr().loopfilter.level_y != [0, 0] {
@@ -2198,10 +2194,10 @@ fn decode_b(
         // reconstruction
         if t.frame_thread.pass == 1 {
             // SAFETY: Function call with all safe args, will be marked safe.
-            unsafe { bd_fn.read_coef_blocks(f, t, ts_c, bs, b) };
+            unsafe { (bd_fn.read_coef_blocks)(f, t, ts_c, bs, b) };
         } else {
             // SAFETY: Function call with all safe args, will be marked safe.
-            unsafe { bd_fn.recon_b_inter(f, t, Some(ts_c), bs, b, &inter)? };
+            unsafe { (bd_fn.recon_b_inter)(f, t, Some(ts_c), bs, b, &inter)? };
         }
 
         splat_intrabc_mv(c, t, &f.rf, bs, r#ref, bw4 as usize, bh4 as usize);
@@ -3092,10 +3088,10 @@ fn decode_b(
         // reconstruction
         if t.frame_thread.pass == 1 {
             // SAFETY: Function call with all safe args, will be marked safe.
-            unsafe { bd_fn.read_coef_blocks(f, t, ts_c, bs, b) };
+            unsafe { (bd_fn.read_coef_blocks)(f, t, ts_c, bs, b) };
         } else {
             // SAFETY: Function call with all safe args, will be marked safe.
-            unsafe { bd_fn.recon_b_inter(f, t, Some(ts_c), bs, b, &inter)? };
+            unsafe { (bd_fn.recon_b_inter)(f, t, Some(ts_c), bs, b, &inter)? };
         }
 
         let frame_hdr = f.frame_hdr();

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -36,13 +36,9 @@ use crate::src::error::Rav1dError;
 use crate::src::filmgrain::Rav1dFilmGrainDSPContext;
 use crate::src::filmgrain::GRAIN_HEIGHT;
 use crate::src::filmgrain::GRAIN_WIDTH;
-use crate::src::intra_edge::EdgeFlags;
 use crate::src::ipred::Rav1dIntraPredDSPContext;
 use crate::src::itx::Rav1dInvTxfmDSPContext;
 use crate::src::levels::Av1Block;
-use crate::src::levels::Av1BlockInter;
-use crate::src::levels::Av1BlockIntra;
-use crate::src::levels::BlockSize;
 use crate::src::levels::Filter2d;
 use crate::src::levels::TxfmType;
 use crate::src::levels::WHT_WHT;
@@ -550,42 +546,6 @@ impl Rav1dFrameContext_bd_fn {
             BPC::BPC8 => &BPC8,
             BPC::BPC16 => &BPC16,
         }
-    }
-
-    pub unsafe fn recon_b_intra(
-        &self,
-        f: &Rav1dFrameData,
-        context: &mut Rav1dTaskContext,
-        ts_c: Option<&mut Rav1dTileStateContext>,
-        block_size: BlockSize,
-        flags: EdgeFlags,
-        block: &Av1Block,
-        intra: &Av1BlockIntra,
-    ) {
-        (self.recon_b_intra)(f, context, ts_c, block_size, flags, block, intra);
-    }
-
-    pub unsafe fn recon_b_inter(
-        &self,
-        f: &Rav1dFrameData,
-        context: &mut Rav1dTaskContext,
-        ts_c: Option<&mut Rav1dTileStateContext>,
-        block_size: BlockSize,
-        block: &Av1Block,
-        inter: &Av1BlockInter,
-    ) -> Result<(), ()> {
-        (self.recon_b_inter)(f, context, ts_c, block_size, block, inter)
-    }
-
-    pub unsafe fn read_coef_blocks(
-        &self,
-        f: &Rav1dFrameData,
-        context: &mut Rav1dTaskContext,
-        ts_c: &mut Rav1dTileStateContext,
-        block_size: BlockSize,
-        block: &Av1Block,
-    ) {
-        (self.read_coef_blocks)(f, context, ts_c, block_size, block);
     }
 }
 

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -2500,7 +2500,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                 if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                     hex_dump::<BD>(
                         y_dst.as_ptr::<BD>(),
-                        y_dst.pixel_stride::<BD>() as usize,
+                        y_dst.stride() as usize,
                         bw4 as usize * 4,
                         bh4 as usize * 4,
                         "y-pal-pred",
@@ -2874,14 +2874,14 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                 if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                     hex_dump::<BD>(
                         u.as_ptr::<BD>(),
-                        u.pixel_stride::<BD>() as usize,
+                        u.stride() as usize,
                         cbw4 as usize * 4,
                         cbh4 as usize * 4,
                         "u-pal-pred",
                     );
                     hex_dump::<BD>(
                         v.as_ptr::<BD>(),
-                        v.pixel_stride::<BD>() as usize,
+                        v.stride() as usize,
                         cbw4 as usize * 4,
                         cbh4 as usize * 4,
                         "v-pal-pred",

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -4,6 +4,7 @@ use crate::include::common::bitdepth::BPC;
 use crate::include::common::dump::ac_dump;
 use crate::include::common::dump::coef_dump;
 use crate::include::common::dump::hex_dump;
+use crate::include::common::dump::hex_dump_pic;
 use crate::include::common::intops::apply_sign64;
 use crate::include::common::intops::clip;
 use crate::include::common::intops::ulog2;
@@ -1771,13 +1772,7 @@ unsafe fn read_coef_tree<BD: BitDepth>(
                 }
                 f.dsp.itx.itxfm_add[ytx as usize][txtp as usize].call::<BD>(y_dst, cf, eob, bd);
                 if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
-                    hex_dump::<BD>(
-                        y_dst.as_ptr::<BD>(),
-                        y_dst.stride() as usize,
-                        t_dim.w as usize * 4,
-                        t_dim.h as usize * 4,
-                        "recon",
-                    );
+                    hex_dump_pic::<BD>(y_dst, t_dim.w as usize * 4, t_dim.h as usize * 4, "recon");
                 }
             }
         }
@@ -2498,13 +2493,7 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     .pal_pred
                     .call::<BD>(y_dst, &pal[0], pal_idx, bw4 * 4, bh4 * 4);
                 if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
-                    hex_dump::<BD>(
-                        y_dst.as_ptr::<BD>(),
-                        y_dst.stride() as usize,
-                        bw4 as usize * 4,
-                        bh4 as usize * 4,
-                        "y-pal-pred",
-                    );
+                    hex_dump_pic::<BD>(y_dst, bw4 as usize * 4, bh4 as usize * 4, "y-pal-pred");
                 }
             }
 
@@ -2605,23 +2594,22 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
 
                         if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                             hex_dump::<BD>(
-                                edge_array[edge_offset - t_dim.h as usize * 4..].as_ptr(),
+                                &edge_array[edge_offset - t_dim.h as usize * 4..],
                                 t_dim.h as usize * 4,
                                 t_dim.h as usize * 4,
                                 2,
                                 "l",
                             );
-                            hex_dump::<BD>(edge_array[edge_offset..].as_ptr(), 0, 1, 1, "tl");
+                            hex_dump::<BD>(&edge_array[edge_offset..], 0, 1, 1, "tl");
                             hex_dump::<BD>(
-                                edge_array[edge_offset + 1..].as_ptr(),
+                                &edge_array[edge_offset + 1..],
                                 t_dim.w as usize * 4,
                                 t_dim.w as usize * 4,
                                 2,
                                 "t",
                             );
-                            hex_dump::<BD>(
-                                y_dst.as_ptr::<BD>(),
-                                y_dst.stride() as usize,
+                            hex_dump_pic::<BD>(
+                                y_dst,
                                 t_dim.w as usize * 4,
                                 t_dim.h as usize * 4,
                                 "y-intra-pred",
@@ -2705,9 +2693,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             f.dsp.itx.itxfm_add[intra.tx as usize][txtp as usize]
                                 .call::<BD>(y_dst, cf, eob, bd);
                             if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
-                                hex_dump::<BD>(
-                                    y_dst.as_ptr::<BD>(),
-                                    y_dst.stride() as usize,
+                                hex_dump_pic::<BD>(
+                                    y_dst,
                                     t_dim.w as usize * 4,
                                     t_dim.h as usize * 4,
                                     "recon",
@@ -2822,9 +2809,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                     ac_dump(ac, 4 * cbw4 as usize, 4 * cbh4 as usize, "ac");
                     for pl in 1..3 {
                         let uv_dst = cur_data[pl].with_offset::<BD>() + uv_off;
-                        hex_dump::<BD>(
-                            uv_dst.as_ptr::<BD>(),
-                            uv_dst.stride() as usize,
+                        hex_dump_pic::<BD>(
+                            uv_dst,
                             cbw4 as usize * 4,
                             cbh4 as usize * 4,
                             ["", "u-cfl-pred", "v-cfl-pred"][pl],
@@ -2862,9 +2848,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                         .pal_pred
                         .call::<BD>(uv, &pal[pl], pal_idx, cbw4 * 4, cbh4 * 4);
                     if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
-                        hex_dump::<BD>(
-                            uv.as_ptr::<BD>(),
-                            uv.stride() as usize,
+                        hex_dump_pic::<BD>(
+                            uv,
                             cbw4 as usize * 4,
                             cbh4 as usize * 4,
                             ["", "u-pal-pred", "v-pal-pred"][pl],
@@ -2984,30 +2969,25 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                             );
                             if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                                 hex_dump::<BD>(
-                                    edge_array[edge_offset - uv_t_dim.h as usize * 4..].as_ptr(),
+                                    &edge_array[edge_offset - uv_t_dim.h as usize * 4..],
                                     uv_t_dim.h as usize * 4,
                                     uv_t_dim.h as usize * 4,
                                     2,
                                     "l",
                                 );
-                                hex_dump::<BD>(edge_array[edge_offset..].as_ptr(), 0, 1, 1, "tl");
+                                hex_dump::<BD>(&edge_array[edge_offset..], 0, 1, 1, "tl");
                                 hex_dump::<BD>(
-                                    edge_array[edge_offset + 1..].as_ptr(),
+                                    &edge_array[edge_offset + 1..],
                                     uv_t_dim.w as usize * 4,
                                     uv_t_dim.w as usize * 4,
                                     2,
                                     "t",
                                 );
-                                hex_dump::<BD>(
-                                    uv_dst.as_ptr::<BD>(),
-                                    uv_dst.stride() as usize,
+                                hex_dump_pic::<BD>(
+                                    uv_dst,
                                     uv_t_dim.w as usize * 4,
                                     uv_t_dim.h as usize * 4,
-                                    if pl != 0 {
-                                        "v-intra-pred"
-                                    } else {
-                                        "u-intra-pred"
-                                    },
+                                    ["u-intra-pred", "v-intra-pred"][pl],
                                 );
                             }
                         }
@@ -3090,9 +3070,8 @@ pub(crate) unsafe fn rav1d_recon_b_intra<BD: BitDepth>(
                                 f.dsp.itx.itxfm_add[b.uvtx as usize][txtp as usize]
                                     .call::<BD>(uv_dst, cf, eob, bd);
                                 if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
-                                    hex_dump::<BD>(
-                                        uv_dst.as_ptr::<BD>(),
-                                        uv_dst.stride() as usize,
+                                    hex_dump_pic::<BD>(
+                                        uv_dst,
                                         uv_t_dim.w as usize * 4,
                                         uv_t_dim.h as usize * 4,
                                         "recon",
@@ -3813,9 +3792,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
     }
 
     if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
-        hex_dump::<BD>(
-            y_dst.as_ptr::<BD>(),
-            y_dst.stride() as usize,
+        hex_dump_pic::<BD>(
+            y_dst,
             b_dim[0] as usize * 4,
             b_dim[1] as usize * 4,
             "y-pred",
@@ -3823,9 +3801,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
         if has_chroma {
             for pl in 1..3 {
                 let uv_dst = cur_data[pl].with_offset::<BD>() + uvdstoff;
-                hex_dump::<BD>(
-                    uv_dst.as_ptr::<BD>(),
-                    uv_dst.stride() as usize,
+                hex_dump_pic::<BD>(
+                    uv_dst,
                     cbw4 as usize * 4,
                     cbh4 as usize * 4,
                     ["", "u-pred", "v-pred"][pl],
@@ -4008,9 +3985,8 @@ pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
                                 );
                                 if debug_block_info!(f, t.b) && DEBUG_B_PIXELS {
                                     let uv_dst = uv_dst + (4 * x as usize);
-                                    hex_dump::<BD>(
-                                        uv_dst.as_ptr::<BD>(),
-                                        uv_dst.stride() as usize,
+                                    hex_dump_pic::<BD>(
+                                        uv_dst,
                                         uvtx.w as usize * 4,
                                         uvtx.h as usize * 4,
                                         "recon",


### PR DESCRIPTION
* Fixes #863.

This makes `fn hex_{,f}dump` safe by splitting it into two versions:
* `fn hex_fdump`: Using slices.
* `fn hex_fdump_pic`: Using `Rav1dPictureDataComponentOffset`.