### PR TITLE
`mod refmvs`: Make safe

### DIFF
--- a/src/align.rs
+++ b/src/align.rs
@@ -104,7 +104,9 @@ macro_rules! def_align {
             type Target = V;
 
             unsafe fn as_mut_ptr(ptr: *mut Self) -> *mut V {
-                (*ptr).0.as_mut_ptr()
+                // SAFETY: `$name` (`Align*`) is a `#[repr(C)]` aligned wrapper around `[V; N]`,
+                // so a `*mut Self` is the same as a `*mut V` to the first `V`.
+                ptr.cast()
             }
 
             fn len(&self) -> usize {
@@ -148,7 +150,7 @@ impl<T: Copy, C: AlignedByteChunk> AlignedVec<T, C> {
         }
     }
 
-    /// Returns the number of elements in the vector.
+    /// Return the number of elements in the vector.
     pub fn len(&self) -> usize {
         self.len
     }
@@ -161,17 +163,17 @@ impl<T: Copy, C: AlignedByteChunk> AlignedVec<T, C> {
         self.inner.as_mut_ptr().cast()
     }
 
-    /// Extracts a slice containing the entire vector.
+    /// Extract a slice containing the entire vector.
     pub fn as_slice(&self) -> &[T] {
-        // Safety: The first `len` elements have been initialized to `T`s in
-        // `Self::resize_with`.
+        // Safety: The first `len` elements have been
+        // initialized to `T`s in `Self::resize_with`.
         unsafe { slice::from_raw_parts(self.as_ptr(), self.len) }
     }
 
-    /// Extracts a mutable slice of the entire vector.
+    /// Extract a mutable slice of the entire vector.
     pub fn as_mut_slice(&mut self) -> &mut [T] {
-        // Safety: The first `len` elements have been initialized to `T`s in
-        // `Self::resize_with`.
+        // Safety: The first `len` elements have been
+        // initialized to `T`s in `Self::resize_with`.
         unsafe { slice::from_raw_parts_mut(self.as_mut_ptr(), self.len) }
     }
 
@@ -192,11 +194,9 @@ impl<T: Copy, C: AlignedByteChunk> AlignedVec<T, C> {
 
         // If we grew the vector, initialize the new elements past `len`.
         for offset in old_len..new_len {
-            // SAFETY: We've allocated enough space to write up to `new_len` elements into
-            // the buffer.
-            unsafe {
-                self.as_mut_ptr().add(offset).write(value);
-            }
+            // SAFETY: We've allocated enough space to write
+            // up to `new_len` elements into the buffer.
+            unsafe { self.as_mut_ptr().add(offset).write(value) };
         }
 
         self.len = new_len;
@@ -243,10 +243,9 @@ unsafe impl<T: Copy, C: AlignedByteChunk> AsMutPtr for AlignedVec<T, C> {
     type Target = T;
 
     unsafe fn as_mut_ptr(ptr: *mut Self) -> *mut Self::Target {
-        // SAFETY: .as_mut_ptr() does not materialize a mutable reference to the
-        // underlying slice so we can still allow immutable references into this
-        // slice.
-        unsafe { (*ptr).as_mut_ptr() }
+        // SAFETY: `.as_mut_ptr()` does not materialize a `&mut` to
+        // the underlying slice, so we can still allow `&`s into this slice.
+        unsafe { &mut *ptr }.as_mut_ptr()
     }
 
     fn len(&self) -> usize {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4138,7 +4138,7 @@ pub(crate) fn rav1d_decode_tile_sbrow(
     }
 
     if c.tc.len() > 1 && frame_hdr.use_ref_frame_mvs != 0 {
-        c.dsp.refmvs.load_tmvs(
+        c.dsp.refmvs.load_tmvs.call(
             &f.rf,
             &f.mvs,
             &f.ref_mvs,
@@ -4744,7 +4744,7 @@ fn rav1d_decode_frame_main(c: &Rav1dContext, f: &mut Rav1dFrameData) -> Rav1dRes
             t.b.y = sby << 4 + seq_hdr.sb128;
             let by_end = t.b.y + f.sb_step >> 1;
             if frame_hdr.use_ref_frame_mvs != 0 {
-                c.dsp.refmvs.load_tmvs(
+                c.dsp.refmvs.load_tmvs.call(
                     &f.rf,
                     &f.mvs,
                     &f.ref_mvs,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4247,7 +4247,7 @@ pub(crate) fn rav1d_decode_tile_sbrow(
         && c.tc.len() > 1
         && f.frame_hdr().frame_type.is_inter_or_switch()
     {
-        c.dsp.refmvs.save_tmvs(
+        c.dsp.refmvs.save_tmvs.call(
             &t.rt,
             &f.rf,
             &f.mvs,
@@ -4762,7 +4762,8 @@ fn rav1d_decode_frame_main(c: &Rav1dContext, f: &mut Rav1dFrameData) -> Rav1dRes
             if f.frame_hdr().frame_type.is_inter_or_switch() {
                 c.dsp
                     .refmvs
-                    .save_tmvs(&t.rt, &f.rf, &f.mvs, 0, f.bw >> 1, t.b.y >> 1, by_end);
+                    .save_tmvs
+                    .call(&t.rt, &f.rf, &f.mvs, 0, f.bw >> 1, t.b.y >> 1, by_end);
             }
 
             // loopfilter + cdef + restoration

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -913,7 +913,7 @@ fn splat_oneref_mv(
         mf: (mode == GLOBALMV && cmp::min(bw4, bh4) >= 2) as u8 | (mode == NEWMV) as u8 * 2,
     });
 
-    c.dsp.refmvs.splat_mv(rf, &t.rt, &tmpl, t.b, bw4, bh4);
+    c.dsp.refmvs.splat_mv.call(rf, &t.rt, &tmpl, t.b, bw4, bh4);
 }
 
 #[inline]
@@ -934,7 +934,7 @@ fn splat_intrabc_mv(
         bs,
         mf: 0,
     });
-    c.dsp.refmvs.splat_mv(rf, &t.rt, &tmpl, t.b, bw4, bh4);
+    c.dsp.refmvs.splat_mv.call(rf, &t.rt, &tmpl, t.b, bw4, bh4);
 }
 
 #[inline]
@@ -959,7 +959,7 @@ fn splat_tworef_mv(
         bs,
         mf: (mode == GLOBALMV_GLOBALMV) as u8 | (1 << mode & 0xbc != 0) as u8 * 2,
     });
-    c.dsp.refmvs.splat_mv(rf, &t.rt, &tmpl, t.b, bw4, bh4);
+    c.dsp.refmvs.splat_mv.call(rf, &t.rt, &tmpl, t.b, bw4, bh4);
 }
 
 #[inline]
@@ -979,7 +979,7 @@ fn splat_intraref(
         bs,
         mf: 0,
     });
-    c.dsp.refmvs.splat_mv(rf, &t.rt, &tmpl, t.b, bw4, bh4);
+    c.dsp.refmvs.splat_mv.call(rf, &t.rt, &tmpl, t.b, bw4, bh4);
 }
 
 fn mc_lowest_px(

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::include::common::intops::apply_sign;
 use crate::include::common::intops::iclip;
 use crate::include::dav1d::headers::Rav1dFrameHeader;

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -247,26 +247,29 @@ impl load_tmvs::Fn {
             n_frame_threads: n_frame_threads as _,
         };
 
+        let rp_proj = FFISafe::new(&rf.rp_proj);
+        let rp_ref = FFISafe::new(rp_ref);
+        let rf = &rf_dav1d;
         // SAFETY: Assembly call. Arguments are safe Rust references converted to
         // pointers for use in assembly. For the Rust fallback function the extra args
-        // `rf.rp_proj` and `rp_ref` are passed to allow for disjointedness checking.
+        // `rp_proj` and `rp_ref` are passed to allow for disjointedness checking.
         unsafe {
             self.get()(
-                &rf_dav1d,
+                rf,
                 tile_row_idx,
                 col_start8,
                 col_end8,
                 row_start8,
                 row_end8,
-                FFISafe::new(&rf.rp_proj),
-                FFISafe::new(rp_ref),
-            );
-        }
+                rp_proj,
+                rp_ref,
+            )
+        };
     }
 }
 
 wrap_fn_ptr!(pub unsafe extern "C" fn save_tmvs(
-    rp: *mut refmvs_temporal_block,
+    rp_ptr: *mut refmvs_temporal_block,
     stride: isize,
     rr: *const [*const refmvs_block; 31],
     ref_sign: *const [u8; 7],

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -1652,9 +1652,10 @@ pub(crate) fn rav1d_refmvs_init_frame(
         1
     };
     let uses_2pass = (n_tile_threads > 1 && n_frame_threads > 1) as usize;
+    // `mem::size_of::<refmvs_block>() == 12`,
+    // but it's accessed using 16-byte loads in asm,
+    // so add `R_PAD` elements to avoid buffer overreads.
     // TODO fallible allocation
-    // mem::size_of::<refmvs_block>() == 12 but it's accessed using 16-byte loads in asm,
-    // so add R_PAD elements to avoid buffer overreads.
     rf.r.resize(
         35 * r_stride as usize * n_tile_rows as usize * (1 + uses_2pass) + R_PAD,
         FromZeroes::new_zeroed(),

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -272,7 +272,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn save_tmvs(
     rp_ptr: *mut refmvs_temporal_block,
     stride: isize,
     rr: *const [*const refmvs_block; 31],
-    ref_sign: *const [u8; 7],
+    ref_sign: &[u8; 7],
     col_end8: i32,
     row_end8: i32,
     col_start8: i32,
@@ -1508,7 +1508,7 @@ unsafe extern "C" fn save_tmvs_c(
     _rp: *mut refmvs_temporal_block,
     stride: isize,
     _rr: *const [*const refmvs_block; 31],
-    ref_sign: *const [u8; 7],
+    ref_sign: &[u8; 7],
     col_end8: i32,
     row_end8: i32,
     col_start8: i32,
@@ -1520,7 +1520,6 @@ unsafe extern "C" fn save_tmvs_c(
     let r = FFISafe::get(r);
     let rp = FFISafe::get(rp);
     let rp = &*rp.inner;
-    let ref_sign = &*ref_sign;
 
     let stride = stride as usize;
     let [col_end8, row_end8, col_start8, row_start8] =

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -353,7 +353,7 @@ impl save_tmvs::Fn {
 
 wrap_fn_ptr!(pub unsafe extern "C" fn splat_mv(
     rr: *mut *mut refmvs_block,
-    rmv: *const Align16<refmvs_block>,
+    rmv: &Align16<refmvs_block>,
     bx4: i32,
     bw4: i32,
     bh4: i32,
@@ -1703,7 +1703,7 @@ pub(crate) fn rav1d_refmvs_init_frame(
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn splat_mv_c(
     rr: *mut *mut refmvs_block,
-    rmv: *const Align16<refmvs_block>,
+    rmv: &Align16<refmvs_block>,
     bx4: i32,
     bw4: i32,
     bh4: i32,
@@ -1711,8 +1711,6 @@ unsafe extern "C" fn splat_mv_c(
     let [bx4, bw4, bh4] = [bx4, bw4, bh4].map(|it| it as usize);
     // SAFETY: Length sliced in `splat_mv::Fn::call`.
     let rr = unsafe { slice::from_raw_parts_mut(rr, bh4) };
-    // SAFETY: Was passed in as a ref.
-    let rmv = unsafe { &*rmv };
     splat_mv_rust(rr, rmv, bx4, bw4, bh4)
 }
 

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -168,7 +168,7 @@ pub struct refmvs_candidate {
 }
 
 wrap_fn_ptr!(pub(crate) unsafe extern "C" fn load_tmvs(
-    rf: *const refmvs_frame,
+    rf: &refmvs_frame,
     tile_row_idx: i32,
     col_start8: i32,
     col_end8: i32,
@@ -1376,7 +1376,7 @@ pub(crate) fn rav1d_refmvs_tile_sbrow_init(
 /// Must be called by [`load_tmvs::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn load_tmvs_c(
-    rf: *const refmvs_frame,
+    rf: &refmvs_frame,
     tile_row_idx: i32,
     col_start8: i32,
     col_end8: i32,
@@ -1385,8 +1385,6 @@ unsafe extern "C" fn load_tmvs_c(
     rp_proj: *const FFISafe<DisjointMut<AlignedVec64<refmvs_temporal_block>>>,
     rp_ref: *const FFISafe<[Option<DisjointMutArcSlice<refmvs_temporal_block>>; 7]>,
 ) {
-    // SAFETY: Was passed as a `&` in `load_tmvs::Fn::call`.
-    let rf = unsafe { &*rf };
     // SAFETY: Was passed as `FFISafe::new(_)` in `load_tmvs::Fn::call`.
     let rp_proj = unsafe { FFISafe::get(rp_proj) };
     // SAFETY: Was passed as `FFISafe::new(_)` in `load_tmvs::Fn::call`.

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -271,7 +271,7 @@ impl load_tmvs::Fn {
 wrap_fn_ptr!(pub unsafe extern "C" fn save_tmvs(
     rp_ptr: *mut refmvs_temporal_block,
     stride: isize,
-    rr: *const [*const refmvs_block; 31],
+    rr: &[*const refmvs_block; 31],
     ref_sign: &[u8; 7],
     col_end8: i32,
     row_end8: i32,
@@ -1507,7 +1507,7 @@ fn load_tmvs_rust(
 unsafe extern "C" fn save_tmvs_c(
     _rp: *mut refmvs_temporal_block,
     stride: isize,
-    _rr: *const [*const refmvs_block; 31],
+    _rr: &[*const refmvs_block; 31],
     ref_sign: &[u8; 7],
     col_end8: i32,
     row_end8: i32,


### PR DESCRIPTION
This
* uses `wrap_fn_ptr!` on the `fn` ptrs here.
* splits the fallback `fn`s into clear `fn *_c`s that do all of the `unsafe` conversions, and safe `fn *_rust`s.
* adds some missing `// SAFETY` comments.