### PR TITLE
aarch64: Check for assembler support for various aarch64 extensions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -369,6 +369,66 @@ if (is_asm_enabled and
     if cc.compiles(check_pic_code)
         cdata.set('PIC', '3')
     endif
+
+    if host_machine.cpu_family() == 'aarch64'
+        have_as_arch = cc.compiles('''__asm__ (".arch armv8-a");''')
+        cdata.set10('HAVE_AS_ARCH_DIRECTIVE', have_as_arch)
+        as_arch_str = ''
+        if have_as_arch
+            as_arch_level = 'armv8-a'
+            # Check what .arch levels are supported. In principle, we only
+            # want to detect up to armv8.2-a here (binutils requires that
+            # in order to enable i8mm). However, older Clang versions
+            # (before Clang 17, and Xcode versions up to and including 15.0)
+            # didn't support controlling dotprod/i8mm extensions via
+            # .arch_extension, therefore try to enable a high enough .arch
+            # level as well, to implicitly make them available via that.
+            foreach arch : ['armv8.2-a', 'armv8.4-a', 'armv8.6-a']
+                if cc.compiles('__asm__ (".arch ' + arch + '\\n");')
+                    as_arch_level = arch
+                endif
+            endforeach
+            # Clang versions before 17 also had a bug
+            # (https://github.com/llvm/llvm-project/issues/32220)
+            # causing a plain ".arch <level>" to not have any effect unless it
+            # had an extra "+<feature>" included - but it was activated on the
+            # next ".arch_extension" directive instead. Check if we can include
+            # "+crc" as dummy feature to make the .arch directive behave as
+            # expected and take effect right away.
+            if cc.compiles('__asm__ (".arch ' + as_arch_level + '+crc\\n");')
+                as_arch_level = as_arch_level + '+crc'
+            endif
+            cdata.set('AS_ARCH_LEVEL', as_arch_level)
+            as_arch_str = '".arch ' + as_arch_level + '\\n"'
+        endif
+        extensions = {
+            'dotprod': 'udot v0.4s, v0.16b, v0.16b',
+            'i8mm':    'usdot v0.4s, v0.16b, v0.16b',
+            'sve':     'whilelt p0.s, x0, x1',
+            'sve2':    'sqrdmulh z0.s, z0.s, z0.s',
+        }
+        foreach name, instr : extensions
+            # Test for support for the various extensions. First test if
+            # the assembler supports the .arch_extension directive for
+            # enabling/disabling the extension, then separately check whether
+            # the instructions themselves are supported. Even if .arch_extension
+            # isn't supported, we may be able to assemble the instructions
+            # if the .arch level includes support for them.
+            code = '__asm__ (' + as_arch_str
+            code += '".arch_extension ' + name + '\\n"'
+            code += ');'
+            supports_archext = cc.compiles(code)
+            cdata.set10('HAVE_AS_ARCHEXT_' + name.to_upper() + '_DIRECTIVE', supports_archext)
+            code = '__asm__ (' + as_arch_str
+            if supports_archext
+                code += '".arch_extension ' + name + '\\n"'
+            endif
+            code += '"' + instr + '\\n"'
+            code += ');'
+            supports_instr = cc.compiles(code, name: name.to_upper())
+            cdata.set10('HAVE_' + name.to_upper(), supports_instr)
+        endforeach
+    endif
 endif
 
 cdata.set10('ARCH_X86', host_machine.cpu_family().startswith('x86'))

--- a/src/arm/asm.S
+++ b/src/arm/asm.S
@@ -34,6 +34,50 @@
 #define x18 do_not_use_x18
 #define w18 do_not_use_w18
 
+#if HAVE_AS_ARCH_DIRECTIVE
+        .arch AS_ARCH_LEVEL
+#endif
+
+#if HAVE_AS_ARCHEXT_DOTPROD_DIRECTIVE
+#define ENABLE_DOTPROD  .arch_extension dotprod
+#define DISABLE_DOTPROD .arch_extension nodotprod
+#else
+#define ENABLE_DOTPROD
+#define DISABLE_DOTPROD
+#endif
+#if HAVE_AS_ARCHEXT_I8MM_DIRECTIVE
+#define ENABLE_I8MM  .arch_extension i8mm
+#define DISABLE_I8MM .arch_extension noi8mm
+#else
+#define ENABLE_I8MM
+#define DISABLE_I8MM
+#endif
+#if HAVE_AS_ARCHEXT_SVE_DIRECTIVE
+#define ENABLE_SVE  .arch_extension sve
+#define DISABLE_SVE .arch_extension nosve
+#else
+#define ENABLE_SVE
+#define DISABLE_SVE
+#endif
+#if HAVE_AS_ARCHEXT_SVE2_DIRECTIVE
+#define ENABLE_SVE2  .arch_extension sve2
+#define DISABLE_SVE2 .arch_extension nosve2
+#else
+#define ENABLE_SVE2
+#define DISABLE_SVE2
+#endif
+
+/* If we do support the .arch_extension directives, disable support for all
+ * the extensions that we may use, in case they were implicitly enabled by
+ * the .arch level. This makes it clear if we try to assemble an instruction
+ * from an unintended extension set; we only allow assmbling such instructions
+ * within regions where we explicitly enable those extensions. */
+DISABLE_DOTPROD
+DISABLE_I8MM
+DISABLE_SVE
+DISABLE_SVE2
+
+
 /* Support macros for
  *   - Armv8.3-A Pointer Authentication and
  *   - Armv8.5-A Branch Target Identification


### PR DESCRIPTION
First check if the assembler supports the ".arch" directive, and what architecture levels are supported.

In principle, we'd only need to check for support for ".arch armv8.2-a", since that's enough for enabling the i8mm and sve2 extensions.

However, recent Clang versions (before version 17) wasn't able to enable the dotprod and i8mm extensions via the ".arch_extension" directives, so check for support for armv8.4-a and armv8.6-a as well, which enable dotprod and i8mm implicitly.

This allows assembling these instructions on most commonly available GCC and Clang based toolchains, while still allowing toggling support for the instruction sets on and off within the source files.

Within assembly, we disable these extensions by default, so that instructions enabled within these extension sets can't be used by accident in unintended functions. Code meaning to use these extensions can be assembled like this:

    #if HAVE_SVE
    ENABLE_SVE
    // code
    DISABLE_SVE
    #endif