### PR TITLE
`enum Rav1dError`: rename fields to more Rusty versions and add docs

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -5,7 +5,7 @@ use std::ptr::NonNull;
 
 use crate::c_arc::CArc;
 use crate::c_box::{CBox, FnFree, Free};
-use crate::error::Rav1dError::EINVAL;
+use crate::error::Rav1dError::InvalidArgument;
 use crate::error::Rav1dResult;
 use crate::include::common::validate::validate_input;
 use crate::include::dav1d::common::Rav1dDataProps;
@@ -39,7 +39,7 @@ impl Rav1dData {
         free_callback: Option<FnFree>,
         cookie: Option<SendSyncNonNull<c_void>>,
     ) -> Rav1dResult<Self> {
-        let free = validate_input!(free_callback.ok_or(EINVAL))?;
+        let free = validate_input!(free_callback.ok_or(InvalidArgument))?;
         let free = Free { free, cookie };
         // SAFETY: Preconditions delegate to `CBox::from_c`'s safety.
         let data = unsafe { CBox::from_c(data, free) };
@@ -56,7 +56,7 @@ impl Rav1dData {
         free_callback: Option<FnFree>,
         cookie: Option<SendSyncNonNull<c_void>>,
     ) -> Rav1dResult {
-        let free = validate_input!(free_callback.ok_or(EINVAL))?;
+        let free = validate_input!(free_callback.ok_or(InvalidArgument))?;
         let free = Free { free, cookie };
         // SAFETY: Preconditions delegate to `CBox::from_c`'s safety.
         let user_data = unsafe { CBox::from_c(user_data, free) };

--- a/src/data.rs
+++ b/src/data.rs
@@ -5,8 +5,7 @@ use std::ptr::NonNull;
 
 use crate::c_arc::CArc;
 use crate::c_box::{CBox, FnFree, Free};
-use crate::error::Rav1dError::InvalidArgument;
-use crate::error::Rav1dResult;
+use crate::error::{Rav1dError, Rav1dResult};
 use crate::include::common::validate::validate_input;
 use crate::include::dav1d::common::Rav1dDataProps;
 use crate::include::dav1d::data::Rav1dData;
@@ -39,7 +38,7 @@ impl Rav1dData {
         free_callback: Option<FnFree>,
         cookie: Option<SendSyncNonNull<c_void>>,
     ) -> Rav1dResult<Self> {
-        let free = validate_input!(free_callback.ok_or(InvalidArgument))?;
+        let free = validate_input!(free_callback.ok_or(Rav1dError::InvalidArgument))?;
         let free = Free { free, cookie };
         // SAFETY: Preconditions delegate to `CBox::from_c`'s safety.
         let data = unsafe { CBox::from_c(data, free) };
@@ -56,7 +55,7 @@ impl Rav1dData {
         free_callback: Option<FnFree>,
         cookie: Option<SendSyncNonNull<c_void>>,
     ) -> Rav1dResult {
-        let free = validate_input!(free_callback.ok_or(InvalidArgument))?;
+        let free = validate_input!(free_callback.ok_or(Rav1dError::InvalidArgument))?;
         let free = Free { free, cookie };
         // SAFETY: Preconditions delegate to `CBox::from_c`'s safety.
         let user_data = unsafe { CBox::from_c(user_data, free) };

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -22,8 +22,7 @@ use crate::env::{
     get_cur_frame_segid, get_drl_context, get_filter_ctx, get_gmv_2d, get_intra_ctx,
     get_jnt_comp_ctx, get_mask_comp_ctx, get_partition_ctx, get_poc_diff, get_tx_ctx, BlockContext,
 };
-use crate::error::Rav1dError::{InvalidArgument, UnsupportedBitstream};
-use crate::error::Rav1dResult;
+use crate::error::{Rav1dError, Rav1dResult};
 use crate::extensions::OptionError as _;
 use crate::include::common::attributes::ctz;
 use crate::include::common::bitdepth::BPC;
@@ -4594,7 +4593,7 @@ pub(crate) fn rav1d_decode_frame_init_cdf(
                 data.len()
             } else {
                 if n_bytes > data.len() {
-                    return Err(InvalidArgument);
+                    return Err(Rav1dError::InvalidArgument);
                 }
                 let (cur_data, rest_data) = CArc::split_at(data, n_bytes);
                 let tile_sz = cur_data
@@ -4605,7 +4604,7 @@ pub(crate) fn rav1d_decode_frame_init_cdf(
                     + 1;
                 data = rest_data;
                 if tile_sz > data.len() {
-                    return Err(InvalidArgument);
+                    return Err(Rav1dError::InvalidArgument);
                 }
                 tile_sz
             };
@@ -4709,7 +4708,7 @@ fn rav1d_decode_frame_main(c: &Rav1dContext, f: &mut Rav1dFrameData) -> Rav1dRes
             }
             for col in 0..cols {
                 t.ts = tile_row * cols + col;
-                rav1d_decode_tile_sbrow(c, &mut t, f).map_err(|()| InvalidArgument)?;
+                rav1d_decode_tile_sbrow(c, &mut t, f).map_err(|()| Rav1dError::InvalidArgument)?;
             }
             if f.frame_hdr().frame_type.is_inter_or_switch() {
                 c.dsp
@@ -4748,7 +4747,7 @@ pub(crate) fn rav1d_decode_frame_exit(
             rf.p.frame_hdr.is_some()
                 && rf.progress.as_ref().unwrap()[1].load(Ordering::SeqCst) == FRAME_ERROR
         }) {
-            retval = Err(InvalidArgument);
+            retval = Err(Rav1dError::InvalidArgument);
             task_thread.error.store(1, Ordering::SeqCst);
             f.sr_cur.progress.as_mut().unwrap()[1].store(FRAME_ERROR, Ordering::SeqCst);
         }
@@ -4932,7 +4931,7 @@ pub fn rav1d_submit_frame(c: &Rav1dContext, state: &mut Rav1dState) -> Rav1dResu
                 &mut state.cached_error_props,
                 &state.in_0.m,
             );
-            return Err(UnsupportedBitstream);
+            return Err(Rav1dError::UnsupportedBitstream);
         }
     };
 
@@ -4953,7 +4952,7 @@ pub fn rav1d_submit_frame(c: &Rav1dContext, state: &mut Rav1dState) -> Rav1dResu
                     &mut state.cached_error_props,
                     &state.in_0.m,
                 );
