### PR TITLE
`fn {mc,warp8x8}{,t}{,_scaled}`: Mark asm calls safe with `TODO SAFETY`s

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1267,8 +1267,7 @@ fn decode_b(
                     }
                 }
 
-                // SAFETY: Function call with all safe args, will be marked safe.
-                unsafe { (bd_fn.recon_b_inter)(f, t, None, bs, b, inter)? };
+                (bd_fn.recon_b_inter)(f, t, None, bs, b, inter)?;
 
                 let filter = &dav1d_filter_dir[inter.filter2d as usize];
                 CaseSet::<32, false>::many(
@@ -2174,8 +2173,7 @@ fn decode_b(
         if t.frame_thread.pass == 1 {
             (bd_fn.read_coef_blocks)(f, t, ts_c, bs, b);
         } else {
-            // SAFETY: Function call with all safe args, will be marked safe.
-            unsafe { (bd_fn.recon_b_inter)(f, t, Some(ts_c), bs, b, &inter)? };
+            (bd_fn.recon_b_inter)(f, t, Some(ts_c), bs, b, &inter)?;
         }
 
         splat_intrabc_mv(c, t, &f.rf, bs, r#ref, bw4 as usize, bh4 as usize);
@@ -3067,8 +3065,7 @@ fn decode_b(
         if t.frame_thread.pass == 1 {
             (bd_fn.read_coef_blocks)(f, t, ts_c, bs, b);
         } else {
-            // SAFETY: Function call with all safe args, will be marked safe.
-            unsafe { (bd_fn.recon_b_inter)(f, t, Some(ts_c), bs, b, &inter)? };
+            (bd_fn.recon_b_inter)(f, t, Some(ts_c), bs, b, &inter)?;
         }
 
         let frame_hdr = f.frame_hdr();

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -1102,7 +1102,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn mc(
 ) -> ());
 
 impl mc::Fn {
-    pub unsafe fn call<BD: BitDepth>(
+    pub fn call<BD: BitDepth>(
         &self,
         dst: Rav1dPictureDataComponentOffset,
         src: Rav1dPictureDataComponentOffset,
@@ -1117,7 +1117,8 @@ impl mc::Fn {
         let src_ptr = src.as_ptr::<BD>().cast();
         let src_stride = src.stride();
         let bd = bd.into_c();
-        self.get()(dst_ptr, dst_stride, src_ptr, src_stride, w, h, mx, my, bd)
+        // TODO Make fallbacks safe
+        unsafe { self.get()(dst_ptr, dst_stride, src_ptr, src_stride, w, h, mx, my, bd) }
     }
 }
 
@@ -1136,7 +1137,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn mc_scaled(
 ) -> ());
 
 impl mc_scaled::Fn {
-    pub unsafe fn call<BD: BitDepth>(
+    pub fn call<BD: BitDepth>(
         &self,
         dst: Rav1dPictureDataComponentOffset,
         src: Rav1dPictureDataComponentOffset,
@@ -1153,9 +1154,12 @@ impl mc_scaled::Fn {
         let src_ptr = src.as_ptr::<BD>().cast();
         let src_stride = src.stride();
         let bd = bd.into_c();
-        self.get()(
-            dst_ptr, dst_stride, src_ptr, src_stride, w, h, mx, my, dx, dy, bd,
-        )
+        // TODO Make fallbacks safe
+        unsafe {
+            self.get()(
+                dst_ptr, dst_stride, src_ptr, src_stride, w, h, mx, my, dx, dy, bd,
+            )
+        }
     }
 }
 
@@ -1171,7 +1175,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn warp8x8(
 ) -> ());
 
 impl warp8x8::Fn {
-    pub unsafe fn call<BD: BitDepth>(
+    pub fn call<BD: BitDepth>(
         &self,
         dst: Rav1dPictureDataComponentOffset,
         src: Rav1dPictureDataComponentOffset,
@@ -1185,7 +1189,8 @@ impl warp8x8::Fn {
         let src_ptr = src.as_ptr::<BD>().cast();
         let src_stride = src.stride();
         let bd = bd.into_c();
-        self.get()(dst_ptr, dst_stride, src_ptr, src_stride, abcd, mx, my, bd)
+        // TODO Make fallbacks safe
+        unsafe { self.get()(dst_ptr, dst_stride, src_ptr, src_stride, abcd, mx, my, bd) }
     }
 }
 
@@ -1201,7 +1206,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn mct(
 ) -> ());
 
 impl mct::Fn {
-    pub unsafe fn call<BD: BitDepth>(
+    pub fn call<BD: BitDepth>(
         &self,
         tmp: &mut [i16],
         src: Rav1dPictureDataComponentOffset,
@@ -1215,7 +1220,8 @@ impl mct::Fn {
         let src_ptr = src.as_ptr::<BD>().cast();
         let src_stride = src.stride();
         let bd = bd.into_c();
-        self.get()(tmp, src_ptr, src_stride, w, h, mx, my, bd)
+        // TODO Make fallbacks safe
+        unsafe { self.get()(tmp, src_ptr, src_stride, w, h, mx, my, bd) }
     }
 }
 
@@ -1233,7 +1239,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn mct_scaled(
 ) -> ());
 
 impl mct_scaled::Fn {
-    pub unsafe fn call<BD: BitDepth>(
+    pub fn call<BD: BitDepth>(
         &self,
         tmp: &mut [i16],
         src: Rav1dPictureDataComponentOffset,
@@ -1249,7 +1255,8 @@ impl mct_scaled::Fn {
         let src_ptr = src.as_ptr::<BD>().cast();
         let src_stride = src.stride();
         let bd = bd.into_c();
-        self.get()(tmp, src_ptr, src_stride, w, h, mx, my, dx, dy, bd)
+        // TODO Make fallbacks safe
+        unsafe { self.get()(tmp, src_ptr, src_stride, w, h, mx, my, dx, dy, bd) }
     }
 }
 
@@ -1266,7 +1273,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn warp8x8t(
 ) -> ());
 
 impl warp8x8t::Fn {
-    pub unsafe fn call<BD: BitDepth>(
+    pub fn call<BD: BitDepth>(
         &self,
         tmp: &mut [i16],
         tmp_stride: usize,
@@ -1281,9 +1288,12 @@ impl warp8x8t::Fn {
         let src_ptr = src.as_ptr::<BD>().cast();
         let src_stride = src.stride();
         let bd = bd.into_c();
-        self.get()(
-            tmp, tmp_stride, src_ptr, src_stride, abcd, mx, my, bd, tmp_len,
-        )
+        // TODO Make fallbacks safe
+        unsafe {
+            self.get()(
+                tmp, tmp_stride, src_ptr, src_stride, abcd, mx, my, bd, tmp_len,
+            )
+        }
     }
 }
 

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -149,7 +149,7 @@ pub(crate) type recon_b_intra_fn = fn(
     &Av1BlockIntra,
 ) -> ();
 
-pub(crate) type recon_b_inter_fn = unsafe fn(
+pub(crate) type recon_b_inter_fn = fn(
     &Rav1dFrameData,
     &mut Rav1dTaskContext,
     Option<&mut Rav1dTileStateContext>,
@@ -2032,7 +2032,7 @@ enum MaybeTempPixels<'a, TmpStride> {
     },
 }
 
-unsafe fn mc<BD: BitDepth>(
+fn mc<BD: BitDepth>(
     f: &Rav1dFrameData,
     emu_edge: &mut ScratchEmuEdge,
     b: Bxy,
@@ -2192,7 +2192,7 @@ unsafe fn mc<BD: BitDepth>(
     Ok(())
 }
 
-unsafe fn obmc<BD: BitDepth>(
+fn obmc<BD: BitDepth>(
     f: &Rav1dFrameData,
     t: &mut Rav1dTaskContext,
     dst: Rav1dPictureDataComponentOffset,
@@ -2313,7 +2313,7 @@ unsafe fn obmc<BD: BitDepth>(
     Ok(())
 }
 
-unsafe fn warp_affine<BD: BitDepth>(
+fn warp_affine<BD: BitDepth>(
     f: &Rav1dFrameData,
     emu_edge: &mut ScratchEmuEdge,
     b: Bxy,
@@ -3075,7 +3075,7 @@ pub(crate) fn rav1d_recon_b_intra<BD: BitDepth>(
     }
 }
 
-pub(crate) unsafe fn rav1d_recon_b_inter<BD: BitDepth>(
+pub(crate) fn rav1d_recon_b_inter<BD: BitDepth>(
     f: &Rav1dFrameData,
     t: &mut Rav1dTaskContext,
     mut ts_c: Option<&mut Rav1dTileStateContext>,


### PR DESCRIPTION
This lets us make `fn {mc,obmc,warp_affine,rav1d_recon_b_inter}` safe, which is a large chunk of safety.  I'll work on the safety of the fallback `fn`s in `mod mc` next.

We're now down to < 200 `unsafe` ops left!  The vast majority (137) in `mod mc`.