### PR TITLE
ci: ensure every CI workflow caches and explicitly installs a `rustup` toolchain

### DIFF
--- a/.github/workflows/build-and-benchmark-x86.yml
+++ b/.github/workflows/build-and-benchmark-x86.yml
@@ -10,12 +10,18 @@ jobs:
         steps:
             - name: git checkout
               uses: actions/checkout@v4
+            - name: install rust toolchain
+              id: toolchain
+              uses: dtolnay/rust-toolchain@master
+              with:
+                toolchain: 1.87.0 # specific version for consistent perf
+                target: x86_64-unknown-linux-gnu
             - name: release build this PR
-              run:  nice cargo build --release
+              run: nice cargo +${{ steps.toolchain.outputs.name }} build --release
             - name: release build main branch
               run: |
                 git fetch --depth 1 origin main && git checkout origin/main
-                nice cargo +stable build --release --target-dir target.main
+                nice cargo +${{ steps.toolchain.outputs.name }} build --release --target-dir target.main
             - name: benchmark on chimera 8-bit test data
               run: |
                 mkdir -p `dirname $LOCAL_FILE`

--- a/.github/workflows/build-and-test-aarch64-android.yml
+++ b/.github/workflows/build-and-test-aarch64-android.yml
@@ -25,15 +25,7 @@ jobs:
           toolchain: stable
           target: aarch64-linux-android
       - name: cache rust dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: aarch64-android-cargo-and-target-${{ hashFiles('**/Cargo.lock') }}
+        uses: Swatinem/rust-cache@v2
       - name: cargo build for aarch64-linux-android
         run: |
             cargo +${{ steps.toolchain.outputs.name }} build --target aarch64-linux-android --release

--- a/.github/workflows/build-and-test-aarch64-android.yml
+++ b/.github/workflows/build-and-test-aarch64-android.yml
@@ -17,6 +17,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+      - name: install rust toolchain
+        id: toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          # aarch64 feature detection is stable
+          toolchain: stable
+          target: aarch64-linux-android
       - name: cache rust dependencies
         uses: actions/cache@v4
         with:
@@ -28,9 +35,8 @@ jobs:
             target/
           key: aarch64-android-cargo-and-target-${{ hashFiles('**/Cargo.lock') }}
       - name: cargo build for aarch64-linux-android
-        run:  |
-            rustup target add --toolchain stable aarch64-linux-android
-            cargo +stable build --target aarch64-linux-android --release
+        run: |
+            cargo +${{ steps.toolchain.outputs.name }} build --target aarch64-linux-android --release
         env:
           AR: llvm-ar
           CC: aarch64-linux-android26-clang

--- a/.github/workflows/build-and-test-aarch64-darwin.yml
+++ b/.github/workflows/build-and-test-aarch64-darwin.yml
@@ -30,15 +30,7 @@ jobs:
           toolchain: stable # aarch64 feature detection is stable
           target: aarch64-apple-darwin
       - name: cache rust dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: arm-darwin-cargo-and-target-${{ hashFiles('**/Cargo.lock') }}
+        uses: Swatinem/rust-cache@v2
       - name: cargo ${{ matrix.build.name }} build for aarch64-apple-darwin
         run:  cargo +${{ steps.toolchain.outputs.name }} build ${{ matrix.build.cargo_flags }}
       - name: test ${{ matrix.build.name }} build without frame delay

--- a/.github/workflows/build-and-test-aarch64-darwin.yml
+++ b/.github/workflows/build-and-test-aarch64-darwin.yml
@@ -23,6 +23,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+      - name: install rust toolchain
+        id: toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable # aarch64 feature detection is stable
+          target: aarch64-apple-darwin
       - name: cache rust dependencies
         uses: actions/cache@v4
         with:
@@ -34,7 +40,7 @@ jobs:
             target/
           key: arm-darwin-cargo-and-target-${{ hashFiles('**/Cargo.lock') }}
       - name: cargo ${{ matrix.build.name }} build for aarch64-apple-darwin
-        run:  cargo +stable build ${{ matrix.build.cargo_flags }}
+        run:  cargo +${{ steps.toolchain.outputs.name }} build ${{ matrix.build.cargo_flags }}
       - name: test ${{ matrix.build.name }} build without frame delay
         run: |
           .github/workflows/test.sh \

--- a/.github/workflows/build-and-test-qemu.yml
+++ b/.github/workflows/build-and-test-qemu.yml
@@ -56,15 +56,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.target }}
       - name: cache rust dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ matrix.target }}-cargo-and-target-${{ hashFiles('**/Cargo.lock') }}
+        uses: Swatinem/rust-cache@v2
       - name: cargo build for ${{ matrix.target }}
         run: |
           RUSTFLAGS="-C target-feature=+crt-static -C linker=${{ matrix.linker }}" \

--- a/.github/workflows/build-and-test-qemu.yml
+++ b/.github/workflows/build-and-test-qemu.yml
@@ -14,10 +14,14 @@ jobs:
             linker: "arm-linux-gnueabihf-gcc"
             wrapper: "qemu-arm-static"
             packages: "g++-arm-linux-gnueabihf libc6-dev-armhf-cross"
