### PR TITLE
perf: `fn rav1d_prepare_intra_edges`: pre-slice

### DIFF
--- a/src/ipred_prepare.rs
+++ b/src/ipred_prepare.rs
@@ -187,7 +187,7 @@ pub fn rav1d_prepare_intra_edges<BD: BitDepth>(
     let bitdepth = bd.bitdepth();
     let stride = dst.pixel_stride::<BD>();
     let is_neg_stride = 0 > stride;
-    let abs_stride = if is_neg_stride { (stride * -1) as usize } else { stride as usize };
+    let abs_stride = stride.unsigned_abs();
 
     match mode {
         VERT_PRED..=VERT_LEFT_PRED => {
@@ -248,23 +248,25 @@ pub fn rav1d_prepare_intra_edges<BD: BitDepth>(
         if have_left {
             let px_have = cmp::min(sz, (h - y << 2) as usize);
             {
-                let slice_offset = if is_neg_stride { px_have as isize * stride } else { 0 };
-                let dst_slice = &*(dst + slice_offset - 1isize)
-                    .slice::<BD>((px_have - 1) * abs_stride + 1);
-                
-                // SAFETY: We've already implcitly bounds checked with the `slice()` call.  
+                let slice_offset = if is_neg_stride {
+                    (px_have - 1) as isize * stride
+                } else {
+                    0
+                };
+                let dst_slice =
+                    &*(dst + slice_offset - 1isize).slice::<BD>((px_have - 1) * abs_stride + 1);
+
+                // SAFETY: We've already implcitly bounds checked with the `slice()` call.
                 //         We can safely avoid any bounds-checking overhead now.
                 if is_neg_stride {
                     for i in 0..px_have {
-                        left[sz - 1 - i] = *unsafe { 
-                            dst_slice.get_unchecked((px_have * abs_stride) - (i * abs_stride))
+                        left[sz - 1 - i] = *unsafe {
+                            dst_slice.get_unchecked(((px_have - 1) * abs_stride) - (i * abs_stride))
                         };
                     }
                 } else {
                     for i in 0..px_have {
-                        left[sz - 1 - i] = *unsafe {
-                            dst_slice.get_unchecked(i * abs_stride)
-                        }
+                        left[sz - 1 - i] = *unsafe { dst_slice.get_unchecked(i * abs_stride) }
                     }
                 }
             }
@@ -295,21 +297,26 @@ pub fn rav1d_prepare_intra_edges<BD: BitDepth>(
             if have_bottomleft {
                 let px_have = cmp::min(sz, (h - y - th << 2) as usize);
                 {
-                    let slice_offset = if is_neg_stride { (px_have + sz) as isize * stride } else { (sz * abs_stride) as isize };
-                    let dst_slice = &*(dst + slice_offset - 1isize).slice::<BD>((px_have - 1) * abs_stride + 1);
-                    // SAFETY: We've already implcitly bounds checked with the `slice()` call.  
+                    let slice_offset = if is_neg_stride {
+                        (px_have - 1 + sz) as isize * stride
+                    } else {
+                        (sz * abs_stride) as isize
+                    };
+                    let dst_slice =
+                        &*(dst + slice_offset - 1isize).slice::<BD>((px_have - 1) * abs_stride + 1);
+                    // SAFETY: We've already implcitly bounds checked with the `slice()` call.
                     //         We can safely avoid any bounds-checking overhead now.
                     if is_neg_stride {
                         for i in 0..px_have {
-                            bottom_left[sz - 1 - i] = *unsafe { 
-                                dst_slice.get_unchecked((px_have * abs_stride) - (i * abs_stride))
+                            bottom_left[sz - 1 - i] = *unsafe {
+                                dst_slice
+                                    .get_unchecked(((px_have - 1) * abs_stride) - (i * abs_stride))
                             };
                         }
                     } else {
                         for i in 0..px_have {
-                            bottom_left[sz - 1 - i] = *unsafe {
-                                dst_slice.get_unchecked(i * abs_stride)
-                            }
+                            bottom_left[sz - 1 - i] =
+                                *unsafe { dst_slice.get_unchecked(i * abs_stride) }
                         }
                     }
                 }


### PR DESCRIPTION
* Part of #1394.

rework `rav1d_prepare_intra_edges` to precalculate and take a slice of the data to be iterated over so we only incur the overhead of taking the `DisjointImmutGuard` once, which also allows us to safely use the unsafe `unsafe fn get_unchecked(..)` within the loop avoiding the overhead of any runtime bounds checks, since the `slice()` opertaion already implcitly bounds checked the slice we're asking for.

inital hyperfine results show a overall improvement (albeit fairly minisucle):
```
Benchmark 1: ./target/release/dav1d -q -i test-data/Chimera-AV1-10bit-1920x1080-6191kbps.ivf -o /dev/null
  Time (mean ± σ):      9.384 s ±  0.057 s    [User: 108.379 s, System: 6.500 s]
  Range (min … max):    9.342 s …  9.516 s    10 runs

Benchmark 1: ./target.main/release/dav1d -q -i test-data/Chimera-AV1-10bit-1920x1080-6191kbps.ivf -o /dev/null
  Time (mean ± σ):      9.490 s ±  0.076 s    [User: 110.062 s, System: 6.521 s]
  Range (min … max):    9.383 s …  9.606 s    10 runs
```
(changed version took ~98.88% of the original runtime)