### PR TITLE
`fn AlignedVec::resize`: Validate safety requirements, specifically overflow

### DIFF
--- a/src/align.rs
+++ b/src/align.rs
@@ -141,12 +141,12 @@ pub struct AlignedVec<T: Copy, C: AlignedByteChunk> {
 }
 
 impl<T: Copy, C: AlignedByteChunk> AlignedVec<T, C> {
-    // Note that in Rust, no single allocation can exceed `isize::MAX` __bytes_.
+    // Note that in Rust, no single allocation can exceed `isize::MAX` _bytes_.
     const MAX_LEN: usize = {
-        if core::mem::size_of::<T>() == 0 {
+        if mem::size_of::<T>() == 0 {
             usize::MAX
         } else {
-            (isize::MAX as usize) / core::mem::size_of::<T>()
+            (isize::MAX as usize) / mem::size_of::<T>()
         }
     };
 
@@ -292,7 +292,7 @@ fn align_vec_fails() {
     // This resize must fail. Otherwise, the code below creates a very small actual allocation, and
     // consequently a slice reference that points to memory outside the buffer.
     v.resize(isize::MAX as usize + 2, 0u16);
-    // Note that in Rust, no single allocation can exceed `isize::MAX` __bytes_. _Meaning it is
+    // Note that in Rust, no single allocation can exceed `isize::MAX` _bytes_. Meaning it is
     // impossible to soundly create a slice of `u16` with `isize::MAX` elements. If we got to this
     // point, everything is broken already. The indexing will the probably also wrap and appear to
     // work.

--- a/src/align.rs
+++ b/src/align.rs
@@ -186,12 +186,12 @@ impl<T: Copy, C: AlignedByteChunk> AlignedVec<T, C> {
         let old_len = self.len();
 
         // Resize the underlying vector to have enough chunks for the new length.
-        // SAFETY: The `new_bytes` calculation must not overflow, ensuring a mathematical match
-        // with the underlying `inner` buffer size. NOTE: one can still pass ludicrous requested
-        // buffer lengths, just not unsound ones.
-        let Some(new_bytes) = mem::size_of::<T>().checked_mul(new_len) else {
-            panic!("Resizing would overflow the underlying aligned buffer");
-        };
+        // SAFETY: The `new_bytes` calculation must not overflow,
+        // ensuring a mathematical match with the underlying `inner` buffer size.
+        // NOTE: one can still pass ludicrous requested buffer lengths, just not unsound ones.
+        let new_bytes = mem::size_of::<T>()
+            .checked_mul(new_len)
+            .expect("Resizing would overflow the underlying aligned buffer");
 
         let chunk_size = mem::size_of::<C>();
         let new_chunks = if (new_bytes % chunk_size) == 0 {


### PR DESCRIPTION
This is a necessary check for soundness, as demonstrated by the test which can SIGSEGV without the check. Before the check, an overflow in the underlying buffer calculation can create incoherent state where the vector believes in an impossibly large buffer of the item type which is not actually backed by a correctly sized buffer of chunks.

* Closes: #1356 