### PR TITLE
`struct SegmentId`: Add newtype wrapper for `seg_id` that enforces in-bounds

### DIFF
--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -1,4 +1,5 @@
 use crate::src::enum_map::EnumKey;
+use crate::src::levels::SegmentId;
 use crate::src::relaxed_atomic::RelaxedAtomic;
 use parking_lot::Mutex;
 use std::ffi::c_int;
@@ -61,7 +62,7 @@ pub const DAV1D_MAX_CDEF_STRENGTHS: usize = 8;
 pub const DAV1D_MAX_OPERATING_POINTS: usize = 32;
 pub const DAV1D_MAX_TILE_COLS: usize = 64;
 pub const DAV1D_MAX_TILE_ROWS: usize = 64;
-pub const DAV1D_MAX_SEGMENTS: u8 = 8;
+pub const DAV1D_MAX_SEGMENTS: u8 = SegmentId::COUNT as _;
 pub const DAV1D_NUM_REF_FRAMES: usize = 8;
 pub const DAV1D_PRIMARY_REF_NONE: u8 = 7;
 pub const DAV1D_REFS_PER_FRAME: usize = 7;
@@ -71,7 +72,6 @@ pub(crate) const RAV1D_MAX_CDEF_STRENGTHS: usize = DAV1D_MAX_CDEF_STRENGTHS;
 pub(crate) const RAV1D_MAX_OPERATING_POINTS: usize = DAV1D_MAX_OPERATING_POINTS;
 pub(crate) const RAV1D_MAX_TILE_COLS: usize = DAV1D_MAX_TILE_COLS;
 pub(crate) const RAV1D_MAX_TILE_ROWS: usize = DAV1D_MAX_TILE_ROWS;
-pub(crate) const RAV1D_MAX_SEGMENTS: u8 = DAV1D_MAX_SEGMENTS;
 pub(crate) const _RAV1D_NUM_REF_FRAMES: usize = DAV1D_NUM_REF_FRAMES;
 pub(crate) const RAV1D_PRIMARY_REF_NONE: u8 = DAV1D_PRIMARY_REF_NONE;
 pub(crate) const RAV1D_REFS_PER_FRAME: usize = DAV1D_REFS_PER_FRAME;
