### PR TITLE
`enum Av1BlockIntraInter`: Remove `#[repr(C)]`, reducing size by 4 bytes

### DIFF
--- a/src/levels.rs
+++ b/src/levels.rs
@@ -532,7 +532,6 @@ pub struct Av1BlockInter {
     pub tx_split1: u16,
 }
 
-#[repr(C)]
 pub enum Av1BlockIntraInter {
     Intra(Av1BlockIntra),
     Inter(Av1BlockInter),


### PR DESCRIPTION
This is a simpler, fully safe alternative to #1331.  It reduces `Av1BlockIntraInter` from 28 to 24 bytes, and `Av1Block` from 36 to 32 bytes, just like #1331.

I haven't checked memory usage, though, since I'm not sure how to do that, but since it reduces the type sizes the same, I assume it would have the same memory savings.