### PR TITLE
ci: switch `awalsh128/cache-apt-pkgs-action@latest` to my own fork to fix `apt-fast` error

### DIFF
--- a/.github/workflows/build-and-test-qemu.yml
+++ b/.github/workflows/build-and-test-qemu.yml
@@ -44,7 +44,7 @@ jobs:
         uses: kkysen/cache-apt-pkgs-action@remove-apt-fast-url-shortener
         with:
           packages: ${{ matrix.packages }} qemu-user-static meson nasm
-          version: 1.0 # version of cache to load
+          version: 3.0 # version of cache to load
       - name: git checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-test-qemu.yml
+++ b/.github/workflows/build-and-test-qemu.yml
@@ -41,7 +41,7 @@ jobs:
     name: test on ${{ matrix.target }}
     steps:
       - name: install prerequisites
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: kkysen/cache-apt-pkgs-action@remove-apt-fast-url-shortener
         with:
           packages: ${{ matrix.packages }} qemu-user-static meson nasm
           version: 1.0 # version of cache to load

--- a/.github/workflows/build-and-test-x86-extra.yml
+++ b/.github/workflows/build-and-test-x86-extra.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: install prerequisites
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: kkysen/cache-apt-pkgs-action@remove-apt-fast-url-shortener
         with:
           packages: meson nasm gcc-multilib
           version: 1.0 # version of cache to load

--- a/.github/workflows/build-and-test-x86-extra.yml
+++ b/.github/workflows/build-and-test-x86-extra.yml
@@ -26,7 +26,7 @@ jobs:
         uses: kkysen/cache-apt-pkgs-action@remove-apt-fast-url-shortener
         with:
           packages: meson nasm gcc-multilib
-          version: 1.0 # version of cache to load
+          version: 3.0 # version of cache to load
       - name: git checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-test-x86.yml
+++ b/.github/workflows/build-and-test-x86.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: install prerequisites
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: kkysen/cache-apt-pkgs-action@remove-apt-fast-url-shortener
         with:
           packages: meson nasm gcc-multilib
           version: 1.0 # version of cache to load

--- a/.github/workflows/build-and-test-x86.yml
+++ b/.github/workflows/build-and-test-x86.yml
@@ -31,7 +31,7 @@ jobs:
         uses: kkysen/cache-apt-pkgs-action@remove-apt-fast-url-shortener
         with:
           packages: meson nasm gcc-multilib
-          version: 1.0 # version of cache to load
+          version: 3.0 # version of cache to load
       - name: git checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
`awalsh128/cache-apt-pkgs-action@latest` is currently broken (see https://github.com/awalsh128/cache-apt-pkgs-action/issues/163), as it tries to use a `git.io` GitHub URL shortener URL to install `apt-fast`, but GitHub has removed that service.  To get CI working now, this switches to my fork which fixes the issue (https://github.com/awalsh128/cache-apt-pkgs-action/pull/164). Once the issue is fixed upstream, we can switch back.