### PR TITLE
`struct CaseSet`: Optimize by `match`ing on `len` once per `set_ctx`

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -52,38 +52,55 @@ use std::iter::zip;
 /// This optimizes for the common cases where `buf.len()` is a small power of 2,
 /// where the array write is optimized as few and large stores as possible.
 #[inline]
-pub fn small_memset<T: Clone + Copy, const UP_TO: usize, const WITH_DEFAULT: bool>(
+pub fn small_memset<T: Clone + Copy, const N: usize, const WITH_DEFAULT: bool>(
     buf: &mut [T],
     val: T,
 ) {
     fn as_array<T: Clone + Copy, const N: usize>(buf: &mut [T]) -> &mut [T; N] {
         buf.try_into().unwrap()
     }
-    match buf.len() {
-        01 if UP_TO >= 01 => *as_array(buf) = [val; 01],
-        02 if UP_TO >= 02 => *as_array(buf) = [val; 02],
-        04 if UP_TO >= 04 => *as_array(buf) = [val; 04],
-        08 if UP_TO >= 08 => *as_array(buf) = [val; 08],
-        16 if UP_TO >= 16 => *as_array(buf) = [val; 16],
-        32 if UP_TO >= 32 => *as_array(buf) = [val; 32],
-        64 if UP_TO >= 64 => *as_array(buf) = [val; 64],
-        _ => {
-            if WITH_DEFAULT {
-                buf.fill(val)
-            }
+    if N == 0 {
+        if WITH_DEFAULT {
+            buf.fill(val)
         }
+    } else {
+        assert!(buf.len() == N); // Meant to be optimized out.
+        *as_array(buf) = [val; N];
     }
 }
 
-pub struct CaseSetter<const UP_TO: usize, const WITH_DEFAULT: bool> {
+pub trait CaseSetter {
+    fn set<T: Clone + Copy>(&self, buf: &mut [T], val: T);
+
+    /// # Safety
+    ///
+    /// Caller must ensure that no elements of the written range are concurrently
+    /// borrowed (immutably or mutably) at all during the call to `set_disjoint`.
+    fn set_disjoint<T, V>(&self, buf: &DisjointMut<T>, val: V)
+    where
+        T: AsMutPtr<Target = V>,
+        V: Clone + Copy;
+}
+
+pub struct CaseSetterN<const N: usize, const WITH_DEFAULT: bool> {
     offset: usize,
     len: usize,
 }
 
-impl<const UP_TO: usize, const WITH_DEFAULT: bool> CaseSetter<UP_TO, WITH_DEFAULT> {
+impl<const N: usize, const WITH_DEFAULT: bool> CaseSetterN<N, WITH_DEFAULT> {
+    const fn len(&self) -> usize {
+        if N == 0 {
+            self.len
+        } else {
+            N
+        }
+    }
+}
+
+impl<const N: usize, const WITH_DEFAULT: bool> CaseSetter for CaseSetterN<N, WITH_DEFAULT> {
     #[inline]
-    pub fn set<T: Clone + Copy>(&self, buf: &mut [T], val: T) {
-        small_memset::<T, UP_TO, WITH_DEFAULT>(&mut buf[self.offset..][..self.len], val);
+    fn set<T: Clone + Copy>(&self, buf: &mut [T], val: T) {
+        small_memset::<_, N, WITH_DEFAULT>(&mut buf[self.offset..][..self.len()], val);
     }
 
     /// # Safety
@@ -91,15 +108,64 @@ impl<const UP_TO: usize, const WITH_DEFAULT: bool> CaseSetter<UP_TO, WITH_DEFAUL
     /// Caller must ensure that no elements of the written range are concurrently
     /// borrowed (immutably or mutably) at all during the call to `set_disjoint`.
     #[inline]
-    pub fn set_disjoint<T, V>(&self, buf: &DisjointMut<T>, val: V)
+    fn set_disjoint<T, V>(&self, buf: &DisjointMut<T>, val: V)
     where
         T: AsMutPtr<Target = V>,
         V: Clone + Copy,
     {
-        let mut buf = buf.index_mut(self.offset..self.offset + self.len);
-        small_memset::<V, UP_TO, WITH_DEFAULT>(&mut *buf, val);
+        let mut buf = buf.index_mut((self.offset.., ..self.len()));
+        small_memset::<_, N, WITH_DEFAULT>(&mut *buf, val);
     }
 }
+
+/// Rank-2 polymorphic closures aren't a thing in Rust yet,
+/// so we need to emulate this through a generic trait with a generic method.
+/// Unforunately, this means we have to write the closure sugar manually.
+pub trait SetCtx<T> {
+    fn call<S: CaseSetter>(self, case: &S, ctx: T) -> Self;
+}
+
+/// Emulate a closure for a [`SetCtx`] `impl`.
+macro_rules! set_ctx {
+    (
+        // `||` is used instead of just `|` due to this bug: <https://github.com/rust-lang/rustfmt/issues/6228>.
+        ||
+            $($lifetime:lifetime,)?
+            $case:ident,
+            $ctx:ident: $T:ty,
+            // Note that the required trailing `,` is so `:expr` can precede `|`.
+            $($up_var:ident: $up_var_ty:ty$( = $up_var_val:expr)?,)*
+        || $body:block
+    ) => {{
+        use $crate::src::ctx::SetCtx;
+        use $crate::src::ctx::CaseSetter;
+
+        struct F$(<$lifetime>)? {
+            $($up_var: $up_var_ty,)*
+        }
+
+        impl$(<$lifetime>)? SetCtx<$T> for F$(<$lifetime>)? {
+            fn call<S: CaseSetter>(self, $case: &S, $ctx: $T) -> Self {
+                let Self {
+                    $($up_var,)*
+                } = self;
+                $body
+                // We destructure and re-structure `Self` so that we
+                // can move out of refs without using `ref`/`ref mut`,
+                // which I don't know how to match on in a macro.
+                Self {
+                    $($up_var,)*
+                }
+            }
+        }
+
+        F {
+            $($up_var$(: $up_var_val)?,)*
+        }
+    }};
+}
+
+pub(crate) use set_ctx;
 
 /// The entrypoint to the [`CaseSet`] API.
 ///
@@ -117,11 +183,25 @@ impl<const UP_TO: usize, const WITH_DEFAULT: bool> CaseSet<UP_TO, WITH_DEFAULT> 
     /// The `len` and `offset` are supplied here and
     /// applied to each `buf` passed to [`CaseSetter::set`] in `set_ctx`.
     #[inline]
-    pub fn one<T, F>(ctx: T, len: usize, offset: usize, mut set_ctx: F)
+    pub fn one<T, F>(ctx: T, len: usize, offset: usize, set_ctx: F) -> F
     where
-        F: FnMut(&CaseSetter<UP_TO, WITH_DEFAULT>, T),
+        F: SetCtx<T>,
     {
-        set_ctx(&CaseSetter { offset, len }, ctx);
+        macro_rules! set_ctx {
+            ($N:literal) => {
+                set_ctx.call(&CaseSetterN::<$N, WITH_DEFAULT> { offset, len }, ctx)
+            };
+        }
+        match len {
+            01 if UP_TO >= 01 => set_ctx!(01),
+            02 if UP_TO >= 02 => set_ctx!(02),
+            04 if UP_TO >= 04 => set_ctx!(04),
+            08 if UP_TO >= 08 => set_ctx!(08),
+            16 if UP_TO >= 16 => set_ctx!(16),
+            32 if UP_TO >= 32 => set_ctx!(32),
+            64 if UP_TO >= 64 => set_ctx!(64),
+            _ => set_ctx!(0),
+        }
     }
 
     /// Perform many case sets in one call.
@@ -138,10 +218,10 @@ impl<const UP_TO: usize, const WITH_DEFAULT: bool> CaseSet<UP_TO, WITH_DEFAULT> 
         offsets: [usize; N],
         mut set_ctx: F,
     ) where
-        F: FnMut(&CaseSetter<UP_TO, WITH_DEFAULT>, T),
+        F: SetCtx<T>,
     {
         for (dir, (len, offset)) in zip(dirs, zip(lens, offsets)) {
-            Self::one(dir, len, offset, &mut set_ctx);
+            set_ctx = Self::one(dir, len, offset, set_ctx);
         }
     }
 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -26,6 +26,7 @@ use crate::src::cdf::rav1d_cdf_thread_init_static;
 use crate::src::cdf::rav1d_cdf_thread_update;
 use crate::src::cdf::CdfMvComponent;
 use crate::src::cdf::CdfThreadContext;
+use crate::src::ctx::set_ctx;
 use crate::src::ctx::CaseSet;
 use crate::src::dequant_tables::dav1d_dq_tbl;
 use crate::src::disjoint_mut::DisjointMut;
@@ -371,7 +372,8 @@ fn read_tx_tree(
             [(&t.l, txh), (&f.a[t.a], txw)],
             [t_dim.h as usize, t_dim.w as usize],
             [by4 as usize, bx4 as usize],
-            |case, (dir, val)| {
+            set_ctx!(||case, dir: (&BlockContext, u8), is_split: bool,|| {
+                let (dir, val) = dir;
                 let tx = if is_split {
                     TxfmSize::S4x4
                 } else {
@@ -379,7 +381,7 @@ fn read_tx_tree(
                     TxfmSize::from_repr(val as _).unwrap()
                 };
                 case.set_disjoint(&dir.tx, tx);
-            },
+            }),
         );
     };
 }
@@ -811,9 +813,9 @@ fn read_vartx_tree(
                 [&t.l, &f.a[t.a]],
                 [bh4 as usize, bw4 as usize],
                 [by4 as usize, bx4 as usize],
-                |case, dir| {
+                set_ctx!(||case, dir: &BlockContext,|| {
                     case.set_disjoint(&dir.tx, TxfmSize::S4x4);
-                },
+                }),
             );
         }
     } else if txfm_mode != Rav1dTxfmMode::Switchable || b.skip != 0 {
@@ -822,11 +824,12 @@ fn read_vartx_tree(
                 [(&t.l, 1), (&f.a[t.a], 0)],
                 [bh4 as usize, bw4 as usize],
                 [by4 as usize, bx4 as usize],
-                |case, (dir, dir_index)| {
+                set_ctx!(||'a, case, dir: (&BlockContext, usize), b_dim: &'a [u8; 4],|| {
+                    let (dir, dir_index) = dir;
                     // TODO check unwrap is optimized out
                     let tx = TxfmSize::from_repr(b_dim[2 + dir_index] as _).unwrap();
                     case.set_disjoint(&dir.tx, tx);
-                },
+                }),
             );
         }
         uvtx = dav1d_max_txfm_size_for_bs[bs as usize][f.cur.p.layout as usize];
@@ -1206,10 +1209,10 @@ fn decode_b(
                     [&t.l, &f.a[t.a]],
                     [bh4 as usize, bw4 as usize],
                     [by4 as usize, bx4 as usize],
-                    |case, dir| {
+                    set_ctx!(||case, dir: &BlockContext, y_mode_nofilt: u8,|| {
                         case.set_disjoint(&dir.mode, y_mode_nofilt);
                         case.set_disjoint(&dir.intra, 1);
-                    },
+                    }),
                 );
                 if frame_type.is_inter_or_switch() {
                     let ri = t.rt.r[(t.b.y as usize & 31) + 5 + bh4 as usize - 1] + t.b.x as usize;
@@ -1231,9 +1234,9 @@ fn decode_b(
                         [&t.l, &f.a[t.a]],
                         [cbh4 as usize, cbw4 as usize],
                         [cby4 as usize, cbx4 as usize],
-                        |case, dir| {
+                        set_ctx!(||'a, case, dir: &BlockContext, intra: &'a Av1BlockIntra,|| {
                             case.set_disjoint(&dir.uvmode, intra.uv_mode);
-                        },
+                        }),
                     );
                 }
             }
@@ -1281,11 +1284,11 @@ fn decode_b(
                     [&t.l, &f.a[t.a]],
                     [bh4 as usize, bw4 as usize],
                     [by4 as usize, bx4 as usize],
-                    |case, dir| {
+                    set_ctx!(||'a, case, dir: &BlockContext, filter: &'a [Rav1dFilterMode; 2],|| {
                         case.set_disjoint(&dir.filter[0], filter[0].into());
                         case.set_disjoint(&dir.filter[1], filter[1].into());
                         case.set_disjoint(&dir.intra, 0);
-                    },
+                    }),
                 );
 
                 if frame_type.is_inter_or_switch() {
@@ -1310,9 +1313,9 @@ fn decode_b(
                         [&t.l, &f.a[t.a]],
                         [cbh4 as usize, cbw4 as usize],
                         [cby4 as usize, cbx4 as usize],
-                        |case, dir| {
+                        set_ctx!(||case, dir: &BlockContext,|| {
                             case.set_disjoint(&dir.uvmode, DC_PRED);
-                        },
+                        }),
                     );
                 }
             }
