### PR TITLE
`enum Rav1dFilterMode`: Use instead of `u8`s or `Dav1dFilterMode` in more places

### DIFF
--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -1,3 +1,4 @@
+use crate::src::align::ArrayDefault;
 use crate::src::enum_map::EnumKey;
 use crate::src::levels::SegmentId;
 use crate::src::relaxed_atomic::RelaxedAtomic;
@@ -139,7 +140,7 @@ pub const DAV1D_FILTER_8TAP_SMOOTH: Dav1dFilterMode =
 pub const DAV1D_FILTER_8TAP_REGULAR: Dav1dFilterMode =
     Rav1dFilterMode::Regular8Tap as Dav1dFilterMode;
 
-#[derive(Clone, Copy, PartialEq, Eq, FromRepr, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, FromRepr, Default, Debug)]
 pub enum Rav1dFilterMode {
     #[default] // Not really a real default.
     Regular8Tap = 0,
@@ -149,9 +150,15 @@ pub enum Rav1dFilterMode {
     Switchable = 4,
 }
 
+impl ArrayDefault for Rav1dFilterMode {
+    fn default() -> Self {
+        Default::default()
+    }
+}
+
 impl Rav1dFilterMode {
     pub const N_FILTERS: usize = 4;
-    pub const N_SWITCHABLE_FILTERS: u8 = 3;
+    pub const N_SWITCHABLE_FILTERS: Self = Self::Bilinear;
 }
 
 impl From<Rav1dFilterMode> for Dav1dFilterMode {

--- a/src/env.rs
+++ b/src/env.rs
@@ -40,7 +40,11 @@ pub struct BlockContext {
     pub intra: DisjointMut<Align8<[u8; 32]>>,
     pub comp_type: DisjointMut<Align8<[Option<CompInterType>; 32]>>,
     pub r#ref: [DisjointMut<Align8<[i8; 32]>>; 2],
-    pub filter: [DisjointMut<Align8<[u8; 32]>>; 2],
+
+    /// No [`Rav1dFilterMode::Switchable`]s here.
+    /// TODO(kkysen) split [`Rav1dFilterMode`] into a version without [`Rav1dFilterMode::Switchable`].
+    pub filter: [DisjointMut<Align8<[Rav1dFilterMode; 32]>>; 2],
+
     pub tx_intra: DisjointMut<Align8<[i8; 32]>>,
     pub tx: DisjointMut<Align8<[u8; 32]>>,
     pub tx_lpf_y: DisjointMut<Align8<[u8; 32]>>,
@@ -169,7 +173,7 @@ pub fn get_filter_ctx(
     });
 
     (comp as u8) * 4
-        + if a_filter == l_filter {
+        + (if a_filter == l_filter {
             a_filter
         } else if a_filter == Rav1dFilterMode::N_SWITCHABLE_FILTERS {
             l_filter
@@ -177,7 +181,7 @@ pub fn get_filter_ctx(
             a_filter
         } else {
             Rav1dFilterMode::N_SWITCHABLE_FILTERS
-        }
+        } as u8)
 }
 
 #[inline]


### PR DESCRIPTION
* Part of #1180.

This removes a bunch of casts and also moves checks to where the `Rav1dFilterMode`s are first calculated, and where it is deducible that no checks are needed.