### PR TITLE
perf: replace unnecessary `usize::try_from` with `as` casts

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -640,7 +640,7 @@ fn read_pal_indices(
     bw4: c_int,
     bh4: c_int,
 ) {
-    let [w4, h4, bw4, bh4] = [w4, h4, bw4, bh4].map(|n| usize::try_from(n).unwrap());
+    let [w4, h4, bw4, bh4] = [w4, h4, bw4, bh4].map(|n| n as usize);
     let pli = pl as usize;
 
     let stride = bw4 * 4;
@@ -3058,9 +3058,8 @@ fn decode_b(
     // update contexts
     let frame_hdr = &***f.frame_hdr.as_ref().unwrap();
     if frame_hdr.segmentation.enabled != 0 && frame_hdr.segmentation.update_map != 0 {
-        // Need checked casts here because we're using `from_raw_parts_mut` and an overflow would be UB.
-        let [by, bx, bh4, bw4] = [t.b.y, t.b.x, bh4, bw4].map(|it| usize::try_from(it).unwrap());
-        let b4_stride = usize::try_from(f.b4_stride).unwrap();
+        let [by, bx, bh4, bw4] = [t.b.y, t.b.x, bh4, bw4].map(|it| it as usize);
+        let b4_stride = f.b4_stride as usize;
         let cur_segmap = &f.cur_segmap.as_ref().unwrap().inner;
         let offset = by * b4_stride + bx;
         CaseSet::<32, false>::one((), bw4, 0, |case, ()| {

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -1307,7 +1307,7 @@ fn cfl_ac_rust<BD: BitDepth>(
     is_ss_ver: bool,
 ) {
     let ac = &mut ac[..width * height];
-    let [w_pad, h_pad] = [w_pad, h_pad].map(|pad| usize::try_from(pad).unwrap() * 4);
+    let [w_pad, h_pad] = [w_pad, h_pad].map(|pad| pad as usize * 4);
     assert!(w_pad < width);
     assert!(h_pad < height);
     let [ss_hor, ss_ver] = [is_ss_hor, is_ss_ver].map(|is_ss| is_ss as u8);


### PR DESCRIPTION
Replace `usize::try_from(n).unwrap()` with `n as usize` in three locations where the checked conversion is unnecessary:

- **`fn read_pal_indices`** (decode.rs:643): Block dimensions (w4, h4, bw4, bh4) are always non-negative per the AV1 spec.

- **Segmentation map update** (decode.rs:3062-3063): The original comment about needing checked casts for `from_raw_parts_mut` is stale — the code now uses bounds-checked `DisjointMut` indexing, so overflow in the cast would cause a bounds-check panic rather than UB. The outdated comment is removed.

- **`fn cfl_ac_rust`** (ipred.rs:1310): w_pad and h_pad are non-negative and immediately asserted to be less than width/height.

This removes the overhead of the checked conversion (comparison + unwrap/panic path) on every call.

* Addresses #1344.