### PR TITLE
`fn FilterResult::{rnd,rnd2,clip}`: Replace the `filter_{8tap,bilin}_{rnd,rnd2,clip}` `fn`s with methods on a shared `FilterResult`

### DIFF
--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -232,6 +232,10 @@ pub trait BitDepth: Clone + Copy {
     fn get_intermediate_bits(&self) -> u8;
 
     const PREP_BIAS: i16;
+
+    fn sub_prep_bias(pixel: i32) -> i16 {
+        (pixel - i32::from(Self::PREP_BIAS)) as i16
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -86,8 +86,8 @@ struct FilterResult {
 }
 
 impl FilterResult {
-    pub fn get(&self) -> i32 {
-        self.pixel
+    pub fn get(&self) -> i16 {
+        self.pixel as i16
     }
 
     pub fn apply(&self, f: impl Fn(i32) -> i32) -> Self {
@@ -170,7 +170,7 @@ unsafe fn put_8tap_rust<BD: BitDepth>(
             src = src.offset(-3 * src_stride);
             for _ in 0..tmp_h {
                 for x in 0..w {
-                    mid_ptr[x] = filter_8tap(src, x, fh, 1).rnd(6 - intermediate_bits).get() as i16;
+                    mid_ptr[x] = filter_8tap(src, x, fh, 1).rnd(6 - intermediate_bits).get();
                 }
 
                 mid_ptr = &mut mid_ptr[128..];
@@ -249,7 +249,7 @@ unsafe fn put_8tap_scaled_rust<BD: BitDepth>(
             mid_ptr[x] = match fh {
                 Some(fh) => filter_8tap(src, ioff, fh, 1)
                     .rnd(6 - intermediate_bits)
-                    .get() as i16,
+                    .get(),
                 None => ((*src.offset(ioff as isize)).as_::<i32>() as i16) << intermediate_bits,
             };
             imx += dx;
@@ -309,7 +309,7 @@ unsafe fn prep_8tap_rust<BD: BitDepth>(
             src = src.offset(-src_stride * 3);
             for _ in 0..tmp_h {
                 for x in 0..w {
-                    mid_ptr[x] = filter_8tap(src, x, fh, 1).rnd(6 - intermediate_bits).get() as i16;
+                    mid_ptr[x] = filter_8tap(src, x, fh, 1).rnd(6 - intermediate_bits).get();
                 }
 
                 mid_ptr = &mut mid_ptr[128..];
@@ -384,7 +384,7 @@ unsafe fn prep_8tap_scaled_rust<BD: BitDepth>(
             mid_ptr[x] = match fh {
                 Some(fh) => filter_8tap(src, ioff, fh, 1)
                     .rnd(6 - intermediate_bits)
-                    .get() as i16,
+                    .get(),
                 None => ((*src.offset(ioff as isize)).as_::<i32>() as i16) << intermediate_bits,
             };
             imx += dx;
@@ -450,8 +450,7 @@ unsafe fn put_bilin_rust<BD: BitDepth>(
 
             for _ in 0..tmp_h {
                 for x in 0..w {
-                    mid_ptr[x] =
-                        filter_bilin(src, x, mx, 1).rnd(4 - intermediate_bits).get() as i16;
+                    mid_ptr[x] = filter_bilin(src, x, mx, 1).rnd(4 - intermediate_bits).get();
                 }
 
                 mid_ptr = &mut mid_ptr[128..];
@@ -524,7 +523,7 @@ unsafe fn put_bilin_scaled_rust<BD: BitDepth>(
         for x in 0..w {
             mid_ptr[x] = filter_bilin(src, ioff, imx >> 6, 1)
                 .rnd(4 - intermediate_bits)
-                .get() as i16;
+                .get();
             imx += dx;
             ioff += imx >> 10;
             imx &= 0x3ff;
@@ -569,8 +568,7 @@ unsafe fn prep_bilin_rust<BD: BitDepth>(
 
             for _ in 0..tmp_h {
                 for x in 0..w {
-                    mid_ptr[x] =
-                        filter_bilin(src, x, mx, 1).rnd(4 - intermediate_bits).get() as i16;
+                    mid_ptr[x] = filter_bilin(src, x, mx, 1).rnd(4 - intermediate_bits).get();
                 }
 
                 mid_ptr = &mut mid_ptr[128..];
@@ -640,7 +638,7 @@ unsafe fn prep_bilin_scaled_rust<BD: BitDepth>(
         for x in 0..w {
             mid_ptr[x] = filter_bilin(src, ioff, imx >> 6, 1)
                 .rnd(4 - intermediate_bits)
-                .get() as i16;
+                .get();
             imx += dx;
             ioff += imx >> 10;
             imx &= 0x3ff;

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -80,59 +80,47 @@ unsafe fn prep_rust<BD: BitDepth>(
     }
 }
 
-unsafe fn filter_8tap<T: Into<i32>>(src: *const T, x: usize, f: &[i8; 8], stride: isize) -> i32 {
-    f.into_iter()
+#[derive(Clone, Copy)]
+struct FilterResult {
+    pixel: i32,
+}
+
+impl FilterResult {
+    pub fn get(&self) -> i32 {
+        self.pixel
+    }
+
+    pub fn rnd(&self, sh: u8) -> Self {
+        let pixel = (self.pixel + ((1 << sh) >> 1)) >> sh;
+        Self { pixel }
+    }
+
+    pub fn rnd2(&self, sh: u8, rnd: u8) -> Self {
+        let pixel = (self.pixel + (rnd as i32)) >> sh;
+        Self { pixel }
+    }
+
+    pub fn clip<BD: BitDepth>(&self, bd: BD) -> BD::Pixel {
+        bd.iclip_pixel(self.pixel)
+    }
+}
+
+unsafe fn filter_8tap<T: Into<i32>>(
+    src: *const T,
+    x: usize,
+    f: &[i8; 8],
+    stride: isize,
+) -> FilterResult {
+    let pixel = f
+        .into_iter()
         .enumerate()
         .map(|(i, &f)| {
             let [i, x] = [i, x].map(|it| it as isize);
             let j = x + (i - 3) * stride;
             i32::from(f) * src.offset(j).read().into()
         })
-        .sum()
-}
-
-unsafe fn rav1d_filter_8tap_rnd<T: Into<i32>>(
-    src: *const T,
-    x: usize,
-    f: &[i8; 8],
-    stride: isize,
-    sh: u8,
-) -> i32 {
-    (filter_8tap(src, x, f, stride) + ((1 << sh) >> 1)) >> sh
-}
-
-unsafe fn rav1d_filter_8tap_rnd2<T: Into<i32>>(
-    src: *const T,
-    x: usize,
-    f: &[i8; 8],
-    stride: isize,
-    rnd: u8,
-    sh: u8,
-) -> i32 {
-    (filter_8tap(src, x, f, stride) + (rnd as i32)) >> sh
-}
-
-unsafe fn rav1d_filter_8tap_clip<BD: BitDepth, T: Into<i32>>(
-    bd: BD,
-    src: *const T,
-    x: usize,
-    f: &[i8; 8],
-    stride: isize,
-    sh: u8,
-) -> BD::Pixel {
-    bd.iclip_pixel(rav1d_filter_8tap_rnd(src, x, f, stride, sh))
-}
-
-unsafe fn rav1d_filter_8tap_clip2<BD: BitDepth, T: Into<i32>>(
-    bd: BD,
-    src: *const T,
-    x: usize,
-    f: &[i8; 8],
-    stride: isize,
-    rnd: u8,
-    sh: u8,
-) -> BD::Pixel {
-    bd.iclip_pixel(rav1d_filter_8tap_rnd2(src, x, f, stride, rnd, sh))
+        .sum();
+    FilterResult { pixel }
 }
 
 fn get_filter(m: usize, d: usize, filter_type: Rav1dFilterMode) -> Option<&'static [i8; 8]> {
@@ -175,7 +163,7 @@ unsafe fn put_8tap_rust<BD: BitDepth>(
             src = src.offset(-3 * src_stride);
             for _ in 0..tmp_h {
                 for x in 0..w {
-                    mid_ptr[x] = rav1d_filter_8tap_rnd(src, x, fh, 1, 6 - intermediate_bits) as i16;
+                    mid_ptr[x] = filter_8tap(src, x, fh, 1).rnd(6 - intermediate_bits).get() as i16;
                 }
 
                 mid_ptr = &mut mid_ptr[128..];
@@ -186,14 +174,9 @@ unsafe fn put_8tap_rust<BD: BitDepth>(
             for _ in 0..h {
                 let dst = slice::from_raw_parts_mut(dst_ptr, w);
                 for (x, dst) in dst.iter_mut().enumerate() {
-                    *dst = rav1d_filter_8tap_clip(
-                        bd,
-                        mid_ptr.as_ptr(),
-                        x,
-                        fv,
-                        128,
-                        6 + intermediate_bits,
-                    );
+                    *dst = filter_8tap(mid_ptr.as_ptr(), x, fv, 128)
+                        .rnd(6 + intermediate_bits)
+                        .clip(bd);
                 }
 
                 mid_ptr = &mut mid_ptr[128..];
@@ -203,7 +186,9 @@ unsafe fn put_8tap_rust<BD: BitDepth>(
             for _ in 0..h {
                 let dst = slice::from_raw_parts_mut(dst_ptr, w);
                 for (x, dst) in dst.iter_mut().enumerate() {
-                    *dst = rav1d_filter_8tap_clip2(bd, src, x, fh, 1, intermediate_rnd, 6);
+                    *dst = filter_8tap(src, x, fh, 1)
+                        .rnd2(6, intermediate_rnd)
+                        .clip(bd);
                 }
 
                 dst_ptr = dst_ptr.offset(dst_stride);
@@ -214,7 +199,7 @@ unsafe fn put_8tap_rust<BD: BitDepth>(
         for _ in 0..h {
             let dst = slice::from_raw_parts_mut(dst_ptr, w);
             for (x, dst) in dst.iter_mut().enumerate() {
-                *dst = rav1d_filter_8tap_clip(bd, src, x, fv, src_stride, 6);
+                *dst = filter_8tap(src, x, fv, src_stride).rnd(6).clip(bd);
             }
 
             dst_ptr = dst_ptr.offset(dst_stride);
@@ -255,7 +240,9 @@ unsafe fn put_8tap_scaled_rust<BD: BitDepth>(
         for x in 0..w {
             let fh = get_filter(imx >> 6, w, h_filter_type);
             mid_ptr[x] = match fh {
-                Some(fh) => rav1d_filter_8tap_rnd(src, ioff, fh, 1, 6 - intermediate_bits) as i16,
+                Some(fh) => filter_8tap(src, ioff, fh, 1)
+                    .rnd(6 - intermediate_bits)
+                    .get() as i16,
                 None => ((*src.offset(ioff as isize)).as_::<i32>() as i16) << intermediate_bits,
             };
             imx += dx;
@@ -273,9 +260,9 @@ unsafe fn put_8tap_scaled_rust<BD: BitDepth>(
         let dst = slice::from_raw_parts_mut(dst_ptr, w);
         for (x, dst) in dst.iter_mut().enumerate() {
             *dst = match fv {
-                Some(fv) => {
-                    rav1d_filter_8tap_clip(bd, mid_ptr.as_ptr(), x, fv, 128, 6 + intermediate_bits)
-                }
+                Some(fv) => filter_8tap(mid_ptr.as_ptr(), x, fv, 128)
+                    .rnd(6 + intermediate_bits)
+                    .clip(bd),
                 None => {
                     bd.iclip_pixel((i32::from(mid_ptr[x]) + intermediate_rnd) >> intermediate_bits)
                 }
@@ -315,7 +302,7 @@ unsafe fn prep_8tap_rust<BD: BitDepth>(
             src = src.offset(-src_stride * 3);
             for _ in 0..tmp_h {
                 for x in 0..w {
-                    mid_ptr[x] = rav1d_filter_8tap_rnd(src, x, fh, 1, 6 - intermediate_bits) as i16;
+                    mid_ptr[x] = filter_8tap(src, x, fh, 1).rnd(6 - intermediate_bits).get() as i16;
                 }
 
                 mid_ptr = &mut mid_ptr[128..];
@@ -325,7 +312,7 @@ unsafe fn prep_8tap_rust<BD: BitDepth>(
             mid_ptr = &mut mid[128 * 3..];
             for _ in 0..h {
                 for x in 0..w {
-                    tmp[x] = (rav1d_filter_8tap_rnd(mid_ptr.as_ptr(), x, fv, 128, 6)
+                    tmp[x] = (filter_8tap(mid_ptr.as_ptr(), x, fv, 128).rnd(6).get()
                         - i32::from(BD::PREP_BIAS))
                     .try_into()
                     .unwrap();
@@ -337,7 +324,7 @@ unsafe fn prep_8tap_rust<BD: BitDepth>(
         } else {
             for _ in 0..h {
                 for x in 0..w {
-                    tmp[x] = (rav1d_filter_8tap_rnd(src, x, fh, 1, 6 - intermediate_bits)
+                    tmp[x] = (filter_8tap(src, x, fh, 1).rnd(6 - intermediate_bits).get()
                         - i32::from(BD::PREP_BIAS)) as i16;
                 }
 
@@ -348,7 +335,9 @@ unsafe fn prep_8tap_rust<BD: BitDepth>(
     } else if let Some(fv) = fv {
         for _ in 0..h {
             for x in 0..w {
-                tmp[x] = (rav1d_filter_8tap_rnd(src, x, fv, src_stride, 6 - intermediate_bits)
+                tmp[x] = (filter_8tap(src, x, fv, src_stride)
+                    .rnd(6 - intermediate_bits)
+                    .get()
                     - i32::from(BD::PREP_BIAS)) as i16;
             }
 
@@ -387,7 +376,9 @@ unsafe fn prep_8tap_scaled_rust<BD: BitDepth>(
         for x in 0..w {
             let fh = get_filter(imx >> 6, w, h_filter_type);
             mid_ptr[x] = match fh {
-                Some(fh) => rav1d_filter_8tap_rnd(src, ioff, fh, 1, 6 - intermediate_bits) as i16,
+                Some(fh) => filter_8tap(src, ioff, fh, 1)
+                    .rnd(6 - intermediate_bits)
+                    .get() as i16,
                 None => ((*src.offset(ioff as isize)).as_::<i32>() as i16) << intermediate_bits,
             };
             imx += dx;
@@ -404,7 +395,7 @@ unsafe fn prep_8tap_scaled_rust<BD: BitDepth>(
         let fv = get_filter(my >> 6, h, v_filter_type);
         for x in 0..w {
             tmp[x] = ((match fv {
-                Some(fv) => rav1d_filter_8tap_rnd(mid_ptr.as_ptr(), x, fv, 128, 6),
+                Some(fv) => filter_8tap(mid_ptr.as_ptr(), x, fv, 128).rnd(6).get(),
                 None => i32::from(mid_ptr[x]),
             }) - i32::from(BD::PREP_BIAS)) as i16;
         }
@@ -415,31 +406,16 @@ unsafe fn prep_8tap_scaled_rust<BD: BitDepth>(
     }
 }
 
-unsafe fn filter_bilin<T: Into<i32>>(src: *const T, x: usize, mxy: usize, stride: isize) -> i32 {
+unsafe fn filter_bilin<T: Into<i32>>(
+    src: *const T,
+    x: usize,
+    mxy: usize,
+    stride: isize,
+) -> FilterResult {
     let x = x as isize;
     let src = |i| -> i32 { src.offset(i).read().into() };
-    16 * src(x) + ((mxy as i32) * (src(x + stride) - src(x)))
-}
-
-unsafe fn filter_bilin_rnd<T: Into<i32>>(
-    src: *const T,
-    x: usize,
-    mxy: usize,
-    stride: isize,
-    sh: u8,
-) -> i32 {
-    (filter_bilin(src, x, mxy, stride) + ((1 << sh) >> 1)) >> sh
-}
-
-unsafe fn filter_bilin_clip<BD: BitDepth, T: Into<i32>>(
-    bd: BD,
-    src: *const T,
-    x: usize,
-    mxy: usize,
-    stride: isize,
-    sh: u8,
-) -> BD::Pixel {
-    bd.iclip_pixel(filter_bilin_rnd(src, x, mxy, stride, sh))
+    let pixel = 16 * src(x) + ((mxy as i32) * (src(x + stride) - src(x)));
+    FilterResult { pixel }
 }
 
 unsafe fn put_bilin_rust<BD: BitDepth>(
@@ -465,7 +441,8 @@ unsafe fn put_bilin_rust<BD: BitDepth>(
 
             for _ in 0..tmp_h {
                 for x in 0..w {
-                    mid_ptr[x] = filter_bilin_rnd(src, x, mx, 1, 4 - intermediate_bits) as i16;
+                    mid_ptr[x] =
+                        filter_bilin(src, x, mx, 1).rnd(4 - intermediate_bits).get() as i16;
                 }
 
                 mid_ptr = &mut mid_ptr[128..];
@@ -475,8 +452,9 @@ unsafe fn put_bilin_rust<BD: BitDepth>(
             for _ in 0..h {
                 let dst = slice::from_raw_parts_mut(dst_ptr, w);
                 for (x, dst) in dst.iter_mut().enumerate() {
-                    *dst =
-                        filter_bilin_clip(bd, mid_ptr.as_ptr(), x, my, 128, 4 + intermediate_bits);
+                    *dst = filter_bilin(mid_ptr.as_ptr(), x, my, 128)
+                        .rnd(4 + intermediate_bits)
+                        .clip(bd)
                 }
 
                 mid_ptr = &mut mid_ptr[128..];
@@ -486,7 +464,7 @@ unsafe fn put_bilin_rust<BD: BitDepth>(
             for _ in 0..h {
                 let dst = slice::from_raw_parts_mut(dst_ptr, w);
                 for (x, dst) in dst.iter_mut().enumerate() {
-                    let px = filter_bilin_rnd(src, x, mx, 1, 4 - intermediate_bits);
+                    let px = filter_bilin(src, x, mx, 1).rnd(4 - intermediate_bits).get();
                     *dst = bd.iclip_pixel((px + intermediate_rnd) >> intermediate_bits);
                 }
 
@@ -498,7 +476,7 @@ unsafe fn put_bilin_rust<BD: BitDepth>(
         for _ in 0..h {
             let dst = slice::from_raw_parts_mut(dst_ptr, w);
             for (x, dst) in dst.iter_mut().enumerate() {
-                *dst = filter_bilin_clip(bd, src, x, my, src_stride, 4);
+                *dst = filter_bilin(src, x, my, src_stride).rnd(4).clip(bd)
             }
 
             dst_ptr = dst_ptr.offset(dst_stride);
@@ -533,7 +511,9 @@ unsafe fn put_bilin_scaled_rust<BD: BitDepth>(
         let mut ioff = 0;
 
         for x in 0..w {
-            mid_ptr[x] = filter_bilin_rnd(src, ioff, imx >> 6, 1, 4 - intermediate_bits) as i16;
+            mid_ptr[x] = filter_bilin(src, ioff, imx >> 6, 1)
+                .rnd(4 - intermediate_bits)
+                .get() as i16;
             imx += dx;
             ioff += imx >> 10;
             imx &= 0x3ff;
@@ -546,7 +526,9 @@ unsafe fn put_bilin_scaled_rust<BD: BitDepth>(
     for _ in 0..h {
         let dst = slice::from_raw_parts_mut(dst_ptr, w);
         for (x, dst) in dst.iter_mut().enumerate() {
-            *dst = filter_bilin_clip(bd, mid_ptr.as_ptr(), x, my >> 6, 128, 4 + intermediate_bits);
+            *dst = filter_bilin(mid_ptr.as_ptr(), x, my >> 6, 128)
+                .rnd(4 + intermediate_bits)
+                .clip(bd)
         }
 
         my += dy;
@@ -576,7 +558,8 @@ unsafe fn prep_bilin_rust<BD: BitDepth>(
 
             for _ in 0..tmp_h {
                 for x in 0..w {
-                    mid_ptr[x] = filter_bilin_rnd(src, x, mx, 1, 4 - intermediate_bits) as i16;
+                    mid_ptr[x] =
+                        filter_bilin(src, x, mx, 1).rnd(4 - intermediate_bits).get() as i16;
                 }
 
                 mid_ptr = &mut mid_ptr[128..];
@@ -585,7 +568,7 @@ unsafe fn prep_bilin_rust<BD: BitDepth>(
             mid_ptr = &mut mid[..];
             for _ in 0..h {
                 for x in 0..w {
-                    tmp[x] = (filter_bilin_rnd(mid_ptr.as_ptr(), x, my, 128, 4)
+                    tmp[x] = (filter_bilin(mid_ptr.as_ptr(), x, my, 128).rnd(4).get()
                         - i32::from(BD::PREP_BIAS)) as i16;
                 }
 
@@ -595,7 +578,7 @@ unsafe fn prep_bilin_rust<BD: BitDepth>(
         } else {
             for _ in 0..h {
                 for x in 0..w {
-                    tmp[x] = (filter_bilin_rnd(src, x, mx, 1, 4 - intermediate_bits)
+                    tmp[x] = (filter_bilin(src, x, mx, 1).rnd(4 - intermediate_bits).get()
                         - i32::from(BD::PREP_BIAS)) as i16;
                 }
 
@@ -606,7 +589,9 @@ unsafe fn prep_bilin_rust<BD: BitDepth>(
     } else if my != 0 {
         for _ in 0..h {
             for x in 0..w {
-                tmp[x] = (filter_bilin_rnd(src, x, my, src_stride, 4 - intermediate_bits)
+                tmp[x] = (filter_bilin(src, x, my, src_stride)
+                    .rnd(4 - intermediate_bits)
+                    .get()
                     - i32::from(BD::PREP_BIAS)) as i16;
             }
 
@@ -641,7 +626,9 @@ unsafe fn prep_bilin_scaled_rust<BD: BitDepth>(
         let mut ioff = 0;
 
         for x in 0..w {
-            mid_ptr[x] = filter_bilin_rnd(src, ioff, imx >> 6, 1, 4 - intermediate_bits) as i16;
+            mid_ptr[x] = filter_bilin(src, ioff, imx >> 6, 1)
+                .rnd(4 - intermediate_bits)
+                .get() as i16;
             imx += dx;
             ioff += imx >> 10;
             imx &= 0x3ff;
@@ -653,7 +640,7 @@ unsafe fn prep_bilin_scaled_rust<BD: BitDepth>(
     mid_ptr = &mut mid[..];
     for _ in 0..h {
         for x in 0..w {
-            tmp[x] = (filter_bilin_rnd(mid_ptr.as_ptr(), x, my >> 6, 128, 4)
+            tmp[x] = (filter_bilin(mid_ptr.as_ptr(), x, my >> 6, 128).rnd(4).get()
                 - i32::from(BD::PREP_BIAS)) as i16;
         }
 


### PR DESCRIPTION
This deduplicates the `{rnd,rnd2,clip}` variants of `filter_8tap` and `filter_bilin` into shared methods on `FilterResult`, which also makes it easier to diverge the implementations of `filter_8tap` and `filter_bilin` for `mid: &[i16]` and `src: Rav1dPictureDataComponentOffset`s inputs, which would be trickier to combine under a single generic interface.  I also simplified some stuff with `BD::PREP_BIAS` that was pretty repetitive.