### PR TITLE
Backport `mod msac` improvements from dav1d 1.4.1

### DIFF
--- a/src/arm/32/msac.S
+++ b/src/arm/32/msac.S
@@ -279,60 +279,67 @@ L(renorm):
         sub             r4,  r4,  r3           // rng = u - v
         clz             r5,  r4                // clz(rng)
         eor             r5,  r5,  #16          // d = clz(rng) ^ 16
-        mvn             r7,  r7                // ~dif
-        add             r7,  r7,  r3, lsl #16  // ~dif + (v << 16)
+        sub             r7,  r7,  r3, lsl #16  // dif - (v << 16)
 L(renorm2):
         lsl             r4,  r4,  r5           // rng << d
         subs            r6,  r6,  r5           // cnt -= d
-        lsl             r7,  r7,  r5           // (~dif + (v << 16)) << d
+        lsl             r7,  r7,  r5           // (dif - (v << 16)) << d
         str             r4,  [r0, #RNG]
-        mvn             r7,  r7                // ~dif
-        bhs             9f
+        bhs             4f
 
         // refill
         ldr             r3,  [r0, #BUF_POS]    // BUF_POS
         ldr             r4,  [r0, #BUF_END]    // BUF_END
         add             r5,  r3,  #4
-        cmp             r5,  r4
-        bgt             2f
+        subs            r5,  r5,  r4
+        bhi             6f
 
-        ldr             r3,  [r3]              // next_bits
-        add             r8,  r6,  #23          // shift_bits = cnt + 23
-        add             r6,  r6,  #16          // cnt += 16
-        rev             r3,  r3                // next_bits = bswap(next_bits)
-        sub             r5,  r5,  r8, lsr #3   // buf_pos -= shift_bits >> 3
-        and             r8,  r8,  #24          // shift_bits &= 24
-        lsr             r3,  r3,  r8           // next_bits >>= shift_bits
-        sub             r8,  r8,  r6           // shift_bits -= 16 + cnt
-        str             r5,  [r0, #BUF_POS]
-        lsl             r3,  r3,  r8           // next_bits <<= shift_bits
-        rsb             r6,  r8,  #16          // cnt = cnt + 32 - shift_bits
-        eor             r7,  r7,  r3           // dif ^= next_bits
-        b               9f
+        ldr             r8,  [r3]              // next_bits
+        rsb             r5,  r6,  #16
+        add             r4,  r6,  #16          // shift_bits = cnt + 16
+        mvn             r8,  r8
+        lsr             r5,  r5,  #3           // num_bytes_read
+        rev             r8,  r8                // next_bits = bswap(next_bits)
+        lsr             r8,  r8,  r4           // next_bits >>= shift_bits
 
-2:      // refill_eob
-        rsb             r5,  r6,  #8           // c = 8 - cnt
-3:
-        cmp             r3,  r4
-        bge             4f
-        ldrb            r8,  [r3], #1
-        lsl             r8,  r8,  r5
-        eor             r7,  r7,  r8
-        subs            r5,  r5,  #8
-        bge             3b
-
-4:      // refill_eob_end
+2:      // refill_end
+        add             r3,  r3,  r5
+        add             r6,  r6,  r5, lsl #3   // cnt += num_bits_read
         str             r3,  [r0, #BUF_POS]
-        rsb             r6,  r5,  #8           // cnt = 8 - c
 
-9:
+3:      // refill_end2
+        orr             r7,  r7,  r8           // dif |= next_bits
+
+4:      // end
         str             r6,  [r0, #CNT]
         str             r7,  [r0, #DIF]
-
         mov             r0,  lr
         add             sp,  sp,  #48
-
         pop             {r4-r10,pc}
+
+5:      // pad_with_ones
+        add             r8,  r6,  #-240
+        lsr             r8,  r8,  r8
+        b               3b
+
+6:      // refill_eob
+        cmp             r3,  r4
+        bhs             5b
+
+        ldr             r8,  [r4, #-4]
+        lsl             r5,  r5,  #3
+        lsr             r8,  r8,  r5
+        add             r5,  r6,  #16
+        mvn             r8,  r8
+        sub             r4,  r4,  r3           // num_bytes_left
+        rev             r8,  r8
+        lsr             r8,  r8,  r5
+        rsb             r5,  r6,  #16
+        lsr             r5,  r5,  #3
+        cmp             r5,  r4
+        it              hs
+        movhs           r5,  r4
+        b               2b
 endfunc
 
 function msac_decode_symbol_adapt8_neon, export=1
@@ -414,53 +421,38 @@ function msac_decode_hi_tok_neon, export=1
         sub             r4,  r4,  r3           // rng = u - v
         clz             r5,  r4                // clz(rng)
         eor             r5,  r5,  #16          // d = clz(rng) ^ 16
-        mvn             r7,  r7                // ~dif
-        add             r7,  r7,  r3, lsl #16  // ~dif + (v << 16)
+        sub             r7,  r7,  r3, lsl #16  // dif - (v << 16)
         lsl             r4,  r4,  r5           // rng << d
         subs            r6,  r6,  r5           // cnt -= d
-        lsl             r7,  r7,  r5           // (~dif + (v << 16)) << d
+        lsl             r7,  r7,  r5           // (dif - (v << 16)) << d
         str             r4,  [r0, #RNG]
         vdup.16         d1,  r4
-        mvn             r7,  r7                // ~dif
-        bhs             9f
+        bhs             5f
 
         // refill
         ldr             r3,  [r0, #BUF_POS]    // BUF_POS
         ldr             r4,  [r0, #BUF_END]    // BUF_END
         add             r5,  r3,  #4
-        cmp             r5,  r4
-        bgt             2f
+        subs            r5,  r5,  r4
+        bhi             7f
 
-        ldr             r3,  [r3]              // next_bits
-        add             r8,  r6,  #23          // shift_bits = cnt + 23
-        add             r6,  r6,  #16          // cnt += 16
-        rev             r3,  r3                // next_bits = bswap(next_bits)
-        sub             r5,  r5,  r8, lsr #3   // buf_pos -= shift_bits >> 3
-        and             r8,  r8,  #24          // shift_bits &= 24
-        lsr             r3,  r3,  r8           // next_bits >>= shift_bits
-        sub             r8,  r8,  r6           // shift_bits -= 16 + cnt
-        str             r5,  [r0, #BUF_POS]
-        lsl             r3,  r3,  r8           // next_bits <<= shift_bits
-        rsb             r6,  r8,  #16          // cnt = cnt + 32 - shift_bits
-        eor             r7,  r7,  r3           // dif ^= next_bits
-        b               9f
+        ldr             r8,  [r3]              // next_bits
+        rsb             r5,  r6,  #16
+        add             r4,  r6,  #16          // shift_bits = cnt + 16
+        mvn             r8,  r8
+        lsr             r5,  r5,  #3           // num_bytes_read
+        rev             r8,  r8                // next_bits = bswap(next_bits)
+        lsr             r8,  r8,  r4           // next_bits >>= shift_bits
 
-2:      // refill_eob
-        rsb             r5,  r6,  #8           // c = 40 - cnt
-3:
-        cmp             r3,  r4
-        bge             4f
-        ldrb            r8,  [r3], #1
-        lsl             r8,  r8,  r5
-        eor             r7,  r7,  r8
-        subs            r5,  r5,  #8
-        bge             3b
-
-4:      // refill_eob_end
+3:      // refill_end
+        add             r3,  r3,  r5
+        add             r6,  r6,  r5, lsl #3   // cnt += num_bits_read
         str             r3,  [r0, #BUF_POS]
-        rsb             r6,  r5,  #8           // cnt = 40 - c
 
-9:
+4:      // refill_end2
+        orr             r7,  r7,  r8           // dif |= next_bits
+
+5:      // end
         lsl             lr,  lr,  #1
         sub             lr,  lr,  #5
         lsr             r12, r7,  #16
@@ -473,6 +465,30 @@ function msac_decode_hi_tok_neon, export=1
         str             r7,  [r0, #DIF]
         lsr             r0,  r2,  #1
         pop             {r4-r10,pc}
+
+6:      // pad_with_ones
+        add             r8,  r6,  #-240
+        lsr             r8,  r8,  r8
+        b               4b
+
+7:      // refill_eob
+        cmp             r3,  r4
+        bhs             6b
+
+        ldr             r8,  [r4, #-4]
+        lsl             r5,  r5,  #3
+        lsr             r8,  r8,  r5
+        add             r5,  r6,  #16
+        mvn             r8,  r8
+        sub             r4,  r4,  r3           // num_bytes_left
+        rev             r8,  r8
+        lsr             r8,  r8,  r5
+        rsb             r5,  r6,  #16
+        lsr             r5,  r5,  #3
+        cmp             r5,  r4
+        it              hs
+        movhs           r5,  r4
+        b               3b
 endfunc
 
 function msac_decode_bool_equi_neon, export=1
@@ -493,7 +509,6 @@ function msac_decode_bool_equi_neon, export=1
         movhs           r7,  r8                // if (ret) dif = dif - vw;
 
         clz             r5,  r4                // clz(rng)
-        mvn             r7,  r7                // ~dif
         eor             r5,  r5,  #16          // d = clz(rng) ^ 16
         mov             lr,  r2
         b               L(renorm2)
@@ -519,7 +534,6 @@ function msac_decode_bool_neon, export=1
         movhs           r7,  r8                // if (ret) dif = dif - vw;
 
         clz             r5,  r4                // clz(rng)
-        mvn             r7,  r7                // ~dif
         eor             r5,  r5,  #16          // d = clz(rng) ^ 16
         mov             lr,  r2
         b               L(renorm2)
@@ -549,7 +563,6 @@ function msac_decode_bool_adapt_neon, export=1
 
         cmp             r10, #0
         clz             r5,  r4                // clz(rng)
-        mvn             r7,  r7                // ~dif
         eor             r5,  r5,  #16          // d = clz(rng) ^ 16
         mov             lr,  r2
 

--- a/src/arm/64/msac.S
+++ b/src/arm/64/msac.S
@@ -208,60 +208,66 @@ L(renorm):
         sub             w4,  w4,  w3           // rng = u - v
         clz             w5,  w4                // clz(rng)
         eor             w5,  w5,  #16          // d = clz(rng) ^ 16
-        mvn             x7,  x7                // ~dif
-        add             x7,  x7,  x3, lsl #48  // ~dif + (v << 48)
+        sub             x7,  x7,  x3, lsl #48  // dif - (v << 48)
 L(renorm2):
         lsl             w4,  w4,  w5           // rng << d
         subs            w6,  w6,  w5           // cnt -= d
-        lsl             x7,  x7,  x5           // (~dif + (v << 48)) << d
+        lsl             x7,  x7,  x5           // (dif - (v << 48)) << d
         str             w4,  [x0, #RNG]
-        mvn             x7,  x7                // ~dif
-        b.hs            9f
+        b.hs            4f
 
         // refill
         ldp             x3,  x4,  [x0]         // BUF_POS, BUF_END
         add             x5,  x3,  #8
-        cmp             x5,  x4
-        b.gt            2f
+        subs            x5,  x5,  x4
+        b.hi            6f
 
-        ldr             x3,  [x3]              // next_bits
-        add             w8,  w6,  #23          // shift_bits = cnt + 23
-        add             w6,  w6,  #16          // cnt += 16
-        rev             x3,  x3                // next_bits = bswap(next_bits)
-        sub             x5,  x5,  x8, lsr #3   // buf_pos -= shift_bits >> 3
-        and             w8,  w8,  #24          // shift_bits &= 24
-        lsr             x3,  x3,  x8           // next_bits >>= shift_bits
-        sub             w8,  w8,  w6           // shift_bits -= 16 + cnt
-        str             x5,  [x0, #BUF_POS]
-        lsl             x3,  x3,  x8           // next_bits <<= shift_bits
-        mov             w4,  #48
-        sub             w6,  w4,  w8           // cnt = cnt + 64 - shift_bits
-        eor             x7,  x7,  x3           // dif ^= next_bits
-        b               9f
+        ldr             x8,  [x3]              // next_bits
+        add             w4,  w6,  #-48         // shift_bits = cnt + 16 (- 64)
+        mvn             x8,  x8
+        neg             w5,  w4
+        rev             x8,  x8                // next_bits = bswap(next_bits)
+        lsr             w5,  w5,  #3           // num_bytes_read
+        lsr             x8,  x8,  x4           // next_bits >>= (shift_bits & 63)
 
-2:      // refill_eob
-        mov             w14, #40
-        sub             w5,  w14, w6           // c = 40 - cnt
-3:
-        cmp             x3,  x4
-        b.ge            4f
-        ldrb            w8,  [x3], #1
-        lsl             x8,  x8,  x5
-        eor             x7,  x7,  x8
-        subs            w5,  w5,  #8
-        b.ge            3b
-
-4:      // refill_eob_end
+2:      // refill_end
+        add             x3,  x3,  x5
+        add             w6,  w6,  w5, lsl #3   // cnt += num_bits_read
         str             x3,  [x0, #BUF_POS]
-        sub             w6,  w14, w5           // cnt = 40 - c
 
-9:
+3:      // refill_end2
+        orr             x7,  x7,  x8           // dif |= next_bits
+
+4:      // end
         str             w6,  [x0, #CNT]
         str             x7,  [x0, #DIF]
 
         mov             w0,  w15
         add             sp,  sp,  #48
         ret
+
+5:      // pad_with_ones
+        add             w8,  w6,  #-16
+        ror             x8,  x8,  x8
+        b               3b
+
+6:      // refill_eob
+        cmp             x3,  x4
+        b.hs            5b
+
+        ldr             x8,  [x4, #-8]
+        lsl             w5,  w5,  #3
+        lsr             x8,  x8,  x5
+        add             w5,  w6,  #-48
+        mvn             x8,  x8
+        sub             w4,  w4,  w3           // num_bytes_left
+        rev             x8,  x8
+        lsr             x8,  x8,  x5
+        neg             w5,  w5
+        lsr             w5,  w5,  #3
+        cmp             w5,  w4
+        csel            w5,  w5,  w4,  lo      // num_bytes_read
+        b               2b
 endfunc
 
 function msac_decode_symbol_adapt8_neon, export=1
@@ -334,54 +340,37 @@ function msac_decode_hi_tok_neon, export=1
         sub             w4,  w4,  w3           // rng = u - v
         clz             w5,  w4                // clz(rng)
         eor             w5,  w5,  #16          // d = clz(rng) ^ 16
-        mvn             x7,  x7                // ~dif
-        add             x7,  x7,  x3, lsl #48  // ~dif + (v << 48)
+        sub             x7,  x7,  x3, lsl #48  // dif - (v << 48)
         lsl             w4,  w4,  w5           // rng << d
         subs            w6,  w6,  w5           // cnt -= d
-        lsl             x7,  x7,  x5           // (~dif + (v << 48)) << d
+        lsl             x7,  x7,  x5           // (dif - (v << 48)) << d
         str             w4,  [x0, #RNG]
         dup             v3.4h,   w4
-        mvn             x7,  x7                // ~dif
-        b.hs            9f
+        b.hs            5f
 
         // refill
         ldp             x3,  x4,  [x0]         // BUF_POS, BUF_END
         add             x5,  x3,  #8
-        cmp             x5,  x4
-        b.gt            2f
+        subs            x5,  x5,  x4
+        b.hi            7f
 
-        ldr             x3,  [x3]              // next_bits
-        add             w8,  w6,  #23          // shift_bits = cnt + 23
-        add             w6,  w6,  #16          // cnt += 16
-        rev             x3,  x3                // next_bits = bswap(next_bits)
-        sub             x5,  x5,  x8, lsr #3   // buf_pos -= shift_bits >> 3
-        and             w8,  w8,  #24          // shift_bits &= 24
-        lsr             x3,  x3,  x8           // next_bits >>= shift_bits
-        sub             w8,  w8,  w6           // shift_bits -= 16 + cnt
-        str             x5,  [x0, #BUF_POS]
-        lsl             x3,  x3,  x8           // next_bits <<= shift_bits
-        mov             w4,  #48
-        sub             w6,  w4,  w8           // cnt = cnt + 64 - shift_bits
-        eor             x7,  x7,  x3           // dif ^= next_bits
-        b               9f
+        ldr             x8,  [x3]              // next_bits
+        add             w4,  w6,  #-48         // shift_bits = cnt + 16 (- 64)
+        mvn             x8,  x8
+        neg             w5,  w4
+        rev             x8,  x8                // next_bits = bswap(next_bits)
+        lsr             w5,  w5,  #3           // num_bytes_read
+        lsr             x8,  x8,  x4           // next_bits >>= (shift_bits & 63)
 
-2:      // refill_eob
-        mov             w14, #40
-        sub             w5,  w14, w6           // c = 40 - cnt
-3:
-        cmp             x3,  x4
-        b.ge            4f
-        ldrb            w8,  [x3], #1
-        lsl             x8,  x8,  x5
-        eor             x7,  x7,  x8
-        subs            w5,  w5,  #8
-        b.ge            3b
-
-4:      // refill_eob_end
+3:      // refill_end
+        add             x3,  x3,  x5
+        add             w6,  w6,  w5, lsl #3   // cnt += num_bits_read
         str             x3,  [x0, #BUF_POS]
-        sub             w6,  w14, w5           // cnt = 40 - c
 
-9:
+4:      // refill_end2
+        orr             x7,  x7,  x8           // dif |= next_bits
+
+5:      // end
         lsl             w15, w15, #1
         sub             w15, w15, #5
         lsr             x12, x7,  #48
@@ -394,6 +383,29 @@ function msac_decode_hi_tok_neon, export=1
         str             x7,  [x0, #DIF]
         lsr             w0,  w13, #1
         ret
+
+6:      // pad_with_ones
+        add             w8,  w6,  #-16
+        ror             x8,  x8,  x8
+        b               4b
+
+7:      // refill_eob
+        cmp             x3,  x4
+        b.hs            6b
+
+        ldr             x8,  [x4, #-8]
+        lsl             w5,  w5,  #3
+        lsr             x8,  x8,  x5
+        add             w5,  w6,  #-48
+        mvn             x8,  x8
+        sub             w4,  w4,  w3           // num_bytes_left
+        rev             x8,  x8
+        lsr             x8,  x8,  x5
+        neg             w5,  w5
+        lsr             w5,  w5,  #3
+        cmp             w5,  w4
+        csel            w5,  w5,  w4,  lo      // num_bytes_read
+        b               3b
 endfunc
 
 function msac_decode_bool_equi_neon, export=1
@@ -410,7 +422,6 @@ function msac_decode_bool_equi_neon, export=1
         csel            x7,  x8,  x7,  hs      // if (ret) dif = dif - vw;
 
         clz             w5,  w4                // clz(rng)
-        mvn             x7,  x7                // ~dif
         eor             w5,  w5,  #16          // d = clz(rng) ^ 16
         b               L(renorm2)
 endfunc
@@ -431,7 +442,6 @@ function msac_decode_bool_neon, export=1
         csel            x7,  x8,  x7,  hs      // if (ret) dif = dif - vw;
 
         clz             w5,  w4                // clz(rng)
-        mvn             x7,  x7                // ~dif
         eor             w5,  w5,  #16          // d = clz(rng) ^ 16
         b               L(renorm2)
 endfunc
@@ -455,7 +465,6 @@ function msac_decode_bool_adapt_neon, export=1
         ldr             w10, [x0, #ALLOW_UPDATE_CDF]
 
         clz             w5,  w4                // clz(rng)
-        mvn             x7,  x7                // ~dif
         eor             w5,  w5,  #16          // d = clz(rng) ^ 16
 
         cbz             w10, L(renorm2)

--- a/src/x86/msac.asm
+++ b/src/x86/msac.asm
@@ -143,10 +143,9 @@ cglobal msac_decode_symbol_adapt4, 0, 6, 6
     mov           esp, [esp]
 %endif
 %endif
-    not            t4
     sub           t2d, t1d ; rng
     shl            t1, gprsize*8-16
-    add            t4, t1  ; ~dif
+    sub            t4, t1  ; dif - v
 .renorm3:
     mov           t1d, [t0+msac.cnt]
     movifnidn      t7, t0
@@ -157,33 +156,31 @@ cglobal msac_decode_symbol_adapt4, 0, 6, 6
     shl           t2d, cl
     shl            t4, cl
     mov [t7+msac.rng], t2d
-    not            t4
     sub           t1d, ecx
     jae .end ; no refill required
 
 ; refill:
-    mov            t2, [t7+msac.buf]
-    mov           rcx, [t7+msac.end]
 %if ARCH_X86_64 == 0
     push           t5
 %endif
-    lea            t5, [t2+gprsize]
-    cmp            t5, rcx
+    mov            t2, [t7+msac.buf]
+    mov            t5, [t7+msac.end]
+    lea           rcx, [t2+gprsize]
+    sub           rcx, t5
     ja .refill_eob
-    mov            t2, [t2]
-    lea           ecx, [t1+23]
-    add           t1d, 16
-    shr           ecx, 3   ; shift_bytes
-    bswap          t2
-    sub            t5, rcx
-    shl           ecx, 3   ; shift_bits
-    shr            t2, cl
-    sub           ecx, t1d ; shift_bits - 16 - cnt
-    mov           t1d, gprsize*8-16
-    shl            t2, cl
-    mov [t7+msac.buf], t5
-    sub           t1d, ecx ; cnt + gprsize*8 - shift_bits
-    xor            t4, t2
+    mov            t5, [t2]
+    lea           ecx, [t1+16-gprsize*8]
+    not            t5
+    bswap          t5
+    shr            t5, cl
+    neg           ecx
+    shr           ecx, 3 ; num_bytes_read
+    or             t4, t5
+.refill_end:
+    add            t2, rcx
+    lea           t1d, [t1+rcx*8] ; cnt += num_bits_read
+    mov [t7+msac.buf], t2
+.refill_end2:
 %if ARCH_X86_64 == 0
     pop            t5
 %endif
@@ -191,29 +188,35 @@ cglobal msac_decode_symbol_adapt4, 0, 6, 6
     mov [t7+msac.cnt], t1d
     mov [t7+msac.dif], t4
     RET
-.refill_eob: ; avoid overreading the input buffer
-    mov            t5, rcx
-    mov           ecx, gprsize*8-24
-    sub           ecx, t1d ; c
-.refill_eob_loop:
-    cmp            t2, t5
-    jae .refill_eob_end    ; eob reached
-    movzx         t1d, byte [t2]
-    inc            t2
-    shl            t1, cl
-    xor            t4, t1
-    sub           ecx, 8
-    jge .refill_eob_loop
-.refill_eob_end:
-    mov           t1d, gprsize*8-24
-%if ARCH_X86_64 == 0
-    pop            t5
+.pad_with_ones:
+    lea           ecx, [t1-16]
+%if ARCH_X86_64
+    ror           rcx, cl
+%else
+    shr           ecx, cl
 %endif
-    sub           t1d, ecx
-    mov [t7+msac.buf], t2
-    mov [t7+msac.dif], t4
-    mov [t7+msac.cnt], t1d
-    RET
+    or             t4, rcx
+    jmp .refill_end2
+.refill_eob: ; avoid overreading the input buffer
+    cmp            t2, t5
+    jae .pad_with_ones ; eob reached
+    ; We can safely do a register-sized load of the last bytes of the buffer
+    ; as this code is only reached if the msac buffer size is >= gprsize.
+    mov            t5, [t5-gprsize]
+    shl           ecx, 3
+    shr            t5, cl
+    lea           ecx, [t1+16-gprsize*8]
+    not            t5
+    bswap          t5
+    shr            t5, cl
+    neg           ecx
+    or             t4, t5
+    mov           t5d, [t7+msac.end]
+    shr           ecx, 3
+    sub           t5d, t2d ; num_bytes_left
+    cmp           ecx, t5d
+    cmovae        ecx, t5d ; num_bytes_read
+    jmp .refill_end
 
 cglobal msac_decode_symbol_adapt8, 0, 6, 6
     DECODE_SYMBOL_ADAPT_INIT
@@ -366,7 +369,6 @@ cglobal msac_decode_bool_adapt, 0, 6, 0
 %if ARCH_X86_64 == 0
     movzx         eax, al
 %endif
-    not            t4
     test          t3d, t3d
     jz m(msac_decode_symbol_adapt4, SUFFIX).renorm3
 %if UNIX64 == 0
@@ -420,7 +422,6 @@ cglobal msac_decode_bool_equi, 0, 6, 0
     mov           ecx, 0xbfff
     setb           al ; the upper 32 bits contains garbage but that's OK
     sub           ecx, t2d
-    not            t4
     ; In this case of this function, (d =) 16 - clz(v) = 2 - (v >> 14)
     ;   i.e. (0 <= d <= 2) and v < (3 << 14)
     shr           ecx, 14           ; d
@@ -447,7 +448,6 @@ cglobal msac_decode_bool, 0, 6, 0
     cmovb         t2d, t1d
     cmovb          t4, t3
     setb           al
-    not            t4
 %if ARCH_X86_64 == 0
     movzx         eax, al
 %endif
@@ -497,48 +497,45 @@ cglobal msac_decode_bool, 0, 6, 0
     tzcnt         eax, eax
     movzx         ecx, word [buf+rax+16]
     movzx         t2d, word [buf+rax+14]
-    not            t4
 %if ARCH_X86_64
     add           t6d, 5
 %endif
     sub           eax, 5   ; setup for merging the tok_br and tok branches
     sub           t2d, ecx
     shl           rcx, gprsize*8-16
-    add            t4, rcx
+    sub            t4, rcx
     bsr           ecx, t2d
     xor           ecx, 15
     shl           t2d, cl
     shl            t4, cl
     movd           m2, t2d
     mov [t7+msac.rng], t2d
-    not            t4
     sub           t5d, ecx
     jae %%end
-    mov            t2, [t7+msac.buf]
-    mov           rcx, [t7+msac.end]
 %if UNIX64 == 0
     push           t8
 %endif
-    lea            t8, [t2+gprsize]
-    cmp            t8, rcx
+    mov            t2, [t7+msac.buf]
+    mov            t8, [t7+msac.end]
+    lea           rcx, [t2+gprsize]
+    sub           rcx, t8
     ja %%refill_eob
-    mov            t2, [t2]
-    lea           ecx, [t5+23]
-    add           t5d, 16
+    mov            t8, [t2]
+    lea           ecx, [t5+16-gprsize*8]
+    not            t8
+    bswap          t8
+    shr            t8, cl
+    neg           ecx
     shr           ecx, 3
-    bswap          t2
-    sub            t8, rcx
-    shl           ecx, 3
-    shr            t2, cl
-    sub           ecx, t5d
-    mov           t5d, gprsize*8-16
-    shl            t2, cl
-    mov [t7+msac.buf], t8
+    or             t4, t8
+%%refill_end:
+    add            t2, rcx
+    lea           t5d, [t5+rcx*8]
+    mov [t7+msac.buf], t2
+%%refill_end2:
 %if UNIX64 == 0
     pop            t8
 %endif
-    sub           t5d, ecx
-    xor            t4, t2
 %%end:
     movp           m3, t4
 %if ARCH_X86_64
@@ -559,27 +556,34 @@ cglobal msac_decode_bool, 0, 6, 0
     shr           eax, 1
     mov [t7+msac.cnt], t5d
     RET
-%%refill_eob:
-    mov            t8, rcx
-    mov           ecx, gprsize*8-24
-    sub           ecx, t5d
-%%refill_eob_loop:
-    cmp            t2, t8
-    jae %%refill_eob_end
-    movzx         t5d, byte [t2]
-    inc            t2
-    shl            t5, cl
-    xor            t4, t5
-    sub           ecx, 8
-    jge %%refill_eob_loop
-%%refill_eob_end:
-%if UNIX64 == 0
-    pop            t8
+%%pad_with_ones:
+    ; ensure that dif is padded with at least 15 bits of ones at the end
+    lea           ecx, [t5-16]
+%if ARCH_X86_64
+    ror           rcx, cl
+%else
+    shr           ecx, cl
 %endif
-    mov           t5d, gprsize*8-24
-    mov [t7+msac.buf], t2
-    sub           t5d, ecx
-    jmp %%end
+    or             t4, rcx
+    jmp %%refill_end2
+%%refill_eob:
+    cmp            t2, t8
+    jae %%pad_with_ones
+    mov            t8, [t8-gprsize]
+    shl           ecx, 3
+    shr            t8, cl
+    lea           ecx, [t5+16-gprsize*8]
+    not            t8
+    bswap          t8
+    shr            t8, cl
+    neg           ecx
+    or             t4, t8
+    mov           t8d, [t7+msac.end]
+    shr           ecx, 3
+    sub           t8d, t2d
+    cmp           ecx, t8d
+    cmovae        ecx, t8d
+    jmp %%refill_end
 %endmacro
 
 cglobal msac_decode_hi_tok, 0, 7 + ARCH_X86_64, 6


### PR DESCRIPTION
Skip the overhead of shifting in ones into the LSB in the common case, that's only required in the EOB padding. In practice this means we only have to invert bits once during the refill process instead of twice in every call to `msac` functions.
    
Also make some improvements to the refill asm, mainly involving keeping partially inserted bytes at the end instead of clearing them.

NOTE: the original dav1d commit also applies changes to `loongarch` asm that aren't included here.