### PR TITLE
Remove inlining of `read_vartx_tree` and `rav1d_create_lf_mask_intra`

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -781,6 +781,8 @@ struct VarTx {
     tx_split1: u16,
 }
 
+// not inlined in C and inlining in Rust degrades performance slightly
+#[inline(never)]
 fn read_vartx_tree(
     t: &mut Rav1dTaskContext,
     f: &Rav1dFrameData,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -386,6 +386,8 @@ fn mask_edges_chroma(
     );
 }
 
+// not inline in C, and inlining in Rust doesn't seem to improve performance
+#[inline(never)]
 pub(crate) fn rav1d_create_lf_mask_intra(
     lflvl: &Av1Filter,
     level_cache: &DisjointMut<Vec<u8>>,


### PR DESCRIPTION
These functions are not inlined in C and removing `read_vartx_tree` inlining speeds up performance on Chimera 8-bit on my 7700X by about 0.7%.