### PR TITLE
`Cargo.toml`: Add `profile.checked-release`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,9 @@ panic = "abort"
 [profile.release-with-debug]
 inherits = "release"
 debug = "line-tables-only"
+
+[profile.checked-release]
+# Close to a release build, but with all checks enabled.
+inherits = "dev"
+opt-level = 2
+codegen-units = 16


### PR DESCRIPTION
Add a `--profile checked-release`, which is mostly `release`, but with all checks enabled (e.x. `debug-assertions` and `overflow-checks`).  This doesn't need to absolute highest performance, so `opt-level = 2` is done instead of `opt-level = 3`, and `codegen-units = 16` is used as well (the normal `release` default, overridden by us to `codegen-units = 1`).

This is especially helpful when running tests locally under qemu, which can be very slow if running the `opt-dev` profile.  This could also be used in CI instead of `opt-dev`, as `opt-level = 2` should help those run quite a bit faster while still having all checks enabled.