### PR TITLE
perf: Use drain + collect over mem::take + into_boxed_slice

### DIFF
--- a/include/dav1d/headers.rs
+++ b/include/dav1d/headers.rs
@@ -820,9 +820,9 @@ impl From<&Rav1dITUTT35> for Dav1dITUTT35 {
 
 impl Rav1dITUTT35 {
     pub fn to_immut(
-        mutable: Vec<Rav1dITUTT35>,
+        mutable: &mut Vec<Rav1dITUTT35>,
     ) -> Arc<DRav1d<Box<[Rav1dITUTT35]>, Box<[Dav1dITUTT35]>>> {
-        let rav1d = mutable.into_boxed_slice();
+        let rav1d: Box<[_]> = mutable.drain(..).collect();
         let dav1d = rav1d.iter().map(Dav1dITUTT35::from).collect();
         Arc::new(DRav1d { rav1d, dav1d })
     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -5135,9 +5135,6 @@ pub fn rav1d_submit_frame(c: &Rav1dContext, state: &mut Rav1dState) -> Rav1dResu
 
     // allocate frame
 
-    // We must take itut_t35 out of the context before the call so borrowck can
-    // see we mutably borrow `c.itut_t35` disjointly from the task thread lock.
-    let itut_t35 = mem::take(&mut state.itut_t35);
     let res = rav1d_thread_picture_alloc(
         &c.fc,
         &c.logger,
@@ -5149,7 +5146,7 @@ pub fn rav1d_submit_frame(c: &Rav1dContext, state: &mut Rav1dState) -> Rav1dResu
         &mut state.frame_flags,
         &mut f,
         bpc,
-        itut_t35,
+        &mut state.itut_t35,
     );
     if res.is_err() {
         on_error(

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2508,7 +2508,7 @@ fn parse_obus(
                     state.content_light.clone(),
                     state.mastering_display.clone(),
                     // Must be moved from the context to the frame.
-                    Rav1dITUTT35::to_immut(mem::take(&mut state.itut_t35)),
+                    Rav1dITUTT35::to_immut(&mut state.itut_t35),
                     props.clone(),
                 );
                 state.event_flags |= state.refs[frame_hdr.existing_frame_idx as usize]
@@ -2568,7 +2568,7 @@ fn parse_obus(
                     state.content_light.clone(),
                     state.mastering_display.clone(),
                     // Must be moved from the context to the frame.
-                    Rav1dITUTT35::to_immut(mem::take(&mut state.itut_t35)),
+                    Rav1dITUTT35::to_immut(&mut state.itut_t35),
                     props.clone(),
                 );
             }

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -261,7 +261,7 @@ pub(crate) fn rav1d_thread_picture_alloc(
     frame_flags: &mut PictureFlags,
     f: &mut Rav1dFrameData,
     bpc: u8,
-    itut_t35: Vec<Rav1dITUTT35>,
+    itut_t35: &mut Vec<Rav1dITUTT35>,
 ) -> Rav1dResult {
     let p = &mut f.sr_cur;
     let have_frame_mt = fc.len() > 1;


### PR DESCRIPTION
This makes `to_immut` always allocate unlike the previous implementation, which (re)allocated whenever the capacity of `state.itut_t35` didn't match its length. However, this new implementation means that the `state.itut_t35` keeps hold of the previous `Vec` allocation, so subsequent calls to `parse_obus` with the same state don't have to allocate when pushing to `state.itut_t35` (up to the capacity previously allocated).

Here's the optimization I was talking about in #1409. I hope the explanation above makes sense. Unless `to_immut` is usually / always called with `Vec`s that are fully filled, this should reduce the number of calls to the allocator, and thus improve performance. Unfortunately, runtime variance for the benchmarks is too high on my notebook for me to be able to detect any perf changes with them (plus this might also be small enough not to register on less noisy systems). Let me know what you think :)