### PR TITLE
`struct InRange`: Add type that enforces its value is within a const generic range

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -56,6 +56,7 @@ pub mod src {
     pub(crate) mod wrap_fn_ptr;
     // TODO(kkysen) Temporarily `pub(crate)` due to a `pub use` until TAIT.
     mod extensions;
+    mod in_range;
     pub(super) mod internal;
     mod intra_edge;
     mod ipred;

--- a/src/in_range.rs
+++ b/src/in_range.rs
@@ -1,0 +1,63 @@
+use crate::src::assume::assume;
+use std::fmt;
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::fmt::Formatter;
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub struct InRange<T, const MIN: u128, const MAX: u128>(T);
+
+impl<T, const MIN: u128, const MAX: u128> InRange<T, MIN, MAX>
+where
+    T: TryFrom<u128, Error: Debug>,
+{
+    pub fn min() -> Self {
+        Self(MIN.try_into().unwrap())
+    }
+
+    pub fn max() -> Self {
+        Self(MAX.try_into().unwrap())
+    }
+}
+
+impl<T, const MIN: u128, const MAX: u128> InRange<T, MIN, MAX>
+where
+    T: TryFrom<u128, Error: Debug> + PartialEq + Eq + PartialOrd + Ord,
+{
+    fn in_bounds(&self) -> bool {
+        *self >= Self::min() && *self <= Self::max()
+    }
+
+    pub fn new(value: T) -> Option<Self> {
+        let this = Self(value);
+        if this.in_bounds() {
+            Some(this)
+        } else {
+            None
+        }
+    }
+
+    pub fn get(self) -> T {
+        // SAFETY: Checked in `Self::new`.
+        unsafe { assume(self.in_bounds()) };
+        self.0
+    }
+}
+
+impl<T, const MIN: u128, const MAX: u128> Default for InRange<T, MIN, MAX>
+where
+    T: TryFrom<u128, Error: Debug>,
+{
+    fn default() -> Self {
+        Self::min()
+    }
+}
+
+impl<T, const MIN: u128, const MAX: u128> Display for InRange<T, MIN, MAX>
+where
+    T: Display,
+{
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -2,6 +2,7 @@
 
 use crate::include::dav1d::headers::Rav1dFilterMode;
 use crate::src::enum_map::EnumKey;
+use crate::src::in_range::InRange;
 use bitflags::bitflags;
 use std::fmt;
 use std::fmt::Display;
@@ -502,23 +503,20 @@ impl Default for Av1BlockIntraInter {
 /// Within range `0..`[`SegmentId::COUNT`].
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SegmentId {
-    id: u8,
+    id: InRange<u8, 0, { Self::COUNT as u128 - 1 }>,
 }
 
 impl SegmentId {
     pub const COUNT: usize = 8;
 
-    pub const fn new(id: u8) -> Option<Self> {
-        if id < Self::COUNT as _ {
-            Some(Self { id })
-        } else {
-            None
-        }
+    pub fn new(id: u8) -> Option<Self> {
+        Some(Self {
+            id: InRange::new(id)?,
+        })
     }
 
-    pub const fn get(&self) -> usize {
-        // Cheaply make sure it is in bounds in a way the compiler can see at call sites.
-        self.id as usize % Self::COUNT
+    pub fn get(&self) -> usize {
+        self.id.get() as usize
     }
 
     pub fn min() -> Self {


### PR DESCRIPTION
* Part of #1180.

Use it, for now, to optimize `struct SegmentId` (already similarly optimized, but not generically) and `fn get_skip_ctx`'s return value.

Note that we need this for `fn get_skip_ctx` because it is not inlined, and thus the bounds checks using `sctx` aren't removed in `fn decode_coefs`.  It is not inlined because `fn get_skip_ctx` is not `BitDepth`-generic, but `fn decode_coefs` is.  I think `dav1d` still had `fn get_skip_ctx` inlined because it is manually duplicated with the templating system.  But if LLVM thinks it is better not to inline this even with an `#[inline]` or even an `#[inline(always)]`, and we're still able to propagate information through the return type, I'm inclined to leave it un-inlined.