### PR TITLE
perf: remove some redundant clones

### DIFF
--- a/src/fg_apply.rs
+++ b/src/fg_apply.rs
@@ -133,7 +133,6 @@ pub(crate) fn rav1d_apply_grain_row<BD: BitDepth>(
     let seq_hdr = &***out.seq_hdr.as_ref().unwrap();
     let frame_hdr = &***out.frame_hdr.as_ref().unwrap();
     let data = &frame_hdr.film_grain.data;
-    let data_c = &data.clone().into();
     let in_data = &r#in.data.as_ref().unwrap().data;
     let out_data = &out.data.as_ref().unwrap().data;
     let w = out.p.w as usize;
@@ -204,7 +203,7 @@ pub(crate) fn rav1d_apply_grain_row<BD: BitDepth>(
                     layout,
                     &out_data[1 + pl],
                     &in_data[1 + pl],
-                    data_c,
+                    data,
                     cpw,
                     &scaling[1 + pl],
                     &grain_lut[1 + pl],

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -702,9 +702,8 @@ pub(crate) fn rav1d_calc_lf_values(
         return;
     }
 
-    let mr_deltas = hdr.loopfilter.mode_ref_deltas.clone().into();
     let mr_deltas = if hdr.loopfilter.mode_ref_delta_enabled != 0 {
-        Some(&mr_deltas)
+        Some(&hdr.loopfilter.mode_ref_deltas)
     } else {
         None
     };


### PR DESCRIPTION
A few `Rav1d*` types were unified with their `Dav1d*` counterparts and thus no longer need to be `.clone()`d and converter.