### PR TITLE
`mod itx`: backport deduplicating `itx` macros

### DIFF
--- a/src/arm/itx.h
+++ b/src/arm/itx.h
@@ -28,34 +28,6 @@
 #include "src/cpu.h"
 #include "src/itx.h"
 
-#define decl_itx2_fns(w, h, opt) \
-decl_itx_fn(BF(dav1d_inv_txfm_add_dct_dct_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_identity_identity_##w##x##h, opt))
-
-#define decl_itx12_fns(w, h, opt) \
-decl_itx2_fns(w, h, opt); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_dct_adst_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_dct_flipadst_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_dct_identity_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_adst_dct_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_adst_adst_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_adst_flipadst_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_flipadst_dct_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_flipadst_adst_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_flipadst_flipadst_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_identity_dct_##w##x##h, opt))
-
-#define decl_itx16_fns(w, h, opt) \
-decl_itx12_fns(w, h, opt); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_adst_identity_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_flipadst_identity_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_identity_adst_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_identity_flipadst_##w##x##h, opt))
-
-#define decl_itx17_fns(w, h, opt) \
-decl_itx16_fns(w, h, opt); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_wht_wht_##w##x##h, opt))
-
 decl_itx17_fns( 4,  4, neon);
 decl_itx16_fns( 4,  8, neon);
 decl_itx16_fns( 4, 16, neon);
@@ -78,41 +50,6 @@ decl_itx_fn(BF(dav1d_inv_txfm_add_dct_dct_64x32, neon));
 decl_itx_fn(BF(dav1d_inv_txfm_add_dct_dct_64x64, neon));
 
 static ALWAYS_INLINE void itx_dsp_init_arm(Dav1dInvTxfmDSPContext *const c, int bpc) {
-#define assign_itx_fn(pfx, w, h, type, type_enum, ext) \
-    c->itxfm_add[pfx##TX_##w##X##h][type_enum] = \
-        BF(dav1d_inv_txfm_add_##type##_##w##x##h, ext)
-
-#define assign_itx1_fn(pfx, w, h, ext) \
-    assign_itx_fn(pfx, w, h, dct_dct,           DCT_DCT,           ext)
-
-#define assign_itx2_fn(pfx, w, h, ext) \
-    assign_itx1_fn(pfx, w, h, ext); \
-    assign_itx_fn(pfx, w, h, identity_identity, IDTX,              ext)
-
-#define assign_itx12_fn(pfx, w, h, ext) \
-    assign_itx2_fn(pfx, w, h, ext); \
-    assign_itx_fn(pfx, w, h, dct_adst,          ADST_DCT,          ext); \
-    assign_itx_fn(pfx, w, h, dct_flipadst,      FLIPADST_DCT,      ext); \
-    assign_itx_fn(pfx, w, h, dct_identity,      H_DCT,             ext); \
-    assign_itx_fn(pfx, w, h, adst_dct,          DCT_ADST,          ext); \
-    assign_itx_fn(pfx, w, h, adst_adst,         ADST_ADST,         ext); \
-    assign_itx_fn(pfx, w, h, adst_flipadst,     FLIPADST_ADST,     ext); \
-    assign_itx_fn(pfx, w, h, flipadst_dct,      DCT_FLIPADST,      ext); \
-    assign_itx_fn(pfx, w, h, flipadst_adst,     ADST_FLIPADST,     ext); \
-    assign_itx_fn(pfx, w, h, flipadst_flipadst, FLIPADST_FLIPADST, ext); \
-    assign_itx_fn(pfx, w, h, identity_dct,      V_DCT,             ext)
-
-#define assign_itx16_fn(pfx, w, h, ext) \
-    assign_itx12_fn(pfx, w, h, ext); \
-    assign_itx_fn(pfx, w, h, adst_identity,     H_ADST,            ext); \
-    assign_itx_fn(pfx, w, h, flipadst_identity, H_FLIPADST,        ext); \
-    assign_itx_fn(pfx, w, h, identity_adst,     V_ADST,            ext); \
-    assign_itx_fn(pfx, w, h, identity_flipadst, V_FLIPADST,        ext)
-
-#define assign_itx17_fn(pfx, w, h, ext) \
-    assign_itx16_fn(pfx, w, h, ext); \
-    assign_itx_fn(pfx, w, h, wht_wht,           WHT_WHT,           ext)
-
     const unsigned flags = dav1d_get_cpu_flags();
 
     if (!(flags & DAV1D_ARM_CPU_FLAG_NEON)) return;

--- a/src/itx.h
+++ b/src/itx.h
@@ -39,10 +39,73 @@ void (name)(pixel *dst, ptrdiff_t dst_stride, coef *coeff, int eob \
             HIGHBD_DECL_SUFFIX)
 typedef decl_itx_fn(*itxfm_fn);
 
+#define decl_itx2_fns(w, h, opt) \
+decl_itx_fn(BF(dav1d_inv_txfm_add_dct_dct_##w##x##h, opt)); \
+decl_itx_fn(BF(dav1d_inv_txfm_add_identity_identity_##w##x##h, opt))
+
+#define decl_itx12_fns(w, h, opt) \
+decl_itx2_fns(w, h, opt); \
+decl_itx_fn(BF(dav1d_inv_txfm_add_dct_adst_##w##x##h, opt)); \
+decl_itx_fn(BF(dav1d_inv_txfm_add_dct_flipadst_##w##x##h, opt)); \
+decl_itx_fn(BF(dav1d_inv_txfm_add_dct_identity_##w##x##h, opt)); \
+decl_itx_fn(BF(dav1d_inv_txfm_add_adst_dct_##w##x##h, opt)); \
+decl_itx_fn(BF(dav1d_inv_txfm_add_adst_adst_##w##x##h, opt)); \
+decl_itx_fn(BF(dav1d_inv_txfm_add_adst_flipadst_##w##x##h, opt)); \
+decl_itx_fn(BF(dav1d_inv_txfm_add_flipadst_dct_##w##x##h, opt)); \
+decl_itx_fn(BF(dav1d_inv_txfm_add_flipadst_adst_##w##x##h, opt)); \
+decl_itx_fn(BF(dav1d_inv_txfm_add_flipadst_flipadst_##w##x##h, opt)); \
+decl_itx_fn(BF(dav1d_inv_txfm_add_identity_dct_##w##x##h, opt))
+
+#define decl_itx16_fns(w, h, opt) \
+decl_itx12_fns(w, h, opt); \
+decl_itx_fn(BF(dav1d_inv_txfm_add_adst_identity_##w##x##h, opt)); \
+decl_itx_fn(BF(dav1d_inv_txfm_add_flipadst_identity_##w##x##h, opt)); \
+decl_itx_fn(BF(dav1d_inv_txfm_add_identity_adst_##w##x##h, opt)); \
+decl_itx_fn(BF(dav1d_inv_txfm_add_identity_flipadst_##w##x##h, opt))
+
+#define decl_itx17_fns(w, h, opt) \
+decl_itx16_fns(w, h, opt); \
+decl_itx_fn(BF(dav1d_inv_txfm_add_wht_wht_##w##x##h, opt))
+
 typedef struct Dav1dInvTxfmDSPContext {
     itxfm_fn itxfm_add[N_RECT_TX_SIZES][N_TX_TYPES_PLUS_LL];
 } Dav1dInvTxfmDSPContext;
 
 bitfn_decls(void dav1d_itx_dsp_init, Dav1dInvTxfmDSPContext *c, int bpc);
+
+#define assign_itx_fn(pfx, w, h, type, type_enum, ext) \
+    c->itxfm_add[pfx##TX_##w##X##h][type_enum] = \
+        BF(dav1d_inv_txfm_add_##type##_##w##x##h, ext)
+
+#define assign_itx1_fn(pfx, w, h, ext) \
+    assign_itx_fn(pfx, w, h, dct_dct,           DCT_DCT,           ext)
+
+#define assign_itx2_fn(pfx, w, h, ext) \
+    assign_itx1_fn(pfx, w, h, ext); \
+    assign_itx_fn(pfx, w, h, identity_identity, IDTX,              ext)
+
+#define assign_itx12_fn(pfx, w, h, ext) \
+    assign_itx2_fn(pfx, w, h, ext); \
+    assign_itx_fn(pfx, w, h, dct_adst,          ADST_DCT,          ext); \
+    assign_itx_fn(pfx, w, h, dct_flipadst,      FLIPADST_DCT,      ext); \
+    assign_itx_fn(pfx, w, h, dct_identity,      H_DCT,             ext); \
+    assign_itx_fn(pfx, w, h, adst_dct,          DCT_ADST,          ext); \
+    assign_itx_fn(pfx, w, h, adst_adst,         ADST_ADST,         ext); \
+    assign_itx_fn(pfx, w, h, adst_flipadst,     FLIPADST_ADST,     ext); \
+    assign_itx_fn(pfx, w, h, flipadst_dct,      DCT_FLIPADST,      ext); \
+    assign_itx_fn(pfx, w, h, flipadst_adst,     ADST_FLIPADST,     ext); \
+    assign_itx_fn(pfx, w, h, flipadst_flipadst, FLIPADST_FLIPADST, ext); \
+    assign_itx_fn(pfx, w, h, identity_dct,      V_DCT,             ext)
+
+#define assign_itx16_fn(pfx, w, h, ext) \
+    assign_itx12_fn(pfx, w, h, ext); \
+    assign_itx_fn(pfx, w, h, adst_identity,     H_ADST,            ext); \
+    assign_itx_fn(pfx, w, h, flipadst_identity, H_FLIPADST,        ext); \
+    assign_itx_fn(pfx, w, h, identity_adst,     V_ADST,            ext); \
+    assign_itx_fn(pfx, w, h, identity_flipadst, V_FLIPADST,        ext)
+
+#define assign_itx17_fn(pfx, w, h, ext) \
+    assign_itx16_fn(pfx, w, h, ext); \
+    assign_itx_fn(pfx, w, h, wht_wht,           WHT_WHT,           ext)
 
 #endif /* DAV1D_SRC_ITX_H */

--- a/src/x86/itx.h
+++ b/src/x86/itx.h
@@ -30,34 +30,6 @@
 
 #define BF_BPC(x, bits, suffix) x##_##bits##bpc_##suffix
 
-#define decl_itx2_fns(w, h, opt) \
-decl_itx_fn(BF(dav1d_inv_txfm_add_dct_dct_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_identity_identity_##w##x##h, opt))
-
-#define decl_itx12_fns(w, h, opt) \
-decl_itx2_fns(w, h, opt); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_dct_adst_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_dct_flipadst_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_dct_identity_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_adst_dct_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_adst_adst_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_adst_flipadst_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_flipadst_dct_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_flipadst_adst_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_flipadst_flipadst_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_identity_dct_##w##x##h, opt))
-
-#define decl_itx16_fns(w, h, opt) \
-decl_itx12_fns(w, h, opt); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_adst_identity_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_flipadst_identity_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_identity_adst_##w##x##h, opt)); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_identity_flipadst_##w##x##h, opt))
-
-#define decl_itx17_fns(w, h, opt) \
-decl_itx16_fns(w, h, opt); \
-decl_itx_fn(BF(dav1d_inv_txfm_add_wht_wht_##w##x##h, opt))
-
 #define decl_itx_fns(ext) \
 decl_itx17_fns( 4,  4, ext); \
 decl_itx16_fns( 4,  8, ext); \
@@ -136,42 +108,6 @@ decl_itx_fn(dav1d_inv_txfm_add_wht_wht_4x4_16bpc_avx2);
 decl_itx_fn(BF(dav1d_inv_txfm_add_wht_wht_4x4, sse2));
 
 static ALWAYS_INLINE void itx_dsp_init_x86(Dav1dInvTxfmDSPContext *const c, const int bpc) {
-#define assign_itx_fn(pfx, w, h, type, type_enum, ext) \
-    c->itxfm_add[pfx##TX_##w##X##h][type_enum] = \
-        BF(dav1d_inv_txfm_add_##type##_##w##x##h, ext)
-
-#define assign_itx1_fn(pfx, w, h, ext) \
-    assign_itx_fn(pfx, w, h, dct_dct,           DCT_DCT,           ext)
-
-#define assign_itx2_fn(pfx, w, h, ext) \
-    assign_itx1_fn(pfx, w, h, ext); \
-    assign_itx_fn(pfx, w, h, identity_identity, IDTX,              ext)
-
-#define assign_itx12_fn(pfx, w, h, ext) \
-    assign_itx2_fn(pfx, w, h, ext); \
-    assign_itx_fn(pfx, w, h, dct_adst,          ADST_DCT,          ext); \
-    assign_itx_fn(pfx, w, h, dct_flipadst,      FLIPADST_DCT,      ext); \
-    assign_itx_fn(pfx, w, h, dct_identity,      H_DCT,             ext); \
-    assign_itx_fn(pfx, w, h, adst_dct,          DCT_ADST,          ext); \
-    assign_itx_fn(pfx, w, h, adst_adst,         ADST_ADST,         ext); \
-    assign_itx_fn(pfx, w, h, adst_flipadst,     FLIPADST_ADST,     ext); \
-    assign_itx_fn(pfx, w, h, flipadst_dct,      DCT_FLIPADST,      ext); \
-    assign_itx_fn(pfx, w, h, flipadst_adst,     ADST_FLIPADST,     ext); \
-    assign_itx_fn(pfx, w, h, flipadst_flipadst, FLIPADST_FLIPADST, ext); \
-    assign_itx_fn(pfx, w, h, identity_dct,      V_DCT,             ext)
-
-#define assign_itx16_fn(pfx, w, h, ext) \
-    assign_itx12_fn(pfx, w, h, ext); \
-    assign_itx_fn(pfx, w, h, adst_identity,     H_ADST,            ext); \
-    assign_itx_fn(pfx, w, h, flipadst_identity, H_FLIPADST,        ext); \
-    assign_itx_fn(pfx, w, h, identity_adst,     V_ADST,            ext); \
-    assign_itx_fn(pfx, w, h, identity_flipadst, V_FLIPADST,        ext)
-
-#define assign_itx17_fn(pfx, w, h, ext) \
-    assign_itx16_fn(pfx, w, h, ext); \
-    assign_itx_fn(pfx, w, h, wht_wht,           WHT_WHT,           ext)
-
-
 #define assign_itx_bpc_fn(pfx, w, h, type, type_enum, bpc, ext) \
     c->itxfm_add[pfx##TX_##w##X##h][type_enum] = \
         BF_BPC(dav1d_inv_txfm_add_##type##_##w##x##h, bpc, ext)


### PR DESCRIPTION
Splitting out of the large #1438.