### PR TITLE
Add features for alternate global allocators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d6fac27761dabcd4ee73571cdb06b7022dc99089acbe5435691edffaac0f4"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +113,15 @@ checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "995942f432bbb4822a7e9c3faa87a695185b0d09273ba85f097b54f4e458f2af"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -177,11 +196,13 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
+ "mimalloc",
  "nasm-rs",
  "parking_lot",
  "paste",
  "raw-cpuid",
  "strum",
+ "tikv-jemallocator",
  "to_method",
  "zerocopy",
 ]
@@ -270,6 +291,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ raw-cpuid = "11.0.1"
 strum = { version = "0.27", features = ["derive"] }
 to_method = "1.1.0"
 zerocopy = { version = "0.7.32", features = ["derive"] }
+mimalloc = { version = "0.1.46", optional = true }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { version = "0.6.0", optional = true }
 
 [build-dependencies]
 cc = "1.0.79"
@@ -42,6 +46,13 @@ asm_arm64_i8mm = ["asm"]
 asm_arm64_sve2 = ["asm"]
 bitdepth_8 = []
 bitdepth_16 = []
+# Use the mimalloc memory allocator
+mimalloc = ["dep:mimalloc"]
+# Use the mimalloc memory allocator in secure mode
+# (This has a ~10% performance penalty!)
+mimalloc_secure = ["mimalloc/secure"]
+# Use the jemalloc memory allocator (used in Firefox)
+jemalloc = ["dep:tikv-jemallocator"]
 
 [profile.dev]
 panic = "abort"

--- a/meson.build
+++ b/meson.build
@@ -556,6 +556,9 @@ cargo_command = [
 if get_option('buildtype') == 'release'
     cargo_command += ['--release']
 endif
+if get_option('malloc') != 'default'
+    cargo_command += ['--features', get_option('malloc')]
+endif
 
 librav1d = custom_target(
     'librav1d',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -79,3 +79,9 @@ option('seek_stress_test_rust_path',
     type: 'string',
     value: '',
     description: 'Use specified Rust binary instead of building it. Path must be relative to build directory.')
+
+option('malloc',
+    type: 'combo',
+    choices: ['default', 'mimalloc', 'mimalloc_secure', 'jemalloc'],
+    value: 'default',
+    description: 'Select memory allocator to use')

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,16 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
+#[cfg(all(feature = "mimalloc", feature = "jemalloc"))]
+compile_error!("You may only use one allocator at a time.");
+
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[cfg(all(not(target_env = "msvc"), feature = "jemalloc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 #[cfg(feature = "bitdepth_16")]
 use crate::include::common::bitdepth::BitDepth16;
 #[cfg(feature = "bitdepth_8")]


### PR DESCRIPTION
This PR adds features for switching the global allocator to mimalloc, mimalloc secure mode, or jemalloc.

As for why these two:
 - mimalloc is a highly performant allocator.
 - jemalloc is used in Firefox and Servo.

PartitionAlloc (used in Chrome) doesn't have Rust bindings, but I could write some if that'd be useful.