### PR TITLE
Support stable Rust on 32-bit ARM

### DIFF
--- a/scripts/pure-rust-smoke-test.sh
+++ b/scripts/pure-rust-smoke-test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/pure-rust-smoke-test.sh [--release] [--target TARGET] [--skip-check]
+
+Builds the rav1d CLI with assembly disabled and verifies a small, representative
+set of AV1 bitstreams against the upstream test-data MD5 checksums.
+
+Options:
+  --release       Build and run the release binary.
+  --target TARGET Run cargo check for TARGET with the same pure-Rust features.
+                  The decode smoke vectors are run on the host binary.
+  --skip-check    Skip the cargo check step.
+EOF
+}
+
+profile=debug
+cargo_profile_args=()
+target=
+skip_check=0
+
+while (($#)); do
+    case "$1" in
+        --release)
+            profile=release
+            cargo_profile_args=(--release)
+            shift
+            ;;
+        --target)
+            if (($# < 2)); then
+                echo "error: --target requires a target triple" >&2
+                exit 2
+            fi
+            target="$2"
+            shift 2
+            ;;
+        --skip-check)
+            skip_check=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+features=bitdepth_8,bitdepth_16
+
+if ((skip_check == 0)); then
+    check_args=(cargo check --lib --no-default-features --features "$features")
+    if [[ -n "$target" ]]; then
+        check_args+=(--target "$target")
+    fi
+    echo "==> ${check_args[*]}"
+    "${check_args[@]}"
+fi
+
+build_args=(
+    cargo build
+    -p rav1d-cli
+    --no-default-features
+    --features "$features"
+    --bin dav1d
+)
+if ((${#cargo_profile_args[@]})); then
+    build_args+=("${cargo_profile_args[@]}")
+fi
+echo "==> ${build_args[*]}"
+"${build_args[@]}"
+
+dav1d_bin="target/$profile/dav1d"
+
+cases=(
+    "8-bit IVF baseline|tests/dav1d-test-data/8-bit/data/00000000.ivf|0b31f7ae90dfa22cefe0f2a1ad97c620"
+    "8-bit Annex B OBU demux|tests/dav1d-test-data/8-bit/features/annexb.obu|f7f32af281ac5871d0b5de9de901588d"
+    "8-bit Section 5 OBU demux|tests/dav1d-test-data/8-bit/features/section5.obu|f7f32af281ac5871d0b5de9de901588d"
+    "8-bit RGB matrix path|tests/dav1d-test-data/8-bit/features/rgb.ivf|3a98407cdaf89c3076b7cdb0f8c7a0ba"
+    "10-bit baseline|tests/dav1d-test-data/10-bit/data/00000671.ivf|827a458a97061dfcdb8b05039ca1e531"
+    "12-bit baseline|tests/dav1d-test-data/12-bit/data/00000686.ivf|7333ff714f1f00df3f0d3ab5fd979599"
+)
+
+for case in "${cases[@]}"; do
+    IFS='|' read -r name input md5 <<<"$case"
+    echo "==> verify: $name"
+    "$dav1d_bin" -q -i "$input" --verify "$md5"
+done
+
+echo "pure-Rust rav1d smoke tests passed"

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -4,7 +4,6 @@ use std::ffi::{c_int, c_uint};
 use std::{cmp, ptr};
 
 use bitflags::bitflags;
-use libc::ptrdiff_t;
 
 use crate::align::AlignedVec64;
 use crate::cpu::CpuFlags;
@@ -24,6 +23,7 @@ use crate::include::common::intops::{apply_sign, iclip};
 use crate::include::dav1d::picture::{
     FFISafeRav1dPictureDataComponentOffset, Rav1dPictureDataComponentOffset,
 };
+use crate::libc_compat::ptrdiff_t;
 use crate::pic_or_buf::PicOrBuf;
 use crate::strided::Strided as _;
 use crate::tables::DAV1D_CDEF_DIRECTIONS;

--- a/src/cdef_apply.rs
+++ b/src/cdef_apply.rs
@@ -4,7 +4,6 @@ use std::cmp;
 use std::ffi::{c_int, c_uint};
 
 use bitflags::bitflags;
-use libc::ptrdiff_t;
 
 use crate::align::{Align16, AlignedVec64};
 use crate::cdef::CdefEdgeFlags;
@@ -14,6 +13,7 @@ use crate::include::common::intops::ulog2;
 use crate::include::dav1d::headers::Rav1dPixelLayout;
 use crate::include::dav1d::picture::Rav1dPictureDataComponentOffset;
 use crate::internal::{Rav1dContext, Rav1dFrameData, Rav1dTaskContext};
+use crate::libc_compat::ptrdiff_t;
 use crate::pic_or_buf::PicOrBuf;
 use crate::strided::{Strided as _, WithStride};
 use crate::with_offset::WithOffset;

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -173,14 +173,11 @@ impl CpuFlags {
 
         #[cfg(target_arch = "arm")]
         {
-            if std::arch::is_arm_feature_detected!("neon") {
+            // `is_arm_feature_detected!` requires nightly on 32-bit ARM.
+            // Keep a stable-safe fallback by using compile-time target features.
+            #[cfg(target_feature = "neon")]
+            {
                 flags |= Self::NEON;
-            }
-            if std::arch::is_arm_feature_detected!("dotprod") {
-                flags |= Self::DOTPROD;
-            }
-            if std::arch::is_arm_feature_detected!("i8mm") {
-                flags |= Self::I8MM;
             }
         }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2,7 +2,6 @@ use std::ffi::{c_int, c_uint};
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::{array, cmp, iter, mem};
 
-use libc::ptrdiff_t;
 use strum::EnumCount;
 
 use crate::align::{Align16, AlignedVec64};
@@ -53,6 +52,7 @@ use crate::lf_mask::{
     rav1d_calc_eih, rav1d_calc_lf_values, rav1d_create_lf_mask_inter, rav1d_create_lf_mask_intra,
     Av1RestorationUnit,
 };
+use crate::libc_compat::ptrdiff_t;
 use crate::log::Rav1dLog as _;
 use crate::lr_apply::LrRestorePlanes;
 use crate::msac::{

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,8 @@ use std::fmt::{self, Display, Formatter};
 
 use strum::FromRepr;
 
+use crate::libc_compat::{EAGAIN, EINVAL, ENOENT, ENOMEM, ENOPROTOOPT, ERANGE};
+
 /// Error enum return by various `rav1d` operations.
 #[derive(Clone, Copy, PartialEq, Eq, FromRepr, Debug)]
 #[repr(u8)]
@@ -22,7 +24,7 @@ pub enum Rav1dError {
     /// No entity.
     ///
     /// No Sequence Header OBUs were found in the buffer.
-    NoEntity = libc::ENOENT as u8,
+    NoEntity = ENOENT,
 
     /// Try again.
     ///
@@ -32,27 +34,27 @@ pub enum Rav1dError {
     ///
     /// If this is returned by [`rav1d_get_picture`], then no decoded frames are pending
     /// currently and more data needs to be sent to the decoder.
-    TryAgain = libc::EAGAIN as u8,
+    TryAgain = EAGAIN,
 
     /// Out of memory.
     ///
     /// Not enough memory is currently available for performing this operation.
-    OutOfMemory = libc::ENOMEM as u8,
+    OutOfMemory = ENOMEM,
 
     /// Invalid argument.
     ///
     /// One of the arguments passed to the function, including the bitstream, is invalid.
-    InvalidArgument = libc::EINVAL as u8,
+    InvalidArgument = EINVAL,
 
     /// Out of range.
     ///
     /// The frame size is larger than the limit.
-    OutOfRange = libc::ERANGE as u8,
+    OutOfRange = ERANGE,
 
     /// Unsupported bitstream.
     ///
     /// The provided bitstream is not supported by `rav1d`.
-    UnsupportedBitstream = libc::ENOPROTOOPT as u8,
+    UnsupportedBitstream = ENOPROTOOPT,
 }
 
 impl Rav1dError {

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -5,7 +5,6 @@ use std::hint::assert_unchecked;
 use std::ops::{Add, Shl, Shr};
 use std::{cmp, mem, ptr};
 
-use libc::{intptr_t, ptrdiff_t};
 use to_method::To;
 
 use crate::cpu::CpuFlags;
@@ -26,6 +25,7 @@ use crate::include::dav1d::picture::{
     Rav1dPictureDataComponentOffset,
 };
 use crate::internal::GrainLut;
+use crate::libc_compat::{intptr_t, ptrdiff_t};
 use crate::strided::Strided as _;
 use crate::tables::dav1d_gaussian_sequence;
 use crate::wrap_fn_ptr::wrap_fn_ptr;

--- a/src/include/dav1d/common.rs
+++ b/src/include/dav1d/common.rs
@@ -1,6 +1,7 @@
 use std::ptr::NonNull;
 
 use crate::c_arc::{CArc, RawCArc};
+use crate::libc_compat::off_t;
 
 #[derive(Default)]
 #[repr(C)]
@@ -35,7 +36,7 @@ impl From<Rav1dUserData> for Dav1dUserData {
 pub struct Dav1dDataProps {
     pub timestamp: i64,
     pub duration: i64,
-    pub offset: libc::off_t,
+    pub offset: off_t,
     pub size: usize,
     pub user_data: Dav1dUserData,
 }

--- a/src/include/dav1d/picture.rs
+++ b/src/include/dav1d/picture.rs
@@ -6,7 +6,6 @@ use std::ptr::NonNull;
 use std::sync::Arc;
 use std::{array, mem};
 
-use libc::{ptrdiff_t, uintptr_t};
 use to_method::To as _;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
@@ -24,6 +23,7 @@ use crate::include::dav1d::headers::{
     Rav1dContentLightLevel, Rav1dFrameHeader, Rav1dITUTT35, Rav1dMasteringDisplay,
     Rav1dPixelLayout, Rav1dSequenceHeader,
 };
+use crate::libc_compat::{ptrdiff_t, uintptr_t};
 use crate::pixels::Pixels;
 use crate::send_sync_non_null::SendSyncNonNull;
 use crate::strided::Strided;

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -6,7 +6,6 @@ use std::sync::{Arc, OnceLock};
 use std::thread::JoinHandle;
 
 use atomig::{Atom, Atomic};
-use libc::ptrdiff_t;
 use parking_lot::{Condvar, Mutex, RwLock, RwLockReadGuard};
 use strum::FromRepr;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
@@ -32,6 +31,7 @@ use crate::ipred::Rav1dIntraPredDSPContext;
 use crate::itx::Rav1dInvTxfmDSPContext;
 use crate::levels::{Av1Block, Filter2d, SegmentId, TxfmType, WHT_WHT};
 use crate::lf_mask::{Av1Filter, Av1FilterLUT, Av1Restoration, Av1RestorationUnit};
+use crate::libc_compat::ptrdiff_t;
 use crate::log::Rav1dLogger;
 use crate::loopfilter::Rav1dLoopFilterDSPContext;
 use crate::looprestoration::Rav1dLoopRestorationDSPContext;

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -3,7 +3,6 @@
 use std::ffi::{c_int, c_uint};
 use std::{cmp, slice};
 
-use libc::ptrdiff_t;
 use strum::FromRepr;
 use zerocopy::{AsBytes, FromBytes};
 
@@ -28,6 +27,7 @@ use crate::levels::{
     DC_128_PRED, DC_PRED, FILTER_PRED, HOR_PRED, LEFT_DC_PRED, N_IMPL_INTRA_PRED_MODES, PAETH_PRED,
     SMOOTH_H_PRED, SMOOTH_PRED, SMOOTH_V_PRED, TOP_DC_PRED, VERT_PRED, Z1_PRED, Z2_PRED, Z3_PRED,
 };
+use crate::libc_compat::ptrdiff_t;
 use crate::strided::Strided as _;
 use crate::tables::{
     dav1d_dr_intra_derivative, dav1d_filter_intra_taps, dav1d_sm_weights, filter_fn, FLT_INCR,

--- a/src/lf_mask.rs
+++ b/src/lf_mask.rs
@@ -2,7 +2,6 @@ use std::cmp;
 use std::ffi::c_int;
 use std::mem::MaybeUninit;
 
-use libc::ptrdiff_t;
 use parking_lot::RwLock;
 use zerocopy::FromBytes;
 
@@ -15,6 +14,7 @@ use crate::include::dav1d::headers::{
 };
 use crate::internal::Bxy;
 use crate::levels::{BlockSize, SegmentId, TxfmSize};
+use crate::libc_compat::ptrdiff_t;
 use crate::relaxed_atomic::RelaxedAtomic;
 use crate::tables::DAV1D_TXFM_DIMENSIONS;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ mod ffi_safe;
 mod fg_apply;
 mod filmgrain;
 mod getbits;
+pub(crate) mod libc_compat;
 pub(crate) mod pic_or_buf;
 pub(crate) mod pixels;
 pub(crate) mod relaxed_atomic;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(target_arch = "arm", feature(stdarch_arm_feature_detection))]
 #![cfg_attr(
     any(target_arch = "riscv32", target_arch = "riscv64"),
     feature(stdarch_riscv_feature_detection)

--- a/src/libc_compat.rs
+++ b/src/libc_compat.rs
@@ -1,0 +1,48 @@
+#[allow(non_camel_case_types)]
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+pub(crate) type intptr_t = isize;
+
+#[allow(non_camel_case_types)]
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+pub(crate) type off_t = i64;
+
+#[allow(non_camel_case_types)]
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+pub(crate) type ptrdiff_t = isize;
+
+#[allow(non_camel_case_types)]
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+pub(crate) type uintptr_t = usize;
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+pub(crate) use libc::{intptr_t, off_t, ptrdiff_t, uintptr_t};
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+pub(crate) const EAGAIN: u8 = 11;
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+pub(crate) const EAGAIN: u8 = libc::EAGAIN as u8;
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+pub(crate) const EINVAL: u8 = 22;
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+pub(crate) const EINVAL: u8 = libc::EINVAL as u8;
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+pub(crate) const ENOENT: u8 = 2;
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+pub(crate) const ENOENT: u8 = libc::ENOENT as u8;
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+pub(crate) const ENOMEM: u8 = 12;
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+pub(crate) const ENOMEM: u8 = libc::ENOMEM as u8;
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+pub(crate) const ENOPROTOOPT: u8 = 92;
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+pub(crate) const ENOPROTOOPT: u8 = libc::ENOPROTOOPT as u8;
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+pub(crate) const ERANGE: u8 = 34;
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+pub(crate) const ERANGE: u8 = libc::ERANGE as u8;

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -3,7 +3,6 @@
 use std::cmp;
 use std::ffi::c_int;
 
-use libc::ptrdiff_t;
 use strum::FromRepr;
 
 use crate::align::{Align16, AlignedVec2};
@@ -22,6 +21,7 @@ use crate::include::dav1d::picture::{
 };
 use crate::internal::Rav1dFrameData;
 use crate::lf_mask::Av1FilterLUT;
+use crate::libc_compat::ptrdiff_t;
 use crate::strided::Strided as _;
 use crate::with_offset::WithOffset;
 use crate::wrap_fn_ptr::wrap_fn_ptr;
@@ -113,20 +113,20 @@ fn loop_filter<BD: BitDepth>(
             *dst(stride_index) = bd.iclip_pixel(pixel);
         };
 
-        let mut p6 = 0;
-        let mut p5 = 0;
-        let mut p4 = 0;
-        let mut p3 = 0;
-        let mut p2 = 0;
+        let mut p6: i32 = 0;
+        let mut p5: i32 = 0;
+        let mut p4: i32 = 0;
+        let mut p3: i32 = 0;
+        let mut p2: i32 = 0;
         let p1 = get_dst(-2);
         let p0 = get_dst(-1);
         let q0 = get_dst(0);
         let q1 = get_dst(1);
-        let mut q2 = 0;
-        let mut q3 = 0;
-        let mut q4 = 0;
-        let mut q5 = 0;
-        let mut q6 = 0;
+        let mut q2: i32 = 0;
+        let mut q3: i32 = 0;
+        let mut q4: i32 = 0;
+        let mut q5: i32 = 0;
+        let mut q6: i32 = 0;
         let mut flat8out = false;
         let mut flat8in = false;
 

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -5,7 +5,6 @@ use std::ops::Add;
 use std::{cmp, iter, mem, slice};
 
 use bitflags::bitflags;
-use libc::ptrdiff_t;
 use to_method::To;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
@@ -28,6 +27,7 @@ use crate::include::common::intops::iclip;
 use crate::include::dav1d::picture::{
     FFISafeRav1dPictureDataComponentOffset, Rav1dPictureDataComponentOffset,
 };
+use crate::libc_compat::ptrdiff_t;
 use crate::strided::Strided as _;
 use crate::tables::dav1d_sgr_x_by_x;
 use crate::wrap_fn_ptr::wrap_fn_ptr;
@@ -954,11 +954,10 @@ fn sgr_mix_rust<BD: BitDepth>(
 mod neon {
     use std::ptr;
 
-    use libc::intptr_t;
-
     use super::*;
     use crate::align::Align16;
     use crate::include::common::bitdepth::bd_fn;
+    use crate::libc_compat::intptr_t;
 
     wrap_fn_ptr!(unsafe extern "C" fn wiener_filter_h(
         dst: *mut i16,

--- a/src/lr_apply.rs
+++ b/src/lr_apply.rs
@@ -5,7 +5,6 @@ use std::ffi::c_int;
 
 use assert_matches::assert_matches;
 use bitflags::bitflags;
-use libc::ptrdiff_t;
 
 use crate::align::Align16;
 use crate::include::common::bitdepth::BitDepth;
@@ -13,6 +12,7 @@ use crate::include::dav1d::headers::{Rav1dPixelLayout, Rav1dRestorationType};
 use crate::include::dav1d::picture::Rav1dPictureDataComponentOffset;
 use crate::internal::{Rav1dContext, Rav1dFrameData};
 use crate::lf_mask::Av1RestorationUnit;
+use crate::libc_compat::ptrdiff_t;
 use crate::looprestoration::{LooprestorationParams, LooprestorationParamsSgr, LrEdgeFlags};
 use crate::strided::Strided as _;
 use crate::tables::DAV1D_SGR_PARAMS;

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use std::{mem, ptr};
 
 use bitflags::bitflags;
-use libc::ptrdiff_t;
 use to_method::To as _;
 
 use crate::error::{Dav1dResult, Rav1dError, Rav1dResult};
@@ -21,6 +20,7 @@ use crate::include::dav1d::picture::{
     Dav1dPicture, Rav1dPicAllocator, Rav1dPicture, Rav1dPictureParameters, RAV1D_PICTURE_ALIGNMENT,
 };
 use crate::internal::{Rav1dFrameContext, Rav1dFrameData};
+use crate::libc_compat::ptrdiff_t;
 use crate::log::{Rav1dLog as _, Rav1dLogger};
 use crate::pool::MemPool;
 use crate::send_sync_non_null::SendSyncNonNull;

--- a/src/recon.rs
+++ b/src/recon.rs
@@ -6,7 +6,6 @@ use std::ops::BitOr;
 use std::{array, cmp, ptr};
 
 use assert_matches::debug_assert_matches;
-use libc::intptr_t;
 use to_method::To as _;
 
 use crate::cdef_apply::rav1d_cdef_brow;
@@ -34,6 +33,7 @@ use crate::levels::{
     WHT_WHT,
 };
 use crate::lf_apply::{rav1d_copy_lpf, rav1d_loopfilter_sbrow_cols, rav1d_loopfilter_sbrow_rows};
+use crate::libc_compat::intptr_t;
 use crate::lr_apply::rav1d_lr_sbrow;
 use crate::msac::{
     rav1d_msac_decode_bool_adapt, rav1d_msac_decode_bool_equi, rav1d_msac_decode_bools,


### PR DESCRIPTION
## Summary

This removes the nightly-only 32-bit ARM `stdarch_arm_feature_detection` gate by avoiding runtime ARM feature detection on `target_arch = "arm"`.

On 32-bit ARM, `std::arch::is_arm_feature_detected!` still requires nightly. This means crates depending on `rav1d` cannot build for 32-bit ARM targets with stable Rust.

Instead, this patch uses the stable `#[cfg(target_feature = "neon")]` compile-time fallback for 32-bit ARM and leaves the existing runtime detection paths for other architectures unchanged.

## Details

- Removes `#![cfg_attr(target_arch = "arm", feature(stdarch_arm_feature_detection))]`
- Replaces 32-bit ARM runtime detection for `neon` with `#[cfg(target_feature ="neon")]`
- Does not change the `aarch64` runtime detection path

The tradeoff is that on 32-bit ARM this only enables NEON when it is known at compile time. That seems preferable to requiring nightly for all stable 32-bit ARM consumers.

## Testing

Tested locally with stable Rust:

```sh
cargo +stable check --lib --no-default-features --features bitdepth_8,bitdepth_16
cargo +stable check --lib --target armv7-linux-androideabi --no-default-features
--features bitdepth_8,bitdepth_16