### PR TITLE
Fix warnings from newer toolchain versions

### DIFF
--- a/src/cdf.rs
+++ b/src/cdf.rs
@@ -145,7 +145,7 @@ impl CdfThreadContext {
         }
     }
 
-    pub fn cdf_write(&self) -> RwLockWriteGuard<CdfContext> {
+    pub fn cdf_write(&self) -> RwLockWriteGuard<'_, CdfContext> {
         match self {
             Self::QCat(_) => panic!("Expected a Cdf"),
             Self::Cdf(cdf) => cdf.cdf.try_write().unwrap(),

--- a/src/include/dav1d/picture.rs
+++ b/src/include/dav1d/picture.rs
@@ -248,7 +248,7 @@ impl Rav1dPictureDataComponent {
         BD::pxstride(self.byte_len() - (-stride) as usize)
     }
 
-    pub fn with_offset<BD: BitDepth>(&self) -> Rav1dPictureDataComponentOffset {
+    pub fn with_offset<BD: BitDepth>(&self) -> Rav1dPictureDataComponentOffset<'_> {
         Rav1dPictureDataComponentOffset {
             data: self,
             offset: self.pixel_offset::<BD>(),
@@ -521,7 +521,7 @@ impl From<Rav1dPicture> for Dav1dPicture {
 }
 
 impl Rav1dPicture {
-    pub fn lf_offsets<BD: BitDepth>(&self, y: c_int) -> [Rav1dPictureDataComponentOffset; 3] {
+    pub fn lf_offsets<BD: BitDepth>(&self, y: c_int) -> [Rav1dPictureDataComponentOffset<'_>; 3] {
         // Init loopfilter offsets. Point the chroma offsets in 4:0:0 to the luma
         // plane here to avoid having additional in-loop branches in various places.
         // We never use those values, so it doesn't really matter what they point

--- a/src/wrap_fn_ptr.rs
+++ b/src/wrap_fn_ptr.rs
@@ -53,7 +53,7 @@ macro_rules! wrap_fn_ptr {
             /// This allows us to add a safer
             /// (type-safe for sure, and increasingly fully safe)
             /// interface for calling a `fn` ptr.
-            #[derive(Clone, Copy, PartialEq, Eq)]
+            #[derive(Clone, Copy)]
             #[repr(transparent)]
             pub struct Fn(FnPtr);
 


### PR DESCRIPTION
This resolves a couple of new warnings that appear when building with newer nightly toolchains.

These warnings don't show up with the toolchain version specified in `rust-toolchain.toml`, but the fixes are fully compatible with it. These changes are purely cosmetic and result in an identical compiled binary.

## Fix mismatched_lifetime_syntaxes warning

The first change addresses the `mismatched_lifetime_syntaxes` lint that became enabled by default in nightly [1.89](https://github.com/rust-lang/rust/pull/138677) - this lint suggests making elided lifetimes in return types explicit to avoid ambiguity.

## Fix function pointer comparison warning

The second change silences a warning about deriving `PartialEq` and `Eq` for the function wrapper `Fn(FnPtr)`, as the address of a given function is not guaranteed to be unique across codegen units.

This was caused by `Fn(FnPtr)` deriving `PartialEq` and `Eq` in the wrap_fn_ptr! macro. Since these traits don't appear to be used anywhere in the project, removing them resolves the warning. If the Actions tests prove this change wrong I'll revert it.
