### PR TITLE
`fn CfSelect::{get,set}`: Remove and replace with direct indexing, slicing once in `fn decode_coefs`

### DIFF
--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -158,6 +158,8 @@ pub trait BitDepth: Clone + Copy {
 
     type Coef: Copy
         + From<i16>
+        + Into<i32>
+        + FromPrimitive<i16>
         + FromPrimitive<u16>
         + FromPrimitive<c_int>
         + FromPrimitive<c_uint>

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -928,17 +928,19 @@ impl Atom for TileStateRef {
     }
 }
 
+pub const CF_LEN: usize = 32 * 32;
+
 /// Array of 32 * 32 coef elements (either `i16` or `i32`).
 #[derive(FromZeroes)]
 #[repr(align(64))]
-pub struct Cf([i32; 32 * 32]);
+pub struct Cf([i32; CF_LEN]);
 
 impl Cf {
-    pub fn select<BD: BitDepth>(&self) -> &[BD::Coef; 32 * 32] {
+    pub fn select<BD: BitDepth>(&self) -> &[BD::Coef; CF_LEN] {
         FromBytes::ref_from_prefix(AsBytes::as_bytes(&self.0)).unwrap()
     }
 
-    pub fn select_mut<BD: BitDepth>(&mut self) -> &mut [BD::Coef; 32 * 32] {
+    pub fn select_mut<BD: BitDepth>(&mut self) -> &mut [BD::Coef; CF_LEN] {
         FromBytes::mut_from_prefix(AsBytes::as_bytes_mut(&mut self.0)).unwrap()
     }
 }


### PR DESCRIPTION
* Part of #1180.

For the `CfSelect::Task` case, no slicing is done, the array is just used as is.  For the `CfSelect::Frame` case, the `DisjointMut` is sliced to get a `CF_LEN` array.  Then `fn get` and `fn set` can directly index into this array with no bounds checks and no `match`.