### PR TITLE
Backport renaming of `BLOCK_SIZE` to `FG_BLOCK_SIZE` from dav1d 1.3.0

### DIFF
--- a/src/arm/32/filmgrain.S
+++ b/src/arm/32/filmgrain.S
@@ -1481,8 +1481,8 @@ function fgy_32x32_8bpc_neon, export=1
         calc_offset     r6,  lr,  r6,  0,   0
         add_offset      r5,  r6,  lr,  r5,  r9
 
-        add             r4,  r4,  #32          // grain_lut += BLOCK_SIZE * bx
-        add             r6,  r11, r9,  lsl #5  // grain_lut += grain_stride * BLOCK_SIZE * by
+        add             r4,  r4,  #32          // grain_lut += FG_BLOCK_SIZE * bx
+        add             r6,  r11, r9,  lsl #5  // grain_lut += grain_stride * FG_BLOCK_SIZE * by
 
         ldr             r10, [sp, #120]        // type
         adr             r11, L(fgy_loop_tbl)
@@ -1490,8 +1490,8 @@ function fgy_32x32_8bpc_neon, export=1
         tst             r10, #1
         ldr             r10, [r11, r10, lsl #2]
 
-        add             r8,  r8,  r9,  lsl #5  // grain_lut += grain_stride * BLOCK_SIZE * by
-        add             r8,  r8,  #32          // grain_lut += BLOCK_SIZE * bx
+        add             r8,  r8,  r9,  lsl #5  // grain_lut += grain_stride * FG_BLOCK_SIZE * by
+        add             r8,  r8,  #32          // grain_lut += FG_BLOCK_SIZE * bx
 
         add             r11, r11, r10
 
@@ -1695,10 +1695,10 @@ function fguv_32x32_\layout\()_8bpc_neon, export=1
         calc_offset     r8,  r12, r8,  \sx, \sy
         add_offset      r5,  r8,  r12, r5,  r10
 
-        add             r4,  r4,  #(32 >> \sx) // grain_lut += BLOCK_SIZE * bx
-        add             r8,  lr,  r10, lsl #(5 - \sy) // grain_lut += grain_stride * BLOCK_SIZE * by
-        add             r11, r11, r10, lsl #(5 - \sy) // grain_lut += grain_stride * BLOCK_SIZE * by
-        add             r11, r11, #(32 >> \sx) // grain_lut += BLOCK_SIZE * bx
+        add             r4,  r4,  #(32 >> \sx) // grain_lut += FG_BLOCK_SIZE * bx
+        add             r8,  lr,  r10, lsl #(5 - \sy) // grain_lut += grain_stride * FG_BLOCK_SIZE * by
+        add             r11, r11, r10, lsl #(5 - \sy) // grain_lut += grain_stride * FG_BLOCK_SIZE * by
+        add             r11, r11, #(32 >> \sx) // grain_lut += FG_BLOCK_SIZE * bx
 
         movrel_local    r12, overlap_coeffs_\sx
         ldr             lr,  [sp, #132]        // type

--- a/src/arm/32/filmgrain16.S
+++ b/src/arm/32/filmgrain16.S
@@ -1353,8 +1353,8 @@ function fgy_32x32_16bpc_neon, export=1
         calc_offset     r6,  lr,  r6,  0,   0
         add_offset      r5,  r6,  lr,  r5,  r9
 
-        add             r4,  r4,  #32*2        // grain_lut += BLOCK_SIZE * bx
-        add             r6,  r11, r9,  lsl #5  // grain_lut += grain_stride * BLOCK_SIZE * by
+        add             r4,  r4,  #32*2        // grain_lut += FG_BLOCK_SIZE * bx
+        add             r6,  r11, r9,  lsl #5  // grain_lut += grain_stride * FG_BLOCK_SIZE * by
 
         ldr             r10, [sp, #120]        // type
         adr             r11, L(fgy_loop_tbl)
@@ -1362,8 +1362,8 @@ function fgy_32x32_16bpc_neon, export=1
         tst             r10, #1
         ldr             r10, [r11, r10, lsl #2]
 
-        add             r8,  r8,  r9,  lsl #5  // grain_lut += grain_stride * BLOCK_SIZE * by
-        add             r8,  r8,  #32*2        // grain_lut += BLOCK_SIZE * bx
+        add             r8,  r8,  r9,  lsl #5  // grain_lut += grain_stride * FG_BLOCK_SIZE * by
+        add             r8,  r8,  #32*2        // grain_lut += FG_BLOCK_SIZE * bx
 
         add             r11, r11, r10
 
@@ -1651,10 +1651,10 @@ function fguv_32x32_\layout\()_16bpc_neon, export=1
 
         vmov.16         d31[3], r7             // overlap y [1]
 
-        add             r4,  r4,  #2*(32 >> \sx)      // grain_lut += BLOCK_SIZE * bx
-        add             r8,  lr,  r10, lsl #(5 - \sy) // grain_lut += grain_stride * BLOCK_SIZE * by
-        add             r11, r11, r10, lsl #(5 - \sy) // grain_lut += grain_stride * BLOCK_SIZE * by
-        add             r11, r11, #2*(32 >> \sx)      // grain_lut += BLOCK_SIZE * bx
+        add             r4,  r4,  #2*(32 >> \sx)      // grain_lut += FG_BLOCK_SIZE * bx
+        add             r8,  lr,  r10, lsl #(5 - \sy) // grain_lut += grain_stride * FG_BLOCK_SIZE * by
+        add             r11, r11, r10, lsl #(5 - \sy) // grain_lut += grain_stride * FG_BLOCK_SIZE * by
+        add             r11, r11, #2*(32 >> \sx)      // grain_lut += FG_BLOCK_SIZE * bx
 
         movrel_local    r12, overlap_coeffs_\sx
         ldr             lr,       [sp, #132]   // type

--- a/src/arm/64/filmgrain.S
+++ b/src/arm/64/filmgrain.S
@@ -1409,14 +1409,14 @@ function fgy_32x32_8bpc_neon, export=1
         ldr             w11, [sp, #24]         // type
         adr             x13, L(fgy_loop_tbl)
 
-        add             x4,  x12, #32          // grain_lut += BLOCK_SIZE * bx
-        add             x6,  x14, x9,  lsl #5  // grain_lut += grain_stride * BLOCK_SIZE * by
+        add             x4,  x12, #32          // grain_lut += FG_BLOCK_SIZE * bx
+        add             x6,  x14, x9,  lsl #5  // grain_lut += grain_stride * FG_BLOCK_SIZE * by
 
         tst             w11, #1
         ldrh            w11, [x13, w11, uxtw #1]
 
-        add             x8,  x16, x9,  lsl #5  // grain_lut += grain_stride * BLOCK_SIZE * by
-        add             x8,  x8,  #32          // grain_lut += BLOCK_SIZE * bx
+        add             x8,  x16, x9,  lsl #5  // grain_lut += grain_stride * FG_BLOCK_SIZE * by
+        add             x8,  x8,  #32          // grain_lut += FG_BLOCK_SIZE * bx
 
         sub             x11, x13, w11, uxtw
 
@@ -1638,10 +1638,10 @@ function fguv_32x32_\layout\()_8bpc_neon, export=1
         add_offset      x17, w16, x17, x5,  x10
         add_offset      x5,  w8,  x11, x5,  x10
 
-        add             x4,  x13, #(32 >> \sx) // grain_lut += BLOCK_SIZE * bx
-        add             x8,  x15, x10, lsl #(5 - \sy) // grain_lut += grain_stride * BLOCK_SIZE * by
-        add             x11, x17, x10, lsl #(5 - \sy) // grain_lut += grain_stride * BLOCK_SIZE * by
-        add             x11, x11, #(32 >> \sx) // grain_lut += BLOCK_SIZE * bx
+        add             x4,  x13, #(32 >> \sx) // grain_lut += FG_BLOCK_SIZE * bx
+        add             x8,  x15, x10, lsl #(5 - \sy) // grain_lut += grain_stride * FG_BLOCK_SIZE * by
+        add             x11, x17, x10, lsl #(5 - \sy) // grain_lut += grain_stride * FG_BLOCK_SIZE * by
+        add             x11, x11, #(32 >> \sx) // grain_lut += FG_BLOCK_SIZE * bx
 
         ldr             w13, [sp, #64]         // type
 

--- a/src/arm/64/filmgrain16.S
+++ b/src/arm/64/filmgrain16.S
@@ -1308,14 +1308,14 @@ function fgy_32x32_16bpc_neon, export=1
         ldr             w11, [sp, #88]         // type
         adr             x13, L(fgy_loop_tbl)
 
-        add             x4,  x12, #32*2        // grain_lut += BLOCK_SIZE * bx
-        add             x6,  x14, x9,  lsl #5  // grain_lut += grain_stride * BLOCK_SIZE * by
+        add             x4,  x12, #32*2        // grain_lut += FG_BLOCK_SIZE * bx
+        add             x6,  x14, x9,  lsl #5  // grain_lut += grain_stride * FG_BLOCK_SIZE * by
 
         tst             w11, #1
         ldrh            w11, [x13, w11, uxtw #1]
 
-        add             x8,  x16, x9,  lsl #5  // grain_lut += grain_stride * BLOCK_SIZE * by
-        add             x8,  x8,  #32*2        // grain_lut += BLOCK_SIZE * bx
+        add             x8,  x16, x9,  lsl #5  // grain_lut += grain_stride * FG_BLOCK_SIZE * by
+        add             x8,  x8,  #32*2        // grain_lut += FG_BLOCK_SIZE * bx
 
         sub             x11, x13, w11, uxtw
 
@@ -1581,10 +1581,10 @@ function fguv_32x32_\layout\()_16bpc_neon, export=1
         add_offset      x17, w16, x17, x5,  x10
         add_offset      x5,  w8,  x11, x5,  x10
 
-        add             x4,  x13, #2*(32 >> \sx)      // grain_lut += BLOCK_SIZE * bx
-        add             x8,  x15, x10, lsl #(5 - \sy) // grain_lut += grain_stride * BLOCK_SIZE * by
-        add             x11, x17, x10, lsl #(5 - \sy) // grain_lut += grain_stride * BLOCK_SIZE * by
-        add             x11, x11, #2*(32 >> \sx)      // grain_lut += BLOCK_SIZE * bx
+        add             x4,  x13, #2*(32 >> \sx)      // grain_lut += FG_BLOCK_SIZE * bx
+        add             x8,  x15, x10, lsl #(5 - \sy) // grain_lut += grain_stride * FG_BLOCK_SIZE * by
+        add             x11, x17, x10, lsl #(5 - \sy) // grain_lut += grain_stride * FG_BLOCK_SIZE * by
+        add             x11, x11, #2*(32 >> \sx)      // grain_lut += FG_BLOCK_SIZE * bx
 
         ldr             w13, [sp, #112]        // type
 

--- a/src/arm/filmgrain.h
+++ b/src/arm/filmgrain.h
@@ -91,8 +91,8 @@ static void fgy_32x32xn_neon(pixel *const dst_row, const pixel *const src_row,
 
     int offsets[2 /* col offset */][2 /* row offset */];
 
-    // process this row in BLOCK_SIZE^2 blocks
-    for (unsigned bx = 0; bx < pw; bx += BLOCK_SIZE) {
+    // process this row in FG_BLOCK_SIZE^2 blocks
+    for (unsigned bx = 0; bx < pw; bx += FG_BLOCK_SIZE) {
 
         if (data->overlap_flag && bx) {
             // shift previous offsets left
@@ -155,8 +155,8 @@ fguv_32x32xn_##nm##_neon(pixel *const dst_row, const pixel *const src_row, \
  \
     int offsets[2 /* col offset */][2 /* row offset */]; \
  \
-    /* process this row in BLOCK_SIZE^2 blocks (subsampled) */ \
-    for (unsigned bx = 0; bx < pw; bx += BLOCK_SIZE >> sx) { \
+    /* process this row in FG_BLOCK_SIZE^2 blocks (subsampled) */ \
+    for (unsigned bx = 0; bx < pw; bx += FG_BLOCK_SIZE >> sx) { \
         if (data->overlap_flag && bx) { \
             /* shift previous offsets left */ \
             for (int i = 0; i < rows; i++) \

--- a/src/fg_apply_tmpl.c
+++ b/src/fg_apply_tmpl.c
@@ -233,7 +233,7 @@ void bitfn(dav1d_apply_grain)(const Dav1dFilmGrainDSPContext *const dsp,
 #else
     uint8_t scaling[3][SCALING_SIZE];
 #endif
-    const int rows = (out->p.h + 31) >> 5;
+    const int rows = (out->p.h + FG_BLOCK_SIZE - 1) / FG_BLOCK_SIZE;
 
     bitfn(dav1d_prep_grain)(dsp, out, in, scaling, grain_lut);
     for (int row = 0; row < rows; row++)

--- a/src/fg_apply_tmpl.c
+++ b/src/fg_apply_tmpl.c
@@ -173,14 +173,14 @@ void bitfn(dav1d_apply_grain_row)(const Dav1dFilmGrainDSPContext *const dsp,
     const int cpw = (out->p.w + ss_x) >> ss_x;
     const int is_id = out->seq_hdr->mtrx == DAV1D_MC_IDENTITY;
     pixel *const luma_src =
-        ((pixel *) in->data[0]) + row * BLOCK_SIZE * PXSTRIDE(in->stride[0]);
+        ((pixel *) in->data[0]) + row * FG_BLOCK_SIZE * PXSTRIDE(in->stride[0]);
 #if BITDEPTH != 8
     const int bitdepth_max = (1 << out->p.bpc) - 1;
 #endif
 
     if (data->num_y_points) {
-        const int bh = imin(out->p.h - row * BLOCK_SIZE, BLOCK_SIZE);
-        dsp->fgy_32x32xn(((pixel *) out->data[0]) + row * BLOCK_SIZE * PXSTRIDE(out->stride[0]),
+        const int bh = imin(out->p.h - row * FG_BLOCK_SIZE, FG_BLOCK_SIZE);
+        dsp->fgy_32x32xn(((pixel *) out->data[0]) + row * FG_BLOCK_SIZE * PXSTRIDE(out->stride[0]),
                          luma_src, out->stride[0], data,
                          out->p.w, scaling[0], grain_lut[0], bh, row HIGHBD_TAIL_SUFFIX);
     }
@@ -191,7 +191,7 @@ void bitfn(dav1d_apply_grain_row)(const Dav1dFilmGrainDSPContext *const dsp,
         return;
     }
 
-    const int bh = (imin(out->p.h - row * BLOCK_SIZE, BLOCK_SIZE) + ss_y) >> ss_y;
+    const int bh = (imin(out->p.h - row * FG_BLOCK_SIZE, FG_BLOCK_SIZE) + ss_y) >> ss_y;
 
     // extend padding pixels
     if (out->p.w & ss_x) {
@@ -202,7 +202,7 @@ void bitfn(dav1d_apply_grain_row)(const Dav1dFilmGrainDSPContext *const dsp,
         }
     }
 
-    const ptrdiff_t uv_off = row * BLOCK_SIZE * PXSTRIDE(out->stride[1]) >> ss_y;
+    const ptrdiff_t uv_off = row * FG_BLOCK_SIZE * PXSTRIDE(out->stride[1]) >> ss_y;
     if (data->chroma_scaling_from_luma) {
         for (int pl = 0; pl < 2; pl++)
             dsp->fguv_32x32xn[in->p.layout - 1](((pixel *) out->data[1 + pl]) + uv_off,

--- a/src/filmgrain.h
+++ b/src/filmgrain.h
@@ -34,7 +34,7 @@
 
 #define GRAIN_WIDTH 82
 #define GRAIN_HEIGHT 73
-#define BLOCK_SIZE 32
+#define FG_BLOCK_SIZE 32
 #if !defined(BITDEPTH) || BITDEPTH == 8
 #define SCALING_SIZE 256
 typedef int8_t entry;

--- a/src/filmgrain_tmpl.c
+++ b/src/filmgrain_tmpl.c
@@ -162,8 +162,8 @@ static inline entry sample_lut(const entry grain_lut[][GRAIN_WIDTH],
     const int randval = offsets[bx][by];
     const int offx = 3 + (2 >> subx) * (3 + (randval >> 4));
     const int offy = 3 + (2 >> suby) * (3 + (randval & 0xF));
-    return grain_lut[offy + y + (BLOCK_SIZE >> suby) * by]
-                    [offx + x + (BLOCK_SIZE >> subx) * bx];
+    return grain_lut[offy + y + (FG_BLOCK_SIZE >> suby) * by]
+                    [offx + x + (FG_BLOCK_SIZE >> subx) * bx];
 }
 
 static void fgy_32x32xn_c(pixel *const dst_row, const pixel *const src_row,
@@ -195,13 +195,13 @@ static void fgy_32x32xn_c(pixel *const dst_row, const pixel *const src_row,
         seed[i] ^= (((row_num - i) * 173 + 105) & 0xFF);
     }
 
-    assert(stride % (BLOCK_SIZE * sizeof(pixel)) == 0);
+    assert(stride % (FG_BLOCK_SIZE * sizeof(pixel)) == 0);
 
     int offsets[2 /* col offset */][2 /* row offset */];
 
-    // process this row in BLOCK_SIZE^2 blocks
-    for (unsigned bx = 0; bx < pw; bx += BLOCK_SIZE) {
-        const int bw = imin(BLOCK_SIZE, (int) pw - bx);
+    // process this row in FG_BLOCK_SIZE^2 blocks
+    for (unsigned bx = 0; bx < pw; bx += FG_BLOCK_SIZE) {
+        const int bw = imin(FG_BLOCK_SIZE, (int) pw - bx);
 
         if (data->overlap_flag && bx) {
             // shift previous offsets left
@@ -306,13 +306,13 @@ fguv_32x32xn_c(pixel *const dst_row, const pixel *const src_row,
         seed[i] ^= (((row_num - i) * 173 + 105) & 0xFF);
     }
 
-    assert(stride % (BLOCK_SIZE * sizeof(pixel)) == 0);
+    assert(stride % (FG_BLOCK_SIZE * sizeof(pixel)) == 0);
 
     int offsets[2 /* col offset */][2 /* row offset */];
 
-    // process this row in BLOCK_SIZE^2 blocks (subsampled)
-    for (unsigned bx = 0; bx < pw; bx += BLOCK_SIZE >> sx) {
-        const int bw = imin(BLOCK_SIZE >> sx, (int)(pw - bx));
+    // process this row in FG_BLOCK_SIZE^2 blocks (subsampled)
+    for (unsigned bx = 0; bx < pw; bx += FG_BLOCK_SIZE >> sx) {
+        const int bw = imin(FG_BLOCK_SIZE >> sx, (int)(pw - bx));
         if (data->overlap_flag && bx) {
             // shift previous offsets left
             for (int i = 0; i < rows; i++)

--- a/src/thread_task.c
+++ b/src/thread_task.c
@@ -500,7 +500,7 @@ static inline void delayed_fg_task(const Dav1dContext *const c,
     case DAV1D_TASK_TYPE_FG_APPLY:;
         int row = atomic_fetch_add(&ttd->delayed_fg.progress[0], 1);
         pthread_mutex_unlock(&ttd->lock);
-        int progmax = (out->p.h + 31) >> 5;
+        int progmax = (out->p.h + FG_BLOCK_SIZE - 1) / FG_BLOCK_SIZE;
     fg_apply_loop:
         if (row + 1 < progmax)
             pthread_cond_signal(&ttd->cond);

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -15,6 +15,7 @@ use crate::src::error::Rav1dError::ENOMEM;
 use crate::src::error::Rav1dResult;
 use crate::src::fg_apply::rav1d_apply_grain_row;
 use crate::src::fg_apply::rav1d_prep_grain;
+use crate::src::filmgrain::FG_BLOCK_SIZE;
 use crate::src::internal::Grain;
 use crate::src::internal::Rav1dBitDepthDSPContext;
 use crate::src::internal::Rav1dContext;
@@ -711,7 +712,7 @@ fn delayed_fg_task<'l, 'ttd: 'l>(
     row = ttd.delayed_fg_progress[0].fetch_add(1, Ordering::SeqCst);
     let _ = task_thread_lock.take();
     let delayed_fg = ttd.delayed_fg.try_read().unwrap();
-    progmax = delayed_fg.out.p.h + 31 >> 5;
+    progmax = (delayed_fg.out.p.h + FG_BLOCK_SIZE as i32 - 1) / FG_BLOCK_SIZE as i32;
     loop {
         if (row + 1) < progmax {
             ttd.cond.notify_one();


### PR DESCRIPTION
Also consistently use named constant instead of magic numbers.