### PR TITLE
Linux/x64: Fix SIMD routines not linking due to illegal relocations

### DIFF
--- a/src/ext/x86/x86inc.asm
+++ b/src/ext/x86/x86inc.asm
@@ -868,6 +868,19 @@ BRANCH_INSTR jz, je, jnz, jne, jl, jle, jnl, jnle, jg, jge, jng, jnge, ja, jae, 
     extern %1
 %endmacro
 
+; %2 and %3 give control over symbol type and symbol visibility, respectively.
+; E.g. `cextern_args some_symbol,data,hidden`.
+;
+; This can be life saving in position-independent contexts, where it is very easy to generate
+; illegal relocations otherwise.
+;
+; See <https://github.com/rerun-io/re_rav1d/pull/3> for more information.
+%macro cextern_args 3
+    %xdefine %1 mangle(private_prefix %+ _ %+ %1)
+    CAT_XDEFINE cglobaled_, %1, 2
+    extern %1:%2 %3
+%endmacro
+
 ; Like cextern, but without the prefix. This should be used for symbols from external libraries.
 %macro cextern_naked 1
     %ifdef PREFIX

--- a/src/x86/filmgrain_common.asm
+++ b/src/x86/filmgrain_common.asm
@@ -43,4 +43,4 @@ struc FGData
     .clip_to_restricted_range:  resd 1
 endstruc
 
-cextern gaussian_sequence
+cextern_args gaussian_sequence,data,hidden

--- a/src/x86/ipred16_avx2.asm
+++ b/src/x86/ipred16_avx2.asm
@@ -129,8 +129,8 @@ JMP_TABLE ipred_cfl_left_16bpc,   avx2, h4, h8, h16, h32
 JMP_TABLE ipred_cfl_ac_444_16bpc, avx2, w4, w8, w16, w32
 JMP_TABLE pal_pred_16bpc,         avx2, w4, w8, w16, w32, w64
 
-cextern dr_intra_derivative
-cextern filter_intra_taps
+cextern_args dr_intra_derivative,data,hidden
+cextern_args filter_intra_taps,data,hidden
 
 SECTION .text
 

--- a/src/x86/ipred16_avx512.asm
+++ b/src/x86/ipred16_avx512.asm
@@ -121,10 +121,10 @@ JMP_TABLE ipred_z2_16bpc,         avx512icl, w4, w8, w16, w32, w64
 JMP_TABLE ipred_z3_16bpc,         avx512icl, w4, w8, w16, w32, w64
 JMP_TABLE pal_pred_16bpc,         avx512icl, w4, w8, w16, w32, w64
 
-cextern smooth_weights_1d_16bpc
-cextern smooth_weights_2d_16bpc
-cextern dr_intra_derivative
-cextern filter_intra_taps
+cextern_args smooth_weights_1d_16bpc,data,hidden
+cextern_args smooth_weights_2d_16bpc,data,hidden
+cextern_args dr_intra_derivative,data,hidden
+cextern_args filter_intra_taps,data,hidden
 
 SECTION .text
 

--- a/src/x86/ipred16_sse.asm
+++ b/src/x86/ipred16_sse.asm
@@ -99,10 +99,10 @@ JMP_TABLE ipred_cfl_left_16bpc,   ssse3, h4, h8, h16, h32
 JMP_TABLE ipred_cfl_ac_444_16bpc, ssse3, w4, w8, w16, w32
 JMP_TABLE pal_pred_16bpc,         ssse3, w4, w8, w16, w32, w64
 
-cextern smooth_weights_1d_16bpc
-cextern smooth_weights_2d_16bpc
-cextern dr_intra_derivative
-cextern filter_intra_taps
+cextern_args smooth_weights_1d_16bpc,data,hidden
+cextern_args smooth_weights_2d_16bpc,data,hidden
+cextern_args dr_intra_derivative,data,hidden
+cextern_args filter_intra_taps,data,hidden
 
 SECTION .text
 

