### PR TITLE
Rename plane_data() back to plane() to match dav1d API

### DIFF
--- a/src/rust_api.rs
+++ b/src/rust_api.rs
@@ -344,7 +344,7 @@ impl Picture {
     }
 
     /// Plane data of the `component` for the decoded frame.
-    pub fn plane_data<'a>(&'a self, component: PlanarImageComponent) -> &'a [u8] {
+    pub fn plane<'a>(&'a self, component: PlanarImageComponent) -> &'a [u8] {
         let data = &self.inner.data.as_ref().unwrap().data;
         let component = &data[component.as_index()];
         let guard = component.slice::<BitDepth8, _>(..);


### PR DESCRIPTION
This is still not an entirely drop-in replacement since dav1d has a newtype around `&[u8]`. I am not convinced that replicating it is worthwhile, but I will do so if the maintainers request it.