-                return Err(InvalidArgument);
+                return Err(Rav1dError::InvalidArgument);
             }
         }
         for i in 0..7 {
@@ -4976,7 +4975,7 @@ pub fn rav1d_submit_frame(c: &Rav1dContext, state: &mut Rav1dState) -> Rav1dResu
                     &mut state.cached_error_props,
                     &state.in_0.m,
                 );
-                return Err(InvalidArgument);
+                return Err(Rav1dError::InvalidArgument);
             }
             f.refp[i] = state.refs[refidx].p.clone();
             ref_coded_width[i] = state.refs[refidx]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -22,7 +22,7 @@ use crate::env::{
     get_cur_frame_segid, get_drl_context, get_filter_ctx, get_gmv_2d, get_intra_ctx,
     get_jnt_comp_ctx, get_mask_comp_ctx, get_partition_ctx, get_poc_diff, get_tx_ctx, BlockContext,
 };
-use crate::error::Rav1dError::{EINVAL, ENOPROTOOPT};
+use crate::error::Rav1dError::{InvalidArgument, UnsupportedBitstream};
 use crate::error::Rav1dResult;
 use crate::extensions::OptionError as _;
 use crate::include::common::attributes::ctz;
@@ -4594,7 +4594,7 @@ pub(crate) fn rav1d_decode_frame_init_cdf(
                 data.len()
             } else {
                 if n_bytes > data.len() {
-                    return Err(EINVAL);
+                    return Err(InvalidArgument);
                 }
                 let (cur_data, rest_data) = CArc::split_at(data, n_bytes);
                 let tile_sz = cur_data
@@ -4605,7 +4605,7 @@ pub(crate) fn rav1d_decode_frame_init_cdf(
                     + 1;
                 data = rest_data;
                 if tile_sz > data.len() {
-                    return Err(EINVAL);
+                    return Err(InvalidArgument);
                 }
                 tile_sz
             };
@@ -4709,7 +4709,7 @@ fn rav1d_decode_frame_main(c: &Rav1dContext, f: &mut Rav1dFrameData) -> Rav1dRes
             }
             for col in 0..cols {
                 t.ts = tile_row * cols + col;
-                rav1d_decode_tile_sbrow(c, &mut t, f).map_err(|()| EINVAL)?;
+                rav1d_decode_tile_sbrow(c, &mut t, f).map_err(|()| InvalidArgument)?;
             }
             if f.frame_hdr().frame_type.is_inter_or_switch() {
                 c.dsp
@@ -4748,7 +4748,7 @@ pub(crate) fn rav1d_decode_frame_exit(
             rf.p.frame_hdr.is_some()
                 && rf.progress.as_ref().unwrap()[1].load(Ordering::SeqCst) == FRAME_ERROR
         }) {
-            retval = Err(EINVAL);
+            retval = Err(InvalidArgument);
             task_thread.error.store(1, Ordering::SeqCst);
             f.sr_cur.progress.as_mut().unwrap()[1].store(FRAME_ERROR, Ordering::SeqCst);
         }
@@ -4932,7 +4932,7 @@ pub fn rav1d_submit_frame(c: &Rav1dContext, state: &mut Rav1dState) -> Rav1dResu
                 &mut state.cached_error_props,
                 &state.in_0.m,
             );
-            return Err(ENOPROTOOPT);
+            return Err(UnsupportedBitstream);
         }
     };
 
@@ -4953,7 +4953,7 @@ pub fn rav1d_submit_frame(c: &Rav1dContext, state: &mut Rav1dState) -> Rav1dResu
                     &mut state.cached_error_props,
                     &state.in_0.m,
                 );
-                return Err(EINVAL);
+                return Err(InvalidArgument);
             }
         }
         for i in 0..7 {
@@ -4976,7 +4976,7 @@ pub fn rav1d_submit_frame(c: &Rav1dContext, state: &mut Rav1dState) -> Rav1dResu
                     &mut state.cached_error_props,
                     &state.in_0.m,
                 );
