### PR TITLE
`fn decode_coefs`: Cleanup, especially `decode_coefs_class!`

### DIFF
--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -158,6 +158,7 @@ pub trait BitDepth: Clone + Copy {
 
     type Coef: Copy
         + From<i16>
+        + FromPrimitive<u16>
         + FromPrimitive<c_int>
         + FromPrimitive<c_uint>
         + ToPrimitive<c_int>

--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -157,7 +157,7 @@ pub trait BitDepth: Clone + Copy {
     type AlignPixelX8: Copy;
 
     type Coef: Copy
-        + From<i8>
+        + From<i16>
         + FromPrimitive<c_int>
         + FromPrimitive<c_uint>
         + ToPrimitive<c_int>

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -99,6 +99,10 @@ impl TxfmSize {
             }
         }
     }
+
+    pub const fn is_rect(self) -> bool {
+        self as u8 >= Self::R4x8 as u8
+    }
 }
 
 #[repr(u8)]

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -818,7 +818,9 @@ fn decode_coefs<BD: BitDepth>(
                             rc_i = (x as u16) << shift2 | y as u16;
                         }
                     }
-                    assert!(x < 32 && y < 32);
+                    debug_assert!(x < 32 && y < 32);
+                    x %= 32;
+                    y %= 32;
                     let level = &mut levels[x as usize * stride as usize + y as usize..];
                     ctx = get_lo_ctx(level, tx_class, &mut mag, lo_ctx_offsets, x, y, stride);
                     if tx_class == TxClass::TwoD {

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -589,14 +589,14 @@ fn decode_coefs<BD: BitDepth>(
                     &mut ts_c.cdf.m.txtp_intra2[t_dim.min as usize][y_mode_nofilt as usize],
                     4,
                 );
-                dav1d_tx_types_per_set[(idx + 0) as usize]
+                dav1d_tx_types_per_set[idx as usize + 0]
             } else {
                 idx = rav1d_msac_decode_symbol_adapt8(
                     &mut ts_c.msac,
                     &mut ts_c.cdf.m.txtp_intra1[t_dim.min as usize][y_mode_nofilt as usize],
                     6,
                 );
-                dav1d_tx_types_per_set[(idx + 5) as usize]
+                dav1d_tx_types_per_set[idx as usize + 5]
             };
             if dbg {
                 println!(
@@ -625,14 +625,14 @@ fn decode_coefs<BD: BitDepth>(
                     &mut ts_c.cdf.m.txtp_inter2.0,
                     11,
                 );
-                dav1d_tx_types_per_set[(idx + 12) as usize]
+                dav1d_tx_types_per_set[idx as usize + 12]
             } else {
                 idx = rav1d_msac_decode_symbol_adapt16(
                     &mut ts_c.msac,
                     &mut ts_c.cdf.m.txtp_inter1[t_dim.min as usize],
                     15,
                 );
-                dav1d_tx_types_per_set[(idx + 24) as usize]
+                dav1d_tx_types_per_set[idx as usize + 24]
             };
             if dbg {
                 println!(

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -732,7 +732,7 @@ fn decode_coefs<BD: BitDepth>(
             rav1d_msac_decode_symbol_adapt4(&mut ts_c.msac, &mut eob_cdf[ctx as usize], 2);
         let mut tok = eob_tok + 1;
         let mut level_tok = tok * 0x41;
-        let mut mag: c_uint = 0;
+        let mut mag = 0;
 
         let mut scan: &[u16] = &[];
 
@@ -838,12 +838,12 @@ fn decode_coefs<BD: BitDepth>(
                         );
                     }
                     if tok == 3 {
-                        mag &= 63;
+                        let mag = mag as u8 & 63;
                         ctx = if y > (tx_class == TxClass::TwoD) as u8 {
                             14
                         } else {
                             7
-                        } + if mag > 12 { 6 } else { (mag as u8 + 1) >> 1 };
+                        } + if mag > 12 { 6 } else { (mag + 1) >> 1 };
                         tok = rav1d_msac_decode_hi_tok(&mut ts_c.msac, &mut hi_cdf[ctx as usize]);
                         if dbg {
                             println!(
@@ -899,8 +899,8 @@ fn decode_coefs<BD: BitDepth>(
                             + levels[1 * stride as usize + 0] as c_uint
                             + levels[1 * stride as usize + 1] as c_uint;
                     }
-                    mag &= 63;
-                    ctx = if mag > 12 { 6 } else { (mag as u8 + 1) >> 1 };
+                    let mag = mag as u8 & 63;
+                    ctx = if mag > 12 { 6 } else { (mag + 1) >> 1 };
                     dc_tok = rav1d_msac_decode_hi_tok(&mut ts_c.msac, &mut hi_cdf[ctx as usize])
                         as c_uint;
                     if dbg {

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -751,7 +751,7 @@ fn decode_coefs<BD: BitDepth>(
                 let mut y;
                 match TX_CLASS {
                     TxClass::TwoD => {
-                        rc = scan[eob as usize] as u32;
+                        rc = scan[eob as usize];
                         x = (rc >> shift) as u8;
                         y = rc as u8 & mask;
                     }
@@ -759,12 +759,12 @@ fn decode_coefs<BD: BitDepth>(
                         // Transposing reduces the stride and padding requirements.
                         x = eob as u8 & mask;
                         y = (eob >> shift) as u8;
-                        rc = eob as u32;
+                        rc = eob as u16;
                     }
                     TxClass::V => {
                         x = eob as u8 & mask;
                         y = (eob >> shift) as u8;
-                        rc = (x as u32) << shift2 | y as u32;
+                        rc = (x as u16) << shift2 | y as u16;
                     }
                 }
                 if dbg {
@@ -803,22 +803,22 @@ fn decode_coefs<BD: BitDepth>(
                 let mut i = eob - 1;
                 while i > 0 {
                     // ac
-                    let rc_i: u32;
+                    let rc_i;
                     match tx_class {
                         TxClass::TwoD => {
-                            rc_i = scan[i as usize] as u32;
+                            rc_i = scan[i as usize];
                             x = (rc_i >> shift) as u8;
                             y = rc_i as u8 & mask;
                         }
                         TxClass::H => {
                             x = i as u8 & mask;
                             y = (i >> shift) as u8;
-                            rc_i = i as u32;
+                            rc_i = i as u16;
                         }
                         TxClass::V => {
                             x = i as u8 & mask;
                             y = (i >> shift) as u8;
-                            rc_i = (x as u32) << shift2 | y as u32;
+                            rc_i = (x as u16) << shift2 | y as u16;
                         }
                     }
                     assert!(x < 32 && y < 32);
@@ -863,7 +863,7 @@ fn decode_coefs<BD: BitDepth>(
                             f,
                             t_cf,
                             rc_i as usize,
-                            (((tok as u32) << 11) | rc).as_::<BD::Coef>(),
+                            (((tok as u16) << 11) | rc).as_::<BD::Coef>(),
                         );
                         rc = rc_i;
                     } else {
@@ -872,7 +872,7 @@ fn decode_coefs<BD: BitDepth>(
                         tok *= 0x17ff41;
                         level[0] = tok as u8;
                         // `tok ? (tok << 11) | rc : 0`
-                        tok = ((tok >> 9) & rc.wrapping_add(!0x7ff));
+                        tok = ((tok >> 9) & (rc as u32).wrapping_add(!0x7ff));
                         if tok != 0 {
                             rc = rc_i;
                         }
@@ -1143,7 +1143,7 @@ fn decode_coefs<BD: BitDepth>(
                     (if sign != 0 { -dq_sat } else { dq_sat }).as_::<BD::Coef>(),
                 );
 
-                rc = rc_tok & 0x3ff;
+                rc = rc_tok as u16 & 0x3ff;
                 if !(rc != 0) {
                     break;
                 }
@@ -1193,7 +1193,7 @@ fn decode_coefs<BD: BitDepth>(
                     (if sign != 0 { -dq } else { dq }).as_::<BD::Coef>(),
                 );
 
-                rc = rc_tok & 0x3ff; // next non-zero `rc`, zero if `eob`
+                rc = rc_tok as u16 & 0x3ff; // next non-zero `rc`, zero if `eob`
                 if !(rc != 0) {
                     break;
                 }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -693,8 +693,7 @@ fn decode_coefs<BD: BitDepth>(
             ts_c.msac.rng,
         );
     }
-    let eob;
-    if eob_bin > 1 {
+    let eob = if eob_bin > 1 {
         let eob_hi_bit_cdf =
             &mut ts_c.cdf.coef.eob_hi_bit[t_dim.ctx as usize][chroma][eob_bin as usize];
         let eob_hi_bit = rav1d_msac_decode_bool_adapt(&mut ts_c.msac, eob_hi_bit_cdf) as c_uint;
@@ -704,14 +703,15 @@ fn decode_coefs<BD: BitDepth>(
                 t_dim.ctx, chroma, eob_bin, eob_hi_bit, ts_c.msac.rng,
             );
         }
-        eob = ((eob_hi_bit | 2) << (eob_bin - 2))
+        let eob = ((eob_hi_bit | 2) << (eob_bin - 2))
             | rav1d_msac_decode_bools(&mut ts_c.msac, eob_bin - 2);
         if dbg {
             println!("Post-eob[{}]: r={}", eob, ts_c.msac.rng);
         }
+        eob
     } else {
-        eob = eob_bin as u32;
-    }
+        eob_bin as u32
+    };
 
     // base tokens
     let eob_cdf = &mut ts_c.cdf.coef.eob_base_tok[t_dim.ctx as usize][chroma];

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -182,7 +182,7 @@ pub(crate) type read_pal_uv_fn = fn(
 ) -> u8; // `pal_sz[1]`
 
 #[inline]
-fn read_golomb(msac: &mut MsacContext) -> c_uint {
+fn read_golomb(msac: &mut MsacContext) -> u32 {
     let mut len = 0;
     let mut val = 1;
 
@@ -190,7 +190,7 @@ fn read_golomb(msac: &mut MsacContext) -> c_uint {
         len += 1;
     }
     for _ in 0..len {
-        val = (val << 1) + rav1d_msac_decode_bool_equi(msac) as c_uint;
+        val = (val << 1) + rav1d_msac_decode_bool_equi(msac) as u32;
     }
 
     val - 1

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -798,8 +798,7 @@ fn decode_coefs<BD: BitDepth>(
                 }
                 cf.set::<BD>(f, t_cf, rc as usize, (tok.to::<i16>() << 11).into());
                 levels[x as usize * stride as usize + y as usize] = level_tok as u8;
-                let mut i = eob - 1;
-                while i > 0 {
+                for i in (1..eob).rev() {
                     // ac
                     let rc_i;
                     match tx_class {
@@ -876,7 +875,6 @@ fn decode_coefs<BD: BitDepth>(
                         }
                         cf.set::<BD>(f, t_cf, rc_i as usize, tok.as_::<BD::Coef>());
                     }
-                    i -= 1;
                 }
                 // dc
                 ctx = if tx_class == TxClass::TwoD {

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -704,15 +704,14 @@ fn decode_coefs<BD: BitDepth>(
                 t_dim.ctx, chroma, eob_bin, eob_hi_bit, ts_c.msac.rng,
             );
         }
-        eob = ((eob_hi_bit | 2) << eob_bin - 2
-            | rav1d_msac_decode_bools(&mut ts_c.msac, eob_bin - 2)) as c_int;
+        eob = ((eob_hi_bit | 2) << (eob_bin - 2))
+            | rav1d_msac_decode_bools(&mut ts_c.msac, eob_bin - 2);
         if dbg {
             println!("Post-eob[{}]: r={}", eob, ts_c.msac.rng);
         }
     } else {
-        eob = eob_bin as c_int;
+        eob = eob_bin as u32;
     }
-    assert!(eob >= 0);
 
     // base tokens
     let eob_cdf = &mut ts_c.cdf.coef.eob_base_tok[t_dim.ctx as usize][chroma];
@@ -727,9 +726,8 @@ fn decode_coefs<BD: BitDepth>(
         let sh = cmp::min(t_dim.h, 8);
 
         // eob
-        let mut ctx = 1
-            + (eob > sw as c_int * sh as c_int * 2) as u8
-            + (eob > sw as c_int * sh as c_int * 4) as u8;
+        let mut ctx =
+            1 + (eob > sw as u32 * sh as u32 * 2) as u8 + (eob > sw as u32 * sh as u32 * 4) as u8;
         let eob_tok =
             rav1d_msac_decode_symbol_adapt4(&mut ts_c.msac, &mut eob_cdf[ctx as usize], 2);
         let mut tok = eob_tok + 1;
@@ -1205,7 +1203,7 @@ fn decode_coefs<BD: BitDepth>(
     // context
     *res_ctx = (cmp::min(cul_level, 63) | dc_sign_level) as u8;
 
-    eob
+    eob as i32
 }
 
 #[derive(Clone, Copy)]

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -918,10 +918,8 @@ fn decode_coefs<BD: BitDepth>(
 
         match tx_class {
             TxClass::TwoD => {
-                let is_rect: c_uint = tx.is_rect() as c_uint;
-                let lo_ctx_offsets = Some(
-                    &dav1d_lo_ctx_offsets[is_rect.wrapping_add(tx as c_uint & is_rect) as usize],
-                );
+                let is_rect = tx.is_rect() as usize;
+                let lo_ctx_offsets = Some(&dav1d_lo_ctx_offsets[is_rect + (tx as usize & is_rect)]);
                 scan = dav1d_scans[tx as usize];
                 let stride = 4 * sh;
                 let shift = if t_dim.lh < 4 { t_dim.lh + 2 } else { 5 };

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -918,10 +918,9 @@ fn decode_coefs<BD: BitDepth>(
 
         match tx_class {
             TxClass::TwoD => {
-                let nonsquare_tx: c_uint = (tx >= TxfmSize::R4x8) as c_uint;
+                let is_rect: c_uint = tx.is_rect() as c_uint;
                 let lo_ctx_offsets = Some(
-                    &dav1d_lo_ctx_offsets
-                        [nonsquare_tx.wrapping_add(tx as c_uint & nonsquare_tx) as usize],
+                    &dav1d_lo_ctx_offsets[is_rect.wrapping_add(tx as c_uint & is_rect) as usize],
                 );
                 scan = dav1d_scans[tx as usize];
                 let stride = 4 * sh;

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -738,7 +738,7 @@ fn decode_coefs<BD: BitDepth>(
 
         macro_rules! decode_coefs_class {
             ($tx_class:expr, $lo_ctx_offsets:expr, $stride:expr, $shift:expr, $shift2:expr, $mask:expr) => {{
-                const TX_CLASS: TxClass = $tx_class;
+                let tx_class = const { $tx_class };
                 let lo_ctx_offsets: Option<&[[u8; 5]; 5]> = $lo_ctx_offsets;
                 let stride: u8 = $stride;
                 let shift: u8 = $shift;
@@ -747,7 +747,7 @@ fn decode_coefs<BD: BitDepth>(
 
                 let mut x;
                 let mut y;
-                match TX_CLASS {
+                match tx_class {
                     TxClass::TwoD => {
                         rc = scan[eob as usize];
                         x = (rc >> shift) as u8;

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -696,7 +696,7 @@ fn decode_coefs<BD: BitDepth>(
     let eob = if eob_bin > 1 {
         let eob_hi_bit_cdf =
             &mut ts_c.cdf.coef.eob_hi_bit[t_dim.ctx as usize][chroma][eob_bin as usize];
-        let eob_hi_bit = rav1d_msac_decode_bool_adapt(&mut ts_c.msac, eob_hi_bit_cdf) as c_uint;
+        let eob_hi_bit = rav1d_msac_decode_bool_adapt(&mut ts_c.msac, eob_hi_bit_cdf) as u16;
         if dbg {
             println!(
                 "Post-eob_hi_bit[{}][{}][{}][{}]: r={}",
@@ -704,13 +704,13 @@ fn decode_coefs<BD: BitDepth>(
             );
         }
         let eob = ((eob_hi_bit | 2) << (eob_bin - 2))
-            | rav1d_msac_decode_bools(&mut ts_c.msac, eob_bin - 2);
+            | rav1d_msac_decode_bools(&mut ts_c.msac, eob_bin - 2) as u16;
         if dbg {
             println!("Post-eob[{}]: r={}", eob, ts_c.msac.rng);
         }
         eob
     } else {
-        eob_bin as u32
+        eob_bin as u16
     };
 
     // base tokens
@@ -727,7 +727,7 @@ fn decode_coefs<BD: BitDepth>(
 
         // eob
         let mut ctx =
-            1 + (eob > sw as u32 * sh as u32 * 2) as u8 + (eob > sw as u32 * sh as u32 * 4) as u8;
+            1 + (eob > sw as u16 * sh as u16 * 2) as u8 + (eob > sw as u16 * sh as u16 * 4) as u8;
         let eob_tok =
             rav1d_msac_decode_symbol_adapt4(&mut ts_c.msac, &mut eob_cdf[ctx as usize], 2);
         let mut tok = eob_tok + 1;


### PR DESCRIPTION
This is a combination of mostly cleanups and some optimization, especially things like narrowing variable types, which can help later optimizations I want to do.