### PR TITLE
Add bounds check to `get_bytes` to prevent out-of-bounds read

### DIFF
--- a/src/getbits.rs
+++ b/src/getbits.rs
@@ -208,6 +208,7 @@ impl<'a> GetBits<'a> {
     }
 
     pub fn get_bytes(&mut self, n: usize) -> &[u8] {
+        assert!(n<=self.remaining_len());
         assert_eq!(self.bits_left, 0);
         let i = self.index;
         self.index += n;


### PR DESCRIPTION
Add a safety check in [get_bytes](https://github.com/memorysafety/rav1d/blob/a654c1e82adb2d9a33ae50d2a82a7a747102cbb6/src/getbits.rs#L210)  to ensure the requested byte count does not exceed the remaining buffer.

Previously, calling `get_bytes(n)` with `n > remaining_len()` would result in a panic due to out-of-bounds slicing. This fix replaces the implicit assumption with an explicit assertion: