### PR TITLE
ci: switch back to `awalsh128` `@latest` for `cache-apt-pkgs-action`

### DIFF
--- a/.github/workflows/build-and-test-qemu.yml
+++ b/.github/workflows/build-and-test-qemu.yml
@@ -41,7 +41,7 @@ jobs:
     name: test on ${{ matrix.target }}
     steps:
       - name: install prerequisites
-        uses: kkysen/cache-apt-pkgs-action@remove-apt-fast-url-shortener
+        uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: ${{ matrix.packages }} qemu-user-static meson nasm
           version: 3.0 # version of cache to load

--- a/.github/workflows/build-and-test-x86-extra.yml
+++ b/.github/workflows/build-and-test-x86-extra.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: install prerequisites
-        uses: kkysen/cache-apt-pkgs-action@remove-apt-fast-url-shortener
+        uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: meson nasm gcc-multilib
           version: 3.0 # version of cache to load

--- a/.github/workflows/build-and-test-x86.yml
+++ b/.github/workflows/build-and-test-x86.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: install prerequisites
-        uses: kkysen/cache-apt-pkgs-action@remove-apt-fast-url-shortener
+        uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: meson nasm gcc-multilib
           version: 3.0 # version of cache to load


### PR DESCRIPTION
My fork has since been merged upstream and a new release published, so we can switch back now.