### PR TITLE
`msac.c`: put c2rust added fns behind `#if ARCH_X86_64`

### DIFF
--- a/src/msac.c
+++ b/src/msac.c
@@ -218,3 +218,43 @@ void dav1d_msac_init(MsacContext *const s, const uint8_t *const data,
     msac_init_x86(s);
 #endif
 }
+
+// C2RUST:
+
+unsigned dav1d_msac_decode_symbol_adapt4(MsacContext *s, uint16_t *cdf,
+                                          size_t n_symbols)
+{
+    return dav1d_msac_decode_symbol_adapt4_impl(s, cdf, n_symbols);
+}
+
+unsigned dav1d_msac_decode_symbol_adapt8(MsacContext *s, uint16_t *cdf,
+                                          size_t n_symbols)
+{
+    return dav1d_msac_decode_symbol_adapt8_impl(s, cdf, n_symbols);
+}
+
+unsigned dav1d_msac_decode_symbol_adapt16(MsacContext *s, uint16_t *cdf,
+                                          size_t n_symbols)
+{
+    return dav1d_msac_decode_symbol_adapt16_impl(s, cdf, n_symbols);
+}
+
+unsigned dav1d_msac_decode_bool_adapt(MsacContext *s, uint16_t *cdf)
+{
+    return dav1d_msac_decode_bool_adapt_impl(s, cdf);
+}
+
+unsigned dav1d_msac_decode_bool_equi(MsacContext *s)
+{
+    return dav1d_msac_decode_bool_equi_impl(s);
+}
+
+unsigned dav1d_msac_decode_bool(MsacContext *s, unsigned f)
+{
+    return dav1d_msac_decode_bool_impl(s, f);
+}
+
+unsigned dav1d_msac_decode_hi_tok(MsacContext *s, uint16_t *cdf)
+{
+    return dav1d_msac_decode_hi_tok_impl(s, cdf);
+}

--- a/src/msac.c
+++ b/src/msac.c
@@ -219,6 +219,8 @@ void dav1d_msac_init(MsacContext *const s, const uint8_t *const data,
 #endif
 }
 
+#if ARCH_X86_64
+
 // C2RUST:
 
 unsigned dav1d_msac_decode_symbol_adapt4(MsacContext *s, uint16_t *cdf,
@@ -258,3 +260,5 @@ unsigned dav1d_msac_decode_hi_tok(MsacContext *s, uint16_t *cdf)
 {
     return dav1d_msac_decode_hi_tok_impl(s, cdf);
 }
+
+#endif


### PR DESCRIPTION
I deleted these in #1456 to get `dav1d` to compile on aarch64, but now they broke x86_64 builds, so I'm putting them behind `#if ARCH_X86_64`.  I'm not exactly sure how to test on 32-bit x86 (I tried `--cross-file=package/crossfiles/i686-linux32.meson` and it worked).