### PR TITLE
Backport dav1d 1.2.1 allocation optimizations

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -65,8 +65,11 @@ int dav1d_data_wrap_internal(Dav1dData *const buf, const uint8_t *const ptr,
     validate_input_or_ret(free_callback != NULL, DAV1D_ERR(EINVAL));
 
     if (sz > SIZE_MAX / 2) return DAV1D_ERR(EINVAL);
-    buf->ref = dav1d_ref_wrap(ptr, free_callback, cookie);
-    if (!buf->ref) return DAV1D_ERR(ENOMEM);
+
+    Dav1dRef *const ref = malloc(sizeof(Dav1dRef));
+    if (!ref) return DAV1D_ERR(ENOMEM);
+
+    buf->ref = dav1d_ref_init(ref, ptr, free_callback, cookie, 1);
     buf->data = ptr;
     buf->sz = sz;
     dav1d_data_props_set_defaults(&buf->m);
@@ -84,8 +87,10 @@ int dav1d_data_wrap_user_data_internal(Dav1dData *const buf,
     validate_input_or_ret(buf != NULL, DAV1D_ERR(EINVAL));
     validate_input_or_ret(free_callback != NULL, DAV1D_ERR(EINVAL));
 
-    buf->m.user_data.ref = dav1d_ref_wrap(user_data, free_callback, cookie);
-    if (!buf->m.user_data.ref) return DAV1D_ERR(ENOMEM);
+    Dav1dRef *const ref = malloc(sizeof(Dav1dRef));
+    if (!ref) return DAV1D_ERR(ENOMEM);
+
+    buf->m.user_data.ref = dav1d_ref_init(ref, user_data, free_callback, cookie, 1);
     buf->m.user_data.data = user_data;
 
     return 0;

--- a/src/internal.h
+++ b/src/internal.h
@@ -198,6 +198,7 @@ struct Dav1dContext {
     Dav1dLogger logger;
 
     Dav1dMemPool *picture_pool;
+    Dav1dMemPool *pic_ctx_pool;
 };
 
 struct Dav1dTask {

--- a/src/lib.c
+++ b/src/lib.c
@@ -188,6 +188,7 @@ COLD int dav1d_open(Dav1dContext **const c_out, const Dav1dSettings *const s) {
         dav1d_mem_pool_init(&c->frame_hdr_pool) ||
         dav1d_mem_pool_init(&c->segmap_pool) ||
         dav1d_mem_pool_init(&c->refmvs_pool) ||
+        dav1d_mem_pool_init(&c->pic_ctx_pool) ||
         dav1d_mem_pool_init(&c->cdf_pool))
     {
         return dav1d_open_error(c, c_out, &thread_attr);
@@ -691,6 +692,7 @@ static COLD void close_internal(Dav1dContext **const c_out, int flush) {
     dav1d_mem_pool_end(c->refmvs_pool);
     dav1d_mem_pool_end(c->cdf_pool);
     dav1d_mem_pool_end(c->picture_pool);
+    dav1d_mem_pool_end(c->pic_ctx_pool);
 
     dav1d_freep_aligned(c_out);
 }

--- a/src/obu.c
+++ b/src/obu.c
@@ -1552,12 +1552,8 @@ ptrdiff_t dav1d_parse_obus(Dav1dContext *const c, Dav1dData *const in) {
                 assert(!c->itut_t35_ref);
                 itut_t35_ctx = malloc(sizeof(struct itut_t35_ctx_context));
                 if (!itut_t35_ctx) return dav1d_parse_obus_error(c, in, &gb);
-                c->itut_t35_ref = dav1d_ref_wrap((uint8_t *)c->itut_t35, dav1d_picture_free_itut_t35,
-                                                 itut_t35_ctx);
-                if (!c->itut_t35_ref) {
-                    free(itut_t35_ctx);
-                    return dav1d_parse_obus_error(c, in, &gb);
-                }
+                c->itut_t35_ref = dav1d_ref_init(&itut_t35_ctx->ref, c->itut_t35,
+                                                 dav1d_picture_free_itut_t35, itut_t35_ctx, 0);
             } else {
                 assert(c->itut_t35_ref && atomic_load(&c->itut_t35_ref->ref_cnt) == 1);
                 itut_t35_ctx = c->itut_t35_ref->user_data;

--- a/src/picture.c
+++ b/src/picture.c
@@ -93,11 +93,12 @@ struct pic_ctx_context {
 };
 
 static void free_buffer(const uint8_t *const data, void *const user_data) {
-    struct pic_ctx_context *pic_ctx = user_data;
+    Dav1dMemPoolBuffer *buf = (Dav1dMemPoolBuffer *)data;
+    struct pic_ctx_context *pic_ctx = buf->data;
 
     pic_ctx->allocator.release_picture_callback(&pic_ctx->pic,
                                                 pic_ctx->allocator.cookie);
-    free(pic_ctx);
+    dav1d_mem_pool_push(user_data, buf);
 }
 
 void dav1d_picture_free_itut_t35(const uint8_t *const data, void *const user_data) {
@@ -117,7 +118,7 @@ static int picture_alloc_with_edges(Dav1dContext *const c,
                                     const int bpc,
                                     const Dav1dDataProps *const props,
                                     Dav1dPicAllocator *const p_allocator,
-                                    const size_t extra, void **const extra_ptr)
+                                    void **const extra_ptr)
 {
     if (p->data[0]) {
         dav1d_log(c, "Picture already allocated!\n");
@@ -125,9 +126,13 @@ static int picture_alloc_with_edges(Dav1dContext *const c,
     }
     assert(bpc > 0 && bpc <= 16);
 
-    struct pic_ctx_context *pic_ctx = malloc(extra + sizeof(struct pic_ctx_context));
-    if (pic_ctx == NULL)
+    size_t extra = c->n_fc > 1 ? sizeof(atomic_int) * 2 : 0;
+    Dav1dMemPoolBuffer *buf = dav1d_mem_pool_pop(c->pic_ctx_pool,
+                                                 extra + sizeof(struct pic_ctx_context));
+    if (buf == NULL)
         return DAV1D_ERR(ENOMEM);
+
+    struct pic_ctx_context *pic_ctx = buf->data;
 
     p->p.w = w;
     p->p.h = h;
@@ -138,16 +143,16 @@ static int picture_alloc_with_edges(Dav1dContext *const c,
     dav1d_data_props_set_defaults(&p->m);
     const int res = p_allocator->alloc_picture_callback(p, p_allocator->cookie);
     if (res < 0) {
-        free(pic_ctx);
+        dav1d_mem_pool_push(c->pic_ctx_pool, buf);
         return res;
     }
 
     pic_ctx->allocator = *p_allocator;
     pic_ctx->pic = *p;
 
-    if (!(p->ref = dav1d_ref_wrap(p->data[0], free_buffer, pic_ctx))) {
+    if (!(p->ref = dav1d_ref_wrap((const uint8_t *)buf, free_buffer, c->pic_ctx_pool))) {
         p_allocator->release_picture_callback(p, p_allocator->cookie);
-        free(pic_ctx);
+        dav1d_mem_pool_push(c->pic_ctx_pool, buf);
         dav1d_log(c, "Failed to wrap picture: %s\n", strerror(errno));
         return DAV1D_ERR(ENOMEM);
     }
@@ -193,14 +198,12 @@ int dav1d_thread_picture_alloc(Dav1dContext *const c, Dav1dFrameContext *const f
                                const int bpc)
 {
     Dav1dThreadPicture *const p = &f->sr_cur;
-    const int have_frame_mt = c->n_fc > 1;
 
     const int res =
         picture_alloc_with_edges(c, &p->p, f->frame_hdr->width[1], f->frame_hdr->height,
                                  f->seq_hdr, f->seq_hdr_ref,
                                  f->frame_hdr, f->frame_hdr_ref,
                                  bpc, &f->tile[0].data.m, &c->allocator,
-                                 have_frame_mt ? sizeof(atomic_int) * 2 : 0,
                                  (void **) &p->progress);
     if (res) return res;
 
@@ -224,7 +227,7 @@ int dav1d_thread_picture_alloc(Dav1dContext *const c, Dav1dFrameContext *const f
 
     p->visible = f->frame_hdr->show_frame;
     p->showable = f->frame_hdr->showable_frame;
-    if (have_frame_mt) {
+    if (c->n_fc > 1) {
         atomic_init(&p->progress[0], 0);
         atomic_init(&p->progress[1], 0);
     }
@@ -234,12 +237,13 @@ int dav1d_thread_picture_alloc(Dav1dContext *const c, Dav1dFrameContext *const f
 int dav1d_picture_alloc_copy(Dav1dContext *const c, Dav1dPicture *const dst, const int w,
                              const Dav1dPicture *const src)
 {
-    struct pic_ctx_context *const pic_ctx = src->ref->user_data;
+    Dav1dMemPoolBuffer *const buf = (Dav1dMemPoolBuffer *)src->ref->const_data;
+    struct pic_ctx_context *const pic_ctx = buf->data;
     const int res = picture_alloc_with_edges(c, dst, w, src->p.h,
                                              src->seq_hdr, src->seq_hdr_ref,
                                              src->frame_hdr, src->frame_hdr_ref,
                                              src->p.bpc, &src->m, &pic_ctx->allocator,
-                                             0, NULL);
+                                             NULL);
     if (res) return res;
 
     dav1d_picture_copy_props(dst, src->content_light, src->content_light_ref,

--- a/src/picture.h
+++ b/src/picture.h
@@ -104,6 +104,7 @@ void dav1d_picture_unref_internal(Dav1dPicture *p);
 struct itut_t35_ctx_context {
     Dav1dITUTT35 *itut_t35;
     size_t n_itut_t35;
+    Dav1dRef ref;
 };
 
 void dav1d_picture_free_itut_t35(const uint8_t *data, void *user_data);

--- a/src/ref.c
+++ b/src/ref.c
@@ -71,23 +71,6 @@ Dav1dRef *dav1d_ref_create_using_pool(Dav1dMemPool *const pool, size_t size) {
     return res;
 }
 
-Dav1dRef *dav1d_ref_wrap(const uint8_t *const ptr,
-                         void (*free_callback)(const uint8_t *data, void *user_data),
-                         void *const user_data)
-{
-    Dav1dRef *res = malloc(sizeof(Dav1dRef));
-    if (!res) return NULL;
-
-    res->data = NULL;
-    res->const_data = ptr;
-    atomic_init(&res->ref_cnt, 1);
-    res->free_ref = 1;
-    res->free_callback = free_callback;
-    res->user_data = user_data;
-
-    return res;
-}
-
 void dav1d_ref_dec(Dav1dRef **const pref) {
     assert(pref != NULL);
 

--- a/src/ref.h
+++ b/src/ref.h
@@ -47,11 +47,21 @@ struct Dav1dRef {
 
 Dav1dRef *dav1d_ref_create(size_t size);
 Dav1dRef *dav1d_ref_create_using_pool(Dav1dMemPool *pool, size_t size);
-Dav1dRef *dav1d_ref_wrap(const uint8_t *ptr,
-                         void (*free_callback)(const uint8_t *data, void *user_data),
-                         void *user_data);
 void dav1d_ref_dec(Dav1dRef **ref);
 int dav1d_ref_is_writable(Dav1dRef *ref);
+
+static inline Dav1dRef *dav1d_ref_init(Dav1dRef *const ref, const void *const ptr,
+                                       void (*const free_callback)(const uint8_t *data, void *user_data),
+                                       void *const user_data, const int free_ref)
+{
+    ref->data = NULL;
+    ref->const_data = ptr;
+    atomic_init(&ref->ref_cnt, 1);
+    ref->free_ref = free_ref;
+    ref->free_callback = free_callback;
+    ref->user_data = user_data;
+    return ref;
+}
 
 static inline void dav1d_ref_inc(Dav1dRef *const ref) {
     atomic_fetch_add_explicit(&ref->ref_cnt, 1, memory_order_relaxed);


### PR DESCRIPTION
Closes #286.

Rust sources are not updated in this PR because these dav1d commits optimize C Dav1dRef allocation paths. rav1d's Rust paths already use CArc/Arc-backed ownership for input data, picture data, and ITU-T T.35 metadata instead of the C Dav1dRef wrappers.