### PR TITLE
`fn get_lo_ctx`: Optimize

### DIFF
--- a/src/levels.rs
+++ b/src/levels.rs
@@ -145,7 +145,7 @@ pub const DCT_ADST: TxfmType = 2;
 pub const ADST_DCT: TxfmType = 1;
 pub const DCT_DCT: TxfmType = 0;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum TxClass {
     TwoD,
     H,

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -468,28 +468,28 @@ fn get_dc_sign_ctx(tx: TxfmSize, a: &[u8], l: &[u8]) -> c_uint {
 fn get_lo_ctx(
     levels: &[u8],
     tx_class: TxClass,
-    hi_mag: &mut c_uint,
+    hi_mag: &mut u32,
     ctx_offsets: Option<&[[u8; 5]; 5]>,
     x: u32,
     y: u32,
     stride: u8,
 ) -> u8 {
     let stride = stride as usize;
-    let level = |y, x| levels[y * stride + x] as usize;
+    let level = |y, x| levels[y * stride + x] as u32;
 
     let mut mag = level(0, 1) + level(1, 0);
     let offset = match ctx_offsets {
         Some(ctx_offsets) => {
             debug_assert_matches!(tx_class, TxClass::TwoD);
             mag += level(1, 1);
-            *hi_mag = mag as c_uint;
+            *hi_mag = mag;
             mag += level(0, 2) + level(2, 0);
             ctx_offsets[cmp::min(y as usize, 4)][cmp::min(x as usize, 4)]
         }
         None => {
             debug_assert_matches!(tx_class, TxClass::H | TxClass::V);
             mag += level(0, 2);
-            *hi_mag = mag as c_uint;
+            *hi_mag = mag;
             mag += level(0, 3) + level(0, 4);
             26 + if y > 1 { 10 } else { y as u8 * 5 }
         }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -470,12 +470,11 @@ fn get_lo_ctx(
     tx_class: TxClass,
     hi_mag: &mut c_uint,
     ctx_offsets: Option<&[[u8; 5]; 5]>,
-    x: usize,
-    y: usize,
+    x: u32,
+    y: u32,
     stride: u8,
 ) -> usize {
     let stride = stride as usize;
-    let levels = &levels[..2 * stride + 4 + 1];
     let level = |y, x| levels[y * stride + x] as usize;
 
     let mut mag = level(0, 1) + level(1, 0);
@@ -485,14 +484,14 @@ fn get_lo_ctx(
             mag += level(1, 1);
             *hi_mag = mag as c_uint;
             mag += level(0, 2) + level(2, 0);
-            ctx_offsets[cmp::min(y, 4)][cmp::min(x, 4)] as usize
+            ctx_offsets[cmp::min(y as usize, 4)][cmp::min(x as usize, 4)] as usize
         }
         None => {
             debug_assert_matches!(tx_class, TxClass::H | TxClass::V);
             mag += level(0, 2);
             *hi_mag = mag as c_uint;
             mag += level(0, 3) + level(0, 4);
-            26 + if y > 1 { 10 } else { y * 5 }
+            26 + if y > 1 { 10 } else { y as usize * 5 }
         }
     };
     offset + if mag > 512 { 4 } else { (mag + 64) >> 7 }
@@ -822,15 +821,8 @@ fn decode_coefs<BD: BitDepth>(
                     }
                     assert!(x < 32 && y < 32);
                     let level = &mut levels[x as usize * stride as usize + y as usize..];
-                    ctx = get_lo_ctx(
-                        level,
-                        tx_class,
-                        &mut mag,
-                        lo_ctx_offsets,
-                        x as usize,
-                        y as usize,
-                        stride,
-                    ) as c_uint;
+                    ctx = get_lo_ctx(level, tx_class, &mut mag, lo_ctx_offsets, x, y, stride)
+                        as c_uint;
                     if tx_class == TxClass::TwoD {
                         y |= x;
                     }
@@ -1018,15 +1010,8 @@ fn decode_coefs<BD: BitDepth>(
                     }
                     assert!(x < 32 && y < 32);
                     let level = &mut levels[x as usize * stride as usize + y as usize..];
-                    ctx = get_lo_ctx(
-                        level,
-                        tx_class,
-                        &mut mag,
-                        lo_ctx_offsets,
-                        x as usize,
-                        y as usize,
-                        stride,
-                    ) as c_uint;
+                    ctx = get_lo_ctx(level, tx_class, &mut mag, lo_ctx_offsets, x, y, stride)
+                        as c_uint;
                     if tx_class == TxClass::TwoD {
                         y |= x;
                     }
@@ -1211,15 +1196,8 @@ fn decode_coefs<BD: BitDepth>(
                     }
                     assert!(x < 32 && y < 32);
                     let level = &mut levels[x as usize * stride as usize + y as usize..];
-                    ctx = get_lo_ctx(
-                        level,
-                        tx_class,
-                        &mut mag,
-                        lo_ctx_offsets,
-                        x as usize,
-                        y as usize,
-                        stride,
-                    ) as c_uint;
+                    ctx = get_lo_ctx(level, tx_class, &mut mag, lo_ctx_offsets, x, y, stride)
+                        as c_uint;
                     if tx_class == TxClass::TwoD {
                         y |= x;
                     }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -473,7 +473,7 @@ fn get_lo_ctx(
     x: u32,
     y: u32,
     stride: u8,
-) -> usize {
+) -> u8 {
     let stride = stride as usize;
     let level = |y, x| levels[y * stride + x] as usize;
 
@@ -484,17 +484,22 @@ fn get_lo_ctx(
             mag += level(1, 1);
             *hi_mag = mag as c_uint;
             mag += level(0, 2) + level(2, 0);
-            ctx_offsets[cmp::min(y as usize, 4)][cmp::min(x as usize, 4)] as usize
+            ctx_offsets[cmp::min(y as usize, 4)][cmp::min(x as usize, 4)]
         }
         None => {
             debug_assert_matches!(tx_class, TxClass::H | TxClass::V);
             mag += level(0, 2);
             *hi_mag = mag as c_uint;
             mag += level(0, 3) + level(0, 4);
-            26 + if y > 1 { 10 } else { y as usize * 5 }
+            26 + if y > 1 { 10 } else { y as u8 * 5 }
         }
     };
-    offset + if mag > 512 { 4 } else { (mag + 64) >> 7 }
+    offset
+        + if mag > 512 {
+            4
+        } else {
+            ((mag + 64) >> 7) as u8
+        }
 }
 
 fn decode_coefs<BD: BitDepth>(

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -718,9 +718,9 @@ fn decode_coefs<BD: BitDepth>(
         let sh = cmp::min(t_dim.h, 8);
 
         // eob
-        let mut ctx: c_uint = 1
-            + (eob > sw as c_int * sh as c_int * 2) as c_uint
-            + (eob > sw as c_int * sh as c_int * 4) as c_uint;
+        let mut ctx = 1
+            + (eob > sw as c_int * sh as c_int * 2) as u8
+            + (eob > sw as c_int * sh as c_int * 4) as u8;
         let eob_tok =
             rav1d_msac_decode_symbol_adapt4(&mut ts_c.msac, &mut eob_cdf[ctx as usize], 2) as c_int;
         let mut tok = eob_tok + 1;
@@ -826,8 +826,7 @@ fn decode_coefs<BD: BitDepth>(
                     }
                     assert!(x < 32 && y < 32);
                     let level = &mut levels[x as usize * stride as usize + y as usize..];
-                    ctx = get_lo_ctx(level, tx_class, &mut mag, lo_ctx_offsets, x, y, stride)
-                        as c_uint;
+                    ctx = get_lo_ctx(level, tx_class, &mut mag, lo_ctx_offsets, x, y, stride);
                     if tx_class == TxClass::TwoD {
                         y |= x;
                     }
@@ -844,16 +843,11 @@ fn decode_coefs<BD: BitDepth>(
                     }
                     if tok == 3 {
                         mag &= 63;
-                        ctx = ((if y > (tx_class == TxClass::TwoD) as c_uint {
+                        ctx = if y > (tx_class == TxClass::TwoD) as c_uint {
                             14
                         } else {
                             7
-                        }) as c_uint)
-                            .wrapping_add(if mag > 12 {
-                                6
-                            } else {
-                                mag.wrapping_add(1) >> 1
-                            });
+                        } + if mag > 12 { 6 } else { (mag as u8 + 1) >> 1 };
                         tok = rav1d_msac_decode_hi_tok(&mut ts_c.msac, &mut hi_cdf[ctx as usize])
                             as c_int;
                         if dbg {
@@ -893,7 +887,7 @@ fn decode_coefs<BD: BitDepth>(
                 ctx = if tx_class == TxClass::TwoD {
                     0
                 } else {
-                    get_lo_ctx(levels, tx_class, &mut mag, lo_ctx_offsets, 0, 0, stride) as c_uint
+                    get_lo_ctx(levels, tx_class, &mut mag, lo_ctx_offsets, 0, 0, stride)
                 };
                 dc_tok =
                     rav1d_msac_decode_symbol_adapt4(&mut ts_c.msac, &mut lo_cdf[ctx as usize], 3)
@@ -911,11 +905,7 @@ fn decode_coefs<BD: BitDepth>(
                             + levels[1 * stride as usize + 1] as c_uint;
                     }
                     mag &= 63;
-                    ctx = if mag > 12 {
-                        6
-                    } else {
-                        mag.wrapping_add(1) >> 1
-                    };
+                    ctx = if mag > 12 { 6 } else { (mag as u8 + 1) >> 1 };
                     dc_tok = rav1d_msac_decode_hi_tok(&mut ts_c.msac, &mut hi_cdf[ctx as usize])
                         as c_uint;
                     if dbg {
@@ -1015,8 +1005,7 @@ fn decode_coefs<BD: BitDepth>(
                     }
                     assert!(x < 32 && y < 32);
                     let level = &mut levels[x as usize * stride as usize + y as usize..];
-                    ctx = get_lo_ctx(level, tx_class, &mut mag, lo_ctx_offsets, x, y, stride)
-                        as c_uint;
+                    ctx = get_lo_ctx(level, tx_class, &mut mag, lo_ctx_offsets, x, y, stride);
                     if tx_class == TxClass::TwoD {
                         y |= x;
                     }
@@ -1033,16 +1022,11 @@ fn decode_coefs<BD: BitDepth>(
                     }
                     if tok == 3 {
                         mag &= 63;
-                        ctx = ((if y > (tx_class == TxClass::TwoD) as c_uint {
+                        ctx = if y > (tx_class == TxClass::TwoD) as c_uint {
                             14
                         } else {
                             7
-                        }) as c_uint)
-                            .wrapping_add(if mag > 12 {
-                                6
-                            } else {
-                                mag.wrapping_add(1) >> 1
-                            });
+                        } + if mag > 12 { 6 } else { (mag as u8 + 1) >> 1 };
                         tok = rav1d_msac_decode_hi_tok(&mut ts_c.msac, &mut hi_cdf[ctx as usize])
                             as c_int;
                         if dbg {
@@ -1079,7 +1063,7 @@ fn decode_coefs<BD: BitDepth>(
                 ctx = if tx_class == TxClass::TwoD {
                     0
                 } else {
-                    get_lo_ctx(levels, tx_class, &mut mag, lo_ctx_offsets, 0, 0, stride) as c_uint
+                    get_lo_ctx(levels, tx_class, &mut mag, lo_ctx_offsets, 0, 0, stride)
                 };
                 dc_tok =
                     rav1d_msac_decode_symbol_adapt4(&mut ts_c.msac, &mut lo_cdf[ctx as usize], 3)
@@ -1097,11 +1081,7 @@ fn decode_coefs<BD: BitDepth>(
                             + levels[1 * stride as usize + 1] as c_uint;
                     }
                     mag &= 63;
-                    ctx = if mag > 12 {
-                        6
-                    } else {
-                        mag.wrapping_add(1) >> 1
-                    };
+                    ctx = if mag > 12 { 6 } else { (mag as u8 + 1) >> 1 };
                     dc_tok = rav1d_msac_decode_hi_tok(&mut ts_c.msac, &mut hi_cdf[ctx as usize])
                         as c_uint;
                     if dbg {
@@ -1201,8 +1181,7 @@ fn decode_coefs<BD: BitDepth>(
                     }
                     assert!(x < 32 && y < 32);
                     let level = &mut levels[x as usize * stride as usize + y as usize..];
-                    ctx = get_lo_ctx(level, tx_class, &mut mag, lo_ctx_offsets, x, y, stride)
-                        as c_uint;
+                    ctx = get_lo_ctx(level, tx_class, &mut mag, lo_ctx_offsets, x, y, stride);
                     if tx_class == TxClass::TwoD {
                         y |= x;
                     }
@@ -1219,16 +1198,11 @@ fn decode_coefs<BD: BitDepth>(
                     }
                     if tok == 3 {
                         mag &= 63;
-                        ctx = ((if y > (tx_class == TxClass::TwoD) as c_uint {
+                        ctx = if y > (tx_class == TxClass::TwoD) as c_uint {
                             14
                         } else {
                             7
-                        }) as c_uint)
-                            .wrapping_add(if mag > 12 {
-                                6
-                            } else {
-                                mag.wrapping_add(1) >> 1
-                            });
+                        } + if mag > 12 { 6 } else { (mag as u8 + 1) >> 1 };
                         tok = rav1d_msac_decode_hi_tok(&mut ts_c.msac, &mut hi_cdf[ctx as usize])
                             as c_int;
                         if dbg {
@@ -1265,7 +1239,7 @@ fn decode_coefs<BD: BitDepth>(
                 ctx = if tx_class == TxClass::TwoD {
                     0
                 } else {
-                    get_lo_ctx(levels, tx_class, &mut mag, lo_ctx_offsets, 0, 0, stride) as c_uint
+                    get_lo_ctx(levels, tx_class, &mut mag, lo_ctx_offsets, 0, 0, stride)
                 };
                 dc_tok =
                     rav1d_msac_decode_symbol_adapt4(&mut ts_c.msac, &mut lo_cdf[ctx as usize], 3)
@@ -1283,11 +1257,7 @@ fn decode_coefs<BD: BitDepth>(
                             + levels[1 * stride as usize + 1] as c_uint;
                     }
                     mag &= 63;
-                    ctx = if mag > 12 {
-                        6
-                    } else {
-                        mag.wrapping_add(1) >> 1
-                    };
+                    ctx = if mag > 12 { 6 } else { (mag as u8 + 1) >> 1 };
                     dc_tok = rav1d_msac_decode_hi_tok(&mut ts_c.msac, &mut hi_cdf[ctx as usize])
                         as c_uint;
                     if dbg {

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -82,6 +82,7 @@ use crate::src::tables::dav1d_txtp_from_uvmode;
 use crate::src::tables::TxfmInfo;
 use crate::src::wedge::dav1d_ii_masks;
 use crate::src::wedge::dav1d_wedge_masks;
+use assert_matches::debug_assert_matches;
 use libc::intptr_t;
 use std::array;
 use std::cmp;
@@ -476,14 +477,16 @@ fn get_lo_ctx(
     let level = |y, x| levels[y * stride + x] as usize;
 
     let mut mag = level(0, 1) + level(1, 0);
-    let offset = match tx_class {
-        TxClass::TwoD => {
+    let offset = match ctx_offsets {
+        Some(ctx_offsets) => {
+            debug_assert_matches!(tx_class, TxClass::TwoD);
             mag += level(1, 1);
             *hi_mag = mag as c_uint;
             mag += level(0, 2) + level(2, 0);
-            ctx_offsets.unwrap()[cmp::min(y, 4)][cmp::min(x, 4)] as usize
+            ctx_offsets[cmp::min(y, 4)][cmp::min(x, 4)] as usize
         }
-        TxClass::H | TxClass::V => {
+        None => {
+            debug_assert_matches!(tx_class, TxClass::H | TxClass::V);
             mag += level(0, 2);
             *hi_mag = mag as c_uint;
             mag += level(0, 3) + level(0, 4);


### PR DESCRIPTION
* Part of #1180.

This optimizes `fn get_lo_ctx`.

9d00ae6 optimizes it enough that it is now inlined (it was already `#[inline]`), which enables other optimizations.

a5c6209 makes `stride` a `u8`, which it is in the caller `fn decode_coefs`, and which tells LLVM that `_ * stride` can't overflow, and thus `2 * stride` being in bounds means that `0 * stride` is in bounds, for example.

242065b then pre-indexes `levels` so that there is only one bounds check per branch.  There is still actually another since LLVM does not know that `stride != 0`.  This can be optimized out with more effort in `fn decode_coefs`, as `stride` is ultimately derived from `t_dim.h`, which comes from `static`/`const` data.