### PR TITLE
`fn Rav1dPictureDataComponentInner::wrap_buf`: Attempt to add lifetimes

### DIFF
--- a/include/common/bitdepth.rs
+++ b/include/common/bitdepth.rs
@@ -135,7 +135,8 @@ pub trait BitDepth: Clone + Copy {
     const BPC: BPC;
     const BITDEPTH: u8 = Self::BPC.bitdepth();
 
-    type Pixel: Copy
+    type Pixel: 'static
+        + Copy
         + Ord
         + Add<Output = Self::Pixel>
         + Mul<Output = Self::Pixel>

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -61,7 +61,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn cdef(
 ) -> ());
 
 pub type CdefTop<'a> = WithOffset<&'a DisjointMut<AlignedVec64<u8>>>;
-pub type CdefBottom<'a> = WithOffset<PicOrBuf<'a, AlignedVec64<u8>>>;
+pub type CdefBottom<'a, 'buf> = WithOffset<PicOrBuf<'a, 'buf, AlignedVec64<u8>>>;
 
 impl cdef::Fn {
     /// CDEF operates entirely on pre-filter data.

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -998,7 +998,7 @@ pub const EMU_EDGE_LEN: usize = 320 * (256 + 7);
 pub struct ScratchEmuEdge([u8; EMU_EDGE_LEN * 2]);
 
 impl ScratchEmuEdge {
-    pub fn buf_mut<BD: BitDepth>(&mut self) -> &mut [BD::Pixel; EMU_EDGE_LEN] {
+    pub fn buf_mut<'a, BD: BitDepth>(&'a mut self) -> &'a mut [BD::Pixel; EMU_EDGE_LEN] {
         FromBytes::mut_from_prefix(&mut self.0).unwrap()
     }
 }

--- a/src/ipred_prepare.rs
+++ b/src/ipred_prepare.rs
@@ -161,7 +161,7 @@ static av1_intra_prediction_edges: [Av1IntraPredictionEdge; N_IMPL_INTRA_PRED_MO
 /// If edges are not available (because the edge position
 /// is outside the tile dimensions or because edge_flags indicates lack of edge availability),
 /// they will be extended from nearby edges as defined by the AV1 spec.
-pub fn rav1d_prepare_intra_edges<BD: BitDepth>(
+pub fn rav1d_prepare_intra_edges<'a, 'buf, BD: BitDepth>(
     x: c_int,
     have_left: bool,
     y: c_int,
@@ -169,7 +169,7 @@ pub fn rav1d_prepare_intra_edges<BD: BitDepth>(
     w: c_int,
     h: c_int,
     edge_flags: EdgeFlags,
-    dst: Rav1dPictureDataComponentOffset,
+    dst: Rav1dPictureDataComponentOffset<'a, 'buf>,
     // Buffer and offset pair. `isize` value is the base offset that should be used
     // when indexing into the buffer.
     prefilter_toplevel_sb_edge: Option<(&DisjointMut<AlignedVec64<u8>>, isize)>,

--- a/src/pic_or_buf.rs
+++ b/src/pic_or_buf.rs
@@ -6,21 +6,21 @@ use crate::src::strided::Strided;
 use crate::src::strided::WithStride;
 use crate::src::with_offset::WithOffset;
 
-pub enum PicOrBuf<'a, T: AsMutPtr<Target = u8>> {
-    Pic(&'a Rav1dPictureDataComponent),
+pub enum PicOrBuf<'a, 'buf, T: AsMutPtr<Target = u8>> {
+    Pic(&'a Rav1dPictureDataComponent<'buf>),
     Buf(WithStride<&'a DisjointMut<T>>),
 }
 
 /// Manual `impl` since `T: Clone` is not required.
-impl<'a, T: AsMutPtr<Target = u8>> Clone for PicOrBuf<'a, T> {
+impl<T: AsMutPtr<Target = u8>> Clone for PicOrBuf<'_, '_, T> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, T: AsMutPtr<Target = u8>> Copy for PicOrBuf<'a, T> {}
+impl<T: AsMutPtr<Target = u8>> Copy for PicOrBuf<'_, '_, T> {}
 
-impl<'a, T: AsMutPtr<Target = u8>> Pixels for PicOrBuf<'a, T> {
+impl<T: AsMutPtr<Target = u8>> Pixels for PicOrBuf<'_, '_, T> {
     fn byte_len(&self) -> usize {
         match self {
             Self::Pic(pic) => pic.byte_len(),
@@ -36,7 +36,7 @@ impl<'a, T: AsMutPtr<Target = u8>> Pixels for PicOrBuf<'a, T> {
     }
 }
 
-impl<'a, T: AsMutPtr<Target = u8>> Strided for PicOrBuf<'a, T> {
+impl<T: AsMutPtr<Target = u8>> Strided for PicOrBuf<'_, '_, T> {
     fn stride(&self) -> isize {
         match self {
             Self::Pic(pic) => pic.stride(),
@@ -45,8 +45,8 @@ impl<'a, T: AsMutPtr<Target = u8>> Strided for PicOrBuf<'a, T> {
     }
 }
 
-impl<'a, T: AsMutPtr<Target = u8>> WithOffset<PicOrBuf<'a, T>> {
-    pub fn pic(pic: WithOffset<&'a Rav1dPictureDataComponent>) -> Self {
+impl<'a, 'buf, T: AsMutPtr<Target = u8>> WithOffset<PicOrBuf<'a, 'buf, T>> {
+    pub fn pic(pic: WithOffset<&'a Rav1dPictureDataComponent<'buf>>) -> Self {
         Self {
             data: PicOrBuf::Pic(pic.data),
             offset: pic.offset,


### PR DESCRIPTION
I'm struggling to figure out the lifetimes here, even though I think they should work.  The `'buf` lifetime, i.e. the lifetime of `Rav1dPictureDataComponentInner::buf`, should outlive `'a`, where `'a` is in `&'a Rav1dPictureDataComponent<'buf>` when stored in `Rav1dPictureDataComponentOffset::data`.  But things aren't working out.  Can anyone else help and figure this out?