### PR TITLE
Be stricter about sequence and frame header presence

### DIFF
--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -10,7 +10,7 @@ use crate::src::align::AlignedVec64;
 use crate::src::cdef::CdefEdgeFlags;
 use crate::src::disjoint_mut::DisjointMut;
 use crate::src::internal::Rav1dContext;
-use crate::src::internal::Rav1dFrameData;
+use crate::src::internal::Rav1dFrameDataWithHeaders;
 use crate::src::internal::Rav1dTaskContext;
 use crate::src::pic_or_buf::PicOrBuf;
 use crate::src::strided::Strided as _;
@@ -134,7 +134,7 @@ fn adjust_strength(strength: u8, var: c_uint) -> c_int {
 pub(crate) fn rav1d_cdef_brow<BD: BitDepth>(
     c: &Rav1dContext,
     tc: &mut Rav1dTaskContext,
-    f: &Rav1dFrameData,
+    f: &Rav1dFrameDataWithHeaders,
     p: [Rav1dPictureDataComponentOffset; 3],
     lflvl_offset: i32,
     by_start: c_int,
@@ -156,7 +156,7 @@ pub(crate) fn rav1d_cdef_brow<BD: BitDepth>(
     let mut ptrs = p;
     let sbsz = 16;
     let sb64w = f.sb128w << 1;
-    let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
+    let frame_hdr = &f.frame_hdr;
     let damping = frame_hdr.cdef.damping + bitdepth_min_8;
     let layout: Rav1dPixelLayout = f.cur.p.layout;
     let uv_idx = (Rav1dPixelLayout::I444 as c_uint).wrapping_sub(layout as c_uint) as c_int;
@@ -167,7 +167,7 @@ pub(crate) fn rav1d_cdef_brow<BD: BitDepth>(
     let uv_dir: &[u8; 8] = &UV_DIRS[(layout == Rav1dPixelLayout::I422) as usize];
 
     let have_tt = c.tc.len() > 1;
-    let sb128 = f.seq_hdr.as_ref().unwrap().sb128;
+    let sb128 = f.seq_hdr.sb128;
     let resize = frame_hdr.size.width[0] != frame_hdr.size.width[1];
     let y_stride: ptrdiff_t = BD::pxstride(f.cur.stride[0]);
     let uv_stride: ptrdiff_t = BD::pxstride(f.cur.stride[1]);

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -9,7 +9,7 @@ use crate::src::align::Align16;
 use crate::src::cpu::CpuFlags;
 use crate::src::disjoint_mut::DisjointMut;
 use crate::src::ffi_safe::FFISafe;
-use crate::src::internal::Rav1dFrameData;
+use crate::src::internal::Rav1dFrameDataWithHeaders;
 use crate::src::lf_mask::Av1FilterLUT;
 use crate::src::strided::Strided as _;
 use crate::src::with_offset::WithOffset;
@@ -41,7 +41,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn loopfilter_sb(
 impl loopfilter_sb::Fn {
     pub fn call<BD: BitDepth>(
         &self,
-        f: &Rav1dFrameData,
+        f: &Rav1dFrameDataWithHeaders,
         dst: Rav1dPictureDataComponentOffset,
         mask: &[u32; 3],
         lvl: WithOffset<&DisjointMut<Vec<u8>>>,


### PR DESCRIPTION
this is a rather broad change, but the overall intention is to move `f.seq_hdr.as_ref().unwrap()` and `f.frame_hdr.as_ref().unwrap()` as far up the call tree as the highest unconditional execution of that statement. in most cases these unwraps are truly dead due to their equivalent execution by some caller several frames up, and in some functions (like decode_b and decode_sb) these are redundantly checked many times.

there doesn't seem to be a substantial effect on runtime or instruction count here, but this does delete many unreachable `unwrap()`s and might help legibility some. this also reduces a release build's size by about 2.6kb.

i didn't see any point that branches the `Some`-ness of these `Arc`s, which is particularly interesting. looks like that's all intended to be decided somewhere higher up when scheduling work? it's not exactly clear to me what a principled boundary would look like - "functions in `thread_task.rs` may not rely on header presence, called functions in the rest of `rav1d` should be able to"?

this is a pretty rough patch as-is, mostly wondering what your interest level is here! there's a somewhat more meaningful change to be had by grouping `{Rav1dContext, Rav1dTaskContext, Rav1dFrameData(WithHeaders)}` together into a single parameter, because the combination of number of parameters, number of calls, and inner calls not being tail calls, does add up to a mild (like.. ~0.5%) amount of overall overhead.