### PR TITLE
ffi_safe: pass only the base pointer through DSP fn ptrs, derive the offset from the element ptr

### DIFF
--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -22,7 +22,7 @@ use crate::include::common::bitdepth::BPC;
 use crate::include::common::bitdepth::{AsPrimitive, BitDepth, DynPixel, LeftPixelRow2px};
 use crate::include::common::intops::{apply_sign, iclip};
 use crate::include::dav1d::picture::{
-    FFISafeRav1dPictureDataComponentOffset, Rav1dPictureDataComponentOffset,
+    FFISafeRav1dPictureDataComponent, Rav1dPictureDataComponentOffset,
 };
 use crate::pic_or_buf::PicOrBuf;
 use crate::strided::Strided as _;
@@ -53,9 +53,9 @@ wrap_fn_ptr!(pub unsafe extern "C" fn cdef(
     damping: c_int,
     edges: CdefEdgeFlags,
     bitdepth_max: c_int,
-    _dst: FFISafeRav1dPictureDataComponentOffset,
-    _top: WithOffset<*const FFISafe<DisjointMut<AlignedVec64<u8>>>>,
-    _bottom: WithOffset<*const FFISafe<PicOrBuf<'_, AlignedVec64<u8>>>>,
+    _dst: FFISafeRav1dPictureDataComponent,
+    _top: *const FFISafe<DisjointMut<AlignedVec64<u8>>>,
+    _bottom: *const FFISafe<PicOrBuf<'_, AlignedVec64<u8>>>,
 ) -> ());
 
 pub type CdefTop<'a> = WithOffset<&'a DisjointMut<AlignedVec64<u8>>>;
