### PR TITLE
`mod looprestoration::neon`: (arm32) Make safe

### DIFF
--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -1231,7 +1231,7 @@ mod neon {
     }
 
     /// Filter with a 3x3 box (radius=1).
-    unsafe fn rav1d_sgr_filter1_neon<BD: BitDepth>(
+    fn rav1d_sgr_filter1_neon<BD: BitDepth>(
         tmp: &mut [i16; 64 * 384],
         src: Rav1dPictureDataComponentOffset,
         left: &[LeftPixelRow<BD::Pixel>],

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -1026,7 +1026,7 @@ mod neon {
             let dst = dst.cast();
             let mid = mid.as_mut_ptr();
             let fv = fv.as_ptr();
-            let mid_stride = mid_stride as ptrdiff_t;
+            let mid_stride = (mid_stride * mem::size_of::<i16>()) as ptrdiff_t;
             let bd = bd.into_c();
             // SAFETY: asm should be safe.
             unsafe { self.get()(dst, stride, mid, w, h, fv, edges, mid_stride, bd) }
@@ -1163,7 +1163,7 @@ mod neon {
             h,
             &filter[1],
             edges,
-            mid_stride * mem::size_of::<i16>(),
+            mid_stride,
             bd,
         );
     }

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -968,7 +968,7 @@ mod neon {
         left: *const LeftPixelRow<DynPixel>,
         src: *const DynPixel,
         stride: ptrdiff_t,
-        fh: *const i16,
+        fh: &[i16; 8],
         w: intptr_t,
         h: c_int,
         edges: LrEdgeFlags,
@@ -991,7 +991,6 @@ mod neon {
             let dst = dst.as_mut_ptr();
             let left = left.cast();
             let src = src.cast();
-            let fh = fh.as_ptr();
             let bd = bd.into_c();
             // SAFETY: asm should be safe.
             unsafe { self.get()(dst, left, src, stride, fh, w, h, edges, bd) }
@@ -1004,7 +1003,7 @@ mod neon {
         mid: *const i16,
         w: c_int,
         h: c_int,
-        fv: *const i16,
+        fv: &[i16; 8],
         edges: LrEdgeFlags,
         mid_stride: ptrdiff_t,
         bitdepth_max: c_int,
@@ -1025,7 +1024,6 @@ mod neon {
         ) {
             let dst = dst.cast();
             let mid = mid.as_mut_ptr();
-            let fv = fv.as_ptr();
             let mid_stride = (mid_stride * mem::size_of::<i16>()) as ptrdiff_t;
             let bd = bd.into_c();
             // SAFETY: asm should be safe.

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -1442,7 +1442,7 @@ mod neon {
         t2: &mut Align16<[i16; 64 * 384]>,
         w: c_int,
         h: c_int,
-        wt: *const i16,
+        wt: &[i16; 2],
         bitdepth_max: c_int,
     ) -> ());
 
@@ -1462,7 +1462,6 @@ mod neon {
             let dst_stride = dst.stride();
             let src_ptr = src.as_ptr::<BD>().cast();
             let src_stride = src.stride();
-            let wt = wt.as_ptr();
             let bd = bd.into_c();
             // SAFETY: asm should be safe.
             unsafe {

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -953,6 +953,7 @@ fn sgr_mix_rust<BD: BitDepth>(
     }
 }
 
+#[deny(unsafe_op_in_unsafe_fn)]
 #[cfg(all(feature = "asm", target_arch = "arm"))]
 mod neon {
     use super::*;

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -983,7 +983,7 @@ mod neon {
             src: *const BD::Pixel,
             stride: ptrdiff_t,
             fh: &[i16; 8],
-            w: intptr_t,
+            w: c_int,
             h: c_int,
             edges: LrEdgeFlags,
             bd: BD,
@@ -991,6 +991,7 @@ mod neon {
             let dst = dst.as_mut_ptr();
             let left = left.cast();
             let src = src.cast();
+            let w = w as intptr_t;
             let bd = bd.into_c();
             // SAFETY: asm should be safe.
             unsafe { self.get()(dst, left, src, stride, fh, w, h, edges, bd) }
@@ -1122,7 +1123,7 @@ mod neon {
             dst,
             stride,
             &filter[0],
-            w as intptr_t,
+            w,
             h,
             edges,
             bd,
@@ -1134,7 +1135,7 @@ mod neon {
                 lpf,
                 stride,
                 &filter[0],
-                w as intptr_t,
+                w,
                 2,
                 edges,
                 bd,
@@ -1147,7 +1148,7 @@ mod neon {
                 lpf.offset(6 * BD::pxstride(stride)),
                 stride,
                 &filter[0],
-                w as intptr_t,
+                w,
                 2,
                 edges,
                 bd,

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -1020,12 +1020,13 @@ mod neon {
             h: c_int,
             fv: &[i16; 8],
             edges: LrEdgeFlags,
-            mid_stride: ptrdiff_t,
+            mid_stride: usize,
             bd: BD,
         ) {
             let dst = dst.cast();
             let mid = mid.as_mut_ptr();
             let fv = fv.as_ptr();
+            let mid_stride = mid_stride as ptrdiff_t;
             let bd = bd.into_c();
             // SAFETY: asm should be safe.
             unsafe { self.get()(dst, stride, mid, w, h, fv, edges, mid_stride, bd) }
@@ -1162,7 +1163,7 @@ mod neon {
             h,
             &filter[1],
             edges,
-            (mid_stride * mem::size_of::<i16>()) as ptrdiff_t,
+            mid_stride * mem::size_of::<i16>(),
             bd,
         );
     }

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -1145,7 +1145,7 @@ mod neon {
             bd_fn!(wiener_filter_h::decl_fn, BD, wiener_filter_h, neon).call(
                 &mut mid.0[(2 + h as usize) * mid_stride..],
                 ptr::null(),
-                lpf.offset(6 * BD::pxstride(stride)),
+                lpf.wrapping_offset(6 * BD::pxstride(stride)),
                 stride,
                 &filter[0],
                 w,

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -1363,7 +1363,7 @@ mod neon {
     }
 
     /// Filter with a 5x5 box (radius=2).
-    unsafe fn rav1d_sgr_filter2_neon<BD: BitDepth>(
+    fn rav1d_sgr_filter2_neon<BD: BitDepth>(
         tmp: &mut [i16; 64 * 384],
         src: Rav1dPictureDataComponentOffset,
         left: &[LeftPixelRow<BD::Pixel>],

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -962,7 +962,7 @@ mod neon {
     use std::ffi::c_void;
     use std::ptr;
 
-    wrap_fn_ptr!(unsafe extern "C" fn sgr_box_v_neon(
+    wrap_fn_ptr!(unsafe extern "C" fn sgr_box_v(
         sumsq: *mut i32,
         sum: *mut i16,
         w: c_int,
@@ -970,7 +970,7 @@ mod neon {
         edges: LrEdgeFlags,
     ) -> ());
 
-    impl sgr_box_v_neon::Fn {
+    impl sgr_box_v::Fn {
         fn call(&self, sumsq: &mut [i32], sum: &mut [i16], w: c_int, h: c_int, edges: LrEdgeFlags) {
             let sumsq = sumsq.as_mut_ptr();
             let sum = sum.as_mut_ptr();
@@ -979,7 +979,7 @@ mod neon {
         }
     }
 
-    wrap_fn_ptr!(unsafe extern "C" fn sgr_calc_ab_neon(
+    wrap_fn_ptr!(unsafe extern "C" fn sgr_calc_ab(
         a: *mut i32,
         b: *mut i16,
         w: c_int,
@@ -988,7 +988,7 @@ mod neon {
         bitdepth_max: c_int,
     ) -> ());
 
-    impl sgr_calc_ab_neon::Fn {
+    impl sgr_calc_ab::Fn {
         fn call<BD: BitDepth>(
             &self,
             a: &mut [i32],
@@ -1321,7 +1321,7 @@ mod neon {
                 edges,
             );
         }
-        sgr_box_v_neon::decl_fn!(fn dav1d_sgr_box3_v_neon).call(
+        sgr_box_v::decl_fn!(fn dav1d_sgr_box3_v_neon).call(
             &mut sumsq[2 * STRIDE..],
             &mut sum[2 * STRIDE..],
             w,
@@ -1330,7 +1330,7 @@ mod neon {
         );
         let a = &mut sumsq[2 * STRIDE..];
         let b = &mut sum[2 * STRIDE..];
-        sgr_calc_ab_neon::decl_fn!(fn dav1d_sgr_calc_ab1_neon).call(a, b, w, h, strength, bd);
+        sgr_calc_ab::decl_fn!(fn dav1d_sgr_calc_ab1_neon).call(a, b, w, h, strength, bd);
         rav1d_sgr_finish_filter1_neon::<BD>(tmp, src, a.as_mut_ptr(), b.as_mut_ptr(), w, h);
     }
 
@@ -1468,7 +1468,7 @@ mod neon {
                 edges,
             );
         }
-        sgr_box_v_neon::decl_fn!(fn dav1d_sgr_box5_v_neon).call(
+        sgr_box_v::decl_fn!(fn dav1d_sgr_box5_v_neon).call(
             &mut sumsq[2 * STRIDE..],
             &mut sum[2 * STRIDE..],
             w,
@@ -1477,7 +1477,7 @@ mod neon {
         );
         let a = &mut sumsq[2 * STRIDE..];
         let b = &mut sum[2 * STRIDE..];
-        sgr_calc_ab_neon::decl_fn!(fn dav1d_sgr_calc_ab2_neon).call(a, b, w, h, strength, bd);
+        sgr_calc_ab::decl_fn!(fn dav1d_sgr_calc_ab2_neon).call(a, b, w, h, strength, bd);
         rav1d_sgr_finish_filter2_neon::<BD>(tmp, src, a.as_mut_ptr(), b.as_mut_ptr(), w, h);
     }
 

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -1207,6 +1207,7 @@ mod neon {
             bd_fn!(wiener_filter_h::decl_fn, BD, wiener_filter_h, neon).call(
                 &mut mid.0[(2 + h as usize) * mid_stride..],
                 ptr::null(),
+                // `lpf` may be negatively out of bounds.
                 lpf.wrapping_offset(6 * BD::pxstride(stride)),
                 stride,
                 &filter[0],
@@ -1275,7 +1276,8 @@ mod neon {
                 &mut sumsq[(h + 2) * STRIDE..],
                 &mut sum[(h + 2) * STRIDE..],
                 None,
-                lpf.offset(6 * src.pixel_stride::<BD>()),
+                // `lpf` may be negatively out of bounds.
+                lpf.wrapping_offset(6 * src.pixel_stride::<BD>()),
                 src.stride(),
                 w,
                 2,
@@ -1423,7 +1425,8 @@ mod neon {
                 sumsq[(h + 2) * STRIDE..].as_mut_ptr(),
                 sum[(h + 2) * STRIDE..].as_mut_ptr(),
                 None,
-                lpf.offset(6 * src.pixel_stride::<BD>()),
+                // `lpf` may be negatively out of bounds.
+                lpf.wrapping_offset(6 * src.pixel_stride::<BD>()),
                 src.stride(),
                 w,
                 2,

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -1127,7 +1127,7 @@ mod neon {
     ) {
         let filter = &params.filter;
         let mut mid = Align16([0; 68 * 384]);
-        let mid_stride = w + 7 & !7;
+        let mid_stride = w as usize + 7 & !7;
         rav1d_wiener_filter_h_neon(
             &mut mid.0[2 * mid_stride as usize..],
             left,
@@ -1154,7 +1154,7 @@ mod neon {
         }
         if edges.contains(LrEdgeFlags::BOTTOM) {
             rav1d_wiener_filter_h_neon(
-                &mut mid.0[(2 + h as usize) * mid_stride as usize..],
+                &mut mid.0[(2 + h as usize) * mid_stride..],
                 ptr::null(),
                 lpf.offset(6 * BD::pxstride(stride)),
                 stride,
@@ -1168,12 +1168,12 @@ mod neon {
         rav1d_wiener_filter_v_neon(
             dst,
             stride,
-            &mut mid.0[2 * mid_stride as usize..],
+            &mut mid.0[2 * mid_stride..],
             w,
             h,
             &filter[1],
             edges,
-            (mid_stride as usize * mem::size_of::<i16>()) as ptrdiff_t,
+            (mid_stride * mem::size_of::<i16>()) as ptrdiff_t,
             bd,
         );
     }

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -1332,42 +1332,34 @@ mod neon {
         }
     }
 
-    unsafe fn rav1d_sgr_finish_filter2_neon<BD: BitDepth>(
-        tmp: &mut [i16; 64 * 384],
-        src: Rav1dPictureDataComponentOffset,
+    wrap_fn_ptr!(unsafe extern "C" fn sgr_finish_filter2(
+        tmp: *mut i16,
+        src: *const DynPixel,
+        stride: ptrdiff_t,
         a: *const i32,
         b: *const i16,
         w: c_int,
         h: c_int,
-    ) {
-        macro_rules! asm_fn {
-            ($name:ident) => {{
-                extern "C" {
-                    fn $name(
-                        tmp: *mut i16,
-                        src: *const c_void,
-                        stride: ptrdiff_t,
-                        a: *const i32,
-                        b: *const i16,
-                        w: c_int,
-                        h: c_int,
-                    );
-                }
-                $name
-            }};
+    ) -> ());
+
+    impl sgr_finish_filter2::Fn {
+        fn call<BD: BitDepth>(
+            &self,
+            tmp: &mut [i16; 64 * 384],
+            src: Rav1dPictureDataComponentOffset,
+            a: &[i32],
+            b: &[i16],
+            w: c_int,
+            h: c_int,
+        ) {
+            let tmp = tmp.as_mut_ptr();
+            let src_ptr = src.as_ptr::<BD>().cast();
+            let stride = src.stride();
+            let a = a.as_ptr();
+            let b = b.as_ptr();
+            // SAFETY: asm should be safe.
+            unsafe { self.get()(tmp, src_ptr, stride, a, b, w, h) }
         }
-        (match BD::BPC {
-            BPC::BPC8 => asm_fn!(dav1d_sgr_finish_filter2_8bpc_neon),
-            BPC::BPC16 => asm_fn!(dav1d_sgr_finish_filter2_16bpc_neon),
-        })(
-            tmp.as_mut_ptr(),
-            src.as_ptr::<BD>().cast(),
-            src.stride(),
-            a,
-            b,
-            w,
-            h,
-        )
     }
 
     /// Filter with a 5x5 box (radius=2).
@@ -1434,7 +1426,8 @@ mod neon {
         let a = &mut sumsq[2 * STRIDE..];
         let b = &mut sum[2 * STRIDE..];
         sgr_calc_ab::decl_fn!(fn dav1d_sgr_calc_ab2_neon).call(a, b, w, h, strength, bd);
-        rav1d_sgr_finish_filter2_neon::<BD>(tmp, src, a.as_mut_ptr(), b.as_mut_ptr(), w, h);
+        bd_fn!(sgr_finish_filter2::decl_fn, BD, sgr_finish_filter2, neon)
+            .call::<BD>(tmp, src, a, b, w, h);
     }
 
     unsafe fn rav1d_sgr_weighted1_neon<BD: BitDepth>(

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -1077,6 +1077,10 @@ mod neon {
         }
     }
 
+    /// # Safety
+    ///
+    /// Must be called by [`loop_restoration_filter::Fn::call`].
+    #[deny(unsafe_op_in_unsafe_fn)]
     pub unsafe extern "C" fn wiener_filter_neon_erased<BD: BitDepth>(
         p: *mut DynPixel,
         stride: ptrdiff_t,
@@ -1090,20 +1094,14 @@ mod neon {
         _p: *const FFISafe<Rav1dPictureDataComponentOffset>,
         _lpf: *const FFISafe<DisjointMut<AlignedVec64<u8>>>,
     ) {
-        wiener_filter_neon(
-            p.cast(),
-            stride,
-            left.cast(),
-            lpf.cast(),
-            w,
-            h,
-            params,
-            edges,
-            BD::from_c(bitdepth_max),
-        )
+        let p = p.cast();
+        let left = left.cast();
+        let lpf = lpf.cast();
+        let bd = BD::from_c(bitdepth_max);
+        wiener_filter_neon(p, stride, left, lpf, w, h, params, edges, bd)
     }
 
-    unsafe fn wiener_filter_neon<BD: BitDepth>(
+    fn wiener_filter_neon<BD: BitDepth>(
         dst: *mut BD::Pixel,
         stride: ptrdiff_t,
         left: *const LeftPixelRow<BD::Pixel>,

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -1111,7 +1111,7 @@ mod neon {
         }
     }
 
-    wrap_fn_ptr!(unsafe extern "C" fn sgr_finish_filter1(
+    wrap_fn_ptr!(unsafe extern "C" fn sgr_finish_filter(
         tmp: *mut i16,
         src: *const DynPixel,
         stride: ptrdiff_t,
@@ -1121,7 +1121,7 @@ mod neon {
         h: c_int,
     ) -> ());
 
-    impl sgr_finish_filter1::Fn {
+    impl sgr_finish_filter::Fn {
         fn call<BD: BitDepth>(
             &self,
             tmp: &mut [i16; 64 * 384],
@@ -1294,7 +1294,7 @@ mod neon {
         let a = &mut sumsq[2 * STRIDE..];
         let b = &mut sum[2 * STRIDE..];
         sgr_calc_ab::decl_fn!(fn dav1d_sgr_calc_ab1_neon).call(a, b, w, h, strength, bd);
-        bd_fn!(sgr_finish_filter1::decl_fn, BD, sgr_finish_filter1, neon)
+        bd_fn!(sgr_finish_filter::decl_fn, BD, sgr_finish_filter1, neon)
             .call::<BD>(tmp, src, a, b, w, h);
     }
 
@@ -1329,36 +1329,6 @@ mod neon {
             let src = src.cast();
             // SAFETY: asm should be safe.
             unsafe { self.get()(sumsq, sum, left, src, stride, w, h, edges) }
-        }
-    }
-
-    wrap_fn_ptr!(unsafe extern "C" fn sgr_finish_filter2(
-        tmp: *mut i16,
-        src: *const DynPixel,
-        stride: ptrdiff_t,
-        a: *const i32,
-        b: *const i16,
-        w: c_int,
-        h: c_int,
-    ) -> ());
-
-    impl sgr_finish_filter2::Fn {
-        fn call<BD: BitDepth>(
-            &self,
-            tmp: &mut [i16; 64 * 384],
-            src: Rav1dPictureDataComponentOffset,
-            a: &[i32],
-            b: &[i16],
-            w: c_int,
-            h: c_int,
-        ) {
-            let tmp = tmp.as_mut_ptr();
-            let src_ptr = src.as_ptr::<BD>().cast();
-            let stride = src.stride();
-            let a = a.as_ptr();
-            let b = b.as_ptr();
-            // SAFETY: asm should be safe.
-            unsafe { self.get()(tmp, src_ptr, stride, a, b, w, h) }
         }
     }
 
@@ -1426,7 +1396,7 @@ mod neon {
         let a = &mut sumsq[2 * STRIDE..];
         let b = &mut sum[2 * STRIDE..];
         sgr_calc_ab::decl_fn!(fn dav1d_sgr_calc_ab2_neon).call(a, b, w, h, strength, bd);
-        bd_fn!(sgr_finish_filter2::decl_fn, BD, sgr_finish_filter2, neon)
+        bd_fn!(sgr_finish_filter::decl_fn, BD, sgr_finish_filter2, neon)
             .call::<BD>(tmp, src, a, b, w, h);
     }
 

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -1506,7 +1506,7 @@ mod neon {
         }
     }
 
-    pub unsafe fn sgr_filter_5x5_neon<BD: BitDepth>(
+    pub fn sgr_filter_5x5_neon<BD: BitDepth>(
         dst: Rav1dPictureDataComponentOffset,
         left: &[LeftPixelRow<BD::Pixel>],
         lpf: *const BD::Pixel,
@@ -1525,7 +1525,7 @@ mod neon {
             .call(dst, dst, &mut tmp.0, w, h, sgr.w0, bd);
     }
 
-    pub unsafe fn sgr_filter_3x3_neon<BD: BitDepth>(
+    pub fn sgr_filter_3x3_neon<BD: BitDepth>(
         dst: Rav1dPictureDataComponentOffset,
         left: &[LeftPixelRow<BD::Pixel>],
         lpf: *const BD::Pixel,
@@ -1544,7 +1544,7 @@ mod neon {
             .call(dst, dst, &mut tmp.0, w, h, sgr.w1, bd);
     }
 
-    pub unsafe fn sgr_filter_mix_neon<BD: BitDepth>(
+    pub fn sgr_filter_mix_neon<BD: BitDepth>(
         dst: Rav1dPictureDataComponentOffset,
         left: &[LeftPixelRow<BD::Pixel>],
         lpf: *const BD::Pixel,


### PR DESCRIPTION
Assuming #1239 is already merged, this removes the last of `unsafe` ops when compiling for `target_arch = "arm"`.  Now only `target_arch = "aarch64"` remains with 110 `unsafe` ops in `mod looprestoration::neon` (`x86`, `x86_64` are already done).