### PR TITLE
`struct Rav1dFrameContextTaskThreadPendingTasks`: remove unused code

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -666,13 +666,6 @@ pub struct Rav1dFrameContextLf {
 
 #[derive(Default)]
 #[repr(C)]
-pub struct Rav1dFrameContextTaskThreadPendingTasks {
-    pub head: Rav1dTaskIndex,
-    pub tail: Rav1dTaskIndex,
-}
-
-#[derive(Default)]
-#[repr(C)]
 pub(crate) struct Rav1dFrameContextTaskThread {
     pub lock: Mutex<()>,
     pub cond: Condvar,


### PR DESCRIPTION
This seems to have been removed a long time ago in 8f78cfe, but we never realized that it was dead code since it was `pub`. The newly released Rust 1.89 warns about this, however, since it was never constructed either, and our `cargo +stable clippy -- -D warnings` CI step uses the latest stable.