### PR TITLE
`fn resize`: Make safe w/ `WithOffset<PicOrBuf<AlignedVec64<u8>>>`

### DIFF
--- a/src/mc.rs
+++ b/src/mc.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::include::common::bitdepth::AsPrimitive;
 use crate::include::common::bitdepth::BitDepth;
 use crate::include::common::bitdepth::DynPixel;

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -7,6 +7,7 @@ use crate::include::dav1d::headers::Rav1dFilterMode;
 use crate::include::dav1d::headers::Rav1dPixelLayoutSubSampled;
 use crate::include::dav1d::picture::Rav1dPictureDataComponent;
 use crate::include::dav1d::picture::Rav1dPictureDataComponentOffset;
+use crate::src::align::AlignedVec64;
 use crate::src::cpu::CpuFlags;
 use crate::src::enum_map::enum_map;
 use crate::src::enum_map::enum_map_ty;
@@ -18,11 +19,13 @@ use crate::src::internal::SCRATCH_INTER_INTRA_BUF_LEN;
 use crate::src::internal::SCRATCH_LAP_LEN;
 use crate::src::internal::SEG_MASK_LEN;
 use crate::src::levels::Filter2d;
+use crate::src::pic_or_buf::PicOrBuf;
 use crate::src::strided::Strided as _;
 use crate::src::tables::dav1d_mc_subpel_filters;
 use crate::src::tables::dav1d_mc_warp_filter;
 use crate::src::tables::dav1d_obmc_masks;
 use crate::src::tables::dav1d_resize_filter;
+use crate::src::with_offset::WithOffset;
 use crate::src::wrap_fn_ptr::wrap_fn_ptr;
 use std::cmp;
 use std::ffi::c_int;
@@ -988,9 +991,8 @@ fn emu_edge_rust<BD: BitDepth>(
     }
 }
 
