### PR TITLE
Bump version numbers to 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "rav1d"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "assert_matches",
  "atomig",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "rav1d-cli"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "cc",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = [".", "tools"]
 [package]
 name = "rav1d"
 authors = ["Rav1d Developers", "Prossimo"]
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.79"
 description = "Rust port of the dav1d AV1 decoder"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rav1d-cli"
 authors = ["Rav1d Developers", "Prossimo"]
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 default-run = "dav1d"
 description = "Rust port of the dav1d AV1 decoder CLI tools"
@@ -20,7 +20,7 @@ name = "seek_stress"
 [dependencies]
 cfg-if = "1.0.0"
 libc = "0.2"
-rav1d = { path = "../", version = "1.0.0", default-features = false }
+rav1d = { path = "../", version = "1.1.0", default-features = false }
 
 [build-dependencies]
 cc = "1.0.79"


### PR DESCRIPTION
* Fixes #1376.

This prepares us for the 1.1.0 release. Let me know if I missed anything else that needs to be changed before we release a new version.