### PR TITLE
Backport extended arm feature detection from dav1d 1.4.1

### DIFF
--- a/src/arm/cpu.c
+++ b/src/arm/cpu.c
@@ -31,22 +31,95 @@
 
 #include "src/arm/cpu.h"
 
-#if defined(__ARM_NEON) || defined(__APPLE__) || defined(_WIN32) || ARCH_AARCH64
-// NEON is always available; runtime tests are not needed.
-#elif defined(HAVE_GETAUXVAL) && ARCH_ARM
+#if defined(HAVE_GETAUXVAL) || defined(HAVE_ELF_AUX_INFO)
 #include <sys/auxv.h>
+
+#if ARCH_AARCH64
+
+#define HWCAP_AARCH64_ASIMDDP (1 << 20)
+#define HWCAP_AARCH64_SVE     (1 << 22)
+#define HWCAP2_AARCH64_SVE2   (1 << 1)
+#define HWCAP2_AARCH64_I8MM   (1 << 13)
+
+COLD unsigned dav1d_get_cpu_flags_arm(void) {
+#ifdef HAVE_GETAUXVAL
+    unsigned long hw_cap = getauxval(AT_HWCAP);
+    unsigned long hw_cap2 = getauxval(AT_HWCAP2);
+#else
+    unsigned long hw_cap = 0;
+    unsigned long hw_cap2 = 0;
+    elf_aux_info(AT_HWCAP, &hw_cap, sizeof(hw_cap));
+    elf_aux_info(AT_HWCAP2, &hw_cap2, sizeof(hw_cap2));
+#endif
+
+    unsigned flags = DAV1D_ARM_CPU_FLAG_NEON;
+    flags |= (hw_cap & HWCAP_AARCH64_ASIMDDP) ? DAV1D_ARM_CPU_FLAG_DOTPROD : 0;
+    flags |= (hw_cap2 & HWCAP2_AARCH64_I8MM) ? DAV1D_ARM_CPU_FLAG_I8MM : 0;
+    flags |= (hw_cap & HWCAP_AARCH64_SVE) ? DAV1D_ARM_CPU_FLAG_SVE : 0;
+    flags |= (hw_cap2 & HWCAP2_AARCH64_SVE2) ? DAV1D_ARM_CPU_FLAG_SVE2 : 0;
+    return flags;
+}
+#else  /* !ARCH_AARCH64 */
 
 #ifndef HWCAP_ARM_NEON
-#define HWCAP_ARM_NEON (1 << 12)
+#define HWCAP_ARM_NEON    (1 << 12)
 #endif
-#define NEON_HWCAP HWCAP_ARM_NEON
+#define HWCAP_ARM_ASIMDDP (1 << 24)
+#define HWCAP_ARM_I8MM    (1 << 27)
 
-#elif defined(HAVE_ELF_AUX_INFO) && ARCH_ARM
-#include <sys/auxv.h>
+COLD unsigned dav1d_get_cpu_flags_arm(void) {
+#ifdef HAVE_GETAUXVAL
+    unsigned long hw_cap = getauxval(AT_HWCAP);
+#else
+    unsigned long hw_cap = 0;
+    elf_aux_info(AT_HWCAP, &hw_cap, sizeof(hw_cap));
+#endif
 
-#define NEON_HWCAP HWCAP_NEON
+    unsigned flags = (hw_cap & HWCAP_ARM_NEON) ? DAV1D_ARM_CPU_FLAG_NEON : 0;
+    flags |= (hw_cap & HWCAP_ARM_ASIMDDP) ? DAV1D_ARM_CPU_FLAG_DOTPROD : 0;
+    flags |= (hw_cap & HWCAP_ARM_I8MM) ? DAV1D_ARM_CPU_FLAG_I8MM : 0;
+    return flags;
+}
+#endif /* ARCH_AARCH64 */
+
+#elif defined(__APPLE__)
+#include <sys/sysctl.h>
+
+static int have_feature(const char *feature) {
+    int supported = 0;
+    size_t size = sizeof(supported);
+    if (sysctlbyname(feature, &supported, &size, NULL, 0) != 0) {
+        return 0;
+    }
+    return supported;
+}
+
+COLD unsigned dav1d_get_cpu_flags_arm(void) {
+    unsigned flags = DAV1D_ARM_CPU_FLAG_NEON;
+    if (have_feature("hw.optional.arm.FEAT_DotProd"))
+        flags |= DAV1D_ARM_CPU_FLAG_DOTPROD;
+    if (have_feature("hw.optional.arm.FEAT_I8MM"))
+        flags |= DAV1D_ARM_CPU_FLAG_I8MM;
+    /* No SVE and SVE2 feature detection available on Apple platforms. */
+    return flags;
+}
+
+#elif defined(_WIN32)
+#include <windows.h>
+
+COLD unsigned dav1d_get_cpu_flags_arm(void) {
+    unsigned flags = DAV1D_ARM_CPU_FLAG_NEON;
+#ifdef PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE
+    if (IsProcessorFeaturePresent(PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE))
+        flags |= DAV1D_ARM_CPU_FLAG_DOTPROD;
+#endif
+    /* No I8MM or SVE feature detection available on Windows at the time of
+     * writing. */
+    return flags;
+}
 
 #elif defined(__ANDROID__)
