### PR TITLE
arm: reduce stack pressure when calling cdef_filter functions

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -69,12 +69,13 @@ impl cdef::Fn {
     /// then the pre-filter data is located in `dst`.
     /// However, the edge pixels above `dst` may be post-filter,
     /// so in order to get access to pre-filter top pixels, use `top`.
+    #[inline]
     pub fn call<BD: BitDepth>(
         &self,
-        dst: Rav1dPictureDataComponentOffset,
+        dst: &Rav1dPictureDataComponentOffset,
         left: &[LeftPixelRow2px<BD::Pixel>; 8],
-        top: CdefTop,
-        bottom: CdefBottom,
+        top: &CdefTop,
+        bottom: &CdefBottom,
         pri_strength: c_int,
         sec_strength: u8,
         dir: c_int,
@@ -87,12 +88,12 @@ impl cdef::Fn {
         let left = ptr::from_ref(left).cast();
         let top_ptr = top.as_ptr::<BD>().cast();
         let bottom_ptr = bottom.wrapping_as_ptr::<BD>().cast();
-        let top = FFISafe::new(&top);
-        let bottom = FFISafe::new(&bottom);
+        let top = FFISafe::new(top);
+        let bottom = FFISafe::new(bottom);
         let sec_strength = sec_strength as c_int;
         let damping = damping as c_int;
         let bd = bd.into_c();
-        let dst = FFISafe::new(&dst);
+        let dst = FFISafe::new(dst);
         // SAFETY: Rust fallback is safe, asm is assumed to do the same.
         unsafe {
             self.get()(
@@ -126,14 +127,14 @@ wrap_fn_ptr!(pub unsafe extern "C" fn cdef_dir(
 impl cdef_dir::Fn {
     pub fn call<BD: BitDepth>(
         &self,
-        dst: Rav1dPictureDataComponentOffset,
+        dst: &Rav1dPictureDataComponentOffset,
         variance: &mut c_uint,
         bd: BD,
     ) -> c_int {
         let dst_ptr = dst.as_ptr::<BD>().cast();
         let dst_stride = dst.stride();
         let bd = bd.into_c();
-        let dst = FFISafe::new(&dst);
+        let dst = FFISafe::new(dst);
         // SAFETY: Fallback `fn cdef_find_dir_rust` is safe; asm is supposed to do the same.
         unsafe { self.get()(dst_ptr, dst_stride, variance, bd, dst) }
     }

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -44,7 +44,7 @@ impl Backup2x8Flags {
 fn backup2lines<BD: BitDepth>(
     dst_buf: &DisjointMut<AlignedVec64<u8>>,
     dst_off: [usize; 3],
-    src: [Rav1dPictureDataComponentOffset; 3],
+    src: &[Rav1dPictureDataComponentOffset; 3],
     layout: Rav1dPixelLayout,
 ) {
     let y_stride = src[0].pixel_stride::<BD>();
@@ -198,7 +198,7 @@ pub(crate) fn rav1d_cdef_brow<BD: BitDepth>(
                 f.lf.cdef_line[!tf as usize][2]
                     .wrapping_add_signed(have_tt as isize * sby as isize * 8 * uv_stride),
             ];
-            backup2lines::<BD>(&f.lf.cdef_line_buf, cdef_top_bak, ptrs, layout);
+            backup2lines::<BD>(&f.lf.cdef_line_buf, cdef_top_bak, &ptrs, layout);
         }
 
         let mut iptrs = ptrs;
@@ -266,7 +266,7 @@ pub(crate) fn rav1d_cdef_brow<BD: BitDepth>(
 
                         let mut variance = 0;
                         let dir = if y_pri_lvl != 0 || uv_pri_lvl != 0 {
-                            f.dsp.cdef.dir.call::<BD>(bptrs[0], &mut variance, bd)
+                            f.dsp.cdef.dir.call::<BD>(&bptrs[0], &mut variance, bd)
                         } else {
                             0
                         };
@@ -337,10 +337,10 @@ pub(crate) fn rav1d_cdef_brow<BD: BitDepth>(
                             let adj_y_pri_lvl = adjust_strength(y_pri_lvl, variance);
                             if adj_y_pri_lvl != 0 || y_sec_lvl != 0 {
                                 f.dsp.cdef.fb[0].call::<BD>(
-                                    bptrs[0],
+                                    &bptrs[0],
                                     &lr_bak[bit as usize][0],
-                                    top,
-                                    bot,
+                                    &top,
+                                    &bot,
                                     adj_y_pri_lvl,
                                     y_sec_lvl,
                                     dir,
@@ -351,10 +351,10 @@ pub(crate) fn rav1d_cdef_brow<BD: BitDepth>(
                             }
                         } else if y_sec_lvl != 0 {
                             f.dsp.cdef.fb[0].call::<BD>(
-                                bptrs[0],
+                                &bptrs[0],
                                 &lr_bak[bit as usize][0],
-                                top,
-                                bot,
+                                &top,
+                                &bot,
                                 0,
                                 y_sec_lvl,
                                 0,
@@ -437,10 +437,10 @@ pub(crate) fn rav1d_cdef_brow<BD: BitDepth>(
                                 });
 
                                 f.dsp.cdef.fb[uv_idx as usize].call::<BD>(
-                                    bptrs[pl],
+                                    &bptrs[pl],
                                     &lr_bak[bit as usize][pl],
-                                    top,
-                                    bot,
+                                    &top,
+                                    &bot,
                                     uv_pri_lvl.into(),
                                     uv_sec_lvl,
                                     uvdir,


### PR DESCRIPTION
## Summary

There seems to be a small slowdown in some of the arm asm functions due to increased stack used in the `cdef::Fn` functions, which is caused by some extra parameters that are only used for the safe Rust fallback.

I implemented this WIP fix which, while ugly, does seem to eliminate the slowdown.

Let me know if you think this is something that's worth pursuing 😄 

## Full details

Another small finding when comparing to `dav1d`: 
the `cdef_filter4_pri_edged_8bpc_neon` asm function seems to be ~20% slower when called from `rav1d`.

Looking at the per-instruction sample count, there's one with a big, consistent diff:

dav1d:
![dav1d](https://github.com/user-attachments/assets/2bc606aa-f27e-4e09-9c45-403cf6fc780d)

rav1d:
![rav1d](https://github.com/user-attachments/assets/607c87b7-43c3-44d5-9e7e-2213d3dc4362)

From this, I tried to look at the callers. My arm assembly skill isn't good enough to analyze this properly, but comparing:


```asm
; dav1d's cdef_filter_4x4_neon
sub sp, sp, #0x150
stp x28, x27, [sp, #0xf0]
stp x26, x25, [sp, #0x100]
stp x24, x23, [sp, #0x110]
stp x22, x21, [sp, #0x120]
stp x20, x19, [sp, #0x130]
stp x29, x30, [sp, #0x140]
mov x19, x7
mov x20, x6
mov x21, x5
...
```

```asm
; rav1d's cdef_filter_neon_erased
stp x28, x27, [sp, #-0x60]!
stp x26, x25, [sp, #0x10]
stp x24, x23, [sp, #0x20]
stp x22, x21, [sp, #0x30]
stp x20, x19, [sp, #0x40]
stp x29, x30, [sp, #0x50]
add x29, sp, #0x50
sub sp, sp, #0x1a0
mov x19, x7
mov x20, x6
...
```

Seems to suggest that there's more stack spillover, which I think is due to the extra params in `cdef::Fn` impl which are used for the safe Rust fallback.

```rust
    _dst: *const FFISafe<Rav1dPictureDataComponentOffset>,
    _top: *const FFISafe<CdefTop>,
    _bottom: *const FFISafe<CdefBottom>,
```

This in turn makes the data the asm function use just "far enough" to cause this slowdown.

With the changes in this PR, we get:
```asm
rav1d::src::cdef::neon::cdef_filter_neon_erased
sub sp, sp, #0x140
stp x28, x27, [sp, #0xe0]
stp x26, x25, [sp, #0xf0]
stp x24, x23, [sp, #0x100]
stp x22, x21, [sp, #0x110]
stp x20, x19, [sp, #0x120]
stp x29, x30, [sp, #0x130]
add x29, sp, #0x130
mov x19, x7
mov x20, x6
mov x21, x5
mov x5, x4
mov x4, x3
...
```

and the diff in the profiler is almost gone.