### PR TITLE
Remove crashy `unwrap()` in `on_error`

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4994,7 +4994,10 @@ pub fn rav1d_submit_frame(c: &Rav1dContext, state: &mut Rav1dState) -> Rav1dResu
     ) {
         fc.task_thread.error.store(1, Ordering::Relaxed);
         let _ = mem::take(&mut *fc.in_cdf.try_write().unwrap());
-        if f.frame_hdr.as_ref().unwrap().refresh_context != 0 {
+        if f.frame_hdr
+            .as_ref()
+            .is_some_and(|frame_hdr| frame_hdr.refresh_context != 0)
+        {
             let _ = mem::take(&mut f.out_cdf);
         }
         for i in 0..7 {


### PR DESCRIPTION
I got a crash here, and I don't want a crash :)

```
thread 'av1_decoder' panicked at 'called `Option::unwrap()` on a `None` value'
6f12e3f/src/decode.rs:4997
```

It seems like this `unwrap` was introduced in https://github.com/memorysafety/rav1d/pull/663 along with many others.

May I suggest enabling the [`clippy::unwrap_used`](https://rust-lang.github.io/rust-clippy/master/index.html#/unwrap_used) lint? Any `.unwrap()` is a panic waiting to happen :/

**EDIT:** The crash happens during decode of the chunk starting at timestamp `114176` of this video: https://storage.googleapis.com/rerun-test-assets/video/Sintel_1080_10s_av1.mp4