### PR TITLE
[WIP] case_set implementation comparison

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,27 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,10 +62,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -62,10 +95,186 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "js-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -84,10 +293,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "nasm-rs"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4d98d0065f4b1daf164b3eafb11974c94662e5e2396cf03f32d0bb5c17da51"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "parking_lot"
@@ -119,6 +361,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "plotters"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +415,7 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if",
+ "criterion",
  "libc",
  "nasm-rs",
  "parking_lot",
@@ -165,6 +436,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,16 +465,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.193"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.193"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0652c533506ad7a2e353cce269330d6afd8bdfb6d75e0ace5b35aacbd7b9e9"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "smallvec"
@@ -236,6 +602,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "to_method"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +622,98 @@ name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "web-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-targets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,21 @@ default-run = "dav1d"
 [lib]
 path = "lib.rs"
 crate-type = ["staticlib", "rlib"]
+bench = false
 
 [[bin]]
 path = "tools/dav1d.rs"
 name = "dav1d"
+bench = false
 
 [[bin]]
 path = "tests/seek_stress.rs"
 name = "seek_stress"
+bench = false
+
+[[bench]]
+name = "case_set"
+harness = false
 
 [dependencies]
 assert_matches = "1.5.0"
@@ -39,6 +46,9 @@ zerocopy = { version = "0.7.32", features = ["derive"] }
 [build-dependencies]
 cc = "1.0.79"
 nasm-rs = "0.2.4"
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["real_blackbox"] }
 
 [features]
 default = ["asm", "bitdepth_8", "bitdepth_16"]

