### PR TITLE
Fix Clippy warning and stale APT package lists

### DIFF
--- a/.github/workflows/build-and-test-x86-extra.yml
+++ b/.github/workflows/build-and-test-x86-extra.yml
@@ -22,11 +22,13 @@ jobs:
         ]
     runs-on: ubuntu-latest
     steps:
+      - name: refresh apt package lists
+        run: sudo apt-get update
       - name: install prerequisites
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: meson nasm gcc-multilib
-          version: 3.0 # version of cache to load
+          version: 4.0 # version of cache to load
       - name: git checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-test-x86.yml
+++ b/.github/workflows/build-and-test-x86.yml
@@ -27,11 +27,13 @@ jobs:
         ]
     runs-on: ubuntu-latest
     steps:
+      - name: refresh apt package lists
+        run: sudo apt-get update
       - name: install prerequisites
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: meson nasm gcc-multilib
-          version: 3.0 # version of cache to load
+          version: 4.0 # version of cache to load
       - name: git checkout
         uses: actions/checkout@v4
         with:

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1939,7 +1939,7 @@ fn parse_frame_hdr(
         size = parse_frame_size(
             state,
             seqhdr,
-            Some(&refidx).filter(|_| use_ref),
+            use_ref.then_some(&refidx),
             frame_size_override,
             gb,
         )?;


### PR DESCRIPTION
CI was blocked by two independent failures: Clippy rejected the indirect `Some(...).filter(...)` construction for an optional reference index, while GitHub’s Ubuntu image advertised glibc packages that had already disappeared from its mirrors, allowing the APT cache action to preserve an incomplete installation without `nasm`. Construct the option with `bool::then_some`, refresh APT metadata before installing the x86 prerequisites, and advance the cache generation so the invalid entry cannot be reused.
