### PR TITLE
`mod refmvs`: backport changes from dav1d 1.5.0

### DIFF
--- a/src/lib.c
+++ b/src/lib.c
@@ -657,7 +657,7 @@ static COLD void close_internal(Dav1dContext **const c_out, int flush) {
         free(f->lf.level);
         free(f->lf.tx_lpf_right_edge[0]);
         free(f->lf.start_of_tile_row);
-        dav1d_refmvs_clear(&f->rf);
+        dav1d_free_aligned(f->rf.r);
         dav1d_free_aligned(f->lf.cdef_line_buf);
         dav1d_free_aligned(f->lf.lr_line_buf);
     }

--- a/src/refmvs.c
+++ b/src/refmvs.c
@@ -657,18 +657,19 @@ void dav1d_refmvs_tile_sbrow_init(refmvs_tile *const rt, const refmvs_frame *con
 {
     if (rf->n_tile_threads == 1) tile_row_idx = 0;
     rt->rp_proj = &rf->rp_proj[16 * rf->rp_stride * tile_row_idx];
+    const ptrdiff_t r_stride = rf->rp_stride * 2;
     const ptrdiff_t pass_off = (rf->n_frame_threads > 1 && pass == 2) ?
-        35 * rf->r_stride * rf->n_tile_rows : 0;
-    refmvs_block *r = &rf->r[35 * rf->r_stride * tile_row_idx + pass_off];
+        35 * 2 * rf->n_blocks : 0;
+    refmvs_block *r = &rf->r[35 * r_stride * tile_row_idx + pass_off];
     const int sbsz = rf->sbsz;
     const int off = (sbsz * sby) & 16;
-    for (int i = 0; i < sbsz; i++, r += rf->r_stride)
+    for (int i = 0; i < sbsz; i++, r += r_stride)
         rt->r[off + 5 + i] = r;
     rt->r[off + 0] = r;
-    r += rf->r_stride;
+    r += r_stride;
     rt->r[off + 1] = NULL;
     rt->r[off + 2] = r;
-    r += rf->r_stride;
+    r += r_stride;
     rt->r[off + 3] = NULL;
     rt->r[off + 4] = r;
     if (sby & 1) {
@@ -804,37 +805,36 @@ int dav1d_refmvs_init_frame(refmvs_frame *const rf,
                             /*const*/ refmvs_temporal_block *const rp_ref[7],
                             const int n_tile_threads, const int n_frame_threads)
 {
+    const int rp_stride = ((frm_hdr->width[0] + 127) & ~127) >> 3;
+    const int n_tile_rows = n_tile_threads > 1 ? frm_hdr->tiling.rows : 1;
+    const int n_blocks = rp_stride * n_tile_rows;
+
     rf->sbsz = 16 << seq_hdr->sb128;
     rf->frm_hdr = frm_hdr;
     rf->iw8 = (frm_hdr->width[0] + 7) >> 3;
     rf->ih8 = (frm_hdr->height + 7) >> 3;
     rf->iw4 = rf->iw8 << 1;
     rf->ih4 = rf->ih8 << 1;
-
-    const ptrdiff_t r_stride = ((frm_hdr->width[0] + 127) & ~127) >> 2;
-    const int n_tile_rows = n_tile_threads > 1 ? frm_hdr->tiling.rows : 1;
-    if (r_stride != rf->r_stride || n_tile_rows != rf->n_tile_rows) {
-        if (rf->r) dav1d_freep_aligned(&rf->r);
-        const int uses_2pass = n_frame_threads > 1;
-        /* sizeof(refmvs_block) == 12 but it's accessed using 16-byte loads in asm,
-         * so add 4 bytes of padding to avoid buffer overreads. */
-        rf->r = dav1d_alloc_aligned(sizeof(*rf->r) * 35 * r_stride * n_tile_rows * (1 + uses_2pass) + 4, 64);
-        if (!rf->r) return DAV1D_ERR(ENOMEM);
-        rf->r_stride = r_stride;
-    }
-
-    const ptrdiff_t rp_stride = r_stride >> 1;
-    if (rp_stride != rf->rp_stride || n_tile_rows != rf->n_tile_rows) {
-        if (rf->rp_proj) dav1d_freep_aligned(&rf->rp_proj);
-        rf->rp_proj = dav1d_alloc_aligned(sizeof(*rf->rp_proj) * 16 * rp_stride * n_tile_rows, 64);
-        if (!rf->rp_proj) return DAV1D_ERR(ENOMEM);
-        rf->rp_stride = rp_stride;
-    }
-    rf->n_tile_rows = n_tile_rows;
+    rf->rp = rp;
+    rf->rp_stride = rp_stride;
     rf->n_tile_threads = n_tile_threads;
     rf->n_frame_threads = n_frame_threads;
-    rf->rp = rp;
-    rf->rp_ref = rp_ref;
+
+    if (n_blocks != rf->n_blocks) {
+        const size_t r_sz = sizeof(*rf->r) * 35 * 2 * n_blocks * (1 + (n_frame_threads > 1));
+        const size_t rp_proj_sz = sizeof(*rf->rp_proj) * 16 * n_blocks;
+        /* Note that sizeof(*rf->r) == 12, but it's accessed using 16-byte unaligned
+         * loads in save_tmvs() asm which can overread 4 bytes into rp_proj. */
+        dav1d_free_aligned(rf->r);
+        rf->r = dav1d_alloc_aligned(ALLOC_REFMVS, r_sz + rp_proj_sz, 64);
+        if (!rf->r) {
+            rf->n_blocks = 0;
+            return DAV1D_ERR(ENOMEM);
+        }
+        rf->rp_proj = (refmvs_temporal_block*)((uintptr_t)rf->r + r_sz);
+        rf->n_blocks = n_blocks;
+    }
+
     const unsigned poc = frm_hdr->frame_offset;
     for (int i = 0; i < 7; i++) {
         const int poc_diff = get_poc_diff(seq_hdr->order_hint_n_bits,
@@ -847,6 +847,7 @@ int dav1d_refmvs_init_frame(refmvs_frame *const rf,
 
     // temporal MV setup
     rf->n_mfmvs = 0;
+    rf->rp_ref = rp_ref;
     if (frm_hdr->use_ref_frame_mvs && seq_hdr->order_hint_n_bits) {
         int total = 2;
         if (rp_ref[0] && ref_ref_poc[0][6] != ref_poc[3] /* alt-of-last != gold */) {
@@ -893,11 +894,6 @@ int dav1d_refmvs_init_frame(refmvs_frame *const rf,
     rf->use_ref_frame_mvs = rf->n_mfmvs > 0;
 
     return 0;
-}
-
-void dav1d_refmvs_clear(refmvs_frame *const rf) {
-    if (rf->r) dav1d_freep_aligned(&rf->r);
-    if (rf->rp_proj) dav1d_freep_aligned(&rf->rp_proj);
 }
 
 static void splat_mv_c(refmvs_block **rr, const refmvs_block *const rmv,

--- a/src/refmvs.h
+++ b/src/refmvs.h
@@ -72,14 +72,14 @@ typedef struct refmvs_frame {
     int mfmv_ref2ref[3][7];
     int n_mfmvs;
 
+    int n_blocks;
     refmvs_temporal_block *rp;
     /*const*/ refmvs_temporal_block *const *rp_ref;
     refmvs_temporal_block *rp_proj;
     ptrdiff_t rp_stride;
 
     refmvs_block *r; // 35 x r_stride memory
-    ptrdiff_t r_stride;
-    int n_tile_rows, n_tile_threads, n_frame_threads;
+    int n_tile_threads, n_frame_threads;
 } refmvs_frame;
 
 typedef struct refmvs_tile {
@@ -120,9 +120,6 @@ typedef struct Dav1dRefmvsDSPContext {
     save_tmvs_fn save_tmvs;
     splat_mv_fn splat_mv;
 } Dav1dRefmvsDSPContext;
-
-// call once per frame thread
-void dav1d_refmvs_clear(refmvs_frame *rf);
 
 // call once per frame
 int dav1d_refmvs_init_frame(refmvs_frame *rf,

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -120,6 +120,8 @@ pub struct RefMvsFrame {
     pub mfmv_ref2ref: [[i32; 7]; 3],
     pub n_mfmvs: i32,
     pub n_blocks: u32,
+    // TODO: The C code uses a single buffer to store `rp_proj` and `r` to minimize
+    // the number of allocated buffers.
     pub rp_proj: DisjointMut<AlignedVec64<RefMvsTemporalBlock>>,
     pub rp_stride: u32,
     pub r: DisjointMut<AlignedVec64<RefMvsBlock>>,

--- a/src/refmvs.rs
+++ b/src/refmvs.rs
@@ -92,13 +92,12 @@ pub(crate) struct AsmRefMvsFrame<'a> {
     pub mfmv_ref2cur: [i32; 3],
     pub mfmv_ref2ref: [[i32; 7]; 3],
     pub n_mfmvs: i32,
+    pub n_blocks: i32,
     pub rp: *mut RefMvsTemporalBlock,
     pub rp_ref: *const *mut RefMvsTemporalBlock,
     pub rp_proj: *mut RefMvsTemporalBlock,
     pub rp_stride: isize,
     pub r: *mut RefMvsBlock,
-    pub r_stride: isize,
-    pub n_tile_rows: i32,
     pub n_tile_threads: i32,
     pub n_frame_threads: i32,
 }
@@ -120,11 +119,10 @@ pub struct RefMvsFrame {
     pub mfmv_ref2cur: [i32; 3],
     pub mfmv_ref2ref: [[i32; 7]; 3],
     pub n_mfmvs: i32,
+    pub n_blocks: u32,
     pub rp_proj: DisjointMut<AlignedVec64<RefMvsTemporalBlock>>,
     pub rp_stride: u32,
     pub r: DisjointMut<AlignedVec64<RefMvsBlock>>,
-    pub r_stride: u32,
-    pub n_tile_rows: u32,
     pub n_tile_threads: u32,
     pub n_frame_threads: u32,
 }
@@ -207,11 +205,10 @@ impl load_tmvs::Fn {
             mfmv_ref2cur,
             mfmv_ref2ref,
             n_mfmvs,
+            n_blocks,
             ref rp_proj,
             rp_stride,
             ref r,
-            r_stride,
-            n_tile_rows,
             n_tile_threads,
             n_frame_threads,
         } = *rf;
@@ -239,13 +236,12 @@ impl load_tmvs::Fn {
             mfmv_ref2cur,
             mfmv_ref2ref,
             n_mfmvs,
+            n_blocks: n_blocks as _,
             rp: mvs_to_dav1d(rp),
             rp_ref: rp_ref_dav1d.as_ptr(),
             rp_proj: rp_proj.as_mut_ptr(),
             rp_stride: rp_stride as _,
             r: r.as_mut_ptr(),
-            r_stride: r_stride as _,
-            n_tile_rows: n_tile_rows as _,
             n_tile_threads: n_tile_threads as _,
             n_frame_threads: n_frame_threads as _,
         };
@@ -1329,10 +1325,10 @@ pub(crate) fn rav1d_refmvs_tile_sbrow_init(
         tile_row_idx = 0;
     }
     let rp_stride = rf.rp_stride as usize;
-    let r_stride = rf.r_stride as usize;
+    let r_stride = rp_stride * 2;
     let rp_proj = 16 * rp_stride * tile_row_idx as usize;
     let pass_off = if rf.n_frame_threads > 1 && pass == 2 {
-        35 * r_stride * rf.n_tile_rows as usize
+        35 * 2 * rf.n_blocks as usize
     } else {
         0
     };
@@ -1582,40 +1578,35 @@ pub(crate) fn rav1d_refmvs_init_frame(
     n_tile_threads: u32,
     n_frame_threads: u32,
 ) -> Rav1dResult {
-    rf.sbsz = 16 << seq_hdr.sb128;
-    rf.iw8 = frm_hdr.size.width[0] + 7 >> 3;
-    rf.ih8 = frm_hdr.size.height + 7 >> 3;
-    rf.iw4 = rf.iw8 << 1;
-    rf.ih4 = rf.ih8 << 1;
-
-    let r_stride = ((frm_hdr.size.width[0] + 127 & !127) >> 2) as u32;
+    let rp_stride = ((frm_hdr.size.width[0] + 127 & !127) >> 3) as u32;
     let n_tile_rows = if n_tile_threads > 1 {
         frm_hdr.tiling.rows as u32
     } else {
         1
     };
-    let uses_2pass = (n_frame_threads > 1) as usize;
-    // `mem::size_of::<refmvs_block>() == 12`,
-    // but it's accessed using 16-byte loads in asm,
-    // so add `R_PAD` elements to avoid buffer overreads.
-    // TODO fallible allocation
-    rf.r.resize(
-        35 * r_stride as usize * n_tile_rows as usize * (1 + uses_2pass) + R_PAD,
-        FromZeroes::new_zeroed(),
-    );
-    rf.r_stride = r_stride;
+    let n_blocks = rp_stride * n_tile_rows;
 
-    let rp_stride = r_stride >> 1;
-    // TODO fallible allocation
-    rf.rp_proj.resize(
-        16 * rp_stride as usize * n_tile_rows as usize,
-        Default::default(),
-    );
+    rf.sbsz = 16 << seq_hdr.sb128;
+    rf.iw8 = frm_hdr.size.width[0] + 7 >> 3;
+    rf.ih8 = frm_hdr.size.height + 7 >> 3;
+    rf.iw4 = rf.iw8 << 1;
+    rf.ih4 = rf.ih8 << 1;
     rf.rp_stride = rp_stride;
-
-    rf.n_tile_rows = n_tile_rows;
     rf.n_tile_threads = n_tile_threads;
     rf.n_frame_threads = n_frame_threads;
+
+    if n_blocks != rf.n_blocks {
+        // `mem::size_of::<RefMvsBlock>() == 12`,
+        // but it's accessed using 16-byte unaligned loads in save_tmvs() asm,
+        // so add `R_PAD` elements to avoid buffer overreads.
+        let r_sz = 35 * 2 * n_blocks as usize * (1 + (n_frame_threads > 1) as usize) + R_PAD;
+        let rp_proj_sz = 16 * n_blocks as usize;
+        // TODO fallible allocation
+        rf.r.resize(r_sz, FromZeroes::new_zeroed());
+        rf.rp_proj.resize(rp_proj_sz, Default::default());
+        rf.n_blocks = n_blocks;
+    }
+
     let poc = frm_hdr.frame_offset as u32;
     for i in 0..7 {
         let poc_diff = get_poc_diff(seq_hdr.order_hint_n_bits, ref_poc[i] as i32, poc as i32);

--- a/src/x86/refmvs.asm
+++ b/src/x86/refmvs.asm
@@ -341,7 +341,7 @@ cglobal load_tmvs, 6, 15, 4, -0x50, rf, tridx, xstart, xend, ystart, yend, \
                                     stride, rp_proj, roff, troff, \
                                     xendi, xstarti, iw8, ih8, dst
     xor           r14d, r14d
-    cmp dword [rfq+212], 1          ; n_tile_threads
+    cmp dword [rfq+200], 1          ; n_tile_threads
     mov           ih8d, [rfq+20]    ; rf->ih8
     mov           iw8d, [rfq+16]    ; rf->iw8
     mov        xstartd, xstartd

--- a/src/x86/refmvs.asm
+++ b/src/x86/refmvs.asm
@@ -92,6 +92,31 @@ JMP_TABLE splat_mv_avx2,      1, 2, 4, 8, 16, 32
 
 JMP_TABLE splat_mv_sse2,      1, 2, 4, 8, 16, 32
 
+struc rf
+    .frm_hdr:         resq 1
+    .iw4:             resd 1
+    .ih4:             resd 1
+    .iw8:             resd 1
+    .ih8:             resd 1
+    .sbsz:            resd 1
+    .use_rf_mvs:      resd 1
+    .sign_bias:       resb 7
+    .mfmv_sign:       resb 7
+    .pocdiff:         resb 7
+    .mfmv_ref:        resb 3
+    .mfmv_ref2cur:    resd 3
+    .mfmv_ref2ref:    resd 3*7
+    .n_mfmvs:         resd 1
+    .n_blocks:        resd 1
+    .rp:              resq 1
+    .rp_ref:          resq 1
+    .rp_proj:         resq 1
+    .rp_stride:       resq 1
+    .r:               resq 1
+    .n_tile_threads:  resd 1
+    .n_frame_threads: resd 1
+endstruc
+
 SECTION .text
 
 %macro movif32 2
@@ -341,16 +366,16 @@ cglobal load_tmvs, 6, 15, 4, -0x50, rf, tridx, xstart, xend, ystart, yend, \
                                     stride, rp_proj, roff, troff, \
                                     xendi, xstarti, iw8, ih8, dst
     xor           r14d, r14d
-    cmp dword [rfq+200], 1          ; n_tile_threads
-    mov           ih8d, [rfq+20]    ; rf->ih8
-    mov           iw8d, [rfq+16]    ; rf->iw8
+    cmp dword [rfq+rf.n_tile_threads], 1
+    mov           ih8d, [rfq+rf.ih8]
+    mov           iw8d, [rfq+rf.iw8]
     mov        xstartd, xstartd
     mov          xendd, xendd
     cmove       tridxd, r14d
     lea       xstartid, [xstartq-8]
     lea         xendid, [xendq+8]
-    mov        strideq, [rfq+184]
-    mov       rp_projq, [rfq+176]
+    mov        strideq, [rfq+rf.rp_stride]
+    mov       rp_projq, [rfq+rf.rp_proj]
     cmp           ih8d, yendd
     mov     [rsp+0x30], strideq
     cmovs        yendd, ih8d
@@ -397,7 +422,7 @@ cglobal load_tmvs, 6, 15, 4, -0x50, rf, tridx, xstart, xend, ystart, yend, \
     jg .init_xloop_start
  DEFINE_ARGS rf, _, xstart, xend, ystart, yend, n7, stride, \
              _, _, xendi, xstarti, stride5, _, n
-    mov           r13d, [rfq+152]   ; rf->n_mfmvs
+    mov           r13d, [rfq+rf.n_mfmvs]
     test          r13d, r13d
     jz .ret
     mov     [rsp+0x0c], r13d
@@ -418,14 +443,14 @@ cglobal load_tmvs, 6, 15, 4, -0x50, rf, tridx, xstart, xend, ystart, yend, \
  DEFINE_ARGS y, off, xstart, xend, ystart, rf, n7, refsign, \
              ref, rp_ref, xendi, xstarti, _, _, n
     mov            rfq, [rsp+0x48]
-    mov           refd, [rfq+56+nq*4]       ; ref2cur
+    mov           refd, [rfq+rf.mfmv_ref2cur+nq*4]
     cmp           refd, 0x80000000
     je .next_n
     mov     [rsp+0x40], refd
     mov           offq, [rsp+0x00]          ; ystart * stride * 5
-    movzx         refd, byte [rfq+53+nq]    ; rf->mfmv_ref[n]
+    movzx         refd, byte [rfq+rf.mfmv_ref+nq]
     lea       refsignq, [refq-4]
-    mov        rp_refq, [rfq+168]
+    mov        rp_refq, [rfq+rf.rp_ref]
     movq            m2, refsignq
     add           offq, [rp_refq+refq*8]    ; r = rp_ref[ref] + row_offset
     mov     [rsp+0x14], nd
@@ -452,8 +477,8 @@ cglobal load_tmvs, 6, 15, 4, -0x50, rf, tridx, xstart, xend, ystart, yend, \
     test          refd, refd
     jz .next_x_bad_ref
     mov            rfq, [rsp+0x48]
-    lea           r14d, [16+n7q+refq]
-    mov       ref2refd, [rfq+r14*4]         ; rf->mfmv_ref2ref[n][b_ref-1]
+    lea       ref2refd, [(rf.mfmv_ref2ref/4)+n7q+refq-1]
+    mov       ref2refd, [rfq+ref2refq*4]    ; rf->mfmv_ref2ref[n][b_ref-1]
     test      ref2refd, ref2refd
     jz .next_x_bad_ref
     lea          fracq, [mv_proj]


### PR DESCRIPTION
Backport changes in `refmvs` allocation but keep memory buffers separate for `RefMvsFrame::r` and `RefMvsFrame::rp_proj` as they use different data types.