### PR TITLE
perf: `fn rav1d_cdef_brow`: reduce stack usage

### DIFF
--- a/src/with_offset.rs
+++ b/src/with_offset.rs
@@ -7,6 +7,7 @@ use std::ops::Sub;
 use std::ops::SubAssign;
 
 #[derive(Clone, Copy)]
+#[repr(C)]
 pub struct WithOffset<T> {
     pub data: T,
     pub offset: usize,


### PR DESCRIPTION
* Supersedes #1402.

## Summary

There seems to be a slowdown in some of the Arm asm functions due to increased stack usage in `rav1d_cdef_brow` (`def_filter4_pri_edged_8bpc_neon` is ~20% slower when called from rav1d).

By keeping `WithOffset`s "internal" to the function, LLVM is able to optimize away most of the `alloca`-s (first commit).

After doing that, it seemed that `backup2x8` was still slower when calling `.stride()` (vs. a version which doesn't have the Rust fallback args _at all_), which I think is related to how LLVM optimizes the entire `rav1d_cdef_brow` (second commit).

main:

(`$ cargo asm -p rav1d-cli --bin dav1d --llvm rav1d_cdef_brow 0`)

```llvm
; rav1d::src::cdef_apply::rav1d_cdef_brow
; Function Attrs: nounwind
define internal fastcc void @rav1d::src::cdef_apply::rav1d_cdef_brow(..) {
  %10 = alloca [16 x i8], align 8
  %11 = alloca [16 x i8], align 8
  %12 = alloca [16 x i8], align 8
  %13 = alloca [16 x i8], align 8
  %14 = alloca [16 x i8], align 8
  %15 = alloca [16 x i8], align 8
  %16 = alloca [16 x i8], align 8
  %17 = alloca [24 x i8], align 8
  %18 = alloca [24 x i8], align 8
  %19 = alloca [4 x i8], align 4
  %20 = alloca [96 x i8], align 16
  %21 = icmp sgt i32 %5, 0
  %22 = select i1 %21, i32 12, i32 8
  %23 = load ptr, ptr %3, align 8
  ..
```

This branch:
```llvm
define internal fastcc void @rav1d::src::cdef_apply::rav1d_cdef_brow(..) {
  %10 = alloca [16 x i8], align 8
  %11 = alloca [24 x i8], align 8
  %12 = alloca [24 x i8], align 8
  %13 = alloca [4 x i8], align 4
  %14 = alloca [96 x i8], align 16
```

~This branch:~
(This is the most "optimized" version in this sense, but couldn't get the same with the current Rust/Asm argument arrangement requirements:)

```llvm
; rav1d::src::cdef_apply::rav1d_cdef_brow
; Function Attrs: nounwind
define internal fastcc void @rav1d::src::cdef_apply::rav1d_cdef_brow(..) {
  %10 = alloca [16 x i8], align 8
  %11 = alloca [4 x i8], align 4
  %12 = alloca [96 x i8], align 16
  %13 = icmp sgt i32 %5, 0
  %14 = select i1 %13, i32 12, i32 8
  %15 = load ptr, ptr %3, align 8
  ..
```


## Full details

When comparing to `dav1d`, the `cdef_filter4_pri_edged_8bpc_neon` asm function seems to be ~20% slower when called from `rav1d`.

Looking at the per-instruction sample count, there's one with a big, consistent diff:

dav1d:
![dav1d](https://github.com/user-attachments/assets/2bc606aa-f27e-4e09-9c45-403cf6fc780d)

rav1d:
![rav1d](https://github.com/user-attachments/assets/607c87b7-43c3-44d5-9e7e-2213d3dc4362)

From this, I tried to look at the callers. The problem _seems_ to be that when the src buffer in `x13` is placed "far enough back" in the stack, the load stalls.

This fix is inspired by what I saw in https://github.com/rust-lang/rust/issues/141649 - since `WithOffset`s  seemed to match the `%10,..,%18` `alloca`-s in the IR above, I tried to force LLVM to do the right thing and optimize them away (I tried a few other things, but this is the most effective one).


With this fix, the diff in the sample count is gone, with a nice speedup:

``` bash
rav1d-pr % hyperfine --warmup 3 --runs 15 --parameter-list profile target/release/dav1d,target/release-baseline/dav1d  '{profile} -q -i ~/workspace/video_files_for_rav1d/Chimera-AV1-8bit-1920x1080-6736kb
ps.ivf -o /dev/null --threads 1'

Benchmark 1: target/release/dav1d -q -i Chimera-AV1-8bit-1920x1080-6736kbps.ivf -o /dev/null --threads 1
  Time (mean ± σ):     71.918 s ±  0.066 s    [User: 71.595 s, System: 0.233 s]
  Range (min … max):   71.812 s … 72.032 s    15 runs

Benchmark 2: target/release-baseline/dav1d -q -i Chimera-AV1-8bit-1920x1080-6736kbps.ivf -o /dev/null --threads 1
  Time (mean ± σ):     72.294 s ±  0.078 s    [User: 71.945 s, System: 0.235 s]
  Range (min … max):   72.183 s … 72.438 s    15 runs

release-baseline = 1be76ea9cbe70ae7cb4ffc9cb4a05971f82669ac
```

I'm not sure how much better this will be in x86, but it should still be faster.