-                return Err(EINVAL);
+                return Err(InvalidArgument);
             }
             f.refp[i] = state.refs[refidx].p.clone();
             ref_coded_width[i] = state.refs[refidx]

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,7 +32,7 @@ pub enum Rav1dError {
     ///
     /// If this is returned by [`Decoder::get_picture`] then no decoded frames are pending
     /// currently and more data needs to be sent to the decoder.
-    Again = libc::EAGAIN as u8,
+    TryAgain = libc::EAGAIN as u8,
 
     /// Out of memory.
     ///
@@ -58,7 +58,7 @@ pub enum Rav1dError {
 impl Rav1dError {
     pub const fn as_str(&self) -> &'static str {
         match self {
-            Rav1dError::Again => "Try again",
+            Rav1dError::TryAgain => "Try again",
             Rav1dError::InvalidArgument => "Invalid argument",
             Rav1dError::OutOfMemory => "Not enough memory available",
             Rav1dError::UnsupportedBitstream => "Unsupported bitstream",

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,13 +2,13 @@ use std::ffi::{c_int, c_uint};
 
 use strum::FromRepr;
 
+/// Error enum return by various `rav1d` operations.
 #[derive(Clone, Copy, PartialEq, Eq, FromRepr, Debug)]
 #[repr(u8)]
 #[non_exhaustive]
 pub enum Rav1dError {
     /// This represents a generic `rav1d` error.
     /// It has nothing to do with the other `errno`-based ones
-    /// (and that's why it's not all caps like the other ones).
     ///
     /// Normally `EPERM = 1`, but `dav1d` never uses `EPERM`,
     /// but does use `-1`, as opposed to the normal `DAV1D_ERR(E*)`.
@@ -17,14 +17,58 @@ pub enum Rav1dError {
     /// which is more optimal since `0` is no error for [`Dav1dResult`].
     EGeneric = 1,
 
-    ENOENT = libc::ENOENT as u8,
-    EIO = libc::EIO as u8,
-    EAGAIN = libc::EAGAIN as u8,
-    ENOMEM = libc::ENOMEM as u8,
-    EINVAL = libc::EINVAL as u8,
-    ERANGE = libc::ERANGE as u8,
-    ENOPROTOOPT = libc::ENOPROTOOPT as u8,
+    /// Invalid buffer.
+    ///
+    /// No Sequence Header OBUs were found in the buffer.
+    InvalidBuffer = libc::ENOENT as u8,
+
+    /// Can't open file.
+    ///
+    /// IO error.
+    CantOpenFile = libc::EIO as u8,
+    /// Try again.
+    ///
+    /// If this is returned by [`Decoder::send_data`] or [`Decoder::send_pending_data`] then there
+    /// are decoded frames pending that first have to be retrieved via [`Decoder::get_picture`]
+    /// before processing any further pending data.
+    ///
+    /// If this is returned by [`Decoder::get_picture`] then no decoded frames are pending
+    /// currently and more data needs to be sent to the decoder.
+    Again = libc::EAGAIN as u8,
+    /// Not enough memory.
+    ///
+    /// Not enough memory is currently available for performing this operation.
+    NotEnoughMemory = libc::ENOMEM as u8,
+    /// Invalid argument.
+    ///
+    /// One of the arguments passed to the function was invalid.
+    InvalidArgument = libc::EINVAL as u8,
+    /// Out of range.
+    ///
+    /// Frame size is larger than the limit
+    OutOfRange = libc::ERANGE as u8,
+    /// Unsupported bitstream.
+    ///
+    /// The provided bitstream is not supported by `rav1d`.
+    UnsupportedBitstream = libc::ENOPROTOOPT as u8,
 }
+
+impl std::fmt::Display for Rav1dError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Rav1dError::Again => write!(fmt, "Try again"),
+            Rav1dError::InvalidArgument => write!(fmt, "Invalid argument"),
+            Rav1dError::NotEnoughMemory => write!(fmt, "Not enough memory available"),
+            Rav1dError::UnsupportedBitstream => write!(fmt, "Unsupported bitstream"),
+            Rav1dError::EGeneric => write!(fmt, "Generic error"),
+            Rav1dError::InvalidBuffer => write!(fmt, "Invalid buffer"),
+            Rav1dError::CantOpenFile => write!(fmt, "Can't open file: IO error"),
+            Rav1dError::OutOfRange => write!(fmt, "Out of range"),
+        }
+    }
+}
+
+impl std::error::Error for Rav1dError {}
 
 pub type Rav1dResult<T = ()> = Result<T, Rav1dError>;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,7 @@ pub enum Rav1dError {
     ///
     /// IO error.
     CantOpenFile = libc::EIO as u8,
+
     /// Try again.
     ///
     /// If this is returned by [`Decoder::send_data`] or [`Decoder::send_pending_data`] then there
@@ -35,18 +36,22 @@ pub enum Rav1dError {
     /// If this is returned by [`Decoder::get_picture`] then no decoded frames are pending
     /// currently and more data needs to be sent to the decoder.
     Again = libc::EAGAIN as u8,
+
     /// Not enough memory.
     ///
     /// Not enough memory is currently available for performing this operation.
     NotEnoughMemory = libc::ENOMEM as u8,
+
     /// Invalid argument.
     ///
     /// One of the arguments passed to the function was invalid.
     InvalidArgument = libc::EINVAL as u8,
+
     /// Out of range.
     ///
-    /// Frame size is larger than the limit
+    /// Frame size is larger than the limit.
     OutOfRange = libc::ERANGE as u8,
+
     /// Unsupported bitstream.
     ///
     /// The provided bitstream is not supported by `rav1d`.

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,7 +62,7 @@ impl Rav1dError {
             Rav1dError::InvalidArgument => "Invalid argument",
             Rav1dError::OutOfMemory => "Not enough memory available",
             Rav1dError::UnsupportedBitstream => "Unsupported bitstream",
-            Rav1dError::Other => "Generic error",
+            Rav1dError::Other => "Other error",
             Rav1dError::NoSequenceHeader => "No sequence header found",
             Rav1dError::OutOfRange => "Out of range",
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use std::ffi::{c_int, c_uint};
+use std::fmt::{self, Display, Formatter};
 
 use strum::FromRepr;
 
@@ -58,18 +59,24 @@ pub enum Rav1dError {
     UnsupportedBitstream = libc::ENOPROTOOPT as u8,
 }
 
-impl std::fmt::Display for Rav1dError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl Rav1dError {
+    pub const fn as_str(&self) -> &'static str {
         match self {
-            Rav1dError::Again => write!(fmt, "Try again"),
-            Rav1dError::InvalidArgument => write!(fmt, "Invalid argument"),
-            Rav1dError::NotEnoughMemory => write!(fmt, "Not enough memory available"),
-            Rav1dError::UnsupportedBitstream => write!(fmt, "Unsupported bitstream"),
-            Rav1dError::EGeneric => write!(fmt, "Generic error"),
-            Rav1dError::InvalidBuffer => write!(fmt, "Invalid buffer"),
-            Rav1dError::CantOpenFile => write!(fmt, "Can't open file: IO error"),
-            Rav1dError::OutOfRange => write!(fmt, "Out of range"),
+            Rav1dError::Again => "Try again",
+            Rav1dError::InvalidArgument => "Invalid argument",
+            Rav1dError::NotEnoughMemory => "Not enough memory available",
+            Rav1dError::UnsupportedBitstream => "Unsupported bitstream",
+            Rav1dError::EGeneric => "Generic error",
+            Rav1dError::InvalidBuffer => "Invalid buffer",
+            Rav1dError::CantOpenFile => "Can't open file: IO error",
+            Rav1dError::OutOfRange => "Out of range",
         }
+    }
+}
+
+impl Display for Rav1dError {
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.as_str())
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::error::Error;
 use std::ffi::{c_int, c_uint};
 use std::fmt::{self, Display, Formatter};
 
@@ -9,24 +10,19 @@ use strum::FromRepr;
 #[non_exhaustive]
 pub enum Rav1dError {
     /// This represents a generic `rav1d` error.
-    /// It has nothing to do with the other `errno`-based ones
+    /// It has nothing to do with the other `errno`-based ones.
     ///
     /// Normally `EPERM = 1`, but `dav1d` never uses `EPERM`,
     /// but does use `-1`, as opposed to the normal `DAV1D_ERR(E*)`.
     ///
-    /// Also Note that this forces `0` to be the niche,
+    /// Also note that this forces `0` to be the niche,
     /// which is more optimal since `0` is no error for [`Dav1dResult`].
-    EGeneric = 1,
+    Other = 1,
 
-    /// Invalid buffer.
+    /// No sequence header.
     ///
     /// No Sequence Header OBUs were found in the buffer.
-    InvalidBuffer = libc::ENOENT as u8,
-
-    /// Can't open file.
-    ///
-    /// IO error.
-    CantOpenFile = libc::EIO as u8,
+    NoSequenceHeader = libc::ENOENT as u8,
 
     /// Try again.
     ///
@@ -38,19 +34,19 @@ pub enum Rav1dError {
     /// currently and more data needs to be sent to the decoder.
     Again = libc::EAGAIN as u8,
 
-    /// Not enough memory.
+    /// Out of memory.
     ///
     /// Not enough memory is currently available for performing this operation.
-    NotEnoughMemory = libc::ENOMEM as u8,
+    OutOfMemory = libc::ENOMEM as u8,
 
     /// Invalid argument.
     ///
-    /// One of the arguments passed to the function was invalid.
+    /// One of the arguments passed to the function, including the bitstream, is invalid.
     InvalidArgument = libc::EINVAL as u8,
 
     /// Out of range.
     ///
-    /// Frame size is larger than the limit.
+    /// The frame size is larger than the limit.
     OutOfRange = libc::ERANGE as u8,
 
     /// Unsupported bitstream.
@@ -64,11 +60,10 @@ impl Rav1dError {
         match self {
             Rav1dError::Again => "Try again",
             Rav1dError::InvalidArgument => "Invalid argument",
-            Rav1dError::NotEnoughMemory => "Not enough memory available",
+            Rav1dError::OutOfMemory => "Not enough memory available",
             Rav1dError::UnsupportedBitstream => "Unsupported bitstream",
-            Rav1dError::EGeneric => "Generic error",
-            Rav1dError::InvalidBuffer => "Invalid buffer",
-            Rav1dError::CantOpenFile => "Can't open file: IO error",
+            Rav1dError::Other => "Generic error",
+            Rav1dError::NoSequenceHeader => "No sequence header found",
             Rav1dError::OutOfRange => "Out of range",
         }
     }
@@ -80,7 +75,7 @@ impl Display for Rav1dError {
     }
 }
 
-impl std::error::Error for Rav1dError {}
+impl Error for Rav1dError {}
 
 pub type Rav1dResult<T = ()> = Result<T, Rav1dError>;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,11 +26,11 @@ pub enum Rav1dError {
 
     /// Try again.
     ///
-    /// If this is returned by [`Decoder::send_data`] or [`Decoder::send_pending_data`] then there
-    /// are decoded frames pending that first have to be retrieved via [`Decoder::get_picture`]
+    /// If this is returned by [`rav1d_send_data`], then there
+    /// are decoded frames pending that first have to be retrieved via [`rav1d_get_picture`]
     /// before processing any further pending data.
     ///
-    /// If this is returned by [`Decoder::get_picture`] then no decoded frames are pending
+    /// If this is returned by [`rav1d_get_picture`], then no decoded frames are pending
     /// currently and more data needs to be sent to the decoder.
     TryAgain = libc::EAGAIN as u8,
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,10 +19,10 @@ pub enum Rav1dError {
     /// which is more optimal since `0` is no error for [`Dav1dResult`].
     Other = 1,
 
-    /// No sequence header.
+    /// No entity.
     ///
     /// No Sequence Header OBUs were found in the buffer.
-    NoSequenceHeader = libc::ENOENT as u8,
+    NoEntity = libc::ENOENT as u8,
 
     /// Try again.
     ///
@@ -63,7 +63,7 @@ impl Rav1dError {
             Rav1dError::OutOfMemory => "Not enough memory available",
             Rav1dError::UnsupportedBitstream => "Unsupported bitstream",
             Rav1dError::Other => "Other error",
-            Rav1dError::NoSequenceHeader => "No sequence header found",
+            Rav1dError::NoEntity => "No sequence header found",
             Rav1dError::OutOfRange => "Out of range",
         }
     }

--- a/src/include/dav1d/dav1d.rs
+++ b/src/include/dav1d/dav1d.rs
@@ -80,7 +80,7 @@ impl TryFrom<Dav1dDecodeFrameType> for Rav1dDecodeFrameType {
     type Error = Rav1dError;
 
     fn try_from(value: Dav1dDecodeFrameType) -> Result<Self, Self::Error> {
-        Self::from_repr(value as usize).ok_or(Rav1dError::EINVAL)
+        Self::from_repr(value as usize).ok_or(Rav1dError::InvalidArgument)
     }
 }
 

--- a/src/include/dav1d/picture.rs
+++ b/src/include/dav1d/picture.rs
@@ -14,7 +14,6 @@ use crate::c_arc::RawArc;
 use crate::disjoint_mut::{
     AsMutPtr, DisjointImmutGuard, DisjointMut, DisjointMutGuard, SliceBounds,
 };
-use crate::error::Rav1dError::InvalidArgument;
 use crate::error::{Dav1dResult, Rav1dError, Rav1dResult};
 use crate::ffi_safe::FFISafe;
 use crate::include::common::bitdepth::BitDepth;
@@ -719,8 +718,12 @@ impl TryFrom<Dav1dPicAllocator> for Rav1dPicAllocator {
         } = value;
         Ok(Self {
             cookie,
-            alloc_picture_callback: validate_input!(alloc_picture_callback.ok_or(InvalidArgument))?,
-            release_picture_callback: validate_input!(release_picture_callback.ok_or(InvalidArgument))?,
+            alloc_picture_callback: validate_input!(
+                alloc_picture_callback.ok_or(Rav1dError::InvalidArgument)
+            )?,
+            release_picture_callback: validate_input!(
+                release_picture_callback.ok_or(Rav1dError::InvalidArgument)
+            )?,
         })
     }
 }

--- a/src/include/dav1d/picture.rs
+++ b/src/include/dav1d/picture.rs
@@ -14,7 +14,7 @@ use crate::c_arc::RawArc;
 use crate::disjoint_mut::{
     AsMutPtr, DisjointImmutGuard, DisjointMut, DisjointMutGuard, SliceBounds,
 };
-use crate::error::Rav1dError::EINVAL;
+use crate::error::Rav1dError::InvalidArgument;
 use crate::error::{Dav1dResult, Rav1dError, Rav1dResult};
 use crate::ffi_safe::FFISafe;
 use crate::include::common::bitdepth::BitDepth;
@@ -719,8 +719,8 @@ impl TryFrom<Dav1dPicAllocator> for Rav1dPicAllocator {
         } = value;
         Ok(Self {
             cookie,
-            alloc_picture_callback: validate_input!(alloc_picture_callback.ok_or(EINVAL))?,
-            release_picture_callback: validate_input!(release_picture_callback.ok_or(EINVAL))?,
+            alloc_picture_callback: validate_input!(alloc_picture_callback.ok_or(InvalidArgument))?,
+            release_picture_callback: validate_input!(release_picture_callback.ok_or(InvalidArgument))?,
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -611,7 +611,7 @@ fn drain_picture(c: &Rav1dContext, state: &mut Rav1dState, out: &mut Rav1dPictur
     if output_picture_ready(c, state, true) {
         return output_image(c, state, out);
     }
-    Err(Rav1dError::Again)
+    Err(Rav1dError::TryAgain)
 }
 
 fn gen_picture(c: &Rav1dContext, state: &mut Rav1dState) -> Rav1dResult {
@@ -653,7 +653,7 @@ pub(crate) fn rav1d_send_data(c: &Rav1dContext, in_0: &mut Rav1dData) -> Rav1dRe
         state.drain = false;
     }
     if state.in_0.data.is_some() {
-        return Err(Rav1dError::Again);
+        return Err(Rav1dError::TryAgain);
     }
     state.in_0 = in_0.clone();
     let res = gen_picture(c, state);
@@ -701,7 +701,7 @@ pub(crate) fn rav1d_get_picture(c: &Rav1dContext, out: &mut Rav1dPicture) -> Rav
     if c.fc.len() > 1 && drain {
         return drain_picture(c, state, out);
     }
-    Err(Rav1dError::Again)
+    Err(Rav1dError::TryAgain)
 }
 
 /// # Safety

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -831,7 +831,7 @@ pub(crate) fn rav1d_flush(c: &Rav1dContext) {
     }
     if c.fc.len() > 1 {
         for fc in wrapping_iter(c.fc.iter(), state.frame_thread.next as usize) {
-            let _ = rav1d_decode_frame_exit(c, fc, Err(Rav1dError::EGeneric));
+            let _ = rav1d_decode_frame_exit(c, fc, Err(Rav1dError::Other));
             *fc.task_thread.retval.try_lock().unwrap() = None;
             let out_delayed = &mut state.frame_thread.out_delayed[fc.index];
             if out_delayed.p.frame_hdr.is_some() {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -518,7 +518,7 @@ fn parse_seq_hdr(
 pub(crate) fn rav1d_parse_sequence_header(
     mut data: &[u8],
 ) -> Rav1dResult<DRav1d<Rav1dSequenceHeader, Dav1dSequenceHeader>> {
-    let mut res = Err(Rav1dError::NoSequenceHeader);
+    let mut res = Err(Rav1dError::NoEntity);
 
     while !data.is_empty() {
         let gb = &mut GetBits::new(data);

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -8,7 +8,7 @@ use std::{array, cmp, fmt, mem};
 use crate::c_arc::CArc;
 use crate::decode::rav1d_submit_frame;
 use crate::env::get_poc_diff;
-use crate::error::Rav1dError::{EINVAL, ENOENT, ERANGE};
+use crate::error::Rav1dError::{InvalidArgument, InvalidBuffer, OutOfRange};
 use crate::error::Rav1dResult;
 use crate::getbits::GetBits;
 use crate::include::common::intops::{clip_u8, ulog2};
@@ -86,7 +86,7 @@ fn check_trailing_bits(gb: &mut GetBits, strict_std_compliance: bool) -> Rav1dRe
     let trailing_one_bit = gb.get_bit();
 
     if gb.has_error() != 0 {
-        return Err(EINVAL);
+        return Err(InvalidArgument);
     }
 
     if !strict_std_compliance {
@@ -94,13 +94,13 @@ fn check_trailing_bits(gb: &mut GetBits, strict_std_compliance: bool) -> Rav1dRe
     }
 
     if !trailing_one_bit || gb.pending_bits() != 0 {
-        return Err(EINVAL);
+        return Err(InvalidArgument);
     }
 
     gb.bytealign();
 
     if gb.get_bytes(gb.remaining_len()).iter().any(|&b| b != 0) {
-        return Err(EINVAL);
+        return Err(InvalidArgument);
     }
 
     Ok(())
@@ -113,13 +113,13 @@ fn parse_seq_hdr(
 ) -> Rav1dResult<Rav1dSequenceHeader> {
     let debug = Debug::new(false, "SEQHDR", gb);
 
-    let profile = Rav1dProfile::from_repr(gb.get_bits(3) as usize).ok_or(EINVAL)?;
+    let profile = Rav1dProfile::from_repr(gb.get_bits(3) as usize).ok_or(InvalidArgument)?;
     debug.post(gb, "post-profile");
 
     let still_picture = gb.get_bit() as u8;
     let reduced_still_picture_header = gb.get_bit() as u8;
     if reduced_still_picture_header != 0 && still_picture == 0 {
-        return Err(EINVAL);
+        return Err(InvalidArgument);
     }
     debug.post(gb, "post-stillpicture_flags");
 
@@ -163,13 +163,13 @@ fn parse_seq_hdr(
             num_units_in_tick = gb.get_bits(32) as u32;
             time_scale = gb.get_bits(32) as u32;
             if strict_std_compliance && (num_units_in_tick == 0 || time_scale == 0) {
-                return Err(EINVAL);
+                return Err(InvalidArgument);
             }
             equal_picture_interval = gb.get_bit() as u8;
             if equal_picture_interval != 0 {
                 let num_ticks_per_picture_ = gb.get_vlc();
                 if num_ticks_per_picture_ == 0xffffffff {
-                    return Err(EINVAL);
+                    return Err(InvalidArgument);
                 }
                 num_ticks_per_picture = num_ticks_per_picture_ + 1;
             } else {
@@ -182,7 +182,7 @@ fn parse_seq_hdr(
                 encoder_decoder_buffer_delay_length = gb.get_bits(5) as u8 + 1;
                 num_units_in_decoding_tick = gb.get_bits(32) as u32;
                 if strict_std_compliance && num_units_in_decoding_tick == 0 {
-                    return Err(EINVAL);
+                    return Err(InvalidArgument);
                 }
                 buffer_removal_delay_length = gb.get_bits(5) as u8 + 1;
                 frame_presentation_delay_length = gb.get_bits(5) as u8 + 1;
@@ -213,7 +213,7 @@ fn parse_seq_hdr(
             let op = &mut operating_points[i as usize];
             op.idc = gb.get_bits(12) as u16;
             if op.idc != 0 && (op.idc & 0xff == 0 || op.idc & 0xf00 == 0) {
-                return Err(EINVAL);
+                return Err(InvalidArgument);
             }
             op.major_level = 2 + gb.get_bits(3) as u8;
             op.minor_level = gb.get_bits(2) as u8;
@@ -381,7 +381,7 @@ fn parse_seq_hdr(
         layout = Rav1dPixelLayout::I444;
         color_range = 1;
         if profile != Rav1dProfile::High && !(profile == Rav1dProfile::Professional && hbd == 2) {
-            return Err(EINVAL);
+            return Err(InvalidArgument);
         }
 
         // Default initialization.
@@ -439,7 +439,7 @@ fn parse_seq_hdr(
         && mtrx == Rav1dMatrixCoefficients::IDENTITY
         && layout != Rav1dPixelLayout::I444
     {
-        return Err(EINVAL);
+        return Err(InvalidArgument);
     }
     let separate_uv_delta_q;
     if monochrome == 0 {
@@ -518,7 +518,7 @@ fn parse_seq_hdr(
 pub(crate) fn rav1d_parse_sequence_header(
     mut data: &[u8],
 ) -> Rav1dResult<DRav1d<Rav1dSequenceHeader, Dav1dSequenceHeader>> {
-    let mut res = Err(ENOENT);
+    let mut res = Err(InvalidBuffer);
 
     while !data.is_empty() {
         let gb = &mut GetBits::new(data);
@@ -534,7 +534,7 @@ pub(crate) fn rav1d_parse_sequence_header(
             let len = gb.get_uleb128() as usize;
             let len = gb.byte_pos() + len;
             if len > data.len() {
-                return Err(EINVAL);
+                return Err(InvalidArgument);
             }
             len
         } else {
@@ -544,13 +544,13 @@ pub(crate) fn rav1d_parse_sequence_header(
         if r#type == Some(Rav1dObuType::SeqHdr) {
             res = Ok(parse_seq_hdr(gb, false)?);
             if gb.byte_pos() > obu_end {
-                return Err(EINVAL);
+                return Err(InvalidArgument);
             }
             gb.bytealign();
         }
 
         if gb.has_error() != 0 {
-            return Err(EINVAL);
+            return Err(InvalidArgument);
         }
         assert!(!gb.has_pending_bits());
 
@@ -571,7 +571,7 @@ fn parse_frame_size(
         for i in 0..7 {
             if gb.get_bit() {
                 let r#ref = &state.refs[refidx[i as usize] as usize].p;
-                let ref_size = &r#ref.p.frame_hdr.as_ref().ok_or(EINVAL)?.size;
+                let ref_size = &r#ref.p.frame_hdr.as_ref().ok_or(InvalidArgument)?.size;
                 let width1 = ref_size.width[1];
                 let height = ref_size.height;
                 let render_width = ref_size.render_width;
@@ -686,7 +686,7 @@ fn parse_refidx(
                         .p
                         .frame_hdr
                         .as_ref()
-                        .ok_or(EINVAL)?
+                        .ok_or(InvalidArgument)?
                         .frame_offset as c_int,
                     frame_offset as c_int,
                 );
@@ -789,7 +789,7 @@ fn parse_refidx(
                 .frame_hdr
                 .as_ref()
                 .filter(|ref_frame_hdr| ref_frame_hdr.frame_id == ref_frame_id)
-                .ok_or(EINVAL)?;
+                .ok_or(InvalidArgument)?;
         }
     }
     Ok(refidx)
@@ -890,7 +890,7 @@ fn parse_tiling(
     if log2_cols != 0 || log2_rows != 0 {
         update = gb.get_bits((log2_cols + log2_rows).into()) as u16;
         if update >= cols as u16 * rows as u16 {
-            return Err(EINVAL);
+            return Err(InvalidArgument);
         }
         n_bytes = gb.get_bits(2) as u8 + 1;
     } else {
@@ -1121,7 +1121,7 @@ fn parse_segmentation(
                 .p
                 .frame_hdr
                 .as_ref()
-                .ok_or(EINVAL)?
+                .ok_or(InvalidArgument)?
                 .segmentation
                 .seg_data
                 .clone()
@@ -1248,7 +1248,7 @@ fn parse_loopfilter(
                 .p
                 .frame_hdr
                 .as_ref()
-                .ok_or(EINVAL)?
+                .ok_or(InvalidArgument)?
                 .loopfilter
                 .mode_ref_deltas
                 .clone();
@@ -1409,7 +1409,7 @@ fn parse_skip_mode(
                 .p
                 .frame_hdr
                 .as_ref()
-                .ok_or(EINVAL)?
+                .ok_or(InvalidArgument)?
                 .frame_offset as c_uint;
 
             let diff = get_poc_diff(seqhdr.order_hint_n_bits, refpoc as c_int, poc as c_int);
@@ -1448,7 +1448,7 @@ fn parse_skip_mode(
                     .p
                     .frame_hdr
                     .as_ref()
-                    .ok_or(EINVAL)?
+                    .ok_or(InvalidArgument)?
                     .frame_offset as c_uint;
                 if get_poc_diff(
                     seqhdr.order_hint_n_bits,
@@ -1523,7 +1523,7 @@ fn parse_gmv(
                     .p
                     .frame_hdr
                     .as_ref()
-                    .ok_or(EINVAL)?
+                    .ok_or(InvalidArgument)?
                     .gmv[i]
             };
             let mat = &mut gmv.matrix;
@@ -1565,14 +1565,14 @@ fn parse_film_grain_data(
 ) -> Rav1dResult<Rav1dFilmGrainData> {
     let num_y_points = gb.get_bits(4) as c_int;
     if num_y_points > 14 {
-        return Err(EINVAL);
+        return Err(InvalidArgument);
     }
 
     let mut y_points = [[0; 2]; 14];
     for i in 0..num_y_points {
         y_points[i as usize][0] = gb.get_bits(8) as u8;
         if i != 0 && y_points[(i - 1) as usize][0] as c_int >= y_points[i as usize][0] as c_int {
-            return Err(EINVAL);
+            return Err(InvalidArgument);
         }
         y_points[i as usize][1] = gb.get_bits(8) as u8;
     }
@@ -1589,7 +1589,7 @@ fn parse_film_grain_data(
         for pl in 0..2 {
             num_uv_points[pl as usize] = gb.get_bits(4) as c_int;
             if num_uv_points[pl as usize] > 10 {
-                return Err(EINVAL);
+                return Err(InvalidArgument);
             }
             for i in 0..num_uv_points[pl as usize] {
                 uv_points[pl as usize][i as usize][0] = gb.get_bits(8) as u8;
@@ -1597,7 +1597,7 @@ fn parse_film_grain_data(
                     && uv_points[pl as usize][(i - 1) as usize][0] as c_int
                         >= uv_points[pl as usize][i as usize][0] as c_int
                 {
-                    return Err(EINVAL);
+                    return Err(InvalidArgument);
                 }
                 uv_points[pl as usize][i as usize][1] = gb.get_bits(8) as u8;
             }
@@ -1608,7 +1608,7 @@ fn parse_film_grain_data(
         && seqhdr.ss_ver == 1
         && (num_uv_points[0] != 0) != (num_uv_points[1] != 0)
     {
-        return Err(EINVAL);
+        return Err(InvalidArgument);
     }
 
     let scaling_shift = gb.get_bits(2) as u8 + 8;
@@ -1694,7 +1694,7 @@ fn parse_film_grain(
                 }
             }
             if !found {
-                return Err(EINVAL);
+                return Err(InvalidArgument);
             }
             Rav1dFilmGrainData {
                 seed,
@@ -1703,7 +1703,7 @@ fn parse_film_grain(
                     .p
                     .frame_hdr
                     .as_ref()
-                    .ok_or(EINVAL)?
+                    .ok_or(InvalidArgument)?
                     .film_grain
                     .data
                     .clone()
@@ -1757,7 +1757,7 @@ fn parse_frame_hdr(
                 .frame_hdr
                 .as_ref()
                 .filter(|ref_frame_hdr| ref_frame_hdr.frame_id == frame_id)
-                .ok_or(EINVAL)?;
+                .ok_or(InvalidArgument)?;
         } else {
             // Default initialization.
             frame_id = Default::default();
@@ -1895,7 +1895,7 @@ fn parse_frame_hdr(
             && frame_type == Rav1dFrameType::Intra
             && refresh_frame_flags == 0xff
         {
-            return Err(EINVAL);
+            return Err(InvalidArgument);
         }
         size = parse_frame_size(state, seqhdr, None, frame_size_override, gb)?;
         allow_intrabc = allow_screen_content_tools && !size.super_res.enabled && gb.get_bit();
@@ -2125,7 +2125,7 @@ fn parse_obus(
     // obu header
     let obu_forbidden_bit = gb.get_bit();
     if c.strict_std_compliance && obu_forbidden_bit {
-        return Err(EINVAL);
+        return Err(InvalidArgument);
     }
     let raw_type = gb.get_bits(4);
     let r#type = Rav1dObuType::from_repr(raw_type as usize);
@@ -2144,10 +2144,10 @@ fn parse_obus(
     // obu length field
     if has_length_field {
         let len = gb.get_uleb128() as usize;
-        gb.set_remaining_len(len).ok_or(EINVAL)?;
+        gb.set_remaining_len(len).ok_or(InvalidArgument)?;
     }
     if gb.has_error() != 0 {
-        return Err(EINVAL);
+        return Err(InvalidArgument);
     }
 
     // We must have read a whole number of bytes at this point
@@ -2174,11 +2174,11 @@ fn parse_obus(
         props: &Rav1dDataProps,
         gb: &mut GetBits,
     ) -> Rav1dResult {
-        let hdr = parse_tile_hdr(&state.frame_hdr.as_ref().ok_or(EINVAL)?.tiling, gb);
+        let hdr = parse_tile_hdr(&state.frame_hdr.as_ref().ok_or(InvalidArgument)?.tiling, gb);
         // Align to the next byte boundary and check for overrun.
         gb.bytealign();
         if gb.has_error() != 0 {
-            return Err(EINVAL);
+            return Err(InvalidArgument);
         }
 
         let mut data = r#in.clone();
@@ -2188,10 +2188,10 @@ fn parse_obus(
         if hdr.start > hdr.end || hdr.start != state.n_tiles {
             state.tiles.clear();
             state.n_tiles = 0;
-            return Err(EINVAL);
+            return Err(InvalidArgument);
         }
         if let Err(_) = state.tiles.try_reserve_exact(1) {
-            return Err(EINVAL);
+            return Err(InvalidArgument);
         }
         state.n_tiles += 1 + hdr.end - hdr.start;
         state.tiles.push(Rav1dTileGroup {
@@ -2213,7 +2213,7 @@ fn parse_obus(
                 writeln!(c.logger, "Error parsing sequence header");
             })?;
             if gb.has_error() != 0 {
-                return Err(EINVAL);
+                return Err(InvalidArgument);
             }
 
             let op_idx = if c.operating_point < seq_hdr.num_operating_points {
@@ -2273,7 +2273,7 @@ fn parse_obus(
             let frame_hdr = parse_frame_hdr(
                 c,
                 state,
-                state.seq_hdr.as_ref().ok_or(EINVAL)?,
+                state.seq_hdr.as_ref().ok_or(InvalidArgument)?,
                 temporal_id,
                 spatial_id,
                 gb,
@@ -2297,13 +2297,13 @@ fn parse_obus(
                     "Frame size {}x{} exceeds limit {}",
                     frame_hdr.size.width[1], frame_hdr.size.height, c.frame_size_limit,
                 );
-                return Err(ERANGE);
+                return Err(OutOfRange);
             }
 
             if r#type == Some(Rav1dObuType::Frame) {
                 // OBU_FRAMEs shouldn't be signaled with `show_existing_frame`.
                 if frame_hdr.show_existing_frame != 0 {
-                    return Err(EINVAL);
+                    return Err(InvalidArgument);
                 }
             }
 
@@ -2326,7 +2326,7 @@ fn parse_obus(
             // obu metadata type field
             let meta_type = gb.get_uleb128();
             if gb.has_error() != 0 {
-                return Err(EINVAL);
+                return Err(InvalidArgument);
             }
 
             match ObuMetaType::from_repr(meta_type as usize) {
@@ -2431,7 +2431,7 @@ fn parse_obus(
                 .p
                 .frame_hdr
                 .as_ref()
-                .ok_or(EINVAL)?
+                .ok_or(InvalidArgument)?
                 .frame_type
             {
                 Rav1dFrameType::Inter | Rav1dFrameType::Switch => {
@@ -2452,12 +2452,12 @@ fn parse_obus(
                 .data
                 .is_none()
             {
-                return Err(EINVAL);
+                return Err(InvalidArgument);
             }
             if c.strict_std_compliance
                 && !state.refs[frame_hdr.existing_frame_idx as usize].p.showable
             {
-                return Err(EINVAL);
+                return Err(InvalidArgument);
             }
             if c.fc.len() == 1 {
                 state.out = state.refs[frame_hdr.existing_frame_idx as usize].p.clone();
@@ -2579,7 +2579,7 @@ fn parse_obus(
                 _ => {}
             }
             if state.tiles.is_empty() {
-                return Err(EINVAL);
+                return Err(InvalidArgument);
             }
             rav1d_submit_frame(c, state)?;
             assert!(state.tiles.is_empty());

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -518,7 +518,7 @@ fn parse_seq_hdr(
 pub(crate) fn rav1d_parse_sequence_header(
     mut data: &[u8],
 ) -> Rav1dResult<DRav1d<Rav1dSequenceHeader, Dav1dSequenceHeader>> {
-    let mut res = Err(Rav1dError::InvalidBuffer);
+    let mut res = Err(Rav1dError::NoSequenceHeader);
 
     while !data.is_empty() {
         let gb = &mut GetBits::new(data);

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -213,7 +213,7 @@ fn picture_alloc_with_edges(
 ) -> Rav1dResult {
     if p.data.is_some() {
         writeln!(logger, "Picture already allocated!",);
-        return Err(Rav1dError::EGeneric);
+        return Err(Rav1dError::Other);
     }
     assert!(bpc > 0 && bpc <= 16);
     let pic = p_allocator.alloc_picture_data(w, h, seq_hdr.unwrap(), frame_hdr)?;

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -10,8 +10,7 @@ use bitflags::bitflags;
 use libc::ptrdiff_t;
 use to_method::To as _;
 
-use crate::error::Rav1dError::EGeneric;
-use crate::error::{Dav1dResult, Rav1dResult};
+use crate::error::{Dav1dResult, Rav1dError, Rav1dResult};
 use crate::include::dav1d::common::Rav1dDataProps;
 use crate::include::dav1d::dav1d::Rav1dEventFlags;
 use crate::include::dav1d::headers::{
@@ -214,7 +213,7 @@ fn picture_alloc_with_edges(
 ) -> Rav1dResult {
     if p.data.is_some() {
         writeln!(logger, "Picture already allocated!",);
-        return Err(EGeneric);
+        return Err(Rav1dError::EGeneric);
     }
     assert!(bpc > 0 && bpc <= 16);
     let pic = p_allocator.alloc_picture_data(w, h, seq_hdr.unwrap(), frame_hdr)?;

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -996,14 +996,7 @@ pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContextTaskThread>) {
                         if res.is_err() || p1_3 == TILE_ERROR {
                             assert!(task_thread_lock.is_none(), "thread lock should not be held");
                             task_thread_lock = Some(ttd.lock.lock());
-                            abort_frame(
-                                c,
-                                fc,
-                                match res {
-                                    Err(err) => Err(err),
-                                    Ok(_) => Err(Rav1dError::InvalidArgument),
-                                },
-                            );
+                            abort_frame(c, fc, res.and_then(|_| Err(Rav1dError::InvalidArgument)));
                             reset_task_cur(c, ttd, t.frame_idx);
                         } else {
                             t.type_0 = TaskType::InitCdf;

--- a/src/thread_task.rs
+++ b/src/thread_task.rs
@@ -627,10 +627,9 @@ fn get_frame_progress(fc: &Rav1dFrameContext, f: &Rav1dFrameData) -> c_int {
 #[inline]
 fn abort_frame(c: &Rav1dContext, fc: &Rav1dFrameContext, error: Rav1dResult) {
     fc.task_thread.error.store(
-        if error == Err(Rav1dError::InvalidArgument) {
-            1
-        } else {
-            -1
+        match error {
+            Err(Rav1dError::InvalidArgument) => 1,
+            _ => -1,
         },
         Ordering::SeqCst,
     );
@@ -1000,10 +999,9 @@ pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContextTaskThread>) {
                             abort_frame(
                                 c,
                                 fc,
-                                if res.is_err() {
-                                    res
-                                } else {
-                                    Err(Rav1dError::InvalidArgument)
+                                match res {
+                                    Err(err) => Err(err),
+                                    Ok(_) => Err(Rav1dError::InvalidArgument),
                                 },
                             );
                             reset_task_cur(c, ttd, t.frame_idx);
@@ -1079,7 +1077,7 @@ pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContextTaskThread>) {
                                         let _ = rav1d_decode_frame_exit(
                                             c,
                                             fc,
-                                            Err(Rav1dError::NotEnoughMemory),
+                                            Err(Rav1dError::OutOfMemory),
                                         );
                                         fc.task_thread.cond.notify_one();
                                     } else {
@@ -1186,7 +1184,7 @@ pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContextTaskThread>) {
                                     if error_0 == 1 {
                                         Err(Rav1dError::InvalidArgument)
                                     } else if error_0 != 0 {
-                                        Err(Rav1dError::NotEnoughMemory)
+                                        Err(Rav1dError::OutOfMemory)
                                     } else {
                                         Ok(())
                                     },
@@ -1361,7 +1359,7 @@ pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContextTaskThread>) {
                         if error_0 == 1 {
                             Err(Rav1dError::InvalidArgument)
                         } else if error_0 != 0 {
-                            Err(Rav1dError::NotEnoughMemory)
+                            Err(Rav1dError::OutOfMemory)
                         } else {
                             Ok(())
                         },
@@ -1416,7 +1414,7 @@ pub fn rav1d_worker_task(task_thread: Arc<Rav1dTaskContextTaskThread>) {
                     if error_0 == 1 {
                         Err(Rav1dError::InvalidArgument)
                     } else if error_0 != 0 {
-                        Err(Rav1dError::NotEnoughMemory)
+                        Err(Rav1dError::OutOfMemory)
                     } else {
                         Ok(())
                     },


### PR DESCRIPTION
Pulled out the `Rav1dError` changes from #1439 into a separate PR.