### PR TITLE
`build.rs`: Fix windows cross compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
 name = "rav1d-cli"
 version = "1.0.0"
 dependencies = [
+ "cc",
  "cfg-if",
  "libc",
  "rav1d",

--- a/build.rs
+++ b/build.rs
@@ -292,10 +292,10 @@ mod asm {
             nasm.files(asm_file_paths);
             #[cfg(debug_assertions)]
             nasm.flag("-g");
-            #[cfg(all(debug_assertions, not(windows)))]
-            nasm.flag("-Fdwarf");
-            #[cfg(all(debug_assertions, windows))]
-            nasm.flag("-fwin64");
+            nasm.flag(match os {
+                "windows" => "-fwin64",
+                _ => "-Fdwarf",
+            });
             nasm.flag(&format!("-I{}/", out_dir.to_str().unwrap()));
             nasm.flag("-Isrc/");
             let obj = nasm.compile_objects().unwrap_or_else(|e| {

--- a/build.rs
+++ b/build.rs
@@ -331,41 +331,4 @@ fn main() {
     {
         asm::main();
     }
-
-    // NOTE: we rely on libraries that are only distributed for Windows so
-    // targeting Windows/MSVC is not supported when cross compiling.
-    #[cfg(all(target_os = "windows", target_env = "msvc"))]
-    {
-        use cc::windows_registry;
-        use std::env;
-
-        let os = env::var("CARGO_CFG_TARGET_OS").expect("missing CARGO_CFG_TARGET_OS");
-        let target = env::var("TARGET").expect("missing TARGET");
-        if os == "windows" {
-            // for sprintf, snprintf, etc.
-            println!("cargo:rustc-link-lib=static=oldnames");
-            let tool = windows_registry::find_tool(&target, "cl.exe")
-                .expect("couldn't find cl.exe; are the Visual Studio C++ tools installed?");
-            let lib_paths = &tool
-                .env()
-                .iter()
-                .find(|(key, _val)| key == "LIB")
-                .expect("LIB path not found")
-                .1;
-            for path in lib_paths.to_str().unwrap().split(';') {
-                if path != "" {
-                    println!("cargo:rustc-link-search={path}");
-                }
-            }
-
-            let getopt = "getopt";
-            cc::Build::new()
-                .files([&"tools/compat/getopt.c"])
-                .include("include/compat")
-                .debug(cfg!(debug_assertions))
-                .compile(&getopt);
-            // cc automatically outputs the following line
-            // println!("cargo:rustc-link-lib=static={getopt}");
-        }
-    }
 }

--- a/build.rs
+++ b/build.rs
@@ -292,6 +292,7 @@ mod asm {
             nasm.files(asm_file_paths);
             #[cfg(debug_assertions)]
             nasm.flag("-g");
+            #[cfg(debug_assertions)]
             nasm.flag(match os {
                 "windows" => "-fwin64",
                 _ => "-Fdwarf",

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -22,6 +22,9 @@ cfg-if = "1.0.0"
 libc = "0.2"
 rav1d = { path = "../", version = "1.0.0", default-features = false }
 
+[build-dependencies]
+cc = "1.0.79"
+
 [features]
 default = ["asm", "asm_arm64_dotprod", "asm_arm64_i8mm", "bitdepth_8", "bitdepth_16"]
 asm = ["rav1d/asm"]

--- a/tools/build.rs
+++ b/tools/build.rs
@@ -1,0 +1,38 @@
+fn main() {
+    // NOTE: we rely on libraries that are only distributed for Windows so
+    // targeting Windows/MSVC is not supported when cross compiling.
+    #[cfg(all(target_os = "windows", target_env = "msvc"))]
+    {
+        use cc::windows_registry;
+        use std::env;
+
+        let os = env::var("CARGO_CFG_TARGET_OS").expect("missing CARGO_CFG_TARGET_OS");
+        let target = env::var("TARGET").expect("missing TARGET");
+        if os == "windows" {
+            // for sprintf, snprintf, etc.
+            println!("cargo:rustc-link-lib=static=oldnames");
+            let tool = windows_registry::find_tool(&target, "cl.exe")
+                .expect("couldn't find cl.exe; are the Visual Studio C++ tools installed?");
+            let lib_paths = &tool
+                .env()
+                .iter()
+                .find(|(key, _val)| key == "LIB")
+                .expect("LIB path not found")
+                .1;
+            for path in lib_paths.to_str().unwrap().split(';') {
+                if path != "" {
+                    println!("cargo:rustc-link-search={path}");
+                }
+            }
+
+            let getopt = "getopt";
+            cc::Build::new()
+                .files([&"../tools/compat/getopt.c"])
+                .include("../include/compat")
+                .debug(cfg!(debug_assertions))
+                .compile(&getopt);
+            // cc automatically outputs the following line
+            // println!("cargo:rustc-link-lib=static={getopt}");
+        }
+    }
+}

--- a/tools/build.rs
+++ b/tools/build.rs
@@ -1,38 +1,52 @@
+use std::env;
+
 fn main() {
+    let os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+
+    let os = os.as_str();
+    let env = env.as_str();
+
+    match (os, env) {
+        ("windows", "msvc") => {
+            if !cfg!(all(target_os = "windows", target_env = "msvc")) {
+                panic!("Cannot cross compile to *-windows-msvc");
+            }
+        }
+        #[allow(clippy::needless_return)]
+        _ => return,
+    }
+
     // NOTE: we rely on libraries that are only distributed for Windows so
     // targeting Windows/MSVC is not supported when cross compiling.
     #[cfg(all(target_os = "windows", target_env = "msvc"))]
     {
         use cc::windows_registry;
-        use std::env;
 
-        let os = env::var("CARGO_CFG_TARGET_OS").expect("missing CARGO_CFG_TARGET_OS");
-        let target = env::var("TARGET").expect("missing TARGET");
-        if os == "windows" {
-            // for sprintf, snprintf, etc.
-            println!("cargo:rustc-link-lib=static=oldnames");
-            let tool = windows_registry::find_tool(&target, "cl.exe")
-                .expect("couldn't find cl.exe; are the Visual Studio C++ tools installed?");
-            let lib_paths = &tool
-                .env()
-                .iter()
-                .find(|(key, _val)| key == "LIB")
-                .expect("LIB path not found")
-                .1;
-            for path in lib_paths.to_str().unwrap().split(';') {
-                if path != "" {
-                    println!("cargo:rustc-link-search={path}");
-                }
+        // for sprintf, snprintf, etc.
+        let target = env::var("TARGET").unwrap();
+        println!("cargo:rustc-link-lib=static=oldnames");
+        let tool = windows_registry::find_tool(&target, "cl.exe")
+            .expect("couldn't find cl.exe; are the Visual Studio C++ tools installed?");
+        let lib_paths = &tool
+            .env()
+            .iter()
+            .find(|(key, _val)| key == "LIB")
+            .expect("LIB path not found")
+            .1;
+        for path in lib_paths.to_str().unwrap().split(';') {
+            if path != "" {
+                println!("cargo:rustc-link-search={path}");
             }
-
-            let getopt = "getopt";
-            cc::Build::new()
-                .files([&"../tools/compat/getopt.c"])
-                .include("../include/compat")
-                .debug(cfg!(debug_assertions))
-                .compile(&getopt);
-            // cc automatically outputs the following line
-            // println!("cargo:rustc-link-lib=static={getopt}");
         }
+
+        let getopt = "getopt";
+        cc::Build::new()
+            .files([&"../tools/compat/getopt.c"])
+            .include("../include/compat")
+            .debug(cfg!(debug_assertions))
+            .compile(&getopt);
+        // cc automatically outputs the following line
+        // println!("cargo:rustc-link-lib=static={getopt}");
     }
 }


### PR DESCRIPTION
@thedataking, I only noticed after you merged #1295 a few things.

This should let us cross-compile from windows, cross-compile to `*-windows-gnu` (I think; the linker wasn't installed so I couldn't test all the way), and print a clear error when trying to cross-compile to `*-windows-msvc`.  It also lets us do full cross-compilation on `rav1d`, as the `snprintf` stuff for windows is only for `rav1d-cli`.

* Fixes #1365.