### PR TITLE
`enum TileStateRef`: Manual `impl Atom` instead of `#[derive(Atom)]`ing it, since the derive may panic

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -104,6 +104,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::thread::JoinHandle;
+use strum::FromRepr;
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 use zerocopy::FromZeroes;
@@ -907,12 +908,24 @@ pub struct Rav1dTileState {
     pub lr_ref: RwLock<[Av1RestorationUnit; 3]>,
 }
 
-#[derive(Clone, Copy, Default, Atom)]
+#[derive(Clone, Copy, Default, FromRepr)]
 #[repr(u8)]
 pub enum TileStateRef {
     #[default]
     Frame,
     Local,
+}
+
+impl Atom for TileStateRef {
+    type Repr = u8;
+
+    fn pack(self) -> Self::Repr {
+        self as u8
+    }
+
+    fn unpack(src: Self::Repr) -> Self {
+        Self::from_repr(src).unwrap_or_default()
+    }
 }
 
 /// Array of 32 * 32 coef elements (either `i16` or `i32`).


### PR DESCRIPTION
* Part of #1180.

It is more optimal to `.unwrap_or_default()`, which is a `cmov`, rather than branching to a panic message, which bloats the code a lot.

This reduces stack usage in `fn decode_coefs` by 64 bytes, from 296 to 232.