### PR TITLE
`enum PicOrBuf`: Add `enum` that can be either a pic or buf and refactor out shared code

### DIFF
--- a/include/common/dump.rs
+++ b/include/common/dump.rs
@@ -2,6 +2,7 @@
 
 use crate::include::common::bitdepth::BitDepth;
 use crate::include::dav1d::picture::Rav1dPictureDataComponentOffset;
+use crate::src::strided::Strided as _;
 use std::fmt::Display;
 use std::io;
 use std::io::stdout;

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -26,16 +26,13 @@ use crate::src::error::Dav1dResult;
 use crate::src::error::Rav1dError;
 use crate::src::error::Rav1dError::EINVAL;
 use crate::src::error::Rav1dResult;
+use crate::src::with_offset::WithOffset;
 use libc::ptrdiff_t;
 use libc::uintptr_t;
 use std::array;
 use std::ffi::c_int;
 use std::ffi::c_void;
 use std::mem;
-use std::ops::Add;
-use std::ops::AddAssign;
-use std::ops::Sub;
-use std::ops::SubAssign;
 use std::ptr::NonNull;
 use std::sync::Arc;
 use to_method::To as _;
@@ -400,79 +397,7 @@ impl Rav1dPictureDataComponent {
     }
 }
 
-#[derive(Clone, Copy)]
-pub struct Rav1dPictureDataComponentOffset<'a> {
-    pub data: &'a Rav1dPictureDataComponent,
-    pub offset: usize,
-}
-
-impl<'a> AddAssign<usize> for Rav1dPictureDataComponentOffset<'a> {
-    #[cfg_attr(debug_assertions, track_caller)]
-    fn add_assign(&mut self, rhs: usize) {
-        self.offset += rhs;
-    }
-}
-
-impl<'a> SubAssign<usize> for Rav1dPictureDataComponentOffset<'a> {
-    #[cfg_attr(debug_assertions, track_caller)]
-    fn sub_assign(&mut self, rhs: usize) {
-        self.offset -= rhs;
-    }
-}
-
-impl<'a> AddAssign<isize> for Rav1dPictureDataComponentOffset<'a> {
-    #[cfg_attr(debug_assertions, track_caller)]
-    fn add_assign(&mut self, rhs: isize) {
-        self.offset = self.offset.wrapping_add_signed(rhs);
-    }
-}
-
-impl<'a> SubAssign<isize> for Rav1dPictureDataComponentOffset<'a> {
-    #[cfg_attr(debug_assertions, track_caller)]
-    fn sub_assign(&mut self, rhs: isize) {
-        self.offset = self.offset.wrapping_add_signed(-rhs);
-    }
-}
-
-impl<'a> Add<usize> for Rav1dPictureDataComponentOffset<'a> {
-    type Output = Self;
-
-    #[cfg_attr(debug_assertions, track_caller)]
-    fn add(mut self, rhs: usize) -> Self::Output {
-        self += rhs;
-        self
-    }
-}
-
-impl<'a> Sub<usize> for Rav1dPictureDataComponentOffset<'a> {
-    type Output = Self;
-
-    #[cfg_attr(debug_assertions, track_caller)]
-    fn sub(mut self, rhs: usize) -> Self::Output {
-        self -= rhs;
-        self
-    }
-}
-
-impl<'a> Add<isize> for Rav1dPictureDataComponentOffset<'a> {
-    type Output = Self;
-
-    #[cfg_attr(debug_assertions, track_caller)]
-    fn add(mut self, rhs: isize) -> Self::Output {
-        self += rhs;
-        self
-    }
-}
-
-impl<'a> Sub<isize> for Rav1dPictureDataComponentOffset<'a> {
-    type Output = Self;
-
-    #[cfg_attr(debug_assertions, track_caller)]
-    fn sub(mut self, rhs: isize) -> Self::Output {
-        self -= rhs;
-        self
-    }
-}
+pub type Rav1dPictureDataComponentOffset<'a> = WithOffset<&'a Rav1dPictureDataComponent>;
 
 impl<'a> Rav1dPictureDataComponentOffset<'a> {
     pub fn stride(&self) -> isize {

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -364,18 +364,6 @@ impl<'a> Rav1dPictureDataComponentOffset<'a> {
 
     #[inline] // Inline to see bounds checks in order to potentially elide them.
     #[cfg_attr(debug_assertions, track_caller)]
-    pub fn as_ptr<BD: BitDepth>(&self) -> *const BD::Pixel {
-        self.data.as_ptr_at::<BD>(self.offset)
-    }
-
-    #[inline] // Inline to see bounds checks in order to potentially elide them.
-    #[cfg_attr(debug_assertions, track_caller)]
-    pub fn as_mut_ptr<BD: BitDepth>(&self) -> *mut BD::Pixel {
-        self.data.as_mut_ptr_at::<BD>(self.offset)
-    }
-
-    #[inline] // Inline to see bounds checks in order to potentially elide them.
-    #[cfg_attr(debug_assertions, track_caller)]
     pub fn index<BD: BitDepth>(
         &self,
     ) -> DisjointImmutGuard<'a, Rav1dPictureDataComponentInner, BD::Pixel> {

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -351,14 +351,6 @@ impl Rav1dPictureDataComponent {
 pub type Rav1dPictureDataComponentOffset<'a> = WithOffset<&'a Rav1dPictureDataComponent>;
 
 impl<'a> Rav1dPictureDataComponentOffset<'a> {
-    pub fn stride(&self) -> isize {
-        self.data.stride()
-    }
-
-    pub fn pixel_stride<BD: BitDepth>(&self) -> isize {
-        self.data.pixel_stride::<BD>()
-    }
-
     #[inline] // Inline to see bounds checks in order to potentially elide them.
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn index<BD: BitDepth>(

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -27,6 +27,7 @@ use crate::src::error::Rav1dError;
 use crate::src::error::Rav1dError::EINVAL;
 use crate::src::error::Rav1dResult;
 use crate::src::pixels::Pixels;
+use crate::src::strided::Strided;
 use crate::src::with_offset::WithOffset;
 use libc::ptrdiff_t;
 use libc::uintptr_t;
@@ -233,22 +234,18 @@ impl Pixels for Rav1dPictureDataComponent {
     }
 }
 
+impl Strided for Rav1dPictureDataComponent {
+    fn stride(&self) -> isize {
+        // SAFETY: We're only accessing the `stride` fields, not `ptr`.
+        unsafe { (*self.0.inner()).stride }
+    }
+}
+
 impl Rav1dPictureDataComponent {
     pub fn wrap_buf<BD: BitDepth>(buf: &mut [BD::Pixel], stride: usize) -> Self {
         Self(DisjointMut::new(
             Rav1dPictureDataComponentInner::wrap_buf::<BD>(buf, stride),
         ))
-    }
-
-    /// Stride in number of [`u8`] bytes.
-    pub fn stride(&self) -> isize {
-        // SAFETY: We're only accessing the `stride` fields, not `ptr`.
-        unsafe { (*self.0.inner()).stride }
-    }
-
-    /// Stride in number of [`BitDepth::Pixel`]s.
-    pub fn pixel_stride<BD: BitDepth>(&self) -> isize {
-        BD::pxstride(self.stride())
     }
 
     pub fn pixel_offset<BD: BitDepth>(&self) -> usize {

--- a/lib.rs
+++ b/lib.rs
@@ -52,6 +52,7 @@ pub mod src {
     mod getbits;
     pub(crate) mod pixels;
     pub(crate) mod relaxed_atomic;
+    pub(crate) mod strided;
     mod unstable_extensions;
     pub(crate) mod with_offset;
     pub(crate) mod wrap_fn_ptr;

--- a/lib.rs
+++ b/lib.rs
@@ -52,6 +52,7 @@ pub mod src {
     mod getbits;
     pub(crate) mod relaxed_atomic;
     mod unstable_extensions;
+    pub(crate) mod with_offset;
     pub(crate) mod wrap_fn_ptr;
     // TODO(kkysen) Temporarily `pub(crate)` due to a `pub use` until TAIT.
     mod extensions;

--- a/lib.rs
+++ b/lib.rs
@@ -50,6 +50,7 @@ pub mod src {
     mod fg_apply;
     mod filmgrain;
     mod getbits;
+    pub(crate) mod pixels;
     pub(crate) mod relaxed_atomic;
     mod unstable_extensions;
     pub(crate) mod with_offset;

--- a/lib.rs
+++ b/lib.rs
@@ -50,6 +50,7 @@ pub mod src {
     mod fg_apply;
     mod filmgrain;
     mod getbits;
+    pub(crate) mod pic_or_buf;
     pub(crate) mod pixels;
     pub(crate) mod relaxed_atomic;
     pub(crate) mod strided;

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -7,6 +7,7 @@ use crate::include::common::intops::iclip;
 use crate::include::dav1d::picture::Rav1dPictureDataComponentOffset;
 use crate::src::cpu::CpuFlags;
 use crate::src::ffi_safe::FFISafe;
+use crate::src::strided::Strided as _;
 use crate::src::tables::dav1d_cdef_directions;
 use crate::src::wrap_fn_ptr::wrap_fn_ptr;
 use bitflags::bitflags;

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -10,6 +10,7 @@ use crate::src::disjoint_mut::DisjointMut;
 use crate::src::internal::Rav1dContext;
 use crate::src::internal::Rav1dFrameData;
 use crate::src::internal::Rav1dTaskContext;
+use crate::src::strided::Strided as _;
 use bitflags::bitflags;
 use libc::ptrdiff_t;
 use std::cmp;

--- a/src/fg_apply.rs
+++ b/src/fg_apply.rs
@@ -9,6 +9,7 @@ use crate::src::align::ArrayDefault;
 use crate::src::filmgrain::Rav1dFilmGrainDSPContext;
 use crate::src::filmgrain::BLOCK_SIZE;
 use crate::src::internal::GrainBD;
+use crate::src::strided::Strided as _;
 use std::cmp;
 
 fn generate_scaling<BD: BitDepth>(bd: BD, points: &[[u8; 2]]) -> BD::Scaling {

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -19,6 +19,7 @@ use crate::src::enum_map::enum_map_ty;
 use crate::src::enum_map::DefaultValue;
 use crate::src::ffi_safe::FFISafe;
 use crate::src::internal::GrainLut;
+use crate::src::strided::Strided as _;
 use crate::src::tables::dav1d_gaussian_sequence;
 use crate::src::wrap_fn_ptr::wrap_fn_ptr;
 use libc::intptr_t;

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -30,6 +30,7 @@ use crate::src::levels::VERT_PRED;
 use crate::src::levels::Z1_PRED;
 use crate::src::levels::Z2_PRED;
 use crate::src::levels::Z3_PRED;
+use crate::src::strided::Strided as _;
 use crate::src::tables::dav1d_dr_intra_derivative;
 use crate::src::tables::dav1d_filter_intra_taps;
 use crate::src::tables::dav1d_sm_weights;

--- a/src/ipred_prepare.rs
+++ b/src/ipred_prepare.rs
@@ -24,6 +24,7 @@ use crate::src::levels::VERT_PRED;
 use crate::src::levels::Z1_PRED;
 use crate::src::levels::Z2_PRED;
 use crate::src::levels::Z3_PRED;
+use crate::src::strided::Strided as _;
 use bitflags::bitflags;
 use std::cmp;
 use std::ffi::c_int;

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -45,6 +45,7 @@ use crate::src::levels::V_ADST;
 use crate::src::levels::V_DCT;
 use crate::src::levels::V_FLIPADST;
 use crate::src::levels::WHT_WHT;
+use crate::src::strided::Strided as _;
 use crate::src::wrap_fn_ptr::wrap_fn_ptr;
 use std::cmp;
 use std::num::NonZeroUsize;

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -11,6 +11,7 @@ use crate::src::lr_apply::LR_RESTORE_U;
 use crate::src::lr_apply::LR_RESTORE_V;
 use crate::src::lr_apply::LR_RESTORE_Y;
 use crate::src::relaxed_atomic::RelaxedAtomic;
+use crate::src::strided::Strided as _;
 use libc::ptrdiff_t;
 use std::array;
 use std::cmp;

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -8,6 +8,7 @@ use crate::src::cpu::CpuFlags;
 use crate::src::ffi_safe::FFISafe;
 use crate::src::internal::Rav1dFrameData;
 use crate::src::lf_mask::Av1FilterLUT;
+use crate::src::strided::Strided as _;
 use crate::src::unstable_extensions::as_chunks;
 use crate::src::unstable_extensions::flatten;
 use crate::src::wrap_fn_ptr::wrap_fn_ptr;

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -11,6 +11,7 @@ use crate::src::cpu::CpuFlags;
 use crate::src::cursor::CursorMut;
 use crate::src::disjoint_mut::DisjointMut;
 use crate::src::ffi_safe::FFISafe;
+use crate::src::strided::Strided as _;
 use crate::src::tables::dav1d_sgr_x_by_x;
 use crate::src::wrap_fn_ptr::wrap_fn_ptr;
 use libc::ptrdiff_t;

--- a/src/lr_apply.rs
+++ b/src/lr_apply.rs
@@ -13,6 +13,7 @@ use crate::src::looprestoration::LR_HAVE_BOTTOM;
 use crate::src::looprestoration::LR_HAVE_LEFT;
 use crate::src::looprestoration::LR_HAVE_RIGHT;
 use crate::src::looprestoration::LR_HAVE_TOP;
+use crate::src::strided::Strided as _;
 use crate::src::tables::dav1d_sgr_params;
 use assert_matches::assert_matches;
 use libc::ptrdiff_t;

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -18,6 +18,7 @@ use crate::src::internal::SCRATCH_INTER_INTRA_BUF_LEN;
 use crate::src::internal::SCRATCH_LAP_LEN;
 use crate::src::internal::SEG_MASK_LEN;
 use crate::src::levels::Filter2d;
+use crate::src::strided::Strided as _;
 use crate::src::tables::dav1d_mc_subpel_filters;
 use crate::src::tables::dav1d_mc_warp_filter;
 use crate::src::tables::dav1d_obmc_masks;

--- a/src/pic_or_buf.rs
+++ b/src/pic_or_buf.rs
@@ -1,0 +1,33 @@
+use crate::include::dav1d::picture::Rav1dPictureDataComponent;
+use crate::src::pixels::Pixels;
+use crate::src::strided::Strided;
+
+pub enum PicOrBuf<'a, B> {
+    Pic(&'a Rav1dPictureDataComponent),
+    Buf(B),
+}
+
+impl<'a, B: Pixels> Pixels for PicOrBuf<'a, B> {
+    fn byte_len(&self) -> usize {
+        match self {
+            Self::Pic(pic) => pic.byte_len(),
+            Self::Buf(buf) => buf.byte_len(),
+        }
+    }
+
+    fn as_byte_mut_ptr(&self) -> *mut u8 {
+        match self {
+            Self::Pic(pic) => pic.as_byte_mut_ptr(),
+            Self::Buf(buf) => buf.as_byte_mut_ptr(),
+        }
+    }
+}
+
+impl<'a, B: Strided> Strided for PicOrBuf<'a, B> {
+    fn stride(&self) -> isize {
+        match self {
+            Self::Pic(pic) => pic.stride(),
+            Self::Buf(buf) => buf.stride(),
+        }
+    }
+}

--- a/src/pixels.rs
+++ b/src/pixels.rs
@@ -1,0 +1,66 @@
+use std::mem;
+
+use crate::include::common::bitdepth::BitDepth;
+use crate::src::disjoint_mut::AsMutPtr;
+use crate::src::disjoint_mut::DisjointMut;
+
+pub trait Pixels {
+    type Buf: AsMutPtr<Target = u8>;
+
+    fn as_buf(&self) -> &DisjointMut<Self::Buf>;
+
+    /// Length in number of [`u8`] bytes.
+    fn len(&self) -> usize {
+        self.as_buf().len()
+    }
+
+    /// Length in number of [`BitDepth::Pixel`]s.
+    fn pixel_len<BD: BitDepth>(&self) -> usize {
+        self.len() / mem::size_of::<BD::Pixel>()
+    }
+
+    /// Absolute ptr to [`BitDepth::Pixel`]s.
+    fn as_mut_ptr<BD: BitDepth>(&self) -> *mut BD::Pixel {
+        // SAFETY: Transmutation is safe because we verify this with `zerocopy` in `Self::slice`.
+        self.as_buf().as_mut_ptr().cast()
+    }
+
+    /// Absolute ptr to [`BitDepth::Pixel`]s.
+    fn _as_ptr<BD: BitDepth>(&self) -> *const BD::Pixel {
+        self.as_mut_ptr::<BD>().cast_const()
+    }
+
+    /// Absolute ptr to [`BitDepth::Pixel`]s starting at `offset`.
+    ///
+    /// Bounds checked, but not [`DisjointMut`]-checked.
+    #[cfg_attr(debug_assertions, track_caller)]
+    fn as_mut_ptr_at<BD: BitDepth>(&self, pixel_offset: usize) -> *mut BD::Pixel {
+        #[inline(never)]
+        #[cfg_attr(debug_assertions, track_caller)]
+        fn out_of_bounds(pixel_offset: usize, pixel_len: usize) -> ! {
+            panic!(
+                "pixel offset {pixel_offset} out of range for slice of pixel length {pixel_len}"
+            );
+        }
+
+        let pixel_len = self.pixel_len::<BD>();
+        if pixel_offset > pixel_len {
+            out_of_bounds(pixel_offset, pixel_len);
+        }
+        // SAFETY: We just checked that `pixel_offset` is in bounds.
+        unsafe { self.as_mut_ptr::<BD>().add(pixel_offset) }
+    }
+
+    /// Absolute ptr to [`BitDepth::Pixel`]s starting at `offset`.
+    ///
+    /// Bounds checked, but not [`DisjointMut`]-checked.
+    #[cfg_attr(debug_assertions, track_caller)]
+    fn as_ptr_at<BD: BitDepth>(&self, offset: usize) -> *const BD::Pixel {
+        self.as_mut_ptr_at::<BD>(offset).cast_const()
+    }
+
+    /// Determine if they reference the same data.
+    fn ref_eq(&self, other: &Self) -> bool {
+        self.as_buf().as_mut_ptr() == other.as_buf().as_mut_ptr()
+    }
+}

--- a/src/pixels.rs
+++ b/src/pixels.rs
@@ -1,6 +1,9 @@
-use std::mem;
-
 use crate::include::common::bitdepth::BitDepth;
+use crate::src::disjoint_mut::AsMutPtr;
+use crate::src::disjoint_mut::DisjointMut;
+use crate::src::strided::WithStride;
+use std::mem;
+use std::ops::Deref;
 
 pub trait Pixels {
     /// Length in number of [`u8`] bytes.
@@ -67,5 +70,25 @@ impl<'a, P: Pixels> Pixels for &'a P {
 
     fn as_byte_mut_ptr(&self) -> *mut u8 {
         (*self).as_byte_mut_ptr()
+    }
+}
+
+impl<P: Pixels> Pixels for WithStride<P> {
+    fn byte_len(&self) -> usize {
+        self.deref().byte_len()
+    }
+
+    fn as_byte_mut_ptr(&self) -> *mut u8 {
+        self.deref().as_byte_mut_ptr()
+    }
+}
+
+impl<T: AsMutPtr<Target = u8>> Pixels for DisjointMut<T> {
+    fn byte_len(&self) -> usize {
+        self.len()
+    }
+
+    fn as_byte_mut_ptr(&self) -> *mut u8 {
+        self.as_mut_ptr()
     }
 }

--- a/src/pixels.rs
+++ b/src/pixels.rs
@@ -1,28 +1,23 @@
 use std::mem;
 
 use crate::include::common::bitdepth::BitDepth;
-use crate::src::disjoint_mut::AsMutPtr;
-use crate::src::disjoint_mut::DisjointMut;
 
 pub trait Pixels {
-    type Buf: AsMutPtr<Target = u8>;
-
-    fn as_buf(&self) -> &DisjointMut<Self::Buf>;
-
     /// Length in number of [`u8`] bytes.
-    fn len(&self) -> usize {
-        self.as_buf().len()
-    }
+    fn byte_len(&self) -> usize;
+
+    /// Absolute ptr to [`u8`] bytes.
+    fn as_byte_mut_ptr(&self) -> *mut u8;
 
     /// Length in number of [`BitDepth::Pixel`]s.
     fn pixel_len<BD: BitDepth>(&self) -> usize {
-        self.len() / mem::size_of::<BD::Pixel>()
+        self.byte_len() / mem::size_of::<BD::Pixel>()
     }
 
     /// Absolute ptr to [`BitDepth::Pixel`]s.
     fn as_mut_ptr<BD: BitDepth>(&self) -> *mut BD::Pixel {
         // SAFETY: Transmutation is safe because we verify this with `zerocopy` in `Self::slice`.
-        self.as_buf().as_mut_ptr().cast()
+        self.as_byte_mut_ptr().cast()
     }
 
     /// Absolute ptr to [`BitDepth::Pixel`]s.
@@ -61,6 +56,6 @@ pub trait Pixels {
 
     /// Determine if they reference the same data.
     fn ref_eq(&self, other: &Self) -> bool {
-        self.as_buf().as_mut_ptr() == other.as_buf().as_mut_ptr()
+        self.as_byte_mut_ptr() == other.as_byte_mut_ptr()
     }
 }

--- a/src/pixels.rs
+++ b/src/pixels.rs
@@ -59,3 +59,13 @@ pub trait Pixels {
         self.as_byte_mut_ptr() == other.as_byte_mut_ptr()
     }
 }
+
+impl<'a, P: Pixels> Pixels for &'a P {
+    fn byte_len(&self) -> usize {
+        (*self).byte_len()
+    }
+
+    fn as_byte_mut_ptr(&self) -> *mut u8 {
+        (*self).as_byte_mut_ptr()
+    }
+}

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -72,6 +72,7 @@ use crate::src::msac::MsacContext;
 use crate::src::picture::Rav1dThreadPicture;
 use crate::src::pixels::Pixels as _;
 use crate::src::scan::dav1d_scans;
+use crate::src::strided::Strided as _;
 use crate::src::tables::dav1d_filter_2d;
 use crate::src::tables::dav1d_filter_mode_to_y_mode;
 use crate::src::tables::dav1d_lo_ctx_offsets;

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -70,6 +70,7 @@ use crate::src::msac::rav1d_msac_decode_symbol_adapt4;
 use crate::src::msac::rav1d_msac_decode_symbol_adapt8;
 use crate::src::msac::MsacContext;
 use crate::src::picture::Rav1dThreadPicture;
+use crate::src::pixels::Pixels as _;
 use crate::src::scan::dav1d_scans;
 use crate::src::tables::dav1d_filter_2d;
 use crate::src::tables::dav1d_filter_mode_to_y_mode;

--- a/src/strided.rs
+++ b/src/strided.rs
@@ -1,0 +1,11 @@
+use crate::include::common::bitdepth::BitDepth;
+
+pub trait Strided {
+    /// Stride in number of [`u8`] bytes.
+    fn stride(&self) -> isize;
+
+    /// Stride in number of [`BitDepth::Pixel`]s.
+    fn pixel_stride<BD: BitDepth>(&self) -> isize {
+        BD::pxstride(self.stride())
+    }
+}

--- a/src/strided.rs
+++ b/src/strided.rs
@@ -12,6 +12,13 @@ pub trait Strided {
     }
 }
 
+impl<'a, S: Strided> Strided for &'a S {
+    fn stride(&self) -> isize {
+        (*self).stride()
+    }
+}
+
+#[derive(Clone, Copy)]
 pub struct WithStride<T> {
     pub buf: T,
     pub stride: isize,

--- a/src/strided.rs
+++ b/src/strided.rs
@@ -1,4 +1,6 @@
 use crate::include::common::bitdepth::BitDepth;
+use std::ops::Deref;
+use std::ops::DerefMut;
 
 pub trait Strided {
     /// Stride in number of [`u8`] bytes.
@@ -7,5 +9,30 @@ pub trait Strided {
     /// Stride in number of [`BitDepth::Pixel`]s.
     fn pixel_stride<BD: BitDepth>(&self) -> isize {
         BD::pxstride(self.stride())
+    }
+}
+
+pub struct WithStride<T> {
+    pub buf: T,
+    pub stride: isize,
+}
+
+impl<T> Strided for WithStride<T> {
+    fn stride(&self) -> isize {
+        self.stride
+    }
+}
+
+impl<T> Deref for WithStride<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.buf
+    }
+}
+
+impl<T> DerefMut for WithStride<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.buf
     }
 }

--- a/src/with_offset.rs
+++ b/src/with_offset.rs
@@ -1,11 +1,10 @@
+use crate::include::common::bitdepth::BitDepth;
+use crate::src::pixels::Pixels;
+use crate::src::strided::Strided;
 use std::ops::Add;
 use std::ops::AddAssign;
 use std::ops::Sub;
 use std::ops::SubAssign;
-
-use crate::include::common::bitdepth::BitDepth;
-use crate::src::pixels::Pixels;
-use crate::src::strided::Strided;
 
 #[derive(Clone, Copy)]
 pub struct WithOffset<T> {
@@ -95,7 +94,7 @@ impl<P: Pixels> WithOffset<P> {
     }
 }
 
-impl<'a, S: Strided> Strided for WithOffset<&'a S> {
+impl<S: Strided> Strided for WithOffset<S> {
     fn stride(&self) -> isize {
         self.data.stride()
     }

--- a/src/with_offset.rs
+++ b/src/with_offset.rs
@@ -3,6 +3,9 @@ use std::ops::AddAssign;
 use std::ops::Sub;
 use std::ops::SubAssign;
 
+use crate::include::common::bitdepth::BitDepth;
+use crate::src::pixels::Pixels;
+
 #[derive(Clone, Copy)]
 pub struct WithOffset<T> {
     pub data: T,
@@ -74,5 +77,19 @@ impl<T> Sub<isize> for WithOffset<T> {
     fn sub(mut self, rhs: isize) -> Self::Output {
         self -= rhs;
         self
+    }
+}
+
+impl<'a, P: Pixels> WithOffset<&'a P> {
+    #[inline] // Inline to see bounds checks in order to potentially elide them.
+    #[cfg_attr(debug_assertions, track_caller)]
+    pub fn as_ptr<BD: BitDepth>(&self) -> *const BD::Pixel {
+        self.data.as_ptr_at::<BD>(self.offset)
+    }
+
+    #[inline] // Inline to see bounds checks in order to potentially elide them.
+    #[cfg_attr(debug_assertions, track_caller)]
+    pub fn as_mut_ptr<BD: BitDepth>(&self) -> *mut BD::Pixel {
+        self.data.as_mut_ptr_at::<BD>(self.offset)
     }
 }

--- a/src/with_offset.rs
+++ b/src/with_offset.rs
@@ -81,7 +81,7 @@ impl<T> Sub<isize> for WithOffset<T> {
     }
 }
 
-impl<'a, P: Pixels> WithOffset<&'a P> {
+impl<P: Pixels> WithOffset<P> {
     #[inline] // Inline to see bounds checks in order to potentially elide them.
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn as_ptr<BD: BitDepth>(&self) -> *const BD::Pixel {

--- a/src/with_offset.rs
+++ b/src/with_offset.rs
@@ -5,6 +5,7 @@ use std::ops::SubAssign;
 
 use crate::include::common::bitdepth::BitDepth;
 use crate::src::pixels::Pixels;
+use crate::src::strided::Strided;
 
 #[derive(Clone, Copy)]
 pub struct WithOffset<T> {
@@ -91,5 +92,11 @@ impl<'a, P: Pixels> WithOffset<&'a P> {
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn as_mut_ptr<BD: BitDepth>(&self) -> *mut BD::Pixel {
         self.data.as_mut_ptr_at::<BD>(self.offset)
+    }
+}
+
+impl<'a, S: Strided> Strided for WithOffset<&'a S> {
+    fn stride(&self) -> isize {
+        self.data.stride()
     }
 }

--- a/src/with_offset.rs
+++ b/src/with_offset.rs
@@ -1,0 +1,78 @@
+use std::ops::Add;
+use std::ops::AddAssign;
+use std::ops::Sub;
+use std::ops::SubAssign;
+
+#[derive(Clone, Copy)]
+pub struct WithOffset<T> {
+    pub data: T,
+    pub offset: usize,
+}
+
+impl<T> AddAssign<usize> for WithOffset<T> {
+    #[cfg_attr(debug_assertions, track_caller)]
+    fn add_assign(&mut self, rhs: usize) {
+        self.offset += rhs;
+    }
+}
+
+impl<T> SubAssign<usize> for WithOffset<T> {
+    #[cfg_attr(debug_assertions, track_caller)]
+    fn sub_assign(&mut self, rhs: usize) {
+        self.offset -= rhs;
+    }
+}
+
+impl<T> AddAssign<isize> for WithOffset<T> {
+    #[cfg_attr(debug_assertions, track_caller)]
+    fn add_assign(&mut self, rhs: isize) {
+        self.offset = self.offset.wrapping_add_signed(rhs);
+    }
+}
+
+impl<T> SubAssign<isize> for WithOffset<T> {
+    #[cfg_attr(debug_assertions, track_caller)]
+    fn sub_assign(&mut self, rhs: isize) {
+        self.offset = self.offset.wrapping_add_signed(-rhs);
+    }
+}
+
+impl<T> Add<usize> for WithOffset<T> {
+    type Output = Self;
+
+    #[cfg_attr(debug_assertions, track_caller)]
+    fn add(mut self, rhs: usize) -> Self::Output {
+        self += rhs;
+        self
+    }
+}
+
+impl<T> Sub<usize> for WithOffset<T> {
+    type Output = Self;
+
+    #[cfg_attr(debug_assertions, track_caller)]
+    fn sub(mut self, rhs: usize) -> Self::Output {
+        self -= rhs;
+        self
+    }
+}
+
+impl<T> Add<isize> for WithOffset<T> {
+    type Output = Self;
+
+    #[cfg_attr(debug_assertions, track_caller)]
+    fn add(mut self, rhs: isize) -> Self::Output {
+        self += rhs;
+        self
+    }
+}
+
+impl<T> Sub<isize> for WithOffset<T> {
+    type Output = Self;
+
+    #[cfg_attr(debug_assertions, track_caller)]
+    fn sub(mut self, rhs: isize) -> Self::Output {
+        self -= rhs;
+        self
+    }
+}


### PR DESCRIPTION
This refactors out the generic `struct WithOffset`, `trait Pixels`, and `trait Strided` from `Rav1dPictureDataComponent{,Offset}` and uses them to implement `enum PicOrBuf`.