### PR TITLE
`struct SendSyncNonNull`: Add a `Send + Sync` `NonNull` type

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -54,6 +54,7 @@ pub mod src {
     pub(crate) mod pic_or_buf;
     pub(crate) mod pixels;
     pub(crate) mod relaxed_atomic;
+    pub mod send_sync_non_null;
     pub(crate) mod strided;
     pub(crate) mod with_offset;
     pub(crate) mod wrap_fn_ptr;

--- a/src/data.rs
+++ b/src/data.rs
@@ -9,6 +9,7 @@ use crate::src::c_box::FnFree;
 use crate::src::c_box::Free;
 use crate::src::error::Rav1dError::EINVAL;
 use crate::src::error::Rav1dResult;
+use crate::src::send_sync_non_null::SendSyncNonNull;
 use std::ffi::c_void;
 use std::ptr::NonNull;
 
@@ -37,7 +38,7 @@ impl Rav1dData {
     pub unsafe fn wrap(
         data: NonNull<[u8]>,
         free_callback: Option<FnFree>,
-        cookie: Option<NonNull<c_void>>,
+        cookie: Option<SendSyncNonNull<c_void>>,
     ) -> Rav1dResult<Self> {
         let free = validate_input!(free_callback.ok_or(EINVAL))?;
         let free = Free { free, cookie };
@@ -54,7 +55,7 @@ impl Rav1dData {
         &mut self,
         user_data: NonNull<u8>,
         free_callback: Option<FnFree>,
-        cookie: Option<NonNull<c_void>>,
+        cookie: Option<SendSyncNonNull<c_void>>,
     ) -> Rav1dResult {
         let free = validate_input!(free_callback.ok_or(EINVAL))?;
         let free = Free { free, cookie };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ use crate::src::obu::rav1d_parse_obus;
 use crate::src::obu::rav1d_parse_sequence_header;
 use crate::src::picture::rav1d_picture_alloc_copy;
 use crate::src::picture::PictureFlags;
+use crate::src::send_sync_non_null::SendSyncNonNull;
 use crate::src::thread_task::rav1d_task_delayed_fg;
 use crate::src::thread_task::rav1d_worker_task;
 use crate::src::thread_task::FRAME_ERROR;
@@ -297,7 +298,7 @@ pub(crate) fn rav1d_open(s: &Rav1dSettings) -> Rav1dResult<Arc<Rav1dContext>> {
         // SAFETY: When `allocator.is_default()`, `allocator.cookie` should be a `&c.picture_pool`.
         // See `Rav1dPicAllocator::cookie` docs for more, including an analysis of the lifetime.
         // Note also that we must do this after we created the `Arc` so that `c` has a stable address.
-        c.allocator.cookie = Some(NonNull::from(&c.picture_pool).cast::<c_void>());
+        c.allocator.cookie = Some(SendSyncNonNull::from_ref(&c.picture_pool).cast::<c_void>());
     }
     let c = c;
 
@@ -864,7 +865,7 @@ pub unsafe extern "C" fn dav1d_data_wrap(
     ptr: Option<NonNull<u8>>,
     sz: usize,
     free_callback: Option<FnFree>,
-    user_data: Option<NonNull<c_void>>,
+    user_data: Option<SendSyncNonNull<c_void>>,
 ) -> Dav1dResult {
     || -> Rav1dResult {
         let buf = validate_input!(buf.ok_or(EINVAL))?;
@@ -891,7 +892,7 @@ pub unsafe extern "C" fn dav1d_data_wrap_user_data(
     buf: Option<NonNull<Dav1dData>>,
     user_data: Option<NonNull<u8>>,
     free_callback: Option<FnFree>,
-    cookie: Option<NonNull<c_void>>,
+    cookie: Option<SendSyncNonNull<c_void>>,
 ) -> Dav1dResult {
     || -> Rav1dResult {
         let buf = validate_input!(buf.ok_or(EINVAL))?;

--- a/src/send_sync_non_null.rs
+++ b/src/send_sync_non_null.rs
@@ -1,0 +1,92 @@
+use std::ptr::NonNull;
+
+/// A [`NonNull`] that is [`Send`]` + `[`Sync`].
+///
+/// Since [`Send`]/[`Sync`] safety can't be guaranteed by the type system
+/// due to the raw [`NonNull`] pointers and [`Self::cast`],
+/// [`Send`]/[`Sync`] safety is instead guaranteed by
+/// the `unsafe`ty of [`Self::new_unchecked`].
+///
+/// Safe wrappers are provided around this, namely
+/// * [`Self::from_ref`]
+/// * [`Self::from_box`]
+///
+/// This can be reversed with the corresponding methods:
+/// * [`Self::as_ref`]
+/// * [`Self::into_box`]
+///
+/// though these are `unsafe` due to the raw pointers
+/// and potential [`Self::cast`] called in between.
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct SendSyncNonNull<T: ?Sized>(NonNull<T>);
+
+// `Self: Clone` doesn't depend on `T: Clone`.
+impl<T: ?Sized> Clone for SendSyncNonNull<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: ?Sized> Copy for SendSyncNonNull<T> {}
+
+/// SAFETY: All public constructors, which all go through [`Self::new_unchecked`],
+/// ensure that [`Self`] stores a [`Send`] type
+/// that is only used in a [`Send`] way.
+unsafe impl<T: ?Sized> Send for SendSyncNonNull<T> {}
+
+/// SAFETY: All public constructors, which all go through [`Self::new_unchecked`],
+/// ensure that [`Self`] stores a [`Sync`] type
+/// that is only used in a [`Sync`] way.
+unsafe impl<T: ?Sized> Sync for SendSyncNonNull<T> {}
+
+impl<T: ?Sized> SendSyncNonNull<T> {
+    pub const fn cast<U>(self) -> SendSyncNonNull<U> {
+        SendSyncNonNull(self.0.cast())
+    }
+}
+
+impl<T: ?Sized + Send + Sync> SendSyncNonNull<T> {
+    /// # Safety
+    ///
+    /// `ptr` must be derived from a type that is [`Send`]` + `[`Sync`],
+    /// and must only be used in a [`Send`]` + `[`Sync`] way.
+    pub const unsafe fn new_unchecked(ptr: NonNull<T>) -> Self {
+        Self(ptr)
+    }
+
+    pub fn from_ref(r#ref: &T) -> Self {
+        let ptr = NonNull::from(r#ref);
+        // SAFETY: `T: Send + Sync => &T: Send + Sync`.
+        unsafe { Self::new_unchecked(ptr) }
+    }
+
+    pub fn from_box(r#box: Box<T>) -> Self {
+        let ptr = NonNull::new(Box::into_raw(r#box)).unwrap();
+        // SAFETY: `T: Send + Sync => Box<T>: Send + Sync`.
+        unsafe { Self::new_unchecked(ptr) }
+    }
+
+    pub const fn as_ptr(&self) -> NonNull<T> {
+        self.0
+    }
+
+    /// # Safety
+    ///
+    /// `self` originally came from [`Self::from_ref`].
+    pub const unsafe fn as_ref(&self) -> &T {
+        // SAFETY: `self` originally came from a `&T` in `Self::from_ref`.
+        unsafe { self.0.as_ref() }
+    }
+
+    /// # Safety
+    ///
+    /// `self` originally came from [`Self::from_box`]
+    /// and was not already converted into a [`Box`] with [`Self::into_box`].
+    pub unsafe fn into_box(self) -> Box<T> {
+        let ptr = self.as_ptr().as_ptr();
+        // SAFETY: `self` originally came from a `Box<T>` in `Self::from_box`.
+        // And since `Self::into_box` hasn't been called yet, it's unique.
+        unsafe { Box::from_raw(ptr) }
+    }
+}


### PR DESCRIPTION
`SendSyncNonNull` is sound through `unsafe` methods, and we use it here to make the `cookie` fields `Send + Sync`.