--- a/src/x86/ipred_avx2.asm
+++ b/src/x86/ipred_avx2.asm
@@ -173,8 +173,8 @@ JMP_TABLE ipred_cfl_ac_422, avx2, w16_pad1, w16_pad2, w16_pad3
 JMP_TABLE ipred_cfl_ac_444, avx2, w32_pad1, w32_pad2, w32_pad3, w4, w8, w16, w32
 JMP_TABLE pal_pred,         avx2, w4, w8, w16, w32, w64
 
-cextern dr_intra_derivative
-cextern filter_intra_taps
+cextern_args dr_intra_derivative,data,hidden
+cextern_args filter_intra_taps,data,hidden
 
 SECTION .text
 

--- a/src/x86/ipred_avx512.asm
+++ b/src/x86/ipred_avx512.asm
@@ -213,8 +213,8 @@ JMP_TABLE ipred_dc_8bpc,         avx512icl, h4, h8, h16, h32, h64, w4, w8, w16, 
                                        s4-10*4, s8-10*4, s16-10*4, s32-10*4, s64-10*4
 JMP_TABLE ipred_dc_left_8bpc,    avx512icl, h4, h8, h16, h32, h64
 
-cextern dr_intra_derivative
-cextern pb_0to63
+cextern_args dr_intra_derivative,data,hidden
+cextern_args pb_0to63,data,hidden
 
 SECTION .text
 

--- a/src/x86/ipred_sse.asm
+++ b/src/x86/ipred_sse.asm
@@ -141,8 +141,8 @@ JMP_TABLE ipred_cfl,        ssse3, h4, h8, h16, h32, w4, w8, w16, w32, \
 JMP_TABLE ipred_cfl_left,   ssse3, h4, h8, h16, h32
 JMP_TABLE ipred_filter,     ssse3, w4, w8, w16, w32
 
-cextern dr_intra_derivative
-cextern filter_intra_taps
+cextern_args dr_intra_derivative,data,hidden
+cextern_args filter_intra_taps,data,hidden
 
 SECTION .text
 

--- a/src/x86/looprestoration16_avx2.asm
+++ b/src/x86/looprestoration16_avx2.asm
@@ -62,8 +62,8 @@ pd_0xf00801c7: dd 0xf00801c7
 
 %define pw_256 sgr_lshuf5
 
-cextern pb_0to63
-cextern sgr_x_by_x_avx2
+cextern_args pb_0to63,data,hidden
+cextern_args sgr_x_by_x_avx2,data,hidden
 
 SECTION .text
 

--- a/src/x86/looprestoration16_avx512.asm
+++ b/src/x86/looprestoration16_avx512.asm
@@ -51,7 +51,7 @@ pd_m9:         dd -9
 pd_8:          dd 8
 pd_2147483648: dd 2147483648
 
-cextern sgr_x_by_x
+cextern_args sgr_x_by_x,data,hidden
 
 SECTION .text
 

--- a/src/x86/looprestoration16_sse.asm
+++ b/src/x86/looprestoration16_sse.asm
@@ -59,7 +59,7 @@ pd_0xfffffff0: times 4 dd 0xfffffff0
 wiener_shifts: dw 4, 4, 2048, 2048, 1, 1, 8192, 8192
 wiener_round:  dd 1049600, 1048832
 
-cextern sgr_x_by_x
+cextern_args sgr_x_by_x,data,hidden
 
 SECTION .text
 

--- a/src/x86/looprestoration_avx512.asm
+++ b/src/x86/looprestoration_avx512.asm
@@ -53,7 +53,7 @@ pd_m9:         dd -9
 pd_34816:      dd 34816
 pd_8421376:    dd 8421376
 
-cextern sgr_x_by_x
+cextern_args sgr_x_by_x,data,hidden
 
 SECTION .text
 

