### PR TITLE
Only add line table debug info in `release-with-debug` profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,4 +61,4 @@ panic = "abort"
 
 [profile.release-with-debug]
 inherits = "release"
-debug = true
+debug = "line-tables-only"


### PR DESCRIPTION
`debug = true` changes the stack layout and variable spill decisions to ensure that variable contents are available in a debugger for their entire lifetime. This results in different code than a release build, which is not helpful when profiling. Adding line tables only instead still gives source line mapping (when possible) but avoids changes to the machine code.