### PR TITLE
`rust-toolchain.toml`: update to `nightly-2026-02-05`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-05-01"
+channel = "nightly-2026-02-05"
 
 # Commented out targets to avoid downloading or caching all these during CI
 # runs. See discussion on rav1d PR #1174. Uncomment to cross-compile locally.


### PR DESCRIPTION
To be used by #1439.