+            # arm feature detection is unstable
+            # should be the same as rust-toolchain.toml
+            toolchain: nightly-2025-05-01 
           - target: "aarch64-unknown-linux-gnu"
             linker: "aarch64-linux-gnu-gcc"
             wrapper: "qemu-aarch64-static"
             packages: "g++-aarch64-linux-gnu libc6-dev-arm64-cross"
+            toolchain: stable # aarch64 feature detection is stable
           - target: "x86_64-unknown-linux-gnu"
             linker: "cc"
             wrapper: "qemu-x86_64-static -cpu max" # enable AVX512
@@ -25,10 +29,14 @@ jobs:
             # NOTE: This appears to work for Ubuntu 22.04 and other systems
             # with a recent version of GNU ld (e.g. 2.38) whereas Ubuntu 20.04
             # fails with the following linker error: unsupported ISA subset `z'
+            toolchain: stable # x86_64 feature detection is stable
           - target: "riscv64gc-unknown-linux-gnu"
             linker: "riscv64-linux-gnu-gcc"
             wrapper: "qemu-riscv64-static"
             packages: "g++-riscv64-linux-gnu libc6-dev-riscv64-cross"
+            # riscv64 feature detection is unstable
+            # should be the same as rust-toolchain.toml
+            toolchain: nightly-2025-05-01
     runs-on: ubuntu-22.04
     name: test on ${{ matrix.target }}
     steps:
@@ -41,6 +49,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+      - name: install rust toolchain
+        id: toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          target: ${{ matrix.target }}
       - name: cache rust dependencies
         uses: actions/cache@v4
         with:
@@ -53,9 +67,8 @@ jobs:
           key: ${{ matrix.target }}-cargo-and-target-${{ hashFiles('**/Cargo.lock') }}
       - name: cargo build for ${{ matrix.target }}
         run: |
-          rustup target add ${{ matrix.target }}
           RUSTFLAGS="-C target-feature=+crt-static -C linker=${{ matrix.linker }}" \
-            cargo build --release --target ${{ matrix.target }}
+            cargo +${{ steps.toolchain.outputs.name }} build --release --target ${{ matrix.target }}
       - name: run tests
         run: |
             .github/workflows/test.sh -t 2 \

--- a/.github/workflows/build-and-test-x86-extra.yml
+++ b/.github/workflows/build-and-test-x86-extra.yml
@@ -37,16 +37,8 @@ jobs:
         with:
           toolchain: stable # x86_64 feature detection is stable
           target: ${{ matrix.target }}
-      - name: cache rust crates
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: cache rust dependencies
+        uses: Swatinem/rust-cache@v2
       - name: cache argon test vectors
         id: cache-argon
         uses: actions/cache@v4

--- a/.github/workflows/build-and-test-x86-extra.yml
+++ b/.github/workflows/build-and-test-x86-extra.yml
@@ -31,14 +31,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: cache rust toolchain
-        uses: actions/cache@v4
+      - name: install rust toolchain
+        id: toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          path: |
-            ~/.rustup/toolchains
-            ~/.rustup/update-hashes
-            ~/.rustup/settings.toml
-          key: ${{ runner.os }}-${{ matrix.target }}-rust-toolchain-${{ hashFiles('rust-toolchain', 'rust-toolchain.toml') }}
+          toolchain: stable # x86_64 feature detection is stable
+          target: ${{ matrix.target }}
       - name: cache rust crates
         uses: actions/cache@v4
         with:
@@ -60,8 +58,7 @@ jobs:
             argon_coveragetool_av1_base_and_extended_profiles_v2.1.1.zip
       - name: cargo build for ${{ matrix.target }} ${{ matrix.build.name }}
         run: |
-          rustup target add --toolchain stable ${{ matrix.target }}
-          cargo +stable build --target ${{ matrix.target }} ${{ matrix.build.flags }}
+          cargo +${{ steps.toolchain.outputs.name }} build --target ${{ matrix.target }} ${{ matrix.build.flags }}
         env:
           RUSTFLAGS: "-C overflow-checks=on"
       - name: download, check, and unpack argon test vectors

--- a/.github/workflows/build-and-test-x86.yml
+++ b/.github/workflows/build-and-test-x86.yml
@@ -42,19 +42,10 @@ jobs:
         with:
           toolchain: stable # x86 and x86_64 feature detection are stable
           target: ${{ matrix.target }}
-      - name: cache rust crates
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: cache rust dependencies
+        uses: Swatinem/rust-cache@v2
       - name: cargo build for ${{ matrix.target }} ${{ matrix.build.name }}
         run: |
-          cargo +${{ steps.toolchain.outputs.name }} clean
           cargo +${{ steps.toolchain.outputs.name }} build --target ${{ matrix.target }} ${{ matrix.build.flags }}
       - name: meson test for ${{ matrix.target }} ${{ matrix.build.name }}
         run: |