--- a/src/x86/looprestoration_sse.asm
+++ b/src/x86/looprestoration_sse.asm
@@ -51,7 +51,7 @@ pd_0xffff:     times 4 dd 0xffff
 pd_0xf00800a4: times 4 dd 0xf00800a4
 pd_0xf00801c7: times 4 dd 0xf00801c7
 
-cextern sgr_x_by_x
+cextern_args sgr_x_by_x,data,hidden
 
 SECTION .text
 

--- a/src/x86/mc16_avx2.asm
+++ b/src/x86/mc16_avx2.asm
@@ -194,11 +194,11 @@ SCALED_JMP_TABLE prep_8tap_scaled, avx2,   4, 8, 16, 32, 64, 128
 
 %define table_offset(type, fn) type %+ fn %+ SUFFIX %+ _table - type %+ SUFFIX
 
-cextern mc_subpel_filters
+cextern_args mc_subpel_filters,data,hidden
 %define subpel_filters (mangle(private_prefix %+ _mc_subpel_filters)-8)
 
-cextern mc_warp_filter
-cextern resize_filter
+cextern_args mc_warp_filter,data,hidden
+cextern_args resize_filter,data,hidden
 
 SECTION .text
 

--- a/src/x86/mc16_avx512.asm
+++ b/src/x86/mc16_avx512.asm
@@ -251,12 +251,12 @@ HV_JMP_TABLE   prep, 8tap,  avx512icl, 2,    4, 8, 16, 32, 64, 128
 
 %define table_offset(type, fn) type %+ fn %+ SUFFIX %+ _table - type %+ SUFFIX
 
-cextern mc_subpel_filters
+cextern_args mc_subpel_filters,data,hidden
 %define subpel_filters (mangle(private_prefix %+ _mc_subpel_filters)-8)
 
-cextern mc_warp_filter
-cextern obmc_masks_avx2
-cextern resize_filter
+cextern_args mc_warp_filter,data,hidden
+cextern_args obmc_masks_avx2,data,hidden
+cextern_args resize_filter,data,hidden
 
 SECTION .text
 

--- a/src/x86/mc16_sse.asm
+++ b/src/x86/mc16_sse.asm
@@ -158,11 +158,11 @@ BASE_JMP_TABLE prep, ssse3,    4, 8, 16, 32, 64, 128
 SCALED_JMP_TABLE put_8tap_scaled, ssse3, 2, 4, 8, 16, 32, 64, 128
 SCALED_JMP_TABLE prep_8tap_scaled, ssse3,   4, 8, 16, 32, 64, 128
 
-cextern mc_subpel_filters
+cextern_args mc_subpel_filters,data,hidden
 %define subpel_filters (mangle(private_prefix %+ _mc_subpel_filters)-8)
 
-cextern mc_warp_filter
-cextern resize_filter
+cextern_args mc_warp_filter,data,hidden
+cextern_args resize_filter,data,hidden
 
 SECTION .text
 

--- a/src/x86/mc_avx2.asm
+++ b/src/x86/mc_avx2.asm
@@ -91,10 +91,10 @@ pd_0x3ff:        dd 0x3ff
 pd_0x4000:       dd 0x4000
 pq_0x40000000:   dq 0x40000000
 
-cextern mc_subpel_filters
-cextern mc_warp_filter2
-cextern resize_filter
-cextern z_filter_s
+cextern_args mc_subpel_filters,data,hidden
+cextern_args mc_warp_filter2,data,hidden
+cextern_args resize_filter,data,hidden
+cextern_args z_filter_s,data,hidden
 
 %define subpel_filters (mangle(private_prefix %+ _mc_subpel_filters)-8)
 

--- a/src/x86/mc_avx512.asm
+++ b/src/x86/mc_avx512.asm
@@ -200,10 +200,10 @@ pd_512:             dd 512
 %define pb_64  (wm_sign+8)
 %define pd_2   (pd_0to7+8)
 
