### PR TITLE
`mod c_{box,arc}`: Make safe

### DIFF
--- a/src/c_arc.rs
+++ b/src/c_arc.rs
@@ -212,7 +212,7 @@ impl<T: ?Sized> CArc<T> {
     pub unsafe fn from_raw(raw: RawCArc<T>) -> Self {
         // Safety: The [`RawCArc`] contains the output of [`Arc::into_raw`],
         // so we can call [`Arc::from_raw`] on it.
-        let owner = raw.0.into_arc();
+        let owner = unsafe { raw.0.into_arc() };
         owner.into()
     }
 }

--- a/src/c_arc.rs
+++ b/src/c_arc.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use crate::src::c_box::CBox;
 use crate::src::error::Rav1dResult;
 use std::marker::PhantomData;

--- a/src/c_box.rs
+++ b/src/c_box.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use std::ffi::c_void;
 use std::marker::PhantomData;
 use std::ops::Deref;

--- a/src/c_box.rs
+++ b/src/c_box.rs
@@ -15,8 +15,15 @@ pub struct Free {
 }
 
 impl Free {
+    /// # Safety
+    ///
+    /// `ptr` is a [`NonNull`]`<T>` and `free` deallocates it.
+    /// It must not be used after this call as it is deallocated.
     pub unsafe fn free(&self, ptr: *mut c_void) {
-        (self.free)(ptr as *const u8, self.cookie)
+        // SAFETY: `self` came from `CBox::from_c`,
+        // which requires `self.free` to deallocate the `NonNull<T>` passed to it,
+        // and `self.cookie` to be passed to it, which it is.
+        unsafe { (self.free)(ptr as *const u8, self.cookie) }
     }
 }
 
@@ -85,7 +92,9 @@ impl<T: ?Sized> CBox<T> {
     /// # Safety
     ///
     /// `data` must be valid to dereference
-    /// until `free` is called on it, which must deallocate it.
+    /// until `free.free` is called on it, which must deallocate it.
+    /// `free.free` is always called with `free.cookie`,
+    /// which must be accessed thread-safely.
     pub unsafe fn from_c(data: NonNull<T>, free: Free) -> Self {
         Self::C {
             data,


### PR DESCRIPTION
Including #1239, this is the last of non-`neon` `unsafe` ops.