### PR TITLE
`fn {get_prev_frame_segid, rav1d_create_lf_mask_inter}`: Remove inlining

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -864,7 +864,6 @@ fn read_vartx_tree(
     }
 }
 
-#[inline]
 fn get_prev_frame_segid(
     frame_hdr: &Rav1dFrameHeader,
     b: Bxy,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -488,6 +488,7 @@ pub(crate) fn rav1d_create_lf_mask_intra(
     );
 }
 
+#[inline(never)]
 pub(crate) fn rav1d_create_lf_mask_inter(
     lflvl: &Av1Filter,
     level_cache: &DisjointMut<Vec<[u8; 4]>>,


### PR DESCRIPTION
`get_prev_frame_segid` does not need to be inlined and performance is slightly better without it being inlined. `rav1d_create_lf_mask_inter` is inlined by default and performance suffers if it is, so mark it as inline(never).