### PR TITLE
create_lf_mask_inter: pull level_cache slice out of inner loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "bytemuck"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +158,7 @@ dependencies = [
  "assert_matches",
  "atomig",
  "bitflags",
+ "bytemuck",
  "cc",
  "cfg-if",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ raw-cpuid = "11.0.1"
 strum = { version = "0.26", features = ["derive"] }
 to_method = "1.1.0"
 zerocopy = { version = "0.7.32", features = ["derive"] }
+bytemuck = { version = "1.23.0" }
 
 [build-dependencies]
 cc = "1.0.79"


### PR DESCRIPTION
Hi,

Heard about the perf contest, I noticed that create lf inter function seems to be slower in rav1d than dav1d and also generates poorer assembly code. Here's my take at an improvement, it isn't quite at parity with dav1d but seems to be significantly better now.

Assuming tests pass, I'll upload some more documentation to this PR later. 
![image (1)](https://github.com/user-attachments/assets/188aea84-d5f5-4fc0-933d-fb55cd05cbca)
![image (2)](https://github.com/user-attachments/assets/5268e58a-77f1-44bf-bcd8-54b342a990ff)

This speeds up create lf mask significantly (and consistently) but the total improvement in time is small, slightly less than 1% which is within the measurement noise on my machine (Ryzen 3700X) so I'm having trouble reliably benchmarking. That said I'm pretty confident it's a net benefit so I'm posting this; if someone can reproduce the performance improvement with lower noise that would be great.