--- a/benches/case_set.rs
+++ b/benches/case_set.rs
@@ -1,0 +1,240 @@
+#![feature(trace_macros)]
+#![allow(unexpected_cfgs)]
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rav1d::src::disjoint_mut::DisjointMut;
+
+// Change this to `rank2` or `ctx_macro` to benchmark the different
+// implementations.
+// 
+// Baseline with: `cargo bench --bench case_set -- --save-baseline main`
+// and compare with `cargo bench --bench case_set -- --baseline main`
+use old::*;
+
+#[allow(unused)]
+mod old {
+    use super::*;
+    use rav1d::src::ctx::CaseSet;
+
+    #[inline(never)]
+    pub fn case_set_one(buf: &mut [u8], len: usize, offset: usize, value: u8) {
+        CaseSet::<32, false>::one(buf, len, offset, |case, buf| case.set(buf, value));
+    }
+
+    #[inline(never)]
+    pub fn case_set_multiple<const N: usize>(
+        bufs: [&mut [u8]; N],
+        len: usize,
+        offset: usize,
+        value: u8,
+    ) {
+        CaseSet::<32, false>::one(bufs, len, offset, |case, bufs| {
+            for buf in bufs {
+                case.set(buf, value);
+            }
+        });
+    }
+
+    #[inline(never)]
+    pub fn case_set_multiple_disjoint<const N: usize>(
+        bufs: [&DisjointMut<[u8; 64]>; N],
+        len: usize,
+        offset: usize,
+        value: u8,
+    ) {
+        CaseSet::<32, false>::one(bufs, len, offset, |case, bufs| {
+            for buf in bufs {
+                case.set_disjoint(buf, value);
+            }
+        });
+    }
+}
+
+#[allow(unused)]
+mod rank2 {
+    use super::*;
+    use rav1d::src::ctx_rank2::{set_ctx, CaseSet};
+
+    #[inline(never)]
+    pub fn case_set_one(buf: &mut [u8], len: usize, offset: usize, value: u8) {
+        CaseSet::<32, false>::one(
+            buf,
+            len,
+            offset,
+            set_ctx!(||
+            case,
+            buf: &mut [u8],
+            value: u8,
+            || {
+                case.set(buf, value)
+            }),
+        );
+    }
+
+    #[inline(never)]
+    pub fn case_set_multiple(
+        bufs: [&mut [u8]; 3],
+        len: usize,
+        offset: usize,
+        value: u8,
+    ) {
+        CaseSet::<32, false>::one(
+            bufs,
+            len,
+            offset,
+            set_ctx!(||case, bufs: [&mut [u8]; 3], value: u8,|| {
+                for buf in bufs {
+                    case.set(buf, value);
+                }
+            }),
+        );
+    }
+
+    #[inline(never)]
+    pub fn case_set_multiple_disjoint(
+        bufs: [&DisjointMut<[u8; 64]>; 3],
+        len: usize,
+        offset: usize,
+        value: u8,
+    ) {
+        CaseSet::<32, false>::one(
+            bufs,
+            len,
+            offset,
+            set_ctx!(||case, bufs: [&DisjointMut<[u8; 64]>; 3], value: u8,|| {
+                for buf in bufs {
+                    case.set_disjoint(buf, value);
+                }
+            }),
+        );
+    }
+}
+
+#[allow(unused)]
+mod ctx_macro {
+    use super::*;
+    use rav1d::case_set;
+
+    #[inline(never)]
+    pub fn case_set_one(buf: &mut [u8], len: usize, offset: usize, value: u8) {
+        case_set!(32, len, offset, {
+            set!(buf, value);
+        });
+    }
+
+    #[inline(never)]
+    pub fn case_set_many(bufs: [&mut [u8]; 2], len: usize, offset: usize, value: u8) {
+        let [buf1, buf2] = bufs;
+        case_set!(32, buf = [buf1, buf2], len = [len, len], offset = [0, 0], {
+            set!(buf, value);
+        });
+    }
+
+    #[inline(never)]
+    pub fn case_set_multiple<const N: usize>(
+        mut bufs: [&mut [u8]; N],
+        len: usize,
+        offset: usize,
+        value: u8,
+    ) {
+        case_set!(32, len, offset, {
+            for buf in &mut bufs {
+                set!(buf, value);
+            }
+        });
+    }
+
+    #[inline(never)]
+    pub fn case_set_multiple_disjoint<const N: usize>(
+        bufs: [&DisjointMut<[u8; 64]>; N],
+        len: usize,
+        offset: usize,
+        value: u8,
+    ) {
+        case_set!(32, len, offset, {
+            for buf in bufs {
+                set_disjoint!(buf, value);
+            }
+        });
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let lengths = [1, 8, 32];
+    let offsets = [0];
+
+    let mut group = c.benchmark_group("case_set_one");
+    for len in lengths {
+        for offset in offsets {
+            group.bench_with_input(
+                format!("len={}, offset={}", len, offset),
+                &(len, offset),
+                |b, &(len, offset)| {
+                    b.iter(|| {
+                        let mut buf = [0; 64];
+                        case_set_one(
+                            black_box(&mut buf),
+                            black_box(len),
+                            black_box(offset),
+                            black_box(0x01),
+                        );
+                    })
+                },
+            );
+        }
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("case_set_multiple");
+    for len in lengths {
+        for offset in offsets {
+            group.bench_with_input(
+                format!("len={}, offset={}", len, offset),
+                &(len, offset),
+                |b, &(len, offset)| {
+                    b.iter(|| {
+                        let mut buf = [0u8; 64];
+                        let mut buf2 = [0u8; 64];
+                        let mut buf3 = [0u8; 64];
+                        let bufs = [&mut buf[..], &mut buf2[..], &mut buf3[..]];
+                        case_set_multiple(
+                            black_box(bufs),
+                            black_box(len),
+                            black_box(offset),
+                            black_box(0x01),
+                        );
+                    })
+                },
+            );
+        }
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("case_set_disjoint_multiple");
+    for len in lengths {
+        for offset in offsets {
+            group.bench_with_input(
+                format!("len={}, offset={}", len, offset),
+                &(len, offset),
+                |b, &(len, offset)| {
+                    b.iter(|| {
+                        let buf = DisjointMut::new([0u8; 64]);
+                        let buf2 = DisjointMut::new([0u8; 64]);
+                        let buf3 = DisjointMut::new([0u8; 64]);
+                        let bufs = [&buf, &buf2, &buf3];
+                        case_set_multiple_disjoint(
+                            black_box(bufs),
+                            black_box(len),
+                            black_box(offset),
+                            black_box(0x01),
+                        );
+                    })
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/lib.rs
+++ b/lib.rs
@@ -37,12 +37,14 @@ pub mod src {
     mod cdf;
     mod const_fn;
     pub mod cpu;
-    mod ctx;
+    pub mod ctx;
+    pub mod ctx_rank2;
+    pub mod ctx_macro;
     mod cursor;
     mod data;
     mod decode;
     mod dequant_tables;
-    pub(crate) mod disjoint_mut;
+    pub mod disjoint_mut;
     pub(crate) mod enum_map;
     mod env;
     pub(crate) mod error;

--- a/src/ctx_macro.rs
+++ b/src/ctx_macro.rs
@@ -1,0 +1,239 @@
+//! The [`case_set!`] macro is a safe and simplified version of the `case_set*` macros in `ctx.h`.
+//!
+//! The `case_set*` macros themselves replaced `memset`s in order to further optimize them
+//! (in e3b5d4d044506f9e0e95e79b3de42fd94386cc61,
+//! which performed the following optimizations:
+//! 1. larger, inlinable writes for small power of 2 lengths
+//! 2. aligned writes for the above
+//! 3. 8-byte aligned fields [`BlockContext`]
+//!   * allows 8-byte aligned writes
+//!   * better cache boundary alignment
+//!
+//! (1) is easy to preserve in Rust, but (2) is difficult to do so without overhead,
+//! as unaligned writes are UB, and so we'd need to check at runtime if they're aligned
+//! (a runtime-determined `off`set is used, so we can't reasonably ensure this at compile-time).
+//!
+//! 
+//! TODO: benchmark new implementation against old one?
+//! 
+//! To more thoroughly check this, I ran the same benchmarks done in
+//! e3b5d4d044506f9e0e95e79b3de42fd94386cc61, which introduced the `case_set*` macros:
+//!
+//! ```sh
+//! cargo build --release && hyperfine './target/release/dav1d -i ./tests/large/chimera_8b_1080p.ivf -l 1000 -o /dev/null'
+//! ```
+//!
+//! for 3 implementations:
+//! 1. the original `case_set*` macros translated directly to `unsafe` Rust `fn`s
+//! 2. the safe [`CaseSet`] implementation below using [`small_memset`] with its small powers of 2 optimization
+//! 3. a safe [`CaseSet`] implementation using [`slice::fill`]/`memset` only
+//!
+//! The [`small_memset`] version was ~1.27% faster than the `case_set*` one,
+//! and ~3.26% faster than the `memset` one.
+//! The `case_set*` macros were also faster than `memset` in C by a similar margin,
+//! meaning the `memset` option is the slowest in both C and Rust,
+//! and since it was replaced with `case_set*` in C, we shouldn't use it in Rust.
+//! Thus, the [`small_memset`] implementation seems optimal, as it:
+//! * is the fastest of the Rust implementations
+//! * is completely safe
+//! * employs the same small powers of 2 optimization the `case_set*` implementation did
+//! * is far simpler than the `case_set*` implementation, consisting of a `match` and array writes
+//!
+//! [`BlockContext`]: crate::src::env::BlockContext
+
+/// Fill small ranges of buffers with a value.
+/// 
+/// This is effectively a specialized version [`slice::fill`] for small
+/// power-of-two sized ranges of buffers.
+/// 
+/// `$UP_TO` is the maximum length that will be optimized, with powers of two up
+/// to 64 supported.
+/// 
+/// If `$WITH_DEFAULT` is `true`, then the implementation falls back to
+/// [`slice::fill`] for buffer lengths not a power of two or greater than
+/// `$UP_TO`. Otherwise no operation is performed in these cases.
+/// 
+/// # Examples
+/// 
+/// ```
+/// # use rav1d::case_set;
+/// let mut buf = [0u8; 32];
+/// let len = 16;
+/// for offset in [0, 16] {
+///     case_set!(32, len, offset, {
+///         set!(&mut buf, 1u8);
+///     });
+/// }
+/// ```
+/// 
+/// In the simplest case, `$len` is the length of the buffer range to fill
+/// starting from `$offset`. The `$body` block is executed with `len` and
+/// `offset` identifiers set to the given length and offset values. Within the
+/// body a `set!` macro is available and must be called to set each buffer range
+/// to a value. `set!` takes a buffer and a value and sets the range
+/// `buf[offset..][..len]` to the value.
+/// ```
+/// # macro_rules! set {
+/// #     ($buf:expr, $val:expr) => {};
+/// # }
+/// set!(buf, value);
+/// ```
+/// 
+/// ## Naming parameters
+/// 
+/// The identifier for either or both of `len` and `offset` can be overridden by
+/// specifying `identifer=value` for those parameters:
+/// ```
+/// # use rav1d::case_set;
+/// let mut buf = [0u8; 32];
+/// let outer_len = 16;
+/// for outer_offset in [0, 16] {
+///     case_set!(32, len=outer_len, offset=outer_offset, {
+///         set!(&mut buf, (offset+len) as u8);
+///     });
+/// }
+/// ```
+/// 
+/// ## `DisjointMut` buffers
+/// 
+/// [`DisjointMut`] buffers can be used in basically the same way as normal
+/// buffers but using the `set_disjoint!` macro instead of `set!`.
+/// ```
+/// # use rav1d::case_set;
+/// # use rav1d::src::disjoint_mut::DisjointMut;
+/// let mut buf = DisjointMut::new([0u8; 32]);
+/// let len = 16;
+/// for offset in [0, 16] {
+///     case_set!(32, len, offset, {
+///         set_disjoint!(&mut buf, 1u8);
+///     });
+/// }
+/// ```
+/// 
+/// ## Multiple buffer ranges
+/// 
+/// Multiple buffers with different lengths and offsets can be filled with the
+/// same body statements. In the following example, two buffers with different
+/// sizes are initialized by quarters.
+/// ```
+/// # use rav1d::case_set;
+/// let mut buf1 = [0u8; 32];
+/// let mut buf2 = [0u8; 64];
+/// for offset in [0, 8, 16, 24] {
+///     case_set!(16, buf=[&mut buf1[..], &mut buf2[..]], len=[8, 16], offset=[offset, offset*2], {
+///         set!(buf, len as u8 >> 3);
+///     });
+/// }
+/// ```
+/// 
+/// A more realistic example of filling multiple buffers with the same value is
+/// initializing different struct fields at the same time (from
+/// `src/decode.rs`):
+/// ```ignore
+/// case_set!(32, ctx=[(&t.l, 1), (&f.a[t.a], 0)], len=[bh4, bw4], offset=[by4, bx4], {
+///      let (dir, dir_index) = ctx;
+///      set_disjoint!(dir.seg_pred, seg_pred.into());
+///      set_disjoint!(dir.skip_mode, b.skip_mode);
+///      set_disjoint!(dir.intra, 0);
+///      set_disjoint!(dir.skip, b.skip);
+///      set_disjoint!(dir.pal_sz, 0);
+/// });
+/// ```
+/// 
+/// [`DisjointMut`]: crate::src::disjoint_mut::DisjointMut
+#[macro_export]
+macro_rules! case_set {
+    ($UP_TO:literal, $($WITH_DEFAULT:literal,)? $ctx:ident=[$($ctx_expr:expr),*], $len:ident=[$($len_expr:expr),*], $offset:ident=[$($offset_expr:expr),*], $body:block) => {
+        for ($ctx, ($len, $offset)) in core::iter::zip([$($ctx_expr,)*], core::iter::zip([$($len_expr,)*], [$($offset_expr,)*])) {
+            case_set!($UP_TO, $($WITH_DEFAULT,)? $ctx=$ctx, $len=$len, $offset=$offset, $body);
+        }
+    };
+    ($UP_TO:literal, $($WITH_DEFAULT:literal,)? $len:ident, $offset:ident, $body:block) => {
+        case_set!($UP_TO, $($WITH_DEFAULT,)? ctx=(), $len=$len, $offset=$offset, $body);
+    };
+    ($UP_TO:literal, $($WITH_DEFAULT:literal,)? $len:ident=$len_expr:expr, $offset:ident, $body:block) => {
+        case_set!($UP_TO, $($WITH_DEFAULT,)? ctx=(), $len=$len_expr, $offset=$offset, { $(($buf, $val)),* });
+    };
+    ($UP_TO:literal, $($WITH_DEFAULT:literal,)? $len:ident, $offset:ident=$offset_expr:expr, $body:block) => {
+        case_set!($UP_TO, $($WITH_DEFAULT,)? ctx=(), $len=$len, $offset=$offset_expr, $body);
+    };
+    ($UP_TO:literal, $($WITH_DEFAULT:literal,)? $len:ident=$len_expr:expr, $offset:ident=$offset_expr:expr, $body:block) => {
+        case_set!($UP_TO, $($WITH_DEFAULT,)? ctx=(), $len=$len_expr, $offset=$offset_expr, $body);
+    };
+    ($UP_TO:literal, $($WITH_DEFAULT:literal,)? $ctx:ident=$ctx_expr:expr, $len:ident=$len_expr:expr, $offset:ident=$offset_expr:expr, $body:block) => {
+        let $ctx = $ctx_expr;
+        let $len = $len_expr;
+        let $offset = $offset_expr;
+        {
+            #[allow(unused_macros)]
+            macro_rules! set {
+                ($buf:expr, $val:expr) => {
+                    assert!($offset <= $buf.len() && $offset + $len <= $buf.len());
+                };
+            }
+            #[allow(unused_macros)]
+            macro_rules! set_disjoint {
+                ($buf:expr, $val:expr) => {
+                    assert!($offset <= $buf.len() && $offset + $len <= $buf.len());
+                };
+            }
+            $body
+        }
+        macro_rules! exec_block {
+            ($N:literal, $block:block) => {
+                {
+                    #[allow(unused_macros)]
+                    macro_rules! set {
+                        ($buf:expr, $val:expr) => {
+                            // SAFETY: The offset and length are checked by the
+                            // assert outside of the match.
+                            let buf_range = unsafe {
+                                $buf.get_unchecked_mut($offset..$offset+$N)
+                            };
+                            *<&mut [_; $N]>::try_from(buf_range).unwrap() = [$val; $N];
+                        };
+                    }
+                    #[allow(unused_macros)]
+                    macro_rules! set_disjoint {
+                        ($buf:expr, $val:expr) => {
+                            // SAFETY: The offset and length are checked by the
+                            // assert outside of the match.
+                            let mut buf_range = unsafe {
+                                $buf.index_mut_unchecked(($offset.., ..$N))
+                            };
+                            *<&mut [_; $N]>::try_from(&mut *buf_range).unwrap() = [$val; $N];
+                        };
+                    }
+                    $block
+                }
+            };
+        }
+        match $len {
+            01 if $UP_TO >= 01 => exec_block!(01, $body),
+            02 if $UP_TO >= 02 => exec_block!(02, $body),
+            04 if $UP_TO >= 04 => exec_block!(04, $body),
+            08 if $UP_TO >= 08 => exec_block!(08, $body),
+            16 if $UP_TO >= 16 => exec_block!(16, $body),
+            32 if $UP_TO >= 32 => exec_block!(32, $body),
+            64 if $UP_TO >= 64 => exec_block!(64, $body),
+            _ => {
+                if $($WITH_DEFAULT ||)? false {
+                    #[allow(unused_macros)]
+                    macro_rules! set {
+                        ($buf:expr, $val:expr) => {
+                            $buf[$offset..][..$len].fill($val);
+                        };
+                    }
+                    #[allow(unused_macros)]
+                    macro_rules! set_disjoint {
+                        ($buf:expr, $val:expr) => {
+                            $buf.index_mut($offset..$offset+$len).fill($val);
+                        };
+                    }
+                    $body
+                }
+            }
+        }
+    };
+}
+pub use case_set;

--- a/src/ctx_rank2.rs
+++ b/src/ctx_rank2.rs
@@ -1,0 +1,228 @@
+//! The [`CaseSet`] API below is a safe and simplified version of the `case_set*` macros in `ctx.h`.
+//!
+//! The `case_set*` macros themselves replaced `memset`s in order to further optimize them
+//! (in e3b5d4d044506f9e0e95e79b3de42fd94386cc61,
+//! which performed the following optimizations:
+//! 1. larger, inlinable writes for small power of 2 lengths
+//! 2. aligned writes for the above
+//! 3. 8-byte aligned fields [`BlockContext`]
+//!   * allows 8-byte aligned writes
+//!   * better cache boundary alignment
+//!
+//! (1) is easy to preserve in Rust, but (2) is difficult to do so without overhead,
+//! as unaligned writes are UB, and so we'd need to check at runtime if they're aligned
+//! (a runtime-determined `off`set is used, so we can't reasonably ensure this at compile-time).
+//!
+//! To more thoroughly check this, I ran the same benchmarks done in
+//! e3b5d4d044506f9e0e95e79b3de42fd94386cc61, which introduced the `case_set*` macros:
+//!
+//! ```sh
+//! cargo build --release && hyperfine './target/release/dav1d -i ./tests/large/chimera_8b_1080p.ivf -l 1000 -o /dev/null'
+//! ```
+//!
+//! for 3 implementations:
+//! 1. the original `case_set*` macros translated directly to `unsafe` Rust `fn`s
+//! 2. the safe [`CaseSet`] implementation below using [`small_memset`] with its small powers of 2 optimization
+//! 3. a safe [`CaseSet`] implementation using [`slice::fill`]/`memset` only
+//!
+//! The [`small_memset`] version was ~1.27% faster than the `case_set*` one,
+//! and ~3.26% faster than the `memset` one.
+//! The `case_set*` macros were also faster than `memset` in C by a similar margin,
+//! meaning the `memset` option is the slowest in both C and Rust,
+//! and since it was replaced with `case_set*` in C, we shouldn't use it in Rust.
+//! Thus, the [`small_memset`] implementation seems optimal, as it:
+//! * is the fastest of the Rust implementations
+//! * is completely safe
+//! * employs the same small powers of 2 optimization the `case_set*` implementation did
+//! * is far simpler than the `case_set*` implementation, consisting of a `match` and array writes
+//!
+//! [`BlockContext`]: crate::src::env::BlockContext
+use crate::src::disjoint_mut::AsMutPtr;
+use crate::src::disjoint_mut::DisjointMut;
+use std::iter::zip;
+
+/// Perform a `memset` optimized for lengths that are small powers of 2.
+///
+/// For power of 2 lengths `<= UP_TO`,
+/// the `memset` is done as an array write of that exactly (compile-time known) length.
+/// If the length is not a power of 2 or `> UP_TO`,
+/// then the `memset` is done by [`slice::fill`] (a `memset` call) if `WITH_DEFAULT` is `true`,
+/// or else skipped if `WITH_DEFAULT` is `false`.
+///
+/// This optimizes for the common cases where `buf.len()` is a small power of 2,
+/// where the array write is optimized as few and large stores as possible.
+#[inline]
+pub fn small_memset<T: Clone + Copy, const N: usize, const WITH_DEFAULT: bool>(
+    buf: &mut [T],
+    val: T,
+) {
+    fn as_array<T: Clone + Copy, const N: usize>(buf: &mut [T]) -> &mut [T; N] {
+        buf.try_into().unwrap()
+    }
+    if N == 0 {
+        if WITH_DEFAULT {
+            buf.fill(val)
+        }
+    } else {
+        assert!(buf.len() == N); // Meant to be optimized out.
+        *as_array(buf) = [val; N];
+    }
+}
+
+pub trait CaseSetter {
+    fn set<T: Clone + Copy>(&self, buf: &mut [T], val: T);
+
+    /// # Safety
+    ///
+    /// Caller must ensure that no elements of the written range are concurrently
+    /// borrowed (immutably or mutably) at all during the call to `set_disjoint`.
+    fn set_disjoint<T, V>(&self, buf: &DisjointMut<T>, val: V)
+    where
+        T: AsMutPtr<Target = V>,
+        V: Clone + Copy;
+}
+
+pub struct CaseSetterN<const N: usize, const WITH_DEFAULT: bool> {
+    offset: usize,
+    len: usize,
+}
+
+impl<const N: usize, const WITH_DEFAULT: bool> CaseSetterN<N, WITH_DEFAULT> {
+    const fn len(&self) -> usize {
+        if N == 0 {
+            self.len
+        } else {
+            N
+        }
+    }
+}
+
+impl<const N: usize, const WITH_DEFAULT: bool> CaseSetter for CaseSetterN<N, WITH_DEFAULT> {
+    #[inline]
+    fn set<T: Clone + Copy>(&self, buf: &mut [T], val: T) {
+        small_memset::<_, N, WITH_DEFAULT>(&mut buf[self.offset..][..self.len()], val);
+    }
+
+    /// # Safety
+    ///
+    /// Caller must ensure that no elements of the written range are concurrently
+    /// borrowed (immutably or mutably) at all during the call to `set_disjoint`.
+    #[inline]
+    fn set_disjoint<T, V>(&self, buf: &DisjointMut<T>, val: V)
+    where
+        T: AsMutPtr<Target = V>,
+        V: Clone + Copy,
+    {
+        let mut buf = buf.index_mut((self.offset.., ..self.len()));
+        small_memset::<_, N, WITH_DEFAULT>(&mut *buf, val);
+    }
+}
+
+/// Rank-2 polymorphic closures aren't a thing in Rust yet,
+/// so we need to emulate this through a generic trait with a generic method.
+/// Unforunately, this means we have to write the closure sugar manually.
+pub trait SetCtx<T> {
+    fn call<S: CaseSetter>(self, case: &S, ctx: T) -> Self;
+}
+
+/// Emulate a closure for a [`SetCtx`] `impl`.
+#[macro_export]
+macro_rules! set_ctx {
+    (
+        // `||` is used instead of just `|` due to this bug: <https://github.com/rust-lang/rustfmt/issues/6228>.
+        ||
+            $($lifetime:lifetime,)?
+            $case:ident,
+            $ctx:ident: $T:ty,
+            // Note that the required trailing `,` is so `:expr` can precede `|`.
+            $($up_var:ident: $up_var_ty:ty$( = $up_var_val:expr)?,)*
+        || $body:block
+    ) => {{
+        use $crate::src::ctx_rank2::SetCtx;
+        use $crate::src::ctx_rank2::CaseSetter;
+
+        struct F$(<$lifetime>)? {
+            $($up_var: $up_var_ty,)*
+        }
+
+        impl$(<$lifetime>)? SetCtx<$T> for F$(<$lifetime>)? {
+            fn call<S: CaseSetter>(self, $case: &S, $ctx: $T) -> Self {
+                let Self {
+                    $($up_var,)*
+                } = self;
+                $body
+                // We destructure and re-structure `Self` so that we
+                // can move out of refs without using `ref`/`ref mut`,
+                // which I don't know how to match on in a macro.
+                Self {
+                    $($up_var,)*
+                }
+            }
+        }
+
+        F {
+            $($up_var$(: $up_var_val)?,)*
+        }
+    }};
+}
+
+pub use set_ctx;
+
+/// The entrypoint to the [`CaseSet`] API.
+///
+/// `UP_TO` and `WITH_DEFAULT` are made const generic parameters rather than have multiple `case_set*` `fn`s,
+/// and these are put in a separate `struct` so that these 2 generic parameters
+/// can be manually specified while the ones on the methods are inferred.
+pub struct CaseSet<const UP_TO: usize, const WITH_DEFAULT: bool>;
+
+impl<const UP_TO: usize, const WITH_DEFAULT: bool> CaseSet<UP_TO, WITH_DEFAULT> {
+    /// Perform one case set.
+    ///
+    /// This API is generic over the element type (`T`) rather than hardcoding `u8`,
+    /// as sometimes other types are used, though only `i8` is used currently.
+    ///
+    /// The `len` and `offset` are supplied here and
+    /// applied to each `buf` passed to [`CaseSetter::set`] in `set_ctx`.
+    #[inline]
+    pub fn one<T, F>(ctx: T, len: usize, offset: usize, set_ctx: F) -> F
+    where
+        F: SetCtx<T>,
+    {
+        macro_rules! set_ctx {
+            ($N:literal) => {
+                set_ctx.call(&CaseSetterN::<$N, WITH_DEFAULT> { offset, len }, ctx)
+            };
+        }
+        match len {
+            01 if UP_TO >= 01 => set_ctx!(01),
+            02 if UP_TO >= 02 => set_ctx!(02),
+            04 if UP_TO >= 04 => set_ctx!(04),
+            08 if UP_TO >= 08 => set_ctx!(08),
+            16 if UP_TO >= 16 => set_ctx!(16),
+            32 if UP_TO >= 32 => set_ctx!(32),
+            64 if UP_TO >= 64 => set_ctx!(64),
+            _ => set_ctx!(0),
+        }
+    }
+
+    /// Perform many case sets in one call.
+    ///
+    /// This allows specifying the `set_ctx` closure inline easily,
+    /// and also allows you to group the same args together.
+    ///
+    /// The `lens`, `offsets`, and `dirs` are zipped and passed to [`CaseSet::one`],
+    /// where `dirs` can be an array of any type and whose elements are passed back to the `set_ctx` closure.
+    #[inline]
+    pub fn many<T, F, const N: usize>(
+        dirs: [T; N],
+        lens: [usize; N],
+        offsets: [usize; N],
+        mut set_ctx: F,
+    ) where
+        F: SetCtx<T>,
+    {
+        for (dir, (len, offset)) in zip(dirs, zip(lens, offsets)) {
+            set_ctx = Self::one(dir, len, offset, set_ctx);
+        }
+    }
+}


### PR DESCRIPTION
This PR compares the performance of our latest CaseSet on main, the implementation from #1283, and a new macro implementation. The implementation in #1283 is slightly faster than main for multiple case sets in one dispatch, but significantly slower for set_disjoints. The new macro implementation is faster across the board, but does contain an unsafe block to hoist bounds checking outside of the match.