### PR TITLE
experiment: use `#[rustc_std_internal_symbol]` to make `#[no_mangle]` tables have hidden visibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/memorysafety/rav1d"
 exclude = ["*.c", "*.h", "*.in", "meson*", "tests/", "doc/", "package/"]
 
 [lib]
-crate-type = ["staticlib", "rlib"]
+crate-type = ["staticlib", "rlib", "cdylib"]
 
 [dependencies]
 assert_matches = "1.5.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-05-01"
+channel = "nightly-2025-04-30"
 
 # Commented out targets to avoid downloading or caching all these during CI
 # runs. See discussion on rav1d PR #1174. Uncomment to cross-compile locally.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(rustc_attrs)]
 #![cfg_attr(target_arch = "arm", feature(stdarch_arm_feature_detection))]
 #![cfg_attr(
     any(target_arch = "riscv32", target_arch = "riscv64"),

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -679,6 +679,7 @@ pub static DAV1D_SGR_PARAMS: Align4<[[u16; 2]; 16]> = Align4([
     [22, 0],
 ]);
 
+#[rustc_std_internal_symbol]
 #[no_mangle]
 pub static dav1d_sgr_x_by_x: Align64<[u8; 256]> = Align64([
     255, 128, 85, 64, 51, 43, 37, 32, 28, 26, 23, 21, 20, 18, 17, 16, 15, 14, 13, 13, 12, 12, 11,
@@ -692,6 +693,7 @@ pub static dav1d_sgr_x_by_x: Align64<[u8; 256]> = Align64([
     1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
 ]);
 
+#[rustc_std_internal_symbol]
 #[no_mangle]
 pub static dav1d_mc_subpel_filters: Align8<[[[i8; 8]; 15]; 6]> = Align8([
     [
@@ -798,6 +800,7 @@ pub static dav1d_mc_subpel_filters: Align8<[[[i8; 8]; 15]; 6]> = Align8([
     ],
 ]);
 
+#[rustc_std_internal_symbol]
 #[no_mangle]
 pub static dav1d_mc_warp_filter: Align8<[[i8; 8]; 193]> = Align8([
     [0, 0, 127, 1, 0, 0, 0, 0],
@@ -995,6 +998,7 @@ pub static dav1d_mc_warp_filter: Align8<[[i8; 8]; 193]> = Align8([
     [0, 0, 0, 0, 2, 127, -1, 0],
 ]);
 
+#[rustc_std_internal_symbol]
 #[no_mangle]
 pub static dav1d_resize_filter: Align8<[[i8; 8]; 64]> = Align8([
     [0, 0, 0, -128, 0, 0, 0, 0],
@@ -1063,6 +1067,7 @@ pub static dav1d_resize_filter: Align8<[[i8; 8]; 64]> = Align8([
     [0, 0, 1, -2, -128, 1, 0, 0],
 ]);
 
+#[rustc_std_internal_symbol]
 #[no_mangle]
 pub static dav1d_sm_weights: Align16<[u8; 128]> = Align16([
     0, 0, 255, 128, 255, 149, 85, 64, 255, 197, 146, 105, 73, 50, 37, 32, 255, 225, 196, 170, 145,
@@ -1073,6 +1078,7 @@ pub static dav1d_sm_weights: Align16<[u8; 128]> = Align16([
     32, 29, 27, 25, 22, 20, 18, 16, 15, 13, 12, 10, 9, 8, 7, 6, 6, 5, 5, 4, 4, 4,
 ]);
 
+#[rustc_std_internal_symbol]
 #[no_mangle]
 pub static dav1d_dr_intra_derivative: [u16; 44] = [
     0, 1023, 0, 547, 372, 0, 0, 273, 215, 0, 178, 151, 0, 132, 116, 0, 102, 0, 90, 80, 0, 71, 64,
@@ -1121,6 +1127,7 @@ const fn gen_filters(f: [[i8; 7]; 8]) -> Align64<[i8; 64]> {
     Align64(a)
 }
 
+#[rustc_std_internal_symbol]
 #[no_mangle]
 pub static dav1d_filter_intra_taps: [Align64<[i8; 64]>; 5] = [
     gen_filters([
@@ -1175,6 +1182,7 @@ pub static dav1d_filter_intra_taps: [Align64<[i8; 64]>; 5] = [
     ]),
 ];
 
+#[rustc_std_internal_symbol]
 #[no_mangle]
 pub static dav1d_obmc_masks: Align16<[u8; 64]> = Align16([
     0, 0, 19, 0, 25, 14, 5, 0, 28, 22, 16, 11, 7, 3, 0, 0, 30, 27, 24, 21, 18, 15, 12, 10, 8, 6, 4,
@@ -1182,6 +1190,7 @@ pub static dav1d_obmc_masks: Align16<[u8; 64]> = Align16([
     3, 2, 0, 0, 0, 0, 0, 0, 0, 0,
 ]);
 
+#[rustc_std_internal_symbol]
 #[no_mangle]
 pub static dav1d_gaussian_sequence: [i16; 2048] = [
     56, 568, -180, 172, 124, -84, 172, -64, -900, 24, 820, 224, 1248, 996, 272, -8, -916, -388,


### PR DESCRIPTION
Based on @ahomescu's investigation:
* https://github.com/memorysafety/rav1d/issues/1417#issuecomment-3100873696
* https://github.com/rust-lang/rfcs/pull/3834
* https://github.com/rust-lang/rust/issues/143422

I tried using `#[rustc_std_internal_symbol]` on `rav1d`'s `#[no_mangle]` symbols (some of the tables in `tables.rs`).  Per https://github.com/rust-lang/rust/issues/143422, `#[rustc_std_internal_symbol]` is unstable and not meant to be used for this, and in fact, no longer works on `#[no_mangle]` symbols (so I had to move our pinned nightly back 1 day), but this is just for experimenting.  This is able to successfully build as a `cdylib` with `cargo build`, not with `cargo build --release`, where I get `error: undefined symbol` for all of these symbols.  So I don't think this works even for the hidden visibility issue (note: also fixed in #1367 through small changes to the assembly).

As for the performance issues raised in #1417, I don't think this addresses them.  #1417 is about Rust calls to asm functions having unnecessary indirection, not about any symbols that Rust defines having any issues.  And it can be fixed by using `RUSTFLAGS="-Z plt=yes"`.