@@ -1508,7 +1508,7 @@ pub struct Dav1dSegmentationDataSet {
 #[derive(Clone, Default)]
 #[repr(C)]
 pub struct Rav1dSegmentationDataSet {
-    pub d: [Rav1dSegmentationData; RAV1D_MAX_SEGMENTS as usize],
+    pub d: [Rav1dSegmentationData; SegmentId::COUNT],
     pub preskip: u8,
     pub last_active_segid: i8,
 }
@@ -2105,8 +2105,8 @@ pub struct Rav1dFrameHeader_segmentation {
     pub update_data: u8,
     pub seg_data: Rav1dSegmentationDataSet,
     /// TODO compress `[bool; 8]` into `u8`.
-    pub lossless: [bool; RAV1D_MAX_SEGMENTS as usize],
-    pub qidx: [u8; RAV1D_MAX_SEGMENTS as usize],
+    pub lossless: [bool; SegmentId::COUNT],
+    pub qidx: [u8; SegmentId::COUNT],
 }
 
 impl From<Dav1dFrameHeader_segmentation> for Rav1dFrameHeader_segmentation {

--- a/lib.rs
+++ b/lib.rs
@@ -63,7 +63,7 @@ pub mod src {
     mod iter;
     mod itx;
     mod itx_1d;
-    mod levels;
+    pub(crate) mod levels;
     mod lf_apply;
     mod lf_mask;
     pub mod lib;

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -2,7 +2,6 @@
 
 use crate::include::dav1d::headers::Rav1dFilterMode;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
-use crate::include::dav1d::headers::RAV1D_MAX_SEGMENTS;
 use crate::src::align::Align16;
 use crate::src::align::Align32;
 use crate::src::align::Align4;
@@ -12,6 +11,7 @@ use crate::src::levels::BlockLevel;
 use crate::src::levels::BlockPartition;
 use crate::src::levels::BlockSize;
 use crate::src::levels::MVJoint;
+use crate::src::levels::SegmentId;
 use crate::src::levels::N_COMP_INTER_PRED_MODES;
 use crate::src::levels::N_INTRA_PRED_MODES;
 use crate::src::levels::N_TX_SIZES;
@@ -103,7 +103,7 @@ pub struct CdfModeContext {
     pub angle_delta: Align16<[[u16; 8]; 8]>,
     pub filter_intra: Align16<[u16; 8]>,
     pub comp_inter_mode: Align16<[[u16; N_COMP_INTER_PRED_MODES]; 8]>,
-    pub seg_id: Align16<[[u16; RAV1D_MAX_SEGMENTS as usize]; 3]>,
+    pub seg_id: Align16<[[u16; SegmentId::COUNT]; 3]>,
     pub pal_sz: Align16<[[[u16; 8]; 7]; 2]>,
     pub color_map: Align16<[[[[u16; 8]; 5]; 7]; 2]>,
     pub filter: Align8<[[[u16; 4]; 8]; 2]>,
@@ -5021,7 +5021,7 @@ pub(crate) fn rav1d_cdf_thread_update(
     update_cdf_4d!(N_TX_SIZES, 2, 41 /*42*/, 3, coef.base_tok);
     update_bit_2d!(2, 3, coef.dc_sign);
     update_cdf_4d!(4, 2, 21, 3, coef.br_tok);
-    update_cdf_2d!(3, (RAV1D_MAX_SEGMENTS - 1) as usize, m.seg_id);
+    update_cdf_2d!(3, SegmentId::COUNT - 1, m.seg_id);
     update_cdf_1d!(7, m.cfl_sign.0);
     update_cdf_2d!(6, 15, m.cfl_alpha);
     update_bit_0d!(m.restore_wiener);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -16,7 +16,6 @@ use crate::include::dav1d::headers::Rav1dTxfmMode;
 use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
 use crate::include::dav1d::headers::Rav1dWarpedMotionType;
 use crate::include::dav1d::headers::SgrIdx;
-use crate::include::dav1d::headers::RAV1D_MAX_SEGMENTS;
 use crate::include::dav1d::headers::RAV1D_PRIMARY_REF_NONE;
 use crate::include::dav1d::picture::Rav1dPicture;
 use crate::src::align::Align16;
@@ -187,13 +186,13 @@ fn init_quant_tables(
     seq_hdr: &Rav1dSequenceHeader,
     frame_hdr: &Rav1dFrameHeader,
     qidx: u8,
-    dq: &[[[RelaxedAtomic<u16>; 2]; 3]; RAV1D_MAX_SEGMENTS as usize],
+    dq: &[[[RelaxedAtomic<u16>; 2]; 3]; SegmentId::COUNT],
 ) {
     let tbl = &dav1d_dq_tbl[seq_hdr.hbd as usize];
 
     let segmentation_is_enabled = frame_hdr.segmentation.enabled != 0;
     let len = if segmentation_is_enabled {
-        RAV1D_MAX_SEGMENTS as usize
+        SegmentId::COUNT
     } else {
         1
     };
@@ -1375,7 +1374,7 @@ fn decode_b(
                 let diff = rav1d_msac_decode_symbol_adapt8(
                     &mut ts_c.msac,
                     &mut ts_c.cdf.m.seg_id[seg_ctx as usize],
-                    RAV1D_MAX_SEGMENTS as usize - 1,
+                    SegmentId::COUNT - 1,
                 );
                 let last_active_seg_id_plus1 =
                     (frame_hdr.segmentation.seg_data.last_active_segid + 1) as u8;
@@ -1463,7 +1462,7 @@ fn decode_b(
                 let diff = rav1d_msac_decode_symbol_adapt8(
                     &mut ts_c.msac,
                     &mut ts_c.cdf.m.seg_id[seg_ctx as usize],
-                    RAV1D_MAX_SEGMENTS as usize - 1,
+                    SegmentId::COUNT - 1,
                 );
                 let last_active_seg_id_plus1 =
                     (frame_hdr.segmentation.seg_data.last_active_segid + 1) as u8;

--- a/src/env.rs
+++ b/src/env.rs
@@ -11,6 +11,7 @@ use crate::src::levels::mv;
 use crate::src::levels::BlockLevel;
 use crate::src::levels::BlockPartition;
 use crate::src::levels::CompInterType;
+use crate::src::levels::SegmentId;
 use crate::src::levels::TxfmSize;
 use crate::src::levels::TxfmType;
 use crate::src::levels::DCT_DCT;
@@ -618,9 +619,9 @@ pub fn get_cur_frame_segid(
     b: Bxy,
     have_top: bool,
     have_left: bool,
-    cur_seg_map: &DisjointMutSlice<u8>,
+    cur_seg_map: &DisjointMutSlice<SegmentId>,
     stride: usize,
-) -> (u8, u8) {
+) -> (SegmentId, u8) {
     let negative_adjustment = have_left as usize + have_top as usize * stride;
     let offset = b.x as usize + b.y as usize * stride - negative_adjustment;
     match (have_left, have_top) {
@@ -639,7 +640,7 @@ pub fn get_cur_frame_segid(
             (seg_id, seg_ctx)
         }
         (true, false) | (false, true) => (*cur_seg_map.index(offset), 0),
-        (false, false) => (0, 0),
+        (false, false) => (Default::default(), 0),
     }
 }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -40,6 +40,7 @@ use crate::src::ipred::Rav1dIntraPredDSPContext;
 use crate::src::itx::Rav1dInvTxfmDSPContext;
 use crate::src::levels::Av1Block;
 use crate::src::levels::Filter2d;
+use crate::src::levels::SegmentId;
 use crate::src::levels::TxfmType;
 use crate::src::levels::WHT_WHT;
 use crate::src::lf_mask::Av1Filter;
@@ -330,7 +331,7 @@ pub(crate) struct TaskThreadData {
 #[repr(C)]
 pub(crate) struct Rav1dContext_refs {
     pub p: Rav1dThreadPicture,
-    pub segmap: Option<DisjointMutArcSlice<u8>>,
+    pub segmap: Option<DisjointMutArcSlice<SegmentId>>,
     pub refmvs: Option<DisjointMutArcSlice<refmvs_temporal_block>>,
     pub refpoc: [c_uint; 7],
 }
@@ -792,8 +793,8 @@ pub(crate) struct Rav1dFrameData {
     pub sr_cur: Rav1dThreadPicture,
     pub mvs: Option<DisjointMutArcSlice<refmvs_temporal_block>>, // Previously pooled.
     pub ref_mvs: [Option<DisjointMutArcSlice<refmvs_temporal_block>>; 7],
-    pub cur_segmap: Option<DisjointMutArcSlice<u8>>, // Previously pooled.
-    pub prev_segmap: Option<DisjointMutArcSlice<u8>>,
+    pub cur_segmap: Option<DisjointMutArcSlice<SegmentId>>, // Previously pooled.
+    pub prev_segmap: Option<DisjointMutArcSlice<SegmentId>>,
     pub refpoc: [c_uint; 7],
     pub refrefpoc: [[c_uint; 7]; 7],
     pub gmv_warp_allowed: [u8; 7],

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -16,7 +16,6 @@ use crate::include::dav1d::headers::Rav1dITUTT35;
 use crate::include::dav1d::headers::Rav1dMasteringDisplay;
 use crate::include::dav1d::headers::Rav1dSequenceHeader;
 use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
-use crate::include::dav1d::headers::RAV1D_MAX_SEGMENTS;
 use crate::include::dav1d::picture::Rav1dPicAllocator;
 use crate::include::dav1d::picture::Rav1dPicture;
 use crate::src::align::Align16;
@@ -827,9 +826,9 @@ pub(crate) struct Rav1dFrameData {
     pub sb_shift: c_int,
     pub sb_step: c_int,
     pub sr_sb128w: c_int,
-    pub dq: [[[RelaxedAtomic<u16>; 2]; 3]; RAV1D_MAX_SEGMENTS as usize], /* [RAV1D_MAX_SEGMENTS][3 plane][2 dc/ac] */
-    pub qm: [[Option<&'static [u8]>; 3]; 19],                            /* [3 plane][19] */
-    pub a: Vec<BlockContext>,                                            /* len = w*tile_rows */
+    pub dq: [[[RelaxedAtomic<u16>; 2]; 3]; SegmentId::COUNT], /* [SegmentId::COUNT][3 plane][2 dc/ac] */
+    pub qm: [[Option<&'static [u8]>; 3]; 19],                 /* [3 plane][19] */
+    pub a: Vec<BlockContext>,                                 /* len = w*tile_rows */
     pub rf: RefMvsFrame,
     pub jnt_weights: [[u8; 7]; 7],
     pub bitdepth_max: c_int,
@@ -898,7 +897,7 @@ pub struct Rav1dTileState {
     // each entry is one tile-sbrow; middle index is refidx
     pub lowest_pixel: usize,
 
-    pub dqmem: [[[RelaxedAtomic<u16>; 2]; 3]; RAV1D_MAX_SEGMENTS as usize], /* [RAV1D_MAX_SEGMENTS][3 plane][2 dc/ac] */
+    pub dqmem: [[[RelaxedAtomic<u16>; 2]; 3]; SegmentId::COUNT], /* [SegmentId::COUNT][3 plane][2 dc/ac] */
     pub dq: RelaxedAtomic<TileStateRef>,
     pub last_qidx: RelaxedAtomic<u8>,
     pub last_delta_lf: RelaxedAtomic<[i8; 4]>,

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -515,9 +515,9 @@ impl SegmentId {
         }
     }
 
-    pub const fn get(&self) -> u8 {
+    pub const fn get(&self) -> usize {
         // Cheaply make sure it is in bounds in a way the compiler can see at call sites.
-        self.id % RAV1D_MAX_SEGMENTS
+        (self.id % RAV1D_MAX_SEGMENTS) as usize
     }
 
     pub fn min() -> Self {

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -501,7 +501,7 @@ impl Default for Av1BlockIntraInter {
 }
 
 /// Within range `0..`[`RAV1D_MAX_SEGMENTS`].
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SegmentId {
     id: u8,
 }
@@ -518,6 +518,14 @@ impl SegmentId {
     pub const fn get(&self) -> u8 {
         // Cheaply make sure it is in bounds in a way the compiler can see at call sites.
         self.id % RAV1D_MAX_SEGMENTS
+    }
+
+    pub fn min() -> Self {
+        Self::new(0).unwrap()
+    }
+
+    pub fn max() -> Self {
+        Self::new(RAV1D_MAX_SEGMENTS - 1).unwrap()
     }
 }
 

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -1,7 +1,6 @@
 #![deny(unsafe_code)]
 
 use crate::include::dav1d::headers::Rav1dFilterMode;
-use crate::include::dav1d::headers::RAV1D_MAX_SEGMENTS;
 use crate::src::enum_map::EnumKey;
 use bitflags::bitflags;
 use std::fmt;
@@ -500,15 +499,17 @@ impl Default for Av1BlockIntraInter {
     }
 }
 
-/// Within range `0..`[`RAV1D_MAX_SEGMENTS`].
+/// Within range `0..`[`SegmentId::COUNT`].
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SegmentId {
     id: u8,
 }
 
 impl SegmentId {
+    pub const COUNT: usize = 8;
+
     pub const fn new(id: u8) -> Option<Self> {
-        if id < RAV1D_MAX_SEGMENTS {
+        if id < Self::COUNT as _ {
             Some(Self { id })
         } else {
             None
@@ -517,7 +518,7 @@ impl SegmentId {
 
     pub const fn get(&self) -> usize {
         // Cheaply make sure it is in bounds in a way the compiler can see at call sites.
-        (self.id % RAV1D_MAX_SEGMENTS) as usize
+        self.id as usize % Self::COUNT
     }
 
     pub fn min() -> Self {
@@ -525,7 +526,7 @@ impl SegmentId {
     }
 
     pub fn max() -> Self {
-        Self::new(RAV1D_MAX_SEGMENTS - 1).unwrap()
+        Self::new(Self::COUNT as u8 - 1).unwrap()
     }
 }
 

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -1,8 +1,12 @@
 #![deny(unsafe_code)]
 
 use crate::include::dav1d::headers::Rav1dFilterMode;
+use crate::include::dav1d::headers::RAV1D_MAX_SEGMENTS;
 use crate::src::enum_map::EnumKey;
 use bitflags::bitflags;
+use std::fmt;
+use std::fmt::Display;
+use std::fmt::Formatter;
 use std::mem;
 use std::ops::Neg;
 use strum::EnumCount;
@@ -496,13 +500,40 @@ impl Default for Av1BlockIntraInter {
     }
 }
 
+/// Within range `0..`[`RAV1D_MAX_SEGMENTS`].
+#[derive(Clone, Copy, Default)]
+pub struct SegmentId {
+    id: u8,
+}
+
+impl SegmentId {
+    pub const fn new(id: u8) -> Option<Self> {
+        if id < RAV1D_MAX_SEGMENTS {
+            Some(Self { id })
+        } else {
+            None
+        }
+    }
+
+    pub const fn get(&self) -> u8 {
+        // Cheaply make sure it is in bounds in a way the compiler can see at call sites.
+        self.id % RAV1D_MAX_SEGMENTS
+    }
+}
+
+impl Display for SegmentId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", self.id)
+    }
+}
+
 #[derive(Default)]
 #[repr(C)]
 pub struct Av1Block {
     pub bl: BlockLevel,
     pub bs: u8,
     pub bp: BlockPartition,
-    pub seg_id: u8,
+    pub seg_id: SegmentId,
     pub skip_mode: u8,
     pub skip: u8,
     pub uvtx: RectTxfmSize,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -4,7 +4,6 @@ use crate::include::dav1d::headers::Rav1dFrameHeader;
 use crate::include::dav1d::headers::Rav1dLoopfilterModeRefDeltas;
 use crate::include::dav1d::headers::Rav1dPixelLayout;
 use crate::include::dav1d::headers::Rav1dRestorationType;
-use crate::include::dav1d::headers::RAV1D_MAX_SEGMENTS;
 use crate::src::align::Align16;
 use crate::src::align::ArrayDefault;
 use crate::src::ctx::CaseSet;
@@ -12,6 +11,7 @@ use crate::src::disjoint_mut::DisjointMut;
 use crate::src::internal::Bxy;
 use crate::src::levels::BlockSize;
 use crate::src::levels::RectTxfmSize;
+use crate::src::levels::SegmentId;
 use crate::src::levels::TX_4X4;
 use crate::src::relaxed_atomic::RelaxedAtomic;
 use crate::src::tables::dav1d_block_dimensions;
@@ -671,12 +671,12 @@ fn calc_lf_value_chroma(
 }
 
 pub(crate) fn rav1d_calc_lf_values(
-    lflvl_values: &mut [Align16<[[[u8; 2]; 8]; 4]>; RAV1D_MAX_SEGMENTS as usize],
+    lflvl_values: &mut [Align16<[[[u8; 2]; 8]; 4]>; SegmentId::COUNT],
     hdr: &Rav1dFrameHeader,
     lf_delta: &[i8; 4],
 ) {
     let n_seg = if hdr.segmentation.enabled != 0 {
-        RAV1D_MAX_SEGMENTS as usize
+        SegmentId::COUNT
     } else {
         1
     };

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -524,7 +524,7 @@ fn decode_coefs<BD: BitDepth>(
     let ts = &f.ts[ts];
     let chroma = plane != 0;
     let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
-    let lossless = frame_hdr.segmentation.lossless[b.seg_id as usize];
+    let lossless = frame_hdr.segmentation.lossless[b.seg_id.get() as usize];
     let t_dim = &dav1d_txfm_dimensions[tx as usize];
     let dbg = dbg_block_info && plane != 0 && false;
 
@@ -565,7 +565,7 @@ fn decode_coefs<BD: BitDepth>(
         // In libaom, lossless is checked by a literal qidx == 0, but not all
         // such blocks are actually lossless. The remainder gets an implicit
         // transform type (for luma)
-        _ if frame_hdr.segmentation.qidx[b.seg_id as usize] == 0 => DCT_DCT,
+        _ if frame_hdr.segmentation.qidx[b.seg_id.get() as usize] == 0 => DCT_DCT,
         Intra(intra) => {
             let y_mode_nofilt = if intra.y_mode == FILTER_PRED {
                 dav1d_filter_mode_to_y_mode[intra.y_angle as usize]
@@ -1335,7 +1335,7 @@ fn decode_coefs<BD: BitDepth>(
         TileStateRef::Frame => &f.dq,
         TileStateRef::Local => &ts.dqmem,
     };
-    let dq_tbl = &dq[b.seg_id as usize][plane];
+    let dq_tbl = &dq[b.seg_id.get() as usize][plane];
     let qm_tbl = if *txtp < IDTX {
         f.qm[tx as usize][plane]
     } else {

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -524,7 +524,7 @@ fn decode_coefs<BD: BitDepth>(
     let ts = &f.ts[ts];
     let chroma = plane != 0;
     let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
-    let lossless = frame_hdr.segmentation.lossless[b.seg_id.get() as usize];
+    let lossless = frame_hdr.segmentation.lossless[b.seg_id.get()];
     let t_dim = &dav1d_txfm_dimensions[tx as usize];
     let dbg = dbg_block_info && plane != 0 && false;
 
@@ -565,7 +565,7 @@ fn decode_coefs<BD: BitDepth>(
         // In libaom, lossless is checked by a literal qidx == 0, but not all
         // such blocks are actually lossless. The remainder gets an implicit
         // transform type (for luma)
-        _ if frame_hdr.segmentation.qidx[b.seg_id.get() as usize] == 0 => DCT_DCT,
+        _ if frame_hdr.segmentation.qidx[b.seg_id.get()] == 0 => DCT_DCT,
         Intra(intra) => {
             let y_mode_nofilt = if intra.y_mode == FILTER_PRED {
                 dav1d_filter_mode_to_y_mode[intra.y_angle as usize]
@@ -1335,7 +1335,7 @@ fn decode_coefs<BD: BitDepth>(
         TileStateRef::Frame => &f.dq,
         TileStateRef::Local => &ts.dqmem,
     };
-    let dq_tbl = &dq[b.seg_id.get() as usize][plane];
+    let dq_tbl = &dq[b.seg_id.get()][plane];
     let qm_tbl = if *txtp < IDTX {
         f.qm[tx as usize][plane]
     } else {


### PR DESCRIPTION
* Part of #1180.

It also removes some checks from `fn decode_b` and its callees, which is also a hot spot.