### PR TITLE
`fn decode_coefs_class`: Fix branch misprediction

### DIFF
--- a/src/recon.rs
+++ b/src/recon.rs
@@ -929,7 +929,7 @@ fn decode_coefs<BD: BitDepth>(
                 } else {
                     0
                 };
-                tok = (tok >> 9) & (rc as u32).wrapping_add(!0x7ff);
+                tok = (tok >> 9) & (rc as u32 + !0x7ff);
                 debug_assert!(tok == tok_check as u32);
                 debug_assert!(tok_non_zero == (tok != 0));
                 if tok_non_zero {


### PR DESCRIPTION
* Part of #1180.

Move the `tok != 0` check before the `*= 0x17ff41` so that `cmov` is used, not a mispredicted branch.