### PR TITLE
`fn filter_plane_cols_{y,uv}`: avoid modulo operation

### DIFF
--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -360,7 +360,7 @@ unsafe fn filter_plane_cols_y<BD: BitDepth>(
         if !have_left && x == 0 {
             continue;
         }
-        let mask = &mask[x % mask.len()]; // To elide the bounds check.;
+        let mask = &mask[x];
         let hmask = if starty4 == 0 {
             if endy4 > 16 {
                 mask.each_ref()
@@ -435,7 +435,7 @@ unsafe fn filter_plane_cols_uv<BD: BitDepth>(
         if !have_left && x == 0 {
             continue;
         }
-        let mask = &mask[x % mask.len()]; // To elide the bounds check.;
+        let mask = &mask[x];
         let hmask = if starty4 == 0 {
             if endy4 > 16 >> ss_ver {
                 mask.each_ref()


### PR DESCRIPTION
Bound check is already elided and modulo operation is superfluous (and potentially costly).