### PR TITLE
Make dotprod and i8mm configurable features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,10 @@ cc = "1.0.79"
 nasm-rs = { version = "0.3", features = ["parallel"] }
 
 [features]
-default = ["asm", "bitdepth_8", "bitdepth_16"]
+default = ["asm", "asm_arm64_dotprod", "asm_arm64_i8mm", "bitdepth_8", "bitdepth_16"]
 asm = []
+asm_arm64_dotprod = ["asm"]
+asm_arm64_i8mm = ["asm"]
 bitdepth_8 = []
 bitdepth_16 = []
 

--- a/build.rs
+++ b/build.rs
@@ -105,8 +105,11 @@ mod asm {
             define(Define::bool("ARCH_AARCH64", arch == ArchArm::Arm64));
 
             if arch == ArchArm::Arm64 {
-                define(Define::bool("HAVE_DOTPROD", true));
-                define(Define::bool("HAVE_I8MM", true));
+                define(Define::bool(
+                    "HAVE_DOTPROD",
+                    cfg!(feature = "asm_arm64_dotprod"),
+                ));
+                define(Define::bool("HAVE_I8MM", cfg!(feature = "asm_arm64_i8mm")));
             }
         }
 

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -2305,7 +2305,7 @@ impl Rav1dMCDSPContext {
         self.warp8x8t = bd_fn!(warp8x8t::decl_fn, BD, warp_affine_8x8t, neon);
         self.emu_edge = bd_fn!(emu_edge::decl_fn, BD, emu_edge, neon);
 
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(all(target_arch = "aarch64", feature = "asm_arm64_dotprod"))]
         if BD::BITDEPTH == 8 {
             if !flags.contains(CpuFlags::DOTPROD) {
                 return self;
@@ -2337,7 +2337,7 @@ impl Rav1dMCDSPContext {
             });
         }
 
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(all(target_arch = "aarch64", feature = "asm_arm64_i8mm"))]
         if BD::BITDEPTH == 8 {
             if !flags.contains(CpuFlags::I8MM) {
                 return self;

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -23,8 +23,10 @@ libc = "0.2"
 rav1d = { path = "../", version = "1.0.0", default-features = false }
 
 [features]
-default = ["asm", "bitdepth_8", "bitdepth_16"]
+default = ["asm", "asm_arm64_dotprod", "asm_arm64_i8mm", "bitdepth_8", "bitdepth_16"]
 asm = ["rav1d/asm"]
+asm_arm64_dotprod = ["rav1d/asm_arm64_dotprod"]
+asm_arm64_i8mm = ["rav1d/asm_arm64_i8mm"]
 bitdepth_8 = ["rav1d/bitdepth_8"]
 bitdepth_16 = ["rav1d/bitdepth_16"]
 


### PR DESCRIPTION
Adds the `asm_arm64_dotprod` and `asm_arm64_i8mm` features. We previously assumed that dotprod and i8mm were always enabled when building for aarch64 and then disabled at runtime if not supported. We also want to support the configuration where we do not even build the code, so these added features (enabled by default) allow this to be configurable.