### PR TITLE
perf: `fn rav1d_create_lf_mask_{intra,inter}`: store as `u16`s

### DIFF
--- a/src/align.rs
+++ b/src/align.rs
@@ -263,6 +263,7 @@ impl<T: Copy, C: AlignedByteChunk> Default for AlignedVec<T, C> {
     }
 }
 
+pub type AlignedVec2<T> = AlignedVec<T, Align2<[u8; 2]>>;
 pub type AlignedVec32<T> = AlignedVec<T, Align32<[u8; 32]>>;
 pub type AlignedVec64<T> = AlignedVec<T, Align64<[u8; 64]>>;
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4538,8 +4538,7 @@ pub(crate) fn rav1d_decode_frame_init(c: &Rav1dContext, fc: &Rav1dFrameContext) 
     f.lf.mask.resize_with(num_sb128 as usize, Default::default);
     // over-allocate by 3 bytes since some of the SIMD implementations
     // index this from the level type and can thus over-read by up to 3 bytes.
-    f.lf.level
-        .resize_with(4 * num_sb128 as usize * 32 * 32 + 3, Default::default); // TODO: Fallible allocation
+    f.lf.level.resize(4 * num_sb128 as usize * 32 * 32 + 3, 0); // TODO: Fallible allocation
     if c.fc.len() > 1 {
         // TODO: Fallible allocation
         f.frame_thread

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,5 +1,6 @@
 use crate::align::Align16;
 use crate::align::Align64;
+use crate::align::AlignedVec2;
 use crate::align::AlignedVec64;
 use crate::cdef::Rav1dCdefDSPContext;
 use crate::cdf::CdfContext;
@@ -701,7 +702,7 @@ impl TxLpfRightEdge {
 #[derive(Default)]
 #[repr(C)]
 pub struct Rav1dFrameContextLf {
-    pub level: DisjointMut<Vec<u8>>,
+    pub level: DisjointMut<AlignedVec2<u8>>,
     pub mask: Vec<Av1Filter>, /* len = w*h */
     pub lr_mask: Vec<Av1Restoration>,
     pub lim_lut: Align16<Av1FilterLUT>,

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -1,5 +1,6 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
+use crate::align::AlignedVec2;
 use crate::align::AlignedVec64;
 use crate::disjoint_mut::DisjointMut;
 use crate::include::common::bitdepth::BitDepth;
@@ -368,7 +369,7 @@ pub(crate) fn rav1d_copy_lpf<BD: BitDepth>(
 fn filter_plane_cols_y<BD: BitDepth>(
     f: &Rav1dFrameData,
     have_left: bool,
-    lvl: WithOffset<&DisjointMut<Vec<u8>>>,
+    lvl: WithOffset<&DisjointMut<AlignedVec2<u8>>>,
     mask: &[[[RelaxedAtomic<u16>; 2]; 3]; 32],
     y_dst: Rav1dPictureDataComponentOffset,
     w: usize,
@@ -405,7 +406,7 @@ fn filter_plane_cols_y<BD: BitDepth>(
 fn filter_plane_rows_y<BD: BitDepth>(
     f: &Rav1dFrameData,
     have_top: bool,
-    lvl: WithOffset<&DisjointMut<Vec<u8>>>,
+    lvl: WithOffset<&DisjointMut<AlignedVec2<u8>>>,
     b4_stride: usize,
     mask: &[[[RelaxedAtomic<u16>; 2]; 3]; 32],
     y_dst: Rav1dPictureDataComponentOffset,
@@ -437,7 +438,7 @@ fn filter_plane_rows_y<BD: BitDepth>(
 fn filter_plane_cols_uv<BD: BitDepth>(
     f: &Rav1dFrameData,
     have_left: bool,
-    lvl: WithOffset<&DisjointMut<Vec<u8>>>,
+    lvl: WithOffset<&DisjointMut<AlignedVec2<u8>>>,
     mask: &[[[RelaxedAtomic<u16>; 2]; 2]; 32],
     u_dst: Rav1dPictureDataComponentOffset,
     v_dst: Rav1dPictureDataComponentOffset,
@@ -480,7 +481,7 @@ fn filter_plane_cols_uv<BD: BitDepth>(
 fn filter_plane_rows_uv<BD: BitDepth>(
     f: &Rav1dFrameData,
     have_top: bool,
-    lvl: WithOffset<&DisjointMut<Vec<u8>>>,
+    lvl: WithOffset<&DisjointMut<AlignedVec2<u8>>>,
     b4_stride: usize,
     mask: &[[[RelaxedAtomic<u16>; 2]; 2]; 32],
     u_dst: Rav1dPictureDataComponentOffset,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -1,4 +1,5 @@
 use crate::align::Align16;
+use crate::align::AlignedVec2;
 use crate::align::ArrayDefault;
 use crate::ctx::CaseSet;
 use crate::disjoint_mut::DisjointMut;
@@ -426,7 +427,7 @@ fn mask_edges_chroma(
 #[inline(never)]
 pub(crate) fn rav1d_create_lf_mask_intra(
     lflvl: &Av1Filter,
-    level_cache: &DisjointMut<Vec<u8>>,
+    level_cache: &DisjointMut<AlignedVec2<u8>>,
     b4_stride: ptrdiff_t,
     filter_level: &Align16<[[[u8; 2]; 8]; 4]>,
     b: Bxy,
@@ -520,7 +521,7 @@ pub(crate) fn rav1d_create_lf_mask_intra(
 #[inline(never)]
 pub(crate) fn rav1d_create_lf_mask_inter(
     lflvl: &Av1Filter,
-    level_cache: &DisjointMut<Vec<u8>>,
+    level_cache: &DisjointMut<AlignedVec2<u8>>,
     b4_stride: ptrdiff_t,
     filter_level: &Align16<[[[u8; 2]; 8]; 4]>,
     r#ref: usize,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -549,6 +549,9 @@ pub(crate) fn rav1d_create_lf_mask_inter(
     let bx4 = bx & 31;
     let by4 = by & 31;
 
+    let filter_level_yuv = filter_level.0.map(|a| a[r#ref][is_gmv]);
+    let [filter_level_y, filter_level_uv] = *<[u16; 2]>::ref_from(&filter_level_yuv).unwrap();
+
     if bw4 != 0 && bh4 != 0 {
         let mut level_cache_off = by * b4_stride + bx;
         for _y in 0..bh4 {
@@ -556,8 +559,7 @@ pub(crate) fn rav1d_create_lf_mask_inter(
                 let idx = 4 * (level_cache_off + x);
                 // `0.., ..2` is for Y
                 let lvl = &mut *level_cache.index_mut((idx + 0.., ..2));
-                lvl[0] = filter_level[0][r#ref][is_gmv];
-                lvl[1] = filter_level[1][r#ref][is_gmv];
+                *u16::mut_from(lvl).unwrap() = filter_level_y;
             }
             level_cache_off += b4_stride;
         }
@@ -605,8 +607,7 @@ pub(crate) fn rav1d_create_lf_mask_inter(
             let idx = 4 * (level_cache_off + x);
             // `2.., ..2` is for UV
             let lvl = &mut *level_cache.index_mut((idx + 2.., ..2));
-            lvl[0] = filter_level[2][r#ref][is_gmv];
-            lvl[1] = filter_level[3][r#ref][is_gmv];
+            *u16::mut_from(lvl).unwrap() = filter_level_uv;
         }
         level_cache_off += b4_stride;
     }

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -1,6 +1,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
 use crate::align::Align16;
+use crate::align::AlignedVec2;
 use crate::cpu::CpuFlags;
 use crate::disjoint_mut::DisjointMut;
 use crate::ffi_safe::FFISafe;
@@ -34,7 +35,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn loopfilter_sb(
     w: c_int,
     bitdepth_max: c_int,
     _dst: *const FFISafe<Rav1dPictureDataComponentOffset>,
-    _lvl: *const FFISafe<WithOffset<&DisjointMut<Vec<u8>>>>,
+    _lvl: *const FFISafe<WithOffset<&DisjointMut<AlignedVec2<u8>>>>,
 ) -> ());
 
 impl loopfilter_sb::Fn {
@@ -43,7 +44,7 @@ impl loopfilter_sb::Fn {
         f: &Rav1dFrameData,
         dst: Rav1dPictureDataComponentOffset,
         mask: &[u32; 3],
-        lvl: WithOffset<&DisjointMut<Vec<u8>>>,
+        lvl: WithOffset<&DisjointMut<AlignedVec2<u8>>>,
         w: usize,
     ) {
         let dst_ptr = dst.as_mut_ptr::<BD>().cast();
@@ -289,7 +290,7 @@ enum YUV {
 fn loop_filter_sb128_rust<BD: BitDepth, const HV: usize, const YUV: usize>(
     mut dst: Rav1dPictureDataComponentOffset,
     vmask: &[u32; 3],
-    mut lvl: WithOffset<&DisjointMut<Vec<u8>>>,
+    mut lvl: WithOffset<&DisjointMut<AlignedVec2<u8>>>,
     b4_stride: usize,
     lut: &Align16<Av1FilterLUT>,
     _wh: c_int,
@@ -367,7 +368,7 @@ unsafe extern "C" fn loop_filter_sb128_c_erased<BD: BitDepth, const HV: usize, c
     wh: c_int,
     bitdepth_max: c_int,
     dst: *const FFISafe<Rav1dPictureDataComponentOffset>,
-    lvl: *const FFISafe<WithOffset<&DisjointMut<Vec<u8>>>>,
+    lvl: *const FFISafe<WithOffset<&DisjointMut<AlignedVec2<u8>>>>,
 ) {
     // SAFETY: Was passed as `FFISafe::new(_)` in `loopfilter_sb::Fn::call`.
     let dst = *unsafe { FFISafe::get(dst) };


### PR DESCRIPTION
Previously, two adjacent 8-bit stores were done.  By doing them as `u16`s instead of `[u8]`s/`[u8; 2]`s, we can get a single 16-bit store to be emitted instead.

This gets `strh`s emitted instead of the pair of `strb`s previously.

Based on what @iximeow found in https://github.com/iximeow/rav1d/commit/e133a89f9a80bfdb69be9ce3535855ae231d0ff8 and https://github.com/memorysafety/rav1d/pull/1401#discussion_r2096219012.

Before:

```asm
❯ cargo asm -p rav1d --lib --rust rav1d_create_lf_mask_intra --color | rg filter_level -C 10
                if start <= end && end <= len {
        cmp x13, x12
        b.hi .LBB440_79
                // /home/khyber/work/rav1d/src/lf_mask.rs : 458
                let lvl = &mut *level_cache.index_mut((idx + 0.., ..2));
        ldr x12, [x1, #8]
                // /home/khyber/.rustup/toolchains/nightly-2025-05-01-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/cmp.rs : 1849
                fn lt(&self, other: &Self) -> bool { *self <  *other }
        subs x7, x7, #1
                // /home/khyber/work/rav1d/src/lf_mask.rs : 459
                lvl[0] = filter_level[0][0][0];
        add x12, x12, x11
                // /home/khyber/.rustup/toolchains/nightly-2025-05-01-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/cmp.rs : 1849
                fn lt(&self, other: &Self) -> bool { *self <  *other }
        add x11, x11, #4
                // /home/khyber/work/rav1d/src/lf_mask.rs : 459
                lvl[0] = filter_level[0][0][0];
        strb w15, [x12]
                // /home/khyber/work/rav1d/src/lf_mask.rs : 460
                lvl[1] = filter_level[1][0][0];
        strb w16, [x12, #1]
                // /home/khyber/work/rav1d/src/lf_mask.rs : 455
                for x in 0..bw4 {
        b.ne .LBB440_4
                // /home/khyber/.rustup/toolchains/nightly-2025-05-01-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/cmp.rs : 1849
                fn lt(&self, other: &Self) -> bool { *self <  *other }
        cmp x6, x20
                // /home/khyber/work/rav1d/src/lf_mask.rs : 454
                for _y in 0..bh4 {
        add x17, x17, x18
--
                // /home/khyber/work/rav1d/src/disjoint_mut.rs : 729
                if start <= end && end <= len {
        add x20, x3, x19
        add x21, x20, #3
        cmp x21, x2
        b.hs .LBB440_80
                // /home/khyber/work/rav1d/src/lf_mask.rs : 496
                let lvl = &mut *level_cache.index_mut((idx + 2.., ..2));
        ldr x2, [x1, #8]
                // /home/khyber/work/rav1d/src/lf_mask.rs : 497
                lvl[0] = filter_level[2][0][0];
        add x2, x2, x3
        add x2, x2, x19
                // /home/khyber/.rustup/toolchains/nightly-2025-05-01-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/cmp.rs : 1849
                fn lt(&self, other: &Self) -> bool { *self <  *other }
        add x19, x19, #4
                // /home/khyber/work/rav1d/src/lf_mask.rs : 493
                for x in 0..cbw4 {
        cmp x18, x19
                // /home/khyber/work/rav1d/src/lf_mask.rs : 497
                lvl[0] = filter_level[2][0][0];
        strb w16, [x2, #2]
                // /home/khyber/work/rav1d/src/lf_mask.rs : 498
                lvl[1] = filter_level[3][0][0];
        strb w17, [x2, #3]
                // /home/khyber/work/rav1d/src/lf_mask.rs : 493
                for x in 0..cbw4 {
        b.ne .LBB440_72
                // /home/khyber/.rustup/toolchains/nightly-2025-05-01-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/cmp.rs : 1849
                fn lt(&self, other: &Self) -> bool { *self <  *other }
        cmp x6, x4
                // /home/khyber/work/rav1d/src/lf_mask.rs : 492
                for _y in 0..cbh4 {
        add x3, x3, x5
```

After:

```asm
❯ cargo asm -p rav1d --lib --rust rav1d_create_lf_mask_intra --color | rg filter_level -C 10
        ldr x24, [sp, #224]
        ldrb w10, [sp, #184]
                // /home/khyber/work/rav1d/src/lf_mask.rs : 447
                let b_dim = b_dim.map(|it| it as usize);
        ldr w8, [x9, x8, lsl #2]
                // /home/khyber/work/rav1d/src/lf_mask.rs : 448
                let bw4 = cmp::min(iw - bx, b_dim[0]);
        sub x9, x25, x28
        ldrb w6, [sp, #176]
                // /home/khyber/work/rav1d/src/lf_mask.rs : 453
                let filter_level_yuv = filter_level.0.map(|a| a[0][0]);
        ldrb w23, [x3, #32]
                // /home/khyber/.rustup/toolchains/nightly-2025-05-01-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/array/mod.rs : 160
                }
        ldrb w14, [x3, #48]
                // /home/khyber/work/rav1d/src/lf_mask.rs : 450
                let bx4 = bx & 31;
        and x30, x28, #0x1f
                // /home/khyber/work/rav1d/src/lf_mask.rs : 447
                let b_dim = b_dim.map(|it| it as usize);
        and x26, x8, #0xff
--
                let lvl = &mut *level_cache.index_mut((idx + 0.., ..2));
        ldr x12, [x1, #8]
        add w13, w11, w12
                // /home/khyber/.rustup/toolchains/nightly-2025-05-01-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/option.rs : 1001
                match self {
        tbnz w13, #0, .LBB440_21
                // /home/khyber/.rustup/toolchains/nightly-2025-05-01-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/cmp.rs : 1849
                fn lt(&self, other: &Self) -> bool { *self <  *other }
        subs x3, x3, #1
                // /home/khyber/work/rav1d/src/lf_mask.rs : 463
                *u16::mut_from(lvl).unwrap() = filter_level_y;
        strh w15, [x12, x11]
                // /home/khyber/.rustup/toolchains/nightly-2025-05-01-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/cmp.rs : 1849
                fn lt(&self, other: &Self) -> bool { *self <  *other }
        add x11, x11, #4
                // /home/khyber/work/rav1d/src/lf_mask.rs : 459
                for x in 0..bw4 {
        b.ne .LBB440_4
                // /home/khyber/.rustup/toolchains/nightly-2025-05-01-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/cmp.rs : 1849
                fn lt(&self, other: &Self) -> bool { *self <  *other }
        cmp x18, x20
--
        tbnz w19, #0, .LBB440_82
        add x2, x2, x17
        add x2, x2, x21
                // /home/khyber/.rustup/toolchains/nightly-2025-05-01-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/cmp.rs : 1849
                fn lt(&self, other: &Self) -> bool { *self <  *other }
        add x21, x21, #4
                // /home/khyber/work/rav1d/src/lf_mask.rs : 496
                for x in 0..cbw4 {
        cmp x16, x21
                // /home/khyber/work/rav1d/src/lf_mask.rs : 500
                *u16::mut_from(lvl).unwrap() = filter_level_uv;
        strh w15, [x2, #2]
                // /home/khyber/work/rav1d/src/lf_mask.rs : 496
                for x in 0..cbw4 {
        b.ne .LBB440_76
                // /home/khyber/.rustup/toolchains/nightly-2025-05-01-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/cmp.rs : 1849
                fn lt(&self, other: &Self) -> bool { *self <  *other }
        cmp x5, x4
                // /home/khyber/work/rav1d/src/lf_mask.rs : 495
                for _y in 0..cbh4 {
        add x17, x17, x18
```