### PR TITLE
[RFC] asm/x86: Use L2 prefetch in mc_avx2 to reduce cache stalls (6% gain at 4K)

### DIFF
--- a/src/x86/mc_avx2.asm
+++ b/src/x86/mc_avx2.asm
@@ -2199,6 +2199,16 @@ cglobal put_8tap_8bpc, 4, 9, 0, dst, ds, src, ss, w, h, mx, my, ss3
     punpcklbw            m3, m6, m0 ; 23
     punpckhbw            m6, m0     ; 56
 .v_w16_loop:
+    .v_w16_loop:
+    ; ===  ===
+    prefetcht1 [r4+ssq*2]       ; Fetch row N+2
+    prefetcht1 [r4+ssq*4]       ; Fetch row N+4
+    ; ============================
+    vbroadcasti128      m12, [r4+ssq*1]
+    lea                  r4, [r4+ssq*2]
+    pmaddubsw           m13, m1, m8  ; a0
+    pmaddubsw           m14, m2, m8  ; b0
+    mova                 m1, m3
     vbroadcasti128      m12, [r4+ssq*1]
     lea                  r4, [r4+ssq*2]
     pmaddubsw           m13, m1, m8  ; a0


### PR DESCRIPTION
**The Bottleneck**
While profiling `mc_avx2.asm` on x86_64, I noticed significant stall cycles during motion compensation, specifically when reading strided reference rows for sub-pixel interpolation on high-resolution workloads. 

**The Experiment**
To combat this without causing L1 cache pollution (which would evict the active filter coefficients), I introduced manual L2 prefetches (`prefetcht1`) for the upcoming rows (`+ssq*2`, etc.).

**The Results**
Benchmarking a 10-second 4K 8-bit IVF file (`hyperfine`, 10 runs, 1 thread) shows a consistent **~6% overall speedup**, with pure User CPU time dropping from 1.808s to 1.756s.

```text
Benchmark 1: ./dav1d_base -i 4k_test_8bit.ivf -o /dev/null --threads 1
  Time (mean ± σ):      2.011 s ±  0.258 s    [User: 1.808 s, System: 0.044 s]

Benchmark 2: ./dav1d_opt -i 4k_test_8bit.ivf -o /dev/null --threads 1
  Time (mean ± σ):      1.894 s ±  0.087 s    [User: 1.756 s, System: 0.044 s]

Summary
  ./dav1d_opt ran 1.06 ± 0.14 times faster than ./dav1d_base
```

**Request for Comments**
I am relatively new to writing assembly and wanted to put this up as an RFC. 
1. Is there  any historical context on why manual L2 prefetching is omitted here? (e.g., regressions on Zen architectures?)
2. If this approach is viable, I would appreciate guidance on how to safely handle the page boundaries at the tail end of the macroblock to avoid TLB miss penalties, as I currently haven't implemented a tail loop for the edges.