### PR TITLE
`enum TxfmSize`: Make a real `enum`

### DIFF
--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -12,9 +12,9 @@ use crate::src::levels::BlockPartition;
 use crate::src::levels::BlockSize;
 use crate::src::levels::MVJoint;
 use crate::src::levels::SegmentId;
+use crate::src::levels::TxfmSize;
 use crate::src::levels::N_COMP_INTER_PRED_MODES;
 use crate::src::levels::N_INTRA_PRED_MODES;
-use crate::src::levels::N_TX_SIZES;
 use crate::src::levels::N_UV_INTRA_PRED_MODES;
 use crate::src::tables::dav1d_partition_type_count;
 use parking_lot::RwLock;
@@ -4999,7 +4999,7 @@ pub(crate) fn rav1d_cdf_thread_update(
         );
     }
     update_cdf_2d!(8, 6, m.angle_delta);
-    for k in 0..N_TX_SIZES - 1 {
+    for k in 0..TxfmSize::NUM_SQUARE - 1 {
         update_cdf_2d!(3, cmp::min(k + 1, 2), m.txsz[k]);
     }
     update_cdf_3d!(2, N_INTRA_PRED_MODES, 6, m.txtp_intra1);
@@ -5008,7 +5008,7 @@ pub(crate) fn rav1d_cdf_thread_update(
     for k in 0..BlockLevel::COUNT {
         update_cdf_2d!(4, dav1d_partition_type_count[k] as usize, m.partition[k]);
     }
-    update_bit_2d!(N_TX_SIZES, 13, coef.skip);
+    update_bit_2d!(TxfmSize::NUM_SQUARE, 13, coef.skip);
     update_cdf_3d!(2, 2, 4, coef.eob_bin_16);
     update_cdf_3d!(2, 2, 5, coef.eob_bin_32);
     update_cdf_3d!(2, 2, 6, coef.eob_bin_64);
@@ -5016,9 +5016,9 @@ pub(crate) fn rav1d_cdf_thread_update(
     update_cdf_3d!(2, 2, 8, coef.eob_bin_256);
     update_cdf_2d!(2, 9, coef.eob_bin_512);
     update_cdf_2d!(2, 10, coef.eob_bin_1024);
-    update_bit_3d!(N_TX_SIZES, 2, 11 /*22*/, coef.eob_hi_bit);
-    update_cdf_4d!(N_TX_SIZES, 2, 4, 2, coef.eob_base_tok);
-    update_cdf_4d!(N_TX_SIZES, 2, 41 /*42*/, 3, coef.base_tok);
+    update_bit_3d!(TxfmSize::NUM_SQUARE, 2, 11 /*22*/, coef.eob_hi_bit);
+    update_cdf_4d!(TxfmSize::NUM_SQUARE, 2, 4, 2, coef.eob_base_tok);
+    update_cdf_4d!(TxfmSize::NUM_SQUARE, 2, 41 /*42*/, 3, coef.base_tok);
     update_bit_2d!(2, 3, coef.dc_sign);
     update_cdf_4d!(4, 2, 21, 3, coef.br_tok);
     update_cdf_2d!(3, SegmentId::COUNT - 1, m.seg_id);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -95,7 +95,6 @@ use crate::src::levels::InterIntraPredMode;
 use crate::src::levels::InterIntraType;
 use crate::src::levels::MVJoint;
 use crate::src::levels::MotionMode;
-use crate::src::levels::RectTxfmSize;
 use crate::src::levels::SegmentId;
 use crate::src::levels::TxfmSize;
 use crate::src::levels::CFL_PRED;
@@ -110,11 +109,7 @@ use crate::src::levels::NEWMV;
 use crate::src::levels::NEWMV_NEWMV;
 use crate::src::levels::N_COMP_INTER_PRED_MODES;
 use crate::src::levels::N_INTRA_PRED_MODES;
-use crate::src::levels::N_RECT_TX_SIZES;
 use crate::src::levels::N_UV_INTRA_PRED_MODES;
-use crate::src::levels::TX_4X4;
-use crate::src::levels::TX_64X64;
-use crate::src::levels::TX_8X8;
 use crate::src::levels::VERT_LEFT_PRED;
 use crate::src::levels::VERT_PRED;
 use crate::src::lf_mask::rav1d_calc_eih;
@@ -285,7 +280,7 @@ fn read_tx_tree(
     t: &mut Rav1dTaskContext,
     f: &Rav1dFrameData,
     ts_c: &mut Rav1dTileStateContext,
-    from: RectTxfmSize,
+    from: TxfmSize,
     depth: c_int,
     masks: &mut [u16; 2],
     x_off: usize,
@@ -298,10 +293,10 @@ fn read_tx_tree(
     let txh = t_dim.lh;
     let is_split;
 
-    if depth < 2 && from > TX_4X4 {
-        let cat = 2 * (TX_64X64 as c_int - t_dim.max as c_int) - depth;
-        let a = (*f.a[t.a].tx.index(bx4 as usize) < txw) as c_int;
-        let l = (*t.l.tx.index(by4 as usize) < txh) as c_int;
+    if depth < 2 && from > TxfmSize::S4x4 {
+        let cat = 2 * (TxfmSize::S64x64 as c_int - t_dim.max as c_int) - depth;
+        let a = ((*f.a[t.a].tx.index(bx4 as usize) as u8) < txw) as c_int;
+        let l = ((*t.l.tx.index(by4 as usize) as u8) < txh) as c_int;
 
         is_split = rav1d_msac_decode_bool_adapt(
             &mut ts_c.msac,
@@ -313,9 +308,9 @@ fn read_tx_tree(
     } else {
         is_split = false;
     }
-    if is_split && t_dim.max as TxfmSize > TX_8X8 {
-        let sub = t_dim.sub as RectTxfmSize;
-        let sub_t_dim = &dav1d_txfm_dimensions[usize::from(sub)]; // `from` used instead of `into` for rust-analyzer type inference
+    if is_split && t_dim.max > TxfmSize::S8x8 as _ {
+        let sub = t_dim.sub;
+        let sub_t_dim = &dav1d_txfm_dimensions[sub as usize];
         let txsw = sub_t_dim.w as c_int;
         let txsh = sub_t_dim.h as c_int;
 
@@ -377,7 +372,13 @@ fn read_tx_tree(
             [t_dim.h as usize, t_dim.w as usize],
             [by4 as usize, bx4 as usize],
             |case, (dir, val)| {
-                case.set_disjoint(&dir.tx, if is_split { TX_4X4 } else { val });
+                let tx = if is_split {
+                    TxfmSize::S4x4
+                } else {
+                    // TODO check unwrap is optimized out
+                    TxfmSize::from_repr(val as _).unwrap()
+                };
+                case.set_disjoint(&dir.tx, tx);
             },
         );
     };
@@ -799,8 +800,9 @@ fn read_vartx_tree(
     let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
     let txfm_mode = frame_hdr.txfm_mode;
     let uvtx;
-    if b.skip == 0 && (frame_hdr.segmentation.lossless[b.seg_id.get()] || max_ytx == TX_4X4) {
-        uvtx = TX_4X4;
+    if b.skip == 0 && (frame_hdr.segmentation.lossless[b.seg_id.get()] || max_ytx == TxfmSize::S4x4)
+    {
+        uvtx = TxfmSize::S4x4;
         max_ytx = uvtx;
         if txfm_mode == Rav1dTxfmMode::Switchable {
             CaseSet::<32, false>::many(
@@ -808,7 +810,7 @@ fn read_vartx_tree(
                 [bh4 as usize, bw4 as usize],
                 [by4 as usize, bx4 as usize],
                 |case, dir| {
-                    case.set_disjoint(&dir.tx, TX_4X4);
+                    case.set_disjoint(&dir.tx, TxfmSize::S4x4);
                 },
             );
         }
@@ -819,13 +821,15 @@ fn read_vartx_tree(
                 [bh4 as usize, bw4 as usize],
                 [by4 as usize, bx4 as usize],
                 |case, (dir, dir_index)| {
-                    case.set_disjoint(&dir.tx, b_dim[2 + dir_index]);
+                    // TODO check unwrap is optimized out
+                    let tx = TxfmSize::from_repr(b_dim[2 + dir_index] as _).unwrap();
+                    case.set_disjoint(&dir.tx, tx);
                 },
             );
         }
         uvtx = dav1d_max_txfm_size_for_bs[bs as usize][f.cur.p.layout as usize];
     } else {
-        assert!(bw4 <= 16 || bh4 <= 16 || max_ytx == TX_64X64);
+        assert!(bw4 <= 16 || bh4 <= 16 || max_ytx == TxfmSize::S64x64);
         let ytx = &dav1d_txfm_dimensions[max_ytx as usize];
         let h = ytx.h as usize;
         let w = ytx.w as usize;
@@ -1871,13 +1875,13 @@ fn decode_b(
         let frame_hdr = f.frame_hdr();
 
         let tx = if frame_hdr.segmentation.lossless[b.seg_id.get()] {
-            b.uvtx = TX_4X4;
+            b.uvtx = TxfmSize::S4x4;
             b.uvtx
         } else {
             let mut tx = dav1d_max_txfm_size_for_bs[bs as usize][0];
             b.uvtx = dav1d_max_txfm_size_for_bs[bs as usize][f.cur.p.layout as usize];
             let mut t_dim = &dav1d_txfm_dimensions[tx as usize];
-            if frame_hdr.txfm_mode == Rav1dTxfmMode::Switchable && t_dim.max > TX_4X4 as u8 {
+            if frame_hdr.txfm_mode == Rav1dTxfmMode::Switchable && t_dim.max > TxfmSize::S4x4 as _ {
                 let tctx = get_tx_ctx(&f.a[t.a], &t.l, t_dim, by4, bx4);
                 let tx_cdf = &mut ts_c.cdf.m.txsz[(t_dim.max - 1) as usize][tctx as usize];
                 let depth =
@@ -1890,7 +1894,7 @@ fn decode_b(
                 }
             }
             if debug_block_info!(f, t.b) {
-                println!("Post-tx[{}]: r={}", tx, ts_c.msac.rng);
+                println!("Post-tx[{:?}]: r={}", tx, ts_c.msac.rng);
             }
             tx
         };
@@ -1962,7 +1966,8 @@ fn decode_b(
             [by4 as usize, bx4 as usize],
             |case, (dir, lw_lh, dir_index)| {
                 case.set_disjoint(&dir.tx_intra, lw_lh as i8);
-                case.set_disjoint(&dir.tx, lw_lh);
+                // TODO check unwrap is optimized out
+                case.set_disjoint(&dir.tx, TxfmSize::from_repr(lw_lh as _).unwrap());
                 case.set_disjoint(&dir.mode, y_mode_nofilt);
                 case.set_disjoint(&dir.pal_sz, pal_sz[0]);
                 case.set_disjoint(&dir.seg_pred, seg_pred.into());
@@ -3064,8 +3069,8 @@ fn decode_b(
             let mut ytx = max_ytx;
             let mut uvtx = b.uvtx;
             if frame_hdr.segmentation.lossless[b.seg_id.get()] {
-                ytx = TX_4X4;
-                uvtx = TX_4X4;
+                ytx = TxfmSize::S4x4;
+                uvtx = TxfmSize::S4x4;
             }
             let lflvl = match ts.lflvl.get() {
                 TileStateRef::Frame => &f.lf.lvl,
@@ -3790,7 +3795,7 @@ fn reset_context(ctx: &mut BlockContext, keyframe: bool, pass: c_int) {
     ctx.tx_lpf_y.get_mut().0.fill(2);
     ctx.tx_lpf_uv.get_mut().0.fill(1);
     ctx.tx_intra.get_mut().0.fill(-1);
-    ctx.tx.get_mut().0.fill(TX_64X64);
+    ctx.tx.get_mut().0.fill(TxfmSize::S64x64);
     if !keyframe {
         for r#ref in &mut ctx.r#ref {
             r#ref.get_mut().0.fill(-1);
@@ -4531,7 +4536,7 @@ pub(crate) fn rav1d_decode_frame_init(c: &Rav1dContext, fc: &Rav1dFrameContext) 
     // setup dequant tables
     init_quant_tables(&seq_hdr, &frame_hdr, frame_hdr.quant.yac, &f.dq);
     if frame_hdr.quant.qm != 0 {
-        for i in 0..N_RECT_TX_SIZES {
+        for i in 0..TxfmSize::COUNT {
             f.qm[i][0] = dav1d_qm_tbl[frame_hdr.quant.qm_y as usize][0][i];
             f.qm[i][1] = dav1d_qm_tbl[frame_hdr.quant.qm_u as usize][1][i];
             f.qm[i][2] = dav1d_qm_tbl[frame_hdr.quant.qm_v as usize][1][i];

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -10,9 +10,8 @@ use crate::src::ctx::CaseSet;
 use crate::src::disjoint_mut::DisjointMut;
 use crate::src::internal::Bxy;
 use crate::src::levels::BlockSize;
-use crate::src::levels::RectTxfmSize;
 use crate::src::levels::SegmentId;
-use crate::src::levels::TX_4X4;
+use crate::src::levels::TxfmSize;
 use crate::src::relaxed_atomic::RelaxedAtomic;
 use crate::src::tables::dav1d_block_dimensions;
 use crate::src::tables::dav1d_txfm_dimensions;
@@ -96,7 +95,7 @@ pub struct Av1Restoration {
 /// the existing `y_off` and `x_off` args and applied at each use site of `txa.
 fn decomp_tx(
     txa: &mut [[[[u8; 32]; 32]; 2]; 2],
-    from: RectTxfmSize,
+    from: TxfmSize,
     depth: usize,
     y_off: u8,
     x_off: u8,
@@ -108,13 +107,13 @@ fn decomp_tx(
     let y0 = (y_off * t_dim.h) as usize;
     let x0 = (x_off * t_dim.w) as usize;
 
-    let is_split = if from == TX_4X4 || depth > 1 {
+    let is_split = if from == TxfmSize::S4x4 || depth > 1 {
         false
     } else {
         (tx_masks[depth] >> (y_off * 4 + x_off)) & 1 != 0
     };
     if is_split {
-        let sub = t_dim.sub as RectTxfmSize;
+        let sub = t_dim.sub;
 
         decomp_tx(txa, sub, depth + 1, y_off * 2 + 0, x_off * 2 + 0, tx_masks);
         if t_dim.w >= t_dim.h {
@@ -151,7 +150,7 @@ fn mask_edges_inter(
     w4: usize,
     h4: usize,
     skip: bool,
-    max_tx: RectTxfmSize,
+    max_tx: TxfmSize,
     tx_masks: &[u16; 2],
     a: &mut [u8],
     l: &mut [u8],
@@ -235,7 +234,7 @@ fn mask_edges_intra(
     bx4: usize,
     w4: usize,
     h4: usize,
-    tx: RectTxfmSize,
+    tx: TxfmSize,
     a: &mut [u8],
     l: &mut [u8],
 ) {
@@ -312,7 +311,7 @@ fn mask_edges_chroma(
     cw4: usize,
     ch4: usize,
     skip_inter: bool,
-    tx: RectTxfmSize,
+    tx: TxfmSize,
     a: &mut [u8],
     l: &mut [u8],
     ss_hor: usize,
@@ -397,8 +396,8 @@ pub(crate) fn rav1d_create_lf_mask_intra(
     iw: c_int,
     ih: c_int,
     bs: BlockSize,
-    ytx: RectTxfmSize,
-    uvtx: RectTxfmSize,
+    ytx: TxfmSize,
+    uvtx: TxfmSize,
     layout: Rav1dPixelLayout,
     ay: &mut [u8],
     ly: &mut [u8],
@@ -502,9 +501,9 @@ pub(crate) fn rav1d_create_lf_mask_inter(
     ih: c_int,
     skip: bool,
     bs: BlockSize,
-    max_ytx: RectTxfmSize,
+    max_ytx: TxfmSize,
     tx_masks: &[u16; 2],
-    uvtx: RectTxfmSize,
+    uvtx: TxfmSize,
     layout: Rav1dPixelLayout,
     ay: &mut [u8],
     ly: &mut [u8],

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -13,7 +13,6 @@ use crate::src::levels::BlockSize;
 use crate::src::levels::SegmentId;
 use crate::src::levels::TxfmSize;
 use crate::src::relaxed_atomic::RelaxedAtomic;
-use crate::src::tables::dav1d_block_dimensions;
 use crate::src::tables::dav1d_txfm_dimensions;
 use libc::ptrdiff_t;
 use parking_lot::RwLock;
@@ -406,7 +405,7 @@ pub(crate) fn rav1d_create_lf_mask_intra(
     let b4_stride = b4_stride as usize;
     let [bx, by, iw, ih] = [b.x, b.y, iw, ih].map(|it| it as usize);
 
-    let b_dim = &dav1d_block_dimensions[bs as usize];
+    let b_dim = bs.dimensions();
     let b_dim = b_dim.map(|it| it as usize);
     let bw4 = cmp::min(iw - bx, b_dim[0]);
     let bh4 = cmp::min(ih - by, b_dim[1]);
@@ -513,7 +512,7 @@ pub(crate) fn rav1d_create_lf_mask_inter(
     let is_gmv = is_gmv as usize;
     let [bx, by, iw, ih] = [b.x, b.y, iw, ih].map(|it| it as usize);
 
-    let b_dim = &dav1d_block_dimensions[bs as usize];
+    let b_dim = bs.dimensions();
     let b_dim = b_dim.map(|it| it as usize);
     let bw4 = cmp::min(iw - bx, b_dim[0]);
     let bh4 = cmp::min(ih - by, b_dim[1]);

--- a/src/qm.rs
+++ b/src/qm.rs
@@ -1,24 +1,7 @@
+use strum::EnumCount;
+
 use crate::src::const_fn::const_for;
-use crate::src::levels::N_RECT_TX_SIZES;
-use crate::src::levels::RTX_16X32;
-use crate::src::levels::RTX_16X4;
-use crate::src::levels::RTX_16X64;
-use crate::src::levels::RTX_16X8;
-use crate::src::levels::RTX_32X16;
-use crate::src::levels::RTX_32X64;
-use crate::src::levels::RTX_32X8;
-use crate::src::levels::RTX_4X16;
-use crate::src::levels::RTX_4X8;
-use crate::src::levels::RTX_64X16;
-use crate::src::levels::RTX_64X32;
-use crate::src::levels::RTX_8X16;
-use crate::src::levels::RTX_8X32;
-use crate::src::levels::RTX_8X4;
-use crate::src::levels::TX_16X16;
-use crate::src::levels::TX_32X32;
-use crate::src::levels::TX_4X4;
-use crate::src::levels::TX_64X64;
-use crate::src::levels::TX_8X8;
+use crate::src::levels::TxfmSize;
 
 static qm_tbl_32x16: [[[u8; 32 * 16]; 2]; 15] = [
     [
@@ -1769,36 +1752,38 @@ static qm_tbl_16x32: [[[u8; 16 * 32]; 2]; 15] = generate_table!(transposed, qm_t
 static qm_tbl_32x8: [[[u8; 32 * 8]; 2]; 15] = generate_table!(subsampled, qm_tbl_32x16, 16, 1, 2);
 static qm_tbl_32x32: [[[u8; 32 * 32]; 2]; 15] = generate_table!(untriangled, qm_tbl_32x32_t, 32);
 
-pub static dav1d_qm_tbl: [[[Option<&'static [u8]>; N_RECT_TX_SIZES]; 2]; 16] = {
-    let mut table = [[[None; N_RECT_TX_SIZES]; 2]; 16];
+pub static dav1d_qm_tbl: [[[Option<&'static [u8]>; TxfmSize::COUNT]; 2]; 16] = {
+    let mut table = [[[None; TxfmSize::COUNT]; 2]; 16];
     const_for!(i in 0..table.len() - 1 => {
         // last row is empty
         const_for!(j in 0..table[i].len() => {
-            let mut row: [Option<&'static [u8]>; N_RECT_TX_SIZES] = [None; N_RECT_TX_SIZES];
+            let mut row: [Option<&'static [u8]>; TxfmSize::COUNT] = [None; TxfmSize::COUNT];
+
+            use TxfmSize::*;
 
             // note that the w/h in the assignment is inverted, this is on purpose
             // because we store coefficients transposed
-            row[RTX_4X8 as usize] = Some(&qm_tbl_8x4[i][j]);
-            row[RTX_8X4 as usize] = Some(&qm_tbl_4x8[i][j]);
-            row[RTX_4X16 as usize] = Some(&qm_tbl_16x4[i][j]);
-            row[RTX_16X4 as usize] = Some(&qm_tbl_4x16[i][j]);
-            row[RTX_8X16 as usize] = Some(&qm_tbl_16x8[i][j]);
-            row[RTX_16X8 as usize] = Some(&qm_tbl_8x16[i][j]);
-            row[RTX_8X32 as usize] = Some(&qm_tbl_32x8[i][j]);
-            row[RTX_32X8 as usize] = Some(&qm_tbl_8x32[i][j]);
-            row[RTX_16X32 as usize] = Some(&qm_tbl_32x16[i][j]);
-            row[RTX_32X16 as usize] = Some(&qm_tbl_16x32[i][j]);
+            row[R4x8 as usize] = Some(&qm_tbl_8x4[i][j]);
+            row[R8x4 as usize] = Some(&qm_tbl_4x8[i][j]);
+            row[R4x16 as usize] = Some(&qm_tbl_16x4[i][j]);
+            row[R16x4 as usize] = Some(&qm_tbl_4x16[i][j]);
+            row[R8x16 as usize] = Some(&qm_tbl_16x8[i][j]);
+            row[R16x8 as usize] = Some(&qm_tbl_8x16[i][j]);
+            row[R8x32 as usize] = Some(&qm_tbl_32x8[i][j]);
+            row[R32x8 as usize] = Some(&qm_tbl_8x32[i][j]);
+            row[R16x32 as usize] = Some(&qm_tbl_32x16[i][j]);
+            row[R32x16 as usize] = Some(&qm_tbl_16x32[i][j]);
 
-            row[TX_4X4 as usize] = Some(&qm_tbl_4x4[i][j]);
-            row[TX_8X8 as usize] = Some(&qm_tbl_8x8[i][j]);
-            row[TX_16X16 as usize] = Some(&qm_tbl_16x16[i][j]);
-            row[TX_32X32 as usize] = Some(&qm_tbl_32x32[i][j]);
+            row[S4x4 as usize] = Some(&qm_tbl_4x4[i][j]);
+            row[S8x8 as usize] = Some(&qm_tbl_8x8[i][j]);
+            row[S16x16 as usize] = Some(&qm_tbl_16x16[i][j]);
+            row[S32x32 as usize] = Some(&qm_tbl_32x32[i][j]);
 
-            row[TX_64X64 as usize] = row[TX_32X32 as usize];
-            row[RTX_64X32 as usize] = row[TX_32X32 as usize];
-            row[RTX_64X16 as usize] = row[RTX_32X16 as usize];
-            row[RTX_32X64 as usize] = row[TX_32X32 as usize];
-            row[RTX_16X64 as usize] = row[RTX_16X32 as usize];
+            row[S64x64 as usize] = row[S32x32 as usize];
+            row[R64x32 as usize] = row[S32x32 as usize];
+            row[R64x16 as usize] = row[R32x16 as usize];
+            row[R32x64 as usize] = row[S32x32 as usize];
+            row[R16x64 as usize] = row[R16x32 as usize];
 
             table[i][j] = row;
         });

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -71,7 +71,6 @@ use crate::src::msac::rav1d_msac_decode_symbol_adapt8;
 use crate::src::msac::MsacContext;
 use crate::src::picture::Rav1dThreadPicture;
 use crate::src::scan::dav1d_scans;
-use crate::src::tables::dav1d_block_dimensions;
 use crate::src::tables::dav1d_filter_2d;
 use crate::src::tables::dav1d_filter_mode_to_y_mode;
 use crate::src::tables::dav1d_lo_ctx_offsets;
@@ -264,7 +263,7 @@ fn get_skip_ctx(
     chroma: bool,
     layout: Rav1dPixelLayout,
 ) -> InRange<u8, 0, { 13 - 1 }> {
-    let b_dim = &dav1d_block_dimensions[bs as usize];
+    let b_dim = bs.dimensions();
     let skip_ctx = if chroma {
         let ss_ver = layout == Rav1dPixelLayout::I420;
         let ss_hor = layout != Rav1dPixelLayout::I444;
@@ -1803,7 +1802,7 @@ pub(crate) fn rav1d_read_coef_blocks<BD: BitDepth>(
     let by4 = t.b.y as usize & 31;
     let cbx4 = bx4 >> ss_hor;
     let cby4 = by4 >> ss_ver;
-    let b_dim = &dav1d_block_dimensions[bs as usize];
+    let b_dim = bs.dimensions();
     let bw4 = b_dim[0];
     let bh4 = b_dim[1];
     let cbw4 = bw4 + ss_hor >> ss_hor;
@@ -2232,7 +2231,7 @@ fn obmc<BD: BitDepth>(
         while x < w4 && i < cmp::min(b_dim[2], 4) {
             // only odd blocks are considered for overlap handling, hence +1
             let a_r = *f.rf.r.index(r[0] + t.b.x as usize + x as usize + 1);
-            let a_b_dim = &dav1d_block_dimensions[a_r.bs as usize];
+            let a_b_dim = a_r.bs.dimensions();
             let step4 = clip(a_b_dim[0], 2, 16);
 
             if a_r.r#ref.r#ref[0] > 0 {
@@ -2280,7 +2279,7 @@ fn obmc<BD: BitDepth>(
         while y < h4 && i < cmp::min(b_dim[3], 4) {
             // only odd blocks are considered for overlap handling, hence +1
             let l_r = *f.rf.r.index(r[y as usize + 1 + 1] + t.b.x as usize - 1);
-            let l_b_dim = &dav1d_block_dimensions[l_r.bs as usize];
+            let l_b_dim = l_r.bs.dimensions();
             let step4 = clip(l_b_dim[1], 2, 16);
 
             if l_r.r#ref.r#ref[0] > 0 {
@@ -2435,7 +2434,7 @@ pub(crate) fn rav1d_recon_b_intra<BD: BitDepth>(
     let ss_hor = (f.cur.p.layout != Rav1dPixelLayout::I444) as c_int;
     let cbx4 = bx4 >> ss_hor;
     let cby4 = by4 >> ss_ver;
-    let b_dim = &dav1d_block_dimensions[bs as usize];
+    let b_dim = bs.dimensions();
     let bw4 = b_dim[0] as c_int;
     let bh4 = b_dim[1] as c_int;
     let w4 = cmp::min(bw4, f.bw - t.b.x);
@@ -3104,7 +3103,7 @@ pub(crate) fn rav1d_recon_b_inter<BD: BitDepth>(
     let ss_hor = (f.cur.p.layout != Rav1dPixelLayout::I444) as c_int;
     let cbx4 = bx4 >> ss_hor;
     let cby4 = by4 >> ss_ver;
-    let b_dim = &dav1d_block_dimensions[bs as usize];
+    let b_dim = bs.dimensions();
     let bw4 = b_dim[0] as c_int;
     let bh4 = b_dim[1] as c_int;
     let w4 = cmp::min(bw4, f.bw - t.b.x);

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -45,8 +45,8 @@ use crate::src::levels::InterIntraPredMode;
 use crate::src::levels::InterIntraType;
 use crate::src::levels::IntraPredMode;
 use crate::src::levels::MotionMode;
-use crate::src::levels::RectTxfmSize;
 use crate::src::levels::TxClass;
+use crate::src::levels::TxfmSize;
 use crate::src::levels::TxfmType;
 use crate::src::levels::CFL_PRED;
 use crate::src::levels::DCT_DCT;
@@ -55,26 +55,7 @@ use crate::src::levels::FILTER_PRED;
 use crate::src::levels::GLOBALMV;
 use crate::src::levels::GLOBALMV_GLOBALMV;
 use crate::src::levels::IDTX;
-use crate::src::levels::RTX_16X32;
-use crate::src::levels::RTX_16X4;
-use crate::src::levels::RTX_16X64;
-use crate::src::levels::RTX_16X8;
-use crate::src::levels::RTX_32X16;
-use crate::src::levels::RTX_32X64;
-use crate::src::levels::RTX_32X8;
-use crate::src::levels::RTX_4X16;
-use crate::src::levels::RTX_4X8;
-use crate::src::levels::RTX_64X16;
-use crate::src::levels::RTX_64X32;
-use crate::src::levels::RTX_8X16;
-use crate::src::levels::RTX_8X32;
-use crate::src::levels::RTX_8X4;
 use crate::src::levels::SMOOTH_PRED;
-use crate::src::levels::TX_16X16;
-use crate::src::levels::TX_32X32;
-use crate::src::levels::TX_4X4;
-use crate::src::levels::TX_64X64;
-use crate::src::levels::TX_8X8;
 use crate::src::levels::WHT_WHT;
 use crate::src::lf_apply::rav1d_copy_lpf;
 use crate::src::lf_apply::rav1d_loopfilter_sbrow_cols;
@@ -352,38 +333,37 @@ fn get_skip_ctx(
     InRange::new(skip_ctx).unwrap()
 }
 
-// `tx: RectTxfmSize` arg is also `TxfmSize`.
-// `TxfmSize` and `RectTxfmSize` should be part of the same `enum`.
 #[inline]
-fn get_dc_sign_ctx(tx: RectTxfmSize, a: &[u8], l: &[u8]) -> c_uint {
+fn get_dc_sign_ctx(tx: TxfmSize, a: &[u8], l: &[u8]) -> c_uint {
     let mask = 0xc0c0c0c0c0c0c0c0 as u64;
     let mul = 0x101010101010101 as u64;
 
+    use TxfmSize::*;
     let s = match tx {
-        TX_4X4 => {
+        S4x4 => {
             let mut t = u8::read_ne(a) as i32 >> 6;
             t += u8::read_ne(l) as i32 >> 6;
             t - 1 - 1
         }
-        TX_8X8 => {
+        S8x8 => {
             let mut t = u16::read_ne(a) as u32 & mask as u32;
             t += u16::read_ne(l) as u32 & mask as u32;
             t = t.wrapping_mul(0x4040404);
             (t >> 24) as i32 - 2 - 2
         }
-        TX_16X16 => {
+        S16x16 => {
             let mut t = (u32::read_ne(a) & mask as u32) >> 6;
             t += (u32::read_ne(l) & mask as u32) >> 6;
             t = t.wrapping_mul(mul as u32);
             (t >> 24) as i32 - 4 - 4
         }
-        TX_32X32 => {
+        S32x32 => {
             let mut t = (u64::read_ne(a) & mask) >> 6;
             t += (u64::read_ne(l) & mask) >> 6;
             t = t.wrapping_mul(mul);
             (t >> 56) as i32 - 8 - 8
         }
-        TX_64X64 => {
+        S64x64 => {
             let mut t = (u64::read_ne(&a[0..]) & mask) >> 6;
             t += (u64::read_ne(&a[8..]) & mask) >> 6;
             t += (u64::read_ne(&l[0..]) & mask) >> 6;
@@ -391,95 +371,94 @@ fn get_dc_sign_ctx(tx: RectTxfmSize, a: &[u8], l: &[u8]) -> c_uint {
             t = t.wrapping_mul(mul);
             (t >> 56) as i32 - 16 - 16
         }
-        RTX_4X8 => {
+        R4x8 => {
             let mut t = u8::read_ne(a) as u32 & mask as u32;
             t += u16::read_ne(l) as u32 & mask as u32;
             t = t.wrapping_mul(0x4040404);
             (t >> 24) as i32 - 1 - 2
         }
-        RTX_8X4 => {
+        R8x4 => {
             let mut t = u16::read_ne(a) as u32 & mask as u32;
             t += u8::read_ne(l) as u32 & mask as u32;
             t = t.wrapping_mul(0x4040404);
             (t >> 24) as i32 - 2 - 1
         }
-        RTX_8X16 => {
+        R8x16 => {
             let mut t = u16::read_ne(a) as u32 & mask as u32;
             t += u32::read_ne(l) & mask as u32;
             t = (t >> 6).wrapping_mul(mul as u32);
             (t >> 24) as i32 - 2 - 4
         }
-        RTX_16X8 => {
+        R16x8 => {
             let mut t = u32::read_ne(a) & mask as u32;
             t += u16::read_ne(l) as c_uint & mask as u32;
             t = (t >> 6).wrapping_mul(mul as u32);
             (t >> 24) as i32 - 4 - 2
         }
-        RTX_16X32 => {
+        R16x32 => {
             let mut t = (u32::read_ne(a) & mask as u32) as u64;
             t += u64::read_ne(l) & mask;
             t = (t >> 6).wrapping_mul(mul);
             (t >> 56) as i32 - 4 - 8
         }
-        RTX_32X16 => {
+        R32x16 => {
             let mut t = u64::read_ne(a) & mask;
             t += (u32::read_ne(l) & mask as u32) as u64;
             t = (t >> 6).wrapping_mul(mul);
             (t >> 56) as i32 - 8 - 4
         }
-        RTX_32X64 => {
+        R32x64 => {
             let mut t = (u64::read_ne(&a[0..]) & mask) >> 6;
             t += (u64::read_ne(&l[0..]) & mask) >> 6;
             t += (u64::read_ne(&l[8..]) & mask) >> 6;
             t = t.wrapping_mul(mul);
             (t >> 56) as i32 - 8 - 16
         }
-        RTX_64X32 => {
+        R64x32 => {
             let mut t = (u64::read_ne(&a[0..]) & mask) >> 6;
             t += (u64::read_ne(&a[8..]) & mask) >> 6;
             t += (u64::read_ne(&l[0..]) & mask) >> 6;
             t = t.wrapping_mul(mul);
             (t >> 56) as i32 - 16 - 8
         }
-        RTX_4X16 => {
+        R4x16 => {
             let mut t = u8::read_ne(a) as u32 & mask as u32;
             t += u32::read_ne(l) & mask as u32;
             t = (t >> 6).wrapping_mul(mul as u32);
             (t >> 24) as i32 - 1 - 4
         }
-        RTX_16X4 => {
+        R16x4 => {
             let mut t = u32::read_ne(a) & mask as u32;
             t += u8::read_ne(l) as u32 & mask as u32;
             t = (t >> 6).wrapping_mul(mul as u32);
             (t >> 24) as i32 - 4 - 1
         }
-        RTX_8X32 => {
+        R8x32 => {
             let mut t = (u16::read_ne(a) as u32 & mask as u32) as u64;
             t += u64::read_ne(l) & mask;
             t = (t >> 6).wrapping_mul(mul);
             (t >> 56) as i32 - 2 - 8
         }
-        RTX_32X8 => {
+        R32x8 => {
             let mut t = u64::read_ne(a) & mask;
             t += (u16::read_ne(l) as u32 & mask as u32) as u64;
             t = (t >> 6).wrapping_mul(mul);
             (t >> 56) as i32 - 8 - 2
         }
-        RTX_16X64 => {
+        R16x64 => {
             let mut t = (u32::read_ne(a) & mask as u32) as u64;
             t += u64::read_ne(&l[0..]) & mask;
             t = (t >> 6) + ((u64::read_ne(&l[8..]) & mask) >> 6);
             t = t.wrapping_mul(mul);
             (t >> 56) as i32 - 4 - 16
         }
-        RTX_64X16 => {
+        R64x16 => {
             let mut t = u64::read_ne(&a[0..]) & mask;
             t += (u32::read_ne(l) & mask as u32) as u64;
             t = (t >> 6) + ((u64::read_ne(&a[8..]) & mask) >> 6);
             t = t.wrapping_mul(mul);
             (t >> 56) as i32 - 16 - 4
         }
-        _ => unreachable!(),
     };
 
     (s != 0) as c_uint + (s > 0) as c_uint
@@ -524,7 +503,7 @@ fn decode_coefs<BD: BitDepth>(
     t_cf: &mut Cf,
     a: &mut [u8],
     l: &mut [u8],
-    tx: RectTxfmSize,
+    tx: TxfmSize,
     bs: BlockSize,
     b: &Av1Block,
     plane: usize,
@@ -568,11 +547,11 @@ fn decode_coefs<BD: BitDepth>(
     use Av1BlockIntraInter::*;
     *txtp = match &b.ii {
         _ if lossless => {
-            assert!(t_dim.max == TX_4X4);
+            assert!(t_dim.max == TxfmSize::S4x4 as _);
             WHT_WHT
         }
-        Intra(_) if t_dim.max >= TX_32X32 => DCT_DCT,
-        Inter(_) if t_dim.max >= TX_64X64 => DCT_DCT,
+        Intra(_) if t_dim.max >= TxfmSize::S32x32 as _ => DCT_DCT,
+        Inter(_) if t_dim.max >= TxfmSize::S64x64 as _ => DCT_DCT,
         Intra(intra) if chroma => dav1d_txtp_from_uvmode[intra.uv_mode as usize],
         // inferred from either the luma txtp (inter) or a LUT (intra)
         Inter(_) if chroma => get_uv_inter_txtp(t_dim, *txtp),
@@ -587,7 +566,7 @@ fn decode_coefs<BD: BitDepth>(
                 intra.y_mode
             };
             let idx;
-            let txtp = if frame_hdr.reduced_txtp_set != 0 || t_dim.min == TX_16X16 {
+            let txtp = if frame_hdr.reduced_txtp_set != 0 || t_dim.min == TxfmSize::S16x16 as _ {
                 idx = rav1d_msac_decode_symbol_adapt8(
                     &mut ts_c.msac,
                     &mut ts_c.cdf.m.txtp_intra2[t_dim.min as usize][y_mode_nofilt as usize],
@@ -604,7 +583,7 @@ fn decode_coefs<BD: BitDepth>(
             };
             if dbg {
                 println!(
-                    "Post-txtp-intra[{}->{}][{}][{}->{}]: r={}",
+                    "Post-txtp-intra[{:?}->{}][{}][{}->{}]: r={}",
                     tx, t_dim.min, y_mode_nofilt, idx, txtp, ts_c.msac.rng,
                 );
             }
@@ -612,7 +591,7 @@ fn decode_coefs<BD: BitDepth>(
         }
         Inter(_) => {
             let idx;
-            let txtp = if frame_hdr.reduced_txtp_set != 0 || t_dim.max == TX_32X32 {
+            let txtp = if frame_hdr.reduced_txtp_set != 0 || t_dim.max == TxfmSize::S32x32 as _ {
                 let bool_idx = rav1d_msac_decode_bool_adapt(
                     &mut ts_c.msac,
                     &mut ts_c.cdf.m.txtp_inter3[t_dim.min as usize],
@@ -623,7 +602,7 @@ fn decode_coefs<BD: BitDepth>(
                 } else {
                     IDTX
                 }
-            } else if t_dim.min == TX_16X16 {
+            } else if t_dim.min == TxfmSize::S16x16 as _ {
                 idx = rav1d_msac_decode_symbol_adapt16(
                     &mut ts_c.msac,
                     &mut ts_c.cdf.m.txtp_inter2.0,
@@ -640,7 +619,7 @@ fn decode_coefs<BD: BitDepth>(
             };
             if dbg {
                 println!(
-                    "Post-txtp-inter[{}->{}][{}->{}]: r={}",
+                    "Post-txtp-inter[{:?}->{}][{}->{}]: r={}",
                     tx, t_dim.min, idx, txtp, ts_c.msac.rng,
                 );
             }
@@ -649,7 +628,8 @@ fn decode_coefs<BD: BitDepth>(
     };
 
     // find end-of-block (eob)
-    let tx2dszctx = cmp::min(t_dim.lw, TX_32X32 as u8) + cmp::min(t_dim.lh, TX_32X32 as u8);
+    let tx2dszctx =
+        cmp::min(t_dim.lw, TxfmSize::S32x32 as u8) + cmp::min(t_dim.lh, TxfmSize::S32x32 as u8);
     let tx_class = dav1d_tx_type_class[*txtp as usize];
     let chroma = chroma as usize;
     let is_1d = (tx_class != TxClass::TwoD) as usize;
@@ -742,7 +722,7 @@ fn decode_coefs<BD: BitDepth>(
         let mut scan: &[u16] = &[];
         match tx_class {
             TxClass::TwoD => {
-                let nonsquare_tx: c_uint = (tx >= RTX_4X8) as c_uint;
+                let nonsquare_tx: c_uint = (tx >= TxfmSize::R4x8) as c_uint;
                 let lo_ctx_offsets = Some(
                     &dav1d_lo_ctx_offsets
                         [nonsquare_tx.wrapping_add(tx as c_uint & nonsquare_tx) as usize],
@@ -1622,7 +1602,7 @@ fn read_coef_tree<BD: BitDepth>(
     mut ts_c: Option<&mut Rav1dTileStateContext>,
     bs: BlockSize,
     b: &Av1Block,
-    ytx: RectTxfmSize,
+    ytx: TxfmSize,
     depth: usize,
     tx_split: [u16; 2],
     x_off: c_int,
@@ -1640,7 +1620,7 @@ fn read_coef_tree<BD: BitDepth>(
     // use `TX_4X4` but can't be splitted.
     // Avoids an undefined left shift.
     if depth < 2 && tx_split[depth] != 0 && tx_split[depth] & 1 << y_off * 4 + x_off != 0 {
-        let sub = t_dim.sub as RectTxfmSize;
+        let sub = t_dim.sub;
         let sub_t_dim = &dav1d_txfm_dimensions[sub as usize];
         let txsw = sub_t_dim.w;
         let txsh = sub_t_dim.h;
@@ -1749,7 +1729,7 @@ fn read_coef_tree<BD: BitDepth>(
             );
             if debug_block_info!(f, t.b) {
                 println!(
-                    "Post-y-cf-blk[tx={},txtp={},eob={}]: r={}",
+                    "Post-y-cf-blk[tx={:?},txtp={},eob={}]: r={}",
                     ytx, txtp, eob, ts_c.msac.rng,
                 );
             }
@@ -1927,7 +1907,7 @@ pub(crate) fn rav1d_read_coef_blocks<BD: BitDepth>(
                             );
                             if debug_block_info!(f, t.b) {
                                 println!(
-                                    "Post-y-cf-blk[tx={},txtp={},eob={}]: r={}",
+                                    "Post-y-cf-blk[tx={:?},txtp={},eob={}]: r={}",
                                     intra.tx, txtp, eob, ts_c.msac.rng,
                                 );
                             }
@@ -2003,7 +1983,7 @@ pub(crate) fn rav1d_read_coef_blocks<BD: BitDepth>(
                             &mut t.cf,
                             &mut a_ccoef.index_mut((a_start.., ..a_len)),
                             &mut l_ccoef.index_mut((l_start.., ..l_len)),
-                            b.uvtx as RectTxfmSize,
+                            b.uvtx,
                             bs,
                             b,
                             1 + pl,
@@ -2013,7 +1993,7 @@ pub(crate) fn rav1d_read_coef_blocks<BD: BitDepth>(
                         );
                         if debug_block_info!(f, t.b) {
                             println!(
-                                "Post-uv-cf-blk[pl={},tx={},txtp={},eob={}]: r={}",
+                                "Post-uv-cf-blk[pl={},tx={:?},txtp={},eob={}]: r={}",
                                 pl, b.uvtx, txtp, eob, ts_c.msac.rng,
                             );
                         }
@@ -2659,7 +2639,7 @@ pub(crate) fn rav1d_recon_b_intra<BD: BitDepth>(
                                     .lcoef
                                     .index_mut(a_start..a_start + t_dim.w as usize),
                                 &mut t.l.lcoef.index_mut(l_start..l_start + t_dim.h as usize),
-                                intra.tx as RectTxfmSize,
+                                intra.tx,
                                 bs,
                                 b,
                                 0,
@@ -2670,7 +2650,7 @@ pub(crate) fn rav1d_recon_b_intra<BD: BitDepth>(
                             cf = t.cf.select_mut::<BD>();
                             if debug_block_info!(f, t.b) {
                                 println!(
-                                    "Post-y-cf-blk[tx={},txtp={},eob={}]: r={}",
+                                    "Post-y-cf-blk[tx={:?},txtp={},eob={}]: r={}",
                                     intra.tx,
                                     txtp,
                                     eob,
@@ -3026,7 +3006,7 @@ pub(crate) fn rav1d_recon_b_intra<BD: BitDepth>(
                                     &mut t.cf,
                                     &mut a_ccoef.index_mut(a_start..a_start + uv_t_dim.w as usize),
                                     &mut l_ccoef.index_mut(l_start..l_start + uv_t_dim.h as usize),
-                                    b.uvtx as RectTxfmSize,
+                                    b.uvtx,
                                     bs,
                                     b,
                                     1 + pl,
@@ -3037,7 +3017,7 @@ pub(crate) fn rav1d_recon_b_intra<BD: BitDepth>(
                                 cf = t.cf.select_mut::<BD>();
                                 if debug_block_info!(f, t.b) {
                                     println!(
-                                            "Post-uv-cf-blk[pl={},tx={},txtp={},eob={}]: r={} [x={},cbx4={}]",
+                                            "Post-uv-cf-blk[pl={},tx={:?},txtp={},eob={}]: r={} [x={},cbx4={}]",
                                             pl,
                                             b.uvtx,
                                             txtp,
@@ -3917,7 +3897,7 @@ pub(crate) fn rav1d_recon_b_inter<BD: BitDepth>(
                                 cf = t.cf.select_mut::<BD>();
                                 if debug_block_info!(f, t.b) {
                                     println!(
-                                        "Post-uv-cf-blk[pl={},tx={},txtp={},eob={}]: r={}",
+                                        "Post-uv-cf-blk[pl={},tx={:?},txtp={},eob={}]: r={}",
                                         pl,
                                         b.uvtx,
                                         txtp,

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -21,7 +21,6 @@ use crate::src::internal::Bxy;
 use crate::src::intra_edge::EdgeFlags;
 use crate::src::levels::mv;
 use crate::src::levels::BlockSize;
-use crate::src::tables::dav1d_block_dimensions;
 use crate::src::wrap_fn_ptr::wrap_fn_ptr;
 use std::cmp;
 use std::marker::PhantomData;
@@ -541,7 +540,7 @@ fn scan_row(
 ) -> i32 {
     let mut cand_b = *r.index(b_offset);
     let first_cand_bs = cand_b.bs;
-    let first_cand_b_dim = &dav1d_block_dimensions[first_cand_bs as usize];
+    let first_cand_b_dim = first_cand_bs.dimensions();
     let mut cand_bw4 = first_cand_b_dim[0] as i32;
     let mut len = cmp::max(step, cmp::min(bw4, cand_bw4));
 
@@ -588,7 +587,7 @@ fn scan_row(
             return 1;
         }
         cand_b = *r.index(b_offset + x as usize);
-        cand_bw4 = dav1d_block_dimensions[cand_b.bs as usize][0] as i32;
+        cand_bw4 = cand_b.bs.dimensions()[0] as i32;
         assert!(cand_bw4 < bw4);
         len = cmp::max(step, cand_bw4);
     }
@@ -611,7 +610,7 @@ fn scan_col(
 ) -> i32 {
     let mut cand_b = *r.index(b[0] + bx4 as usize);
     let first_cand_bs = cand_b.bs;
-    let first_cand_b_dim = &dav1d_block_dimensions[first_cand_bs as usize];
+    let first_cand_b_dim = first_cand_bs.dimensions();
     let mut cand_bh4 = first_cand_b_dim[1] as i32;
     let mut len = cmp::max(step, cmp::min(bh4, cand_bh4));
 
@@ -658,7 +657,7 @@ fn scan_col(
             return 1;
         }
         cand_b = *r.index(b[y as usize] + bx4 as usize);
-        cand_bh4 = dav1d_block_dimensions[cand_b.bs as usize][1] as i32;
+        cand_bh4 = cand_b.bs.dimensions()[1] as i32;
         assert!(cand_bh4 < bh4);
         len = cmp::max(step, cand_bh4);
     }
@@ -887,7 +886,7 @@ pub(crate) fn rav1d_refmvs_find(
     bx4: i32,
     frame_hdr: &Rav1dFrameHeader,
 ) {
-    let b_dim = &dav1d_block_dimensions[bs as usize];
+    let b_dim = bs.dimensions();
     let bw4 = b_dim[0] as i32;
     let w4 = cmp::min(cmp::min(bw4, 16), rt.tile_col.end - bx4);
     let bh4 = b_dim[1] as i32;
@@ -1175,7 +1174,7 @@ pub(crate) fn rav1d_refmvs_find(
                         r#ref,
                         &rf.sign_bias,
                     );
-                    x += dav1d_block_dimensions[cand_b.bs as usize][0] as i32;
+                    x += cand_b.bs.dimensions()[0] as i32;
                 }
             }
 
@@ -1193,7 +1192,7 @@ pub(crate) fn rav1d_refmvs_find(
                         r#ref,
                         &rf.sign_bias,
                     );
-                    y += dav1d_block_dimensions[cand_b.bs as usize][1] as i32;
+                    y += cand_b.bs.dimensions()[1] as i32;
                 }
             }
 
@@ -1275,7 +1274,7 @@ pub(crate) fn rav1d_refmvs_find(
             while x < sz4 && *cnt < 2 {
                 let cand_b = *rf.r.index(b_top + x as usize + b_top_offset);
                 add_single_extended_candidate(mvstack, cnt, cand_b, sign, &rf.sign_bias);
-                x += dav1d_block_dimensions[cand_b.bs as usize][0] as i32;
+                x += cand_b.bs.dimensions()[0] as i32;
             }
         }
 
@@ -1285,7 +1284,7 @@ pub(crate) fn rav1d_refmvs_find(
             while y < sz4 && *cnt < 2 {
                 let cand_b = *rf.r.index(b_left[y as usize] + bx4 as usize - 1);
                 add_single_extended_candidate(mvstack, cnt, cand_b, sign, &rf.sign_bias);
-                y += dav1d_block_dimensions[cand_b.bs as usize][1] as i32;
+                y += cand_b.bs.dimensions()[1] as i32;
             }
         }
     }
@@ -1554,7 +1553,7 @@ fn save_tmvs_rust(
         let mut x = col_start8;
         while x < col_end8 {
             let cand_b = *r.index(b + x * 2 + 1);
-            let bw8 = dav1d_block_dimensions[cand_b.bs as usize][0] + 1 >> 1;
+            let bw8 = cand_b.bs.dimensions()[0] + 1 >> 1;
             let block = |i: usize| {
                 let mv = cand_b.mv.mv[i];
                 let r#ref = cand_b.r#ref.r#ref[i];

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,5 +1,7 @@
+use strum::EnumCount;
+
 use crate::src::align::Align32;
-use crate::src::levels::N_RECT_TX_SIZES;
+use crate::src::levels::TxfmSize;
 
 static scan_4x4: Align32<[u16; 16]> =
     Align32([0, 4, 1, 2, 5, 8, 12, 9, 6, 3, 7, 10, 13, 14, 11, 15]);
@@ -201,7 +203,7 @@ static scan_32x32: Align32<[u16; 1024]> = Align32([
     990, 1021, 1022, 991, 1023,
 ]);
 
-pub static dav1d_scans: [&'static [u16]; N_RECT_TX_SIZES] = [
+pub static dav1d_scans: [&'static [u16]; TxfmSize::COUNT] = [
     &scan_4x4.0,
     &scan_8x8.0,
     &scan_16x16.0,

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -160,7 +160,7 @@ pub static dav1d_block_sizes: [[[BlockSize; 2]; BlockPartition::COUNT]; BlockLev
     ]
 };
 
-pub static dav1d_block_dimensions: [[u8; 4]; BlockSize::COUNT] = [
+static dav1d_block_dimensions: [[u8; 4]; BlockSize::COUNT] = [
     [32, 32, 5, 5],
     [32, 16, 5, 4],
     [16, 32, 4, 5],
@@ -184,6 +184,13 @@ pub static dav1d_block_dimensions: [[u8; 4]; BlockSize::COUNT] = [
     [1, 2, 0, 1],
     [1, 1, 0, 0],
 ];
+
+impl BlockSize {
+    #[inline]
+    pub fn dimensions(self) -> &'static [u8; 4] {
+        &dav1d_block_dimensions[self as usize]
+    }
+}
 
 pub static dav1d_txfm_dimensions: [TxfmInfo; TxfmSize::COUNT] = {
     use TxfmSize::*;

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -5,12 +5,14 @@ use crate::src::align::Align16;
 use crate::src::align::Align4;
 use crate::src::align::Align64;
 use crate::src::align::Align8;
+use crate::src::enum_map::DefaultValue;
 use crate::src::levels::BlockLevel;
 use crate::src::levels::BlockPartition;
 use crate::src::levels::BlockSize;
 use crate::src::levels::Filter2d;
 use crate::src::levels::InterPredMode;
 use crate::src::levels::TxClass;
+use crate::src::levels::TxfmSize;
 use crate::src::levels::TxfmType;
 use crate::src::levels::ADST_ADST;
 use crate::src::levels::ADST_DCT;
@@ -45,32 +47,12 @@ use crate::src::levels::NEWMV_NEARMV;
 use crate::src::levels::NEWMV_NEWMV;
 use crate::src::levels::N_COMP_INTER_PRED_MODES;
 use crate::src::levels::N_INTRA_PRED_MODES;
-use crate::src::levels::N_RECT_TX_SIZES;
 use crate::src::levels::N_TX_TYPES_PLUS_LL;
 use crate::src::levels::N_UV_INTRA_PRED_MODES;
 use crate::src::levels::PAETH_PRED;
-use crate::src::levels::RTX_16X32;
-use crate::src::levels::RTX_16X4;
-use crate::src::levels::RTX_16X64;
-use crate::src::levels::RTX_16X8;
-use crate::src::levels::RTX_32X16;
-use crate::src::levels::RTX_32X64;
-use crate::src::levels::RTX_32X8;
-use crate::src::levels::RTX_4X16;
-use crate::src::levels::RTX_4X8;
-use crate::src::levels::RTX_64X16;
-use crate::src::levels::RTX_64X32;
-use crate::src::levels::RTX_8X16;
-use crate::src::levels::RTX_8X32;
-use crate::src::levels::RTX_8X4;
 use crate::src::levels::SMOOTH_H_PRED;
 use crate::src::levels::SMOOTH_PRED;
 use crate::src::levels::SMOOTH_V_PRED;
-use crate::src::levels::TX_16X16;
-use crate::src::levels::TX_32X32;
-use crate::src::levels::TX_4X4;
-use crate::src::levels::TX_64X64;
-use crate::src::levels::TX_8X8;
 use crate::src::levels::VERT_LEFT_PRED;
 use crate::src::levels::VERT_PRED;
 use crate::src::levels::VERT_RIGHT_PRED;
@@ -88,7 +70,7 @@ pub struct TxfmInfo {
     pub lh: u8,
     pub min: u8,
     pub max: u8,
-    pub sub: u8,
+    pub sub: TxfmSize,
     pub ctx: u8,
 }
 
@@ -203,263 +185,230 @@ pub static dav1d_block_dimensions: [[u8; 4]; BlockSize::COUNT] = [
     [1, 1, 0, 0],
 ];
 
-pub static dav1d_txfm_dimensions: [TxfmInfo; N_RECT_TX_SIZES] = [
-    TxfmInfo {
-        w: 1,
-        h: 1,
-        lw: 0,
-        lh: 0,
-        min: 0,
-        max: 0,
-        sub: 0,
-        ctx: 0,
-    },
-    TxfmInfo {
-        w: 2,
-        h: 2,
-        lw: 1,
-        lh: 1,
-        min: 1,
-        max: 1,
-        sub: TX_4X4 as u8,
-        ctx: 1,
-    },
-    TxfmInfo {
-        w: 4,
-        h: 4,
-        lw: 2,
-        lh: 2,
-        min: 2,
-        max: 2,
-        sub: TX_8X8 as u8,
-        ctx: 2,
-    },
-    TxfmInfo {
-        w: 8,
-        h: 8,
-        lw: 3,
-        lh: 3,
-        min: 3,
-        max: 3,
-        sub: TX_16X16 as u8,
-        ctx: 3,
-    },
-    TxfmInfo {
-        w: 16,
-        h: 16,
-        lw: 4,
-        lh: 4,
-        min: 4,
-        max: 4,
-        sub: TX_32X32 as u8,
-        ctx: 4,
-    },
-    TxfmInfo {
-        w: 1,
-        h: 2,
-        lw: 0,
-        lh: 1,
-        min: 0,
-        max: 1,
-        sub: TX_4X4 as u8,
-        ctx: 1,
-    },
-    TxfmInfo {
-        w: 2,
-        h: 1,
-        lw: 1,
-        lh: 0,
-        min: 0,
-        max: 1,
-        sub: TX_4X4 as u8,
-        ctx: 1,
-    },
-    TxfmInfo {
-        w: 2,
-        h: 4,
-        lw: 1,
-        lh: 2,
-        min: 1,
-        max: 2,
-        sub: TX_8X8 as u8,
-        ctx: 2,
-    },
-    TxfmInfo {
-        w: 4,
-        h: 2,
-        lw: 2,
-        lh: 1,
-        min: 1,
-        max: 2,
-        sub: TX_8X8 as u8,
-        ctx: 2,
-    },
-    TxfmInfo {
-        w: 4,
-        h: 8,
-        lw: 2,
-        lh: 3,
-        min: 2,
-        max: 3,
-        sub: TX_16X16 as u8,
-        ctx: 3,
-    },
-    TxfmInfo {
-        w: 8,
-        h: 4,
-        lw: 3,
-        lh: 2,
-        min: 2,
-        max: 3,
-        sub: TX_16X16 as u8,
-        ctx: 3,
-    },
-    TxfmInfo {
-        w: 8,
-        h: 16,
-        lw: 3,
-        lh: 4,
-        min: 3,
-        max: 4,
-        sub: TX_32X32 as u8,
-        ctx: 4,
-    },
-    TxfmInfo {
-        w: 16,
-        h: 8,
-        lw: 4,
-        lh: 3,
-        min: 3,
-        max: 4,
-        sub: TX_32X32 as u8,
-        ctx: 4,
-    },
-    TxfmInfo {
-        w: 1,
-        h: 4,
-        lw: 0,
-        lh: 2,
-        min: 0,
-        max: 2,
-        sub: RTX_4X8 as u8,
-        ctx: 1,
-    },
-    TxfmInfo {
-        w: 4,
-        h: 1,
-        lw: 2,
-        lh: 0,
-        min: 0,
-        max: 2,
-        sub: RTX_8X4 as u8,
-        ctx: 1,
-    },
-    TxfmInfo {
-        w: 2,
-        h: 8,
-        lw: 1,
-        lh: 3,
-        min: 1,
-        max: 3,
-        sub: RTX_8X16 as u8,
-        ctx: 2,
-    },
-    TxfmInfo {
-        w: 8,
-        h: 2,
-        lw: 3,
-        lh: 1,
-        min: 1,
-        max: 3,
-        sub: RTX_16X8 as u8,
-        ctx: 2,
-    },
-    TxfmInfo {
-        w: 4,
-        h: 16,
-        lw: 2,
-        lh: 4,
-        min: 2,
-        max: 4,
-        sub: RTX_16X32 as u8,
-        ctx: 3,
-    },
-    TxfmInfo {
-        w: 16,
-        h: 4,
-        lw: 4,
-        lh: 2,
-        min: 2,
-        max: 4,
-        sub: RTX_32X16 as u8,
-        ctx: 3,
-    },
-];
+pub static dav1d_txfm_dimensions: [TxfmInfo; TxfmSize::COUNT] = {
+    use TxfmSize::*;
+    [
+        TxfmInfo {
+            w: 1,
+            h: 1,
+            lw: 0,
+            lh: 0,
+            min: 0,
+            max: 0,
+            sub: DefaultValue::DEFAULT,
+            ctx: 0,
+        },
+        TxfmInfo {
+            w: 2,
+            h: 2,
+            lw: 1,
+            lh: 1,
+            min: 1,
+            max: 1,
+            sub: S4x4,
+            ctx: 1,
+        },
+        TxfmInfo {
+            w: 4,
+            h: 4,
+            lw: 2,
+            lh: 2,
+            min: 2,
+            max: 2,
+            sub: S8x8,
+            ctx: 2,
+        },
+        TxfmInfo {
+            w: 8,
+            h: 8,
+            lw: 3,
+            lh: 3,
+            min: 3,
+            max: 3,
+            sub: S16x16,
+            ctx: 3,
+        },
+        TxfmInfo {
+            w: 16,
+            h: 16,
+            lw: 4,
+            lh: 4,
+            min: 4,
+            max: 4,
+            sub: S32x32,
+            ctx: 4,
+        },
+        TxfmInfo {
+            w: 1,
+            h: 2,
+            lw: 0,
+            lh: 1,
+            min: 0,
+            max: 1,
+            sub: S4x4,
+            ctx: 1,
+        },
+        TxfmInfo {
+            w: 2,
+            h: 1,
+            lw: 1,
+            lh: 0,
+            min: 0,
+            max: 1,
+            sub: S4x4,
+            ctx: 1,
+        },
+        TxfmInfo {
+            w: 2,
+            h: 4,
+            lw: 1,
+            lh: 2,
+            min: 1,
+            max: 2,
+            sub: S8x8,
+            ctx: 2,
+        },
+        TxfmInfo {
+            w: 4,
+            h: 2,
+            lw: 2,
+            lh: 1,
+            min: 1,
+            max: 2,
+            sub: S8x8,
+            ctx: 2,
+        },
+        TxfmInfo {
+            w: 4,
+            h: 8,
+            lw: 2,
+            lh: 3,
+            min: 2,
+            max: 3,
+            sub: S16x16,
+            ctx: 3,
+        },
+        TxfmInfo {
+            w: 8,
+            h: 4,
+            lw: 3,
+            lh: 2,
+            min: 2,
+            max: 3,
+            sub: S16x16,
+            ctx: 3,
+        },
+        TxfmInfo {
+            w: 8,
+            h: 16,
+            lw: 3,
+            lh: 4,
+            min: 3,
+            max: 4,
+            sub: S32x32,
+            ctx: 4,
+        },
+        TxfmInfo {
+            w: 16,
+            h: 8,
+            lw: 4,
+            lh: 3,
+            min: 3,
+            max: 4,
+            sub: S32x32,
+            ctx: 4,
+        },
+        TxfmInfo {
+            w: 1,
+            h: 4,
+            lw: 0,
+            lh: 2,
+            min: 0,
+            max: 2,
+            sub: R4x8,
+            ctx: 1,
+        },
+        TxfmInfo {
+            w: 4,
+            h: 1,
+            lw: 2,
+            lh: 0,
+            min: 0,
+            max: 2,
+            sub: R8x4,
+            ctx: 1,
+        },
+        TxfmInfo {
+            w: 2,
+            h: 8,
+            lw: 1,
+            lh: 3,
+            min: 1,
+            max: 3,
+            sub: R8x16,
+            ctx: 2,
+        },
+        TxfmInfo {
+            w: 8,
+            h: 2,
+            lw: 3,
+            lh: 1,
+            min: 1,
+            max: 3,
+            sub: R16x8,
+            ctx: 2,
+        },
+        TxfmInfo {
+            w: 4,
+            h: 16,
+            lw: 2,
+            lh: 4,
+            min: 2,
+            max: 4,
+            sub: R16x32,
+            ctx: 3,
+        },
+        TxfmInfo {
+            w: 16,
+            h: 4,
+            lw: 4,
+            lh: 2,
+            min: 2,
+            max: 4,
+            sub: R32x16,
+            ctx: 3,
+        },
+    ]
+};
 
-pub static dav1d_max_txfm_size_for_bs: [[u8; 4]; BlockSize::COUNT] = [
+pub static dav1d_max_txfm_size_for_bs: [[TxfmSize; 4]; BlockSize::COUNT] = {
+    use TxfmSize::*;
+    const DEFAULT: TxfmSize = DefaultValue::DEFAULT;
     [
-        TX_64X64 as u8,
-        TX_32X32 as u8,
-        TX_32X32 as u8,
-        TX_32X32 as u8,
-    ],
-    [
-        TX_64X64 as u8,
-        TX_32X32 as u8,
-        TX_32X32 as u8,
-        TX_32X32 as u8,
-    ],
-    [TX_64X64 as u8, TX_32X32 as u8, 0, TX_32X32 as u8],
-    [
-        TX_64X64 as u8,
-        TX_32X32 as u8,
-        TX_32X32 as u8,
-        TX_32X32 as u8,
-    ],
-    [
-        RTX_64X32 as u8,
-        RTX_32X16 as u8,
-        TX_32X32 as u8,
-        TX_32X32 as u8,
-    ],
-    [
-        RTX_64X16 as u8,
-        RTX_32X8 as u8,
-        RTX_32X16 as u8,
-        RTX_32X16 as u8,
-    ],
-    [RTX_32X64 as u8, RTX_16X32 as u8, 0, TX_32X32 as u8],
-    [
-        TX_32X32 as u8,
-        TX_16X16 as u8,
-        RTX_16X32 as u8,
-        TX_32X32 as u8,
-    ],
-    [
-        RTX_32X16 as u8,
-        RTX_16X8 as u8,
-        TX_16X16 as u8,
-        RTX_32X16 as u8,
-    ],
-    [
-        RTX_32X8 as u8,
-        RTX_16X4 as u8,
-        RTX_16X8 as u8,
-        RTX_32X8 as u8,
-    ],
-    [RTX_16X64 as u8, RTX_8X32 as u8, 0, RTX_16X32 as u8],
-    [RTX_16X32 as u8, RTX_8X16 as u8, 0, RTX_16X32 as u8],
-    [TX_16X16 as u8, TX_8X8 as u8, RTX_8X16 as u8, TX_16X16 as u8],
-    [RTX_16X8 as u8, RTX_8X4 as u8, TX_8X8 as u8, RTX_16X8 as u8],
-    [RTX_16X4 as u8, RTX_8X4 as u8, RTX_8X4 as u8, RTX_16X4 as u8],
-    [RTX_8X32 as u8, RTX_4X16 as u8, 0, RTX_8X32 as u8],
-    [RTX_8X16 as u8, RTX_4X8 as u8, 0, RTX_8X16 as u8],
-    [TX_8X8 as u8, TX_4X4 as u8, RTX_4X8 as u8, TX_8X8 as u8],
-    [RTX_8X4 as u8, TX_4X4 as u8, TX_4X4 as u8, RTX_8X4 as u8],
-    [RTX_4X16 as u8, RTX_4X8 as u8, 0, RTX_4X16 as u8],
-    [RTX_4X8 as u8, TX_4X4 as u8, 0, RTX_4X8 as u8],
-    [TX_4X4 as u8, TX_4X4 as u8, TX_4X4 as u8, TX_4X4 as u8],
-];
+        [S64x64, S32x32, S32x32, S32x32],
+        [S64x64, S32x32, S32x32, S32x32],
+        [S64x64, S32x32, DEFAULT, S32x32],
+        [S64x64, S32x32, S32x32, S32x32],
+        [R64x32, R32x16, S32x32, S32x32],
+        [R64x16, R32x8, R32x16, R32x16],
+        [R32x64, R16x32, DEFAULT, S32x32],
+        [S32x32, S16x16, R16x32, S32x32],
+        [R32x16, R16x8, S16x16, R32x16],
+        [R32x8, R16x4, R16x8, R32x8],
+        [R16x64, R8x32, DEFAULT, R16x32],
+        [R16x32, R8x16, DEFAULT, R16x32],
+        [S16x16, S8x8, R8x16, S16x16],
+        [R16x8, R8x4, S8x8, R16x8],
+        [R16x4, R8x4, R8x4, R16x4],
+        [R8x32, R4x16, DEFAULT, R8x32],
+        [R8x16, R4x8, DEFAULT, R8x16],
+        [S8x8, S4x4, R4x8, S8x8],
+        [R8x4, S4x4, S4x4, R8x4],
+        [R4x16, R4x8, DEFAULT, R4x16],
+        [R4x8, S4x4, DEFAULT, R4x8],
+        [S4x4, S4x4, S4x4, S4x4],
+    ]
+};
 
 pub static dav1d_txtp_from_uvmode: [TxfmType; N_UV_INTRA_PRED_MODES] = {
     let mut tbl = [0; N_UV_INTRA_PRED_MODES];


### PR DESCRIPTION
* Part of #1180.

This makes `TxfmSize` and `RectTxfmSize` into a real `enum`, which eliminates many bounds checks in hot `fn`s like `fn decode_ceofs`.  It also lets us further simplify the `itx` macros and eliminate the distinction between the `R`ect ones.

Note that `TxfmSize` defined the square sizes; these ones are named with an `S` prefix, while the `R`-prefixed `RectTxfmSize` stay `R`-prefixed.

There are a few new places where we have to create `TxfmSize`s using `from_repr` and thus do a bounds check.  These should be pretty cheap, but there are optimizable out, as they ultimately come from `static`/`const` data whos bounds are known but LLVM is not able to deduce them.  This is why I added 7f0cdc2, starting to try to fix this, though it's a little complicated, so I didn't want to finish it in this PR. 