-unsafe fn resize_rust<BD: BitDepth>(
-    dst: *mut BD::Pixel,
-    dst_stride: isize,
+fn resize_rust<BD: BitDepth>(
+    dst: WithOffset<PicOrBuf<AlignedVec64<u8>>>,
     src: Rav1dPictureDataComponentOffset,
     dst_w: usize,
     h: usize,
@@ -1003,10 +1005,13 @@ unsafe fn resize_rust<BD: BitDepth>(
     for y in 0..h {
         let mut mx = mx0;
         let mut src_x = -1 - 3;
-        let dst = dst.offset(y as isize * BD::pxstride(dst_stride));
+        let dst = dst + (y as isize * dst.pixel_stride::<BD>());
         let src = src + (y as isize * src.pixel_stride::<BD>());
         let src = &*src.slice::<BD>(src_w);
-        let dst = slice::from_raw_parts_mut(dst, dst_w);
+        let dst = match dst.data {
+            PicOrBuf::Pic(pic) => &mut *pic.slice_mut::<BD, _>((dst.offset.., ..dst_w)),
+            PicOrBuf::Buf(buf) => &mut *buf.mut_slice_as((dst.offset.., ..dst_w)),
+        };
         for dst_x in 0..dst_w {
             let f = &dav1d_resize_filter[(mx >> 8) as usize];
             dst[dst_x] = bd.iclip_pixel(
@@ -1496,13 +1501,13 @@ wrap_fn_ptr!(pub unsafe extern "C" fn resize(
     mx: i32,
     bitdepth_max: i32,
     _src: *const FFISafe<Rav1dPictureDataComponentOffset>,
+    _dst: *const FFISafe<WithOffset<PicOrBuf<AlignedVec64<u8>>>>,
 ) -> ());
 
 impl resize::Fn {
-    pub unsafe fn call<BD: BitDepth>(
+    pub fn call<BD: BitDepth>(
         &self,
-        dst: *mut BD::Pixel,
-        dst_stride: isize,
+        dst: WithOffset<PicOrBuf<AlignedVec64<u8>>>,
         src: Rav1dPictureDataComponentOffset,
         dst_w: usize,
         h: usize,
@@ -1511,7 +1516,8 @@ impl resize::Fn {
         mx: i32,
         bd: BD,
     ) {
-        let dst = dst.cast();
+        let dst_ptr = dst.as_mut_ptr::<BD>().cast();
+        let dst_stride = dst.stride();
         let src_ptr = src.as_ptr::<BD>().cast();
         let src_stride = src.stride();
         let dst_w = dst_w as c_int;
@@ -1519,9 +1525,13 @@ impl resize::Fn {
         let src_w = src_w as c_int;
         let bd = bd.into_c();
         let src = FFISafe::new(&src);
-        self.get()(
-            dst, dst_stride, src_ptr, src_stride, dst_w, h, src_w, dx, mx, bd, src,
-        )
+        let dst = FFISafe::new(&dst);
+        // SAFETY: Fallback `fn resize_rust` is safe; asm is supposed to do the same.
+        unsafe {
+            self.get()(
+                dst_ptr, dst_stride, src_ptr, src_stride, dst_w, h, src_w, dx, mx, bd, src, dst,
+            )
+        }
     }
 }
 
@@ -1915,8 +1925,8 @@ unsafe extern "C" fn emu_edge_c_erased<BD: BitDepth>(
 }
 
 unsafe extern "C" fn resize_c_erased<BD: BitDepth>(
-    dst: *mut DynPixel,
-    dst_stride: isize,
+    _dst_ptr: *mut DynPixel,
+    _dst_stride: isize,
     _src_ptr: *const DynPixel,
     _src_stride: isize,
     dst_w: i32,
@@ -1926,15 +1936,17 @@ unsafe extern "C" fn resize_c_erased<BD: BitDepth>(
     mx0: i32,
     bitdepth_max: i32,
     src: *const FFISafe<Rav1dPictureDataComponentOffset>,
+    dst: *const FFISafe<WithOffset<PicOrBuf<AlignedVec64<u8>>>>,
 ) {
-    let dst = dst.cast();
+    // SAFETY: Was passed as `FFISafe::new(_)` in `resize::Fn::call`.
+    let dst = *unsafe { FFISafe::get(dst) };
     // SAFETY: Was passed as `FFISafe::new(_)` in `resize::Fn::call`.
     let src = *unsafe { FFISafe::get(src) };
     let dst_w = dst_w as usize;
     let h = h as usize;
     let src_w = src_w as usize;
     let bd = BD::from_c(bitdepth_max);
-    resize_rust(dst, dst_stride, src, dst_w, h, src_w, dx, mx0, bd)
+    resize_rust(dst, src, dst_w, h, src_w, dx, mx0, bd)
 }
 
 impl Rav1dMCDSPContext {

--- a/src/pic_or_buf.rs
+++ b/src/pic_or_buf.rs
@@ -53,10 +53,10 @@ impl<'a, T: AsMutPtr<Target = u8>> WithOffset<PicOrBuf<'a, T>> {
         }
     }
 
-    pub fn buf(buf: &'a DisjointMut<T>, stride: isize, offset: usize) -> Self {
+    pub fn buf(buf: WithOffset<WithStride<&'a DisjointMut<T>>>) -> Self {
         Self {
-            data: PicOrBuf::Buf(WithStride { buf, stride }),
-            offset,
+            data: PicOrBuf::Buf(buf.data),
+            offset: buf.offset,
         }
     }
 }

--- a/src/pic_or_buf.rs
+++ b/src/pic_or_buf.rs
@@ -4,6 +4,7 @@ use crate::src::disjoint_mut::DisjointMut;
 use crate::src::pixels::Pixels;
 use crate::src::strided::Strided;
 use crate::src::strided::WithStride;
+use crate::src::with_offset::WithOffset;
 
 pub enum PicOrBuf<'a, T: AsMutPtr<Target = u8>> {
     Pic(&'a Rav1dPictureDataComponent),
@@ -40,6 +41,22 @@ impl<'a, T: AsMutPtr<Target = u8>> Strided for PicOrBuf<'a, T> {
         match self {
             Self::Pic(pic) => pic.stride(),
             Self::Buf(buf) => buf.stride(),
+        }
+    }
+}
+
+impl<'a, T: AsMutPtr<Target = u8>> WithOffset<PicOrBuf<'a, T>> {
+    pub fn pic(pic: WithOffset<&'a Rav1dPictureDataComponent>) -> Self {
+        Self {
+            data: PicOrBuf::Pic(pic.data),
+            offset: pic.offset,
+        }
+    }
+
+    pub fn buf(buf: &'a DisjointMut<T>, stride: isize, offset: usize) -> Self {
+        Self {
+            data: PicOrBuf::Buf(WithStride { buf, stride }),
+            offset,
         }
     }
 }

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -86,6 +86,7 @@ use crate::src::tables::dav1d_txtp_from_uvmode;
 use crate::src::tables::TxfmInfo;
 use crate::src::wedge::dav1d_ii_masks;
 use crate::src::wedge::dav1d_wedge_masks;
+use crate::src::with_offset::WithOffset;
 use assert_matches::debug_assert_matches;
 use libc::intptr_t;
 use std::array;
@@ -3714,7 +3715,7 @@ pub(crate) unsafe fn rav1d_filter_sbrow_cdef<BD: BitDepth>(
     rav1d_cdef_brow::<BD>(c, tc, f, p, mask_offset, start, end, false, sby);
 }
 
-pub(crate) unsafe fn rav1d_filter_sbrow_resize<BD: BitDepth>(
+pub(crate) fn rav1d_filter_sbrow_resize<BD: BitDepth>(
     _c: &Rav1dContext,
     f: &Rav1dFrameData,
     _t: &mut Rav1dTaskContext,
@@ -3741,8 +3742,7 @@ pub(crate) unsafe fn rav1d_filter_sbrow_resize<BD: BitDepth>(
         let img_h = f.cur.p.h - sbsz * 4 * sby + ss_ver >> ss_ver;
 
         f.dsp.mc.resize.call::<BD>(
-            dst.as_mut_ptr::<BD>(),
-            dst.stride(),
+            WithOffset::pic(dst),
             src,
             dst_w as usize,
             (cmp::min(img_h, h_end) + h_start) as usize,


### PR DESCRIPTION
* Fixes #842.

This pattern can also be used in #1239 and can be used to resolve https://github.com/memorysafety/rav1d/pull/1239#discussion_r1656418583.