### PR TITLE
`fn cdef`: Make safe

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -54,8 +54,8 @@ wrap_fn_ptr!(pub unsafe extern "C" fn cdef(
     edges: CdefEdgeFlags,
     bitdepth_max: c_int,
     _dst: *const FFISafe<Rav1dPictureDataComponentOffset>,
-    _top: *const FFISafe<CdefTop<'_>>,
-    _bottom: *const FFISafe<CdefBottom<'_>>,
+    _top: *const FFISafe<CdefTop>,
+    _bottom: *const FFISafe<CdefBottom>,
 ) -> ());
 
 pub type CdefTop<'a> = WithOffset<&'a DisjointMut<AlignedVec64<u8>>>;
@@ -71,8 +71,8 @@ impl cdef::Fn {
         &self,
         dst: Rav1dPictureDataComponentOffset,
         left: &[LeftPixelRow2px<BD::Pixel>; 8],
-        top: CdefTop<'_>,
-        bottom: CdefBottom<'_>,
+        top: CdefTop,
+        bottom: CdefBottom,
         pri_strength: c_int,
         sec_strength: u8,
         dir: c_int,
@@ -168,8 +168,8 @@ fn padding<BD: BitDepth>(
     tmp: &mut [i16; TMP_STRIDE * TMP_STRIDE],
     src: Rav1dPictureDataComponentOffset,
     left: &[LeftPixelRow2px<BD::Pixel>; 8],
-    top: CdefTop<'_>,
-    bottom: CdefBottom<'_>,
+    top: CdefTop,
+    bottom: CdefBottom,
     w: usize,
     h: usize,
     edges: CdefEdgeFlags,
@@ -239,8 +239,8 @@ fn padding<BD: BitDepth>(
 fn cdef_filter_block_rust<BD: BitDepth>(
     dst: Rav1dPictureDataComponentOffset,
     left: &[LeftPixelRow2px<BD::Pixel>; 8],
-    top: CdefTop<'_>,
-    bottom: CdefBottom<'_>,
+    top: CdefTop,
+    bottom: CdefBottom,
     pri_strength: c_int,
     sec_strength: c_int,
     dir: c_int,
@@ -384,8 +384,8 @@ unsafe extern "C" fn cdef_filter_block_c_erased<BD: BitDepth, const W: usize, co
     edges: CdefEdgeFlags,
     bitdepth_max: c_int,
     dst: *const FFISafe<Rav1dPictureDataComponentOffset>,
-    top: *const FFISafe<CdefTop<'_>>,
-    bottom: *const FFISafe<CdefBottom<'_>>,
+    top: *const FFISafe<CdefTop>,
+    bottom: *const FFISafe<CdefBottom>,
 ) {
     // SAFETY: Was passed as `FFISafe::new(_)` in `cdef_dir::Fn::call`.
     let dst = *unsafe { FFISafe::get(dst) };
@@ -551,8 +551,8 @@ unsafe extern "C" fn cdef_filter_neon_erased<
     edges: CdefEdgeFlags,
     bitdepth_max: c_int,
     _dst: *const FFISafe<Rav1dPictureDataComponentOffset>,
-    _top: *const FFISafe<CdefTop<'_>>,
-    _bottom: *const FFISafe<CdefBottom<'_>>,
+    _top: *const FFISafe<CdefTop>,
+    _bottom: *const FFISafe<CdefBottom>,
 ) {
     use crate::src::align::Align16;
 

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -19,6 +19,7 @@ use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
 use std::ptr;
+use crate::src::pixels::Pixels;
 
 #[cfg(all(
     feature = "asm",
@@ -28,6 +29,7 @@ use crate::include::common::bitdepth::bd_fn;
 
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 use crate::include::common::bitdepth::{bpc_fn, BPC};
+
 
 bitflags! {
     #[repr(transparent)]

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -381,6 +381,7 @@ fn cdef_filter_block_rust<BD: BitDepth>(
 /// # Safety
 ///
 /// Must be called by [`cdef::Fn::call`].
+#[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn cdef_filter_block_c_erased<BD: BitDepth, const W: usize, const H: usize>(
     _dst_ptr: *mut DynPixel,
     _stride: ptrdiff_t,

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -69,7 +69,7 @@ impl cdef::Fn {
     /// then the pre-filter data is located in `dst`.
     /// However, the edge pixels above `dst` may be post-filter,
     /// so in order to get access to pre-filter top pixels, use `top`.
-    pub unsafe fn call<BD: BitDepth>(
+    pub fn call<BD: BitDepth>(
         &self,
         dst: Rav1dPictureDataComponentOffset,
         left: &[LeftPixelRow2px<BD::Pixel>; 8],
@@ -98,22 +98,25 @@ impl cdef::Fn {
         let damping = damping as c_int;
         let bd = bd.into_c();
         let dst = FFISafe::new(&dst);
-        self.get()(
-            dst_ptr,
-            stride,
-            left,
-            top_ptr,
-            bottom_ptr,
-            pri_strength,
-            sec_strength,
-            dir,
-            damping,
-            edges,
-            bd,
-            dst,
-            top,
-            bottom,
-        )
+        // SAFETY: Rust fallback is safe, asm is assumed to do the same.
+        unsafe {
+            self.get()(
+                dst_ptr,
+                stride,
+                left,
+                top_ptr,
+                bottom_ptr,
+                pri_strength,
+                sec_strength,
+                dir,
+                damping,
+                edges,
+                bd,
+                dst,
+                top,
+                bottom,
+            )
+        }
     }
 }
 

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -5,8 +5,7 @@ use crate::include::common::bitdepth::LeftPixelRow2px;
 use crate::include::common::intops::apply_sign;
 use crate::include::common::intops::iclip;
 use crate::include::dav1d::picture::Rav1dPictureDataComponentOffset;
-use crate::src::align::Align64;
-use crate::src::align::AlignedVec;
+use crate::src::align::AlignedVec64;
 use crate::src::cpu::CpuFlags;
 use crate::src::disjoint_mut::DisjointMut;
 use crate::src::ffi_safe::FFISafe;
@@ -53,14 +52,14 @@ wrap_fn_ptr!(pub unsafe extern "C" fn cdef(
     edges: CdefEdgeFlags,
     bitdepth_max: c_int,
     _dst: *const FFISafe<Rav1dPictureDataComponentOffset>,
-    _top: *const FFISafe<DisjointMut<AlignedVec<u8, Align64<[u8; 64]>>>>,
+    _top: *const FFISafe<DisjointMut<AlignedVec64<u8>>>,
     _bottom: *const FFISafe<CdefBottom<'_>>,
 ) -> ());
 
 #[derive(Clone, Copy)]
 pub enum CdefBottom<'a> {
     Pic(Rav1dPictureDataComponentOffset<'a>),
-    LineBuf((&'a DisjointMut<AlignedVec<u8, Align64<[u8; 64]>>>, usize)),
+    LineBuf((&'a DisjointMut<AlignedVec64<u8>>, usize)),
 }
 
 impl cdef::Fn {
@@ -73,7 +72,7 @@ impl cdef::Fn {
         &self,
         dst: Rav1dPictureDataComponentOffset,
         left: &[LeftPixelRow2px<BD::Pixel>; 8],
-        (top, top_off): (&DisjointMut<AlignedVec<u8, Align64<[u8; 64]>>>, usize),
+        (top, top_off): (&DisjointMut<AlignedVec64<u8>>, usize),
         bottom: CdefBottom<'_>,
         pri_strength: c_int,
         sec_strength: u8,
@@ -175,7 +174,7 @@ fn padding<BD: BitDepth>(
     tmp: &mut [i16; TMP_STRIDE * TMP_STRIDE],
     src: Rav1dPictureDataComponentOffset,
     left: &[LeftPixelRow2px<BD::Pixel>; 8],
-    (top, top_off): (&DisjointMut<AlignedVec<u8, Align64<[u8; 64]>>>, usize),
+    (top, top_off): (&DisjointMut<AlignedVec64<u8>>, usize),
     mut bottom: CdefBottom<'_>,
     w: usize,
     h: usize,
@@ -250,7 +249,7 @@ fn padding<BD: BitDepth>(
 fn cdef_filter_block_rust<BD: BitDepth>(
     dst: Rav1dPictureDataComponentOffset,
     left: &[LeftPixelRow2px<BD::Pixel>; 8],
-    top: (&DisjointMut<AlignedVec<u8, Align64<[u8; 64]>>>, usize),
+    top: (&DisjointMut<AlignedVec64<u8>>, usize),
     bottom: CdefBottom<'_>,
     pri_strength: c_int,
     sec_strength: c_int,
@@ -395,7 +394,7 @@ unsafe extern "C" fn cdef_filter_block_c_erased<BD: BitDepth, const W: usize, co
     edges: CdefEdgeFlags,
     bitdepth_max: c_int,
     dst: *const FFISafe<Rav1dPictureDataComponentOffset>,
-    top: *const FFISafe<DisjointMut<AlignedVec<u8, Align64<[u8; 64]>>>>,
+    top: *const FFISafe<DisjointMut<AlignedVec64<u8>>>,
     bottom: *const FFISafe<CdefBottom<'_>>,
 ) {
     // SAFETY: Was passed as `FFISafe::new(_)` in `cdef_dir::Fn::call`.
@@ -566,7 +565,7 @@ unsafe extern "C" fn cdef_filter_neon_erased<
     edges: CdefEdgeFlags,
     bitdepth_max: c_int,
     _dst: *const FFISafe<Rav1dPictureDataComponentOffset>,
-    _top: *const FFISafe<DisjointMut<AlignedVec<u8, Align64<[u8; 64]>>>>,
+    _top: *const FFISafe<DisjointMut<AlignedVec64<u8>>>,
     _bottom: *const FFISafe<CdefBottom<'_>>,
 ) {
     use crate::src::align::Align16;

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -232,6 +232,8 @@ fn padding<BD: BitDepth>(
     for (i, y) in (h + 2..y_end).enumerate() {
         let tmp = &mut tmp[y * TMP_STRIDE..];
         let bottom_off = bottom_off.wrapping_add_signed(i as isize * stride);
+        // This is a fallback `fn`, so perf is not as important here, so an extra branch
+        // here should be okay.
         let bottom = match bottom {
             CdefBottom::Pic(pic) => &*pic.slice::<BD, _>((bottom_off.., ..x_end)),
             CdefBottom::LineBuf(buf) => &*buf.slice_as((bottom_off.., ..x_end)),

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -290,30 +290,28 @@ pub(crate) fn rav1d_cdef_brow<BD: BitDepth>(
                                 offset: f.lf.cdef_line[tf as usize][0],
                             } + (sby * 4) as isize * y_stride
                                 + (bx * 4) as isize;
-                            let (buf, offset) = if resize {
-                                (
-                                    &f.lf.cdef_line_buf,
-                                    f.lf.cdef_lpf_line[0].wrapping_add_signed(
-                                        (sby * 4 + 2) as isize * y_stride + (bx * 4) as isize,
-                                    ),
-                                )
+                            let buf = if resize {
+                                WithOffset {
+                                    data: &f.lf.cdef_line_buf,
+                                    offset: f.lf.cdef_lpf_line[0],
+                                } + (sby * 4 + 2) as isize * y_stride
+                                    + (bx * 4) as isize
                             } else {
                                 let line = sby * (4 << sb128) + 4 * sb128 as c_int + 2;
-                                (
-                                    &f.lf.lr_line_buf,
-                                    f.lf.lr_lpf_line[0].wrapping_add_signed(
-                                        line as isize * y_stride + (bx * 4) as isize,
-                                    ),
-                                )
+                                WithOffset {
+                                    data: &f.lf.lr_line_buf,
+                                    offset: f.lf.lr_lpf_line[0],
+                                } + line as isize * y_stride
+                                    + (bx * 4) as isize
                             };
                             Some((
                                 top,
                                 WithOffset {
                                     data: PicOrBuf::Buf(WithStride {
-                                        buf,
+                                        buf: buf.data,
                                         stride: y_stride,
                                     }),
-                                    offset,
+                                    offset: buf.offset,
                                 },
                             ))
                         } else {
@@ -395,32 +393,28 @@ pub(crate) fn rav1d_cdef_brow<BD: BitDepth>(
                                         offset: f.lf.cdef_line[tf as usize][pl],
                                     } + (sby * 8) as isize * uv_stride
                                         + (bx * 4 >> ss_hor) as isize;
-                                    let (buf, offset) = if resize {
-                                        (
-                                            &f.lf.cdef_line_buf,
-                                            f.lf.cdef_lpf_line[pl].wrapping_add_signed(
-                                                (sby * 4 + 2) as isize * uv_stride
-                                                    + (bx * 4 >> ss_hor) as isize,
-                                            ),
-                                        )
+                                    let buf = if resize {
+                                        WithOffset {
+                                            data: &f.lf.cdef_line_buf,
+                                            offset: f.lf.cdef_lpf_line[pl],
+                                        } + (sby * 4 + 2) as isize * uv_stride
+                                            + (bx * 4 >> ss_hor) as isize
                                     } else {
                                         let line = sby * (4 << sb128) + 4 * sb128 as c_int + 2;
-                                        (
-                                            &f.lf.lr_line_buf,
-                                            f.lf.lr_lpf_line[pl].wrapping_add_signed(
-                                                line as isize * uv_stride
-                                                    + (bx * 4 >> ss_hor) as isize,
-                                            ),
-                                        )
+                                        WithOffset {
+                                            data: &f.lf.lr_line_buf,
+                                            offset: f.lf.lr_lpf_line[pl],
+                                        } + line as isize * uv_stride
+                                            + (bx * 4 >> ss_hor) as isize
                                     };
                                     Some((
                                         top,
                                         WithOffset {
                                             data: PicOrBuf::Buf(WithStride {
-                                                buf,
+                                                buf: buf.data,
                                                 stride: uv_stride,
                                             }),
-                                            offset,
+                                            offset: buf.offset,
                                         },
                                     ))
                                 } else {

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -278,7 +278,7 @@ pub(crate) fn rav1d_cdef_brow<BD: BitDepth>(
                                 (
                                     &f.lf.lr_line_buf,
                                     f.lf.lr_lpf_line[0].wrapping_add_signed(
-                                        (sby * ((4 as c_int) << sb128) - 4) as isize * y_stride
+                                        (sby * (4 << sb128) - 4) as isize * y_stride
                                             + (bx * 4) as isize,
                                     ),
                                 )
@@ -300,7 +300,7 @@ pub(crate) fn rav1d_cdef_brow<BD: BitDepth>(
                                     ),
                                 )
                             } else {
-                                let line = sby * ((4 as c_int) << sb128) + 4 * sb128 as c_int + 2;
+                                let line = sby * (4 << sb128) + 4 * sb128 as c_int + 2;
                                 (
                                     &f.lf.lr_line_buf,
                                     f.lf.lr_lpf_line[0].wrapping_add_signed(
@@ -381,7 +381,7 @@ pub(crate) fn rav1d_cdef_brow<BD: BitDepth>(
                                             ),
                                         )
                                     } else {
-                                        let line = sby * ((4 as c_int) << sb128) - 4;
+                                        let line = sby * (4 << sb128) - 4;
                                         (
                                             &f.lf.lr_line_buf,
                                             f.lf.lr_lpf_line[pl].wrapping_add_signed(
@@ -409,8 +409,7 @@ pub(crate) fn rav1d_cdef_brow<BD: BitDepth>(
                                             ),
                                         )
                                     } else {
-                                        let line =
-                                            sby * ((4 as c_int) << sb128) + 4 * sb128 as c_int + 2;
+                                        let line = sby * (4 << sb128) + 4 * sb128 as c_int + 2;
                                         (
                                             &f.lf.lr_line_buf,
                                             f.lf.lr_lpf_line[pl].wrapping_add_signed(

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -263,20 +263,19 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
 
                         let mut top = 0 as *const BD::Pixel;
                         let mut bot = 0 as *const BD::Pixel;
-                        let mut offset: ptrdiff_t;
                         let st_y: bool;
 
                         if !have_tt {
                             st_y = true;
                         } else if sbrow_start && by == by_start {
                             if resize {
-                                offset = ((sby - 1) * 4) as isize * y_stride + (bx * 4) as isize;
+                                let offset = ((sby - 1) * 4) as isize * y_stride + (bx * 4) as isize;
                                 top = &*f
                                     .lf
                                     .cdef_line_buf
                                     .element_as((f.lf.cdef_lpf_line[0] as isize + offset) as usize);
                             } else {
-                                offset = (sby * ((4 as c_int) << sb128) - 4) as isize * y_stride
+                                let offset = (sby * ((4 as c_int) << sb128) - 4) as isize * y_stride
                                     + (bx * 4) as isize;
                                 top = &*f
                                     .lf
@@ -287,12 +286,12 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                             bot = bottom.as_ptr::<BD>();
                             st_y = false;
                         } else if !sbrow_start && by + 2 >= by_end {
-                            offset = (sby * 4) as isize * y_stride + (bx * 4) as isize;
+                            let offset = (sby * 4) as isize * y_stride + (bx * 4) as isize;
                             top = &*f.lf.cdef_line_buf.element_as(
                                 (f.lf.cdef_line[tf as usize][0] as isize + offset) as usize,
                             );
                             if resize {
-                                offset = (sby * 4 + 2) as isize * y_stride + (bx * 4) as isize;
+                                let offset = (sby * 4 + 2) as isize * y_stride + (bx * 4) as isize;
                                 // FIXME incorrect; should be kept as an offset for later slices.
                                 bot = &*f
                                     .lf
@@ -300,7 +299,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                                     .element_as((f.lf.cdef_lpf_line[0] as isize + offset) as usize);
                             } else {
                                 let line = sby * ((4 as c_int) << sb128) + 4 * sb128 as c_int + 2;
-                                offset = line as isize * y_stride + (bx * 4) as isize;
+                                let offset = line as isize * y_stride + (bx * 4) as isize;
                                 // FIXME incorrect; should be kept as an offset for later slices.
                                 bot = &*f
                                     .lf
@@ -313,7 +312,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                         }
 
                         if st_y {
-                            offset = have_tt as isize * (sby * 4) as isize * y_stride
+                            let offset = have_tt as isize * (sby * 4) as isize * y_stride
                                 + (bx * 4) as isize;
                             top = &*f.lf.cdef_line_buf.element_as(
                                 (f.lf.cdef_line[tf as usize][0] as isize + offset) as usize,
@@ -367,14 +366,14 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                                     st_uv = true;
                                 } else if sbrow_start && by == by_start {
                                     if resize {
-                                        offset = ((sby - 1) * 4) as isize * uv_stride
+                                        let offset = ((sby - 1) * 4) as isize * uv_stride
                                             + (bx * 4 >> ss_hor) as isize;
                                         top = &*f.lf.cdef_line_buf.element_as(
                                             (f.lf.cdef_lpf_line[pl] as isize + offset) as usize,
                                         );
                                     } else {
                                         let line_0 = sby * ((4 as c_int) << sb128) - 4;
-                                        offset = line_0 as isize * uv_stride
+                                        let offset = line_0 as isize * uv_stride
                                             + (bx * 4 >> ss_hor) as isize;
                                         top = &*f.lf.lr_line_buf.element_as(
                                             (f.lf.lr_lpf_line[pl] as isize + offset) as usize,
@@ -391,7 +390,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                                             as usize,
                                     );
                                     if resize {
-                                        offset = (sby * 4 + 2) as isize * uv_stride
+                                        let offset = (sby * 4 + 2) as isize * uv_stride
                                             + (bx * 4 >> ss_hor) as isize;
                                         // FIXME incorrect; should be kept as an offset for later slices.
                                         bot = &*f.lf.cdef_line_buf.element_as(
@@ -400,7 +399,7 @@ pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
                                     } else {
                                         let line =
                                             sby * ((4 as c_int) << sb128) + 4 * sb128 as c_int + 2;
-                                        offset =
+                                        let offset =
                                             line as isize * uv_stride + (bx * 4 >> ss_hor) as isize;
                                         // FIXME incorrect; should be kept as an offset for later slices.
                                         bot = &*f.lf.lr_line_buf.element_as(

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -272,28 +272,24 @@ pub(crate) fn rav1d_cdef_brow<BD: BitDepth>(
                             let top = if resize {
                                 WithOffset {
                                     data: &f.lf.cdef_line_buf,
-                                    offset: f.lf.cdef_lpf_line[0].wrapping_add_signed(
-                                        ((sby - 1) * 4) as isize * y_stride + (bx * 4) as isize,
-                                    ),
-                                }
+                                    offset: f.lf.cdef_lpf_line[0],
+                                } + ((sby - 1) * 4) as isize * y_stride
+                                    + (bx * 4) as isize
                             } else {
                                 WithOffset {
                                     data: &f.lf.lr_line_buf,
-                                    offset: f.lf.lr_lpf_line[0].wrapping_add_signed(
-                                        (sby * (4 << sb128) - 4) as isize * y_stride
-                                            + (bx * 4) as isize,
-                                    ),
-                                }
+                                    offset: f.lf.lr_lpf_line[0],
+                                } + (sby * (4 << sb128) - 4) as isize * y_stride
+                                    + (bx * 4) as isize
                             };
                             let bottom = bptrs[0] + (8 * y_stride);
                             Some((top, WithOffset::pic(bottom)))
                         } else if !sbrow_start && by + 2 >= by_end {
                             let top = WithOffset {
                                 data: &f.lf.cdef_line_buf,
-                                offset: f.lf.cdef_line[tf as usize][0].wrapping_add_signed(
-                                    (sby * 4) as isize * y_stride + (bx * 4) as isize,
-                                ),
-                            };
+                                offset: f.lf.cdef_line[tf as usize][0],
+                            } + (sby * 4) as isize * y_stride
+                                + (bx * 4) as isize;
                             let (buf, offset) = if resize {
                                 (
                                     &f.lf.cdef_line_buf,
@@ -327,11 +323,9 @@ pub(crate) fn rav1d_cdef_brow<BD: BitDepth>(
                         let (top, bot) = top_bot.unwrap_or_else(|| {
                             let top = WithOffset {
                                 data: &f.lf.cdef_line_buf,
-                                offset: f.lf.cdef_line[tf as usize][0].wrapping_add_signed(
-                                    have_tt as isize * (sby * 4) as isize * y_stride
-                                        + (bx * 4) as isize,
-                                ),
-                            };
+                                offset: f.lf.cdef_line[tf as usize][0],
+                            } + have_tt as isize * (sby * 4) as isize * y_stride
+                                + (bx * 4) as isize;
                             let bottom = bptrs[0] + (8 * y_stride);
                             (top, WithOffset::pic(bottom))
                         });
@@ -382,32 +376,25 @@ pub(crate) fn rav1d_cdef_brow<BD: BitDepth>(
                                     let top = if resize {
                                         WithOffset {
                                             data: &f.lf.cdef_line_buf,
-                                            offset: f.lf.cdef_lpf_line[pl].wrapping_add_signed(
-                                                ((sby - 1) * 4) as isize * uv_stride
-                                                    + (bx * 4 >> ss_hor) as isize,
-                                            ),
-                                        }
+                                            offset: f.lf.cdef_lpf_line[pl],
+                                        } + ((sby - 1) * 4) as isize * uv_stride
+                                            + (bx * 4 >> ss_hor) as isize
                                     } else {
                                         let line = sby * (4 << sb128) - 4;
                                         WithOffset {
                                             data: &f.lf.lr_line_buf,
-                                            offset: f.lf.lr_lpf_line[pl].wrapping_add_signed(
-                                                line as isize * uv_stride
-                                                    + (bx * 4 >> ss_hor) as isize,
-                                            ),
-                                        }
+                                            offset: f.lf.lr_lpf_line[pl],
+                                        } + line as isize * uv_stride
+                                            + (bx * 4 >> ss_hor) as isize
                                     };
                                     let bottom = bptrs[pl] + ((8 >> ss_ver) * uv_stride);
                                     Some((top, WithOffset::pic(bottom)))
                                 } else if !sbrow_start && by + 2 >= by_end {
                                     let top = WithOffset {
                                         data: &f.lf.cdef_line_buf,
-                                        offset: f.lf.cdef_line[tf as usize][pl]
-                                            .wrapping_add_signed(
-                                                (sby * 8) as isize * uv_stride
-                                                    + (bx * 4 >> ss_hor) as isize,
-                                            ),
-                                    };
+                                        offset: f.lf.cdef_line[tf as usize][pl],
+                                    } + (sby * 8) as isize * uv_stride
+                                        + (bx * 4 >> ss_hor) as isize;
                                     let (buf, offset) = if resize {
                                         (
                                             &f.lf.cdef_line_buf,
@@ -443,12 +430,9 @@ pub(crate) fn rav1d_cdef_brow<BD: BitDepth>(
                                 let (top, bot) = top_bot.unwrap_or_else(|| {
                                     let top = WithOffset {
                                         data: &f.lf.cdef_line_buf,
-                                        offset: f.lf.cdef_line[tf as usize][pl]
-                                            .wrapping_add_signed(
-                                                have_tt as isize * (sby * 8) as isize * uv_stride
-                                                    + (bx * 4 >> ss_hor) as isize,
-                                            ),
-                                    };
+                                        offset: f.lf.cdef_line[tf as usize][pl],
+                                    } + have_tt as isize * (sby * 8) as isize * uv_stride
+                                        + (bx * 4 >> ss_hor) as isize;
                                     let bottom = bptrs[pl] + ((8 >> ss_ver) * uv_stride);
                                     (top, WithOffset::pic(bottom))
                                 });

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_code)]
+
 use crate::include::common::bitdepth::BitDepth;
 use crate::include::common::bitdepth::BPC;
 use crate::include::common::intops::ulog2;

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -126,7 +126,7 @@ fn adjust_strength(strength: u8, var: c_uint) -> c_int {
     strength as c_int * (4 + i) + 8 >> 4
 }
 
-pub(crate) unsafe fn rav1d_cdef_brow<BD: BitDepth>(
+pub(crate) fn rav1d_cdef_brow<BD: BitDepth>(
     c: &Rav1dContext,
     tc: &mut Rav1dTaskContext,
     f: &Rav1dFrameData,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -509,8 +509,7 @@ pub(crate) struct Rav1dFrameContext_bd_fn {
     pub filter_sbrow: filter_sbrow_fn,
     pub filter_sbrow_deblock_cols: filter_sbrow_fn,
     pub filter_sbrow_deblock_rows: filter_sbrow_fn,
-    pub filter_sbrow_cdef:
-        unsafe fn(&Rav1dContext, &Rav1dFrameData, &mut Rav1dTaskContext, c_int) -> (),
+    pub filter_sbrow_cdef: fn(&Rav1dContext, &Rav1dFrameData, &mut Rav1dTaskContext, c_int) -> (),
     pub filter_sbrow_resize: filter_sbrow_fn,
     pub filter_sbrow_lr: filter_sbrow_fn,
     pub backup_ipred_edge: backup_ipred_edge_fn,

--- a/src/pixels.rs
+++ b/src/pixels.rs
@@ -24,7 +24,7 @@ pub trait Pixels {
     }
 
     /// Absolute ptr to [`BitDepth::Pixel`]s.
-    fn _as_ptr<BD: BitDepth>(&self) -> *const BD::Pixel {
+    fn as_ptr<BD: BitDepth>(&self) -> *const BD::Pixel {
         self.as_mut_ptr::<BD>().cast_const()
     }
 

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -3709,14 +3709,12 @@ pub(crate) fn rav1d_filter_sbrow_cdef<BD: BitDepth>(
             let ss_ver = f.cur.p.layout == Rav1dPixelLayout::I420 && i != 0;
             p[i] - ((8 * p[i].pixel_stride::<BD>()) >> ss_ver as u8)
         });
-        // TODO make safe
-        unsafe { rav1d_cdef_brow::<BD>(c, tc, f, p_up, prev_mask, start - 2, start, true, sby) };
+        rav1d_cdef_brow::<BD>(c, tc, f, p_up, prev_mask, start - 2, start, true, sby);
     }
 
     let n_blks = sbsz - 2 * ((sby + 1) < f.sbh) as c_int;
     let end = cmp::min(start + n_blks, f.bh);
-    // TODO make safe
-    unsafe { rav1d_cdef_brow::<BD>(c, tc, f, p, mask_offset, start, end, false, sby) };
+    rav1d_cdef_brow::<BD>(c, tc, f, p, mask_offset, start, end, false, sby);
 }
 
 pub(crate) fn rav1d_filter_sbrow_resize<BD: BitDepth>(

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -1275,10 +1275,7 @@ pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContext_task_thread>) {
                         let seq_hdr = &***f.seq_hdr.as_ref().unwrap();
                         if seq_hdr.cdef != 0 {
                             if fc.task_thread.error.load(Ordering::SeqCst) == 0 {
-                                // SAFETY: TODO make safe
-                                unsafe {
-                                    (f.bd_fn().filter_sbrow_cdef)(c, &f, &mut tc, sby);
-                                }
+                                (f.bd_fn().filter_sbrow_cdef)(c, &f, &mut tc, sby);
                             }
                             drop(f);
                             reset_task_cur_async(ttd, t.frame_idx, c.fc.len() as u32);


### PR DESCRIPTION
Makes the remaining Rust fallback in `cdef.rs` safe by passing in additional arguments.

* Closes #850.
* Closes #851.