### PR TITLE
`struct *::cookie`: Make `*mut c_void`s into `Option<NonNull<c_void>>`s

### DIFF
--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -549,7 +549,7 @@ impl Rav1dPicture {
 #[repr(C)]
 pub struct Dav1dPicAllocator {
     /// Custom data to pass to the allocator callbacks.
-    pub cookie: *mut c_void,
+    pub cookie: Option<NonNull<c_void>>,
 
     /// Allocate the picture buffer based on the [`Dav1dPictureParameters`].
     ///
@@ -608,8 +608,12 @@ pub struct Dav1dPicAllocator {
     /// [`stride`]: Dav1dPicture::data
     /// [`allocator_data`]: Dav1dPicture::allocator_data
     /// [`release_picture_callback`]: Self::release_picture_callback
-    pub alloc_picture_callback:
-        Option<unsafe extern "C" fn(pic: *mut Dav1dPicture, cookie: *mut c_void) -> Dav1dResult>,
+    pub alloc_picture_callback: Option<
+        unsafe extern "C" fn(
+            pic: *mut Dav1dPicture,
+            cookie: Option<NonNull<c_void>>,
+        ) -> Dav1dResult,
+    >,
 
     /// Release the picture buffer.
     ///
@@ -647,7 +651,7 @@ pub struct Dav1dPicAllocator {
     /// [`dav1d_get_picture`]: crate::src::lib::dav1d_get_picture
     /// [`alloc_picture_callback`]: Self::alloc_picture_callback
     pub release_picture_callback:
-        Option<unsafe extern "C" fn(pic: *mut Dav1dPicture, cookie: *mut c_void) -> ()>,
+        Option<unsafe extern "C" fn(pic: *mut Dav1dPicture, cookie: Option<NonNull<c_void>>) -> ()>,
 }
 
 #[derive(Clone)]
@@ -675,7 +679,7 @@ pub(crate) struct Rav1dPicAllocator {
     ///
     /// [`Rav1dContext::picture_pool`]: crate::src::internal::Rav1dContext::picture_pool
     /// [`Rav1dContext`]: crate::src::internal::Rav1dContext
-    pub cookie: *mut c_void,
+    pub cookie: Option<NonNull<c_void>>,
 
     /// See [`Dav1dPicAllocator::alloc_picture_callback`].
     ///
@@ -685,8 +689,10 @@ pub(crate) struct Rav1dPicAllocator {
     ///
     /// If frame threading is used, accesses to [`Self::cookie`] must be thread-safe,
     /// i.e. [`Self::cookie`] must be [`Send`]` + `[`Sync`].
-    pub alloc_picture_callback:
-        unsafe extern "C" fn(pic: *mut Dav1dPicture, cookie: *mut c_void) -> Dav1dResult,
+    pub alloc_picture_callback: unsafe extern "C" fn(
+        pic: *mut Dav1dPicture,
+        cookie: Option<NonNull<c_void>>,
+    ) -> Dav1dResult,
 
     /// See [`Dav1dPicAllocator::release_picture_callback`].
     ///
@@ -697,7 +703,7 @@ pub(crate) struct Rav1dPicAllocator {
     /// If frame threading is used, accesses to [`Self::cookie`] must be thread-safe,
     /// i.e. [`Self::cookie`] must be [`Send`]` + `[`Sync`].
     pub release_picture_callback:
-        unsafe extern "C" fn(pic: *mut Dav1dPicture, cookie: *mut c_void) -> (),
+        unsafe extern "C" fn(pic: *mut Dav1dPicture, cookie: Option<NonNull<c_void>>) -> (),
 }
 
 impl TryFrom<Dav1dPicAllocator> for Rav1dPicAllocator {

--- a/src/c_box.rs
+++ b/src/c_box.rs
@@ -7,13 +7,13 @@ use std::pin::Pin;
 use std::ptr::drop_in_place;
 use std::ptr::NonNull;
 
-pub type FnFree = unsafe extern "C" fn(ptr: *const u8, cookie: *mut c_void);
+pub type FnFree = unsafe extern "C" fn(ptr: *const u8, cookie: Option<NonNull<c_void>>);
 
 /// A `free` "closure", i.e. a [`FnFree`] and an enclosed context [`Self::cookie`].
 #[derive(Debug)]
 pub struct Free {
     pub free: FnFree,
-    pub cookie: *mut c_void,
+    pub cookie: Option<NonNull<c_void>>,
 }
 
 impl Free {

--- a/src/data.rs
+++ b/src/data.rs
@@ -37,7 +37,7 @@ impl Rav1dData {
     pub unsafe fn wrap(
         data: NonNull<[u8]>,
         free_callback: Option<FnFree>,
-        cookie: *mut c_void,
+        cookie: Option<NonNull<c_void>>,
     ) -> Rav1dResult<Self> {
         let free = validate_input!(free_callback.ok_or(EINVAL))?;
         let free = Free { free, cookie };
@@ -54,7 +54,7 @@ impl Rav1dData {
         &mut self,
         user_data: NonNull<u8>,
         free_callback: Option<FnFree>,
-        cookie: *mut c_void,
+        cookie: Option<NonNull<c_void>>,
     ) -> Rav1dResult {
         let free = validate_input!(free_callback.ok_or(EINVAL))?;
         let free = Free { free, cookie };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -864,7 +864,7 @@ pub unsafe extern "C" fn dav1d_data_wrap(
     ptr: Option<NonNull<u8>>,
     sz: usize,
     free_callback: Option<FnFree>,
-    user_data: *mut c_void,
+    user_data: Option<NonNull<c_void>>,
 ) -> Dav1dResult {
     || -> Rav1dResult {
         let buf = validate_input!(buf.ok_or(EINVAL))?;
@@ -891,7 +891,7 @@ pub unsafe extern "C" fn dav1d_data_wrap_user_data(
     buf: Option<NonNull<Dav1dData>>,
     user_data: Option<NonNull<u8>>,
     free_callback: Option<FnFree>,
-    cookie: *mut c_void,
+    cookie: Option<NonNull<c_void>>,
 ) -> Dav1dResult {
     || -> Rav1dResult {
         let buf = validate_input!(buf.ok_or(EINVAL))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ pub(crate) fn rav1d_open(s: &Rav1dSettings) -> Rav1dResult<Arc<Rav1dContext>> {
     validate_input!((s.max_frame_delay >= 0 && s.max_frame_delay <= 256, EINVAL))?;
     validate_input!((s.operating_point <= 31, EINVAL))?;
     validate_input!((
-        !s.allocator.is_default() || s.allocator.cookie.is_null(),
+        !s.allocator.is_default() || s.allocator.cookie.is_none(),
         EINVAL
     ))?;
 
@@ -297,7 +297,7 @@ pub(crate) fn rav1d_open(s: &Rav1dSettings) -> Rav1dResult<Arc<Rav1dContext>> {
         // SAFETY: When `allocator.is_default()`, `allocator.cookie` should be a `&c.picture_pool`.
         // See `Rav1dPicAllocator::cookie` docs for more, including an analysis of the lifetime.
         // Note also that we must do this after we created the `Arc` so that `c` has a stable address.
-        c.allocator.cookie = ptr::from_ref(&c.picture_pool).cast::<c_void>().cast_mut();
+        c.allocator.cookie = Some(NonNull::from(&c.picture_pool).cast::<c_void>());
     }
     let c = c;
 

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -305,7 +305,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
             alloc_picture_callback: None,
             release_picture_callback: None,
         },
-        logger: Dav1dLogger::new(0 as *mut c_void, None),
+        logger: Dav1dLogger::new(None, None),
         strict_std_compliance: 0,
         output_invisible_frames: 0,
         inloop_filters: DAV1D_INLOOPFILTER_NONE,

--- a/tools/dav1d.rs
+++ b/tools/dav1d.rs
@@ -208,7 +208,10 @@ unsafe fn print_stats(istty: c_int, n: c_uint, num: c_uint, elapsed: u64, i_fps:
     fputs(buf.as_mut_ptr(), stderr);
 }
 
-unsafe extern "C" fn picture_alloc(p: *mut Dav1dPicture, _: *mut c_void) -> Dav1dResult {
+unsafe extern "C" fn picture_alloc(
+    p: *mut Dav1dPicture,
+    _: Option<NonNull<c_void>>,
+) -> Dav1dResult {
     let hbd = ((*p).p.bpc > 8) as c_int;
     let aligned_w = (*p).p.w + 127 & !(127 as c_int);
     let aligned_h = (*p).p.h + 127 & !(127 as c_int);
@@ -266,7 +269,7 @@ unsafe extern "C" fn picture_alloc(p: *mut Dav1dPicture, _: *mut c_void) -> Dav1
     Dav1dResult(0)
 }
 
-unsafe extern "C" fn picture_release(p: *mut Dav1dPicture, _: *mut c_void) {
+unsafe extern "C" fn picture_release(p: *mut Dav1dPicture, _: Option<NonNull<c_void>>) {
     if let Some(data) = (*p).allocator_data {
         free(data.as_ptr());
     }
@@ -298,7 +301,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
         all_layers: 0,
         frame_size_limit: 0,
         allocator: Dav1dPicAllocator {
-            cookie: 0 as *mut c_void,
+            cookie: None,
             alloc_picture_callback: None,
             release_picture_callback: None,
         },

--- a/tools/seek_stress.rs
+++ b/tools/seek_stress.rs
@@ -306,7 +306,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
             alloc_picture_callback: None,
             release_picture_callback: None,
         },
-        logger: Dav1dLogger::new(0 as *mut c_void, None),
+        logger: Dav1dLogger::new(None, None),
         strict_std_compliance: 0,
         output_invisible_frames: 0,
         inloop_filters: DAV1D_INLOOPFILTER_NONE,

--- a/tools/seek_stress.rs
+++ b/tools/seek_stress.rs
@@ -302,7 +302,7 @@ unsafe fn main_0(argc: c_int, argv: *const *mut c_char) -> c_int {
         all_layers: 0,
         frame_size_limit: 0,
         allocator: Dav1dPicAllocator {
-            cookie: 0 as *mut c_void,
+            cookie: None,
             alloc_picture_callback: None,
             release_picture_callback: None,
         },


### PR DESCRIPTION
This helps simplify some upcoming changes for `Send + Sync` safety.