### PR TITLE
`#![allow(non_camel_case_types)]`: Fix and remove

### DIFF
--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -1762,7 +1762,7 @@ impl From<Rav1dFilmGrainData> for Dav1dFilmGrainData {
 
 #[derive(Clone)]
 #[repr(C)]
-pub struct Dav1dFrameHeader_film_grain {
+pub struct Dav1dFrameHeaderFilmGrain {
     pub data: Dav1dFilmGrainData,
     pub present: u8,
     pub update: u8,
@@ -1770,15 +1770,15 @@ pub struct Dav1dFrameHeader_film_grain {
 
 #[derive(Clone, Default)]
 #[repr(C)]
-pub struct Rav1dFrameHeader_film_grain {
+pub struct Rav1dFrameHeaderFilmGrain {
     pub data: Rav1dFilmGrainData,
     pub present: u8,
     pub update: u8,
 }
 
-impl From<Dav1dFrameHeader_film_grain> for Rav1dFrameHeader_film_grain {
-    fn from(value: Dav1dFrameHeader_film_grain) -> Self {
-        let Dav1dFrameHeader_film_grain {
+impl From<Dav1dFrameHeaderFilmGrain> for Rav1dFrameHeaderFilmGrain {
+    fn from(value: Dav1dFrameHeaderFilmGrain) -> Self {
+        let Dav1dFrameHeaderFilmGrain {
             data,
             present,
             update,
@@ -1791,9 +1791,9 @@ impl From<Dav1dFrameHeader_film_grain> for Rav1dFrameHeader_film_grain {
     }
 }
 
-impl From<Rav1dFrameHeader_film_grain> for Dav1dFrameHeader_film_grain {
-    fn from(value: Rav1dFrameHeader_film_grain) -> Self {
-        let Rav1dFrameHeader_film_grain {
+impl From<Rav1dFrameHeaderFilmGrain> for Dav1dFrameHeaderFilmGrain {
+    fn from(value: Rav1dFrameHeaderFilmGrain) -> Self {
+        let Rav1dFrameHeaderFilmGrain {
             data,
             present,
             update,
@@ -1842,21 +1842,21 @@ impl From<Rav1dFrameHeaderOperatingPoint> for Dav1dFrameHeaderOperatingPoint {
 
 #[derive(Clone)]
 #[repr(C)]
-pub struct Dav1dFrameHeader_super_res {
+pub struct Dav1dFrameHeaderSuperRes {
     pub width_scale_denominator: u8,
     pub enabled: u8,
 }
 
 #[derive(Clone, Default)]
 #[repr(C)]
-pub struct Rav1dFrameHeader_super_res {
+pub struct Rav1dFrameHeaderSuperRes {
     pub width_scale_denominator: u8,
     pub enabled: bool,
 }
 
-impl From<Dav1dFrameHeader_super_res> for Rav1dFrameHeader_super_res {
-    fn from(value: Dav1dFrameHeader_super_res) -> Self {
-        let Dav1dFrameHeader_super_res {
+impl From<Dav1dFrameHeaderSuperRes> for Rav1dFrameHeaderSuperRes {
+    fn from(value: Dav1dFrameHeaderSuperRes) -> Self {
+        let Dav1dFrameHeaderSuperRes {
             width_scale_denominator,
             enabled,
         } = value;
@@ -1867,9 +1867,9 @@ impl From<Dav1dFrameHeader_super_res> for Rav1dFrameHeader_super_res {
     }
 }
 
-impl From<Rav1dFrameHeader_super_res> for Dav1dFrameHeader_super_res {
-    fn from(value: Rav1dFrameHeader_super_res) -> Self {
-        let Rav1dFrameHeader_super_res {
+impl From<Rav1dFrameHeaderSuperRes> for Dav1dFrameHeaderSuperRes {
+    fn from(value: Rav1dFrameHeaderSuperRes) -> Self {
+        let Rav1dFrameHeaderSuperRes {
             width_scale_denominator,
             enabled,
         } = value;
@@ -1882,7 +1882,7 @@ impl From<Rav1dFrameHeader_super_res> for Dav1dFrameHeader_super_res {
 
 #[derive(Clone)]
 #[repr(C)]
-pub struct Dav1dFrameHeader_tiling {
+pub struct Dav1dFrameHeaderTiling {
     pub uniform: u8,
     pub n_bytes: u8,
     pub min_log2_cols: u8,
@@ -1900,7 +1900,7 @@ pub struct Dav1dFrameHeader_tiling {
 
 #[derive(Clone)]
 #[repr(C)]
-pub struct Rav1dFrameHeader_tiling {
+pub struct Rav1dFrameHeaderTiling {
     pub uniform: u8,
     pub n_bytes: u8,
     pub min_log2_cols: u8,
@@ -1916,7 +1916,7 @@ pub struct Rav1dFrameHeader_tiling {
     pub update: u16,
 }
 
-impl Default for Rav1dFrameHeader_tiling {
+impl Default for Rav1dFrameHeaderTiling {
     fn default() -> Self {
         Self {
             uniform: Default::default(),
@@ -1936,9 +1936,9 @@ impl Default for Rav1dFrameHeader_tiling {
     }
 }
 
-impl From<Dav1dFrameHeader_tiling> for Rav1dFrameHeader_tiling {
-    fn from(value: Dav1dFrameHeader_tiling) -> Self {
-        let Dav1dFrameHeader_tiling {
+impl From<Dav1dFrameHeaderTiling> for Rav1dFrameHeaderTiling {
+    fn from(value: Dav1dFrameHeaderTiling) -> Self {
+        let Dav1dFrameHeaderTiling {
             uniform,
             n_bytes,
             min_log2_cols,
@@ -1971,9 +1971,9 @@ impl From<Dav1dFrameHeader_tiling> for Rav1dFrameHeader_tiling {
     }
 }
 
-impl From<Rav1dFrameHeader_tiling> for Dav1dFrameHeader_tiling {
-    fn from(value: Rav1dFrameHeader_tiling) -> Self {
-        let Rav1dFrameHeader_tiling {
+impl From<Rav1dFrameHeaderTiling> for Dav1dFrameHeaderTiling {
+    fn from(value: Rav1dFrameHeaderTiling) -> Self {
+        let Rav1dFrameHeaderTiling {
             uniform,
             n_bytes,
             min_log2_cols,
@@ -2008,7 +2008,7 @@ impl From<Rav1dFrameHeader_tiling> for Dav1dFrameHeader_tiling {
 
 #[derive(Clone)]
 #[repr(C)]
-pub struct Dav1dFrameHeader_quant {
+pub struct Dav1dFrameHeaderQuant {
     pub yac: u8,
     pub ydc_delta: i8,
     pub udc_delta: i8,
@@ -2023,7 +2023,7 @@ pub struct Dav1dFrameHeader_quant {
 
 #[derive(Clone, Default)]
 #[repr(C)]
-pub struct Rav1dFrameHeader_quant {
+pub struct Rav1dFrameHeaderQuant {
     pub yac: u8,
     pub ydc_delta: i8,
     pub udc_delta: i8,
@@ -2036,9 +2036,9 @@ pub struct Rav1dFrameHeader_quant {
     pub qm_v: u8,
 }
 
-impl From<Dav1dFrameHeader_quant> for Rav1dFrameHeader_quant {
-    fn from(value: Dav1dFrameHeader_quant) -> Self {
-        let Dav1dFrameHeader_quant {
+impl From<Dav1dFrameHeaderQuant> for Rav1dFrameHeaderQuant {
+    fn from(value: Dav1dFrameHeaderQuant) -> Self {
+        let Dav1dFrameHeaderQuant {
             yac,
             ydc_delta,
             udc_delta,
@@ -2065,9 +2065,9 @@ impl From<Dav1dFrameHeader_quant> for Rav1dFrameHeader_quant {
     }
 }
 
-impl From<Rav1dFrameHeader_quant> for Dav1dFrameHeader_quant {
-    fn from(value: Rav1dFrameHeader_quant) -> Self {
-        let Rav1dFrameHeader_quant {
+impl From<Rav1dFrameHeaderQuant> for Dav1dFrameHeaderQuant {
+    fn from(value: Rav1dFrameHeaderQuant) -> Self {
+        let Rav1dFrameHeaderQuant {
             yac,
             ydc_delta,
             udc_delta,
@@ -2096,7 +2096,7 @@ impl From<Rav1dFrameHeader_quant> for Dav1dFrameHeader_quant {
 
 #[derive(Clone)]
 #[repr(C)]
-pub struct Dav1dFrameHeader_segmentation {
+pub struct Dav1dFrameHeaderSegmentation {
     pub enabled: u8,
     pub update_map: u8,
     pub temporal: u8,
@@ -2108,7 +2108,7 @@ pub struct Dav1dFrameHeader_segmentation {
 
 #[derive(Clone, Default)]
 #[repr(C)]
-pub struct Rav1dFrameHeader_segmentation {
+pub struct Rav1dFrameHeaderSegmentation {
     pub enabled: u8,
     pub update_map: u8,
     pub temporal: u8,
@@ -2119,9 +2119,9 @@ pub struct Rav1dFrameHeader_segmentation {
     pub qidx: [u8; SegmentId::COUNT],
 }
 
-impl From<Dav1dFrameHeader_segmentation> for Rav1dFrameHeader_segmentation {
-    fn from(value: Dav1dFrameHeader_segmentation) -> Self {
-        let Dav1dFrameHeader_segmentation {
+impl From<Dav1dFrameHeaderSegmentation> for Rav1dFrameHeaderSegmentation {
+    fn from(value: Dav1dFrameHeaderSegmentation) -> Self {
+        let Dav1dFrameHeaderSegmentation {
             enabled,
             update_map,
             temporal,
@@ -2142,9 +2142,9 @@ impl From<Dav1dFrameHeader_segmentation> for Rav1dFrameHeader_segmentation {
     }
 }
 
-impl From<Rav1dFrameHeader_segmentation> for Dav1dFrameHeader_segmentation {
-    fn from(value: Rav1dFrameHeader_segmentation) -> Self {
-        let Rav1dFrameHeader_segmentation {
+impl From<Rav1dFrameHeaderSegmentation> for Dav1dFrameHeaderSegmentation {
+    fn from(value: Rav1dFrameHeaderSegmentation) -> Self {
+        let Rav1dFrameHeaderSegmentation {
             enabled,
             update_map,
             temporal,
@@ -2167,35 +2167,35 @@ impl From<Rav1dFrameHeader_segmentation> for Dav1dFrameHeader_segmentation {
 
 #[derive(Clone)]
 #[repr(C)]
-pub struct Dav1dFrameHeader_delta_q {
+pub struct Dav1dFrameHeaderDeltaQ {
     pub present: u8,
     pub res_log2: u8,
 }
 
 #[derive(Clone, Default)]
 #[repr(C)]
-pub struct Rav1dFrameHeader_delta_q {
+pub struct Rav1dFrameHeaderDeltaQ {
     pub present: u8,
     pub res_log2: u8,
 }
 
-impl From<Dav1dFrameHeader_delta_q> for Rav1dFrameHeader_delta_q {
-    fn from(value: Dav1dFrameHeader_delta_q) -> Self {
-        let Dav1dFrameHeader_delta_q { present, res_log2 } = value;
+impl From<Dav1dFrameHeaderDeltaQ> for Rav1dFrameHeaderDeltaQ {
+    fn from(value: Dav1dFrameHeaderDeltaQ) -> Self {
+        let Dav1dFrameHeaderDeltaQ { present, res_log2 } = value;
         Self { present, res_log2 }
     }
 }
 
-impl From<Rav1dFrameHeader_delta_q> for Dav1dFrameHeader_delta_q {
-    fn from(value: Rav1dFrameHeader_delta_q) -> Self {
-        let Rav1dFrameHeader_delta_q { present, res_log2 } = value;
+impl From<Rav1dFrameHeaderDeltaQ> for Dav1dFrameHeaderDeltaQ {
+    fn from(value: Rav1dFrameHeaderDeltaQ) -> Self {
+        let Rav1dFrameHeaderDeltaQ { present, res_log2 } = value;
         Self { present, res_log2 }
     }
 }
 
 #[derive(Clone)]
 #[repr(C)]
-pub struct Dav1dFrameHeader_delta_lf {
+pub struct Dav1dFrameHeaderDeltaLF {
     pub present: u8,
     pub res_log2: u8,
     pub multi: u8,
@@ -2203,15 +2203,15 @@ pub struct Dav1dFrameHeader_delta_lf {
 
 #[derive(Clone, Default)]
 #[repr(C)]
-pub struct Rav1dFrameHeader_delta_lf {
+pub struct Rav1dFrameHeaderDeltaLF {
     pub present: u8,
     pub res_log2: u8,
     pub multi: u8,
 }
 
-impl From<Dav1dFrameHeader_delta_lf> for Rav1dFrameHeader_delta_lf {
-    fn from(value: Dav1dFrameHeader_delta_lf) -> Self {
-        let Dav1dFrameHeader_delta_lf {
+impl From<Dav1dFrameHeaderDeltaLF> for Rav1dFrameHeaderDeltaLF {
+    fn from(value: Dav1dFrameHeaderDeltaLF) -> Self {
+        let Dav1dFrameHeaderDeltaLF {
             present,
             res_log2,
             multi,
@@ -2224,9 +2224,9 @@ impl From<Dav1dFrameHeader_delta_lf> for Rav1dFrameHeader_delta_lf {
     }
 }
 
-impl From<Rav1dFrameHeader_delta_lf> for Dav1dFrameHeader_delta_lf {
-    fn from(value: Rav1dFrameHeader_delta_lf) -> Self {
-        let Rav1dFrameHeader_delta_lf {
+impl From<Rav1dFrameHeaderDeltaLF> for Dav1dFrameHeaderDeltaLF {
+    fn from(value: Rav1dFrameHeaderDeltaLF) -> Self {
+        let Rav1dFrameHeaderDeltaLF {
             present,
             res_log2,
             multi,
@@ -2241,21 +2241,21 @@ impl From<Rav1dFrameHeader_delta_lf> for Dav1dFrameHeader_delta_lf {
 
 #[derive(Clone)]
 #[repr(C)]
-pub struct Dav1dFrameHeader_delta {
-    pub q: Dav1dFrameHeader_delta_q,
-    pub lf: Dav1dFrameHeader_delta_lf,
+pub struct Dav1dFrameHeaderDelta {
+    pub q: Dav1dFrameHeaderDeltaQ,
+    pub lf: Dav1dFrameHeaderDeltaLF,
 }
 
 #[derive(Clone, Default)]
 #[repr(C)]
-pub struct Rav1dFrameHeader_delta {
-    pub q: Rav1dFrameHeader_delta_q,
-    pub lf: Rav1dFrameHeader_delta_lf,
+pub struct Rav1dFrameHeaderDelta {
+    pub q: Rav1dFrameHeaderDeltaQ,
+    pub lf: Rav1dFrameHeaderDeltaLF,
 }
 
-impl From<Dav1dFrameHeader_delta> for Rav1dFrameHeader_delta {
-    fn from(value: Dav1dFrameHeader_delta) -> Self {
-        let Dav1dFrameHeader_delta { q, lf } = value;
+impl From<Dav1dFrameHeaderDelta> for Rav1dFrameHeaderDelta {
+    fn from(value: Dav1dFrameHeaderDelta) -> Self {
+        let Dav1dFrameHeaderDelta { q, lf } = value;
         Self {
             q: q.into(),
             lf: lf.into(),
@@ -2263,9 +2263,9 @@ impl From<Dav1dFrameHeader_delta> for Rav1dFrameHeader_delta {
     }
 }
 
-impl From<Rav1dFrameHeader_delta> for Dav1dFrameHeader_delta {
-    fn from(value: Rav1dFrameHeader_delta) -> Self {
-        let Rav1dFrameHeader_delta { q, lf } = value;
+impl From<Rav1dFrameHeaderDelta> for Dav1dFrameHeaderDelta {
+    fn from(value: Rav1dFrameHeaderDelta) -> Self {
+        let Rav1dFrameHeaderDelta { q, lf } = value;
         Self {
             q: q.into(),
             lf: lf.into(),
@@ -2275,7 +2275,7 @@ impl From<Rav1dFrameHeader_delta> for Dav1dFrameHeader_delta {
 
 #[derive(Clone)]
 #[repr(C)]
-pub struct Dav1dFrameHeader_loopfilter {
+pub struct Dav1dFrameHeaderLoopFilter {
     pub level_y: [u8; 2],
     pub level_u: u8,
     pub level_v: u8,
@@ -2287,7 +2287,7 @@ pub struct Dav1dFrameHeader_loopfilter {
 
 #[derive(Clone, Default)]
 #[repr(C)]
-pub struct Rav1dFrameHeader_loopfilter {
+pub struct Rav1dFrameHeaderLoopFilter {
     pub level_y: [u8; 2],
     pub level_u: u8,
     pub level_v: u8,
@@ -2297,9 +2297,9 @@ pub struct Rav1dFrameHeader_loopfilter {
     pub sharpness: u8,
 }
 
-impl From<Dav1dFrameHeader_loopfilter> for Rav1dFrameHeader_loopfilter {
-    fn from(value: Dav1dFrameHeader_loopfilter) -> Self {
-        let Dav1dFrameHeader_loopfilter {
+impl From<Dav1dFrameHeaderLoopFilter> for Rav1dFrameHeaderLoopFilter {
+    fn from(value: Dav1dFrameHeaderLoopFilter) -> Self {
+        let Dav1dFrameHeaderLoopFilter {
             level_y,
             level_u,
             level_v,
@@ -2320,9 +2320,9 @@ impl From<Dav1dFrameHeader_loopfilter> for Rav1dFrameHeader_loopfilter {
     }
 }
 
-impl From<Rav1dFrameHeader_loopfilter> for Dav1dFrameHeader_loopfilter {
-    fn from(value: Rav1dFrameHeader_loopfilter) -> Self {
-        let Rav1dFrameHeader_loopfilter {
+impl From<Rav1dFrameHeaderLoopFilter> for Dav1dFrameHeaderLoopFilter {
+    fn from(value: Rav1dFrameHeaderLoopFilter) -> Self {
+        let Rav1dFrameHeaderLoopFilter {
             level_y,
             level_u,
             level_v,
@@ -2345,7 +2345,7 @@ impl From<Rav1dFrameHeader_loopfilter> for Dav1dFrameHeader_loopfilter {
 
 #[derive(Clone)]
 #[repr(C)]
-pub struct Dav1dFrameHeader_cdef {
+pub struct Dav1dFrameHeaderCdef {
     pub damping: u8,
     pub n_bits: u8,
     pub y_strength: [u8; DAV1D_MAX_CDEF_STRENGTHS],
@@ -2354,16 +2354,16 @@ pub struct Dav1dFrameHeader_cdef {
 
 #[derive(Clone, Default)]
 #[repr(C)]
-pub struct Rav1dFrameHeader_cdef {
+pub struct Rav1dFrameHeaderCdef {
     pub damping: u8,
     pub n_bits: u8,
     pub y_strength: [u8; RAV1D_MAX_CDEF_STRENGTHS],
     pub uv_strength: [u8; RAV1D_MAX_CDEF_STRENGTHS],
 }
 
-impl From<Dav1dFrameHeader_cdef> for Rav1dFrameHeader_cdef {
-    fn from(value: Dav1dFrameHeader_cdef) -> Self {
-        let Dav1dFrameHeader_cdef {
+impl From<Dav1dFrameHeaderCdef> for Rav1dFrameHeaderCdef {
+    fn from(value: Dav1dFrameHeaderCdef) -> Self {
+        let Dav1dFrameHeaderCdef {
             damping,
             n_bits,
             y_strength,
@@ -2378,9 +2378,9 @@ impl From<Dav1dFrameHeader_cdef> for Rav1dFrameHeader_cdef {
     }
 }
 
-impl From<Rav1dFrameHeader_cdef> for Dav1dFrameHeader_cdef {
-    fn from(value: Rav1dFrameHeader_cdef) -> Self {
-        let Rav1dFrameHeader_cdef {
+impl From<Rav1dFrameHeaderCdef> for Dav1dFrameHeaderCdef {
+    fn from(value: Rav1dFrameHeaderCdef) -> Self {
+        let Rav1dFrameHeaderCdef {
             damping,
             n_bits,
             y_strength,
@@ -2397,21 +2397,21 @@ impl From<Rav1dFrameHeader_cdef> for Dav1dFrameHeader_cdef {
 
 #[derive(Clone)]
 #[repr(C)]
-pub struct Dav1dFrameHeader_restoration {
+pub struct Dav1dFrameHeaderRestoration {
     pub r#type: [Dav1dRestorationType; 3],
     pub unit_size: [u8; 2],
 }
 
 #[derive(Clone, Default)]
 #[repr(C)]
-pub struct Rav1dFrameHeader_restoration {
+pub struct Rav1dFrameHeaderRestoration {
     pub r#type: [Rav1dRestorationType; 3],
     pub unit_size: [u8; 2],
 }
 
-impl From<Dav1dFrameHeader_restoration> for Rav1dFrameHeader_restoration {
-    fn from(value: Dav1dFrameHeader_restoration) -> Self {
-        let Dav1dFrameHeader_restoration { r#type, unit_size } = value;
+impl From<Dav1dFrameHeaderRestoration> for Rav1dFrameHeaderRestoration {
+    fn from(value: Dav1dFrameHeaderRestoration) -> Self {
+        let Dav1dFrameHeaderRestoration { r#type, unit_size } = value;
         Self {
             r#type: r#type.map(|e| Rav1dRestorationType::from_repr(e as usize).unwrap()),
             unit_size,
@@ -2419,9 +2419,9 @@ impl From<Dav1dFrameHeader_restoration> for Rav1dFrameHeader_restoration {
     }
 }
 
-impl From<Rav1dFrameHeader_restoration> for Dav1dFrameHeader_restoration {
-    fn from(value: Rav1dFrameHeader_restoration) -> Self {
-        let Rav1dFrameHeader_restoration { r#type, unit_size } = value;
+impl From<Rav1dFrameHeaderRestoration> for Dav1dFrameHeaderRestoration {
+    fn from(value: Rav1dFrameHeaderRestoration) -> Self {
+        let Rav1dFrameHeaderRestoration { r#type, unit_size } = value;
         Self {
             r#type: r#type.map(|e| e.to_repr()),
             unit_size,
@@ -2432,7 +2432,7 @@ impl From<Rav1dFrameHeader_restoration> for Dav1dFrameHeader_restoration {
 #[derive(Clone)]
 #[repr(C)]
 pub struct Dav1dFrameHeader {
-    pub film_grain: Dav1dFrameHeader_film_grain,
+    pub film_grain: Dav1dFrameHeaderFilmGrain,
     pub frame_type: Dav1dFrameType,
     pub width: [c_int; 2],
     pub height: c_int,
@@ -2456,7 +2456,7 @@ pub struct Dav1dFrameHeader {
     pub refresh_frame_flags: u8,
     pub render_width: c_int,
     pub render_height: c_int,
-    pub super_res: Dav1dFrameHeader_super_res,
+    pub super_res: Dav1dFrameHeaderSuperRes,
     pub have_render_size: u8,
     pub allow_intrabc: u8,
     pub frame_ref_short_signaling: u8,
@@ -2466,14 +2466,14 @@ pub struct Dav1dFrameHeader {
     pub switchable_motion_mode: u8,
     pub use_ref_frame_mvs: u8,
     pub refresh_context: u8,
-    pub tiling: Dav1dFrameHeader_tiling,
-    pub quant: Dav1dFrameHeader_quant,
-    pub segmentation: Dav1dFrameHeader_segmentation,
-    pub delta: Dav1dFrameHeader_delta,
+    pub tiling: Dav1dFrameHeaderTiling,
+    pub quant: Dav1dFrameHeaderQuant,
+    pub segmentation: Dav1dFrameHeaderSegmentation,
+    pub delta: Dav1dFrameHeaderDelta,
     pub all_lossless: u8,
-    pub loopfilter: Dav1dFrameHeader_loopfilter,
-    pub cdef: Dav1dFrameHeader_cdef,
-    pub restoration: Dav1dFrameHeader_restoration,
+    pub loopfilter: Dav1dFrameHeaderLoopFilter,
+    pub cdef: Dav1dFrameHeaderCdef,
+    pub restoration: Dav1dFrameHeaderRestoration,
     pub txfm_mode: Dav1dTxfmMode,
     pub switchable_comp_refs: u8,
     pub skip_mode_allowed: u8,
@@ -2491,7 +2491,7 @@ pub struct Rav1dFrameSize {
     pub height: c_int,
     pub render_width: c_int,
     pub render_height: c_int,
-    pub super_res: Rav1dFrameHeader_super_res,
+    pub super_res: Rav1dFrameHeaderSuperRes,
     pub have_render_size: u8,
 }
 
@@ -2507,7 +2507,7 @@ pub struct Rav1dFrameSkipMode {
 #[repr(C)]
 pub struct Rav1dFrameHeader {
     pub size: Rav1dFrameSize,
-    pub film_grain: Rav1dFrameHeader_film_grain,
+    pub film_grain: Rav1dFrameHeaderFilmGrain,
     pub frame_type: Rav1dFrameType,
     pub frame_offset: u8,
     pub temporal_id: u8,
@@ -2535,14 +2535,14 @@ pub struct Rav1dFrameHeader {
     pub switchable_motion_mode: u8,
     pub use_ref_frame_mvs: u8,
     pub refresh_context: u8,
-    pub tiling: Rav1dFrameHeader_tiling,
-    pub quant: Rav1dFrameHeader_quant,
-    pub segmentation: Rav1dFrameHeader_segmentation,
-    pub delta: Rav1dFrameHeader_delta,
+    pub tiling: Rav1dFrameHeaderTiling,
+    pub quant: Rav1dFrameHeaderQuant,
+    pub segmentation: Rav1dFrameHeaderSegmentation,
+    pub delta: Rav1dFrameHeaderDelta,
     pub all_lossless: bool,
-    pub loopfilter: Rav1dFrameHeader_loopfilter,
-    pub cdef: Rav1dFrameHeader_cdef,
-    pub restoration: Rav1dFrameHeader_restoration,
+    pub loopfilter: Rav1dFrameHeaderLoopFilter,
+    pub cdef: Rav1dFrameHeaderCdef,
+    pub restoration: Rav1dFrameHeaderRestoration,
     pub txfm_mode: Rav1dTxfmMode,
     pub switchable_comp_refs: u8,
     pub skip_mode: Rav1dFrameSkipMode,

--- a/lib.rs
+++ b/lib.rs
@@ -1,4 +1,3 @@
-#![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![cfg_attr(target_arch = "arm", feature(stdarch_arm_feature_detection))]

--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -169,7 +169,7 @@ impl Default for CdfModeInterContext {
 #[derive(Clone)]
 pub enum CdfThreadContext {
     QCat(c_uint),
-    Cdf(Arc<CdfThreadContext_data>),
+    Cdf(Arc<CdfThreadContextData>),
 }
 
 impl CdfThreadContext {
@@ -195,7 +195,7 @@ impl Default for CdfThreadContext {
 }
 
 #[repr(C)]
-pub struct CdfThreadContext_data {
+pub struct CdfThreadContextData {
     /// This context should not be contended but needs interior mutability. It
     /// should always be accessible with `.try_*` methods.
     cdf: RwLock<CdfContext>,
@@ -5106,7 +5106,7 @@ pub fn rav1d_cdf_thread_copy(src: &CdfThreadContext) -> CdfContext {
 pub fn rav1d_cdf_thread_alloc(have_frame_mt: bool) -> Rav1dResult<CdfThreadContext> {
     // TODO fallible allocation
     // Previously pooled.
-    Ok(CdfThreadContext::Cdf(Arc::new(CdfThreadContext_data {
+    Ok(CdfThreadContext::Cdf(Arc::new(CdfThreadContextData {
         cdf: Default::default(),
         progress: have_frame_mt.then_some(AtomicU32::new(0)),
     })))

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -7,7 +7,7 @@ use crate::include::common::intops::iclip;
 use crate::include::dav1d::common::Rav1dDataProps;
 use crate::include::dav1d::headers::Rav1dFilterMode;
 use crate::include::dav1d::headers::Rav1dFrameHeader;
-use crate::include::dav1d::headers::Rav1dFrameHeader_tiling;
+use crate::include::dav1d::headers::Rav1dFrameHeaderTiling;
 use crate::include::dav1d::headers::Rav1dPixelLayout;
 use crate::include::dav1d::headers::Rav1dRestorationType;
 use crate::include::dav1d::headers::Rav1dSequenceHeader;
@@ -4790,7 +4790,7 @@ fn rav1d_decode_frame_main(c: &Rav1dContext, f: &mut Rav1dFrameData) -> Rav1dRes
 
     // no threading - we explicitly interleave tile/sbrow decoding
     // and post-filtering, so that the full process runs in-line
-    let Rav1dFrameHeader_tiling { rows, cols, .. } = frame_hdr.tiling;
+    let Rav1dFrameHeaderTiling { rows, cols, .. } = frame_hdr.tiling;
     let [rows, cols] = [rows, cols].map(|it| it.try_into().unwrap());
     // Need to clone this because `(f.bd_fn().filter_sbrow)(f, sby);` takes a `&mut` to `f` within the loop.
     let row_start_sb = frame_hdr.tiling.row_start_sb.clone();

--- a/src/ipred_prepare.rs
+++ b/src/ipred_prepare.rs
@@ -73,11 +73,11 @@ bitflags! {
 }
 
 #[derive(Clone, Copy)]
-struct av1_intra_prediction_edge {
+struct Av1IntraPredictionEdge {
     pub needs: Needs,
 }
 
-static av1_intra_prediction_edges: [av1_intra_prediction_edge; N_IMPL_INTRA_PRED_MODES] = {
+static av1_intra_prediction_edges: [Av1IntraPredictionEdge; N_IMPL_INTRA_PRED_MODES] = {
     const LEFT: Needs = Needs::LEFT;
     const TOP: Needs = Needs::TOP;
     const TOP_LEFT: Needs = Needs::TOP_LEFT;
@@ -108,7 +108,7 @@ static av1_intra_prediction_edges: [av1_intra_prediction_edge; N_IMPL_INTRA_PRED
     a[PAETH_PRED as usize] = all([LEFT, TOP, TOP_LEFT]);
     a[FILTER_PRED as usize] = all([LEFT, TOP, TOP_LEFT]);
 
-    let mut b = [av1_intra_prediction_edge {
+    let mut b = [Av1IntraPredictionEdge {
         needs: Needs::empty(),
     }; N_IMPL_INTRA_PRED_MODES];
     const_for!(i in 0..N_IMPL_INTRA_PRED_MODES => {

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -60,7 +60,7 @@ use crate::include::common::bitdepth::bd_fn;
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 use crate::include::common::bitdepth::bpc_fn;
 
-pub type itx_1d_fn = fn(c: &mut [i32], stride: NonZeroUsize, min: i32, max: i32);
+pub type Itx1dFn = fn(c: &mut [i32], stride: NonZeroUsize, min: i32, max: i32);
 
 #[inline(never)]
 fn inv_txfm_add<BD: BitDepth>(
@@ -70,8 +70,8 @@ fn inv_txfm_add<BD: BitDepth>(
     w: usize,
     h: usize,
     shift: u8,
-    first_1d_fn: itx_1d_fn,
-    second_1d_fn: itx_1d_fn,
+    first_1d_fn: Itx1dFn,
+    second_1d_fn: Itx1dFn,
     has_dc_only: bool,
     bd: BD,
 ) {
@@ -218,7 +218,7 @@ fn inv_txfm_add_rust<const W: usize, const H: usize, const TYPE: TxfmType, BD: B
         _ => unreachable!(),
     };
 
-    fn resolve_1d_fn(r#type: Type, n: usize) -> itx_1d_fn {
+    fn resolve_1d_fn(r#type: Type, n: usize) -> Itx1dFn {
         match (r#type, n) {
             (Identity, 4) => rav1d_inv_identity4_1d_c,
             (Identity, 8) => rav1d_inv_identity8_1d_c,

--- a/src/levels.rs
+++ b/src/levels.rs
@@ -356,12 +356,12 @@ pub enum InterIntraType {
 /// [`refmvs_block`]: crate::src::refmvs::refmvs_block
 #[derive(Clone, Copy, PartialEq, Eq, Default, FromZeroes, FromBytes, AsBytes)]
 #[repr(C)]
-pub struct mv {
+pub struct Mv {
     pub y: i16,
     pub x: i16,
 }
 
-impl mv {
+impl Mv {
     pub const ZERO: Self = Self { y: 0, x: 0 };
 
     pub const INVALID: Self = Self {
@@ -379,7 +379,7 @@ impl mv {
     }
 }
 
-impl Neg for mv {
+impl Neg for Mv {
     type Output = Self;
 
     fn neg(self) -> Self::Output {
@@ -451,7 +451,7 @@ impl From<MaskedInterIntraPredMode> for InterIntraPredMode {
 #[derive(Clone, Default, FromZeroes, FromBytes, AsBytes)]
 #[repr(C)]
 pub struct Av1BlockInter1d {
-    pub mv: [mv; 2],
+    pub mv: [Mv; 2],
     pub wedge_idx: u8,
 
     /// Stored as a [`u8`] since [`bool`] is not [`FromBytes`].
@@ -472,7 +472,7 @@ impl Av1BlockInter1d {
 #[derive(Clone, FromZeroes, FromBytes, AsBytes)]
 #[repr(C)]
 pub struct Av1BlockInter2d {
-    pub mv2d: mv,
+    pub mv2d: Mv,
 
     /// These are `i14`s (except for an [`i16::MIN`] stored as a discriminant).
     /// Not sure how we could stably use that niche, though.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,13 +33,13 @@ use crate::src::extensions::OptionError as _;
 use crate::src::fg_apply;
 use crate::src::internal::Rav1dBitDepthDSPContext;
 use crate::src::internal::Rav1dContext;
+use crate::src::internal::Rav1dContextFrameThread;
 use crate::src::internal::Rav1dContextTaskThread;
 use crate::src::internal::Rav1dContextTaskType;
-use crate::src::internal::Rav1dContext_frame_thread;
 use crate::src::internal::Rav1dFrameContext;
 use crate::src::internal::Rav1dState;
 use crate::src::internal::Rav1dTaskContext;
-use crate::src::internal::Rav1dTaskContext_task_thread;
+use crate::src::internal::Rav1dTaskContextTaskThread;
 use crate::src::internal::TaskThreadData;
 use crate::src::iter::wrapping_iter;
 use crate::src::log::Rav1dLog as _;
@@ -237,7 +237,7 @@ pub(crate) fn rav1d_open(s: &Rav1dSettings) -> Rav1dResult<Arc<Rav1dContext>> {
         .collect();
 
     let state = Mutex::new(Rav1dState {
-        frame_thread: Rav1dContext_frame_thread {
+        frame_thread: Rav1dContextFrameThread {
             out_delayed: if n_fc > 1 {
                 (0..n_fc).map(|_| Default::default()).collect()
             } else {
@@ -251,7 +251,7 @@ pub(crate) fn rav1d_open(s: &Rav1dSettings) -> Rav1dResult<Arc<Rav1dContext>> {
     let tc = (0..n_tc)
         .map(|n| {
             let task_thread = Arc::clone(&task_thread);
-            let thread_data = Arc::new(Rav1dTaskContext_task_thread::new(task_thread));
+            let thread_data = Arc::new(Rav1dTaskContextTaskThread::new(task_thread));
             let thread_data_copy = Arc::clone(&thread_data);
             let task = if n_tc > 1 {
                 let handle = thread::Builder::new()

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -37,7 +37,6 @@ use crate::src::intra_edge::EdgeFlags;
 use crate::src::ipred_prepare::rav1d_prepare_intra_edges;
 use crate::src::ipred_prepare::sm_flag;
 use crate::src::ipred_prepare::sm_uv_flag;
-use crate::src::levels::mv;
 use crate::src::levels::Av1Block;
 use crate::src::levels::Av1BlockInter;
 use crate::src::levels::Av1BlockIntra;
@@ -49,6 +48,7 @@ use crate::src::levels::InterIntraPredMode;
 use crate::src::levels::InterIntraType;
 use crate::src::levels::IntraPredMode;
 use crate::src::levels::MotionMode;
+use crate::src::levels::Mv;
 use crate::src::levels::TxClass;
 use crate::src::levels::TxfmSize;
 use crate::src::levels::TxfmType;
@@ -128,7 +128,7 @@ pub(crate) use debug_block_info;
 
 const DEBUG_B_PIXELS: bool = false;
 
-pub(crate) type recon_b_intra_fn = fn(
+pub(crate) type ReconBIntraFn = fn(
     &Rav1dFrameData,
     &mut Rav1dTaskContext,
     Option<&mut Rav1dTileStateContext>,
@@ -138,7 +138,7 @@ pub(crate) type recon_b_intra_fn = fn(
     &Av1BlockIntra,
 ) -> ();
 
-pub(crate) type recon_b_inter_fn = fn(
+pub(crate) type ReconBInterFn = fn(
     &Rav1dFrameData,
     &mut Rav1dTaskContext,
     Option<&mut Rav1dTileStateContext>,
@@ -147,12 +147,12 @@ pub(crate) type recon_b_inter_fn = fn(
     &Av1BlockInter,
 ) -> Result<(), ()>;
 
-pub(crate) type filter_sbrow_fn =
+pub(crate) type FilterSbrowFn =
     fn(&Rav1dContext, &Rav1dFrameData, &mut Rav1dTaskContext, c_int) -> ();
 
-pub(crate) type backup_ipred_edge_fn = fn(&Rav1dFrameData, &mut Rav1dTaskContext) -> ();
+pub(crate) type BackupIpredEdgeFn = fn(&Rav1dFrameData, &mut Rav1dTaskContext) -> ();
 
-pub(crate) type read_coef_blocks_fn = fn(
+pub(crate) type ReadCoefBlocksFn = fn(
     &Rav1dFrameData,
     &mut Rav1dTaskContext,
     &mut Rav1dTileStateContext,
@@ -160,7 +160,7 @@ pub(crate) type read_coef_blocks_fn = fn(
     &Av1Block,
 ) -> ();
 
-pub(crate) type copy_pal_block_fn = fn(
+pub(crate) type CopyPalBlockFn = fn(
     t: &mut Rav1dTaskContext,
     f: &Rav1dFrameData,
     bx4: usize,
@@ -169,7 +169,7 @@ pub(crate) type copy_pal_block_fn = fn(
     bh4: usize,
 ) -> ();
 
-pub(crate) type read_pal_plane_fn = fn(
+pub(crate) type ReadPalPlaneFn = fn(
     t: &mut Rav1dTaskContext,
     f: &Rav1dFrameData,
     ts_c: &mut Rav1dTileStateContext,
@@ -179,7 +179,7 @@ pub(crate) type read_pal_plane_fn = fn(
     by4: usize,
 ) -> u8; // `pal_sz`
 
-pub(crate) type read_pal_uv_fn = fn(
+pub(crate) type ReadPalUVFn = fn(
     t: &mut Rav1dTaskContext,
     f: &Rav1dFrameData,
     ts_c: &mut Rav1dTileStateContext,
@@ -1716,7 +1716,7 @@ fn mc<BD: BitDepth>(
     bx: c_int,
     by: c_int,
     pl: usize,
-    mv: mv,
+    mv: Mv,
     refp: &Rav1dThreadPicture,
     refidx: usize,
     filter_2d: Filter2d,

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -20,11 +20,11 @@ use crate::src::internal::Grain;
 use crate::src::internal::Rav1dBitDepthDSPContext;
 use crate::src::internal::Rav1dContext;
 use crate::src::internal::Rav1dFrameContext;
-use crate::src::internal::Rav1dFrameContext_task_thread;
+use crate::src::internal::Rav1dFrameContextTaskThread;
 use crate::src::internal::Rav1dFrameData;
 use crate::src::internal::Rav1dTask;
 use crate::src::internal::Rav1dTaskContext;
-use crate::src::internal::Rav1dTaskContext_task_thread;
+use crate::src::internal::Rav1dTaskContextTaskThread;
 use crate::src::internal::TaskThreadData;
 use crate::src::internal::TaskType;
 use crate::src::iter::wrapping_iter;
@@ -340,7 +340,7 @@ impl Rav1dTasks {
     }
 }
 
-impl Rav1dFrameContext_task_thread {
+impl Rav1dFrameContextTaskThread {
     fn insert_task(&self, c: &Rav1dContext, task: Rav1dTask, cond_signal: c_int) -> Rav1dTaskIndex {
         let idx = self.tasks.push(task);
         self.tasks.insert_tasks(c, idx, idx, cond_signal);
@@ -542,7 +542,7 @@ fn ensure_progress<'l, 'ttd: 'l>(
 #[inline]
 fn check_tile(
     f: &Rav1dFrameData,
-    task_thread: &Rav1dFrameContext_task_thread,
+    task_thread: &Rav1dFrameContextTaskThread,
     t: &Rav1dTask,
     frame_mt: c_int,
 ) -> c_int {
@@ -772,7 +772,7 @@ fn delayed_fg_task<'l, 'ttd: 'l>(
     }
 }
 
-pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContext_task_thread>) {
+pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContextTaskThread>) {
     // The main thread will unpark us once `task_thread.c` is set.
     thread::park();
     let c = &*task_thread.c.lock().take().unwrap();

--- a/src/warpmv.rs
+++ b/src/warpmv.rs
@@ -4,7 +4,7 @@ use crate::include::common::intops::iclip;
 use crate::include::common::intops::u64log2;
 use crate::include::common::intops::ulog2;
 use crate::include::dav1d::headers::Rav1dWarpedMotionParams;
-use crate::src::levels::mv;
+use crate::src::levels::Mv;
 use std::ffi::c_int;
 
 static div_lut: [u16; 257] = [
@@ -100,7 +100,7 @@ fn get_mult_shift_diag(px: i64, idet: c_int, shift: c_int) -> c_int {
 pub(crate) fn rav1d_set_affine_mv2d(
     bw4: c_int,
     bh4: c_int,
-    mv: mv,
+    mv: Mv,
     wm: &mut Rav1dWarpedMotionParams,
     bx4: c_int,
     by4: c_int,
@@ -128,7 +128,7 @@ pub(crate) fn rav1d_find_affine_int(
     np: usize,
     bw4: c_int,
     bh4: c_int,
-    mv: mv,
+    mv: Mv,
     wm: &mut Rav1dWarpedMotionParams,
     bx4: c_int,
     by4: c_int,

--- a/tests/seek_stress.rs
+++ b/tests/seek_stress.rs
@@ -1,4 +1,3 @@
-#![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 #![feature(extern_types)]
 #![feature(c_variadic)]

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -1,4 +1,3 @@
-#![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 #![feature(extern_types)]
 #![feature(c_variadic)]

--- a/tools/dav1d_cli_parse.rs
+++ b/tools/dav1d_cli_parse.rs
@@ -51,12 +51,12 @@ extern "C" {
 
 // TODO(kkysen) These are used in `dav1d.rs` and `seek_stress.rs`
 // but are still marked as unused since `[[bin]]` are only supposed to be one file in `cargo`.
-pub type CLISettings_realtime = c_uint;
+pub type CLISettingsRealTime = c_uint;
 #[allow(dead_code)]
-pub const REALTIME_CUSTOM: CLISettings_realtime = 2;
+pub const REALTIME_CUSTOM: CLISettingsRealTime = 2;
 #[allow(dead_code)]
-pub const REALTIME_INPUT: CLISettings_realtime = 1;
-pub const REALTIME_DISABLE: CLISettings_realtime = 0;
+pub const REALTIME_INPUT: CLISettingsRealTime = 1;
+pub const REALTIME_DISABLE: CLISettingsRealTime = 0;
 
 #[repr(C)]
 pub struct CLISettings {
@@ -69,7 +69,7 @@ pub struct CLISettings {
     pub limit: c_uint,
     pub skip: c_uint,
     pub quiet: c_int,
-    pub realtime: CLISettings_realtime,
+    pub realtime: CLISettingsRealTime,
     pub realtime_fps: c_double,
     pub realtime_cache: c_uint,
     pub neg_stride: c_int,
@@ -81,24 +81,24 @@ pub struct EnumParseTable {
     pub val: c_int,
 }
 
-pub const ARG_DECODE_FRAME_TYPE: arg = 273;
-pub const ARG_INLOOP_FILTERS: arg = 272;
-pub const ARG_OUTPUT_INVISIBLE: arg = 271;
-pub const ARG_NEG_STRIDE: arg = 270;
-pub const ARG_CPU_MASK: arg = 269;
-pub const ARG_STRICT_STD_COMPLIANCE: arg = 268;
-pub const ARG_SIZE_LIMIT: arg = 267;
-pub const ARG_ALL_LAYERS: arg = 266;
-pub const ARG_OPPOINT: arg = 265;
-pub const ARG_FILM_GRAIN: arg = 264;
-pub const ARG_VERIFY: arg = 263;
-pub const ARG_FRAME_DELAY: arg = 262;
-pub const ARG_THREADS: arg = 261;
-pub const ARG_REALTIME_CACHE: arg = 260;
-pub const ARG_REALTIME: arg = 259;
-pub const ARG_FRAME_TIMES: arg = 258;
-pub const ARG_MUXER: arg = 257;
-pub const ARG_DEMUXER: arg = 256;
+pub const ARG_DECODE_FRAME_TYPE: Arg = 273;
+pub const ARG_INLOOP_FILTERS: Arg = 272;
+pub const ARG_OUTPUT_INVISIBLE: Arg = 271;
+pub const ARG_NEG_STRIDE: Arg = 270;
+pub const ARG_CPU_MASK: Arg = 269;
+pub const ARG_STRICT_STD_COMPLIANCE: Arg = 268;
+pub const ARG_SIZE_LIMIT: Arg = 267;
+pub const ARG_ALL_LAYERS: Arg = 266;
+pub const ARG_OPPOINT: Arg = 265;
+pub const ARG_FILM_GRAIN: Arg = 264;
+pub const ARG_VERIFY: Arg = 263;
+pub const ARG_FRAME_DELAY: Arg = 262;
+pub const ARG_THREADS: Arg = 261;
+pub const ARG_REALTIME_CACHE: Arg = 260;
+pub const ARG_REALTIME: Arg = 259;
+pub const ARG_FRAME_TIMES: Arg = 258;
+pub const ARG_MUXER: Arg = 257;
+pub const ARG_DEMUXER: Arg = 256;
 cfg_if! {
     if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
         pub const X86_CPU_MASK_AVX512ICL: CpuMask = 31;
@@ -117,7 +117,7 @@ cfg_if! {
         const ALLOWED_CPU_MASKS: &[u8; 42] = b"not yet implemented for this architecture\0";
     }
 }
-pub type arg = c_uint;
+pub type Arg = c_uint;
 
 static short_opts: [c_char; 11] =
     unsafe { *::core::mem::transmute::<&[u8; 11], &[c_char; 11]>(b"i:o:vql:s:\0") };
@@ -727,7 +727,7 @@ pub unsafe fn parse(
                         ARG_REALTIME as c_int,
                         *argv.offset(0),
                         &mut (*cli_settings).realtime_fps,
-                    )) as CLISettings_realtime;
+                    )) as CLISettingsRealTime;
             }
             260 => {
                 (*cli_settings).realtime_cache =


### PR DESCRIPTION
* Fixes `#![allow(non_camel_case_types)]` of #1299.

Supersedes #1301 by just fixing the warnings instead of papering over what appears to be a `rust-analyzer` false positive bug.