### PR TITLE
Revert QEMU tests to Ubuntu 24.04 image

### DIFF
--- a/.github/workflows/build-and-test-qemu.yml
+++ b/.github/workflows/build-and-test-qemu.yml
@@ -5,7 +5,7 @@ on:
       - 'main'
   pull_request:
 jobs:
-  test-on-ubuntu-latest-with-qemu:
+  test-on-ubuntu-2404-with-qemu:
     strategy:
       matrix:
         # only test specific parameter pairs, not the cross product
@@ -16,7 +16,7 @@ jobs:
             packages: "g++-arm-linux-gnueabihf libc6-dev-armhf-cross"
             # arm feature detection is unstable
             # should be the same as rust-toolchain.toml
-            toolchain: nightly-2025-05-01 
+            toolchain: nightly-2025-05-01
           - target: "aarch64-unknown-linux-gnu"
             linker: "aarch64-linux-gnu-gcc"
             wrapper: "qemu-aarch64-static"
@@ -24,7 +24,7 @@ jobs:
             toolchain: stable # aarch64 feature detection is stable
           - target: "x86_64-unknown-linux-gnu"
             linker: "cc"
-            wrapper: "qemu-x86_64-static -cpu max" # enable AVX512
+            wrapper: "qemu-x86_64-static -cpu host" # enable all features supported by the host
             packages: ""
             # NOTE: This appears to work for Ubuntu 22.04 and other systems
             # with a recent version of GNU ld (e.g. 2.38) whereas Ubuntu 20.04
@@ -37,7 +37,7 @@ jobs:
             # riscv64 feature detection is unstable
             # should be the same as rust-toolchain.toml
             toolchain: nightly-2025-05-01
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: test on ${{ matrix.target }}
     steps:
       - name: install prerequisites


### PR DESCRIPTION
Testing whether fixing the CPU type resolves the errors we previously observed on ubuntu-latest aka ubuntu-24.04.