### PR TITLE
`trait Pixels`: Add `fn wrapping_*as_{mut_,}ptr` methods for non-bounds checked versions

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -86,7 +86,7 @@ impl cdef::Fn {
         let stride = dst.stride();
         let left = ptr::from_ref(left).cast();
         let top_ptr = top.as_ptr::<BD>().cast();
-        let bottom_ptr = bottom.as_ptr::<BD>().cast();
+        let bottom_ptr = bottom.wrapping_as_ptr::<BD>().cast();
         let top = FFISafe::new(&top);
         let bottom = FFISafe::new(&bottom);
         let sec_strength = sec_strength as c_int;

--- a/src/pixels.rs
+++ b/src/pixels.rs
@@ -28,7 +28,7 @@ pub trait Pixels {
         self.as_mut_ptr::<BD>().cast_const()
     }
 
-    /// Absolute ptr to [`BitDepth::Pixel`]s starting at `offset`.
+    /// Absolute ptr to [`BitDepth::Pixel`]s starting at `pixel_offset`.
     ///
     /// Bounds checked, but not [`DisjointMut`]-checked.
     #[cfg_attr(debug_assertions, track_caller)]
@@ -49,12 +49,26 @@ pub trait Pixels {
         unsafe { self.as_mut_ptr::<BD>().add(pixel_offset) }
     }
 
-    /// Absolute ptr to [`BitDepth::Pixel`]s starting at `offset`.
+    /// Absolute ptr to [`BitDepth::Pixel`]s starting at `pixel_offset`.
     ///
     /// Bounds checked, but not [`DisjointMut`]-checked.
     #[cfg_attr(debug_assertions, track_caller)]
-    fn as_ptr_at<BD: BitDepth>(&self, offset: usize) -> *const BD::Pixel {
-        self.as_mut_ptr_at::<BD>(offset).cast_const()
+    fn as_ptr_at<BD: BitDepth>(&self, pixel_offset: usize) -> *const BD::Pixel {
+        self.as_mut_ptr_at::<BD>(pixel_offset).cast_const()
+    }
+
+    /// Absolute ptr to [`BitDepth::Pixel`]s starting at `pixel_offset`.
+    ///
+    /// There is no bounds checking and this ptr may wrap and go out of bounds.
+    fn wrapping_as_mut_ptr_at<BD: BitDepth>(&self, pixel_offset: usize) -> *mut BD::Pixel {
+        self.as_mut_ptr::<BD>().wrapping_add(pixel_offset)
+    }
+
+    /// Absolute ptr to [`BitDepth::Pixel`]s starting at `pixel_offset`.
+    ///
+    /// There is no bounds checking and this ptr may wrap and go out of bounds.
+    fn wrapping_as_ptr_at<BD: BitDepth>(&self, pixel_offset: usize) -> *const BD::Pixel {
+        self.as_ptr::<BD>().wrapping_add(pixel_offset)
     }
 
     /// Determine if they reference the same data.

--- a/src/with_offset.rs
+++ b/src/with_offset.rs
@@ -92,6 +92,14 @@ impl<P: Pixels> WithOffset<P> {
     pub fn as_mut_ptr<BD: BitDepth>(&self) -> *mut BD::Pixel {
         self.data.as_mut_ptr_at::<BD>(self.offset)
     }
+
+    pub fn wrapping_as_ptr<BD: BitDepth>(&self) -> *const BD::Pixel {
+        self.data.wrapping_as_ptr_at::<BD>(self.offset)
+    }
+
+    pub fn wrapping_as_mut_ptr<BD: BitDepth>(&self) -> *const BD::Pixel {
+        self.data.wrapping_as_mut_ptr_at::<BD>(self.offset)
+    }
 }
 
 impl<S: Strided> Strided for WithOffset<S> {


### PR DESCRIPTION
* Fixes #1336.

That specific test should pass now.