### PR TITLE
`fn decode_coefs_class`: Make a `fn` from a macro

### DIFF
--- a/src/levels.rs
+++ b/src/levels.rs
@@ -149,7 +149,7 @@ pub const DCT_ADST: TxfmType = 2;
 pub const ADST_DCT: TxfmType = 1;
 pub const DCT_DCT: TxfmType = 0;
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, FromRepr)]
 pub enum TxClass {
     TwoD,
     H,


### PR DESCRIPTION
There are a lot of captured args here, so I first tried a closure. But there is no stable way to mark it `#[inline]`, and it wasn't being inlined, which is crucial, since there's a lot of redundant code for each `TxClass` that needs to be dead-code eliminated. Keeping it as a macro is an option, but it's very annoying since rust-analyzer doesn't really work well inside of it, and so it makes future refactorings and optimizations much harder to do. With a `fn`, I can pass `tx_class` as a const generic macro, ensuring it gets DCEd, and I can mark it `#[inline]`, ensuring it gets inlined (though I did have to repeat the arg list for each separate call).

Also note that I had to move some initialization into the `fn`, both things for the borrowck like `{eob,hi}_cdf`, which had to be duplicated, and things like `lo_cdf`, `levels`, `sw`, `sh`.
These should hopefully be not duplicated in the resultant asm, though, since it's all inlined. Inspecting the asm, it seems to be quite similar, with mostly inconsequential changes, and a few minor changes. Benchmarking it, though, the new version was slightly faster, so I think it's all good.