+#include <ctype.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -58,18 +131,25 @@ static unsigned parse_proc_cpuinfo(const char *flag) {
     char line_buffer[120];
     const char *line;
 
+    size_t flaglen = strlen(flag);
     while ((line = fgets(line_buffer, sizeof(line_buffer), file))) {
-        if (strstr(line, flag)) {
-            fclose(file);
-            return 1;
+        // check all occurances as whole words
+        const char *found = line;
+        while ((found = strstr(found, flag))) {
+            if ((found == line_buffer || !isgraph(found[-1])) &&
+                (isspace(found[flaglen]) || feof(file))) {
+                fclose(file);
+                return 1;
+            }
+            found += flaglen;
         }
         // if line is incomplete seek back to avoid splitting the search
         // string into two buffers
-        if (!strchr(line, '\n') && strlen(line) > strlen(flag)) {
+        if (!strchr(line, '\n') && strlen(line) > flaglen) {
             // use fseek since the 64 bit fseeko is only available since
             // Android API level 24 and meson defines _FILE_OFFSET_BITS
             // by default 64
-            if (fseek(file, -strlen(flag), SEEK_CUR))
+            if (fseek(file, -flaglen, SEEK_CUR))
                 break;
         }
     }
@@ -78,22 +158,23 @@ static unsigned parse_proc_cpuinfo(const char *flag) {
 
     return 0;
 }
-#endif
 
 COLD unsigned dav1d_get_cpu_flags_arm(void) {
-    unsigned flags = 0;
-#if defined(__ARM_NEON) || defined(__APPLE__) || defined(_WIN32) || ARCH_AARCH64
-    flags |= DAV1D_ARM_CPU_FLAG_NEON;
-#elif defined(HAVE_GETAUXVAL) && ARCH_ARM
-    unsigned long hw_cap = getauxval(AT_HWCAP);
-    flags |= (hw_cap & NEON_HWCAP) ? DAV1D_ARM_CPU_FLAG_NEON : 0;
-#elif defined(HAVE_ELF_AUX_INFO) && ARCH_ARM
-    unsigned long hw_cap = 0;
-    elf_aux_info(AT_HWCAP, &hw_cap, sizeof(hw_cap));
-    flags |= (hw_cap & NEON_HWCAP) ? DAV1D_ARM_CPU_FLAG_NEON : 0;
-#elif defined(__ANDROID__)
-    flags |= parse_proc_cpuinfo("neon") ? DAV1D_ARM_CPU_FLAG_NEON : 0;
-#endif
-
+    unsigned flags = parse_proc_cpuinfo("neon") ? DAV1D_ARM_CPU_FLAG_NEON : 0;
+    flags |= parse_proc_cpuinfo("asimd") ? DAV1D_ARM_CPU_FLAG_NEON : 0;
+    flags |= parse_proc_cpuinfo("asimddp") ? DAV1D_ARM_CPU_FLAG_DOTPROD : 0;
+    flags |= parse_proc_cpuinfo("i8mm") ? DAV1D_ARM_CPU_FLAG_I8MM : 0;
+#if ARCH_AARCH64
+    flags |= parse_proc_cpuinfo("sve") ? DAV1D_ARM_CPU_FLAG_SVE : 0;
+    flags |= parse_proc_cpuinfo("sve2") ? DAV1D_ARM_CPU_FLAG_SVE2 : 0;
+#endif /* ARCH_AARCH64 */
     return flags;
 }
+
+#else  /* Unsupported OS */
+
+COLD unsigned dav1d_get_cpu_flags_arm(void) {
+    return 0;
+}
+
+#endif

--- a/src/arm/cpu.h
+++ b/src/arm/cpu.h
@@ -30,6 +30,10 @@
 
 enum CpuFlags {
     DAV1D_ARM_CPU_FLAG_NEON = 1 << 0,
+    DAV1D_ARM_CPU_FLAG_DOTPROD = 1 << 1,
+    DAV1D_ARM_CPU_FLAG_I8MM = 1 << 2,
+    DAV1D_ARM_CPU_FLAG_SVE = 1 << 3,
+    DAV1D_ARM_CPU_FLAG_SVE2 = 1 << 4,
 };
 
 unsigned dav1d_get_cpu_flags_arm(void);

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -64,6 +64,20 @@ static ALWAYS_INLINE unsigned dav1d_get_cpu_flags(void) {
 #if defined(__ARM_NEON) || defined(__APPLE__) || defined(_WIN32) || ARCH_AARCH64
     flags |= DAV1D_ARM_CPU_FLAG_NEON;
 #endif
+#ifdef __ARM_FEATURE_DOTPROD
+    flags |= DAV1D_ARM_CPU_FLAG_DOTPROD;
+#endif
+#ifdef __ARM_FEATURE_MATMUL_INT8
+    flags |= DAV1D_ARM_CPU_FLAG_I8MM;
+#endif
+#if ARCH_AARCH64
+#ifdef __ARM_FEATURE_SVE
+    flags |= DAV1D_ARM_CPU_FLAG_SVE;
+#endif
+#ifdef __ARM_FEATURE_SVE2
+    flags |= DAV1D_ARM_CPU_FLAG_SVE2;
+#endif
+#endif /* ARCH_AARCH64 */
 #elif ARCH_PPC64LE
 #if defined(__VSX__)
     flags |= DAV1D_PPC_CPU_FLAG_VSX;

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -43,6 +43,10 @@ bitflags! {
     #[derive(Clone, Copy)]
     pub struct CpuFlags: c_uint {
         const NEON = 1 << 0;
+        const DOTPROD = 1 << 1;
+        const I8MM = 1 << 2;
+        const SVE = 1 << 3;
+        const SVE2 = 1 << 4;
     }
 }
 
@@ -84,6 +88,14 @@ impl CpuFlags {
             CpuFlags::AVX512ICL,
             #[cfg(target_feature = "neon")]
             CpuFlags::NEON,
+            #[cfg(target_feature = "i8mm")]
+            CpuFlags::I8MM,
+            #[cfg(target_feature = "dotprod")]
+            CpuFlags::DOTPROD,
+            #[cfg(target_feature = "sve")]
+            CpuFlags::SVE,
+            #[cfg(target_feature = "sve2")]
+            CpuFlags::SVE2,
             #[cfg(target_feature = "v")]
             CpuFlags::V,
         ];
@@ -159,13 +171,35 @@ impl CpuFlags {
         }
 
         #[cfg(target_arch = "arm")]
-        if std::arch::is_arm_feature_detected!("neon") {
-            flags |= Self::NEON;
+        {
+            if std::arch::is_arm_feature_detected!("neon") {
+                flags |= Self::NEON;
+            }
+            if std::arch::is_arm_feature_detected!("dotprod") {
+                flags |= Self::DOTPROD;
+            }
+            if std::arch::is_arm_feature_detected!("i8mm") {
+                flags |= Self::I8MM;
+            }
         }
 
         #[cfg(target_arch = "aarch64")]
-        if std::arch::is_aarch64_feature_detected!("neon") {
-            flags |= Self::NEON;
+        {
+            if std::arch::is_aarch64_feature_detected!("neon") {
+                flags |= Self::NEON;
+            }
+            if std::arch::is_aarch64_feature_detected!("dotprod") {
+                flags |= Self::DOTPROD;
+            }
+            if std::arch::is_aarch64_feature_detected!("i8mm") {
+                flags |= Self::I8MM;
+            }
+            if std::arch::is_aarch64_feature_detected!("sve") {
+                flags |= Self::SVE;
+            }
+            if std::arch::is_aarch64_feature_detected!("sve2") {
+                flags |= Self::SVE2;
+            }
         }
 
         #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]

--- a/tests/checkasm/checkasm.c
+++ b/tests/checkasm/checkasm.c
@@ -97,6 +97,12 @@ static const struct cpu {
     { "AVX-512 (Ice Lake)", "avx512icl", DAV1D_X86_CPU_FLAG_AVX512ICL },
 #elif ARCH_AARCH64 || ARCH_ARM
     { "NEON",               "neon",      DAV1D_ARM_CPU_FLAG_NEON },
+    { "DOTPROD",            "dotprod",   DAV1D_ARM_CPU_FLAG_DOTPROD },
+    { "I8MM",               "i8mm",      DAV1D_ARM_CPU_FLAG_I8MM },
+#if ARCH_AARCH64
+    { "SVE",                "sve",       DAV1D_ARM_CPU_FLAG_SVE },
+    { "SVE2",               "sve2",      DAV1D_ARM_CPU_FLAG_SVE2 },
+#endif /* ARCH_AARCH64 */
 #elif ARCH_PPC64LE
     { "VSX",                "vsx",       DAV1D_PPC_CPU_FLAG_VSX },
 #elif ARCH_LOONGARCH

--- a/tools/dav1d_cli_parse.c
+++ b/tools/dav1d_cli_parse.c
@@ -219,7 +219,13 @@ enum CpuMask {
 
 static const EnumParseTable cpu_mask_tbl[] = {
 #if ARCH_AARCH64 || ARCH_ARM
-    { "neon", DAV1D_ARM_CPU_FLAG_NEON },
+    { "neon",    DAV1D_ARM_CPU_FLAG_NEON },
+    { "dotprod", DAV1D_ARM_CPU_FLAG_DOTPROD },
+    { "i8mm",    DAV1D_ARM_CPU_FLAG_I8MM },
+#if ARCH_AARCH64
+    { "sve",     DAV1D_ARM_CPU_FLAG_SVE },
+    { "sve2",    DAV1D_ARM_CPU_FLAG_SVE2 },
+#endif /* ARCH_AARCH64 */
 #elif ARCH_LOONGARCH
     { "lsx", DAV1D_LOONGARCH_CPU_FLAG_LSX },
     { "lasx", DAV1D_LOONGARCH_CPU_FLAG_LASX },

--- a/tools/dav1d_cli_parse.rs
+++ b/tools/dav1d_cli_parse.rs
@@ -435,12 +435,57 @@ unsafe fn parse_optional_fraction(
 
 // TODO: add other architectures supported by dav1d
 cfg_if! {
-    if #[cfg(any(target_arch = "arm", target_arch = "aarch64"))] {
-        static mut cpu_mask_tbl: [EnumParseTable; 1] = [
+    if #[cfg(any(target_arch = "arm"))] {
+        static mut cpu_mask_tbl: [EnumParseTable; 3] = [
             {
                 EnumParseTable {
                     str_0: b"neon\0" as *const u8 as *const c_char,
                     val: CpuFlags::NEON.bits() as c_int,
+                }
+            },
+            {
+                EnumParseTable {
+                    str_0: b"dotprod\0" as *const u8 as *const c_char,
+                    val: CpuFlags::DOTPROD.bits() as c_int,
+                }
+            },
+            {
+                EnumParseTable {
+                    str_0: b"i8mm\0" as *const u8 as *const c_char,
+                    val: CpuFlags::I8MM.bits() as c_int,
+                }
+            },
+        ];
+    } else if #[cfg(any(target_arch = "aarch64"))] {
+        static mut cpu_mask_tbl: [EnumParseTable; 5] = [
+            {
+                EnumParseTable {
+                    str_0: b"neon\0" as *const u8 as *const c_char,
+                    val: CpuFlags::NEON.bits() as c_int,
+                }
+            },
+            {
+                EnumParseTable {
+                    str_0: b"dotprod\0" as *const u8 as *const c_char,
+                    val: CpuFlags::DOTPROD.bits() as c_int,
+                }
+            },
+            {
+                EnumParseTable {
+                    str_0: b"i8mm\0" as *const u8 as *const c_char,
+                    val: CpuFlags::I8MM.bits() as c_int,
+                }
+            },
+            {
+                EnumParseTable {
+                    str_0: b"sve\0" as *const u8 as *const c_char,
+                    val: CpuFlags::SVE.bits() as c_int,
+                }
+            },
+            {
+                EnumParseTable {
+                    str_0: b"sve2\0" as *const u8 as *const c_char,
+                    val: CpuFlags::SVE2.bits() as c_int,
                 }
             },
         ];


### PR DESCRIPTION
Add run-time CPU feature detection for DotProd, i8mm, SVE and SVE2. SVE and SVE2 are AArch64-only features.