-cextern mc_subpel_filters
+cextern_args mc_subpel_filters,data,hidden
 %define subpel_filters (mangle(private_prefix %+ _mc_subpel_filters)-8)
-cextern mc_warp_filter
-cextern resize_filter
+cextern_args mc_warp_filter,data,hidden
+cextern_args resize_filter,data,hidden
 
 %macro BASE_JMP_TABLE 3-*
     %xdefine %1_%2_table (%%table - %3)

--- a/src/x86/mc_sse.asm
+++ b/src/x86/mc_sse.asm
@@ -202,7 +202,7 @@ const mc_warp_filter2 ; dav1d_mc_warp_filter[] reordered for pmaddubsw usage
 
 pw_258:  times 2 dw 258
 
-cextern mc_subpel_filters
+cextern_args mc_subpel_filters,data,hidden
 %define subpel_filters (mangle(private_prefix %+ _mc_subpel_filters)-8)
 
 %macro BIDIR_JMP_TABLE 2-*
@@ -9357,7 +9357,7 @@ cglobal emu_edge_8bpc, 10, 13, 2, bw, bh, iw, ih, x, \
 %undef reg_blkm
 %undef reg_tmp
 
-cextern resize_filter
+cextern_args resize_filter,data,hidden
 
 %macro SCRATCH 3
 %if ARCH_X86_32


### PR DESCRIPTION
On linux/x64, if using any of the assembly SIMD routines that rely on the tables defined in `tables.rs`, `rav1d` will fail to link with the following errors:
```
mold: error: /home/cmc/dev/rerun-io/rerun/target/debug/deps/libre_rav1d-d1774017185e2712.rlib(mc_avx2.o):(.text): R_X86_64_PC32 relocation at offset 0x7562 against symbol `dav1d_mc_subpel_filters' can not be used; recompile with -fPIC
mold: error: /home/cmc/dev/rerun-io/rerun/target/debug/deps/libre_rav1d-d1774017185e2712.rlib(mc16_avx2.o):(.text): R_X86_64_PC32 relocation at offset 0xa65c against symbol `dav1d_resize_filter' can not be used; recompile with -fPIC
mold: error: /home/cmc/dev/rerun-io/rerun/target/debug/deps/libre_rav1d-d1774017185e2712.rlib(mc16_avx2.o):(.text): R_X86_64_PC32 relocation at offset 0xa687 against symbol `dav1d_resize_filter' can not be used; recompile with -fPIC
mold: error: /home/cmc/dev/rerun-io/rerun/target/debug/deps/libre_rav1d-d1774017185e2712.rlib(mc_avx2.o):(.text): R_X86_64_PC32 relocation at offset 0x7581 against symbol `dav1d_mc_subpel_filters' can not be used; recompile with -fPIC
mold: error: /home/cmc/dev/rerun-io/rerun/target/debug/deps/libre_rav1d-d1774017185e2712.rlib(mc16_avx2.o):(.text): R_X86_64_PC32 relocation at offset 0xa691 against symbol `dav1d_resize_filter' can not be used; recompile with -fPIC
# ... more of the same ...
```

Long story short, the reason this fails is because these tables are exposed publicly in the final ELF artifact, when they shouldn't be.

The C implementation avoids this problem by making use of compiler intrinsincs:
https://github.com/memorysafety/rav1d/blob/c7d127e7e31bd3366ac7dc1717dda9782905c605/src/tables.h#L113-L115
where `EXTERN` is defined as:
https://github.com/memorysafety/rav1d/blob/c7d127e7e31bd3366ac7dc1717dda9782905c605/include/common/attributes.h#L116-L120

As far as I know, there doesn't exist any way of modifying the ELF visibility of Rust symbols directly from code.
Therefore, the best approach I have found is to modify the assembly itself in order to hide these extern references directly, and then the linker gets the hint.

For a long-winded, much more in depth explanation, see:
* https://github.com/rerun-io/re_rav1d/pull/3