### PR TITLE
ci: missed installing `clippy` component on aarch64 darwin CI

### DIFF
--- a/.github/workflows/build-and-test-aarch64-darwin.yml
+++ b/.github/workflows/build-and-test-aarch64-darwin.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           toolchain: stable # aarch64 feature detection is stable
           target: aarch64-apple-darwin
+          components: clippy
       - name: cache rust dependencies
         uses: Swatinem/rust-cache@v2
       - name: cargo ${{ matrix.build.name }} build for aarch64-apple-darwin


### PR DESCRIPTION
Fixes https://github.com/memorysafety/rav1d/actions/runs/18050648613/job/51371714091?pr=1457.