### PR TITLE
`fn DisjointImmutGuard::get_unchecked`: add `unsafe fn` to bypass `DisjointMut`

### DIFF
--- a/src/disjoint_mut.rs
+++ b/src/disjoint_mut.rs
@@ -208,6 +208,18 @@ impl<'a, T: ?Sized + AsMutPtr, V: ?Sized> Deref for DisjointImmutGuard<'a, T, V>
     }
 }
 
+impl<'a, T: ?Sized + AsMutPtr, V: ?Sized> DisjointImmutGuard<'a, T, V> {
+    // # Safety
+    //
+    // The slice of the [`DisjointMut`] this guard protects
+    // must not have overlapping mutable borrows.
+    //
+    // That is, this bypasses the disjoint mut check.
+    pub unsafe fn get_unchecked(&self) -> &'a V {
+        self.slice
+    }
+}
+
 /// Convert from a mutable pointer to a collection to a mutable pointer to the
 /// underlying slice without ever creating a mutable reference to the slice.
 ///


### PR DESCRIPTION
For use in https://github.com/memorysafety/rav1d/pull/1439#discussion_r2945310882.