@@ -93,16 +84,8 @@ jobs:
         with:
           toolchain: stable # x86_64 feature detection is stable
           target: x86_64-apple-darwin
-      - name: cache rust crates
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: cache rust dependencies
+        uses: Swatinem/rust-cache@v2
       - name: cargo build for x86_64-apple-darwin
         run: |
           cargo +${{ steps.toolchain.outputs.name }} build --release

--- a/.github/workflows/build-and-test-x86.yml
+++ b/.github/workflows/build-and-test-x86.yml
@@ -36,14 +36,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: cache rust toolchain
-        uses: actions/cache@v4
+      - name: install rust toolchain
+        id: toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          path: |
-            ~/.rustup/toolchains
-            ~/.rustup/update-hashes
-            ~/.rustup/settings.toml
-          key: ${{ runner.os }}-${{ matrix.target }}-rust-toolchain-${{ hashFiles('rust-toolchain', 'rust-toolchain.toml') }}
+          toolchain: stable # x86 and x86_64 feature detection are stable
+          target: ${{ matrix.target }}
       - name: cache rust crates
         uses: actions/cache@v4
         with:
@@ -56,9 +54,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: cargo build for ${{ matrix.target }} ${{ matrix.build.name }}
         run: |
-          cargo clean
-          rustup target add --toolchain stable ${{ matrix.target }}
-          cargo +stable build --target ${{ matrix.target }} ${{ matrix.build.flags }}
+          cargo +${{ steps.toolchain.outputs.name }} clean
+          cargo +${{ steps.toolchain.outputs.name }} build --target ${{ matrix.target }} ${{ matrix.build.flags }}
       - name: meson test for ${{ matrix.target }} ${{ matrix.build.name }}
         run: |
           .github/workflows/test.sh \
@@ -90,14 +87,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: cache rust toolchain
-        uses: actions/cache@v4
+      - name: install rust toolchain
+        id: toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          path: |
-            ~/.rustup/toolchains
-            ~/.rustup/update-hashes
-            ~/.rustup/settings.toml
-          key: ${{ runner.os }}-rust-toolchain-${{ hashFiles('rust-toolchain', 'rust-toolchain.toml') }}
+          toolchain: stable # x86_64 feature detection is stable
+          target: x86_64-apple-darwin
       - name: cache rust crates
         uses: actions/cache@v4
         with:
@@ -110,7 +105,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: cargo build for x86_64-apple-darwin
         run: |
-          cargo +stable build --release
+          cargo +${{ steps.toolchain.outputs.name }} build --release
       - name: meson test for x86_64-apple-darwin
         run: |
           .github/workflows/test.sh \
@@ -147,5 +142,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+      - name: install rust toolchain
+        id: toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable # x86_64 feature detection is stable
+          target: x86_64-pc-windows-msvc
       - name: cargo build
-        run: cargo build --release
+        run: cargo +${{ steps.toolchain.outputs.name }} build --release

--- a/.github/workflows/cargo-fmt.yml
+++ b/.github/workflows/cargo-fmt.yml
@@ -12,14 +12,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: cache rust toolchain
-        uses: actions/cache@v4
+      - name: install rust toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          path: |
-            ~/.rustup/toolchains
-            ~/.rustup/update-hashes
-            ~/.rustup/settings.toml
-          key: ${{ runner.os }}-rust-toolchain-${{ hashFiles('rust-toolchain', 'rust-toolchain.toml') }}
+          toolchain: stable
+          components: rustfmt
       - name: cache rust crates
         uses: actions/cache@v4
         with:

--- a/.github/workflows/cargo-fmt.yml
+++ b/.github/workflows/cargo-fmt.yml
@@ -17,15 +17,7 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt
-      - name: cache rust crates
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: cache rust dependencies
+        uses: Swatinem/rust-cache@v2
       - name: Check formatting
         run: cargo fmt --check


### PR DESCRIPTION
* Fixes #1391.

`rustup` no longer automatically installs a toolchain in `rust-toolchain.toml`, so we get errors like https://github.com/memorysafety/rav1d/issues/1391 now.  Moreover, we only use the pinned nightly for targets where CPU feature detection is unstable (`arm`, `riscv64`, `riscv32`).  Elsewhere we use `stable` for stability, so it helps to be more explicit about using the `stable` toolchain there.

This also adds some missing `rustup` toolchain caching steps.

Distinguishing between `stable` and the pinned nightly from `rust-toolchain.toml` is also quite tricky, so this switches to using `dtolnay/rust-toolchain` for that, which is also used by many `rust-lang` repos.

This also switches to using a pinned stable version for benchmarking for performance consistency.

Since I'm updating CI already, I also switched to `rust-cache` instead of our manual caching, as it's a lot smarter and more precise.  For example, in some places (our main CI workflow) we previously had to run `cargo clean` before `cargo build`, defeating the purpose of most of the caching.

`rust-cache` is also used by many `rust-lang` repos.