@@ -1973,7 +1976,17 @@ fn decode_b(
             [(&t.l, t_dim.lh, 1), (&f.a[t.a], t_dim.lw, 0)],
             [bh4 as usize, bw4 as usize],
             [by4 as usize, bx4 as usize],
-            |case, (dir, lw_lh, dir_index)| {
+            set_ctx!(||'a, case, dir: (&BlockContext, u8, usize),
+                y_mode_nofilt: u8,
+                pal_sz: [u8; 2],
+                seg_pred: bool,
+                b: &'a Av1Block,
+                // Only real closures can do partial borrows.
+                pal_sz_uv: &'a mut [[u8; 32]; 2] = &mut t.pal_sz_uv,
+                has_chroma: bool,
+                is_inter_or_switch: bool,
+            || {
+                let (dir, lw_lh, dir_index) = dir;
                 case.set_disjoint(&dir.tx_intra, lw_lh as i8);
                 // TODO check unwrap is optimized out
                 case.set_disjoint(&dir.tx, TxfmSize::from_repr(lw_lh as _).unwrap());
@@ -1985,7 +1998,7 @@ fn decode_b(
                 case.set_disjoint(&dir.skip, b.skip);
                 // see aomedia bug 2183 for why we use luma coordinates here
                 case.set(
-                    &mut t.pal_sz_uv[dir_index],
+                    &mut pal_sz_uv[dir_index],
                     if has_chroma { pal_sz[1] } else { 0 },
                 );
                 if is_inter_or_switch {
@@ -1995,7 +2008,7 @@ fn decode_b(
                     case.set_disjoint(&dir.filter[0], Rav1dFilterMode::N_SWITCHABLE_FILTERS);
                     case.set_disjoint(&dir.filter[1], Rav1dFilterMode::N_SWITCHABLE_FILTERS);
                 }
-            },
+            }),
         );
         if pal_sz[0] != 0 {
             (bd_fn.copy_pal_block_y)(t, f, bx4 as usize, by4 as usize, bw4 as usize, bh4 as usize);
@@ -2005,9 +2018,9 @@ fn decode_b(
                 [&t.l, &f.a[t.a]],
                 [cbh4 as usize, cbw4 as usize],
                 [cby4 as usize, cbx4 as usize],
-                |case, dir| {
+                set_ctx!(||case, dir: &BlockContext, uv_mode: u8,|| {
                     case.set_disjoint(&dir.uvmode, uv_mode);
-                },
+                }),
             );
             if pal_sz[1] != 0 {
                 (bd_fn.copy_pal_block_uv)(
@@ -2182,26 +2195,33 @@ fn decode_b(
             [(&t.l, 1), (&f.a[t.a], 0)],
             [bh4 as usize, bw4 as usize],
             [by4 as usize, bx4 as usize],
-            |case, (dir, dir_index)| {
+            set_ctx!(||'a, case, dir: (&BlockContext, usize),
+                b_dim: &'a [u8; 4],
+                seg_pred: bool,
+                // Only real closures can do partial borrows.
+                pal_sz_uv: &'a mut [[u8; 32]; 2] = &mut t.pal_sz_uv,
+                b: &'a Av1Block,
+            || {
+                let (dir, dir_index) = dir;
                 case.set_disjoint(&dir.tx_intra, b_dim[2 + dir_index] as i8);
                 case.set_disjoint(&dir.mode, DC_PRED);
                 case.set_disjoint(&dir.pal_sz, 0);
                 // see aomedia bug 2183 for why this is outside `if has_chroma {}`
-                case.set(&mut t.pal_sz_uv[dir_index], 0);
+                case.set(&mut pal_sz_uv[dir_index], 0);
                 case.set_disjoint(&dir.seg_pred, seg_pred.into());
                 case.set_disjoint(&dir.skip_mode, 0);
                 case.set_disjoint(&dir.intra, 0);
                 case.set_disjoint(&dir.skip, b.skip);
-            },
+            }),
         );
         if has_chroma {
             CaseSet::<32, false>::many(
                 [&t.l, &f.a[t.a]],
                 [cbh4 as usize, cbw4 as usize],
                 [cby4 as usize, cbx4 as usize],
-                |case, dir| {
+                set_ctx!(||case, dir: &BlockContext,|| {
                     case.set_disjoint(&dir.uvmode, DC_PRED);
-                },
+                }),
             );
         }
     } else {
@@ -3135,14 +3155,25 @@ fn decode_b(
             [(&t.l, 1), (&f.a[t.a], 0)],
             [bh4 as usize, bw4 as usize],
             [by4 as usize, bx4 as usize],
-            |case, (dir, dir_index)| {
+            set_ctx!(||'a, case, dir: (&BlockContext, usize),
+                seg_pred: bool,
+                b: &'a Av1Block,
+                // Only real closures can do partial borrows.
+                pal_sz_uv: &'a mut [[u8; 32]; 2] = &mut t.pal_sz_uv,
+                b_dim: &'a [u8; 4],
+                comp_type: Option<CompInterType>,
+                filter: [Rav1dFilterMode; 2],
+                inter_mode: u8,
+                r#ref: [i8; 2],
+            || {
+                let (dir, dir_index) = dir;
                 case.set_disjoint(&dir.seg_pred, seg_pred.into());
                 case.set_disjoint(&dir.skip_mode, b.skip_mode);
                 case.set_disjoint(&dir.intra, 0);
                 case.set_disjoint(&dir.skip, b.skip);
                 case.set_disjoint(&dir.pal_sz, 0);
                 // see aomedia bug 2183 for why this is outside if (has_chroma)
-                case.set(&mut t.pal_sz_uv[dir_index], 0);
+                case.set(&mut pal_sz_uv[dir_index], 0);
                 case.set_disjoint(&dir.tx_intra, b_dim[2 + dir_index] as i8);
                 case.set_disjoint(&dir.comp_type, comp_type);
                 case.set_disjoint(&dir.filter[0], filter[0]);
@@ -3150,7 +3181,7 @@ fn decode_b(
                 case.set_disjoint(&dir.mode, inter_mode);
                 case.set_disjoint(&dir.r#ref[0], r#ref[0]);
                 case.set_disjoint(&dir.r#ref[1], r#ref[1]);
-            },
+            }),
         );
 
         if has_chroma {
@@ -3158,9 +3189,9 @@ fn decode_b(
                 [&t.l, &f.a[t.a]],
                 [cbh4 as usize, cbw4 as usize],
                 [cby4 as usize, cbx4 as usize],
-                |case, dir| {
+                set_ctx!(||case, dir: &BlockContext,|| {
                     case.set_disjoint(&dir.uvmode, DC_PRED);
-                },
+                }),
             );
         }
     }
@@ -3173,12 +3204,24 @@ fn decode_b(
         let b4_stride = usize::try_from(f.b4_stride).unwrap();
         let cur_segmap = &f.cur_segmap.as_ref().unwrap().inner;
         let offset = by * b4_stride + bx;
-        CaseSet::<32, false>::one((), bw4, 0, |case, ()| {
-            for i in 0..bh4 {
-                let i = offset + i * b4_stride;
-                case.set(&mut cur_segmap.index_mut((i.., ..bw4)), b.seg_id);
-            }
-        });
+        CaseSet::<32, false>::one(
+            (),
+            bw4,
+            0,
+            set_ctx!(||'a, case, _dir: (),
+                bw4: usize,
+                bh4: usize,
+                offset: usize,
+                b4_stride: usize,
+                cur_segmap: &'a DisjointMutSlice<SegmentId>,
+                b: &'a Av1Block,
+            || {
+                for i in 0..bh4 {
+                    let i = offset + i * b4_stride;
+                    case.set(&mut cur_segmap.index_mut((i.., ..bw4)), b.seg_id);
+                }
+            }),
+        );
     }
     if b.skip == 0 {
         let mask = !0u32 >> 32 - bw4 << (bx4 & 15);
@@ -3795,12 +3838,16 @@ fn decode_sb(
             [(&f.a[t.a], 0), (&t.l, 1)],
             [hsz as usize; 2],
             [bx8 as usize, by8 as usize],
-            |case, (dir, dir_index)| {
+            set_ctx!(||case, dir: (&BlockContext, usize),
+                bl: BlockLevel,
+                bp: BlockPartition,
+            || {
+                let (dir, dir_index) = dir;
                 case.set_disjoint(
                     &dir.partition,
                     dav1d_al_part_ctx[dir_index][bl as usize][bp as usize],
                 );
-            },
+            }),
         );
     }
 


### PR DESCRIPTION
In C, `case_set` works by `switch`ing once on `len`, once per `set_ctx`, but my `CaseSet` implementation in Rust accidentally switched to `match`ing on `buf.len()` each time. This goes back to the original, optimal behavior.

To do this, `set_ctx` is made a rank-2 polymorphic "closure". This does not exist in Rust, so it's emulated through a generic trait with a generic method. This inner generic over `trait CaseSetter` is what allows `fn CaseSet::one` to select the correct `CaseSetterN` at compile time.

However, this means that closures can't be used anymore, which is very annoying. To partially remedy this, I added the `set_ctx!` macro, which emulates the `set_ctx` closure as much as possible. All captures (up vars in `rustc`) and their types must be declared.

I didn't actually benchmark this or look at the asm yet, though, if anyone wants to do that.