### PR TITLE
`fn decode_b`: Performance improvements

### DIFF
--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -80,9 +80,10 @@ fn backup2lines<BD: BitDepth>(
     }
 }
 
+#[inline(always)]
 fn backup2x8<BD: BitDepth>(
     dst: &mut [[[BD::Pixel; 2]; 8]; 3],
-    src: [Rav1dPictureDataComponentOffset; 3],
+    src: &[Rav1dPictureDataComponentOffset; 3],
     x_off: c_int,
     layout: Rav1dPixelLayout,
     flag: Backup2x8Flags,
@@ -252,11 +253,11 @@ pub(crate) fn rav1d_cdef_brow<BD: BitDepth>(
                         if !do_left.is_empty() && edges.contains(CdefEdgeFlags::HAVE_LEFT) {
                             // we didn't backup the prefilter data because it wasn't
                             // there, so do it here instead
-                            backup2x8::<BD>(&mut lr_bak[bit as usize], bptrs, 0, layout, do_left);
+                            backup2x8::<BD>(&mut lr_bak[bit as usize], &bptrs, 0, layout, do_left);
                         }
                         if edges.contains(CdefEdgeFlags::HAVE_RIGHT) {
                             // backup pre-filter data for next iteration
-                            backup2x8::<BD>(&mut lr_bak[!bit as usize], bptrs, 8, layout, flag);
+                            backup2x8::<BD>(&mut lr_bak[!bit as usize], &bptrs, 8, layout, flag);
                         }
 
                         let mut variance = 0;


### PR DESCRIPTION
Inlines `backup2x8` which is inlined in C and improves performance slightly.

The `f.a[t.a]` block context reference is constant
throughout `decode_b`, but it appears that the
function is too complex for the optimizer to not
recompute this reference. Making it a local
improves performance measurably (~1% on a Ryzen
7700X for 8-bit Chimera).