@@ -89,9 +89,9 @@ impl cdef::Fn {
         let damping = damping as c_int;
         let bd = bd.into_c();
 
-        let dst = dst.into_ffi_safe();
-        let top = top.into_ffi_safe();
-        let bottom = bottom.as_ref().into_ffi_safe();
+        let dst = FFISafe::new(dst.data);
+        let top = FFISafe::new(top.data);
+        let bottom = FFISafe::new(&bottom.data);
 
         // SAFETY: Rust fallback is safe, asm is assumed to do the same.
         unsafe {
@@ -120,7 +120,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn cdef_dir(
     dst_stride: ptrdiff_t,
     variance: &mut c_uint,
     bitdepth_max: c_int,
-    _dst: FFISafeRav1dPictureDataComponentOffset,
+    _dst: FFISafeRav1dPictureDataComponent,
 ) -> c_int);
 
 impl cdef_dir::Fn {
@@ -133,7 +133,7 @@ impl cdef_dir::Fn {
         let dst_ptr = dst.as_ptr::<BD>().cast();
         let dst_stride = dst.stride();
         let bd = bd.into_c();
-        let dst = dst.into_ffi_safe();
+        let dst = FFISafe::new(dst.data);
         // SAFETY: Fallback `fn cdef_find_dir_rust` is safe; asm is supposed to do the same.
         unsafe { self.get()(dst_ptr, dst_stride, variance, bd, dst) }
     }
@@ -375,32 +375,32 @@ fn cdef_filter_block_rust<BD: BitDepth>(
 /// Must be called by [`cdef::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn cdef_filter_block_c_erased<BD: BitDepth, const W: usize, const H: usize>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
     left: *const [LeftPixelRow2px<DynPixel>; 8],
-    _top_ptr: *const DynPixel,
-    _bottom_ptr: *const DynPixel,
+    top_ptr: *const DynPixel,
+    bottom_ptr: *const DynPixel,
     pri_strength: c_int,
     sec_strength: c_int,
     dir: c_int,
     damping: c_int,
     edges: CdefEdgeFlags,
     bitdepth_max: c_int,
-    dst: FFISafeRav1dPictureDataComponentOffset,
-    top: WithOffset<*const FFISafe<DisjointMut<AlignedVec64<u8>>>>,
-    bottom: WithOffset<*const FFISafe<PicOrBuf<'_, AlignedVec64<u8>>>>,
+    dst: FFISafeRav1dPictureDataComponent,
+    top: *const FFISafe<DisjointMut<AlignedVec64<u8>>>,
+    bottom: *const FFISafe<PicOrBuf<'_, AlignedVec64<u8>>>,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `cdef::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `cdef::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
 
     // SAFETY: Reverse of cast in `cdef::Fn::call`.
     let left = unsafe { &*left.cast() };
 
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `cdef::Fn::call`.
-    let top = unsafe { FFISafe::from_with_offset(top) };
+    // SAFETY: `top` was passed as `FFISafe::new(_)` and `top_ptr` was computed from the same `WithOffset` in `cdef::Fn::call`.
+    let top = unsafe { FFISafe::with_offset_of(top, top_ptr.cast::<BD::Pixel>()) };
 
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `cdef::Fn::call`.
-    let bottom = unsafe { FFISafe::from_with_offset(bottom) };
+    // SAFETY: `bottom` was passed as `FFISafe::new(_)` and `bottom_ptr` was computed from the same `WithOffset` in `cdef::Fn::call`.
+    let bottom = unsafe { FFISafe::with_offset_of(bottom, bottom_ptr.cast::<BD::Pixel>()) };
 
     let bd = BD::from_c(bitdepth_max);
     cdef_filter_block_rust(
@@ -424,14 +424,14 @@ unsafe extern "C" fn cdef_filter_block_c_erased<BD: BitDepth, const W: usize, co
 /// Must be called by [`cdef_dir::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn cdef_find_dir_c_erased<BD: BitDepth>(
-    _img_ptr: *const DynPixel,
+    img_ptr: *const DynPixel,
     _stride: ptrdiff_t,
     variance: &mut c_uint,
     bitdepth_max: c_int,
-    img: FFISafeRav1dPictureDataComponentOffset,
+    img: FFISafeRav1dPictureDataComponent,
 ) -> c_int {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `cdef_dir::Fn::call`.
-    let img = unsafe { FFISafe::from_with_offset(img) };
+    // SAFETY: `img` was passed as `FFISafe::new(_)` and `img_ptr` was computed from the same `WithOffset` in `cdef_dir::Fn::call`.
+    let img = unsafe { FFISafe::with_offset_of(img, img_ptr.cast::<BD::Pixel>()) };
     let bd = BD::from_c(bitdepth_max);
     cdef_find_dir_rust(img, variance, bd)
 }
@@ -638,9 +638,9 @@ mod neon {
         damping: c_int,
         edges: CdefEdgeFlags,
         bitdepth_max: c_int,
-        _dst: FFISafeRav1dPictureDataComponentOffset,
-        _top: WithOffset<*const FFISafe<DisjointMut<AlignedVec64<u8>>>>,
-        _bottom: WithOffset<*const FFISafe<PicOrBuf<'_, AlignedVec64<u8>>>>,
+        _dst: FFISafeRav1dPictureDataComponent,
+        _top: *const FFISafe<DisjointMut<AlignedVec64<u8>>>,
+        _bottom: *const FFISafe<PicOrBuf<'_, AlignedVec64<u8>>>,
     ) {
         use crate::align::Align16;
 

--- a/src/ffi_safe.rs
+++ b/src/ffi_safe.rs
@@ -1,12 +1,18 @@
 use std::marker::PhantomData;
-use std::ptr;
+use std::{mem, ptr};
 
+use crate::pixels::Pixels;
 use crate::with_offset::WithOffset;
 
 /// A type that bypasses `#[warn(improper_ctypes)]` checks of FFI safe types.
 /// This type is meant to roundtrip a reference to a type `T` with lifetime `'a`
 /// through an `extern "C" fn` ptr from a Rust caller to Rust callee.
 /// Non-Rust callees should not access this type.
+///
+/// A `WithOffset<&'a T>` is roundtripped by passing `FFISafe::new(data)`
+/// alongside the raw element ptr the caller already computed from it
+/// (`base + offset`, e.g. [`WithOffset::as_ptr`]); the callee recomputes
+/// the offset from that ptr with [`Self::with_offset_of`].
 #[repr(C)]
 pub struct FFISafe<'a, T> {
     phantom: PhantomData<&'a T>,
@@ -38,20 +44,30 @@ impl<'a, T> FFISafe<'a, T> {
         unsafe { &mut *this.cast() }
     }
 
+    /// Reconstruct the `WithOffset<&'a T>` that `ptr` was computed from.
+    ///
+    /// Only the address of `ptr` is used; the returned reference carries the
+    /// provenance of `this`. The offset is recovered with wrapping arithmetic,
+    /// so a `ptr` computed with [`WithOffset::wrapping_as_ptr`] that lies
+    /// outside the buffer still yields the original offset.
+    ///
     /// # Safety
     ///
-    /// `this` must have been returned from [`WithOffset::into_ffi_safe`].
-    pub unsafe fn from_with_offset(this: WithOffset<*const FFISafe<'a, T>>) -> WithOffset<&'a T> {
-        // SAFETY: We required that the caller created `this` using `into_ffi_safe`, which uses `FFISafe::new`.
-        this.map(|data| unsafe { FFISafe::get(data) })
-    }
-}
-
-impl<'a, T> WithOffset<&'a T> {
-    /// Convert `self` into an FFI-safe type.
-    ///
-    /// LLVM is able to better optimize the resulting type than a `*const FFISafe<'a, WithOffset<...>>`.
-    pub fn into_ffi_safe(self) -> WithOffset<*const FFISafe<'a, T>> {
-        self.map(FFISafe::new)
+    /// `this` must have been returned from [`Self::new`], and `ptr` must have been
+    /// computed from the same `WithOffset<&'a T>` as `base + offset`
+    /// (e.g. [`WithOffset::as_ptr`]), where `base` is [`Pixels::as_byte_mut_ptr`]
+    /// of the same `T` and `E` is the element type `offset` counts in.
+    pub unsafe fn with_offset_of<E>(this: *const Self, ptr: *const E) -> WithOffset<&'a T>
+    where
+        T: Pixels,
+    {
+        // SAFETY: `this` was a `&'a T` in `Self::new`.
+        let data = unsafe { Self::get(this) };
+        let byte_offset = (ptr as usize).wrapping_sub(data.as_byte_mut_ptr() as usize);
+        debug_assert_eq!(byte_offset % mem::size_of::<E>(), 0);
+        WithOffset {
+            data,
+            offset: byte_offset / mem::size_of::<E>(),
+        }
     }
 }

--- a/src/filmgrain.rs
+++ b/src/filmgrain.rs
@@ -22,8 +22,7 @@ use crate::include::dav1d::headers::{
     Dav1dFilmGrainData, Rav1dFilmGrainData, Rav1dPixelLayoutSubSampled,
 };
 use crate::include::dav1d::picture::{
-    FFISafeRav1dPictureDataComponentOffset, Rav1dPictureDataComponent,
-    Rav1dPictureDataComponentOffset,
+    FFISafeRav1dPictureDataComponent, Rav1dPictureDataComponent, Rav1dPictureDataComponentOffset,
 };
 use crate::internal::GrainLut;
 use crate::strided::Strided as _;
@@ -97,8 +96,8 @@ wrap_fn_ptr!(pub unsafe extern "C" fn fgy_32x32xn(
     bh: c_int,
     row_num: c_int,
     bitdepth_max: c_int,
-    _dst_row: FFISafeRav1dPictureDataComponentOffset,
-    _src_src: FFISafeRav1dPictureDataComponentOffset,
+    _dst_row: FFISafeRav1dPictureDataComponent,
+    _src_src: FFISafeRav1dPictureDataComponent,
 ) -> ());
 
 impl fgy_32x32xn::Fn {
@@ -126,8 +125,8 @@ impl fgy_32x32xn::Fn {
         let bh = bh as c_int;
         let row_num = row_num as c_int;
         let bd = bd.into_c();
-        let dst_row = dst_row.into_ffi_safe();
-        let src_row = src_row.into_ffi_safe();
+        let dst_row = FFISafe::new(dst_row.data);
+        let src_row = FFISafe::new(src_row.data);
         // SAFETY: Fallback `fn fgy_32x32xn_rust` is safe; asm is supposed to do the same.
         unsafe {
             self.get()(
@@ -163,9 +162,9 @@ wrap_fn_ptr!(pub unsafe extern "C" fn fguv_32x32xn(
     uv_pl: c_int,
     is_id: c_int,
     bitdepth_max: c_int,
-    _dst_row: FFISafeRav1dPictureDataComponentOffset,
-    _src_row: FFISafeRav1dPictureDataComponentOffset,
-    _luma_row: FFISafeRav1dPictureDataComponentOffset,
+    _dst_row: FFISafeRav1dPictureDataComponent,
+    _src_row: FFISafeRav1dPictureDataComponent,
+    _luma_row: FFISafeRav1dPictureDataComponent,
 ) -> ());
 
 impl fguv_32x32xn::Fn {
@@ -203,9 +202,9 @@ impl fguv_32x32xn::Fn {
         let uv_pl = is_uv as c_int;
         let is_id = is_id as c_int;
         let bd = bd.into_c();
-        let dst_row = dst_row.into_ffi_safe();
-        let src_row = src_row.into_ffi_safe();
-        let luma_row = luma_row.into_ffi_safe();
+        let dst_row = FFISafe::new(dst_row.data);
+        let src_row = FFISafe::new(src_row.data);
+        let luma_row = FFISafe::new(luma_row.data);
         // SAFETY: Fallback `fn fguv_32x32xn_rust` is safe; asm is supposed to do the same.
         unsafe {
             self.get()(
@@ -519,8 +518,8 @@ fn sample_lut<BD: BitDepth>(
 /// Must be called by [`fgy_32x32xn::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn fgy_32x32xn_c_erased<BD: BitDepth>(
-    _dst_row_ptr: *mut DynPixel,
-    _src_row_ptr: *const DynPixel,
+    dst_row_ptr: *mut DynPixel,
+    src_row_ptr: *const DynPixel,
     _stride: ptrdiff_t,
     data: &Dav1dFilmGrainData,
     pw: usize,
@@ -529,11 +528,14 @@ unsafe extern "C" fn fgy_32x32xn_c_erased<BD: BitDepth>(
     bh: c_int,
     row_num: c_int,
     bitdepth_max: c_int,
-    dst_row: FFISafeRav1dPictureDataComponentOffset,
-    src_row: FFISafeRav1dPictureDataComponentOffset,
+    dst_row: FFISafeRav1dPictureDataComponent,
+    src_row: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `fgy_32x32xn::Fn::call`.
-    let [dst_row, src_row] = [dst_row, src_row].map(|it| unsafe { FFISafe::from_with_offset(it) });
+    let [dst_row, src_row] =
+        [(dst_row, dst_row_ptr.cast_const()), (src_row, src_row_ptr)].map(|(row, ptr)| {
+            // SAFETY: `row` was passed as `FFISafe::new(_)` and `ptr` was computed from the same `WithOffset` in `fgy_32x32xn::Fn::call`.
+            unsafe { FFISafe::with_offset_of(row, ptr.cast::<BD::Pixel>()) }
+        });
     let data = &data.clone().into();
     // SAFETY: Casting back to the original type from the `fn` ptr call.
     let scaling = unsafe { &*scaling.cast() };
@@ -854,8 +856,8 @@ unsafe extern "C" fn fguv_32x32xn_c_erased<
     const IS_SX: bool,
     const IS_SY: bool,
 >(
-    _dst_row_ptr: *mut DynPixel,
-    _src_row_ptr: *const DynPixel,
+    dst_row_ptr: *mut DynPixel,
+    src_row_ptr: *const DynPixel,
     _stride: ptrdiff_t,
     data: &Dav1dFilmGrainData,
     pw: usize,
@@ -863,18 +865,23 @@ unsafe extern "C" fn fguv_32x32xn_c_erased<
     grain_lut: *const GrainLut<DynEntry>,
     bh: c_int,
     row_num: c_int,
-    _luma_row_ptr: *const DynPixel,
+    luma_row_ptr: *const DynPixel,
     _luma_stride: ptrdiff_t,
     uv_pl: c_int,
     is_id: c_int,
     bitdepth_max: c_int,
-    dst_row: FFISafeRav1dPictureDataComponentOffset,
-    src_row: FFISafeRav1dPictureDataComponentOffset,
-    luma_row: FFISafeRav1dPictureDataComponentOffset,
+    dst_row: FFISafeRav1dPictureDataComponent,
+    src_row: FFISafeRav1dPictureDataComponent,
+    luma_row: FFISafeRav1dPictureDataComponent,
 ) {
-    let [dst_row, src_row, luma_row] = [dst_row, src_row, luma_row].map(|row| {
-        // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `fguv_32x32xn::Fn::call`.
-        unsafe { FFISafe::from_with_offset(row) }
+    let [dst_row, src_row, luma_row] = [
+        (dst_row, dst_row_ptr.cast_const()),
+        (src_row, src_row_ptr),
+        (luma_row, luma_row_ptr),
+    ]
+    .map(|(row, ptr)| {
+        // SAFETY: `row` was passed as `FFISafe::new(_)` and `ptr` was computed from the same `WithOffset` in `fguv_32x32xn::Fn::call`.
+        unsafe { FFISafe::with_offset_of(row, ptr.cast::<BD::Pixel>()) }
     });
     let data = &data.clone().into();
     // SAFETY: Casting back to the original type from the `fn` ptr call.
@@ -981,8 +988,8 @@ mod neon {
         bh: c_int,
         row_num: c_int,
         bitdepth_max: c_int,
-        _dst_row: FFISafeRav1dPictureDataComponentOffset,
-        _src_row: FFISafeRav1dPictureDataComponentOffset,
+        _dst_row: FFISafeRav1dPictureDataComponent,
+        _src_row: FFISafeRav1dPictureDataComponent,
     ) {
         let dst_row = dst_row_ptr.cast();
         let src_row = src_row_ptr.cast();
@@ -1145,9 +1152,9 @@ mod neon {
         uv: c_int,
         is_id: c_int,
         bitdepth_max: c_int,
-        _dst_row: FFISafeRav1dPictureDataComponentOffset,
-        _src_row: FFISafeRav1dPictureDataComponentOffset,
-        _luma_row: FFISafeRav1dPictureDataComponentOffset,
+        _dst_row: FFISafeRav1dPictureDataComponent,
+        _src_row: FFISafeRav1dPictureDataComponent,
+        _luma_row: FFISafeRav1dPictureDataComponent,
     ) {
         let dst_row = dst_row_ptr.cast();
         let src_row = src_row_ptr.cast();

--- a/src/include/dav1d/picture.rs
+++ b/src/include/dav1d/picture.rs
@@ -341,8 +341,7 @@ impl Rav1dPictureDataComponent {
 }
 
 pub type Rav1dPictureDataComponentOffset<'a> = WithOffset<&'a Rav1dPictureDataComponent>;
-pub type FFISafeRav1dPictureDataComponentOffset<'a> =
-    WithOffset<*const FFISafe<'a, Rav1dPictureDataComponent>>;
+pub type FFISafeRav1dPictureDataComponent<'a> = *const FFISafe<'a, Rav1dPictureDataComponent>;
 
 impl<'a> Rav1dPictureDataComponentOffset<'a> {
     #[inline] // Inline to see bounds checks in order to potentially elide them.

--- a/src/ipred.rs
+++ b/src/ipred.rs
@@ -21,7 +21,7 @@ use crate::include::common::bitdepth::{AsPrimitive, BitDepth, DynPixel, BPC};
 use crate::include::common::intops::{apply_sign, iclip};
 use crate::include::dav1d::headers::Rav1dPixelLayoutSubSampled;
 use crate::include::dav1d::picture::{
-    FFISafeRav1dPictureDataComponentOffset, Rav1dPictureDataComponentOffset,
+    FFISafeRav1dPictureDataComponent, Rav1dPictureDataComponentOffset,
 };
 use crate::internal::{SCRATCH_AC_TXTP_LEN, SCRATCH_EDGE_LEN};
 use crate::levels::{
@@ -45,7 +45,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn angular_ipred(
     max_height: c_int,
     bitdepth_max: c_int,
     _topleft_off: usize,
-    _dst: FFISafeRav1dPictureDataComponentOffset,
+    _dst: FFISafeRav1dPictureDataComponent,
 ) -> ());
 
 impl angular_ipred::Fn {
@@ -65,7 +65,7 @@ impl angular_ipred::Fn {
         let stride = dst.stride();
         let topleft = topleft[topleft_off..].as_ptr().cast();
         let bd = bd.into_c();
-        let dst = dst.into_ffi_safe();
+        let dst = FFISafe::new(dst.data);
         // SAFETY: Fallbacks are safe; asm is supposed to do the same, where the fallbacks are:
         // * `fn splat_dc`
         // * `fn ipred_{v,h}_rust`
@@ -100,7 +100,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn cfl_ac(
     h_pad: c_int,
     cw: c_int,
     ch: c_int,
-    _y: FFISafeRav1dPictureDataComponentOffset,
+    _y: FFISafeRav1dPictureDataComponent,
 ) -> ());
 
 impl cfl_ac::Fn {
@@ -115,7 +115,7 @@ impl cfl_ac::Fn {
     ) {
         let y_ptr = y.as_ptr::<BD>().cast();
         let stride = y.stride();
-        let y = y.into_ffi_safe();
+        let y = FFISafe::new(y.data);
         // SAFETY: Fallback `fn cfl_ac_rust` is safe; asm is supposed to do the same.
         unsafe { self.get()(ac, y_ptr, stride, w_pad, h_pad, cw, ch, y) }
     }
@@ -131,7 +131,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn cfl_pred(
     alpha: c_int,
     bitdepth_max: c_int,
     _topleft_off: usize,
-    _dst: FFISafeRav1dPictureDataComponentOffset,
+    _dst: FFISafeRav1dPictureDataComponent,
 ) -> ());
 
 impl cfl_pred::Fn {
@@ -150,7 +150,7 @@ impl cfl_pred::Fn {
         let stride = dst.stride();
         let topleft = topleft[topleft_off..].as_ptr().cast();
         let bd = bd.into_c();
-        let dst = dst.into_ffi_safe();
+        let dst = FFISafe::new(dst.data);
         // SAFETY: Fallback `fn cfl_pred` is safe; asm is supposed to do the same.
         unsafe {
             self.get()(
@@ -176,7 +176,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn pal_pred(
     idx: *const u8,
     w: c_int,
     h: c_int,
-    _dst: FFISafeRav1dPictureDataComponentOffset,
+    _dst: FFISafeRav1dPictureDataComponent,
 ) -> ());
 
 impl pal_pred::Fn {
@@ -194,7 +194,7 @@ impl pal_pred::Fn {
         let stride = dst.stride();
         let pal = pal.as_ptr().cast();
         let idx = idx[..(w * h) as usize / 2].as_ptr();
-        let dst = dst.into_ffi_safe();
+        let dst = FFISafe::new(dst.data);
         // SAFETY: Fallback `fn pal_pred_rust` is safe; asm is supposed to do the same.
         unsafe { self.get()(dst_ptr, stride, pal, idx, w, h, dst) }
     }
@@ -370,7 +370,7 @@ unsafe fn reconstruct_topleft<'a, BD: BitDepth>(
 /// Must be called by [`angular_ipred::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn ipred_dc_c_erased<BD: BitDepth, const DC_GEN: u8>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
     topleft: *const DynPixel,
     width: c_int,
@@ -380,12 +380,12 @@ unsafe extern "C" fn ipred_dc_c_erased<BD: BitDepth, const DC_GEN: u8>(
     _max_height: c_int,
     bitdepth_max: c_int,
     topleft_off: usize,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
     let dc_gen = DcGen::from_repr(DC_GEN).unwrap();
 
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `angular_ipred::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `angular_ipred::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     // SAFETY: `fn angular_ipred::Fn::call` makes `topleft` `topleft_off` from the beginning of the array.
     let topleft = unsafe { reconstruct_topleft::<BD>(topleft, topleft_off) };
     let dc = dc_gen.call::<BD>(topleft, topleft_off, width, height) as c_int;
@@ -398,7 +398,7 @@ unsafe extern "C" fn ipred_dc_c_erased<BD: BitDepth, const DC_GEN: u8>(
 /// Must be called by [`cfl_pred::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn ipred_cfl_c_erased<BD: BitDepth, const DC_GEN: u8>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
     topleft: *const DynPixel,
     width: c_int,
@@ -407,12 +407,12 @@ unsafe extern "C" fn ipred_cfl_c_erased<BD: BitDepth, const DC_GEN: u8>(
     alpha: c_int,
     bitdepth_max: c_int,
     topleft_off: usize,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
     let dc_gen = DcGen::from_repr(DC_GEN).unwrap();
 
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `cfl_pred::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `cfl_pred::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     // SAFETY: `fn cfl_pred::Fn::call` makes `topleft` `topleft_off` from the beginning of the array.
     let topleft = unsafe { reconstruct_topleft::<BD>(topleft, topleft_off) };
     let dc = dc_gen.call::<BD>(topleft, topleft_off, width, height) as c_int;
@@ -425,7 +425,7 @@ unsafe extern "C" fn ipred_cfl_c_erased<BD: BitDepth, const DC_GEN: u8>(
 /// Must be called by [`angular_ipred::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn ipred_dc_128_c_erased<BD: BitDepth>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
     _topleft: *const DynPixel,
     width: c_int,
@@ -435,10 +435,10 @@ unsafe extern "C" fn ipred_dc_128_c_erased<BD: BitDepth>(
     _max_height: c_int,
     bitdepth_max: c_int,
     _topleft_off: usize,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `angular_ipred::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `angular_ipred::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     let bd = BD::from_c(bitdepth_max);
     let dc = bd.bitdepth_max().as_::<c_int>() + 1 >> 1;
     splat_dc(dst, width, height, dc, bd)
@@ -449,7 +449,7 @@ unsafe extern "C" fn ipred_dc_128_c_erased<BD: BitDepth>(
 /// Must be called by [`cfl_pred::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn ipred_cfl_128_c_erased<BD: BitDepth>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
     _topleft: *const DynPixel,
     width: c_int,
@@ -458,10 +458,10 @@ unsafe extern "C" fn ipred_cfl_128_c_erased<BD: BitDepth>(
     alpha: c_int,
     bitdepth_max: c_int,
     _topleft_off: usize,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `cfl_pred::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `cfl_pred::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     let bd = BD::from_c(bitdepth_max);
     let dc = bd.bitdepth_max().as_::<c_int>() + 1 >> 1;
     cfl_pred(dst, width, height, dc, ac, alpha, bd)
@@ -492,7 +492,7 @@ fn ipred_v_rust<BD: BitDepth>(
 /// Must be called by [`angular_ipred::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn ipred_v_c_erased<BD: BitDepth>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
     topleft: *const DynPixel,
     width: c_int,
@@ -502,10 +502,10 @@ unsafe extern "C" fn ipred_v_c_erased<BD: BitDepth>(
     _max_height: c_int,
     _bitdepth_max: c_int,
     topleft_off: usize,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `angular_ipred::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `angular_ipred::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     // SAFETY: `fn angular_ipred::Fn::call` makes `topleft` `topleft_off` from the beginning of the array.
     let topleft = unsafe { reconstruct_topleft::<BD>(topleft, topleft_off) };
     ipred_v_rust::<BD>(dst, topleft, topleft_off, width, height)
@@ -536,7 +536,7 @@ fn ipred_h_rust<BD: BitDepth>(
 /// Must be called by [`angular_ipred::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn ipred_h_c_erased<BD: BitDepth>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
     topleft: *const DynPixel,
     width: c_int,
@@ -546,10 +546,10 @@ unsafe extern "C" fn ipred_h_c_erased<BD: BitDepth>(
     _max_height: c_int,
     _bitdepth_max: c_int,
     topleft_off: usize,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `angular_ipred::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `angular_ipred::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     // SAFETY: `fn angular_ipred::Fn::call` makes `topleft` `topleft_off` from the beginning of the array.
     let topleft = unsafe { reconstruct_topleft::<BD>(topleft, topleft_off) };
     ipred_h_rust::<BD>(dst, topleft, topleft_off, width, height)
@@ -594,7 +594,7 @@ fn ipred_paeth_rust<BD: BitDepth>(
 /// Must be called by [`angular_ipred::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn ipred_paeth_c_erased<BD: BitDepth>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
     tl_ptr: *const DynPixel,
     width: c_int,
@@ -604,10 +604,10 @@ unsafe extern "C" fn ipred_paeth_c_erased<BD: BitDepth>(
     _max_height: c_int,
     _bitdepth_max: c_int,
     topleft_off: usize,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `angular_ipred::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `angular_ipred::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     // SAFETY: `fn angular_ipred::Fn::call` makes `topleft` `topleft_off` from the beginning of the array.
     let topleft = unsafe { reconstruct_topleft::<BD>(tl_ptr, topleft_off) };
     ipred_paeth_rust::<BD>(dst, topleft, topleft_off, width, height)
@@ -645,7 +645,7 @@ fn ipred_smooth_rust<BD: BitDepth>(
 /// Must be called by [`angular_ipred::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn ipred_smooth_c_erased<BD: BitDepth>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
     topleft: *const DynPixel,
     width: c_int,
@@ -655,10 +655,10 @@ unsafe extern "C" fn ipred_smooth_c_erased<BD: BitDepth>(
     _max_height: c_int,
     _bitdepth_max: c_int,
     topleft_off: usize,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `angular_ipred::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `angular_ipred::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     // SAFETY: `fn angular_ipred::Fn::call` makes `topleft` `topleft_off` from the beginning of the array.
     let topleft = unsafe { reconstruct_topleft::<BD>(topleft, topleft_off) };
     ipred_smooth_rust::<BD>(dst, topleft, topleft_off, width, height)
@@ -692,7 +692,7 @@ fn ipred_smooth_v_rust<BD: BitDepth>(
 /// Must be called by [`angular_ipred::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn ipred_smooth_v_c_erased<BD: BitDepth>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
     topleft: *const DynPixel,
     width: c_int,
@@ -702,10 +702,10 @@ unsafe extern "C" fn ipred_smooth_v_c_erased<BD: BitDepth>(
     _max_height: c_int,
     _bitdepth_max: c_int,
     topleft_off: usize,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `angular_ipred::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `angular_ipred::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     // SAFETY: `fn angular_ipred::Fn::call` makes `topleft` `topleft_off` from the beginning of the array.
     let topleft = unsafe { reconstruct_topleft::<BD>(topleft, topleft_off) };
     ipred_smooth_v_rust::<BD>(dst, topleft, topleft_off, width, height)
@@ -739,7 +739,7 @@ fn ipred_smooth_h_rust<BD: BitDepth>(
 /// Must be called by [`angular_ipred::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn ipred_smooth_h_c_erased<BD: BitDepth>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
     topleft: *const DynPixel,
     width: c_int,
@@ -749,10 +749,10 @@ unsafe extern "C" fn ipred_smooth_h_c_erased<BD: BitDepth>(
     _max_height: c_int,
     _bitdepth_max: c_int,
     topleft_off: usize,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `angular_ipred::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `angular_ipred::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     // SAFETY: `fn angular_ipred::Fn::call` makes `topleft` `topleft_off` from the beginning of the array.
     let topleft = unsafe { reconstruct_topleft::<BD>(topleft, topleft_off) };
     ipred_smooth_h_rust::<BD>(dst, topleft, topleft_off, width, height)
@@ -1175,7 +1175,7 @@ fn ipred_z3_rust<BD: BitDepth>(
 /// Must be called by [`angular_ipred::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn ipred_z_c_erased<BD: BitDepth, const Z: usize>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
     topleft_in: *const DynPixel,
     width: c_int,
@@ -1185,10 +1185,10 @@ unsafe extern "C" fn ipred_z_c_erased<BD: BitDepth, const Z: usize>(
     max_height: c_int,
     bitdepth_max: c_int,
     topleft_off: usize,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `angular_ipred::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `angular_ipred::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     // SAFETY: `fn angular_ipred::Fn::call` makes `topleft` `topleft_off` from the beginning of the array.
     let topleft_in = unsafe { reconstruct_topleft::<BD>(topleft_in, topleft_off) };
     let bd = BD::from_c(bitdepth_max);
@@ -1265,7 +1265,7 @@ fn ipred_filter_rust<BD: BitDepth>(
 }
 
 unsafe extern "C" fn ipred_filter_c_erased<BD: BitDepth>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
     topleft_in: *const DynPixel,
     width: c_int,
@@ -1275,10 +1275,10 @@ unsafe extern "C" fn ipred_filter_c_erased<BD: BitDepth>(
     max_height: c_int,
     bitdepth_max: c_int,
     topleft_off: usize,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `angular_ipred::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `angular_ipred::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     // SAFETY: `fn angular_ipred::Fn::call` makes `topleft` `topleft_off` from the beginning of the array.
     let topleft = unsafe { reconstruct_topleft::<BD>(topleft_in, topleft_off) };
     let bd = BD::from_c(bitdepth_max);
@@ -1366,16 +1366,16 @@ fn cfl_ac_rust<BD: BitDepth>(
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn cfl_ac_c_erased<BD: BitDepth, const IS_SS_HOR: bool, const IS_SS_VER: bool>(
     ac: &mut [i16; SCRATCH_AC_TXTP_LEN],
-    _y_ptr: *const DynPixel,
+    y_ptr: *const DynPixel,
     _stride: ptrdiff_t,
     w_pad: c_int,
     h_pad: c_int,
     cw: c_int,
     ch: c_int,
-    y: FFISafeRav1dPictureDataComponentOffset,
+    y: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `cfl_ac::Fn::call`.
-    let y = unsafe { FFISafe::from_with_offset(y) };
+    // SAFETY: `y` was passed as `FFISafe::new(_)` and `y_ptr` was computed from the same `WithOffset` in `cfl_ac::Fn::call`.
+    let y = unsafe { FFISafe::with_offset_of(y, y_ptr.cast::<BD::Pixel>()) };
     let cw = cw as usize;
     let ch = ch as usize;
     cfl_ac_rust::<BD>(ac, y, w_pad, h_pad, cw, ch, IS_SS_HOR, IS_SS_VER);
@@ -1411,16 +1411,16 @@ fn pal_pred_rust<BD: BitDepth>(
 /// Must be called by [`pal_pred::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn pal_pred_c_erased<BD: BitDepth>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
     pal: *const [DynPixel; 8],
     idx: *const u8,
     w: c_int,
     h: c_int,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `FFISafe::new(dst)` in `pal_pred::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `pal_pred::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     // SAFETY: Undoing dyn cast in `pal_pred::Fn::call`.
     let pal = unsafe { &*pal.cast() };
     // SAFETY: Length sliced in `pal_pred::Fn::call`.
@@ -1964,7 +1964,7 @@ mod neon {
         max_height: c_int,
         bitdepth_max: c_int,
         topleft_off: usize,
-        _dst: FFISafeRav1dPictureDataComponentOffset,
+        _dst: FFISafeRav1dPictureDataComponent,
     ) {
         let dst = dst.cast();
         // SAFETY: Reconstructed from args passed by `angular_ipred::Fn::call`.

--- a/src/itx.rs
+++ b/src/itx.rs
@@ -16,7 +16,7 @@ use crate::include::common::bitdepth::bpc_fn;
 use crate::include::common::bitdepth::{AsPrimitive, BitDepth, DynCoef, DynPixel};
 use crate::include::common::intops::iclip;
 use crate::include::dav1d::picture::{
-    FFISafeRav1dPictureDataComponentOffset, Rav1dPictureDataComponentOffset,
+    FFISafeRav1dPictureDataComponent, Rav1dPictureDataComponentOffset,
 };
 #[cfg(not(all(feature = "asm", target_feature = "neon")))]
 use crate::itx_1d::rav1d_inv_wht4_1d_c;
@@ -244,16 +244,16 @@ unsafe extern "C" fn inv_txfm_add_c_erased<
     const TYPE: TxfmType,
     BD: BitDepth,
 >(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _stride: isize,
     coeff: *mut DynCoef,
     eob: i32,
     bitdepth_max: i32,
     coeff_len: u16,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `itxfm::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `itxfm::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     // SAFETY: `fn itxfm::Fn::call` passes `coeff.len()` as `coeff_len`.
     let coeff = unsafe { slice::from_raw_parts_mut(coeff.cast(), coeff_len.into()) };
     let bd = BD::from_c(bitdepth_max);
@@ -267,7 +267,7 @@ wrap_fn_ptr!(unsafe extern "C" fn itxfm(
     eob: i32,
     bitdepth_max: i32,
     _coeff_len: u16,
-    _dst: FFISafeRav1dPictureDataComponentOffset,
+    _dst: FFISafeRav1dPictureDataComponent,
 ) -> ());
 
 impl itxfm::Fn {
@@ -283,7 +283,7 @@ impl itxfm::Fn {
         let coeff_len = coeff.len() as u16;
         let coeff = coeff.as_mut_ptr().cast();
         let bd = bd.into_c();
-        let dst = dst.into_ffi_safe();
+        let dst = FFISafe::new(dst.data);
         // SAFETY: Fallback `fn inv_txfm_add_rust` is safe; asm is supposed to do the same.
         unsafe { self.get()(dst_ptr, dst_stride, coeff, eob, bd, coeff_len, dst) }
     }

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -18,7 +18,7 @@ use crate::include::common::bitdepth::bd_fn;
 use crate::include::common::bitdepth::{AsPrimitive, BitDepth, DynPixel};
 use crate::include::common::intops::iclip;
 use crate::include::dav1d::picture::{
-    FFISafeRav1dPictureDataComponentOffset, Rav1dPictureDataComponentOffset,
+    FFISafeRav1dPictureDataComponent, Rav1dPictureDataComponentOffset,
 };
 use crate::internal::Rav1dFrameData;
 use crate::lf_mask::Av1FilterLUT;
@@ -35,8 +35,8 @@ wrap_fn_ptr!(pub unsafe extern "C" fn loopfilter_sb(
     lut: &Align16<Av1FilterLUT>,
     w: c_int,
     bitdepth_max: c_int,
-    _dst: FFISafeRav1dPictureDataComponentOffset,
-    _lvl: WithOffset<*const FFISafe<DisjointMut<AlignedVec2<u8>>>>,
+    _dst: FFISafeRav1dPictureDataComponent,
+    _lvl: *const FFISafe<DisjointMut<AlignedVec2<u8>>>,
 ) -> ());
 
 impl loopfilter_sb::Fn {
@@ -58,8 +58,8 @@ impl loopfilter_sb::Fn {
         let lut = &f.lf.lim_lut;
         let w = w as c_int;
         let bd = f.bitdepth_max;
-        let dst = dst.into_ffi_safe();
-        let lvl = lvl.into_ffi_safe();
+        let dst = FFISafe::new(dst.data);
+        let lvl = FFISafe::new(lvl.data);
         // SAFETY: Fallback `fn loop_filter_sb128_rust` is safe; asm is supposed to do the same.
         unsafe {
             self.get()(
@@ -360,21 +360,21 @@ fn loop_filter_sb128_rust<BD: BitDepth, const HV: usize, const YUV: usize>(
 /// Must be called by [`loopfilter_sb::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn loop_filter_sb128_c_erased<BD: BitDepth, const HV: usize, const YUV: usize>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
     vmask: &[u32; 3],
-    _lvl_ptr: *const [u8; 4],
+    lvl_ptr: *const [u8; 4],
     b4_stride: isize,
     lut: &Align16<Av1FilterLUT>,
     wh: c_int,
     bitdepth_max: c_int,
-    dst: FFISafeRav1dPictureDataComponentOffset,
-    lvl: WithOffset<*const FFISafe<DisjointMut<AlignedVec2<u8>>>>,
+    dst: FFISafeRav1dPictureDataComponent,
+    lvl: *const FFISafe<DisjointMut<AlignedVec2<u8>>>,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `loopfilter_sb::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `loopfilter_sb::Fn::call`.
-    let lvl = unsafe { FFISafe::from_with_offset(lvl) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `loopfilter_sb::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
+    // SAFETY: `lvl` was passed as `FFISafe::new(_)` and `lvl_ptr` was computed from the same `WithOffset` in `loopfilter_sb::Fn::call`.
+    let lvl = unsafe { FFISafe::with_offset_of(lvl, lvl_ptr.cast::<u8>()) };
     let b4_stride = b4_stride as usize;
     let bd = BD::from_c(bitdepth_max);
     loop_filter_sb128_rust::<BD, { HV }, { YUV }>(dst, vmask, lvl, b4_stride, lut, wh, bd)

--- a/src/looprestoration.rs
+++ b/src/looprestoration.rs
@@ -26,7 +26,7 @@ use crate::include::common::bitdepth::{
 };
 use crate::include::common::intops::iclip;
 use crate::include::dav1d::picture::{
-    FFISafeRav1dPictureDataComponentOffset, Rav1dPictureDataComponentOffset,
+    FFISafeRav1dPictureDataComponent, Rav1dPictureDataComponentOffset,
 };
 use crate::strided::Strided as _;
 use crate::tables::dav1d_sgr_x_by_x;
@@ -111,7 +111,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn loop_restoration_filter(
     params: &LooprestorationParams,
     edges: LrEdgeFlags,
     bitdepth_max: c_int,
-    _dst: FFISafeRav1dPictureDataComponentOffset,
+    _dst: FFISafeRav1dPictureDataComponent,
     _lpf: *const FFISafe<DisjointMut<AlignedVec64<u8>>>,
 ) -> ());
 
@@ -152,7 +152,7 @@ impl loop_restoration_filter::Fn {
             .wrapping_offset(lpf_off)
             .cast();
         let bd = bd.into_c();
-        let dst = dst.into_ffi_safe();
+        let dst = FFISafe::new(dst.data);
         let lpf = FFISafe::new(lpf);
         // SAFETY: Fallbacks `fn wiener_rust`, `fn sgr_{3x3,5x5,mix}_rust` are safe; asm is supposed to do the same.
         unsafe {
@@ -347,7 +347,7 @@ fn reconstruct_lpf_offset<BD: BitDepth>(
 /// Must be called by [`loop_restoration_filter::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn wiener_c_erased<BD: BitDepth>(
-    _p_ptr: *mut DynPixel,
+    p_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
     left: *const LeftPixelRow<DynPixel>,
     lpf_ptr: *const DynPixel,
@@ -356,11 +356,11 @@ unsafe extern "C" fn wiener_c_erased<BD: BitDepth>(
     params: &LooprestorationParams,
     edges: LrEdgeFlags,
     bitdepth_max: c_int,
-    p: FFISafeRav1dPictureDataComponentOffset,
+    p: FFISafeRav1dPictureDataComponent,
     lpf: *const FFISafe<DisjointMut<AlignedVec64<u8>>>,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `loop_restoration_filter::Fn::call`.
-    let p = unsafe { FFISafe::from_with_offset(p) };
+    // SAFETY: `p` was passed as `FFISafe::new(_)` and `p_ptr` was computed from the same `WithOffset` in `loop_restoration_filter::Fn::call`.
+    let p = unsafe { FFISafe::with_offset_of(p, p_ptr.cast::<BD::Pixel>()) };
     let left = left.cast();
     // SAFETY: Was passed as `FFISafe::new(_)` in `loop_restoration_filter::Fn::call`.
     let lpf = unsafe { FFISafe::get(lpf) };
@@ -763,7 +763,7 @@ fn selfguided_filter<BD: BitDepth>(
 /// Must be called by [`loop_restoration_filter::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn sgr_5x5_c_erased<BD: BitDepth>(
-    _p_ptr: *mut DynPixel,
+    p_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
     left: *const LeftPixelRow<DynPixel>,
     lpf_ptr: *const DynPixel,
@@ -772,11 +772,11 @@ unsafe extern "C" fn sgr_5x5_c_erased<BD: BitDepth>(
     params: &LooprestorationParams,
     edges: LrEdgeFlags,
     bitdepth_max: c_int,
-    p: FFISafeRav1dPictureDataComponentOffset,
+    p: FFISafeRav1dPictureDataComponent,
     lpf: *const FFISafe<DisjointMut<AlignedVec64<u8>>>,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `loop_restoration_filter::Fn::call`.
-    let p = unsafe { FFISafe::from_with_offset(p) };
+    // SAFETY: `p` was passed as `FFISafe::new(_)` and `p_ptr` was computed from the same `WithOffset` in `loop_restoration_filter::Fn::call`.
+    let p = unsafe { FFISafe::with_offset_of(p, p_ptr.cast::<BD::Pixel>()) };
     let left = left.cast();
     // SAFETY: Was passed as `FFISafe::new(_)` in `loop_restoration_filter::Fn::call`.
     let lpf = unsafe { FFISafe::get(lpf) };
@@ -829,7 +829,7 @@ fn sgr_5x5_rust<BD: BitDepth>(
 /// Must be called by [`loop_restoration_filter::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn sgr_3x3_c_erased<BD: BitDepth>(
-    _p_ptr: *mut DynPixel,
+    p_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
     left: *const LeftPixelRow<DynPixel>,
     lpf_ptr: *const DynPixel,
@@ -838,11 +838,11 @@ unsafe extern "C" fn sgr_3x3_c_erased<BD: BitDepth>(
     params: &LooprestorationParams,
     edges: LrEdgeFlags,
     bitdepth_max: c_int,
-    p: FFISafeRav1dPictureDataComponentOffset,
+    p: FFISafeRav1dPictureDataComponent,
     lpf: *const FFISafe<DisjointMut<AlignedVec64<u8>>>,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `loop_restoration_filter::Fn::call`.
-    let p = unsafe { FFISafe::from_with_offset(p) };
+    // SAFETY: `p` was passed as `FFISafe::new(_)` and `p_ptr` was computed from the same `WithOffset` in `loop_restoration_filter::Fn::call`.
+    let p = unsafe { FFISafe::with_offset_of(p, p_ptr.cast::<BD::Pixel>()) };
     let left = left.cast();
     // SAFETY: Was passed as `FFISafe::new(_)` in `loop_restoration_filter::Fn::call`.
     let lpf = unsafe { FFISafe::get(lpf) };
@@ -890,7 +890,7 @@ fn sgr_3x3_rust<BD: BitDepth>(
 /// Must be called by [`loop_restoration_filter::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn sgr_mix_c_erased<BD: BitDepth>(
-    _p_ptr: *mut DynPixel,
+    p_ptr: *mut DynPixel,
     _stride: ptrdiff_t,
     left: *const LeftPixelRow<DynPixel>,
     lpf_ptr: *const DynPixel,
@@ -899,11 +899,11 @@ unsafe extern "C" fn sgr_mix_c_erased<BD: BitDepth>(
     params: &LooprestorationParams,
     edges: LrEdgeFlags,
     bitdepth_max: c_int,
-    p: FFISafeRav1dPictureDataComponentOffset,
+    p: FFISafeRav1dPictureDataComponent,
     lpf: *const FFISafe<DisjointMut<AlignedVec64<u8>>>,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `loop_restoration_filter::Fn::call`.
-    let p = unsafe { FFISafe::from_with_offset(p) };
+    // SAFETY: `p` was passed as `FFISafe::new(_)` and `p_ptr` was computed from the same `WithOffset` in `loop_restoration_filter::Fn::call`.
+    let p = unsafe { FFISafe::with_offset_of(p, p_ptr.cast::<BD::Pixel>()) };
     let left = left.cast();
     // SAFETY: Was passed as `FFISafe::new(_)` in `loop_restoration_filter::Fn::call`.
     let lpf = unsafe { FFISafe::get(lpf) };
@@ -1043,7 +1043,7 @@ mod neon {
         params: &LooprestorationParams,
         edges: LrEdgeFlags,
         bitdepth_max: c_int,
-        _p: FFISafeRav1dPictureDataComponentOffset,
+        _p: FFISafeRav1dPictureDataComponent,
         _lpf: *const FFISafe<DisjointMut<AlignedVec64<u8>>>,
     ) {
         let p = p.cast();
@@ -3311,7 +3311,7 @@ mod neon_erased {
     /// Must be called by [`loop_restoration_filter::Fn::call`].
     #[deny(unsafe_op_in_unsafe_fn)]
     pub unsafe extern "C" fn sgr_filter_5x5_neon_erased<BD: BitDepth>(
-        _p_ptr: *mut DynPixel,
+        p_ptr: *mut DynPixel,
         _stride: ptrdiff_t,
         left: *const LeftPixelRow<DynPixel>,
         lpf: *const DynPixel,
@@ -3320,11 +3320,11 @@ mod neon_erased {
         params: &LooprestorationParams,
         edges: LrEdgeFlags,
         bitdepth_max: c_int,
-        p: FFISafeRav1dPictureDataComponentOffset,
+        p: FFISafeRav1dPictureDataComponent,
         _lpf: *const FFISafe<DisjointMut<AlignedVec64<u8>>>,
     ) {
-        // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `loop_restoration_filter::Fn::call`.
-        let p = unsafe { FFISafe::from_with_offset(p) };
+        // SAFETY: `p` was passed as `FFISafe::new(_)` and `p_ptr` was computed from the same `WithOffset` in `loop_restoration_filter::Fn::call`.
+        let p = unsafe { FFISafe::with_offset_of(p, p_ptr.cast::<BD::Pixel>()) };
         let left = left.cast();
         let lpf = lpf.cast();
         let bd = BD::from_c(bitdepth_max);
@@ -3340,7 +3340,7 @@ mod neon_erased {
     /// Must be called by [`loop_restoration_filter::Fn::call`].
     #[deny(unsafe_op_in_unsafe_fn)]
     pub unsafe extern "C" fn sgr_filter_3x3_neon_erased<BD: BitDepth>(
-        _p_ptr: *mut DynPixel,
+        p_ptr: *mut DynPixel,
         _stride: ptrdiff_t,
         left: *const LeftPixelRow<DynPixel>,
         lpf: *const DynPixel,
@@ -3349,11 +3349,11 @@ mod neon_erased {
         params: &LooprestorationParams,
         edges: LrEdgeFlags,
         bitdepth_max: c_int,
-        p: FFISafeRav1dPictureDataComponentOffset,
+        p: FFISafeRav1dPictureDataComponent,
         _lpf: *const FFISafe<DisjointMut<AlignedVec64<u8>>>,
     ) {
-        // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `loop_restoration_filter::Fn::call`.
-        let p = unsafe { FFISafe::from_with_offset(p) };
+        // SAFETY: `p` was passed as `FFISafe::new(_)` and `p_ptr` was computed from the same `WithOffset` in `loop_restoration_filter::Fn::call`.
+        let p = unsafe { FFISafe::with_offset_of(p, p_ptr.cast::<BD::Pixel>()) };
         let left = left.cast();
         let lpf = lpf.cast();
         let w = w as usize;
@@ -3369,7 +3369,7 @@ mod neon_erased {
     /// Must be called by [`loop_restoration_filter::Fn::call`].
     #[deny(unsafe_op_in_unsafe_fn)]
     pub unsafe extern "C" fn sgr_filter_mix_neon_erased<BD: BitDepth>(
-        _p_ptr: *mut DynPixel,
+        p_ptr: *mut DynPixel,
         _stride: ptrdiff_t,
         left: *const LeftPixelRow<DynPixel>,
         lpf: *const DynPixel,
@@ -3378,11 +3378,11 @@ mod neon_erased {
         params: &LooprestorationParams,
         edges: LrEdgeFlags,
         bitdepth_max: c_int,
-        p: FFISafeRav1dPictureDataComponentOffset,
+        p: FFISafeRav1dPictureDataComponent,
         _lpf: *const FFISafe<DisjointMut<AlignedVec64<u8>>>,
     ) {
-        // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `loop_restoration_filter::Fn::call`.
-        let p = unsafe { FFISafe::from_with_offset(p) };
+        // SAFETY: `p` was passed as `FFISafe::new(_)` and `p_ptr` was computed from the same `WithOffset` in `loop_restoration_filter::Fn::call`.
+        let p = unsafe { FFISafe::with_offset_of(p, p_ptr.cast::<BD::Pixel>()) };
         let left = left.cast();
         let lpf = lpf.cast();
         let bd = BD::from_c(bitdepth_max);

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -25,8 +25,7 @@ use crate::include::common::bitdepth::{AsPrimitive, BitDepth, DynPixel};
 use crate::include::common::intops::{clip, iclip};
 use crate::include::dav1d::headers::{Rav1dFilterMode, Rav1dPixelLayoutSubSampled};
 use crate::include::dav1d::picture::{
-    FFISafeRav1dPictureDataComponentOffset, Rav1dPictureDataComponent,
-    Rav1dPictureDataComponentOffset,
+    FFISafeRav1dPictureDataComponent, Rav1dPictureDataComponent, Rav1dPictureDataComponentOffset,
 };
 use crate::internal::{
     COMPINTER_LEN, EMU_EDGE_LEN, SCRATCH_INTER_INTRA_BUF_LEN, SCRATCH_LAP_LEN, SEG_MASK_LEN,
@@ -1036,8 +1035,8 @@ wrap_fn_ptr!(pub unsafe extern "C" fn mc(
     mx: i32,
     my: i32,
     bitdepth_max: i32,
-    _dst: FFISafeRav1dPictureDataComponentOffset,
-    _src: FFISafeRav1dPictureDataComponentOffset,
+    _dst: FFISafeRav1dPictureDataComponent,
+    _src: FFISafeRav1dPictureDataComponent,
 ) -> ());
 
 impl mc::Fn {
@@ -1056,8 +1055,8 @@ impl mc::Fn {
         let src_ptr = src.as_ptr::<BD>().cast();
         let src_stride = src.stride();
         let bd = bd.into_c();
-        let dst = dst.into_ffi_safe();
-        let src = src.into_ffi_safe();
+        let dst = FFISafe::new(dst.data);
+        let src = FFISafe::new(src.data);
         // SAFETY: Fallbacks `fn put_{8tpap,bilin}_rust` are safe; asm is supposed to do the same.
         unsafe {
             self.get()(
@@ -1079,8 +1078,8 @@ wrap_fn_ptr!(pub unsafe extern "C" fn mc_scaled(
     dx: i32,
     dy: i32,
     bitdepth_max: i32,
-    _dst: FFISafeRav1dPictureDataComponentOffset,
-    _src: FFISafeRav1dPictureDataComponentOffset,
+    _dst: FFISafeRav1dPictureDataComponent,
+    _src: FFISafeRav1dPictureDataComponent,
 ) -> ());
 
 impl mc_scaled::Fn {
@@ -1101,8 +1100,8 @@ impl mc_scaled::Fn {
         let src_ptr = src.as_ptr::<BD>().cast();
         let src_stride = src.stride();
         let bd = bd.into_c();
-        let dst = dst.into_ffi_safe();
-        let src = src.into_ffi_safe();
+        let dst = FFISafe::new(dst.data);
+        let src = FFISafe::new(src.data);
         // SAFETY: Fallbacks `fn put_{8tpap,bilin}_scaled_rust` are safe; asm is supposed to do the same.
         unsafe {
             self.get()(
@@ -1121,8 +1120,8 @@ wrap_fn_ptr!(pub unsafe extern "C" fn warp8x8(
     mx: i32,
     my: i32,
     bitdepth_max: i32,
-    _dst: FFISafeRav1dPictureDataComponentOffset,
-    _src: FFISafeRav1dPictureDataComponentOffset,
+    _dst: FFISafeRav1dPictureDataComponent,
+    _src: FFISafeRav1dPictureDataComponent,
 ) -> ());
 
 impl warp8x8::Fn {
@@ -1140,8 +1139,8 @@ impl warp8x8::Fn {
         let src_ptr = src.as_ptr::<BD>().cast();
         let src_stride = src.stride();
         let bd = bd.into_c();
-        let dst = dst.into_ffi_safe();
-        let src = src.into_ffi_safe();
+        let dst = FFISafe::new(dst.data);
+        let src = FFISafe::new(src.data);
         // SAFETY: Fallback `fn prep_c_rust` is safe; asm is supposed to do the same.
         unsafe {
             self.get()(
@@ -1160,7 +1159,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn mct(
     mx: i32,
     my: i32,
     bitdepth_max: i32,
-    _src: FFISafeRav1dPictureDataComponentOffset,
+    _src: FFISafeRav1dPictureDataComponent,
 ) -> ());
 
 impl mct::Fn {
@@ -1178,7 +1177,7 @@ impl mct::Fn {
         let src_ptr = src.as_ptr::<BD>().cast();
         let src_stride = src.stride();
         let bd = bd.into_c();
-        let src = src.into_ffi_safe();
+        let src = FFISafe::new(src.data);
         // SAFETY: Fallbacks `fn prep_{8tpap,bilin}_rust` are safe; asm is supposed to do the same.
         unsafe { self.get()(tmp, src_ptr, src_stride, w, h, mx, my, bd, src) }
     }
@@ -1195,7 +1194,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn mct_scaled(
     dx: i32,
     dy: i32,
     bitdepth_max: i32,
-    _src: FFISafeRav1dPictureDataComponentOffset,
+    _src: FFISafeRav1dPictureDataComponent,
 ) -> ());
 
 impl mct_scaled::Fn {
@@ -1215,7 +1214,7 @@ impl mct_scaled::Fn {
         let src_ptr = src.as_ptr::<BD>().cast();
         let src_stride = src.stride();
         let bd = bd.into_c();
-        let src = src.into_ffi_safe();
+        let src = FFISafe::new(src.data);
         // SAFETY: Fallbacks `fn prep_{8tpap,bilin}_scaled_rust` are safe; asm is supposed to do the same.
         unsafe { self.get()(tmp, src_ptr, src_stride, w, h, mx, my, dx, dy, bd, src) }
     }
@@ -1231,7 +1230,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn warp8x8t(
     my: i32,
     bitdepth_max: i32,
     _tmp_len: usize,
-    _src: FFISafeRav1dPictureDataComponentOffset,
+    _src: FFISafeRav1dPictureDataComponent,
 ) -> ());
 
 impl warp8x8t::Fn {
@@ -1250,7 +1249,7 @@ impl warp8x8t::Fn {
         let src_ptr = src.as_ptr::<BD>().cast();
         let src_stride = src.stride();
         let bd = bd.into_c();
-        let src = src.into_ffi_safe();
+        let src = FFISafe::new(src.data);
         // SAFETY: Fallback `fn warp_affine_8x8t_rust` is safe; asm is supposed to do the same.
         unsafe {
             self.get()(
@@ -1268,7 +1267,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn avg(
     w: i32,
     h: i32,
     bitdepth_max: i32,
-    _dst: FFISafeRav1dPictureDataComponentOffset,
+    _dst: FFISafeRav1dPictureDataComponent,
 ) -> ());
 
 impl avg::Fn {
@@ -1284,7 +1283,7 @@ impl avg::Fn {
         let dst_ptr = dst.as_mut_ptr::<BD>().cast();
         let dst_stride = dst.stride();
         let bd = bd.into_c();
-        let dst = dst.into_ffi_safe();
+        let dst = FFISafe::new(dst.data);
         // SAFETY: Fallback `fn avg_rust` is safe; asm is supposed to do the same.
         unsafe { self.get()(dst_ptr, dst_stride, tmp1, tmp2, w, h, bd, dst) }
     }
@@ -1299,7 +1298,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn w_avg(
     h: i32,
     weight: i32,
     bitdepth_max: i32,
-    _dst: FFISafeRav1dPictureDataComponentOffset,
+    _dst: FFISafeRav1dPictureDataComponent,
 ) -> ());
 
 impl w_avg::Fn {
@@ -1316,7 +1315,7 @@ impl w_avg::Fn {
         let dst_ptr = dst.as_mut_ptr::<BD>().cast();
         let dst_stride = dst.stride();
         let bd = bd.into_c();
-        let dst = dst.into_ffi_safe();
+        let dst = FFISafe::new(dst.data);
         // SAFETY: Fallback `fn w_avg_rust` is safe; asm is supposed to do the same.
         unsafe { self.get()(dst_ptr, dst_stride, tmp1, tmp2, w, h, weight, bd, dst) }
     }
@@ -1331,7 +1330,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn mask(
     h: i32,
     mask: *const u8,
     bitdepth_max: i32,
-    _dst: FFISafeRav1dPictureDataComponentOffset,
+    _dst: FFISafeRav1dPictureDataComponent,
 ) -> ());
 
 impl mask::Fn {
@@ -1349,7 +1348,7 @@ impl mask::Fn {
         let dst_stride = dst.stride();
         let mask = mask[..(w * h) as usize].as_ptr();
         let bd = bd.into_c();
-        let dst = dst.into_ffi_safe();
+        let dst = FFISafe::new(dst.data);
         // SAFETY: Fallback `fn mask_rust` is safe; asm is supposed to do the same.
         unsafe { self.get()(dst_ptr, dst_stride, tmp1, tmp2, w, h, mask, bd, dst) }
     }
@@ -1365,7 +1364,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn w_mask(
     mask: &mut [u8; SEG_MASK_LEN],
     sign: i32,
     bitdepth_max: i32,
-    _dst: FFISafeRav1dPictureDataComponentOffset,
+    _dst: FFISafeRav1dPictureDataComponent,
 ) -> ());
 
 impl w_mask::Fn {
@@ -1383,7 +1382,7 @@ impl w_mask::Fn {
         let dst_ptr = dst.as_mut_ptr::<BD>().cast();
         let dst_stride = dst.stride();
         let bd = bd.into_c();
-        let dst = dst.into_ffi_safe();
+        let dst = FFISafe::new(dst.data);
         // SAFETY: Fallback `fn w_mask_rust` is safe; asm is supposed to do the same.
         unsafe { self.get()(dst_ptr, dst_stride, tmp1, tmp2, w, h, mask, sign, bd, dst) }
     }
@@ -1396,7 +1395,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn blend(
     w: i32,
     h: i32,
     mask: *const u8,
-    _dst: FFISafeRav1dPictureDataComponentOffset,
+    _dst: FFISafeRav1dPictureDataComponent,
 ) -> ());
 
 impl blend::Fn {
@@ -1412,7 +1411,7 @@ impl blend::Fn {
         let dst_stride = dst.stride();
         let tmp = ptr::from_ref(tmp).cast();
         let mask = mask[..(w * h) as usize].as_ptr();
-        let dst = dst.into_ffi_safe();
+        let dst = FFISafe::new(dst.data);
         // SAFETY: Fallback `fn blend_rust` is safe; asm is supposed to do the same.
         unsafe { self.get()(dst_ptr, dst_stride, tmp, w, h, mask, dst) }
     }
@@ -1424,7 +1423,7 @@ wrap_fn_ptr!(pub unsafe extern "C" fn blend_dir(
     tmp: *const [DynPixel; SCRATCH_LAP_LEN],
     w: i32,
     h: i32,
-    _dst: FFISafeRav1dPictureDataComponentOffset,
+    _dst: FFISafeRav1dPictureDataComponent,
 ) -> ());
 
 impl blend_dir::Fn {
@@ -1438,7 +1437,7 @@ impl blend_dir::Fn {
         let dst_ptr = dst.as_mut_ptr::<BD>().cast();
         let dst_stride = dst.stride();
         let tmp = ptr::from_ref(tmp).cast();
-        let dst = dst.into_ffi_safe();
+        let dst = FFISafe::new(dst.data);
         // SAFETY: Fallback `fn blend_{h,v}_rust` are safe; asm is supposed to do the same.
         unsafe { self.get()(dst_ptr, dst_stride, tmp, w, h, dst) }
     }
@@ -1496,8 +1495,8 @@ wrap_fn_ptr!(pub unsafe extern "C" fn resize(
     dx: i32,
     mx: i32,
     bitdepth_max: i32,
-    _src: FFISafeRav1dPictureDataComponentOffset,
-    _dst: WithOffset<*const FFISafe<PicOrBuf<AlignedVec64<u8>>>>,
+    _src: FFISafeRav1dPictureDataComponent,
+    _dst: *const FFISafe<PicOrBuf<AlignedVec64<u8>>>,
 ) -> ());
 
 impl resize::Fn {
@@ -1520,8 +1519,8 @@ impl resize::Fn {
         let h = h as c_int;
         let src_w = src_w as c_int;
         let bd = bd.into_c();
-        let src = src.into_ffi_safe();
-        let dst = dst.as_ref().into_ffi_safe();
+        let src = FFISafe::new(src.data);
+        let dst = FFISafe::new(&dst.data);
         // SAFETY: Fallback `fn resize_rust` is safe; asm is supposed to do the same.
         unsafe {
             self.get()(
@@ -1554,22 +1553,22 @@ pub struct Rav1dMCDSPContext {
 /// Must be called by [`mc::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn put_c_erased<BD: BitDepth, const FILTER: usize>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _dst_stride: isize,
-    _src_ptr: *const DynPixel,
+    src_ptr: *const DynPixel,
     _src_stride: isize,
     w: i32,
     h: i32,
     mx: i32,
     my: i32,
     bitdepth_max: i32,
-    dst: FFISafeRav1dPictureDataComponentOffset,
-    src: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
+    src: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `mc::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `mc::Fn::call`.
-    let src = unsafe { FFISafe::from_with_offset(src) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `mc::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
+    // SAFETY: `src` was passed as `FFISafe::new(_)` and `src_ptr` was computed from the same `WithOffset` in `mc::Fn::call`.
+    let src = unsafe { FFISafe::with_offset_of(src, src_ptr.cast::<BD::Pixel>()) };
     let w = w as usize;
     let h = h as usize;
     let mx = mx as usize;
@@ -1588,9 +1587,9 @@ unsafe extern "C" fn put_c_erased<BD: BitDepth, const FILTER: usize>(
 /// Must be called by [`mc_scaled::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn put_scaled_c_erased<BD: BitDepth, const FILTER: usize>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _dst_stride: isize,
-    _src_ptr: *const DynPixel,
+    src_ptr: *const DynPixel,
     _src_stride: isize,
     w: i32,
     h: i32,
@@ -1599,13 +1598,13 @@ unsafe extern "C" fn put_scaled_c_erased<BD: BitDepth, const FILTER: usize>(
     dx: i32,
     dy: i32,
     bitdepth_max: i32,
-    dst: FFISafeRav1dPictureDataComponentOffset,
-    src: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
+    src: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `mc_scaled::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `mc_scaled::Fn::call`.
-    let src = unsafe { FFISafe::from_with_offset(src) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `mc_scaled::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
+    // SAFETY: `src` was passed as `FFISafe::new(_)` and `src_ptr` was computed from the same `WithOffset` in `mc_scaled::Fn::call`.
+    let src = unsafe { FFISafe::with_offset_of(src, src_ptr.cast::<BD::Pixel>()) };
     let w = w as usize;
     let h = h as usize;
     let mx = mx as usize;
@@ -1627,17 +1626,17 @@ unsafe extern "C" fn put_scaled_c_erased<BD: BitDepth, const FILTER: usize>(
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn prep_c_erased<BD: BitDepth, const FILTER: usize>(
     tmp: *mut i16,
-    _src_ptr: *const DynPixel,
+    src_ptr: *const DynPixel,
     _src_stride: isize,
     w: i32,
     h: i32,
     mx: i32,
     my: i32,
     bitdepth_max: i32,
-    src: FFISafeRav1dPictureDataComponentOffset,
+    src: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `mct::Fn::call`.
-    let src = unsafe { FFISafe::from_with_offset(src) };
+    // SAFETY: `src` was passed as `FFISafe::new(_)` and `src_ptr` was computed from the same `WithOffset` in `mct::Fn::call`.
+    let src = unsafe { FFISafe::with_offset_of(src, src_ptr.cast::<BD::Pixel>()) };
     let w = w as usize;
     let h = h as usize;
     // SAFETY: Length sliced in `mct::Fn::call`.
@@ -1659,7 +1658,7 @@ unsafe extern "C" fn prep_c_erased<BD: BitDepth, const FILTER: usize>(
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn prep_scaled_c_erased<BD: BitDepth, const FILTER: usize>(
     tmp: *mut i16,
-    _src_ptr: *const DynPixel,
+    src_ptr: *const DynPixel,
     _src_stride: isize,
     w: i32,
     h: i32,
@@ -1668,10 +1667,10 @@ unsafe extern "C" fn prep_scaled_c_erased<BD: BitDepth, const FILTER: usize>(
     dx: i32,
     dy: i32,
     bitdepth_max: i32,
-    src: FFISafeRav1dPictureDataComponentOffset,
+    src: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `mct_scaled::Fn::call`.
-    let src = unsafe { FFISafe::from_with_offset(src) };
+    // SAFETY: `src` was passed as `FFISafe::new(_)` and `src_ptr` was computed from the same `WithOffset` in `mct_scaled::Fn::call`.
+    let src = unsafe { FFISafe::with_offset_of(src, src_ptr.cast::<BD::Pixel>()) };
     let w = w as usize;
     let h = h as usize;
     // SAFETY: Length sliced in `mct_scaled::Fn::call`.
@@ -1694,17 +1693,17 @@ unsafe extern "C" fn prep_scaled_c_erased<BD: BitDepth, const FILTER: usize>(
 /// Must be called by [`avg::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn avg_c_erased<BD: BitDepth>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _dst_stride: isize,
     tmp1: &[i16; COMPINTER_LEN],
     tmp2: &[i16; COMPINTER_LEN],
     w: i32,
     h: i32,
     bitdepth_max: i32,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `avg::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `avg::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     let w = w as usize;
     let h = h as usize;
     let bd = BD::from_c(bitdepth_max);
@@ -1716,7 +1715,7 @@ unsafe extern "C" fn avg_c_erased<BD: BitDepth>(
 /// Must be called by [`w_avg::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn w_avg_c_erased<BD: BitDepth>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _dst_stride: isize,
     tmp1: &[i16; COMPINTER_LEN],
     tmp2: &[i16; COMPINTER_LEN],
@@ -1724,10 +1723,10 @@ unsafe extern "C" fn w_avg_c_erased<BD: BitDepth>(
     h: i32,
     weight: i32,
     bitdepth_max: i32,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `w_avg::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `w_avg::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     let w = w as usize;
     let h = h as usize;
     let bd = BD::from_c(bitdepth_max);
@@ -1739,7 +1738,7 @@ unsafe extern "C" fn w_avg_c_erased<BD: BitDepth>(
 /// Must be called by [`mask::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn mask_c_erased<BD: BitDepth>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _dst_stride: isize,
     tmp1: &[i16; COMPINTER_LEN],
     tmp2: &[i16; COMPINTER_LEN],
@@ -1747,10 +1746,10 @@ unsafe extern "C" fn mask_c_erased<BD: BitDepth>(
     h: i32,
     mask: *const u8,
     bitdepth_max: i32,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `mask::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `mask::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     let w = w as usize;
     let h = h as usize;
     // SAFETY: Length sliced in `mask::Fn::call`.
@@ -1764,7 +1763,7 @@ unsafe extern "C" fn mask_c_erased<BD: BitDepth>(
 /// Must be called by [`w_mask::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn w_mask_c_erased<const SS_HOR: bool, const SS_VER: bool, BD: BitDepth>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _dst_stride: isize,
     tmp1: &[i16; COMPINTER_LEN],
     tmp2: &[i16; COMPINTER_LEN],
@@ -1773,10 +1772,10 @@ unsafe extern "C" fn w_mask_c_erased<const SS_HOR: bool, const SS_VER: bool, BD:
     mask: &mut [u8; SEG_MASK_LEN],
     sign: i32,
     bitdepth_max: i32,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `w_mask::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `w_mask::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     let w = w as usize;
     let h = h as usize;
     debug_assert!(sign == 1 || sign == 0);
@@ -1790,16 +1789,16 @@ unsafe extern "C" fn w_mask_c_erased<const SS_HOR: bool, const SS_VER: bool, BD:
 /// Must be called by [`blend::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn blend_c_erased<BD: BitDepth>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _dst_stride: isize,
     tmp: *const [DynPixel; SCRATCH_INTER_INTRA_BUF_LEN],
     w: i32,
     h: i32,
     mask: *const u8,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `blend::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `blend::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     // SAFETY: Reverse of cast in `blend::Fn::call`.
     let tmp = unsafe { &*tmp.cast() };
     let w = w as usize;
@@ -1814,15 +1813,15 @@ unsafe extern "C" fn blend_c_erased<BD: BitDepth>(
 /// Must be called by [`blend_dir::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn blend_v_c_erased<BD: BitDepth>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _dst_stride: isize,
     tmp: *const [DynPixel; SCRATCH_LAP_LEN],
     w: i32,
     h: i32,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `blend_dir::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `blend_dir::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     // SAFETY: Reverse of cast in `blend_dir::Fn::call`.
     let tmp = unsafe { &*tmp.cast() };
     let w = w as usize;
@@ -1835,15 +1834,15 @@ unsafe extern "C" fn blend_v_c_erased<BD: BitDepth>(
 /// Must be called by [`blend_dir::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn blend_h_c_erased<BD: BitDepth>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _dst_stride: isize,
     tmp: *const [DynPixel; SCRATCH_LAP_LEN],
     w: i32,
     h: i32,
-    dst: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `blend_dir::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `blend_dir::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     // SAFETY: Reverse of cast in `blend_dir::Fn::call`.
     let tmp = unsafe { &*tmp.cast() };
     let w = w as usize;
@@ -1856,21 +1855,21 @@ unsafe extern "C" fn blend_h_c_erased<BD: BitDepth>(
 /// Must be called by [`warp8x8::Fn::call`].
 #[deny(unsafe_op_in_unsafe_fn)]
 unsafe extern "C" fn warp_affine_8x8_c_erased<BD: BitDepth>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _dst_stride: isize,
-    _src_ptr: *const DynPixel,
+    src_ptr: *const DynPixel,
     _src_stride: isize,
     abcd: &[i16; 4],
     mx: i32,
     my: i32,
     bitdepth_max: i32,
-    dst: FFISafeRav1dPictureDataComponentOffset,
-    src: FFISafeRav1dPictureDataComponentOffset,
+    dst: FFISafeRav1dPictureDataComponent,
+    src: FFISafeRav1dPictureDataComponent,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `warp_8x8::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `warp_8x8::Fn::call`.
-    let src = unsafe { FFISafe::from_with_offset(src) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `warp_8x8::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
+    // SAFETY: `src` was passed as `FFISafe::new(_)` and `src_ptr` was computed from the same `WithOffset` in `warp_8x8::Fn::call`.
+    let src = unsafe { FFISafe::with_offset_of(src, src_ptr.cast::<BD::Pixel>()) };
     let bd = BD::from_c(bitdepth_max);
     warp_affine_8x8_rust(dst, src, abcd, mx, my, bd)
 }
@@ -1882,19 +1881,19 @@ unsafe extern "C" fn warp_affine_8x8_c_erased<BD: BitDepth>(
 unsafe extern "C" fn warp_affine_8x8t_c_erased<BD: BitDepth>(
     tmp: *mut i16,
     tmp_stride: usize,
-    _src_ptr: *const DynPixel,
+    src_ptr: *const DynPixel,
     _src_stride: isize,
     abcd: &[i16; 4],
     mx: i32,
     my: i32,
     bitdepth_max: i32,
     tmp_len: usize,
-    src: FFISafeRav1dPictureDataComponentOffset,
+    src: FFISafeRav1dPictureDataComponent,
 ) {
     // SAFETY: `warp8x8t::Fn::call` passed `tmp.len()` as `tmp_len`.
     let tmp = unsafe { slice::from_raw_parts_mut(tmp, tmp_len) };
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `warp8x8t::Fn::call`.
-    let src = unsafe { FFISafe::from_with_offset(src) };
+    // SAFETY: `src` was passed as `FFISafe::new(_)` and `src_ptr` was computed from the same `WithOffset` in `warp8x8t::Fn::call`.
+    let src = unsafe { FFISafe::with_offset_of(src, src_ptr.cast::<BD::Pixel>()) };
     let bd = BD::from_c(bitdepth_max);
     warp_affine_8x8t_rust(tmp, tmp_stride, src, abcd, mx, my, bd)
 }
@@ -1923,9 +1922,9 @@ unsafe extern "C" fn emu_edge_c_erased<BD: BitDepth>(
 }
 
 unsafe extern "C" fn resize_c_erased<BD: BitDepth>(
-    _dst_ptr: *mut DynPixel,
+    dst_ptr: *mut DynPixel,
     _dst_stride: isize,
-    _src_ptr: *const DynPixel,
+    src_ptr: *const DynPixel,
     _src_stride: isize,
     dst_w: i32,
     h: i32,
@@ -1933,14 +1932,14 @@ unsafe extern "C" fn resize_c_erased<BD: BitDepth>(
     dx: i32,
     mx0: i32,
     bitdepth_max: i32,
-    src: FFISafeRav1dPictureDataComponentOffset,
-    dst: WithOffset<*const FFISafe<PicOrBuf<AlignedVec64<u8>>>>,
+    src: FFISafeRav1dPictureDataComponent,
+    dst: *const FFISafe<PicOrBuf<AlignedVec64<u8>>>,
 ) {
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `resize::Fn::call`.
-    let dst = unsafe { FFISafe::from_with_offset(dst) };
+    // SAFETY: `dst` was passed as `FFISafe::new(_)` and `dst_ptr` was computed from the same `WithOffset` in `resize::Fn::call`.
+    let dst = unsafe { FFISafe::with_offset_of(dst, dst_ptr.cast::<BD::Pixel>()) };
     let dst = dst.map(|data| *data);
-    // SAFETY: Was passed as `WithOffset::into_ffi_safe(_)` in `resize::Fn::call`.
-    let src = unsafe { FFISafe::from_with_offset(src) };
+    // SAFETY: `src` was passed as `FFISafe::new(_)` and `src_ptr` was computed from the same `WithOffset` in `resize::Fn::call`.
+    let src = unsafe { FFISafe::with_offset_of(src, src_ptr.cast::<BD::Pixel>()) };
     let dst_w = dst_w as usize;
     let h = h as usize;
     let src_w = src_w as usize;


### PR DESCRIPTION
Every DSP function pointer carried one or two trailing FFISafe arguments so that the Rust fallback could recover a `Rav1dPictureDataComponentOffset` (a 16-byte pointer-plus-offset struct) while the assembly ignored them. On x86-64 the integer argument registers are exhausted by the real arguments, so each struct became a `byval` stack copy: LLVM built it with two 8-byte stores and then copied it into the outgoing argument area with one 16-byte vector load. That load cannot be forwarded from the two pending stores and stalls for the store-to-load-forwarding penalty on every call. `perf stat` showed 42.9M store-forward blocks for rav1d against 14.6M for C dav1d on the 720p Chimera clip, most of them attributed to `recon::mc`.

Pass only the base pointer (`*const FFISafe<T>`, one register or one stack slot) and let the fallback recompute the offset from the element pointer it already receives, via a new `FFISafe::with_offset_of`. No struct crosses the boundary any more. Asm-visible arguments are unchanged; only the trailing Rust-only `_`-prefixed arguments change.

Chimera 720p 8-bit, `--limit 1000 --threads 1`, interleaved runs against main (d3d1cd67):

- Sapphire Rapids (Xeon Platinum 8488C): 2.360s -> 2.324s (C dav1d 2.241s); `ld_blocks.store_forward` 42.9M -> 15.6M (C: 14.2M).
- 4-vCPU Xeon @ 2.10GHz VM, no hardware counters: paired per-round ratio 0.987 (95% CI 0.976..0.998 over 60 rounds); callgrind instruction count -0.38%.

Possible regressions to look for
--------------------------------
- aarch64 is expected to be neutral. With the integer registers already used up (e.g. `mc` has nine real arguments), AAPCS64 stores the old 16-byte struct straight into the outgoing argument area with one `stp` and never reloads it, so the store-forwarding stall that x86-64 pays for the `byval` copy (four 8-byte stores followed by 16-byte `movups` reloads) does not occur there. The change saves two stores and 16 bytes of stack per DSP call on aarch64, which is likely within noise. Verified from the generated asm of a model of the call shape, not measured on arm64 hardware. The earlier `WithOffset<*const FFISafe>` shape (#1418, #1431) was tuned for arm64 stack usage.
- The no-asm build is the path that actually executes `with_offset_of`; it is covered by the checked-release no-asm test run below.

Testing
-------
- `cargo build --release`; `test.sh -r target/release/dav1d -s ...`: Ok 1527 / Fail 0.
- `cargo build --profile checked-release` (DisjointMut overlap checker on); `test.sh ... -t 4`: Ok 1527 / Fail 0; `test.sh ... -t 4 -f 1`: Ok 792 / Fail 0.
- `cargo build --profile checked-release --no-default-features --features bitdepth_8,bitdepth_16`; `test.sh ... -t 4`: Ok 1527 / Fail 0.
- `cargo fmt --check`; `cargo +stable clippy -- -D warnings` and `cargo clippy -- -D warnings` on nightly-2026-02-05: clean.
- Bit-exact against C dav1d (`--muxer md5 --limit 300`) on Chimera 720p 8-bit and 1080p 10-bit at 1 and 8 threads.


